### PR TITLE
feat: add MOV (ProRes 4444) as transparent video output format

### DIFF
--- a/docs/guides/rendering.mdx
+++ b/docs/guides/rendering.mdx
@@ -1,9 +1,9 @@
 ---
 title: Rendering
-description: "Render compositions to MP4 locally or in Docker."
+description: "Render compositions to MP4, MOV, or WebM locally or in Docker."
 ---
 
-Render your Hyperframes [compositions](/concepts/compositions) to MP4 with the [CLI](/packages/cli). The rendering pipeline is frame-by-frame and seek-driven — see [Deterministic Rendering](/concepts/determinism) for how this works under the hood.
+Render your Hyperframes [compositions](/concepts/compositions) to MP4, MOV, or WebM with the [CLI](/packages/cli). The rendering pipeline is frame-by-frame and seek-driven — see [Deterministic Rendering](/concepts/determinism) for how this works under the hood.
 
 ## Getting Started
 
@@ -114,6 +114,7 @@ Render your Hyperframes [compositions](/concepts/compositions) to MP4 with the [
 | Flag | Values | Default | Description |
 |------|--------|---------|-------------|
 | `--output` | path | `renders/<name>.mp4` | Output file path |
+| `--format` | mp4, mov, webm | mp4 | Output format (see [Transparent Video](#transparent-video) below) |
 | `--fps` | 24, 30, 60 | 30 | Frames per second |
 | `--quality` | draft, standard, high | standard | Encoding quality preset |
 | `--workers` | 1-8 or `auto` | auto | Parallel render workers (see [Workers](#workers) below) |
@@ -166,6 +167,75 @@ npx hyperframes render --workers 8 --output output.mp4
 - Long compositions (30+ seconds) on a machine with 8+ cores and 16+ GB RAM
 - Dedicated render machines or CI runners
 - Docker mode on a well-provisioned host
+
+## Transparent Video
+
+Hyperframes supports rendering with a transparent background — useful for overlays, lower thirds, subscribe cards, and any element you want to composite over other footage in a video editor.
+
+### Recommended format: MOV (ProRes 4444)
+
+```bash Terminal
+npx hyperframes render --format mov --output overlay.mov
+```
+
+**MOV with ProRes 4444** is the industry standard for transparent video. It works in all major video editors:
+
+- CapCut
+- Final Cut Pro
+- Adobe Premiere Pro
+- DaVinci Resolve
+- After Effects
+
+<Warning>
+  ProRes MOV files are large (typically 5-40 MB for short clips) because ProRes is a high-quality intermediate codec optimized for editing, not delivery. This is expected — the same tradeoff Remotion and professional pipelines make.
+</Warning>
+
+### Format comparison
+
+| Format | Codec | Transparency | Video editors | Browsers | File size |
+|--------|-------|-------------|---------------|----------|-----------|
+| **MOV** | ProRes 4444 | Yes | CapCut, Final Cut, Premiere, DaVinci, After Effects | No | Large |
+| **WebM** | VP9 | Yes | None (shows black background) | Chrome, Firefox | Small |
+| **MP4** | H.264 | No | All | All | Small |
+
+<Note>
+  **WebM VP9 alpha** is technically supported but all major video editors ignore the alpha channel and render transparent areas as black. Only Chromium-based browsers (Chrome, Arc, Brave, Edge) decode VP9 alpha correctly. Safari does not support it. Use MOV for editor workflows and WebM only for browser-based playback.
+</Note>
+
+### How it works
+
+When you render with `--format mov` or `--format webm`, Hyperframes:
+
+1. Captures each frame as a **PNG with alpha channel** (instead of JPEG for MP4)
+2. Sets Chrome's page background to transparent via `Emulation.setDefaultBackgroundColorOverride`
+3. Encodes with an alpha-capable codec (ProRes 4444 for MOV, VP9 for WebM)
+
+Your composition's HTML should **not** set a `background` on `html` or `body` — leave it unset so the transparent background comes through.
+
+### Authoring transparent compositions
+
+```html
+<style>
+  /* Do NOT set background on html/body — leave them transparent */
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  [data-composition-id="my-overlay"] {
+    position: relative;
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    /* No background here either */
+  }
+</style>
+```
+
+Only the visible elements (cards, text, images) will appear in the final video. Everything else will be transparent.
+
+### Verifying transparency
+
+- **In a browser:** Open the MOV file — it won't play (ProRes is not a browser codec). Instead, render a WebM copy and open it in Chrome on a checkerboard background page.
+- **In a video editor:** Import the MOV file and place it on a track above other footage. Transparent areas should show the footage below.
+- **Online tool:** Use [rotato.app/tools/transparent-video](https://rotato.app/tools/transparent-video) to verify your MOV or WebM has working transparency.
 
 ## Tips
 

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -26,6 +26,7 @@ import type { RenderJob } from "@hyperframes/producer";
 const VALID_FPS = new Set([24, 30, 60]);
 const VALID_QUALITY = new Set(["draft", "standard", "high"]);
 const VALID_FORMAT = new Set(["mp4", "webm", "mov"]);
+const FORMAT_EXT: Record<string, string> = { mp4: ".mp4", webm: ".webm", mov: ".mov" };
 
 const CPU_CORE_COUNT = cpus().length;
 
@@ -133,7 +134,7 @@ export default defineCommand({
 
     // ── Resolve output path ───────────────────────────────────────────────
     const rendersDir = resolve("renders");
-    const ext = format === "webm" ? ".webm" : format === "mov" ? ".mov" : ".mp4";
+    const ext = FORMAT_EXT[format] ?? ".mp4";
     const now = new Date();
     const datePart = now.toISOString().slice(0, 10);
     const timePart = now.toTimeString().slice(0, 8).replace(/:/g, "-");

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, statSync } from "node:fs";
 
 export const examples: Example[] = [
   ["Render to MP4", "hyperframes render --output output.mp4"],
+  ["Render transparent overlay (ProRes)", "hyperframes render --format mov --output overlay.mov"],
   ["Render transparent WebM overlay", "hyperframes render --format webm --output overlay.webm"],
   ["High quality at 60fps", "hyperframes render --fps 60 --quality high --output hd.mp4"],
   ["Deterministic render via Docker", "hyperframes render --docker --output deterministic.mp4"],
@@ -24,7 +25,7 @@ import type { RenderJob } from "@hyperframes/producer";
 
 const VALID_FPS = new Set([24, 30, 60]);
 const VALID_QUALITY = new Set(["draft", "standard", "high"]);
-const VALID_FORMAT = new Set(["mp4", "webm"]);
+const VALID_FORMAT = new Set(["mp4", "webm", "mov"]);
 
 const CPU_CORE_COUNT = cpus().length;
 
@@ -36,7 +37,7 @@ function defaultWorkerCount(): number {
 export default defineCommand({
   meta: {
     name: "render",
-    description: "Render a composition to MP4 or WebM",
+    description: "Render a composition to MP4, WebM, or MOV",
   },
   args: {
     dir: {
@@ -60,7 +61,7 @@ export default defineCommand({
     },
     format: {
       type: "string",
-      description: "Output format: mp4, webm (WebM renders with transparency)",
+      description: "Output format: mp4, webm, mov (MOV/WebM render with transparency)",
       default: "mp4",
     },
     workers: {
@@ -114,10 +115,10 @@ export default defineCommand({
     // ── Validate format ─────────────────────────────────────────────────
     const formatRaw = args.format ?? "mp4";
     if (!VALID_FORMAT.has(formatRaw)) {
-      errorBox("Invalid format", `Got "${formatRaw}". Must be mp4 or webm.`);
+      errorBox("Invalid format", `Got "${formatRaw}". Must be mp4, webm, or mov.`);
       process.exit(1);
     }
-    const format = formatRaw as "mp4" | "webm";
+    const format = formatRaw as "mp4" | "webm" | "mov";
 
     // ── Validate workers ──────────────────────────────────────────────────
     let workers: number | undefined;
@@ -132,7 +133,7 @@ export default defineCommand({
 
     // ── Resolve output path ───────────────────────────────────────────────
     const rendersDir = resolve("renders");
-    const ext = format === "webm" ? ".webm" : ".mp4";
+    const ext = format === "webm" ? ".webm" : format === "mov" ? ".mov" : ".mp4";
     const now = new Date();
     const datePart = now.toISOString().slice(0, 10);
     const timePart = now.toTimeString().slice(0, 8).replace(/:/g, "-");
@@ -262,7 +263,7 @@ export default defineCommand({
 interface RenderOptions {
   fps: 24 | 30 | 60;
   quality: "draft" | "standard" | "high";
-  format: "mp4" | "webm";
+  format: "mp4" | "webm" | "mov";
   workers: number;
   gpu: boolean;
   quiet: boolean;

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -177,7 +177,7 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
           await executeRenderJob(job, opts.project.dir, opts.outputPath, onProgress);
           state.status = "complete";
           state.progress = 100;
-          const metaPath = opts.outputPath.replace(/\.(mp4|webm)$/, ".meta.json");
+          const metaPath = opts.outputPath.replace(/\.(mp4|webm|mov)$/, ".meta.json");
           writeFileSync(
             metaPath,
             JSON.stringify({ status: "complete", durationMs: Date.now() - startTime }),
@@ -186,7 +186,7 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
           state.status = "failed";
           state.error = err instanceof Error ? err.message : String(err);
           try {
-            const metaPath = opts.outputPath.replace(/\.(mp4|webm)$/, ".meta.json");
+            const metaPath = opts.outputPath.replace(/\.(mp4|webm|mov)$/, ".meta.json");
             writeFileSync(metaPath, JSON.stringify({ status: "failed" }));
           } catch {
             /* ignore */

--- a/packages/cli/src/utils/mime.ts
+++ b/packages/cli/src/utils/mime.ts
@@ -10,6 +10,7 @@ export const MIME_TYPES: Record<string, string> = {
   ".gif": "image/gif",
   ".webp": "image/webp",
   ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
   ".webm": "video/webm",
   ".mp3": "audio/mpeg",
   ".wav": "audio/wav",

--- a/packages/core/src/studio-api/helpers/mime.ts
+++ b/packages/core/src/studio-api/helpers/mime.ts
@@ -12,6 +12,7 @@ export const MIME_TYPES: Record<string, string> = {
   ".webp": "image/webp",
   ".ico": "image/x-icon",
   ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
   ".webm": "video/webm",
   ".mp3": "audio/mpeg",
   ".wav": "audio/wav",

--- a/packages/core/src/studio-api/routes/render.ts
+++ b/packages/core/src/studio-api/routes/render.ts
@@ -50,7 +50,9 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
       quality?: string;
       format?: string;
     };
-    const format = body.format === "webm" ? "webm" : body.format === "mov" ? "mov" : "mp4";
+    const VALID_FORMATS = new Set(["mp4", "webm", "mov"]);
+    const FORMAT_EXT: Record<string, string> = { mp4: ".mp4", webm: ".webm", mov: ".mov" };
+    const format = VALID_FORMATS.has(body.format ?? "") ? (body.format as string) : "mp4";
     const fps: 24 | 30 | 60 = body.fps === 24 || body.fps === 60 ? body.fps : 30;
     const quality = ["draft", "standard", "high"].includes(body.quality ?? "")
       ? (body.quality as string)
@@ -62,7 +64,7 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     const jobId = `${project.id}_${datePart}_${timePart}`;
     const rendersDir = adapter.rendersDir(project);
     if (!existsSync(rendersDir)) mkdirSync(rendersDir, { recursive: true });
-    const ext = format === "webm" ? ".webm" : format === "mov" ? ".mov" : ".mp4";
+    const ext = FORMAT_EXT[format] ?? ".mp4";
     const outputPath = join(rendersDir, `${jobId}${ext}`);
 
     const jobState = adapter.startRender({

--- a/packages/core/src/studio-api/routes/render.ts
+++ b/packages/core/src/studio-api/routes/render.ts
@@ -128,6 +128,18 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     });
   });
 
+  const RENDER_MIME: Record<string, string> = {
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+  };
+  const RENDER_EXTENSIONS = Object.keys(RENDER_MIME);
+
+  function renderContentType(filePath: string): string {
+    const ext = RENDER_EXTENSIONS.find((e) => filePath.endsWith(e));
+    return (ext && RENDER_MIME[ext]) ?? "video/mp4";
+  }
+
   // Serve render inline (for in-browser playback — opens in a new tab)
   api.get("/render/:jobId/view", (c) => {
     const { jobId } = c.req.param();
@@ -135,8 +147,7 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     if (!job?.outputPath || !existsSync(job.outputPath)) {
       return c.json({ error: "not found" }, 404);
     }
-    const isWebm = job.outputPath.endsWith(".webm");
-    const contentType = isWebm ? "video/webm" : "video/mp4";
+    const contentType = renderContentType(job.outputPath);
     const filename = job.outputPath.split("/").pop() ?? `render.mp4`;
     const content = readFileSync(job.outputPath);
     return new Response(content, {
@@ -156,8 +167,7 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     if (!job?.outputPath || !existsSync(job.outputPath)) {
       return c.json({ error: "not found" }, 404);
     }
-    const isWebm = job.outputPath.endsWith(".webm");
-    const contentType = isWebm ? "video/webm" : "video/mp4";
+    const contentType = renderContentType(job.outputPath);
     const filename = job.outputPath.split("/").pop() ?? `render.mp4`;
     const content = readFileSync(job.outputPath);
     return new Response(content, {
@@ -174,7 +184,7 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     for (const [, state] of renderJobs) {
       if (state.id === jobId && state.outputPath) {
         const dir = state.outputPath.replace(/\/[^/]+$/, "");
-        for (const ext of [".mp4", ".webm", ".meta.json"]) {
+        for (const ext of [".mp4", ".webm", ".mov", ".meta.json"]) {
           const fp = join(dir, `${jobId}${ext}`);
           if (existsSync(fp)) unlinkSync(fp);
         }
@@ -194,8 +204,7 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     const rendersDir = adapter.rendersDir(project);
     const fp = join(rendersDir, filename);
     if (!existsSync(fp)) return c.json({ error: "not found" }, 404);
-    const isWebm = fp.endsWith(".webm");
-    const contentType = isWebm ? "video/webm" : "video/mp4";
+    const contentType = renderContentType(fp);
     const content = readFileSync(fp);
     return new Response(content, {
       headers: {
@@ -214,11 +223,11 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     const rendersDir = adapter.rendersDir(project);
     if (!existsSync(rendersDir)) return c.json({ renders: [] });
     const files = readdirSync(rendersDir)
-      .filter((f) => f.endsWith(".mp4") || f.endsWith(".webm"))
+      .filter((f) => f.endsWith(".mp4") || f.endsWith(".webm") || f.endsWith(".mov"))
       .map((f) => {
         const fp = join(rendersDir, f);
         const stat = statSync(fp);
-        const rid = f.replace(/\.(mp4|webm)$/, "");
+        const rid = f.replace(/\.(mp4|webm|mov)$/, "");
         const metaPath = join(rendersDir, `${rid}.meta.json`);
         let status: "complete" | "failed" = "complete";
         let durationMs: number | undefined;

--- a/packages/core/src/studio-api/routes/render.ts
+++ b/packages/core/src/studio-api/routes/render.ts
@@ -50,7 +50,7 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
       quality?: string;
       format?: string;
     };
-    const format = body.format === "webm" ? "webm" : "mp4";
+    const format = body.format === "webm" ? "webm" : body.format === "mov" ? "mov" : "mp4";
     const fps: 24 | 30 | 60 = body.fps === 24 || body.fps === 60 ? body.fps : 30;
     const quality = ["draft", "standard", "high"].includes(body.quality ?? "")
       ? (body.quality as string)
@@ -62,13 +62,13 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     const jobId = `${project.id}_${datePart}_${timePart}`;
     const rendersDir = adapter.rendersDir(project);
     if (!existsSync(rendersDir)) mkdirSync(rendersDir, { recursive: true });
-    const ext = format === "webm" ? ".webm" : ".mp4";
+    const ext = format === "webm" ? ".webm" : format === "mov" ? ".mov" : ".mp4";
     const outputPath = join(rendersDir, `${jobId}${ext}`);
 
     const jobState = adapter.startRender({
       project,
       outputPath,
-      format: format as "mp4" | "webm",
+      format: format as "mp4" | "webm" | "mov",
       fps,
       quality,
       jobId,

--- a/packages/core/src/studio-api/types.ts
+++ b/packages/core/src/studio-api/types.ts
@@ -57,7 +57,7 @@ export interface StudioApiAdapter {
   startRender(opts: {
     project: ResolvedProject;
     outputPath: string;
-    format: "mp4" | "webm";
+    format: "mp4" | "webm" | "mov";
     fps: number;
     quality: string;
     jobId: string;

--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -56,6 +56,21 @@ describe("getEncoderPreset", () => {
     }
   });
 
+  it("returns prores 4444 with yuva444p10le for mov format", () => {
+    const preset = getEncoderPreset("standard", "mov");
+    expect(preset.codec).toBe("prores");
+    expect(preset.preset).toBe("4444");
+    expect(preset.pixelFormat).toBe("yuva444p10le");
+  });
+
+  it("uses prores 4444 for all mov quality levels", () => {
+    for (const q of ["draft", "standard", "high"] as const) {
+      const preset = getEncoderPreset(q, "mov");
+      expect(preset.codec).toBe("prores");
+      expect(preset.preset).toBe("4444");
+    }
+  });
+
   it("defaults to mp4 when format is omitted", () => {
     const preset = getEncoderPreset("standard");
     expect(preset.codec).toBe("h264");

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -130,6 +130,7 @@ export function buildEncoderArgs(
     }
   } else if (codec === "prores") {
     args.push("-c:v", "prores_ks", "-profile:v", preset, "-vendor", "apl0");
+    args.push("-pix_fmt", pixelFormat);
     return [...args, "-y", outputPath];
   }
 
@@ -318,7 +319,11 @@ export async function encodeFramesChunkedConcat(
     }
     const startNumber = i * chunkSize;
     const framesInChunk = Math.min(chunkSize, files.length - startNumber);
-    const ext = outputPath.endsWith(".webm") ? ".webm" : ".mp4";
+    const ext = outputPath.endsWith(".webm")
+      ? ".webm"
+      : outputPath.endsWith(".mov")
+        ? ".mov"
+        : ".mp4";
     const chunkPath = join(chunkDir, `chunk_${String(i).padStart(4, "0")}${ext}`);
     const inputPath = join(framesDir, framePattern);
     const inputArgs = [

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -23,12 +23,13 @@ export const ENCODER_PRESETS = {
 
 /**
  * Get encoder preset for a given quality and output format.
- * WebM uses VP9 with alpha-capable pixel format; MP4 uses h264.
+ * WebM uses VP9 with alpha-capable pixel format; MP4 uses h264;
+ * MOV uses ProRes 4444 with alpha for editor-compatible transparency.
  */
 export function getEncoderPreset(
   quality: "draft" | "standard" | "high",
-  format: "mp4" | "webm" = "mp4",
-): { preset: string; quality: number; codec: "h264" | "vp9"; pixelFormat: string } {
+  format: "mp4" | "webm" | "mov" = "mp4",
+): { preset: string; quality: number; codec: "h264" | "vp9" | "prores"; pixelFormat: string } {
   const base = ENCODER_PRESETS[quality];
   if (format === "webm") {
     return {
@@ -36,6 +37,14 @@ export function getEncoderPreset(
       quality: base.quality,
       codec: "vp9",
       pixelFormat: "yuva420p",
+    };
+  }
+  if (format === "mov") {
+    return {
+      preset: "4444",
+      quality: base.quality,
+      codec: "prores",
+      pixelFormat: "yuva444p10le",
     };
   }
   return { ...base, pixelFormat: "yuv420p" };
@@ -415,10 +424,13 @@ export async function muxVideoWithAudio(
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
 
   const isWebm = outputPath.endsWith(".webm");
+  const isMov = outputPath.endsWith(".mov");
   const args = ["-i", videoPath, "-i", audioPath, "-c:v", "copy"];
 
   if (isWebm) {
     args.push("-c:a", "libopus", "-b:a", "128k");
+  } else if (isMov) {
+    args.push("-c:a", "aac", "-b:a", "192k");
   } else {
     args.push("-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart");
   }
@@ -453,8 +465,9 @@ export async function applyFaststart(
   signal?: AbortSignal,
   config?: Partial<Pick<EngineConfig, "ffmpegProcessTimeout">>,
 ): Promise<MuxResult> {
-  // faststart is MP4-only (moves moov atom to file start for streaming)
-  if (outputPath.endsWith(".webm")) {
+  // faststart is MP4-only (moves moov atom to file start for streaming).
+  // WebM and MOV don't need it — skip the re-mux.
+  if (outputPath.endsWith(".webm") || outputPath.endsWith(".mov")) {
     if (inputPath !== outputPath) copyFileSync(inputPath, outputPath);
     return { success: true, outputPath, durationMs: 0 };
   }

--- a/packages/engine/src/services/streamingEncoder.ts
+++ b/packages/engine/src/services/streamingEncoder.ts
@@ -190,6 +190,7 @@ function buildStreamingArgs(
     }
   } else if (codec === "prores") {
     args.push("-c:v", "prores_ks", "-profile:v", preset, "-vendor", "apl0");
+    args.push("-pix_fmt", pixelFormat);
     return [...args, "-y", outputPath];
   }
 

--- a/packages/producer/src/server.ts
+++ b/packages/producer/src/server.ts
@@ -66,7 +66,7 @@ interface RenderInput {
   outputPath?: string | null;
   fps: 24 | 30 | 60;
   quality: "draft" | "standard" | "high";
-  format?: "mp4" | "webm";
+  format?: "mp4" | "webm" | "mov";
   workers?: number;
   useGpu: boolean;
   debug: boolean;
@@ -98,10 +98,9 @@ function parseRenderOptions(body: Record<string, unknown>): Omit<RenderInput, "p
       ? body.entryFile.trim()
       : undefined;
 
-  const format = (["mp4", "webm"].includes(body.format as string) ? body.format : undefined) as
-    | "mp4"
-    | "webm"
-    | undefined;
+  const format = (
+    ["mp4", "webm", "mov"].includes(body.format as string) ? body.format : undefined
+  ) as "mp4" | "webm" | "mov" | undefined;
 
   return { outputPath, fps, quality, workers, useGpu, debug, entryFile, format };
 }

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -783,7 +783,8 @@ export async function executeRenderJob(
 
     const workerCount = calculateOptimalWorkers(job.totalFrames!, job.config.workers, cfg);
 
-    const videoExt = isMov ? ".mov" : isWebm ? ".webm" : ".mp4";
+    const FORMAT_EXT: Record<string, string> = { mp4: ".mp4", webm: ".webm", mov: ".mov" };
+    const videoExt = FORMAT_EXT[outputFormat] ?? ".mp4";
     const videoOnlyPath = join(workDir, `video-only${videoExt}`);
     const preset = getEncoderPreset(job.config.quality, outputFormat);
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -99,8 +99,8 @@ export type RenderStatus =
 export interface RenderConfig {
   fps: 24 | 30 | 60;
   quality: "draft" | "standard" | "high";
-  /** Output container format. WebM uses VP9+alpha for transparency. */
-  format?: "mp4" | "webm";
+  /** Output container format. WebM uses VP9+alpha, MOV uses ProRes 4444+alpha for transparency. */
+  format?: "mp4" | "webm" | "mov";
   workers?: number;
   useGpu?: boolean;
   debug?: boolean;
@@ -369,10 +369,12 @@ export async function executeRenderJob(
   const perfStages: Record<string, number> = {};
   const perfOutputPath = join(workDir, "perf-summary.json");
   const cfg = { ...(job.config.producerConfig ?? resolveConfig()) };
-  const outputFormat = (job.config.format ?? "mp4") as "mp4" | "webm";
+  const outputFormat = (job.config.format ?? "mp4") as "mp4" | "webm" | "mov";
   const isWebm = outputFormat === "webm";
-  // WebM/transparency requires screenshot mode — beginFrame doesn't support alpha channel
-  if (isWebm) {
+  const isMov = outputFormat === "mov";
+  const needsAlpha = isWebm || isMov;
+  // Transparency requires screenshot mode — beginFrame doesn't support alpha channel
+  if (needsAlpha) {
     cfg.forceScreenshot = true;
   }
   const enableChunkedEncode = cfg.enableChunkedEncode;
@@ -478,8 +480,8 @@ export async function executeRenderJob(
         width,
         height,
         fps: job.config.fps,
-        format: isWebm ? "png" : "jpeg",
-        quality: isWebm ? undefined : 80,
+        format: needsAlpha ? "png" : "jpeg",
+        quality: needsAlpha ? undefined : 80,
       };
       probeSession = await createCaptureSession(
         fileServer.url,
@@ -775,13 +777,13 @@ export async function executeRenderJob(
       width,
       height,
       fps: job.config.fps,
-      format: isWebm ? "png" : "jpeg",
-      quality: isWebm ? undefined : job.config.quality === "draft" ? 80 : 95,
+      format: needsAlpha ? "png" : "jpeg",
+      quality: needsAlpha ? undefined : job.config.quality === "draft" ? 80 : 95,
     };
 
     const workerCount = calculateOptimalWorkers(job.totalFrames!, job.config.workers, cfg);
 
-    const videoExt = isWebm ? ".webm" : ".mp4";
+    const videoExt = isMov ? ".mov" : isWebm ? ".webm" : ".mp4";
     const videoOnlyPath = join(workDir, `video-only${videoExt}`);
     const preset = getEncoderPreset(job.config.quality, outputFormat);
 
@@ -1015,7 +1017,7 @@ export async function executeRenderJob(
       const stage5Start = Date.now();
       updateJobStatus(job, "encoding", "Encoding video", 75, onProgress);
 
-      const frameExt = isWebm ? "png" : "jpg";
+      const frameExt = needsAlpha ? "png" : "jpg";
       const framePattern = `frame_%06d.${frameExt}`;
       const encoderOpts = {
         fps: job.config.fps,
@@ -1131,7 +1133,7 @@ export async function executeRenderJob(
     if (job.config.debug) {
       // Copy output MP4 into debug dir for easy access
       if (existsSync(outputPath)) {
-        const debugOutput = join(workDir, isWebm ? "output.webm" : "output.mp4");
+        const debugOutput = join(workDir, `output${videoExt}`);
         copyFileSync(outputPath, debugOutput);
       }
     } else {

--- a/packages/studio/src/components/renders/RenderQueue.tsx
+++ b/packages/studio/src/components/renders/RenderQueue.tsx
@@ -7,7 +7,7 @@ interface RenderQueueProps {
   projectId: string;
   onDelete: (jobId: string) => void;
   onClearCompleted: () => void;
-  onStartRender: (format: "mp4" | "webm") => void;
+  onStartRender: (format: "mp4" | "webm" | "mov") => void;
   isRendering: boolean;
 }
 
@@ -15,20 +15,21 @@ function FormatExportButton({
   onStartRender,
   isRendering,
 }: {
-  onStartRender: (format: "mp4" | "webm") => void;
+  onStartRender: (format: "mp4" | "webm" | "mov") => void;
   isRendering: boolean;
 }) {
-  const [format, setFormat] = useState<"mp4" | "webm">("mp4");
+  const [format, setFormat] = useState<"mp4" | "webm" | "mov">("mp4");
 
   return (
     <div className="flex items-center gap-0.5">
       <select
         value={format}
-        onChange={(e) => setFormat(e.target.value as "mp4" | "webm")}
+        onChange={(e) => setFormat(e.target.value as "mp4" | "webm" | "mov")}
         disabled={isRendering}
         className="h-5 px-1 text-[10px] rounded-l bg-neutral-800 border border-neutral-700 text-neutral-300 outline-none disabled:opacity-50"
       >
         <option value="mp4">MP4</option>
+        <option value="mov">MOV</option>
         <option value="webm">WebM</option>
       </select>
       <button

--- a/packages/studio/src/components/renders/useRenderQueue.ts
+++ b/packages/studio/src/components/renders/useRenderQueue.ts
@@ -96,7 +96,8 @@ export function useRenderQueue(projectId: string | null) {
       }
       const { jobId } = await res.json();
 
-      const ext = format === "webm" ? ".webm" : format === "mov" ? ".mov" : ".mp4";
+      const FORMAT_EXT: Record<string, string> = { mp4: ".mp4", webm: ".webm", mov: ".mov" };
+      const ext = FORMAT_EXT[format] ?? ".mp4";
       const job: RenderJob = {
         id: jobId,
         status: "rendering",

--- a/packages/studio/src/components/renders/useRenderQueue.ts
+++ b/packages/studio/src/components/renders/useRenderQueue.ts
@@ -59,7 +59,7 @@ export function useRenderQueue(projectId: string | null) {
 
   // Start a render and track progress via SSE
   const startRender = useCallback(
-    async (fps = 30, quality = "standard", format: "mp4" | "webm" = "mp4") => {
+    async (fps = 30, quality = "standard", format: "mp4" | "webm" | "mov" = "mp4") => {
       if (!projectId) return;
 
       const startTime = Date.now();
@@ -96,7 +96,7 @@ export function useRenderQueue(projectId: string | null) {
       }
       const { jobId } = await res.json();
 
-      const ext = format === "webm" ? ".webm" : ".mp4";
+      const ext = format === "webm" ? ".webm" : format === "mov" ? ".mov" : ".mp4";
       const job: RenderJob = {
         id: jobId,
         status: "rendering",

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -201,7 +201,7 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
                 if (evt.type === "complete") {
                   state.status = "complete";
                   state.outputPath = evt.outputPath || opts.outputPath;
-                  const metaPath = opts.outputPath.replace(/\.(mp4|webm)$/, ".meta.json");
+                  const metaPath = opts.outputPath.replace(/\.(mp4|webm|mov)$/, ".meta.json");
                   writeFileSync(
                     metaPath,
                     JSON.stringify({ status: "complete", durationMs: Date.now() - startTime }),
@@ -209,7 +209,7 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
                 }
                 if (evt.type === "error") {
                   state.status = "failed";
-                  const metaPath = opts.outputPath.replace(/\.(mp4|webm)$/, ".meta.json");
+                  const metaPath = opts.outputPath.replace(/\.(mp4|webm|mov)$/, ".meta.json");
                   writeFileSync(metaPath, JSON.stringify({ status: "failed" }));
                 }
               } catch {
@@ -219,7 +219,7 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
           }
           if (state.status === "rendering") {
             state.status = "complete";
-            const metaPath = opts.outputPath.replace(/\.(mp4|webm)$/, ".meta.json");
+            const metaPath = opts.outputPath.replace(/\.(mp4|webm|mov)$/, ".meta.json");
             writeFileSync(
               metaPath,
               JSON.stringify({ status: "complete", durationMs: Date.now() - startTime }),
@@ -229,7 +229,7 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
         .catch(() => {
           state.status = "failed";
           try {
-            const metaPath = opts.outputPath.replace(/\.(mp4|webm)$/, ".meta.json");
+            const metaPath = opts.outputPath.replace(/\.(mp4|webm|mov)$/, ".meta.json");
             writeFileSync(metaPath, JSON.stringify({ status: "failed" }));
           } catch {
             /* ignore */


### PR DESCRIPTION
## Summary

- Adds `--format mov` to the render CLI for ProRes 4444 transparent video output
- ProRes 4444 with alpha is the industry standard for transparent video overlays, supported by CapCut, Final Cut, Premiere, DaVinci, and After Effects
- WebM VP9 alpha technically works but is ignored by all major video editors — only browsers decode it
- Adds MOV to the studio export dropdown alongside MP4 and WebM

## Transparency format comparison

| Format | Codec | Alpha | Video editors | Browsers | File size |
| --- | --- | --- | --- | --- | --- |
| **MOV** | ProRes 4444 | Yes | CapCut, Final Cut, Premiere, DaVinci, After Effects | No (won't play in browser) | Large (~5-40 MB) |
| **WebM** | VP9 | Yes | None (shows black) | Chrome, Firefox | Small (~200 KB) |
| **MP4** | H.264 | No | All | All | Small |

> **Note:** ProRes MOV files do not play in Chromium browsers — they are an intermediate/editing format, not a delivery format. Use [rotato.app/tools/transparent-video](https://rotato.app/tools/transparent-video) to verify transparency works correctly.

## Changes

- **CLI**: Add `mov` to `--format` validation, examples, and output path logic
- **Engine**: `getEncoderPreset()` returns ProRes 4444 (`yuva444p10le`) for `mov` format; handle `.mov` in `applyFaststart` and `muxVideoWithAudio`; add `pix_fmt` to streaming encoder ProRes path
- **Producer**: Treat `mov` like `webm` for alpha capture (PNG frames, screenshot mode, `forceScreenshot`)
- **Studio**: Add MOV option to export format dropdown and render queue hook
- **Core**: Add `mov` to studio API types, render route, and mime helpers
- **Tests**: Add encoder preset tests for mov format (42 total, all passing)

## Usage

```bash
hyperframes render --format mov --output overlay.mov
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm --filter @hyperframes/engine test` — 42 tests pass (2 new for MOV)
- [x] `oxlint` and `oxfmt` clean on all 12 changed files
- [x] End-to-end local render produces ProRes 4444 (`yuva444p12le`) with working alpha
- [x] Docker render with `--format mov` — ProRes 4444 confirmed via ffprobe
- [x] Studio dropdown shows MOV option in built JS
- [x] Transparency verified with [rotato.app/tools/transparent-video](https://rotato.app/tools/transparent-video)