### PR TITLE
chore(shader-transitions): add to CI publish pipeline and README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,7 @@ jobs:
           publish_pkg "@hyperframes/engine" "@hyperframes/engine"
           publish_pkg "@hyperframes/player" "@hyperframes/player"
           publish_pkg "@hyperframes/producer" "@hyperframes/producer"
+          publish_pkg "@hyperframes/shader-transitions" "@hyperframes/shader-transitions"
           publish_pkg "@hyperframes/studio" "@hyperframes/studio"
 
           # CLI is @hyperframes/cli in the monorepo but published as unscoped "hyperframes" on npm.

--- a/packages/shader-transitions/README.md
+++ b/packages/shader-transitions/README.md
@@ -1,0 +1,122 @@
+# @hyperframes/shader-transitions
+
+WebGL shader transitions for HyperFrames compositions. Renders GPU-accelerated scene-to-scene transitions using fragment shaders, driven by GSAP timelines.
+
+## Install
+
+```bash
+npm install @hyperframes/shader-transitions
+```
+
+Or load directly via CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@hyperframes/shader-transitions/dist/index.global.js"></script>
+```
+
+## Usage
+
+```typescript
+import { init } from "@hyperframes/shader-transitions";
+
+const tl = init({
+  bgColor: "#0a0a0a",
+  accentColor: "#ff6b2b",
+  scenes: ["scene-1", "scene-2", "scene-3"],
+  transitions: [
+    { time: 3, shader: "domain-warp", duration: 0.8 },
+    { time: 8, shader: "light-leak", duration: 0.7 },
+  ],
+});
+```
+
+The `init()` function captures each scene to a WebGL texture at transition time, crossfades between them using the selected shader, and returns a GSAP timeline. If WebGL is unavailable, it falls back to hard cuts.
+
+### With an existing timeline
+
+Pass your own GSAP timeline to layer transitions onto it:
+
+```typescript
+const tl = gsap.timeline({ paused: true });
+// ... add your scene animations ...
+
+init({
+  bgColor: "#000",
+  scenes: ["intro", "demo", "outro"],
+  transitions: [
+    { time: 5, shader: "cinematic-zoom" },
+    { time: 12, shader: "glitch", duration: 0.5 },
+  ],
+  timeline: tl,
+});
+```
+
+## Available shaders
+
+| Shader                | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `domain-warp`         | Organic noise-based warp with glowing edge           |
+| `ridged-burn`         | Ridged noise burn with sparks and heat glow          |
+| `whip-pan`            | Horizontal motion blur simulating a fast camera pan  |
+| `sdf-iris`            | Circular iris wipe with glowing ring edge            |
+| `ripple-waves`        | Concentric ripple distortion radiating from center   |
+| `gravitational-lens`  | Warping gravity well with chromatic aberration       |
+| `cinematic-zoom`      | Radial zoom blur with chromatic fringing             |
+| `chromatic-split`     | RGB channel separation expanding from center         |
+| `glitch`              | Digital glitch with block displacement and scanlines |
+| `swirl-vortex`        | Spiral rotation with noise-based warping             |
+| `thermal-distortion`  | Heat shimmer rising from the bottom                  |
+| `flash-through-white` | Flash to white then reveal the next scene            |
+| `cross-warp-morph`    | Noise-driven morph blending both scenes              |
+| `light-leak`          | Warm cinematic light leak with lens flare            |
+
+## API
+
+### `init(config): GsapTimeline`
+
+| Option          | Type                 | Required | Description                                                  |
+| --------------- | -------------------- | -------- | ------------------------------------------------------------ |
+| `bgColor`       | `string`             | yes      | Background color (hex) for scene capture                     |
+| `accentColor`   | `string`             | no       | Accent color (hex) for shader glow effects                   |
+| `scenes`        | `string[]`           | yes      | Element IDs of each scene, in order                          |
+| `transitions`   | `TransitionConfig[]` | yes      | Transition definitions (see below)                           |
+| `timeline`      | `GsapTimeline`       | no       | Existing timeline to attach transitions to                   |
+| `compositionId` | `string`             | no       | Override the `data-composition-id` for timeline registration |
+
+### `TransitionConfig`
+
+| Option     | Type         | Default          | Description                      |
+| ---------- | ------------ | ---------------- | -------------------------------- |
+| `time`     | `number`     | —                | Start time in seconds            |
+| `shader`   | `ShaderName` | —                | Shader name from the table above |
+| `duration` | `number`     | `0.7`            | Transition duration in seconds   |
+| `ease`     | `string`     | `"power2.inOut"` | GSAP easing function             |
+
+### `SHADER_NAMES`
+
+Array of all available shader name strings, useful for validation or building UIs.
+
+```typescript
+import { SHADER_NAMES } from "@hyperframes/shader-transitions";
+// ["domain-warp", "ridged-burn", "whip-pan", ...]
+```
+
+## Distribution
+
+| Format | File                   | Use case                       |
+| ------ | ---------------------- | ------------------------------ |
+| ESM    | `dist/index.js`        | Bundlers (Vite, webpack, etc.) |
+| CJS    | `dist/index.cjs`       | Node.js / require()            |
+| IIFE   | `dist/index.global.js` | `<script>` tag, CDN            |
+
+All formats include source maps. TypeScript definitions included.
+
+## Related packages
+
+- [`@hyperframes/core`](../core) -- types, parsers, runtime
+- [`@hyperframes/engine`](../engine) -- rendering engine
+- [`hyperframes`](../cli) -- CLI
+
+## License
+
+MIT

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",
@@ -20,6 +20,19 @@
       "import": "./src/index.ts",
       "require": "./dist/index.cjs"
     }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "script": "./dist/index.global.js",
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "build": "tsup",

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -20,7 +20,9 @@ import { execSync } from "child_process";
 const PACKAGES = [
   "packages/core",
   "packages/engine",
+  "packages/player",
   "packages/producer",
+  "packages/shader-transitions",
   "packages/studio",
   "packages/cli",
 ];


### PR DESCRIPTION
## Summary
- Add `@hyperframes/shader-transitions` to the publish workflow (`publish.yml`)
- Add `shader-transitions` and `player` (was also missing) to `set-version.ts`
- Bump shader-transitions version from `0.2.4` to `0.3.0` to match other packages
- Add `publishConfig` with dist paths for correct resolution by consumers
- Add package README documenting all 14 shaders, API, and usage

Package was manually published as `@hyperframes/shader-transitions@0.3.0` — future releases will go through CI.

**Reminder:** Configure OIDC trusted publishing on npmjs.com for `@hyperframes/shader-transitions` (same as other packages) to avoid ENEEDAUTH on the next CI publish.

## Testing
- [x] `@hyperframes/shader-transitions@0.3.0` published successfully to npm
- [x] Pre-commit hooks pass (lint, format, typecheck)
- [x] `bun run build` succeeds for the package