### PR TITLE
chore: release v0.1.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "bin": {
     "hyperframes": "./dist/cli.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "files": [
     "dist",
     "docs",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "files": [
     "dist/"

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
## Release v0.1.3

Bumps all packages to v0.1.3.

### Changes since v0.1.2
- fix(producer): resolve manifest from sibling dist/ directory
- fix(producer): add margin reset when wrapping HTML fragments
- fix(producer): exclude test files from tsc build
- feat(cli): add opt-out anonymous telemetry via PostHog
- feat: add HyperFrames skills for AI coding tools
- fix(cli): resolve npx hyperframes from inside monorepo
- fix(ci): publish workflow fixes (remove provenance, idempotent steps, remove prepublishOnly)

After merging, the release tag is created automatically, which triggers npm publish.