### PR TITLE
feat(cli): add skills command that installs all without selection

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,6 +37,7 @@ const subCommands = {
   docs: () => import("./commands/docs.js").then((m) => m.default),
   doctor: () => import("./commands/doctor.js").then((m) => m.default),
   upgrade: () => import("./commands/upgrade.js").then((m) => m.default),
+  skills: () => import("./commands/skills.js").then((m) => m.default),
   telemetry: () => import("./commands/telemetry.js").then((m) => m.default),
   validate: () => import("./commands/validate.js").then((m) => m.default),
 };

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { execFileSync, execFile } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import * as clack from "@clack/prompts";
 import { c } from "../ui/colors.js";
 
@@ -12,20 +12,17 @@ function hasNpx(): boolean {
   }
 }
 
-function runSkillsAdd(repo: string, extraArgs: string[]): Promise<void> {
+function runSkillsAdd(repo: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    execFile(
-      "npx",
-      ["skills", "add", repo, "--all", "-g", ...extraArgs],
-      {
-        stdio: "ignore",
-        timeout: 120_000,
-      },
-      (error) => {
-        if (error) reject(error);
-        else resolve();
-      },
-    );
+    const child = spawn("npx", ["skills", "add", repo, "--all", "-g"], {
+      stdio: "ignore",
+      timeout: 120_000,
+    });
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`npx skills add exited with code ${code}`));
+    });
+    child.on("error", reject);
   });
 }
 
@@ -56,7 +53,7 @@ export default defineCommand({
       const spinner = clack.spinner();
       spinner.start(`Installing ${source.name} skills...`);
       try {
-        await runSkillsAdd(source.repo, []);
+        await runSkillsAdd(source.repo);
         installed.push(source.name);
         spinner.stop(c.success(`${source.name} skills installed`));
       } catch {

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,0 +1,79 @@
+import { defineCommand } from "citty";
+import { execFileSync, execFile } from "node:child_process";
+import * as clack from "@clack/prompts";
+import { c } from "../ui/colors.js";
+
+function hasNpx(): boolean {
+  try {
+    execFileSync("npx", ["--version"], { stdio: "ignore", timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runSkillsAdd(repo: string, extraArgs: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "npx",
+      ["skills", "add", repo, "--all", "-g", ...extraArgs],
+      {
+        stdio: "ignore",
+        timeout: 120_000,
+      },
+      (error) => {
+        if (error) reject(error);
+        else resolve();
+      },
+    );
+  });
+}
+
+const SOURCES = [
+  { name: "HyperFrames", repo: "heygen-com/hyperframes" },
+  { name: "GSAP", repo: "greensock/gsap-skills" },
+];
+
+export default defineCommand({
+  meta: {
+    name: "skills",
+    description: "Install HyperFrames and GSAP skills for AI coding tools",
+  },
+  args: {},
+  async run() {
+    clack.intro(c.bold("hyperframes skills"));
+
+    if (!hasNpx()) {
+      clack.log.error(c.error("npx not found. Install Node.js and retry."));
+      clack.outro(c.warn("No skills installed."));
+      return;
+    }
+
+    const installed: string[] = [];
+    const skipped: string[] = [];
+
+    for (const source of SOURCES) {
+      const spinner = clack.spinner();
+      spinner.start(`Installing ${source.name} skills...`);
+      try {
+        await runSkillsAdd(source.repo, []);
+        installed.push(source.name);
+        spinner.stop(c.success(`${source.name} skills installed`));
+      } catch {
+        skipped.push(source.name);
+        spinner.stop(c.dim(`${source.name} skills skipped (unavailable)`));
+      }
+    }
+
+    if (skipped.length > 0) {
+      console.log(`   ${c.dim("Skipped:")}  ${skipped.join(", ")}`);
+      console.log();
+    }
+
+    if (installed.length > 0) {
+      clack.outro(c.success(`${installed.join(" + ")} skills installed.`));
+    } else {
+      clack.outro(c.warn("No skills installed."));
+    }
+  },
+});

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -88,10 +88,7 @@ async function loadExamples(name: string): Promise<Example[] | undefined> {
 // Commands without their own file (e.g. listed in help but not yet a real command)
 const STATIC_EXAMPLES: Record<string, Example[]> = {
   skills: [
-    ["Install skills to all supported AI tools", "hyperframes skills"],
-    ["Install to Claude Code only", "hyperframes skills --claude"],
-    ["Install to Cursor (project-level)", "hyperframes skills --cursor"],
-    ["Install to specific tools", "hyperframes skills --claude --gemini"],
+    ["Install all skills to all supported AI tools", "hyperframes skills"],
   ],
 };
 

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -87,9 +87,7 @@ async function loadExamples(name: string): Promise<Example[] | undefined> {
 
 // Commands without their own file (e.g. listed in help but not yet a real command)
 const STATIC_EXAMPLES: Record<string, Example[]> = {
-  skills: [
-    ["Install all skills to all supported AI tools", "hyperframes skills"],
-  ],
+  skills: [["Install all skills to all supported AI tools", "hyperframes skills"]],
 };
 
 // ── Render root help ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Re-adds `hyperframes skills` command that was removed in #177
- Wraps `npx skills add --all -g` for each source repo (HyperFrames + GSAP), so users don't need to manually select which skills or targets to install
- Just run `npx hyperframes skills` → everything gets installed to all supported AI tools

## Test plan

- [x] `npx hyperframes skills` installs all skills without any selection prompt
- [x] `npx hyperframes skills --help` shows the command
- [x] `npx hyperframes --help` lists `skills` under AI & Integrations