### PR TITLE
docs: add skillx quick-start to README and introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ npx hyperframes render       # render to MP4
 
 **Requirements:** Node.js >= 22, FFmpeg
 
+<!-- skillx:begin:setup-skillx -->
+## Try it with skillx
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+Run these skills without installing anything:
+
+```bash
+skillx run --auto-approve https://github.com/heygen-com/hyperframes/tree/main/skills/hyperframes "Create a 15-second product intro with a fade-in title and background music."
+skillx run --auto-approve https://github.com/heygen-com/hyperframes/tree/main/skills/website-to-hyperframes "https://example.com"
+```
+
+Powered by [skillx](https://skillx.run) — fetch, scan, inject, and clean up any agent skill in one command.
+
+*Note: this command lets the agent act without per-step permission prompts. Only run if you trust the skill source. Drop `--auto-approve` if you'd rather approve each action manually.*
+<!-- skillx:end:setup-skillx -->
+
 ## Why Hyperframes?
 
 - **HTML-native** — compositions are HTML files with data attributes. No React, no proprietary DSL.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -38,6 +38,21 @@ Run `npx hyperframes render --output demo.mp4` and this produces an MP4 with det
   </Card>
 </CardGroup>
 
+{/* skillx:begin:setup-skillx */}
+## Try It with skillx
+
+Run the skills directly, no install required:
+
+```bash
+skillx run --auto-approve https://github.com/heygen-com/hyperframes/tree/main/skills/hyperframes "Build a 30-second launch teaser with rotating product shots and typewriter captions."
+skillx run --auto-approve https://github.com/heygen-com/hyperframes/tree/main/skills/website-to-hyperframes "https://example.com"
+```
+
+<Tip>
+  [skillx](https://skillx.run) fetches, scans, injects, and cleans up any agent skill in one command. Drop `--auto-approve` if you'd rather approve each action manually.
+</Tip>
+{/* skillx:end:setup-skillx */}
+
 ## Why Hyperframes?
 
 <Tabs>


### PR DESCRIPTION
## Summary
- Add a "Try it with skillx" block to `README.md` and `docs/introduction.mdx` so readers can try the `hyperframes` and `website-to-hyperframes` skills without installing anything.
- Block is wrapped in idempotency markers (`skillx:begin/end:setup-skillx`) so a later `setup-skillx` run can update it in place.
- Uses `--auto-approve` to match the task-based, one-shot flow these two skills drive end-to-end.

## Test plan
- [x] Render `README.md` on GitHub — confirm the shields.io badge, fenced code block, and italic disclaimer display correctly.
- [x] Build the docs site and confirm `introduction.mdx` renders cleanly (JSX comments hidden, `<Tip>` + code block layout intact).
- [x] Run `skillx run --auto-approve https://github.com/heygen-com/hyperframes/tree/main/skills/hyperframes "test"` in a scratch dir to verify the URL resolves and the skill is fetched.