### PR TITLE
chore: release v0.4.4

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.4.4 — patch bump of all `@hyperframes/*` packages (and `hyperframes` CLI) from v0.4.3.

Merging this PR triggers the publish workflow, which tags `v0.4.4` and publishes to npm under the `latest` dist-tag.

## Changes since v0.4.3

- fix(engine): suppress font-load 404s by checking console location URL (#313)
- fix(studio): iPhone Safari layout + touch-drag scrubber (#308)
- fix(player): address #298 review — tighter drift, dynamic proxies, ownership event (#307)
- fix(cli): serialize port-availability probes (#309) (#310)
- fix(docs): serve hyperframes.json / registry JSON schemas (#304) (#305)
- PR #299: capture improvements v2 (Gemini 3.1 Flash Lite, double-audio fix, lint/docs improvements)

All commits since v0.4.3 are fixes or internal changes — no public API changes.