### PR TITLE
feat: add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "hyperframes",
+  "description": "Write HTML, render video. Compositions, GSAP animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
+  "version": "0.1.0",
+  "author": {
+    "name": "HeyGen",
+    "email": "hyperframes@heygen.com",
+    "url": "https://hyperframes.heygen.com"
+  },
+  "homepage": "https://hyperframes.heygen.com",
+  "repository": "https://github.com/heygen-com/hyperframes",
+  "license": "Apache-2.0"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "description": "Write HTML, render video. Compositions, GSAP animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
+  "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "version": "0.1.0",
   "author": {
     "name": "HeyGen",

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For Codex specifically, the same skills are also exposed as an [OpenAI Codex plu
 codex plugin marketplace add heygen-com/hyperframes --sparse .codex-plugin --sparse skills --sparse assets
 ```
 
-For Claude Code, the repo also ships a [Claude Code plugin manifest](./.claude-plugin/plugin.json): test it locally with `claude --plugin-dir .`, and for marketplace submission use the title `HyperFrames by HeyGen` plus the dark/light icons at [`assets/claude-code-icon-dark.svg`](./assets/claude-code-icon-dark.svg) and [`assets/claude-code-icon-light.svg`](./assets/claude-code-icon-light.svg).
+For Claude Code, the repo also ships a [Claude Code plugin manifest](./.claude-plugin/plugin.json): test it locally with `claude --plugin-dir .`. The manifest intentionally omits `skills` because Claude Code auto-discovers the root `skills/` directory by convention, and for marketplace submission use the title `HyperFrames by HeyGen` plus the black/white icon assets at [`assets/claude-code-icon-dark.svg`](./assets/claude-code-icon-dark.svg) and [`assets/claude-code-icon-light.svg`](./assets/claude-code-icon-light.svg) for the two theme slots.
 For Cursor, the same skills are packaged as a [Cursor plugin](./.cursor-plugin/plugin.json) — install from the Cursor Marketplace, or sideload by cloning this repo and pointing **Settings → Plugins → Load unpacked** at the repo root.
 
 #### Try it: example prompts

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ For Codex specifically, the same skills are also exposed as an [OpenAI Codex plu
 codex plugin marketplace add heygen-com/hyperframes --sparse .codex-plugin --sparse skills --sparse assets
 ```
 
+For Claude Code plugin packaging, the repo also ships a [Claude Code plugin manifest](./.claude-plugin/plugin.json). It reuses the root `skills/` directory, so Claude Code and Codex stay on the same source of truth. Test it locally from the repo root with:
+
+```bash
+claude --plugin-dir .
+```
 For Cursor, the same skills are packaged as a [Cursor plugin](./.cursor-plugin/plugin.json) — install from the Cursor Marketplace, or sideload by cloning this repo and pointing **Settings → Plugins → Load unpacked** at the repo root.
 
 #### Try it: example prompts

--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ For Codex specifically, the same skills are also exposed as an [OpenAI Codex plu
 codex plugin marketplace add heygen-com/hyperframes --sparse .codex-plugin --sparse skills --sparse assets
 ```
 
-For Claude Code plugin packaging, the repo also ships a [Claude Code plugin manifest](./.claude-plugin/plugin.json). It reuses the root `skills/` directory, so Claude Code and Codex stay on the same source of truth. Test it locally from the repo root with:
-
-```bash
-claude --plugin-dir .
-```
+For Claude Code, the repo also ships a [Claude Code plugin manifest](./.claude-plugin/plugin.json): test it locally with `claude --plugin-dir .`, and for marketplace submission use the title `HyperFrames by HeyGen` plus the dark/light icons at [`assets/claude-code-icon-dark.svg`](./assets/claude-code-icon-dark.svg) and [`assets/claude-code-icon-light.svg`](./assets/claude-code-icon-light.svg).
 For Cursor, the same skills are packaged as a [Cursor plugin](./.cursor-plugin/plugin.json) — install from the Cursor Marketplace, or sideload by cloning this repo and pointing **Settings → Plugins → Load unpacked** at the repo root.
 
 #### Try it: example prompts

--- a/assets/claude-code-icon-dark.svg
+++ b/assets/claude-code-icon-dark.svg
@@ -1,0 +1,15 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="100" height="100" fill="black"/>
+<path d="M10.1851 57.8021L33.1145 73.8313C36.2202 75.9978 41.5173 73.5433 42.4816 69.4984L51.7611 30.4271C52.7253 26.3822 48.5802 23.9277 44.4602 26.0942L13.917 42.1235C6.96677 45.7676 4.97564 54.1579 10.1851 57.8021Z" fill="url(#paint0_linear_2204_3080)"/>
+<path d="M87.5129 57.5141L56.9696 73.5433C52.8371 75.7098 48.7046 73.2553 49.6688 69.2104L58.9483 30.1391C59.9125 26.0942 65.2097 23.6397 68.3154 25.8062L91.2447 41.8354C96.4668 45.4796 94.4631 53.8699 87.5129 57.5141Z" fill="url(#paint1_linear_2204_3080)"/>
+<defs>
+<linearGradient id="paint0_linear_2204_3080" x1="48.5676" y1="25" x2="44.7804" y2="71.9384" gradientUnits="userSpaceOnUse">
+<stop stop-color="#06E3FA"/>
+<stop offset="1" stop-color="#4FDB5E"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2204_3080" x1="54.8282" y1="73.8392" x2="72.0989" y2="32.8932" gradientUnits="userSpaceOnUse">
+<stop stop-color="#06E3FA"/>
+<stop offset="1" stop-color="#4FDB5E"/>
+</linearGradient>
+</defs>
+</svg>

--- a/assets/claude-code-icon-light.svg
+++ b/assets/claude-code-icon-light.svg
@@ -1,0 +1,15 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="100" height="100" fill="white"/>
+<path d="M10.1851 57.8021L33.1145 73.8313C36.2202 75.9978 41.5173 73.5433 42.4816 69.4984L51.7611 30.4271C52.7253 26.3822 48.5802 23.9277 44.4602 26.0942L13.917 42.1235C6.96677 45.7676 4.97564 54.1579 10.1851 57.8021Z" fill="url(#paint0_linear_2204_3074)"/>
+<path d="M87.5129 57.5141L56.9696 73.5433C52.8371 75.7098 48.7046 73.2553 49.6688 69.2104L58.9483 30.1391C59.9125 26.0942 65.2097 23.6397 68.3154 25.8062L91.2447 41.8354C96.4668 45.4796 94.4631 53.8699 87.5129 57.5141Z" fill="url(#paint1_linear_2204_3074)"/>
+<defs>
+<linearGradient id="paint0_linear_2204_3074" x1="48.5676" y1="25" x2="44.7804" y2="71.9384" gradientUnits="userSpaceOnUse">
+<stop stop-color="#06E3FA"/>
+<stop offset="1" stop-color="#4FDB5E"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2204_3074" x1="54.8282" y1="73.8392" x2="72.0989" y2="32.8932" gradientUnits="userSpaceOnUse">
+<stop stop-color="#06E3FA"/>
+<stop offset="1" stop-color="#4FDB5E"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary
- add the repo-root Claude Code plugin manifest at `.claude-plugin/plugin.json`, alongside the existing Codex plugin surface
- document Claude Code usage in `README.md` next to the Codex install note
- add Claude marketplace submission assets at `assets/claude-code-icon-dark.svg` and `assets/claude-code-icon-light.svg`
- brand the plugin description as `HyperFrames by HeyGen`
- document that Claude Code auto-discovers the root `skills/` directory when the manifest omits a `skills` field
- use black/white Claude marketplace icon assets for the two theme slots

## Diff
- `.claude-plugin/plugin.json`
- `README.md`
- `assets/claude-code-icon-dark.svg`
- `assets/claude-code-icon-light.svg`

## Verification
- `claude plugin validate .`

## Notes
- Claude Code's repo-side schema rejects `displayName`, `title`, `icon`, and `logo`, so the explicit marketplace title/icon choice is documented in-repo for submission rather than encoded in `plugin.json`.
- `assets/claude-code-icon-dark.svg` now uses a black background and `assets/claude-code-icon-light.svg` uses a white background.
- The branch lives in the dedicated worktree at `/Users/miguel07code/dev/hyperframes-oss/.claude/worktrees/feat+claude-code-plugin` for any follow-up fixes.