### PR TITLE
fix(cli): catch output directory creation errors in render

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -126,7 +126,17 @@ Examples:
       : join(rendersDir, `${project.name}_${datePart}_${timePart}${ext}`);
 
     // Ensure output directory exists
-    mkdirSync(dirname(outputPath), { recursive: true });
+    try {
+      mkdirSync(dirname(outputPath), { recursive: true });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      errorBox(
+        "Cannot create output directory",
+        `${dirname(outputPath)}: ${message}`,
+        "Check that you have write permission or specify a different path with --output.",
+      );
+      process.exit(1);
+    }
 
     const useDocker = args.docker ?? false;
     const useGpu = args.gpu ?? false;


### PR DESCRIPTION
## Summary
- `mkdirSync` for the render output path was not wrapped in try-catch
- When the path was invalid or permissions were denied, Node.js threw a raw EACCES error with full stack trace
- Now catches the error and displays a clean error box via the existing `errorBox` helper

## Reproducer
```bash
npx hyperframes render --output /root/nope/output.mp4
# Was: raw "Error: EACCES: permission denied, mkdir '/root/nope'"
#   at Object.mkdirSync (node:fs:1379:3)
#   at ...12 lines of stack trace...
# Now: clean "Cannot create output directory" error box
```

## Stack
7/8 in the HyperFrames new-user bug fixes stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)