### PR TITLE
refactor(skills): move contrast + animation-map scripts into hyperframes skill

### DIFF
--- a/packages/cli/src/commands/contrast-audit.browser.js
+++ b/packages/cli/src/commands/contrast-audit.browser.js
@@ -3,7 +3,7 @@
 // esbuild mangling (page.evaluate serializes functions; __name helpers break).
 //
 // NOTE: WCAG math (relLum, wcagRatio, parseColor, median) is duplicated in
-// skills/hyperframes-contrast/scripts/contrast-report.mjs — keep in sync.
+// skills/hyperframes/scripts/contrast-report.mjs — keep in sync.
 
 /* eslint-disable */
 window.__contrastAudit = async function (imgBase64, time) {

--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -285,7 +285,7 @@ Use `--no-contrast` to skip if iterating rapidly and you'll check later.
 After authoring animations, run the animation map to verify choreography:
 
 ```bash
-node skills/hyperframes-animation-map/scripts/animation-map.mjs <composition-dir> \
+node skills/hyperframes/scripts/animation-map.mjs <composition-dir> \
   --out <composition-dir>/.hyperframes/anim-map
 ```
 

--- a/skills/hyperframes/scripts/animation-map.mjs
+++ b/skills/hyperframes/scripts/animation-map.mjs
@@ -6,7 +6,7 @@
 // human-readable summaries. Outputs a single animation-map.json.
 //
 // Usage:
-//   node skills/hyperframes-animation-map/scripts/animation-map.mjs <composition-dir> \
+//   node skills/hyperframes/scripts/animation-map.mjs <composition-dir> \
 //     [--frames N] [--out <dir>] [--min-duration S] [--width W] [--height H] [--fps N]
 
 import { mkdir, writeFile } from "node:fs/promises";

--- a/skills/hyperframes/scripts/contrast-report.mjs
+++ b/skills/hyperframes/scripts/contrast-report.mjs
@@ -9,7 +9,7 @@
 //   - contrast-overlay.png  (sprite grid; magenta=fail AA, yellow=pass AA only, green=AAA)
 //
 // Usage:
-//   node skills/hyperframes-contrast/scripts/contrast-report.mjs <composition-dir> \
+//   node skills/hyperframes/scripts/contrast-report.mjs <composition-dir> \
 //     [--samples N] [--out <dir>] [--width W] [--height H] [--fps N]
 //
 // The composition directory must contain an index.html. Raw authoring HTML


### PR DESCRIPTION
## What

Moves `skills/hyperframes-animation-map/` and `skills/hyperframes-contrast/` scripts into `skills/hyperframes/scripts/`, and removes the now-empty top-level skill directories.

## Why

These two directories had scripts but no `SKILL.md` — they looked like broken/incomplete skills and wouldn't be installed by `npx skills add`. They're actually helper scripts invoked by the main `hyperframes` skill (SKILL.md already references them in the "Quality Checks" section). Moving them under `skills/hyperframes/scripts/` makes them part of the skill they belong to, so they get installed alongside it.

## How

- Moved `skills/hyperframes-animation-map/scripts/animation-map.mjs` → `skills/hyperframes/scripts/animation-map.mjs`
- Moved `skills/hyperframes-contrast/scripts/contrast-report.mjs` → `skills/hyperframes/scripts/contrast-report.mjs`
- Removed empty `skills/hyperframes-animation-map/` and `skills/hyperframes-contrast/` directories
- Updated path references in:
  - `skills/hyperframes/SKILL.md` (animation-map usage example)
  - `skills/hyperframes/scripts/animation-map.mjs` (usage comment)
  - `skills/hyperframes/scripts/contrast-report.mjs` (usage comment)
  - `packages/cli/src/commands/contrast-audit.browser.js` (keep-in-sync comment)

## Test plan

- [ ] Verify `grep -r "hyperframes-animation-map\|hyperframes-contrast" . --include="*.md" --include="*.mjs" --include="*.js" --include="*.ts"` returns no results (excluding node_modules)
- [ ] Verify `skills/hyperframes/scripts/` contains both scripts
- [ ] Verify `skills/hyperframes/SKILL.md` references the new path
- [x] Documentation updated (if applicable)