### PR TITLE
docs(readme): note git-lfs requirement for full clones

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,9 +36,7 @@
     },
     {
       "enabled": false,
-      "matchPackageNames": [
-        "/^@hyperframes//"
-      ]
+      "matchPackageNames": ["/^@hyperframes//"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ brew install git-lfs
 # Ubuntu/Debian
 sudo apt install git-lfs
 
+# Windows
+winget install GitHub.GitLFS
+# (or install Git for Windows, which bundles Git LFS as an optional component)
+
 # Then (once, per machine)
 git lfs install
 ```

--- a/README.md
+++ b/README.md
@@ -191,6 +191,27 @@ npx skills add heygen-com/hyperframes
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+### Cloning the repo
+
+The repo uses [Git LFS](https://git-lfs.com) for golden regression-test baselines under `packages/producer/tests/**/output.mp4` (~240 MB of `.mp4` files). If you're cloning the full repo for development, install Git LFS first:
+
+```bash
+# macOS
+brew install git-lfs
+
+# Ubuntu/Debian
+sudo apt install git-lfs
+
+# Then (once, per machine)
+git lfs install
+```
+
+If you hit `git-lfs filter-process: command not found` during `git clone` or `npx skills add heygen-com/hyperframes`, install Git LFS and retry. You can also skip LFS content if you only need the source files:
+
+```bash
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/heygen-com/hyperframes.git
+```
+
 ## License
 
 [Apache 2.0](LICENSE)


### PR DESCRIPTION
## What

Adds a "Cloning the repo" subsection under Contributing in the README, explaining the Git LFS requirement and the `GIT_LFS_SKIP_SMUDGE=1` workaround.

## Why

Reported in #407. The repo uses Git LFS for ~240 MB of regression-test baselines under `packages/producer/tests/**/output.mp4`. Users cloning without `git-lfs` installed hit a cryptic error:

```
git-lfs filter-process: git-lfs: command not found
fatal: the remote end hung up unexpectedly
warning: Clone succeeded, but checkout failed.
```

The `skills add heygen-com/hyperframes` install path hits the same wall, because that command does a full clone under the hood.

Note: a proper code-level fix for the `skills` CLI is in progress upstream — this README note covers direct-clone contributors and anyone on a `skills` version that doesn't yet ship that fix.

## How

Added a short subsection with:
- Explanation of why LFS is used here (regression baselines)
- Install commands for macOS (`brew`) and Debian/Ubuntu (`apt`)
- The `GIT_LFS_SKIP_SMUDGE=1 git clone` escape hatch for users who only need the source files

## Test plan

- [ ] Unit tests added/updated — N/A (docs-only)
- [x] Manual testing performed — verified `GIT_LFS_SKIP_SMUDGE=1 git clone` succeeds and leaves LFS files as pointer files, which is the expected behavior for anyone not running the regression suite
- [x] Documentation updated (if applicable) — this PR is the doc update

Refs #407