### PR TITLE
Security: Path safety check is vulnerable to symlink-based directory escape

### DIFF
--- a/packages/core/src/studio-api/helpers/safePath.ts
+++ b/packages/core/src/studio-api/helpers/safePath.ts
@@ -1,10 +1,33 @@
-import { resolve, sep, join } from "node:path";
-import { readdirSync } from "node:fs";
+import { resolve, sep, join, dirname, basename } from "node:path";
+import { readdirSync, realpathSync } from "node:fs";
 
 /** Reject paths that escape the project directory. */
 export function isSafePath(base: string, resolved: string): boolean {
-  const norm = resolve(base) + sep;
-  return resolved.startsWith(norm) || resolved === resolve(base);
+  try {
+    const baseReal = realpathSync(resolve(base));
+    const target = resolve(resolved);
+    let probe = target;
+    const segments: string[] = [];
+    let targetReal: string;
+
+    while (true) {
+      try {
+        const real = realpathSync(probe);
+        targetReal = segments.length ? join(real, ...segments.reverse()) : real;
+        break;
+      } catch {
+        const parent = dirname(probe);
+        if (parent === probe) return false;
+        segments.push(basename(probe));
+        probe = parent;
+      }
+    }
+
+    const norm = baseReal + sep;
+    return targetReal.startsWith(norm) || targetReal === baseReal;
+  } catch {
+    return false;
+  }
 }
 
 const IGNORE_DIRS = new Set([".thumbnails", "node_modules", ".git"]);


### PR DESCRIPTION
## Problem

`isSafePath` only verifies string prefix containment after `resolve()`. This does not account for symlinks inside the project directory that point outside the base path. Downstream file reads/writes that rely on this helper can be tricked into accessing files outside the intended project root via symlink traversal.

**Severity**: `medium`
**File**: `packages/core/src/studio-api/helpers/safePath.ts`

## Solution

Use `realpath` (or `realpathSync`) on both base and target before comparison, and reject targets whose real path is outside the base real path. For write paths, also open files with flags that reduce symlink-follow risks where possible.

## Changes

- `packages/core/src/studio-api/helpers/safePath.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
