### PR TITLE
feat(studio): add render queue panel with progress tracking

### DIFF
--- a/packages/studio/src/components/renders/RenderQueue.tsx
+++ b/packages/studio/src/components/renders/RenderQueue.tsx
@@ -1,0 +1,79 @@
+import { memo, useRef, useEffect } from "react";
+import { RenderQueueItem } from "./RenderQueueItem";
+import type { RenderJob } from "./useRenderQueue";
+
+interface RenderQueueProps {
+  jobs: RenderJob[];
+  onDelete: (jobId: string) => void;
+  onClearCompleted: () => void;
+  onStartRender: () => void;
+  isRendering: boolean;
+}
+
+export const RenderQueue = memo(function RenderQueue({
+  jobs,
+  onDelete,
+  onClearCompleted,
+  onStartRender,
+  isRendering,
+}: RenderQueueProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const prevCount = useRef(jobs.length);
+
+  // Auto-scroll to bottom when new jobs are added
+  useEffect(() => {
+    if (jobs.length > prevCount.current && listRef.current) {
+      listRef.current.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
+    }
+    prevCount.current = jobs.length;
+  }, [jobs.length]);
+
+  const completedCount = jobs.filter((j) => j.status !== "rendering").length;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-800/50 flex-shrink-0">
+        <span className="text-[11px] font-medium text-neutral-500 uppercase tracking-wider">
+          Renders ({jobs.length})
+        </span>
+        <div className="flex items-center gap-1.5">
+          {completedCount > 0 && (
+            <button
+              onClick={onClearCompleted}
+              className="text-[10px] text-neutral-600 hover:text-neutral-400 transition-colors"
+            >
+              Clear
+            </button>
+          )}
+          <button
+            onClick={onStartRender}
+            disabled={isRendering}
+            className="flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium rounded bg-blue-600 text-white hover:bg-blue-500 transition-colors disabled:opacity-50"
+          >
+            {isRendering ? "Rendering..." : "Export MP4"}
+          </button>
+        </div>
+      </div>
+
+      {/* Job list */}
+      <div ref={listRef} className="flex-1 overflow-y-auto">
+        {jobs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full px-4 gap-2">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-neutral-700">
+              <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M7 2v20M17 2v20M2 12h20M2 7h5M2 17h5M17 17h5M17 7h5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            <p className="text-[10px] text-neutral-600 text-center">
+              No renders yet
+            </p>
+          </div>
+        ) : (
+          jobs.map((job) => (
+            <RenderQueueItem key={job.id} job={job} onDelete={() => onDelete(job.id)} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+});

--- a/packages/studio/src/components/renders/RenderQueueItem.tsx
+++ b/packages/studio/src/components/renders/RenderQueueItem.tsx
@@ -1,0 +1,105 @@
+import { memo, useCallback, useState } from "react";
+import type { RenderJob } from "./useRenderQueue";
+
+interface RenderQueueItemProps {
+  job: RenderJob;
+  onDelete: () => void;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 1000);
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+function formatTimeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  if (diff < 60000) return "just now";
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  return `${Math.floor(diff / 3600000)}h ago`;
+}
+
+export const RenderQueueItem = memo(function RenderQueueItem({ job, onDelete }: RenderQueueItemProps) {
+  const [hovered, setHovered] = useState(false);
+
+  const handleDownload = useCallback(() => {
+    const a = document.createElement("a");
+    a.href = `/api/render/${job.id}/download`;
+    a.download = job.filename;
+    a.click();
+  }, [job.id, job.filename]);
+
+  return (
+    <div
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+      className="px-3 py-2.5 border-b border-neutral-800/30 last:border-0"
+    >
+      <div className="flex items-center gap-2">
+        {/* Status indicator */}
+        <div className="flex-shrink-0">
+          {job.status === "rendering" && (
+            <div className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
+          )}
+          {job.status === "complete" && <div className="w-2 h-2 rounded-full bg-green-400" />}
+          {job.status === "failed" && <div className="w-2 h-2 rounded-full bg-red-400" />}
+          {job.status === "cancelled" && <div className="w-2 h-2 rounded-full bg-neutral-600" />}
+        </div>
+
+        {/* Info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] font-medium text-neutral-300 truncate">{job.filename}</span>
+            {job.durationMs && (
+              <span className="text-[9px] text-neutral-600 flex-shrink-0">
+                {formatDuration(job.durationMs)}
+              </span>
+            )}
+          </div>
+
+          {/* Progress bar */}
+          {job.status === "rendering" && (
+            <div className="mt-1 w-full h-1 bg-neutral-800 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-blue-500 rounded-full transition-all duration-300"
+                style={{ width: `${job.progress}%` }}
+              />
+            </div>
+          )}
+
+          {job.status !== "rendering" && (
+            <span className="text-[9px] text-neutral-600">{formatTimeAgo(job.createdAt)}</span>
+          )}
+        </div>
+
+        {/* Actions */}
+        {hovered && (
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {job.status === "complete" && (
+              <button
+                onClick={handleDownload}
+                className="p-1 rounded text-neutral-500 hover:text-green-400 transition-colors"
+                title="Download"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+              </button>
+            )}
+            <button
+              onClick={onDelete}
+              className="p-1 rounded text-neutral-500 hover:text-red-400 transition-colors"
+              title="Remove"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M18 6L6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/packages/studio/src/components/renders/useRenderQueue.ts
+++ b/packages/studio/src/components/renders/useRenderQueue.ts
@@ -1,0 +1,136 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface RenderJob {
+  id: string;
+  status: "rendering" | "complete" | "failed" | "cancelled";
+  progress: number;
+  filename: string;
+  createdAt: number;
+  durationMs?: number;
+}
+
+export function useRenderQueue(projectId: string | null) {
+  const [jobs, setJobs] = useState<RenderJob[]>([]);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const activeJobRef = useRef<string | null>(null);
+
+  // Load completed renders from the server
+  const loadRenders = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      const res = await fetch(`/api/projects/${projectId}/renders`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data.renders)) {
+        setJobs((prev) => {
+          const existing = new Set(prev.map((j) => j.id));
+          const fromServer: RenderJob[] = data.renders
+            .filter((r: { id: string }) => !existing.has(r.id))
+            .map((r: { id: string; filename: string; createdAt: number; size: number }) => ({
+              id: r.id,
+              status: "complete" as const,
+              progress: 100,
+              filename: r.filename,
+              createdAt: r.createdAt,
+            }));
+          return [...prev, ...fromServer];
+        });
+      }
+    } catch {
+      // ignore
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    loadRenders();
+  }, [loadRenders]);
+
+  // Start a render and track progress via SSE
+  const startRender = useCallback(
+    async (fps = 30, quality = "standard") => {
+      if (!projectId) return;
+
+      const startTime = Date.now();
+      const res = await fetch(`/api/projects/${projectId}/render`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fps, quality }),
+      });
+      if (!res.ok) return;
+      const { jobId } = await res.json();
+
+      const job: RenderJob = {
+        id: jobId,
+        status: "rendering",
+        progress: 0,
+        filename: `${jobId}.mp4`,
+        createdAt: startTime,
+      };
+      setJobs((prev) => [...prev, job]);
+      activeJobRef.current = jobId;
+
+      // Track progress via SSE
+      const es = new EventSource(`/api/render/${jobId}/progress`);
+      eventSourceRef.current = es;
+
+      es.addEventListener("progress", (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          setJobs((prev) =>
+            prev.map((j) =>
+              j.id === jobId
+                ? {
+                    ...j,
+                    progress: data.progress ?? j.progress,
+                    status: data.status === "complete" ? "complete" : data.status === "failed" ? "failed" : j.status,
+                    durationMs: data.status === "complete" ? Date.now() - startTime : undefined,
+                  }
+                : j,
+            ),
+          );
+          if (data.status === "complete" || data.status === "failed") {
+            es.close();
+            activeJobRef.current = null;
+          }
+        } catch {
+          // ignore parse errors
+        }
+      });
+
+      es.onerror = () => {
+        es.close();
+        setJobs((prev) =>
+          prev.map((j) => (j.id === jobId && j.status === "rendering" ? { ...j, status: "failed" } : j)),
+        );
+        activeJobRef.current = null;
+      };
+
+      return jobId;
+    },
+    [projectId],
+  );
+
+  const deleteRender = useCallback(
+    async (jobId: string) => {
+      try {
+        await fetch(`/api/render/${jobId}`, { method: "DELETE" });
+      } catch {
+        // ignore
+      }
+      setJobs((prev) => prev.filter((j) => j.id !== jobId));
+    },
+    [],
+  );
+
+  const clearCompleted = useCallback(() => {
+    setJobs((prev) => prev.filter((j) => j.status === "rendering"));
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      eventSourceRef.current?.close();
+    };
+  }, []);
+
+  return { jobs, startRender, deleteRender, clearCompleted, isRendering: activeJobRef.current !== null };
+}

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -9,6 +9,7 @@ import {
   lstatSync,
   realpathSync,
   createReadStream,
+  unlinkSync,
 } from "node:fs";
 import { join, resolve, sep } from "node:path";
 
