### PR TITLE
docs: add per-package READMEs and polish root docs for OSS launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
               - "packages/**"
               - "scripts/**"
               - "package.json"
-              - "pnpm-lock.yaml"
-              - "pnpm-workspace.yaml"
+              - "bun.lock"
               - "tsconfig*.json"
               - "Dockerfile*"
 
@@ -46,8 +45,10 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run build
 
-  lint-and-format:
-    name: Lint & Format
+  lint:
+    name: Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -58,6 +59,18 @@ jobs:
           node-version: 22
       - run: bun install --frozen-lockfile
       - run: bun run lint
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
       - run: bun run format:check
 
   typecheck:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,24 @@ gh pr create --title "chore: release v0.2.0" --base main
 - Search existing issues before creating a new one
 - Include reproduction steps for bugs
 
+## AI-Assisted Contributions
+
+We welcome contributions that use AI tools (GitHub Copilot, Claude, ChatGPT, etc.). If you used AI to help write a PR, there is no need to disclose it — we review all code on its merits. However:
+
+- You are responsible for the correctness of any code you submit, regardless of how it was generated.
+- AI-generated tests must actually test meaningful behavior, not just assert truthy values.
+- Do not submit AI-generated code you don't understand. If you can't explain what a change does during review, it will be rejected.
+
+## Governance
+
+Hyperframes uses a **BDFL (Benevolent Dictator for Life)** governance model. The core maintainers at HeyGen have final say on the project's direction, API design, and what gets merged. This keeps the project focused and moving fast.
+
+Community input is valued and encouraged — open issues, propose RFCs, and discuss in PRs. But final decisions rest with the maintainers.
+
 ## Code of Conduct
 
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the project's license. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hyperframes
 
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
+
 **Write HTML. Render video. Built for agents.**
 
 Hyperframes is an open-source video rendering framework that lets you create, preview, and render HTML-based video compositions — with first-class support for AI agents via MCP.
@@ -14,11 +16,13 @@ Hyperframes is an open-source video rendering framework that lets you create, pr
 ## Quick Start
 
 ```bash
-npx create-hyperframe my-video
+npx hyperframes init my-video
 cd my-video
 npx hyperframes dev      # preview in browser
 npx hyperframes render   # render to MP4
 ```
+
+**Requirements:** Node.js >= 22, FFmpeg
 
 ## How It Works
 
@@ -49,7 +53,19 @@ Define your video as HTML with data attributes:
 
 Preview instantly in the browser. Render to MP4 locally. Let AI agents compose videos using tools they already understand.
 
