### PR TITLE
fix(cli): use 'where' instead of 'which' on Windows for FFmpeg and br…

### DIFF
--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -3,12 +3,16 @@ import { execSync } from "node:child_process";
 export function findFFmpeg(): string | undefined {
   try {
     const cmd = process.platform === "win32" ? "where ffmpeg" : "which ffmpeg";
-    const result = execSync(cmd, {
+    const output = execSync(cmd, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
-    }).trim();
-    return result || undefined;
+    });
+    const first = output
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find(Boolean);
+    return first || undefined;
   } catch {
     return undefined;
   }

--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -2,7 +2,8 @@ import { execSync } from "node:child_process";
 
 export function findFFmpeg(): string | undefined {
   try {
-    const result = execSync("which ffmpeg", {
+    const cmd = process.platform === "win32" ? "where ffmpeg" : "which ffmpeg";
+    const result = execSync(cmd, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -38,7 +38,8 @@ const SYSTEM_CHROME_PATHS: ReadonlyArray<string> =
 
 function whichBinary(name: string): string | undefined {
   try {
-    const result = execSync(`which ${name}`, {
+    const cmd = process.platform === "win32" ? `where ${name}` : `which ${name}`;
+    const result = execSync(cmd, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -39,12 +39,16 @@ const SYSTEM_CHROME_PATHS: ReadonlyArray<string> =
 function whichBinary(name: string): string | undefined {
   try {
     const cmd = process.platform === "win32" ? `where ${name}` : `which ${name}`;
-    const result = execSync(cmd, {
+    const output = execSync(cmd, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
-    }).trim();
-    return result || undefined;
+    });
+    const first = output
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find(Boolean);
+    return first || undefined;
   } catch {
     return undefined;
   }

--- a/packages/cli/src/tts/synthesize.ts
+++ b/packages/cli/src/tts/synthesize.ts
@@ -11,20 +11,26 @@ import { ensureModel, ensureVoices, DEFAULT_VOICE } from "./manager.js";
 function findPython(): string | undefined {
   for (const name of ["python3", "python"]) {
     try {
-      const result = execFileSync("which", [name], {
+      const cmd = process.platform === "win32" ? "where" : "which";
+      const output = execFileSync(cmd, [name], {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
         timeout: 5000,
-      }).trim();
+      });
+      const first = output
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .find(Boolean);
+      if (!first) continue;
 
       // Verify it's Python 3
-      const version = execFileSync(result, ["--version"], {
+      const version = execFileSync(first, ["--version"], {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
         timeout: 5000,
       }).trim();
 
-      if (version.includes("Python 3")) return result;
+      if (version.includes("Python 3")) return first;
     } catch {
       // not found or not Python 3
     }

--- a/packages/cli/src/utils/clipboard.ts
+++ b/packages/cli/src/utils/clipboard.ts
@@ -31,9 +31,10 @@ function detectProvider(): ClipboardProvider | undefined {
     { cmd: "xclip", args: ["-selection", "clipboard"] },
     { cmd: "xsel", args: ["--clipboard", "--input"] },
   ];
+  const cmd = process.platform === "win32" ? "where" : "which";
   for (const p of candidates) {
-    const which = spawnSync("which", [p.cmd], { stdio: "ignore" });
-    if (which.status === 0) return p;
+    const result = spawnSync(cmd, [p.cmd], { stdio: "ignore" });
+    if (result.status === 0) return p;
   }
   return undefined;
 }

--- a/packages/cli/src/whisper/manager.ts
+++ b/packages/cli/src/whisper/manager.ts
@@ -22,12 +22,17 @@ function getModelUrl(model: string): string {
 
 function whichBinary(name: string): string | undefined {
   try {
-    const result = execFileSync("which", [name], {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    const output = execFileSync(cmd, [name], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
-    }).trim();
-    return result || undefined;
+    });
+    const first = output
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find(Boolean);
+    return first || undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
Fixes #333

Windows uses `where` instead of `which`. This PR adds platform detection to both `findFFmpeg()` and `whichBinary()` functions.