### PR TITLE
docs(website-to-hyperframes): add load-bearing GSAP authoring rules

### DIFF
--- a/skills/website-to-hyperframes/references/step-6-build.md
+++ b/skills/website-to-hyperframes/references/step-6-build.md
@@ -164,3 +164,64 @@ These exist because the capture engine is deterministic. Violations produce brok
 - **Never use ANY CSS `transform` for centering** — not `translate(-50%, -50%)`, not `translateX(-50%)`, not `translateY(-50%)`. GSAP animates the `transform` property, which overwrites ALL CSS transforms including centering. The element flies offscreen. Use flexbox centering instead: `display:flex; align-items:center; justify-content:center` on a wrapper div. The linter catches this (`gsap_css_transform_conflict`) but only if you run it.
 - **Minimum font sizes**: 20px body, 16px labels
 - **No full-screen dark linear gradients** — H.264 banding
+
+---
+
+## Load-bearing rules for animation authoring
+
+Rules below came out of two independent website-to-hyperframes builds (2026-04-20) where compositions lint-clean and still ship broken — elements that never appear, ambient motion that doesn't scrub, entrance tweens that silently kill their target. The linter cannot catch these; the rules must be followed by the author.
+
+- **No iframes for captured content.** Iframes do not seek deterministically with the timeline — the capture engine cannot scrub inside them, so they appear frozen (or blank) in the rendered output. If the source you're stylizing is a live web app, use the screenshots from `capture/` as stacked panels or layered images, not live embeds.
+
+- **Never stack two transform tweens on the same element.** A common failure: a `y` entrance plus a `scale` Ken Burns on the same `<img>`. The second tween's `immediateRender` resets the first, and the element ends up invisible or offscreen without any lint warning. Fix one of two ways:
+
+  ```html
+  <!-- BAD: two transforms on one element -->
+  <img class="hero" src="...">
+  <script>
+    tl.from(".hero", {y: 50, opacity: 0, duration: 0.6}, 0);
+    tl.to(".hero",   {scale: 1.04, duration: beat}, 0);   // kills the entrance
+  </script>
+
+  <!-- GOOD option A: combine into one tween -->
+  <script>
+    tl.fromTo(".hero",
+      {y: 50, opacity: 0, scale: 1.00},
+      {y: 0,  opacity: 1, scale: 1.04, duration: beat, ease: "none"},
+    0);
+  </script>
+
+  <!-- GOOD option B: split across parent + child -->
+  <div class="hero-wrap"><img class="hero" src="..."></div>
+  <script>
+    tl.from(".hero-wrap", {y: 50, opacity: 0, duration: 0.6}, 0);   // entrance on parent
+    tl.to  (".hero",      {scale: 1.04, duration: beat}, 0);        // Ken Burns on child
+  </script>
+  ```
+
+- **Prefer `tl.fromTo()` over `tl.from()` inside `.clip` scenes.** `gsap.from()` sets `immediateRender: true` by default, which writes the "from" state at timeline construction — before the `.clip` scene's `data-start` is active. Elements can flash visible, start from the wrong position, or skip their entrance entirely when the scene is seeked non-linearly (which the capture engine does). Explicit `fromTo` makes the state at every timeline position deterministic:
+
+  ```js
+  // BRITTLE: immediateRender interacts badly with scene boundaries
+  tl.from(el, {opacity: 0, y: 50, duration: 0.6}, t);
+
+  // DETERMINISTIC: state is defined at both ends, no immediateRender surprise
+  tl.fromTo(el, {opacity: 0, y: 50}, {opacity: 1, y: 0, duration: 0.6}, t);
+  ```
+
+- **Ambient pulses must attach to the seekable `tl`, never bare `gsap.to()`.** Auras, shimmers, gentle float loops, logo breathing — all of these must be added to the scene's timeline, not fired standalone. Standalone tweens run on wallclock time and do not scrub with the capture engine, so the effect is absent in the rendered video even though it looks correct in the studio preview:
+
+  ```js
+  // BAD: lives outside the timeline, never renders in capture
+  gsap.to(".aura", {scale: 1.08, yoyo: true, repeat: 5, duration: 1.2});
+
+  // GOOD: seekable, deterministic, renders
+  tl.to(".aura", {scale: 1.08, yoyo: true, repeat: 5, duration: 1.2}, 0);
+  ```
+
+- **Hard-kill every scene boundary, not just captions.** The caption hard-kill rule above generalizes: any element whose visibility changes at a beat boundary needs a deterministic `tl.set()` kill after its fade, because later tweens on the same element (or `immediateRender` from a sibling tween) can resurrect it. Apply to every element with an exit animation:
+
+  ```js
+  tl.to (el, {opacity: 0, duration: 0.3}, beatEnd);
+  tl.set(el, {opacity: 0, visibility: "hidden"}, beatEnd + 0.3);   // deterministic kill
+  ```

