### PR TITLE
fix(engine,cli): download headless-shell instead of using system Chrome for local renders

### DIFF
--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -107,12 +107,23 @@ export async function findBrowser(): Promise<BrowserResult | undefined> {
 }
 
 /**
- * Find or download a browser.
- * Resolution: env var -> cached download -> system Chrome -> auto-download.
+ * Find or download a browser suitable for rendering.
+ * Resolution: env var -> cached headless-shell -> auto-download.
+ *
+ * System Chrome is NOT used for rendering because it does not support
+ * the HeadlessExperimental.beginFrame CDP command required for
+ * deterministic frame capture, and older system Chrome versions are
+ * often incompatible with the version of puppeteer-core bundled in
+ * the engine (protocol mismatch → silent 120s timeout).
  */
 export async function ensureBrowser(options?: EnsureBrowserOptions): Promise<BrowserResult> {
-  const existing = await findBrowser();
-  if (existing) return existing;
+  // Env override and cached headless-shell are trusted.
+  // System Chrome is skipped — it causes silent render timeouts.
+  const fromEnv = findFromEnv();
+  if (fromEnv) return fromEnv;
+
+  const fromCache = await findFromCache();
+  if (fromCache) return fromCache;
 
   const platform = detectBrowserPlatform();
   if (!platform) {

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -97,16 +97,22 @@ export async function acquireBrowser(
   const headlessShell = resolveHeadlessShellPath(config);
 
   // BeginFrame requires chrome-headless-shell AND Linux (crashes on macOS/Windows).
+  // System Chrome (google-chrome, chromium) does NOT support the
+  // HeadlessExperimental.beginFrame CDP command — only the dedicated
+  // chrome-headless-shell binary does.  Passing system Chrome as the
+  // executable causes a 120-second silent hang followed by a timeout.
   const isLinux = process.platform === "linux";
   const forceScreenshot = config?.forceScreenshot ?? DEFAULT_CONFIG.forceScreenshot;
+  const isHeadlessShellBinary = headlessShell ? /chrome-headless-shell/.test(headlessShell) : false;
   let captureMode: CaptureMode;
   let executablePath: string | undefined;
 
-  if (headlessShell && isLinux && !forceScreenshot) {
+  if (headlessShell && isLinux && isHeadlessShellBinary && !forceScreenshot) {
     captureMode = "beginframe";
     executablePath = headlessShell;
   } else {
-    // Screenshot mode with renderSeek: works on all platforms.
+    // Screenshot mode with renderSeek: works on all platforms, and
+    // as a fallback when system Chrome is the only available binary.
     captureMode = "screenshot";
     executablePath = headlessShell ?? undefined;
   }


### PR DESCRIPTION
## Summary
This was the **#1 new-user friction point** — `npx hyperframes render` (without `--docker`) silently hung for 120s then timed out on machines with system Chrome but no cached `chrome-headless-shell`.

**Root cause:** Two issues working together:
1. **CLI** (`browser/manager.ts`): `ensureBrowser()` returned system Chrome (`/usr/bin/google-chrome`) as a valid browser for rendering, but system Chrome doesn't support the `HeadlessExperimental.beginFrame` CDP command required for deterministic frame capture, and older versions are incompatible with the bundled puppeteer-core (protocol mismatch)
2. **Engine** (`browserManager.ts`): `acquireBrowser()` assumed any binary passed via `PRODUCER_HEADLESS_SHELL_PATH` was chrome-headless-shell and selected `beginframe` capture mode

**Fix (two layers):**
1. **CLI**: `ensureBrowser()` now skips system Chrome entirely for rendering — only uses env override, cached headless-shell, or auto-downloads headless-shell. `findBrowser()` still returns system Chrome for non-render use cases (dev server, etc.)
2. **Engine**: `acquireBrowser()` now validates the binary path contains `chrome-headless-shell` before selecting beginframe mode. Falls back to screenshot mode otherwise — defense in depth.

## Reproducer
```bash
# On a machine with system Chrome but no cached headless-shell
npx hyperframes init test --template blank --non-interactive
cd test && npx hyperframes render --output out.mp4
# Was: 120s silent hang → "Timed out after waiting 120000ms"
# Now: downloads headless-shell → renders successfully in ~6s
```

## Verified
```
◇  Browser: download          ← first render downloads headless-shell
   507.5 KB · 5.8s · completed

◇  Browser: cache             ← subsequent renders use cached binary
   507.5 KB · 5.8s · completed
```

## Stack
9/9 — Top of stack. Depends on #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)