### PR TITLE
feat(cli): scaffold CLAUDE.md + project-level skills into init

### DIFF
--- a/.claude/skills/captions
+++ b/.claude/skills/captions
@@ -1,0 +1,1 @@
+../../skills/captions

--- a/.claude/skills/compose-video
+++ b/.claude/skills/compose-video
@@ -1,0 +1,1 @@
+../../skills/compose-video

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# Hyperframes
+
+## Skills — USE THESE FIRST
+
+This repo ships skills that are installed globally via `npx hyperframes skills` (runs automatically during `hyperframes init`). **Always use the appropriate skill instead of writing code from scratch or fetching external docs.**
+
+### HyperFrames Skills (from this repo)
+
+| Skill             | Invoke with      | When to use                                                                                                                                                                           |
+| ----------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **compose-video** | `/compose-video` | Creating ANY HTML composition — videos, animations, title cards, overlays. Contains required HTML structure, `class="clip"` rules, GSAP timeline patterns, and rendering constraints. |
+| **captions**      | `/captions`      | Building tone-adaptive captions from whisper transcripts — style detection, per-word styling, positioning.                                                                            |
+
+### GSAP Skills (from [greensock/gsap-skills](https://github.com/greensock/gsap-skills))
+
+| Skill                  | Invoke with           | When to use                                                                      |
+| ---------------------- | --------------------- | -------------------------------------------------------------------------------- |
+| **gsap-core**          | `/gsap-core`          | `gsap.to()`, `from()`, `fromTo()`, easing, duration, stagger, defaults           |
+| **gsap-timeline**      | `/gsap-timeline`      | Timeline sequencing, position parameter, labels, nesting, playback               |
+| **gsap-performance**   | `/gsap-performance`   | Performance best practices — transforms over layout props, will-change, batching |
+| **gsap-plugins**       | `/gsap-plugins`       | ScrollTrigger, Flip, Draggable, SplitText, and other GSAP plugins                |
+| **gsap-scrolltrigger** | `/gsap-scrolltrigger` | Scroll-linked animations, pinning, scrub, triggers                               |
+| **gsap-utils**         | `/gsap-utils`         | `gsap.utils` helpers — clamp, mapRange, snap, toArray, wrap, pipe                |
+
+### Why this matters
+
+The skills encode HyperFrames-specific patterns (e.g., required `class="clip"` on all timed elements, GSAP timeline registration via `window.__GSAP_TIMELINE`, `data-*` attribute semantics) that are NOT in generic web docs. Skipping the skills and writing from scratch will produce broken compositions.
+
+### Rules
+
+- When creating or modifying HTML compositions → invoke `/compose-video` BEFORE writing any code
+- When adding captions → invoke `/captions` BEFORE writing any code
+- When writing GSAP animations → invoke `/gsap-core` and `/gsap-timeline` BEFORE writing any code
+- When optimizing animation performance → invoke `/gsap-performance` BEFORE making changes
+
+### Installing skills
+
+```bash
+npx hyperframes skills          # install all to Claude, Gemini, Codex
+npx hyperframes skills --claude # Claude Code only
+npx skills add greensock/gsap-skills  # alternative: via skills CLI
+```
+
+## Project Overview
+
+Open-source video rendering framework: write HTML, render video.
+
+```
+packages/
+  cli/       → hyperframes CLI (create, preview, lint, render)
+  core/      → Types, parsers, generators, linter, runtime, frame adapters
+  engine/    → Seekable page-to-video capture engine (Puppeteer + FFmpeg)
+  producer/  → Full rendering pipeline (capture + encode + audio mix)
+  studio/    → Browser-based composition editor UI
+```
+
+## Development
+
+```bash
+pnpm install    # Install dependencies
+pnpm build      # Build all packages
+pnpm test       # Run tests
+```
+
+## Key Concepts
+
+- **Compositions** are HTML files with `data-*` attributes defining timeline, tracks, and media
+- **Frame Adapters** bridge animation runtimes (GSAP, Lottie, CSS) to the capture engine
+- **Producer** orchestrates capture → encode → audio mix into final MP4
+- **BeginFrame rendering** uses `HeadlessExperimental.beginFrame` for deterministic frame capture

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ Preview instantly in the browser. Render to MP4 locally. Let AI agents compose v
 | [`@hyperframes/producer`](packages/producer) | Full rendering pipeline (capture + encode + audio mix)      |
 | [`@hyperframes/studio`](packages/studio)     | Browser-based composition editor UI                         |
 
