### PR TITLE
test(engine): cover h265 NVENC in preset-mapping regression tests

### DIFF
--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -190,6 +190,26 @@ describe("buildEncoderArgs GPU preset mapping", () => {
     expect(presetArg(args)).toBe("p5");
   });
 
+  // hevc_nvenc uses the same p1..p7 preset vocabulary as h264_nvenc, so the
+  // mapping must apply to both codecs. Locks in "H.264 and H.265 NVENC share
+  // the preset mapping" against a future refactor that might split the path.
+  it("translates libx264 preset names to NVENC p1..p7 for h265 as well", () => {
+    for (const [libx264, nvencPreset] of [
+      ["ultrafast", "p1"],
+      ["medium", "p4"],
+      ["veryslow", "p7"],
+    ] as const) {
+      const args = buildEncoderArgs(
+        { ...baseOptions, codec: "h265", preset: libx264, quality: 23, useGpu: true },
+        inputArgs,
+        "out.mp4",
+        "nvenc",
+      );
+      expect(args[args.indexOf("-c:v") + 1]).toBe("hevc_nvenc");
+      expect(presetArg(args)).toBe(nvencPreset);
+    }
+  });
+
   it("rewrites QSV's unsupported ultrafast preset to veryfast", () => {
     const args = buildEncoderArgs(
       { ...baseOptions, codec: "h264", preset: "ultrafast", quality: 28, useGpu: true },

--- a/packages/engine/src/services/streamingEncoder.test.ts
+++ b/packages/engine/src/services/streamingEncoder.test.ts
@@ -191,6 +191,24 @@ describe("buildStreamingArgs", () => {
       expect(presetArg(args)).toBe("p4");
     });
 
+    // Same mapping applies to hevc_nvenc: NVENC's preset vocabulary is
+    // codec-agnostic, so the helper must translate for H.265 too.
+    it("translates libx264 preset names to NVENC pN for h265 as well", () => {
+      for (const [libx264, nvencPreset] of [
+        ["ultrafast", "p1"],
+        ["medium", "p4"],
+        ["veryslow", "p7"],
+      ] as const) {
+        const args = buildStreamingArgs(
+          { ...baseGpu, codec: "h265", preset: libx264 },
+          "/tmp/out.mp4",
+          "nvenc",
+        );
+        expect(args[args.indexOf("-c:v") + 1]).toBe("hevc_nvenc");
+        expect(presetArg(args)).toBe(nvencPreset);
+      }
+    });
+
     it("rewrites QSV's unsupported ultrafast preset to veryfast", () => {
       const args = buildStreamingArgs(baseGpu, "/tmp/out.mp4", "qsv");
       expect(presetArg(args)).toBe("veryfast");


### PR DESCRIPTION
## What

Adds `codec: "h265"` regression cases to the NVENC preset-mapping test block added in #442.

## Why

Follow-up to #442 per [review comment from @jrusso1020](https://github.com/heygen-com/hyperframes/pull/442#pullrequestreview):

> hevc_nvenc also uses p1..p7 and the fix correctly applies to both H.264 and H.265 NVENC paths — but the integration tests only cover `codec: "h264"`. NVENC's preset vocabulary is codec-agnostic so the mapping is correct for both, but one `codec: "h265"` case in chunkEncoder.test.ts would lock in "both codecs share the mapping" against a future refactor.

Locks in "both H.264 and H.265 NVENC share the preset mapping" so a future refactor that splits the codec paths can't silently regress one of them.

## How

Three-case table-driven block (`ultrafast → p1`, `medium → p4`, `veryslow → p7`) under `codec: "h265"`, added to both `buildEncoderArgs` (chunkEncoder.test.ts) and `buildStreamingArgs` (streamingEncoder.test.ts). Each case also asserts `-c:v hevc_nvenc` lands in the arg vector so the test fails loudly if the codec plumbing breaks, not just the preset translation.

No production-code changes — pure test additions.

## Test plan

- [x] Unit tests added/updated — 2 new cases (one per encoder file); each case loops over 3 preset/codec combos
- [x] `bun run --filter @hyperframes/engine test src/services/chunkEncoder.test.ts src/services/streamingEncoder.test.ts` → 68/68 pass (was 66, +2)
- [x] `oxfmt --check` clean on both files
- [ ] Documentation updated (if applicable) — test-only, no docs.