### PR TITLE
fix: improve auto worker handling for webgl-heavy renders

### DIFF
--- a/docs/guides/rendering.mdx
+++ b/docs/guides/rendering.mdx
@@ -154,16 +154,13 @@ Each render worker launches a **separate Chrome browser process** to capture fra
 
 ### Default behavior
 
-By default, Hyperframes uses **half of your CPU cores, capped at 4**:
+By default, HyperFrames uses a frame-aware auto heuristic instead of a fixed per-machine table:
 
-| Machine | CPU cores | Default workers |
-|---------|-----------|----------------|
-| MacBook Air (M1) | 8 | 4 |
-| MacBook Pro (M3) | 12 | 4 (capped) |
-| 4-core laptop | 4 | 2 |
-| 2-core VM | 2 | 1 |
+- very short renders stay single-worker, because parallel startup overhead outweighs the gain
+- longer renders scale up based on CPU, available memory, and total frame count
+- very large renders are capped again to avoid Chrome/FFmpeg contention
 
-This is intentionally conservative. Each worker spawns its own Chrome process, so the per-worker overhead is significant. Fewer workers avoids resource contention with FFmpeg encoding and your other applications.
+This is intentionally conservative. Each worker spawns its own Chrome process, so the per-worker overhead is significant. Fewer workers avoids resource contention with FFmpeg encoding, GPU-heavy capture, and your other applications.
 
 ### Choosing a worker count
 
@@ -182,11 +179,16 @@ npx hyperframes render --workers 8 --output output.mp4
   Start with the default. If renders feel slow and your system has headroom (check Activity Monitor / `htop`), try increasing `--workers`. If you see high memory pressure or fan noise, reduce it.
 </Tip>
 
+<Tip>
+  If a WebGL-heavy, Three.js, or bloom-heavy composition times out under `--workers auto`, try `--workers 2` before dropping all the way to sequential capture. Scenes with multiple actively seeking video elements may still need `--workers 1`.
+</Tip>
+
 ### When to use 1 worker
 
 - Short compositions (under 2 seconds / 60 frames) — parallelism overhead exceeds the benefit
 - Low-memory machines (4 GB or less)
 - Running renders alongside other heavy processes (video editing, large builds)
+- Multi-video compositions that keep timing out under parallel capture
 
 ### When to increase workers
 

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -11,7 +11,7 @@ export const examples: Example[] = [
   ["Parallel rendering with 6 workers", "hyperframes render --workers 6 --output fast.mp4"],
   ["HDR output (H.265 10-bit)", "hyperframes render --hdr --output hdr-output.mp4"],
 ];
-import { cpus, freemem, tmpdir } from "node:os";
+import { freemem, tmpdir } from "node:os";
 import { resolve, dirname, join, basename } from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import { resolveProject } from "../utils/project.js";
@@ -32,13 +32,6 @@ const VALID_FPS = new Set([24, 30, 60]);
 const VALID_QUALITY = new Set(["draft", "standard", "high"]);
 const VALID_FORMAT = new Set(["mp4", "webm", "mov"]);
 const FORMAT_EXT: Record<string, string> = { mp4: ".mp4", webm: ".webm", mov: ".mov" };
