### PR TITLE
feat(cli): prompt to install skills during init

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -692,10 +692,19 @@ export default defineCommand({
     const files = readdirSync(destDir);
     clack.note(files.map((f) => c.accent(f)).join("\n"), c.success(`Created ${name}/`));
 
-    clack.log.message(
-      `${c.dim("Tip:")} Install AI coding skills: ${c.accent("npx skills add heygen-com/hyperframes")}\n` +
-        `${c.dim("     Then open this project with")} ${c.accent("Claude Code")}${c.dim(",")} ${c.accent("Cursor")}${c.dim(", or your preferred agent.")}`,
-    );
+    // Offer to install AI coding skills
+    const installSkills = await clack.confirm({
+      message: "Install AI coding skills? (for Claude Code, Cursor, Codex, etc.)",
+      initialValue: true,
+    });
+    if (clack.isCancel(installSkills)) {
+      clack.cancel("Setup cancelled.");
+      process.exit(0);
+    }
+    if (installSkills) {
+      const skillsCmd = await import("./skills.js").then((m) => m.default);
+      await runCommand(skillsCmd, { rawArgs: [] });
+    }
 
     // Auto-launch studio preview
     clack.log.info("Opening studio preview...");

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -14,12 +14,13 @@ function hasNpx(): boolean {
 
 function runSkillsAdd(repo: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn("npx", ["skills", "add", repo, "--all", "-g"], {
-      stdio: "ignore",
+    const child = spawn("npx", ["skills", "add", repo, "--all"], {
+      stdio: "inherit",
       timeout: 120_000,
     });
-    child.on("close", (code) => {
+    child.on("close", (code, signal) => {
       if (code === 0) resolve();
+      else if (signal === "SIGINT" || code === 130) process.exit(0);
       else reject(new Error(`npx skills add exited with code ${code}`));
     });
     child.on("error", reject);
@@ -38,39 +39,20 @@ export default defineCommand({
   },
   args: {},
   async run() {
-    clack.intro(c.bold("hyperframes skills"));
-
     if (!hasNpx()) {
       clack.log.error(c.error("npx not found. Install Node.js and retry."));
-      clack.outro(c.warn("No skills installed."));
       return;
     }
 
-    const installed: string[] = [];
-    const skipped: string[] = [];
-
     for (const source of SOURCES) {
-      const spinner = clack.spinner();
-      spinner.start(`Installing ${source.name} skills...`);
+      console.log();
+      console.log(c.bold(`Installing ${source.name} skills...`));
+      console.log();
       try {
         await runSkillsAdd(source.repo);
-        installed.push(source.name);
-        spinner.stop(c.success(`${source.name} skills installed`));
       } catch {
-        skipped.push(source.name);
-        spinner.stop(c.dim(`${source.name} skills skipped (unavailable)`));
+        console.log(c.dim(`${source.name} skills skipped`));
       }
-    }
-
-    if (skipped.length > 0) {
-      console.log(`   ${c.dim("Skipped:")}  ${skipped.join(", ")}`);
-      console.log();
-    }
-
-    if (installed.length > 0) {
-      clack.outro(c.success(`${installed.join(" + ")} skills installed.`));
-    } else {
-      clack.outro(c.warn("No skills installed."));
     }
   },
 });


### PR DESCRIPTION
## Summary
- Replaces the static "Tip: install AI coding skills" message at the end of `hyperframes init` with an interactive `clack.confirm` prompt (defaults to Yes)
- When accepted, runs the `skills` command which calls `npx skills add` with `--all` and `stdio: "inherit"` so the native installer output is visible
- Ctrl+C on the prompt exits cleanly; Ctrl+C during install exits the process

## Test plan
- [ ] Run `bun run packages/cli/src/cli.ts init /tmp/test --template blank` — verify the skills prompt appears after scaffolding
- [ ] Accept the prompt — verify skills install with visible output
- [ ] Decline the prompt — verify it skips to studio preview
- [ ] Ctrl+C on the prompt — verify it exits cleanly
- [ ] Run with `--non-interactive` — verify no skills prompt (non-interactive path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)