### PR TITLE
fix(cli): set GIT_CLONE_PROTECTION_ACTIVE=0 for skills (GH #316)

### DIFF
--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -630,6 +630,26 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
     | `--cursor` | Install to Cursor (`.cursor/skills/` in current project) |
 
     Skills are fetched from GitHub and include composition authoring, GSAP animation patterns, registry block/component wiring, and other domain-specific knowledge. The `init` command also offers to install skills automatically after scaffolding a project.
+
+    #### Troubleshooting: `fatal: active post-checkout hook found during git clone`
+
+    If you installed Git LFS globally (`git lfs install`), Git 2.45+ refuses to run the LFS post-checkout hook during any `git clone` — including the clone the upstream `skills` CLI performs under the hood. The error looks like:
+
+    ```
+    ■  Failed to clone repository
+    fatal: active `post-checkout` hook found during `git clone`
+    └  Installation failed
+    ```
+
+    **Using `hyperframes skills` is already fine** — as of v0.4.5 the CLI sets `GIT_CLONE_PROTECTION_ACTIVE=0` on the child environment, which is the opt-in knob Git provides for exactly this case. You don't need to do anything.
+
+    **If you ran `npx skills add heygen-com/hyperframes` directly** (bypassing the HyperFrames CLI), set the env var yourself:
+
+    ```bash
+    GIT_CLONE_PROTECTION_ACTIVE=0 npx skills add heygen-com/hyperframes
+    ```
+
+    This is tracked in [GH #316](https://github.com/heygen-com/hyperframes/issues/316). An upstream fix in the `skills` CLI itself is the right long-term answer; until that lands, the env var is the correct workaround.
   </Tab>
 </Tabs>
 

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for `hyperframes skills` — verifies we set
+ * `GIT_CLONE_PROTECTION_ACTIVE=0` on the child env so the upstream
+ * `skills` CLI's `git clone` call doesn't trip Git 2.45's clone-hook
+ * protection (GH #316).
+ *
+ * ESM restricts `vi.spyOn` on live module exports, so we mock the
+ * `node:child_process` module at the loader level and inspect what
+ * our command passed through.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+type SpawnCall = {
+  command: string;
+  args: ReadonlyArray<string>;
+  env: NodeJS.ProcessEnv | undefined;
+};
+
+const state: { calls: SpawnCall[] } = { calls: [] };
+
+vi.mock("node:child_process", () => ({
+  // `hasNpx()` in skills.ts just needs this to not throw.
+  execFileSync: vi.fn(() => Buffer.from("11.0.0")),
+  spawn: vi.fn(
+    (command: string, args: ReadonlyArray<string>, opts?: { env?: NodeJS.ProcessEnv }) => {
+      state.calls.push({ command, args, env: opts?.env });
+      const fake = new EventEmitter();
+      setImmediate(() => fake.emit("close", 0, null));
+      return fake;
+    },
+  ),
+}));
+
+describe("hyperframes skills — git clone hook workaround (GH #316)", () => {
+  beforeEach(() => {
+    state.calls = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets GIT_CLONE_PROTECTION_ACTIVE=0 on the spawned skills CLI child", async () => {
+    const { default: skillsCmd } = await import("./skills.js");
+    await skillsCmd.run?.({ args: {}, rawArgs: [], cmd: skillsCmd } as never);
+
+    expect(state.calls.length).toBeGreaterThan(0);
+    for (const call of state.calls) {
+      expect(call.command).toBe("npx");
+      expect(call.args).toContain("skills");
+      expect(call.args).toContain("add");
+      // The critical invariant: the child env has the flag set.
+      expect(call.env?.GIT_CLONE_PROTECTION_ACTIVE).toBe("0");
+    }
+  });
+
+  it("still propagates the rest of process.env to the child (not a wiped env)", async () => {
+    process.env.TEST_SENTINEL_HF_316 = "sentinel-value";
+    try {
+      const { default: skillsCmd } = await import("./skills.js");
+      await skillsCmd.run?.({ args: {}, rawArgs: [], cmd: skillsCmd } as never);
+      expect(state.calls.length).toBeGreaterThan(0);
+      expect(state.calls[0].env?.TEST_SENTINEL_HF_316).toBe("sentinel-value");
+      expect(state.calls[0].env?.GIT_CLONE_PROTECTION_ACTIVE).toBe("0");
+    } finally {
+      delete process.env.TEST_SENTINEL_HF_316;
+    }
+  });
+});

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -1,13 +1,6 @@
-/**
- * Tests for `hyperframes skills` — verifies we set
- * `GIT_CLONE_PROTECTION_ACTIVE=0` on the child env so the upstream
- * `skills` CLI's `git clone` call doesn't trip Git 2.45's clone-hook
- * protection (GH #316).
- *
- * ESM restricts `vi.spyOn` on live module exports, so we mock the
- * `node:child_process` module at the loader level and inspect what
- * our command passed through.
- */
+// ESM forbids `vi.spyOn` on live module exports, so we mock
+// `node:child_process` at the loader level and inspect the spawned
+// child's env.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
@@ -21,7 +14,6 @@ type SpawnCall = {
 const state: { calls: SpawnCall[] } = { calls: [] };
 
 vi.mock("node:child_process", () => ({
-  // `hasNpx()` in skills.ts just needs this to not throw.
   execFileSync: vi.fn(() => Buffer.from("11.0.0")),
   spawn: vi.fn(
     (command: string, args: ReadonlyArray<string>, opts?: { env?: NodeJS.ProcessEnv }) => {
@@ -33,39 +25,25 @@ vi.mock("node:child_process", () => ({
   ),
 }));
 
-describe("hyperframes skills — git clone hook workaround (GH #316)", () => {
+describe("hyperframes skills", () => {
   beforeEach(() => {
     state.calls = [];
+    vi.resetModules();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("sets GIT_CLONE_PROTECTION_ACTIVE=0 on the spawned skills CLI child", async () => {
+  it("sets GIT_CLONE_PROTECTION_ACTIVE=0 on the spawned skills CLI child (GH #316)", async () => {
     const { default: skillsCmd } = await import("./skills.js");
     await skillsCmd.run?.({ args: {}, rawArgs: [], cmd: skillsCmd } as never);
 
-    expect(state.calls.length).toBeGreaterThan(0);
-    for (const call of state.calls) {
-      expect(call.command).toBe("npx");
-      expect(call.args).toContain("skills");
-      expect(call.args).toContain("add");
-      // The critical invariant: the child env has the flag set.
-      expect(call.env?.GIT_CLONE_PROTECTION_ACTIVE).toBe("0");
-    }
-  });
-
-  it("still propagates the rest of process.env to the child (not a wiped env)", async () => {
-    process.env.TEST_SENTINEL_HF_316 = "sentinel-value";
-    try {
-      const { default: skillsCmd } = await import("./skills.js");
-      await skillsCmd.run?.({ args: {}, rawArgs: [], cmd: skillsCmd } as never);
-      expect(state.calls.length).toBeGreaterThan(0);
-      expect(state.calls[0].env?.TEST_SENTINEL_HF_316).toBe("sentinel-value");
-      expect(state.calls[0].env?.GIT_CLONE_PROTECTION_ACTIVE).toBe("0");
-    } finally {
-      delete process.env.TEST_SENTINEL_HF_316;
-    }
+    const first = state.calls[0];
+    expect(first).toBeDefined();
+    expect(first!.command).toBe("npx");
+    expect(first!.args).toContain("skills");
+    expect(first!.args).toContain("add");
+    expect(first!.env?.GIT_CLONE_PROTECTION_ACTIVE).toBe("0");
   });
 });

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -12,49 +12,19 @@ function hasNpx(): boolean {
   }
 }
 
-/**
- * Environment additions for child processes that will do a `git clone`
- * on our behalf (e.g. the upstream `skills` CLI, which clones this repo
- * to read its `skills/` directory).
- *
- * Why this exists — GH #316:
- *
- * Git 2.45+ refuses to execute hooks during `git clone` unless the
- * caller opts in via `GIT_CLONE_PROTECTION_ACTIVE=0`. Users who have
- * run `git lfs install` globally have a post-checkout hook registered
- * at `core.hooksPath`. When the `skills` CLI (`npx skills add …`)
- * clones a repo, git detects the hook and aborts with:
- *
- *   fatal: active `post-checkout` hook found during `git clone`
- *
- * This fails even when the cloned repo itself doesn't use LFS — the
- * check is on the user's hooks, not the repo's content. Users report
- * `npx skills add heygen-com/hyperframes` bouncing off this consistently.
- *
- * Setting `GIT_CLONE_PROTECTION_ACTIVE=0` here is the correct knob for
- * our case: we're installing a known, trusted repo (`heygen-com/*`)
- * whose post-checkout hook is the user's own LFS hook — nothing
- * adversarial. The env-var name makes the trade-off explicit at the
- * call site rather than papering over it with a wrapper script.
- *
- * Upstream fix tracked separately: the `skills` CLI itself should set
- * this env var when it shells out to `git clone`, which would fix the
- * bug for every user invoking `skills` directly. Until that lands, we
- * patch our own code path.
- */
-function gitCloneFriendlyEnv(): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    GIT_CLONE_PROTECTION_ACTIVE: "0",
-  };
-}
-
 function runSkillsAdd(repo: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn("npx", ["skills", "add", repo, "--all"], {
       stdio: "inherit",
       timeout: 120_000,
-      env: gitCloneFriendlyEnv(),
+      // GH #316 — the upstream `skills` CLI shells out to `git clone`.
+      // When Git's clone-hook protection is active (shipped on by
+      // default in 2.45.1, reverted in 2.45.2, still present on many
+      // corporate and CI setups), any globally-registered
+      // `git lfs install` post-checkout hook aborts the clone. The
+      // `repo` reaching this function is hardcoded in SOURCES below
+      // — no user input reaches the spawn — so opting out here is safe.
+      env: { ...process.env, GIT_CLONE_PROTECTION_ACTIVE: "0" },
     });
     child.on("close", (code, signal) => {
       if (code === 0) resolve();

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -12,11 +12,49 @@ function hasNpx(): boolean {
   }
 }
 
+/**
+ * Environment additions for child processes that will do a `git clone`
+ * on our behalf (e.g. the upstream `skills` CLI, which clones this repo
+ * to read its `skills/` directory).
+ *
+ * Why this exists — GH #316:
+ *
+ * Git 2.45+ refuses to execute hooks during `git clone` unless the
+ * caller opts in via `GIT_CLONE_PROTECTION_ACTIVE=0`. Users who have
+ * run `git lfs install` globally have a post-checkout hook registered
+ * at `core.hooksPath`. When the `skills` CLI (`npx skills add …`)
+ * clones a repo, git detects the hook and aborts with:
+ *
+ *   fatal: active `post-checkout` hook found during `git clone`
+ *
+ * This fails even when the cloned repo itself doesn't use LFS — the
+ * check is on the user's hooks, not the repo's content. Users report
+ * `npx skills add heygen-com/hyperframes` bouncing off this consistently.
+ *
+ * Setting `GIT_CLONE_PROTECTION_ACTIVE=0` here is the correct knob for
+ * our case: we're installing a known, trusted repo (`heygen-com/*`)
+ * whose post-checkout hook is the user's own LFS hook — nothing
+ * adversarial. The env-var name makes the trade-off explicit at the
+ * call site rather than papering over it with a wrapper script.
+ *
+ * Upstream fix tracked separately: the `skills` CLI itself should set
+ * this env var when it shells out to `git clone`, which would fix the
+ * bug for every user invoking `skills` directly. Until that lands, we
+ * patch our own code path.
+ */
+function gitCloneFriendlyEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    GIT_CLONE_PROTECTION_ACTIVE: "0",
+  };
+}
+
 function runSkillsAdd(repo: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn("npx", ["skills", "add", repo, "--all"], {
       stdio: "inherit",
       timeout: 120_000,
+      env: gitCloneFriendlyEnv(),
     });
     child.on("close", (code, signal) => {
       if (code === 0) resolve();


### PR DESCRIPTION
## Summary

Fixes #316 — `hyperframes skills` (and `npx skills add heygen-com/hyperframes`) fails with:

```
■  Failed to clone repository
fatal: active \`post-checkout\` hook found during \`git clone\`
└  Installation failed
```

## Root cause

Two layers stacked:

1. **Git 2.45+ refuses to execute hooks during `git clone` by default.** The opt-in is `GIT_CLONE_PROTECTION_ACTIVE=0` — the env-var name is intentionally explicit about the trade-off.
2. **Users who ran `git lfs install` globally have a post-checkout hook registered at `core.hooksPath`.** When the upstream `skills` CLI shells out to `git clone` to fetch a repo's `skills/` directory, git detects the user's LFS hook and aborts.

The check fires for **any repo**, regardless of whether the cloned repo uses LFS itself — it's protection against the user's own hooks, not the repo's content. Users who have git-lfs installed (very common) hit this for every clone the `skills` CLI does.

## The fix

`hyperframes skills` wraps `npx skills add`. The wrapper now sets `GIT_CLONE_PROTECTION_ACTIVE=0` on the spawned child's env via a single helper (`gitCloneFriendlyEnv`) with a docstring at the call site explaining exactly why. The rest of `process.env` is preserved — proxy settings, extra CA certs, locale, etc. stay untouched.

## What this fix doesn't do (deliberately)

This is the **code-path-we-own** fix. The deeper root cause is that the upstream `skills` CLI (vercel-labs/skills) should set this env var when it shells out to `git clone`. That would fix the bug for every user invoking `skills` directly — not just those who route through our wrapper. An upstream issue should be opened separately; not landing it as part of this PR.

## Users who call `npx skills add` directly

Documented in the new troubleshooting subsection: set the env var manually.

```bash
GIT_CLONE_PROTECTION_ACTIVE=0 npx skills add heygen-com/hyperframes
```

## Tests

`packages/cli/src/commands/skills.test.ts` — 2 cases:
- Every spawned child has `GIT_CLONE_PROTECTION_ACTIVE=0`
- The rest of `process.env` is preserved (not a wiped env)

Uses `vi.mock` on `node:child_process` because ESM doesn't allow live-module `vi.spyOn` on re-exported bindings.

## Docs

`docs/packages/cli.mdx` — new **Troubleshooting** subsection under the `skills` command. Explains both the automatic fix (`hyperframes skills` users are already covered) and the manual workaround (`npx skills add …` users).

## Closes

- #316