### PR TITLE
fix(engine): lower default CRF for better gradient rendering

### DIFF
--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -17,8 +17,8 @@ export type { EncoderOptions, EncodeResult, MuxResult } from "./chunkEncoder.typ
 
 export const ENCODER_PRESETS = {
   draft: { preset: "ultrafast", quality: 28, codec: "h264" as const },
-  standard: { preset: "medium", quality: 23, codec: "h264" as const },
-  high: { preset: "slow", quality: 18, codec: "h264" as const },
+  standard: { preset: "medium", quality: 18, codec: "h264" as const },
+  high: { preset: "slow", quality: 15, codec: "h264" as const },
 };
 
 /**


### PR DESCRIPTION
## Summary

- Standard preset CRF 23→18, high preset CRF 18→15
- Reduces H.264 quantization artifacts on subtle gradients

## What it targets

Eval prompts 3, 5, 10, 14 all noted "color banding" on dark gradient backgrounds. Lower CRF preserves more color precision in smooth gradient regions.

## Honest assessment

After testing: the CRF reduction provides marginal improvement for dark gradient banding. The visual difference between CRF 23 and 18 is subtle — most of the banding visible in the eval videos comes from the 8-bit color depth of yuv420p, which CRF alone can't fix.

**The higher-impact fix is PR #217** (skill guardrails), which tells agents to avoid full-screen dark linear gradients entirely and use radial gradients or solid backgrounds with localized glows instead.

This PR still has value as a general quality bump — CRF 18 is more appropriate for a video rendering tool where output quality matters more than file size.

## Trade-off

~30-50% larger file sizes for standard/high quality.

## Test plan

- [x] `pnpm --filter @hyperframes/engine test` — all 26 tests pass
- [x] Synthetic gradient comparison (CRF 23 vs 18) — marginal visual difference confirmed
- [x] File size comparison — within expected range

🤖 Generated with [Claude Code](https://claude.com/claude-code)