### PR TITLE
fix: rename root package to avoid shadowing published CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hyperframes",
+  "name": "hyperframes-monorepo",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- `npx hyperframes init` failed with "could not determine executable to run" because the monorepo root `package.json` had `"name": "hyperframes"` — the same name as the published npm package
- npx resolved the local root (no `bin` field) instead of the published package
- Renamed root to `"hyperframes-monorepo"`, following the same convention as Remotion

## Test plan
- [x] Run `npx hyperframes init` from inside the monorepo — should now resolve the published package
- [x] Verify `pnpm install` and `pnpm build` still work