### PR TITLE
fix(readme): correct skills table to match actual skill names

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ npx skills add heygen-com/hyperframes    # HyperFrames skills
 npx skills add greensock/gsap-skills     # GSAP animation skills
 ```
 
-| Skill                                             | What it teaches                                                        |
-| ------------------------------------------------- | ---------------------------------------------------------------------- |
-| `hyperframes-compose`                             | HTML composition structure, `data-*` attributes, timeline registration |
-| `hyperframes-captions`                            | Caption/subtitle authoring and transcript integration                  |
-| `hyperframes-registry`                            | Block and component installation via `hyperframes add`                 |
-| `gsap-core`, `gsap-timeline`, `gsap-plugins`, ... | GSAP animation API, sequencing, ScrollTrigger, performance             |
+| Skill                  | What it teaches                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------- |
+| `hyperframes`          | HTML composition authoring, captions, TTS, audio-reactive animation, transitions             |
+| `hyperframes-cli`      | CLI commands: init, lint, preview, render, transcribe, tts, doctor                           |
+| `hyperframes-registry` | Block and component installation via `hyperframes add`                                       |
+| `gsap`                 | GSAP animation API, timelines, easing, ScrollTrigger, plugins, React/Vue/Svelte, performance |
 
 ## Contributing
 


### PR DESCRIPTION
## What

Fixes the Skills table in the README to match the actual skill names in the repo.

## Why

The previous table listed `hyperframes-compose` and `hyperframes-captions` as separate skills, but they don't exist — captions/compose are part of the `hyperframes` skill. It also listed `gsap-core, gsap-timeline, gsap-plugins, ...` but the actual skill is just `gsap`. And `hyperframes-cli` was missing entirely.

## How

Updated the skills table to match the four actual skills in the `skills/` directory:
- `hyperframes` — composition authoring, captions, TTS, audio-reactive, transitions
- `hyperframes-cli` — CLI commands (was missing)
- `hyperframes-registry` — block/component installation
- `gsap` — full GSAP reference (was listed as `gsap-core, gsap-timeline, ...`)

## Test plan

- [ ] Verify skill names match `skills/*/SKILL.md` in the repo
- [ ] Manual testing performed
- [x] Documentation updated (if applicable)