### PR TITLE
fix(producer): propagate data-start to inner composition during compilation

### DIFF
--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -580,6 +580,18 @@ function inlineSubCompositions(
 
     host.removeAttribute("data-composition-src");
 
+    // Propagate data-start from the host element to the inner composition
+    // element so the runtime can resolve the correct start offset when nesting
+    // sub-timelines into the root. After inlining, data-start lives on the
+    // host while data-composition-id lives on the inner element.
+    const hostDataStart = host.getAttribute("data-start");
+    if (hostDataStart != null) {
+      const innerComp = host.querySelector("[data-composition-id]");
+      if (innerComp && !innerComp.getAttribute("data-start")) {
+        innerComp.setAttribute("data-start", hostDataStart);
+      }
+    }
+
     // Set explicit pixel dimensions on the host element so children using
     // width/height: 100% resolve correctly. The runtime does this
     // automatically but compiled HTML needs it inline.


### PR DESCRIPTION
## Summary
- When the producer's htmlCompiler inlines sub-compositions, `data-start` stays on the host element while `data-composition-id` is on the inner element
- The runtime resolves start offsets by querying `data-composition-id`, finds the inner element with no `data-start`, and falls back to 0
- This causes sub-compositions with non-zero `data-start` (e.g. an outro scene at t=14) to be nested at offset 0 in the root GSAP timeline, rendering all animations at their end state

**Fix**: After inlining, copy `data-start` from the host to the inner `[data-composition-id]` element.

## Test plan
- [x] Rendered a composition with scene5-logo-outro at `data-start="14"` — logo now animates correctly instead of appearing at final state
- [x] Earlier scenes (scene1 at `data-start="0"`, scene2-4 at `data-start="1.5"`) still work correctly
- [x] Lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)