### PR TITLE
feat: use @pierre/trees for Studio file tree

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.4.11",
+      "version": "0.4.13-alpha.4",
       "bin": {
         "hyperframes": "./dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.4.11",
+      "version": "0.4.13-alpha.4",
       "dependencies": {
         "@chenglou/pretext": "^0.0.5",
       },
@@ -88,7 +88,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.4.11",
+      "version": "0.4.13-alpha.4",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
         "@hyperframes/core": "workspace:^",
@@ -106,7 +106,7 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.4.11",
+      "version": "0.4.13-alpha.4",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -115,7 +115,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.4.11",
+      "version": "0.4.13-alpha.4",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -154,7 +154,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.4.11",
+      "version": "0.4.13-alpha.4",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -166,7 +166,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.4.11",
+      "version": "0.4.13-alpha.4",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
@@ -181,6 +181,7 @@
         "@hyperframes/core": "workspace:*",
         "@hyperframes/player": "workspace:*",
         "@phosphor-icons/react": "^2.1.10",
+        "@pierre/trees": "^1.0.0-beta.3",
         "codemirror": "^6.0.1",
         "motion": "^12.38.0",
       },
@@ -645,6 +646,8 @@
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ=="],
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": "18.3.1", "react-dom": "18.3.1" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
+
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.3", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -1333,6 +1336,10 @@
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "3.0.0", "util-deprecate": "1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -39,6 +39,7 @@
     "@hyperframes/core": "workspace:*",
     "@hyperframes/player": "workspace:*",
     "@phosphor-icons/react": "^2.1.10",
+    "@pierre/trees": "^1.0.0-beta.3",
     "codemirror": "^6.0.1",
     "motion": "^12.38.0"
   },

--- a/packages/studio/src/components/editor/FileTree.test.ts
+++ b/packages/studio/src/components/editor/FileTree.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMoveDestinationPath,
+  buildStudioTreePaths,
+  createPlaceholderPath,
+  getDropPathData,
+  isPendingCreateCleared,
+} from "./FileTree";
+
+describe("buildStudioTreePaths", () => {
+  it("converts .gitkeep placeholders into visible folders", () => {
+    expect(
+      new Set(
+        buildStudioTreePaths([
+          "index.html",
+          "assets/.gitkeep",
+          "nested/empty/.gitkeep",
+          "src/main.ts",
+        ]),
+      ),
+    ).toEqual(new Set(["index.html", "assets/", "nested/empty/", "src/main.ts"]));
+  });
+
+  it("deduplicates repeated paths", () => {
+    expect(buildStudioTreePaths(["assets/.gitkeep", "assets/.gitkeep", "assets/logo.png"])).toEqual(
+      ["assets/", "assets/logo.png"],
+    );
+  });
+});
+
+describe("createPlaceholderPath", () => {
+  it("creates unique file placeholders inside a folder", () => {
+    expect(createPlaceholderPath(["src/untitled", "src/untitled-2"], "src", "file")).toBe(
+      "src/untitled-3",
+    );
+  });
+
+  it("creates unique folder placeholders at the root", () => {
+    expect(createPlaceholderPath(["new-folder/", "new-folder-2/"], "", "folder")).toBe(
+      "new-folder-3/",
+    );
+  });
+});
+
+describe("getDropPathData", () => {
+  it("uses the hovered folder path", () => {
+    expect(
+      getDropPathData([
+        { itemPath: "src/", itemType: "folder" },
+        { itemPath: "src/index.ts", itemType: "file" },
+      ]),
+    ).toBe("src/");
+  });
+
+  it("falls back to a file parent path", () => {
+    expect(
+      getDropPathData([{ itemParentPath: "src/", itemPath: "src/index.ts", itemType: "file" }]),
+    ).toBe("src/");
+  });
+
+  it("falls back to the root when there is no row target", () => {
+    expect(getDropPathData([])).toBe("");
+  });
+});
+
+describe("buildMoveDestinationPath", () => {
+  it("builds a root move destination", () => {
+    expect(buildMoveDestinationPath("src/index.ts", null)).toBe("index.ts");
+  });
+
+  it("builds a folder move destination for files and folders", () => {
+    expect(buildMoveDestinationPath("src/index.ts", "assets/")).toBe("assets/index.ts");
+    expect(buildMoveDestinationPath("src/components/", "assets/")).toBe("assets/components");
+  });
+});
+
+describe("isPendingCreateCleared", () => {
+  it("keeps pending creates alive across rename moves", () => {
+    expect(
+      isPendingCreateCleared(
+        { operation: "move", from: "untitled", to: "record-note.html" },
+        "untitled",
+      ),
+    ).toBe(false);
+  });
+
+  it("clears pending creates when the placeholder is removed", () => {
+    expect(isPendingCreateCleared({ operation: "remove", path: "untitled" }, "untitled")).toBe(
+      true,
+    );
+  });
+
+  it("clears pending creates on model reset", () => {
+    expect(isPendingCreateCleared({ operation: "reset" }, "untitled")).toBe(true);
+  });
+});

--- a/packages/studio/src/components/editor/FileTree.tsx
+++ b/packages/studio/src/components/editor/FileTree.tsx
@@ -1,418 +1,426 @@
-import { memo, useState, useCallback, useMemo, useRef, useEffect } from "react";
 import {
-  FileHtml,
-  FileCss,
-  FileJs,
-  FileJsx,
-  FileTs,
-  FileTsx,
-  FileTxt,
-  FileMd,
-  FileSvg,
-  FilePng,
-  FileJpg,
-  FileVideo,
-  FileCode,
-  File,
-  Waveform,
-  TextAa,
-  Image as PhImage,
-  PencilSimple,
-  Copy,
-  Trash,
-  Plus,
-  FolderSimplePlus,
-  FilePlus,
-  FolderSimple,
-} from "@phosphor-icons/react";
-import { ChevronDown, ChevronRight } from "../../icons/SystemIcons";
+  FILE_TREE_TAG_NAME,
+  type ContextMenuItem,
+  type ContextMenuOpenContext,
+  type FileTreeDirectoryHandle,
+  type FileTreeItemHandle,
+  type FileTree as PierreTreeModel,
+  type FileTreeMutationEvent,
+  type FileTreeSortComparator,
+} from "@pierre/trees";
+import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
+import { Copy, FilePlus, FolderSimplePlus, PencilSimple, Plus, Trash } from "@phosphor-icons/react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
-// ── Types ──
+type FileTreeActionResult = void | Promise<void>;
 
 export interface FileTreeProps {
   files: string[];
   activeFile: string | null;
   onSelectFile: (path: string) => void;
-  onCreateFile?: (path: string) => void;
-  onCreateFolder?: (path: string) => void;
-  onDeleteFile?: (path: string) => void;
-  onRenameFile?: (oldPath: string, newPath: string) => void;
-  onDuplicateFile?: (path: string) => void;
-  onMoveFile?: (oldPath: string, newPath: string) => void;
-  onImportFiles?: (files: FileList, dir?: string) => void;
+  onCreateFile?: (path: string) => FileTreeActionResult;
+  onCreateFolder?: (path: string) => FileTreeActionResult;
+  onDeleteFile?: (path: string) => FileTreeActionResult;
+  onRenameFile?: (oldPath: string, newPath: string) => FileTreeActionResult;
+  onDuplicateFile?: (path: string) => FileTreeActionResult;
+  onMoveFile?: (oldPath: string, newPath: string) => FileTreeActionResult;
+  onImportFiles?: (files: FileList, dir?: string) => FileTreeActionResult;
 }
 
