### PR TITLE
docs(quickstart): collapse prerequisites into expandable accordion

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -11,7 +11,10 @@ A 1920x1080 video with an animated title that fades in from above — rendered t
 
 ## Prerequisites
 
-<Accordion title="Node.js 22+ & FFmpeg (expand for install instructions)">
+- **Node.js 22+** — runtime for the CLI and dev server
+- **FFmpeg** — video encoding for local renders
+
+<Accordion title="Install instructions">
   <Steps>
     <Step title="Install Node.js 22+">
       Hyperframes requires Node.js 22 or later. Check your version:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -11,47 +11,49 @@ A 1920x1080 video with an animated title that fades in from above — rendered t
 
 ## Prerequisites
 
-<Steps>
-  <Step title="Install Node.js 22+">
-    Hyperframes requires Node.js 22 or later. Check your version:
+<Accordion title="Node.js 22+ & FFmpeg (expand for install instructions)">
+  <Steps>
+    <Step title="Install Node.js 22+">
+      Hyperframes requires Node.js 22 or later. Check your version:
 
-    ```bash
-    node --version
-    ```
+      ```bash
+      node --version
+      ```
 
-    ```bash Expected output
-    v22.0.0   # or any version >= 22
-    ```
-  </Step>
+      ```bash Expected output
+      v22.0.0   # or any version >= 22
+      ```
+    </Step>
 
-  <Step title="Install FFmpeg">
-    FFmpeg is required for local video rendering (encoding captured frames into MP4).
+    <Step title="Install FFmpeg">
+      FFmpeg is required for local video rendering (encoding captured frames into MP4).
 
-    <CodeGroup>
-    ```bash macOS
-    brew install ffmpeg
-    ```
-    ```bash Ubuntu / Debian
-    sudo apt install ffmpeg
-    ```
-    ```bash Windows
-    # Download from https://ffmpeg.org/download.html
-    # or install via winget:
-    winget install ffmpeg
-    ```
-    </CodeGroup>
+      <CodeGroup>
+      ```bash macOS
+      brew install ffmpeg
+      ```
+      ```bash Ubuntu / Debian
+      sudo apt install ffmpeg
+      ```
+      ```bash Windows
+      # Download from https://ffmpeg.org/download.html
+      # or install via winget:
+      winget install ffmpeg
+      ```
+      </CodeGroup>
 
-    Verify the installation:
+      Verify the installation:
 
-    ```bash
-    ffmpeg -version
-    ```
+      ```bash
+      ffmpeg -version
+      ```
 
-    ```bash Expected output
-    ffmpeg version 7.x ...
-    ```
-  </Step>
-</Steps>
+      ```bash Expected output
+      ffmpeg version 7.x ...
+      ```
+    </Step>
+  </Steps>
+</Accordion>
 
 ## Create your first video
 


### PR DESCRIPTION
## Description
Wraps the Node.js and FFmpeg install instructions in a Mintlify `<Accordion>` component so the quickstart page is less verbose for returning users who already have the dependencies installed.

Feedback from @benliu95 in [Slack thread](https://heygen.slack.com/archives/C0ACCNHLG3U/p1775976883426999).

**Before:** Prerequisites section is fully expanded by default, taking up significant page real estate.
**After:** Collapsed into "Node.js 22+ & FFmpeg (expand for install instructions)" — click to expand.

## Testing
- Verified the `<Accordion>` component is used elsewhere in these docs (data-attributes.mdx, troubleshooting.mdx)
- Mintlify preview link will be posted automatically on this PR