### PR TITLE
docs: restructure README with skills-first quick start, add catalog, fix pnpm refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,40 +8,50 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/hyperframes"><img src="https://img.shields.io/npm/v/hyperframes.svg?style=flat" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/hyperframes"><img src="https://img.shields.io/npm/dm/hyperframes.svg?style=flat" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node.js"></a>
 </p>
 
-**Write HTML. Render video. Built for agents.**
+<p align="center"><b>Write HTML. Render video. Built for agents.</b></p>
 
-Hyperframes is an open-source video rendering framework that lets you create, preview, and render HTML-based video compositions — with first-class support for AI agents via MCP.
-
-## Why Hyperframes?
-
-- **HTML-native** — AI agents already speak HTML. No React required.
-- **Frame Adapter pattern** — bring your own animation runtime (GSAP, Lottie, CSS, Three.js).
-- **Deterministic rendering** — same input = identical output. Built for automated pipelines.
-- **AI-first design** — not a bolted-on afterthought.
+Hyperframes is an open-source video rendering framework that lets you create, preview, and render HTML-based video compositions — with first-class support for AI agents.
 
 ## Quick Start
+
+### Option 1: With an AI coding agent (recommended)
+
+Install the HyperFrames skills, then describe the video you want:
+
+```bash
+npx skills add heygen-com/hyperframes
+```
+
+This teaches your agent (Claude Code, Cursor, Gemini CLI, Codex) how to write correct compositions and GSAP animations. Then just prompt it:
+
+> "Create a 10-second product intro video with a fade-in title, a background video, and background music"
+
+The agent handles scaffolding, animation, and rendering.
+
+### Option 2: Start a project manually
 
 ```bash
 npx hyperframes init my-video
 cd my-video
-```
-
-Then open the project with your AI coding agent (Claude Code, Cursor, etc.) — it has HyperFrames skills installed and knows how to create and edit compositions.
-
-```bash
 npx hyperframes preview      # preview in browser (live reload)
-npx hyperframes render   # render to MP4
+npx hyperframes render       # render to MP4
 ```
+
+`hyperframes init` installs skills automatically, so you can hand off to your AI agent at any point.
 
 **Requirements:** Node.js >= 22, FFmpeg
 
-## Documentation
+## Why Hyperframes?
 
