### PR TITLE
fix(ci): remove --provenance from npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,27 +25,27 @@ jobs:
       - run: bun run build
 
       - name: Publish @hyperframes/core
-        run: npm --workspace packages/core publish --access public --provenance --no-git-checks
+        run: npm --workspace packages/core publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @hyperframes/engine
-        run: npm --workspace packages/engine publish --access public --provenance --no-git-checks
+        run: npm --workspace packages/engine publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @hyperframes/producer
-        run: npm --workspace packages/producer publish --access public --provenance --no-git-checks
+        run: npm --workspace packages/producer publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @hyperframes/studio
-        run: npm --workspace packages/studio publish --access public --provenance --no-git-checks
+        run: npm --workspace packages/studio publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish hyperframes (CLI)
-        run: npm --workspace packages/cli publish --access public --provenance --no-git-checks
+        run: npm --workspace packages/cli publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
npm provenance requires a public GitHub repo. The repo is "internal" visibility, causing `E422 Unprocessable Entity` on every publish attempt.

Remove `--provenance` flag until the repo is made public. Provenance can be re-added once visibility changes.

## Urgency
Blocks v0.1.2 npm publish. Merge and re-tag to unblock.