### PR TITLE
chore: release v0.1.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -54,7 +54,6 @@
     "build:hyperframes-runtime": "tsx scripts/build-hyperframes-runtime-artifact.ts",
     "build:hyperframes-runtime:modular": "SANDBOX_RUNTIME_VARIANT=modular tsx scripts/build-hyperframes-runtime-artifact.ts",
     "build:hyperframe-runtime": "tsx scripts/build-hyperframes-runtime-artifact.ts",
-
     "test:hyperframe-runtime-contract": "tsx scripts/test-hyperframe-runtime-contract.ts",
     "test:hyperframe-runtime-behavior": "tsx scripts/test-hyperframe-runtime-behavior.ts",
     "test:hyperframe-runtime-seek": "tsx scripts/test-hyperframe-runtime-seek.ts",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",


### PR DESCRIPTION
## What

Bump all packages from 0.1.0 → 0.1.1.

## Why

Test the publish workflow end-to-end.

## How

`pnpm set-version 0.1.1 --tag` (minus the tag — will tag after merge).

## After merge

```bash
git checkout main && git pull
git tag v0.1.1
git push origin v0.1.1
```

This triggers the publish workflow.