--- a/skills/website-to-hyperframes/references/step-6-build.md
+++ b/skills/website-to-hyperframes/references/step-6-build.md
@@ -177,25 +177,27 @@ Rules below came out of two independent website-to-hyperframes builds (2026-04-2
 
   ```html
   <!-- BAD: two transforms on one element -->
-  <img class="hero" src="...">
+  <img class="hero" src="..." />
   <script>
-    tl.from(".hero", {y: 50, opacity: 0, duration: 0.6}, 0);
-    tl.to(".hero",   {scale: 1.04, duration: beat}, 0);   // kills the entrance
+    tl.from(".hero", { y: 50, opacity: 0, duration: 0.6 }, 0);
+    tl.to(".hero", { scale: 1.04, duration: beat }, 0); // kills the entrance
   </script>
 
   <!-- GOOD option A: combine into one tween -->
   <script>
-    tl.fromTo(".hero",
-      {y: 50, opacity: 0, scale: 1.00},
-      {y: 0,  opacity: 1, scale: 1.04, duration: beat, ease: "none"},
-    0);
+    tl.fromTo(
+      ".hero",
+      { y: 50, opacity: 0, scale: 1.0 },
+      { y: 0, opacity: 1, scale: 1.04, duration: beat, ease: "none" },
+      0,
+    );
   </script>
 
   <!-- GOOD option B: split across parent + child -->
-  <div class="hero-wrap"><img class="hero" src="..."></div>
+  <div class="hero-wrap"><img class="hero" src="..." /></div>
   <script>
-    tl.from(".hero-wrap", {y: 50, opacity: 0, duration: 0.6}, 0);   // entrance on parent
-    tl.to  (".hero",      {scale: 1.04, duration: beat}, 0);        // Ken Burns on child
+    tl.from(".hero-wrap", { y: 50, opacity: 0, duration: 0.6 }, 0); // entrance on parent
+    tl.to(".hero", { scale: 1.04, duration: beat }, 0); // Ken Burns on child
   </script>
   ```
 
@@ -203,25 +205,25 @@ Rules below came out of two independent website-to-hyperframes builds (2026-04-2
 
   ```js
   // BRITTLE: immediateRender interacts badly with scene boundaries
-  tl.from(el, {opacity: 0, y: 50, duration: 0.6}, t);
+  tl.from(el, { opacity: 0, y: 50, duration: 0.6 }, t);
 
   // DETERMINISTIC: state is defined at both ends, no immediateRender surprise
-  tl.fromTo(el, {opacity: 0, y: 50}, {opacity: 1, y: 0, duration: 0.6}, t);
+  tl.fromTo(el, { opacity: 0, y: 50 }, { opacity: 1, y: 0, duration: 0.6 }, t);
   ```
 
 - **Ambient pulses must attach to the seekable `tl`, never bare `gsap.to()`.** Auras, shimmers, gentle float loops, logo breathing — all of these must be added to the scene's timeline, not fired standalone. Standalone tweens run on wallclock time and do not scrub with the capture engine, so the effect is absent in the rendered video even though it looks correct in the studio preview:
 
   ```js
   // BAD: lives outside the timeline, never renders in capture
-  gsap.to(".aura", {scale: 1.08, yoyo: true, repeat: 5, duration: 1.2});
+  gsap.to(".aura", { scale: 1.08, yoyo: true, repeat: 5, duration: 1.2 });
 
   // GOOD: seekable, deterministic, renders
-  tl.to(".aura", {scale: 1.08, yoyo: true, repeat: 5, duration: 1.2}, 0);
+  tl.to(".aura", { scale: 1.08, yoyo: true, repeat: 5, duration: 1.2 }, 0);
   ```
 
 - **Hard-kill every scene boundary, not just captions.** The caption hard-kill rule above generalizes: any element whose visibility changes at a beat boundary needs a deterministic `tl.set()` kill after its fade, because later tweens on the same element (or `immediateRender` from a sibling tween) can resurrect it. Apply to every element with an exit animation:
 
   ```js
-  tl.to (el, {opacity: 0, duration: 0.3}, beatEnd);
-  tl.set(el, {opacity: 0, visibility: "hidden"}, beatEnd + 0.3);   // deterministic kill
+  tl.to(el, { opacity: 0, duration: 0.3 }, beatEnd);
+  tl.set(el, { opacity: 0, visibility: "hidden" }, beatEnd + 0.3); // deterministic kill
   ```

--- a/skills/website-to-hyperframes/references/step-6-build.md
+++ b/skills/website-to-hyperframes/references/step-6-build.md
@@ -173,7 +173,7 @@ Rules below came out of two independent website-to-hyperframes builds (2026-04-2
 
 - **No iframes for captured content.** Iframes do not seek deterministically with the timeline — the capture engine cannot scrub inside them, so they appear frozen (or blank) in the rendered output. If the source you're stylizing is a live web app, use the screenshots from `capture/` as stacked panels or layered images, not live embeds.
 
-- **Never stack two transform tweens on the same element.** A common failure: a `y` entrance plus a `scale` Ken Burns on the same `<img>`. The second tween's `immediateRender` resets the first, and the element ends up invisible or offscreen without any lint warning. Fix one of two ways:
+- **Never stack two transform tweens on the same element.** A common failure: a `y` entrance plus a `scale` Ken Burns on the same `<img>`. The second tween's `immediateRender: true` writes the element's initial state at construction time, overwriting whatever the first tween set — leaving the element invisible or offscreen with no lint warning. A secondary mechanism: `tl.from()` resets to its declared "from" state when the playhead is seeked past the timeline's end, so an element that looked correct in linear playback vanishes in the capture engine's non-linear seek. Fix one of two ways:
 
   ```html
   <!-- BAD: two transforms on one element -->


### PR DESCRIPTION
## Summary

Adds a new **Load-bearing rules for animation authoring** subsection to `skills/website-to-hyperframes/references/step-6-build.md`, capturing five GSAP authoring rules the linter cannot catch but that silently ship broken output — compositions that pass lint and render elements invisible, unscrubbing, or frozen.

## Evidence

Surfaced from two independent website-to-hyperframes builds on 2026-04-20:
- `spatial-deck/promo/hyperframes-auto/` — single-page SPA source
- `~/harvardxr-auto/` — marketing-site source

Both lint-clean on the first try. Both rendered cleanly **only** because we injected these rules into the sub-agent prompt before dispatch. Without them, sub-agents produced lint-passing compositions with:
- Hero images that entered then vanished (stacked `y`-entrance + `scale` Ken Burns tweens on one element)
- Auras that looked right in the studio preview but were missing from the rendered MP4 (standalone `gsap.to()` that didn't scrub)
- Scene transitions where elements flashed visible before their own entrance (`gsap.from()` `immediateRender` interacting with `.clip` boundaries)

## Rules added

1. **No iframes for captured content** — don't seek deterministically, cannot scrub.
2. **Never stack two transform tweens on one element** — the second tween's `immediateRender` resets the first, element ends up invisible. With before/after code showing two fixes (combine into one `fromTo`, or split across parent/child wrappers).
3. **Prefer `tl.fromTo()` over `tl.from()` inside `.clip` scenes** — `from()`'s default `immediateRender: true` writes state before the scene's `data-start` is active and misbehaves under non-linear seeking.
4. **Ambient pulses must attach to the seekable `tl`, never bare `gsap.to()`** — standalone tweens run on wallclock, don't scrub, absent from rendered output.
5. **Generalize the existing caption hard-kill rule to every scene-boundary exit** — any element whose visibility changes at a beat boundary needs the deterministic `tl.set()` kill after its fade, not just captions.

Rules already present in the file (`repeat: -1`, `data-start`/`data-duration` on template roots, caption hard-kill) are untouched — these five are net-new or are generalizations.

## Related observations (not in this PR, flagging for maintainers)

Two adjacent findings from the same builds, worth filing separately if you want them tracked:

- **Linter heuristic inconsistency.** Identical hard-kill patterns at beat boundaries trigger `overlapping_gsap_tweens` on some builds but not others. Stabilizing this heuristic would remove a source of sub-agent confusion.
- **`step-1-capture.md` thin output on canvas-driven / deck-style sources.** Single-page apps that navigate via keyboard or internal state produce `sections: 0, CTAs: 0, scroll-screenshots: 1`. A `--deck-mode` flag that navigates via keyboard and captures per-state — or a documented pre-seed-screenshots workaround — would help.

Happy to open either as a separate issue if useful.

## Test plan

- [ ] Render the diff locally and confirm markdown formatting is consistent with the rest of `step-6-build.md` (code fences, hyphen bullets, em-dashes).
- [ ] Optional: re-run the website-to-hyperframes skill against a test site with these rules present vs. absent — the "ambient pulse doesn't scrub" failure is the easiest to reproduce.