### PR TITLE
fix(ci): update publish workflow to use bun install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,16 +16,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
       - uses: pnpm/action-setup@v4
         with:
           version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
           registry-url: "https://registry.npmjs.org"
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      - run: bun install --frozen-lockfile
+      - run: bun run build
 
       - name: Publish @hyperframes/core
         run: pnpm --filter @hyperframes/core publish --access public --provenance --no-git-checks

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -23,7 +23,6 @@ jobs:
               - "packages/**"
               - "scripts/**"
               - "Dockerfile*"
-              - "pnpm-lock.yaml"
 
   regression-shards:
     needs: changes

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -16,21 +16,21 @@ Thanks for your interest in contributing to Hyperframes! This guide covers every
     ```
   </Step>
   <Step title="Install dependencies">
-    Hyperframes uses [pnpm](https://pnpm.io/) for package management:
+    Hyperframes uses [bun](https://bun.sh/) for package management:
     ```bash
-    pnpm install
+    bun install
     ```
   </Step>
   <Step title="Build all packages">
     Build the monorepo to ensure everything compiles:
     ```bash
-    pnpm build
+    bun run build
     ```
   </Step>
   <Step title="Run the studio">
     Start the development server to verify your setup:
     ```bash
-    pnpm dev
+    bun run dev
     ```
     If the studio opens at `http://localhost:3000` with a preview, your environment is ready.
   </Step>
@@ -47,33 +47,33 @@ Thanks for your interest in contributing to Hyperframes! This guide covers every
 ### Common Commands
 
 ```bash
-pnpm install        # Install all dependencies
-pnpm dev            # Start the studio (composition editor + live preview)
-pnpm build          # Build all packages
-pnpm -r typecheck   # Type-check all packages
+bun install                          # Install all dependencies
+bun run dev                          # Start the studio (composition editor + live preview)
+bun run build                        # Build all packages
+bun run --filter '*' typecheck       # Type-check all packages
 ```
 
 ### Running Tests
 
 <CodeGroup>
 ```bash Core
-pnpm --filter @hyperframes/core test
+bun run --filter @hyperframes/core test
 ```
 ```bash Engine
-pnpm --filter @hyperframes/engine test
+bun run --filter @hyperframes/engine test
 ```
 ```bash Runtime Contract
-pnpm --filter @hyperframes/core test:hyperframe-runtime-ci
+bun run --filter @hyperframes/core test:hyperframe-runtime-ci
 ```
 ```bash Producer (Docker)
-cd packages/producer && pnpm docker:build:test && pnpm docker:test
+cd packages/producer && bun run docker:build:test && bun run docker:test
 ```
 </CodeGroup>
 
 ### Running All Tests
 
 ```bash
-pnpm -r test
+bun run --filter '*' test
 ```
 
 ## Packages
@@ -114,8 +114,8 @@ test: add regression test for nested composition timing
 
 All of the following must pass before your PR can be merged:
 
-- **Build** — `pnpm build` succeeds
-- **Type check** — `pnpm -r typecheck` reports no errors
+- **Build** — `bun run build` succeeds
+- **Type check** — `bun run --filter '*' typecheck` reports no errors
 - **Tests** — all test suites pass
 - **Semantic PR title** — PR title follows conventional commit format
 

--- a/docs/packages/core.mdx
+++ b/docs/packages/core.mdx
@@ -126,7 +126,7 @@ The runtime is the JavaScript that runs inside the browser (or headless Chrome) 
 Build the runtime from source:
 
 ```bash
-pnpm --filter @hyperframes/core build:hyperframes-runtime
+bun run --filter @hyperframes/core build:hyperframes-runtime
 ```
 
 <Warning>

--- a/docs/packages/producer.mdx
+++ b/docs/packages/producer.mdx
@@ -131,13 +131,13 @@ The producer includes a regression harness for comparing render output against g
 cd packages/producer
 
 # Build the test Docker image
-pnpm docker:build:test
+bun run docker:build:test
 
 # Run regression tests (compares output against golden baselines)
-pnpm docker:test
+bun run docker:test
 
 # Regenerate golden baselines after intentional changes
-pnpm docker:test:update
+bun run docker:test:update
 ```
 
 ## Benchmarking
@@ -150,7 +150,7 @@ npx hyperframes benchmark
 
 # Directly from the producer package
 cd packages/producer
-pnpm benchmark
+bun run benchmark
 ```
 
 The benchmark runs several compositions with different quality and FPS settings and reports timing for each combination.

--- a/docs/packages/studio.mdx
+++ b/docs/packages/studio.mdx
@@ -39,10 +39,10 @@ This starts the studio development server, opens your composition in the browser
 
 ```bash
 # From the root
-pnpm dev
+bun run dev
 
 # Or target the studio package directly
-pnpm --filter @hyperframes/studio dev
+bun run --filter @hyperframes/studio dev
 ```
 
 The studio starts at `http://localhost:3000` by default.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -163,7 +163,7 @@ A 1920x1080 video with an animated title that fades in from above — rendered t
 | Dependency | Required | Notes |
 |-----------|----------|-------|
 | **Node.js** 20+ | Yes | Runtime for CLI and dev server |
