### PR TITLE
fix(engine): suppress font-loading 404 noise in render console output

### DIFF
--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -150,13 +150,17 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     const type = msg.type();
     const text = msg.text();
 
-    // Suppress font-loading 404s — these are expected when deterministic font
-    // injection replaces Google Fonts @import URLs with embedded base64 data.
-    if (type === "error" && text.startsWith("Failed to load resource")) return;
+    // Downgrade "Failed to load resource" to buffer-only — these are typically
+    // font 404s from @import URLs replaced by deterministic font injection.
+    // Real asset failures are caught by the file server's own 404 logging.
+    // Still stored in browserConsoleBuffer for diagnostics if needed.
+    const isResourceLoadError = type === "error" && text.startsWith("Failed to load resource");
 
     const prefix =
       type === "error" ? "[Browser:ERROR]" : type === "warn" ? "[Browser:WARN]" : "[Browser]";
-    console.log(`${prefix} ${text}`);
+    if (!isResourceLoadError) {
+      console.log(`${prefix} ${text}`);
+    }
 
     session.browserConsoleBuffer.push(`${prefix} ${text}`);
     if (session.browserConsoleBuffer.length > BROWSER_CONSOLE_BUFFER_SIZE) {

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -149,6 +149,11 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   page.on("console", (msg: ConsoleMessage) => {
     const type = msg.type();
     const text = msg.text();
+
+    // Suppress font-loading 404s — these are expected when deterministic font
+    // injection replaces Google Fonts @import URLs with embedded base64 data.
+    if (type === "error" && text.startsWith("Failed to load resource")) return;
+
     const prefix =
       type === "error" ? "[Browser:ERROR]" : type === "warn" ? "[Browser:WARN]" : "[Browser]";
     console.log(`${prefix} ${text}`);

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -150,15 +150,18 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     const type = msg.type();
     const text = msg.text();
 
-    // Downgrade "Failed to load resource" to buffer-only — these are typically
-    // font 404s from @import URLs replaced by deterministic font injection.
-    // Real asset failures are caught by the file server's own 404 logging.
-    // Still stored in browserConsoleBuffer for diagnostics if needed.
-    const isResourceLoadError = type === "error" && text.startsWith("Failed to load resource");
+    // Suppress font-loading 404s only. These are expected when deterministic
+    // font injection replaces Google Fonts @import URLs with embedded base64.
+    // Narrowed to font CDN domains and font file extensions to avoid hiding
+    // real asset failures (images, scripts, videos).
+    const isFontLoadError =
+      type === "error" &&
+      text.startsWith("Failed to load resource") &&
+      /fonts\.googleapis|fonts\.gstatic|\.woff2?(\b|$)/i.test(text);
 
     const prefix =
       type === "error" ? "[Browser:ERROR]" : type === "warn" ? "[Browser:WARN]" : "[Browser]";
-    if (!isResourceLoadError) {
+    if (!isFontLoadError) {
       console.log(`${prefix} ${text}`);
     }
 


### PR DESCRIPTION
## Summary

Filters "Failed to load resource" console errors from render output. These 404s come from font `@import` URLs that the deterministic font compiler replaces with embedded base64 — the original URLs 404 harmlessly but spam every render with 4+ error lines.

The `validate` command already has this exact filter (validate.ts:104). This applies the same pattern to the render engine.

**Part 3 of 5** in a stacked PR series fixing E2E test findings.

## Test plan

- [x] Render any composition — no more "Failed to load resource: 404" lines in output
- [x] Real browser errors (e.g., `gsap is not defined`) still appear