### PR TITLE
feat(cli): add remote template fetching via giget

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "bin": {
         "hyperframes": "./dist/cli.js",
       },
@@ -30,6 +30,7 @@
         "cheerio": "^1.2.0",
         "citty": "^0.2.1",
         "esbuild": "^0.25.0",
+        "giget": "^3.2.0",
         "hono": "^4.0.0",
         "mime-types": "^3.0.2",
         "open": "^10.0.0",
@@ -58,7 +59,7 @@
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "dependencies": {
         "@chenglou/pretext": "^0.0.3",
       },
@@ -84,7 +85,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
         "@hyperframes/core": "workspace:^",
@@ -101,7 +102,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -131,7 +132,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
@@ -954,6 +955,8 @@
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "5.2.0", "data-uri-to-buffer": "6.0.2", "debug": "4.4.3" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "giget": ["giget@3.2.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A=="],
 
     "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "2.6.0", "meow": "13.2.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "build:fonts": "cd ../producer && tsx scripts/generate-font-data.ts",
     "build:studio": "cd ../studio && bun run build",
     "build:runtime": "tsx scripts/build-runtime.ts",
-    "build:copy": "mkdir -p dist/studio dist/docs dist/templates dist/skills && cp -r ../studio/dist/* dist/studio/ && cp -r src/templates/* dist/templates/ && cp -r ../../skills/hyperframes-compose ../../skills/hyperframes-captions dist/skills/ && (cp src/docs/*.md dist/docs/ 2>/dev/null || true)",
+    "build:copy": "mkdir -p dist/studio dist/docs dist/templates dist/skills && cp -r ../studio/dist/* dist/studio/ && cp -r src/templates/blank src/templates/_shared dist/templates/ && cp -r ../../skills/hyperframes-compose ../../skills/hyperframes-captions dist/skills/ && (cp src/docs/*.md dist/docs/ 2>/dev/null || true)",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -31,6 +31,7 @@
     "cheerio": "^1.2.0",
     "citty": "^0.2.1",
     "esbuild": "^0.25.0",
+    "giget": "^3.2.0",
     "hono": "^4.0.0",
     "mime-types": "^3.0.2",
     "open": "^10.0.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,7 +15,7 @@ import * as clack from "@clack/prompts";
 import { c } from "../ui/colors.js";
 import { printBanner } from "../ui/banner.js";
 import {
-  ALL_TEMPLATE_IDS,
+  BUNDLED_TEMPLATES,
   resolveTemplateList,
   type TemplateOption,
 } from "../templates/generators.js";
