### PR TITLE
fix(docs): update studio README to use bun instead of pnpm

### DIFF
--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -23,9 +23,9 @@ The studio is embedded in the `hyperframes dev` command. To develop the studio U
 
 ```bash
 cd packages/studio
-pnpm dev        # Start Vite dev server
-pnpm build      # Build for production
-pnpm typecheck  # Type-check
+bun run dev        # Start Vite dev server
+bun run build      # Build for production
+bun run typecheck  # Type-check
 ```
 
 ## Tech stack


### PR DESCRIPTION
## What

Replace `pnpm` references with `bun run` in the studio README.

## Why

Missed during #34 — the bun migration (#28) had already merged but three lines in the new studio README still referenced pnpm.

Fixes https://github.com/heygen-com/hyperframes/pull/34#issuecomment-4115410969

## Test plan

- [x] Verified no other `pnpm` references remain in package READMEs