### PR TITLE
ci(windows-ffmpeg): pin BtbN release to specific autobuild tag

### DIFF
--- a/.github/actions/install-ffmpeg-windows/action.yml
+++ b/.github/actions/install-ffmpeg-windows/action.yml
@@ -10,10 +10,12 @@ description: >-
 inputs:
   release-url:
     description: >-
-      URL of the BtbN/FFmpeg-Builds zip to install. Pinned by default so a new
-      upstream release can't silently change the encoder/muxer set under us.
+      URL of a BtbN/FFmpeg-Builds zip to install. Pinned to a specific
+      autobuild tag so a new upstream nightly can't silently change encoder
+      behavior under us. The asset filename embeds the git hash, so both
+      the tag and the filename must be bumped together when upgrading.
     required: false
-    default: https://github.com/BtbN/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-win64-gpl.zip
+    default: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-23-13-16/ffmpeg-N-124085-g162ad61486-win64-gpl.zip
   max-attempts:
     description: Max download attempts before failing.
     required: false


### PR DESCRIPTION
## What

Pin the BtbN/FFmpeg-Builds Windows download to a specific `autobuild-2026-04-23-13-16` release tag instead of the rolling `latest` nightly.

## Why

Follow-up to #436. The `release-url` input description claimed "pinned by default" but the actual default pointed at `releases/latest/download/…` — a nightly rolling build. A new upstream build could silently change encoder behavior or ABI between CI runs. The feature-inventory check catches codec removals but not within-codec behavioral shifts across nightlies.

## How

Replaced the `latest` URL with a specific dated autobuild tag + its git-hash-stamped asset filename. Updated the input description to note that both the tag and filename must be bumped together when upgrading (the asset filename embeds the git hash).

## Test plan

- [x] Verified pinned URL resolves (302 → 200) via `curl -sI -L`
- [x] Confirmed feature-inventory step uses `ffmpeg -encoders`/`-decoders` output, not the asset filename — no assumptions broken by the rename
- [ ] **Note:** Windows install/render/test jobs were skipped on this PR (YAML-only change didn't trigger Windows paths). The pinned download will be exercised by the next Windows-touching PR.