### PR TITLE
fix(player): handle Infinity duration; add lint rules for data-duration and Math.ceil overshoot

### DIFF
--- a/packages/core/src/lint/rules/composition.ts
+++ b/packages/core/src/lint/rules/composition.ts
@@ -210,6 +210,26 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
     return findings;
   },
 
+  // root_composition_missing_data_duration
+  ({ rootTag }) => {
+    const findings: HyperframeLintFinding[] = [];
+    if (!rootTag) return findings;
+    const compId = readAttr(rootTag.raw, "data-composition-id");
+    if (!compId) return findings;
+    const hasDuration = readAttr(rootTag.raw, "data-duration") !== null;
+    if (!hasDuration) {
+      findings.push({
+        code: "root_composition_missing_data_duration",
+        severity: "warning",
+        message: `Root composition "${compId}" is missing data-duration. Without an explicit duration, the runtime may infer Infinity for compositions with repeating animations, causing playback issues.`,
+        fixHint:
+          'Add data-duration="X" to the root composition element, where X is the total duration in seconds.',
+        snippet: truncateSnippet(rootTag.raw),
+      });
+    }
+    return findings;
+  },
+
   // standalone_composition_wrapped_in_template
   ({ rawSource, options }) => {
     const findings: HyperframeLintFinding[] = [];

--- a/packages/core/src/lint/rules/gsap.ts
+++ b/packages/core/src/lint/rules/gsap.ts
@@ -500,9 +500,40 @@ export const gsapRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
           message:
             "GSAP tween uses `repeat: -1` (infinite). Infinite repeats break the deterministic " +
             "capture engine which seeks to exact frame times. Use a finite repeat count calculated " +
-            "from the composition duration: `repeat: Math.ceil(duration / cycleDuration) - 1`.",
+            "from the composition duration: `repeat: Math.floor(duration / cycleDuration) - 1`.",
           fixHint:
-            "Replace `repeat: -1` with a finite count, e.g. `repeat: Math.ceil(totalDuration / singleCycleDuration) - 1`.",
+            "Replace `repeat: -1` with a finite count, e.g. `repeat: Math.floor(totalDuration / singleCycleDuration) - 1`. " +
+            "Use Math.floor (not Math.ceil) to ensure the animation fits within the total duration.",
+          snippet: truncateSnippet(snippet),
+        });
+      }
+    }
+    return findings;
+  },
+
+  // gsap_repeat_ceil_overshoot
+  ({ scripts }) => {
+    const findings: HyperframeLintFinding[] = [];
+    for (const script of scripts) {
+      const content = script.content;
+      // Match patterns like: repeat: Math.ceil(duration / X) - 1
+      // or repeat: Math.ceil(totalDuration / cycleDuration) - 1
+      const pattern = /repeat\s*:\s*Math\.ceil\s*\([^)]+\)\s*-\s*1/g;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(content)) !== null) {
+        const contextStart = Math.max(0, match.index - 40);
+        const contextEnd = Math.min(content.length, match.index + match[0].length + 40);
+        const snippet = content.slice(contextStart, contextEnd).trim();
+        findings.push({
+          code: "gsap_repeat_ceil_overshoot",
+          severity: "warning",
+          message:
+            "GSAP repeat calculation uses `Math.ceil` which can overshoot the composition duration. " +
+            "For example, Math.ceil(10.5 / 2) - 1 = 5 repeats → 6 cycles × 2s = 12s, exceeding 10.5s.",
+          fixHint:
+            "Use `Math.floor` instead of `Math.ceil` to ensure the animation fits within the duration: " +
+            "`repeat: Math.floor(totalDuration / cycleDuration) - 1`. " +
+            "Math.floor(10.5 / 2) - 1 = 4 repeats → 5 cycles × 2s = 10s ✓",
           snippet: truncateSnippet(snippet),
         });
       }

