### PR TITLE
fix(cli): inject version from package.json, fix docker hint, add --port to dev

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -37,9 +37,11 @@ export default defineCommand({
   meta: { name: "dev", description: "Start the studio for local development" },
   args: {
     dir: { type: "positional", description: "Project directory", required: false },
+    port: { type: "string", description: "Port to run the dev server on", default: "3002" },
   },
   async run({ args }) {
     const dir = resolve(args.dir ?? ".");
+    const startPort = parseInt(args.port ?? "3002", 10);
 
     if (isDevMode()) {
       return runDevMode(dir);
@@ -50,7 +52,7 @@ export default defineCommand({
       return runLocalStudioMode(dir);
     }
 
-    const port = await findAvailablePort(3002);
+    const port = await findAvailablePort(startPort);
     return runEmbeddedMode(dir, port);
   },
 });

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -171,7 +171,7 @@ async function renderDocker(
   } catch (error: unknown) {
     trackRenderError({ fps: options.fps, quality: options.quality, docker: true });
     const message = error instanceof Error ? error.message : String(error);
-    errorBox("Render failed", message, "Try --docker for containerized rendering");
+    errorBox("Render failed", message, "Check Docker is running: docker info");
     process.exit(1);
   }
 

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,1 +1,2 @@
-export const VERSION = "0.1.0";
+declare const __CLI_VERSION__: string;
+export const VERSION = __CLI_VERSION__;

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from "tsup";
 import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8")) as {
+  version: string;
+};
 
 export default defineConfig({
   entry: ["src/cli.ts"],
@@ -44,6 +49,9 @@ const __dirname = __hf_dirname(__filename);`,
     "is-unicode-supported",
     "citty",
   ],
+  define: {
+    __CLI_VERSION__: JSON.stringify(pkg.version),
+  },
   esbuildOptions(options) {
     options.alias = {
       "@hyperframes/producer": resolve(__dirname, "../producer/src/index.ts"),


### PR DESCRIPTION
## What

Three small fixes found while testing the CLI as a new user via `npx hyperframes`.

## Why / What was broken

### 1. Version mismatch (`--version` always reported `0.1.0`)
`version.ts` had `VERSION = "0.1.0"` hardcoded. Every release shipped the wrong version string unless someone manually updated the constant. `hyperframes@0.1.4` reported `0.1.0`.

### 2. Circular `--docker` hint
`renderDocker`'s error handler told the user to `Try --docker for containerized rendering` — even though they were already using `--docker`. Changed to `Check Docker is running: docker info`.

### 3. `--port` silently ignored in embedded mode
The `dev` command's `args` definition had no `--port` entry. `hyperframes dev --port 4567` was silently dropped and the server always started from port 3002. Added the arg and wired it to `findAvailablePort`.

## How

- `version.ts`: export `__CLI_VERSION__` (a compile-time constant)
- `tsup.config.ts`: inject `define.__CLI_VERSION__` from `package.json` at build time
- `render.ts`: contextual hint in `renderDocker` catch block
- `dev.ts`: add `--port` to `args`, pass `startPort` to `findAvailablePort`

## Test plan

- [x] `hyperframes --version` reports `0.1.4`
- [x] `hyperframes dev --port 4567` starts on 4567
- [x] `hyperframes render --docker` failure shows "Check Docker is running: docker info"
- [x] Build passes (`bun run build`)
- [x] Lint and format pass