### PR TITLE
fix(shader-transitions): harden capture against visibility, scrub, Safari taint

### DIFF
--- a/packages/shader-transitions/src/capture.ts
+++ b/packages/shader-transitions/src/capture.ts
@@ -37,14 +37,27 @@ export function captureScene(sceneEl: HTMLElement, bgColor: string): Promise<HTM
     // with <filter> elements (e.g. feTurbulence grain backgrounds), certain
     // cross-origin images, and mask/clip-path url() refs can taint the
     // output canvas on WebKit. Without these flags, html2canvas throws
-    // `SecurityError: The operation is insecure` on read-back and every
-    // shader transition falls through to the hard-cut catch handler —
-    // observed in Safari + Claude Design's cross-origin iframe sandbox.
+    // `SecurityError: The operation is insecure` during its own read-back
+    // path and every shader transition falls through to the catch handler
+    // — observed in Safari + Claude Design's cross-origin iframe sandbox.
     //
-    // useCORS:    send CORS headers on same-/cross-origin image fetches.
-    // allowTaint: proceed even when canvas becomes tainted; the resulting
-    //             canvas is still usable as a WebGL texture via
-    //             gl.texImage2D (no pixel read-back required).
+    // useCORS:    send CORS headers on image fetches so cross-origin images
+    //             with proper `Access-Control-Allow-Origin` don't taint the
+    //             canvas in the first place. Strict improvement.
+    // allowTaint: let html2canvas complete and return a canvas even when it
+    //             becomes tainted (instead of throwing). Important caveat:
+    //             a tainted canvas CANNOT be uploaded to WebGL via
+    //             `gl.texImage2D` — WebGL spec requires SecurityError on
+    //             non-origin-clean sources, with no opt-out. So this flag
+    //             only moves the failure point from html2canvas to the
+    //             texImage2D call in webgl.ts. In both cases `hyper-shader.ts`
+    //             catches the rejected promise and runs the CSS crossfade
+    //             fallback. Net effect: the end-user UX is the same (smooth
+    //             CSS fade in either case), but we get a cleaner, more
+    //             predictable error site and the flag is defensively
+    //             correct for the non-taint branches where it genuinely
+    //             helps (e.g., `crossOrigin="anonymous"` image fetches
+    //             that already had CORS headers).
     useCORS: true,
     allowTaint: true,
     ignoreElements: (el: Element) => el.tagName === "CANVAS" || el.hasAttribute("data-no-capture"),

--- a/packages/shader-transitions/src/capture.ts
+++ b/packages/shader-transitions/src/capture.ts
@@ -33,6 +33,20 @@ export function captureScene(sceneEl: HTMLElement, bgColor: string): Promise<HTM
     scale: 1,
     backgroundColor: bgColor,
     logging: false,
+    // Safari applies stricter canvas-taint rules than Chrome. SVG data URLs
+    // with <filter> elements (e.g. feTurbulence grain backgrounds), certain
+    // cross-origin images, and mask/clip-path url() refs can taint the
+    // output canvas on WebKit. Without these flags, html2canvas throws
+    // `SecurityError: The operation is insecure` on read-back and every
+    // shader transition falls through to the hard-cut catch handler —
+    // observed in Safari + Claude Design's cross-origin iframe sandbox.
+    //
+    // useCORS:    send CORS headers on same-/cross-origin image fetches.
+    // allowTaint: proceed even when canvas becomes tainted; the resulting
+    //             canvas is still usable as a WebGL texture via
+    //             gl.texImage2D (no pixel read-back required).
+    useCORS: true,
+    allowTaint: true,
     ignoreElements: (el: Element) => el.tagName === "CANVAS" || el.hasAttribute("data-no-capture"),
   });
 }
@@ -41,6 +55,18 @@ export function captureScene(sceneEl: HTMLElement, bgColor: string): Promise<HTM
  * Capture the incoming scene with .scene-content hidden (background + decoratives only).
  * Shows the scene behind the outgoing scene via z-index, waits 2 rAFs for font rendering,
  * captures, then restores.
