### PR TITLE
chore: release v0.3.0 (+ studio SSR and captions fixes)

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.2.5",
+  "version": "0.2.9",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/studio/src/captions/generator.test.ts
+++ b/packages/studio/src/captions/generator.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { generateCaptionHtml } from "./generator.js";
-import { buildCaptionModel, TranscriptWord } from "./parser.js";
+import { generateCaptionHtml } from "./generator";
+import { buildCaptionModel, TranscriptWord } from "./parser";
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/studio/src/captions/generator.ts
+++ b/packages/studio/src/captions/generator.ts
@@ -8,7 +8,7 @@ import type {
   CaptionContainerStyle,
   CaptionShadow,
   CaptionGlow,
-} from "./types.js";
+} from "./types";
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/packages/studio/src/captions/parser.test.ts
+++ b/packages/studio/src/captions/parser.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { extractTranscript, buildCaptionModel, TranscriptWord } from "./parser.js";
-import { DEFAULT_STYLE, DEFAULT_CONTAINER, DEFAULT_ANIMATION_SET } from "./types.js";
+import { extractTranscript, buildCaptionModel, TranscriptWord } from "./parser";
+import { DEFAULT_STYLE, DEFAULT_CONTAINER, DEFAULT_ANIMATION_SET } from "./types";
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/studio/src/captions/parser.ts
+++ b/packages/studio/src/captions/parser.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_STYLE,
   DEFAULT_CONTAINER,
   DEFAULT_ANIMATION_SET,
-} from "./types.js";
+} from "./types";
 
 export interface TranscriptWord {
   id?: string;

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -1,7 +1,9 @@
 import { forwardRef, useRef } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
 import type { HyperframesPlayer } from "@hyperframes/player";
-import "@hyperframes/player"; // registers <hyperframes-player> custom element
+// NOTE: importing "@hyperframes/player" registers a class extending HTMLElement
+// at module load, which throws under SSR. Defer the import to the mount effect
+// so it only runs in the browser.
 
 interface PlayerProps {
   projectId?: string;
@@ -27,55 +29,68 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
       const container = containerRef.current;
       if (!container) return;
 
-      // Create the web component imperatively to avoid JSX custom-element typing.
-      const player = document.createElement("hyperframes-player") as HyperframesPlayer;
-      const src = directUrl || `/api/projects/${projectId}/preview`;
-      player.setAttribute("src", src);
-      player.setAttribute("width", String(portrait ? 1080 : 1920));
-      player.setAttribute("height", String(portrait ? 1920 : 1080));
-      player.style.width = "100%";
-      player.style.height = "100%";
-      player.style.display = "block";
-      container.appendChild(player);
+      let canceled = false;
+      let cleanup: (() => void) | undefined;
 
-      // Bridge the inner iframe to the forwarded ref for useTimelinePlayer.
-      const iframe = player.iframeElement;
-      if (typeof ref === "function") {
-        ref(iframe);
-      } else if (ref) {
-        (ref as React.MutableRefObject<HTMLIFrameElement | null>).current = iframe;
-      }
+      // Dynamic import registers the custom element in the browser only.
+      import("@hyperframes/player").then(() => {
+        if (canceled) return;
 
-      // Prevent the web component's built-in click-to-toggle behavior.
-      // The studio manages playback exclusively via useTimelinePlayer.
-      const preventToggle = (e: Event) => e.stopImmediatePropagation();
-      player.addEventListener("click", preventToggle, { capture: true });
+        // Create the web component imperatively to avoid JSX custom-element typing.
+        const player = document.createElement("hyperframes-player") as HyperframesPlayer;
+        const src = directUrl || `/api/projects/${projectId}/preview`;
+        player.setAttribute("src", src);
+        player.setAttribute("width", String(portrait ? 1080 : 1920));
+        player.setAttribute("height", String(portrait ? 1920 : 1080));
+        player.style.width = "100%";
+        player.style.height = "100%";
+        player.style.display = "block";
+        container.appendChild(player);
 
-      // Forward the iframe's native load event to the studio's onIframeLoad.
-      const handleLoad = () => {
-        loadCountRef.current++;
-        // Reveal animation on reload (hot-reload, composition switch)
-        if (loadCountRef.current > 1) {
-          container.classList.remove("preview-revealing");
-          void container.offsetWidth;
-          container.classList.add("preview-revealing");
-          const onEnd = () => container.classList.remove("preview-revealing");
-          container.addEventListener("animationend", onEnd, { once: true });
+        // Bridge the inner iframe to the forwarded ref for useTimelinePlayer.
+        const iframe = player.iframeElement;
+        if (typeof ref === "function") {
+          ref(iframe);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLIFrameElement | null>).current = iframe;
         }
-        onLoad();
-      };
-      iframe.addEventListener("load", handleLoad);
+
+        // Prevent the web component's built-in click-to-toggle behavior.
+        // The studio manages playback exclusively via useTimelinePlayer.
+        const preventToggle = (e: Event) => e.stopImmediatePropagation();
+        player.addEventListener("click", preventToggle, { capture: true });
+
+        // Forward the iframe's native load event to the studio's onIframeLoad.
+        const handleLoad = () => {
+          loadCountRef.current++;
+          // Reveal animation on reload (hot-reload, composition switch)
+          if (loadCountRef.current > 1) {
+            container.classList.remove("preview-revealing");
+            void container.offsetWidth;
+            container.classList.add("preview-revealing");
+            const onEnd = () => container.classList.remove("preview-revealing");
+            container.addEventListener("animationend", onEnd, { once: true });
+          }
+          onLoad();
+        };
+        iframe.addEventListener("load", handleLoad);
+
+        cleanup = () => {
+          iframe.removeEventListener("load", handleLoad);
+          player.removeEventListener("click", preventToggle, { capture: true });
+          container.removeChild(player);
+          // Clear the forwarded ref
+          if (typeof ref === "function") {
+            ref(null);
+          } else if (ref) {
+            (ref as React.MutableRefObject<HTMLIFrameElement | null>).current = null;
+          }
+        };
+      });
 
       return () => {
-        iframe.removeEventListener("load", handleLoad);
-        player.removeEventListener("click", preventToggle, { capture: true });
-        container.removeChild(player);
-        // Clear the forwarded ref
-        if (typeof ref === "function") {
-          ref(null);
-        } else if (ref) {
-          (ref as React.MutableRefObject<HTMLIFrameElement | null>).current = null;
-        }
+        canceled = true;
+        cleanup?.();
       };
     });
 


