### PR TITLE
fix: resolve oxlint errors across codebase

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from "citty";
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
 import { c } from "../ui/colors.js";
 import { findBrowser } from "../browser/manager.js";
 import { findFFmpeg } from "../browser/ffmpeg.js";

--- a/packages/core/src/generators/hyperframes.test.ts
+++ b/packages/core/src/generators/hyperframes.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from "vitest";
 import { generateHyperframesHtml, generateGsapTimelineScript, generateHyperframesStyles } from "./hyperframes.js";
 import { GSAP_CDN } from "../templates/constants.js";
-import type { TimelineTextElement, TimelineMediaElement, TimelineCompositionElement } from "../core.types";
+import type { TimelineTextElement, TimelineMediaElement } from "../core.types";
 
 function makeTextElement(overrides: Partial<TimelineTextElement> = {}): TimelineTextElement {
   return {

--- a/packages/core/src/generators/hyperframes.ts
+++ b/packages/core/src/generators/hyperframes.ts
@@ -280,7 +280,6 @@ export function generateHyperframesHtml(
     includeStyles = false,
   } = options;
 
-  const { width, height } = CANVAS_DIMENSIONS[resolution];
   // Include zoom keyframes in duration calculation
   const maxZoomTime =
     stageZoomKeyframes && stageZoomKeyframes.length > 0 ? Math.max(...stageZoomKeyframes.map((kf) => kf.time)) : 0;

--- a/packages/core/src/runtime/adapters/css.test.ts
+++ b/packages/core/src/runtime/adapters/css.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createCssAdapter } from "./css";
 
 describe("css adapter", () => {

--- a/packages/core/src/runtime/adapters/waapi.test.ts
+++ b/packages/core/src/runtime/adapters/waapi.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createWaapiAdapter } from "./waapi";
 
 describe("waapi adapter", () => {

--- a/packages/core/src/runtime/bridge.test.ts
+++ b/packages/core/src/runtime/bridge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { installRuntimeControlBridge } from "./bridge";
 
 function createMockDeps() {

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { refreshRuntimeMediaCache, syncRuntimeMedia } from "./media";
 import type { RuntimeMediaClip } from "./media";
 

--- a/packages/core/src/runtime/player.test.ts
+++ b/packages/core/src/runtime/player.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createRuntimePlayer } from "./player";
 import type { RuntimeTimelineLike } from "./types";
 

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -121,7 +121,7 @@ export async function createCaptureSession(
 }
 
 export async function initializeSession(session: CaptureSession): Promise<void> {
-  const { page, serverUrl, options } = session;
+  const { page, serverUrl } = session;
 
   // Forward browser console to host with [Browser] prefix
   page.on("console", (msg: ConsoleMessage) => {

--- a/packages/producer/src/regression-harness.ts
+++ b/packages/producer/src/regression-harness.ts
@@ -70,14 +70,6 @@ function logPretty(message: string, emoji = "•") {
   console.error(`${emoji} ${message}`);
 }
 
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-  const minutes = Math.floor(ms / 60000);
-  const seconds = Math.floor((ms % 60000) / 1000);
-  return `${minutes}m ${seconds}s`;
-}
-
 function parseArgs(argv: string[]): CliOptions {
   const testNames: string[] = [];
   const excludeTags: string[] = [];
@@ -464,7 +456,7 @@ function saveFailureDetails(
             join(framesDir, `expected_${timeStr}s.png`),
             suite.meta.renderConfig.fps
           );
-        } catch (error) {
+        } catch {
           logPretty(`  Warning: Could not extract frame at ${checkpoint.time}s`, "⚠️");
         }
       }

--- a/packages/producer/src/services/compilationTester.ts
+++ b/packages/producer/src/services/compilationTester.ts
@@ -298,7 +298,7 @@ export function validateCompilation(
   }
 
   // Check for missing elements (in golden but not in actual)
-  for (const [id, goldenEl] of goldenMap) {
+  for (const [id] of goldenMap) {
     if (!actualMap.has(id)) {
       errors.push(
         `Missing element [${id}] (present in golden, not in actual)`

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -209,7 +209,7 @@ export function StudioApp() {
     "idle",
   );
   const [renderProgress, setRenderProgress] = useState(0);
-  const [renderError, setRenderError] = useState<string | null>(null);
+  const [_renderError, setRenderError] = useState<string | null>(null);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const projectIdRef = useRef(projectId);
 

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -126,6 +126,7 @@ export const NLELayout = memo(function NLELayout({
         return [...prev, { id: resolvedPath, label, previewUrl }];
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- iframeRef_ is a stable ref; .current mutates and should not be a dep
     [projectId, compIdToSrc],
   );
 

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -388,6 +388,7 @@ export function useTimelinePlayer() {
         console.warn("Could not find __player, __timeline, or __timelines on iframe after 5s");
       }
     }, 200);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- setElements is a stable zustand setter
   }, [getAdapter, setDuration, setCurrentTime, setTimelineReady, setIsPlaying, processTimelineMessage]);
 
   /** Save the current playback time so the next onIframeLoad restores it. */

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -141,7 +141,7 @@ function devProjectApi(): Plugin {
             const bundled = bundler ? await bundler(projectDir) : readFileSync(join(projectDir, "index.html"), "utf-8");
             res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
             res.end(bundled);
-          } catch (err) {
+          } catch {
             // Fallback to raw HTML if bundling fails
             const file = join(projectDir, "index.html");
             if (existsSync(file)) {


### PR DESCRIPTION
## Summary
- Remove 5 unused `beforeEach` imports from test files
- Remove unused imports (`existsSync`, `TimelineCompositionElement`)
- Remove unused destructured variables (`options`, `width`, `height`, `goldenEl`)
- Remove dead `formatDuration` function
- Fix unused catch parameters (`catch (err)` → `catch`)
- Prefix unused `renderError` state with `_`
- Add `eslint-disable-next-line` for 2 React exhaustive-deps false positives (stable ref + zustand setter)

Part 2/4 of [VA-851](https://linear.app/heygen/issue/VA-851/pre-migration-configure-eslint-prettier-and-conventional-commits)

## Test plan
- [x] `pnpm lint` — 0 errors on 193 files
- [x] All 348 tests pass (core + engine)