+ *
+ * IMPORTANT: We force `visibility: visible` during capture because the HyperFrames runtime's
+ * time-based visibility gate (in `packages/core/src/runtime/init.ts`) sets `style.visibility
+ * = "hidden"` on every `[data-start]` element that's outside its current playback window —
+ * every frame. When a shader transition fires *before* the incoming scene's `data-start`
+ * boundary (the recommended "transition.time = boundary - duration/2" centered placement),
+ * the runtime has `visibility: hidden` on the incoming scene. Without the visibility override
+ * here, `html2canvas` captures the element as blank → shader transitions from the real
+ * outgoing scene to a blank incoming texture → users see content fade/morph into the
+ * background color mid-transition (a visible "blink"). Forcing `visibility: visible` only
+ * for the duration of the capture fixes this without affecting what the user sees during
+ * normal playback.
  */
 export function captureIncomingScene(
   toScene: HTMLElement,
@@ -49,14 +75,17 @@ export function captureIncomingScene(
   return new Promise<HTMLCanvasElement>((resolve, reject) => {
     const origZ = toScene.style.zIndex;
     const origOpacity = toScene.style.opacity;
+    const origVisibility = toScene.style.visibility;
     toScene.style.zIndex = "-1";
     toScene.style.opacity = "1";
+    toScene.style.visibility = "visible";
 
     const contentEl = toScene.querySelector<HTMLElement>(".scene-content");
     if (contentEl) contentEl.style.visibility = "hidden";
 
     const restore = () => {
       if (contentEl) contentEl.style.visibility = "";
+      toScene.style.visibility = origVisibility;
       toScene.style.opacity = origOpacity;
       toScene.style.zIndex = origZ;
     };

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -318,17 +318,20 @@ export function init(config: HyperShaderConfig): GsapTimeline {
             // images, iframe sandbox restrictions, etc.) the old hard-cut
             // was jarring. A CSS crossfade is strictly better UX.
             console.warn("[HyperShader] Capture failed, CSS crossfade fallback:", e);
-            const fromEl = document.getElementById(fromId);
-            const toEl = document.getElementById(toId);
-            if (fromEl && toEl) {
-              gsap.to(fromEl, { opacity: 0, duration: dur, ease });
-              gsap.fromTo(toEl, { opacity: 0 }, { opacity: 1, duration: dur, ease });
-            } else {
-              // Last-resort hard cut if elements are somehow missing
-              document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
-                s.style.opacity = "0";
-              });
-              if (toEl) toEl.style.opacity = "1";
+            const nowTime = tl.time();
+            const inWindow = nowTime >= T && nowTime < T + dur;
+            if (inWindow) {
+              const fromEl = document.getElementById(fromId);
+              const toEl = document.getElementById(toId);
+              if (fromEl && toEl) {
+                gsap.to(fromEl, { opacity: 0, duration: dur, ease });
+                gsap.fromTo(toEl, { opacity: 0 }, { opacity: 1, duration: dur, ease });
+              } else {
+                document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
+                  s.style.opacity = "0";
+                });
+                if (toEl) toEl.style.opacity = "1";
+              }
             }
             if (wasPlaying) tl.play();
           });

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -14,12 +14,19 @@ import { initCapture, captureScene, captureIncomingScene } from "./capture.js";
 
 declare const gsap: {
   timeline: (opts: Record<string, unknown>) => GsapTimeline;
+  to: (target: HTMLElement | string, vars: Record<string, unknown>) => unknown;
+  fromTo: (
+    target: HTMLElement | string,
+    from: Record<string, unknown>,
+    to: Record<string, unknown>,
+  ) => unknown;
 };
 
 interface GsapTimeline {
   paused: () => boolean;
   play: () => GsapTimeline;
   pause: () => GsapTimeline;
+  time: () => number;
   call: (fn: () => void, args: null, position: number) => GsapTimeline;
   to: (
     target: Record<string, unknown>,
@@ -271,25 +278,58 @@ export function init(config: HyperShaderConfig): GsapTimeline {
             const toTex = textures.get(toId);
             if (toTex) uploadTexture(gl, toTex, toCanvas);
 
-            document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
-              s.style.opacity = "0";
-            });
-            canvasEl.style.display = "block";
-            state.prog = prog;
-            state.fromId = fromId;
-            state.toId = toId;
-            state.progress = 0;
-            state.active = true;
+            // Guard: only apply transition-state DOM changes if the playhead
+            // is STILL inside this transition's [T, T+dur] window. Without
+            // this, a seek that crosses multiple transitions launches several
+            // async captures in parallel; each resolves ~80-200ms later and
+            // unconditionally calls querySelectorAll(".scene").opacity = "0"
+            // + canvas.display = "block" + state.active = true. The last one
+            // to resolve wins, so after seeking past a transition, state gets
+            // stuck pointing at the wrong transition and every scene is
+            // hidden — manifesting as the "scrub blanks until the next scene
+            // begins" bug. Checking tl.time() against the transition window
+            // keeps async capture completions from corrupting state the
+            // end-callback (at T+dur) or the next transition's start-callback
+            // has already set correctly.
+            const nowTime = tl.time();
+            const inWindow = nowTime >= T && nowTime < T + dur;
+            if (inWindow) {
+              document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
+                s.style.opacity = "0";
+              });
+              canvasEl.style.display = "block";
+              state.prog = prog;
+              state.fromId = fromId;
+              state.toId = toId;
+              state.progress = 0;
+              state.active = true;
+            }
 
             if (wasPlaying) tl.play();
           })
           .catch((e) => {
-            console.warn("[HyperShader] Capture failed, falling back to hard cut:", e);
-            document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
-              s.style.opacity = "0";
-            });
-            const scene = document.getElementById(toId);
-            if (scene) scene.style.opacity = "1";
+            // Graceful fallback for unavoidable capture failures. The most
+            // common cause is Safari's stricter canvas-taint rules combined
+            // with SVG-filter-based background images (e.g. inline
+            // `<feTurbulence>` grain data URLs): html2canvas returns a
+            // tainted canvas, then `gl.texImage2D` throws SecurityError
+            // with no framework opt-out (WebGL spec). In Chrome this path
+            // rarely fires, but when it does (CORS-less cross-origin
+            // images, iframe sandbox restrictions, etc.) the old hard-cut
+            // was jarring. A CSS crossfade is strictly better UX.
+            console.warn("[HyperShader] Capture failed, CSS crossfade fallback:", e);
+            const fromEl = document.getElementById(fromId);
+            const toEl = document.getElementById(toId);
+            if (fromEl && toEl) {
+              gsap.to(fromEl, { opacity: 0, duration: dur, ease });
+              gsap.fromTo(toEl, { opacity: 0 }, { opacity: 1, duration: dur, ease });
+            } else {
+              // Last-resort hard cut if elements are somehow missing
+              document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
+                s.style.opacity = "0";
+              });
+              if (toEl) toEl.style.opacity = "1";
+            }
             if (wasPlaying) tl.play();
           });
       },


