### PR TITLE
fix: resolve build and typecheck failures across packages

### DIFF
--- a/packages/cli/src/commands/benchmark.ts
+++ b/packages/cli/src/commands/benchmark.ts
@@ -103,13 +103,12 @@ export default defineCommand({
 
         try {
           const startTime = Date.now();
-          await producer.renderComposition(project.dir, {
-            output: outputPath,
+          const job = producer.createRenderJob({
             fps: config.fps,
             quality: config.quality,
             workers: config.workers,
-            quiet: true,
           });
+          await producer.executeRenderJob(job, project.dir, outputPath);
           const elapsedMs = Date.now() - startTime;
 
           let fileSize: number | null = null;

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -143,14 +143,13 @@ async function renderDocker(
   const startTime = Date.now();
 
   try {
-    await producer.renderComposition(projectDir, {
-      output: outputPath,
+    const job = producer.createRenderJob({
       fps: options.fps,
       quality: options.quality,
-      workers: options.workers ?? null,
-      gpu: options.gpu,
-      quiet: options.quiet,
+      workers: options.workers,
+      useGpu: options.gpu,
     });
+    await producer.executeRenderJob(job, projectDir, outputPath);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     errorBox("Render failed", message, "Try --docker for containerized rendering");

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -22,7 +23,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.1",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": ">=22"

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -14,5 +14,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/packages/producer/build.mjs
+++ b/packages/producer/build.mjs
@@ -57,4 +57,10 @@ await Promise.all([
   }),
 ]);
 
-console.log("[Build] Complete: dist/index.js, dist/public-server.js");
+// Generate .d.ts declarations (esbuild doesn't emit them)
+import { execSync } from "child_process";
+execSync("tsc --emitDeclarationOnly --declaration --declarationMap", {
+  stdio: "inherit",
+});
+
+console.log("[Build] Complete: dist/index.js, dist/public-server.js, *.d.ts");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(jsdom@29.0.1)
 
   packages/producer:
     dependencies:
@@ -3545,6 +3548,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@22.19.15))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.15)
+
   '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@24.12.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -4978,6 +4989,24 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vite-node@3.2.4(@types/node@22.19.15):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.2.4(@types/node@24.12.0):
     dependencies:
       cac: 6.7.14
@@ -4996,6 +5025,15 @@ snapshots:
       - supports-color
       - terser
 
+  vite@5.4.21(@types/node@22.19.15):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+
   vite@5.4.21(@types/node@24.12.0):
     dependencies:
       esbuild: 0.21.5
@@ -5013,6 +5051,45 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.15)(jsdom@29.0.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@22.19.15))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@22.19.15)
+      vite-node: 3.2.4(@types/node@22.19.15)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@3.2.4(@types/node@24.12.0)(jsdom@29.0.1):
     dependencies:


### PR DESCRIPTION
## What

Fix pre-existing build and typecheck failures that prevent `pnpm build` and `pnpm -r typecheck` from succeeding.

## Why

CI pipeline (next PR in stack) needs clean build + typecheck. These issues block that.

## How

- **engine**: Exclude `*.test.ts` from tsconfig `exclude` (tsc was failing on vitest imports)
- **engine**: Add missing `vitest` devDependency and `test` script
- **producer**: Generate `.d.ts` declarations via `tsc --emitDeclarationOnly` after esbuild bundle (CLI couldn't resolve producer types)
- **cli**: Replace stale `renderComposition()` calls with `createRenderJob()` + `executeRenderJob()` (API was renamed during migration)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm -r typecheck` passes
- [x] `pnpm --filter @hyperframes/core test` — 330 tests pass
- [x] `pnpm --filter @hyperframes/engine test` — 18 tests pass
- [x] `pnpm --filter @hyperframes/core test:hyperframe-runtime-ci` — all contract tests pass