### PR TITLE
docs(guides): add Performance guide and preview-stutter troubleshooting

### DIFF
--- a/docs/concepts/determinism.mdx
+++ b/docs/concepts/determinism.mdx
@@ -70,6 +70,8 @@ The browser preview and the rendered MP4 should match. Hyperframes achieves this
 - **Producer-canonical behavior** -- the [producer's](/packages/producer) seek semantics are the source of truth
 - **Readiness gates** -- `__playerReady` and `__renderReady` ensure the [composition](/concepts/compositions) is fully loaded before any frame is captured
 
+Parity here means **visual fidelity** — every frame looks the same. It does *not* mean performance parity. Preview plays in real time in a browser, so frame-rate limits are bound by your hardware. Render is seek-driven and frame-at-a-time, so it never drops frames regardless of per-frame cost. A composition can stutter in preview and render perfectly. See [Performance](/guides/performance) for why.
+
 <Note>
   Local rendering (without Docker) may show slight differences due to platform-specific font rendering and Chrome version. Use Docker mode when exact reproducibility matters.
 </Note>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,6 +73,7 @@
               "guides/prompting",
               "guides/gsap-animation",
               "guides/rendering",
+              "guides/performance",
               "guides/common-mistakes",
               "guides/troubleshooting"
             ]

--- a/docs/guides/common-mistakes.mdx
+++ b/docs/guides/common-mistakes.mdx
@@ -120,6 +120,75 @@ These are mistakes that cannot be caught by the linter. For automated checks, ru
     </Note>
   </Accordion>
 
