### PR TITLE
fix(producer): hoist CDN scripts and rewrite asset paths from sub-compositions

### DIFF
--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -490,6 +490,7 @@ function inlineSubCompositions(
 
   const collectedStyles: string[] = [];
   const collectedScripts: string[] = [];
+  const collectedExternalScriptSrcs: string[] = [];
 
   for (const host of hosts) {
     const srcPath = host.getAttribute("data-composition-src");
@@ -541,7 +542,15 @@ function inlineSubCompositions(
 
     for (const scriptEl of contentDoc.querySelectorAll("script")) {
       const src = (scriptEl.getAttribute("src") || "").trim();
-      if (src) continue;
+      if (src) {
+        // External CDN/remote script — collect for deduped hoisting into the
+        // parent document, mirroring the core bundler's behavior.
+        if (!collectedExternalScriptSrcs.includes(src)) {
+          collectedExternalScriptSrcs.push(src);
+        }
+        scriptEl.remove();
+        continue;
+      }
       const content = (scriptEl.textContent || "").trim();
       if (content) {
         const scriptMountCompId = compId || inferredCompId || "";
@@ -567,6 +576,36 @@ function inlineSubCompositions(
 })()`);
       }
       scriptEl.remove();
+    }
+
+    // Rewrite relative asset paths (src, href) so they resolve correctly after
+    // inlining. A sub-composition at "compositions/scene.html" referencing
+    // "../icon.svg" means the project root — but after inlining into root
+    // index.html, "../" escapes the project. Resolve each relative path
+    // against the sub-composition's directory, then normalize to project root.
+    const compDir = dirname(srcPath);
+    if (compDir && compDir !== ".") {
+      const rewriteTarget = innerRoot || contentDoc;
+      for (const el of rewriteTarget.querySelectorAll("[src], [href]")) {
+        for (const attr of ["src", "href"] as const) {
+          const val = (el.getAttribute(attr) || "").trim();
+          if (
+            !val ||
+            val.startsWith("http://") ||
+            val.startsWith("https://") ||
+            val.startsWith("//") ||
+            val.startsWith("data:") ||
+            val.startsWith("#")
+          ) {
+            continue;
+          }
+          const resolved = join(compDir, val);
+          const normalized = resolve("/", resolved).slice(1);
+          if (normalized !== val) {
+            el.setAttribute(attr, normalized);
+          }
+        }
+      }
     }
 
     if (innerRoot) {
@@ -622,6 +661,25 @@ function inlineSubCompositions(
     const styleEl = document.createElement("style");
     styleEl.textContent = collectedStyles.join("\n\n");
     head.appendChild(styleEl);
+  }
+
+  // Inject hoisted external CDN scripts before inline scripts so plugins
+  // (e.g. TextPlugin, ScrollTrigger) are registered before composition code
+  // runs. Deduplicate against scripts already present in the document.
+  if (collectedExternalScriptSrcs.length && body) {
+    const existingScriptSrcs = new Set(
+      Array.from(document.querySelectorAll("script[src]")).map((el) =>
+        (el.getAttribute("src") || "").trim(),
+      ),
+    );
+    for (const src of collectedExternalScriptSrcs) {
+      if (!existingScriptSrcs.has(src)) {
+        const scriptEl = document.createElement("script");
+        scriptEl.setAttribute("src", src);
+        body.appendChild(scriptEl);
+        existingScriptSrcs.add(src);
+      }
+    }
   }
 
   if (collectedScripts.length && body) {


### PR DESCRIPTION
## Summary

Two bugs in the producer's `inlineSubCompositions` that break sub-composition assets during `hyperframes render`:

- **External CDN scripts silently discarded** — sub-composition `<script src="...TextPlugin.min.js">` was skipped (`if (src) continue`) then deleted by `querySelectorAll("style, script").forEach(remove)`, causing `ReferenceError` at render time
- **Relative asset paths broken after inlining** — `../icon.svg` in `compositions/scene.html` resolves to project root, but after inlining into root `index.html` the `../` escapes the project and the browser 404s

## Fixes

**CDN script hoisting**: Mirrors the core bundler's approach — collect external script `src` URLs, deduplicate against the parent document, inject as `<script>` tags before inline composition scripts so plugins register first.

**Path rewriting**: Before inlining, resolves each relative `src`/`href` against the sub-composition's directory, then normalizes to be relative to the project root.

Supersedes #164 (includes that fix plus the path rewriting).

## How to reproduce

**Script bug:**
```html
<!-- compositions/scene.html -->
<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/TextPlugin.min.js"></script>
<script>gsap.registerPlugin(TextPlugin); /* ... */</script>
```
`hyperframes render` → `ReferenceError: TextPlugin is not defined`

**Path bug:**
```html
<!-- compositions/scene.html -->
<img src="../v0-icon.svg" />
```
`hyperframes render` → broken image (404)

## Test plan

- [ ] Render project with TextPlugin in sub-composition — no `ReferenceError`
- [ ] Render project with `<img src="../asset.svg">` in sub-composition — image renders
- [ ] CDN scripts deduped (same URL in 2 sub-compositions → 1 `<script>` tag)
- [ ] CDN scripts already in `index.html` are not duplicated
- [ ] Paths that don't need rewriting (absolute, http, data:, #) are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)