### PR TITLE
Fix windows external assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,23 +81,6 @@ npx hyperframes render       # render to MP4
 - **Deterministic rendering** — same input = identical output. Built for automated pipelines.
 - **Frame Adapter pattern** — bring your own animation runtime (GSAP, Lottie, CSS, Three.js).
 
-## HyperFrames vs. Remotion
-
-[Remotion](https://github.com/remotion-dev/remotion) is an excellent React-based video framework, and parts of HyperFrames are intentionally inspired by it. The comparison below is based on the projects' official READMEs and license pages:
-
-| Topic | HyperFrames | Remotion |
-| --- | --- | --- |
-| Authoring model | HTML compositions with `data-*` attributes, described in the [HyperFrames README](https://github.com/heygen-com/hyperframes) as "HTML-based video compositions" with "No React" | React components and JSX, described in the [Remotion README](https://github.com/remotion-dev/remotion) as "videos programmatically using React" |
-| Best fit | Teams that want an HTML-first, agent-friendly workflow with deterministic rendering, as described in the [HyperFrames README](https://github.com/heygen-com/hyperframes) | Teams that already want a React-first workflow and value the React strengths listed in the [Remotion README](https://github.com/remotion-dev/remotion) |
-| Pros | Officially emphasizes HTML-native authoring, AI-first workflows, deterministic rendering, frame adapters, and an [Apache 2.0 license](https://github.com/heygen-com/hyperframes/blob/main/LICENSE) | Officially emphasizes React benefits such as reusable components, composition, Fast Refresh, package ecosystem, and a large [documentation surface](https://remotion.dev/docs) |
-| Cons | Less ideal if your team specifically wants to author videos as React components | Less ideal if you want to avoid React entirely; [Remotion's license](https://github.com/remotion-dev/remotion/blob/main/LICENSE.md) also notes that a company license is required in some cases |
-
-In practice:
-
-- Choose **HyperFrames** if you want video authoring to feel like HTML/CSS, especially when AI agents are generating or editing compositions.
-- Choose **Remotion** if your team already thinks in React and wants to reuse that component model directly for video.
-- If you're deciding between them, the biggest question is usually **HTML-first workflow vs. React-first workflow**, not rendering quality.
-
 ## How It Works
 
 Define your video as HTML with data attributes:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ npx hyperframes render       # render to MP4
 - **Deterministic rendering** — same input = identical output. Built for automated pipelines.
 - **Frame Adapter pattern** — bring your own animation runtime (GSAP, Lottie, CSS, Three.js).
 
+## HyperFrames vs. Remotion
+
+[Remotion](https://github.com/remotion-dev/remotion) is an excellent React-based video framework, and parts of HyperFrames are intentionally inspired by it. The comparison below is based on the projects' official READMEs and license pages:
+
+| Topic | HyperFrames | Remotion |
+| --- | --- | --- |
+| Authoring model | HTML compositions with `data-*` attributes, described in the [HyperFrames README](https://github.com/heygen-com/hyperframes) as "HTML-based video compositions" with "No React" | React components and JSX, described in the [Remotion README](https://github.com/remotion-dev/remotion) as "videos programmatically using React" |
+| Best fit | Teams that want an HTML-first, agent-friendly workflow with deterministic rendering, as described in the [HyperFrames README](https://github.com/heygen-com/hyperframes) | Teams that already want a React-first workflow and value the React strengths listed in the [Remotion README](https://github.com/remotion-dev/remotion) |
+| Pros | Officially emphasizes HTML-native authoring, AI-first workflows, deterministic rendering, frame adapters, and an [Apache 2.0 license](https://github.com/heygen-com/hyperframes/blob/main/LICENSE) | Officially emphasizes React benefits such as reusable components, composition, Fast Refresh, package ecosystem, and a large [documentation surface](https://remotion.dev/docs) |
+| Cons | Less ideal if your team specifically wants to author videos as React components | Less ideal if you want to avoid React entirely; [Remotion's license](https://github.com/remotion-dev/remotion/blob/main/LICENSE.md) also notes that a company license is required in some cases |
+
+In practice:
+
+- Choose **HyperFrames** if you want video authoring to feel like HTML/CSS, especially when AI agents are generating or editing compositions.
+- Choose **Remotion** if your team already thinks in React and wants to reuse that component model directly for video.
+- If you're deciding between them, the biggest question is usually **HTML-first workflow vs. React-first workflow**, not rendering quality.
+
 ## How It Works
 
 Define your video as HTML with data attributes:

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, mock, beforeAll } from "bun:test";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { collectExternalAssets, inlineExternalScripts } from "./htmlCompiler.js";
+import {
+  collectExternalAssets,
+  inlineExternalScripts,
+  isPathInsideDir,
+  toExternalAssetKey,
+} from "./htmlCompiler.js";
 
 // ── collectExternalAssets ──────────────────────────────────────────────────
 
@@ -119,6 +124,20 @@ describe("collectExternalAssets", () => {
 });
 
 // ── inlineExternalScripts ──────────────────────────────────────────────────
+
+describe("path helpers", () => {
+  it("treats Windows-style child paths as being inside the parent directory", () => {
+    expect(
+      isPathInsideDir("D:\\coder\\reactGin\\hyperframes\\reading", "D:\\coder\\reactGin\\hyperframes\\reading\\assets\\segment_001.wav"),
+    ).toBe(true);
+  });
+
+  it("creates Windows-safe external asset keys", () => {
+    expect(toExternalAssetKey("D:\\coder\\reactGin\\hyperframes\\reading\\assets\\segment_001.wav")).toBe(
+      "hf-ext/D/coder/reactGin/hyperframes/reading/assets/segment_001.wav",
+    );
+  });
+});
 
 describe("inlineExternalScripts", () => {
   it("returns HTML unchanged when no external scripts exist", async () => {

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -56,6 +56,22 @@ function dedupeElementsById<T extends { id: string }>(elements: T[]): T[] {
   return Array.from(deduped.values());
 }
 
+function normalizePathForComparison(filePath: string): string {
+  return resolve(filePath).replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+export function isPathInsideDir(parentDir: string, targetPath: string): boolean {
+  const normalizedParent = normalizePathForComparison(parentDir);
+  const normalizedTarget = normalizePathForComparison(targetPath);
+  return normalizedTarget === normalizedParent || normalizedTarget.startsWith(`${normalizedParent}/`);
+}
+
+export function toExternalAssetKey(absPath: string): string {
+  const normalized = resolve(absPath).replace(/\\/g, "/").replace(/^\/+/, "");
+  const portable = normalized.replace(/^([A-Za-z]):/, "$1");
+  return `hf-ext/${portable}`;
+}
+
 async function resolveMediaDuration(
   src: string,
   mediaStart: number,
@@ -804,12 +820,12 @@ export function collectExternalAssets(
       return null;
     }
     const absPath = resolve(absProjectDir, trimmed);
-    if (absPath.startsWith(absProjectDir + "/") || absPath === absProjectDir) {
+    if (isPathInsideDir(absProjectDir, absPath)) {
       return null; // inside projectDir, file server handles this
     }
     if (!existsSync(absPath)) return null;
     // resolve() already canonicalizes the path (no .. components remain)
-    const safeKey = "hf-ext/" + absPath.replace(/^\//, "");
+    const safeKey = toExternalAssetKey(absPath);
     externalAssets.set(safeKey, absPath);
     return safeKey;
   }

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -66,6 +66,7 @@ import {
   recompileWithResolutions,
   discoverMediaFromBrowser,
   type CompiledComposition,
+  isPathInsideDir,
 } from "./htmlCompiler.js";
 import { defaultLogger, type ProducerLogger } from "../logger.js";
 
@@ -266,7 +267,7 @@ function writeCompiledArtifacts(
   // so the file server can serve them.
   for (const [relativePath, absolutePath] of compiled.externalAssets) {
     const outPath = resolve(join(compileDir, relativePath));
-    if (!outPath.startsWith(compileDir + "/")) {
+    if (!isPathInsideDir(compileDir, outPath)) {
       console.warn(`[Render] Skipping external asset with unsafe path: ${relativePath}`);
       continue;
     }


### PR DESCRIPTION
## What

Fixes a Windows-specific rendering bug where local assets inside the project directory could be misclassified as unsafe external assets and skipped during render.

## Why

Issue #321 reports that local audio files such as `.\assets\segment_001.wav` are being rewritten to `hf-ext/...` paths, then rejected as unsafe and served as 404s during render on Windows. This breaks compositions that reference local assets with Windows-style paths.

## How

Updated the producer asset-handling logic to normalize paths before checking whether a file is inside the project or compiled output directory.

The change:
- Replaces POSIX-only `startsWith(... + "/")` containment checks with a separator-normalizing helper
- Generates Windows-safe `hf-ext/...` asset keys using forward slashes instead of raw drive-letter paths
- Reuses the same normalized path containment logic when copying external assets into the compiled render directory
- Adds regression coverage for Windows-style path handling and external asset key generation

A notable design decision was to centralize the path comparison logic so the compiler and render orchestrator use the same rules, rather than fixing only one side of the pipeline.

## Test plan

Could not run the repo’s normal test/format commands in this environment because `bun` and `bunx` are not installed here. Added regression tests for the Windows path behavior in the producer test suite.

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)
