### PR TITLE
refactor(claude-design-skill): template-first rewrite with bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx skills add heygen-com/hyperframes
 
 This teaches your agent (Claude Code, Cursor, Gemini CLI, Codex) how to write correct compositions and GSAP animations. In Claude Code, the skills register as slash commands — invoke `/hyperframes` to author compositions, `/hyperframes-cli` for CLI commands, and `/gsap` for animation help.
 
-For Claude Design, use the GitHub-hosted entry point at [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) and let Claude fetch the repo's `skills/` tree from there. See the [Claude Design guide](https://hyperframes.heygen.com/guides/claude-design).
+For Claude Design, download [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) and attach it to your chat. Claude Design produces a valid first draft; refine it in any AI coding agent. See the [Claude Design guide](https://hyperframes.heygen.com/guides/claude-design).
 
 For Codex specifically, the same skills are also exposed as an [OpenAI Codex plugin](./.codex-plugin/plugin.json) — sparse-install just the plugin surface:
 
@@ -184,14 +184,14 @@ HyperFrames ships [skills](https://github.com/vercel-labs/skills) that teach AI 
 npx skills add heygen-com/hyperframes
 ```
 
-| Skill                       | What it teaches                                                                                         |
-| --------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `claude-design-hyperframes` | Claude Design entry point that pulls the upstream `skills/` tree and standardizes player-based previews |
-| `hyperframes`               | HTML composition authoring, captions, TTS, audio-reactive animation, transitions                        |
-| `hyperframes-cli`           | CLI commands: init, lint, preview, render, transcribe, tts, doctor                                      |
-| `hyperframes-registry`      | Block and component installation via `hyperframes add`                                                  |
-| `website-to-hyperframes`    | Capture a URL and turn it into a video — full website-to-video pipeline                                 |
-| `gsap`                      | GSAP animation API, timelines, easing, ScrollTrigger, plugins, React/Vue/Svelte, performance            |
+| Skill                       | What it teaches                                                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `claude-design-hyperframes` | Template-first Claude Design skill — pre-valid skeletons, produces video drafts for refinement in any coding agent |
+| `hyperframes`               | HTML composition authoring, captions, TTS, audio-reactive animation, transitions                                   |
+| `hyperframes-cli`           | CLI commands: init, lint, preview, render, transcribe, tts, doctor                                                 |
+| `hyperframes-registry`      | Block and component installation via `hyperframes add`                                                             |
+| `website-to-hyperframes`    | Capture a URL and turn it into a video — full website-to-video pipeline                                            |
+| `gsap`                      | GSAP animation API, timelines, easing, ScrollTrigger, plugins, React/Vue/Svelte, performance                       |
 
 ## Contributing
 

--- a/docs/guides/claude-design.mdx
+++ b/docs/guides/claude-design.mdx
@@ -1,31 +1,37 @@
 ---
 title: Claude Design
-description: "Use HyperFrames from Claude Design with a GitHub-hosted skill entry point that pulls the repo's existing skills and preview patterns."
+description: "Create HyperFrames video drafts in Claude Design using a template-first skill, then refine in any AI coding agent."
 ---
 
-Claude Design needs a different setup than Claude Code, Cursor, or Codex. The local `npx skills add heygen-com/hyperframes` flow is the right path for coding agents. For Claude Design, attach the HyperFrames skill file to your chat — empirically that produces sharper, more rule-compliant output than pasting the URL.
+Claude Design produces a **valid first draft** of a HyperFrames video — brand identity, scene content, layout, animations, and transitions. You then download the ZIP and refine in any AI coding agent (Claude Code, Cursor, Codex, Windsurf, etc.) with linting and live preview.
 
-## Get the skill
+## Get started
 
-<CardGroup cols={2}>
-  <Card
-    title="Download SKILL.md"
-    icon="download"
-    href="https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md"
-  >
-    Save the file, then drag it into a Claude Design chat as an attachment.
-  </Card>
-  <Card
-    title="View on GitHub"
-    icon="github"
-    href="https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md"
-  >
-    Read the skill, copy sections, or link to it in a prompt.
-  </Card>
-</CardGroup>
+<Steps>
+  <Step title="Download the skill">
+    Save [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) to your computer.
+  </Step>
+  <Step title="Open Claude Design">
+    Start a new chat at [claude.ai](https://claude.ai) with Claude Design enabled.
+  </Step>
+  <Step title="Attach the skill + describe your video">
+    Drag the SKILL.md file into the chat. Describe what you want — include screenshots, brand assets, or a palette if you have them.
+  </Step>
+  <Step title="Download the ZIP">
+    Claude Design produces `index.html`, `preview.html`, `README.md`, and `DESIGN.md`. Download the ZIP.
+  </Step>
+  <Step title="Refine in any AI coding agent">
+    Open the project in Claude Code, Cursor, Codex, or any agent with terminal access for animation polish, timing, and production QA.
+    ```bash
+    npx skills add heygen-com/hyperframes   # install skills (one-time)
+    npx hyperframes lint                     # should pass with zero errors
+    npx hyperframes preview                  # open the studio
+    ```
+  </Step>
+</Steps>
 
 <Tip>
-  **Prefer attaching the file over pasting the URL.** Claude Design reads file attachments natively with detail preserved. URL-driven runs produce usable output but consistently miss more rules than attachment-driven runs.
+  **Attach the file, don't paste the URL.** Claude Design reads file attachments natively with detail preserved. URL-driven runs produce usable output but consistently miss more rules.
 </Tip>
 
 ## Which setup to use
@@ -36,40 +42,51 @@ Claude Design needs a different setup than Claude Code, Cursor, or Codex. The lo
 | Claude Code                 | `npx skills add heygen-com/hyperframes`, then use `/hyperframes`                                                              |
 | Cursor / Codex / Gemini CLI | `npx skills add heygen-com/hyperframes`                                                                                       |
 
-## Prompt shape for Claude Design
+## How the skill works
 
-Claude Design does not use slash commands. Lead with the skill file (attached or URL), describe the video, and ideally give Claude Design something to synthesize from — screenshots, a brand PDF, a reference video, a pasted palette, or at minimum a vibe in words.
+The skill gives Claude Design **pre-valid HTML skeletons** — the structural rules (data attributes, timeline registration, scene visibility, preview token forwarding) are already embedded. Claude Design fills in the creative work:
 
-The skill reads inputs in this order of reliability: **attachments → pasted content → web research → URLs**. A modern SPA homepage returns almost nothing via `web_fetch` because JavaScript isn't executed, so brand-accurate output on brief like "make a video for linear.app" depends on attaching screenshots or letting Claude Design search for the brand's blog, press, or Wikipedia.
+1. **Palette + typography** — CSS custom properties on `:root`
+2. **Scene content** — text, images, layout inside `.scene-content` wrappers
+3. **Animations** — GSAP entrance tweens and mid-scene activity
+4. **Transitions** — hard cuts for most scenes, shader transitions at 2-3 key moments
 
-Strong Claude Design prompts usually include:
+This template-first approach means the output passes `npx hyperframes lint` with zero errors on first download — Claude Code can start refining immediately without structural fixes.
 
-- the attached skill file (or its URL)
-- the source material: screenshots, a brand PDF, a reference video, pasted copy, or a URL
-- duration and aspect ratio
-- tone or visual direction (if you have one — otherwise let Claude Design ask)
-- explicit deliverables: `index.html`, `preview.html`, `README.md`
-
-## Copy-paste prompts
+## Example prompts
 
 <CardGroup cols={1}>
-  <Card title="Rich brief (attach SKILL.md + screenshots)">
+  <Card title="Feature announcement (attach SKILL.md)">
     ```text
-    Use the attached skill. Make a 30-second 16:9 product walkthrough for my app,
-    matching the design in these screenshots. 5 scenes: hero, three features,
-    closing CTA. Shader transitions between scenes.
+    Use the attached skill. I just shipped dark mode for my app. Make me a
+    15-second Instagram reel announcing it.
+
+    - App name: Taskflow
+    - Primary color: #6C5CE7
+    - The vibe is clean, minimal, dark
+    - Key stat: "47% of users requested this"
     ```
   </Card>
-  <Card title="Pasted-content brief (attach SKILL.md + paste your copy)">
+  <Card title="Founder pitch (attach SKILL.md)">
     ```text
-    Use the attached skill. 30s hero reel with this copy for each scene:
+    Use the attached skill. 25-second LinkedIn video for my startup.
 
-    1. "The fast web broke us."
-    2. "Every app optimized for attention. None for thought."
-    3. "Something is changing. Blogs are back."
-    4. "Welcome to the slow web."
+    Problem: Sales teams waste 3 hours/day on manual CRM updates.
+    Solution: AutoCRM — AI that logs every call, email, and meeting.
+    Traction: 200+ teams, $1.2M ARR, 18% MoM growth.
+    CTA: autocrmhq.com
 
-    Dark theme, editorial, serif typography (not Playfair).
+    Professional but not corporate. Think Linear or Vercel energy.
+    ```
+  </Card>
+  <Card title="Stat highlight (attach SKILL.md)">
+    ```text
+    Use the attached skill. 10-second reel. Just one big number:
+
+    "$4.2 billion processed in Q1 2026"
+
+    Dark background, the number should animate up from zero. Subtle,
+    confident. End with logo placeholder and "stripe.com"
     ```
   </Card>
   <Card title="Sparse brief (attach SKILL.md, let it ask)">
@@ -77,86 +94,47 @@ Strong Claude Design prompts usually include:
     Use the attached skill. Make a 30-second launch video for Orbit.
     ```
 
-    The skill will ask ONE short question offering five input channels
-    (screenshot, PDF, reference video, vibe word, must-have element) plus
-    a "just build" escape hatch before generating.
-  </Card>
-  <Card title="Static URL brief (editorial piece, not a SPA)">
-    ```text
-    Use the HyperFrames Claude Design skill at
-    https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md
-    and turn https://www.anthropic.com/news/claude-design-anthropic-labs into a
-    45-second editorial explainer. Keep copy close to the article's real headlines.
-    ```
+    The skill asks ONE short clarifying question before generating.
   </Card>
 </CardGroup>
 
-## Preview with `@hyperframes/player`
+## What to include in your prompt
 
-When Claude Design generates a `preview.html`, it embeds the composition with `<hyperframes-player>` and forwards the Claude Design sandbox's preview token into the iframe src. Without the token forward, the in-pane preview renders black (the sandbox serves a `"preview token required"` placeholder to the iframe).
+Claude Design reads inputs in this order of reliability: **attachments > pasted content > web research > URLs**.
 
-Copy this template verbatim:
+| Input type | What it gives Claude Design |
+| --- | --- |
+| Screenshots / PDFs / brand guides | Palette, typography, UI patterns, tone — strongest source |
+| Pasted hex codes, typefaces, copy | Authoritative for what it covers |
+| Brand name (well-known) | Claude Design can research blogs, press, Wikipedia |
+| SPA URL (React/Vue homepage) | Returns near-empty shell — pivot to blog/press instead |
 
-```html
-<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>HyperFrames Preview</title>
-  <style>html,body{margin:0;padding:0;background:#111;height:100%;overflow:hidden}</style>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@hyperframes/player"></script>
-</head>
-<body>
-  <hyperframes-player id="p" controls autoplay muted
-    style="display:block;width:100vw;height:100vh"></hyperframes-player>
-  <script>
-    document.getElementById("p").setAttribute(
-      "src",
-      "./index.html" + location.search,
-    );
-  </script>
-</body>
-</html>
+The more specific your prompt, the better the output. Include palette, fonts, duration, and scene ideas when you have them.
+
+## Known limitations
+
+- **In-pane preview** — scrubbing is unreliable in Claude Design's iframe sandbox. Download and use `npx hyperframes preview` locally for reliable playback.
+- **No linting** — Claude Design can't run `npx hyperframes lint`. The template-first skeletons handle structural validity, but the self-review checklist is the only QA before download.
+- **No shaders on vertical** — HyperShader's WebGL canvas is hardcoded to 1920x1080. Vertical (1080x1920) compositions use hard cuts only.
+- **3 fetch limit** — Claude Design limits web fetches per turn. All critical rules are inlined in the skill; external references are for edge cases only.
+- **Seeking backwards** — scrubbing backwards in the in-pane preview can show blank frames (async capture race condition). Forward seeking usually works.
+
+## The handoff to your coding agent
+
+Claude Design's output is a valid first draft. Open it in Claude Code, Cursor, Codex, or any AI coding agent with terminal access:
+
+```bash
+npx skills add heygen-com/hyperframes   # one-time setup
+npx hyperframes lint                     # verify structure
+npx hyperframes preview                  # open the studio
 ```
 
-When `location.search` is empty (opened locally, outside Claude Design's sandbox), the token-forward line is a no-op and the player loads `./index.html` as expected.
+Then iterate:
 
-The composition (`index.html`) must also pre-load the HyperFrames runtime right after GSAP so the player can drive playback inside Claude Design's sandbox:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js"></script>
-```
-
-If a classic script tag is needed instead of ESM, use the global player build with the same token-forwarding script:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/@hyperframes/player/dist/hyperframes-player.global.js"></script>
-<hyperframes-player id="p" controls autoplay muted
-  style="display:block;width:100vw;height:100vh"></hyperframes-player>
-<script>
-  document.getElementById("p").setAttribute(
-    "src",
-    "./index.html" + location.search,
-  );
-</script>
-```
-
-See [`@hyperframes/player`](/packages/player) for the full API and framework examples.
-
-## What the skill teaches Claude Design
-
-The skill is self-contained — it includes every HyperFrames-specific contract and every known Claude Design sandbox workaround, so Claude Design rarely needs to fetch additional references. Highlights:
-
-- An explicit opening redirect: Claude Design is told NOT to reach for its default video artifacts (`copy_starter_component` with `kind: "animations.jsx"`, the built-in "Animated video" skill, React + Babel JSX, hand-rolled scale-to-fit stage wrappers). This is the single change that most reliably keeps Claude Design on the HyperFrames path
-- Correct `data-*` composition structure, the clip contract on scenes, and paused GSAP timelines registered on `window.__timelines`
-- Shader-transition timing rules: transitions must span the scene boundary (not start at it), animated content must be wrapped in `<div class="scene-content">` so its pre-animation state doesn't leak into the WebGL texture, and the `scenes.length === transitions.length + 1` invariant (with `flash-through-white` as the invisible-bridge escape hatch)
-- Sandbox-compatible preview: token-forwarding `preview.html` template, runtime pre-load in `index.html`, `data-composition-id` ↔ `__timelines` key match (and a convention that the root element's DOM `id` matches too)
-- Attachment-first input model: read screenshots / PDFs / reference videos when provided, otherwise ask one short clarifying question before generating
-- A banned-font list (including Fraunces, Inter Tight, and common AI defaults) plus a banned-pairings line to break the training-data monoculture
-- Deterministic render-safe animation choices (no `Date.now()`, no unseeded `Math.random()`, no `repeat: -1`, no `stagger: { from: "random" }`)
-- Four worked-example anti-patterns with WRONG/RIGHT code pairs — exit tweens before shader transitions, non-deterministic `stagger` origins, absolute-positioned content containers, and SVG filter data URLs as `background-image` (the last one causes `SecurityError` on Safari + cross-origin iframe environments)
-- A `README.md` template for the end user with `npx hyperframes doctor` / `preview` / `render` commands and FFmpeg install instructions
+- "Make scene 3's entrance snappier"
+- "Add a counter animation to the stat in scene 5"
+- "Tighten the pacing — scenes 4 and 6 feel too long"
+- "Change the shader on transition 2 to glitch"
 
 ## Next steps
 

--- a/docs/guides/prompting.mdx
+++ b/docs/guides/prompting.mdx
@@ -29,13 +29,18 @@ In Claude Code, restart the session after installing. Skills register as **slash
 
 ## Claude Design
 
-Claude Design uses a different setup. Instead of local slash commands, point it at the GitHub-hosted Claude Design entry point for HyperFrames:
+Claude Design uses a different setup. Download [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) and **attach it to your chat** (don't paste the URL — file attachments produce better output):
 
 ```text
-Use https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md and make a 30-second product video about [topic]. Deliver index.html, preview.html, and README.md.
+Use the attached skill. 25-second LinkedIn video for my startup.
+
+Problem: Sales teams waste 3 hours/day on manual CRM updates.
+Solution: AutoCRM — AI that logs every call, email, and meeting.
+Traction: 200+ teams, $1.2M ARR, 18% MoM growth.
+CTA: autocrmhq.com
 ```
 
-That entry point tells Claude Design to fetch the broader [`skills/`](https://github.com/heygen-com/hyperframes/tree/main/skills) tree, apply the same HyperFrames rules, and use `@hyperframes/player` for preview pages. See the [Claude Design guide](/guides/claude-design) for the recommended prompt shape.
+Claude Design produces a valid first draft (brand identity, scene content, animations, transitions). Download the ZIP and refine in any AI coding agent with `npx hyperframes preview` running. See the [Claude Design guide](/guides/claude-design) for the full workflow.
 
 ## The two prompt shapes
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,7 +16,7 @@ npx skills add heygen-com/hyperframes
 This teaches your agent (Claude Code, Cursor, Gemini CLI, Codex) how to write correct compositions and GSAP animations. In Claude Code the skills register as slash commands — `/hyperframes` for composition authoring, `/hyperframes-cli` for CLI commands, and `/gsap` for animation help. Invoking the slash command loads the skill context explicitly, which produces correct output the first time.
 
 <Note>
-  Claude Design uses a different entry path. Point Claude Design at [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) so it can fetch the repo's `skills/` tree and generate a HyperFrames handoff. See the [Claude Design guide](/guides/claude-design).
+  Claude Design uses a different entry path. Download [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) and attach it to your Claude Design chat. It produces a valid first draft you can refine in any AI coding agent. See the [Claude Design guide](/guides/claude-design).
 </Note>
 
 ### Try it: example prompts

--- a/skills/claude-design-hyperframes/SKILL.md
+++ b/skills/claude-design-hyperframes/SKILL.md
@@ -1,677 +1,445 @@
 ---
 name: claude-design-hyperframes
-description: Claude Design entry point for HyperFrames. Produce renderable HyperFrames videos in Claude Design with a working in-pane preview. Use for any request to create a video, animation, launch teaser, editorial explainer, product tour, social reel, or motion deliverable.
+description: Use when running inside Claude Design specifically. Produces a valid, brand-accurate HyperFrames video draft using pre-valid skeletons. For Claude Code / Cursor / Codex, use the `hyperframes` skill instead.
 ---
 
-# Claude Design + HyperFrames
+# Claude Design + HyperFrames (Template-First)
 
-For this project, your medium is **HyperFrames compositions**: plain HTML + CSS + a paused GSAP timeline. A separate CLI (`npx hyperframes render index.html`) turns the HTML into an MP4. You are authoring the HTML files — the user runs the CLI locally. You do NOT need a CLI environment to produce these files.
+Your medium is **HyperFrames compositions**: plain HTML + CSS + a paused GSAP timeline. The CLI (`npx hyperframes render index.html`) turns the HTML into an MP4. You author the HTML -- the user renders locally.
 
-**HyperFrames replaces your default video-artifact workflow for this project.** When the user asks for a video, animation, launch teaser, editorial explainer, product tour, social reel, or any motion deliverable:
-
-- Do **NOT** call `copy_starter_component` with `kind: "animations.jsx"`. The animations.jsx starter is the wrong format here — HyperFrames uses plain HTML + GSAP, not React Sprites.
-- Do **NOT** invoke the built-in "Animated video" skill. HyperFrames replaces it for this project.
-- Do **NOT** use React, Babel, or `<script type="text/babel">`. Compositions are plain HTML; animation state lives on a paused GSAP timeline registered on `window.__timelines`.
-- Do **NOT** hand-roll a 1920×1080 scale-to-fit stage wrapper. `<hyperframes-player>` (loaded in `preview.html`) handles viewport scaling and letterboxing for you.
-
-Your first action on a new brief is to **read the brief, ask a clarifying question if it's sparse, and commit to a visual identity** — not to copy a starter component.
-
-Users attach this skill to a Claude Design chat, drop brand assets (screenshots, PDFs, reference videos, pasted palettes), and describe a video. You return `index.html`, `preview.html`, `README.md`, and `DESIGN.md` as a downloadable ZIP. The user runs `npx hyperframes render index.html` locally to produce the MP4. Work through the five steps below — each has a gate you must pass before moving to the next.
+**HyperFrames replaces your default video-artifact workflow.** Do NOT call `copy_starter_component`, do NOT invoke the built-in "Animated video" skill, do NOT use React/Babel. Plain HTML + GSAP only.
 
 ---
 
-## Approach
+## Your role
 
-Before touching HTML, think in phases. Skipping phases is the single biggest quality problem in AI-generated video.
+**You produce a valid first draft -- not a final render.** Your strengths are visual identity, layout, and brand-accurate content decisions. You are not a motion design tool -- you're a rapid prototyping tool that produces structurally valid HyperFrames projects.
 
-1. **Brief** — what does the user want? What have they given you to synthesize from?
-2. **Identity** — what does this video LOOK like? palette, type, motion character, committed in one document before any HTML.
-3. **Beats** — what happens in what order? scenes, durations, verbs per element, mid-scene activity.
-4. **Build** — static layout first, then motion, then self-review.
-5. **Deliver** — preview shell + README for local render + caveats.
+The user's workflow:
+
+1. **Claude Design** (you) -- brand identity, scene content, layout, first-pass animations, shader choices
+2. **Download ZIP** -- user gets a valid HyperFrames project
+3. **Claude Code** (or any AI coding agent) -- animation polish, timing refinement, pacing, production QA with linting and live preview
+
+Your output must be a **valid starting point that Claude Code can open and immediately work with** -- no structural fixes needed, just creative refinement.
+
+### What you optimize for (your strengths)
+
+- Correct brand identity from attachments (palette, typography, tone)
+- Strong visual layout per scene (hierarchy, spacing, readability)
+- Scene content that tells the story (headlines, stats, copy, imagery)
+- Structural validity (passes `npx hyperframes lint` with zero errors)
+- Appropriate shader transition choices for the mood
+- Reasonable scene count and durations for the video type
+
+### What Claude Code polishes after you (refinement, not creation)
+
+You create ALL the animations, transitions, and mid-scene activity. Every scene ships with entrance tweens, breathing motion, and shader transitions. The video plays with full motion from your first draft.
+
+What Claude Code does is **watch the full playthrough with reliable preview tools and fine-tune**:
+
+- Ease curve tweaks (swapping `power3.out` for `expo.out` after seeing it play)
+- Stagger timing adjustments (0.12 → 0.08 feels tighter for this specific scene)
+- Scene duration micro-adjustments (scene 4 drags at 4.5s, trim to 3.8s)
+- Adding richer mid-scene activity where a scene feels too static after playback
+- Shader swaps (this `cinematic-zoom` should be `whip-pan` for the energy shift)
+- Production QA (snapshot verification, cross-browser testing)
+
+Think of it as: **you create the first cut of the film, Claude Code does the edit bay refinement.**
+
+---
+
+## How this works
+
+You get a **pre-valid skeleton** that already passes the HyperFrames linter. Your job:
+
+1. Read the brief, pick a skeleton
+2. Fill in the palette + typography (CSS custom properties)
+3. Fill in scene content (text, layout inside `.scene-content`)
+4. Fill in GSAP animations (timeline blocks marked per scene)
+5. Verify the preview, deliver the ZIP
+
+The skeleton handles the structural rules -- data attributes, timeline registration, HyperShader wiring, initial visibility, `preview.html` token forwarding. You focus on the creative work.
+
+**What you can change:** CSS custom properties, scene content, animation tweens, scene count (add/remove scenes following the rules below), shader choices, durations.
+
+**What you must not touch:** The `<script>` loading order, `window.__timelines` initialization, the `.scene.clip` class on scene containers, the `.scene-content` wrapper inside each scene, the `preview.html` structure.
 
 ---
 
 ## Step 1: Understand the brief
 
-**Gate:** You can name the subject, the duration, the aspect ratio, and at least one source of visual direction (attachment, pasted palette/type/copy, named aesthetic, or clarifying-question answer). If you can't — you don't have enough to build.
+**Gate:** You can name the subject, duration, aspect ratio, and at least one source of visual direction.
 
 ### Inputs, in order of reliability
 
-1. **Attachments (strongest visual source).** `.fig` Figma files, PDFs (brand guidelines, spec docs), `.docx`/`.pptx`, images/screenshots, reference video stills. Claude Design reads these natively with detail preserved. Mine for palette, typography, spacing, UI chrome, tone of voice.
-2. **Pasted content.** Hex codes, typefaces, copy samples, scripts, pasted style guides. Authoritative for what it covers.
-3. **Research.** When a brand, product, or topic is named, `web_search` and `web_fetch` aggressively. Static pages fetch fine — company blogs (`<brand>.com/blog`), press pages, Wikipedia, Crunchbase, TechCrunch, docs sites — and yield (a) tone/positioning, (b) real copy (taglines, feature names, product language), (c) sometimes hex codes + typeface names from press kits. SPA marketing homepages (React/Vue/Angular) are the one weak case — they return near-empty shells because JavaScript isn't executed. Pivot to the brand's blog / press / Wikipedia when the homepage returns little.
-4. **URLs the user provided.** Start there, expand outward.
+1. **Attachments** (strongest) -- screenshots, PDFs, brand guides, reference images. Mine for palette, type, tone.
+2. **Pasted content** -- hex codes, typefaces, copy, scripts.
+3. **Research** -- `web_search` the brand. Static pages (blogs, press, Wikipedia) work. SPA homepages return empty shells -- pivot to blog/press/Wikipedia.
+4. **URLs the user provided** -- start there, expand outward.
 
-Combine channels. Strong attachments + light research gives you brand-accurate visuals AND brand-accurate copy.
+### Ask ONE question if the brief is sparse
 
-### Mechanical trigger — ask ONE short question if the brief is sparse
-
-If the prompt contains NONE of the following, ask one clarifying question before generating:
-
-- A file attachment
-- A pasted hex code or named typeface
-- A named aesthetic / style / movement / director / genre
-- A specific brand with a well-known visual identity (Apple, Linear, Stripe, Notion, Figma, Vercel, Tesla, Spotify, etc.)
-- The words "go", "just build", "make it", "surprise me", "ship it"
-- A follow-up turn continuing an existing composition
-
-Do NOT rationalize past this check. "The user's email domain is the brand so I know what they want" is NOT a valid skip condition. "It's a well-known company so I'll just build" is NOT valid unless the brand is in the list above.
-
-Send one short message (4–6 lines) with concrete options:
-
-> To make this look like _yours_ — drop any of these (or describe in words):
->
-> - A screenshot or two of your product, site, or an ad you like.
-> - A brand PDF / style guide.
-> - A reference video for pacing / color / energy.
-> - A vibe in words — _"clinical and cold"_, _"loud and fast"_, _"a particular director / movie"_.
-> - A must-have — a specific shader, transition, text effect, or element you already want.
->
-> Or say _"just build"_ and I'll commit to _<one concrete aesthetic you've chosen for this brief — named concretely, not "warm editorial" or "generic dark mode">_.
-
-Wait for the reply. When the user answers, incorporate fully. When they say "just build" / "go" / "ship it" / "surprise me", commit to the aesthetic you offered and proceed.
+If the prompt has NONE of: an attachment, a hex code or named typeface, a named aesthetic/style/director, a well-known brand, or "just build" / "surprise me" -- ask one short clarifying question with concrete options. Wait for the reply.
 
 ---
 
-## Step 2: Commit to a visual identity
+## Step 2: Pick a skeleton and fill identity
 
-**Gate:** `DESIGN.md` exists in the project directory with palette, typography, and motion character defined.
+**Gate:** A working `index.html` exists with your palette and typography on `:root`. The preview renders (even if scenes are empty).
 
-### Visual Identity Gate
+### Choose by video type
 
-<HARD-GATE>
-Before writing ANY composition HTML, you MUST have a visual identity defined. Do NOT write compositions with default or generic colors.
-</HARD-GATE>
+| Type                     | Duration | Scenes | Skeleton   |
+| ------------------------ | -------- | ------ | ---------- |
+| Social reel (9:16)       | 10-15s   | 5-7    | Skeleton A |
+| Launch teaser (16:9)     | 15-25s   | 7-10   | Skeleton B |
+| Product explainer (16:9) | 30-60s   | 10-18  | Skeleton C |
+| Cinematic title (16:9)   | 45-90s   | 7-12   | Skeleton D |
 
-Commit to ONE aesthetic and write `DESIGN.md` before `index.html`. The document is a thinking step, not a deliverable template.
+Copy the skeleton (Section 7 below), then **immediately fill the `:root` CSS custom properties**:
 
-`DESIGN.md` contains:
-
-- **Palette.** Name each color's role (bg, ink, accent, muted). Use exact hex values or OKLCH. One accent hue, tinted neutrals.
-- **Typography.** Display face + body face. See banned list below — and look beyond the standard pairs. Weight contrast must be dramatic (300 vs 900, not 400 vs 700). Video sizes: 60px+ headlines, 20px+ body, 16px+ data labels.
-- **Motion character.** Pacing (fast/medium/slow/cinematic), primary transition family (CSS vs shader, which shader), easing defaults, what NOT to do.
-
-Reference the tokens via CSS custom properties on `:root` in `index.html`.
+```css
+:root {
+  /* === FILL: Your brand identity === */
+  --bg: #0a0a0d;
+  --ink: #f5f5f7;
+  --accent: #7c6cff;
+  --muted: #5a6270;
+  --accent-dim: #3d3680;
+  --font-display: "Space Grotesk", sans-serif;
+  --font-data: "JetBrains Mono", monospace;
+}
+```
 
 ### Anti-monoculture
 
-Training-data defaults every LLM reaches for. Commit to something the brief specifically calls for instead.
+These are the defaults every LLM reaches for. Pick something the brief actually calls for:
 
-- **Don't default to warm editorial** (cream paper + serif + terracotta accent).
-- **Don't default to generic dark-mode tech** (black + violet accent + Inter + geometric sans).
-- **Banned fonts:** Inter, Inter Tight, Roboto, Open Sans, Noto Sans, Arimo, Lato, Source Sans, PT Sans, Nunito, Poppins, Outfit, Sora, Fraunces, Playfair Display, Cormorant Garamond, Bodoni Moda, EB Garamond, Cinzel, Prata, Syne. Full list and reasoning: `skills/hyperframes/references/typography.md`.
-- **Banned pairings (observed AI defaults):** Fraunces + JetBrains Mono (every test-run of an editorial brief lands here); Inter + anything; Playfair + Lato. Pick different faces each time.
-- **Lazy defaults to question:** gradient text, left-edge accent stripes, cyan-on-dark, pure `#000` / `#fff`, identical card grids, everything centered with equal weight. See `skills/hyperframes/house-style.md` for the full list.
+- **Banned fonts:** Inter, Inter Tight, Roboto, Open Sans, Noto Sans, Lato, Poppins, Outfit, Sora, Fraunces, Playfair Display, Cormorant Garamond, EB Garamond, Syne, Cinzel, Prata, Bodoni Moda, Nunito, Source Sans, PT Sans, Arimo.
+- **Banned pairings:** Fraunces + JetBrains Mono, Inter + anything, Playfair + Lato.
+- **Question these defaults:** gradient text, cyan-on-dark, pure `#000`/`#fff`, identical card grids, left-edge accent stripes, everything centered with equal weight.
 
----
-
-## Step 3: Plan the beats
-
-**Gate:** You can list every scene, its duration, and at least one verb per animated element in that scene. If a verb is missing, the element isn't designed yet.
-
-### Scene plan + pacing
-
-**Hard ceiling: no scene longer than 5 seconds unless there's a deliberate pacing reason.** Scenes in the 6–12s range read as draggy slides; viewers feel the stall. Only go longer than 5s when you can name the reason — a deliberate hold on a hero frame, a long cinematic push, a silence beat, a counter that animates over 6+ seconds to feel substantial. Default to quick. Slow down with intention.
-
-**Hard floor: scene must last at least as long as a viewer needs to read its text.** A 2-second scene with a 20-word paragraph is broken — viewers cannot read it before the transition fires. The "too short" failure is as real as "too long."
-
-Reading-time budget per scene:
-
-| Displayed text (visible during the scene)         | Minimum scene duration                                                                           |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| No text (hero image, icon, decorative)            | **1.5–2s**                                                                                       |
-| 1–3 words (kicker, label, number, short headline) | **2–3s**                                                                                         |
-| 4–10 words (short headline + tiny subhead)        | **3–4s**                                                                                         |
-| 11–20 words (a full sentence or two short lines)  | **4–6s**                                                                                         |
-| 21–35 words (multi-line paragraph, bullet list)   | **6–8s**                                                                                         |
-| 35+ words (dense explainer text)                  | **Split into two scenes.** A single scene should not ask the viewer to read more than ~35 words. |
-
-On top of reading time, add entrance-animation buffer: 0.6–1.0s for the text to finish entering before the viewer can start reading it. Practical formula: **scene_duration ≥ entrance_buffer + (word_count × 0.25s) + 0.5s transition tail**, with a minimum of 1.5s.
-
-Apply this per scene. If scene-3's display text is 18 words of serif body copy, scene-3 needs ~5s, not 3s. If scene-12 is a single-word slam ("Design."), 2s is fine — maybe ideal.
-
-**Last readable element must finish entering by the 50% mark of the scene.** That gives the viewer the second half of the scene to actually read the text before the transition starts. If the last `tl.from("#s5-sub", …)` on a 4-second scene finishes at t=3.5s, the viewer has only 0.5s to read — not enough. Pull entrances earlier or lengthen the scene.
-
-**Anti-pattern:** dividing total duration by scene count AND ignoring per-scene reading-time. A 2-minute video ÷ 10 scenes = 12-second scenes (too long per hard ceiling); or ÷ 60 scenes = 2-second scenes (too short if any of them has sentence-length text).
-
-**Better:** pick a scene count targeting 3–5s average, then ADJUST each scene up or down based on what it has to show. Short scenes for punches, images, and kickers. Medium scenes for headlines. Longer scenes for body copy or bullet lists.
-
-| Video length       | Target scene count | Avg scene | Notes                                                |
-| ------------------ | ------------------ | --------- | ---------------------------------------------------- |
-| 10–15s social ad   | 5–8                | 2–3s      | Relentless cuts, every scene is a punch              |
-| 20–30s teaser      | 8–12               | 2–4s      | Open / build / payoff / close, varied                |
-| 30–60s explainer   | 12–20              | 3–5s      | Each beat its own scene — don't combine two ideas    |
-| 60–120s narrative  | 24–40              | 3–5s      | Dense pacing. Think YouTube explainer, not slideshow |
-| 120–240s long-form | 40–70              | 4–5s      | Split into sub-compositions, each act ~8–14 scenes   |
-
-Four mechanical checks before closing Step 3:
-
-1. **Per-scene reading-time check:** count the words of display text in each scene. Does `scene.data-duration` satisfy the reading-time budget above? If not, extend the scene (if budget headroom exists) or split the text across two scenes.
-2. **Last-readable-element check:** for each scene, find the last `tl.from` on a readable text element. Does it finish (start + duration) before the 50% mark of the scene? If not, pull the entrance earlier.
-3. **If a scene's `data-duration` exceeds 5 seconds, write one sentence justifying why it holds that long.** If you can't, split it into two scenes with different beats.
-4. **Model the rhythm as a wave, not a flat line.** `short-short-LONG-short-short-LONG-short` reads as intentional pacing. `flat-flat-flat-flat` reads as a slideshow. Same-duration across scenes = dividing, not designing.
-
-### Build / Breathe / Resolve (per scene)
-
-Every scene > 4 seconds has three phases. Dumping everything in the build and leaving nothing for breathe/resolve is the #1 quality failure.
-
-| Phase       | When       | What                                                                                   |
-| ----------- | ---------- | -------------------------------------------------------------------------------------- |
-| **Build**   | 0 – 30%    | Elements enter, staggered. Don't dump everything at once. Offset first tween 0.1–0.3s. |
-| **Breathe** | 30% – 70%  | Content visible, alive with at least ONE ambient motion. No element stands still here. |
-| **Resolve** | 70% – 100% | A beat resolves — accent pulse, number lands, secondary element arrives, decisive end. |
-
-Full motion theory (easing as emotion, direction rules, speed as weight, transitions as meaning): `skills/hyperframes/references/motion-principles.md`.
-
-### Animation verbs
-
-Every element gets a verb. If you can't name the verb, the element is not yet designed.
-
-| Energy        | Verbs                                         | Example                               |
-| ------------- | --------------------------------------------- | ------------------------------------- |
-| High impact   | SLAMS, CRASHES, PUNCHES, STAMPS, SHATTERS     | "$1.9T" SLAMS in from left at -5°     |
-| Medium energy | CASCADE, SLIDES, DROPS, FILLS, DRAWS          | Three cards CASCADE in staggered 0.3s |
-| Low energy    | types on, FLOATS, morphs, COUNTS UP, fades in | Counter COUNTS UP from 0 to 135K      |
-
-### Mid-scene activity (kills the "animated slides" failure)
-
-Every visible element must have motion during the Breathe phase — not just an entrance. A still image on a still background is a JPEG with a progress bar.
-
-| Element type           | Mid-scene activity                                                                                |
-| ---------------------- | ------------------------------------------------------------------------------------------------- |
-| Image / screenshot     | Slow zoom (`scale: 1 → 1.03-1.05` over scene duration), slow pan, or Ken Burns                    |
-| Stat / number          | Counter animates from 0 to target                                                                 |
-| Chart / bars           | Bars fill in sequence; line draws via `strokeDashoffset`                                          |
-| Logo / lockup          | Subtle shimmer sweep, gentle scale pulse, or audio-reactive (if music present)                    |
-| Background decoratives | Radial glow breathing, gradient shift, grain drift, hairline rule pulse                           |
-| Any persistent element | Subtle float (`y: ±4-6px`, `sine.inOut`, `yoyo: true, repeat: 1`) so it's alive instead of frozen |
-
-**Anti-pattern:** entrance tween at t=0.5, element never moves again for the remaining 4+ seconds. If that's the shape of a scene, it's a slideshow, not video.
-
-### Cinematic planning, not CSS planning
-
-Write each scene as an experience first, specs second. The difference:
-
-**Mediocre:** _"Dark navy background. '$1.9T' in white, 280px. Logo top-left. Wave image bottom-right."_
-
-**Great:** _"Camera is already mid-flight over a vast dark canvas. The gradient wave sweeps across the frame like aurora borealis — alive, shifting. '$1.9T' SLAMS into existence with such force the wave ripples in response. This isn't a slide — it's a moment."_
-
-The first describes pixels. The second describes an experience. Write the second, then figure out the pixels.
+Pick a real typeface pair. Weight contrast must be dramatic (300 vs 900, not 400 vs 700). Video sizes: 60px+ headlines, 20px+ body, 16px+ labels.
 
 ---
 
-## Step 4: Build
+## Step 3: Fill scenes -- content + animation
 
-**Gate:** Every composition you wrote passes the self-review checklist at the end of this section.
+**Gate:** Every scene has visible content, at least 2 animation patterns from Section 8, and mid-scene activity. No scene is a static slide.
 
-### Layout Before Animation
+Work scene by scene. For each:
 
-Static layout FIRST, motion SECOND.
+### 3a. Fill scene content
 
-1. Write the scene's HTML + CSS as if it were a static poster — where every element LANDS at its most-visible moment.
-2. Verify the static layout works in a browser (no GSAP, no JS).
-3. Only after the layout is correct, add timeline + animations. `gsap.from()` animates FROM offscreen/invisible TO the CSS position. The CSS position is the ground truth.
-
-Scene containers use `.scene-content` flex centering, not absolute positioning on inner content. Keep decoratives (backgrounds, glows, hairlines, grain) OUTSIDE `.scene-content`. Keep animated content INSIDE `.scene-content`.
-
-### Clip contract
-
-Every scene is a HyperFrames clip. **EVERY scene has a `<div class="scene-content">` wrapper — not just scene-1. This is the single most-missed rule in output audits.** The wrapper exists so `HyperShader.captureIncomingScene()` can hide scene content during `html2canvas` capture, preventing pre-animation from-states from leaking into the WebGL texture. Without the wrapper on a non-first scene, you'll see boxes, clipped text, or empty placeholders during the transition INTO that scene.
+Put text, images, and layout inside the `.scene-content` wrapper. The wrapper already exists in the skeleton -- add your elements inside it.
 
 ```html
-<!-- SCENE 1 — visible from t=0, no inline style -->
-<div class="scene clip" id="s1" data-start="0" data-duration="5" data-track-index="0">
-  <!-- OUTSIDE .scene-content: backgrounds, decoratives. Captured into shader textures. -->
-  <div class="bg-grain"></div>
-  <div class="bg-vignette"></div>
-  <!-- INSIDE .scene-content: every animated element. REQUIRED on every scene. -->
-  <div class="scene-content">
-    <h1 id="s1-title">…</h1>
-    <p id="s1-sub">…</p>
-  </div>
-</div>
-
-<!-- SCENE 2+ — starts hidden; same wrapper structure.
-     Inline style is opacity:0 ONLY (no visibility:hidden). See "Scene initial visibility" below. -->
-<div
-  class="scene clip"
-  id="s2"
-  data-start="5"
-  data-duration="5"
-  data-track-index="0"
-  style="opacity:0;"
->
-  <div class="bg-grain"></div>
-  <div class="scene-content">
-    <!-- ← MANDATORY, not just a scene-1 pattern -->
-    <h1 id="s2-title">…</h1>
-    <p id="s2-sub">…</p>
-  </div>
+<div class="scene-content">
+  <h1 id="s3-title" class="display">$1.9 Trillion</h1>
+  <p id="s3-sub" class="body-text">processed annually</p>
+  <div id="s3-bar-chart">...</div>
 </div>
 ```
 
-### Data attributes
+Keep decoratives (glows, grain, vignette) OUTSIDE `.scene-content`, inside the scene div directly.
 
-Every timed element (scene, image, video, audio, sub-composition host) is a "clip" and must carry:
+### 3b. Fill entrance animations
 
-| Attribute          | Required                          | Values                                                |
-| ------------------ | --------------------------------- | ----------------------------------------------------- |
-| `id`               | yes                               | unique identifier                                     |
-| `class="clip"`     | yes                               | literal string (scenes use `"scene clip"`)            |
-| `data-start`       | yes                               | seconds, or clip-id reference (`"el-1"`, `"intro+2"`) |
-| `data-duration`    | required for img/div/compositions | seconds. video/audio default to media duration        |
-| `data-track-index` | yes                               | integer. same-track clips cannot overlap in time      |
-| `data-media-start` | no                                | trim offset into source (seconds) for video/audio     |
-| `data-volume`      | no                                | 0–1 (default 1) for audio                             |
-
-`data-track-index` is TIMELINE layering (which clip's timeline wraps which) — **not visual z-order.** Use CSS `z-index` for stacking. Same-track clips can't overlap in time; use different tracks for simultaneous clips or put them on the same track with non-overlapping windows.
-
-Composition roots (the outer `index.html` and any `<template>`-wrapped sub-comp root) also need:
-
-| Attribute              | Required | Values                                                    |
-| ---------------------- | -------- | --------------------------------------------------------- |
-| `data-composition-id`  | yes      | unique ID. root uses `"main"` by convention               |
-| `data-start`           | yes      | root: `"0"`                                               |
-| `data-duration`        | yes      | seconds. takes precedence over GSAP timeline length       |
-| `data-width`           | yes      | pixel width (1920 for 16:9, 1080 for 9:16, 1080 for 1:1)  |
-| `data-height`          | yes      | pixel height (1080 for 16:9, 1920 for 9:16, 1080 for 1:1) |
-| `data-composition-src` | no       | path to external HTML sub-composition (`compositions/…`)  |
-
-### Timeline contract
-
-- Every composition has exactly ONE timeline, created `paused: true`.
-- Register it on `window.__timelines["<composition-id>"]` — the key MUST match the root's `data-composition-id` exactly.
-- The composition root's DOM `id` attribute should also equal its `data-composition-id` (convention: `<div id="main" data-composition-id="main" …>`). Nothing in the runtime enforces this, but consistent IDs make `#main` selectors in your timeline code and the `__timelines` key one word apart — preventing the `id="root"` / `data-composition-id="main"` / `__timelines["main"]` three-way drift that's easy to typo.
-- Never call `.play()` on the timeline — the player/render engine drives playback via frame-accurate seeking.
-- Framework auto-nests sub-comp timelines — DO NOT manually `.add()` them to the root timeline.
-- Duration comes from `data-duration` on the root, NOT from GSAP timeline length.
-- Construct synchronously at page load. No `async`/`await`/`setTimeout` wrapping timeline code.
-
-### Video and audio
-
-Video elements must be `muted playsinline`. Browsers silently block audio playback on inline video, so HyperFrames **never uses `<video>` for audio** — even when the audio is from the same source file, it goes on a separate `<audio>` element with its own `data-track-index`. Never call `video.play()` or `audio.play()` in your code; the framework owns media playback.
-
-```html
-<video
-  id="v-main"
-  class="clip"
-  data-start="0"
-  data-duration="30"
-  data-track-index="0"
-  src="footage.mp4"
-  muted
-  playsinline
-></video>
-
-<audio
-  id="v-main-audio"
-  class="clip"
-  data-start="0"
-  data-duration="30"
-  data-track-index="2"
-  src="footage.mp4"
-  data-volume="1"
-></audio>
-```
-
-If your video has audio that only plays during part of the scene, use `data-media-start` to offset into the source, and trim `data-duration` to the audible window.
-
-### Scene initial visibility — TWO paths depending on whether HyperShader runs in this file
-
-The runtime's visibility gate sets `style.visibility = "hidden"` on every `[data-start]` element outside its window — BUT it **never touches `style.opacity`**. That splits the rules for non-first scenes:
-
-**WITH HyperShader in this file:** non-first scenes carry `style="opacity:0;"` ONLY — no `visibility:hidden`. The runtime's visibility gate already keeps the scene hidden before its `data-start`, and HyperShader's `captureIncomingScene` temporarily forces `opacity:1` during `html2canvas` capture so the shader gets a real texture of the incoming scene's background + decoratives. At transition end, HyperShader sets the incoming scene's `style.opacity = "1"` itself.
-
-Do NOT add `visibility:hidden` in the inline style on these scenes. It's redundant (the runtime gate handles hiding) AND it breaks `captureIncomingScene` — `html2canvas` sees the element as `visibility:hidden`, renders it as blank, and the shader ends up transitioning from a real outgoing scene to a blank incoming texture. Visually: content morphs/fades into the background color during the transition, then pops in after — a visible "blink" at the transition.
-
-**WITHOUT HyperShader in this file:** non-first scenes carry `style="visibility:hidden;"` ONLY — no `opacity:0`. Nothing animates scene-container opacity back to 1 without HyperShader; if you include `opacity:0` the scene stays invisible for its entire window.
-
-Scene-1 always has no inline style — it's visible from t=0.
-
-### Shader transitions
-
-Use `@hyperframes/shader-transitions`. Exactly **14 shader names** are valid — any other string throws `[HyperShader] Unknown shader`:
-
-`domain-warp`, `ridged-burn`, `whip-pan`, `sdf-iris`, `ripple-waves`, `gravitational-lens`, `cinematic-zoom`, `chromatic-split`, `swirl-vortex`, `thermal-distortion`, `flash-through-white`, `cross-warp-morph`, `light-leak`, `glitch`.
-
-Authoritative list: `packages/shader-transitions/src/shaders/registry.ts`.
-
-Mood → shader mapping: `skills/hyperframes/references/transitions.md`.
-
-The IIFE build registers the package on **`window.HyperShader`** (not `HyperframesShaderTransitions`):
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/@hyperframes/shader-transitions/dist/index.global.js"></script>
-<script>
-  const tl = gsap.timeline({ paused: true });
-  window.HyperShader.init({
-    bgColor: "#0a0a0d",
-    scenes: ["s1", "s2", "s3"],
-    timeline: tl,
-    transitions: [
-      { time: 5.75, shader: "cinematic-zoom", duration: 0.5 },
-      { time: 11.75, shader: "whip-pan", duration: 0.5 },
-    ],
-  });
-  window.__timelines["main"] = tl;
-</script>
-```
-
-**Scene-count invariant — `scenes.length === transitions.length + 1`:** HyperShader enforces this at init. Pick one anchor scene BEFORE the first transition, and one anchor AFTER each transition. A video with three act-boundary transitions needs exactly four anchor scenes. Scenes between anchors (non-bracketing, runtime-managed) carry `style="visibility:hidden;"` instead of `style="opacity:0;"` — they're not HyperShader-managed so nothing animates their opacity back to 1.
-
-The simplest working pattern: list only the scene just before AND just after each shader cut. Do NOT list every scene in Act II just because they "span" a transition — that violates the invariant. If you genuinely need MORE listed anchors than real shader transitions (rare — e.g., tracking an additional fade beat that's not a visible shader bridge), insert `{ shader: "flash-through-white", duration: 0.01 }` as an invisible no-op bridge to satisfy the invariant. This is a workaround; the cleaner fix is almost always to drop the extra anchor.
-
-**Transition timing (critical — the scene boundary must fall INSIDE the transition window):**
-
-Scene windows are half-open (`[start, start+duration)`). At time `B` (the boundary), the runtime has already flipped the outgoing scene to `visibility:hidden`. If `transition.time === B`, `html2canvas` captures a blank outgoing texture → shader transitions from blank → incoming → visible blink.
-
-Rule: `transition.time < B` AND `transition.time + duration > B`. Simplest — center it: `transition.time = B - duration/2`. Example: scene-1 ends at 6, duration 0.5 → `time: 5.75`.
-
-**Scene visibility: HANDS OFF.** HyperShader owns scene `opacity` end-to-end. Do NOT add `tl.set(#scene-N, {autoAlpha: …}, …)` on scene containers. If you do, you create the same visibility race that produces the blink.
-
-### Sub-compositions — default NO for videos ≤ 3 minutes
-
-Default to a single `index.html` with scenes tiled inline. 30-second to 2-minute compositions fit cleanly in one file (~1500–2000 lines). Single file = single HyperShader instance = no canvas conflicts = everything works.
-
-Split into sub-compositions ONLY when one of these is true:
-
-- Video length > 3 minutes AND you need organizational structure.
-- You're extracting a REUSABLE sub-comp that appears in multiple places (chart block, logo outro).
-- A single scene is so complex it deserves its own file (full UI recreation, heavy data-vis).
-
-If you do split, **HyperShader lives at the ROOT `index.html` ONLY** — never inside a sub-composition. HyperShader hardcodes `#gl-canvas` as its canvas ID (see the canvas creation path in `packages/shader-transitions/src/hyper-shader.ts`); multiple HyperShader instances can't share one canvas. When a sub-comp's HyperShader fails silently on canvas conflict, its fallback code calls `document.querySelectorAll(".scene")` document-wide and sets every scene's opacity to 0 — corrupting visibility across the whole document. Symptom: only scene-1 of each act shows, scenes 2+ never appear.
-
-#### Sub-composition file shape
-
-Every sub-comp file in `compositions/` is wrapped in a `<template>`. The template's contents are INERT in the browser by spec — the runtime extracts and nests them into the parent at render time. A standalone `index.html` (the main composition) does NOT use `<template>`; the data-composition-id div goes directly in `<body>`.
-
-```html
-<!-- compositions/act-1-intro.html -->
-<template id="act-1-intro-template">
-  <div class="hf-sub" data-composition-id="act-1-intro" data-width="1920" data-height="1080">
-    <style>
-      .hf-sub {
-        position: relative;
-        width: 1920px;
-        height: 1080px;
-      }
-      /* scene styles scoped to this sub-comp */
-    </style>
-
-    <div class="scene clip" id="a1-s1" data-start="0" data-duration="5" data-track-index="0">
-      <div class="scene-content">…</div>
-    </div>
-    <div
-      class="scene clip"
-      id="a1-s2"
-      data-start="5"
-      data-duration="5"
-      data-track-index="0"
-      style="visibility:hidden;"
-    >
-      <div class="scene-content">…</div>
-    </div>
-
-    <script>
-      // Sub-comp does NOT re-load GSAP — parent loads it once.
-      window.__timelines = window.__timelines || {};
-      const tl = gsap.timeline({ paused: true });
-      // Tween positions are LOCAL (0 = sub-comp start). Parent auto-offsets at its data-start.
-      tl.from("#a1-s1 .title", { y: 40, autoAlpha: 0, duration: 0.8 }, 0.3);
-      tl.from("#a1-s2 .body", { y: 20, autoAlpha: 0, duration: 0.6 }, 5.3);
-      // DO NOT call window.HyperShader.init() here — HyperShader is root-only.
-      window.__timelines["act-1-intro"] = tl;
-    </script>
-  </div>
-</template>
-```
-
-#### Parent `index.html` wiring
-
-The parent mounts each sub-comp via `data-composition-src` on an empty div that carries the clip contract:
-
-```html
-<div
-  id="act-1"
-  class="scene clip"
-  data-composition-id="act-1-intro"
-  data-composition-src="compositions/act-1-intro.html"
-  data-start="0"
-  data-duration="30"
-  data-track-index="0"
-></div>
-```
-
-Three rules when splitting:
-
-1. `<template id="<id>-template">` wrapper required on every sub-comp. Contents are inert; the runtime extracts them.
-2. The `data-composition-id` on the sub-comp's inner root div MUST match BOTH (a) the parent container's `data-composition-id` AND (b) the key in `window.__timelines[...]` inside the sub-comp's script.
-3. Tween positions in a sub-comp are LOCAL to that sub-comp (0 = its start). The parent auto-offsets by the container's `data-start`. Never manually add sub-timelines to the root timeline.
-
-Since the sub-comps in this pattern don't use HyperShader (by the rule above), their non-first scenes carry `style="visibility:hidden;"` only — see "Scene initial visibility" above for why.
-
-### Determinism ❌ / ✅
-
-The render engine seeks to exact frames and expects pixel-identical output on every repeat render. Violations produce broken output.
-
-| ❌ Never                                   | ✅ Use instead                                        |
-| ------------------------------------------ | ----------------------------------------------------- |
-| `Date.now()`, `performance.now()`          | `tl.time()` inside `onUpdate`, or hard-coded timing   |
-| `Math.random()` unseeded                   | seeded PRNG (e.g. mulberry32) with a known seed       |
-| `setInterval`, `setTimeout` in timeline    | timeline tweens + `onUpdate` callbacks                |
-| `repeat: -1` on any tween or timeline      | `repeat: Math.ceil(duration / cycleDuration) - 1`     |
-| Timelines built in `async`/`await` wrapper | Construct synchronously at page load                  |
-| `video.play()`, `audio.play()` in code     | Framework owns media playback                         |
-| Animating `visibility` or `display`        | `autoAlpha` (animates opacity AND toggles visibility) |
-
-### Motion rules (HyperFrames-native, non-negotiable)
-
-Inherited from `skills/hyperframes/SKILL.md#Rules-Non-Negotiable`:
-
-- **GSAP visual properties only.** Animate `opacity`, `x`, `y`, `scale`, `rotation`, `color`, `transforms`. Do NOT animate `visibility` or `display` directly (use `autoAlpha`).
-- **One paused timeline per composition.** `{ paused: true }`. Register on `window.__timelines["<composition-id>"]`. Never call `.play()`.
-- **Vary eases** — at least 3 different eases per scene. Don't default to `power2.out` on everything.
-- **Offset first tween 0.1–0.3s.** Zero-delay entrances feel like jump cuts.
-- **Exit animations BANNED** except on the final scene. The transition IS the exit. See the code examples below — this is the single most frequently-violated rule in generated output.
-
-### Motion anti-patterns (observed in generated output, with fixes)
-
-These four patterns keep appearing in generated compositions despite the rules above. Each one is observed in real outputs; each has a known-clean replacement. Pattern-match these, not just the prose rules.
-
-#### Anti-pattern 1: Exit tween before a shader transition
-
-The shader's `captureScene(fromScene)` runs `html2canvas` on the outgoing scene at transition time. If you've animated content to `opacity: 0` (or `autoAlpha: 0`, or off-screen) before the transition fires, `html2canvas` captures an empty scene. The shader morphs from an empty outgoing texture → the incoming scene, which looks like "the content vanished, then the transition happened." This is independent of whether the shader itself works — it's a composition-level bug.
-
-This matches industry practice: in Remotion's `<TransitionSeries>`, in the GSAP community's own guidance, and in HyperFrames' core `references/transitions.md` — the transition component owns the visual handoff. The scene's content does not animate its own exit.
+In the timeline block marked for this scene, add `tl.from()` tweens. Animate FROM offscreen/invisible TO the CSS position:
 
 ```js
-// ✖ WRONG — card fades to 0 before transition at t=17.80 fires.
-//   Shader captures an empty phone. User sees the card disappear
-//   0.85s before the transition, then an empty-phone-to-next-scene morph.
-tl.to("#s6-card", { x: 180, rotation: 14, duration: 0.55, ease: "power3.in" }, 16.5);
-tl.to("#s6-card", { autoAlpha: 0, duration: 0.25 }, 16.95); // BANNED
-
-// HyperShader transition at 17.80 captures #s6 with card invisible
-```
-
-```js
-// ✓ RIGHT — mid-scene swipe gesture, then a different beat holds the final
-//   frame. Card moves but stays visible. Transition handles the actual exit.
-tl.to("#s6-card", { x: 180, rotation: 14, duration: 0.55, ease: "power3.in" }, 15.3);
-tl.from("#s6-check", { scale: 0, duration: 0.3, ease: "back.out(2)" }, 15.6);
-tl.from("#s6-match-stamp", { scale: 1.5, autoAlpha: 0, duration: 0.4 }, 16.1);
-// scene 6 ends at 18.0 with the matched-stamp + pulsing check button visible.
-// HyperShader transition at 17.80 captures a FULL scene → clean morph.
-```
-
-Common trap: "I want to show a swipe gesture, so the card has to exit." No — the swipe gesture happens mid-scene, at 60–70% of scene duration. The last 30% of the scene shows the RESULT of the swipe (a match stamp, a confirmation, a badge). Keep something visible at transition time. If there's nothing logically left to show, the scene is too long — shorten it.
-
-#### Anti-pattern 2: Non-deterministic `stagger` origin
-
-```js
-// ✖ WRONG — `from: "random"` picks a random origin at timeline-construction
-//   time using GSAP's internal unseeded random. Two renders of the same
-//   composition produce different stagger orderings. Fails PSNR regression
-//   tests and violates the deterministic-render rule.
+// === SCENE 3 ===
+tl.from("#s3-title", { y: 40, autoAlpha: 0, duration: 0.6, ease: "power3.out" }, 10.3);
+tl.from("#s3-sub", { y: 20, autoAlpha: 0, duration: 0.5, ease: "power2.out" }, 10.7);
 tl.from(
-  "#s12 .card",
-  {
-    scale: 0.7,
-    autoAlpha: 0,
-    y: 40,
-    duration: 0.45,
-    stagger: { each: 0.04, from: "random" }, // BANNED
-  },
-  34.55,
+  "#s3-bar-chart",
+  { scaleY: 0, transformOrigin: "bottom", duration: 0.8, ease: "expo.out" },
+  11.0,
 );
 ```
 
-```js
-// ✓ RIGHT — deterministic stagger origins. All of these are safe.
-tl.from(
-  "#s12 .card",
-  { scale: 0.7, autoAlpha: 0, y: 40, duration: 0.45, stagger: { each: 0.04, from: "start" } },
-  34.55,
-); // natural order
+**Offset first tween 0.1-0.3s** into the scene. Zero-delay entrances feel like jump cuts.
 
-tl.from(
-  "#s12 .card",
-  { scale: 0.7, autoAlpha: 0, y: 40, duration: 0.45, stagger: { each: 0.04, from: "center" } },
-  34.55,
-); // ripple outward
+### 3c. Fill mid-scene activity (this is what separates video from slides)
 
-tl.from(
-  "#s12 .card",
-  {
-    scale: 0.7,
-    autoAlpha: 0,
-    y: 40,
-    duration: 0.45,
-    stagger: { each: 0.04, grid: [3, 5], from: [0, 0] },
-  },
-  34.55,
-); // grid-aware
-```
+Every visible element must keep moving AFTER its entrance. A still element on a still background is a JPEG with a progress bar. Use at least 2 patterns from Section 8 per scene.
 
-If you truly need pseudo-random ordering (rare), pre-shuffle the cards in the markup using a seeded PRNG like mulberry32 — the ordering is then committed to the DOM and deterministic forever.
+| Element            | Mid-scene motion                  | Pattern from Section 8                                                                       |
+| ------------------ | --------------------------------- | -------------------------------------------------------------------------------------------- |
+| Stat / number      | Counter animates from 0 to target | Counter animation                                                                            |
+| SVG line / path    | Draws itself in real-time         | SVG stroke draw                                                                              |
+| Title / wordmark   | Characters enter one by one       | Character stagger                                                                            |
+| Logo / lockup      | Subtle vertical drift             | Breathing float                                                                              |
+| Chart / bars       | Bars fill sequentially            | Bar chart fill                                                                               |
+| Image / screenshot | Slow zoom: `scale: 1 -> 1.03`     | Ken Burns (just `tl.to(el, { scale: 1.03, duration: sceneLength, ease: "none" })`)           |
+| Accent / highlight | Sweep across text                 | Highlight sweep                                                                              |
+| Background glow    | Opacity pulse                     | `tl.to(".glow", { opacity: 0.6, duration: 1.5, ease: "sine.inOut", yoyo: true, repeat: 1 })` |
 
-#### Anti-pattern 3: Centering content with `position: absolute; top; left` on `.scene-content`
+**The minimum per scene:** entrance tweens + at least one continuous motion (float, counter, zoom, or glow). Scenes with stats or charts should always use the counter or bar-fill pattern — these are the most visually engaging and easiest to implement.
 
-```css
-/* ✖ WRONG — absolute-positioned content container with hardcoded pixels.
-   Renders at 1920×1080 but overflows at any other aspect ratio. Also
-   pushes you toward absolute-positioning every child, which is fragile. */
-.scene-content {
-  position: absolute;
-  top: 200px;
-  left: 160px;
-  width: 1920px;
-  height: 1080px;
-}
-```
+### 3d. Adjust scene duration
 
-```css
-/* ✓ RIGHT — flex-filled container with padding for the positioning.
-   Works at any aspect ratio. Children flow naturally. */
-.scene-content {
-  width: 100%;
-  height: 100%;
-  padding: 120px 160px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 24px;
-  box-sizing: border-box;
-}
-```
+The skeleton has placeholder durations. Adjust each scene's `data-duration` based on:
 
-See `skills/hyperframes/SKILL.md#Layout-Before-Animation` for the full rationale — in short: position every element at its final landing state first, then `gsap.from()` the entrance animating TO that position.
+- **Reading time:** count words of display text, use the budget below
+- **Last readable element** must finish entering by 50% of scene duration
 
-#### Anti-pattern 4: SVG filter data URLs used as `background-image` (grain, noise, turbulence)
+| Display text                        | Min duration          |
+| ----------------------------------- | --------------------- |
+| No text (hero, icon)                | 1.5-2s                |
+| 1-3 words (kicker, number)          | 2-3s                  |
+| 4-10 words (headline + subhead)     | 3-4s                  |
+| 11-20 words (sentence or two lines) | 4-6s                  |
+| 21-35 words (paragraph)             | 6-8s                  |
+| 35+ words                           | Split into two scenes |
 
-Safari's WebKit applies stricter canvas-taint rules than Chrome. When a scene has a `<filter>` SVG element referenced as a `background-image: url("data:image/svg+xml...")` — a common grain/noise pattern — `html2canvas` produces a tainted canvas. Safari's WebGL then throws `SecurityError: The operation is insecure` at `gl.texImage2D()`, which has no framework opt-out (WebGL spec requires the check). Every shader transition falls through to the CSS-crossfade fallback; in Claude Design's cross-origin iframe sandbox this compounds with iframe throttling, and users see the whole piece play as hard cuts.
+**Hard ceiling: 5s per scene** unless you name a specific reason (hero hold, cinematic push, long counter animation).
 
-Empirically observed: skill-test8 in Safari + Claude Design = transitions work. skill-test-9 (identical framework, different grain implementation) in the same environment = zero shader transitions, all catch-handler fallbacks. The only structural difference was this:
+When you change a scene's duration, update `data-start` on subsequent scenes to keep them tiled end-to-end. Also update the root's `data-duration` to match the total.
 
-```css
-/* ✖ WRONG — SVG filter as background-image.
-   Taints html2canvas's output canvas in Safari → breaks every shader
-   transition in Safari + cross-origin iframes. Also measurably slower in
-   WebKit than CSS gradients even when it does work. */
-.grain {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.08;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-  mix-blend-mode: overlay;
-}
-```
+### Vary eases
 
-```css
-/* ✓ RIGHT — layered CSS radial-gradient dots. Same grain effect visually,
-   pure CSS rendering, zero canvas taint, fast everywhere. */
-.grain {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.18;
-  background-image:
-    radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1.2px),
-    radial-gradient(rgba(0, 0, 0, 0.18) 1px, transparent 1.2px);
-  background-size:
-    3px 3px,
-    5px 5px;
-  background-position:
-    0 0,
-    1px 2px;
-  mix-blend-mode: overlay;
-}
-```
+Use at least 3 different eases per scene. Don't default to `power2.out` on everything.
 
-The same principle applies to other SVG-filter decoratives (paper fiber via `feTurbulence + feDisplacementMap`, CRT scanline overlays built from SVG patterns, etc.). In general, **avoid SVG filter data URLs in scene markup** — prefer layered CSS gradients, `backdrop-filter`, or solid-color overlays.
-
-**Escape hatch for unavoidable SVG effects.** If a scene genuinely needs an SVG filter (rare — usually a specific decorative that cannot be replicated in CSS), mark that element with `data-no-capture`. The shader's `captureScene()` already has logic to skip elements with this attribute — it won't enter the html2canvas clone pass, so it can't taint the output canvas. The element will still render live in the browser; it just won't appear in the shader transition textures (which for a grain overlay is usually invisible anyway, since the overlay is typically so subtle and repetitive that not seeing it mid-transition is imperceptible).
-
-```html
-<!-- SVG decorative element skipped from shader capture only — still renders live -->
-<div class="grain svg-filter-grain" data-no-capture></div>
-```
-
-### Self-review — run this checklist before calling the build done
-
-Check every item with actual code, not assumptions.
-
-- [ ] Every scene has `class="scene clip"` + `data-start` + `data-duration` + `data-track-index`.
-- [ ] Non-first scenes have the correct inline style for the path in use. With HyperShader: `style="opacity:0;"` ONLY (no `visibility:hidden` — it breaks `captureIncomingScene` and produces content-fading-into-blank blinks during transitions). Without HyperShader: `style="visibility:hidden;"` ONLY (no `opacity:0` — nothing animates it back to 1).
-- [ ] Scene windows tile end-to-end with no gaps (scene-N's `data-duration` = next scene's `data-start` − this scene's `data-start`).
-- [ ] **Every scene has a `<div class="scene-content">` wrapper — not just scene-1.** Scan each scene's opening block and confirm the wrapper is present. Missing on any scene causes boxes/clipped elements during that scene's transition.
-- [ ] Animated content is INSIDE `.scene-content`; static decoratives are OUTSIDE.
-- [ ] **No scene is longer than 5 seconds** unless you can name the specific pacing reason (hero hold, cinematic push, silence beat, counter that needs ≥6s of runtime). Scenes of uniform length indicate you divided total duration by scene count instead of designing the rhythm.
-- [ ] **Every scene is long enough for its text to be read** — per the reading-time budget table in Step 3. 11–20 words needs ≥4s; 21–35 words needs ≥6s. The last readable text element in each scene finishes entering by the 50% mark of the scene so the viewer has the second half to actually read.
-- [ ] Shader transitions (if used) have the scene boundary strictly INSIDE the transition window — `transition.time < boundary < transition.time + duration`.
-- [ ] Zero `tl.set` / `tl.to` / `tl.from` / `tl.fromTo` on scene containers.
-- [ ] Every visible scene > 4s has a Breathe phase — at least one element in continuous motion, not just entrance + static.
-- [ ] Every element has a verb (from the verbs table) and an identifiable beat (build / breathe / resolve).
-- [ ] No banned fonts. No Inter, Roboto, Playfair, Syne. Check the full list.
-- [ ] No `Date.now()`, `Math.random()` unseeded, `repeat: -1`, `setInterval`, async timeline construction.
-- [ ] No `stagger: { from: "random" }` — GSAP's random is unseeded (Anti-pattern 2). Use `from: "start"`, `"center"`, `"end"`, or a grid origin instead.
-- [ ] No exit tweens except on the final scene. Grep every scene for `tl.to(..., { opacity: 0 })`, `tl.to(..., { autoAlpha: 0 })`, and `tl.to(..., { y: <offscreen> })` — these are Anti-pattern 1 and produce empty-scene captures.
-- [ ] No SVG filter data URLs as `background-image` (Anti-pattern 4). Grep for `data:image/svg+xml` in the CSS — if present, either replace with layered `radial-gradient`s (preferred) or add `data-no-capture` to the element. SVG filters taint html2canvas's canvas in Safari, killing every shader transition in Safari + cross-origin iframe environments.
-- [ ] Minimum font sizes: 60px+ headlines, 20px+ body, 16px+ labels. `font-variant-numeric: tabular-nums` on number columns.
-- [ ] No full-screen dark linear gradients (H.264 banding). Use radial or solid + localized glow.
-- [ ] `window.__timelines["<id>"] = tl` is registered and the id matches `data-composition-id` on the root.
+| Feeling    | Ease            | Duration |
+| ---------- | --------------- | -------- |
+| Smooth     | `power2.out`    | 0.4-0.6s |
+| Snappy     | `power4.out`    | 0.2-0.3s |
+| Bouncy     | `back.out(1.6)` | 0.3-0.5s |
+| Dramatic   | `expo.out`      | 0.3-0.5s |
+| Dreamy     | `sine.inOut`    | 0.5-0.8s |
+| Mechanical | `steps(5)`      | 0.3-0.5s |
 
 ---
 
-## Step 5: Deliver
+## Step 4: Transitions
 
-**Gate:** `index.html`, `preview.html`, `README.md`, and (when identity was invented) `DESIGN.md` all exist in the project. `preview.html` loads in Claude Design's in-pane preview.
+### The professional rule: most cuts are hard cuts
 
-### `preview.html` template (copy verbatim)
+In professional video, ~95% of scene changes are hard cuts. Effect transitions (shaders, dissolves) are reserved for 2-3 key moments — a hero reveal, an energy shift, the CTA landing. Using a shader on every cut is the video equivalent of bolding every word in a paragraph.
 
-Claude Design's sandbox requires a `?t=<token>` query on every internal URL. Without token forwarding, the iframe receives a `"preview token required"` placeholder and renders black.
+The skeleton pre-wires **2 shader transitions at key moments** and **hard cuts everywhere else**. This gives you varied rhythm: cut-cut-SHADER-cut-cut-SHADER-cut.
+
+### Three transition types
+
+**Hard cut (default -- most scenes use this):**
+No transition code needed. Scene N disappears, scene N+1 appears. The entrance animations on the new scene do all the visual work. This is the professional default.
+
+**Shader transition (2-3 per video -- hero/climax/CTA moments):**
+Pre-wired in the skeleton at key positions. HyperShader captures both scenes as textures and composites them pixel-by-pixel via WebGL.
+
+**When to use shaders vs hard cuts:**
+
+| Use shader for                  | Use hard cut for                     |
+| ------------------------------- | ------------------------------------ |
+| Hero reveal / product unveil    | Connective scenes between features   |
+| Major energy shift or act break | Rapid-fire lists or stats            |
+| CTA / final brand moment        | 3+ consecutive quick scene changes   |
+| Any moment the music punctuates | Scenes where pacing should feel fast |
+
+Rule of thumb: a 6-8 scene video wants **2 shader transitions** and the rest hard cuts.
+
+### Adjusting shader transitions
+
+**Change shader names** -- pick from these 14:
+
+`domain-warp`, `ridged-burn`, `whip-pan`, `sdf-iris`, `ripple-waves`, `gravitational-lens`, `cinematic-zoom`, `chromatic-split`, `swirl-vortex`, `thermal-distortion`, `flash-through-white`, `cross-warp-morph`, `light-leak`, `glitch`
+
+**Match shaders to energy:**
+
+| Energy               | Shaders                                              |
+| -------------------- | ---------------------------------------------------- |
+| Calm, editorial      | `cross-warp-morph`, `light-leak`, `domain-warp`      |
+| Medium, professional | `cinematic-zoom`, `whip-pan`, `sdf-iris`             |
+| High, aggressive     | `glitch`, `chromatic-split`, `ridged-burn`           |
+| Ethereal, mysterious | `gravitational-lens`, `ripple-waves`, `swirl-vortex` |
+
+**Adjust transition timing** -- when you change scene durations, recalculate each transition's `time`:
+
+```
+transition.time = scene_boundary - (transition.duration / 2)
+```
+
+Example: scene-3 ends at 8s, transition duration 0.5s -> `time: 7.75`.
+
+**Minimum transition duration: 0.3s.** Sweet spot is 0.5s.
+
+### How the skeleton handles this
+
+The skeleton only lists **anchor scenes** (the ones bracketing shader transitions) in `HyperShader.init()`. Anchor scenes use `style="opacity:0;"` because HyperShader manages their opacity. Non-anchor scenes use `style="visibility:hidden;"`.
+
+**CRITICAL — two bugs cause "invisible middle scenes" if you don't handle them:**
+
+1. **Non-anchor scenes need explicit `tl.set` visibility toggles.** Without them, the scene container stays at `visibility:hidden` and child animations play inside an invisible parent.
+
+2. **The first anchor scene in each shader group needs `tl.set("#sN", { opacity: 1 }, <start-time>)`.** HyperShader browser mode does NOT auto-show the first anchor. It stays at `opacity:0` for its entire window. Every demov4 composition has this bug.
+
+The skeleton pre-wires these toggles for every non-anchor scene using **`autoAlpha`** (not `visibility`):
+
+```js
+// --- Non-anchor scene toggles (REQUIRED — must use autoAlpha, not visibility) ---
+tl.set("#s1", { autoAlpha: 0 }, 2.5); // hide s1 at its end time
+tl.set("#s2", { autoAlpha: 1 }, 2.5); // show s2 at its start
+tl.set("#s2", { autoAlpha: 0 }, 5.0); // hide s2 at its end
+tl.set("#s3", { autoAlpha: 1 }, 5.0); // show s3 at its start
+tl.set("#s3", { autoAlpha: 0 }, 7.5); // hide s3 at its end
+```
+
+**Why `autoAlpha` and NOT `visibility`:** When any shader transition fires, HyperShader blanks ALL `.scene` elements to `opacity:0`. If a non-anchor scene only toggles `visibility`, the blanket reset poisons its `opacity` — the scene becomes `visibility:visible` but `opacity:0` (invisible). `autoAlpha` sets BOTH `opacity` AND `visibility` in one call, overriding the blanket reset.
+
+**Rules:**
+
+- Every non-anchor scene gets `tl.set("#sN", { autoAlpha: 1 }, <data-start>)` AND `tl.set("#sN", { autoAlpha: 0 }, <data-start + data-duration>)`
+- Scene 1 gets only a hide at its end time (it starts visible)
+- Anchor scenes do NOT get autoAlpha toggles — HyperShader owns their opacity
+- When you add or remove scenes, update these toggles to match
+
+Example for an 8-scene video with shaders at s4→s5 and s7→s8:
+
+- Anchor scenes: s4, s5, s7, s8 (listed in HyperShader `scenes` array, use `opacity:0`)
+- Non-anchor scenes: s1, s2, s3, s6 (NOT in HyperShader, use `visibility:hidden`, with explicit `tl.set` toggles)
+- Scene 1 has no inline style (visible from t=0)
+
+### Adding or removing shader transitions
+
+To add a shader transition between two scenes:
+
+1. Add both scene IDs to the `scenes` array in `HyperShader.init()`
+2. Add a transition object to the `transitions` array
+3. Change both scenes from `visibility:hidden` to `opacity:0`
+4. Invariant: `scenes.length === transitions.length + 1`
+
+To remove a shader transition (make it a hard cut instead):
+
+1. Remove the scene IDs from `scenes` (unless they're also anchors for another transition)
+2. Remove the transition from `transitions`
+3. Change affected scenes from `opacity:0` to `visibility:hidden`
+
+**BANNED: invisible bridge transitions.** Never pad with `flash-through-white` at 0.01s.
+
+---
+
+## Step 5: Verify the preview + deliver
+
+**Gate:** Preview plays start to finish. All scenes visible. No blinking. Text readable.
+
+### Verify in the preview pane
+
+Scrub through every scene and check:
+
+1. Does scene 1 appear immediately? (If black: runtime not loaded, or `__timelines` key mismatch)
+2. Do shader transitions fire cleanly? (If blinking: transition too short, or exit animation before transition)
+3. Is all text readable against its background?
+4. Does every scene have motion during its hold? (If static: missing mid-scene activity)
+5. Do animations play in the correct order?
+
+### Troubleshooting: preview is black
+
+| Symptom                       | Cause                                                 | Fix                                                                                                                                                                   |
+| ----------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| All black                     | Runtime script missing or wrong order                 | Check GSAP loads before runtime in `<head>`                                                                                                                           |
+| All black                     | `__timelines` key doesn't match `data-composition-id` | Both must be `"main"`                                                                                                                                                 |
+| All black                     | Token not forwarded in preview.html                   | Check `location.search` is appended to src                                                                                                                            |
+| Scene doesn't appear          | Wrong `data-start` / `data-duration`                  | Check scene windows tile end-to-end                                                                                                                                   |
+| Blink before transition       | Exit animation before shader fires                    | Remove exit tweens -- shader IS the exit                                                                                                                              |
+| Blink before transition       | Transition duration < 0.3s                            | Increase to 0.5s                                                                                                                                                      |
+| Seeking backwards shows blank | Async capture race condition                          | Known bug in HyperShader browser mode. Forward seek usually works. For reliable scrubbing, download and use `npx hyperframes preview` locally                         |
+| Middle scene invisible        | First shader anchor not shown                         | Add `tl.set("#sN", { opacity: 1 }, startTime)` for first anchor in each shader group                                                                                  |
+| Middle scene invisible        | Non-anchor uses `visibility` instead of `autoAlpha`   | Change to `tl.set("#sN", { autoAlpha: 1 }, start)` and `tl.set("#sN", { autoAlpha: 0 }, end)`. Shader blanket reset poisons opacity; `visibility` alone can't fix it. |
+
+### Deliver
+
+Provide: `index.html`, `preview.html`, `README.md`, and `DESIGN.md`.
+
+The `preview.html` and `README.md` are already in the skeleton -- don't modify `preview.html`. Generate `DESIGN.md` from your `:root` custom properties as a reference document.
+
+In your final message, tell the user:
+
+1. **What you built** -- scene count, duration, visual identity summary, shader transitions used
+2. **What to do next** -- download the ZIP, run `npx hyperframes preview` locally to see the full composition with reliable playback
+3. **What to refine in Claude Code** -- be specific about which scenes need animation polish, where timing could be tighter, which mid-scene activities are basic and could be richer. Don't just say "refine in Claude Code" -- say "scene 4's counter animation could be smoother with a longer duration, and scene 6 would benefit from a breathing float on the logo."
+4. **Caveats** -- placeholder assets, unverified stats, elements inspired by a real brand
+
+---
+
+## Section 6: Rules you cannot break
+
+The skeleton handles most structural rules. These are the runtime rules the skeleton can't enforce:
+
+### Determinism (non-negotiable)
+
+| Never                             | Use instead                                    |
+| --------------------------------- | ---------------------------------------------- |
+| `Math.random()`                   | Seeded PRNG (only if you need randomness)      |
+| `Date.now()`, `performance.now()` | Hard-coded timing or `tl.time()` in `onUpdate` |
+| `setInterval`, `setTimeout`       | Timeline tweens + `onUpdate`                   |
+| `repeat: -1`                      | `repeat: Math.ceil(duration / cycle) - 1`      |
+| `stagger: { from: "random" }`     | `from: "start"`, `"center"`, `"end"`           |
+| Async timeline construction       | Synchronous at page load                       |
+
+### Media rules
+
+| Never                           | Use instead                 |
+| ------------------------------- | --------------------------- |
+| `video.play()`, `audio.play()`  | Framework owns playback     |
+| `<video>` without `muted`       | Always `muted playsinline`  |
+| Audio on `<video>`              | Separate `<audio>` element  |
+| Base64 media                    | File reference or HTTPS URL |
+| Placeholder URLs (placehold.co) | Real assets                 |
+
+### Animation rules
+
+| Never                                  | Use instead                                   |
+| -------------------------------------- | --------------------------------------------- |
+| Exit tweens before shader transition   | Shader IS the exit -- content stays visible   |
+| `tl.set` / `tl.to` on scene containers | HyperShader owns scene opacity                |
+| `requestAnimationFrame`                | GSAP tweens                                   |
+| Template literals in selectors         | Hardcoded strings                             |
+| CSS `transform` for centering          | Flexbox centering on a wrapper                |
+| SVG filter `data:image/svg+xml` grain  | CSS radial-gradient grain (see pattern below) |
+| Animating `visibility` / `display`     | Use `autoAlpha`                               |
+
+### Self-review checklist
+
+Run before delivering. Check with actual code, not assumptions.
+
+**Structural validity (must pass -- Claude Code can't fix these easily):**
+
+- [ ] Every scene has `class="scene clip"` + all data attributes
+- [ ] Every scene has a `<div class="scene-content">` wrapper
+- [ ] Anchor scenes have `style="opacity:0;"`. Non-anchor scenes have `style="visibility:hidden;"`
+- [ ] **Every non-anchor scene has `tl.set` with `autoAlpha`** (NOT `visibility`). `autoAlpha: 1` at start, `autoAlpha: 0` at end.
+- [ ] **First anchor scene in each shader group has `tl.set("#sN", { opacity: 1 }, startTime)`**. Without this, it stays invisible.
+- [ ] Scene windows tile end-to-end (no gaps)
+- [ ] Shader transitions have boundary INSIDE the window: `time < boundary < time + duration`
+- [ ] No transition shorter than 0.3s
+- [ ] No exit tweens except on the final scene
+- [ ] No `Date.now()`, unseeded `Math.random()`, `repeat: -1`
+- [ ] No SVG filter data URLs as `background-image`
+- [ ] `window.__timelines["main"] = tl` matches `data-composition-id`
+
+**Brand + content accuracy (your core job -- get these right):**
+
+- [ ] Colors match the brief / attachments exactly
+- [ ] No banned fonts
+- [ ] Minimum font sizes: 60px+ headlines, 20px+ body, 16px+ labels
+- [ ] `font-variant-numeric: tabular-nums` on number columns
+- [ ] Every scene has meaningful content (not placeholder text)
+- [ ] Scene count and durations match the video type
+
+**Animation baseline (good enough to start -- Claude Code will polish):**
+
+- [ ] Every scene has at least one entrance tween (`tl.from`)
+- [ ] Every scene > 4s has at least one mid-scene activity (float, counter, glow)
+- [ ] No scene is completely static (no tweens at all)
+- [ ] Scene text is readable in the time allowed
+
+---
+
+## Section 7: Skeletons
+
+### preview.html (universal -- copy verbatim for all video types)
 
 ```html
 <!doctype html>
@@ -706,11 +474,7 @@ Claude Design's sandbox requires a `?t=<token>` query on every internal URL. Wit
 </html>
 ```
 
-Verbatim means verbatim. No decorative chrome (no header, wordmark, aspect-ratio wrapper, caption bar). `<hyperframes-player>` fills the viewport.
-
-### `README.md` template (for the user who downloads the ZIP)
-
-Claude Design can't run CLI commands — the user runs them locally after download. Include these instructions verbatim. Swap `<project-name>` and adjust render flags if the brief needs non-default resolution / fps.
+### README.md (universal -- swap `<project-name>`)
 
 ````markdown
 # <project-name>
@@ -719,144 +483,746 @@ A HyperFrames video composition. Plain HTML + GSAP; rendered to MP4 by the `hype
 
 ## Requirements
 
-- **Node.js 22+** — [nodejs.org](https://nodejs.org/)
-- **FFmpeg** — `brew install ffmpeg` (macOS) · `sudo apt install ffmpeg` (Debian/Ubuntu) · [ffmpeg.org/download](https://ffmpeg.org/download.html) (Windows)
+- **Node.js 22+** -- [nodejs.org](https://nodejs.org/)
+- **FFmpeg** -- `brew install ffmpeg` (macOS) or `sudo apt install ffmpeg` (Debian/Ubuntu) or [ffmpeg.org/download](https://ffmpeg.org/download.html) (Windows)
 
-Chrome is downloaded automatically on first preview/render. Verify the environment with:
+Verify: `npx hyperframes doctor`
 
-```bash
-npx hyperframes doctor
-```
-
-`npx` downloads the `hyperframes` CLI from npm on first use — no global install required.
-
-## Preview in your browser
+## Preview
 
 ```bash
 npx hyperframes preview
 ```
 
-Opens the HyperFrames Studio at `http://localhost:3002`.
+Opens the HyperFrames Studio at `http://localhost:3002` with frame-accurate scrubbing.
 
-## Render to MP4
+## Refine with Claude Code
+
+This project was drafted in Claude Design. To polish animations, timing, and pacing:
+
+```bash
+npx skills add heygen-com/hyperframes   # install HyperFrames skills (one-time)
+npx hyperframes lint                     # verify structure (should pass with zero errors)
+npx hyperframes preview                  # open the studio for live feedback
+```
+
+Then open in Claude Code and iterate:
+
+- "Make scene 3's entrance snappier"
+- "Add a counter animation to the stat in scene 5"
+- "Tighten the pacing -- scenes 4 and 6 feel too long"
+- "Change the shader on transition 3 to glitch"
+
+## Render
 
 ```bash
 npx hyperframes render index.html -o output.mp4
 ```
 
-Produces `output.mp4` at 1920×1080 / 30fps by default. Roughly 1–3× real-time on a modern laptop. Use `--fps 60` or `--resolution 3840x2160` to override.
-
-## Troubleshooting
-
-- **"FFmpeg not found"** — install FFmpeg per Requirements.
-- **"Node version too old"** — install Node 22+.
-- **Full docs** — [hyperframes.heygen.com](https://hyperframes.heygen.com/).
+1920x1080 / 30fps by default. Use `--fps 60` or `--resolution 3840x2160` to override.
 ````
 
-### Caveats to surface to the user
+### Skeleton A -- Social Reel (1080x1920, 15s, 6 scenes)
 
-When relevant, call these out in your final message:
+All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardcoded to 1920x1080. It does not support vertical (1080x1920) compositions. Shaders render at the wrong aspect ratio and distort. For vertical video, rely on entrance animations and mid-scene activity to carry the energy.
 
-- Placeholder assets (stripe patterns, CSS shapes, gradient blocks used where real images/video should go) — tell the user which selectors to replace and with what.
-- Unverified stats or numbers in the composition — label them as illustrative and say where real figures should be confirmed.
-- Any element copied from a real brand's identity — flag that the composition is an original interpretation, not a recreation of branded UI.
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1920" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js"></script>
+    <!-- No shader-transitions script — shaders are hardcoded to 1920x1080 and don't support vertical -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- FILL: Google Fonts link for your chosen typefaces -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&family=JetBrains+Mono:wght@400&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        /* === FILL: Your brand identity === */
+        --bg: #0a0a0d;
+        --ink: #f5f5f7;
+        --accent: #7c6cff;
+        --muted: #5a6270;
+        --accent-dim: #3d3680;
+        --font-display: "Space Grotesk", sans-serif;
+        --font-data: "JetBrains Mono", monospace;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1920px;
+        overflow: hidden;
+        background: var(--bg);
+        color: var(--ink);
+      }
+
+      .scene {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 1080px;
+        height: 1920px;
+        overflow: hidden;
+      }
+      .scene-content {
+        width: 100%;
+        height: 100%;
+        padding: 120px 80px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 24px;
+        box-sizing: border-box;
+        position: relative;
+        z-index: 1;
+      }
+      .clip {
+      }
+
+      .display {
+        font-family: var(--font-display);
+        font-weight: 700;
+        line-height: 1.1;
+      }
+      .body-text {
+        font-family: var(--font-display);
+        font-weight: 300;
+        line-height: 1.4;
+        color: var(--muted);
+      }
+      .data-text {
+        font-family: var(--font-data);
+        font-weight: 400;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .grain {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 50;
+        opacity: 0.18;
+        background-image:
+          radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1.2px),
+          radial-gradient(rgba(0, 0, 0, 0.18) 1px, transparent 1.2px);
+        background-size:
+          3px 3px,
+          5px 5px;
+        background-position:
+          0 0,
+          1px 2px;
+        mix-blend-mode: overlay;
+      }
+
+      /* === FILL: Per-scene styles below === */
+    </style>
+  </head>
+  <body>
+    <div
+      id="main"
+      data-composition-id="main"
+      data-width="1080"
+      data-height="1920"
+      data-start="0"
+      data-duration="15"
+    >
+      <!-- ALL HARD CUTS — no shaders on vertical. Entrance animations carry the energy. -->
+
+      <!-- SCENE 1 -- visible from t=0 -->
+      <div class="scene clip" id="s1" data-start="0" data-duration="2.5" data-track-index="0">
+        <div class="grain"></div>
+        <div class="scene-content">
+          <!-- FILL: Scene 1 — hook / opener -->
+        </div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s2"
+        data-start="2.5"
+        data-duration="2.5"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="scene-content">
+          <!-- FILL: Scene 2 — build / context -->
+        </div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s3"
+        data-start="5"
+        data-duration="2.5"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="scene-content">
+          <!-- FILL: Scene 3 — feature -->
+        </div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s4"
+        data-start="7.5"
+        data-duration="2.5"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="scene-content">
+          <!-- FILL: Scene 4 — hero / key stat -->
+        </div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s5"
+        data-start="10"
+        data-duration="2.5"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="scene-content">
+          <!-- FILL: Scene 5 — proof -->
+        </div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s6"
+        data-start="12.5"
+        data-duration="2.5"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="scene-content">
+          <!-- FILL: Scene 6 — CTA / close -->
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      // --- Scene toggles (REQUIRED — use autoAlpha, not visibility) ---
+      tl.set("#s1", { autoAlpha: 0 }, 2.5);
+      tl.set("#s2", { autoAlpha: 1 }, 2.5);
+      tl.set("#s2", { autoAlpha: 0 }, 5.0);
+      tl.set("#s3", { autoAlpha: 1 }, 5.0);
+      tl.set("#s3", { autoAlpha: 0 }, 7.5);
+      tl.set("#s4", { autoAlpha: 1 }, 7.5);
+      tl.set("#s4", { autoAlpha: 0 }, 10.0);
+      tl.set("#s5", { autoAlpha: 1 }, 10.0);
+      tl.set("#s5", { autoAlpha: 0 }, 12.5);
+      tl.set("#s6", { autoAlpha: 1 }, 12.5);
+
+      // === SCENE 1 (0-2.5s) — hook ===
+      // FILL: entrance + mid-scene activity (use 2+ patterns from Section 8)
+
+      // === SCENE 2 (2.5-5s) ===
+      // FILL: entrance + mid-scene activity
+
+      // === SCENE 3 (5-7.5s) ===
+      // FILL: entrance + mid-scene activity
+
+      // === SCENE 4 (7.5-10s) — hero ===
+      // FILL: entrance + mid-scene activity
+
+      // === SCENE 5 (10-12.5s) — proof ===
+      // FILL: entrance + mid-scene activity
+
+      // === SCENE 6 (12.5-15s) — CTA, final scene, exit OK ===
+      // FILL: entrance + mid-scene activity + optional exit
+
+      // No HyperShader — vertical compositions use hard cuts only.
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>
+```
+
+### Skeleton B -- Launch Teaser (1920x1080, 25s, 8 scenes)
+
+Transition plan: s1→s2 hard cut, s2→s3 hard cut, s3→s4 hard cut, **s4→s5 SHADER** (hero reveal), **s5→s7 SHADER** (energy shift, s6 plays as runtime-managed interstitial), **s7→s8 SHADER** (CTA landing). 3 shaders out of 7 cuts.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@hyperframes/shader-transitions/dist/index.global.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- FILL: Google Fonts link -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&family=JetBrains+Mono:wght@400&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        /* === FILL: Your brand identity === */
+        --bg: #0a0a0d;
+        --ink: #f5f5f7;
+        --accent: #7c6cff;
+        --muted: #5a6270;
+        --accent-dim: #3d3680;
+        --font-display: "Space Grotesk", sans-serif;
+        --font-data: "JetBrains Mono", monospace;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: var(--bg);
+        color: var(--ink);
+      }
+
+      .scene {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+      }
+      .scene-content {
+        width: 100%;
+        height: 100%;
+        padding: 100px 160px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 24px;
+        box-sizing: border-box;
+        position: relative;
+        z-index: 1;
+      }
+      .clip {
+      }
+
+      .display {
+        font-family: var(--font-display);
+        font-weight: 700;
+        line-height: 1.1;
+      }
+      .body-text {
+        font-family: var(--font-display);
+        font-weight: 300;
+        line-height: 1.4;
+        color: var(--muted);
+      }
+      .data-text {
+        font-family: var(--font-data);
+        font-weight: 400;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .grain {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 50;
+        opacity: 0.18;
+        background-image:
+          radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1.2px),
+          radial-gradient(rgba(0, 0, 0, 0.18) 1px, transparent 1.2px);
+        background-size:
+          3px 3px,
+          5px 5px;
+        background-position:
+          0 0,
+          1px 2px;
+        mix-blend-mode: overlay;
+      }
+
+      .vignette {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 49;
+        background: radial-gradient(ellipse at center, transparent 50%, rgba(0, 0, 0, 0.4) 100%);
+      }
+
+      /* === FILL: Per-scene styles below === */
+    </style>
+  </head>
+  <body>
+    <div
+      id="main"
+      data-composition-id="main"
+      data-width="1920"
+      data-height="1080"
+      data-start="0"
+      data-duration="25"
+    >
+      <!-- SCENE 1 -- visible from t=0 -->
+      <div class="scene clip" id="s1" data-start="0" data-duration="3" data-track-index="0">
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: hook --></div>
+      </div>
+
+      <!-- s2-s3: hard cuts, runtime-managed -->
+      <div
+        class="scene clip"
+        id="s2"
+        data-start="3"
+        data-duration="3"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: context --></div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s3"
+        data-start="6"
+        data-duration="3"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: build --></div>
+      </div>
+
+      <!-- s4-s5: SHADER ANCHOR pair (hero reveal) -->
+      <div
+        class="scene clip"
+        id="s4"
+        data-start="9"
+        data-duration="3.5"
+        data-track-index="0"
+        style="opacity:0;"
+      >
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: build-up before hero --></div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s5"
+        data-start="12.5"
+        data-duration="3"
+        data-track-index="0"
+        style="opacity:0;"
+      >
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: hero / key feature --></div>
+      </div>
+
+      <!-- s6: hard cut, runtime-managed -->
+      <div
+        class="scene clip"
+        id="s6"
+        data-start="15.5"
+        data-duration="3"
+        data-track-index="0"
+        style="visibility:hidden;"
+      >
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: proof / social proof --></div>
+      </div>
+
+      <!-- s7-s8: SHADER ANCHOR pair (CTA landing) -->
+      <div
+        class="scene clip"
+        id="s7"
+        data-start="18.5"
+        data-duration="3"
+        data-track-index="0"
+        style="opacity:0;"
+      >
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: build to close --></div>
+      </div>
+
+      <div
+        class="scene clip"
+        id="s8"
+        data-start="21.5"
+        data-duration="3.5"
+        data-track-index="0"
+        style="opacity:0;"
+      >
+        <div class="grain"></div>
+        <div class="vignette"></div>
+        <div class="scene-content"><!-- FILL: CTA / close --></div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      // --- Non-anchor scene visibility toggles (REQUIRED) ---
+      tl.set("#s1", { autoAlpha: 0 }, 3.0);
+      tl.set("#s2", { autoAlpha: 1 }, 3.0);
+      tl.set("#s2", { autoAlpha: 0 }, 6.0);
+      tl.set("#s3", { autoAlpha: 1 }, 6.0);
+      tl.set("#s3", { autoAlpha: 0 }, 9.0);
+
+      // --- First shader anchor must be explicitly shown ---
+      tl.set("#s4", { opacity: 1 }, 9.0);
+
+      // s4, s5 are shader anchors — HyperShader manages their opacity after transitions
+      tl.set("#s6", { autoAlpha: 1 }, 15.5);
+      tl.set("#s6", { autoAlpha: 0 }, 18.5);
+
+      // --- Second shader group's first anchor must also be shown ---
+      tl.set("#s7", { opacity: 1 }, 18.5);
+      // s7, s8 are shader anchors — HyperShader manages their opacity after transitions
+
+      // === SCENE 1 (0-3s) — hook ===
+
+      // === SCENE 2 (3-6s) — hard cut ===
+
+      // === SCENE 3 (6-9s) — hard cut ===
+
+      // === SCENE 4 (9-12.5s) — SHADER ANCHOR, no exit tweens ===
+
+      // === SCENE 5 (12.5-15.5s) — shader from s4, hero reveal ===
+
+      // === SCENE 6 (15.5-18.5s) — hard cut ===
+
+      // === SCENE 7 (18.5-21.5s) — SHADER ANCHOR, no exit tweens ===
+
+      // === SCENE 8 (21.5-25s) — shader from s7, CTA. Final, exit OK ===
+
+      // --- Shader transitions: 2 key moments ---
+      // s4->s5 (hero reveal) and s7->s8 (CTA landing)
+      // HyperShader requires consecutive anchors, so we use two groups:
+      // Group 1: [s4, s5] with 1 transition
+      // Group 2: [s7, s8] with 1 transition
+      // But HyperShader only supports one init() call, so we chain them:
+      // [s4, s5] — shader — then runtime hard-cuts s5->s6->s7 — then [s7, s8]
+      // To satisfy the invariant with one init(), we include s5->s7 gap scenes.
+      // Simplest: just use one contiguous anchor block [s4, s5, s7, s8] with
+      // the s5->s7 transition as a real (visible) shader too. This gives you
+      // 3 shaders total — still well under the "every cut" anti-pattern.
+      window.HyperShader.init({
+        bgColor:
+          getComputedStyle(document.documentElement).getPropertyValue("--bg").trim() || "#0a0a0d",
+        scenes: ["s4", "s5", "s7", "s8"],
+        timeline: tl,
+        transitions: [
+          { time: 12.25, shader: "cinematic-zoom", duration: 0.5 },
+          { time: 15.25, shader: "light-leak", duration: 0.5 },
+          { time: 21.25, shader: "cross-warp-morph", duration: 0.5 },
+        ],
+      });
+
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>
+```
+
+### Skeleton C -- Product Explainer (1920x1080, 45s, 12 scenes)
+
+Use the same structure as Skeleton B but with 12 scene divs (s1-s12), data-duration totaling 45s, and 11 transitions. Adjust scene durations: mix 3s, 3.5s, 4s, and 5s scenes based on content density. Include a scene rhythm like: `3-3-4-3.5-4-5-3.5-4-3.5-4-4-3.5`.
+
+### Skeleton D -- Cinematic Title (1920x1080, 60s, 7 scenes)
+
+Use the same structure with 7 scene divs (s1-s7), longer durations (6-10s each), fewer transitions (6), and more restrained shaders (`cross-warp-morph`, `thermal-distortion`). Scene rhythm: `8-7-8-10-9-10-8`.
 
 ---
 
-## Claude Design sandbox essentials
+## Section 8: Common animation patterns
 
-These are the non-negotiable Claude-Design-specific invariants. All must hold:
+Copy-paste these. They appear in every production composition.
 
-1. **Runtime preload.** `index.html` loads GSAP, then IMMEDIATELY on the next line loads `@hyperframes/core/dist/hyperframe.runtime.iife.js`. Without the runtime pre-load, the player reports `ready` but `currentTime` never advances — the preview is a static frame.
+### Counter animation
 
-   ```html
-   <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-   <script src="https://cdn.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js"></script>
-   ```
+```js
+var counterObj = { v: 0 };
+tl.to(
+  counterObj,
+  {
+    v: 1900000000000,
+    duration: 2.0,
+    ease: "power2.out",
+    onUpdate: function () {
+      document.getElementById("s3-stat").textContent = "$" + (counterObj.v / 1e12).toFixed(1) + "T";
+    },
+  },
+  10.5,
+);
+```
 
-2. **Preview token forwarding.** `preview.html` sets the player's `src` via the inline script `document.getElementById("p").setAttribute("src", "./index.html" + location.search)` — not via `src=` on the element. See the verbatim template in Step 5.
+### SVG stroke draw
 
-3. **`data-composition-id` ↔ `__timelines` key match.** The string on the root element and the key in `window.__timelines["..."]` must be identical. Default to `"main"` unless the brief specifies otherwise.
+```html
+<svg viewBox="0 0 400 200" style="position:absolute; bottom:100px; left:160px;">
+  <path
+    id="s2-line"
+    d="M 0 100 Q 200 20 400 100"
+    stroke="var(--accent)"
+    stroke-width="3"
+    fill="none"
+    stroke-linecap="round"
+    stroke-dasharray="440"
+    stroke-dashoffset="440"
+  />
+</svg>
+```
 
-4. **HyperShader root-only for multi-act compositions.** If you split into sub-compositions, call `HyperShader.init()` at the root level only, never inside a sub-comp. See Step 4.
+```js
+tl.to("#s2-line", { strokeDashoffset: 0, duration: 1.0, ease: "power2.out" }, 3.5);
+```
 
-5. **Every scene has a `<div class="scene-content">` wrapper** — not just scene-1. Non-first scenes without this wrapper cause visible boxes / clipped elements / empty placeholders during every shader transition into them, because `captureIncomingScene()` can't isolate pre-animation from-state from the shader texture.
+### Character stagger
 
-6. **Deterministic rendering.** No `Date.now()`, no unseeded `Math.random()`, no `setInterval`, no `setTimeout` inside timeline construction, no `repeat: -1`.
+```html
+<h1 class="display" style="font-size:120px;">
+  <span class="char">N</span><span class="char">O</span><span class="char">R</span>
+  <span class="char">T</span><span class="char">H</span>
+</h1>
+```
+
+```js
+tl.from(
+  ".char",
+  {
+    y: 60,
+    autoAlpha: 0,
+    duration: 0.5,
+    ease: "power3.out",
+    stagger: { each: 0.12, from: "start" },
+  },
+  29.5,
+);
+```
+
+### Breathing float (mid-scene activity)
+
+```js
+tl.to(
+  "#s4-logo",
+  {
+    y: -5,
+    duration: 1.5,
+    ease: "sine.inOut",
+    yoyo: true,
+    repeat: 1,
+  },
+  15.0,
+);
+```
+
+### Bar chart fill
+
+```js
+["#bar1", "#bar2", "#bar3", "#bar4"].forEach(function (sel, i) {
+  tl.from(
+    sel,
+    {
+      scaleY: 0,
+      transformOrigin: "bottom",
+      duration: 0.6,
+      ease: "expo.out",
+    },
+    11.0 + i * 0.15,
+  );
+});
+```
+
+### Orbit / rotation
+
+```js
+tl.to(
+  "#orbit-dot",
+  {
+    rotation: 360,
+    duration: 3.0,
+    ease: "none",
+    transformOrigin: "50% 200px",
+  },
+  8.5,
+);
+```
+
+### Highlight sweep (background-size animation)
+
+```css
+#s5-headline {
+  background: linear-gradient(var(--accent), var(--accent)) no-repeat 0 85% / 0% 30%;
+}
+```
+
+```js
+tl.to("#s5-headline", { backgroundSize: "100% 30%", duration: 0.6, ease: "power2.out" }, 22.0);
+```
+
+### CSS radial-gradient grain (safe for Safari + Claude Design iframe)
+
+```css
+.grain {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 50;
+  opacity: 0.18;
+  background-image:
+    radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1.2px),
+    radial-gradient(rgba(0, 0, 0, 0.18) 1px, transparent 1.2px);
+  background-size:
+    3px 3px,
+    5px 5px;
+  background-position:
+    0 0,
+    1px 2px;
+  mix-blend-mode: overlay;
+}
+```
+
+**NEVER use SVG filter `data:image/svg+xml` grain** -- it taints html2canvas in Safari, breaking every shader transition in Claude Design's cross-origin iframe.
 
 ---
 
-## Video types quick reference
+## References (fetch only when needed)
 
-| Type                        | Duration | Scenes | Avg scene | Format (default)       |
-| --------------------------- | -------- | ------ | --------- | ---------------------- |
-| Social ad (IG/TikTok/Reels) | 10–15s   | 5–8    | 2–3s      | 1080×1920 (9:16)       |
-| Launch teaser               | 10–20s   | 6–10   | 2–3s      | 1920×1080 or 1080×1920 |
-| Product demo                | 20–45s   | 8–14   | 3–4s      | 1920×1080              |
-| Feature announcement        | 15–30s   | 6–12   | 2–4s      | 1920×1080              |
-| Brand reel                  | 20–45s   | 8–14   | 3–4s      | 1920×1080              |
-| Explainer                   | 30–60s   | 12–20  | 3–5s      | 1920×1080              |
-| Long-form narrative         | 60–180s  | 24–45  | 3–5s      | 1920×1080              |
+Everything critical is inlined above. These are for edge cases:
 
-Default to 1920×1080 at 30fps unless the brief specifies otherwise.
-
----
-
-## References (loaded on demand)
-
-Everything critical is inlined above — you should rarely need to fetch more. These fallbacks exist for edge cases.
-
-**Foundational — fetch when you hit a pattern this skill doesn't cover:**
-
-- Core composition contract (data attributes, composition structure, sub-comp wiring, video/audio, timeline contract): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/SKILL.md
-- Motion theory (build/breathe/resolve, easing as emotion, direction rules, speed as weight, transitions as meaning): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/motion-principles.md
-- Typography (full banned list, weight contrast rules, font-discovery Python script, dark-background compensations, OpenType features): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/typography.md
-- House style (lazy AI defaults, palette guidance, background layer ideas): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/house-style.md
-- Palettes (9 named palettes with hex values): https://github.com/heygen-com/hyperframes/tree/main/skills/hyperframes/palettes
-- Transitions (energy/mood tables, shader catalog, CSS transition patterns): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/transitions.md
-- GSAP deep reference (advanced timelines, stagger, keyframes, plugins): https://github.com/heygen-com/hyperframes/blob/main/skills/gsap/SKILL.md
-- `@hyperframes/player` docs (player element internals, event hooks, framework examples): https://github.com/heygen-com/hyperframes/blob/main/packages/player/README.md
-- CLI reference (advanced `npx hyperframes` flags, non-standard commands): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes-cli/SKILL.md
-- Registry examples (real working compositions authored by the framework team): https://github.com/heygen-com/hyperframes/tree/main/registry/examples
-- Full docs site: https://hyperframes.heygen.com/
-
-**Feature-specific — fetch only when the brief needs the feature:**
-
-- URL-to-video capture pipeline (when the user wants a video built from a captured website): https://github.com/heygen-com/hyperframes/blob/main/skills/website-to-hyperframes/SKILL.md
-- Captions / subtitles synced to audio: https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/captions.md
-- TTS narration (Kokoro-82M): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/tts.md
-- Audio-reactive animation (amplitude, frequency bands): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/audio-reactive.md
-- CSS text-highlight patterns (marker, circle, burst, scribble, sketchout): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/css-patterns.md
-- Dynamic caption animations (karaoke, slam, scatter, elastic, 3D): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/dynamic-techniques.md
-- Audio transcript generation: https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/transcript-guide.md
-- Installable blocks + components (`hyperframes add`): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes-registry/SKILL.md
-
----
-
-## Example prompts users tend to type
-
-Prefer attachment-driven briefs — they produce brand-accurate output. URL-only briefs on SPA homepages produce generic results.
-
-**Attachment-driven (strongest):**
-
-- _[user drops 3 UI screenshots]_ — `Use the attached skill. 30s product walkthrough matching these screenshots. Feature-led, 16:9, dark theme.`
-- _[user drops a brand PDF]_ — `Use the attached skill. 15s 9:16 teaser for the brand in this PDF. Honor palette and type exactly.`
-- _[user drops a reference video]_ — `Use the attached skill. 20s video in the same tonal register as this reference. Match pacing, color, shader character; my copy below.`
-
-**Pasted-content:**
-
-- `Use the attached skill. 30s hero reel with this copy for each scene: [pasted script]. Dark theme, technical, no warmth.`
-- `Use the attached skill. 45s editorial explainer. Palette: #0a0a0d / #f5f5f7 / #7c6cff. Type: Space Grotesk + JetBrains Mono. Copy below.`
-
-**URL-only (weakest — may need to ask for attachments):**
-
-- `Use the HyperFrames Claude Design skill. Turn https://www.anthropic.com/news/claude-design-anthropic-labs into a 45-second editorial explainer.` — static article, `web_fetch` works here.
-- `Use the HyperFrames Claude Design skill. 30-second product video for linear.app.` — SPA, `web_fetch` returns little; ask for screenshots or pivot to the brand's blog/press/Wikipedia.
-
-**Sparse (triggers the clarifying question):**
-
-- `Use the attached skill. Make me a 30-second launch video for Orbit. Make it cool.` → expect the clarifying message with 5 options.
-
-**Follow-up (skip the question):**
-
-- `Cut it to 20 seconds and drop scene 3.` — continuing an existing composition; build immediately.
+- Core composition contract (data attributes, sub-comp wiring): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/SKILL.md
+- Motion theory (easing as emotion, direction rules): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/motion-principles.md
+- Typography (full banned list, weight contrast, OpenType): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/typography.md
+- Transitions (shader catalog, CSS transition patterns): https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/transitions.md
+- Captions synced to audio: https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/captions.md
+- Full docs: https://hyperframes.heygen.com/


### PR DESCRIPTION
## What

Replaces the rule-heavy Claude Design skill with a template-first approach. Instead of 863 lines of prose rules and building from scratch, provides pre-valid HTML skeletons where structural rules are embedded. Claude Design fills in palette, content, and animations.

## Why

Testing across 12 compositions (demov4-1 through demov4-6, demov5-1 through demov5-5) revealed systematic bugs:

1. **First shader anchor invisible** — HyperShader browser mode never auto-shows `scenes[0]`. Every composition had this.
2. **Non-anchor scenes invisible** — HyperShader's blanket `querySelectorAll(".scene").forEach(s => s.style.opacity = "0")` poisons all scenes. `visibility` toggles alone can't override `opacity:0`.
3. **Shaders broken on vertical** — `webgl.ts` hardcodes canvas to 1920×1080. Vertical (1080×1920) compositions get distorted transitions.
4. **Every cut is a shader** — professional video uses ~95% hard cuts. Shader on every boundary flattens impact.
5. **Claude Design builds from scratch poorly** — it skips rules, forgets `.scene-content` wrappers, misses timeline registration. Templates eliminate these structural failures.

## How

- Pre-valid HTML skeletons for 4 video types (social reel, launch teaser, product explainer, cinematic title)
- `autoAlpha` toggles (sets both opacity AND visibility) for non-anchor scenes instead of `visibility` alone
- Explicit `tl.set("#sN", { opacity: 1 }, startTime)` for first anchor in each shader group
- No shaders on vertical skeleton (Skeleton A) — hard cuts only
- Mixed transitions on landscape: 2-3 shaders at hero/CTA moments, hard cuts elsewhere
- 7 inline animation patterns for Claude Design to copy-paste
- Claude Design → Claude Code handoff workflow in README template
- Skill description disambiguated from `hyperframes` skill per Jake's review on #353

## Test plan

- [x] 12 compositions audited for invisible scenes — root causes identified and fixes verified
- [x] HyperShader non-adjacent anchor behavior verified via source code review
- [x] Vertical shader limitation confirmed in `packages/shader-transitions/src/webgl.ts:3-4`
- [x] `bunx oxlint` — passes
- [x] `bunx oxfmt --check` — passes
- [x] End-to-end: attach skill to Claude Design, generate compositions with test prompts, verify all scenes visible
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)