### PR TITLE
feat(studio): export AudioWaveform and useMountEffect

### DIFF
--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -12,6 +12,7 @@ export {
   PreviewPanel,
   VideoThumbnail,
   CompositionThumbnail,
+  AudioWaveform,
   useTimelinePlayer,
   usePlayerStore,
   liveTime,
@@ -28,6 +29,7 @@ export { FileTree } from "./components/editor/FileTree";
 export { StudioApp } from "./App";
 
 // Hooks
+export { useMountEffect } from "./hooks/useMountEffect";
 export { useCodeEditor } from "./hooks/useCodeEditor";
 export type { OpenFile, UseCodeEditorReturn } from "./hooks/useCodeEditor";
 export { useElementPicker } from "./hooks/useElementPicker";

--- a/packages/studio/src/player/index.ts
+++ b/packages/studio/src/player/index.ts
@@ -5,6 +5,7 @@ export { Timeline } from "./components/Timeline";
 export { PreviewPanel } from "./components/PreviewPanel";
 export { VideoThumbnail } from "./components/VideoThumbnail";
 export { CompositionThumbnail } from "./components/CompositionThumbnail";
+export { AudioWaveform } from "./components/AudioWaveform";
 
 // Hooks
 export { useTimelinePlayer } from "./hooks/useTimelinePlayer";


### PR DESCRIPTION
## Summary
- Exports `AudioWaveform` component (real PCM waveform with fake fallback)
- Exports `useMountEffect` hook

These are needed by the internal demo app to replace its local copies.

## Test plan
- [ ] `import { AudioWaveform, useMountEffect } from "@hyperframes/studio"` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)