### PR TITLE
fix(producer): normalize path separators in asset collection for Windows

### DIFF
--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -804,12 +804,16 @@ export function collectExternalAssets(
       return null;
     }
     const absPath = resolve(absProjectDir, trimmed);
-    if (absPath.startsWith(absProjectDir + "/") || absPath === absProjectDir) {
+    // Normalize to forward slashes so path comparisons and URL routing
+    // work on Windows, where path.resolve() returns backslash paths.
+    const normAbsPath = absPath.replace(/\\/g, "/");
+    const normProjectDir = absProjectDir.replace(/\\/g, "/");
+    if (normAbsPath.startsWith(normProjectDir + "/") || normAbsPath === normProjectDir) {
       return null; // inside projectDir, file server handles this
     }
     if (!existsSync(absPath)) return null;
     // resolve() already canonicalizes the path (no .. components remain)
-    const safeKey = "hf-ext/" + absPath.replace(/^\//, "");
+    const safeKey = "hf-ext/" + normAbsPath.replace(/^\//, "");
     externalAssets.set(safeKey, absPath);
     return safeKey;
   }


### PR DESCRIPTION
## Summary

On Windows, every project-local asset (videos, audio, images referenced with relative `src`/`href`/CSS `url()`) is misrouted to the external-file handler, producing URLs like `hf-ext/C:/Users/.../assets/foo.mp4` that the file server cannot serve — renders fail with 404s on all assets.

**Root cause:** `path.resolve()` returns backslash paths on Windows, but the project-dir containment check in `collectExternalAssets` uses a forward-slash literal:

```ts
if (absPath.startsWith(absProjectDir + "/") || absPath === absProjectDir) {
  return null; // inside projectDir, file server handles this
}
```

On Windows `absPath` is `C:\Users\…\project\assets\foo.mp4` and `absProjectDir + "/"` is `C:\Users\…\project/` — they never match, so the asset is treated as external and routed through `hf-ext/`. The resulting `safeKey` also contains backslashes and a drive colon, which the file server can't route.

**Fix:** Normalize both paths to forward slashes before comparison, and use the normalized path when building the `hf-ext/` safeKey so the URL is always valid.

## How this was discovered

Hit it on a plain Fiverr gig intro render — three `.mp4`/`.wav`/`.jpg` assets in the project's `assets/` folder, all 404'd during capture:

```
[FileServer] 404 Not Found: /hf-ext/C:/Users/david/.../fiverr-gig-intro/assets/logo.jpg
[FileServer] 404 Not Found: /hf-ext/C:/Users/david/.../fiverr-gig-intro/assets/reaper-scroll.mp4
[FileServer] 404 Not Found: /hf-ext/C:/Users/david/.../fiverr-gig-intro/assets/fiverr-music-ducked.wav
[WARN] Parallel capture timed out with 6 workers.
```

After the patch: same project renders cleanly in 2m 35s.

## Test coverage

The existing test `"does not collect assets inside projectDir"` already covers this. It silently passed on macOS/Linux because `os.tmpdir()` returns forward-slash paths there, but failed on Windows where `tmpdir()` returns a backslash path.

Before patch (on Windows):
```
(fail) collectExternalAssets > does not collect assets inside projectDir
(fail) collectExternalAssets > collects and rewrites assets outside projectDir via src attribute
17 pass / 2 fail
```

After patch (on Windows):
```
19 pass / 0 fail
```

## Test plan

- [x] All 19 `htmlCompiler.test.ts` tests pass on Windows (previously 2 failed)
- [x] `bunx oxlint` clean on changed file
- [x] `bunx oxfmt` clean on changed file
- [x] `bun run --filter @hyperframes/producer typecheck` passes
- [x] Verified end-to-end by rendering a real composition with project-local video/audio/image assets on Windows 11

## Environment

- Windows 11 Pro 26100
- Node 24.14.0
- Bun 1.3.12
- HyperFrames main @ commit prior to this PR