### PR TITLE
feat: add design system , theme.json, reusable components, docs

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,29 @@
+# Design System & Reusable Components
+
+Hyperframes supports a global design system via `theme.json` and reusable HTML components.
+
+## 1. Global Theme (`templates/theme.json`)
+
+Define your brand's colors, typography, and spacing once:
+
+```json
+{
+  "colors": { "accent": "#FF5733" },
+  "typography": { "heading": { "fontSize": "72px" } }
+}
+```
+
+All CSS variables are auto-injected at render time with the prefix `--hf-*`:
+- `--hf-color-accent`
+- `--hf-font-family`
+- `--hf-heading-size`
+- `--hf-spacing-margin`
+
+## 2. Reusable Components (`templates/components/`)
+
+Pre-built components live in `templates/components/`. Copy any into your composition:
+
+- `LowerThird.html` — name + title overlay
+- `Outro.html` — branded end card
+
+## 3. Style Inheritance Order

--- a/templates/components/LowerThird.html
+++ b/templates/components/LowerThird.html
@@ -11,8 +11,6 @@
   data-start="2"
   data-duration="4"
   data-track-index="3"
-  data-title="Your Name"
-  data-subtitle="Your Title"
   style="
     position: absolute;
     bottom: var(--hf-spacing-margin, 48px);
@@ -24,21 +22,23 @@
 >
   <span
     style="
-      font-family: var(--hf-font-family, &quot;Inter, sans-serif&quot;);
+      font-family: var(--hf-font-family, &quot;Inter&quot;), sans-serif;
       font-size: var(--hf-heading-size, 48px);
       font-weight: 700;
       color: var(--hf-color-primary, #ffffff);
     "
     data-bind="title"
-  ></span>
+    >Your Name</span
+  >
 
   <span
     style="
-      font-family: var(--hf-font-family, &quot;Inter, sans-serif&quot;);
+      font-family: var(--hf-font-family, &quot;Inter&quot;), sans-serif;
       font-size: var(--hf-body-size, 28px);
       font-weight: 400;
       color: var(--hf-color-accent, #ff5733);
     "
     data-bind="subtitle"
-  ></span>
+    >Your Title</span
+  >
 </div>

--- a/templates/components/LowerThird.html
+++ b/templates/components/LowerThird.html
@@ -1,0 +1,44 @@
+<!--
+  @component LowerThird
+  @props title, subtitle
+  @description Reusable lower-third name/title overlay.
+  Inherits colors and typography from theme.json.
+  Usage: copy this block into your composition and fill in data-title / data-subtitle.
+-->
+<div
+  id="lower-third"
+  class="clip"
+  data-start="2"
+  data-duration="4"
+  data-track-index="3"
+  data-title="Your Name"
+  data-subtitle="Your Title"
+  style="
+    position: absolute;
+    bottom: var(--hf-spacing-margin, 48px);
+    left: var(--hf-spacing-margin, 48px);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  "
+>
+  <span
+    style="
+      font-family: var(--hf-font-family, &quot;Inter, sans-serif&quot;);
+      font-size: var(--hf-heading-size, 48px);
+      font-weight: 700;
+      color: var(--hf-color-primary, #ffffff);
+    "
+    data-bind="title"
+  ></span>
+
+  <span
+    style="
+      font-family: var(--hf-font-family, &quot;Inter, sans-serif&quot;);
+      font-size: var(--hf-body-size, 28px);
+      font-weight: 400;
+      color: var(--hf-color-accent, #ff5733);
+    "
+    data-bind="subtitle"
+  ></span>
+</div>

--- a/templates/components/Outro.html
+++ b/templates/components/Outro.html
@@ -19,7 +19,7 @@
 >
   <h1
     style="
-      font-family: var(--hf-font-family, &quot;Inter, sans-serif&quot;);
+      font-family: var(--hf-font-family, &quot;Inter&quot;), sans-serif;
       font-size: var(--hf-heading-size, 72px);
       font-weight: 700;
       color: var(--hf-color-primary, #ffffff);

--- a/templates/components/Outro.html
+++ b/templates/components/Outro.html
@@ -1,0 +1,30 @@
+<!--
+  @component Outro
+  @description Reusable branded end card. Inherits from theme.json.
+-->
+<div
+  id="outro"
+  class="clip"
+  data-start="0"
+  data-duration="5"
+  data-track-index="0"
+  style="
+    width: 100%;
+    height: 100%;
+    background: var(--hf-color-background, #0f0f0f);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  "
+>
+  <h1
+    style="
+      font-family: var(--hf-font-family, &quot;Inter, sans-serif&quot;);
+      font-size: var(--hf-heading-size, 72px);
+      font-weight: 700;
+      color: var(--hf-color-primary, #ffffff);
+    "
+  >
+    Thanks for watching.
+  </h1>
+</div>

--- a/templates/theme.json
+++ b/templates/theme.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schemas/theme.json",
+  "name": "default",
+  "version": "1.0.0",
+  "colors": {
+    "background": "#0F0F0F",
+    "primary": "#FFFFFF",
+    "accent": "#FF5733",
+    "muted": "#888888"
+  },
+  "typography": {
+    "fontFamily": "Inter, sans-serif",
+    "heading": {
+      "fontSize": "72px",
+      "fontWeight": "700",
+      "lineHeight": "1.1"
+    },
+    "body": {
+      "fontSize": "32px",
+      "fontWeight": "400",
+      "lineHeight": "1.5"
+    },
+    "caption": {
+      "fontSize": "24px",
+      "fontWeight": "400"
+    }
+  },
+  "spacing": {
+    "margin": "48px",
+    "gap": "24px",
+    "padding": "32px"
+  },
+  "composition": {
+    "width": 1920,
+    "height": 1080
+  }
+}


### PR DESCRIPTION
## Summary
Closes / contributes to #340

Adds a foundational Design System layer to Hyperframes so creators can maintain
consistent brand identity across multiple video compositions without repeating styles.

## Changes
- `templates/theme.json` , global design tokens (colors, typography, spacing)
- `templates/components/LowerThird.html` , reusable branded lower-third overlay
- `templates/components/Outro.html` , reusable branded end card
- `docs/design-system.md` , documentation for the design system

## How it works
- Theme values are declared once in `theme.json`
- CSS variables (`--hf-color-accent`, `--hf-font-family`, etc.) are injected at render
- Components in `templates/components/` can be copied into any composition
- Style inheritance: theme.json → composition → inline

## Testing
1. `npx hyperframes init my-video`
2. Copy `theme.json` and a component into the project
3. Run `npx hyperframes preview` , tokens should resolve correctly