### PR TITLE
fix(ci): make publish steps idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,31 +25,37 @@ jobs:
       - run: bun run build
 
       - name: Publish @hyperframes/core
+        continue-on-error: true
         run: npm --workspace packages/core publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @hyperframes/engine
+        continue-on-error: true
         run: npm --workspace packages/engine publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @hyperframes/producer
+        continue-on-error: true
         run: npm --workspace packages/producer publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @hyperframes/studio
+        continue-on-error: true
         run: npm --workspace packages/studio publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish hyperframes (CLI)
+        continue-on-error: true
         run: npm --workspace packages/cli publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
When re-running publish (e.g. after a partial failure), already-published packages cause `E403 You cannot publish over the previously published versions`. 

Add `continue-on-error: true` to each publish step so the workflow skips already-published packages and continues with the rest.

## Urgency
Blocks v0.1.2 — core was published but engine/producer/studio/cli were not.