-interface TreeNode {
+interface DeleteConfirmProps {
   name: string;
-  fullPath: string;
-  children: Map<string, TreeNode>;
-  isFile: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
 }
 
-interface ContextMenuState {
+interface RootContextMenuState {
   x: number;
   y: number;
-  targetPath: string;
-  targetIsFolder: boolean;
 }
 
-interface InlineInputState {
-  /** Parent folder path (empty string for root) */
-  parentPath: string;
-  /** "file" or "folder" creation, or "rename" */
-  mode: "new-file" | "new-folder" | "rename";
-  /** For rename mode, the original full path */
-  originalPath?: string;
-  /** For rename mode, the original name */
-  originalName?: string;
-  onCommit?: (name: string) => void;
-  onCancel?: () => void;
+interface TreeActionMenuProps {
+  item?: ContextMenuItem;
+  onNewFile?: () => void;
+  onNewFolder?: () => void;
+  onRename?: () => void;
+  onDuplicate?: () => void;
+  onDelete?: () => void;
 }
 
-// ── Constants ──
-
-const SZ = 14;
-const W = "duotone" as const;
-
-// ── FileIcon ──
-
-function FileIcon({ path }: { path: string }) {
-  const ext = path.split(".").pop()?.toLowerCase() ?? "";
-  const c = "flex-shrink-0";
-  if (ext === "html") return <FileHtml size={SZ} weight={W} color="#E44D26" className={c} />;
-  if (ext === "css") return <FileCss size={SZ} weight={W} color="#264DE4" className={c} />;
-  if (ext === "js" || ext === "mjs" || ext === "cjs")
-    return <FileJs size={SZ} weight={W} color="#F0DB4F" className={c} />;
-  if (ext === "jsx") return <FileJsx size={SZ} weight={W} color="#61DAFB" className={c} />;
-  if (ext === "ts" || ext === "mts")
-    return <FileTs size={SZ} weight={W} color="#3178C6" className={c} />;
-  if (ext === "tsx") return <FileTsx size={SZ} weight={W} color="#3178C6" className={c} />;
-  if (ext === "json") return <FileCode size={SZ} weight={W} color="#4ADE80" className={c} />;
-  if (ext === "svg") return <FileSvg size={SZ} weight={W} color="#F97316" className={c} />;
-  if (ext === "md" || ext === "mdx")
-    return <FileMd size={SZ} weight={W} color="#9CA3AF" className={c} />;
-  if (ext === "txt") return <FileTxt size={SZ} weight={W} color="#9CA3AF" className={c} />;
-  if (ext === "png") return <FilePng size={SZ} weight={W} color="#22C55E" className={c} />;
-  if (ext === "jpg" || ext === "jpeg")
-    return <FileJpg size={SZ} weight={W} color="#22C55E" className={c} />;
-  if (ext === "webp" || ext === "gif" || ext === "ico")
-    return <PhImage size={SZ} weight={W} color="#22C55E" className={c} />;
-  if (ext === "mp4" || ext === "webm" || ext === "mov")
-    return <FileVideo size={SZ} weight={W} color="#A855F7" className={c} />;
-  if (ext === "mp3" || ext === "wav" || ext === "ogg" || ext === "m4a")
-    return <Waveform size={SZ} weight={W} color="#3CE6AC" className={c} />;
-  if (ext === "woff" || ext === "woff2" || ext === "ttf" || ext === "otf")
-    return <TextAa size={SZ} weight={W} color="#6B7280" className={c} />;
-  return <File size={SZ} weight={W} color="#6B7280" className={c} />;
+interface RootContextMenuProps extends RootContextMenuState {
+  onClose: () => void;
+  onNewFile?: () => void;
+  onNewFolder?: () => void;
 }
 
-// ── Tree Helpers ──
+interface PendingCreateState {
+  kind: "file" | "folder";
+  placeholderPath: string;
+}
 
-function buildTree(files: string[]): TreeNode {
-  const root: TreeNode = { name: "", fullPath: "", children: new Map(), isFile: false };
+interface DropPathData {
+  itemParentPath?: string;
+  itemPath?: string;
+  itemType?: string;
+}
+
+const TREE_HOST_STYLE = {
+  "--trees-accent-override": "#3CE6AC",
+  "--trees-bg-override": "#0a0a0a",
+  "--trees-bg-muted-override": "rgba(38, 38, 38, 0.7)",
+  "--trees-border-color-override": "rgba(38, 38, 38, 0.8)",
+  "--trees-fg-override": "#a3a3a3",
+  "--trees-fg-muted-override": "#737373",
+  "--trees-font-family-override": "inherit",
+  "--trees-font-size-override": "12px",
+  "--trees-item-margin-x-override": "0px",
+  "--trees-item-padding-x-override": "8px",
+  "--trees-item-row-gap-override": "6px",
+  "--trees-level-gap-override": "8px",
+  "--trees-padding-inline-override": "8px",
+  "--trees-search-bg-override": "#171717",
+  "--trees-search-fg-override": "#d4d4d8",
+  "--trees-selected-bg-override": "rgba(60, 230, 172, 0.12)",
+  "--trees-selected-fg-override": "#e5e7eb",
+  "--trees-selected-focused-border-color-override": "rgba(60, 230, 172, 0.45)",
+  height: "100%",
+} as CSSProperties;
+
+const TREE_UNSAFE_CSS = `
+  [data-studio-external-drag-target='true'] {
+    background-color: var(--trees-selected-bg);
+  }
+`;
+
+const compareStudioTreeEntries: FileTreeSortComparator = (left, right) => {
+  if (left.basename === "index.html" && right.basename !== "index.html") return -1;
+  if (right.basename === "index.html" && left.basename !== "index.html") return 1;
+  if (left.isDirectory !== right.isDirectory) return left.isDirectory ? -1 : 1;
+  return left.path.localeCompare(right.path, undefined, { numeric: true });
+};
+
+function isCanonicalDirectoryPath(path: string): boolean {
+  return path.endsWith("/");
+}
+
+function toCanonicalDirectoryPath(path: string): string {
+  return isCanonicalDirectoryPath(path) ? path : `${path}/`;
+}
+
+function toPublicPath(path: string): string {
+  return isCanonicalDirectoryPath(path) ? path.slice(0, -1) : path;
+}
+
+function getPathBasename(path: string): string {
+  const normalized = toPublicPath(path);
+  const index = normalized.lastIndexOf("/");
+  return index >= 0 ? normalized.slice(index + 1) : normalized;
+}
+
+function getCanonicalParentDirectoryPath(path: string): string | null {
+  const normalized = toPublicPath(path);
+  const index = normalized.lastIndexOf("/");
+  if (index < 0) return null;
+  return `${normalized.slice(0, index + 1)}`;
+}
+
+function getAncestorDirectoryPaths(path: string): string[] {
+  const normalized = toPublicPath(path);
+  if (!normalized) return [];
+  const segments = normalized.split("/");
+  return segments.slice(0, -1).map((_, index) => `${segments.slice(0, index + 1).join("/")}/`);
+}
+
+function buildStudioTreePaths(files: string[]): string[] {
+  const deduped = new Set<string>();
   for (const file of files) {
-    const parts = file.split("/");
-    let current = root;
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      const isLast = i === parts.length - 1;
-      const fullPath = parts.slice(0, i + 1).join("/");
-      if (!current.children.has(part)) {
-        current.children.set(part, {
-          name: part,
-          fullPath,
-          children: new Map(),
-          isFile: isLast,
-        });
-      }
-      current = current.children.get(part)!;
-      if (isLast) current.isFile = true;
+    if (file.endsWith("/.gitkeep")) {
+      const folderPath = file.slice(0, -"/.gitkeep".length);
+      if (folderPath) deduped.add(toCanonicalDirectoryPath(folderPath));
+      continue;
     }
+    deduped.add(file);
   }
-  return root;
+  return Array.from(deduped);
 }
 
-function sortChildren(children: Map<string, TreeNode>): TreeNode[] {
-  return Array.from(children.values()).sort((a, b) => {
-    // index.html always first
-    if (a.name === "index.html") return -1;
-    if (b.name === "index.html") return 1;
-    // Directories before files
-    if (!a.isFile && b.isFile) return -1;
-    if (a.isFile && !b.isFile) return 1;
-    return a.name.localeCompare(b.name);
-  });
+function createPlaceholderPath(
+  existingPaths: readonly string[],
+  parentPath: string,
+  kind: PendingCreateState["kind"],
+): string {
+  const existing = new Set(existingPaths);
+  const prefix = parentPath ? `${parentPath}/` : "";
+  const stem = kind === "folder" ? "new-folder" : "untitled";
+  let counter = 1;
+
+  while (true) {
+    const suffix = counter === 1 ? stem : `${stem}-${counter}`;
+    const nextPath = `${prefix}${suffix}`;
+    const candidate = kind === "folder" ? toCanonicalDirectoryPath(nextPath) : nextPath;
+    if (!existing.has(candidate)) return candidate;
+    counter += 1;
+  }
 }
 
-function isActiveInSubtree(node: TreeNode, activeFile: string | null): boolean {
-  if (!activeFile) return false;
-  if (node.fullPath === activeFile) return true;
-  for (const child of node.children.values()) {
-    if (isActiveInSubtree(child, activeFile)) return true;
+function buildMoveDestinationPath(sourcePath: string, targetDirectoryPath: string | null): string {
+  const baseName = getPathBasename(sourcePath);
+  const parentPath = targetDirectoryPath ? toPublicPath(targetDirectoryPath) : "";
+  return parentPath ? `${parentPath}/${baseName}` : baseName;
+}
+
+function getHostElement(root: HTMLElement | null): HTMLElement | null {
+  return root?.querySelector<HTMLElement>(FILE_TREE_TAG_NAME) ?? null;
+}
+
+function collectExpandedPaths(host: HTMLElement | null): string[] {
+  if (!host?.shadowRoot) return [];
+  return Array.from(
+    host.shadowRoot.querySelectorAll<HTMLElement>(
+      '[data-type="item"][data-item-type="folder"][aria-expanded="true"]',
+    ),
+  )
+    .map((element) => element.dataset.itemPath ?? "")
+    .filter((path) => path.length > 0);
+}
+
+function getDropPathData(elements: readonly DropPathData[]): string {
+  for (const element of elements) {
+    if (!element.itemPath) continue;
+    if (element.itemType === "folder") return element.itemPath;
+    if (element.itemParentPath) return element.itemParentPath;
+    return "";
   }
+  return "";
+}
+
+function resolveImportTargetPath(event: DragEvent): string {
+  const pathData: DropPathData[] = [];
+  for (const entry of event.composedPath()) {
+    if (!(entry instanceof HTMLElement)) continue;
+    pathData.push({
+      itemParentPath: entry.dataset.itemParentPath,
+      itemPath: entry.dataset.itemPath,
+      itemType: entry.dataset.itemType,
+    });
+  }
+  return getDropPathData(pathData);
+}
+
+function hasExternalFiles(dataTransfer: DataTransfer | null): boolean {
+  if (!dataTransfer) return false;
+  return Array.from(dataTransfer.items).some((item) => item.kind === "file");
+}
+
+function escapeAttributeValue(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replace(/["\\]/g, "\\$&");
+}
+
+function isDirectoryHandle(item: FileTreeItemHandle | null): item is FileTreeDirectoryHandle {
+  return item?.isDirectory() === true;
+}
+
+function renderMountedTree(model: PierreTreeModel, host: HTMLElement | null) {
+  if (!host) return;
+  model.render({ fileTreeContainer: host });
+}
+
+function syncSelection(model: PierreTreeModel, activeFile: string | null) {
+  const selectedPaths = model.getSelectedPaths();
+  if (!activeFile) {
+    for (const path of selectedPaths) {
+      model.getItem(path)?.deselect();
+    }
+    return;
+  }
+
+  const target = model.getItem(activeFile);
+  if (!target) return;
+
+  for (const ancestorPath of getAncestorDirectoryPaths(activeFile)) {
+    const ancestor = model.getItem(ancestorPath);
+    if (isDirectoryHandle(ancestor)) ancestor.expand();
+  }
+
+  const focusedPath = model.getFocusedPath();
+  if (selectedPaths.length === 1 && selectedPaths[0] === activeFile && focusedPath === activeFile) {
+    return;
+  }
+
+  for (const path of selectedPaths) {
+    if (path !== activeFile) model.getItem(path)?.deselect();
+  }
+
+  target.select();
+  model.focusPath(activeFile);
+}
+
+function isPendingCreateCleared(event: FileTreeMutationEvent, pendingPath: string): boolean {
+  if (event.operation === "remove") return event.path === pendingPath;
+  if (event.operation === "batch")
+    return event.events.some((entry) => isPendingCreateCleared(entry, pendingPath));
+  if (event.operation === "reset") return true;
   return false;
 }
 
-// ── Context Menu Component ──
-
-function ContextMenu({
-  state,
-  onClose,
+function TreeActionMenu({
+  item,
   onNewFile,
   onNewFolder,
   onRename,
   onDuplicate,
   onDelete,
-}: {
-  state: ContextMenuState;
-  onClose: () => void;
-  onNewFile: (parentPath: string) => void;
-  onNewFolder: (parentPath: string) => void;
-  onRename: (path: string) => void;
-  onDuplicate: (path: string) => void;
-  onDelete: (path: string) => void;
-}) {
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  // eslint-disable-next-line no-restricted-syntax
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [onClose]);
-
-  // Adjust position so menu doesn't overflow viewport
-  const adjustedX = Math.min(state.x, window.innerWidth - 180);
-  const adjustedY = Math.min(state.y, window.innerHeight - 200);
-
-  const parentPath = state.targetIsFolder
-    ? state.targetPath
-    : state.targetPath.includes("/")
-      ? state.targetPath.slice(0, state.targetPath.lastIndexOf("/"))
-      : "";
+}: TreeActionMenuProps) {
+  const isFolder = item?.kind === "directory";
+  const canCreateFolder = item == null || isFolder;
 
   return (
-    <div
-      ref={menuRef}
-      className="fixed z-50 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[160px]"
-      style={{ left: adjustedX, top: adjustedY }}
-    >
-      {state.targetIsFolder && (
+    <div className="min-w-[168px] rounded-md border border-neutral-700 bg-neutral-900 py-1 shadow-lg">
+      {(onNewFile || onNewFolder) && (
         <>
-          <button
-            className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800 cursor-pointer text-left"
-            onClick={() => {
-              onNewFile(state.targetPath);
-              onClose();
-            }}
-          >
-            <FilePlus size={12} weight="duotone" className="text-neutral-500" />
-            New File
-          </button>
-          <button
-            className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800 cursor-pointer text-left"
-            onClick={() => {
-              onNewFolder(state.targetPath);
-              onClose();
-            }}
-          >
-            <FolderSimplePlus size={12} weight="duotone" className="text-neutral-500" />
-            New Folder
-          </button>
-          <div className="border-t border-neutral-700 my-1" />
+          {onNewFile && (
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs text-neutral-300 hover:bg-neutral-800"
+              onClick={onNewFile}
+            >
+              <FilePlus size={12} weight="duotone" className="text-neutral-500" />
+              New File
+            </button>
+          )}
+          {canCreateFolder && onNewFolder && (
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs text-neutral-300 hover:bg-neutral-800"
+              onClick={onNewFolder}
+            >
+              <FolderSimplePlus size={12} weight="duotone" className="text-neutral-500" />
+              New Folder
+            </button>
+          )}
+          {(onRename || onDuplicate || onDelete) && (
+            <div className="my-1 border-t border-neutral-700" />
+          )}
         </>
       )}
-      {!state.targetIsFolder && (
-        <>
-          <button
-            className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800 cursor-pointer text-left"
-            onClick={() => {
-              onNewFile(parentPath);
-              onClose();
-            }}
-          >
-            <FilePlus size={12} weight="duotone" className="text-neutral-500" />
-            New File
-          </button>
-          <div className="border-t border-neutral-700 my-1" />
-        </>
-      )}
-      <button
-        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800 cursor-pointer text-left"
-        onClick={() => {
-          onRename(state.targetPath);
-          onClose();
-        }}
-      >
-        <PencilSimple size={12} weight="duotone" className="text-neutral-500" />
-        Rename
-      </button>
-      {!state.targetIsFolder && (
+
+      {onRename && (
         <button
-          className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800 cursor-pointer text-left"
-          onClick={() => {
-            onDuplicate(state.targetPath);
-            onClose();
-          }}
+          type="button"
+          className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs text-neutral-300 hover:bg-neutral-800"
+          onClick={onRename}
+        >
+          <PencilSimple size={12} weight="duotone" className="text-neutral-500" />
+          Rename
+        </button>
+      )}
+
+      {!isFolder && onDuplicate && (
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs text-neutral-300 hover:bg-neutral-800"
+          onClick={onDuplicate}
         >
           <Copy size={12} weight="duotone" className="text-neutral-500" />
           Duplicate
         </button>
       )}
-      <div className="border-t border-neutral-700 my-1" />
-      <button
-        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/30 cursor-pointer text-left"
-        onClick={() => {
-          onDelete(state.targetPath);
-          onClose();
-        }}
-      >
-        <Trash size={12} weight="duotone" />
-        Delete
-      </button>
+
+      {onDelete && (
+        <>
+          {(onRename || onDuplicate) && <div className="my-1 border-t border-neutral-700" />}
+          <button
+            type="button"
+            className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs text-red-400 hover:bg-red-900/30"
+            onClick={onDelete}
+          >
+            <Trash size={12} weight="duotone" />
+            Delete
+          </button>
+        </>
+      )}
     </div>
   );
 }
 
-// ── Inline Input (for new file/folder/rename) ──
+function RootContextMenu({ x, y, onClose, onNewFile, onNewFolder }: RootContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
 
-function InlineInput({
-  defaultValue,
-  depth,
-  isFolder,
-  onCommit,
-  onCancel,
-}: {
-  defaultValue: string;
-  depth: number;
-  isFolder: boolean;
-  onCommit: (value: string) => void;
-  onCancel: () => void;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const committedRef = useRef(false);
-  const [value, setValue] = useState(defaultValue);
-
-  // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
-    const el = inputRef.current;
-    if (!el) return;
-    el.focus();
-    // Select just the filename (not extension) for rename
-    if (defaultValue && defaultValue.includes(".")) {
-      const dotIdx = defaultValue.lastIndexOf(".");
-      el.setSelectionRange(0, dotIdx);
-    } else {
-      el.select();
-    }
-  }, [defaultValue]);
+    const handlePointerDown = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
 
-  const commit = (name: string) => {
-    if (committedRef.current) return;
-    committedRef.current = true;
-    onCommit(name);
-  };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      const trimmed = value.trim();
-      if (trimmed && !(/[/\\]/.test(trimmed) || trimmed.includes(".."))) commit(trimmed);
-      else onCancel();
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      onCancel();
-    }
-  };
-
-  const handleBlur = () => {
-    const trimmed = value.trim();
-    if (trimmed && trimmed !== defaultValue && !(/[/\\]/.test(trimmed) || trimmed.includes("..")))
-      commit(trimmed);
-    else onCancel();
-  };
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onClose]);
 
   return (
     <div
-      className="flex items-center gap-2 py-0.5 min-h-7"
-      style={{ paddingLeft: `${8 + depth * 12 + (isFolder ? 0 : 14)}px` }}
+      ref={menuRef}
+      className="fixed z-50"
+      style={{
+        left: Math.min(x, window.innerWidth - 180),
+        top: Math.min(y, window.innerHeight - 120),
+      }}
     >
-      {isFolder ? (
-        <FolderSimple size={SZ} weight="duotone" color="#6B7280" className="flex-shrink-0" />
-      ) : (
-        <FileIcon path={value} />
-      )}
-      <input
-        ref={inputRef}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onBlur={handleBlur}
-        className="flex-1 min-w-0 bg-neutral-800 text-neutral-200 text-xs px-1.5 py-0.5 rounded border border-neutral-600 outline-none focus:border-[#3CE6AC]"
-        spellCheck={false}
-      />
+      <TreeActionMenu onNewFile={onNewFile} onNewFolder={onNewFolder} />
     </div>
   );
 }
 
-// ── Delete Confirmation ──
-
-function DeleteConfirm({
-  name,
-  onConfirm,
-  onCancel,
-}: {
-  name: string;
-  onConfirm: () => void;
-  onCancel: () => void;
-}) {
+function DeleteConfirm({ name, onConfirm, onCancel }: DeleteConfirmProps) {
   const ref = useRef<HTMLDivElement>(null);
 
-  // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onCancel();
     };
-    const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onCancel();
+    const handlePointerDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) onCancel();
     };
+
     document.addEventListener("keydown", handleEscape);
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("mousedown", handlePointerDown);
     return () => {
       document.removeEventListener("keydown", handleEscape);
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("mousedown", handlePointerDown);
     };
   }, [onCancel]);
 
   return (
     <div
       ref={ref}
-      className="mx-1 my-0.5 p-2 bg-neutral-800 border border-neutral-700 rounded-md text-xs"
+      className="mx-1 my-0.5 rounded-md border border-neutral-700 bg-neutral-800 p-2 text-xs"
     >
-      <p className="text-neutral-300 mb-2">
+      <p className="mb-2 text-neutral-300">
         Delete <span className="font-medium text-neutral-100">{name}</span>?
       </p>
       <div className="flex gap-1.5">
         <button
+          type="button"
           onClick={onCancel}
-          className="flex-1 px-2 py-1 rounded bg-neutral-700 text-neutral-300 hover:bg-neutral-600 transition-colors"
+          className="flex-1 rounded bg-neutral-700 px-2 py-1 text-neutral-300 transition-colors hover:bg-neutral-600"
         >
           Cancel
         </button>
         <button
+          type="button"
           onClick={onConfirm}
-          className="flex-1 px-2 py-1 rounded bg-red-900/60 text-red-300 hover:bg-red-800/60 transition-colors"
+          className="flex-1 rounded bg-red-900/60 px-2 py-1 text-red-300 transition-colors hover:bg-red-800/60"
         >
           Delete
         </button>
@@ -420,216 +428,6 @@ function DeleteConfirm({
     </div>
   );
 }
-
-// ── TreeFolder ──
-
-function TreeFolder({
-  node,
-  depth,
-  activeFile,
-  onSelectFile,
-  defaultOpen,
-  onContextMenu,
-  inlineInput,
-  onDragStart,
-  onDragOver,
-  onDrop,
-  onDragLeave,
-  dragOverFolder,
-}: {
-  node: TreeNode;
-  depth: number;
-  activeFile: string | null;
-  onSelectFile: (path: string) => void;
-  defaultOpen: boolean;
-  onContextMenu: (e: React.MouseEvent, path: string, isFolder: boolean) => void;
-  inlineInput: InlineInputState | null;
-  onDragStart: (e: React.DragEvent, path: string) => void;
-  onDragOver: (e: React.DragEvent, folderPath: string) => void;
-  onDrop: (e: React.DragEvent, folderPath: string) => void;
-  onDragLeave: () => void;
-  dragOverFolder: string | null;
-}) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-  const toggle = useCallback(() => setIsOpen((v) => !v), []);
-  const children = useMemo(() => sortChildren(node.children), [node.children]);
-  const Chevron = isOpen ? ChevronDown : ChevronRight;
-  const isDragOver = dragOverFolder === node.fullPath;
-  const isRenaming = inlineInput?.mode === "rename" && inlineInput.originalPath === node.fullPath;
-
-  if (isRenaming) {
-    return (
-      <InlineInput
-        defaultValue={inlineInput.originalName ?? node.name}
-        depth={depth}
-        isFolder={true}
-        onCommit={(name) => {
-          inlineInput?.onCommit?.(name);
-        }}
-        onCancel={() => {
-          inlineInput?.onCancel?.();
-        }}
-      />
-    );
-  }
-
-  return (
-    <>
-      <button
-        draggable
-        onDragStart={(e) => onDragStart(e, node.fullPath)}
-        onClick={toggle}
-        onContextMenu={(e) => {
-          e.preventDefault();
-          onContextMenu(e, node.fullPath, true);
-        }}
-        onDragOver={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          onDragOver(e, node.fullPath);
-        }}
-        onDrop={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          onDrop(e, node.fullPath);
-        }}
-        onDragLeave={onDragLeave}
-        className={`w-full flex items-center gap-1.5 px-2.5 py-1 min-h-7 text-left text-xs text-neutral-400 hover:bg-neutral-800/30 hover:text-neutral-300 transition-colors ${
-          isDragOver ? "bg-[#3CE6AC]/10 outline outline-1 outline-[#3CE6AC]/40" : ""
-        }`}
-        style={{ paddingLeft: `${8 + depth * 12}px` }}
-      >
-        <Chevron size={10} className="flex-shrink-0 text-neutral-600" />
-        <span className="truncate font-medium">{node.name}</span>
-      </button>
-      {isOpen && (
-        <>
-          {/* Inline input for new file/folder inside this folder */}
-          {inlineInput &&
-            (inlineInput.mode === "new-file" || inlineInput.mode === "new-folder") &&
-            inlineInput.parentPath === node.fullPath && (
-              <InlineInput
-                defaultValue=""
-                depth={depth + 1}
-                isFolder={inlineInput.mode === "new-folder"}
-                onCommit={(name) => {
-                  // onCommit is handled by the parent FileTree component
-                  // via the inlineInputCommit callback
-                  inlineInput?.onCommit?.(name);
-                }}
-                onCancel={() => {
-                  inlineInput?.onCancel?.();
-                }}
-              />
-            )}
-          {children.map((child) =>
-            child.isFile && child.children.size === 0 ? (
-              <TreeFile
-                key={child.fullPath}
-                node={child}
-                depth={depth + 1}
-                activeFile={activeFile}
-                onSelectFile={onSelectFile}
-                onContextMenu={onContextMenu}
-                inlineInput={inlineInput}
-                onDragStart={onDragStart}
-              />
-            ) : child.children.size > 0 ? (
-              <TreeFolder
-                key={child.fullPath}
-                node={child}
-                depth={depth + 1}
-                activeFile={activeFile}
-                onSelectFile={onSelectFile}
-                defaultOpen={isActiveInSubtree(child, activeFile)}
-                onContextMenu={onContextMenu}
-                inlineInput={inlineInput}
-                onDragStart={onDragStart}
-                onDragOver={onDragOver}
-                onDrop={onDrop}
-                onDragLeave={onDragLeave}
-                dragOverFolder={dragOverFolder}
-              />
-            ) : (
-              <TreeFile
-                key={child.fullPath}
-                node={child}
-                depth={depth + 1}
-                activeFile={activeFile}
-                onSelectFile={onSelectFile}
-                onContextMenu={onContextMenu}
-                inlineInput={inlineInput}
-                onDragStart={onDragStart}
-              />
-            ),
-          )}
-        </>
-      )}
-    </>
-  );
-}
-
-// ── TreeFile ──
-
-function TreeFile({
-  node,
-  depth,
-  activeFile,
-  onSelectFile,
-  onContextMenu,
-  inlineInput,
-  onDragStart,
-}: {
-  node: TreeNode;
-  depth: number;
-  activeFile: string | null;
-  onSelectFile: (path: string) => void;
-  onContextMenu: (e: React.MouseEvent, path: string, isFolder: boolean) => void;
-  inlineInput: InlineInputState | null;
-  onDragStart: (e: React.DragEvent, path: string) => void;
-}) {
-  const isActive = node.fullPath === activeFile;
-  const isRenaming = inlineInput?.mode === "rename" && inlineInput.originalPath === node.fullPath;
-
-  if (isRenaming) {
-    return (
-      <InlineInput
-        defaultValue={inlineInput.originalName ?? node.name}
-        depth={depth}
-        isFolder={false}
-        onCommit={(name) => {
-          inlineInput?.onCommit?.(name);
-        }}
-        onCancel={() => {
-          inlineInput?.onCancel?.();
-        }}
-      />
-    );
-  }
-
-  return (
-    <button
-      draggable
-      onDragStart={(e) => onDragStart(e, node.fullPath)}
-      onClick={() => onSelectFile(node.fullPath)}
-      onContextMenu={(e) => {
-        e.preventDefault();
-        onContextMenu(e, node.fullPath, false);
-      }}
-      className={`w-full flex items-center gap-2 py-1 min-h-7 text-left transition-all text-xs ${
-        isActive
-          ? "bg-neutral-800/60 text-neutral-200"
-          : "text-neutral-500 hover:bg-neutral-800/30 hover:text-neutral-300"
-      }`}
-      style={{ paddingLeft: `${8 + depth * 12 + 14}px` }}
-    >
-      <FileIcon path={node.name} />
-      <span className="truncate">{node.name}</span>
-    </button>
-  );
-}
-
-// ── Main FileTree Component ──
 
 export const FileTree = memo(function FileTree({
   files,
@@ -643,302 +441,441 @@ export const FileTree = memo(function FileTree({
   onMoveFile,
   onImportFiles,
 }: FileTreeProps) {
-  const tree = useMemo(() => buildTree(files), [files]);
-  const children = useMemo(() => sortChildren(tree.children), [tree]);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const hostRef = useRef<HTMLElement | null>(null);
+  const callbacksRef = useRef({
+    onCreateFile,
+    onCreateFolder,
+    onDeleteFile,
+    onDuplicateFile,
+    onImportFiles,
+    onMoveFile,
+    onRenameFile,
+    onSelectFile,
+  });
+  callbacksRef.current = {
+    onCreateFile,
+    onCreateFolder,
+    onDeleteFile,
+    onDuplicateFile,
+    onImportFiles,
+    onMoveFile,
+    onRenameFile,
+    onSelectFile,
+  };
 
-  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const [inlineInput, setInlineInput] = useState<InlineInputState | null>(null);
+  const displayPaths = useMemo(() => buildStudioTreePaths(files), [files]);
+  const displayPathsRef = useRef(displayPaths);
+  displayPathsRef.current = displayPaths;
+
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
-  const [dragOverFolder, setDragOverFolder] = useState<string | null>(null);
-  const dragSourceRef = useRef<string | null>(null);
+  const [externalDropTarget, setExternalDropTarget] = useState<string | null>(null);
+  const [rootContextMenu, setRootContextMenu] = useState<RootContextMenuState | null>(null);
+  const pendingCreateRef = useRef<PendingCreateState | null>(null);
 
-  const hasFileOps = !!(
-    onCreateFile ||
-    onCreateFolder ||
-    onDeleteFile ||
-    onRenameFile ||
-    onDuplicateFile
+  const modelRef = useRef<PierreTreeModel | null>(null);
+  const hasFileOps = Boolean(
+    onCreateFile || onCreateFolder || onDeleteFile || onRenameFile || onDuplicateFile,
   );
+  const hasRootCreateActions = Boolean(onCreateFile || onCreateFolder);
 
-  // ── Context Menu handlers ──
-
-  const handleContextMenu = useCallback(
-    (e: React.MouseEvent, path: string, isFolder: boolean) => {
-      if (!hasFileOps) return;
-      e.preventDefault();
-      setContextMenu({ x: e.clientX, y: e.clientY, targetPath: path, targetIsFolder: isFolder });
+  const { model } = useFileTree({
+    composition: hasFileOps
+      ? {
+          contextMenu: {
+            buttonVisibility: "when-needed",
+            triggerMode: "both",
+          },
+        }
+      : undefined,
+    dragAndDrop: onMoveFile
+      ? {
+          canDrag: (paths) => paths.length === 1,
+          onDropComplete: (event) => {
+            const sourcePath = event.draggedPaths[0];
+            if (!sourcePath) return;
+            const nextPath = buildMoveDestinationPath(sourcePath, event.target.directoryPath);
+            void Promise.resolve(
+              callbacksRef.current.onMoveFile?.(toPublicPath(sourcePath), nextPath),
+            ).catch(console.error);
+          },
+        }
+      : false,
+    icons: { colored: true, set: "complete" },
+    initialExpandedPaths: activeFile ? getAncestorDirectoryPaths(activeFile) : undefined,
+    initialExpansion: "closed",
+    initialSelectedPaths: activeFile ? [activeFile] : undefined,
+    itemHeight: 28,
+    onSelectionChange: (selectedPaths) => {
+      const focusedPath = modelRef.current?.getFocusedPath() ?? null;
+      if (!focusedPath || isCanonicalDirectoryPath(focusedPath)) return;
+      if (!selectedPaths.includes(focusedPath)) return;
+      callbacksRef.current.onSelectFile(focusedPath);
     },
-    [hasFileOps],
-  );
+    paths: displayPaths,
+    renaming: {
+      onError: (error) => {
+        console.error(`[Studio] File tree rename failed: ${error}`);
+      },
+      onRename: (event) => {
+        const pending = pendingCreateRef.current;
+        const isPendingRename =
+          pending && toPublicPath(pending.placeholderPath) === event.sourcePath;
 
-  const handleCloseContextMenu = useCallback(() => setContextMenu(null), []);
+        if (isPendingRename) {
+          pendingCreateRef.current = null;
+          void Promise.resolve(
+            pending.kind === "folder"
+              ? callbacksRef.current.onCreateFolder?.(event.destinationPath)
+              : callbacksRef.current.onCreateFile?.(event.destinationPath),
+          ).catch(console.error);
+          return;
+        }
 
-  // ── New File ──
-
-  const handleNewFile = useCallback(
-    (parentPath: string) => {
-      setInlineInput({
-        parentPath,
-        mode: "new-file",
-        onCommit: (name: string) => {
-          const fullPath = parentPath ? `${parentPath}/${name}` : name;
-          onCreateFile?.(fullPath);
-          setInlineInput(null);
-        },
-        onCancel: () => setInlineInput(null),
-      });
+        void Promise.resolve(
+          callbacksRef.current.onRenameFile?.(event.sourcePath, event.destinationPath),
+        ).catch(console.error);
+      },
     },
-    [onCreateFile],
-  );
+    sort: compareStudioTreeEntries,
+    unsafeCSS: TREE_UNSAFE_CSS,
+  });
+  modelRef.current = model;
 
-  // ── New Folder ──
+  const closeRootContextMenu = useCallback(() => {
+    setRootContextMenu(null);
+  }, []);
 
-  const handleNewFolder = useCallback(
-    (parentPath: string) => {
-      setInlineInput({
-        parentPath,
-        mode: "new-folder",
-        onCommit: (name: string) => {
-          const fullPath = parentPath ? `${parentPath}/${name}` : name;
-          onCreateFolder?.(fullPath);
-          setInlineInput(null);
-        },
-        onCancel: () => setInlineInput(null),
-      });
+  const startCreate = useCallback(
+    (kind: PendingCreateState["kind"], parentPath: string) => {
+      if (pendingCreateRef.current) return;
+
+      const placeholderPath = createPlaceholderPath(displayPathsRef.current, parentPath, kind);
+      pendingCreateRef.current = { kind, placeholderPath };
+
+      const parentDirectory = parentPath ? toCanonicalDirectoryPath(parentPath) : null;
+      if (parentDirectory) {
+        const parentItem = model.getItem(parentDirectory);
+        if (isDirectoryHandle(parentItem)) parentItem.expand();
+      }
+
+      try {
+        model.add(placeholderPath);
+        renderMountedTree(model, hostRef.current);
+        requestAnimationFrame(() => {
+          if (model.startRenaming(placeholderPath, { removeIfCanceled: true }) !== false) {
+            renderMountedTree(model, hostRef.current);
+            return;
+          }
+
+          model.remove(
+            placeholderPath,
+            isCanonicalDirectoryPath(placeholderPath) ? { recursive: true } : undefined,
+          );
+          pendingCreateRef.current = null;
+        });
+      } catch (error) {
+        pendingCreateRef.current = null;
+        console.error(error);
+      }
     },
-    [onCreateFolder],
+    [model],
   );
-
-  // ── Rename ──
 
   const handleRename = useCallback(
     (path: string) => {
-      const name = path.includes("/") ? path.slice(path.lastIndexOf("/") + 1) : path;
-      const parentPath = path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "";
-      setInlineInput({
-        parentPath,
-        mode: "rename",
-        originalPath: path,
-        originalName: name,
-        onCommit: (newName: string) => {
-          if (newName !== name) {
-            const newPath = parentPath ? `${parentPath}/${newName}` : newName;
-            onRenameFile?.(path, newPath);
-          }
-          setInlineInput(null);
-        },
-        onCancel: () => setInlineInput(null),
-      });
+      model.startRenaming(path);
+      renderMountedTree(model, hostRef.current);
     },
-    [onRenameFile],
+    [model],
   );
 
-  // ── Duplicate ──
-
-  const handleDuplicate = useCallback(
-    (path: string) => {
-      onDuplicateFile?.(path);
-    },
-    [onDuplicateFile],
-  );
-
-  // ── Delete ──
-
-  const handleDelete = useCallback((path: string) => {
-    setDeleteTarget(path);
-  }, []);
-
-  // Since DeleteConfirm is rendered inside TreeFile, we need callbacks on that component.
-  // Instead, let's use a portal-style approach: render the confirm at the FileTree level.
   const handleDeleteConfirm = useCallback(() => {
-    if (deleteTarget) {
-      onDeleteFile?.(deleteTarget);
-      setDeleteTarget(null);
-    }
-  }, [deleteTarget, onDeleteFile]);
-
-  const handleDeleteCancel = useCallback(() => {
+    if (!deleteTarget) return;
+    void Promise.resolve(callbacksRef.current.onDeleteFile?.(deleteTarget)).catch(console.error);
     setDeleteTarget(null);
-  }, []);
+  }, [deleteTarget]);
 
-  // ── Drag and Drop ──
+  const renderContextMenu = useCallback(
+    (item: ContextMenuItem, context: ContextMenuOpenContext) => {
+      const publicPath = toPublicPath(item.path);
+      const parentPath = toPublicPath(getCanonicalParentDirectoryPath(item.path) ?? "");
+      const createPath = item.kind === "directory" ? publicPath : parentPath;
 
-  const handleDragStart = useCallback((e: React.DragEvent, path: string) => {
-    dragSourceRef.current = path;
-    e.dataTransfer.effectAllowed = "move";
-    e.dataTransfer.setData("text/plain", path);
-  }, []);
-
-  const handleDragOver = useCallback((_e: React.DragEvent, folderPath: string) => {
-    setDragOverFolder(folderPath);
-  }, []);
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent, folderPath: string) => {
-      // External files from desktop — import into the target folder
-      if (e.dataTransfer.files.length > 0 && !dragSourceRef.current) {
-        e.preventDefault();
-        onImportFiles?.(e.dataTransfer.files, folderPath || undefined);
-        setDragOverFolder(null);
-        return;
-      }
-
-      const sourcePath = dragSourceRef.current;
-      if (!sourcePath || !onMoveFile) {
-        setDragOverFolder(null);
-        return;
-      }
-      // Extract filename from source path
-      const fileName = sourcePath.includes("/")
-        ? sourcePath.slice(sourcePath.lastIndexOf("/") + 1)
-        : sourcePath;
-      const newPath = folderPath ? `${folderPath}/${fileName}` : fileName;
-      // Don't move to same location or into own subtree
-      if (newPath !== sourcePath && !folderPath.startsWith(sourcePath + "/")) {
-        onMoveFile(sourcePath, newPath);
-      }
-      setDragOverFolder(null);
-      dragSourceRef.current = null;
+      return (
+        <TreeActionMenu
+          item={item}
+          onNewFile={
+            onCreateFile
+              ? () => {
+                  context.close({ restoreFocus: false });
+                  startCreate("file", createPath);
+                }
+              : undefined
+          }
+          onNewFolder={
+            item.kind === "directory" && onCreateFolder
+              ? () => {
+                  context.close({ restoreFocus: false });
+                  startCreate("folder", createPath);
+                }
+              : undefined
+          }
+          onRename={
+            onRenameFile
+              ? () => {
+                  context.close({ restoreFocus: false });
+                  handleRename(item.path);
+                }
+              : undefined
+          }
+          onDuplicate={
+            item.kind === "file" && onDuplicateFile
+              ? () => {
+                  context.close();
+                  void Promise.resolve(callbacksRef.current.onDuplicateFile?.(publicPath)).catch(
+                    console.error,
+                  );
+                }
+              : undefined
+          }
+          onDelete={
+            onDeleteFile
+              ? () => {
+                  context.close();
+                  setDeleteTarget(publicPath);
+                }
+              : undefined
+          }
+        />
+      );
     },
-    [onMoveFile, onImportFiles],
+    [
+      handleRename,
+      onCreateFile,
+      onCreateFolder,
+      onDeleteFile,
+      onDuplicateFile,
+      onRenameFile,
+      startCreate,
+    ],
   );
 
-  const handleDragLeave = useCallback(() => {
-    setDragOverFolder(null);
-  }, []);
-
-  // ── Root-level context menu (right-click on empty space) ──
-
-  const handleRootContextMenu = useCallback(
-    (e: React.MouseEvent) => {
-      if (!hasFileOps) return;
-      // Only trigger if clicking directly on the container, not on a file/folder button
-      if (e.target === e.currentTarget) {
-        e.preventDefault();
-        setContextMenu({ x: e.clientX, y: e.clientY, targetPath: "", targetIsFolder: true });
+  useEffect(() => {
+    const unsubscribe = model.onMutation("*", (event) => {
+      const pending = pendingCreateRef.current;
+      if (!pending) return;
+      if (isPendingCreateCleared(event, pending.placeholderPath)) {
+        pendingCreateRef.current = null;
       }
-    },
-    [hasFileOps],
-  );
+    });
+
+    return unsubscribe;
+  }, [model]);
+
+  useEffect(() => {
+    hostRef.current = getHostElement(wrapperRef.current);
+  });
+
+  useEffect(() => {
+    const host = getHostElement(wrapperRef.current);
+    hostRef.current = host;
+    const expandedPaths = collectExpandedPaths(host);
+    model.resetPaths(displayPaths, {
+      initialExpandedPaths: expandedPaths.length > 0 ? expandedPaths : undefined,
+    });
+  }, [displayPaths, model]);
+
+  useEffect(() => {
+    syncSelection(model, activeFile);
+  }, [activeFile, model]);
+
+  useEffect(() => {
+    const host = getHostElement(wrapperRef.current);
+    hostRef.current = host;
+    if (!host) return;
+
+    const handleContextMenu = (event: MouseEvent) => {
+      if (!hasRootCreateActions) return;
+      const path = event
+        .composedPath()
+        .find(
+          (entry) => entry instanceof HTMLElement && typeof entry.dataset.itemPath === "string",
+        );
+      if (path) return;
+
+      const headerTarget = event
+        .composedPath()
+        .find(
+          (entry) =>
+            entry instanceof HTMLElement &&
+            (entry.slot === "header" || entry.closest?.('[slot="header"]') != null),
+        );
+      if (headerTarget) return;
+
+      event.preventDefault();
+      setRootContextMenu({ x: event.clientX, y: event.clientY });
+    };
+
+    const handleDragOver = (event: DragEvent) => {
+      if (!callbacksRef.current.onImportFiles || !hasExternalFiles(event.dataTransfer)) return;
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+      setExternalDropTarget(resolveImportTargetPath(event));
+    };
+
+    const handleDragLeave = (event: DragEvent) => {
+      const nextTarget = event.relatedTarget;
+      if (
+        nextTarget instanceof Node &&
+        (host.contains(nextTarget) || host.shadowRoot?.contains(nextTarget))
+      ) {
+        return;
+      }
+      setExternalDropTarget(null);
+    };
+
+    const handleDrop = (event: DragEvent) => {
+      if (!callbacksRef.current.onImportFiles || !hasExternalFiles(event.dataTransfer)) return;
+      event.preventDefault();
+      const targetPath = resolveImportTargetPath(event);
+      const targetDir = targetPath ? toPublicPath(targetPath) || undefined : undefined;
+      if (event.dataTransfer?.files.length) {
+        void Promise.resolve(
+          callbacksRef.current.onImportFiles(event.dataTransfer.files, targetDir),
+        ).catch(console.error);
+      }
+      setExternalDropTarget(null);
+    };
+
+    const handleDragEnd = () => {
+      setExternalDropTarget(null);
+    };
+
+    host.addEventListener("contextmenu", handleContextMenu);
+    host.addEventListener("dragover", handleDragOver);
+    host.addEventListener("dragleave", handleDragLeave);
+    host.addEventListener("drop", handleDrop);
+    window.addEventListener("dragend", handleDragEnd);
+
+    return () => {
+      host.removeEventListener("contextmenu", handleContextMenu);
+      host.removeEventListener("dragover", handleDragOver);
+      host.removeEventListener("dragleave", handleDragLeave);
+      host.removeEventListener("drop", handleDrop);
+      window.removeEventListener("dragend", handleDragEnd);
+    };
+  }, [hasRootCreateActions]);
+
+  useEffect(() => {
+    const host = hostRef.current ?? getHostElement(wrapperRef.current);
+    if (!host?.shadowRoot) return;
+
+    for (const element of host.shadowRoot.querySelectorAll<HTMLElement>(
+      "[data-studio-external-drag-target='true']",
+    )) {
+      element.removeAttribute("data-studio-external-drag-target");
+    }
+
+    if (!externalDropTarget) return;
+    if (externalDropTarget === "") return;
+
+    const selector = `[data-type="item"][data-item-path="${escapeAttributeValue(externalDropTarget)}"]`;
+    host.shadowRoot
+      .querySelector<HTMLElement>(selector)
+      ?.setAttribute("data-studio-external-drag-target", "true");
+  }, [externalDropTarget]);
 
   return (
-    <div className="flex flex-col h-full min-h-0">
-      {/* FILES header with action buttons */}
+    <div className="flex h-full min-h-0 flex-col">
       {hasFileOps && (
-        <div className="flex items-center justify-between px-2.5 py-1.5 border-b border-neutral-800/50 flex-shrink-0">
-          <span className="text-[10px] font-semibold tracking-wider text-neutral-600 uppercase">
-            Files
-          </span>
-          <div className="flex items-center gap-0.5">
-            <button
-              onClick={() => handleNewFile("")}
-              className="p-0.5 rounded hover:bg-neutral-800 text-neutral-600 hover:text-neutral-400 transition-colors"
-              title="New File"
-            >
-              <Plus size={12} weight="bold" />
-            </button>
-            <button
-              onClick={() => handleNewFolder("")}
-              className="p-0.5 rounded hover:bg-neutral-800 text-neutral-600 hover:text-neutral-400 transition-colors"
-              title="New Folder"
-            >
-              <FolderSimplePlus size={12} weight="duotone" />
-            </button>
+        <div className="shrink-0 border-b border-neutral-800/50 px-2.5 py-1.5">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-600">
+              Files
+            </span>
+            <div className="flex items-center gap-0.5">
+              {onCreateFile && (
+                <button
+                  type="button"
+                  onClick={() => startCreate("file", "")}
+                  className="rounded p-0.5 text-neutral-600 transition-colors hover:bg-neutral-800 hover:text-neutral-400"
+                  title="New File"
+                >
+                  <Plus size={12} weight="bold" />
+                </button>
+              )}
+              {onCreateFolder && (
+                <button
+                  type="button"
+                  onClick={() => startCreate("folder", "")}
+                  className="rounded p-0.5 text-neutral-600 transition-colors hover:bg-neutral-800 hover:text-neutral-400"
+                  title="New Folder"
+                >
+                  <FolderSimplePlus size={12} weight="duotone" />
+                </button>
+              )}
+            </div>
           </div>
         </div>
       )}
 
       <div
-        className={`flex-1 overflow-y-auto py-1 transition-colors ${
-          dragOverFolder === ""
-            ? "bg-[#3CE6AC]/5 outline outline-1 outline-[#3CE6AC]/30 -outline-offset-1"
+        ref={wrapperRef}
+        className={`flex-1 min-h-0 ${
+          externalDropTarget === ""
+            ? "bg-[#3CE6AC]/5 outline outline-1 -outline-offset-1 outline-[#3CE6AC]/30"
             : ""
         }`}
-        onContextMenu={handleRootContextMenu}
-        onDragOver={(e) => {
-          e.preventDefault();
-          // Show root highlight when dragging over the background (not a child folder)
-          if (e.target === e.currentTarget) setDragOverFolder("");
-        }}
-        onDragLeave={(e) => {
-          if (e.target === e.currentTarget) setDragOverFolder(null);
-        }}
-        onDrop={(e) => {
-          e.preventDefault();
-          handleDrop(e, "");
-        }}
       >
-        {/* Root-level inline input for new file/folder */}
-        {inlineInput &&
-          (inlineInput.mode === "new-file" || inlineInput.mode === "new-folder") &&
-          inlineInput.parentPath === "" && (
-            <InlineInput
-              defaultValue=""
-              depth={0}
-              isFolder={inlineInput.mode === "new-folder"}
-              onCommit={(name) => inlineInput.onCommit?.(name)}
-              onCancel={() => inlineInput.onCancel?.()}
-            />
-          )}
-        {children.map((child) =>
-          child.isFile && child.children.size === 0 ? (
-            <TreeFile
-              key={child.fullPath}
-              node={child}
-              depth={0}
-              activeFile={activeFile}
-              onSelectFile={onSelectFile}
-              onContextMenu={handleContextMenu}
-              inlineInput={inlineInput}
-              onDragStart={handleDragStart}
-            />
-          ) : (
-            <TreeFolder
-              key={child.fullPath}
-              node={child}
-              depth={0}
-              activeFile={activeFile}
-              onSelectFile={onSelectFile}
-              defaultOpen={isActiveInSubtree(child, activeFile)}
-              onContextMenu={handleContextMenu}
-              inlineInput={inlineInput}
-              onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
-              onDrop={handleDrop}
-              onDragLeave={handleDragLeave}
-              dragOverFolder={dragOverFolder}
-            />
-          ),
-        )}
+        <PierreFileTree
+          className="block h-full"
+          model={model}
+          renderContextMenu={hasFileOps ? renderContextMenu : undefined}
+          style={TREE_HOST_STYLE}
+        />
       </div>
 
-      {/* Delete confirmation overlay */}
       {deleteTarget && (
-        <div className="border-t border-neutral-800/50 flex-shrink-0">
+        <div className="shrink-0 border-t border-neutral-800/50">
           <DeleteConfirm
-            name={
-              deleteTarget.includes("/")
-                ? deleteTarget.slice(deleteTarget.lastIndexOf("/") + 1)
-                : deleteTarget
-            }
+            name={getPathBasename(deleteTarget)}
+            onCancel={() => setDeleteTarget(null)}
             onConfirm={handleDeleteConfirm}
-            onCancel={handleDeleteCancel}
           />
         </div>
       )}
 
-      {/* Context menu */}
-      {contextMenu && (
-        <ContextMenu
-          state={contextMenu}
-          onClose={handleCloseContextMenu}
-          onNewFile={handleNewFile}
-          onNewFolder={handleNewFolder}
-          onRename={handleRename}
-          onDuplicate={handleDuplicate}
-          onDelete={handleDelete}
+      {rootContextMenu && (
+        <RootContextMenu
+          {...rootContextMenu}
+          onClose={closeRootContextMenu}
+          onNewFile={
+            onCreateFile
+              ? () => {
+                  closeRootContextMenu();
+                  startCreate("file", "");
+                }
+              : undefined
+          }
+          onNewFolder={
+            onCreateFolder
+              ? () => {
+                  closeRootContextMenu();
+                  startCreate("folder", "");
+                }
+              : undefined
+          }
         />
       )}
     </div>
   );
 });
+
+export {
+  buildMoveDestinationPath,
+  buildStudioTreePaths,
+  createPlaceholderPath,
+  getDropPathData,
+  isPendingCreateCleared,
+};


### PR DESCRIPTION
## What changed

- replaced the Studio file tree with an `@pierre/trees`-based wrapper while keeping the existing Studio actions and affordances wired through it
- preserved create, rename, delete, duplicate, import targeting, root and row context menus, selection syncing, and empty-folder `.gitkeep` handling
- added focused tests for path shaping, drop targeting, move destination building, and pending-create lifecycle behavior

## Why

Studio needed the richer tree viewer from `@pierre/trees`, but the first integration attempt exposed a wrapper bug: inline renames for newly created items could lose pending-create state and fall through to a rename request instead of the Studio create API. This patch fixes that race so new files and folders persist correctly after the inline rename flow.

## Impact

- Studio gets the new tree viewer library without regressing the existing file operations UX
- newly created files and folders now reliably hit the correct Studio backend APIs during inline rename

## Validation

- `bunx oxfmt packages/studio/src/App.tsx packages/studio/src/components/editor/FileTree.tsx packages/studio/src/components/editor/FileTree.test.ts`
- `bunx oxlint packages/studio/src/App.tsx packages/studio/src/components/editor/FileTree.tsx packages/studio/src/components/editor/FileTree.test.ts`
- `bun run --cwd packages/studio test src/components/editor/FileTree.test.ts`
- `bun run --cwd packages/studio typecheck`
- `agent-browser` browser verification on local Studio for file-create and folder-create inline rename flows, including persistence after reload

## Notes

- left an unrelated untracked `.thumbnails/` artifact out of the PR scope
- keeping this PR as a draft so drag/drop move behavior can still get a final manual browser pass on GitHub if desired