+  <Accordion title="Oversized source images">
+    **Symptom:** Preview stutters during scenes with images on screen. Render is slower than expected.
+
+    **Cause:** Source images at much higher resolution than the canvas. Chrome decodes images to raw RGBA bitmaps before displaying them, and bitmap size is `width × height × 4` bytes — independent of file size on disk. A 7000×5000 JPEG is 140MB decoded, even if the file is only 2MB.
+
+    Displaying such an image in a 384×1080 region wastes memory and forces the compositor to resample a huge texture every frame.
+
+    **Before (bloated):**
+
+    ```html index.html
+    <!-- 7000x5000 source, ~140MB decoded -->
+    <img class="clip" data-start="0" data-duration="3"
+         src="./assets/hero-scene.jpg" />
+    ```
+
+    **After (sized to the canvas):**
+
+    ```bash Terminal
+    # Resize a batch of images to fit within 3840x3840, preserving aspect ratio
+    mkdir -p assets/resized
+    mogrify -path assets/resized -resize 3840x3840\> assets/*.jpg
+    ```
+
+    ```html index.html
+    <!-- ~3840x2560 source, ~40MB decoded -->
+    <img class="clip" data-start="0" data-duration="3"
+         src="./assets/resized/hero-scene.jpg" />
+    ```
+
+    **Rule of thumb:** source images at most 2x the canvas dimensions. For a 1920×1080 composition, 3840×2160 is already plenty. See [Performance: Image sizing](/guides/performance#image-sizing).
+  </Accordion>
+
+  <Accordion title="Heavy backdrop-filter stacks">
+    **Symptom:** Specific scenes drop to 5-10fps in preview. The composition is fine elsewhere.
+
+    **Cause:** `backdrop-filter: blur()` on large elements, especially stacked at high radii. Each blur layer forces the compositor to sample pixels behind the element, run a blur kernel, and composite the result. Stacked layers multiply the cost.
+
+    **Before (expensive):**
+
+    ```css
+    /* 8 layers per side = 16 blur passes every frame */
+    .pb-1 { backdrop-filter: blur(1px); }
+    .pb-2 { backdrop-filter: blur(2px); }
+    .pb-3 { backdrop-filter: blur(4px); }
+    .pb-4 { backdrop-filter: blur(8px); }
+    .pb-5 { backdrop-filter: blur(16px); }
+    .pb-6 { backdrop-filter: blur(32px); }
+    .pb-7 { backdrop-filter: blur(64px); }
+    .pb-8 { backdrop-filter: blur(128px); }
+    ```
+
+    **After (3 tuned layers):**
+
+    ```css
+    /* Fewer passes with hand-picked radii — visually similar, much cheaper */
+    .pb-1 { backdrop-filter: blur(4px); }
+    .pb-2 { backdrop-filter: blur(16px); }
+    .pb-3 { backdrop-filter: blur(48px); }
+    ```
+
+    **Guidelines:**
+
+    - Keep stacked `backdrop-filter` layers to 2-3 per region
+    - Avoid radii above 64px over large areas — the biggest radii dominate the total cost
+    - For a static blur effect, pre-render it into a PNG once and overlay with a regular `<img>`
+
+    See [Performance: backdrop-filter: blur()](/guides/performance#backdrop-filter-blur) for the full breakdown.
+  </Accordion>
+
   <Accordion title="Timeline key doesn't match data-composition-id">
     **Symptom:** Animations don't play. The composition appears static.
 

--- a/docs/guides/performance.mdx
+++ b/docs/guides/performance.mdx
@@ -1,0 +1,119 @@
+---
+title: Performance
+description: "How to keep preview playback smooth and diagnose expensive compositions."
+---
+
+Preview plays your composition in real time, so any frame that takes longer than 33ms (at 30fps) shows up as stutter. This page covers the patterns that blow that budget and how to spot them.
+
+## Preview vs. render
+
+Render captures frames one at a time and stitches them into a video. Slow frames make the render take longer, but you never see the pauses — you watch the finished mp4.
+
+Preview does the same work in real time. If a frame takes 200ms to paint, you see a 200ms freeze.
+
+This is why "render looks fine, preview stutters" is expected for paint-heavy compositions. It doesn't mean preview is broken — it means individual frames are too expensive for real-time playback.
+
+## Expensive CSS patterns
+
+These are the patterns that most often cause preview to drop below 30fps.
+
+### backdrop-filter: blur()
+
+Each `backdrop-filter: blur(radius)` sampled over a large area forces the compositor to read pixels from behind the element, run a blur kernel across them, and composite the result. Cost scales with both the blurred area and the radius.
+
+Stacked blur layers multiply the cost. Eight layers at progressively larger radii (1, 2, 4, 8, 16, 32, 64, 128px) will happily take 200ms per frame over a 1920x1080 region on mid-tier GPUs.
+
+**What to do:**
+- Keep stacked layers to 2-3 maximum, with manually tuned radii
+- Avoid `blur(128px)` or `blur(64px)` over large areas — the biggest radii dominate the cost
+- For a static blur, render it once into a PNG and use a regular `<img>` overlay
+
+### filter: blur() and filter: drop-shadow()
+
+Same story as `backdrop-filter` but applied to the element itself rather than behind it. Fine on small elements, expensive on large ones.
+
+### Shadows on many elements
+
+`box-shadow` and `text-shadow` on a few elements are fine. On dozens of elements that also animate, the compositor re-rasterizes each shadowed layer on every frame.
+
+### Large gradients with mask-image
+
+Combined with `backdrop-filter`, `mask-image` can force additional compositor passes. If you have both on the same element, consider whether you need both.
+
+## Image sizing
+
+Image source resolution matters more than file size. Chrome decodes JPEGs and PNGs to raw RGBA bitmaps before displaying them — a decoded bitmap is:
+
+```
+bitmap_bytes = width × height × 4
+```
+
+A 7000×5000 source image is 140MB decoded, regardless of whether the JPEG on disk is 2MB or 5MB.
+
+**Rule of thumb:** resize source images to at most 2x the canvas dimensions. For a 1920x1080 canvas, 3840x2160 source images are already overkill. Anything above that is paying for memory and texture-upload cost that never shows on screen.
+
+```bash Terminal
+# ImageMagick one-liner to downsize a directory of images
+mogrify -path resized -resize 3840x3840\> *.jpg
+```
+
+## Measuring a slow composition
+
+Don't guess — measure. Chrome DevTools has everything you need.
+
+<Steps>
+  <Step title="Run preview">
+    Start the preview server and open it in Chrome:
+
+    ```bash Terminal
+    npx hyperframes preview
+    ```
+  </Step>
+  <Step title="Open DevTools → Performance">
+    `Cmd+Option+I` (macOS) or `Ctrl+Shift+I` (Linux/Windows), then switch to the **Performance** tab.
+  </Step>
+  <Step title="Record during playback">
+    Hit the record button, click play in the preview, let it run 3-5 seconds through the jank-prone scene, then stop recording.
+  </Step>
+  <Step title="Read the main thread track">
+    Look for long tasks (red-flagged in the timeline). Expand the tallest bars and check what Chrome labels them:
+
+    - **Composite Layers / Paint** with a large duration = compositor cost (backdrop-filter, shadows, large textures)
+    - **Decode Image** = image decode on first paint (rare in Chrome 131+, images decode off-thread by default)
+    - **Layout / Recalculate Style** = layout thrashing from script
+    - **Script** = JS work (rare for compositions, check author scripts)
+  </Step>
+</Steps>
+
+Once you know which category dominates, you know what to change.
+
+<Tip>
+  A composition that runs at 60fps in isolation but stutters only during specific scenes is usually a composite-cost problem. Check which layers become visible during those scenes.
+</Tip>
+
+## When preview is unavoidable slow
+
+Some compositions are legitimately too expensive for real-time playback. If you've reduced what you can and preview still stutters, render-to-mp4 and watch the output is a fine workflow — render is still accurate.
+
+```bash Terminal
+npx hyperframes render --quality draft --output preview.mp4
+```
+
+Draft quality renders fast and is visually close to the final render for everything except encoder-level detail.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Troubleshooting" icon="wrench" href="/guides/troubleshooting">
+    Environment, tooling, and rendering issues
+  </Card>
+  <Card title="Common Mistakes" icon="triangle-exclamation" href="/guides/common-mistakes">
+    Composition pitfalls that break rendering
+  </Card>
+  <Card title="Rendering" icon="film" href="/guides/rendering">
+    Rendering modes, options, and flags
+  </Card>
+  <Card title="CLI Reference" icon="terminal" href="/packages/cli">
+    Full list of CLI commands
+  </Card>
+</CardGroup>

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -71,6 +71,31 @@ If your issue is about a specific coding mistake (animations not working, video 
     4. Clear the browser cache if CSS changes are not reflected
   </Accordion>
 
+  <Accordion title="Preview stutters or plays at a low frame rate">
+    **Symptom:** Preview playback is jerky or skips frames, but the rendered mp4 looks fine.
+
+    **Cause:** Individual frames are taking longer than 16-33ms to paint. Render hides this (it captures frames one at a time), preview does not.
+
+    **Common culprits, most to least frequent:**
+
+    - Stacked `backdrop-filter: blur()` layers, especially at radii above 32px
+    - Source images at very high resolution (above 4K) displayed in small regions
+    - `filter: blur()` or `filter: drop-shadow()` on large elements
+    - Many elements with `box-shadow` or `text-shadow` that also animate
+
+    **First thing to check:** does the stutter happen only during specific scenes, or throughout? Scene-specific stutter usually points at an element, often a blur overlay, that becomes visible in that scene.
+
+    **How to diagnose:** open Chrome DevTools, switch to the Performance tab, record a few seconds of playback, and look for long tasks labeled "Composite Layers" or "Paint". See [Performance: Measuring a slow composition](/guides/performance#measuring-a-slow-composition) for the full walkthrough.
+
+    **Temporary workaround:** render to mp4 and watch the output. Render is accurate regardless of per-frame cost.
+
+    ```bash Terminal
+    npx hyperframes render --quality draft --output preview.mp4
+    ```
+
+    See [Performance](/guides/performance) for the full guide on expensive CSS patterns and how to fix them.
+  </Accordion>
+
   <Accordion title="Render looks different from preview">
     Use `--docker` mode for [deterministic output](/concepts/determinism). Local renders may differ due to:
 

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -373,6 +373,10 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
 
     Opens your composition in the Hyperframes Studio with live preview. Edits to `index.html` and any referenced sub-compositions are reflected automatically. The preview uses the same Hyperframes runtime as production rendering, so what you see is what you get.
 
+    <Note>
+      Visual output matches render exactly. Playback *performance* does not: preview plays in real time in your browser, so paint-heavy compositions (large images, stacked `backdrop-filter` layers, many shadowed elements) may stutter depending on your hardware. The rendered mp4 is always accurate regardless — render captures frames one at a time, so per-frame cost shows up as longer render duration, not dropped frames. See [Performance](/guides/performance) for details.
+    </Note>
+
     The preview server runs in three modes, auto-detected:
 
     1. **Embedded mode** (default for `npx`) — runs a standalone server with the studio bundled in the CLI. Zero extra dependencies.

--- a/docs/packages/studio.mdx
+++ b/docs/packages/studio.mdx
@@ -185,6 +185,10 @@ The studio renders your composition in an iframe using the Hyperframes runtime. 
 
 Changes to your HTML are picked up automatically through hot reload, so you can edit `index.html` in your editor and see the result in the browser within milliseconds.
 
+<Note>
+  The *visual* output of preview matches render exactly. Real-time *playback smoothness* depends on your hardware, because preview actually plays the composition in your browser at 30/60fps. Render doesn't have that constraint — it captures each frame individually via a seek-driven pipeline, so expensive frames make the render slower but never drop. If you see stutter in preview but the rendered mp4 is clean, that's expected. See [Performance](/guides/performance) for the patterns that most often cause it.
+</Note>
+
 ### Timeline View
 
 The timeline panel provides a visual representation of your composition's structure:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,9 @@ pre-commit:
       run: bunx oxlint {staged_files}
     format:
       glob: "*.{js,jsx,ts,tsx,json,md,yaml,yml}"
-      run: bunx oxfmt --check {staged_files}
+      # --no-error-on-unmatched-pattern: don't fail when staged files all
+      # fall under .prettierignore (e.g. docs-only changes to docs/docs.json).
+      run: bunx oxfmt --check --no-error-on-unmatched-pattern {staged_files}
     typecheck:
       glob: "*.{ts,tsx}"
       run: cd packages/core && bunx tsc --noEmit && cd ../studio && bunx tsc --noEmit


### PR DESCRIPTION
## What

Adds a dedicated Performance guide under `guides/` and cross-links it from existing troubleshooting and common-mistakes pages. Also a one-line fix to `lefthook.yml` so docs-only commits don't get stuck on the format hook.

New / changed:

- **New:** `docs/guides/performance.mdx` — the preview-vs-render cost model, expensive CSS patterns (backdrop-filter, filter, shadows, gradients), image sizing with bitmap-size math, and a walkthrough of using Chrome DevTools Performance to diagnose slow compositions.
- **`docs/guides/troubleshooting.mdx`** — new "Preview stutters or plays at a low frame rate" accordion with a quick checklist and a link out to the Performance guide.
- **`docs/guides/common-mistakes.mdx`** — two new accordions: "Oversized source images" and "Heavy backdrop-filter stacks", both with before/after examples.
- **`docs/docs.json`** — wire the new page into the Guides sidebar.
- **`lefthook.yml`** — add `--no-error-on-unmatched-pattern` to the `oxfmt --check` invocation so docs-only commits (where all staged files land under `.prettierignore`) don't fail the hook with exit 2.

## Why

Grounded in a real user issue (#317): compositions with stacked `backdrop-filter` layers stutter in preview even when the rendered mp4 looks fine. I measured the reporter's repro and the jank is almost entirely compositor-side paint cost, which there was nowhere to point users to in the docs. Existing guidance (`troubleshooting.mdx`, `common-mistakes.mdx`) covers environment issues and coding mistakes, but nothing about why certain CSS patterns make preview fall below 30fps.

The Performance page fills that gap. The troubleshooting and common-mistakes additions give users two natural on-ramps to it when they hit the symptom.

Modeled loosely after Remotion's structure (`/docs/performance` as the top-level perf reference, plus targeted troubleshooting accordions for specific symptoms).

## How

Followed the repo's `DOCS_GUIDELINES.md` conventions: one-sentence page intro, concrete before/after examples, `<Steps>` for the DevTools walkthrough, `<CardGroup>` next-steps at the bottom. No new Mintlify components introduced.

Ran `mint validate` and `mint broken-links` against `docs/` — both pass.

The lefthook fix is unrelated to the docs content but was required to land this PR: `oxfmt` exits 2 when the only staged files matching the format glob are all covered by `.prettierignore` (the case for `docs/docs.json`). `--no-error-on-unmatched-pattern` is the documented escape hatch for that exact case.

## Test plan

- [x] `mint validate` passes
- [x] `mint broken-links` passes
- [x] Pre-commit hook passes (post lefthook fix)
- [x] Commit message passes commitlint
- [ ] Preview the built docs on Mintlify after merge to verify navigation placement and cross-links render correctly