### PR TITLE
ci: scope regression tests to core/producer/engine packages only

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           filters: |
             code:
-              - "packages/**"
+              - "packages/core/**"
+              - "packages/producer/**"
+              - "packages/engine/**"
               - "scripts/**"
               - "Dockerfile*"
 


### PR DESCRIPTION
## What

Updated the GitHub Actions regression workflow to monitor specific package directories instead of the entire packages folder.

## Why

This change provides more granular control over when regression tests are triggered, allowing the workflow to run only when changes are made to the core, producer, or engine packages rather than any package in the repository.

## How

Modified the path filters in the regression workflow to explicitly list the three critical package directories (`packages/core/**`, `packages/producer/**`, `packages/engine/**`) instead of using the broad `packages/**` pattern.

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)