### PR TITLE
fix(producer): fall back to data-duration when GSAP timeline is empty

### DIFF
--- a/packages/producer/src/services/fileServer.ts
+++ b/packages/producer/src/services/fileServer.ts
@@ -164,13 +164,22 @@ const RENDER_MODE_SCRIPT = `(function() {
  * Injected after RENDER_MODE_SCRIPT so the engine's frameCapture can find window.__hf.
  */
 const HF_BRIDGE_SCRIPT = `(function() {
+  function getDeclaredDuration() {
+    var root = document.querySelector('[data-composition-id]');
+    if (!root) return 0;
+    var d = Number(root.getAttribute('data-duration'));
+    return Number.isFinite(d) && d > 0 ? d : 0;
+  }
   function bridge() {
     var p = window.__player;
     if (!p || typeof p.renderSeek !== "function" || typeof p.getDuration !== "function") {
       return false;
     }
     window.__hf = {
-      get duration() { return p.getDuration(); },
+      get duration() {
+        var d = p.getDuration();
+        return d > 0 ? d : getDeclaredDuration();
+      },
       seek: function(t) { p.renderSeek(t); },
     };
     return true;


### PR DESCRIPTION
## What

When a composition has an empty GSAP timeline (no animations), `window.__hf.duration` was always 0, causing `hyperframes render` to time out after 45 seconds waiting for `duration > 0`.

## Why

The HF bridge script reads duration from `window.__player.getDuration()`, which returns the GSAP timeline duration. An empty timeline has duration 0. The render engine waits for `window.__hf.duration > 0` to confirm the runtime is ready — so compositions with no animations would always deadlock.

This hits the `--template blank` scaffold immediately: it generates an empty GSAP timeline and relies solely on `data-duration="10"` for composition timing.

## How

One-line change to the bridge script: when `getDuration()` returns 0, fall back to reading `data-duration` from the root `[data-composition-id]` element. This is the same value the static compiler already extracted — so we get a correct duration without any extra browser round-trips.

```js
get duration() {
  var d = p.getDuration();
  return d > 0 ? d : getDeclaredDuration(); // reads data-duration from root element
}
```

## Test plan

- [x] `hyperframes init my-video --template blank && hyperframes render my-video` completes successfully
- [x] Output: `output.mp4` — 10s, 1920×1080, 30fps ✓  
- [x] Compositions with actual GSAP animations unaffected (fallback only triggers when timeline duration is 0)
- [x] Build passes, lint/format clean