### PR TITLE
Update README.md to use skilllkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Hyperframes is an open-source video rendering framework that lets you create, pr
 Install the HyperFrames skills, then describe the video you want:
 
 ```bash
-npx skills add heygen-com/hyperframes
+npx skillkit add heygen-com/hyperframes
 ```
 
 This teaches your agent (Claude Code, Cursor, Gemini CLI, Codex) how to write correct compositions and GSAP animations. In Claude Code, the skills register as slash commands — invoke `/hyperframes` to author compositions, `/hyperframes-cli` for CLI commands, and `/gsap` for animation help.


### PR DESCRIPTION
## What


This pull request updates the installation instructions in the `README.md` to use the new `skillkit` tool instead of the deprecated `skills` command. This ensures users follow the current recommended method for adding HyperFrames skills.

## Why

[Why is this change needed?](https://github.com/user-attachments/assets/b1843a07-2c54-422d-8903-f30a790cfb37)

