### PR TITLE
ci: add global-install smoke test for CLI preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,77 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run --filter @hyperframes/core test:hyperframe-runtime-ci
 
+  smoke-global-install:
+    name: "Smoke: global install"
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+
+      # Pack the CLI as a tarball (simulates what `npm publish` produces)
+      - name: Pack CLI tarball
+        run: cd packages/cli && npm pack
+
+      # Install globally using --prefix to avoid sudo
+      - name: Install globally via npm
+        run: npm install -g --prefix /tmp/hf-smoke ./packages/cli/hyperframes-cli-*.tgz
+
+      # Scaffold a blank project
+      - name: Init blank project
+        run: |
+          export PATH="/tmp/hf-smoke/bin:$PATH"
+          mkdir /tmp/hf-project && cd /tmp/hf-project
+          hyperframes init test-project --example blank
+
+      # Start preview, probe the runtime endpoint, assert no esbuild errors
+      - name: Smoke-test preview server
+        run: |
+          export PATH="/tmp/hf-smoke/bin:$PATH"
+          cd /tmp/hf-project/test-project
+
+          # Start the preview server in the background; capture stderr
+          CI=true hyperframes preview --port 3099 2>/tmp/hf-stderr.log &
+          SERVER_PID=$!
+
+          # Wait for the server to be ready (up to 15 s)
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3099/ >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.5
+          done
+
+          # Probe the runtime JS endpoint
+          BODY=$(curl -sf http://localhost:3099/api/runtime.js | head -c 200 || true)
+          if [ -z "$BODY" ]; then
+            echo "FAIL: /api/runtime.js returned empty response"
+            kill $SERVER_PID 2>/dev/null || true
+            cat /tmp/hf-stderr.log
+            exit 1
+          fi
+
+          kill $SERVER_PID 2>/dev/null || true
+          wait $SERVER_PID 2>/dev/null || true
+
+          # Assert stderr does not contain esbuild / runtime load errors
+          if grep -qE '✘ \[ERROR\]|Failed to load runtime' /tmp/hf-stderr.log; then
+            echo "FAIL: preview emitted runtime errors:"
+            cat /tmp/hf-stderr.log
+            exit 1
+          fi
+
+          echo "PASS: global install smoke test succeeded"
+
   semantic-pr-title:
     name: Semantic PR title
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
               - "bun.lock"
               - "tsconfig*.json"
               - "Dockerfile*"
+              - ".github/workflows/**"
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

Adds a CI smoke test that reproduces the exact failure from #452 — `hyperframes preview` printing `✘ [ERROR] Could not resolve "…/runtime/entry.ts"` when installed globally via npm.

The job simulates what a real user does:
1. `npm pack` the CLI → install globally with `--prefix`
2. `hyperframes init test-project --example blank`
3. `hyperframes preview --port 3099` in background
4. `curl http://localhost:3099/api/runtime.js` — assert non-empty JS
5. Assert stderr has no `✘ [ERROR]` or `Failed to load runtime`

Also adds `.github/workflows/**` to the change detection filter so CI jobs run when workflow files change.

## Validation: the test catches the broken state

Verified locally that the grep pattern fires on the pre-#452 code and passes on the fixed code:

**Broken (0.4.15-alpha.1, globally installed via `npm i -g hyperframes@alpha`):**
```
$ hyperframes preview --port 3098 2>/tmp/hf-stderr.log
$ grep -E '✘ \[ERROR\]|Failed to load runtime' /tmp/hf-stderr.log
✘ [ERROR] Could not resolve "/opt/homebrew/lib/node_modules/hyperframes/runtime/entry.ts"
[studio] Failed to load runtime source fallback: Error: Build failed with 1 error: …
→ CAUGHT: assertion fires, test fails ✓
```

**Fixed (built from #452 fix branch):**
```
$ node packages/cli/dist/cli.js preview --port 3098 2>/tmp/hf-stderr.log
$ grep -E '✘ \[ERROR\]|Failed to load runtime' /tmp/hf-stderr.log
(empty)
→ PASS: no errors ✓
```

If this smoke test had existed before #452, it would have caught the bug before it shipped.

## Test plan

- [x] Grep pattern catches broken state — verified locally against pre-#452 global install
- [x] Fixed state passes — verified locally against #452-fixed build
- [x] CI job runs green — https://github.com/heygen-com/hyperframes/actions/runs/24854025990/job/72762086753