### PR TITLE
ci: add CI pipeline with build, typecheck, and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm -r typecheck
+
+  test-core:
+    name: "Test: core"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @hyperframes/core test -- --coverage
+
+  test-engine:
+    name: "Test: engine"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @hyperframes/engine test
+
+  test-runtime-contract:
+    name: "Test: runtime contract"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @hyperframes/core test:hyperframe-runtime-ci
+
+  semantic-pr-title:
+    name: Semantic PR title
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert


### PR DESCRIPTION
## What

Add GitHub Actions CI workflow that runs on every PR and push to `main`.

## Why

OSS contributors need automated guardrails. This is item 1 from VA-855.

## How

6 parallel jobs in `.github/workflows/ci.yml`:
1. **Build** — `pnpm build` (all packages)
2. **Typecheck** — `pnpm -r typecheck` (all packages)
3. **Test: core** — vitest with coverage thresholds (75% statements, 70% branches, 80% functions)
4. **Test: engine** — vitest
5. **Test: runtime contract** — runtime contract, behavior, seek, duration guards, parity, security
6. **Semantic PR title** — enforces conventional commit prefixes on PR titles via `amannn/action-semantic-pull-request`

Other details:
- Concurrency group cancels stale runs on same ref
- 10-minute timeout per job
- pnpm cache enabled

**Not included (deferred):**
- Lint/format jobs (waiting on VA-851 tooling choice)
- Producer regression tests (test files need cleanup first)

## Test plan

- [x] YAML validated
- [x] All jobs verified locally: build, typecheck, core tests (330), engine tests (18), runtime contract tests
- [ ] Verify CI runs on this PR

**Stack:** depends on #9