### PR TITLE
fix(cli): doctor shows platform-correct install hints

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -6,7 +6,7 @@ export const examples: Example[] = [["Check system dependencies", "hyperframes d
 import { freemem, platform } from "node:os";
 import { c } from "../ui/colors.js";
 import { findBrowser } from "../browser/manager.js";
-import { findFFmpeg } from "../browser/ffmpeg.js";
+import { findFFmpeg, getFFmpegInstallHint } from "../browser/ffmpeg.js";
 import { VERSION } from "../version.js";
 import { getUpdateMeta } from "../utils/updateCheck.js";
 import { getSystemMeta, getShmSizeMb, getFreeDiskMb, bytesToMb } from "../telemetry/system.js";
@@ -36,19 +36,22 @@ function checkFFmpeg(): CheckResult {
   return {
     ok: false,
     detail: "Not found",
-    hint: process.platform === "darwin" ? "brew install ffmpeg" : "sudo apt install ffmpeg",
+    hint: getFFmpegInstallHint(),
   };
 }
 
 function checkFFprobe(): CheckResult {
+  // `ffprobe -version` works cross-platform if it's on PATH — no need for
+  // `which`/`where` shell detection, which differs by OS.
   try {
-    const result = execSync("which ffprobe", { encoding: "utf-8", timeout: 5000 }).trim();
-    return { ok: true, detail: result };
+    const version =
+      execSync("ffprobe -version", { encoding: "utf-8", timeout: 5000 }).split("\n")[0] ?? "";
+    return { ok: true, detail: version.trim() };
   } catch {
     return {
       ok: false,
       detail: "Not found",
-      hint: "Installed with ffmpeg",
+      hint: `Installed with ffmpeg — ${getFFmpegInstallHint()}`,
     };
   }
 }


### PR DESCRIPTION
## Summary

`hyperframes doctor` shipped two bugs that misled non-Debian-Linux and Windows users:

1. **Wrong FFmpeg install hint.** When FFmpeg was missing, the hint was hardcoded as `sudo apt install ffmpeg` for every non-macOS platform. Windows users saw an apt command that doesn't exist on their system; Red Hat / Arch users got the wrong package manager.

2. **FFprobe check broken on Windows.** `checkFFprobe` called `which ffprobe` via `execSync`. `which` isn't a command on Windows (cmd uses `where`), so the check always reported "Not found" even when ffprobe was on PATH.

## Fix

- `checkFFmpeg` now uses `getFFmpegInstallHint()` — the helper already exists in `browser/ffmpeg.ts`, already handles `darwin` / `linux` / `win32` correctly, and is already used by `render.ts`. Just reuse it here.
- `checkFFprobe` now runs `ffprobe -version` directly instead of shelling out to `which`. This works on every platform where ffprobe is resolvable on PATH, and surfaces the version string in the same style as the FFmpeg check.
- The "not found" hint for ffprobe now falls through to the same platform-aware ffmpeg install hint (they ship together).

## Before / After

Before (on Windows, ffprobe present):
```
✗ FFprobe    Not found
             Installed with ffmpeg
```

After:
```
✓ FFprobe    ffprobe version 8.1 Copyright (c) 2007-2026 …
```

Before (on Windows, FFmpeg missing):
```
✗ FFmpeg     Not found
             sudo apt install ffmpeg      ← wrong OS
```

After:
```
✗ FFmpeg     Not found
             https://ffmpeg.org/download.html
```

## Test plan

- [x] `bunx oxlint packages/cli/src/commands/doctor.ts` — clean
- [x] `bunx oxfmt --check packages/cli/src/commands/doctor.ts` — clean
- [x] Pre-commit typecheck hook passes
- [x] `bunx tsx packages/cli/src/cli.ts doctor` runs locally on macOS — FFprobe now reports version instead of path, all other behavior unchanged

## Notes

Scope intentionally kept small. `findFFmpeg()` in `browser/ffmpeg.ts` still uses `which ffmpeg` which has the same Windows issue — happy to fix in a follow-up PR if the maintainers want it, but it has a wider blast radius (used by `render.ts` too) so I left it out of this one.