### PR TITLE
fix(ci): remove prepublishOnly build scripts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
     "test:hyperframe-runtime-ci": "bun run build:hyperframes-runtime && bun run test:hyperframe-runtime-contract && bun run test:hyperframe-runtime-behavior && bun run test:hyperframe-runtime-seek && bun run test:hyperframe-runtime-duration-guards && bun run test:hyperframe-runtime-parity && bun run test:hyperframe-runtime-security",
     "check:hyperframe-html": "tsx scripts/check-hyperframe-static.ts",
     "debug:timeline": "tsx scripts/debug-timeline.ts",
-    "prepublishOnly": "bun run build"
+    "prepublishOnly": "echo skip"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.0",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -36,7 +36,7 @@
     "docker:build:test": "docker build -f ../../Dockerfile.test -t hyperframes-producer:test ../..",
     "docker:test": "docker run --rm --security-opt seccomp=unconfined --shm-size=2g -v ./tests:/app/packages/producer/tests hyperframes-producer:test",
     "docker:test:update": "docker run --rm --security-opt seccomp=unconfined --shm-size=2g -v ./tests:/app/packages/producer/tests hyperframes-producer:test --update",
-    "prepublishOnly": "pnpm build"
+    "prepublishOnly": "echo skip"
   },
   "dependencies": {
     "@fontsource/archivo-black": "^5.2.8",


### PR DESCRIPTION
## Summary
Producer's `prepublishOnly` calls `pnpm build` but pnpm isn't installed in the publish CI (which uses bun). The workflow already runs `bun run build` before publishing, making these scripts redundant.

Replace with no-op to prevent `sh: pnpm: not found` during `npm publish`.

## Urgency
Blocks v0.1.2 npm publish.