### PR DESCRIPTION
## What

Three interrelated bug fixes for the live-player path in `@hyperframes/shader-transitions` — the code path used by Studio preview, `<hyperframes-player>` embeds, and Claude Design's in-pane iframe. `initEngineMode` is untouched, so the CLI `hyperframes render` pipeline and the producer package produce byte-identical MP4 output before and after this PR.

1. **`captureIncomingScene` now forces `visibility: visible` during `html2canvas` capture**, then restores. Without this, the HF runtime's visibility gate (`visibility: hidden` on `[data-start]` elements outside their playback window) meant incoming scenes were captured blank at centered-transition times → visible "blink" mid-transition.

2. **`post-capture.dom` handler guards on `tl.time()` window before mutating DOM.** Previously, scrubbing across multiple shader transitions launched several async captures in parallel; each `.then()` unconditionally blanked all scenes, enabled the shader canvas, and set `state.active` to point at its own transition. The last to resolve won — even for transitions the playhead had already crossed. Result: scenes stuck `opacity:0` mid-scene, blank screen until the next transition's `end.call` fired. Fix checks `tl.time() ∈ [T, T+dur]` before applying state.

3. **`.catch` fallback now does a CSS crossfade instead of a hard cut.** When capture fails (Safari canvas taint from SVG data URLs, CORS errors without headers, extreme DOM complexity) the old catch snapped all scenes to `opacity:0` then set the incoming to `opacity:1` — a jarring instant jump. New fallback uses `gsap.to`/`gsap.fromTo` on scene opacity over the intended transition duration. Strictly better UX.

Also adds defensive `useCORS: true` and `allowTaint: true` to the `html2canvas` options. No behavior change in Chrome where capture already succeeds; resilience for cross-origin CORS-enabled images and SVG-tainted canvases respectively.

## Why

Three real bugs observed while testing HyperFrames compositions in Claude Design:

- **Visible blink on scene transitions** whenever the incoming scene had distinct background decoratives (grain, gradients, colored backgrounds). The runtime visibility gate is documented and correct; the shader capture just didn't account for it. Users reported it as "transitions look broken on scenes 3→4, 9→10" in high-contrast compositions.

- **Scrub/seek showed blank content mid-scene.** When dragging the scrubber to mid-scene, the player showed a blank frame until playback reached the next scene boundary. Root cause was the async-capture race described above — empirically validated with instrumented logs showing 3-4 post-capture callbacks firing per scrub, each clobbering DOM state.

- **Safari + Claude Design's cross-origin iframe showed hard cuts instead of shader transitions** for compositions using SVG `<feTurbulence>` grain patterns as `background-image`. Root cause is WebKit's stricter canvas-taint rules + WebGL's spec-required SecurityError on `texImage2D` with tainted canvas. Framework can't opt out, but can fail gracefully.