-Full documentation at **[hyperframes.heygen.com](https://hyperframes.heygen.com)** — start with the [Quickstart](https://hyperframes.heygen.com/quickstart), then explore guides, concepts, API reference, and package docs.
+- **HTML-native** — compositions are HTML files with data attributes. No React, no proprietary DSL.
+- **AI-first** — agents already speak HTML. The CLI is non-interactive by default, designed for agent-driven workflows.
+- **Deterministic rendering** — same input = identical output. Built for automated pipelines.
+- **Frame Adapter pattern** — bring your own animation runtime (GSAP, Lottie, CSS, Three.js).
 
 ## How It Works
 
@@ -53,24 +63,47 @@ Define your video as HTML with data attributes:
     id="clip-1"
     data-start="0"
     data-duration="5"
-    data-track="0"
+    data-track-index="0"
     src="intro.mp4"
     muted
     playsinline
   ></video>
-  <img id="overlay" data-start="2" data-duration="3" data-track="1" src="logo.png" />
+  <img
+    id="overlay"
+    class="clip"
+    data-start="2"
+    data-duration="3"
+    data-track-index="1"
+    src="logo.png"
+  />
   <audio
     id="bg-music"
     data-start="0"
     data-duration="9"
-    data-track="2"
+    data-track-index="2"
     data-volume="0.5"
     src="music.wav"
   ></audio>
 </div>
 ```
 
-Preview instantly in the browser. Render to MP4 locally. Let AI agents compose videos using tools they already understand.
+Preview instantly in the browser. Render to MP4 locally or in Docker.
+
+## Catalog
+
+50+ ready-to-use blocks and components — social overlays, shader transitions, data visualizations, and cinematic effects:
+
+```bash
+npx hyperframes add flash-through-white   # shader transition
+npx hyperframes add instagram-follow      # social overlay
+npx hyperframes add data-chart            # animated chart
+```
+
+Browse the full catalog at **[hyperframes.heygen.com/catalog](https://hyperframes.heygen.com/catalog/blocks/data-chart)**.
+
+## Documentation
+
+Full documentation at **[hyperframes.heygen.com](https://hyperframes.heygen.com)** — [Quickstart](https://hyperframes.heygen.com/quickstart) | [Guides](https://hyperframes.heygen.com/guides/gsap-animation) | [API Reference](https://hyperframes.heygen.com/packages/core) | [Catalog](https://hyperframes.heygen.com/catalog/blocks/data-chart)
 
 ## Packages
 
@@ -81,45 +114,28 @@ Preview instantly in the browser. Render to MP4 locally. Let AI agents compose v
 | [`@hyperframes/engine`](packages/engine)     | Seekable page-to-video capture engine (Puppeteer + FFmpeg)  |
 | [`@hyperframes/producer`](packages/producer) | Full rendering pipeline (capture + encode + audio mix)      |
 | [`@hyperframes/studio`](packages/studio)     | Browser-based composition editor UI                         |
+| [`@hyperframes/player`](packages/player)     | Embeddable `<hyperframes-player>` web component             |
 
-## AI Agent Skills
+## Skills
 
-HyperFrames ships skills that teach AI coding agents (Claude Code, Gemini CLI, Codex, Cursor) how to write correct compositions and GSAP animations. **Use these instead of writing from scratch — they encode framework-specific patterns that generic docs don't cover.**
-
-### Install via CLI (recommended)
-
-```bash
-# Install all skills (HyperFrames + GSAP) — runs automatically during `hyperframes init`
-npx hyperframes skills
-
-# Or install to a specific agent
-npx hyperframes skills --claude
-npx hyperframes skills --cursor
-```
-
-### Or via `npx skills add`
+HyperFrames ships [skills](https://github.com/vercel-labs/skills) that teach AI agents framework-specific patterns that generic docs don't cover.
 
 ```bash
-# HyperFrames skills (hyperframes-compose, hyperframes-captions)
-npx skills add heygen-com/hyperframes
-
-# GSAP skills (gsap-core, gsap-timeline, gsap-scrolltrigger, gsap-plugins, gsap-performance, gsap-utils, gsap-react, gsap-frameworks)
-npx skills add greensock/gsap-skills
+npx skills add heygen-com/hyperframes    # HyperFrames skills
+npx skills add greensock/gsap-skills     # GSAP animation skills
 ```
 
-### Installed Skills
-
-| Source                                               | Skills                                                                                                                                | What they teach                                                                                                                                                  |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **HyperFrames**                                      | `hyperframes-compose`, `hyperframes-captions`, `hyperframes-registry`                                                                 | HTML composition structure, `class="clip"` rules, `data-*` attributes, timeline registration, rendering constraints, registry block/component install and wiring |
-| **[GSAP](https://github.com/greensock/gsap-skills)** | `gsap-core`, `gsap-timeline`, `gsap-performance`, `gsap-plugins`, `gsap-scrolltrigger`, `gsap-utils`, `gsap-react`, `gsap-frameworks` | Core API, timeline sequencing, ScrollTrigger, plugin usage, performance best practices                                                                           |
-
-In Claude Code, invoke with `/hyperframes-compose`, `/hyperframes-captions`, `/gsap-core`, etc.
+| Skill                                             | What it teaches                                                        |
+| ------------------------------------------------- | ---------------------------------------------------------------------- |
+| `hyperframes-compose`                             | HTML composition structure, `data-*` attributes, timeline registration |
+| `hyperframes-captions`                            | Caption/subtitle authoring and transcript integration                  |
+| `hyperframes-registry`                            | Block and component installation via `hyperframes add`                 |
+| `gsap-core`, `gsap-timeline`, `gsap-plugins`, ... | GSAP animation API, sequencing, ScrollTrigger, performance             |
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+[Apache 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -103,18 +103,19 @@ Browse the full catalog at **[hyperframes.heygen.com/catalog](https://hyperframe
 
 ## Documentation
 
-Full documentation at **[hyperframes.heygen.com](https://hyperframes.heygen.com)** — [Quickstart](https://hyperframes.heygen.com/quickstart) | [Guides](https://hyperframes.heygen.com/guides/gsap-animation) | [API Reference](https://hyperframes.heygen.com/packages/core) | [Catalog](https://hyperframes.heygen.com/catalog/blocks/data-chart)
+Full documentation at **[hyperframes.heygen.com/introduction](https://hyperframes.heygen.com/introduction)** — [Quickstart](https://hyperframes.heygen.com/quickstart) | [Guides](https://hyperframes.heygen.com/guides/gsap-animation) | [API Reference](https://hyperframes.heygen.com/packages/core) | [Catalog](https://hyperframes.heygen.com/catalog/blocks/data-chart)
 
 ## Packages
 
-| Package                                      | Description                                                 |
-| -------------------------------------------- | ----------------------------------------------------------- |
-| [`hyperframes`](packages/cli)                | CLI — create, preview, lint, and render compositions        |
-| [`@hyperframes/core`](packages/core)         | Types, parsers, generators, linter, runtime, frame adapters |
-| [`@hyperframes/engine`](packages/engine)     | Seekable page-to-video capture engine (Puppeteer + FFmpeg)  |
-| [`@hyperframes/producer`](packages/producer) | Full rendering pipeline (capture + encode + audio mix)      |
-| [`@hyperframes/studio`](packages/studio)     | Browser-based composition editor UI                         |
-| [`@hyperframes/player`](packages/player)     | Embeddable `<hyperframes-player>` web component             |
+| Package                                                          | Description                                                 |
+| ---------------------------------------------------------------- | ----------------------------------------------------------- |
+| [`hyperframes`](packages/cli)                                    | CLI — create, preview, lint, and render compositions        |
+| [`@hyperframes/core`](packages/core)                             | Types, parsers, generators, linter, runtime, frame adapters |
+| [`@hyperframes/engine`](packages/engine)                         | Seekable page-to-video capture engine (Puppeteer + FFmpeg)  |
+| [`@hyperframes/producer`](packages/producer)                     | Full rendering pipeline (capture + encode + audio mix)      |
+| [`@hyperframes/studio`](packages/studio)                         | Browser-based composition editor UI                         |
+| [`@hyperframes/player`](packages/player)                         | Embeddable `<hyperframes-player>` web component             |
+| [`@hyperframes/shader-transitions`](packages/shader-transitions) | WebGL shader transitions for compositions                   |
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ HyperFrames ships [skills](https://github.com/vercel-labs/skills) that teach AI 
 ```bash
 npx skills add heygen-com/hyperframes    # HyperFrames skills
 npx skills add greensock/gsap-skills     # GSAP animation skills
+
+# Or install via the CLI (also runs automatically during `hyperframes init`)
+npx hyperframes skills
+npx hyperframes skills --claude          # install to a specific agent
+npx hyperframes skills --cursor
 ```
 
 | Skill                                             | What it teaches                                                        |

--- a/README.md
+++ b/README.md
@@ -124,11 +124,6 @@ HyperFrames ships [skills](https://github.com/vercel-labs/skills) that teach AI 
 ```bash
 npx skills add heygen-com/hyperframes    # HyperFrames skills
 npx skills add greensock/gsap-skills     # GSAP animation skills
-
-# Or install via the CLI (also runs automatically during `hyperframes init`)
-npx hyperframes skills
-npx hyperframes skills --claude          # install to a specific agent
-npx hyperframes skills --cursor
 ```
 
 | Skill                                             | What it teaches                                                        |

--- a/docs/contributing/testing-local-changes.mdx
+++ b/docs/contributing/testing-local-changes.mdx
@@ -11,26 +11,25 @@ Build the monorepo first. Every time you change source files, rebuild before tes
 
 ```bash
 # From the monorepo root
-pnpm build
+bun run build
 ```
 
-## Option 1: pnpm link (recommended)
+## Option 1: bun link (recommended)
 
-`pnpm link --global` makes the `hyperframes` binary in your `$PATH` point at your local build. It survives across terminal sessions and auto-picks up new builds without re-linking.
+`bun link` makes the `hyperframes` binary in your `$PATH` point at your local build. It survives across terminal sessions and auto-picks up new builds without re-linking.
 
 ```bash
 # If you previously installed hyperframes globally, remove it first —
-# a global install takes priority over pnpm link and shadows your local build.
-pnpm remove -g hyperframes 2>/dev/null || npm uninstall -g hyperframes 2>/dev/null
+# a global install takes priority over bun link and shadows your local build.
+npm uninstall -g hyperframes 2>/dev/null
 
 # Link your local build
 cd packages/cli
-pnpm link --global
+bun link
 
 # Verify — should print your local version AND point to the monorepo
 hyperframes --version
 which hyperframes
-# The path should contain your monorepo, NOT pnpm/global/.pnpm/hyperframes@...
 ```
 
 Now use `hyperframes` normally in any directory:
@@ -40,12 +39,12 @@ cd ~/my-video-project
 hyperframes preview .
 ```
 
-**After every `pnpm build`** the linked binary is already up to date — no re-linking needed.
+**After every `bun run build`** the linked binary is already up to date — no re-linking needed.
 
 To restore the published release when you're done:
 
 ```bash
-pnpm unlink --global hyperframes
+bun unlink hyperframes
 npm install -g hyperframes@latest
 ```
 
@@ -55,13 +54,13 @@ If you don't want to touch your global `$PATH`, add a shell alias or call `node`
 
 ```bash
 # Temporary alias for your current shell session
-alias hyperframes="node /path/to/hyperframes-oss/packages/cli/dist/cli.js"
+alias hyperframes="node /path/to/hyperframes/packages/cli/dist/cli.js"
 
 # Or invoke directly
-node /path/to/hyperframes-oss/packages/cli/dist/cli.js preview .
+node /path/to/hyperframes/packages/cli/dist/cli.js preview .
 ```
 
-Replace `/path/to/hyperframes-oss` with your actual monorepo path.
+Replace `/path/to/hyperframes` with your actual monorepo path.
 
 ## Option 3: npm pack (test the exact published artifact)
 
@@ -74,9 +73,9 @@ npm pack
 
 # Test it in an isolated directory
 mkdir /tmp/pack-test && cd /tmp/pack-test
-npx /path/to/hyperframes-oss/packages/cli/hyperframes-<version>.tgz init my-video
+npx /path/to/hyperframes/packages/cli/hyperframes-<version>.tgz init my-video
 cd my-video
-npx /path/to/hyperframes-oss/packages/cli/hyperframes-<version>.tgz preview .
+npx /path/to/hyperframes/packages/cli/hyperframes-<version>.tgz preview .
 ```
 
 ## Testing the fix branches
@@ -105,26 +104,23 @@ Common test scenarios:
 
 ## Troubleshooting
 
-**Changes not reflected after `pnpm build`**
+**Changes not reflected after `bun run build`**
 
-The CLI binary is a single bundled file at `packages/cli/dist/cli.js`. If your change is in `@hyperframes/core` or another workspace package, make sure `pnpm build` rebuilt _all_ packages — the CLI bundles its dependencies at build time.
+The CLI binary is a single bundled file at `packages/cli/dist/cli.js`. If your change is in `@hyperframes/core` or another workspace package, make sure `bun run build` rebuilt _all_ packages — the CLI bundles its dependencies at build time.
 
 **`hyperframes` still shows the old version / old UI**
 
-A globally installed `hyperframes` package shadows `pnpm link`. Check which binary is active:
+A globally installed `hyperframes` package shadows `bun link`. Check which binary is active:
 
 ```bash
 which hyperframes
-# BAD:  /Users/you/Library/pnpm/hyperframes → pnpm/global/.pnpm/hyperframes@0.x.x/...
-# GOOD: /Users/you/Library/pnpm/hyperframes → your-monorepo/packages/cli/dist/cli.js
 ```
 
-If it points to the global store, remove the global install and re-link:
+If it points to a global store rather than your monorepo, remove the global install and re-link:
 
 ```bash
-pnpm remove -g hyperframes
-npm uninstall -g hyperframes   # in case it was installed via npm
-cd packages/cli && pnpm link --global
+npm uninstall -g hyperframes
+cd packages/cli && bun link
 ```
 
 **Port already in use**


### PR DESCRIPTION
## Summary

- **README Quick Start restructured**: Skills install is now Option 1 (recommended), matching the homepage's onboarding flow. Manual CLI is Option 2. This aligns the GitHub landing page with the "AI-first" positioning on hyperframes.heygen.com.
- **Catalog section added**: 50+ blocks and components were invisible from GitHub — now showcased with install examples and link to the catalog.
- **`@hyperframes/player` added to packages table**: Was shipped but missing from the README.
- **npm downloads badge added**: Social proof for adoption.
- **HTML example fixed**: `data-track` → `data-track-index`, added missing `class="clip"` on img element to match actual API.
- **Skills section condensed**: Was 40+ lines with redundant install methods; now a concise table.
- **testing-local-changes.mdx**: All `pnpm` references replaced with `bun` — the repo uses bun, and CLAUDE.md explicitly says "Do NOT run pnpm install".

## Context

From a full docs audit comparing against Remotion, Next.js, Tailwind, and other top OSS projects. The biggest gap was that the README told a CLI-first story while the homepage tells an AI-agent-first story. This PR aligns them.

## Test plan

- [ ] Verify README renders correctly on GitHub (logo, badges, tables, code blocks)
- [ ] Verify all links resolve (docs site, catalog, packages, contributing)
- [ ] Verify npm downloads badge loads
- [ ] Read through testing-local-changes.mdx for any remaining pnpm references