### PR TITLE
fix(cli): force exit after render to prevent process hang

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -209,6 +209,12 @@ Examples:
         browserPath,
       });
     }
+
+    // Force exit — Node keeps the process alive due to lingering HTTP
+    // connections (fetch keep-alive pool from update checks / telemetry).
+    // The 'exit' event handler in cli.ts fires flushSync() which spawns a
+    // detached child process so telemetry data is not lost.
+    process.exit(0);
   },
 });
 

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -209,12 +209,6 @@ Examples:
         browserPath,
       });
     }
-
-    // Force exit — Node keeps the process alive due to lingering HTTP
-    // connections (fetch keep-alive pool from update checks / telemetry).
-    // The 'exit' event handler in cli.ts fires flushSync() which spawns a
-    // detached child process so telemetry data is not lost.
-    process.exit(0);
   },
 });
 

--- a/packages/cli/src/telemetry/client.ts
+++ b/packages/cli/src/telemetry/client.ts
@@ -105,7 +105,7 @@ export async function flush(): Promise<void> {
   try {
     await fetch(`${POSTHOG_HOST}/batch/`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Connection: "close" },
       body: JSON.stringify({ api_key: POSTHOG_API_KEY, batch }),
       signal: controller.signal,
     });

--- a/packages/cli/src/utils/updateCheck.ts
+++ b/packages/cli/src/utils/updateCheck.ts
@@ -42,7 +42,10 @@ export async function checkForUpdate(force?: boolean): Promise<UpdateCheckResult
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    const res = await fetch(NPM_REGISTRY_URL, { signal: controller.signal });
+    const res = await fetch(NPM_REGISTRY_URL, {
+      signal: controller.signal,
+      headers: { Connection: "close" },
+    });
     clearTimeout(timeout);
 
     if (!res.ok) return fallbackResult(config.latestVersion);


### PR DESCRIPTION
## Summary

- Adds `process.exit(0)` after render completes in the CLI `render` command
- Fixes the process hanging indefinitely after `npx hyperframes render --output video.mp4`
- Root cause: Node.js `fetch()` keep-alive pool (from update checks and telemetry) keeps TCP connections open, preventing the event loop from draining
- Telemetry is preserved — the `exit` handler in `cli.ts` calls `flushSync()` which spawns a detached child process

## Test plan

- [x] Run `npx hyperframes render --output test.mp4` and verify the process exits after completion
- [x] Verify telemetry events are still sent (check PostHog)