### PR TITLE
feat(ci): add workflow_dispatch release trigger with dry-run and GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     environment: npm-publish
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -41,3 +41,13 @@ jobs:
 
       - name: Publish hyperframes (CLI)
         run: pnpm --filter hyperframes publish --access public --provenance --no-git-checks
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh release create "v${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --title "v${VERSION}" \
+            --generate-notes

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,24 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    name: Create release tag
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version and create tag
+        run: |
+          VERSION="${{ github.event.pull_request.head.ref }}"
+          VERSION="${VERSION#release/}"
+          echo "Tagging ${VERSION}"
+          git tag "${VERSION}"
+          git push origin "${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 0.2.0, 1.0.0-beta.1)"
+        required: true
+        type: string
+
+jobs:
+  prepare:
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Bump versions
+        run: pnpm set-version ${{ inputs.version }}
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="release/v${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add packages/*/package.json
+          git commit -m "chore: release v${{ inputs.version }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: release v${{ inputs.version }}" \
+            --body "$(cat <<'BODY'
+          ## Release v${{ inputs.version }}
+
+          Bumps all packages to v${{ inputs.version }}.
+
+          **After merging**, the release tag is created automatically, which triggers npm publish.
+          BODY
+          )" \
+            --base main \
+            --head "$BRANCH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,29 +46,25 @@ pnpm --filter @hyperframes/core test:hyperframe-runtime-ci  # Runtime contract t
 
 All packages use **fixed versioning** — every release bumps all packages to the same version.
 
-### Steps
+### Via GitHub UI (recommended)
+
+1. Go to **Actions** → **Prepare Release** → **Run workflow**
+2. Enter the version (e.g., `0.2.0`)
+3. Click **Run workflow** — this creates a release PR
+4. Review and merge the PR
+5. Merging auto-creates the `v0.2.0` tag, which triggers npm publish and a GitHub Release
+
+### Via CLI
 
 ```bash
-# 1. Bump version, commit, and tag
-pnpm set-version 0.1.1 --tag
-
-# 2. Push to trigger the publish workflow
-git push origin main --tags
-```
-
-The `v*` tag triggers CI, which validates (build + typecheck + tests) then publishes all packages to npm with provenance attestation.
-
-### Without `--tag` (manual control)
-
-```bash
-# 1. Bump versions only (no commit/tag)
-pnpm set-version 0.1.1
-
-# 2. Review changes, commit yourself
-git add -A
-git commit -m "chore: release v0.1.1"
-git tag v0.1.1
-git push origin main --tags
+# Bump versions, commit to a branch, create PR
+pnpm set-version 0.2.0
+git checkout -b release/v0.2.0
+git add packages/*/package.json
+git commit -m "chore: release v0.2.0"
+git push origin release/v0.2.0
+gh pr create --title "chore: release v0.2.0" --base main
+# After merge, the tag + publish happen automatically
 ```
 
 ## Reporting Issues


### PR DESCRIPTION
## What

Add a PR-based release flow that works with branch protection rules. No direct pushes to main.

## Why

Branch rulesets block direct pushes to main from `github-actions[bot]`. The previous approach tried to push version bumps directly. This uses PRs instead.

## How

Three workflows:

### 1. Prepare Release (`release.yml`) — `workflow_dispatch`
- Maintainer goes to Actions → Prepare Release → enters version → Run
- Creates a `release/v*` branch with version bumps and opens a PR

### 2. Tag Release (`release-tag.yml`) — auto on PR merge
- Detects when a `release/v*` PR is merged to main
- Automatically creates the `v*` git tag

### 3. Publish (`publish.yml`) — auto on `v*` tag
- Existing workflow, triggered by the auto-created tag
- Builds, publishes all 5 packages to npm with provenance
- Creates a GitHub Release with auto-generated notes

### Full flow
```
Maintainer clicks "Run workflow" with version
  → PR created (release/v0.2.0 → main)
    → Maintainer reviews + merges
      → Tag v0.2.0 auto-created
        → npm publish + GitHub Release
```

No direct push to main. No bypass rules needed. Standard PR review flow.

Updated CONTRIBUTING.md with the new release instructions.

## Test plan

- [x] All YAML validated
- [ ] Test Prepare Release workflow_dispatch after merge
- [ ] Verify auto-tag on release PR merge
- [ ] Verify publish triggers from auto-tag