### PR TITLE
feat(core): add data-props interpolation for parameterized sub-compositions

### DIFF
--- a/packages/cli/src/docs/compositions.md
+++ b/packages/cli/src/docs/compositions.md
@@ -36,17 +36,18 @@ Reuse a composition with different data using `data-props`:
 <!-- compositions/card.html -->
 <template id="card-template">
   <div data-composition-id="card" data-width="1920" data-height="1080">
-    <style>.card { background: {{color}}; }</style>
-    <h2>{{title}}</h2>
-    <p>{{price}}/mo</p>
+    <style>.card { background: {{color:#6366f1}}; }</style>
+    <h2>{{title:Card Title}}</h2>
+    <p>{{price:$0}}/mo</p>
   </div>
 </template>
 ```
 
 - `data-props` accepts a JSON object
-- `{{key}}` placeholders are replaced in HTML, CSS, and scripts
-- Values are HTML-escaped (XSS-safe)
-- Unmatched placeholders are preserved
+- `{{key}}` — replaced with value, left as-is if unmatched
+- `{{key:default}}` — replaced with value, or default if unmatched (use this so compositions render standalone)
+- Works in HTML, CSS, and scripts
+- Values are HTML-escaped in content, raw in CSS, JS-escaped in scripts
 
 ## Listing Compositions
 

--- a/packages/cli/src/docs/compositions.md
+++ b/packages/cli/src/docs/compositions.md
@@ -20,14 +20,34 @@ Embed one composition inside another:
 <div data-composition-src="./intro.html" data-start="0" data-duration="5"></div>
 ```
 
+## Parameterized Compositions
+
+Reuse a composition with different data using `data-props`:
+
+```html
+<!-- Root: same component, different data -->
+<div class="clip"
+  data-composition-src="compositions/card.html"
+  data-props='{"title":"Pro","price":"$29","color":"#ec4899"}'
+  data-start="0" data-duration="5" data-track-index="0">
+</div>
+
+<!-- Sub-composition: uses {{key}} placeholders -->
+<!-- compositions/card.html -->
+<template id="card-template">
+  <div data-composition-id="card" data-width="1920" data-height="1080">
+    <style>.card { background: {{color}}; }</style>
+    <h2>{{title}}</h2>
+    <p>{{price}}/mo</p>
+  </div>
+</template>
+```
+
+- `data-props` accepts a JSON object
+- `{{key}}` placeholders are replaced in HTML, CSS, and scripts
+- Values are HTML-escaped (XSS-safe)
+- Unmatched placeholders are preserved
+
 ## Listing Compositions
 
 Use `npx hyperframes compositions` to see all compositions in a project.
-
-## Variables
-
-Compositions can expose variables for dynamic content:
-
-```html
-<div data-composition-id="card" data-var-title="string" data-var-color="color"></div>
-```

--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -329,4 +329,29 @@ describe("bundleToSingleHtml", () => {
     // The raw script tag should NOT appear as actual HTML content (only in the JSON attribute)
     expect(bundled).not.toContain("<p>Hello, <script>alert(1)</script></p>");
   });
+
+  it("resolves {{key:default}} when no data-props provided", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><head></head><body>
+  <template id="card-template">
+    <div data-composition-id="card" data-width="1920" data-height="1080">
+      <style>.card { background: {{bgColor:#6366f1}}; }</style>
+      <h2>{{title:Default Title}}</h2>
+    </div>
+  </template>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div data-composition-id="card"
+      data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+</body></html>`,
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    expect(bundled).toContain("Default Title");
+    expect(bundled).toContain("#6366f1");
+    expect(bundled).not.toContain("{{title");
+    expect(bundled).not.toContain("{{bgColor");
+  });
 });

--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -227,4 +227,106 @@ describe("bundleToSingleHtml", () => {
     expect(bundled).toContain('url("fonts/brand.woff2")');
     expect(bundled).not.toContain('url("../fonts/brand.woff2")');
   });
+
+  it("interpolates {{key}} placeholders in sub-compositions using data-props", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><head>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+</head><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="card1"
+      data-composition-id="card1"
+      data-composition-src="compositions/card.html"
+      data-props='{"title":"Pro Plan","price":"$19/mo","featured":true}'
+      data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+    <div id="card2"
+      data-composition-id="card2"
+      data-composition-src="compositions/card.html"
+      data-props='{"title":"Enterprise","price":"$49/mo","featured":false}'
+      data-start="5" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>window.__timelines={}; const tl=gsap.timeline({paused:true}); window.__timelines["main"]=tl;</script>
+</body></html>`,
+      "compositions/card.html": `<template id="card1-template">
+  <div data-composition-id="card1" data-width="1920" data-height="1080">
+    <h2 class="card-title">{{title}}</h2>
+    <p class="card-price">{{price}}</p>
+    <span class="badge">Featured: {{featured}}</span>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const cardTl = gsap.timeline({ paused: true });
+      window.__timelines["card1"] = cardTl;
+    </script>
+  </div>
+</template>`,
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    // Card 1 should have interpolated values
+    expect(bundled).toContain("Pro Plan");
+    expect(bundled).toContain("$19/mo");
+
+    // Card 2 should have its own interpolated values
+    expect(bundled).toContain("Enterprise");
+    expect(bundled).toContain("$49/mo");
+
+    // No raw mustache placeholders should remain for resolved keys
+    expect(bundled).not.toContain("{{title}}");
+    expect(bundled).not.toContain("{{price}}");
+  });
+
+  it("interpolates {{key}} in inline template compositions", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><head></head><body>
+  <template id="badge-template">
+    <div data-composition-id="badge" data-width="1920" data-height="1080">
+      <span class="label">{{label}}</span>
+      <style>.label { color: {{color}}; }</style>
+    </div>
+  </template>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div data-composition-id="badge"
+      data-props='{"label":"BEST VALUE","color":"#ff0000"}'
+      data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+</body></html>`,
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    expect(bundled).toContain("BEST VALUE");
+    expect(bundled).toContain("#ff0000");
+    expect(bundled).not.toContain("{{label}}");
+    expect(bundled).not.toContain("{{color}}");
+  });
+
+  it("HTML-escapes interpolated values to prevent XSS", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><head></head><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="xss-test"
+      data-composition-id="xss-test"
+      data-composition-src="compositions/unsafe.html"
+      data-props='{"name":"<script>alert(1)</script>"}'
+      data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+</body></html>`,
+      "compositions/unsafe.html": `<template id="xss-test-template">
+  <div data-composition-id="xss-test" data-width="1920" data-height="1080">
+    <p>Hello, {{name}}</p>
+  </div>
+</template>`,
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    // The interpolated content inside <p> should be escaped
+    expect(bundled).toContain("Hello, &lt;script&gt;alert(1)&lt;/script&gt;");
+    // The raw script tag should NOT appear as actual HTML content (only in the JSON attribute)
+    expect(bundled).not.toContain("<p>Hello, <script>alert(1)</script></p>");
+  });
 });

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -5,7 +5,12 @@ import { transformSync } from "esbuild";
 import { compileHtml, type MediaDurationProber } from "./htmlCompiler";
 import { rewriteAssetPaths, rewriteCssAssetUrls } from "./rewriteSubCompPaths";
 import { validateHyperframeHtmlContract } from "./staticGuard";
-import { parseVariableValues, interpolateProps, interpolateScriptProps } from "./interpolateProps";
+import {
+  parseVariableValues,
+  interpolateProps,
+  interpolateScriptProps,
+  interpolateCssProps,
+} from "./interpolateProps";
 
 /**
  * Parse an HTML string into a document. Fragments (without a full document
@@ -432,15 +437,12 @@ export async function bundleToSingleHtml(
       continue;
     }
 
-    // Parse variable values from host element for prop interpolation
+    // Parse variable values from host element for per-context interpolation
     const variableValues = parseVariableValues(hostEl.getAttribute("data-props"));
 
-    // Interpolate {{key}} placeholders in the composition HTML before parsing
-    const interpolatedCompHtml = variableValues
-      ? interpolateProps(compHtml, variableValues)
-      : compHtml;
-
-    const compDoc = parseHTMLContent(interpolatedCompHtml);
+    // Parse first — interpolation happens per-context below (HTML-escaped for
+    // text/attributes, raw for CSS, JS-escaped for scripts).
+    const compDoc = parseHTMLContent(compHtml);
     const compId = hostEl.getAttribute("data-composition-id");
     const contentRoot = compDoc.querySelector("template");
     const contentHtml = contentRoot ? contentRoot.innerHTML || "" : compDoc.body.innerHTML || "";
@@ -451,8 +453,8 @@ export async function bundleToSingleHtml(
 
     for (const s of [...contentDoc.querySelectorAll("style")]) {
       const cssText = s.textContent || "";
-      // Interpolate props in CSS (e.g., {{accentColor}} in style rules)
-      const interpolatedCss = variableValues ? interpolateProps(cssText, variableValues) : cssText;
+      // Interpolate props in CSS with raw replacement (HTML entities are invalid in CSS)
+      const interpolatedCss = interpolateCssProps(cssText, variableValues);
       compStyleChunks.push(rewriteCssAssetUrls(interpolatedCss, src));
       s.remove();
     }
@@ -467,9 +469,7 @@ export async function bundleToSingleHtml(
       } else {
         const scriptText = s.textContent || "";
         // Interpolate props in script content (e.g., {{duration}} in GSAP timelines)
-        const interpolatedScript = variableValues
-          ? interpolateScriptProps(scriptText, variableValues)
-          : scriptText;
+        const interpolatedScript = interpolateScriptProps(scriptText, variableValues);
         compScriptChunks.push(
           `(function(){ try { ${interpolatedScript} } catch (_err) { console.error('[HyperFrames] composition script error:', _err); } })();`,
         );
@@ -490,6 +490,15 @@ export async function bundleToSingleHtml(
         el.setAttribute(attr, val);
       },
     );
+
+    // Interpolate {{key}} and {{key:default}} in remaining HTML content (always run for defaults)
+    {
+      const targetRoot = innerRoot ?? contentDoc.body;
+      if (targetRoot) {
+        const rawInner = targetRoot.innerHTML || "";
+        targetRoot.innerHTML = interpolateProps(rawInner, variableValues);
+      }
+    }
 
     if (innerRoot) {
       const innerCompId = innerRoot.getAttribute("data-composition-id");
@@ -525,25 +534,23 @@ export async function bundleToSingleHtml(
     if (!host) continue;
     if (host.children.length > 0) continue; // already has content
 
-    // Get template content and inject into host
+    // Get template content and parse (interpolation happens per-context below)
     const templateHtml = templateEl.innerHTML || "";
-
-    // Interpolate {{key}} placeholders in inline template compositions
     const templateVarValues = parseVariableValues(host.getAttribute("data-props"));
-    const interpolatedTemplateHtml = templateVarValues
-      ? interpolateProps(templateHtml, templateVarValues)
-      : templateHtml;
+
+    // Interpolate HTML content (always run so defaults resolve even without data-props)
+    const interpolatedTemplateHtml = interpolateProps(templateHtml, templateVarValues);
 
     const innerDoc = parseHTMLContent(interpolatedTemplateHtml);
     const innerRoot = innerDoc.querySelector(`[data-composition-id="${compId}"]`);
 
     if (innerRoot) {
-      // Hoist styles into the collected style chunks
+      // Hoist styles into the collected style chunks (CSS: raw interpolation)
       for (const styleEl of [...innerRoot.querySelectorAll("style")]) {
-        compStyleChunks.push(styleEl.textContent || "");
+        compStyleChunks.push(interpolateCssProps(styleEl.textContent || "", templateVarValues));
         styleEl.remove();
       }
-      // Hoist scripts into the collected script chunks
+      // Hoist scripts into the collected script chunks (JS: JS-escaped interpolation)
       for (const scriptEl of [...innerRoot.querySelectorAll("script")]) {
         const externalSrc = (scriptEl.getAttribute("src") || "").trim();
         if (externalSrc) {
@@ -551,8 +558,9 @@ export async function bundleToSingleHtml(
             compExternalScriptSrcs.push(externalSrc);
           }
         } else {
+          const scriptText = interpolateScriptProps(scriptEl.textContent || "", templateVarValues);
           compScriptChunks.push(
-            `(function(){ try { ${scriptEl.textContent || ""} } catch (_err) { console.error('[HyperFrames] composition script error:', _err); } })();`,
+            `(function(){ try { ${scriptText} } catch (_err) { console.error('[HyperFrames] composition script error:', _err); } })();`,
           );
         }
         scriptEl.remove();
@@ -569,7 +577,7 @@ export async function bundleToSingleHtml(
     } else {
       // No matching inner root — inject all template content directly
       for (const styleEl of [...innerDoc.querySelectorAll("style")]) {
-        compStyleChunks.push(styleEl.textContent || "");
+        compStyleChunks.push(interpolateCssProps(styleEl.textContent || "", templateVarValues));
         styleEl.remove();
       }
       for (const scriptEl of [...innerDoc.querySelectorAll("script")]) {
@@ -579,8 +587,9 @@ export async function bundleToSingleHtml(
             compExternalScriptSrcs.push(externalSrc);
           }
         } else {
+          const scriptText = interpolateScriptProps(scriptEl.textContent || "", templateVarValues);
           compScriptChunks.push(
-            `(function(){ try { ${scriptEl.textContent || ""} } catch (_err) { console.error('[HyperFrames] composition script error:', _err); } })();`,
+            `(function(){ try { ${scriptText} } catch (_err) { console.error('[HyperFrames] composition script error:', _err); } })();`,
           );
         }
         scriptEl.remove();

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -534,23 +534,21 @@ export async function bundleToSingleHtml(
     if (!host) continue;
     if (host.children.length > 0) continue; // already has content
 
-    // Get template content and parse (interpolation happens per-context below)
+    // Parse first (raw), then interpolate per-context — matching the external
+    // composition path so CSS gets raw values and scripts get JS-escaped values.
     const templateHtml = templateEl.innerHTML || "";
     const templateVarValues = parseVariableValues(host.getAttribute("data-props"));
 
-    // Interpolate HTML content (always run so defaults resolve even without data-props)
-    const interpolatedTemplateHtml = interpolateProps(templateHtml, templateVarValues);
-
-    const innerDoc = parseHTMLContent(interpolatedTemplateHtml);
+    const innerDoc = parseHTMLContent(templateHtml);
     const innerRoot = innerDoc.querySelector(`[data-composition-id="${compId}"]`);
 
     if (innerRoot) {
-      // Hoist styles into the collected style chunks (CSS: raw interpolation)
+      // Hoist styles (CSS: raw interpolation)
       for (const styleEl of [...innerRoot.querySelectorAll("style")]) {
         compStyleChunks.push(interpolateCssProps(styleEl.textContent || "", templateVarValues));
         styleEl.remove();
       }
-      // Hoist scripts into the collected script chunks (JS: JS-escaped interpolation)
+      // Hoist scripts (JS: JS-escaped interpolation)
       for (const scriptEl of [...innerRoot.querySelectorAll("script")]) {
         const externalSrc = (scriptEl.getAttribute("src") || "").trim();
         if (externalSrc) {
@@ -572,7 +570,8 @@ export async function bundleToSingleHtml(
       if (innerW && !host.getAttribute("data-width")) host.setAttribute("data-width", innerW);
       if (innerH && !host.getAttribute("data-height")) host.setAttribute("data-height", innerH);
 
-      // Set host content from inner root
+      // Interpolate remaining HTML content (HTML-escaped via innerHTML serialization)
+      innerRoot.innerHTML = interpolateProps(innerRoot.innerHTML || "", templateVarValues);
       host.innerHTML = innerRoot.innerHTML || "";
     } else {
       // No matching inner root — inject all template content directly
@@ -594,6 +593,8 @@ export async function bundleToSingleHtml(
         }
         scriptEl.remove();
       }
+      // Interpolate remaining HTML content
+      innerDoc.body.innerHTML = interpolateProps(innerDoc.body.innerHTML || "", templateVarValues);
       host.innerHTML = innerDoc.body.innerHTML || "";
     }
 

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -5,6 +5,7 @@ import { transformSync } from "esbuild";
 import { compileHtml, type MediaDurationProber } from "./htmlCompiler";
 import { rewriteAssetPaths, rewriteCssAssetUrls } from "./rewriteSubCompPaths";
 import { validateHyperframeHtmlContract } from "./staticGuard";
+import { parseVariableValues, interpolateProps, interpolateScriptProps } from "./interpolateProps";
 
 /**
  * Parse an HTML string into a document. Fragments (without a full document
@@ -431,7 +432,15 @@ export async function bundleToSingleHtml(
       continue;
     }
 
-    const compDoc = parseHTMLContent(compHtml);
+    // Parse variable values from host element for prop interpolation
+    const variableValues = parseVariableValues(hostEl.getAttribute("data-props"));
+
+    // Interpolate {{key}} placeholders in the composition HTML before parsing
+    const interpolatedCompHtml = variableValues
+      ? interpolateProps(compHtml, variableValues)
+      : compHtml;
+
+    const compDoc = parseHTMLContent(interpolatedCompHtml);
     const compId = hostEl.getAttribute("data-composition-id");
     const contentRoot = compDoc.querySelector("template");
     const contentHtml = contentRoot ? contentRoot.innerHTML || "" : compDoc.body.innerHTML || "";
@@ -441,7 +450,10 @@ export async function bundleToSingleHtml(
       : contentDoc.querySelector("[data-composition-id]");
 
     for (const s of [...contentDoc.querySelectorAll("style")]) {
-      compStyleChunks.push(rewriteCssAssetUrls(s.textContent || "", src));
+      const cssText = s.textContent || "";
+      // Interpolate props in CSS (e.g., {{accentColor}} in style rules)
+      const interpolatedCss = variableValues ? interpolateProps(cssText, variableValues) : cssText;
+      compStyleChunks.push(rewriteCssAssetUrls(interpolatedCss, src));
       s.remove();
     }
     for (const s of [...contentDoc.querySelectorAll("script")]) {
@@ -453,8 +465,13 @@ export async function bundleToSingleHtml(
           compExternalScriptSrcs.push(externalSrc);
         }
       } else {
+        const scriptText = s.textContent || "";
+        // Interpolate props in script content (e.g., {{duration}} in GSAP timelines)
+        const interpolatedScript = variableValues
+          ? interpolateScriptProps(scriptText, variableValues)
+          : scriptText;
         compScriptChunks.push(
-          `(function(){ try { ${s.textContent || ""} } catch (_err) { console.error('[HyperFrames] composition script error:', _err); } })();`,
+          `(function(){ try { ${interpolatedScript} } catch (_err) { console.error('[HyperFrames] composition script error:', _err); } })();`,
         );
       }
       s.remove();
@@ -510,7 +527,14 @@ export async function bundleToSingleHtml(
 
     // Get template content and inject into host
     const templateHtml = templateEl.innerHTML || "";
-    const innerDoc = parseHTMLContent(templateHtml);
+
+    // Interpolate {{key}} placeholders in inline template compositions
+    const templateVarValues = parseVariableValues(host.getAttribute("data-props"));
+    const interpolatedTemplateHtml = templateVarValues
+      ? interpolateProps(templateHtml, templateVarValues)
+      : templateHtml;
+
+    const innerDoc = parseHTMLContent(interpolatedTemplateHtml);
     const innerRoot = innerDoc.querySelector(`[data-composition-id="${compId}"]`);
 
     if (innerRoot) {

--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -24,4 +24,9 @@ export {
 } from "./staticGuard";
 
 // Prop interpolation
-export { interpolateProps, interpolateScriptProps, parseVariableValues } from "./interpolateProps";
+export {
+  interpolateProps,
+  interpolateScriptProps,
+  interpolateCssProps,
+  parseVariableValues,
+} from "./interpolateProps";

--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -22,3 +22,6 @@ export {
   type HyperframeStaticFailureReason,
   type HyperframeStaticGuardResult,
 } from "./staticGuard";
+
+// Prop interpolation
+export { interpolateProps, interpolateScriptProps, parseVariableValues } from "./interpolateProps";

--- a/packages/core/src/compiler/interpolateProps.test.ts
+++ b/packages/core/src/compiler/interpolateProps.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { interpolateProps, interpolateScriptProps, parseVariableValues } from "./interpolateProps";
+import {
+  interpolateProps,
+  interpolateScriptProps,
+  interpolateCssProps,
+  parseVariableValues,
+} from "./interpolateProps";
 
 describe("parseVariableValues", () => {
   it("parses valid JSON object", () => {
@@ -93,6 +98,51 @@ describe("interpolateProps", () => {
     const result = interpolateProps("{{card.title}}", { "card.title": "Premium" });
     expect(result).toBe("Premium");
   });
+
+  it("uses default when no value provided", () => {
+    const result = interpolateProps("<h2>{{title:Hello World}}</h2>");
+    expect(result).toBe("<h2>Hello World</h2>");
+  });
+
+  it("uses default when values object is empty", () => {
+    const result = interpolateProps("<h2>{{title:Fallback}}</h2>", {});
+    expect(result).toBe("<h2>Fallback</h2>");
+  });
+
+  it("overrides default with provided value", () => {
+    const result = interpolateProps("<h2>{{title:Fallback}}</h2>", { title: "Override" });
+    expect(result).toBe("<h2>Override</h2>");
+  });
+
+  it("handles default with special characters", () => {
+    const result = interpolateProps("<p>{{color:#ff0000}}</p>");
+    expect(result).toBe("<p>#ff0000</p>");
+  });
+
+  it("handles empty default", () => {
+    const result = interpolateProps("<p>{{title:}}</p>");
+    expect(result).toBe("<p></p>");
+  });
+
+  it("handles default with spaces", () => {
+    const result = interpolateProps("<p>{{label:Hello World}}</p>");
+    expect(result).toBe("<p>Hello World</p>");
+  });
+
+  it("HTML-escapes defaults too", () => {
+    const result = interpolateProps("<p>{{val:<b>bold</b>}}</p>");
+    expect(result).toBe("<p>&lt;b&gt;bold&lt;/b&gt;</p>");
+  });
+
+  it("mixes defaulted and non-defaulted placeholders", () => {
+    const result = interpolateProps("{{title:Default}} by {{author}}", { author: "Alice" });
+    expect(result).toBe("Default by Alice");
+  });
+
+  it("resolves all defaults when called with no values", () => {
+    const result = interpolateProps('<div style="color:{{color:#333}}">{{text:Sample}}</div>');
+    expect(result).toBe('<div style="color:#333">Sample</div>');
+  });
 });
 
 describe("interpolateScriptProps", () => {
@@ -109,8 +159,100 @@ describe("interpolateScriptProps", () => {
     expect(result).toBe("const x = {{unknown}};");
   });
 
-  it("does not escape special characters in scripts", () => {
+  it("does not HTML-escape ampersands in scripts", () => {
     const result = interpolateScriptProps('const s = "{{val}}";', { val: "A & B" });
     expect(result).toBe('const s = "A & B";');
+  });
+
+  it("JS-escapes quotes to prevent injection", () => {
+    const result = interpolateScriptProps('const s = "{{val}}";', {
+      val: 'hello"; alert(1); //',
+    });
+    expect(result).toBe('const s = "hello\\"; alert(1); //";');
+  });
+
+  it("JS-escapes backslashes and backticks", () => {
+    const result = interpolateScriptProps("const s = `{{val}}`;", { val: "a\\b`c" });
+    expect(result).toBe("const s = `a\\\\b\\`c`;");
+  });
+
+  it("JS-escapes </script> to prevent tag breakout", () => {
+    const result = interpolateScriptProps('const s = "{{val}}";', {
+      val: "</script><script>alert(1)",
+    });
+    expect(result).not.toContain("</script>");
+    expect(result).toContain("<\\/script>");
+  });
+
+  it("does not escape numbers and booleans", () => {
+    const result = interpolateScriptProps("const n = {{num}}; const b = {{bool}};", {
+      num: 42,
+      bool: true,
+    });
+    expect(result).toBe("const n = 42; const b = true;");
+  });
+
+  it("preserves $ in regular string contexts", () => {
+    const result = interpolateScriptProps('const p = "{{price}}";', { price: "$19/mo" });
+    expect(result).toBe('const p = "$19/mo";');
+  });
+
+  it("escapes ${ in template literal contexts", () => {
+    const result = interpolateScriptProps("const s = `{{val}}`;", { val: "${dangerous}" });
+    expect(result).toBe("const s = `\\${dangerous}`;");
+  });
+
+  it("uses default when no value provided", () => {
+    const result = interpolateScriptProps("const dur = {{duration:10}};");
+    expect(result).toBe("const dur = 10;");
+  });
+
+  it("overrides default with provided value", () => {
+    const result = interpolateScriptProps("const dur = {{duration:10}};", { duration: 5 });
+    expect(result).toBe("const dur = 5;");
+  });
+
+  it("JS-escapes defaults containing special characters", () => {
+    const result = interpolateScriptProps('const s = "{{label:hello\\"world}}";');
+    expect(result).toBe('const s = "hello\\\\\\"world";');
+  });
+});
+
+describe("interpolateCssProps", () => {
+  it("replaces placeholders with raw values", () => {
+    const result = interpolateCssProps(".card { background: {{bgColor}}; }", {
+      bgColor: "#ec4899",
+    });
+    expect(result).toBe(".card { background: #ec4899; }");
+  });
+
+  it("does not HTML-escape values in CSS", () => {
+    const result = interpolateCssProps(".card { content: '{{text}}'; }", {
+      text: "A & B",
+    });
+    expect(result).toBe(".card { content: 'A & B'; }");
+    expect(result).not.toContain("&amp;");
+  });
+
+  it("preserves unmatched placeholders", () => {
+    const result = interpolateCssProps(".card { color: {{unknown}}; }", { bg: "red" });
+    expect(result).toBe(".card { color: {{unknown}}; }");
+  });
+
+  it("returns original content when values is empty and no defaults", () => {
+    const css = ".card { color: {{color}}; }";
+    expect(interpolateCssProps(css, {})).toBe(css);
+  });
+
+  it("uses default when no value provided", () => {
+    const result = interpolateCssProps(".card { background: {{bgColor:#6366f1}}; }");
+    expect(result).toBe(".card { background: #6366f1; }");
+  });
+
+  it("overrides default with provided value", () => {
+    const result = interpolateCssProps(".card { background: {{bgColor:#6366f1}}; }", {
+      bgColor: "#ec4899",
+    });
+    expect(result).toBe(".card { background: #ec4899; }");
   });
 });

--- a/packages/core/src/compiler/interpolateProps.test.ts
+++ b/packages/core/src/compiler/interpolateProps.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { interpolateProps, interpolateScriptProps, parseVariableValues } from "./interpolateProps";
+
+describe("parseVariableValues", () => {
+  it("parses valid JSON object", () => {
+    expect(parseVariableValues('{"title":"Hello","price":19}')).toEqual({
+      title: "Hello",
+      price: 19,
+    });
+  });
+
+  it("returns null for null/undefined/empty", () => {
+    expect(parseVariableValues(null)).toBeNull();
+    expect(parseVariableValues(undefined)).toBeNull();
+    expect(parseVariableValues("")).toBeNull();
+  });
+
+  it("returns null for non-object JSON", () => {
+    expect(parseVariableValues('"just a string"')).toBeNull();
+    expect(parseVariableValues("[1,2,3]")).toBeNull();
+    expect(parseVariableValues("42")).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseVariableValues("{broken}")).toBeNull();
+  });
+
+  it("handles boolean values", () => {
+    expect(parseVariableValues('{"featured":true}')).toEqual({ featured: true });
+  });
+});
+
+describe("interpolateProps", () => {
+  it("replaces {{key}} placeholders with values", () => {
+    const result = interpolateProps('<div class="card"><h2>{{title}}</h2><p>{{price}}</p></div>', {
+      title: "Pro Plan",
+      price: "$19/mo",
+    });
+    expect(result).toBe('<div class="card"><h2>Pro Plan</h2><p>$19/mo</p></div>');
+  });
+
+  it("handles numeric values", () => {
+    const result = interpolateProps("<span>{{count}} items</span>", { count: 42 });
+    expect(result).toBe("<span>42 items</span>");
+  });
+
+  it("handles boolean values", () => {
+    const result = interpolateProps("<span>Featured: {{featured}}</span>", { featured: true });
+    expect(result).toBe("<span>Featured: true</span>");
+  });
+
+  it("preserves unmatched placeholders", () => {
+    const result = interpolateProps("<span>{{title}} and {{unknown}}</span>", { title: "Hello" });
+    expect(result).toBe("<span>Hello and {{unknown}}</span>");
+  });
+
+  it("handles whitespace in placeholder keys", () => {
+    const result = interpolateProps("<span>{{ title }}</span>", { title: "Hello" });
+    expect(result).toBe("<span>Hello</span>");
+  });
+
+  it("HTML-escapes values to prevent XSS", () => {
+    const result = interpolateProps("<span>{{name}}</span>", {
+      name: '<script>alert("xss")</script>',
+    });
+    expect(result).toBe("<span>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</span>");
+  });
+
+  it("escapes ampersands and quotes", () => {
+    const result = interpolateProps('<div title="{{label}}">{{text}}</div>', {
+      label: 'A & B "quoted"',
+      text: "Tom & Jerry",
+    });
+    expect(result).toContain("A &amp; B &quot;quoted&quot;");
+    expect(result).toContain("Tom &amp; Jerry");
+  });
+
+  it("returns original html when values is empty", () => {
+    const html = "<div>{{title}}</div>";
+    expect(interpolateProps(html, {})).toBe(html);
+  });
+
+  it("returns original html when html is empty", () => {
+    expect(interpolateProps("", { title: "Hello" })).toBe("");
+  });
+
+  it("handles multiple occurrences of the same key", () => {
+    const result = interpolateProps("{{name}} said {{name}}", { name: "Alice" });
+    expect(result).toBe("Alice said Alice");
+  });
+
+  it("handles dotted keys", () => {
+    const result = interpolateProps("{{card.title}}", { "card.title": "Premium" });
+    expect(result).toBe("Premium");
+  });
+});
+
+describe("interpolateScriptProps", () => {
+  it("replaces placeholders without HTML escaping", () => {
+    const result = interpolateScriptProps('const title = "{{title}}"; const dur = {{duration}};', {
+      title: "My Video",
+      duration: 10,
+    });
+    expect(result).toBe('const title = "My Video"; const dur = 10;');
+  });
+
+  it("preserves unmatched placeholders", () => {
+    const result = interpolateScriptProps("const x = {{unknown}};", { title: "Hello" });
+    expect(result).toBe("const x = {{unknown}};");
+  });
+
+  it("does not escape special characters in scripts", () => {
+    const result = interpolateScriptProps('const s = "{{val}}";', { val: "A & B" });
+    expect(result).toBe('const s = "A & B";');
+  });
+});

--- a/packages/core/src/compiler/interpolateProps.ts
+++ b/packages/core/src/compiler/interpolateProps.ts
@@ -1,16 +1,21 @@
 /**
- * Interpolate `{{key}}` mustache-style placeholders in HTML content
- * using values from a `data-props` JSON attribute.
+ * Interpolate `{{key}}` and `{{key:default}}` mustache-style placeholders
+ * in HTML content using values from a `data-props` JSON attribute.
  *
  * Supports:
- * - `{{key}}` — replaced with the value (HTML-escaped for safety)
+ * - `{{key}}` — replaced with the value, or left as-is if no value provided
+ * - `{{key:default}}` — replaced with the value, or the default if no value provided
  * - Nested keys are NOT supported (flat key-value only)
- * - Unmatched placeholders are left as-is (no error)
  *
  * Values are coerced to strings. Numbers and booleans are stringified.
  */
 
-const MUSTACHE_RE = /\{\{(\s*[\w.-]+\s*)\}\}/g;
+/**
+ * Matches `{{key}}` and `{{key:default value}}`.
+ * Group 1: key (trimmed)
+ * Group 2: default value (everything after the first colon, if present)
+ */
+const MUSTACHE_RE = /\{\{(\s*[\w.-]+\s*)(?::([^}]*))?\}\}/g;
 
 /**
  * Parse `data-props` JSON from an element attribute.
@@ -42,41 +47,91 @@ function escapeHtml(str: string): string {
 }
 
 /**
- * Interpolate `{{key}}` placeholders in an HTML string using the provided values.
- * Values are HTML-escaped to prevent XSS. Unmatched placeholders are preserved.
+ * Escape a string for safe insertion into a JavaScript string context.
+ * Handles quote characters, backslashes, template literal delimiters,
+ * and `</script>` sequences that would prematurely close a script tag.
+ */
+function escapeJsString(str: string): string {
+  return str
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "\\'")
+    .replace(/`/g, "\\`")
+    .replace(/\$\{/g, "\\${")
+    .replace(/<\/(script)/gi, "<\\/$1");
+}
+
+/**
+ * Interpolate `{{key}}` and `{{key:default}}` placeholders in an HTML string.
+ * Values are HTML-escaped to prevent XSS. When no value is provided and a
+ * default is specified, the default is used. Unmatched placeholders without
+ * defaults are preserved as-is.
  */
 export function interpolateProps(
   html: string,
-  values: Record<string, string | number | boolean>,
+  values?: Record<string, string | number | boolean> | null,
 ): string {
-  if (!html || Object.keys(values).length === 0) return html;
-  return html.replace(MUSTACHE_RE, (_match, rawKey: string) => {
+  if (!html) return html;
+  const vals = values ?? {};
+  return html.replace(MUSTACHE_RE, (_match, rawKey: string, rawDefault: string | undefined) => {
     const key = rawKey.trim();
-    if (key in values) {
-      return escapeHtml(String(values[key]));
+    if (key in vals) {
+      return escapeHtml(String(vals[key]));
     }
-    return _match; // preserve unmatched placeholders
+    if (rawDefault !== undefined) {
+      return escapeHtml(rawDefault);
+    }
+    return _match;
   });
 }
 
 /**
- * Interpolate props in script content. Values are NOT HTML-escaped here
- * since they'll be used as JavaScript string values.
- * Replaces `{{key}}` with the raw string value.
+ * Interpolate props in script content. String values are JS-escaped to
+ * prevent breaking out of string delimiters. Numbers and booleans are
+ * inserted as-is (safe for direct use as JS literals).
+ * Defaults are used when no value is provided.
  */
 export function interpolateScriptProps(
   scriptContent: string,
-  values: Record<string, string | number | boolean>,
+  values?: Record<string, string | number | boolean> | null,
 ): string {
-  if (!scriptContent || Object.keys(values).length === 0) return scriptContent;
-  return scriptContent.replace(MUSTACHE_RE, (_match, rawKey: string) => {
-    const key = rawKey.trim();
-    if (key in values) {
-      const val = values[key];
-      // For strings, return the raw value (caller wraps in quotes if needed)
-      // For numbers/booleans, return the stringified value
-      return String(val);
-    }
-    return _match;
-  });
+  if (!scriptContent) return scriptContent;
+  const vals = values ?? {};
+  return scriptContent.replace(
+    MUSTACHE_RE,
+    (_match, rawKey: string, rawDefault: string | undefined) => {
+      const key = rawKey.trim();
+      if (key in vals) {
+        const val = vals[key];
+        if (typeof val === "string") return escapeJsString(val);
+        return String(val);
+      }
+      if (rawDefault !== undefined) {
+        return escapeJsString(rawDefault);
+      }
+      return _match;
+    },
+  );
+}
+
+/**
+ * Interpolate props in CSS content. Values are inserted raw — HTML entity
+ * escaping (`&amp;`, `&lt;`) is invalid in CSS and would produce broken rules.
+ * Defaults are used when no value is provided.
+ */
+export function interpolateCssProps(
+  cssContent: string,
+  values?: Record<string, string | number | boolean> | null,
+): string {
+  if (!cssContent) return cssContent;
+  const vals = values ?? {};
+  return cssContent.replace(
+    MUSTACHE_RE,
+    (_match, rawKey: string, rawDefault: string | undefined) => {
+      const key = rawKey.trim();
+      if (key in vals) return String(vals[key]);
+      if (rawDefault !== undefined) return rawDefault;
+      return _match;
+    },
+  );
 }

--- a/packages/core/src/compiler/interpolateProps.ts
+++ b/packages/core/src/compiler/interpolateProps.ts
@@ -1,0 +1,82 @@
+/**
+ * Interpolate `{{key}}` mustache-style placeholders in HTML content
+ * using values from a `data-props` JSON attribute.
+ *
+ * Supports:
+ * - `{{key}}` — replaced with the value (HTML-escaped for safety)
+ * - Nested keys are NOT supported (flat key-value only)
+ * - Unmatched placeholders are left as-is (no error)
+ *
+ * Values are coerced to strings. Numbers and booleans are stringified.
+ */
+
+const MUSTACHE_RE = /\{\{(\s*[\w.-]+\s*)\}\}/g;
+
+/**
+ * Parse `data-props` JSON from an element attribute.
+ * Returns null if the attribute is missing or invalid JSON.
+ */
+export function parseVariableValues(
+  raw: string | null | undefined,
+): Record<string, string | number | boolean> | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, string | number | boolean>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Escape a string for safe insertion into HTML content.
+ */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Interpolate `{{key}}` placeholders in an HTML string using the provided values.
+ * Values are HTML-escaped to prevent XSS. Unmatched placeholders are preserved.
+ */
+export function interpolateProps(
+  html: string,
+  values: Record<string, string | number | boolean>,
+): string {
+  if (!html || Object.keys(values).length === 0) return html;
+  return html.replace(MUSTACHE_RE, (_match, rawKey: string) => {
+    const key = rawKey.trim();
+    if (key in values) {
+      return escapeHtml(String(values[key]));
+    }
+    return _match; // preserve unmatched placeholders
+  });
+}
+
+/**
+ * Interpolate props in script content. Values are NOT HTML-escaped here
+ * since they'll be used as JavaScript string values.
+ * Replaces `{{key}}` with the raw string value.
+ */
+export function interpolateScriptProps(
+  scriptContent: string,
+  values: Record<string, string | number | boolean>,
+): string {
+  if (!scriptContent || Object.keys(values).length === 0) return scriptContent;
+  return scriptContent.replace(MUSTACHE_RE, (_match, rawKey: string) => {
+    const key = rawKey.trim();
+    if (key in values) {
+      const val = values[key];
+      // For strings, return the raw value (caller wraps in quotes if needed)
+      // For numbers/booleans, return the stringified value
+      return String(val);
+    }
+    return _match;
+  });
+}

--- a/packages/core/src/generators/hyperframes.ts
+++ b/packages/core/src/generators/hyperframes.ts
@@ -532,7 +532,7 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
     }
     if (element.variableValues && Object.keys(element.variableValues).length > 0) {
       const varJson = JSON.stringify(element.variableValues);
-      compositionAttrs.push(`data-variable-values='${varJson.replace(/'/g, "&#39;")}'`);
+      compositionAttrs.push(`data-props='${varJson.replace(/'/g, "&#39;")}'`);
     }
     const attrs = compositionAttrs.join(" ");
     // Build iframe src with variable values as query params if present

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,6 +130,7 @@ export {
 export {
   interpolateProps,
   interpolateScriptProps,
+  interpolateCssProps,
   parseVariableValues,
 } from "./compiler/interpolateProps";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,6 +126,13 @@ export {
   rewriteCssAssetUrls,
 } from "./compiler/rewriteSubCompPaths";
 
+// Prop interpolation
+export {
+  interpolateProps,
+  interpolateScriptProps,
+  parseVariableValues,
+} from "./compiler/interpolateProps";
+
 // Inline scripts
 export {
   HYPERFRAME_RUNTIME_ARTIFACTS,

--- a/packages/core/src/lint/context.ts
+++ b/packages/core/src/lint/context.ts
@@ -13,7 +13,10 @@ import type { OpenTag, ExtractedBlock } from "./utils";
 export type { OpenTag, ExtractedBlock };
 
 export type LintContext = {
+  /** Source after template unwrapping (used by most rules). */
   source: string;
+  /** Original unmodified HTML (for rules that need to cross-reference templates with hosts). */
+  rawSource: string;
   tags: OpenTag[];
   styles: ExtractedBlock[];
   scripts: ExtractedBlock[];
@@ -27,7 +30,8 @@ export type LintContext = {
 export type { HyperframeLintFinding };
 
 export function buildLintContext(html: string, options: HyperframeLinterOptions = {}): LintContext {
-  let source = html || "";
+  const rawSource = html || "";
+  let source = rawSource;
   const templateMatch = source.match(/<template[^>]*>([\s\S]*)<\/template>/i);
   if (templateMatch?.[1]) source = templateMatch[1];
 
@@ -40,6 +44,7 @@ export function buildLintContext(html: string, options: HyperframeLinterOptions 
 
   return {
     source,
+    rawSource,
     tags,
     styles,
     scripts,

--- a/packages/core/src/lint/rules/composition.test.ts
+++ b/packages/core/src/lint/rules/composition.test.ts
@@ -201,6 +201,227 @@ describe("composition rules", () => {
     });
   });
 
+  describe("invalid_data_props_json", () => {
+    it("flags invalid JSON in data-props", () => {
+      const html = `
+<html><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="card" data-composition-src="card.html" data-props='{broken json}' data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "invalid_data_props_json");
+      expect(finding).toBeDefined();
+      expect(finding?.severity).toBe("error");
+    });
+
+    it("flags array in data-props", () => {
+      const html = `
+<html><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="card" data-composition-src="card.html" data-props='[1,2,3]' data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "invalid_data_props_json");
+      expect(finding).toBeDefined();
+    });
+
+    it("passes with valid data-props JSON", () => {
+      const html = `
+<html><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="card" data-composition-src="card.html" data-props='{"title":"Pro","price":29}' data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html);
+      expect(result.findings.find((f) => f.code === "invalid_data_props_json")).toBeUndefined();
+    });
+
+    it("no finding when data-props is absent", () => {
+      const html = `
+<html><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="card" data-composition-src="card.html" data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html);
+      expect(result.findings.find((f) => f.code === "invalid_data_props_json")).toBeUndefined();
+    });
+  });
+
+  describe("mustache_placeholder_without_default", () => {
+    it("warns about placeholders without defaults in sub-compositions", () => {
+      const html = `<template id="card-template">
+  <div data-composition-id="card" data-width="1920" data-height="1080">
+    <h2>{{title}}</h2>
+    <p>{{price}}</p>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["card"] = gsap.timeline({ paused: true });
+    </script>
+  </div>
+</template>`;
+      const result = lintHyperframeHtml(html, { filePath: "compositions/card.html" });
+      const findings = result.findings.filter(
+        (f) => f.code === "mustache_placeholder_without_default",
+      );
+      expect(findings).toHaveLength(2);
+      expect(findings[0]?.message).toContain("{{title}}");
+      expect(findings[1]?.message).toContain("{{price}}");
+      expect(findings[0]?.severity).toBe("warning");
+    });
+
+    it("does not warn when placeholders have defaults", () => {
+      const html = `<template id="card-template">
+  <div data-composition-id="card" data-width="1920" data-height="1080">
+    <h2>{{title:Card Title}}</h2>
+    <p>{{price:$0}}</p>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["card"] = gsap.timeline({ paused: true });
+    </script>
+  </div>
+</template>`;
+      const result = lintHyperframeHtml(html, { filePath: "compositions/card.html" });
+      expect(
+        result.findings.find((f) => f.code === "mustache_placeholder_without_default"),
+      ).toBeUndefined();
+    });
+
+    it("does not warn for placeholders in root index.html", () => {
+      const html = `
+<html><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <h2>{{title}}</h2>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html, { filePath: "index.html" });
+      expect(
+        result.findings.find((f) => f.code === "mustache_placeholder_without_default"),
+      ).toBeUndefined();
+    });
+
+    it("deduplicates warnings for the same key used multiple times", () => {
+      const html = `<template id="card-template">
+  <div data-composition-id="card" data-width="1920" data-height="1080">
+    <h2>{{title}}</h2>
+    <p>Also: {{title}}</p>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["card"] = gsap.timeline({ paused: true });
+    </script>
+  </div>
+</template>`;
+      const result = lintHyperframeHtml(html, { filePath: "compositions/card.html" });
+      const findings = result.findings.filter(
+        (f) => f.code === "mustache_placeholder_without_default",
+      );
+      expect(findings).toHaveLength(1);
+    });
+  });
+
+  describe("unused_data_props_key", () => {
+    it("warns about props keys that don't match any placeholder in inline template", () => {
+      const html = `
+<html><body>
+  <template id="card-template">
+    <div data-composition-id="card" data-width="1920" data-height="1080">
+      <h2>{{title:Default}}</h2>
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        window.__timelines = window.__timelines || {};
+        window.__timelines["card"] = gsap.timeline({ paused: true });
+      </script>
+    </div>
+  </template>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="my-card" data-composition-id="card"
+      data-props='{"title":"Pro","typo":"oops"}'
+      data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html);
+      const findings = result.findings.filter((f) => f.code === "unused_data_props_key");
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.message).toContain('"typo"');
+      expect(findings[0]?.severity).toBe("warning");
+      expect(findings[0]?.fixHint).toContain("{{title}}");
+    });
+
+    it("does not warn when all props keys match placeholders", () => {
+      const html = `
+<html><body>
+  <template id="card-template">
+    <div data-composition-id="card" data-width="1920" data-height="1080">
+      <h2>{{title:Default}}</h2>
+      <p>{{price:$0}}</p>
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        window.__timelines = window.__timelines || {};
+        window.__timelines["card"] = gsap.timeline({ paused: true });
+      </script>
+    </div>
+  </template>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div data-composition-id="card"
+      data-props='{"title":"Pro","price":"$29"}'
+      data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html);
+      expect(result.findings.find((f) => f.code === "unused_data_props_key")).toBeUndefined();
+    });
+
+    it("skips external compositions (data-composition-src)", () => {
+      const html = `
+<html><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div data-composition-id="card" data-composition-src="compositions/card.html"
+      data-props='{"typo":"oops"}'
+      data-start="0" data-duration="5" data-track-index="0" class="clip"></div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = lintHyperframeHtml(html);
+      expect(result.findings.find((f) => f.code === "unused_data_props_key")).toBeUndefined();
+    });
+  });
+
   describe("requestanimationframe_in_composition", () => {
     it("flags requestAnimationFrame usage in script content", () => {
       const html = `

--- a/packages/core/src/lint/rules/composition.ts
+++ b/packages/core/src/lint/rules/composition.ts
@@ -1,5 +1,5 @@
 import type { LintContext, HyperframeLintFinding } from "../context";
-import { readAttr, truncateSnippet } from "../utils";
+import { readAttr, truncateSnippet, extractOpenTags } from "../utils";
 
 export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
   // timed_element_missing_visibility_hidden
@@ -188,6 +188,134 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
       }
     }
 
+    return findings;
+  },
+
+  // invalid_data_props_json
+  ({ tags }) => {
+    const findings: HyperframeLintFinding[] = [];
+    // readAttr uses [^"']+ which breaks on JSON containing quotes inside
+    // single-quoted attributes. Use a dedicated regex that captures the full
+    // single-quoted or double-quoted attribute value.
+    const dataPropsRe = /\bdata-props\s*=\s*(?:'([^']*)'|"([^"]*)")/i;
+    for (const tag of tags) {
+      const match = tag.raw.match(dataPropsRe);
+      if (!match) continue;
+      const propsRaw = (match[1] ?? match[2] ?? "")
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, "&");
+      try {
+        const parsed = JSON.parse(propsRaw);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new Error("not a plain object");
+        }
+      } catch {
+        const elementId = readAttr(tag.raw, "id") || undefined;
+        findings.push({
+          code: "invalid_data_props_json",
+          severity: "error",
+          message: `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> has data-props with invalid JSON. Value must be a JSON object: '{"key":"value"}'.`,
+          elementId,
+          fixHint:
+            'Fix the data-props JSON. It must be a valid JSON object with string keys. Example: data-props=\'{"title":"Hello","color":"#fff"}\'',
+          snippet: truncateSnippet(tag.raw),
+        });
+      }
+    }
+    return findings;
+  },
+
+  // mustache_placeholder_without_default
+  ({ source, options }) => {
+    const findings: HyperframeLintFinding[] = [];
+    // Only warn in sub-composition files (not index.html), where standalone rendering matters
+    const filePath = options.filePath || "";
+    const isSubComposition =
+      filePath.includes("compositions/") || filePath.includes("compositions\\");
+    if (!isSubComposition) return findings;
+
+    const placeholderRe = /\{\{(\s*[\w.-]+\s*)(?::([^}]*))?\}\}/g;
+    let match: RegExpExecArray | null;
+    const seen = new Set<string>();
+    while ((match = placeholderRe.exec(source)) !== null) {
+      const key = (match[1] ?? "").trim();
+      const hasDefault = match[2] !== undefined;
+      if (!hasDefault && !seen.has(key)) {
+        seen.add(key);
+        findings.push({
+          code: "mustache_placeholder_without_default",
+          severity: "warning",
+          message: `Placeholder {{${key}}} has no default value. This composition will show raw "{{${key}}}" when rendered standalone (preview, lint, render without a parent).`,
+          fixHint: `Add a default: {{${key}:your default value}}. This ensures the composition renders correctly both standalone and when used with data-props.`,
+          snippet: match[0],
+        });
+      }
+    }
+    return findings;
+  },
+
+  // unused_data_props_key (inline templates only — cross-file not supported)
+  ({ rawSource }) => {
+    const findings: HyperframeLintFinding[] = [];
+    const placeholderRe = /\{\{(\s*[\w.-]+\s*)(?::[^}]*)?\}\}/g;
+
+    // Use rawSource (not template-stripped source) to find hosts with data-props
+    const rawTags = extractOpenTags(rawSource);
+    for (const tag of rawTags) {
+      // Only check hosts that reference inline templates (same-file)
+      const compId = readAttr(tag.raw, "data-composition-id");
+      if (!compId) continue;
+      if (readAttr(tag.raw, "data-composition-src")) continue; // external — can't check
+
+      const dataPropsMatch = tag.raw.match(/\bdata-props\s*=\s*(?:'([^']*)'|"([^"]*)")/i);
+      if (!dataPropsMatch) continue;
+
+      const propsRaw = (dataPropsMatch[1] ?? dataPropsMatch[2] ?? "")
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, "&");
+      let propsKeys: Set<string>;
+      try {
+        const parsed = JSON.parse(propsRaw);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
+        propsKeys = new Set(Object.keys(parsed));
+      } catch {
+        continue; // invalid JSON is caught by invalid_data_props_json rule
+      }
+      if (propsKeys.size === 0) continue;
+
+      // Find the matching inline template
+      const templateRe = new RegExp(
+        `<template[^>]*id=["']${compId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-template["'][^>]*>([\\s\\S]*?)</template>`,
+        "i",
+      );
+      const templateMatch = rawSource.match(templateRe);
+      if (!templateMatch?.[1]) continue;
+
+      // Collect all placeholder keys in the template
+      const templateKeys = new Set<string>();
+      let pMatch: RegExpExecArray | null;
+      const pRe = new RegExp(placeholderRe.source, placeholderRe.flags);
+      while ((pMatch = pRe.exec(templateMatch[1])) !== null) {
+        templateKeys.add((pMatch[1] ?? "").trim());
+      }
+
+      // Warn about props keys that don't match any placeholder
+      for (const key of propsKeys) {
+        if (!templateKeys.has(key)) {
+          const elementId = readAttr(tag.raw, "id") || undefined;
+          findings.push({
+            code: "unused_data_props_key",
+            severity: "warning",
+            message: `data-props key "${key}" on <${tag.name}${elementId ? ` id="${elementId}"` : ""}> does not match any {{${key}}} placeholder in the "${compId}" template. Possible typo.`,
+            elementId,
+            fixHint: `Check the key name. Available placeholders in the template: ${[...templateKeys].map((k) => `{{${k}}}`).join(", ") || "(none found)"}`,
+            snippet: truncateSnippet(tag.raw),
+          });
+        }
+      }
+    }
     return findings;
   },
 

--- a/packages/core/src/parsers/htmlParser.ts
+++ b/packages/core/src/parsers/htmlParser.ts
@@ -272,7 +272,7 @@ export function parseHtml(html: string): ParsedHtml {
       const sourceHeight = sourceHeightAttr ? parseInt(sourceHeightAttr, 10) : undefined;
 
       // Parse variable values if present
-      const variableValuesAttr = el.getAttribute("data-variable-values");
+      const variableValuesAttr = el.getAttribute("data-props");
       let variableValues: Record<string, string | number | boolean> | undefined;
       if (variableValuesAttr) {
         try {

--- a/packages/core/src/runtime/compositionLoader.ts
+++ b/packages/core/src/runtime/compositionLoader.ts
@@ -1,6 +1,7 @@
 // ── Prop interpolation (browser-safe) ─────────────────────────────────────
 
-const MUSTACHE_RE = /\{\{(\s*[\w.-]+\s*)\}\}/g;
+/** Matches `{{key}}` and `{{key:default value}}`. */
+const MUSTACHE_RE = /\{\{(\s*[\w.-]+\s*)(?::([^}]*))?\}\}/g;
 
 function parseVariableValues(raw: string | null): Record<string, string | number | boolean> | null {
   if (!raw) return null;
@@ -13,22 +14,96 @@ function parseVariableValues(raw: string | null): Record<string, string | number
   }
 }
 
-function escapeHtml(str: string): string {
+function escapeJsString(str: string): string {
   return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "\\'")
+    .replace(/`/g, "\\`")
+    .replace(/\$\{/g, "\\${")
+    .replace(/<\/(script)/gi, "<\\/$1");
 }
 
-function interpolateHtml(html: string, values: Record<string, string | number | boolean>): string {
-  if (!html || Object.keys(values).length === 0) return html;
-  return html.replace(MUSTACHE_RE, (_match, rawKey: string) => {
+function interpolateScriptContent(
+  content: string,
+  values?: Record<string, string | number | boolean> | null,
+): string {
+  if (!content) return content;
+  const vals = values ?? {};
+  return content.replace(MUSTACHE_RE, (_match, rawKey: string, rawDefault: string | undefined) => {
     const key = rawKey.trim();
-    if (key in values) return escapeHtml(String(values[key]));
+    if (key in vals) {
+      const val = vals[key];
+      if (typeof val === "string") return escapeJsString(val);
+      return String(val);
+    }
+    if (rawDefault !== undefined) return escapeJsString(rawDefault);
     return _match;
   });
+}
+
+/** Raw interpolation for CSS — HTML entity escaping is invalid in CSS. */
+function interpolateCss(
+  content: string,
+  values?: Record<string, string | number | boolean> | null,
+): string {
+  if (!content) return content;
+  const vals = values ?? {};
+  return content.replace(MUSTACHE_RE, (_match, rawKey: string, rawDefault: string | undefined) => {
+    const key = rawKey.trim();
+    if (key in vals) return String(vals[key]);
+    if (rawDefault !== undefined) return rawDefault;
+    return _match;
+  });
+}
+
+/**
+ * Walk a parsed DOM document and interpolate {{key}} placeholders in-place,
+ * using context-appropriate escaping: HTML-escaped for text nodes and
+ * attributes, raw for CSS, JS-escaped for scripts.
+ */
+function interpolateParsedDocument(
+  doc: Document,
+  values?: Record<string, string | number | boolean> | null,
+): void {
+  // CSS: raw interpolation
+  for (const style of Array.from(doc.querySelectorAll("style"))) {
+    const text = style.textContent || "";
+    if (MUSTACHE_RE.test(text)) {
+      MUSTACHE_RE.lastIndex = 0;
+      style.textContent = interpolateCss(text, values);
+    }
+  }
+  // Scripts: JS-escaped interpolation
+  for (const script of Array.from(doc.querySelectorAll("script"))) {
+    const text = script.textContent || "";
+    if (MUSTACHE_RE.test(text)) {
+      MUSTACHE_RE.lastIndex = 0;
+      script.textContent = interpolateScriptContent(text, values);
+    }
+  }
+  // Text nodes and attributes: raw replacement. The browser auto-escapes
+  // when rendering textContent / setAttribute, so we must NOT HTML-escape here.
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+  let node: Text | null;
+  while ((node = walker.nextNode() as Text | null)) {
+    const parent = node.parentElement;
+    if (parent && (parent.tagName === "STYLE" || parent.tagName === "SCRIPT")) continue;
+    const text = node.textContent || "";
+    if (MUSTACHE_RE.test(text)) {
+      MUSTACHE_RE.lastIndex = 0;
+      node.textContent = interpolateCss(text, values); // raw replacement
+    }
+  }
+  // Attributes
+  for (const el of Array.from(doc.querySelectorAll("*"))) {
+    for (const attr of Array.from(el.attributes)) {
+      if (MUSTACHE_RE.test(attr.value)) {
+        MUSTACHE_RE.lastIndex = 0;
+        el.setAttribute(attr.name, interpolateCss(attr.value, values)); // raw replacement
+      }
+    }
+  }
 }
 
 // ── Composition loader types ──────────────────────────────────────────────
@@ -250,12 +325,26 @@ export async function loadInlineTemplateCompositions(
       `template#${CSS.escape(compId)}-template`,
     )!;
 
+    // Interpolate {{key}} and {{key:default}} placeholders using data-props from host.
+    // Always run interpolation so defaults resolve even when data-props is absent.
+    const varValues = parseVariableValues(host.getAttribute("data-props"));
+    // Serialize template content to HTML, parse as a full document for
+    // interpolateParsedDocument (which needs querySelectorAll on <style>/<script>).
+    const container = document.createElement("div");
+    container.appendChild(document.importNode(template.content, true));
+    const rawHtml = container.innerHTML;
+    const tempDoc = new DOMParser().parseFromString(rawHtml, "text/html");
+    interpolateParsedDocument(tempDoc, varValues);
+    const tempTemplate = document.createElement("template");
+    tempTemplate.innerHTML = tempDoc.body.innerHTML;
+    const sourceNode: ParentNode = tempTemplate.content;
+
     resetCompositionHost(host);
     await mountCompositionContent({
       host,
       hostCompositionId: compId,
       hostCompositionSrc: `template#${compId}-template`,
-      sourceNode: template.content,
+      sourceNode,
       hasTemplate: true,
       fallbackBodyInnerHtml: "",
       compositionUrl: null,
@@ -312,16 +401,15 @@ export async function loadExternalCompositions(
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
-        let html = await response.text();
-
-        // Interpolate {{key}} placeholders using data-props from host
-        const varValues = parseVariableValues(host.getAttribute("data-props"));
-        if (varValues) {
-          html = interpolateHtml(html, varValues);
-        }
+        const html = await response.text();
 
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, "text/html");
+
+        // Interpolate {{key}} and {{key:default}} placeholders per-context after
+        // parsing. Always run so defaults resolve even without data-props.
+        const varValues = parseVariableValues(host.getAttribute("data-props"));
+        interpolateParsedDocument(doc, varValues);
         const template =
           (hostCompositionId
             ? doc.querySelector<HTMLTemplateElement>(

--- a/packages/core/src/runtime/compositionLoader.ts
+++ b/packages/core/src/runtime/compositionLoader.ts
@@ -1,3 +1,38 @@
+// ── Prop interpolation (browser-safe) ─────────────────────────────────────
+
+const MUSTACHE_RE = /\{\{(\s*[\w.-]+\s*)\}\}/g;
+
+function parseVariableValues(raw: string | null): Record<string, string | number | boolean> | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, string | number | boolean>;
+  } catch {
+    return null;
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function interpolateHtml(html: string, values: Record<string, string | number | boolean>): string {
+  if (!html || Object.keys(values).length === 0) return html;
+  return html.replace(MUSTACHE_RE, (_match, rawKey: string) => {
+    const key = rawKey.trim();
+    if (key in values) return escapeHtml(String(values[key]));
+    return _match;
+  });
+}
+
+// ── Composition loader types ──────────────────────────────────────────────
+
 type LoadExternalCompositionsParams = {
   injectedStyles: HTMLStyleElement[];
   injectedScripts: HTMLScriptElement[];
@@ -277,7 +312,14 @@ export async function loadExternalCompositions(
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
-        const html = await response.text();
+        let html = await response.text();
+
+        // Interpolate {{key}} placeholders using data-props from host
+        const varValues = parseVariableValues(host.getAttribute("data-props"));
+        if (varValues) {
+          html = interpolateHtml(html, varValues);
+        }
+
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, "text/html");
         const template =

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -23,6 +23,8 @@ import {
   rewriteAssetPaths,
   rewriteCssAssetUrls,
   interpolateProps,
+  interpolateScriptProps,
+  interpolateCssProps,
   parseVariableValues,
 } from "@hyperframes/core";
 import { extractVideoMetadata, extractAudioMetadata } from "../utils/ffprobe.js";
@@ -509,11 +511,8 @@ function inlineSubCompositions(
       continue;
     }
 
-    // Interpolate {{key}} placeholders using data-props from the host element
+    // Parse variable values from host element for per-context interpolation
     const varValues = parseVariableValues(host.getAttribute("data-props"));
-    if (varValues) {
-      compHtml = interpolateProps(compHtml, varValues);
-    }
 
     const compDoc = parseHTML(compHtml).document;
     const compId = host.getAttribute("data-composition-id");
@@ -533,8 +532,29 @@ function inlineSubCompositions(
       : contentDoc.querySelector("[data-composition-id]");
     const inferredCompId = innerRoot?.getAttribute("data-composition-id")?.trim() || null;
 
+    // Interpolate {{key}} and {{key:default}} in HTML text/attributes (always run for defaults)
+    {
+      const bodyEl2 = contentDoc.querySelector("body");
+      if (bodyEl2) {
+        for (const el of bodyEl2.querySelectorAll("*")) {
+          if (el.tagName === "STYLE" || el.tagName === "SCRIPT") continue;
+          for (const attr of [...el.attributes]) {
+            el.setAttribute(attr.name, interpolateProps(attr.value, varValues));
+          }
+        }
+        const walk = contentDoc.createTreeWalker(bodyEl2, 4 /* NodeFilter.SHOW_TEXT */);
+        let textNode: Node | null;
+        while ((textNode = walk.nextNode())) {
+          const parent = textNode.parentNode as Element | null;
+          if (parent && (parent.tagName === "STYLE" || parent.tagName === "SCRIPT")) continue;
+          textNode.textContent = interpolateProps(textNode.textContent || "", varValues);
+        }
+      }
+    }
+
     for (const styleEl of contentDoc.querySelectorAll("style")) {
-      const css = rewriteCssAssetUrls(styleEl.textContent || "", srcPath);
+      let css = rewriteCssAssetUrls(styleEl.textContent || "", srcPath);
+      css = interpolateCssProps(css, varValues);
       const scopeId = compId || inferredCompId;
       if (scopeId && css.trim()) {
         // Scope sub-composition styles to their composition ID to prevent
@@ -559,7 +579,9 @@ function inlineSubCompositions(
         scriptEl.remove();
         continue;
       }
-      const content = (scriptEl.textContent || "").trim();
+      let content = (scriptEl.textContent || "").trim();
+      // Interpolate script content with JS-safe escaping (always run for defaults)
+      if (content) content = interpolateScriptProps(content, varValues);
       if (content) {
         const scriptMountCompId = compId || inferredCompId || "";
         const compIdLiteral = JSON.stringify(scriptMountCompId);

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -22,7 +22,6 @@ import {
   type UnresolvedElement,
   rewriteAssetPaths,
   rewriteCssAssetUrls,
-  interpolateProps,
   interpolateScriptProps,
   interpolateCssProps,
   parseVariableValues,
@@ -532,14 +531,16 @@ function inlineSubCompositions(
       : contentDoc.querySelector("[data-composition-id]");
     const inferredCompId = innerRoot?.getAttribute("data-composition-id")?.trim() || null;
 
-    // Interpolate {{key}} and {{key:default}} in HTML text/attributes (always run for defaults)
+    // Interpolate {{key}} and {{key:default}} in HTML text/attributes (always run for defaults).
+    // Use raw replacement (interpolateCssProps) since linkedom auto-escapes on serialization —
+    // HTML-escaping here would double-escape (e.g., "A & B" → "A &amp;amp; B").
     {
       const bodyEl2 = contentDoc.querySelector("body");
       if (bodyEl2) {
         for (const el of bodyEl2.querySelectorAll("*")) {
           if (el.tagName === "STYLE" || el.tagName === "SCRIPT") continue;
           for (const attr of [...el.attributes]) {
-            el.setAttribute(attr.name, interpolateProps(attr.value, varValues));
+            el.setAttribute(attr.name, interpolateCssProps(attr.value, varValues));
           }
         }
         const walk = contentDoc.createTreeWalker(bodyEl2, 4 /* NodeFilter.SHOW_TEXT */);
@@ -547,7 +548,7 @@ function inlineSubCompositions(
         while ((textNode = walk.nextNode())) {
           const parent = textNode.parentNode as Element | null;
           if (parent && (parent.tagName === "STYLE" || parent.tagName === "SCRIPT")) continue;
-          textNode.textContent = interpolateProps(textNode.textContent || "", varValues);
+          textNode.textContent = interpolateCssProps(textNode.textContent || "", varValues);
         }
       }
     }

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -22,6 +22,8 @@ import {
   type UnresolvedElement,
   rewriteAssetPaths,
   rewriteCssAssetUrls,
+  interpolateProps,
+  parseVariableValues,
 } from "@hyperframes/core";
 import { extractVideoMetadata, extractAudioMetadata } from "../utils/ffprobe.js";
 import {
@@ -505,6 +507,12 @@ function inlineSubCompositions(
     }
     if (!compHtml) {
       continue;
+    }
+
+    // Interpolate {{key}} placeholders using data-props from the host element
+    const varValues = parseVariableValues(host.getAttribute("data-props"));
+    if (varValues) {
+      compHtml = interpolateProps(compHtml, varValues);
     }
 
     const compDoc = parseHTML(compHtml).document;

--- a/skills/hyperframes-compose/SKILL.md
+++ b/skills/hyperframes-compose/SKILL.md
@@ -98,16 +98,16 @@ Reuse a single composition with different data by passing `data-props` — a JSO
 ></div>
 ```
 
-**Sub-composition (compositions/card.html) — uses `{{key}}` placeholders:**
+**Sub-composition (compositions/card.html) — uses `{{key:default}}` placeholders:**
 
 ```html
 <template id="card-free-template">
   <div data-composition-id="card-free" data-width="1920" data-height="1080">
     <style>
-      .card { background: {{bgColor}}; }
+      .card { background: {{bgColor:#6366f1}}; }
     </style>
-    <h2>{{title}}</h2>
-    <p>{{price}}/mo</p>
+    <h2>{{title:Card Title}}</h2>
+    <p>{{price:$0}}/mo</p>
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
     <script>
       window.__timelines = window.__timelines || {};
@@ -122,11 +122,13 @@ Reuse a single composition with different data by passing `data-props` — a JSO
 **Rules:**
 
 - `data-props` value must be valid JSON: `'{"key":"value"}'`
-- Placeholders use mustache syntax: `{{key}}` (whitespace OK: `{{ key }}`)
+- `{{key}}` — replaced with value, or left as-is if no value provided
+- `{{key:default}}` — replaced with value, or the default if no value provided
+- Whitespace OK: `{{ key }}`, `{{ key : default }}`
 - Works in HTML content, CSS `<style>` blocks, and `<script>` blocks
-- Values are HTML-escaped in content/CSS (XSS-safe), raw in scripts
-- Unmatched `{{key}}` placeholders are left as-is (no error)
+- Values are HTML-escaped in content (XSS-safe), raw in CSS, JS-escaped in scripts
 - Supported value types: string, number, boolean
+- **Always use defaults** so compositions render standalone (preview, lint, render all work without a parent)
 
 **When to use:** Any time you have 2+ similar elements (pricing cards, team members, testimonials, chart bars, timeline steps). Write the component once, instantiate with different data.
 

--- a/skills/hyperframes-compose/SKILL.md
+++ b/skills/hyperframes-compose/SKILL.md
@@ -37,12 +37,13 @@ When no `visual-style.md` or animation direction is provided, follow [house-styl
 
 ### Composition Clips
 
-| Attribute                    | Required | Values                                       |
-| ---------------------------- | -------- | -------------------------------------------- |
-| `data-composition-id`        | Yes      | Unique composition ID                        |
-| `data-duration`              | Yes      | Takes precedence over GSAP timeline duration |
-| `data-width` / `data-height` | Yes      | Pixel dimensions (1920x1080 or 1080x1920)    |
-| `data-composition-src`       | No       | Path to external HTML file                   |
+| Attribute                    | Required | Values                                                            |
+| ---------------------------- | -------- | ----------------------------------------------------------------- |
+| `data-composition-id`        | Yes      | Unique composition ID                                             |
+| `data-duration`              | Yes      | Takes precedence over GSAP timeline duration                      |
+| `data-width` / `data-height` | Yes      | Pixel dimensions (1920x1080 or 1080x1920)                         |
+| `data-composition-src`       | No       | Path to external HTML file                                        |
+| `data-props`                 | No       | JSON object passed to sub-composition for `{{key}}` interpolation |
 
 ## Composition Structure
 
@@ -69,6 +70,65 @@ Every composition is a `<template>` wrapping a `<div>` with `data-composition-id
 ```
 
 Load in root: `<div id="el-1" data-composition-id="my-comp" data-composition-src="compositions/my-comp.html" data-start="0" data-duration="10" data-track-index="1"></div>`
+
+## Parameterized Compositions (data-props)
+
+Reuse a single composition with different data by passing `data-props` — a JSON object whose keys replace `{{key}}` placeholders in the sub-composition's HTML, CSS, and scripts.
+
+**Root (index.html) — use the same card 3 times:**
+
+```html
+<div
+  class="clip"
+  data-composition-id="card-free"
+  data-composition-src="compositions/card.html"
+  data-props='{"title":"Free","price":"$0","bgColor":"#6366f1"}'
+  data-start="0"
+  data-duration="4"
+  data-track-index="1"
+></div>
+<div
+  class="clip"
+  data-composition-id="card-pro"
+  data-composition-src="compositions/card.html"
+  data-props='{"title":"Pro","price":"$29","bgColor":"#ec4899"}'
+  data-start="4"
+  data-duration="4"
+  data-track-index="1"
+></div>
+```
+
+**Sub-composition (compositions/card.html) — uses `{{key}}` placeholders:**
+
+```html
+<template id="card-free-template">
+  <div data-composition-id="card-free" data-width="1920" data-height="1080">
+    <style>
+      .card { background: {{bgColor}}; }
+    </style>
+    <h2>{{title}}</h2>
+    <p>{{price}}/mo</p>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("h2", { opacity: 0, y: -20, duration: 0.6 }, 0.2);
+      window.__timelines["card-free"] = tl;
+    </script>
+  </div>
+</template>
+```
+
+**Rules:**
+
+- `data-props` value must be valid JSON: `'{"key":"value"}'`
+- Placeholders use mustache syntax: `{{key}}` (whitespace OK: `{{ key }}`)
+- Works in HTML content, CSS `<style>` blocks, and `<script>` blocks
+- Values are HTML-escaped in content/CSS (XSS-safe), raw in scripts
+- Unmatched `{{key}}` placeholders are left as-is (no error)
+- Supported value types: string, number, boolean
+
+**When to use:** Any time you have 2+ similar elements (pricing cards, team members, testimonials, chart bars, timeline steps). Write the component once, instantiate with different data.
 
 ## Video and Audio
 
@@ -147,6 +207,7 @@ For audio-driven animation (beat sync, glow, pulse), see the `audio-reactive` sk
 - [ ] Every top-level container has `data-composition-id`
 - [ ] Every composition has `data-width`, `data-height`, `data-duration`
 - [ ] Compositions in own HTML files, loaded via `data-composition-src`
+- [ ] Repeated elements use `data-props` instead of copy-pasting HTML
 - [ ] `<template>` wrapper on sub-compositions
 - [ ] `window.__timelines` registered for every composition
 - [ ] 100% deterministic — no randomness

--- a/skills/hyperframes-compose/patterns.md
+++ b/skills/hyperframes-compose/patterns.md
@@ -127,11 +127,11 @@ Write a composition once, use it N times with different data. Avoids copy-pastin
 <template id="stat-card-template">
   <div data-composition-id="stat-card" data-width="1920" data-height="1080">
     <style>
-      .stat-value { font-size: 120px; font-weight: 900; color: {{color}}; }
+      .stat-value { font-size: 120px; font-weight: 900; color: {{color:#22c55e}}; }
       .stat-label { font-size: 32px; color: #fff; }
     </style>
-    <div class="stat-value" id="val-inner">{{value}}</div>
-    <div class="stat-label" id="lbl-inner">{{label}}</div>
+    <div class="stat-value" id="val-inner">{{value:$0}}</div>
+    <div class="stat-label" id="lbl-inner">{{label:Metric}}</div>
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
     <script>
       window.__timelines = window.__timelines || {};

--- a/skills/hyperframes-compose/patterns.md
+++ b/skills/hyperframes-compose/patterns.md
@@ -116,3 +116,66 @@ Use separate elements on the same track, each with its own time range. Slides au
   </script>
 </div>
 ```
+
+## Reusable Components (data-props)
+
+Write a composition once, use it N times with different data. Avoids copy-pasting HTML for repeated elements like cards, team members, or chart bars.
+
+**Component file (compositions/stat-card.html):**
+
+```html
+<template id="stat-card-template">
+  <div data-composition-id="stat-card" data-width="1920" data-height="1080">
+    <style>
+      .stat-value { font-size: 120px; font-weight: 900; color: {{color}}; }
+      .stat-label { font-size: 32px; color: #fff; }
+    </style>
+    <div class="stat-value" id="val-inner">{{value}}</div>
+    <div class="stat-label" id="lbl-inner">{{label}}</div>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#val-inner", { opacity: 0, scale: 0.5, duration: 0.8, ease: "back.out(2)" }, 0.2);
+      tl.from("#lbl-inner", { opacity: 0, y: 20, duration: 0.5 }, 0.6);
+      window.__timelines["stat-card"] = tl;
+    </script>
+  </div>
+</template>
+```
+
+**Root (index.html) — 3 instances:**
+
+```html
+<div
+  class="clip"
+  data-composition-id="revenue"
+  data-composition-src="compositions/stat-card.html"
+  data-props='{"value":"$2.4M","label":"Revenue","color":"#22c55e"}'
+  data-start="0"
+  data-duration="3"
+  data-track-index="1"
+></div>
+
+<div
+  class="clip"
+  data-composition-id="users"
+  data-composition-src="compositions/stat-card.html"
+  data-props='{"value":"14K","label":"Active Users","color":"#3b82f6"}'
+  data-start="3"
+  data-duration="3"
+  data-track-index="1"
+></div>
+
+<div
+  class="clip"
+  data-composition-id="nps"
+  data-composition-src="compositions/stat-card.html"
+  data-props='{"value":"72","label":"NPS Score","color":"#f59e0b"}'
+  data-start="6"
+  data-duration="3"
+  data-track-index="1"
+></div>
+```
+
+**Key:** Each host needs a unique `data-composition-id`. The `{{key}}` placeholders work in HTML, CSS, and scripts.


### PR DESCRIPTION
## What

Adds parameterized sub-compositions to HyperFrames via `data-props` and `{{key:default}}` interpolation.

A composition file can now contain mustache-style placeholders. A parent passes values via `data-props` JSON; the placeholders resolve at build time, render time, and in the live preview. Placeholders with defaults (`{{key:default}}`) resolve standalone — no parent required.

```html
<!-- Parent: same component, 3 different instances -->
<div class="clip"
  data-composition-src="compositions/card.html"
  data-props='{"title":"Pro","price":"$29","bgColor":"#ec4899"}'
  data-start="0" data-duration="5" data-track-index="0">
</div>
```

```html
<!-- compositions/card.html: renders standalone with defaults, or with parent props -->
<style>.card { background: {{bgColor:#6366f1}}; }</style>
<h2>{{title:Card Title}}</h2>
<p>{{price:$0}}/mo</p>
```

## Why

Before this PR, every repeated element in a HyperFrames composition was hand-coded. 3 pricing cards = 3x copy-pasted HTML. 10 countdown numbers = 10 nearly-identical blocks. 4 team members = 4 duplicated structures. There was no way to write a component once and reuse it with different data.

This was the #1 pain point across 40 stress-test projects built by AI agents comparing HyperFrames to Remotion. Every agent independently flagged it. Remotion solves this naturally with React components and props — HyperFrames had no equivalent.

`data-props` closes that gap without adding React, TypeScript, node_modules, or a build step. It fits the existing `data-*` attribute model and works with the linter, renderer, and studio as-is.

The `{{key:default}}` syntax solves a follow-on problem: if a composition contains `{{bgColor}}` and is opened standalone (preview, lint, render without a parent), the CSS breaks. Inline defaults make every composition self-contained.

## How

**New file:** **`interpolateProps.ts`** — shared interpolation engine with three context-aware functions:

- `interpolateProps()` — HTML-escaped for content (XSS-safe)
- `interpolateCssProps()` — raw values for CSS (entity escaping breaks CSS)
- `interpolateScriptProps()` — JS-escaped for scripts (prevents string breakout)

**Wired into three pipelines:**

1. `htmlBundler.ts` — build-time (`npx hyperframes render` via bundler)
2. `producer/htmlCompiler.ts` — render-time (before PostCSS scoping)
3. `compositionLoader.ts` — browser runtime (preview + studio)

**Also:**

- Renamed `data-variable-values` → `data-props` (the old attribute was never shipped publicly)
- Updated `htmlParser.ts` and `generators/hyperframes.ts` for the rename
- Updated skill docs ([SKILL.md](http://SKILL.md), [patterns.md](http://patterns.md)) and CLI docs ([compositions.md](http://compositions.md))

## Test plan

- [x] 465/465 core tests pass (40 unit + 4 integration — 21 new)
- [x] Build succeeds across all packages (core, cli, producer, studio)
- [x] Pre-commit hooks pass (oxlint, oxfmt, typecheck, commitlint)
- [x] E2E: created a project with 3 parameterized pricing cards using `data-props`, linted (0 errors), rendered to MP4 (12s, 1920x1080, 49KB)
- [x] Verified CSS interpolation works with PostCSS scoping (producer pipeline)
- [x] Verified XSS: `<script>alert(1)</script>` in props is escaped to `&lt;script&gt;` in output
- [x] Verified standalone rendering: composition with `{{key:default}}` renders without parent `data-props`
- [x] Verified unmatched placeholders without defaults are preserved as-is