### PR TITLE
chore: add linguist overrides so TypeScript is the dominant language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # Golden baseline videos for regression tests
 packages/producer/tests/*/output/output.mp4 filter=lfs diff=lfs merge=lfs -text
+
+# GitHub Linguist overrides — HTML files are compositions (user content / templates),
+# not the framework source. Hide them from the repo language stats so TypeScript,
+# which is the actual implementation, surfaces as the dominant language.
+registry/**/*.html linguist-vendored
+*.html linguist-detectable=false


### PR DESCRIPTION
## What

Adds two GitHub Linguist overrides to `.gitattributes`:

\`\`\`
registry/**/*.html linguist-vendored
*.html linguist-detectable=false
\`\`\`

## Why

The repo language bar on GitHub currently shows HTML as dominant because the registry ships several hundred composition templates as `.html` files, and the block/example HTML content dwarfs the framework source. But the framework itself — the CLI, runtime, engine, producer, player, studio — is TypeScript. The language bar should reflect the implementation language, not the bundled content.

## How

- `registry/**/*.html linguist-vendored` — marks registry block/example HTML as third-party content so it doesn't count toward language stats.
- `*.html linguist-detectable=false` — belt-and-suspenders: tells Linguist not to use any `.html` file for language detection. Applies to `packages/*/docs/*.html` quickstart templates and other content HTML too.

Effect: HTML drops out of the repo language bar and TypeScript surfaces as the dominant language.

## Test plan

- [x] Verified the rules render correctly in `.gitattributes` (valid Linguist syntax)
- [ ] Confirm after merge: https://github.com/heygen-com/hyperframes language stats update within a few minutes (Linguist re-runs on push to default branch)

Suggested by a Claude Code review thread; trivial change with immediate payoff.