@@ -366,13 +366,12 @@ async function scaffoldProject(
   templateId: string,
   localVideoName: string | undefined,
   durationSeconds?: number,
-  forceRemote?: boolean,
 ): Promise<void> {
   mkdirSync(destDir, { recursive: true });
 
-  // Try local bundled template first, fall back to remote fetch
+  // Use bundled template if available, otherwise fetch from GitHub
   const templateDir = getStaticTemplateDir(templateId);
-  if (!forceRemote && existsSync(templateDir)) {
+  if (existsSync(templateDir)) {
     cpSync(templateDir, destDir, { recursive: true });
   } else {
     await fetchRemoteTemplate(templateId, destDir);
@@ -433,20 +432,14 @@ Examples:
   hyperframes init my-video                            # interactive wizard
   hyperframes init my-video --template warm-grain      # pick a template
   hyperframes init my-video --video video.mp4          # with video file
-  hyperframes init my-video --example warm-grain         # fetch template from GitHub
   hyperframes init my-video --non-interactive           # skip prompts (CI/agents)`,
   },
   args: {
     name: { type: "positional", description: "Project name", required: false },
     template: {
       type: "string",
-      description: `Template (${ALL_TEMPLATE_IDS.join(", ")})`,
+      description: "Template name (e.g. warm-grain, swiss-grid, blank)",
       alias: "t",
-    },
-    example: {
-      type: "string",
-      description: "Fetch a template from GitHub (e.g. warm-grain)",
-      alias: "e",
     },
     video: {
       type: "string",
@@ -483,7 +476,6 @@ Examples:
   },
   async run({ args }) {
     const templateFlag = args.template;
-    const exampleFlag = args.example;
     const videoFlag = args.video;
     const audioFlag = args.audio;
     const skipSkills = args["skip-skills"] === true;
@@ -493,23 +485,11 @@ Examples:
     const languageFlag = args.language;
     const interactive = !nonInteractive && process.stdout.isTTY === true;
 
-    // --example always forces remote fetch
-    const forceRemote = exampleFlag !== undefined;
-    const effectiveTemplate = exampleFlag ?? templateFlag;
-
     // -----------------------------------------------------------------------
     // Non-interactive mode — all inputs from flags, defaults where missing
     // -----------------------------------------------------------------------
     if (!interactive) {
-      const resolvedTemplate = effectiveTemplate ?? "blank";
-      // For --example, any template ID is valid (fetched from GitHub)
-      if (!forceRemote && !(ALL_TEMPLATE_IDS as readonly string[]).includes(resolvedTemplate)) {
-        console.error(c.error(`Unknown template: ${resolvedTemplate}`));
-        console.error(`Available: ${ALL_TEMPLATE_IDS.join(", ")}`);
-        console.error(c.dim("Tip: use --example to fetch any template from GitHub"));
-        process.exit(1);
-      }
-      const templateId = resolvedTemplate;
+      const templateId = templateFlag ?? "blank";
       const name = args.name ?? "my-video";
       const destDir = resolve(name);
 
@@ -579,9 +559,6 @@ Examples:
       }
 
       // Scaffold
-      if (forceRemote) {
-        console.log(`Downloading template ${c.accent(templateId)} from GitHub...`);
-      }
       try {
         await scaffoldProject(
           destDir,
@@ -589,19 +566,14 @@ Examples:
           templateId,
           localVideoName,
           videoDuration,
-          forceRemote,
         );
       } catch (err) {
         console.error(
           c.error(
-            `Failed to fetch template "${templateId}": ${err instanceof Error ? err.message : err}`,
+            `Failed to scaffold template "${templateId}": ${err instanceof Error ? err.message : err}`,
           ),
         );
-        if (forceRemote) {
-          console.error(
-            c.dim("Check your network connection or use --template blank for offline use."),
-          );
-        }
+        console.error(c.dim("Use --template blank for offline use."));
         process.exit(1);
       }
       trackInitTemplate(templateId);
@@ -753,20 +725,12 @@ Examples:
       }
     }
 
-    // 3. Pick template — skip prompt if --template or --example was provided
+    // 3. Pick template — skip prompt if --template was provided
     let templateId: string;
-    let useRemote = forceRemote;
 
-    if (exampleFlag) {
-      templateId = exampleFlag;
-      useRemote = true;
-    } else if (templateFlag && (ALL_TEMPLATE_IDS as readonly string[]).includes(templateFlag)) {
+    if (templateFlag) {
       templateId = templateFlag;
     } else {
-      if (templateFlag) {
-        clack.log.warn(`Unknown template "${templateFlag}" — pick from the list below`);
-      }
-
       // Resolve full template list (bundled + remote)
       const allTemplates = await resolveTemplateList();
       const defaultTemplate = isAudioOnly ? "warm-grain" : "blank";
@@ -784,30 +748,27 @@ Examples:
         process.exit(0);
       }
       templateId = templateResult;
-
-      // Check if the selected template needs remote fetch
-      const selected = allTemplates.find((t: TemplateOption) => t.id === templateId);
-      if (selected?.source === "remote") {
-        useRemote = true;
-      }
     }
 
-    // 4. Copy template and patch
-    if (useRemote) {
-      const spin = clack.spinner();
+    // 4. Scaffold project (bundled templates are instant, remote templates download from GitHub)
+    const spin = clack.spinner();
+    const isBundled = BUNDLED_TEMPLATES.some((t) => t.id === templateId);
+    if (!isBundled) {
       spin.start(`Downloading template ${c.accent(templateId)}...`);
-      try {
-        await scaffoldProject(destDir, name, templateId, localVideoName, videoDuration, true);
-        spin.stop(c.success(`Downloaded ${templateId}`));
-      } catch (err) {
-        spin.stop(c.error(`Failed to download template`));
-        clack.log.error(
-          `${err instanceof Error ? err.message : err}\n${c.dim("Check your network connection or use --template blank for offline use.")}`,
-        );
-        process.exit(1);
-      }
-    } else {
+    }
+    try {
       await scaffoldProject(destDir, name, templateId, localVideoName, videoDuration);
+      if (!isBundled) {
+        spin.stop(c.success(`Downloaded ${templateId}`));
+      }
+    } catch (err) {
+      if (!isBundled) {
+        spin.stop(c.error("Download failed"));
+      }
+      clack.log.error(
+        `${err instanceof Error ? err.message : err}\n${c.dim("Use --template blank for offline use.")}`,
+      );
+      process.exit(1);
     }
     trackInitTemplate(templateId);
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -733,7 +733,7 @@ Examples:
     } else {
       // Resolve full template list (bundled + remote)
       const allTemplates = await resolveTemplateList();
-      const defaultTemplate = isAudioOnly ? "warm-grain" : "blank";
+      const defaultTemplate = "blank";
       const templateResult = await clack.select({
         message: "Pick a template",
         options: allTemplates.map((t: TemplateOption) => ({

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,7 +14,12 @@ import { execFileSync, spawn } from "node:child_process";
 import * as clack from "@clack/prompts";
 import { c } from "../ui/colors.js";
 import { printBanner } from "../ui/banner.js";
-import { TEMPLATES, type TemplateId } from "../templates/generators.js";
+import {
+  ALL_TEMPLATE_IDS,
+  resolveTemplateList,
+  type TemplateOption,
+} from "../templates/generators.js";
+import { fetchRemoteTemplate } from "../templates/remote.js";
 import { trackInitTemplate } from "../telemetry/events.js";
 import { hasFFmpeg } from "../whisper/manager.js";
 
@@ -79,8 +84,6 @@ async function installSkills(interactive: boolean): Promise<void> {
     }
   }
 }
-
-const ALL_TEMPLATE_IDS = TEMPLATES.map((t) => t.id);
 
 interface VideoMeta {
   durationSeconds: number;
@@ -357,17 +360,23 @@ async function handleVideoFile(
 // scaffoldProject — copy template, patch video refs, write meta.json
 // ---------------------------------------------------------------------------
 
-function scaffoldProject(
+async function scaffoldProject(
   destDir: string,
   name: string,
-  templateId: TemplateId,
+  templateId: string,
   localVideoName: string | undefined,
   durationSeconds?: number,
-): void {
+  forceRemote?: boolean,
+): Promise<void> {
   mkdirSync(destDir, { recursive: true });
 
+  // Try local bundled template first, fall back to remote fetch
   const templateDir = getStaticTemplateDir(templateId);
-  cpSync(templateDir, destDir, { recursive: true });
+  if (!forceRemote && existsSync(templateDir)) {
+    cpSync(templateDir, destDir, { recursive: true });
+  } else {
+    await fetchRemoteTemplate(templateId, destDir);
+  }
   patchVideoSrc(destDir, localVideoName, durationSeconds);
 
   writeFileSync(
@@ -424,6 +433,7 @@ Examples:
   hyperframes init my-video                            # interactive wizard
   hyperframes init my-video --template warm-grain      # pick a template
   hyperframes init my-video --video video.mp4          # with video file
+  hyperframes init my-video --example warm-grain         # fetch template from GitHub
   hyperframes init my-video --non-interactive           # skip prompts (CI/agents)`,
   },
   args: {
@@ -432,6 +442,11 @@ Examples:
       type: "string",
       description: `Template (${ALL_TEMPLATE_IDS.join(", ")})`,
       alias: "t",
+    },
+    example: {
+      type: "string",
+      description: "Fetch a template from GitHub (e.g. warm-grain)",
+      alias: "e",
     },
     video: {
       type: "string",
@@ -468,6 +483,7 @@ Examples:
   },
   async run({ args }) {
     const templateFlag = args.template;
+    const exampleFlag = args.example;
     const videoFlag = args.video;
     const audioFlag = args.audio;
     const skipSkills = args["skip-skills"] === true;
@@ -477,17 +493,23 @@ Examples:
     const languageFlag = args.language;
     const interactive = !nonInteractive && process.stdout.isTTY === true;
 
+    // --example always forces remote fetch
+    const forceRemote = exampleFlag !== undefined;
+    const effectiveTemplate = exampleFlag ?? templateFlag;
+
     // -----------------------------------------------------------------------
     // Non-interactive mode — all inputs from flags, defaults where missing
     // -----------------------------------------------------------------------
     if (!interactive) {
-      const resolvedTemplate = templateFlag ?? "blank";
-      if (!ALL_TEMPLATE_IDS.includes(resolvedTemplate as TemplateId)) {
+      const resolvedTemplate = effectiveTemplate ?? "blank";
+      // For --example, any template ID is valid (fetched from GitHub)
+      if (!forceRemote && !(ALL_TEMPLATE_IDS as readonly string[]).includes(resolvedTemplate)) {
         console.error(c.error(`Unknown template: ${resolvedTemplate}`));
         console.error(`Available: ${ALL_TEMPLATE_IDS.join(", ")}`);
+        console.error(c.dim("Tip: use --example to fetch any template from GitHub"));
         process.exit(1);
       }
-      const templateId = resolvedTemplate as TemplateId;
+      const templateId = resolvedTemplate;
       const name = args.name ?? "my-video";
       const destDir = resolve(name);
 
@@ -557,7 +579,31 @@ Examples:
       }
 
       // Scaffold
-      scaffoldProject(destDir, basename(destDir), templateId, localVideoName, videoDuration);
+      if (forceRemote) {
+        console.log(`Downloading template ${c.accent(templateId)} from GitHub...`);
+      }
+      try {
+        await scaffoldProject(
+          destDir,
+          basename(destDir),
+          templateId,
+          localVideoName,
+          videoDuration,
+          forceRemote,
+        );
+      } catch (err) {
+        console.error(
+          c.error(
+            `Failed to fetch template "${templateId}": ${err instanceof Error ? err.message : err}`,
+          ),
+        );
+        if (forceRemote) {
+          console.error(
+            c.dim("Check your network connection or use --template blank for offline use."),
+          );
+        }
+        process.exit(1);
+      }
       trackInitTemplate(templateId);
       const transcriptFile = resolve(destDir, "transcript.json");
       if (existsSync(transcriptFile)) {
@@ -707,38 +753,68 @@ Examples:
       }
     }
 
-    // 3. Pick template — skip prompt if --template was provided
-    let templateId: TemplateId;
-    if (templateFlag && ALL_TEMPLATE_IDS.includes(templateFlag as TemplateId)) {
-      templateId = templateFlag as TemplateId;
+    // 3. Pick template — skip prompt if --template or --example was provided
+    let templateId: string;
+    let useRemote = forceRemote;
+
+    if (exampleFlag) {
+      templateId = exampleFlag;
+      useRemote = true;
+    } else if (templateFlag && (ALL_TEMPLATE_IDS as readonly string[]).includes(templateFlag)) {
+      templateId = templateFlag;
     } else {
       if (templateFlag) {
         clack.log.warn(`Unknown template "${templateFlag}" — pick from the list below`);
       }
+
+      // Resolve full template list (bundled + remote)
+      const allTemplates = await resolveTemplateList();
+      const defaultTemplate = isAudioOnly ? "warm-grain" : "blank";
       const templateResult = await clack.select({
         message: "Pick a template",
-        options: TEMPLATES.map((t) => ({
+        options: allTemplates.map((t: TemplateOption) => ({
           value: t.id,
           label: t.label,
-          hint: t.hint,
+          hint: t.source === "remote" ? `${t.hint} (download)` : t.hint,
         })),
-        initialValue: "blank" as TemplateId,
+        initialValue: defaultTemplate,
       });
       if (clack.isCancel(templateResult)) {
         clack.cancel("Setup cancelled.");
         process.exit(0);
       }
       templateId = templateResult;
+
+      // Check if the selected template needs remote fetch
+      const selected = allTemplates.find((t: TemplateOption) => t.id === templateId);
+      if (selected?.source === "remote") {
+        useRemote = true;
+      }
     }
 
     // 4. Copy template and patch
-    scaffoldProject(destDir, name, templateId, localVideoName, videoDuration);
+    if (useRemote) {
+      const spin = clack.spinner();
+      spin.start(`Downloading template ${c.accent(templateId)}...`);
+      try {
+        await scaffoldProject(destDir, name, templateId, localVideoName, videoDuration, true);
+        spin.stop(c.success(`Downloaded ${templateId}`));
+      } catch (err) {
+        spin.stop(c.error(`Failed to download template`));
+        clack.log.error(
+          `${err instanceof Error ? err.message : err}\n${c.dim("Check your network connection or use --template blank for offline use.")}`,
+        );
+        process.exit(1);
+      }
+    } else {
+      await scaffoldProject(destDir, name, templateId, localVideoName, videoDuration);
+    }
     trackInitTemplate(templateId);
 
     // 4b. Patch captions with transcript if available
     const transcriptFile = resolve(destDir, "transcript.json");
     if (existsSync(transcriptFile)) {
-      patchTranscript(destDir, transcriptFile);
+      await patchTranscript(destDir, transcriptFile);
     }
 
     // 5. Install AI coding skills

--- a/packages/cli/src/templates/generators.ts
+++ b/packages/cli/src/templates/generators.ts
@@ -1,23 +1,5 @@
 import { listRemoteTemplates, type RemoteTemplateInfo } from "./remote.js";
 
-/**
- * All known template IDs (bundled + remote).
- * Used for --template validation and help text.
- */
-export const ALL_TEMPLATE_IDS = [
-  "blank",
-  "warm-grain",
-  "play-mode",
-  "swiss-grid",
-  "vignelli",
-  "decision-tree",
-  "kinetic-type",
-  "product-promo",
-  "nyt-graph",
-] as const;
-
-export type TemplateId = (typeof ALL_TEMPLATE_IDS)[number];
-
 export type TemplateSource = "bundled" | "remote";
 
 export interface TemplateOption {
@@ -39,7 +21,8 @@ export const BUNDLED_TEMPLATES: TemplateOption[] = [
 
 /**
  * Resolve the full template list by merging bundled and remote templates.
- * If remote fetch fails (offline), returns only bundled templates.
+ * Fetches templates.json from GitHub (cached 24h). No CLI release needed to add templates.
+ * If offline, returns only bundled templates.
  */
 export async function resolveTemplateList(): Promise<TemplateOption[]> {
   const bundled = [...BUNDLED_TEMPLATES];

--- a/packages/cli/src/templates/generators.ts
+++ b/packages/cli/src/templates/generators.ts
@@ -1,32 +1,65 @@
-export type TemplateId =
-  | "blank"
-  | "warm-grain"
-  | "play-mode"
-  | "swiss-grid"
-  | "vignelli"
-  | "decision-tree"
-  | "kinetic-type"
-  | "product-promo"
-  | "nyt-graph";
+import { listRemoteTemplates, type RemoteTemplateInfo } from "./remote.js";
+
+/**
+ * All known template IDs (bundled + remote).
+ * Used for --template validation and help text.
+ */
+export const ALL_TEMPLATE_IDS = [
+  "blank",
+  "warm-grain",
+  "play-mode",
+  "swiss-grid",
+  "vignelli",
+  "decision-tree",
+  "kinetic-type",
+  "product-promo",
+  "nyt-graph",
+] as const;
+
+export type TemplateId = (typeof ALL_TEMPLATE_IDS)[number];
+
+export type TemplateSource = "bundled" | "remote";
 
 export interface TemplateOption {
-  id: TemplateId;
+  id: string;
   label: string;
   hint: string;
+  source: TemplateSource;
 }
 
-export const TEMPLATES: TemplateOption[] = [
-  { id: "blank", label: "Blank", hint: "Empty composition — just the scaffolding" },
-  { id: "warm-grain", label: "Warm Grain", hint: "Cream aesthetic with grain texture" },
-  { id: "play-mode", label: "Play Mode", hint: "Playful elastic animations" },
-  { id: "swiss-grid", label: "Swiss Grid", hint: "Structured grid layout" },
-  { id: "vignelli", label: "Vignelli", hint: "Bold typography with red accents" },
-  { id: "decision-tree", label: "Decision Tree", hint: "Animated flowchart with branching paths" },
-  { id: "kinetic-type", label: "Kinetic Type", hint: "Bold kinetic typography promo" },
+/** Templates bundled in the CLI package (available offline). */
+export const BUNDLED_TEMPLATES: TemplateOption[] = [
   {
-    id: "product-promo",
-    label: "Product Promo",
-    hint: "Multi-scene product showcase with SVG assets",
+    id: "blank",
+    label: "Blank",
+    hint: "Empty composition — just the scaffolding",
+    source: "bundled",
   },
-  { id: "nyt-graph", label: "NYT Graph", hint: "Animated data chart in print editorial style" },
 ];
+
+/**
+ * Resolve the full template list by merging bundled and remote templates.
+ * If remote fetch fails (offline), returns only bundled templates.
+ */
+export async function resolveTemplateList(): Promise<TemplateOption[]> {
+  const bundled = [...BUNDLED_TEMPLATES];
+  const bundledIds = new Set(bundled.map((t) => t.id));
+
+  let remote: RemoteTemplateInfo[] = [];
+  try {
+    remote = await listRemoteTemplates();
+  } catch {
+    // Offline — return bundled only
+  }
+
+  const remoteOptions: TemplateOption[] = remote
+    .filter((r) => !r.bundled && !bundledIds.has(r.id))
+    .map((r) => ({
+      id: r.id,
+      label: r.label,
+      hint: r.hint,
+      source: "remote" as const,
+    }));
+
+  return [...bundled, ...remoteOptions];
+}

--- a/packages/cli/src/templates/remote.ts
+++ b/packages/cli/src/templates/remote.ts
@@ -78,12 +78,26 @@ export async function fetchRemoteTemplate(
   destDir: string,
   options?: { ref?: string },
 ): Promise<void> {
+  // Validate against manifest before downloading
+  const known = await listRemoteTemplates();
+  if (known.length > 0 && !known.some((t) => t.id === templateId)) {
+    const available = known.map((t) => t.id).join(", ");
+    throw new Error(`Template "${templateId}" not found. Available: ${available}`);
+  }
+
   const { downloadTemplate } = await import("giget");
   const ref = options?.ref ?? "main";
   const source = `github:${REPO}/${TEMPLATES_DIR}/${templateId}#${ref}`;
 
   await downloadTemplate(source, {
     dir: destDir,
-    force: true, // overwrite if dir exists
+    force: true,
   });
+
+  // Safety check — giget can succeed with empty dir if path doesn't exist
+  if (!existsSync(join(destDir, "index.html"))) {
+    throw new Error(
+      `Template "${templateId}" downloaded but missing index.html. The template may be malformed.`,
+    );
+  }
 }

--- a/packages/cli/src/templates/remote.ts
+++ b/packages/cli/src/templates/remote.ts
@@ -1,0 +1,89 @@
+/**
+ * Remote Template Fetching
+ *
+ * Downloads templates from the hyperframes GitHub repository using giget.
+ * Templates live in the `examples/` directory of the repo.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const REPO = "heygen-com/hyperframes";
+const EXAMPLES_DIR = "examples";
+const MANIFEST_FILENAME = "templates.json";
+
+/** Cache directory for remote template metadata. */
+const CACHE_DIR = join(homedir(), ".hyperframes", "cache");
+const MANIFEST_CACHE_PATH = join(CACHE_DIR, "remote-templates.json");
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export interface RemoteTemplateInfo {
+  id: string;
+  label: string;
+  hint: string;
+  bundled: boolean;
+}
+
+interface ManifestCache {
+  fetchedAt: number;
+  templates: RemoteTemplateInfo[];
+}
+
+/**
+ * Fetch the remote template manifest from GitHub.
+ * Caches the result for 24 hours to avoid rate limits.
+ */
+export async function listRemoteTemplates(): Promise<RemoteTemplateInfo[]> {
+  // Check cache first
+  if (existsSync(MANIFEST_CACHE_PATH)) {
+    try {
+      const cached: ManifestCache = JSON.parse(readFileSync(MANIFEST_CACHE_PATH, "utf-8"));
+      if (Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+        return cached.templates;
+      }
+    } catch {
+      // Cache corrupt — refetch
+    }
+  }
+
+  // Fetch from GitHub raw content
+  const url = `https://raw.githubusercontent.com/${REPO}/main/${EXAMPLES_DIR}/${MANIFEST_FILENAME}`;
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const data = (await res.json()) as { templates: RemoteTemplateInfo[] };
+    const templates = data.templates;
+
+    // Write cache
+    mkdirSync(CACHE_DIR, { recursive: true });
+    const cache: ManifestCache = { fetchedAt: Date.now(), templates };
+    writeFileSync(MANIFEST_CACHE_PATH, JSON.stringify(cache), "utf-8");
+
+    return templates;
+  } catch {
+    // Offline or rate-limited — return empty (caller should fall back to bundled)
+    return [];
+  }
+}
+
+/**
+ * Download a template from GitHub into destDir using giget.
+ * Fetches from `examples/<templateId>` in the hyperframes repo.
+ */
+export async function fetchRemoteTemplate(
+  templateId: string,
+  destDir: string,
+  options?: { ref?: string },
+): Promise<void> {
+  const { downloadTemplate } = await import("giget");
+  const ref = options?.ref ?? "main";
+  const source = `github:${REPO}/${EXAMPLES_DIR}/${templateId}#${ref}`;
+
+  await downloadTemplate(source, {
+    dir: destDir,
+    force: true, // overwrite if dir exists
+  });
+}

--- a/packages/cli/src/templates/remote.ts
+++ b/packages/cli/src/templates/remote.ts
@@ -2,7 +2,7 @@
  * Remote Template Fetching
  *
  * Downloads templates from the hyperframes GitHub repository using giget.
- * Templates live in the `examples/` directory of the repo.
+ * Templates live in the `templates/` directory of the repo.
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 const REPO = "heygen-com/hyperframes";
-const EXAMPLES_DIR = "examples";
+const TEMPLATES_DIR = "templates";
 const MANIFEST_FILENAME = "templates.json";
 
 /** Cache directory for remote template metadata. */
@@ -48,7 +48,7 @@ export async function listRemoteTemplates(): Promise<RemoteTemplateInfo[]> {
   }
 
   // Fetch from GitHub raw content
-  const url = `https://raw.githubusercontent.com/${REPO}/main/${EXAMPLES_DIR}/${MANIFEST_FILENAME}`;
+  const url = `https://raw.githubusercontent.com/${REPO}/main/${TEMPLATES_DIR}/${MANIFEST_FILENAME}`;
   try {
     const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
     if (!res.ok) {
@@ -80,7 +80,7 @@ export async function fetchRemoteTemplate(
 ): Promise<void> {
   const { downloadTemplate } = await import("giget");
   const ref = options?.ref ?? "main";
-  const source = `github:${REPO}/${EXAMPLES_DIR}/${templateId}#${ref}`;
+  const source = `github:${REPO}/${TEMPLATES_DIR}/${templateId}#${ref}`;
 
   await downloadTemplate(source, {
     dir: destDir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      giget:
+        specifier: ^3.2.0
+        version: 3.2.0
       linkedom:
         specifier: ^0.18.12
         version: 0.18.12
@@ -117,6 +120,9 @@ importers:
       '@chenglou/pretext':
         specifier: ^0.0.3
         version: 0.0.3
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.9
     devDependencies:
       '@types/jsdom':
         specifier: ^28.0.0
@@ -2447,6 +2453,10 @@ packages:
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  giget@3.2.0:
+    resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
+    hasBin: true
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
@@ -5449,6 +5459,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  giget@3.2.0: {}
 
   git-raw-commits@5.0.1(conventional-commits-parser@6.3.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
+      giget:
+        specifier: ^3.2.0
+        version: 3.2.0
       hono:
         specifier: ^4.0.0
         version: 4.12.9
@@ -93,9 +96,6 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
-      giget:
-        specifier: ^3.2.0
-        version: 3.2.0
       linkedom:
         specifier: ^0.18.12
         version: 0.18.12


### PR DESCRIPTION
## What

Add remote template fetching via `giget` so templates are downloaded from GitHub at runtime. Only `blank` is bundled for offline use. Adding new templates requires no CLI release.

## Why

Following the pattern of `create-next-app` and `create-astro` — templates are fetched from GitHub. This keeps the CLI package small and allows templates to be added/updated by just pushing to the repo.

## How

- **Single `--template` flag** handles both bundled and remote templates seamlessly
- **`packages/cli/src/templates/remote.ts`**: Uses `giget` to download from `github:heygen-com/hyperframes/templates/<id>`. Fetches `templates.json` manifest from GitHub (cached 24h). Validates template ID against manifest before downloading.
- **`generators.ts`**: Only `BUNDLED_TEMPLATES` (blank) + `resolveTemplateList()` that merges bundled + remote from GitHub manifest. No static template ID list.
- **`init.ts`**: `scaffoldProject` checks bundled first, falls back to remote. Interactive picker fetches template list from GitHub. Error handling with clear offline fallback messaging.

## Adding a new template (no CLI release needed)

1. Add template directory to `templates/<name>/`
2. Add entry to `templates/templates.json`
3. Push to main — users get it immediately via `--template <name>`

## Test plan

- [x] `--template blank` works offline (bundled)
- [x] `--template warm-grain` fetches from GitHub
- [x] `--template totally-fake` fails fast with available template list
- [x] Interactive picker shows bundled + remote templates