### PR TITLE
fix(cli): make blank template a full HTML document

### DIFF
--- a/packages/cli/src/templates/blank/index.html
+++ b/packages/cli/src/templates/blank/index.html
@@ -1,44 +1,69 @@
-<div
-  id="root"
-  data-composition-id="main"
-  data-start="0"
-  data-duration="__VIDEO_DURATION__"
-  data-width="1920"
-  data-height="1080"
->
-  <video
-    id="a-roll"
-    src="__VIDEO_SRC__"
-    muted
-    playsinline
-    data-start="0"
-    data-duration="__VIDEO_DURATION__"
-    data-track-index="0"
-  ></video>
-  <audio
-    id="a-roll-audio"
-    src="__VIDEO_SRC__"
-    data-start="0"
-    data-duration="__VIDEO_DURATION__"
-    data-track-index="2"
-    data-volume="1"
-  ></audio>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="__VIDEO_DURATION__"
+      data-width="1920"
+      data-height="1080"
+    >
+      <video
+        id="a-roll"
+        src="__VIDEO_SRC__"
+        muted
+        playsinline
+        data-start="0"
+        data-duration="__VIDEO_DURATION__"
+        data-track-index="0"
+        style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover"
+      ></video>
+      <audio
+        id="a-roll-audio"
+        src="__VIDEO_SRC__"
+        data-start="0"
+        data-duration="__VIDEO_DURATION__"
+        data-track-index="2"
+        data-volume="1"
+      ></audio>
 
-  <div
-    id="captions-comp"
-    data-composition-id="captions"
-    data-composition-src="compositions/captions.html"
-    data-start="0"
-    data-duration="__VIDEO_DURATION__"
-    data-track-index="3"
-    data-width="1920"
-    data-height="1080"
-  ></div>
+      <div
+        id="captions-comp"
+        data-composition-id="captions"
+        data-composition-src="compositions/captions.html"
+        data-start="0"
+        data-duration="__VIDEO_DURATION__"
+        data-track-index="3"
+        data-width="1920"
+        data-height="1080"
+      ></div>
+    </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-  <script>
-    window.__timelines = window.__timelines || {};
-    const tl = gsap.timeline({ paused: true });
-    window.__timelines["main"] = tl;
-  </script>
-</div>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -388,8 +388,9 @@ export function StudioApp() {
       }
 
       setLintModal(findings);
-    } catch {
-      setLintModal([{ severity: "error", message: "Failed to run lint." }]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setLintModal([{ severity: "error", message: `Failed to run lint: ${msg}` }]);
     } finally {
       setLinting(false);
     }


### PR DESCRIPTION
## What

Convert the blank template from an HTML fragment to a complete HTML document and improve error handling in the studio lint functionality.

## Why

The blank template needed proper HTML document structure with DOCTYPE, head, and body elements to ensure better browser compatibility and standards compliance. The lint error handling was too generic and didn't provide useful debugging information when failures occurred.

## How

- Wrapped the existing template content in a complete HTML5 document structure
- Added meta tags for charset and viewport configuration
- Moved GSAP script to the head section and added CSS reset styles
- Applied absolute positioning and cover styling to the video element for proper layout
- Enhanced the lint error catch block to extract and display the actual error message instead of a generic failure message

## Test plan

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)