### PR TITLE
feat(skills): add marker-highlight skill for canvas-based text emphasis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This repo ships skills that are installed globally via `npx hyperframes skills` 
 | ------------------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **hyperframes-compose**  | `/hyperframes-compose`  | Creating ANY HTML composition — videos, animations, title cards, overlays. Contains required HTML structure, `class="clip"` rules, GSAP timeline patterns, and rendering constraints. |
 | **hyperframes-captions** | `/hyperframes-captions` | Any task involving text synced to audio: captions, subtitles, lyrics, lyric videos, karaoke. Also covers transcription strategy (whisper model selection, transcript format).         |
+| **marker-highlight**     | `/marker-highlight`     | Canvas-based animated text highlighting — marker sweeps, hand-drawn circles, burst lines, scribble underlines, sketchout effects. Use with captions for dynamic emphasis.             |
 
 ### GSAP Skills (from [greensock/gsap-skills](https://github.com/greensock/gsap-skills))
 
@@ -34,6 +35,7 @@ The skills encode HyperFrames-specific patterns (e.g., required `class="clip"` o
 - When creating a video from audio (music video, lyric video, audio visualizer with text) → invoke BOTH `/hyperframes-compose` AND `/hyperframes-captions`
 - When writing GSAP animations → invoke `/gsap-core` and `/gsap-timeline` BEFORE writing any code
 - When optimizing animation performance → invoke `/gsap-performance` BEFORE making changes
+- When adding animated text emphasis (highlight sweeps, circles, bursts, scribbles) → invoke `/marker-highlight` BEFORE writing any code
 - After creating or editing any `.html` composition → run `npx hyperframes lint` and `npx hyperframes validate` in parallel, fix all errors before opening the studio or considering the task complete. `lint` checks the HTML structure statically; `validate` loads the composition in headless Chrome and catches runtime JS errors, missing assets, and failed network requests. Always validate before `npx hyperframes preview`.
 
 ### Installing skills
@@ -44,7 +46,6 @@ npx skills add greensock/gsap-skills     # GSAP skills
 ```
 
 Uses [vercel-labs/skills](https://github.com/vercel-labs/skills). Installs to Claude Code, Gemini CLI, and Codex CLI by default. Pass `-a <agent>` for other targets.
-
 
 ## Project Overview
 

--- a/skills/hyperframes-captions/SKILL.md
+++ b/skills/hyperframes-captions/SKILL.md
@@ -20,7 +20,6 @@ When transcribing:
 
 ---
 
-
 Analyze the spoken content to determine caption style. If the user specifies a style, use that. Otherwise, detect tone from the transcript.
 
 ## Transcript Source
@@ -98,6 +97,7 @@ For each detected word, specify:
 - Color override (specific hex value)
 - Weight/style change (bolder, italic)
 - Animation variant (overshoot entrance, glow pulse, scale pop)
+- **Marker highlight mode** — for visual emphasis beyond color/scale, add a marker-style effect: highlight sweep behind the word, hand-drawn circle around it, burst lines radiating from it, or scribble underline beneath it. See the `/marker-highlight` skill for CSS+GSAP patterns for all five modes and the energy-to-mode mapping table.
 
 ## Script-to-Style Mapping
 
@@ -198,6 +198,8 @@ Place this **before** `window.__timelines[id] = tl` so it runs at composition in
 ## References
 
 For dynamic animation techniques (karaoke, clip-path reveals, slam words, scatter exits, elastic entrances, 3D rotation, audio-reactive captions, pretext-based positioning and grouping), see [dynamic-techniques.md](./dynamic-techniques.md).
+
+For canvas-based text emphasis (highlight sweeps, hand-drawn circles, burst lines, scribble underlines, sketchout effects) that pairs with per-word styling, see the `/marker-highlight` skill.
 
 For transcription commands, whisper models, external APIs, and troubleshooting, see [transcript-guide.md](./transcript-guide.md).
 

--- a/skills/hyperframes-captions/dynamic-techniques.md
+++ b/skills/hyperframes-captions/dynamic-techniques.md
@@ -16,6 +16,8 @@ You are here because SKILL.md told you to read this file before writing animatio
 
 **Emphasis words always break the pattern.** When a word is flagged as emphasis (emotional keyword, ALL CAPS, brand name), give it a stronger animation than surrounding words (larger scale, accent color, overshoot ease). This creates contrast.
 
+**Marker highlight modes add a visual layer on top of karaoke.** For emphasis words that need more than color/scale, add a marker-style effect — highlight sweep, circle, burst, or scribble — using the CSS+GSAP patterns from the `/marker-highlight` skill. Match mode to energy: burst for hype, circle for key terms, highlight for standard, scribble for subtle.
+
 ## Audio-Reactive Captions (Mandatory for Music)
 
 **If the source audio is music (vocals over instrumentation, beats, any musical content), you MUST extract audio data and add audio-reactive animations.** This is not optional — music without audio reactivity looks disconnected. Even low-energy ballads get subtle bass pulse and treble glow.
@@ -73,6 +75,8 @@ python3 skills/gsap-effects/scripts/extract-audio-data.py audio.mp3 --fps 30 --b
 ## Combining Techniques
 
 Don't use the same highlight animation on every group — cycle through styles using the group index. Don't combine multiple competing animations on the same word at the same timestamp. Vary techniques across groups to match the content's pace changes.
+
+**Marker highlight effects** (from the `/marker-highlight` skill) layer well with karaoke — use karaoke for the word-by-word reveal, then add a marker effect on emphasis words only. For example: karaoke highlights each word in white, but brand names get a yellow highlight sweep and stats get a red circle. Cycle marker modes across groups for visual variety (see the mode-to-energy mapping in the marker-highlight skill).
 
 ## Available Tools
 

--- a/skills/marker-highlight/SKILL.md
+++ b/skills/marker-highlight/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: marker-highlight
+description: Canvas-based animated text highlighting for HyperFrames captions using MarkerHighlight.js. Five drawing modes (highlight, circle, burst, scribble, sketchout) for dynamic emphasis in video compositions.
+trigger: When captions or text overlays need animated highlighting, marker-style emphasis, hand-drawn circles, burst effects, scribble underlines, or canvas-based text decoration in HyperFrames compositions.
+---
+
+# Marker Highlight
+
+Canvas-based animated text highlighting for HyperFrames compositions. Uses [MarkerHighlight.js](https://marker-highlight.solarise.dev/) to add dynamic, hand-drawn-style emphasis to text — highlight sweeps, circles, bursts, scribbles, and sketchouts rendered on a `<canvas>` overlay.
+
+## When to Use
+
+Use this skill when captions or text overlays need visual emphasis beyond simple color changes:
+
+- **Highlight mode** — yellow marker sweep behind important words
+- **Circle mode** — hand-drawn circle around key terms
+- **Burst mode** — radiating lines from emphasized text
+- **Scribble mode** — wavy underlines or strikethroughs
+- **Sketchout mode** — cross-hatch deletion effect
+
+Combine with the `hyperframes-captions` skill for tone-adaptive captions that use marker highlighting as the emphasis mechanism.
+
+## Setup
+
+Load MarkerHighlight.js from CDN inside the composition:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/marker-highlight@latest/dist/marker-highlight.min.js"></script>
+```
+
+The library attaches `MarkerHighlight` to the global scope. No import/export — use it directly in composition scripts.
+
+## Basic Pattern
+
+```html
+<div id="caption-text">This is <span class="mh-target">important</span> information</div>
+
+<script>
+  // Create instance AFTER DOM is ready
+  var marker = new MarkerHighlight({
+    color: "#FDD835",
+    mode: "highlight",
+    animation: {
+      duration: 600,
+      delay: 0,
+    },
+  });
+
+  // Mark target elements — canvas overlay is created automatically
+  marker.mark(".mh-target");
+</script>
+```
+
+## Configuration Reference
+
+```js
+var marker = new MarkerHighlight({
+  // Drawing mode (required)
+  mode: "highlight", // 'highlight' | 'circle' | 'burst' | 'scribble' | 'sketchout'
+
+  // Color (any CSS color)
+  color: "#FDD835",
+
+  // Animation timing
+  animation: {
+    duration: 600, // ms — total draw time
+    delay: 0, // ms — wait before starting
+  },
+
+  // Mode-specific options
+  padding: 4, // px — space around text (highlight, circle)
+  height: 0.35, // 0-1 — highlight bar height relative to text
+  skew: -2, // degrees — highlight bar angle
+  wave: 0.02, // 0-1 — waviness for scribble/circle
+  lineWidth: 3, // px — stroke width for circle/scribble/burst
+  burstLines: 12, // number of burst rays
+  burstLength: 40, // px — burst ray length
+});
+```
+
+## Integration with GSAP Timelines
+
+MarkerHighlight.js uses its own animation system, which conflicts with HyperFrames' deterministic frame-by-frame capture. **Do not use MarkerHighlight's built-in animation in rendered compositions.** Instead, use the canvas-based rendering for the visual style and control timing with GSAP.
+
+### Pattern: GSAP-Controlled Marker Highlighting
+
+```js
+window.__timelines = window.__timelines || {};
+var tl = gsap.timeline({ paused: true });
+
+// 1. Create marker with animation disabled (duration: 0)
+var marker = new MarkerHighlight({
+  color: "#FDD835",
+  mode: "highlight",
+  animation: { duration: 0, delay: 0 },
+});
+
+// 2. Mark targets — creates canvas but draws instantly (0ms duration)
+marker.mark(".mh-target");
+
+// 3. Get the canvas element MarkerHighlight created
+var canvas = document.querySelector(".marker-highlight-canvas");
+
+// 4. Control visibility via GSAP
+gsap.set(canvas, { opacity: 0 });
+tl.to(canvas, { opacity: 1, duration: 0.3, ease: "power2.out" }, 1.0);
+tl.to(canvas, { opacity: 0, duration: 0.2, ease: "power2.in" }, 3.0);
+
+window.__timelines["my-comp"] = tl;
+```
+
+### Pattern: CSS Simulation (No Library Dependency)
+
+For deterministic rendering without external dependencies, simulate MarkerHighlight's visual effects with pure CSS + GSAP. This is the **recommended approach** for production compositions:
+
+```html
+<!-- Highlight mode: colored bar behind text -->
+<div class="marker-hl-wrapper">
+  <div class="marker-hl-bar" id="hl-bar-1"></div>
+  <span class="marker-hl-text">highlighted text</span>
+</div>
+
+<style>
+  .marker-hl-wrapper {
+    position: relative;
+    display: inline-block;
+  }
+  .marker-hl-bar {
+    position: absolute;
+    top: 0;
+    left: -6px;
+    right: -6px;
+    bottom: 0;
+    background: #fdd835;
+    opacity: 0.35;
+    transform: scaleX(0);
+    transform-origin: left center;
+    border-radius: 3px;
+    z-index: 0;
+  }
+  .marker-hl-text {
+    position: relative;
+    z-index: 1;
+  }
+</style>
+
+<script>
+  tl.to("#hl-bar-1", { scaleX: 1, duration: 0.5, ease: "power2.out" }, 0.6);
+</script>
+```
+
+See [css-patterns.md](./css-patterns.md) for all five modes implemented as CSS + GSAP.
+
+## Mode-to-Caption Mapping
+
+Match MarkerHighlight modes to caption energy levels detected by the `hyperframes-captions` skill:
+
+| Caption energy | Recommended mode      | Visual effect                            | Use for                                 |
+| -------------- | --------------------- | ---------------------------------------- | --------------------------------------- |
+| High           | `burst` + `highlight` | Radiating lines + sweep on hero words    | Product launches, hype videos           |
+| Medium-high    | `circle`              | Hand-drawn emphasis circles              | Key stats, important terms              |
+| Medium         | `highlight`           | Classic marker sweep                     | Standard emphasis, clean professional   |
+| Medium-low     | `scribble`            | Wavy underlines                          | Subtle emphasis, tutorials              |
+| Low            | `sketchout`           | Gentle cross-hatch on de-emphasized text | Storytelling, contrast with active text |
+
+## Per-Word Styling with Modes
+
+Different words in the same caption group can use different modes:
+
+```js
+// Hero word gets burst
+new MarkerHighlight({ mode: "burst", color: "#E53935" }).mark("#word-hero");
+
+// Supporting words get highlight
+new MarkerHighlight({ mode: "highlight", color: "#FDD835" }).mark(".word-support");
+
+// De-emphasized words get sketchout
+new MarkerHighlight({ mode: "sketchout", color: "#666" }).mark(".word-dim");
+```
+
+## Color Palette
+
+MarkerHighlight.js's default palette (from the library's documentation page):
+
+| Color  | Hex       | Use for                            |
+| ------ | --------- | ---------------------------------- |
+| Red    | `#E53935` | Circles, burst lines, alerts       |
+| Yellow | `#FDD835` | Highlight bars, primary emphasis   |
+| Blue   | `#1E88E5` | Burst accents, scribble underlines |
+| Black  | `#1a1a1a` | Background, sketchout              |
+| White  | `#fafafa` | Text on dark backgrounds           |
+
+Adapt to the composition's existing palette — these are starting points, not mandates.
+
+## Constraints
+
+- **Deterministic.** No `Math.random()`, no `Date.now()`. MarkerHighlight's internal randomness must be seeded or bypassed via CSS simulation.
+- **GSAP owns timing.** Never rely on MarkerHighlight's built-in animation timing — use `duration: 0` and control visibility with GSAP tweens.
+- **Canvas layering.** MarkerHighlight creates `<canvas>` overlays. Set appropriate `z-index` to keep canvas behind or in front of text as needed.
+- **Font loading.** Canvas-based highlighting measures text bounding boxes. Fonts must be fully loaded before calling `marker.mark()`. Use `font-display: block` and load fonts via `@font-face` or Google Fonts `@import`.
+
+## References
+
+- [css-patterns.md](./css-patterns.md) — Pure CSS + GSAP implementations of all five modes (recommended for deterministic rendering)
+- [MarkerHighlight.js docs](https://marker-highlight.solarise.dev/) — Library documentation and interactive demos

--- a/skills/marker-highlight/css-patterns.md
+++ b/skills/marker-highlight/css-patterns.md
@@ -1,0 +1,363 @@
+# CSS Patterns for Marker Highlighting
+
+Pure CSS + GSAP implementations of all five MarkerHighlight.js drawing modes. Use these for deterministic rendering in HyperFrames compositions — no external library dependency, full GSAP timeline control.
+
+## 1. Highlight Mode
+
+Yellow marker sweep behind text. The most common mode.
+
+```html
+<div class="mh-highlight-wrap">
+  <div class="mh-highlight-bar" id="hl-1"></div>
+  <span class="mh-highlight-text">highlighted text</span>
+</div>
+```
+
+```css
+.mh-highlight-wrap {
+  position: relative;
+  display: inline-block;
+}
+.mh-highlight-bar {
+  position: absolute;
+  top: 0;
+  left: -6px;
+  right: -6px;
+  bottom: 0;
+  background: #fdd835;
+  opacity: 0.35;
+  transform: scaleX(0);
+  transform-origin: left center;
+  border-radius: 3px;
+  z-index: 0;
+}
+.mh-highlight-text {
+  position: relative;
+  z-index: 1;
+}
+```
+
+```js
+// Sweep in from left
+tl.to("#hl-1", { scaleX: 1, duration: 0.5, ease: "power2.out" }, 0.6);
+
+// Optional: skew for hand-drawn feel
+// gsap.set("#hl-1", { skewX: -2 });
+```
+
+### Multi-line Highlight
+
+Stagger bars across multiple lines:
+
+```js
+tl.to(
+  ".mh-highlight-bar",
+  {
+    scaleX: 1,
+    duration: 0.5,
+    ease: "power2.out",
+    stagger: 0.3,
+  },
+  0.6,
+);
+```
+
+## 2. Circle Mode
+
+Hand-drawn circle around text. Use `border-radius: 50%` with a slight rotation for organic feel.
+
+```html
+<div class="mh-circle-wrap">
+  <span class="mh-circle-text" id="circle-word">IMPORTANT</span>
+  <div class="mh-circle-ring" id="circle-1"></div>
+</div>
+```
+
+```css
+.mh-circle-wrap {
+  position: relative;
+  display: inline-block;
+}
+.mh-circle-text {
+  position: relative;
+  z-index: 1;
+}
+.mh-circle-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 130%;
+  height: 160%;
+  transform: translate(-50%, -50%) rotate(-3deg) scale(0);
+  border: 3px solid #e53935;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+}
+```
+
+```js
+// Circle scales in with a wobble
+tl.to(
+  "#circle-1",
+  {
+    scale: 1,
+    rotation: -3,
+    duration: 0.6,
+    ease: "back.out(1.7)",
+    transformOrigin: "center center",
+  },
+  0.7,
+);
+```
+
+### Variations
+
+```css
+/* Tighter circle (for short words) */
+.mh-circle-ring.tight {
+  width: 150%;
+  height: 180%;
+}
+
+/* Squared circle (rounded rectangle) */
+.mh-circle-ring.rounded {
+  border-radius: 30%;
+  width: 120%;
+  height: 140%;
+}
+
+/* Ellipse (wider than tall) */
+.mh-circle-ring.ellipse {
+  width: 150%;
+  height: 130%;
+  border-radius: 50%;
+}
+```
+
+## 3. Burst Mode
+
+Radiating lines from text center. Each line is a positioned div rotated to its angle.
+
+```html
+<div class="mh-burst-wrap">
+  <span class="mh-burst-text">WOW</span>
+  <div class="mh-burst-container" id="burst-1">
+    <div class="mh-burst-line" style="--angle: 0deg; --len: 70px;"></div>
+    <div class="mh-burst-line" style="--angle: 30deg; --len: 55px;"></div>
+    <div class="mh-burst-line" style="--angle: 60deg; --len: 80px;"></div>
+    <div class="mh-burst-line" style="--angle: 90deg; --len: 45px;"></div>
+    <div class="mh-burst-line" style="--angle: 120deg; --len: 65px;"></div>
+    <div class="mh-burst-line" style="--angle: 150deg; --len: 75px;"></div>
+    <div class="mh-burst-line" style="--angle: 180deg; --len: 50px;"></div>
+    <div class="mh-burst-line" style="--angle: 210deg; --len: 60px;"></div>
+    <div class="mh-burst-line" style="--angle: 240deg; --len: 80px;"></div>
+    <div class="mh-burst-line" style="--angle: 270deg; --len: 40px;"></div>
+    <div class="mh-burst-line" style="--angle: 300deg; --len: 70px;"></div>
+    <div class="mh-burst-line" style="--angle: 330deg; --len: 55px;"></div>
+  </div>
+</div>
+```
+
+```css
+.mh-burst-wrap {
+  position: relative;
+  display: inline-block;
+}
+.mh-burst-text {
+  position: relative;
+  z-index: 2;
+}
+.mh-burst-container {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 1;
+}
+.mh-burst-line {
+  position: absolute;
+  width: 3px;
+  height: var(--len);
+  background: #1e88e5;
+  left: -1.5px;
+  top: calc(-1 * var(--len));
+  transform: rotate(var(--angle));
+  transform-origin: bottom center;
+  opacity: 0;
+}
+```
+
+```js
+// All lines burst outward simultaneously with slight stagger
+tl.fromTo(
+  "#burst-1 .mh-burst-line",
+  { scaleY: 0, opacity: 0 },
+  { scaleY: 1, opacity: 1, duration: 0.4, ease: "power2.out", stagger: 0.03 },
+  0.7,
+);
+```
+
+**Vary line lengths** (40-80px range) for an organic, hand-drawn feel. Equal lengths look mechanical.
+
+## 4. Scribble Mode
+
+Wavy SVG underlines and strikethroughs that draw themselves via `stroke-dashoffset`.
+
+```html
+<div class="mh-scribble-wrap">
+  <span class="mh-scribble-text">underlined text</span>
+  <svg class="mh-scribble-svg" viewBox="0 0 500 24" preserveAspectRatio="none">
+    <path
+      id="scribble-1"
+      d="M0,12 Q31,0 62,12 Q93,24 125,12 Q156,0 187,12 Q218,24 250,12 Q281,0 312,12 Q343,24 375,12 Q406,0 437,12 Q468,24 500,12"
+      fill="none"
+      stroke="#FDD835"
+      stroke-width="3"
+      stroke-linecap="round"
+    />
+  </svg>
+</div>
+```
+
+```css
+.mh-scribble-wrap {
+  position: relative;
+  display: inline-block;
+}
+.mh-scribble-text {
+  position: relative;
+  z-index: 1;
+}
+.mh-scribble-svg {
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 24px;
+  z-index: 0;
+}
+```
+
+```js
+// Measure path length and set initial dash state
+var path = document.querySelector("#scribble-1");
+var len = path.getTotalLength();
+gsap.set(path, { strokeDasharray: len, strokeDashoffset: len });
+
+// Draw the line
+tl.to(
+  "#scribble-1",
+  {
+    strokeDashoffset: 0,
+    duration: 0.8,
+    ease: "power1.inOut",
+  },
+  0.7,
+);
+```
+
+### Strikethrough Variant
+
+Position the SVG at `top: 50%; transform: translateY(-50%)` instead of `bottom: -6px`.
+
+### Wavy Path Generator
+
+Scale the path's viewBox width to match text width. The wave pattern `Q x1,y1 x2,y2` alternates between `y=0` and `y=24` for a natural wobble. Adjust the control points for tighter or looser waves:
+
+- **Tight waves**: smaller x-increments (25px per half-wave)
+- **Loose waves**: larger x-increments (50px per half-wave)
+- **Amplitude**: change the y range (0-24 for standard, 0-16 for subtle)
+
+## 5. Sketchout Mode
+
+Cross-hatch lines over de-emphasized text. Multiple angled lines create a "crossed out" effect.
+
+```html
+<div class="mh-sketchout-wrap">
+  <span class="mh-sketchout-text">old price</span>
+  <div class="mh-sketchout-lines" id="sketchout-1">
+    <div class="mh-sketchout-line mh-sketchout-fwd"></div>
+    <div class="mh-sketchout-line mh-sketchout-bwd"></div>
+  </div>
+</div>
+```
+
+```css
+.mh-sketchout-wrap {
+  position: relative;
+  display: inline-block;
+}
+.mh-sketchout-text {
+  position: relative;
+  z-index: 0;
+}
+.mh-sketchout-lines {
+  position: absolute;
+  top: 0;
+  left: -4px;
+  right: -4px;
+  bottom: 0;
+  overflow: hidden;
+  z-index: 1;
+}
+.mh-sketchout-line {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: #e53935;
+  transform-origin: left center;
+  transform: scaleX(0);
+}
+.mh-sketchout-fwd {
+  transform: scaleX(0) rotate(-12deg);
+}
+.mh-sketchout-bwd {
+  transform: scaleX(0) rotate(12deg);
+}
+```
+
+```js
+// Forward slash draws first
+tl.to(
+  "#sketchout-1 .mh-sketchout-fwd",
+  {
+    scaleX: 1,
+    duration: 0.3,
+    ease: "power2.out",
+  },
+  1.0,
+);
+
+// Backward slash follows
+tl.to(
+  "#sketchout-1 .mh-sketchout-bwd",
+  {
+    scaleX: 1,
+    duration: 0.3,
+    ease: "power2.out",
+  },
+  1.15,
+);
+```
+
+## Combining Modes in Captions
+
+Use mode cycling for visual variety across caption groups:
+
+```js
+var MODES = ["highlight", "circle", "burst", "scribble"];
+
+GROUPS.forEach(function (group, gi) {
+  var mode = MODES[gi % MODES.length];
+  // Apply the mode's CSS pattern to emphasis words in this group
+  group.emphasisWords.forEach(function (word) {
+    applyMode(word.el, mode, tl, word.start);
+  });
+});
+```
+
+Cycle every 2-3 groups for high energy, every 3-4 for medium, every 4-5 for low.


### PR DESCRIPTION
## Summary

- Adds new `marker-highlight` skill teaching how to use [MarkerHighlight.js](https://marker-highlight.solarise.dev/) for animated text highlighting in HyperFrames compositions
- Covers all five drawing modes: highlight (marker sweep), circle (hand-drawn emphasis), burst (radiating lines), scribble (wavy underlines/strikethroughs), and sketchout (cross-hatch deletion)
- Provides two integration patterns: direct library usage with GSAP-controlled opacity, and **pure CSS+GSAP simulation** (recommended) for fully deterministic rendering
- Includes mode-to-caption energy mapping table for integration with the existing `hyperframes-captions` skill

## Files

| File | Purpose |
| --- | --- |
| `skills/marker-highlight/SKILL.md` | Main skill — setup, config reference, GSAP integration, mode mapping, constraints |
| `skills/marker-highlight/css-patterns.md` | Drop-in CSS+GSAP patterns for all 5 modes with code examples |
| `CLAUDE.md` | Updated skills table and rules section |

## Test plan

- [x] `npx tsx scripts/lint-skills.ts` passes (verified: 6 files, no issues)
- [x] `bunx oxfmt --check` passes on all changed files (verified)
- [x] `commitlint` passes (verified via lefthook)
- [x] Skill loads correctly via `/marker-highlight` in Claude Code
- [x] CSS patterns from `css-patterns.md` render correctly in a test composition