### PR TITLE
feat(tts): add MiniMax cloud TTS provider

### DIFF
--- a/packages/cli/src/commands/tts.ts
+++ b/packages/cli/src/commands/tts.ts
@@ -9,18 +9,25 @@ export const examples: Example[] = [
   ["Adjust speech speed", 'hyperframes tts "Slow and clear" --speed 0.8'],
   ["Read text from a file", "hyperframes tts script.txt"],
   ["List available voices", "hyperframes tts --list"],
+  [
+    "Use MiniMax cloud TTS (requires MINIMAX_API_KEY)",
+    'hyperframes tts "Hello world" --provider minimax',
+  ],
+  [
+    "MiniMax with a specific voice",
+    'hyperframes tts "Hello world" --provider minimax --voice English_Persuasive_Man',
+  ],
 ];
 import { resolve, extname } from "node:path";
 import * as clack from "@clack/prompts";
 import { c } from "../ui/colors.js";
 import { DEFAULT_VOICE, BUNDLED_VOICES } from "../tts/manager.js";
-
-const voiceList = BUNDLED_VOICES.map((v) => `${v.id} (${v.label})`).join(", ");
+import { MINIMAX_VOICES, MINIMAX_DEFAULT_VOICE } from "../tts/minimax.js";
 
 export default defineCommand({
   meta: {
     name: "tts",
-    description: "Generate speech audio from text using a local AI model (Kokoro-82M)",
+    description: "Generate speech audio from text (local Kokoro model or MiniMax cloud API)",
   },
   args: {
     input: {
@@ -30,12 +37,19 @@ export default defineCommand({
     },
     output: {
       type: "string",
-      description: "Output file path (default: speech.wav in current directory)",
+      description: "Output file path (default: speech.wav for kokoro, speech.mp3 for minimax)",
       alias: "o",
+    },
+    provider: {
+      type: "string",
+      description:
+        'TTS provider: "kokoro" (local, default) or "minimax" (cloud, requires MINIMAX_API_KEY)',
+      alias: "p",
+      default: "kokoro",
     },
     voice: {
       type: "string",
-      description: `Voice ID (default: ${DEFAULT_VOICE}). Options: ${voiceList}`,
+      description: `Voice ID. Kokoro default: ${DEFAULT_VOICE}; MiniMax default: ${MINIMAX_DEFAULT_VOICE}`,
       alias: "v",
     },
     speed: {
@@ -45,7 +59,7 @@ export default defineCommand({
     },
     list: {
       type: "boolean",
-      description: "List available voices and exit",
+      description: "List available voices for the selected provider and exit",
       default: false,
     },
     json: {
@@ -55,9 +69,18 @@ export default defineCommand({
     },
   },
   async run({ args }) {
+    const provider = args.provider ?? "kokoro";
+
+    if (provider !== "kokoro" && provider !== "minimax") {
+      console.error(
+        c.error(`Unknown provider "${provider}". Choose "kokoro" (default) or "minimax".`),
+      );
+      process.exit(1);
+    }
+
     // ── List voices mode ──────────────────────────────────────────────
     if (args.list) {
-      return listVoices(args.json);
+      return listVoices(args.json, provider);
     }
 
     // ── Resolve input text ────────────────────────────────────────────
@@ -85,8 +108,8 @@ export default defineCommand({
     }
 
     // ── Resolve output path ───────────────────────────────────────────
-    const output = resolve(args.output ?? "speech.wav");
-    const voice = args.voice ?? DEFAULT_VOICE;
+    const defaultOutput = provider === "minimax" ? "speech.mp3" : "speech.wav";
+    const output = resolve(args.output ?? defaultOutput);
     const speed = args.speed ? parseFloat(args.speed) : 1.0;
 
     if (isNaN(speed) || speed <= 0 || speed > 3) {
@@ -95,42 +118,83 @@ export default defineCommand({
     }
 
     // ── Synthesize ────────────────────────────────────────────────────
-    const { synthesize } = await import("../tts/synthesize.js");
     const spin = args.json ? null : clack.spinner();
-    spin?.start(`Generating speech with ${c.accent(voice)}...`);
 
-    try {
-      const result = await synthesize(text, output, {
-        voice,
-        speed,
-        onProgress: spin ? (msg) => spin.message(msg) : undefined,
-      });
-
-      if (args.json) {
-        console.log(
-          JSON.stringify({
-            ok: true,
-            voice,
-            speed,
-            durationSeconds: result.durationSeconds,
-            outputPath: result.outputPath,
-          }),
-        );
-      } else {
-        spin?.stop(
-          c.success(
-            `Generated ${c.accent(result.durationSeconds.toFixed(1) + "s")} of speech → ${c.accent(result.outputPath)}`,
-          ),
-        );
+    if (provider === "minimax") {
+      const voice = args.voice ?? MINIMAX_DEFAULT_VOICE;
+      spin?.start(`Generating speech with MiniMax voice ${c.accent(voice)}...`);
+      try {
+        const { synthesizeWithMiniMax } = await import("../tts/minimax.js");
+        const result = await synthesizeWithMiniMax(text, output, {
+          voice,
+          speed,
+          onProgress: spin ? (msg) => spin.message(msg) : undefined,
+        });
+        if (args.json) {
+          console.log(
+            JSON.stringify({
+              ok: true,
+              provider: "minimax",
+              voice,
+              speed,
+              durationSeconds: result.durationSeconds,
+              outputPath: result.outputPath,
+            }),
+          );
+        } else {
+          spin?.stop(
+            c.success(
+              `Generated ${c.accent(result.durationSeconds.toFixed(1) + "s")} of speech → ${c.accent(result.outputPath)}`,
+            ),
+          );
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (args.json) {
+          console.log(JSON.stringify({ ok: false, error: message }));
+        } else {
+          spin?.stop(c.error(`Speech synthesis failed: ${message}`));
+        }
+        process.exit(1);
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (args.json) {
-        console.log(JSON.stringify({ ok: false, error: message }));
-      } else {
-        spin?.stop(c.error(`Speech synthesis failed: ${message}`));
+    } else {
+      // kokoro (default)
+      const voice = args.voice ?? DEFAULT_VOICE;
+      spin?.start(`Generating speech with ${c.accent(voice)}...`);
+      try {
+        const { synthesize } = await import("../tts/synthesize.js");
+        const result = await synthesize(text, output, {
+          voice,
+          speed,
+          onProgress: spin ? (msg) => spin.message(msg) : undefined,
+        });
+        if (args.json) {
+          console.log(
+            JSON.stringify({
+              ok: true,
+              provider: "kokoro",
+              voice,
+              speed,
+              durationSeconds: result.durationSeconds,
+              outputPath: result.outputPath,
+            }),
+          );
+        } else {
+          spin?.stop(
+            c.success(
+              `Generated ${c.accent(result.durationSeconds.toFixed(1) + "s")} of speech → ${c.accent(result.outputPath)}`,
+            ),
+          );
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (args.json) {
+          console.log(JSON.stringify({ ok: false, error: message }));
+        } else {
+          spin?.stop(c.error(`Speech synthesis failed: ${message}`));
+        }
+        process.exit(1);
       }
-      process.exit(1);
     }
   },
 });
@@ -139,7 +203,30 @@ export default defineCommand({
 // List voices
 // ---------------------------------------------------------------------------
 
-function listVoices(json: boolean): void {
+function listVoices(json: boolean, provider: string): void {
+  if (provider === "minimax") {
+    if (json) {
+      console.log(JSON.stringify(MINIMAX_VOICES));
+      return;
+    }
+    console.log(`\n${c.bold("Available voices")} (MiniMax TTS)\n`);
+    console.log(
+      `  ${c.dim("ID")}                           ${c.dim("Name")}                ${c.dim("Language")}   ${c.dim("Gender")}`,
+    );
+    console.log(`  ${c.dim("─".repeat(70))}`);
+    for (const v of MINIMAX_VOICES) {
+      const id = v.id.padEnd(30);
+      const label = v.label.padEnd(20);
+      const lang = v.language.padEnd(10);
+      console.log(`  ${c.accent(id)} ${label} ${lang} ${v.gender}`);
+    }
+    console.log(
+      `\n  ${c.dim("Requires MINIMAX_API_KEY. See https://platform.minimax.io/docs/api-reference/speech-t2a-http")}\n`,
+    );
+    return;
+  }
+
+  // kokoro
   if (json) {
     console.log(JSON.stringify(BUNDLED_VOICES));
     return;

--- a/packages/cli/src/tts/minimax.test.ts
+++ b/packages/cli/src/tts/minimax.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Tests for MiniMax TTS provider (packages/cli/src/tts/minimax.ts)
+// ---------------------------------------------------------------------------
+
+describe("MiniMax TTS — MINIMAX_VOICES", () => {
+  it("exports a non-empty voice list", async () => {
+    const { MINIMAX_VOICES } = await import("./minimax.js");
+    expect(MINIMAX_VOICES.length).toBeGreaterThan(0);
+  });
+
+  it("all voices have required fields", async () => {
+    const { MINIMAX_VOICES } = await import("./minimax.js");
+    for (const v of MINIMAX_VOICES) {
+      expect(v.id).toBeTruthy();
+      expect(v.label).toBeTruthy();
+      expect(v.language).toBeTruthy();
+      expect(["female", "male", "neutral"]).toContain(v.gender);
+    }
+  });
+
+  it("default voice is present in the list", async () => {
+    const { MINIMAX_VOICES, MINIMAX_DEFAULT_VOICE } = await import("./minimax.js");
+    const ids = MINIMAX_VOICES.map((v) => v.id);
+    expect(ids).toContain(MINIMAX_DEFAULT_VOICE);
+  });
+});
+
+describe("MiniMax TTS — constants", () => {
+  it("MINIMAX_BASE_URL uses the international MiniMax domain", async () => {
+    const { MINIMAX_BASE_URL } = await import("./minimax.js");
+    expect(MINIMAX_BASE_URL).toMatch(/^https:\/\/api\.minimax\.io/);
+  });
+
+  it("MINIMAX_DEFAULT_MODEL is speech-2.8-hd", async () => {
+    const { MINIMAX_DEFAULT_MODEL } = await import("./minimax.js");
+    expect(MINIMAX_DEFAULT_MODEL).toBe("speech-2.8-hd");
+  });
+});
+
+describe("MiniMax TTS — synthesizeWithMiniMax", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "minimax-test-"));
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("throws when MINIMAX_API_KEY is missing and no apiKey provided", async () => {
+    vi.stubEnv("MINIMAX_API_KEY", "");
+    const { synthesizeWithMiniMax } = await import("./minimax.js");
+    await expect(synthesizeWithMiniMax("hello", join(tmpDir, "out.mp3"))).rejects.toThrow(
+      /MINIMAX_API_KEY/,
+    );
+  });
+
+  it("calls the correct endpoint with Authorization header", async () => {
+    // Build a minimal SSE response with one audio chunk (hex-encoded "ID3")
+    const hexChunk = Buffer.from("ID3").toString("hex"); // "494433"
+    const sseBody = [
+      `data: ${JSON.stringify({ data: { audio: hexChunk, status: 1 }, base_resp: { status_code: 0, status_msg: "success" } })}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(sseBody, { status: 200 }));
+
+    const { synthesizeWithMiniMax } = await import("./minimax.js");
+    const outPath = join(tmpDir, "out.mp3");
+    const result = await synthesizeWithMiniMax("Hello world", outPath, {
+      apiKey: "test-key",
+    });
+
+    // Verify API endpoint contains /v1/t2a_v2
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/t2a_v2"),
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    // Verify Authorization header
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer test-key");
+
+    // Verify output file was written
+    expect(existsSync(outPath)).toBe(true);
+
+    // Verify result shape
+    expect(result.outputPath).toBe(outPath);
+    expect(result.durationSeconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("uses custom baseUrl when provided", async () => {
+    const hexChunk = Buffer.from("data").toString("hex");
+    const sseBody = [
+      `data: ${JSON.stringify({ data: { audio: hexChunk, status: 1 }, base_resp: { status_code: 0, status_msg: "success" } })}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(sseBody, { status: 200 }));
+
+    const { synthesizeWithMiniMax } = await import("./minimax.js");
+    await synthesizeWithMiniMax("Hello", join(tmpDir, "out.mp3"), {
+      apiKey: "test-key",
+      baseUrl: "https://custom.example.com",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://custom.example.com/v1/t2a_v2",
+      expect.anything(),
+    );
+  });
+
+  it("throws on non-OK HTTP response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("Unauthorized", { status: 401 }));
+
+    const { synthesizeWithMiniMax } = await import("./minimax.js");
+    await expect(
+      synthesizeWithMiniMax("Hello", join(tmpDir, "out.mp3"), { apiKey: "bad-key" }),
+    ).rejects.toThrow(/401/);
+  });
+
+  it("throws when API returns a non-zero status_code in SSE event", async () => {
+    const sseBody = [
+      `data: ${JSON.stringify({ base_resp: { status_code: 2013, status_msg: "invalid voice" } })}`,
+      "",
+    ].join("\n");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(sseBody, { status: 200 }));
+
+    const { synthesizeWithMiniMax } = await import("./minimax.js");
+    await expect(
+      synthesizeWithMiniMax("Hello", join(tmpDir, "out.mp3"), { apiKey: "test-key" }),
+    ).rejects.toThrow(/2013/);
+  });
+
+  it("uses default model speech-2.8-hd in request body", async () => {
+    const hexChunk = Buffer.from("data").toString("hex");
+    const sseBody = [
+      `data: ${JSON.stringify({ data: { audio: hexChunk, status: 1 }, base_resp: { status_code: 0, status_msg: "success" } })}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(sseBody, { status: 200 }));
+
+    const { synthesizeWithMiniMax } = await import("./minimax.js");
+    await synthesizeWithMiniMax("Hello", join(tmpDir, "out.mp3"), { apiKey: "test-key" });
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { model: string };
+    expect(body.model).toBe("speech-2.8-hd");
+  });
+
+  it("uses MINIMAX_API_KEY from environment if no explicit apiKey", async () => {
+    vi.stubEnv("MINIMAX_API_KEY", "env-key");
+
+    const hexChunk = Buffer.from("data").toString("hex");
+    const sseBody = [
+      `data: ${JSON.stringify({ data: { audio: hexChunk, status: 1 }, base_resp: { status_code: 0, status_msg: "success" } })}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(sseBody, { status: 200 }));
+
+    const { synthesizeWithMiniMax } = await import("./minimax.js");
+    await synthesizeWithMiniMax("Hello", join(tmpDir, "out.mp3"));
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer env-key");
+  });
+});
+
+describe("MiniMax TTS — audio decoding", () => {
+  it("correctly decodes hex-encoded audio", () => {
+    const original = Buffer.from("Hello audio data");
+    const hex = original.toString("hex");
+    const decoded = Buffer.from(hex, "hex");
+    expect(decoded).toEqual(original);
+  });
+
+  it("concatenates multiple hex-encoded chunks correctly", () => {
+    const chunk1 = Buffer.from("Hello ");
+    const chunk2 = Buffer.from("world");
+    const combined = Buffer.concat([
+      Buffer.from(chunk1.toString("hex"), "hex"),
+      Buffer.from(chunk2.toString("hex"), "hex"),
+    ]);
+    expect(combined.toString()).toBe("Hello world");
+  });
+});

--- a/packages/cli/src/tts/minimax.ts
+++ b/packages/cli/src/tts/minimax.ts
@@ -1,0 +1,185 @@
+/**
+ * MiniMax TTS Provider
+ *
+ * Cloud-based text-to-speech via the MiniMax T2A (Text-to-Audio) API.
+ * Requires MINIMAX_API_KEY environment variable.
+ *
+ * API reference: https://platform.minimax.io/docs/api-reference/speech-t2a-http
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Voices
+// ---------------------------------------------------------------------------
+
+export interface MiniMaxVoiceInfo {
+  id: string;
+  label: string;
+  language: string;
+  gender: "female" | "male" | "neutral";
+}
+
+export const MINIMAX_VOICES: MiniMaxVoiceInfo[] = [
+  { id: "English_Graceful_Lady", label: "Graceful Lady", language: "en", gender: "female" },
+  { id: "English_Insightful_Speaker", label: "Insightful Speaker", language: "en", gender: "male" },
+  { id: "English_radiant_girl", label: "Radiant Girl", language: "en", gender: "female" },
+  { id: "English_Persuasive_Man", label: "Persuasive Man", language: "en", gender: "male" },
+  { id: "English_Lucky_Robot", label: "Lucky Robot", language: "en", gender: "neutral" },
+  {
+    id: "English_expressive_narrator",
+    label: "Expressive Narrator",
+    language: "en",
+    gender: "male",
+  },
+];
+
+export const MINIMAX_DEFAULT_VOICE = "English_Graceful_Lady";
+export const MINIMAX_DEFAULT_MODEL = "speech-2.8-hd";
+export const MINIMAX_BASE_URL = "https://api.minimax.io";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MiniMaxSynthesizeOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  voice?: string;
+  speed?: number;
+  onProgress?: (message: string) => void;
+}
+
+export interface MiniMaxSynthesizeResult {
+  outputPath: string;
+  durationSeconds: number;
+}
+
+// ---------------------------------------------------------------------------
+// SSE helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Server-Sent Events stream and collect hex-encoded audio chunks.
+ * The MiniMax T2A API returns audio in hex format (not base64).
+ */
+async function collectAudioChunks(response: Response): Promise<Buffer> {
+  if (!response.body) {
+    throw new Error("MiniMax TTS: response body is empty");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const audioChunks: Buffer[] = [];
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data:")) continue;
+      const jsonStr = line.slice(5).trim();
+      if (!jsonStr || jsonStr === "[DONE]") continue;
+      try {
+        const event = JSON.parse(jsonStr) as {
+          data?: { audio?: string; status?: number };
+          base_resp?: { status_code: number; status_msg: string };
+        };
+        if (event.base_resp && event.base_resp.status_code !== 0) {
+          throw new Error(
+            `MiniMax TTS API error: ${event.base_resp.status_code} — ${event.base_resp.status_msg}`,
+          );
+        }
+        // status=1: partial chunk, status=2: final summary (contains full audio, skip in streaming)
+        if (event.data?.audio && event.data.status !== 2) {
+          audioChunks.push(Buffer.from(event.data.audio, "hex"));
+        }
+      } catch (err) {
+        if (err instanceof SyntaxError) continue; // incomplete JSON, skip
+        throw err;
+      }
+    }
+  }
+
+  if (audioChunks.length === 0) {
+    throw new Error("MiniMax TTS: no audio data received from API");
+  }
+
+  return Buffer.concat(audioChunks);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesize text to speech using the MiniMax T2A v2 API.
+ * Streams audio chunks via SSE and writes MP3 output to `outputPath`.
+ */
+export async function synthesizeWithMiniMax(
+  text: string,
+  outputPath: string,
+  options?: MiniMaxSynthesizeOptions,
+): Promise<MiniMaxSynthesizeResult> {
+  const apiKey = options?.apiKey ?? process.env.MINIMAX_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MiniMax TTS requires MINIMAX_API_KEY environment variable. " +
+        "Get your key at https://platform.minimax.io",
+    );
+  }
+
+  const baseUrl = options?.baseUrl ?? MINIMAX_BASE_URL;
+  const model = options?.model ?? MINIMAX_DEFAULT_MODEL;
+  const voiceId = options?.voice ?? MINIMAX_DEFAULT_VOICE;
+  const speed = options?.speed ?? 1.0;
+
+  options?.onProgress?.(`Generating speech with MiniMax voice ${voiceId}...`);
+
+  const response = await fetch(`${baseUrl}/v1/t2a_v2`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      text,
+      stream: true,
+      voice_setting: {
+        voice_id: voiceId,
+        speed,
+        vol: 1,
+        pitch: 0,
+      },
+      audio_setting: {
+        sample_rate: 32000,
+        bitrate: 128000,
+        format: "mp3",
+        channel: 1,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`MiniMax TTS request failed (${response.status}): ${body}`);
+  }
+
+  options?.onProgress?.("Receiving audio stream...");
+  const audioBuffer = await collectAudioChunks(response);
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, audioBuffer);
+
+  // Estimate duration from MP3 bitrate: 128 kbps → 16 KB/s
+  const durationSeconds = audioBuffer.length / (128_000 / 8);
+
+  return { outputPath, durationSeconds: Math.round(durationSeconds * 1000) / 1000 };
+}


### PR DESCRIPTION
This PR adds MiniMax as an optional cloud TTS provider for the `hyperframes tts` command, alongside the existing local Kokoro-82M model.

## Changes

- **`packages/cli/src/tts/minimax.ts`** — New MiniMax TTS provider module with SSE streaming, hex-encoded audio decoding, 6 bundled English voices, and `MINIMAX_API_KEY` env var support
- **`packages/cli/src/commands/tts.ts`** — Extended with `--provider` flag: `kokoro` (default, unchanged) or `minimax` (cloud API, no Python/ONNX runtime needed)
- **`packages/cli/src/tts/minimax.test.ts`** — 14 unit tests covering API calls, error handling, env var fallback, and audio hex decoding

## Usage

```bash
hyperframes tts "Welcome to HyperFrames" --provider minimax
hyperframes tts --provider minimax --list
```

Set `MINIMAX_API_KEY` from platform.minimax.io.

API reference: https://platform.minimax.io/docs/api-reference/speech-t2a-http