## How

**`packages/shader-transitions/src/capture.ts`** (+29 lines):

- `captureIncomingScene`: save `toScene.style.visibility`, override to `"visible"`, capture, restore in `.finally` (matches the existing save/override/restore pattern for `zIndex` and `opacity`).
- `captureScene`: add `useCORS: true` and `allowTaint: true` to `html2canvas` options with rationale in a comment.

**`packages/shader-transitions/src/hyper-shader.ts`** (+69/-15 lines):

- Added `time: () => number` to the `GsapTimeline` interface (type hygiene).
- `post-capture.dom` handler: check `tl.time() ∈ [T, T+dur]` — apply DOM state changes only if the playhead is still inside this transition's window.
- `.catch` handler: swap `querySelectorAll(.scene).opacity=0` + `toScene.opacity=1` for `gsap.to(fromEl, {opacity:0, duration:dur, ease})` + `gsap.fromTo(toEl, {opacity:0}, {opacity:1, duration:dur, ease})`. Hard-cut preserved as last-resort if elements are missing.

**Design decisions:**

- **Engine mode untouched.** `initEngineMode` is byte-identical (`git diff origin/main -- packages/shader-transitions/src/hyper-shader.ts | grep initEngineMode` → no matches). Producer regression tests unaffected.

- **CSS crossfade fallback uses fire-and-forget `gsap.to`/`gsap.fromTo`, not `tl.set`.** Since this only fires when capture has failed, the transition is in degraded mode regardless; seeking through a fallback fade is fine as a wall-clock animation. Keeping it out of the timeline graph avoids edge cases around timeline mutation during async callbacks.

- **Kept `allowTaint: true` even though it doesn't fix Safari fully.** It moves the SecurityError from html2canvas to WebGL's `texImage2D` (which ultimately hits the catch handler → CSS fallback). Same end-user outcome. Doesn't regress Chrome (where capture normally succeeds).

- **Not addressing Safari's `cloneNode` slowness.** That's a WebKit engine issue (html2canvas [#3108](https://github.com/niklasvh/html2canvas/issues/3108)) causing ~1.5–2s per capture in Safari + iframe. Real fix requires pre-capture architecture (cache incoming-scene textures at init) — out of scope for this PR, tracked as a follow-up.

## Test plan

- [x] `bunx oxlint packages/shader-transitions/src/*.ts` — 0 warnings, 0 errors
- [x] `bunx oxfmt --check ...` — all files correctly formatted
- [x] `bun run --cwd packages/shader-transitions build` — TS type-check clean, IIFE/ESM/CJS builds succeed
- [x] **Direct `html2canvas` visibility probe** (`test-runs/shader-blink-repro/html2canvas-probe.html` in the dev session): confirmed `html2canvas` returns blank on `visibility:hidden` element in current Chrome; with override, returns real content. Verdict: "BUG CONFIRMED."
- [x] **Bug B scrub validation in Chrome**: side-by-side pre-fix vs post-fix in `skill-test8-postfix`. Pre-fix: scrub to mid-scene shows blank. Post-fix: scrub shows content immediately. Instrumented logs confirm `post-capture.dom.skipped` firing for out-of-window callbacks.
- [x] **Safari validation**: tested in Safari + localhost with a composition containing SVG-filter grain (skill-test-9). Pre-fix: hard cuts between every scene. Post-fix: smooth CSS crossfades. SecurityError still logs (unavoidable — WebGL spec) but UX is restored.
- [x] **Engine-mode safety**: confirmed via `git diff origin/main` that `initEngineMode` has zero diff. CLI `hyperframes render` output unchanged.
- [ ] Producer Docker regression tests — not run locally (would require Docker build per `CLAUDE.md`). Logical safety argument: engine-mode code path is unchanged; these tests exercise only engine mode; therefore they must pass. CI will confirm.

## Follow-ups tracked

- **Safari cross-origin iframe performance** (1.5–2s per capture in Safari + CD's in-pane preview). Needs pre-capture architecture — cache incoming-scene textures at `init()` time since `captureIncomingScene` hides `.scene-content` and only captures static decoratives. Design doc + separate PR.
- **SVG filter data URLs in compositions** — addressed at the Claude Design skill level via Anti-pattern 4 in PR #353. Compositions generated after that ships will use layered `radial-gradient` dots instead of `feTurbulence` grain, avoiding the taint entirely.

Made with [Cursor](https://cursor.com)