### PR TITLE
docs: add skill review guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,21 @@ will not match CI. Use it only for local-only experimentation.
 ## Skills
 
 Composition authoring (not repo development) is guided by skills installed via `npx skills add heygen-com/hyperframes`. See `skills/` for source. Invoke `/hyperframes`, `/hyperframes-cli`, `/hyperframes-registry`, or `/gsap` when authoring compositions. When a user provides a website URL and wants a video, invoke `/website-to-hyperframes` — it runs the full 7-step capture-to-video pipeline.
+
+### Reviewing skill changes
+
+When reviewing a changeset that touches `skills/`, review as an agent-instruction
+designer who has shipped many skills and watched agents fail on each one. Focus on:
+
+- **Where will agents misinterpret?** Ambiguous vocabulary, instructions that assume
+  context the agent won't have 200 lines later, field names that don't match across
+  files (e.g., a picker emits "Canvas" but an eval checks for "bg").
+- **Where will agents silently skip?** Soft suggestions agents will deprioritize,
+  gates that lack enforcement, steps with no verification that they ran.
+- **Where will agents produce wrong output on first attempt?** Missing examples
+  (agents need to see the shape, not just read the rules), under-specified formats,
+  instructions that require multi-step reasoning to combine.
+
+Assume the agent reads the full SKILL.md before authoring and has no memory
+between compositions. Consider: will this instruction survive in a 300+ line
+file? Will the agent connect Step 0's context to a quality check 250 lines later?


### PR DESCRIPTION
## Summary
- Adds a "Reviewing skill changes" section to CLAUDE.md with guidance for reviewing `skills/` diffs
- Frames review through three lenses: where agents misinterpret, silently skip, or produce wrong output on first attempt
- Reminds reviewers that agents have no memory between compositions and must survive in 300+ line instruction files

## Why
Skill review requires a different mindset than code review — instructions that look correct to a human reader can still fail when an agent processes them. This codifies the review heuristics we've been applying manually.

## Test plan
- [x] Read the added section for clarity and completeness
- [x] Verified CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)