### PR TITLE
fix(cli): host hyperframes.json schema so $schema resolves

### DIFF
--- a/docs/public/schema/hyperframes.json
+++ b/docs/public/schema/hyperframes.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "title": "Hyperframes Project Config",
+  "description": "Per-project configuration created by `hyperframes init`. Lives at the repo root as `hyperframes.json` and controls which registry `hyperframes add` pulls from and where each item type lands in the project tree.",
+  "type": "object",
+  "required": [
+    "registry",
+    "paths"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of this JSON Schema. Enables IDE autocompletion and validation."
+    },
+    "registry": {
+      "type": "string",
+      "format": "uri",
+      "description": "Base URL of the registry to pull items from (e.g. the default Hyperframes registry or a private one)."
+    },
+    "paths": {
+      "type": "object",
+      "required": [
+        "blocks",
+        "components",
+        "assets"
+      ],
+      "additionalProperties": false,
+      "description": "Target paths for each item type, relative to project root.",
+      "properties": {
+        "blocks": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where `hyperframes:block` items land, relative to project root."
+        },
+        "components": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where `hyperframes:component` items land, relative to project root."
+        },
+        "assets": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where asset files (images, fonts, videos) land, relative to project root."
+        }
+      }
+    }
+  }
+}

--- a/docs/public/schema/registry-item.json
+++ b/docs/public/schema/registry-item.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "title": "Hyperframes Registry Item",
+  "description": "Manifest for a single distributable item (example, block, or component).",
+  "type": "object",
+  "required": ["name", "type", "title", "description", "files"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+      "description": "Item name in kebab-case, must start and end with alphanumeric."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["hyperframes:example", "hyperframes:block", "hyperframes:component"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1,
+      "description": "SPDX license identifier (e.g. \"Apache-2.0\", \"MIT\")."
+    },
+    "minCliVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+      "description": "Minimum `hyperframes` CLI version required to install this item."
+    },
+    "deprecated": {
+      "type": "string",
+      "minLength": 1,
+      "description": "If set, the item is deprecated; the value is the reason or migration note."
+    },
+    "dimensions": {
+      "type": "object",
+      "required": ["width", "height"],
+      "additionalProperties": false,
+      "properties": {
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "duration": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "description": "Duration in seconds. Must be > 0."
+    },
+    "registryDependencies": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+      }
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["path", "target", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Source path, relative to registry-item.json."
+          },
+          "target": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Destination path in the user's project, relative to project root. Must not traverse outside the project (no `..` segments, no absolute paths).",
+            "not": {
+              "anyOf": [
+                { "pattern": "(^|[/\\\\])\\.\\.([/\\\\]|$)" },
+                { "pattern": "^[/\\\\]" },
+                { "pattern": "^[A-Za-z]:[/\\\\]" }
+              ]
+            }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "hyperframes:composition",
+              "hyperframes:asset",
+              "hyperframes:snippet",
+              "hyperframes:style",
+              "hyperframes:timeline"
+            ]
+          }
+        }
+      }
+    },
+    "preview": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "video": { "type": "string" },
+        "poster": { "type": "string" }
+      }
+    },
+    "relatedSkill": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["type"],
+        "properties": { "type": { "const": "hyperframes:component" } }
+      },
+      "then": {
+        "not": {
+          "anyOf": [{ "required": ["dimensions"] }, { "required": ["duration"] }]
+        }
+      },
+      "else": {
+        "required": ["dimensions", "duration"]
+      }
+    }
+  ]
+}

--- a/docs/public/schema/registry.json
+++ b/docs/public/schema/registry.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hyperframes.heygen.com/schema/registry.json",
+  "title": "Hyperframes Registry Manifest",
+  "description": "Top-level manifest describing all items in a Hyperframes registry.",
+  "type": "object",
+  "required": ["name", "homepage", "items"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Registry name (e.g. \"hyperframes\")."
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri",
+      "description": "Registry homepage URL."
+    },
+    "items": {
+      "type": "array",
+      "description": "Items in this registry. Each entry is a shorthand reference; the full item manifest lives at <type-dir>/<name>/registry-item.json.",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+            "description": "Item name in kebab-case, must start and end with alphanumeric."
+          },
+          "type": {
+            "type": "string",
+            "enum": ["hyperframes:example", "hyperframes:block", "hyperframes:component"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/schemas/hyperframes.json
+++ b/packages/core/schemas/hyperframes.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "title": "Hyperframes Project Config",
+  "description": "Per-project configuration created by `hyperframes init`. Lives at the repo root as `hyperframes.json` and controls which registry `hyperframes add` pulls from and where each item type lands in the project tree.",
+  "type": "object",
+  "required": [
+    "registry",
+    "paths"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of this JSON Schema. Enables IDE autocompletion and validation."
+    },
+    "registry": {
+      "type": "string",
+      "format": "uri",
+      "description": "Base URL of the registry to pull items from (e.g. the default Hyperframes registry or a private one)."
+    },
+    "paths": {
+      "type": "object",
+      "required": [
+        "blocks",
+        "components",
+        "assets"
+      ],
+      "additionalProperties": false,
+      "description": "Target paths for each item type, relative to project root.",
+      "properties": {
+        "blocks": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where `hyperframes:block` items land, relative to project root."
+        },
+        "components": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where `hyperframes:component` items land, relative to project root."
+        },
+        "assets": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where asset files (images, fonts, videos) land, relative to project root."
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/registry/docs-schema-sync.test.ts
+++ b/packages/core/src/registry/docs-schema-sync.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schemasDir = resolve(here, "..", "..", "schemas");
+const docsSchemaDir = resolve(here, "..", "..", "..", "..", "docs", "public", "schema");
+
+const SCHEMA_FILES = ["hyperframes.json", "registry.json", "registry-item.json"] as const;
+
+describe("docs/public/schema/ stays in sync with packages/core/schemas/", () => {
+  for (const file of SCHEMA_FILES) {
+    it(`${file} in docs matches the canonical copy in core`, () => {
+      const canonical = readFileSync(resolve(schemasDir, file), "utf-8");
+      const mirrored = readFileSync(resolve(docsSchemaDir, file), "utf-8");
+      expect(mirrored).toBe(canonical);
+    });
+
+    it(`${file} declares the public URL as its $id`, () => {
+      const parsed = JSON.parse(readFileSync(resolve(schemasDir, file), "utf-8")) as Record<string, unknown>;
+      expect(parsed.$id).toBe(`https://hyperframes.heygen.com/schema/${file}`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a canonical `hyperframes.json` schema under `packages/core/schemas`
- mirror the public schemas into `docs/public/schema` so Mintlify serves the expected URLs
- add a drift test to keep the canonical and published schemas in sync

## Why
The generated `hyperframes.json` pointed at `https://hyperframes.heygen.com/schema/hyperframes.json`, but that URL returned `404` because the schema was not being published from the docs site.

## Validation
- `bun test packages/core/src/registry/docs-schema-sync.test.ts`