-| **pnpm** or npm | Yes | Package manager (pnpm recommended) |
+| **bun** or npm | Yes | Package manager (bun recommended) |
 | **FFmpeg** | Yes | Video encoding for local renders |
 | **Docker** | No | Optional — for deterministic, reproducible renders |
 

--- a/packages/core/scripts/check-hyperframe-static.ts
+++ b/packages/core/scripts/check-hyperframe-static.ts
@@ -34,7 +34,7 @@ function main() {
   const inputPath = positionalArgs[0];
   if (!inputPath) {
     console.error(
-      "Usage: pnpm check:hyperframe-html [--json] <path-to-html>\nExample: pnpm check:hyperframe-html core/src/tests/broken-video.html",
+      "Usage: bun run check:hyperframe-html [--json] <path-to-html>\nExample: bun run check:hyperframe-html core/src/tests/broken-video.html",
     );
     process.exit(2);
   }

--- a/packages/core/scripts/debug-timeline.ts
+++ b/packages/core/scripts/debug-timeline.ts
@@ -195,7 +195,7 @@ function resolveRootTag(tags: ParsedTag[]): ParsedTag | null {
 function main() {
   const { inputPath, forcedFps, forcedMaxDuration } = parseArgs();
   if (!inputPath) {
-    console.error("Usage: pnpm debug:timeline <path-to-html> [--fps 30] [--max-duration 1800]");
+    console.error("Usage: bun run debug:timeline <path-to-html> [--fps 30] [--max-duration 1800]");
     process.exit(2);
   }
 

--- a/packages/core/src/runtime/README.md
+++ b/packages/core/src/runtime/README.md
@@ -41,7 +41,7 @@ Determinism baseline:
 ## Build
 
 ```bash
-pnpm -C core build:hyperframes-runtime
+bun run --filter @hyperframes/core build:hyperframes-runtime
 ```
 
 ## Security Expectations

--- a/packages/producer/src/benchmark.ts
+++ b/packages/producer/src/benchmark.ts
@@ -6,10 +6,10 @@
  * Results are saved to producer/tests/perf/benchmark-results.json.
  *
  * Usage:
- *   pnpm benchmark                    # 3 runs per fixture (default)
- *   pnpm benchmark -- --runs 5        # 5 runs per fixture
- *   pnpm benchmark -- --only chat     # single fixture
- *   pnpm benchmark -- --exclude-tags slow
+ *   bun run benchmark                    # 3 runs per fixture (default)
+ *   bun run benchmark -- --runs 5        # 5 runs per fixture
+ *   bun run benchmark -- --only chat     # single fixture
+ *   bun run benchmark -- --exclude-tags slow
  */
 
 import {
@@ -196,7 +196,7 @@ async function runBenchmark(): Promise<void> {
           avg(
             fixtureRuns
               .filter((r) => r.perfSummary.captureAvgMs != null)
-              .map((r) => r.perfSummary.captureAvgMs!),
+              .map((r) => r.perfSummary.captureAvgMs ?? 0),
           ) || null,
         stages: avgStages,
       },

--- a/packages/producer/tests/parity/README.md
+++ b/packages/producer/tests/parity/README.md
@@ -16,7 +16,7 @@ Then in another terminal:
 
 ```bash
 cd producer
-pnpm parity:check \
+bun run parity:check \
   --preview-url "http://127.0.0.1:4173/minimal-wysiwyg.html" \
   --producer-url "http://127.0.0.1:4173/minimal-wysiwyg.html?mode=producer" \
   --checkpoints "0,0.5,1,1.5" \

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -3,8 +3,8 @@
  * Set the version across all publishable packages in the monorepo.
  *
  * Usage:
- *   pnpm set-version 0.1.1
- *   pnpm set-version 0.1.1 --tag   # also creates a git commit and tag
+ *   bun run set-version 0.1.1
+ *   bun run set-version 0.1.1 --tag   # also creates a git commit and tag
  *
  * All packages share a single version number (fixed versioning).
  */
@@ -29,8 +29,8 @@ function main() {
   const shouldTag = args.includes("--tag");
 
   if (!version) {
-    console.error("Usage: pnpm set-version <version> [--tag]");
-    console.error("Example: pnpm set-version 0.1.1 --tag");
+    console.error("Usage: bun run set-version <version> [--tag]");
+    console.error("Example: bun run set-version 0.1.1 --tag");
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- `publish.yml` still used `pnpm install --frozen-lockfile` but `pnpm-lock.yaml` was removed in the bun migration (#28)
- Use `bun install` for deps and `bun run build` for building
- Keep `pnpm publish` for the actual publish step (`publishConfig` overrides + `--provenance`)

## Test plan
- [x] Workflow has both `oven-sh/setup-bun` and `pnpm/action-setup` installed
- [x] `bun install --frozen-lockfile` uses `bun.lock`
- [x] `pnpm publish` commands unchanged