### PR TITLE
fix(engine): suppress font-load 404s by checking console location URL

### DIFF
--- a/packages/engine/src/services/frameCapture.test.ts
+++ b/packages/engine/src/services/frameCapture.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { isFontResourceError } from "./frameCapture.js";
+
+describe("isFontResourceError", () => {
+  it("matches Google Fonts CSS load failures via location.url", () => {
+    expect(
+      isFontResourceError(
+        "error",
+        "Failed to load resource: net::ERR_FAILED",
+        "https://fonts.googleapis.com/css2?family=Inter",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches gstatic font binaries via location.url", () => {
+    expect(
+      isFontResourceError(
+        "error",
+        "Failed to load resource: the server responded with a status of 404 (Not Found)",
+        "https://fonts.gstatic.com/s/inter/v12/foo.woff2",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches self-hosted woff2 failures", () => {
+    expect(
+      isFontResourceError(
+        "error",
+        "Failed to load resource: net::ERR_CONNECTION_REFUSED",
+        "http://localhost:9999/font.woff2",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches .ttf and .otf URLs", () => {
+    expect(
+      isFontResourceError("error", "Failed to load resource: 404", "http://example.com/a.ttf"),
+    ).toBe(true);
+    expect(
+      isFontResourceError("error", "Failed to load resource: 404", "http://example.com/b.otf"),
+    ).toBe(true);
+  });
+
+  it("does NOT match non-font resources (images, scripts, videos)", () => {
+    expect(
+      isFontResourceError("error", "Failed to load resource: 404", "https://example.com/img.png"),
+    ).toBe(false);
+    expect(
+      isFontResourceError(
+        "error",
+        "Failed to load resource: 404",
+        "https://cdn.example.com/bundle.js",
+      ),
+    ).toBe(false);
+    expect(
+      isFontResourceError("error", "Failed to load resource: 404", "https://example.com/video.mp4"),
+    ).toBe(false);
+  });
+
+  it("does NOT match when location.url is missing and text has no URL (safe default)", () => {
+    expect(isFontResourceError("error", "Failed to load resource: 404", "")).toBe(false);
+  });
+
+  it("still matches when URL appears in text (older Chrome formats)", () => {
+    expect(
+      isFontResourceError(
+        "error",
+        "Failed to load resource: https://fonts.googleapis.com/... 404",
+        "",
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT match non-error console messages", () => {
+    expect(
+      isFontResourceError(
+        "warn",
+        "Failed to load resource: 404",
+        "https://fonts.googleapis.com/css2",
+      ),
+    ).toBe(false);
+    expect(
+      isFontResourceError(
+        "info",
+        "Failed to load resource: 404",
+        "https://fonts.googleapis.com/css2",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT match unrelated error messages", () => {
+    expect(isFontResourceError("error", "Uncaught ReferenceError: x is not defined", "")).toBe(
+      false,
+    );
+    expect(
+      isFontResourceError("error", "Some other error", "https://fonts.googleapis.com/css2"),
+    ).toBe(false);
+  });
+
+  it("is case-insensitive for URL matching", () => {
+    expect(
+      isFontResourceError(
+        "error",
+        "Failed to load resource: 404",
+        "https://FONTS.GOOGLEAPIS.COM/css2",
+      ),
+    ).toBe(true);
+    expect(
+      isFontResourceError("error", "Failed to load resource: 404", "http://example.com/FONT.WOFF2"),
+    ).toBe(true);
+  });
+});

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -142,6 +142,27 @@ export async function createCaptureSession(
   };
 }
 
+/**
+ * Classify a console "Failed to load resource" error as a font-load failure.
+ *
+ * These are expected when deterministic font injection replaces Google Fonts
+ * @import URLs with embedded base64 — or when the render environment has no
+ * network access to Google Fonts. Suppressing them reduces noise in render
+ * output without hiding real asset failures (images, videos, scripts, etc.).
+ *
+ * Chrome's `msg.text()` for a failed resource is typically just
+ * `"Failed to load resource: net::ERR_FAILED"` — the URL is only on
+ * `msg.location().url`. We match against both so the filter works regardless
+ * of which form Chrome emits.
+ */
+export function isFontResourceError(type: string, text: string, locationUrl: string): boolean {
+  if (type !== "error") return false;
+  if (!text.startsWith("Failed to load resource")) return false;
+  return /fonts\.googleapis|fonts\.gstatic|\.(woff2?|ttf|otf)(\b|$)/i.test(
+    `${locationUrl} ${text}`,
+  );
+}
+
 export async function initializeSession(session: CaptureSession): Promise<void> {
   const { page, serverUrl } = session;
 
@@ -149,13 +170,8 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   page.on("console", (msg: ConsoleMessage) => {
     const type = msg.type();
     const text = msg.text();
-
-    // Suppress font-loading 404s entirely. These are expected when deterministic
-    // font injection replaces Google Fonts @import URLs with embedded base64.
-    const isFontLoadError =
-      type === "error" &&
-      text.startsWith("Failed to load resource") &&
-      /fonts\.googleapis|fonts\.gstatic|\.woff2?(\b|$)/i.test(text);
+    const locationUrl = msg.location()?.url ?? "";
+    const isFontLoadError = isFontResourceError(type, text, locationUrl);
 
     // Other "Failed to load resource" 404s are typically non-blocking (e.g.
     // favicon, sourcemaps, optional assets). Prefix them so users know they


### PR DESCRIPTION
## Problem

In headless render environments, every font-load 404 appears in the render output as `[non-blocking] Failed to load resource: …` noise — the exact symptom that PR #311 was targeting:

```
[Compiler] Injected deterministic @font-face rules for 2 requested font families
[non-blocking] Failed to load resource: the server responded with a status of 404 (Not Found)
[non-blocking] Failed to load resource: the server responded with a status of 404 (Not Found)
```

The existing filter in `packages/engine/src/services/frameCapture.ts` was supposed to suppress these (see the comment at line 153-154: "Suppress font-loading 404s entirely. These are expected…"), but it doesn't actually work:

```ts
const isFontLoadError =
  type === "error" &&
  text.startsWith("Failed to load resource") &&
  /fonts\.googleapis|fonts\.gstatic|\.woff2?(\b|$)/i.test(text); // ← only checks text
```

Chrome's console message `text()` for a failed resource is just `"Failed to load resource: net::ERR_FAILED"` or `"Failed to load resource: the server responded with a status of 404 (Not Found)"` — **the URL is not in the text**, it's on `msg.location().url`. So the regex never matches and every font 404 falls through to the `[non-blocking]` prefix.

### Reproducer

```js
// Puppeteer console event for a 404'd Google Fonts <link>:
// msg.text()         → "Failed to load resource: net::ERR_FAILED"
// msg.location().url → "https://fonts.googleapis.com/css2?family=NonExistent:wght@400"
```

The old regex test against `text` returns `false`, so the event is logged. Verified locally with a minimal Puppeteer reproducer.

## Fix

Extract the classifier into a testable `isFontResourceError(type, text, locationUrl)` function and match against both `text` and `locationUrl`. Also extend the extension set to `.ttf` and `.otf`.

This is a targeted fix for the same noise PR #311 was after, without changing any font-resolution behavior.

## Why not the SYSTEM_FONTS approach in PR #311

PR #311 adds a ~120-entry `SYSTEM_FONTS` skip set to `extractRequestedFontFamilies()`. It silently shadows entries already in `FONT_ALIASES`:

- `arial → inter`
- `helvetica`, `helvetica neue`, `helvetica bold → inter`
- `courier`, `courier new → jetbrains-mono`
- `segoe ui → roboto`
- `arial black`, `futura → montserrat`

With that PR applied, those aliases become dead code because `extractRequestedFontFamilies` skips the font before `buildFontFaceCss` ever runs. On render fleets (e.g. `Dockerfile.test` — `fonts-liberation`/`fonts-dejavu-core`/`fonts-noto-*`, no Arial/Helvetica/SF Pro/Segoe UI/Tahoma installed), compositions that previously rendered with the aliased web font would shift to whatever fontconfig substitutes (Liberation Sans/Mono). That's a silent visual regression for existing fixtures such as `packages/producer/tests/style-15-prod/src/compositions/hero_moment.html` which uses `"Helvetica Neue", Helvetica, Arial, sans-serif`.

It also misidentifies the root cause: `Courier New` and `Courier` are already in `FONT_ALIASES` and never reach Google Fonts, so the 404s attributed to them in that PR's description aren't coming from Path 2 in `buildFontFaceCss`. They're the generic `<link rel="stylesheet" href="fonts.googleapis.com/…">` tag (emitted by `packages/core/src/generators/hyperframes.ts:104-107`) failing in a sandbox, which the broken filter above was supposed to hide.

## Testing

- Added `packages/engine/src/services/frameCapture.test.ts` with 10 cases:
  - Google Fonts CSS / gstatic binaries / self-hosted woff2 / .ttf / .otf all suppressed via `location.url`
  - Images, scripts, videos NOT suppressed
  - URL-in-text (older Chrome format) still suppressed
  - Non-error log levels not suppressed
  - Case-insensitive URL matching
- `bun run --filter @hyperframes/engine test` → 52/52 pass (5 files)
- `bunx oxlint` / `bunx oxfmt --check` clean on changed files

## Verified behavior

Before fix, reproducer shows:
```
[console.error] text="Failed to load resource: net::ERR_FAILED" — filter-matches=false
  (location.url: https://fonts.googleapis.com/css2?family=NonExistent:wght@400)
```

After fix, the same event matches the filter and is suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)