### PR TITLE
fix: change workspace:* to workspace:^ for npm publish

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",
-    "@hyperframes/core": "workspace:*",
+    "@hyperframes/core": "workspace:^",
     "hono": "^4.6.0",
     "linkedom": "^0.18.12",
     "puppeteer": "^24.0.0",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -39,8 +39,8 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@hyperframes/core": "workspace:*",
-    "@hyperframes/engine": "workspace:*",
+    "@hyperframes/core": "workspace:^",
+    "@hyperframes/engine": "workspace:^",
     "@fontsource/archivo-black": "^5.2.8",
     "@fontsource/eb-garamond": "^5.2.7",
     "@fontsource/ibm-plex-mono": "^5.2.7",


### PR DESCRIPTION
## Summary

`workspace:*` in producer and engine deps was left unconverted when published to npm, causing install failures for external consumers (`@hyperframes/core@workspace:*` is not a valid npm version).

`workspace:^` is converted by pnpm to `^0.1.0` during `pnpm publish`.

After merging, all three packages need to be republished:
```bash
pnpm --filter @hyperframes/core publish --no-git-checks
pnpm --filter @hyperframes/engine publish --no-git-checks
pnpm --filter @hyperframes/producer publish --no-git-checks
```