### PR TITLE
fix(producer): propagate data-start to inner composition element during compilation

### DIFF
--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -580,6 +580,16 @@ function inlineSubCompositions(
 
     host.removeAttribute("data-composition-src");
 
+    // Propagate data-start from the host element to the inserted inner composition
+    // node so runtime timeline nesting resolves the correct start offset.
+    const hostDataStart = host.getAttribute("data-start");
+    if (hostDataStart != null) {
+      const innerComp = host.querySelector("[data-composition-id]");
+      if (innerComp && !innerComp.getAttribute("data-start")) {
+        innerComp.setAttribute("data-start", hostDataStart);
+      }
+    }
+
     // Set explicit pixel dimensions on the host element so children using
     // width/height: 100% resolve correctly. The runtime does this
     // automatically but compiled HTML needs it inline.


### PR DESCRIPTION
## Summary
- copy data-start from the host sub-composition node to the inlined inner composition root
- preserve the correct runtime offset lookup for nested compositions after producer compilation
- avoid nested GSAP timelines snapping to their end state when the host starts later than t=0
