### PR TITLE
fix(cli): respect --json flag on lint error paths

### DIFF
--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -15,63 +15,86 @@ export default defineCommand({
     json: { type: "boolean", description: "Output findings as JSON", default: false },
   },
   async run({ args }) {
-    const project = resolveProject(args.dir);
-    const htmlFiles = walkDir(project.dir).filter((f) => f.endsWith(".html"));
+    try {
+      const project = resolveProject(args.dir);
+      const htmlFiles = walkDir(project.dir).filter((f) => f.endsWith(".html"));
 
-    const allFindings: (HyperframeLintFinding & { file: string })[] = [];
-    let totalErrors = 0;
-    let totalWarnings = 0;
+      const allFindings: (HyperframeLintFinding & { file: string })[] = [];
+      let totalErrors = 0;
+      let totalWarnings = 0;
 
-    for (const file of htmlFiles) {
-      const html = readFileSync(join(project.dir, file), "utf-8");
-      const result = lintHyperframeHtml(html, { filePath: file });
-      for (const f of result.findings) {
-        allFindings.push({ ...f, file });
+      for (const file of htmlFiles) {
+        const html = readFileSync(join(project.dir, file), "utf-8");
+        const result = lintHyperframeHtml(html, { filePath: file });
+        for (const f of result.findings) {
+          allFindings.push({ ...f, file });
+        }
+        totalErrors += result.errorCount;
+        totalWarnings += result.warningCount;
       }
-      totalErrors += result.errorCount;
-      totalWarnings += result.warningCount;
-    }
 
-    if (args.json) {
+      if (args.json) {
+        console.log(
+          JSON.stringify(
+            withMeta({
+              ok: totalErrors === 0,
+              findings: allFindings,
+              errorCount: totalErrors,
+              warningCount: totalWarnings,
+              filesScanned: htmlFiles.length,
+            }),
+            null,
+            2,
+          ),
+        );
+        process.exit(totalErrors > 0 ? 1 : 0);
+      }
+
       console.log(
-        JSON.stringify(
-          withMeta({
-            ok: totalErrors === 0,
-            findings: allFindings,
-            errorCount: totalErrors,
-            warningCount: totalWarnings,
-            filesScanned: htmlFiles.length,
-          }),
-          null,
-          2,
-        ),
+        `${c.accent("◆")}  Linting ${c.accent(project.name)} (${htmlFiles.length} HTML files)`,
       );
+      console.log();
+
+      if (allFindings.length === 0) {
+        console.log(`${c.success("◇")}  ${c.success("0 errors, 0 warnings")}`);
+        return;
+      }
+
+      for (const finding of allFindings) {
+        const prefix = finding.severity === "error" ? c.error("✗") : c.warn("⚠");
+        const loc = finding.elementId ? ` ${c.accent(`[${finding.elementId}]`)}` : "";
+        console.log(
+          `${prefix}  ${c.bold(finding.code)}${loc}: ${finding.message} ${c.dim(finding.file)}`,
+        );
+        if (finding.fixHint) {
+          console.log(`   ${c.dim(`Fix: ${finding.fixHint}`)}`);
+        }
+      }
+
+      const summaryIcon = totalErrors > 0 ? c.error("◇") : c.success("◇");
+      console.log(`\n${summaryIcon}  ${totalErrors} error(s), ${totalWarnings} warning(s)`);
       process.exit(totalErrors > 0 ? 1 : 0);
-    }
-
-    console.log(
-      `${c.accent("◆")}  Linting ${c.accent(project.name)} (${htmlFiles.length} HTML files)`,
-    );
-    console.log();
-
-    if (allFindings.length === 0) {
-      console.log(`${c.success("◇")}  ${c.success("0 errors, 0 warnings")}`);
-      return;
-    }
-
-    for (const finding of allFindings) {
-      const prefix = finding.severity === "error" ? c.error("✗") : c.warn("⚠");
-      const loc = finding.elementId ? ` ${c.accent(`[${finding.elementId}]`)}` : "";
-      console.log(
-        `${prefix}  ${c.bold(finding.code)}${loc}: ${finding.message} ${c.dim(finding.file)}`,
-      );
-      if (finding.fixHint) {
-        console.log(`   ${c.dim(`Fix: ${finding.fixHint}`)}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (args.json) {
+        console.log(
+          JSON.stringify(
+            withMeta({
+              ok: false,
+              error: message,
+              findings: [],
+              errorCount: 0,
+              warningCount: 0,
+              filesScanned: 0,
+            }),
+            null,
+            2,
+          ),
+        );
+        process.exit(1);
       }
+      console.error(message);
+      process.exit(1);
     }
-
-    const summaryIcon = totalErrors > 0 ? c.error("◇") : c.success("◇");
-    console.log(`\n${summaryIcon}  ${totalErrors} error(s), ${totalWarnings} warning(s)`);
-    process.exit(totalErrors > 0 ? 1 : 0);
   },
 });


### PR DESCRIPTION
## PR Stack
| # | PR | Status |
|---|-----|--------|
| 1 | #122 — fix: info width/height swap | ← base |
| 2 | #123 — fix: include all 9 templates in build |  |
| 3 | #124 — fix: suppress ANSI in non-TTY |  |
| 4 | #125 — fix: lint --json error paths |  |
| 5 | #126 — fix: separate info/warning counts |  |
| 6 | #127 — fix: lint severity display |  |
| 7 | #128 — fix: render output path error |  |
| 8 | #129 — fix: zero-duration error message | ← top |

---

## Summary
- When `lint --json` encountered an error (e.g., invalid directory), it output plain text instead of JSON, breaking agent JSON parsing pipelines
- `resolveProject()` threw before the JSON output logic was reached
- Now wraps the entire `run()` body in try-catch that emits JSON errors when `--json` is set

## Reproducer
```bash
npx hyperframes lint --json /nonexistent/path
# Was: "Not a directory: /nonexistent/path" (plain text, breaks JSON.parse)
# Now: {"ok": false, "error": "Not a directory: /nonexistent/path", "_meta": {...}}
```

## Stack
4/8 — Depends on #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)