### PR TITLE
fix(cli): read actual data-width/data-height in info command

### DIFF
--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -34,12 +34,20 @@ export default defineCommand({
     ensureDOMParser();
     const parsed = parseHtml(html);
 
+    // Read actual dimensions from root composition element via DOM query
+    // (same approach as compositions.ts — avoids regex matching wrong element)
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    const root = doc.querySelector("[data-composition-id]");
+    const width = parseInt(root?.getAttribute("data-width") ?? "1920", 10);
+    const height = parseInt(root?.getAttribute("data-height") ?? "1080", 10);
+    const resolution = width > height ? "landscape" : "portrait";
+
     const tracks = new Set(parsed.elements.map((el) => el.zIndex));
     const maxEnd = parsed.elements.reduce(
       (max, el) => Math.max(max, el.startTime + el.duration),
       0,
     );
-    const resolution = parsed.resolution === "portrait" ? "1080x1920" : "1920x1080";
     const size = totalSize(project.dir);
 
     const typeCounts: Record<string, number> = {};
@@ -55,9 +63,9 @@ export default defineCommand({
         JSON.stringify(
           withMeta({
             name: project.name,
-            resolution: parsed.resolution,
-            width: parsed.resolution === "portrait" ? 1080 : 1920,
-            height: parsed.resolution === "portrait" ? 1920 : 1080,
+            resolution: resolution as "landscape" | "portrait",
+            width,
+            height,
             duration: maxEnd,
             elements: parsed.elements.length,
             tracks: tracks.size,
@@ -72,7 +80,7 @@ export default defineCommand({
     }
 
     console.log(`${c.success("◇")}  ${c.accent(project.name)}`);
-    console.log(label("Resolution", resolution));
+    console.log(label("Resolution", `${width}x${height}`));
     console.log(label("Duration", `${maxEnd.toFixed(1)}s`));
     console.log(label("Elements", `${parsed.elements.length}${typeStr ? ` (${typeStr})` : ""}`));
     console.log(label("Tracks", `${tracks.size}`));


### PR DESCRIPTION
## PR Stack
| # | PR | Status |
|---|-----|--------|
| 1 | #122 — fix: info width/height swap | ← base |
| 2 | #123 — fix: include all 9 templates in build |  |
| 3 | #124 — fix: suppress ANSI in non-TTY |  |
| 4 | #125 — fix: lint --json error paths |  |
| 5 | #126 — fix: separate info/warning counts |  |
| 6 | #127 — fix: lint severity display |  |
| 7 | #128 — fix: render output path error |  |
| 8 | #129 — fix: zero-duration error message | ← top |

---

## Summary
- The `info` command was hardcoding dimensions based on portrait/landscape detection, which always defaulted to "portrait" because `parseHtml()` doesn't read `data-width`/`data-height` from composition root elements
- Now reads the actual attribute values directly from the HTML

## Reproducer
```bash
npx hyperframes init test --template blank --non-interactive
cd test && npx hyperframes info
# Shows "1080x1920" (portrait) but index.html has data-width="1920" data-height="1080"
npx hyperframes info --json | jq '{width, height}'
# Was: {"width": 1080, "height": 1920}
# Now: {"width": 1920, "height": 1080}
```

## Stack
1/8 — This is part of a stack of bug fixes found during automated new-user testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)