### PR TITLE
fix(player,studio): resolve root timeline from DOM instead of last key

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",
@@ -11,13 +11,13 @@
     "dist"
   ],
   "type": "module",
-  "main": "./src/hyperframes-player.ts",
-  "types": "./src/hyperframes-player.ts",
+  "main": "./dist/hyperframes-player.js",
+  "types": "./dist/hyperframes-player.d.ts",
   "exports": {
     ".": {
-      "types": "./src/hyperframes-player.ts",
+      "types": "./dist/hyperframes-player.d.ts",
       "script": "./dist/hyperframes-player.global.js",
-      "import": "./src/hyperframes-player.ts",
+      "import": "./dist/hyperframes-player.js",
       "require": "./dist/hyperframes-player.cjs"
     }
   },

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -314,7 +314,16 @@ class HyperframesPlayer extends HTMLElement {
           if (win.__timelines) {
             const keys = Object.keys(win.__timelines);
             if (keys.length > 0) {
-              const tl = win.__timelines[keys[keys.length - 1]];
+              // Resolve the root composition id from the DOM — the outermost
+              // `[data-composition-id]` element is the master. Bundled previews
+              // register the root composition alongside sub-compositions, and
+              // without this lookup Object.keys() order would make a
+              // sub-composition's duration hijack the overall video length.
+              const rootId = this.iframe.contentDocument
+                ?.querySelector("[data-composition-id]")
+                ?.getAttribute("data-composition-id");
+              const key = rootId && rootId in win.__timelines ? rootId : keys[keys.length - 1];
+              const tl = win.__timelines[key];
               return { getDuration: () => tl.duration() };
             }
           }

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -238,7 +238,17 @@ export function useTimelinePlayer() {
 
       if (win.__timelines) {
         const keys = Object.keys(win.__timelines);
-        if (keys.length > 0) return wrapTimeline(win.__timelines[keys[keys.length - 1]]);
+        if (keys.length > 0) {
+          // Resolve the root composition id from the DOM — the outermost
+          // `[data-composition-id]` element is the master. Without this,
+          // Object.keys() order would let a sub-composition's timeline
+          // hijack play/pause/seek and the duration readout.
+          const rootId = iframe?.contentDocument
+            ?.querySelector("[data-composition-id]")
+            ?.getAttribute("data-composition-id");
+          const key = rootId && rootId in win.__timelines ? rootId : keys[keys.length - 1];
+          return wrapTimeline(win.__timelines[key]);
+        }
       }
 
       return null;


### PR DESCRIPTION
## Problem

Bundled previews register the master composition alongside its sub-compositions in `window.__timelines`:

```js
{
  main: GSAPTimeline(14s),
  intro: GSAPTimeline(1.5s),
  'scene2-4-canvas': GSAPTimeline(12.6s),
  'scene5-logo-outro': GSAPTimeline(3.2s),
}
```

Both `@hyperframes/player`'s probe and `@hyperframes/studio`'s `useTimelinePlayer.getAdapter()` selected the adapter with `keys[keys.length - 1]`. Object key ordering meant the last-registered sub-composition would win — so the player reported **3.2s** as the video duration (from `scene5-logo-outro`) instead of the master's 14s, and `play`/`pause`/`seek` operated on that sub-composition instead of the full composition.

## Fix

Resolve the root composition id from the DOM — the outermost `[data-composition-id]` element is the master:

```ts
const rootId = iframe?.contentDocument
  ?.querySelector("[data-composition-id]")
  ?.getAttribute("data-composition-id");
const key = rootId && rootId in win.__timelines ? rootId : keys[keys.length - 1];
```

This is authoritative — it uses the actual DOM structure rather than guessing by naming convention or registration order. Falls back to the last key when no `[data-composition-id]` element exists (standalone sub-composition previews drilled-into via the studio) so that flow keeps working.

## Bonus

Also restores `main`/`import` entry points on `@hyperframes/player`'s `package.json` to point at the compiled `dist/` output. The `src/` paths introduced in #238 broke workspace consumers that only receive the published tarball (the tarball excludes `src/` via `"files": ["dist"]`), producing `Module not found: Can't resolve '@hyperframes/player'` on build.

## Test plan

- [x] Verified `player.duration` and `PlayerControls` time display now report the master duration (14s) on a multi-composition bundled preview where the old code reported 3.2s
- [x] Confirmed play/pause/seek drive the master timeline rather than a sub-composition
- [x] Drill-into-composition view (single composition, no master) still detects duration via the last-key fallback