### PR TITLE
fix(skill): all file paths use capture/ subfolder prefix

### DIFF
--- a/skills/website-to-hyperframes/references/step-1-capture.md
+++ b/skills/website-to-hyperframes/references/step-1-capture.md
@@ -27,38 +27,38 @@ Read each file below. After reading each one, **write a 1-2 sentence summary** o
 ### Must read (do not skip)
 
 1. **View the scroll screenshots** — viewport-sized captures covering the full page height (the number depends on the page length). Start with:
-   - `screenshots/scroll-000.png` — the hero section at full 1920x1080 resolution. This is the most important image. Describe: is the background light or dark? What's the dominant visual element? What colors jump out?
+   - `capture/screenshots/scroll-000.png` — the hero section at full 1920x1080 resolution. This is the most important image. Describe: is the background light or dark? What's the dominant visual element? What colors jump out?
    - Then scan through the rest to see the full page. Each screenshot overlaps the previous by ~30%.
 
    After viewing them, write 3-4 sentences describing the site's visual mood, layout patterns, color strategy, and overall feel.
 
-2. **`extracted/tokens.json`** — Note the top 5-7 colors (HEX), all font families with their weights (e.g. `Inter (400,700)` or `Sohne (100-900 variable)`), number of sections, and number of headings/CTAs.
+2. **`capture/extracted/tokens.json`** — Note the top 5-7 colors (HEX), all font families with their weights (e.g. `Inter (400,700)` or `Sohne (100-900 variable)`), number of sections, and number of headings/CTAs.
 
-3. **`extracted/visible-text.txt`** — Each line is prefixed with the HTML tag: `[h1] Heading`, `[p] Body text`, `[a] Link text`. Use these tags to understand hierarchy — headings are key messages, paragraphs are supporting copy. Strip the `[tag]` prefix when quoting text in the script.
+3. **`capture/extracted/visible-text.txt`** — Each line is prefixed with the HTML tag: `[h1] Heading`, `[p] Body text`, `[a] Link text`. Use these tags to understand hierarchy — headings are key messages, paragraphs are supporting copy. Strip the `[tag]` prefix when quoting text in the script.
 
-4. **`extracted/asset-descriptions.md`** — One-line-per-file summary of all downloaded assets. Note which assets are most visually striking or useful for video (hero images, logos, product screenshots).
+4. **`capture/extracted/asset-descriptions.md`** — One-line-per-file summary of all downloaded assets. Note which assets are most visually striking or useful for video (hero images, logos, product screenshots).
 
 ### Read if they exist
 
-5. **`extracted/animations.json`** — Note if the site uses scroll-triggered animations, marquees, canvas/WebGL, or named CSS animations.
+5. **`capture/extracted/animations.json`** — Note if the site uses scroll-triggered animations, marquees, canvas/WebGL, or named CSS animations.
 
-6. **`extracted/lottie-manifest.json`** — View each preview image at `assets/lottie/previews/` to see what the animations look like.
+6. **`capture/extracted/lottie-manifest.json`** — View each preview image at `capture/assets/lottie/previews/` to see what the animations look like.
 
-7. **`extracted/video-manifest.json`** — View each preview at `assets/videos/previews/` to see what each video shows.
+7. **`capture/extracted/video-manifest.json`** — View each preview at `capture/assets/videos/previews/` to see what each video shows.
 
-8. **`extracted/shaders.json`** — If present, this contains the actual GLSL shader code that powers the site's WebGL visual effects (gradient waves, particle systems, noise fields). Read the fragment shaders to extract: color values used in gradients, noise algorithms, blend functions. You can recreate similar effects in your compositions using Canvas 2D or by embedding the shader patterns with a `<canvas>` + WebGL context. See the Canvas 2D and procedural art patterns in `techniques.md`.
+8. **`capture/extracted/shaders.json`** — If present, this contains the actual GLSL shader code that powers the site's WebGL visual effects (gradient waves, particle systems, noise fields). Read the fragment shaders to extract: color values used in gradients, noise algorithms, blend functions. You can recreate similar effects in your compositions using Canvas 2D or by embedding the shader patterns with a `<canvas>` + WebGL context. See the Canvas 2D and procedural art patterns in `techniques.md`.
 
 ### On-demand (read when building scenes)
 
