### PR TITLE
feat(cli): improve FTUX to guide users toward AI agent workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ Hyperframes is an open-source video rendering framework that lets you create, pr
 ```bash
 npx hyperframes init my-video
 cd my-video
-npx hyperframes dev      # preview in browser
+```
+
+Then open the project with your AI coding agent (Claude Code, Cursor, etc.) — it has HyperFrames skills installed and knows how to create and edit compositions.
+
+```bash
+npx hyperframes dev      # preview in browser (live reload)
 npx hyperframes render   # render to MP4
 ```
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,7 +3,7 @@ title: Quickstart
 description: "Create, preview, and render your first Hyperframes video in under two minutes."
 ---
 
-Go from zero to a rendered MP4 in four steps: scaffold a project, preview it live, customize the composition, and render.
+Go from zero to a rendered MP4: scaffold a project, edit with your AI agent, preview live, and render.
 
 ## What you'll build
 
@@ -58,14 +58,14 @@ A 1920x1080 video with an animated title that fades in from above — rendered t
 <Steps>
   <Step title="Scaffold the project">
     ```bash
-    npx hyperframes init my-video --template blank
+    npx hyperframes init my-video
     cd my-video
     ```
 
-    The CLI is non-interactive by default — pass `--template` to select a template. For interactive mode with prompts and menus, add `--human-friendly`:
+    This starts an interactive wizard that walks you through template selection and media import. To skip prompts (e.g. in CI or from an agent), use `--non-interactive`:
 
     ```bash
-    npx hyperframes init --human-friendly
+    npx hyperframes init my-video --non-interactive --template blank
     ```
 
     See [Templates](/guides/templates) for all available templates.
@@ -113,7 +113,9 @@ A 1920x1080 video with an animated title that fades in from above — rendered t
   </Step>
 
   <Step title="Edit the composition">
-    Open `index.html` and replace it with this composition:
+    Open the project with your AI coding agent (Claude Code, Cursor, etc.) — HyperFrames skills are installed automatically and your agent knows how to create and edit compositions.
+
+    Or edit `index.html` directly — here's a minimal composition:
 
     ```html index.html
     <div id="root" data-composition-id="my-video"

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -306,9 +306,7 @@ async function runEmbeddedMode(dir: string, startPort: number): Promise<void> {
   console.log(`  ${c.dim("Project")}   ${c.accent(projectName)}`);
   console.log(`  ${c.dim("Studio")}    ${c.accent(url)}`);
   console.log();
-  console.log(
-    `  ${c.dim("Edit compositions with your AI agent — it has HyperFrames skills installed.")}`,
-  );
+  console.log(`  ${c.dim("Edit with your AI agent — it has HyperFrames skills installed.")}`);
   console.log(`  ${c.dim("Changes reload automatically in the studio.")}`);
   console.log();
   console.log(`  ${c.dim("Press Ctrl+C to stop")}`);

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -306,6 +306,11 @@ async function runEmbeddedMode(dir: string, startPort: number): Promise<void> {
   console.log(`  ${c.dim("Project")}   ${c.accent(projectName)}`);
   console.log(`  ${c.dim("Studio")}    ${c.accent(url)}`);
   console.log();
+  console.log(
+    `  ${c.dim("Edit compositions with your AI agent — it has HyperFrames skills installed.")}`,
+  );
+  console.log(`  ${c.dim("Changes reload automatically in the studio.")}`);
+  console.log();
   console.log(`  ${c.dim("Press Ctrl+C to stop")}`);
   console.log();
   import("open").then((mod) => mod.default(`${url}#project/${projectName}`)).catch(() => {});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -646,23 +646,22 @@ Examples:
         console.log(`  ${c.accent(f)}`);
       }
       console.log();
-      console.log("Next steps:");
+      console.log("Get started:");
+      console.log();
+      console.log(`  ${c.accent("1.")} Open this project in your AI coding agent:`);
       console.log(
-        `  ${c.accent(`cd ${name}`)} && ${c.accent("npx hyperframes dev")}      ${c.dim("# preview in studio")}`,
+        `     ${c.accent(`cd ${name}`)} then start ${c.accent("Claude Code")}, ${c.accent("Cursor")}, or your preferred agent`,
       );
       console.log(
-        `  ${c.accent(`cd ${name}`)} && ${c.accent("npx hyperframes render")}   ${c.dim("# render to MP4")}`,
-      );
-      console.log(
-        `  ${c.accent("npx hyperframes docs")} ${c.dim("<topic>")}              ${c.dim("# learn composition syntax")}`,
-      );
-      console.log(
-        `    ${c.dim("topics: data-attributes, gsap, compositions, rendering, templates, troubleshooting")}`,
+        `     ${c.dim("AI skills are installed — your agent knows how to create and edit compositions.")}`,
       );
       console.log();
