### PR TITLE
fix(core): separate info count from warning count in linter results

### DIFF
--- a/packages/core/src/lint/hyperframeLinter.ts
+++ b/packages/core/src/lint/hyperframeLinter.ts
@@ -636,12 +636,14 @@ export function lintHyperframeHtml(
   }
 
   const errorCount = findings.filter((finding) => finding.severity === "error").length;
-  const warningCount = findings.length - errorCount;
+  const warningCount = findings.filter((finding) => finding.severity === "warning").length;
+  const infoCount = findings.filter((finding) => finding.severity === "info").length;
 
   return {
     ok: errorCount === 0,
     errorCount,
     warningCount,
+    infoCount,
     findings,
   };
 }

--- a/packages/core/src/lint/types.ts
+++ b/packages/core/src/lint/types.ts
@@ -15,6 +15,7 @@ export type HyperframeLintResult = {
   ok: boolean;
   errorCount: number;
   warningCount: number;
+  infoCount: number;
   findings: HyperframeLintFinding[];
 };
 


### PR DESCRIPTION
## PR Stack
| # | PR | Status |
|---|-----|--------|
| 1 | #122 — fix: info width/height swap | ← base |
| 2 | #123 — fix: include all 9 templates in build |  |
| 3 | #124 — fix: suppress ANSI in non-TTY |  |
| 4 | #125 — fix: lint --json error paths |  |
| 5 | #126 — fix: separate info/warning counts |  |
| 6 | #127 — fix: lint severity display |  |
| 7 | #128 — fix: render output path error |  |
| 8 | #129 — fix: zero-duration error message | ← top |

---

## Summary
- The linter computed `warningCount` as `findings.length - errorCount`, which lumped info-severity findings into the warning count
- Now counts warnings and infos separately with explicit filters
- Adds a new `infoCount` field to `HyperframeLintResult`

## Reproducer
```bash
# Create composition with timed element missing class="clip"
npx hyperframes lint --json | jq '{warningCount, infoCount}'
# Was: {"warningCount": 1}  (but severity was "info")
# Now: {"warningCount": 0, "infoCount": 1}
```

## Stack
5/8 — Depends on #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)