### PR TITLE
fix(skills): default to non-.en whisper models to prevent silent translation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,13 +111,13 @@ Default is `small.en`. Upgrade for better accuracy:
 
 | Model       | Size   | Use case                         |
 | ----------- | ------ | -------------------------------- |
-| `tiny.en`   | 75 MB  | Quick testing                    |
-| `base.en`   | 142 MB | Short clips, clear audio         |
-| `small.en`  | 466 MB | **Default** — most content       |
-| `medium.en` | 1.5 GB | Important content, noisy audio   |
-| `large-v3`  | 3.1 GB | Multilingual, production quality |
+| `tiny`      | 75 MB  | Quick testing                    |
+| `base`      | 142 MB | Short clips, clear audio         |
+| `small`     | 466 MB | **Default** — most content       |
+| `medium`    | 1.5 GB | Important content, noisy audio   |
+| `large-v3`  | 3.1 GB | Production quality               |
 
-Use `.en` suffix for English-only (more accurate). Drop it for multilingual content.
+**Only use `.en` suffix when you know the audio is English.** `.en` models translate non-English audio into English instead of transcribing it.
 
 ### Supported transcript formats
 

--- a/skills/hyperframes-captions/SKILL.md
+++ b/skills/hyperframes-captions/SKILL.md
@@ -6,6 +6,19 @@ trigger: Use this skill whenever a task involves syncing text to audio timing. T
 
 # Captions
 
+## Language Rule (Non-Negotiable)
+
+**Never use `.en` models unless the user explicitly states the audio is English.** `.en` models (small.en, medium.en) TRANSLATE non-English audio into English instead of transcribing it. This silently destroys the original language.
+
+When transcribing:
+1. If the user says the language → use `--model small --language <code>` (no `.en` suffix)
+2. If the user says it's English → use `--model small.en`
+3. If the language is unknown → use `--model small` (no `.en`, no `--language`) — whisper auto-detects
+
+**Default model is `small` (not `small.en`).** Only add `.en` when explicitly told the audio is English.
+
+---
+
 Analyze the spoken content to determine caption style. If the user specifies a style, use that. Otherwise, detect tone from the transcript.
 
 ## Transcript Source

--- a/skills/hyperframes-captions/transcript-guide.md
+++ b/skills/hyperframes-captions/transcript-guide.md
@@ -40,13 +40,13 @@ The default model (`small.en`) balances accuracy and speed. For better results, 
 
 | Model       | Size   | Speed    | Accuracy  | When to use                           |
 | ----------- | ------ | -------- | --------- | ------------------------------------- |
-| `tiny.en`   | 75 MB  | Fastest  | Low       | Quick previews, testing pipeline      |
-| `base.en`   | 142 MB | Fast     | Fair      | Short clips, clear audio              |
-| `small.en`  | 466 MB | Moderate | Good      | **Default** — good for most content   |
-| `medium.en` | 1.5 GB | Slow     | Very good | Important content, noisy audio, music |
-| `large-v3`  | 3.1 GB | Slowest  | Best      | Multilingual, production captions     |
+| `tiny`      | 75 MB  | Fastest  | Low       | Quick previews, testing pipeline      |
+| `base`      | 142 MB | Fast     | Fair      | Short clips, clear audio              |
+| `small`     | 466 MB | Moderate | Good      | **Default** — good for most content   |
+| `medium`    | 1.5 GB | Slow     | Very good | Important content, noisy audio, music |
+| `large-v3`  | 3.1 GB | Slowest  | Best      | Production quality                    |
 
-`.en` models are English-only and more accurate for English. Drop the `.en` suffix for multilingual (e.g., `medium` instead of `medium.en`).
+**Only add `.en` suffix when the user explicitly says the audio is English.** `.en` models are slightly more accurate for English but will TRANSLATE non-English audio instead of transcribing it.
 
 **Critical: `.en` models translate non-English audio into English** — they don't transcribe it. If the audio might not be English, always use a model without the `.en` suffix and pass `--language` to specify the source language. If you're unsure of the language, use `small` (not `small.en`) without `--language` — whisper will auto-detect.
 


### PR DESCRIPTION
## Summary

- `.en` whisper models (small.en, medium.en) translate non-English audio into English instead of transcribing it, silently destroying the original language
- Added non-negotiable language rule to captions skill: never use `.en` unless user explicitly says audio is English
- Updated default model tables in SKILL.md, transcript-guide.md, and CLAUDE.md from `.en` variants to multilingual models
- The transcribe CLI already has language auto-detection — this fix ensures agents don't bypass it by specifying `.en` models directly

## Test plan

- [ ] Run `hyperframes transcribe` on non-English audio without specifying a model — should transcribe in original language, not translate
- [ ] Verify captions skill instructions clearly state the language rule at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)