### PR TITLE
fix(cli): point agents to docs CLI and llms.txt instead of guessing URLs

### DIFF
--- a/packages/cli/src/templates/_shared/CLAUDE.md
+++ b/packages/cli/src/templates/_shared/CLAUDE.md
@@ -25,9 +25,21 @@ npx hyperframes lint         # validate compositions
 npx hyperframes docs <topic> # reference docs in terminal
 ```
 
-Available doc topics: `data-attributes`, `gsap`, `compositions`, `rendering`, `templates`, `troubleshooting`
+## Documentation
 
-Full docs: [hyperframes.heygen.com](https://hyperframes.heygen.com)
+**For quick reference**, use the local CLI docs command (no network required):
+
+```bash
+npx hyperframes docs <topic>
+```
+
+Topics: `data-attributes`, `gsap`, `compositions`, `rendering`, `templates`, `troubleshooting`
+
+**For full documentation**, discover pages via the machine-readable index — do NOT guess URLs:
+
+```
+https://hyperframes.heygen.com/llms.txt
+```
 
 ## Project Structure
 


### PR DESCRIPTION
## What

Updates the shared `CLAUDE.md` template (copied into every scaffolded project) to direct AI agents toward the correct documentation sources.

## Why

Agents were seeing `hyperframes.heygen.com` + topic names like `compositions` in the same file and guessing incorrect URLs (e.g. `/compositions` instead of `/concepts/compositions`), resulting in 404s.

## How

- Separates docs guidance into two clear paths:
  1. **Local CLI**: `npx hyperframes docs <topic>` for quick reference (no network)
  2. **Web docs**: `https://hyperframes.heygen.com/llms.txt` for full URL discovery — explicitly says "do NOT guess URLs"
- Removes the bare `hyperframes.heygen.com` link that was triggering the guessing

## Test plan

- [x] Verified `llms.txt` returns correct URL index
- [x] Verified `hyperframes docs <topic>` CLI command works with all 6 topics
- [ ] Manual testing: scaffold a project and confirm agent uses CLI/llms.txt instead of guessing