-      console.log(
-        `  ${c.dim("AI skills installed — open this folder in your AI coding agent to get started.")}`,
-      );
+      console.log(`  ${c.accent("2.")} Preview in the browser:`);
+      console.log(`     ${c.accent(`cd ${name}`)} && ${c.accent("npx hyperframes dev")}`);
+      console.log();
+      console.log(`  ${c.accent("3.")} Render to MP4 when ready:`);
+      console.log(`     ${c.accent(`cd ${name}`)} && ${c.accent("npx hyperframes render")}`);
+      console.log();
       console.log(`  ${c.dim("Full docs: hyperframes.heygen.com")}`);
       return;
     }
@@ -859,6 +858,11 @@ Examples:
 
     const files = readdirSync(destDir);
     clack.note(files.map((f) => c.accent(f)).join("\n"), c.success(`Created ${name}/`));
+
+    clack.log.message(
+      `${c.dim("Tip:")} Open this project in ${c.accent("Claude Code")}, ${c.accent("Cursor")}, or your preferred AI agent.\n` +
+        `${c.dim("     AI skills are installed — your agent knows how to create and edit compositions.")}`,
+    );
 
     await nextStepLoop(destDir);
   },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -648,7 +648,7 @@ Examples:
       console.log();
       console.log("Get started:");
       console.log();
-      console.log(`  ${c.accent("1.")} Open this project in your AI coding agent:`);
+      console.log(`  ${c.accent("1.")} Open this project with your AI coding agent:`);
       console.log(
         `     ${c.accent(`cd ${name}`)} then start ${c.accent("Claude Code")}, ${c.accent("Cursor")}, or your preferred agent`,
       );
@@ -860,7 +860,7 @@ Examples:
     clack.note(files.map((f) => c.accent(f)).join("\n"), c.success(`Created ${name}/`));
 
     clack.log.message(
-      `${c.dim("Tip:")} Open this project in ${c.accent("Claude Code")}, ${c.accent("Cursor")}, or your preferred AI agent.\n` +
+      `${c.dim("Tip:")} Open this project with ${c.accent("Claude Code")}, ${c.accent("Cursor")}, or your preferred AI agent.\n` +
         `${c.dim("     AI skills are installed — your agent knows how to create and edit compositions.")}`,
     );
 


### PR DESCRIPTION
## What

Updates the first-time user experience across CLI output, README, and docs to make the AI-first golden path clear.

## Why

The previous FTUX buried the agent workflow in a dim footnote and led with CLI commands. Since the core value prop is AI agents creating videos from HTML, the getting started flow should guide users toward that immediately.

## How

### CLI output changes

**After `hyperframes init my-video` (non-interactive):**
```
✔ Created my-video/
  compositions
  index.html
  meta.json

Get started:

  1. Open this project with your AI coding agent:
     cd my-video then start Claude Code, Cursor, or your preferred agent
     AI skills are installed — your agent knows how to create and edit compositions.

  2. Preview in the browser:
     cd my-video && npx hyperframes dev

  3. Render to MP4 when ready:
     cd my-video && npx hyperframes render

  Full docs: hyperframes.heygen.com
```

**After `hyperframes init` (interactive wizard):**
Shows a tip after scaffolding:
```
ℹ Tip: Open this project with Claude Code, Cursor, or your preferred AI agent.
       AI skills are installed — your agent knows how to create and edit compositions.
```

**After `hyperframes dev`:**
```
◇ Studio running

  Project   my-video
  Studio    http://localhost:3002

  Edit with your AI agent — it has HyperFrames skills installed.
  Changes reload automatically in the studio.

  Press Ctrl+C to stop
```

### Docs changes

- **README** — Quick Start now leads with opening in an AI agent after init
- **Quickstart docs** — updated to reflect interactive wizard as default, `--non-interactive` replaces `--human-friendly`, edit step mentions AI agent first

## Test plan

- [ ] `npx hyperframes init test-project --non-interactive` — shows numbered agent-first steps
- [ ] `npx hyperframes init test-project` (interactive) — shows agent tip after scaffold
- [ ] `npx hyperframes dev` — shows agent hint in server output
- [ ] README reads correctly on GitHub
- [ ] Quickstart docs render correctly on Mintlify