### PR TITLE
docs(compositions): remove Variables section referencing unshipped syntax

### DIFF
--- a/docs/concepts/compositions.mdx
+++ b/docs/concepts/compositions.mdx
@@ -125,16 +125,6 @@ Every composition has two layers:
   Never use scripts to play/pause/seek media elements or to show/hide clips based on timing. The framework handles this automatically from data attributes. Scripts that duplicate this behavior will conflict with the framework. See [Common Mistakes](/guides/common-mistakes) for examples.
 </Warning>
 
-## Variables
-
-Compositions can expose variables for dynamic content:
-
-```html compositions/card.html
-<div data-composition-id="card" data-var-title="string" data-var-color="color">
-```
-
-Variables make compositions reusable as [examples](/examples) -- the same composition can render different content by injecting variable values at render time.
-
 ## Listing Compositions
 
 Use the [CLI](/packages/cli) to see all compositions in a project:


### PR DESCRIPTION
## What

Removes the **Variables** section from `docs/concepts/compositions.mdx` (lines 128–136 on main).

## Why

Reported in #416. The docs example shows a syntax that doesn't exist:

```html
<div data-composition-id="card" data-var-title="string" data-var-color="color">
```

Grep confirms `data-var-` appears only in that one docs snippet (and its bundled copy at `packages/cli/dist/docs/compositions.md`). The parser and generator don't read per-attribute `data-var-<name>` at all — they read `data-composition-variables` (schema JSON on `<html>`) and `data-variable-values` (instance JSON on the composition element).

Beyond the wrong attribute name, the variable system isn't really author-facing yet:

- No Studio UI for editing or surfacing declared variables
- No example composition in the repo uses variables
- No runtime helper or documented consumer pattern — an author would have to manually read `URLSearchParams(location.search)` inside their composition script (the generator encodes values as iframe query-string params), and nothing in the docs says so

So the section was actively misleading — it advertised a reusability feature with a syntax that isn't wired up and a consumer story that isn't documented.

## How

Deleted the `## Variables` heading and its three content lines. No other docs referenced the removed section (grepped for `#variables` anchors; none exist), so no dangling links.

The underlying parser/generator support (`extractCompositionMetadata`, `data-variable-values` serialization) stays in place and can be re-documented once there is a real author-facing surface — Studio UI + consumer helper + example composition.

## Test plan

- [ ] Unit tests added/updated — N/A (docs-only)
- [x] Manual testing performed — grepped `docs/` for broken anchor refs to the removed section; none found
- [x] Documentation updated (if applicable) — this PR is the doc update

Closes #416