### PR TITLE
fix(producer): resolve manifest from sibling dist/ directory

### DIFF
--- a/packages/producer/src/services/hyperframeRuntimeLoader.test.ts
+++ b/packages/producer/src/services/hyperframeRuntimeLoader.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+
+const THIS_DIR = dirname(fileURLToPath(import.meta.url));
+const SIBLING_PATH = resolve(THIS_DIR, "hyperframe.manifest.json");
+const MONOREPO_PATH = resolve(THIS_DIR, "../../../core/dist/hyperframe.manifest.json");
+
+describe("resolveHyperframeManifestPath", () => {
+  const originalEnv = process.env.PRODUCER_HYPERFRAME_MANIFEST_PATH;
+
+  beforeEach(() => {
+    delete process.env.PRODUCER_HYPERFRAME_MANIFEST_PATH;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.PRODUCER_HYPERFRAME_MANIFEST_PATH = originalEnv;
+    } else {
+      delete process.env.PRODUCER_HYPERFRAME_MANIFEST_PATH;
+    }
+  });
+
+  it("returns env var when PRODUCER_HYPERFRAME_MANIFEST_PATH is set", async () => {
+    process.env.PRODUCER_HYPERFRAME_MANIFEST_PATH = "/custom/path/manifest.json";
+    const { resolveHyperframeManifestPath } = await import("./hyperframeRuntimeLoader.js");
+    expect(resolveHyperframeManifestPath()).toBe("/custom/path/manifest.json");
+  });
+
+  it("sibling path resolves to same directory as the module file", () => {
+    // Key invariant: after build, dist/hyperframe.manifest.json sits next to
+    // dist/index.js. In source, SIBLING_MANIFEST_PATH is next to this file.
+    // This verifies the path construction is correct.
+    expect(SIBLING_PATH).toBe(resolve(THIS_DIR, "hyperframe.manifest.json"));
+    expect(SIBLING_PATH).toContain("producer/src/services/hyperframe.manifest.json");
+  });
+
+  it("includes sibling path as first candidate in resolution order", async () => {
+    // Import the actual source and verify the sibling path is found when it
+    // exists. In the monorepo, the monorepo-relative path also exists, so we
+    // verify the sibling would win by checking its position in candidates.
+    //
+    // We can't easily mock existsSync in ESM, but we CAN verify the
+    // structural invariant: the function checks SIBLING first by reading the
+    // source and confirming the candidate array order.
+    const { readFileSync } = await import("node:fs");
+    const source = readFileSync(resolve(THIS_DIR, "hyperframeRuntimeLoader.ts"), "utf8");
+
+    // The candidates array must list SIBLING_MANIFEST_PATH before the others
+    const candidatesMatch = source.match(/const candidates = \[([\s\S]*?)\];/);
+    expect(candidatesMatch).not.toBeNull();
+    const candidatesBody = candidatesMatch![1];
+
+    const siblingIdx = candidatesBody.indexOf("SIBLING_MANIFEST_PATH");
+    const cwdIdx = candidatesBody.indexOf("CWD_RELATIVE_MANIFEST_PATHS");
+    const moduleIdx = candidatesBody.indexOf("MODULE_RELATIVE_MANIFEST_PATH");
+
+    expect(siblingIdx).toBeGreaterThan(-1);
+    expect(siblingIdx).toBeLessThan(cwdIdx);
+    expect(cwdIdx).toBeLessThan(moduleIdx);
+  });
+
+  it("finds manifest via monorepo-relative path in dev (integration check)", async () => {
+    // In the monorepo, the core/dist manifest should exist from the build.
+    // This acts as a smoke test that the resolution works in the dev env.
+    if (!existsSync(MONOREPO_PATH)) {
+      // Skip if core hasn't been built — this is expected in CI before build
+      return;
+    }
+    const { resolveHyperframeManifestPath } = await import("./hyperframeRuntimeLoader.js");
+    const result = resolveHyperframeManifestPath();
+    expect(existsSync(result)).toBe(true);
+  });
+});

--- a/packages/producer/src/services/hyperframeRuntimeLoader.ts
+++ b/packages/producer/src/services/hyperframeRuntimeLoader.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PRODUCER_DIR = dirname(fileURLToPath(import.meta.url));
+const SIBLING_MANIFEST_PATH = resolve(PRODUCER_DIR, "hyperframe.manifest.json");
 const MODULE_RELATIVE_MANIFEST_PATH = resolve(
   PRODUCER_DIR,
   "../../../core/dist/hyperframe.manifest.json",
@@ -32,7 +33,11 @@ export function resolveHyperframeManifestPath(): string {
   if (process.env.PRODUCER_HYPERFRAME_MANIFEST_PATH) {
     return process.env.PRODUCER_HYPERFRAME_MANIFEST_PATH;
   }
-  const candidates = [...CWD_RELATIVE_MANIFEST_PATHS, MODULE_RELATIVE_MANIFEST_PATH];
+  const candidates = [
+    SIBLING_MANIFEST_PATH,
+    ...CWD_RELATIVE_MANIFEST_PATHS,
+    MODULE_RELATIVE_MANIFEST_PATH,
+  ];
   for (const candidate of candidates) {
     if (existsSync(candidate)) {
       return candidate;

--- a/packages/producer/tsconfig.json
+++ b/packages/producer/tsconfig.json
@@ -14,5 +14,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- The `build.mjs` script already copies `hyperframe.manifest.json` into the producer's `dist/` directory, but `hyperframeRuntimeLoader.ts` never checked there
- This caused `window.__hf not ready after 45000ms` timeouts when rendering via the published npm package (`npx hyperframes render`) outside the monorepo, since the only candidate paths were monorepo-relative (`../../../core/dist/`)
- Adds a sibling-directory lookup (same dir as the bundled module) as the **first** candidate path

## Root Cause

The manifest resolution order was:
1. `PRODUCER_HYPERFRAME_MANIFEST_PATH` env var
2. `CWD/../core/dist/hyperframe.manifest.json`
3. `CWD/core/dist/hyperframe.manifest.json`
4. `<module_dir>/../../../core/dist/hyperframe.manifest.json`

None of these resolve when running from a bundled `dist/index.js` or npm install. But the build already places the manifest at `dist/hyperframe.manifest.json` — we just needed to look there.

## Testing

Tested rendering an Aries demo composition (bar+line chart, 4s @ 30fps):
- **Before fix:** `npx hyperframes render` fails with `[HyperframeRuntimeLoader] Missing manifest` → `window.__hf not ready after 45000ms`
- **After fix:** renders successfully (269.5 KB, 5.2s) without needing the `PRODUCER_HYPERFRAME_MANIFEST_PATH` workaround
- Both local and `--docker` paths produce identical correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)