-9. **Individual images in `assets/`** — Use `asset-descriptions.md` as your index. View specific images when you need them for a beat.
+9. **Individual images in `capture/assets/`** — Use `capture/extracted/asset-descriptions.md` as your index. View specific images when you need them for a beat.
 
-10. **`extracted/assets-catalog.json`** — Use to find remote URLs when you need an asset that wasn't downloaded.
+10. **`capture/extracted/assets-catalog.json`** — Use to find remote URLs when you need an asset that wasn't downloaded.
 
 ### For rich captures (30+ images)
 
 Launch a sub-agent to view all images and SVGs:
 
-> "Read every image in assets/ and every SVG in assets/svgs/. For each, write one line: filename — what it shows, dominant colors, approximate size. Return the complete catalog."
+> "Read every image in capture/assets/ and every SVG in capture/assets/svgs/. For each, write one line: filename — what it shows, dominant colors, approximate size. Return the complete catalog."
 
 Use the sub-agent's catalog as your asset reference for the rest of the workflow.
 

--- a/skills/website-to-hyperframes/references/step-2-design.md
+++ b/skills/website-to-hyperframes/references/step-2-design.md
@@ -12,7 +12,7 @@ DESIGN.md is NOT the creative plan. The STORYBOARD (Step 4) drives creative dire
 
 ### `## Colors`
 
-5-10 key colors with HEX values from tokens.json and their roles:
+5-10 key colors with HEX values from `capture/extracted/tokens.json` and their roles:
 
 ```
 - **Primary Surface**: `#020204` — deep black background
