### PR TITLE
chore(ci): add Renovate config for grouped dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommits", ":dependencyDashboard"],
+  "schedule": ["before 6am on monday"],
+  "timezone": "America/Los_Angeles",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "dev dependencies (non-major)"
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "matchDepTypes": ["dependencies"],
+      "groupName": "prod patch updates"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "pinDigests": true
+    },
+    {
+      "matchPackagePatterns": ["^@hyperframes/"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a `.github/renovate.json` config for the [Renovate](https://docs.renovatebot.com/) GitHub App, which needs to be installed on the repo after this merges.

## Why

This monorepo currently has no dependency-update bot configured. Dependabot would create a separate PR per package per update (noisy for a workspace repo). Renovate supports grouping, batching, and lock-file maintenance across Bun workspaces, which scales better — it's what Vite/Vitest/Astro/Remotion all use for the same reason.

## How

`.github/renovate.json` uses:

- `config:recommended` + `:semanticCommits` + `:dependencyDashboard` as the base
- **Weekly schedule** (`before 6am on monday`, LA time) so updates land in one batch, not continuously
- **Grouping rules**:
  - Dev-dep minor/patch updates → one PR
  - Prod-dep patch updates → one PR
  - GitHub Actions → one PR, with digest pinning
  - Major updates → gated behind the Dependency Dashboard (require approval before opening a PR)
- **Workspace self-links** (`@hyperframes/*`) disabled — those are local workspace refs, not external deps
- **Lock-file maintenance** on the same weekly schedule to refresh `bun.lock`
- PR concurrency capped at 5, hourly limit 2

One follow-up step after this merges: install the Renovate GitHub App on `heygen-com/hyperframes` from https://github.com/apps/renovate. Renovate will open an onboarding PR against `main` confirming the config.

## Test plan

- [ ] JSON validates against the Renovate schema (linked in `$schema`)
- [ ] Manual testing performed — the config follows standard Renovate preset syntax; the actual validation happens when Renovate runs against it post-install
- [ ] Documentation updated (if applicable) — N/A