### PR TITLE
fix(cli): include all 9 templates in build output

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "build:fonts": "cd ../producer && tsx scripts/generate-font-data.ts",
     "build:studio": "cd ../studio && bun run build",
     "build:runtime": "tsx scripts/build-runtime.ts",
-    "build:copy": "mkdir -p dist/studio dist/docs dist/templates dist/skills && cp -r ../studio/dist/* dist/studio/ && cp -r src/templates/blank src/templates/warm-grain src/templates/play-mode src/templates/swiss-grid src/templates/vignelli src/templates/_shared dist/templates/ && cp -r ../../skills/hyperframes-compose ../../skills/hyperframes-captions dist/skills/ && (cp src/docs/*.md dist/docs/ 2>/dev/null || true)",
+    "build:copy": "mkdir -p dist/studio dist/docs dist/templates dist/skills && cp -r ../studio/dist/* dist/studio/ && cp -r src/templates/blank src/templates/warm-grain src/templates/play-mode src/templates/swiss-grid src/templates/vignelli src/templates/decision-tree src/templates/kinetic-type src/templates/product-promo src/templates/nyt-graph src/templates/_shared dist/templates/ && cp -r ../../skills/hyperframes-compose ../../skills/hyperframes-captions dist/skills/ && (cp src/docs/*.md dist/docs/ 2>/dev/null || true)",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## PR Stack
| # | PR | Status |
|---|-----|--------|
| 1 | #122 — fix: info width/height swap | ← base |
| 2 | #123 — fix: include all 9 templates in build |  |
| 3 | #124 — fix: suppress ANSI in non-TTY |  |
| 4 | #125 — fix: lint --json error paths |  |
| 5 | #126 — fix: separate info/warning counts |  |
| 6 | #127 — fix: lint severity display |  |
| 7 | #128 — fix: render output path error |  |
| 8 | #129 — fix: zero-duration error message | ← top |

---

## Summary
- The `decision-tree`, `kinetic-type`, `product-promo`, and `nyt-graph` templates existed in source but were not copied to `dist/templates/` during build
- Users selecting these from `init --help` got an unhandled ENOENT crash with a raw Node.js stack trace
- Added the 4 missing templates to the `build:copy` script in `package.json`

## Reproducer
```bash
npx hyperframes init test --template decision-tree --non-interactive
# Crashes: Error: ENOENT: no such file or directory, lstat '.../dist/templates/decision-tree'
#   at cpSyncFn (node:internal/fs/cp/cp-sync:56:13)
#   at cpSync (node:fs:3131:3)
#   ...raw stack trace...
```

## Stack
2/8 — Depends on #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)