### PR TITLE
fix(cli): improve error message for zero-duration composition renders

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -256,7 +256,13 @@ async function renderDocker(
     });
     await producer.executeRenderJob(job, projectDir, outputPath);
   } catch (error: unknown) {
-    handleRenderError(error, options, startTime, true, "Check Docker is running: docker info");
+    handleRenderError(
+      error,
+      options,
+      startTime,
+      true,
+      renderHintForError(error, "Check Docker is running: docker info"),
+    );
   }
 
   const elapsed = Date.now() - startTime;
@@ -297,7 +303,13 @@ async function renderLocal(
   try {
     await producer.executeRenderJob(job, projectDir, outputPath, onProgress);
   } catch (error: unknown) {
-    handleRenderError(error, options, startTime, false, "Try --docker for containerized rendering");
+    handleRenderError(
+      error,
+      options,
+      startTime,
+      false,
+      renderHintForError(error, "Try --docker for containerized rendering"),
+    );
   }
 
   const elapsed = Date.now() - startTime;
@@ -310,6 +322,14 @@ function getMemorySnapshot() {
     peakMemoryMb: bytesToMb(process.memoryUsage.rss()),
     memoryFreeMb: bytesToMb(freemem()),
   };
+}
+
+function renderHintForError(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("__hf not ready")) {
+    return "Composition may have zero duration. Add data-duration to the root element or ensure the GSAP timeline has tweens.";
+  }
+  return fallback;
 }
 
 function handleRenderError(


### PR DESCRIPTION
## PR Stack
| # | PR | Status |
|---|-----|--------|
| 1 | #122 — fix: info width/height swap | ← base |
| 2 | #123 — fix: include all 9 templates in build |  |
| 3 | #124 — fix: suppress ANSI in non-TTY |  |
| 4 | #125 — fix: lint --json error paths |  |
| 5 | #126 — fix: separate info/warning counts |  |
| 6 | #127 — fix: lint severity display |  |
| 7 | #128 — fix: render output path error |  |
| 8 | #129 — fix: zero-duration error message | ← top |

---

## Summary
- When a composition had zero duration (empty GSAP timeline, no `data-duration`), Docker render hung for 45s then showed the misleading hint "Check Docker is running" even though Docker was fine
- Now detects the `__hf not ready` timeout error and provides a context-aware hint about zero duration instead

## Reproducer
```bash
# Create a composition with an empty GSAP timeline and no data-duration
cat > index.html << 'HTML'
<div data-composition-id="test" data-width="1920" data-height="1080" data-start="0">
  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
  <script>
    window.__timelines = window.__timelines || {};
    window.__timelines["test"] = gsap.timeline({ paused: true });
    // No tweens — timeline has zero duration
  </script>
</div>
HTML
npx hyperframes render --docker --output out.mp4
# Was: "Check Docker is running: docker info"
# Now: "Composition may have zero duration. Add data-duration to the root element or ensure the GSAP timeline has tweens."
```

## Stack
8/8 — Depends on #128. Last PR in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)