### PR TITLE
fix(player+core): correctly render and pause nested compositions

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1374,6 +1374,8 @@ export function initSandboxRuntimeModular(): void {
     setTimeline: (timeline) => {
       state.capturedTimeline = timeline;
     },
+    getTimelineRegistry: () =>
+      (window.__timelines ?? {}) as Record<string, RuntimeTimelineLike | undefined>,
     getIsPlaying: () => state.isPlaying,
     setIsPlaying: (playing) => {
       state.isPlaying = playing;

--- a/packages/core/src/runtime/player.test.ts
+++ b/packages/core/src/runtime/player.test.ts
@@ -127,6 +127,106 @@ describe("createRuntimePlayer", () => {
     });
   });
 
+  // Regression: nested compositions register sibling timelines alongside
+  // the master (e.g. `scene1-logo-intro` + `scene2-4-canvas` next to the
+  // master's own inline timeline). Before this, pausing the master would
+  // leave siblings free-running, so scene animations kept advancing and the
+  // composition would visibly drift past the paused time even though the
+  // player UI was frozen.
+  describe("timeline registry propagation", () => {
+    it("pauses every sibling timeline, not just the master", () => {
+      const master = createMockTimeline({ time: 5 });
+      const scene1 = createMockTimeline();
+      const scene2 = createMockTimeline();
+      const deps = createMockDeps(master);
+      const player = createRuntimePlayer({
+        ...deps,
+        getTimelineRegistry: () => ({ main: master, scene1, scene2 }),
+      });
+      player.pause();
+      expect(master.pause).toHaveBeenCalledTimes(1);
+      expect(scene1.pause).toHaveBeenCalledTimes(1);
+      expect(scene2.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("plays every sibling timeline when the master plays", () => {
+      const master = createMockTimeline({ time: 0, duration: 10 });
+      const scene1 = createMockTimeline();
+      const scene2 = createMockTimeline();
+      const deps = createMockDeps(master);
+      const player = createRuntimePlayer({
+        ...deps,
+        getTimelineRegistry: () => ({ main: master, scene1, scene2 }),
+      });
+      player.play();
+      expect(master.play).toHaveBeenCalledTimes(1);
+      expect(scene1.play).toHaveBeenCalledTimes(1);
+      expect(scene2.play).toHaveBeenCalledTimes(1);
+    });
+
+    it("propagates playbackRate to siblings on play", () => {
+      const master = createMockTimeline({ time: 0, duration: 10 });
+      const scene1 = createMockTimeline();
+      const deps = createMockDeps(master);
+      deps.getPlaybackRate.mockReturnValue(2);
+      const player = createRuntimePlayer({
+        ...deps,
+        getTimelineRegistry: () => ({ main: master, scene1 }),
+      });
+      player.play();
+      expect(scene1.timeScale).toHaveBeenCalledWith(2);
+    });
+
+    it("does not call pause/play on the master twice through the registry", () => {
+      const master = createMockTimeline({ time: 5 });
+      const deps = createMockDeps(master);
+      const player = createRuntimePlayer({
+        ...deps,
+        // The master is identity-equal to one of the registry entries.
+        getTimelineRegistry: () => ({ main: master }),
+      });
+      player.pause();
+      expect(master.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows errors from a broken sibling without breaking pause", () => {
+      const master = createMockTimeline({ time: 5 });
+      const broken = createMockTimeline();
+      (broken.pause as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+      const ok = createMockTimeline();
+      const deps = createMockDeps(master);
+      const player = createRuntimePlayer({
+        ...deps,
+        getTimelineRegistry: () => ({ main: master, broken, ok }),
+      });
+      expect(() => player.pause()).not.toThrow();
+      expect(master.pause).toHaveBeenCalled();
+      expect(ok.pause).toHaveBeenCalled();
+    });
+
+    it("is a no-op when no registry is supplied (back-compat)", () => {
+      const master = createMockTimeline({ time: 5 });
+      const deps = createMockDeps(master);
+      const player = createRuntimePlayer(deps);
+      expect(() => player.pause()).not.toThrow();
+      expect(master.pause).toHaveBeenCalled();
+    });
+
+    it("tolerates undefined entries in the registry", () => {
+      const master = createMockTimeline({ time: 5 });
+      const scene = createMockTimeline();
+      const deps = createMockDeps(master);
+      const player = createRuntimePlayer({
+        ...deps,
+        getTimelineRegistry: () => ({ main: master, gone: undefined, scene }),
+      });
+      expect(() => player.pause()).not.toThrow();
+      expect(scene.pause).toHaveBeenCalled();
+    });
+  });
+
   describe("seek", () => {
     it("does nothing without a timeline", () => {
       const deps = createMockDeps(null);

--- a/packages/core/src/runtime/player.ts
+++ b/packages/core/src/runtime/player.ts
@@ -17,7 +17,32 @@ type PlayerDeps = {
   onRenderFrameSeek: (timeSeconds: number) => void;
   onShowNativeVideos: () => void;
   getSafeDuration?: () => number;
+  /**
+   * Optional registry of sibling timelines (typically `window.__timelines`).
+   * Provided so that play/pause propagate to sub-scene timelines registered
+   * alongside the master — e.g. a nested-composition master with per-scene
+   * timelines like `scene1-logo-intro`, `scene2-4-canvas`. Without this,
+   * pausing the master would leave scene timelines free-running and
+   * animations would continue to advance visually past the paused time.
+   */
+  getTimelineRegistry?: () => Record<string, RuntimeTimelineLike | undefined>;
 };
+
+function forEachSiblingTimeline(
+  registry: Record<string, RuntimeTimelineLike | undefined> | undefined | null,
+  master: RuntimeTimelineLike,
+  fn: (tl: RuntimeTimelineLike) => void,
+): void {
+  if (!registry) return;
+  for (const tl of Object.values(registry)) {
+    if (!tl || tl === master) continue;
+    try {
+      fn(tl);
+    } catch {
+      // ignore sibling failures — one broken timeline shouldn't poison play/pause
+    }
+  }
+}
 
 function seekTimelineDeterministically(
   timeline: RuntimeTimelineLike,
@@ -59,6 +84,10 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
         timeline.timeScale(deps.getPlaybackRate());
       }
       timeline.play();
+      forEachSiblingTimeline(deps.getTimelineRegistry?.(), timeline, (tl) => {
+        if (typeof tl.timeScale === "function") tl.timeScale(deps.getPlaybackRate());
+        tl.play();
+      });
       deps.onDeterministicPlay();
       deps.setIsPlaying(true);
       deps.onShowNativeVideos();
@@ -68,6 +97,9 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
       const timeline = deps.getTimeline();
       if (!timeline) return;
       timeline.pause();
+      forEachSiblingTimeline(deps.getTimelineRegistry?.(), timeline, (tl) => {
+        tl.pause();
+      });
       const time = Math.max(0, Number(timeline.time()) || 0);
       deps.onDeterministicSeek(time);
       deps.onDeterministicPause();

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -1,4 +1,5 @@
 import { createControls, SPEED_PRESETS, type ControlsCallbacks } from "./controls.js";
+import { shouldInjectRuntime } from "./shouldInjectRuntime.js";
 import { PLAYER_STYLES } from "./styles.js";
 
 const DEFAULT_FPS = 30;
@@ -422,9 +423,18 @@ class HyperframesPlayer extends HTMLElement {
         // Check if the runtime bridge is active (__hf or __player from the runtime)
         const hasRuntime = !!(win.__hf || win.__player);
         const hasTimelines = !!(win.__timelines && Object.keys(win.__timelines).length > 0);
+        const hasNestedCompositions =
+          !!this.iframe.contentDocument?.querySelector("[data-composition-src]");
 
-        // Auto-inject runtime if GSAP timelines exist but no runtime bridge
-        if (!hasRuntime && hasTimelines && !this._runtimeInjected && attempts >= 5) {
+        if (
+          shouldInjectRuntime({
+            hasRuntime,
+            hasTimelines,
+            hasNestedCompositions,
+            runtimeInjected: this._runtimeInjected,
+            attempts,
+          })
+        ) {
           this._injectRuntime();
           return; // Wait for runtime to load and initialize
         }

--- a/packages/player/src/shouldInjectRuntime.test.ts
+++ b/packages/player/src/shouldInjectRuntime.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { shouldInjectRuntime, type ProbeState } from "./shouldInjectRuntime.js";
+
+const baseState: ProbeState = {
+  hasRuntime: false,
+  hasTimelines: false,
+  hasNestedCompositions: false,
+  runtimeInjected: false,
+  attempts: 1,
+};
+
+describe("shouldInjectRuntime", () => {
+  it("never injects when the runtime bridge is already present", () => {
+    for (let attempts = 0; attempts <= 40; attempts++) {
+      expect(
+        shouldInjectRuntime({
+          ...baseState,
+          hasRuntime: true,
+          hasTimelines: true,
+          hasNestedCompositions: true,
+          attempts,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("never injects twice — runtimeInjected short-circuits", () => {
+    expect(
+      shouldInjectRuntime({
+        ...baseState,
+        hasTimelines: true,
+        hasNestedCompositions: true,
+        runtimeInjected: true,
+        attempts: 10,
+      }),
+    ).toBe(false);
+  });
+
+  describe("nested compositions (data-composition-src children)", () => {
+    it("injects on the first tick — no attempts gate", () => {
+      expect(
+        shouldInjectRuntime({
+          ...baseState,
+          hasNestedCompositions: true,
+          attempts: 1,
+        }),
+      ).toBe(true);
+    });
+
+    // Regression: product-promo and other registry examples register inline
+    // pre-runtime timelines (`window.__timelines["main"]`) with only partial
+    // durations during iframe load. Without this, the adapter path would
+    // resolve against that partial timeline and lock the player into a
+    // broken "ready" state before the 5-tick fallback ever fires.
+    it("injects even when pre-runtime timelines are already registered", () => {
+      expect(
+        shouldInjectRuntime({
+          ...baseState,
+          hasTimelines: true,
+          hasNestedCompositions: true,
+          attempts: 1,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not re-inject once runtimeInjected flips", () => {
+      expect(
+        shouldInjectRuntime({
+          ...baseState,
+          hasNestedCompositions: true,
+          runtimeInjected: true,
+          attempts: 1,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("self-contained compositions (GSAP-only, no nested children)", () => {
+    it("waits during the grace period (attempts < 5) even with timelines", () => {
+      for (let attempts = 0; attempts < 5; attempts++) {
+        expect(
+          shouldInjectRuntime({
+            ...baseState,
+            hasTimelines: true,
+            attempts,
+          }),
+        ).toBe(false);
+      }
+    });
+
+    it("injects as a fallback at attempt 5", () => {
+      expect(
+        shouldInjectRuntime({
+          ...baseState,
+          hasTimelines: true,
+          attempts: 5,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not inject when there are neither timelines nor nested scenes", () => {
+      for (let attempts = 0; attempts <= 40; attempts++) {
+        expect(
+          shouldInjectRuntime({
+            ...baseState,
+            attempts,
+          }),
+        ).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/player/src/shouldInjectRuntime.ts
+++ b/packages/player/src/shouldInjectRuntime.ts
@@ -1,0 +1,38 @@
+/**
+ * Decide whether the player should inject the HyperFrames runtime on the
+ * current probe tick.
+ *
+ * The player polls the loaded iframe every 200ms to discover either:
+ *   - a runtime bridge already installed (`window.__hf` / `window.__player`), or
+ *   - GSAP timelines registered at `window.__timelines`.
+ *
+ * Two classes of composition require different injection timing:
+ *
+ *   Nested — the composition uses `data-composition-src` on child elements to
+ *   lazy-load sub-scenes. The runtime is what loads those children, so the
+ *   composition cannot possibly render on its own. We inject immediately; if
+ *   we waited, an inline pre-runtime `gsap.timeline` (common for authoring a
+ *   preview before the runtime rebuilds the master timeline) would register
+ *   at `__timelines["main"]` with a partial duration, and the adapter path
+ *   would then lock the player into `ready` against that incomplete timeline.
+ *
+ *   Self-contained — the composition has no nested scenes and ships all of
+ *   its animation inline (timelines registered under `__timelines`). These
+ *   don't strictly need the runtime; the adapter can drive them directly.
+ *   We give the adapter path first shot (a 5-tick grace period) and only
+ *   inject the runtime as a fallback if no adapter emerges.
+ */
+export interface ProbeState {
+  hasRuntime: boolean;
+  hasTimelines: boolean;
+  hasNestedCompositions: boolean;
+  runtimeInjected: boolean;
+  attempts: number;
+}
+
+export function shouldInjectRuntime(state: ProbeState): boolean {
+  if (state.hasRuntime || state.runtimeInjected) return false;
+  if (state.hasNestedCompositions) return true;
+  if (state.hasTimelines && state.attempts >= 5) return true;
+  return false;
+}


### PR DESCRIPTION
Two related fixes for nested-composition playback in `<hyperframes-player>`. Both surface when a composition uses `data-composition-src` to lazy-load child scenes (e.g. `registry/examples/product-promo`) **and** is served through the async/non-bundled path — i.e. raw static files or a custom server that doesn't run the composition through `bundleToSingleHtml`.

The studio preview (`hyperframes preview`) already bundles compositions via `bundleToSingleHtml` before serving, so it masks both bugs. They're latent for studio users but visible to anyone embedding the player against raw composition HTML (static hosts, CDN embeds, the upcoming HyperFrames Vercel template, etc.).

## 1. `fix(player)`: inject runtime immediately for nested compositions

### Problem
`<hyperframes-player>` renders an empty black iframe when loading any composition that uses `data-composition-src` on child elements. The composition is structured correctly and renders perfectly via `hyperframes render` server-side — but the browser preview is blank.

### Root cause
The probe loop in `hyperframes-player.ts` has two paths to \"ready\":

1. Inject the runtime if `hasTimelines && !hasRuntime && attempts >= 5`
2. Use an adapter built from whatever's at `window.__timelines` or `window.__player` if `adapter.getDuration() > 0`

For nested compositions in the async path, path (2) wins the race. The composition registers inline pre-runtime GSAP timelines at `window.__timelines[\"main\"]` while the iframe document is loading (typically covering only a partial duration — 14s of a 20s master, for `product-promo`). On the very first probe tick — long before attempts reaches 5 — the adapter check finds that timeline, treats it as source of truth, and locks the player into a broken \"ready\" state. The runtime never gets injected, so scenes declared via `data-composition-src` never load. The iframe stays blank.

### Fix
Split the injection decision into a pure helper (`shouldInjectRuntime(state)`) and treat compositions with `data-composition-src` children as \"inject immediately, skip the attempts gate.\" Self-contained GSAP-only compositions retain the 5-tick grace period so the adapter path keeps first shot for them (no regression).

## 2. `fix(core)`: propagate play/pause to all sibling timelines

### Problem
Even after the runtime loads, clicking pause on the player only freezes the master timeline (which, for `product-promo`, is the partial inline `mainTl` plus captions). The per-scene timelines keep playing, and after a few seconds the composition ends up in an empty gray end-state while the player UI still shows the paused time.

### Root cause
`packages/core/src/runtime/player.ts:67-78` — `player.pause()` only calls `.pause()` on the single adapter-selected timeline (`state.capturedTimeline`). In the async scene-loading path, each scene's timeline is registered as a **sibling** in `window.__timelines` (e.g. `scene1-logo-intro`, `scene2-4-canvas`, `scene5-logo-outro`), driven independently off GSAP's ticker. Pausing master leaves them free-running. Same issue symmetrically on `play()`.

Bundled compositions happen to avoid this because the bundled pipeline nests everything synchronously, and nested children inherit their parent's paused state.

### Fix
Wire `window.__timelines` into the runtime player via a new optional `getTimelineRegistry` dep, iterate the registry on play/pause, and forward `timeScale` to siblings on play so a changed playback-rate applies uniformly. Identity-equality check ensures the master isn't double-invoked; a try/catch isolates one broken sibling from breaking the whole pause. The change is a no-op on the bundled path (siblings there are already paused as nested children).

## Files

- `packages/player/src/shouldInjectRuntime.ts` — new pure decision helper
- `packages/player/src/shouldInjectRuntime.test.ts` — 8 unit tests
- `packages/player/src/hyperframes-player.ts` — compute `hasNestedCompositions`, call the helper
- `packages/core/src/runtime/player.ts` — add `getTimelineRegistry` to `PlayerDeps`, iterate on play/pause
- `packages/core/src/runtime/player.test.ts` — 7 new unit tests covering propagation, playbackRate, identity, errors, back-compat, undefined entries
- `packages/core/src/runtime/init.ts` — wire `window.__timelines` into the dep

## Testing

- [x] `cd packages/player && bunx vitest run` — 35/35 pass (8 new + 27 existing)
- [x] `cd packages/core && bunx vitest run` — 488/488 pass (7 new + 481 existing)
- [x] `bunx oxlint` clean across all changed files
- [x] `bunx oxfmt --check` clean
- [x] `bun run typecheck` clean in both packages
- [x] End-to-end verified via Playwright against a live Vercel deploy of a Next.js template using the unmodified `product-promo` composition: preview at t=0 matches rendered MP4 frame 0, preview at t=3s matches frame 3. Pause freezes the full composition, not just the master timeline.
- [x] Manually verified the bug in the release: running `npx hyperframes@latest preview registry/examples/product-promo` (which goes through the **bundled** path) pauses correctly — consistent with this being a bug in the async-scene-loading path only.