+## AI Agent Skills
+
+HyperFrames ships skills that teach AI coding agents (Claude Code, Gemini CLI, Codex, Cursor) how to write correct compositions and GSAP animations. **Use these instead of writing from scratch — they encode framework-specific patterns that generic docs don't cover.**
+
+### Install via CLI (recommended)
+
+```bash
+# Install all skills (HyperFrames + GSAP) — runs automatically during `hyperframes init`
+npx hyperframes skills
+
+# Or install to a specific agent
+npx hyperframes skills --claude
+npx hyperframes skills --cursor
+```
+
+### Or via `npx skills add`
+
+```bash
+# HyperFrames skills (compose-video, captions)
+npx skills add heygen-com/hyperframes
+
+# GSAP skills (gsap-core, gsap-timeline, gsap-scrolltrigger, gsap-plugins, gsap-performance, gsap-utils, gsap-react, gsap-frameworks)
+npx skills add greensock/gsap-skills
+```
+
+### Installed Skills
+
+| Source                                               | Skills                                                                                                                                | What they teach                                                                                                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **HyperFrames**                                      | `compose-video`, `captions`                                                                                                           | HTML composition structure, `class="clip"` rules, `data-*` attributes, timeline registration, rendering constraints |
+| **[GSAP](https://github.com/greensock/gsap-skills)** | `gsap-core`, `gsap-timeline`, `gsap-performance`, `gsap-plugins`, `gsap-scrolltrigger`, `gsap-utils`, `gsap-react`, `gsap-frameworks` | Core API, timeline sequencing, ScrollTrigger, plugin usage, performance best practices                              |
+
+In Claude Code, invoke with `/compose-video`, `/captions`, `/gsap-core`, etc.
+
 ## Documentation
 
 Full docs at [hyperframes.heygen.com](https://hyperframes.heygen.com) — includes guides, concepts, API reference, and package documentation.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "build:fonts": "cd ../producer && tsx scripts/generate-font-data.ts",
     "build:studio": "cd ../studio && bun run build",
     "build:runtime": "tsx scripts/build-runtime.ts",
-    "build:copy": "mkdir -p dist/studio dist/docs dist/templates && cp -r ../studio/dist/* dist/studio/ && cp -r src/templates/blank src/templates/warm-grain src/templates/play-mode src/templates/swiss-grid src/templates/vignelli dist/templates/ && (cp src/docs/*.md dist/docs/ 2>/dev/null || true)",
+    "build:copy": "mkdir -p dist/studio dist/docs dist/templates dist/skills && cp -r ../studio/dist/* dist/studio/ && cp -r src/templates/blank src/templates/warm-grain src/templates/play-mode src/templates/swiss-grid src/templates/vignelli src/templates/_shared dist/templates/ && cp -r ../../skills/compose-video ../../skills/captions dist/skills/ && (cp src/docs/*.md dist/docs/ 2>/dev/null || true)",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -205,6 +205,22 @@ function getStaticTemplateDir(templateId: string): string {
   return existsSync(devPath) ? devPath : builtPath;
 }
 
+function getSharedTemplateDir(): string {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const devPath = resolve(dir, "..", "templates", "_shared");
+  const builtPath = resolve(dir, "templates", "_shared");
+  return existsSync(devPath) ? devPath : builtPath;
+}
+
+function getBundledSkillsDir(): string {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  // In dev: cli/src/commands/ → ../../../../skills = repo root skills/
+  // In built: cli/dist/ → skills = cli/dist/skills/
+  const devPath = resolve(dir, "..", "..", "..", "..", "skills");
+  const builtPath = resolve(dir, "skills");
+  return existsSync(devPath) ? devPath : builtPath;
+}
+
 function patchVideoSrc(
   dir: string,
   videoFilename: string | undefined,
@@ -410,6 +426,32 @@ function scaffoldProject(
     ),
     "utf-8",
   );
+
+  // Copy shared files (CLAUDE.md, AGENTS.md) for AI agent context
+  const sharedDir = getSharedTemplateDir();
+  if (existsSync(sharedDir)) {
+    for (const entry of readdirSync(sharedDir, { withFileTypes: true })) {
+      const src = join(sharedDir, entry.name);
+      const dest = resolve(destDir, entry.name);
+      if (entry.isFile() || entry.isSymbolicLink()) {
+        copyFileSync(src, dest);
+      }
+    }
+  }
+
+  // Copy project-level skills (.claude/skills/) for immediate availability
+  const skillsSrcDir = getBundledSkillsDir();
+  if (existsSync(skillsSrcDir)) {
+    const projectSkills = ["compose-video", "captions"];
+    for (const skill of projectSkills) {
+      const src = join(skillsSrcDir, skill);
+      if (existsSync(src)) {
+        const dest = resolve(destDir, ".claude", "skills", skill);
+        mkdirSync(dest, { recursive: true });
+        cpSync(src, dest, { recursive: true });
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -578,9 +620,28 @@ Examples:
       }
 
       console.log(c.success(`Created ${c.accent(name + "/")}`));
-      for (const f of readdirSync(destDir)) {
+      for (const f of readdirSync(destDir).filter((f) => !f.startsWith("."))) {
         console.log(`  ${c.accent(f)}`);
       }
+      console.log();
+      console.log("Next steps:");
+      console.log(
+        `  ${c.accent(`cd ${name}`)} && ${c.accent("npx hyperframes dev")}      ${c.dim("# preview in studio")}`,
+      );
+      console.log(
+        `  ${c.accent(`cd ${name}`)} && ${c.accent("npx hyperframes render")}   ${c.dim("# render to MP4")}`,
+      );
+      console.log(
+        `  ${c.accent("npx hyperframes docs")} ${c.dim("<topic>")}              ${c.dim("# learn composition syntax")}`,
+      );
+      console.log(
+        `    ${c.dim("topics: data-attributes, gsap, compositions, rendering, templates, troubleshooting")}`,
+      );
+      console.log();
+      console.log(
+        `  ${c.dim("AI skills installed — open this folder in your AI coding agent to get started.")}`,
+      );
+      console.log(`  ${c.dim("Full docs: hyperframes.heygen.com")}`);
       return;
     }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -196,29 +196,26 @@ function transcodeToMp4(inputPath: string, outputPath: string): Promise<boolean>
 // Static template helpers
 // ---------------------------------------------------------------------------
 
-function getStaticTemplateDir(templateId: string): string {
-  const dir = dirname(fileURLToPath(import.meta.url));
-  // In dev: cli/src/commands/ → ../templates = cli/src/templates/
-  // In built: cli/dist/ → templates = cli/dist/templates/
-  const devPath = resolve(dir, "..", "templates", templateId);
-  const builtPath = resolve(dir, "templates", templateId);
+/** Resolve an asset directory that differs between dev (src/) and built (dist/). */
+function resolveAssetDir(devSegments: string[], builtSegments: string[]): string {
+  const base = dirname(fileURLToPath(import.meta.url));
+  const devPath = resolve(base, ...devSegments);
+  const builtPath = resolve(base, ...builtSegments);
   return existsSync(devPath) ? devPath : builtPath;
+}
+
+function getStaticTemplateDir(templateId: string): string {
+  return resolveAssetDir(["..", "templates", templateId], ["templates", templateId]);
 }
 
 function getSharedTemplateDir(): string {
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const devPath = resolve(dir, "..", "templates", "_shared");
-  const builtPath = resolve(dir, "templates", "_shared");
-  return existsSync(devPath) ? devPath : builtPath;
+  return resolveAssetDir(["..", "templates", "_shared"], ["templates", "_shared"]);
 }
 
 function getBundledSkillsDir(): string {
-  const dir = dirname(fileURLToPath(import.meta.url));
-  // In dev: cli/src/commands/ → ../../../../skills = repo root skills/
-  // In built: cli/dist/ → skills = cli/dist/skills/
-  const devPath = resolve(dir, "..", "..", "..", "..", "skills");
-  const builtPath = resolve(dir, "skills");
-  return existsSync(devPath) ? devPath : builtPath;
+  // In dev: cli/src/commands/ → repo root skills/
+  // In built: cli/dist/ → cli/dist/skills/
+  return resolveAssetDir(["..", "..", "..", "..", "skills"], ["skills"]);
 }
 
 function patchVideoSrc(

--- a/packages/cli/src/commands/install-skills.ts
+++ b/packages/cli/src/commands/install-skills.ts
@@ -13,6 +13,8 @@ import { c } from "../ui/colors.js";
 interface Target {
   name: string;
   flag: string;
+  /** Agent name for `npx skills add -a <agent>` */
+  skillsAgent: string;
   dir: string;
   defaultEnabled: boolean;
 }
@@ -21,24 +23,28 @@ const TARGETS: Target[] = [
   {
     name: "Claude Code",
     flag: "claude",
+    skillsAgent: "claude-code",
     dir: join(homedir(), ".claude", "skills"),
     defaultEnabled: true,
   },
   {
     name: "Gemini CLI",
     flag: "gemini",
+    skillsAgent: "gemini-cli",
     dir: join(homedir(), ".gemini", "skills"),
     defaultEnabled: true,
   },
   {
     name: "Codex CLI",
     flag: "codex",
+    skillsAgent: "codex",
     dir: join(homedir(), ".codex", "skills"),
     defaultEnabled: true,
   },
   {
     name: "Cursor",
     flag: "cursor",
+    skillsAgent: "cursor",
     get dir() {
       return join(process.cwd(), ".cursor", "skills");
     },
@@ -47,34 +53,61 @@ const TARGETS: Target[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Skill sources — all fetched from GitHub
+// Skill sources — GitHub repos containing skill directories
 // ---------------------------------------------------------------------------
 
 interface SkillSource {
   name: string;
+  /** GitHub shorthand (owner/repo) or full URL */
   repo: string;
-  /** Subdirectory within the repo that contains skill folders */
+  /** For fallback: subdirectory within the repo that contains skill folders */
   skillsPath: string;
+  /** For fallback: local cache directory */
   cache: string;
 }
 
 const SOURCES: SkillSource[] = [
   {
     name: "HyperFrames",
-    repo: "https://github.com/heygen-com/hyperframes.git",
+    repo: "heygen-com/hyperframes",
     skillsPath: "skills",
     cache: join(homedir(), ".cache", "hyperframes", "hyperframes-skills"),
   },
   {
     name: "GSAP",
-    repo: "https://github.com/greensock/gsap-skills.git",
+    repo: "greensock/gsap-skills",
     skillsPath: "skills",
     cache: join(homedir(), ".cache", "hyperframes", "gsap-skills"),
   },
 ];
 
 // ---------------------------------------------------------------------------
-// Git helpers
+// npx skills add — primary install method
+// ---------------------------------------------------------------------------
+
+function hasNpx(): boolean {
+  try {
+    execFileSync("npx", ["--version"], { stdio: "ignore", timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runSkillsAdd(repo: string, agents: string[], global: boolean): void {
+  const args = ["skills", "add", repo, "-y"];
+  if (global) args.push("-g");
+  for (const agent of agents) {
+    args.push("-a", agent);
+  }
+  execFileSync("npx", args, {
+    stdio: "ignore",
+    timeout: 120_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fallback — git clone + copy (used when npx skills add is unavailable)
 // ---------------------------------------------------------------------------
 
 function hasGit(): boolean {
@@ -86,7 +119,6 @@ function hasGit(): boolean {
   }
 }
 
-// Suppress git credential prompts — fail fast instead of hanging
 const GIT_ENV = { ...process.env, GIT_TERMINAL_PROMPT: "0" };
 
 function gitClone(repo: string, dest: string): void {
@@ -97,7 +129,8 @@ function gitClone(repo: string, dest: string): void {
   });
 }
 
-function fetchRepo(source: SkillSource): string {
+function fetchRepo(source: SkillSource): string | undefined {
+  const gitUrl = `https://github.com/${source.repo}.git`;
   if (existsSync(source.cache)) {
     try {
       execFileSync("git", ["pull", "--ff-only"], {
@@ -107,30 +140,22 @@ function fetchRepo(source: SkillSource): string {
         env: GIT_ENV,
       });
     } catch {
-      // Pull failed — use stale cache if valid
       const skillsDir = join(source.cache, source.skillsPath);
-      if (existsSync(skillsDir)) {
-        return skillsDir;
-      }
-      // Cache is broken — re-clone
+      if (existsSync(skillsDir)) return skillsDir;
       rmSync(source.cache, { recursive: true, force: true });
-      gitClone(source.repo, source.cache);
+      gitClone(gitUrl, source.cache);
     }
   } else {
     mkdirSync(dirname(source.cache), { recursive: true });
-    gitClone(source.repo, source.cache);
+    gitClone(gitUrl, source.cache);
   }
-  return join(source.cache, source.skillsPath);
+  const skillsDir = join(source.cache, source.skillsPath);
+  return existsSync(skillsDir) ? skillsDir : undefined;
 }
-
-// ---------------------------------------------------------------------------
-// Install logic
-// ---------------------------------------------------------------------------
 
 interface InstalledSkill {
   name: string;
   source: string;
-  overwritten: boolean;
 }
 
 function installSkillsFromDir(
@@ -148,13 +173,47 @@ function installSkillsFromDir(
     if (!existsSync(skillFile)) continue;
 
     const destDir = join(targetDir, entry.name);
-    const overwritten = existsSync(destDir);
-    if (overwritten) rmSync(destDir, { recursive: true, force: true });
+    if (existsSync(destDir)) rmSync(destDir, { recursive: true, force: true });
     mkdirSync(destDir, { recursive: true });
     cpSync(join(sourceDir, entry.name), destDir, { recursive: true });
-    installed.push({ name: entry.name, source: sourceName, overwritten });
+    installed.push({ name: entry.name, source: sourceName });
   }
   return installed;
+}
+
+function fallbackInstall(targets: Target[]): {
+  count: number;
+  installed: InstalledSkill[];
+  skipped: string[];
+} {
+  const skipped: string[] = [];
+  const fetched: { source: SkillSource; skillsDir: string }[] = [];
+
+  for (const source of SOURCES) {
+    try {
+      const skillsDir = fetchRepo(source);
+      if (skillsDir) {
+        fetched.push({ source, skillsDir });
+      } else {
+        skipped.push(source.name);
+      }
+    } catch {
+      skipped.push(source.name);
+    }
+  }
+
+  const allInstalled: InstalledSkill[] = [];
+  let counted = false;
+  for (const target of targets) {
+    mkdirSync(target.dir, { recursive: true });
+    for (const { skillsDir, source } of fetched) {
+      const skills = installSkillsFromDir(skillsDir, target.dir, source.name);
+      if (!counted) allInstalled.push(...skills);
+    }
+    counted = true;
+  }
+
+  return { count: allInstalled.length, installed: allInstalled, skipped };
 }
 
 // ---------------------------------------------------------------------------
@@ -166,46 +225,35 @@ export { TARGETS };
 export async function installAllSkills(
   targetNames?: string[],
 ): Promise<{ count: number; targets: string[]; skipped: string[] }> {
-  if (!hasGit()) return { count: 0, targets: [], skipped: SOURCES.map((s) => s.name) };
-
   const targets = targetNames
     ? TARGETS.filter((t) => targetNames.includes(t.flag))
     : TARGETS.filter((t) => t.defaultEnabled);
-  let totalCount = 0;
-  const skipped: string[] = [];
+  const agents = targets.map((t) => t.skillsAgent);
 
-  // Fetch sources
-  const fetched: { source: SkillSource; skillsDir: string }[] = [];
-  for (const source of SOURCES) {
-    try {
-      const skillsDir = fetchRepo(source);
-      if (existsSync(skillsDir)) {
-        fetched.push({ source, skillsDir });
-      } else {
+  // Try npx skills add first
+  if (hasNpx()) {
+    const skipped: string[] = [];
+    let count = 0;
+    for (const source of SOURCES) {
+      try {
+        runSkillsAdd(source.repo, agents, true);
+        count += 1; // count sources, not individual skills (we don't get that from npx)
+      } catch {
         skipped.push(source.name);
       }
-    } catch {
-      skipped.push(source.name);
     }
+    if (count > 0) {
+      return { count, targets: targets.map((t) => t.name), skipped };
+    }
+    // npx skills add failed for all sources — try fallback
   }
 
-  // Install to first target and count, then install to remaining targets
-  const [firstTarget, ...remainingTargets] = targets;
-  if (firstTarget) {
-    mkdirSync(firstTarget.dir, { recursive: true });
-    for (const { skillsDir, source } of fetched) {
-      const skills = installSkillsFromDir(skillsDir, firstTarget.dir, source.name);
-      totalCount += skills.length;
-    }
+  // Fallback: git clone + copy
+  if (!hasGit()) {
+    return { count: 0, targets: [], skipped: SOURCES.map((s) => s.name) };
   }
-  for (const target of remainingTargets) {
-    mkdirSync(target.dir, { recursive: true });
-    for (const { skillsDir, source } of fetched) {
-      installSkillsFromDir(skillsDir, target.dir, source.name);
-    }
-  }
-
-  return { count: totalCount, targets: targets.map((t) => t.name), skipped };
+  const result = fallbackInstall(targets);
+  return { count: result.count, targets: targets.map((t) => t.name), skipped: result.skipped };
 }
 
 // ---------------------------------------------------------------------------
@@ -223,84 +271,71 @@ function resolveTargets(args: Record<string, unknown>): Target[] {
 async function runInstall({ args }: { args: Record<string, unknown> }): Promise<void> {
   clack.intro(c.bold("hyperframes skills"));
 
+  const targets = resolveTargets(args);
+  const agents = targets.map((t) => t.skillsAgent);
+
+  // Try npx skills add
+  if (hasNpx()) {
+    const installed: string[] = [];
+    const skippedSources: string[] = [];
+
+    for (const source of SOURCES) {
+      const spinner = clack.spinner();
+      spinner.start(`Installing ${source.name} skills...`);
+      try {
+        runSkillsAdd(source.repo, agents, true);
+        installed.push(source.name);
+        spinner.stop(c.success(`${source.name} skills installed`));
+      } catch {
+        skippedSources.push(source.name);
+        spinner.stop(c.dim(`${source.name} skills skipped (unavailable)`));
+      }
+    }
+
+    console.log();
+    console.log(`   ${c.dim("Targets:")}  ${targets.map((t) => t.name).join(", ")}`);
+    if (skippedSources.length > 0) {
+      console.log(`   ${c.dim("Skipped:")}  ${skippedSources.join(", ")}`);
+    }
+    console.log();
+
+    if (installed.length > 0) {
+      clack.outro(c.success(`${installed.join(" + ")} skills installed.`));
+    } else {
+      clack.log.warn("npx skills add failed — trying fallback...");
+      // Fall through to git fallback below
+    }
+
+    if (installed.length > 0) return;
+  }
+
+  // Fallback: git clone + copy
   if (!hasGit()) {
-    clack.log.error(c.error("git is required to install skills. Install git and retry."));
+    clack.log.error(c.error("Neither npx nor git available. Install Node.js or git and retry."));
     clack.outro(c.warn("No skills installed."));
     return;
   }
 
-  const targets = resolveTargets(args);
+  clack.log.info(c.dim("Using git fallback..."));
 
-  // 1. Fetch all skill sources
-  const fetched: { source: SkillSource; skillsDir: string }[] = [];
+  const result = fallbackInstall(targets);
 
-  for (const source of SOURCES) {
-    const spinner = clack.spinner();
-    spinner.start(`Fetching ${source.name} skills...`);
-    try {
-      const skillsDir = fetchRepo(source);
-      if (existsSync(skillsDir)) {
-        fetched.push({ source, skillsDir });
-        spinner.stop(c.success(`${source.name} skills fetched`));
-      } else {
-        spinner.stop(c.warn(`${source.name}: no skills directory found`));
-      }
-    } catch {
-      spinner.stop(c.dim(`${source.name} skills skipped (repo not accessible)`));
-    }
-  }
-
-  // 2. Install to each target
-  const allInstalled: InstalledSkill[] = [];
-
-  let counted = false;
-  for (const target of targets) {
-    const spinner = clack.spinner();
-    spinner.start(`Installing to ${target.name}...`);
-
-    mkdirSync(target.dir, { recursive: true });
-
-    let count = 0;
-    for (const { source, skillsDir } of fetched) {
-      const skills = installSkillsFromDir(skillsDir, target.dir, source.name);
-      count += skills.length;
-      if (!counted) allInstalled.push(...skills);
-    }
-    counted = true;
-
-    spinner.stop(c.success(`${count} skills → ${target.name} ${c.dim(target.dir)}`));
-  }
-
-  // 3. Summary
   console.log();
   for (const source of SOURCES) {
-    const names = allInstalled.filter((s) => s.source === source.name).map((s) => s.name);
+    const names = result.installed.filter((s) => s.source === source.name).map((s) => s.name);
     if (names.length > 0) {
       const label = `${source.name}:`.padEnd(14);
       console.log(`   ${c.dim(label)} ${names.map((s) => c.accent(s)).join(", ")}`);
     }
   }
   console.log(`   ${c.dim("Targets:")}      ${targets.map((t) => t.name).join(", ")}`);
-  console.log();
-
-  const skippedSources = SOURCES.filter((s) => !fetched.some((f) => f.source.name === s.name));
-  if (skippedSources.length > 0) {
-    console.log(
-      `   ${c.dim("Skipped:")}      ${skippedSources.map((s) => s.name).join(", ")} (repo not accessible)`,
-    );
+  if (result.skipped.length > 0) {
+    console.log(`   ${c.dim("Skipped:")}      ${result.skipped.join(", ")}`);
   }
   console.log();
 
-  if (allInstalled.length > 0 && skippedSources.length > 0) {
-    const readySources = fetched.map((f) => f.source.name).join(", ");
-    const skippedNames = skippedSources.map((s) => s.name).join(", ");
-    clack.outro(
-      c.warn(
-        `${allInstalled.length} skills ready (${readySources}). Unavailable: ${skippedNames}.`,
-      ),
-    );
-  } else if (allInstalled.length > 0) {
-    clack.outro(c.success(`${allInstalled.length} skills ready.`));
+  if (result.count > 0) {
+    clack.outro(c.success(`${result.count} skills ready.`));
   } else {
     clack.outro(c.warn("No skills installed."));
   }

--- a/packages/cli/src/commands/install-skills.ts
+++ b/packages/cli/src/commands/install-skills.ts
@@ -202,15 +202,20 @@ function fallbackInstall(targets: Target[]): {
     }
   }
 
+  // Install to first target and collect results, then copy to remaining targets
+  const [first, ...rest] = targets;
   const allInstalled: InstalledSkill[] = [];
-  let counted = false;
-  for (const target of targets) {
+  if (first) {
+    mkdirSync(first.dir, { recursive: true });
+    for (const { skillsDir, source } of fetched) {
+      allInstalled.push(...installSkillsFromDir(skillsDir, first.dir, source.name));
+    }
+  }
+  for (const target of rest) {
     mkdirSync(target.dir, { recursive: true });
     for (const { skillsDir, source } of fetched) {
-      const skills = installSkillsFromDir(skillsDir, target.dir, source.name);
-      if (!counted) allInstalled.push(...skills);
+      installSkillsFromDir(skillsDir, target.dir, source.name);
     }
-    counted = true;
   }
 
   return { count: allInstalled.length, installed: allInstalled, skipped };
@@ -301,12 +306,10 @@ async function runInstall({ args }: { args: Record<string, unknown> }): Promise<
 
     if (installed.length > 0) {
       clack.outro(c.success(`${installed.join(" + ")} skills installed.`));
-    } else {
-      clack.log.warn("npx skills add failed — trying fallback...");
-      // Fall through to git fallback below
+      return;
     }
 
-    if (installed.length > 0) return;
+    clack.log.warn("npx skills add failed — trying fallback...");
   }
 
   // Fallback: git clone + copy

--- a/packages/cli/src/templates/_shared/AGENTS.md
+++ b/packages/cli/src/templates/_shared/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/cli/src/templates/_shared/CLAUDE.md
+++ b/packages/cli/src/templates/_shared/CLAUDE.md
@@ -1,0 +1,50 @@
+# HyperFrames Composition Project
+
+## Skills — USE THESE FIRST
+
+**Always invoke the relevant skill before writing or modifying compositions.** Skills encode framework-specific patterns (e.g., `class="clip"`, `window.__timelines`, `data-*` attributes) that are NOT in generic web docs. Skipping them produces broken compositions.
+
+| Skill                | Command             | When to use                                                                                            |
+| -------------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
+| **compose-video**    | `/compose-video`    | Creating or editing ANY HTML composition — videos, animations, title cards, overlays, sub-compositions |
+| **captions**         | `/captions`         | Building captions from whisper transcripts — style detection, per-word styling                         |
+| **gsap-core**        | `/gsap-core`        | GSAP tweens: `gsap.to()`, `from()`, `fromTo()`, easing, stagger, defaults                              |
+| **gsap-timeline**    | `/gsap-timeline`    | Timeline sequencing, position parameter, labels, nesting                                               |
+| **gsap-performance** | `/gsap-performance` | Animation performance — transforms over layout props, will-change, batching                            |
+
+> **Skills not available?** Ask the user to run `npx hyperframes skills` and restart their
+> agent session, or install manually: `npx skills add heygen-com/hyperframes` and
+> `npx skills add greensock/gsap-skills`.
+
+## Commands
+
+```bash
+npx hyperframes dev          # preview in browser (studio editor)
+npx hyperframes render       # render to MP4
+npx hyperframes lint         # validate compositions
+npx hyperframes docs <topic> # reference docs in terminal
+```
+
+Available doc topics: `data-attributes`, `gsap`, `compositions`, `rendering`, `templates`, `troubleshooting`
+
+Full docs: [hyperframes.heygen.com](https://hyperframes.heygen.com)
+
+## Project Structure
+
+- `index.html` — main composition (root timeline)
+- `compositions/` — sub-compositions referenced via `data-composition-src`
+- `meta.json` — project metadata (id, name)
+- `transcript.json` — whisper word-level transcript (if generated)
+
+## Key Rules
+
+1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`
+2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control
+3. Timelines must be paused and registered on `window.__timelines`:
+   ```js
+   window.__timelines = window.__timelines || {};
+   window.__timelines["composition-id"] = gsap.timeline({ paused: true });
+   ```
+4. Videos use `muted` with a separate `<audio>` element for the audio track
+5. Sub-compositions use `data-composition-src="compositions/file.html"` to reference other HTML files
+6. Only deterministic logic — no `Date.now()`, no `Math.random()`, no network fetches


### PR DESCRIPTION
## What

`hyperframes init` now scaffolds AI agent context into every new project, so agents immediately know how to work with HyperFrames compositions.

## Why

New Claude Code / Gemini / Codex sessions working on HyperFrames projects had no context about the framework. They'd write compositions from scratch, miss framework-specific patterns like `class="clip"` and `window.__timelines`, and produce broken output. Skills were installed globally but not discoverable in the current session.

## How

**Scaffolded into every new project (`hyperframes init`):**
- `CLAUDE.md` + `AGENTS.md` (symlink) — teaches agents about available skills, CLI commands, project structure, and the 6 key framework rules
- `.claude/skills/{compose-video,captions}/` — project-level skills for immediate availability (global skills require a session restart)
- CLAUDE.md includes a "skills not available?" guardrail directing agents to suggest `npx hyperframes skills`

**Updated post-init output:**
- Shows `npx hyperframes docs <topic>` with all 6 available topics
- Links to hyperframes.heygen.com
- Generic "AI skills installed" message (agent-agnostic)

**Updated README:**
- "AI Agent Skills" section with `npx hyperframes skills` and `npx skills add` install paths
- Full table of HyperFrames + GSAP skills

**Repo-level CLAUDE.md** for framework contributors (separate from the project-template CLAUDE.md).

**Also includes:** Migrate `hyperframes skills` to use `npx skills add` (vercel-labs/skills ecosystem standard) with git-clone fallback.

### Scaffolded project structure (after)
```
my-video/
  CLAUDE.md                              # Agent context
  AGENTS.md                              # Symlink → CLAUDE.md (multi-agent)
  index.html                             # Main composition
  compositions/captions.html             # Sub-composition  
  meta.json                              # Project metadata
  .claude/skills/compose-video/          # Immediate skill availability
  .claude/skills/captions/               # Immediate skill availability
```

## Test plan

- [x] `hyperframes init --template blank --skip-skills` scaffolds CLAUDE.md, AGENTS.md, `.claude/skills/`
- [x] CLAUDE.md and AGENTS.md are identical content
- [x] Project-level skills contain SKILL.md + support files (patterns.md, house-style.md, palettes/)
- [x] Next-steps output shows `docs`, topics, and docs site link
- [x] `hyperframes skills --claude` installs all 10 skills (2 HyperFrames + 8 GSAP) via `npx skills add`
- [x] Fallback to git-clone works if npx unavailable
- [ ] Open scaffolded project in Claude Code — agent should see compose-video/captions in skills list and invoke `/compose-video` when asked to create a composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)