@@ -65,11 +65,11 @@ For each, note the distinctive visual treatment (border-radius, spacing, hover b
 
 ## Rules
 
-- Use **exact HEX values** from tokens.json. Do not approximate.
+- Use **exact HEX values** from `capture/extracted/tokens.json`. Do not approximate.
 - Name components by what you see in the screenshot, not generic terms.
 - Keep it under 100 lines. This is a cheat sheet, not a design system document.
 - No "Style Prompt" section — the storyboard handles creative direction.
-- No "Assets" section — `asset-descriptions.md` already covers this.
+- No "Assets" section — `capture/extracted/asset-descriptions.md` already covers this.
 - No "Motion" section — the storyboard specifies motion per-beat.
 
 ## Example

--- a/skills/website-to-hyperframes/references/step-3-script.md
+++ b/skills/website-to-hyperframes/references/step-3-script.md
@@ -1,6 +1,6 @@
 # Step 3: Write the Narration Script
 
-**Before writing, re-read DESIGN.md** — specifically the Overview and Components sections. The script should reference real product features, real stats, and real components that the website highlights. Use exact numbers from `extracted/visible-text.txt`.
+**Before writing, re-read DESIGN.md** — specifically the Overview and Components sections. The script should reference real product features, real stats, and real components that the website highlights. Use exact numbers from `capture/extracted/visible-text.txt`.
 
 The script is the backbone. Everything downstream — scene durations, animation timing, beat pacing — comes from the narration. Write it before the storyboard.
 

--- a/skills/website-to-hyperframes/references/step-4-storyboard.md
+++ b/skills/website-to-hyperframes/references/step-4-storyboard.md
@@ -3,7 +3,7 @@
 **Before writing anything, fully re-read these files:**
 
 - **DESIGN.md** — your color palette, font rules, components, Do's/Don'ts. Every creative decision must be grounded in this brand identity. If it says "white backgrounds with purple accent" — plan light scenes, not dark moody ones.
-- **`extracted/asset-descriptions.md`** — read EVERY line. This is your menu of available visuals. Each line describes what the image actually shows (e.g., "translucent ribbons in orange, pink, and purple on white background" or "a high-speed train under a dark starry sky"). Use these descriptions to decide which assets belong in which beat. Assets you don't understand from the description — view them directly before assigning.
+- **`capture/extracted/asset-descriptions.md`** — read EVERY line. This is your menu of available visuals. Each line describes what the image actually shows (e.g., "translucent ribbons in orange, pink, and purple on white background" or "a high-speed train under a dark starry sky"). Use these descriptions to decide which assets belong in which beat. Assets you don't understand from the description — view them directly before assigning.
 - **[techniques.md](techniques.md)** — 11 visual techniques (SVG path drawing, Canvas 2D art, CSS 3D, per-word typography, Lottie, video compositing, typing effect, variable fonts, MotionPath, velocity transitions, audio-reactive). Pick 2-3 per beat and specify them in the storyboard.
 
 The storyboard is the creative north star. It tells the engineer exactly what to build for each beat — mood, camera, animations, transitions, assets, sound. Write it as if you're briefing a motion designer who's never seen the website.
@@ -96,9 +96,9 @@ Cultural and design references, not hex codes:
 
 Which captured files to use, referenced by filename:
 
-- "Background: `assets/wave-fallback-desktop.png` — full-bleed, slow zoom 1→1.04 over beat duration"
-- "Logo: `assets/svgs/stripe-logo.svg` — centered, fades in at 0.5s"
-- "Enterprise photo: `assets/enterprise-accordion-hertz.png` — Ken Burns pan, 70% opacity overlay"
+- "Background: `capture/assets/wave-fallback-desktop.png` — full-bleed, slow zoom 1→1.04 over beat duration"
+- "Logo: `capture/assets/svgs/stripe-logo.svg` — centered, fades in at 0.5s"
+- "Enterprise photo: `capture/assets/enterprise-accordion-hertz.png` — Ken Burns pan, 70% opacity overlay"
 
 ### Animation choreography
 
@@ -172,7 +172,21 @@ project/
 ├── STORYBOARD.md                 THIS FILE — creative north star
 ├── transcript.json               word-level timestamps (from Step 5)
 ├── narration.wav                 TTS audio (from Step 5)
-├── captures/<name>/              captured website data
+├── capture/                      captured website data (from Step 1)
+│   ├── screenshots/
+│   ├── assets/
+│   │   ├── svgs/
+│   │   ├── fonts/
+│   │   └── lottie/
+│   ├── extracted/
+│   │   ├── tokens.json
+│   │   ├── visible-text.txt
+│   │   ├── asset-descriptions.md
+│   │   ├── animations.json
+│   │   ├── assets-catalog.json
+│   │   └── detected-libraries.json
+│   ├── AGENTS.md
+│   └── CLAUDE.md
 └── compositions/
     ├── beat-1-hook.html
     ├── beat-2-features.html

--- a/skills/website-to-hyperframes/references/step-4-storyboard.md
+++ b/skills/website-to-hyperframes/references/step-4-storyboard.md
@@ -177,7 +177,8 @@ project/
 │   ├── assets/
 │   │   ├── svgs/
 │   │   ├── fonts/
-│   │   └── lottie/
+│   │   ├── lottie/
+│   │   └── videos/
 │   ├── extracted/
 │   │   ├── tokens.json
 │   │   ├── visible-text.txt

--- a/skills/website-to-hyperframes/references/step-5-vo.md
+++ b/skills/website-to-hyperframes/references/step-5-vo.md
@@ -14,7 +14,7 @@ Pick the voice that sounds most natural and conversational. Listen for pacing �
 
 Generate the full script as `narration.wav` (or `.mp3`) in the project directory.
 
-**Also save the exact spoken text** — with pronunciation substitutions applied (e.g., `API` → `A P I`, `$2T` → `two trillion`) — as `narration.txt` in the same directory. This is the string passed to TTS, distinct from `SCRIPT.md` which is the human-readable creative doc. Having `narration.txt` makes it trivial to regenerate the audio later with a different voice without re-deriving the substitutions. Name it exactly `narration.txt` — not `narration-input.txt` or variations.
+**Also save the exact spoken text** — with pronunciation substitutions applied (e.g., `API` → `A P I`, `$2T` → `two trillion`) — as `narration.txt` in the same directory. This is the string passed to TTS, distinct from `SCRIPT.md` which is the human-readable creative doc. Having `narration.txt` makes it trivial to regenerate the audio later with a different voice without re-deriving the substitutions. Name it exactly `narration.txt`.
 
 ## Transcribe for word-level timestamps
 

--- a/skills/website-to-hyperframes/references/step-6-build.md
+++ b/skills/website-to-hyperframes/references/step-6-build.md
@@ -4,7 +4,7 @@
 
 - **DESIGN.md** — your color palette, fonts, components, and Do's/Don'ts. Every composition must use EXACT hex colors and font families from this file. If it says "white backgrounds" — use white, not dark.
 - **STORYBOARD.md** — the beat-by-beat plan you're executing. Each beat specifies assets, animations, transitions, and which techniques to use.
-- **`extracted/asset-descriptions.md`** — when the storyboard assigns an asset to a beat, re-read the description to understand what it shows and how to position/style it correctly.
+- **`capture/extracted/asset-descriptions.md`** — when the storyboard assigns an asset to a beat, re-read the description to understand what it shows and how to position/style it correctly.
 - **[techniques.md](techniques.md)** — code patterns for the 10 visual techniques. When the storyboard says "SVG path drawing" or "per-word kinetic typography" — read the code pattern from this file and adapt it.
 - **transcript.json** — word-level timestamps that drive scene durations.
 
@@ -21,19 +21,19 @@ STORYBOARD for this beat:
 [paste the beat section from STORYBOARD.md]
 
 ASSETS — reference by path, do NOT read/inline the file contents:
-- Logo: <img src="../assets/favicon.svg"> (top-left, 40x40px)
-- Hero image: <img src="../assets/hero-bg.png"> (full-bleed background)
-- Noise texture: ../assets/noise.png (full-frame overlay, 3% opacity)
+- Logo: <img src="../capture/assets/favicon.svg"> (top-left, 40x40px)
+- Hero image: <img src="../capture/assets/hero-bg.png"> (full-bleed background)
+- Noise texture: ../capture/assets/noise.png (full-frame overlay, 3% opacity)
 
 FONTS — use @font-face with the captured font files, NOT Google Fonts:
-@font-face { font-family: 'BrandFont'; src: url('../assets/fonts/BrandFont-Regular.woff2'); }
+@font-face { font-family: 'BrandFont'; src: url('../capture/assets/fonts/BrandFont-Regular.woff2'); }
 
 Read DESIGN.md for exact colors and Do's/Don'ts.
 Read techniques.md for animation code patterns.
 Load the `hyperframes` skill for composition structure rules.
 ```
 
-After each sub-agent finishes, verify the composition references `../assets/` — if it used inline SVGs or Google Fonts instead of the captured files, fix it before moving on.
+After each sub-agent finishes, verify the composition references `../capture/assets/` — if it used inline SVGs or Google Fonts instead of the captured files, fix it before moving on.
 
 Load the `hyperframes` skill first — it has the rules for data attributes, timeline contracts, deterministic rendering, and layout. Everything below supplements those rules, not replaces them.
 
@@ -96,8 +96,8 @@ Before self-review, verify you actually used the assets you planned to:
 2. List every asset that was assigned to this beat
 3. Search the composition HTML for each filename (e.g., grep for "wave-fallback-desktop")
 4. If any assigned asset is missing from the HTML, add it now
-5. Check for the inline anti-pattern: if the HTML contains `<svg xmlns=` or `data:image/` but no `../assets/` references, the assets were inlined instead of referenced. Replace inline content with `<img src="../assets/filename.svg">`
-6. Check fonts: if the HTML uses `fonts.googleapis.com` but there are captured fonts in `assets/fonts/`, replace with `@font-face` pointing to the local files
+5. Check for the inline anti-pattern: if the HTML contains `<svg xmlns=` or `data:image/` but no `../capture/assets/` references, the assets were inlined instead of referenced. Replace inline content with `<img src="../capture/assets/filename.svg">`
+6. Check fonts: if the HTML uses `fonts.googleapis.com` but there are captured fonts in `capture/assets/fonts/`, replace with `@font-face` pointing to the local files (e.g., `src: url('../capture/assets/fonts/BrandFont-Regular.woff2')`)
 
 This step catches the two most common failures: compositions ending up text-only, and assets being inlined instead of file-referenced.
 

--- a/skills/website-to-hyperframes/references/techniques.md
+++ b/skills/website-to-hyperframes/references/techniques.md
@@ -252,7 +252,7 @@ Animate font-variation-settings to reshape glyphs in real-time. Works with varia
 ```html
 <style>
   /* Load the captured local variable font — do NOT use Google Fonts @import.
-     Replace this placeholder with an @font-face pointing to capture/assets/fonts/. */
+     Replace this placeholder with an @font-face pointing to ../capture/assets/fonts/. */
   @font-face {
     font-family: "Fraunces";
     src: url("../capture/assets/fonts/Fraunces-Variable.woff2") format("woff2");

--- a/skills/website-to-hyperframes/references/techniques.md
+++ b/skills/website-to-hyperframes/references/techniques.md
@@ -158,7 +158,7 @@ Vector animations that play inside a composition. Use for logos, character anima
 <script src="https://cdn.jsdelivr.net/npm/@dotlottie/player-component@2.7.12/dist/dotlottie-player.js"></script>
 <dotlottie-player
   class="lottie"
-  src="../assets/lottie/animation-0.json"
+  src="../capture/assets/lottie/animation-0.json"
   autoplay
   loop
   speed="1.5"
@@ -179,7 +179,7 @@ var anim = lottie.loadAnimation({
   renderer: "svg",
   loop: false,
   autoplay: false,
-  path: "../assets/lottie/animation-0.json",
+  path: "../capture/assets/lottie/animation-0.json",
 });
 ```
 
@@ -193,7 +193,7 @@ Embed real video footage inside compositions. Videos must be `muted` with `plays
 <div class="video-frame" style="width:680px;height:840px;border-radius:16px;overflow:hidden;">
   <video
     id="footage"
-    src="../assets/videos/clip.mp4"
+    src="../capture/assets/videos/clip.mp4"
     muted
     playsinline
     style="width:100%;height:100%;object-fit:cover;"
@@ -252,10 +252,10 @@ Animate font-variation-settings to reshape glyphs in real-time. Works with varia
 ```html
 <style>
   /* Load the captured local variable font — do NOT use Google Fonts @import.
-     Replace this placeholder with an @font-face pointing to assets/fonts/. */
+     Replace this placeholder with an @font-face pointing to capture/assets/fonts/. */
   @font-face {
     font-family: "Fraunces";
-    src: url("../assets/fonts/Fraunces-Variable.woff2") format("woff2");
+    src: url("../capture/assets/fonts/Fraunces-Variable.woff2") format("woff2");
     font-weight: 100 900;
     font-style: normal;
     font-display: block;


### PR DESCRIPTION
## What

Fix all asset/file path references in the website-to-hyperframes skill to match the new `capture/` subfolder structure.

## Why

Step-1 was updated to capture into `<project-dir>/capture/` but steps 2-6 and techniques.md still referenced bare paths (`extracted/tokens.json`, `../assets/hero.png`). Every composition built with the skill would 404 on images, fonts, Lottie files, and videos.

## How

Prefixed all file-read instructions with `capture/`:

| File | Changes |
|------|---------|
| step-1 | 12+ file-read paths: `extracted/` → `capture/extracted/`, `assets/` → `capture/assets/`, `screenshots/` → `capture/screenshots/` |
| step-2 | `tokens.json` and `asset-descriptions.md` paths |
| step-3 | `visible-text.txt` path |
| step-4 | `asset-descriptions.md`, asset examples, directory tree expanded to show `capture/` children |
| step-5 | Minor cleanup |
| step-6 | `asset-descriptions.md` path (composition `../capture/assets/` refs already correct) |
| techniques.md | Lottie, video, font code examples |

Verified: `grep -r "\.\./assets/" skills/website-to-hyperframes/` returns 0 results (all converted to `../capture/assets/`).

## Test plan

- [x] `grep` confirms zero bare `../assets/` references remain
- [x] 35 correctly prefixed `capture/` paths across all files
- [x] End-to-end validation running (Stripe, Linear, Basecamp)