### PR TITLE
fix: make set-version commit and tag by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,16 +60,17 @@ Git hooks (via [lefthook](https://github.com/evilmartians/lefthook)) run automat
 All packages use **fixed versioning** — every release bumps all packages to the same version.
 
 ```bash
-bun run set-version 0.2.0
-git checkout -b release/v0.2.0
-git add packages/*/package.json
-git commit -m "chore: release v0.2.0"
-git push origin release/v0.2.0
-gh pr create --title "chore: release v0.2.0" --base main
-# After merge, tag + npm publish + GitHub Release happen automatically
+bun run set-version 0.2.0            # bumps all packages, commits, and creates git tag
+git push origin main --tags           # triggers the publish workflow
 ```
 
-You can also publish manually by pushing a tag: `git tag v0.2.0 && git push origin v0.2.0`
+The `set-version` script automatically creates a `chore: release v<version>` commit and a `v<version>` git tag. Pushing the tag triggers CI to publish all packages to npm and create a GitHub Release.
+
+If you need to bump versions without committing (e.g., for a release PR), pass `--no-tag`:
+
+```bash
+bun run set-version 0.2.0 --no-tag   # updates package.json files only
+```
 
 ## Reporting Issues
 

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env tsx
 /**
- * Set the version across all publishable packages in the monorepo.
+ * Set the version across all publishable packages in the monorepo,
+ * then create a git commit and tag.
  *
  * Usage:
- *   bun run set-version 0.1.1
- *   bun run set-version 0.1.1 --tag   # also creates a git commit and tag
+ *   bun run set-version 0.1.1          # bump, commit, and tag
+ *   bun run set-version 0.1.1 --no-tag # bump only (no commit or tag)
  *
  * All packages share a single version number (fixed versioning).
  */
@@ -26,11 +27,11 @@ const ROOT = join(import.meta.dirname, "..");
 function main() {
   const args = process.argv.slice(2);
   const version = args.find((a) => !a.startsWith("--"));
-  const shouldTag = args.includes("--tag");
+  const skipTag = args.includes("--no-tag");
 
   if (!version) {
-    console.error("Usage: bun run set-version <version> [--tag]");
-    console.error("Example: bun run set-version 0.1.1 --tag");
+    console.error("Usage: bun run set-version <version> [--no-tag]");
+    console.error("Example: bun run set-version 0.1.1");
     process.exit(1);
   }
 
@@ -51,31 +52,34 @@ function main() {
 
   console.log(`\nSet ${PACKAGES.length} packages to v${version}`);
 
-  if (shouldTag) {
-    // Verify working tree is clean (aside from the version bumps we just made)
-    const status = execSync("git status --porcelain", {
-      cwd: ROOT,
-      encoding: "utf-8",
-    }).trim();
-    const unexpected = status
-      .split("\n")
-      .filter((line) => line && !PACKAGES.some((pkg) => line.includes(pkg)));
-    if (unexpected.length > 0) {
-      console.error("\nUnexpected uncommitted changes:");
-      unexpected.forEach((line) => console.error(`  ${line}`));
-      console.error("Commit or stash these before tagging.");
-      process.exit(1);
-    }
-
-    execSync(`git add ${PACKAGES.map((p) => join(p, "package.json")).join(" ")}`, {
-      cwd: ROOT,
-      stdio: "inherit",
-    });
-    execSync(`git commit -m "chore: release v${version}"`, { cwd: ROOT, stdio: "inherit" });
-    execSync(`git tag v${version}`, { cwd: ROOT, stdio: "inherit" });
-    console.log(`\nCreated commit and tag v${version}`);
-    console.log(`Run 'git push origin main --tags' to trigger the publish workflow.`);
+  if (skipTag) {
+    console.log(`\nSkipped commit and tag (--no-tag). Remember to commit and tag manually.`);
+    return;
   }
+
+  // Verify working tree is clean (aside from the version bumps we just made)
+  const status = execSync("git status --porcelain", {
+    cwd: ROOT,
+    encoding: "utf-8",
+  }).trim();
+  const unexpected = status
+    .split("\n")
+    .filter((line) => line && !PACKAGES.some((pkg) => line.includes(pkg)));
+  if (unexpected.length > 0) {
+    console.error("\nUnexpected uncommitted changes:");
+    unexpected.forEach((line) => console.error(`  ${line}`));
+    console.error("Commit or stash these before releasing.");
+    process.exit(1);
+  }
+
+  execSync(`git add ${PACKAGES.map((p) => join(p, "package.json")).join(" ")}`, {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+  execSync(`git commit -m "chore: release v${version}"`, { cwd: ROOT, stdio: "inherit" });
+  execSync(`git tag v${version}`, { cwd: ROOT, stdio: "inherit" });
+  console.log(`\nCreated commit and tag v${version}`);
+  console.log(`Run 'git push origin main --tags' to trigger the publish workflow.`);
 }
 
 main();


### PR DESCRIPTION
## What

Invert the `set-version` script's default behavior: it now always creates a git commit and tag. The old `--tag` flag is removed and replaced with `--no-tag` as an escape hatch.

## Why

v0.1.11 and v0.1.12 were bumped without the `--tag` flag, so no git tags were created and the publish workflow never ran. Making commit+tag the default prevents this class of mistake.

## How

- `set-version.ts`: Removed `--tag` flag, made commit+tag the default path, added `--no-tag` to skip
- `CONTRIBUTING.md`: Updated release instructions to reflect the new simpler workflow

## Test plan

- [x] Manual testing: ran `bun run set-version 0.1.13 --no-tag` to verify the escape hatch works
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)