### PR DESCRIPTION
## Summary

Coordinated `0.3.0` release across all published packages, carrying two studio fixes that never made it out of #247's branch.

## Version bumps

| Package | from | to |
|---|---|---|
| \`@hyperframes/cli\` | 0.2.5 | **0.3.0** |
| \`@hyperframes/core\` | 0.2.5 | **0.3.0** |
| \`@hyperframes/engine\` | 0.2.5 | **0.3.0** |
| \`@hyperframes/player\` | 0.2.7 | **0.3.0** |
| \`@hyperframes/producer\` | 0.2.5 | **0.3.0** |
| \`@hyperframes/studio\` | 0.2.9 | **0.3.0** |

## Fixes included in 0.3.0

### \`fix(studio): load @hyperframes/player lazily to support SSR\`

\`Player.tsx\` had a top-level \`import \"@hyperframes/player\"\`, which runs the package's \`customElements.define(...)\` side effect at module evaluation time. That fails under Next.js App Router SSR because \`HTMLElement\` is not defined in the Node runtime — any consumer page that transitively pulled \`@hyperframes/studio\` in for server rendering threw:

\`\`\`
ReferenceError: HTMLElement is not defined
  at module evaluation (@hyperframes/studio/src/player/components/Player.tsx)
\`\`\`

Moved the import inside the mount effect via \`import(...)\` so it only runs in the browser. Added a cancellation flag and deferred cleanup so a fast unmount before the promise resolves doesn't leak listeners or DOM nodes.

### \`fix(studio): remove .js extensions from captions-internal imports\`

Recently-added captions modules imported siblings as \`./types.js\` / \`./parser.js\`. That's legal ESM TypeScript, but bundlers in consumer apps — Turbopack in particular — refuse to resolve those specifiers against \`.ts\` files in \`node_modules\`, breaking any build that transitively pulls in the captions module. The rest of \`@hyperframes/studio\` uses extensionless imports. Aligned captions with the rest of the codebase.

## Test plan

- [x] \`pnpm --filter @hyperframes/studio typecheck\` / \`test\` (103 passing) / \`build\` (Vite code-splits \`@hyperframes/player\` into its own chunk, confirming the import is no longer eager)
- [x] \`pnpm --filter @hyperframes/player typecheck\` / \`test\` (11 passing)
- [x] End-to-end against a Next.js consumer: no SSR 500 on the session page, composition preview orchestrates sub-composition timelines correctly, seek lands on the expected scene

## After merge

- \`npm publish\` for each package (workspace deps resolved via \`pnpm publish\`)
- Bump downstream consumers (internal demo-next, etc.) to the \`0.3.0\` series