-
-const CPU_CORE_COUNT = cpus().length;
-
-/** 3/4 of CPU cores, capped at 8. Each worker spawns a Chrome process (~256 MB). */
-function defaultWorkerCount(): number {
-  return Math.max(1, Math.min(Math.floor((CPU_CORE_COUNT * 3) / 4), 8));
-}
 
 export default defineCommand({
   meta: {
@@ -216,12 +209,9 @@ export default defineCommand({
     }
 
     // ── Print render plan ─────────────────────────────────────────────────
-    const workerCount = workers ?? defaultWorkerCount();
     if (!quiet) {
       const workerLabel =
-        args.workers != null
-          ? `${workerCount} workers`
-          : `${workerCount} workers (auto — ${CPU_CORE_COUNT} cores detected)`;
+        workers != null ? `${workers} workers` : "workers auto (frame-aware heuristic)";
       console.log("");
       console.log(
         c.accent("\u25C6") +
@@ -307,7 +297,7 @@ export default defineCommand({
         fps,
         quality,
         format,
-        workers: workerCount,
+        workers,
         gpu: useGpu,
         hdr: args.hdr ?? false,
         crf,
@@ -319,7 +309,7 @@ export default defineCommand({
         fps,
         quality,
         format,
-        workers: workerCount,
+        workers,
         gpu: useGpu,
         hdr: args.hdr ?? false,
         crf,
@@ -335,7 +325,7 @@ interface RenderOptions {
   fps: 24 | 30 | 60;
   quality: "draft" | "standard" | "high";
   format: "mp4" | "webm" | "mov";
-  workers: number;
+  workers?: number;
   gpu: boolean;
   hdr: boolean;
   crf?: number;
@@ -601,7 +591,7 @@ function trackRenderMetrics(
     durationMs: elapsedMs,
     fps: options.fps,
     quality: options.quality,
-    workers: options.workers,
+    workers: job.perfSummary?.workers ?? options.workers,
     docker,
     gpu: options.gpu,
     compositionDurationMs,

--- a/packages/cli/src/docs/rendering.md
+++ b/packages/cli/src/docs/rendering.md
@@ -26,4 +26,6 @@ Requires: Docker installed and running.
 
 - Use `draft` quality for fast previews during development
 - Use `npx hyperframes benchmark` to find optimal settings
-- 4 workers is usually the sweet spot for most compositions
+- Leave `--workers` on `auto` unless you have a reason to override it
+- If a WebGL-heavy or bloom-heavy scene times out under `auto`, try `--workers 2`
+- If a composition has multiple actively seeking video elements, try `--workers 1`

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -8,7 +8,7 @@ export function trackRenderComplete(props: {
   durationMs: number;
   fps: number;
   quality: string;
-  workers: number;
+  workers?: number;
   docker: boolean;
   gpu: boolean;
   // Composition metadata

--- a/packages/cli/src/utils/dockerRunArgs.test.ts
+++ b/packages/cli/src/utils/dockerRunArgs.test.ts
@@ -159,4 +159,12 @@ describe("buildDockerRunArgs", () => {
     expect(args).toContain("10M");
     expect(args).not.toContain("--crf");
   });
+
+  it("omits --workers when auto-selection should happen inside the container", () => {
+    const args = buildDockerRunArgs({
+      ...FIXED_INPUT,
+      options: { ...BASE, workers: undefined },
+    });
+    expect(args).not.toContain("--workers");
+  });
 });

--- a/packages/cli/src/utils/dockerRunArgs.ts
+++ b/packages/cli/src/utils/dockerRunArgs.ts
@@ -22,7 +22,7 @@ export interface DockerRenderOptions {
   fps: 24 | 30 | 60;
   quality: "draft" | "standard" | "high";
   format: "mp4" | "webm" | "mov";
-  workers: number;
+  workers?: number;
   gpu: boolean;
   hdr: boolean;
   crf?: number;
@@ -54,8 +54,7 @@ export function buildDockerRunArgs(input: DockerRunArgsInput): string[] {
     options.quality,
     "--format",
     options.format,
-    "--workers",
-    String(options.workers),
+    ...(options.workers != null ? ["--workers", String(options.workers)] : []),
     ...(options.crf != null ? ["--crf", String(options.crf)] : []),
     ...(options.videoBitrate ? ["--video-bitrate", options.videoBitrate] : []),
     ...(options.quiet ? ["--quiet"] : []),

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -327,6 +327,36 @@ describe("detectRenderModeHints", () => {
     expect(result.reasons.map((reason) => reason.code)).toEqual(["requestAnimationFrame"]);
   });
 
+  it("detects inline WebGL and Three.js scenes without forcing screenshot mode", () => {
+    const html = `<!DOCTYPE html>
+<html><body>
+  <canvas id="scene"></canvas>
+  <script>
+    import * as THREE from "three";
+    const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById("scene") });
+    const composer = new EffectComposer(renderer);
+  </script>
+</body></html>`;
+
+    const result = detectRenderModeHints(html);
+
+    expect(result.recommendScreenshot).toBe(false);
+    expect(result.reasons.map((reason) => reason.code)).toEqual(["webgl"]);
+  });
+
+  it("detects external Three.js scripts as WebGL-heavy", () => {
+    const html = `<!DOCTYPE html>
+<html><body>
+  <canvas id="scene"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160/build/three.module.min.js"></script>
+</body></html>`;
+
+    const result = detectRenderModeHints(html);
+
+    expect(result.recommendScreenshot).toBe(false);
+    expect(result.reasons.map((reason) => reason.code)).toEqual(["webgl"]);
+  });
+
   it("ignores requestAnimationFrame inside comments and external scripts", () => {
     const html = `<!DOCTYPE html>
 <html><body>

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -53,7 +53,7 @@ export interface CompiledComposition {
   renderModeHints: RenderModeHints;
 }
 
-export type RenderModeHintCode = "iframe" | "requestAnimationFrame";
+export type RenderModeHintCode = "iframe" | "requestAnimationFrame" | "webgl";
 
 export interface RenderModeHint {
   code: RenderModeHintCode;
@@ -76,6 +76,11 @@ function dedupeElementsById<T extends { id: string }>(elements: T[]): T[] {
 const INLINE_SCRIPT_PATTERN = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
 const COMPILER_MOUNT_BLOCK_START = "/* __HF_COMPILER_MOUNT_START__ */";
 const COMPILER_MOUNT_BLOCK_END = "/* __HF_COMPILER_MOUNT_END__ */";
+const WEBGL_CONTEXT_PATTERN = /\bgetContext\s*\(\s*["'`](?:webgl2?|experimental-webgl)["'`]\s*\)/i;
+const WEBGL_INLINE_PATTERN =
+  /\b(?:THREE\.(?:WebGLRenderer|PMREMGenerator)|WebGL(?:2)?RenderingContext|PMREMGenerator|EffectComposer|UnrealBloomPass)\b|(?:import\s*\(?\s*["'`]three(?:\/|["'`]))/i;
+const WEBGL_SCRIPT_SRC_PATTERN =
+  /(?:@react-three\/(?:fiber|drei))|(?:^|[/@-])three(?:[./@-]|(?:\.module|\.min)?(?:\.js)?(?:$|[?#/]))/i;
 
 function stripJsComments(source: string): string {
   return source.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
@@ -105,21 +110,49 @@ export function detectRenderModeHints(html: string): RenderModeHints {
 
   let scriptMatch: RegExpExecArray | null;
   const scriptPattern = new RegExp(INLINE_SCRIPT_PATTERN.source, INLINE_SCRIPT_PATTERN.flags);
+  let detectedInlineRequestAnimationFrame = false;
+  let detectedWebgl = false;
   while ((scriptMatch = scriptPattern.exec(html)) !== null) {
     const attrs = scriptMatch[1] || "";
-    if (/\bsrc\s*=/i.test(attrs)) continue;
+    if (/\bsrc\s*=/i.test(attrs)) {
+      const srcMatch = attrs.match(/\bsrc\s*=\s*["']([^"']+)["']/i);
+      if (srcMatch?.[1] && WEBGL_SCRIPT_SRC_PATTERN.test(srcMatch[1])) {
+        detectedWebgl = true;
+      }
+      continue;
+    }
     const content = stripJsComments(stripCompilerMountBootstrap(scriptMatch[2] || ""));
-    if (!/requestAnimationFrame\s*\(/.test(content)) continue;
+    if (!detectedInlineRequestAnimationFrame && /requestAnimationFrame\s*\(/.test(content)) {
+      detectedInlineRequestAnimationFrame = true;
+    }
+    if (
+      !detectedWebgl &&
+      (WEBGL_CONTEXT_PATTERN.test(content) || WEBGL_INLINE_PATTERN.test(content))
+    ) {
+      detectedWebgl = true;
+    }
+  }
+
+  if (detectedInlineRequestAnimationFrame) {
     reasons.push({
       code: "requestAnimationFrame",
       message:
         "Detected raw requestAnimationFrame() in an inline script. This render is routed through screenshot capture mode with virtual time enabled.",
     });
-    break;
+  }
+
+  if (detectedWebgl) {
+    reasons.push({
+      code: "webgl",
+      message:
+        "Detected WebGL/Three.js scene setup. GPU-heavy compositions often need fewer auto workers to avoid Chrome compositor starvation.",
+    });
   }
 
   return {
-    recommendScreenshot: reasons.length > 0,
+    recommendScreenshot: reasons.some(
+      (reason) => reason.code === "iframe" || reason.code === "requestAnimationFrame",
+    ),
     reasons,
   };
 }

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -6,6 +6,7 @@ import type { EngineConfig } from "@hyperframes/engine";
 import type { CompiledComposition } from "./htmlCompiler.js";
 
 import {
+  applyAutoWorkerCompatibilityHints,
   applyRenderModeHints,
   extractStandaloneEntryFromIndex,
   writeCompiledArtifacts,
@@ -242,5 +243,87 @@ describe("applyRenderModeHints", () => {
     applyRenderModeHints(cfg, compiled, log);
 
     expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyAutoWorkerCompatibilityHints", () => {
+  function createCompiledComposition(
+    reasonCodes: Array<"iframe" | "requestAnimationFrame">,
+  ): CompiledComposition {
+    return {
+      html: "<html></html>",
+      subCompositions: new Map(),
+      videos: [],
+      audios: [],
+      unresolvedCompositions: [],
+      externalAssets: new Map(),
+      width: 1920,
+      height: 1080,
+      staticDuration: 5,
+      renderModeHints: {
+        recommendScreenshot: reasonCodes.length > 0,
+        reasons: reasonCodes.map((code) => ({
+          code,
+          message: `reason: ${code}`,
+        })),
+      },
+    };
+  }
+
+  it("caps auto workers for requestAnimationFrame screenshot-mode compositions", () => {
+    const log = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    const workers = applyAutoWorkerCompatibilityHints(
+      6,
+      { fps: 30, quality: "standard" },
+      createCompiledComposition(["requestAnimationFrame"]),
+      log,
+    );
+
+    expect(workers).toBe(2);
+    expect(log.info).toHaveBeenCalledOnce();
+  });
+
+  it("does not cap explicitly requested workers", () => {
+    const log = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    const workers = applyAutoWorkerCompatibilityHints(
+      6,
+      { fps: 30, quality: "standard", workers: 6 },
+      createCompiledComposition(["requestAnimationFrame"]),
+      log,
+    );
+
+    expect(workers).toBe(6);
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it("does not cap when compatibility hints are unrelated to requestAnimationFrame", () => {
+    const log = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    const workers = applyAutoWorkerCompatibilityHints(
+      6,
+      { fps: 30, quality: "standard" },
+      createCompiledComposition(["iframe"]),
+      log,
+    );
+
+    expect(workers).toBe(6);
+    expect(log.info).not.toHaveBeenCalled();
   });
 });

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -13,6 +13,31 @@ import {
 } from "./renderOrchestrator.js";
 import { toExternalAssetKey } from "../utils/paths.js";
 
+function createCompiledComposition(
+  reasonCodes: Array<"iframe" | "requestAnimationFrame" | "webgl">,
+): CompiledComposition {
+  return {
+    html: "<html></html>",
+    subCompositions: new Map(),
+    videos: [],
+    audios: [],
+    unresolvedCompositions: [],
+    externalAssets: new Map(),
+    width: 1920,
+    height: 1080,
+    staticDuration: 5,
+    renderModeHints: {
+      recommendScreenshot: reasonCodes.some(
+        (code) => code === "iframe" || code === "requestAnimationFrame",
+      ),
+      reasons: reasonCodes.map((code) => ({
+        code,
+        message: `reason: ${code}`,
+      })),
+    },
+  };
+}
+
 describe("extractStandaloneEntryFromIndex", () => {
   it("reuses the index wrapper and keeps only the requested composition host", () => {
     const indexHtml = `<!DOCTYPE html>
@@ -160,29 +185,6 @@ describe("writeCompiledArtifacts — external assets on Windows drive-letter pat
 });
 
 describe("applyRenderModeHints", () => {
-  function createCompiledComposition(
-    reasonCodes: Array<"iframe" | "requestAnimationFrame">,
-  ): CompiledComposition {
-    return {
-      html: "<html></html>",
-      subCompositions: new Map(),
-      videos: [],
-      audios: [],
-      unresolvedCompositions: [],
-      externalAssets: new Map(),
-      width: 1920,
-      height: 1080,
-      staticDuration: 5,
-      renderModeHints: {
-        recommendScreenshot: reasonCodes.length > 0,
-        reasons: reasonCodes.map((code) => ({
-          code,
-          message: `reason: ${code}`,
-        })),
-      },
-    };
-  }
-
   function createConfig(): EngineConfig {
     return {
       fps: 30,
@@ -247,29 +249,6 @@ describe("applyRenderModeHints", () => {
 });
 
 describe("applyAutoWorkerCompatibilityHints", () => {
-  function createCompiledComposition(
-    reasonCodes: Array<"iframe" | "requestAnimationFrame">,
-  ): CompiledComposition {
-    return {
-      html: "<html></html>",
-      subCompositions: new Map(),
-      videos: [],
-      audios: [],
-      unresolvedCompositions: [],
-      externalAssets: new Map(),
-      width: 1920,
-      height: 1080,
-      staticDuration: 5,
-      renderModeHints: {
-        recommendScreenshot: reasonCodes.length > 0,
-        reasons: reasonCodes.map((code) => ({
-          code,
-          message: `reason: ${code}`,
-        })),
-      },
-    };
-  }
-
   it("caps auto workers for requestAnimationFrame screenshot-mode compositions", () => {
     const log = {
       error: vi.fn(),
@@ -306,6 +285,25 @@ describe("applyAutoWorkerCompatibilityHints", () => {
 
     expect(workers).toBe(6);
     expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it("caps auto workers for detected WebGL-heavy compositions", () => {
+    const log = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    const workers = applyAutoWorkerCompatibilityHints(
+      6,
+      { fps: 30, quality: "standard" },
+      createCompiledComposition(["webgl"]),
+      log,
+    );
+
+    expect(workers).toBe(2);
+    expect(log.info).toHaveBeenCalledOnce();
   });
 
   it("does not cap when compatibility hints are unrelated to requestAnimationFrame", () => {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -396,6 +396,32 @@ export function applyRenderModeHints(
   });
 }
 
+const SCREENSHOT_MODE_AUTO_WORKER_CAP = 2;
+
+export function applyAutoWorkerCompatibilityHints(
+  workerCount: number,
+  config: RenderConfig,
+  compiled: CompiledComposition,
+  log: ProducerLogger = defaultLogger,
+): number {
+  if (config.workers !== undefined) return workerCount;
+
+  const hasRequestAnimationFrameHint = compiled.renderModeHints.reasons.some(
+    (reason) => reason.code === "requestAnimationFrame",
+  );
+  if (!hasRequestAnimationFrameHint || workerCount <= SCREENSHOT_MODE_AUTO_WORKER_CAP) {
+    return workerCount;
+  }
+
+  const reducedWorkerCount = SCREENSHOT_MODE_AUTO_WORKER_CAP;
+  log.info("Reduced auto worker count for screenshot-mode composition", {
+    from: workerCount,
+    to: reducedWorkerCount,
+    reasonCodes: compiled.renderModeHints.reasons.map((reason) => reason.code),
+  });
+  return reducedWorkerCount;
+}
+
 /**
  * Blit a single HDR video layer onto an rgb48le canvas.
  *
@@ -1172,7 +1198,12 @@ export async function executeRenderJob(
       quality: needsAlpha ? undefined : job.config.quality === "draft" ? 80 : 95,
     };
 
-    const workerCount = calculateOptimalWorkers(totalFrames, job.config.workers, cfg);
+    const workerCount = applyAutoWorkerCompatibilityHints(
+      calculateOptimalWorkers(totalFrames, job.config.workers, cfg),
+      job.config,
+      compiled,
+      log,
+    );
 
     const FORMAT_EXT: Record<string, string> = { mp4: ".mp4", webm: ".webm", mov: ".mov" };
     const videoExt = FORMAT_EXT[outputFormat] ?? ".mp4";
@@ -2359,7 +2390,8 @@ export async function executeRenderJob(
     if (isTimeoutError && wasParallel) {
       log.warn(
         `Parallel capture timed out with ${job.config.workers ?? "auto"} workers. ` +
-          `Video-heavy compositions often need sequential capture. Retry with --workers 1`,
+          `WebGL-heavy scenes often need lower parallelism. Retry with --workers 2 first; ` +
+          `video-heavy compositions with multiple active elements may still need --workers 1`,
       );
     }
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -396,7 +396,9 @@ export function applyRenderModeHints(
   });
 }
 
-const SCREENSHOT_MODE_AUTO_WORKER_CAP = 2;
+// Issue #410 reported that 2 workers stayed stable for GPU-heavy scenes where
+// the default auto heuristic chose 6 and hit Chrome compositor starvation.
+const WEBGL_AUTO_WORKER_CAP = 2;
 
 export function applyAutoWorkerCompatibilityHints(
   workerCount: number,
@@ -406,15 +408,15 @@ export function applyAutoWorkerCompatibilityHints(
 ): number {
   if (config.workers !== undefined) return workerCount;
 
-  const hasRequestAnimationFrameHint = compiled.renderModeHints.reasons.some(
-    (reason) => reason.code === "requestAnimationFrame",
+  const hasCompatibilityHint = compiled.renderModeHints.reasons.some(
+    (reason) => reason.code === "requestAnimationFrame" || reason.code === "webgl",
   );
-  if (!hasRequestAnimationFrameHint || workerCount <= SCREENSHOT_MODE_AUTO_WORKER_CAP) {
+  if (!hasCompatibilityHint || workerCount <= WEBGL_AUTO_WORKER_CAP) {
     return workerCount;
   }
 
-  const reducedWorkerCount = SCREENSHOT_MODE_AUTO_WORKER_CAP;
-  log.info("Reduced auto worker count for screenshot-mode composition", {
+  const reducedWorkerCount = WEBGL_AUTO_WORKER_CAP;
+  log.info("Reduced auto worker count for WebGL-heavy composition", {
     from: workerCount,
     to: reducedWorkerCount,
     reasonCodes: compiled.renderModeHints.reasons.map((reason) => reason.code),


### PR DESCRIPTION
## Summary
- preserve `--workers auto` through the CLI and Docker paths so the producer/container resolves worker count instead of the CLI forcing a CPU-only default
- broaden render compatibility hints so the producer detects WebGL/Three.js-heavy compositions in addition to raw inline `requestAnimationFrame`, then cap auto-selected workers at `2` for those GPU-heavy cases unless the user explicitly overrides workers
- update render guidance and timeout messaging for WebGL-heavy scenes, add comments/naming around the cap, and cover the CLI, compiler, and producer behavior with tests

Fixes #410

## Verification
- `bun run --filter @hyperframes/cli typecheck`
- `bun run --filter @hyperframes/producer typecheck`
- `bun run --filter @hyperframes/cli test src/utils/dockerRunArgs.test.ts`
- `bun test packages/producer/src/services/htmlCompiler.test.ts`
- `bunx vitest run packages/producer/src/services/renderOrchestrator.test.ts`
- `bunx oxlint packages/cli/src/commands/render.ts packages/cli/src/utils/dockerRunArgs.ts packages/cli/src/utils/dockerRunArgs.test.ts packages/cli/src/telemetry/events.ts packages/producer/src/services/htmlCompiler.ts packages/producer/src/services/htmlCompiler.test.ts packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/renderOrchestrator.test.ts`
- live render check with a temp `requestAnimationFrame` composition: `render --workers auto` logged reduction from `6` to `2` workers and captured at `2 workers`
- live render check with a temp WebGL canvas composition: compile metadata included `reasonCodes:["webgl"]`, then `render --workers auto` logged `Reduced auto worker count for WebGL-heavy composition {"from":6,"to":2}` and captured at `2 workers`
- browser verification with `agent-browser` against local studio preview at `http://localhost:5191/#project/demo`, including recording `/tmp/hf-410-vXuYvI/preview-pass.webm` and screenshot `/tmp/hf-410-vXuYvI/preview-shot.png`

## Notes
- `bun run packages/cli/src/cli.ts validate /tmp/hf-410-vXuYvI/demo` currently fails in this checkout with `Missing 'default' export in .../packages/cli/src/commands/contrast-audit.browser.js`; that appears unrelated to this patch and did not block the render/browser verification above.
