### PR TITLE
docs: add contextual menu for AI-assisted docs browsing

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,6 +12,23 @@
     "dark": "/logo/dark.svg"
   },
   "favicon": "/favicon.svg",
+  "contextual": {
+    "options": [
+      "copy",
+      "claude",
+      "cursor",
+      "vscode",
+      "windsurf",
+      "mcp",
+      {
+        "title": "Open an issue",
+        "description": "Report a bug or request a feature",
+        "icon": "github",
+        "iconType": "brands",
+        "href": "https://github.com/heygen-com/hyperframes/issues/new"
+      }
+    ]
+  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
## What

Adds Mintlify's [contextual menu](https://www.mintlify.com/docs/ai/contextual-menu) to every docs page via `docs.json`.

## Why

Makes it easy for developers to use our docs as context in AI tools — copy page content, open in Claude, connect via MCP to their IDE, or file a GitHub issue, all from the docs header.

## How

Single `contextual` config block in `docs.json`. Options chosen to align with our AI-first workflow (Claude skills, MCP integration):

| Option | What it does |
|--------|-------------|
| `copy` | Copy page as Markdown to clipboard |
| `claude` | Open in Claude with page as context |
| `cursor` | Connect Mintlify MCP server to Cursor |
| `vscode` | Connect Mintlify MCP server to VS Code |
| `windsurf` | Connect Mintlify MCP server to Windsurf |
| `mcp` | Copy raw MCP server URL (any tool) |
| **Open an issue** | Custom link → GitHub Issues new issue form |

No ChatGPT/Perplexity/Grok — we lean into Claude given our skills ecosystem.

## Test plan

- [ ] Deploy preview shows contextual menu button in docs header
- [ ] Each option works (copy, Claude, IDE connections, GitHub link)