@@ -229,6 +230,50 @@ function devProjectApi(): Plugin {
           });
           const stream = createReadStream(jobState.outputPath);
           stream.pipe(res);
+          return;
+        }
+
+        // GET /api/projects/:id/renders — list render outputs for a project
+        const rendersMatch =
+          req.method === "GET" && req.url?.match(/^\/api\/projects\/([^/]+)\/renders/);
+        if (rendersMatch) {
+          const rendersDir = resolve(dataDir, "../renders");
+          if (!existsSync(rendersDir)) {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ renders: [] }));
+            return;
+          }
+          const files = readdirSync(rendersDir)
+            .filter((f: string) => f.endsWith(".mp4"))
+            .map((f: string) => {
+              const fp = join(rendersDir, f);
+              const stat = statSync(fp);
+              return {
+                id: f.replace(".mp4", ""),
+                filename: f,
+                size: stat.size,
+                createdAt: stat.mtimeMs,
+              };
+            })
+            .sort((a: { createdAt: number }, b: { createdAt: number }) => b.createdAt - a.createdAt);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ renders: files }));
+          return;
+        }
+
+        // DELETE /api/render/:jobId — delete a render output
+        const deleteRenderMatch =
+          req.method === "DELETE" && req.url?.match(/^\/api\/render\/([^/]+)$/);
+        if (deleteRenderMatch) {
+          const jobId = deleteRenderMatch[1];
+          const rendersDir = resolve(dataDir, "../renders");
+          const fp = join(rendersDir, `${jobId}.mp4`);
+          if (existsSync(fp)) {
+            unlinkSync(fp);
+          }
+          renderJobs.delete(jobId);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ deleted: true }));
           return;
         }
 


### PR DESCRIPTION
Part 2 of studio v2 features.

- **RenderQueue** component showing all renders (in-progress, completed, failed)
- Per-render: progress bar, status badge, duration, download button
- **useRenderQueue** hook: starts renders via API, tracks SSE progress, manages state
- Auto-scroll to newest render
- Delete individual renders + clear completed
- New API endpoints:
  - `GET /api/projects/:id/renders` — list render MP4 outputs
  - `DELETE /api/render/:jobId` — delete a render file