### PR TITLE
fix(cli): distinguish info vs warning severity in lint output

### DIFF
--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -22,6 +22,7 @@ export default defineCommand({
       const allFindings: (HyperframeLintFinding & { file: string })[] = [];
       let totalErrors = 0;
       let totalWarnings = 0;
+      let totalInfos = 0;
 
       for (const file of htmlFiles) {
         const html = readFileSync(join(project.dir, file), "utf-8");
@@ -31,6 +32,7 @@ export default defineCommand({
         }
         totalErrors += result.errorCount;
         totalWarnings += result.warningCount;
+        totalInfos += result.infoCount;
       }
 
       if (args.json) {
@@ -41,6 +43,7 @@ export default defineCommand({
               findings: allFindings,
               errorCount: totalErrors,
               warningCount: totalWarnings,
+              infoCount: totalInfos,
               filesScanned: htmlFiles.length,
             }),
             null,
@@ -61,7 +64,12 @@ export default defineCommand({
       }
 
       for (const finding of allFindings) {
-        const prefix = finding.severity === "error" ? c.error("✗") : c.warn("⚠");
+        const prefix =
+          finding.severity === "error"
+            ? c.error("✗")
+            : finding.severity === "warning"
+              ? c.warn("⚠")
+              : c.dim("ℹ");
         const loc = finding.elementId ? ` ${c.accent(`[${finding.elementId}]`)}` : "";
         console.log(
           `${prefix}  ${c.bold(finding.code)}${loc}: ${finding.message} ${c.dim(finding.file)}`,
@@ -72,7 +80,11 @@ export default defineCommand({
       }
 
       const summaryIcon = totalErrors > 0 ? c.error("◇") : c.success("◇");
-      console.log(`\n${summaryIcon}  ${totalErrors} error(s), ${totalWarnings} warning(s)`);
+      const summaryParts = [`${totalErrors} error(s)`, `${totalWarnings} warning(s)`];
+      if (totalInfos > 0) {
+        summaryParts.push(`${totalInfos} info(s)`);
+      }
+      console.log(`\n${summaryIcon}  ${summaryParts.join(", ")}`);
       process.exit(totalErrors > 0 ? 1 : 0);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -85,6 +97,7 @@ export default defineCommand({
               findings: [],
               errorCount: 0,
               warningCount: 0,
+              infoCount: 0,
               filesScanned: 0,
             }),
             null,

--- a/packages/core/scripts/check-hyperframe-static.ts
+++ b/packages/core/scripts/check-hyperframe-static.ts
@@ -3,11 +3,20 @@ import path from "node:path";
 import { lintHyperframeHtml } from "../src/lint/hyperframeLinter";
 import type { HyperframeLintResult } from "../src/lint/types";
 
+function formatCounts(result: HyperframeLintResult): string {
+  const parts = [`${result.warningCount} warning${result.warningCount === 1 ? "" : "s"}`];
+  if (result.infoCount > 0) {
+    parts.push(`${result.infoCount} info${result.infoCount === 1 ? "" : "s"}`);
+  }
+  return parts.join(", ");
+}
+
 function formatHumanOutput(result: HyperframeLintResult, resolvedPath: string): string {
+  const counts = result.ok
+    ? formatCounts(result)
+    : `${result.errorCount} error${result.errorCount === 1 ? "" : "s"}, ${formatCounts(result)}`;
   const lines = [
-    result.ok
-      ? `PASS ${resolvedPath} (${result.warningCount} warning${result.warningCount === 1 ? "" : "s"})`
-      : `FAIL ${resolvedPath} (${result.errorCount} error${result.errorCount === 1 ? "" : "s"}, ${result.warningCount} warning${result.warningCount === 1 ? "" : "s"})`,
+    result.ok ? `PASS ${resolvedPath} (${counts})` : `FAIL ${resolvedPath} (${counts})`,
   ];
 
   for (const finding of result.findings) {


### PR DESCRIPTION
## PR Stack
| # | PR | Status |
|---|-----|--------|
| 1 | #122 — fix: info width/height swap | ← base |
| 2 | #123 — fix: include all 9 templates in build |  |
| 3 | #124 — fix: suppress ANSI in non-TTY |  |
| 4 | #125 — fix: lint --json error paths |  |
| 5 | #126 — fix: separate info/warning counts |  |
| 6 | #127 — fix: lint severity display |  |
| 7 | #128 — fix: render output path error |  |
| 8 | #129 — fix: zero-duration error message | ← top |

---

## Summary
- The lint CLI displayed info-level findings with the warning ⚠ icon and counted them in the warning total
- JSON output correctly reported `severity: "info"` but human output said "1 warning(s)"
- Now info findings show a distinct ℹ icon and the summary includes a separate info count

## Reproducer
```bash
# Create composition with timed element missing class="clip"
npx hyperframes lint
# Was: "⚠  timed_element_missing_visibility_hidden ... 0 error(s), 1 warning(s)"
# Now: "ℹ  timed_element_missing_visibility_hidden ... 0 error(s), 0 warning(s), 1 info(s)"
```

## Stack
6/8 — Depends on #126. Pairs with #126 (core linter change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)