### PR TITLE
feat(lint): add template_literal_selector rule

### DIFF
--- a/packages/core/src/lint/hyperframeLinter.test.ts
+++ b/packages/core/src/lint/hyperframeLinter.test.ts
@@ -218,3 +218,60 @@ describe("lintScriptUrls", () => {
     vi.unstubAllGlobals();
   });
 });
+
+describe("template_literal_selector rule", () => {
+  it("reports error when querySelector uses template literal variable", () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080">
+    <div class="chart"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const compId = "main";
+    const el = document.querySelector(\`[data-composition-id="\${compId}"] .chart\`);
+    const tl = gsap.timeline({ paused: true });
+    window.__timelines["main"] = tl;
+  </script>
+</body></html>`;
+    const result = lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "template_literal_selector");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+  });
+
+  it("reports error for querySelectorAll with template literal variable", () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"></div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const id = "main";
+    document.querySelectorAll(\`[data-composition-id="\${id}"] .item\`);
+    const tl = gsap.timeline({ paused: true });
+    window.__timelines["main"] = tl;
+  </script>
+</body></html>`;
+    const result = lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "template_literal_selector");
+    expect(finding).toBeDefined();
+  });
+
+  it("does not report error for hardcoded querySelector strings", () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080">
+    <div class="chart"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const el = document.querySelector('[data-composition-id="main"] .chart');
+    const tl = gsap.timeline({ paused: true });
+    window.__timelines["main"] = tl;
+  </script>
+</body></html>`;
+    const result = lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "template_literal_selector");
+    expect(finding).toBeUndefined();
+  });
+});

--- a/packages/core/src/lint/hyperframeLinter.ts
+++ b/packages/core/src/lint/hyperframeLinter.ts
@@ -502,6 +502,26 @@ export function lintHyperframeHtml(
     }
   }
 
+  // ── Template literal variables in querySelector (breaks cheerio bundler) ──
+  for (const script of scripts) {
+    const templateLiteralSelectorPattern =
+      /(?:querySelector|querySelectorAll)\s*\(\s*`[^`]*\$\{[^}]+\}[^`]*`\s*\)/g;
+    let tlMatch: RegExpExecArray | null;
+    while ((tlMatch = templateLiteralSelectorPattern.exec(script.content)) !== null) {
+      pushFinding({
+        code: "template_literal_selector",
+        severity: "error",
+        message:
+          "querySelector uses a template literal variable (e.g. `${compId}`). " +
+          "The HTML bundler's CSS parser crashes on these. Use a hardcoded string instead.",
+        file: filePath,
+        fixHint:
+          "Replace the template literal variable with a hardcoded string. The bundler's CSS parser cannot handle interpolated variables in script content.",
+        snippet: truncateSnippet(tlMatch[0]),
+      });
+    }
+  }
+
   const errorCount = findings.filter((finding) => finding.severity === "error").length;
   const warningCount = findings.length - errorCount;
 


### PR DESCRIPTION
## What

Adds a lint rule (`template_literal_selector`) that catches `querySelector`/`querySelectorAll` calls using template literal variables inside `<script>` tags in compositions.

```js
// ERROR — breaks the bundler
document.querySelector(`[data-composition-id="${compId}"] .chart`);

// OK
document.querySelector('[data-composition-id="nyt-chart"] .chart');
```

## Why

The HTML bundler (cheerio + css-what) parses all script content during compilation. When it encounters `${variable}` syntax in what looks like a CSS selector string, css-what throws `Expected name, found #${compId}`. This causes the bundler to fail silently and fall back to raw HTML without runtime injection — the composition appears blank in the studio with no error message.

This was the root cause of the nyt-graph template not rendering.

## Severity

`error` — the composition will not render in the studio or produce correct output when bundled.

## Test plan

- [x] 354 tests pass (all existing + 2 new)
- [x] Detects template literal variable in querySelector
- [x] Allows hardcoded querySelector strings
- [x] `hyperframes lint` on the fixed nyt-graph template passes clean