--- a/packages/player/src/controls.ts
+++ b/packages/player/src/controls.ts
@@ -20,7 +20,11 @@ export function formatSpeed(speed: number): string {
 }
 
 export function formatTime(seconds: number): string {
-  const s = Math.max(0, Math.floor(seconds));
+  // Handle non-finite values gracefully
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "0:00";
+  }
+  const s = Math.floor(seconds);
   const m = Math.floor(s / 60);
   const sec = s % 60;
   return `${m}:${sec.toString().padStart(2, "0")}`;

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -284,6 +284,11 @@ class HyperframesPlayer extends HTMLElement {
           return; // Wait for runtime to load and initialize
         }
 
+        // Runtime was injected but hasn't loaded yet — keep waiting
+        if (this._runtimeInjected && !hasRuntime) {
+          return;
+        }
+
         const getAdapter = () => {
           if (win.__player && typeof win.__player.getDuration === "function") return win.__player;
           if (win.__timelines) {

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -242,8 +242,12 @@ class HyperframesPlayer extends HTMLElement {
     }
 
     if (data.type === "timeline" && data.durationInFrames > 0) {
-      this._duration = data.durationInFrames / DEFAULT_FPS;
-      this.controlsApi?.updateTime(this._currentTime, this._duration);
+      // Ignore Infinity duration from runtime (caused by loop-inflated timelines without data-duration)
+      // The player already has duration from the initial probe, so keep that.
+      if (Number.isFinite(data.durationInFrames)) {
+        this._duration = data.durationInFrames / DEFAULT_FPS;
+        this.controlsApi?.updateTime(this._currentTime, this._duration);
+      }
     }
 
     if (data.type === "stage-size" && data.width > 0 && data.height > 0) {


### PR DESCRIPTION
## What

Two fixes and two new lint rules addressing playback issues caused by compositions with repeating animations that lack `data-duration`.

### Player fixes
- Ignore `Infinity` values in `durationInFrames` from runtime timeline messages
- Guard `formatTime` against non-finite inputs (returns `"0:00"` instead of `"Infinity:NaN"`)

### New lint rules
- **`root_composition_missing_data_duration`** (warning): flags root composition elements missing `data-duration`
- **`gsap_repeat_ceil_overshoot`** (warning): catches `repeat: Math.ceil(d/c) - 1` patterns that overshoot the intended duration

### Fix to existing rule
- **`gsap_infinite_repeat`**: updated `fixHint` to recommend `Math.floor` instead of `Math.ceil`

## Why

When a composition has looping GSAP animations (e.g. `repeat: 6`) but no `data-duration` attribute, the runtime intentionally sends `durationInFrames: Infinity` to signal non-determinism. The player was not handling this, resulting in:

1. Controls showing `"Infinity:NaN"` for duration
2. Broken scrub bar and time display

Additionally, LLMs following the linter's `fixHint` were using `Math.ceil(duration / cycleDuration) - 1` to replace `repeat: -1`, which overshoots the intended composition duration (e.g. a 10s composition playing to 14s).

## How

**Player** (`hyperframes-player.ts`): Added `Number.isFinite()` guard before setting `_duration` from runtime timeline messages. If the runtime sends `Infinity`, the player keeps its existing duration from the initial probe.

**Controls** (`controls.ts`): `formatTime` now returns `"0:00"` for `NaN`, `Infinity`, or negative values instead of passing them through `Math.floor`.

**Lint rules** (`composition.ts`, `gsap.ts`): Added two new rule functions to the existing rule arrays, following the same pattern as adjacent rules. The `gsap_repeat_ceil_overshoot` rule uses a regex to detect the `Math.ceil(…) - 1` pattern in repeat values.

## Test plan

- [x] Manual testing: verified player displays correct duration with compositions that have `data-duration`
- [x] Manual testing: verified player no longer shows `Infinity:NaN` for compositions without `data-duration`
- [x] Manual testing: verified `gsap_repeat_ceil_overshoot` lint rule fires on compositions using `Math.ceil` in repeat calculations
- [x] Manual testing: verified `root_composition_missing_data_duration` lint rule fires on compositions missing the attribute
- [ ] Unit tests added/updated
- [ ] Documentation updated (if applicable)