### PR TITLE
fix(skills): correct README skills table and move orphaned scripts into hyperframes skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ npx skills add heygen-com/hyperframes    # HyperFrames skills
 npx skills add greensock/gsap-skills     # GSAP animation skills
 ```
 
-| Skill                                             | What it teaches                                                        |
-| ------------------------------------------------- | ---------------------------------------------------------------------- |
-| `hyperframes-compose`                             | HTML composition structure, `data-*` attributes, timeline registration |
-| `hyperframes-captions`                            | Caption/subtitle authoring and transcript integration                  |
-| `hyperframes-registry`                            | Block and component installation via `hyperframes add`                 |
-| `gsap-core`, `gsap-timeline`, `gsap-plugins`, ... | GSAP animation API, sequencing, ScrollTrigger, performance             |
+| Skill                  | What it teaches                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------- |
+| `hyperframes`          | HTML composition authoring, captions, TTS, audio-reactive animation, transitions             |
+| `hyperframes-cli`      | CLI commands: init, lint, preview, render, transcribe, tts, doctor                           |
+| `hyperframes-registry` | Block and component installation via `hyperframes add`                                       |
+| `gsap`                 | GSAP animation API, timelines, easing, ScrollTrigger, plugins, React/Vue/Svelte, performance |
 
 ## Contributing
 

--- a/packages/cli/src/commands/contrast-audit.browser.js
+++ b/packages/cli/src/commands/contrast-audit.browser.js
@@ -3,7 +3,7 @@
 // esbuild mangling (page.evaluate serializes functions; __name helpers break).
 //
 // NOTE: WCAG math (relLum, wcagRatio, parseColor, median) is duplicated in
-// skills/hyperframes-contrast/scripts/contrast-report.mjs — keep in sync.
+// skills/hyperframes/scripts/contrast-report.mjs — keep in sync.
 
 /* eslint-disable */
 window.__contrastAudit = async function (imgBase64, time) {

--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -285,7 +285,7 @@ Use `--no-contrast` to skip if iterating rapidly and you'll check later.
 After authoring animations, run the animation map to verify choreography:
 
 ```bash
-node skills/hyperframes-animation-map/scripts/animation-map.mjs <composition-dir> \
+node skills/hyperframes/scripts/animation-map.mjs <composition-dir> \
   --out <composition-dir>/.hyperframes/anim-map
 ```
 

--- a/skills/hyperframes/scripts/animation-map.mjs
+++ b/skills/hyperframes/scripts/animation-map.mjs
@@ -6,7 +6,7 @@
 // human-readable summaries. Outputs a single animation-map.json.
 //
 // Usage:
-//   node skills/hyperframes-animation-map/scripts/animation-map.mjs <composition-dir> \
+//   node skills/hyperframes/scripts/animation-map.mjs <composition-dir> \
 //     [--frames N] [--out <dir>] [--min-duration S] [--width W] [--height H] [--fps N]
 
 import { mkdir, writeFile } from "node:fs/promises";

--- a/skills/hyperframes/scripts/contrast-report.mjs
+++ b/skills/hyperframes/scripts/contrast-report.mjs
@@ -9,7 +9,7 @@
 //   - contrast-overlay.png  (sprite grid; magenta=fail AA, yellow=pass AA only, green=AAA)
 //
 // Usage:
-//   node skills/hyperframes-contrast/scripts/contrast-report.mjs <composition-dir> \
+//   node skills/hyperframes/scripts/contrast-report.mjs <composition-dir> \
 //     [--samples N] [--out <dir>] [--width W] [--height H] [--fps N]
 //
 // The composition directory must contain an index.html. Raw authoring HTML


### PR DESCRIPTION
## What

Fixes the README skills table to match actual skill names, and moves two orphaned script directories into the `hyperframes` skill where they belong.

## Why

**README**: Listed `hyperframes-compose` and `hyperframes-captions` as separate skills — these don't exist. Captions/compose are part of the `hyperframes` skill. Also listed `gsap-core, gsap-timeline, gsap-plugins, ...` but the actual skill is just `gsap`. Missing `hyperframes-cli` entirely.

**Orphaned scripts**: `skills/hyperframes-animation-map/` and `skills/hyperframes-contrast/` had scripts but no `SKILL.md` — they looked like broken skills and wouldn't be installed by `npx skills add`. They're helper scripts invoked by the main `hyperframes` skill (SKILL.md already references them in the "Quality Checks" section). Moving them under `skills/hyperframes/scripts/` makes them part of the skill they belong to.

## How

**README skills table** — corrected to match the 4 actual skills:
- `hyperframes` (was `hyperframes-compose` + `hyperframes-captions`)
- `hyperframes-cli` (was missing)
- `hyperframes-registry` (unchanged)
- `gsap` (was `gsap-core, gsap-timeline, gsap-plugins, ...`)

**Script moves:**
- `skills/hyperframes-animation-map/scripts/animation-map.mjs` → `skills/hyperframes/scripts/`
- `skills/hyperframes-contrast/scripts/contrast-report.mjs` → `skills/hyperframes/scripts/`
- Removed empty `skills/hyperframes-animation-map/` and `skills/hyperframes-contrast/`
- Updated path references in SKILL.md, both script headers, and `contrast-audit.browser.js`

## Test plan

- [ ] `grep -r "hyperframes-animation-map\|hyperframes-contrast" --include="*.md" --include="*.mjs" --include="*.js" --include="*.ts" .` returns no results
- [ ] `ls skills/` shows only `gsap`, `hyperframes`, `hyperframes-cli`, `hyperframes-registry`
- [ ] README skills table matches `skills/*/SKILL.md` names
- [x] Documentation updated (if applicable)