### PR TITLE
chore: release v0.2.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps all packages from 0.2.4 → 0.2.5.

Merging this PR will trigger the publish workflow, tag `v0.2.5`, publish all packages to npm, and create a GitHub release.

## What's in this release

- fix(studio): support web-component refs in `useTimelinePlayer` — `resolveIframe` helper + export so consumers wrapping the player in a shadow-DOM custom element get working seek/play/pause (#245)
- fix(player): add speed control with popup menu and CSS theming (#241)
- fix(player): handle Infinity duration; add lint rules for `data-duration` and `Math.ceil` overshoot (#243)
- fix(lint): upgrade bare composition HTML to error (#242)
- docs(quickstart): collapse prerequisites into expandable accordion (#244)