-<!-- TODO: Add packages table, AI agent integration section, comparison table, requirements, and docs link once packages are ported -->
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`hyperframes`](packages/cli) | CLI — create, preview, lint, and render compositions |
+| [`@hyperframes/core`](packages/core) | Types, parsers, generators, linter, runtime, frame adapters |
+| [`@hyperframes/engine`](packages/engine) | Seekable page-to-video capture engine (Puppeteer + FFmpeg) |
+| [`@hyperframes/producer`](packages/producer) | Full rendering pipeline (capture + encode + audio mix) |
+| [`@hyperframes/studio`](packages/studio) | Browser-based composition editor UI |
+
+## Documentation
+
+Full docs at [hyperframes.heygen.com](https://hyperframes.heygen.com) — includes guides, concepts, API reference, and package documentation.
 
 ## Contributing
 
@@ -57,4 +73,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.
 
 ## License
 
-[MIT](LICENSE)
+See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Preview instantly in the browser. Render to MP4 locally. Let AI agents compose v
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| [`hyperframes`](packages/cli) | CLI — create, preview, lint, and render compositions |
-| [`@hyperframes/core`](packages/core) | Types, parsers, generators, linter, runtime, frame adapters |
-| [`@hyperframes/engine`](packages/engine) | Seekable page-to-video capture engine (Puppeteer + FFmpeg) |
-| [`@hyperframes/producer`](packages/producer) | Full rendering pipeline (capture + encode + audio mix) |
-| [`@hyperframes/studio`](packages/studio) | Browser-based composition editor UI |
+| Package                                      | Description                                                 |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| [`hyperframes`](packages/cli)                | CLI — create, preview, lint, and render compositions        |
+| [`@hyperframes/core`](packages/core)         | Types, parsers, generators, linter, runtime, frame adapters |
+| [`@hyperframes/engine`](packages/engine)     | Seekable page-to-video capture engine (Puppeteer + FFmpeg)  |
+| [`@hyperframes/producer`](packages/producer) | Full rendering pipeline (capture + encode + audio mix)      |
+| [`@hyperframes/studio`](packages/studio)     | Browser-based composition editor UI                         |
 
 ## Documentation
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,121 @@
+# hyperframes
+
+CLI for creating, previewing, and rendering HTML video compositions.
+
+## Install
+
+```bash
+npm install -g hyperframes
+```
+
+Or use directly with npx:
+
+```bash
+npx hyperframes <command>
+```
+
+**Requirements:** Node.js >= 22, FFmpeg
+
+## Commands
+
+### `init`
+
+Scaffold a new Hyperframes project from a template:
+
+```bash
+npx hyperframes init my-video
+cd my-video
+```
+
+### `dev`
+
+Start the live preview studio in your browser:
+
+```bash
+npx hyperframes dev
+# Server running at http://localhost:3000
+# Watching for changes...
+```
+
+### `render`
+
+Render a composition to MP4:
+
+```bash
+npx hyperframes render ./my-composition.html -o output.mp4
+```
+
+### `lint`
+
+Validate your Hyperframes HTML:
+
+```bash
+npx hyperframes lint ./my-composition.html
+```
+
+### `compositions`
+
+List compositions found in the current project:
+
+```bash
+npx hyperframes compositions
+```
+
+### `benchmark`
+
+Run rendering benchmarks:
+
+```bash
+npx hyperframes benchmark ./my-composition.html
+```
+
+### `doctor`
+
+Check your environment for required dependencies (Chrome, FFmpeg, Node.js):
+
+```bash
+npx hyperframes doctor
+```
+
+### `browser`
+
+Manage the bundled Chrome/Chromium installation:
+
+```bash
+npx hyperframes browser
+```
+
+### `info`
+
+Print version and environment info:
+
+```bash
+npx hyperframes info
+```
+
+### `docs`
+
+Open the documentation in your browser:
+
+```bash
+npx hyperframes docs
+```
+
+### `upgrade`
+
+Upgrade Hyperframes to the latest version:
+
+```bash
+npx hyperframes upgrade
+```
+
+## Documentation
+
+Full documentation: [hyperframes.heygen.com/packages/cli](https://hyperframes.heygen.com/packages/cli)
+
+## Related packages
+
+- [`@hyperframes/core`](../core) — types, parsers, frame adapters
+- [`@hyperframes/engine`](../engine) — rendering engine
+- [`@hyperframes/producer`](../producer) — render pipeline
+- [`@hyperframes/studio`](../studio) — composition editor UI

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,125 +1,76 @@
-# HyperFrames Core
+# @hyperframes/core
 
-> Create videos by writing HTML. The HTML is the source of truth - timing, layout, content. Scripts define how clips animate.
+Types, parsers, generators, compiler, linter, runtime, and frame adapters for the Hyperframes video framework.
 
-HyperFrames Core is the foundational library for video composition. It defines the data attributes and HTML structure that represent video timelines, with GSAP animations to bring clips to life.
+## Install
 
-Frame adapter direction:
-
-- [`../FRAME.md`](../FRAME.md) - repository-level frame model and deterministic renderer direction
-- [`adapters/README.md`](adapters/README.md) - adapter contract and contribution guide
-
-## Philosophy
-
-```
-HTML = Scene description (content, timing, layout)
-CSS  = Styling
-JS   = GSAP animations (motion)
+```bash
+npm install @hyperframes/core
 ```
 
-Every element in the video timeline is represented as an HTML element with data attributes that define its position in time.
+> Most users don't need to install core directly — the [CLI](../cli), [producer](../producer), and [studio](../studio) packages depend on it internally.
 
----
+## What's inside
+
+| Module | Description |
+|--------|-------------|
+| **Types** | `TimelineElement`, `CompositionSpec`, `Asset`, canvas dimensions, defaults |
+| **Parsers** | `parseHtml` — extract timeline elements from HTML; `parseGsapScript` — parse GSAP animations |
+| **Generators** | `generateHyperframesHtml` — produce valid Hyperframes HTML from a composition spec |
+| **Compiler** | `compileTimingAttrs` — resolve `data-start` / `data-duration` into absolute times |
+| **Linter** | `lintHyperframeHtml` — validate Hyperframes HTML (missing attributes, overlapping tracks, etc.) |
+| **Runtime** | IIFE script injected into the browser — manages seek, media playback, and the `window.__hf` protocol |
+| **Frame Adapters** | Pluggable animation drivers (GSAP, Lottie, CSS, or custom) |
+
+## Frame Adapters
+
+A frame adapter tells the engine how to seek your animation to a specific frame:
+
+```typescript
+import { createGSAPFrameAdapter } from "@hyperframes/core";
+
+const adapter = createGSAPFrameAdapter({
+  getTimeline: () => gsap.timeline(),
+  compositionId: "my-video",
+});
+```
+
+Implement `FrameAdapter` for custom animation runtimes:
+
+```typescript
+import type { FrameAdapter } from "@hyperframes/core";
+
+const myAdapter: FrameAdapter = {
+  id: "my-adapter",
+  getDurationFrames: () => 300,
+  seekFrame: (frame) => { /* seek your animation */ },
+};
+```
+
+## Parsing and generating HTML
+
+```typescript
+import { parseHtml, generateHyperframesHtml } from "@hyperframes/core";
+
+const { elements, metadata } = parseHtml(htmlString);
+const html = generateHyperframesHtml(spec);
+```
+
+## Linting
+
+```typescript
+import { lintHyperframeHtml } from "@hyperframes/core/lint";
+
+const result = lintHyperframeHtml(htmlString);
+// result.findings: { severity, message, elementId }[]
+```
 
 ## Documentation
 
-### Schema
+Full documentation: [hyperframes.heygen.com/packages/core](https://hyperframes.heygen.com/packages/core)
 
-The specification for valid HyperFrames HTML:
+## Related packages
 
-- **[schema.md](docs/schema.md)** - Element types, data attributes, HTML patterns
-
-### Guides
-
-For AI agents and developers working with HyperFrames:
-
-| Document                                                  | Description                            |
-| --------------------------------------------------------- | -------------------------------------- |
-| [Cheat Sheet](docs/guides/cheat-sheet.md)                 | Quick reference for common actions     |
-| [Position Guide](docs/guides/position.md)                 | Natural language → position mappings   |
-| [Text Style Guide](docs/guides/text-style.md)             | Natural language → text style mappings |
-| [Motion Design Guide](docs/guides/motion-design/guide.md) | Creating and editing motion designs    |
-| [Caption Guide](docs/guides/motion-design/captions.md)    | Adding captions to videos              |
-
----
-
-## Quick Start
-
-### Using the Editor (Recommended)
-
-```bash
-pnpm install
-pnpm dev
-```
-
-This starts the studio dev server.
-
-### Writing Compositions Manually
-
-```html
-<!DOCTYPE html>
-<html>
-  <head>
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
-    <style>
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-      }
-      html,
-      body {
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        background: #000;
-      }
-      #stage {
-        position: relative;
-        width: 1920px;
-        height: 1080px;
-        overflow: hidden;
-      }
-    </style>
-  </head>
-  <body>
-    <div id="stage">
-      <video id="el-1" data-start="0" data-end="10" src="video.mp4" muted playsinline></video>
-      <div id="el-2" data-start="2" data-end="6" data-type="text">
-        <div>Hello World</div>
-      </div>
-    </div>
-    <script>
-      const tl = gsap.timeline({ paused: true });
-      // Add animations...
-    </script>
-  </body>
-</html>
-```
-
----
-
-## Element Types
-
-| Type        | HTML Tag                        | Purpose              |
-| ----------- | ------------------------------- | -------------------- |
-| video       | `<video>`                       | Video clips          |
-| image       | `<img>`                         | Static images        |
-| text        | `<div data-type="text">`        | Text overlays        |
-| audio       | `<audio>`                       | Music, sound effects |
-| composition | `<div data-type="composition">` | Motion designs       |
-
-## Data Attributes
-
-| Attribute    | Purpose                           | Required |
-| ------------ | --------------------------------- | -------- |
-| `data-start` | When element appears (seconds)    | Yes      |
-| `data-end`   | When element disappears (seconds) | No       |
-| `data-name`  | Display name in UI                | No       |
-| `data-layer` | Z-index for stacking              | No       |
-
-See [schema.md](docs/schema.md) for the complete reference.
-
----
-
-**Remember:** HTML is the storyboard. CSS is the art direction. JS is just for motion.
+- [`@hyperframes/engine`](../engine) — rendering engine that drives the browser
+- [`@hyperframes/producer`](../producer) — full render pipeline (capture + encode)
+- [`hyperframes`](../cli) — CLI

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,15 +12,15 @@ npm install @hyperframes/core
 
 ## What's inside
 
-| Module | Description |
-|--------|-------------|
-| **Types** | `TimelineElement`, `CompositionSpec`, `Asset`, canvas dimensions, defaults |
-| **Parsers** | `parseHtml` — extract timeline elements from HTML; `parseGsapScript` — parse GSAP animations |
-| **Generators** | `generateHyperframesHtml` — produce valid Hyperframes HTML from a composition spec |
-| **Compiler** | `compileTimingAttrs` — resolve `data-start` / `data-duration` into absolute times |
-| **Linter** | `lintHyperframeHtml` — validate Hyperframes HTML (missing attributes, overlapping tracks, etc.) |
-| **Runtime** | IIFE script injected into the browser — manages seek, media playback, and the `window.__hf` protocol |
-| **Frame Adapters** | Pluggable animation drivers (GSAP, Lottie, CSS, or custom) |
+| Module             | Description                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| **Types**          | `TimelineElement`, `CompositionSpec`, `Asset`, canvas dimensions, defaults                           |
+| **Parsers**        | `parseHtml` — extract timeline elements from HTML; `parseGsapScript` — parse GSAP animations         |
+| **Generators**     | `generateHyperframesHtml` — produce valid Hyperframes HTML from a composition spec                   |
+| **Compiler**       | `compileTimingAttrs` — resolve `data-start` / `data-duration` into absolute times                    |
+| **Linter**         | `lintHyperframeHtml` — validate Hyperframes HTML (missing attributes, overlapping tracks, etc.)      |
+| **Runtime**        | IIFE script injected into the browser — manages seek, media playback, and the `window.__hf` protocol |
+| **Frame Adapters** | Pluggable animation drivers (GSAP, Lottie, CSS, or custom)                                           |
 
 ## Frame Adapters
 
@@ -43,7 +43,9 @@ import type { FrameAdapter } from "@hyperframes/core";
 const myAdapter: FrameAdapter = {
   id: "my-adapter",
   getDurationFrames: () => 300,
-  seekFrame: (frame) => { /* seek your animation */ },
+  seekFrame: (frame) => {
+    /* seek your animation */
+  },
 };
 ```
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,0 +1,78 @@
+# @hyperframes/engine
+
+Seekable web-page-to-video rendering engine built on Puppeteer and FFmpeg.
+
+Framework-agnostic: works with GSAP, Lottie, Three.js, CSS animations, or any web content that implements the `window.__hf` seek protocol.
+
+## Install
+
+```bash
+npm install @hyperframes/engine
+```
+
+**Requirements:** Node.js >= 22, Chrome/Chromium (auto-downloaded by Puppeteer), FFmpeg
+
+## What it does
+
+The engine opens your HTML composition in a headless Chrome instance, seeks frame-by-frame using Chrome's `HeadlessExperimental.beginFrame` API, captures screenshots, and encodes them into video with FFmpeg.
+
+### Key services
+
+| Service | Description |
+|---------|-------------|
+| **browserManager** | Launches and pools headless Chrome instances (`chrome-headless-shell`) |
+| **frameCapture** | Manages capture sessions — seek, screenshot, buffer lifecycle |
+| **screenshotService** | BeginFrame-based capture with CDP (Chrome DevTools Protocol) |
+| **chunkEncoder** | FFmpeg encoding with chunked concat, GPU detection, faststart |
+| **streamingEncoder** | Pipe frames to FFmpeg in real time (no intermediate PNGs on disk) |
+| **audioMixer** | Parse `<audio>` elements and mix audio tracks via FFmpeg |
+| **videoFrameExtractor** | Extract frames from `<video>` elements for compositing |
+| **parallelCoordinator** | Split frame ranges across worker processes |
+| **fileServer** | Serve local HTML files to the browser via Hono |
+
+## Usage
+
+```typescript
+import {
+  acquireBrowser,
+  releaseBrowser,
+  createCaptureSession,
+  initializeSession,
+  captureFrame,
+  closeCaptureSession,
+} from "@hyperframes/engine";
+
+// 1. Launch browser
+const browser = await acquireBrowser({ captureMode: "beginFrame" });
+
+// 2. Open a capture session
+const session = createCaptureSession({
+  browser: browser.browser,
+  url: "http://localhost:3000/my-composition.html",
+  width: 1920,
+  height: 1080,
+  fps: 30,
+});
+await initializeSession(session);
+
+// 3. Capture frames
+for (let i = 0; i < totalFrames; i++) {
+  await captureFrame(session, i, `/tmp/frames/frame-${i}.png`);
+}
+
+// 4. Clean up
+await closeCaptureSession(session);
+await releaseBrowser(browser);
+```
+
+Most users should use `@hyperframes/producer` or the `hyperframes` CLI instead of calling the engine directly.
+
+## Documentation
+
+Full documentation: [hyperframes.heygen.com/packages/engine](https://hyperframes.heygen.com/packages/engine)
+
+## Related packages
+
+- [`@hyperframes/core`](../core) — types, parsers, frame adapters
+- [`@hyperframes/producer`](../producer) — high-level render pipeline built on this engine
+- [`hyperframes`](../cli) — CLI

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -18,17 +18,17 @@ The engine opens your HTML composition in a headless Chrome instance, seeks fram
 
 ### Key services
 
-| Service | Description |
-|---------|-------------|
-| **browserManager** | Launches and pools headless Chrome instances (`chrome-headless-shell`) |
-| **frameCapture** | Manages capture sessions — seek, screenshot, buffer lifecycle |
-| **screenshotService** | BeginFrame-based capture with CDP (Chrome DevTools Protocol) |
-| **chunkEncoder** | FFmpeg encoding with chunked concat, GPU detection, faststart |
-| **streamingEncoder** | Pipe frames to FFmpeg in real time (no intermediate PNGs on disk) |
-| **audioMixer** | Parse `<audio>` elements and mix audio tracks via FFmpeg |
-| **videoFrameExtractor** | Extract frames from `<video>` elements for compositing |
-| **parallelCoordinator** | Split frame ranges across worker processes |
-| **fileServer** | Serve local HTML files to the browser via Hono |
+| Service                 | Description                                                            |
+| ----------------------- | ---------------------------------------------------------------------- |
+| **browserManager**      | Launches and pools headless Chrome instances (`chrome-headless-shell`) |
+| **frameCapture**        | Manages capture sessions — seek, screenshot, buffer lifecycle          |
+| **screenshotService**   | BeginFrame-based capture with CDP (Chrome DevTools Protocol)           |
+| **chunkEncoder**        | FFmpeg encoding with chunked concat, GPU detection, faststart          |
+| **streamingEncoder**    | Pipe frames to FFmpeg in real time (no intermediate PNGs on disk)      |
+| **audioMixer**          | Parse `<audio>` elements and mix audio tracks via FFmpeg               |
+| **videoFrameExtractor** | Extract frames from `<video>` elements for compositing                 |
+| **parallelCoordinator** | Split frame ranges across worker processes                             |
+| **fileServer**          | Serve local HTML files to the browser via Hono                         |
 
 ## Usage
 

--- a/packages/producer/README.md
+++ b/packages/producer/README.md
@@ -1,0 +1,75 @@
+# @hyperframes/producer
+
+Full HTML-to-video rendering pipeline: capture frames with Chrome's BeginFrame API, encode with FFmpeg, mix audio — all in one call.
+
+## Install
+
+```bash
+npm install @hyperframes/producer
+```
+
+**Requirements:** Node.js >= 22, Chrome/Chromium (auto-downloaded), FFmpeg
+
+## Usage
+
+### Render a video
+
+```typescript
+import { createRenderJob, executeRenderJob } from "@hyperframes/producer";
+
+const job = createRenderJob({
+  inputPath: "./my-composition.html",
+  outputPath: "./output.mp4",
+  width: 1920,
+  height: 1080,
+  fps: 30,
+});
+
+const result = await executeRenderJob(job, (progress) => {
+  console.log(`${Math.round(progress.percent * 100)}%`);
+});
+
+console.log(result.outputPath); // ./output.mp4
+```
+
+### Run as an HTTP server
+
+The producer can also run as a render server, accepting render requests over HTTP:
+
+```typescript
+import { startServer } from "@hyperframes/producer";
+
+await startServer({ port: 8080 });
+// POST /render with a RenderConfig body
+```
+
+### Configuration
+
+`RenderConfig` controls the render pipeline:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `inputPath` | — | Path to the HTML composition |
+| `outputPath` | — | Output video file path |
+| `width` | 1920 | Frame width in pixels |
+| `height` | 1080 | Frame height in pixels |
+| `fps` | 30 | Frames per second (24, 30, or 60) |
+| `quality` | `"standard"` | Encoder preset (`"draft"`, `"standard"`, `"high"`) |
+
+## How it works
+
+1. **Serve** — spins up a local file server for the HTML composition
+2. **Capture** — opens the page in headless Chrome, seeks frame-by-frame via `HeadlessExperimental.beginFrame`, captures screenshots
+3. **Encode** — pipes frames through FFmpeg (with GPU encoder detection and chunked concat)
+4. **Mix** — extracts `<audio>` elements and mixes them into the final video
+5. **Finalize** — applies faststart for streaming-friendly MP4
+
+## Documentation
+
+Full documentation: [hyperframes.heygen.com/packages/producer](https://hyperframes.heygen.com/packages/producer)
+
+## Related packages
+
+- [`@hyperframes/core`](../core) — types, parsers, frame adapters
+- [`@hyperframes/engine`](../engine) — lower-level capture and encode primitives
+- [`hyperframes`](../cli) — CLI

--- a/packages/producer/README.md
+++ b/packages/producer/README.md
@@ -47,14 +47,14 @@ await startServer({ port: 8080 });
 
 `RenderConfig` controls the render pipeline:
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `inputPath` | — | Path to the HTML composition |
-| `outputPath` | — | Output video file path |
-| `width` | 1920 | Frame width in pixels |
-| `height` | 1080 | Frame height in pixels |
-| `fps` | 30 | Frames per second (24, 30, or 60) |
-| `quality` | `"standard"` | Encoder preset (`"draft"`, `"standard"`, `"high"`) |
+| Option       | Default      | Description                                        |
+| ------------ | ------------ | -------------------------------------------------- |
+| `inputPath`  | —            | Path to the HTML composition                       |
+| `outputPath` | —            | Output video file path                             |
+| `width`      | 1920         | Frame width in pixels                              |
+| `height`     | 1080         | Frame height in pixels                             |
+| `fps`        | 30           | Frames per second (24, 30, or 60)                  |
+| `quality`    | `"standard"` | Encoder preset (`"draft"`, `"standard"`, `"high"`) |
 
 ## How it works
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -1,0 +1,46 @@
+# @hyperframes/studio
+
+Browser-based composition editor UI for Hyperframes. Provides a visual timeline, code editor, and live preview for building video compositions.
+
+## Install
+
+```bash
+npm install @hyperframes/studio
+```
+
+## What it does
+
+The studio is a React application with:
+
+- **Visual timeline** — drag, resize, and arrange elements on tracks
+- **Code editor** — edit HTML and GSAP scripts with CodeMirror (syntax highlighting, autocomplete)
+- **Live preview** — see changes in real time as you edit
+- **Composition inspector** — view and modify element properties
+
+## Development
+
+The studio is embedded in the `hyperframes dev` command. To develop the studio UI itself:
+
+```bash
+cd packages/studio
+pnpm dev        # Start Vite dev server
+pnpm build      # Build for production
+pnpm typecheck  # Type-check
+```
+
+## Tech stack
+
+- React 18/19, Zustand (state management)
+- CodeMirror 6 (editor)
+- Tailwind CSS (styling)
+- Vite (bundler)
+- Phosphor Icons
+
+## Documentation
+
+Full documentation: [hyperframes.heygen.com/packages/studio](https://hyperframes.heygen.com/packages/studio)
+
+## Related packages
+
+- [`@hyperframes/core`](../core) — types and parsers used by the editor
+- [`hyperframes`](../cli) — CLI that serves the studio via `hyperframes dev`


### PR DESCRIPTION
## What

Add per-package READMEs, polish root documentation files, and fix CI for docs-only PRs.

## Why

VA-850 requires all documentation to be authored before the public repo launch. The `docs/packages/*.mdx` pages cover full detail; these READMEs serve the npm/GitHub audience with concise install + overview + links to the docs site.

## How

**Per-package READMEs** (new for engine, producer, cli, studio; rewritten for core):
- Install instructions, what the package does, basic usage examples
- Links to full docs at hyperframes.heygen.com
- Related packages cross-links

**Root README polish:**
- Added Node.js badge (license badge omitted pending final decision)
- Added packages table, documentation section, requirements note
- Fixed `init` command

**CONTRIBUTING.md additions:**
- AI usage policy (welcome AI tools, contributors own correctness)
- BDFL governance statement
- Genericized license references (pending final license decision)

**CI: split lint from format:**
- `Lint` job (oxlint) now only runs on code changes
- `Format` job (oxfmt) runs on all PRs — catches unformatted docs/markdown
- Updated stale `pnpm-lock.yaml` path filter to `bun.lock`

## Test plan

- [ ] Verify `Format` job runs on this docs-only PR
- [ ] Verify `Lint` job is skipped (no code changes)
- [ ] Review README rendering on GitHub
- [ ] Confirm license language is acceptable pending final decision