### PR TITLE
fix(cli): suppress ANSI escape codes in non-TTY progress output

### DIFF
--- a/packages/cli/src/ui/progress.ts
+++ b/packages/cli/src/ui/progress.ts
@@ -2,7 +2,19 @@ import { c } from "./colors.js";
 
 const { stdout } = process;
 
+let lastPrintedThreshold = -1;
+
 export function renderProgress(percent: number, stage: string, row?: number): void {
+  // Non-TTY: write clean lines at 10% intervals, skip bar computation entirely
+  if (!stdout.isTTY) {
+    const rounded = Math.round(percent);
+    if ((rounded % 10 === 0 || rounded === 100) && rounded !== lastPrintedThreshold) {
+      lastPrintedThreshold = rounded;
+      stdout.write(`  ${rounded}%  ${stage}\n`);
+    }
+    return;
+  }
+
   const width = 25;
   const filled = Math.floor(percent / (100 / width));
   const empty = width - filled;
@@ -10,7 +22,7 @@ export function renderProgress(percent: number, stage: string, row?: number): vo
 
   const line = `  ${bar}  ${c.bold(String(Math.round(percent)) + "%")}  ${c.dim(stage)}`;
 
-  if (row !== undefined && stdout.isTTY) {
+  if (row !== undefined) {
     stdout.write(`\x1b[${row};1H\x1b[2K${line}`);
   } else {
     stdout.write(`\r\x1b[2K${line}`);


### PR DESCRIPTION
## PR Stack
| # | PR | Status |
|---|-----|--------|
| 1 | #122 — fix: info width/height swap | ← base |
| 2 | #123 — fix: include all 9 templates in build |  |
| 3 | #124 — fix: suppress ANSI in non-TTY |  |
| 4 | #125 — fix: lint --json error paths |  |
| 5 | #126 — fix: separate info/warning counts |  |
| 6 | #127 — fix: lint severity display |  |
| 7 | #128 — fix: render output path error |  |
| 8 | #129 — fix: zero-duration error message | ← top |

---

## Summary
- `renderProgress()` was writing `\r\x1b[2K` escape codes even when stdout is not a TTY, corrupting output for CI pipelines and AI agents
- Now checks `stdout.isTTY` and writes clean text lines at 10% intervals when piped/redirected

## Reproducer
```bash
cd my-video
npx hyperframes render --output out.mp4 2>&1 | cat
# Output contained raw escape codes visible as garbled text
# Now outputs clean: "  50%  Capturing frames"
```

## Stack
3/8 — Depends on #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)