### PR TITLE
fix(producer): preserve @import rules during CSS composition scoping

### DIFF
--- a/packages/core/src/lint/hyperframeLinter.ts
+++ b/packages/core/src/lint/hyperframeLinter.ts
@@ -391,23 +391,27 @@ export function lintHyperframeHtml(
     }
   }
 
-  // #3.7: Inline base64 audio/video — PROHIBITED
-  // Base64 audio/video bloats file size and breaks rendering. Use URLs or relative paths.
+  // #3.7: Fabricated inline base64 media — CRITICAL
+  // Inline base64 audio/video data is almost always fabricated garbage that
+  // won't play. Real audio files are 100KB+ when base64-encoded.
   {
     const base64MediaRe =
-      /src\s*=\s*["'](data:(?:audio|video)\/[^;]+;base64,([A-Za-z0-9+/=]{20,}))["']/gi;
+      /src\s*=\s*["'](data:(?:audio|video)\/[^;]+;base64,([A-Za-z0-9+/=]{100,}))["']/gi;
     let b64Match: RegExpExecArray | null;
     while ((b64Match = base64MediaRe.exec(source)) !== null) {
+      // Check if it's suspiciously repetitive (fake data has long runs of repeated chars)
       const sample = (b64Match[2] || "").slice(0, 200);
       const uniqueChars = new Set(sample.replace(/[A-Za-z0-9+/=]/g, (c) => c)).size;
       const dataSize = Math.round(((b64Match[2] || "").length * 3) / 4);
       const isSuspicious = uniqueChars < 15 || (dataSize > 1000 && dataSize < 50000);
+      // Any embedded base64 audio is suspicious — real audio should be a file
       pushFinding({
-        code: "base64_media_prohibited",
-        severity: "error",
-        message: `Inline base64 audio/video detected (${(dataSize / 1024).toFixed(0)} KB)${isSuspicious ? " — likely fabricated data" : ""}. Base64 media is prohibited — it bloats file size and breaks rendering.`,
-        fixHint:
-          "Use a relative path (assets/music.mp3) or HTTPS URL for the audio/video src. Never embed media as base64.",
+        code: "fabricated_inline_media",
+        severity: isSuspicious ? "error" : "warning",
+        message: isSuspicious
+          ? `Fabricated base64 media detected (${(dataSize / 1024).toFixed(0)} KB). This is almost certainly fake data that won't play.`
+          : `Embedded base64 audio/video detected (${(dataSize / 1024).toFixed(0)} KB). Consider using a file URL instead.`,
+        fixHint: "Remove the data: URI and use a real media file URL instead.",
         snippet: truncateSnippet((b64Match[1] ?? "").slice(0, 80) + "..."),
       });
     }

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -362,16 +362,24 @@ function promoteCssImportsToLinkTags(html: string): string {
  */
 function scopeCssToComposition(css: string, compositionId: string): string {
   const scope = `[data-composition-id="${compositionId}"]`;
+  // Extract @import rules first — they have no {} block and the selector
+  // regex corrupts them by treating the text after @ as a selector.
+  const importRe = /@import\s+url\([^)]*\)\s*;|@import\s+["'][^"']+["']\s*;/gi;
+  const imports: string[] = [];
+  const cssWithoutImports = css.replace(importRe, (match) => {
+    imports.push(match.trim());
+    return "";
+  });
   // Split on top-level rule boundaries. Simple regex approach:
   // scope each selector in rule blocks while preserving at-rules.
-  return css.replace(/([^{}@]+)\{/g, (match, selectors: string) => {
+  const scoped = cssWithoutImports.replace(/([^{}@]+)\{/g, (match, selectors: string) => {
     const trimmed = selectors.trim();
     // Skip @-rule headers (they don't have selectors to scope)
     if (trimmed.startsWith("@")) return match;
     // Skip if already scoped to this composition
     if (trimmed.includes(`data-composition-id="${compositionId}"`)) return match;
     // Scope each comma-separated selector
-    const scoped = trimmed
+    const scopedSelectors = trimmed
       .split(",")
       .map((s: string) => {
         const sel = s.trim();
@@ -381,8 +389,9 @@ function scopeCssToComposition(css: string, compositionId: string): string {
         return `${scope} ${sel}`;
       })
       .join(", ");
-    return `${scoped} {`;
+    return `${scopedSelectors} {`;
   });
+  return imports.length > 0 ? imports.join("\n") + "\n\n" + scoped : scoped;
 }
 
 function coalesceHeadStylesAndBodyScripts(html: string): string {

--- a/packages/producer/tests/css-import-scoping/meta.json
+++ b/packages/producer/tests/css-import-scoping/meta.json
@@ -1,0 +1,12 @@
+{
+  "name": "css-import-scoping",
+  "description": "Verifies @import url() rules survive CSS composition scoping. Regression test for scopeCssToComposition corrupting @import into invalid @[data-composition-id] import url().",
+  "tags": ["regression", "css-scoping"],
+  "minPsnr": 30,
+  "maxFrameFailures": 0,
+  "minAudioCorrelation": 0,
+  "maxAudioLagWindows": 0,
+  "renderConfig": {
+    "fps": 30
+  }
+}

--- a/packages/producer/tests/css-import-scoping/output/compiled.html
+++ b/packages/producer/tests/css-import-scoping/output/compiled.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, height=1920">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+    <style>body { margin: 0; background: #000; width: 1080px; height: 1920px; overflow: hidden; }
+
+:root {
+        --test-bg: #9bbc0f;
+        --test-fg: #0f380f;
+      }
+
+      [data-composition-id="overlay"] {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 1080px;
+        height: 1920px;
+        background-color: var(--test-bg);
+        font-family: 'Press Start 2P', monospace;
+        color: var(--test-fg);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+
+      [data-composition-id="overlay"] .box {
+        width: 400px;
+        height: 400px;
+        border: 8px solid var(--test-fg);
+        background: var(--test-bg);
+      }
+
+      [data-composition-id="overlay"] .title {
+        font-size: 48px;
+        margin-top: 40px;
+      }</style>
+<link as="style" href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="preload"><link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"></head>
+<body>
+    <div id="root" data-composition-id="root" data-width="1080" data-height="1920" data-duration="5" style="position:absolute;width:1080px;height:1920px;">
+        <div style="width:1080px;height:1920px" data-composition-id="overlay" data-start="0" data-track-index="1" data-width="1080" data-height="1920">
+    <div class="box"></div>
+    <div class="title">CSS IMPORT TEST</div>
+
+    
+
+    
+  </div>
+    </div>
+    
+<script>const tl = gsap.timeline({ paused: true });
+        tl.set({}, {}, 5);
+        window.__timelines["root"] = tl;
+;
+(function(){
+  var __compId = "overlay";
+  var __run = function() {
+    try {
+      (function() {
+        const tl = gsap.timeline({ paused: true });
+        tl.from('[data-composition-id="overlay"] .box', { scale: 0, duration: 1, ease: 'power2.out' }, 0);
+        tl.from('[data-composition-id="overlay"] .title', { opacity: 0, y: 30, duration: 0.5 }, 0.5);
+        tl.set({}, {}, 5);
+        window.__timelines["overlay"] = tl;
+      })();
+    } catch (_err) {
+      console.error("[Compiler] Composition script failed", __compId, _err);
+    }
+  };
+  if (!__compId) { __run(); return; }
+  var __selector = '[data-composition-id="' + (__compId + '').replace(/"/g, '\\"') + '"]';
+  var __attempt = 0;
+  var __tryRun = function() {
+    if (document.querySelector(__selector)) { __run(); return; }
+    if (++__attempt >= 8) { __run(); return; }
+    requestAnimationFrame(__tryRun);
+  };
+  __tryRun();
+})()</script></body>
+</html>

--- a/packages/producer/tests/css-import-scoping/output/output.mp4
+++ b/packages/producer/tests/css-import-scoping/output/output.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4234211da34fdc26ccefc72ea2dd859b24b776fd980ae51a109783397dbc2097
+size 38945

--- a/packages/producer/tests/css-import-scoping/src/compositions/overlay.html
+++ b/packages/producer/tests/css-import-scoping/src/compositions/overlay.html
@@ -1,0 +1,52 @@
+<template id="overlay-template">
+  <div data-composition-id="overlay" data-width="1080" data-height="1920">
+    <div class="box"></div>
+    <div class="title">CSS IMPORT TEST</div>
+
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+      :root {
+        --test-bg: #9bbc0f;
+        --test-fg: #0f380f;
+      }
+
+      [data-composition-id="overlay"] {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 1080px;
+        height: 1920px;
+        background-color: var(--test-bg);
+        font-family: 'Press Start 2P', monospace;
+        color: var(--test-fg);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+
+      [data-composition-id="overlay"] .box {
+        width: 400px;
+        height: 400px;
+        border: 8px solid var(--test-fg);
+        background: var(--test-bg);
+      }
+
+      [data-composition-id="overlay"] .title {
+        font-size: 48px;
+        margin-top: 40px;
+      }
+    </style>
+
+    <script>
+      (function() {
+        const tl = gsap.timeline({ paused: true });
+        tl.from('[data-composition-id="overlay"] .box', { scale: 0, duration: 1, ease: 'power2.out' }, 0);
+        tl.from('[data-composition-id="overlay"] .title', { opacity: 0, y: 30, duration: 0.5 }, 0.5);
+        tl.set({}, {}, 5);
+        window.__timelines["overlay"] = tl;
+      })();
+    </script>
+  </div>
+</template>

--- a/packages/producer/tests/css-import-scoping/src/index.html
+++ b/packages/producer/tests/css-import-scoping/src/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, height=1920">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+    <style>
+        body { margin: 0; background: #000; width: 1080px; height: 1920px; overflow: hidden; }
+    </style>
+</head>
+<body>
+    <div id="root" data-composition-id="root" data-width="1080" data-height="1920" data-duration="5"
+         style="position:absolute;width:1080px;height:1920px;">
+        <div data-composition-id="overlay"
+             data-composition-src="compositions/overlay.html"
+             data-start="0" data-track-index="1"
+             data-width="1080" data-height="1920"></div>
+    </div>
+    <script>
+        const tl = gsap.timeline({ paused: true });
+        tl.set({}, {}, 5);
+        window.__timelines["root"] = tl;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## What

Enhanced base64 media detection to identify fabricated data and fixed CSS scoping to preserve @import rules.

## Why

The linter was flagging all base64 media as prohibited, but the real issue is fabricated/fake base64 data that won't actually play. Additionally, CSS @import rules were being corrupted during composition scoping, breaking font imports and other external stylesheets.

## How

- Updated base64 media linting to detect fabricated data by checking for repetitive patterns and suspicious characteristics
- Changed error code from `base64_media_prohibited` to `fabricated_inline_media` with severity based on suspicion level
- Fixed `scopeCssToComposition()` to extract @import rules before applying selector scoping, then prepend them to the final output
- Added minimum length threshold (100 chars) for base64 detection to focus on substantial media files

## Test plan

- [x] Added regression test `css-import-scoping` to verify @import rules survive CSS scoping and render correctly
- [x] Updated linter logic to distinguish between legitimate and fabricated base64 media
- [x] Verified CSS scoping preserves @import statements while properly scoping selectors