### PR TITLE
fix(cli): resolve SyntaxError in bundled ESM output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "hono": "^4.0.0",
         "mime-types": "^3.0.2",
         "open": "^10.0.0",
+        "postcss": "^8.5.8",
         "puppeteer-core": "^24.39.1",
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
     "hono": "^4.0.0",
     "mime-types": "^3.0.2",
     "open": "^10.0.0",
+    "postcss": "^8.5.8",
     "puppeteer-core": "^24.39.1"
   },
   "devDependencies": {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -20,9 +20,9 @@ export default defineConfig({
     js: `import { createRequire as __hf_createRequire } from "node:module";
 import { fileURLToPath as __hf_fileURLToPath } from "node:url";
 import { dirname as __hf_dirname } from "node:path";
-const require = __hf_createRequire(import.meta.url);
-const __filename = __hf_fileURLToPath(import.meta.url);
-const __dirname = __hf_dirname(__filename);`,
+var require = __hf_createRequire(import.meta.url);
+var __filename = __hf_fileURLToPath(import.meta.url);
+var __dirname = __hf_dirname(__filename);`,
   },
   external: [
     "puppeteer-core",
@@ -37,6 +37,7 @@ const __dirname = __hf_dirname(__filename);`,
     "adm-zip",
     "esbuild",
     "giget",
+    "postcss",
   ],
   noExternal: [
     "@hyperframes/core",


### PR DESCRIPTION
## Summary
- Fix `SyntaxError: Identifier '__filename' has already been declared` when running `npx hyperframes` — changed tsup banner from `const` to `var` so esbuild's CJS-to-ESM shims can coexist
- Fix `Cannot find package 'postcss'` at runtime — added postcss as an external CLI dependency so it resolves through bun's isolated module layout

## Test plan
- [ ] `npx hyperframes --help` runs without SyntaxError
- [ ] `npx hyperframes render` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)