### PR TITLE
chore: release v0.1.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "bin": {
     "hyperframes": "./dist/cli.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "files": [
     "dist",
     "docs",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "files": [
     "dist/"

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
## What

Bump all `@hyperframes/*` packages from 0.1.6 to 0.1.7.

## Why

New release to publish latest changes to npm.

## How

Used `scripts/set-version.ts 0.1.7` to update all 5 package.json files. Tag `v0.1.7` created to trigger the publish workflow.

## Test plan

- [x] Version set via `set-version.ts` script
- [x] Tag `v0.1.7` pushed — will trigger npm publish workflow on merge