### PR TITLE
docs: fix SKILL.md download UX across all references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx skills add heygen-com/hyperframes
 
 This teaches your agent (Claude Code, Cursor, Gemini CLI, Codex) how to write correct compositions and GSAP animations. In Claude Code, the skills register as slash commands — invoke `/hyperframes` to author compositions, `/hyperframes-cli` for CLI commands, and `/gsap` for animation help.
 
-For Claude Design, download [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) and attach it to your chat. Claude Design produces a valid first draft; refine it in any AI coding agent. See the [Claude Design guide](https://hyperframes.heygen.com/guides/claude-design).
+For Claude Design, open [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) on GitHub and click the download button (↓) to save it, then attach the file to your Claude Design chat. It produces a valid first draft; refine in any AI coding agent. See the [Claude Design guide](https://hyperframes.heygen.com/guides/claude-design).
 
 For Codex specifically, the same skills are also exposed as an [OpenAI Codex plugin](./.codex-plugin/plugin.json) — sparse-install just the plugin surface:
 

--- a/docs/guides/claude-design.mdx
+++ b/docs/guides/claude-design.mdx
@@ -9,7 +9,7 @@ Claude Design produces a **valid first draft** of a HyperFrames video — brand 
 
 <Steps>
   <Step title="Download the skill">
-    Save [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) to your computer.
+    Right-click [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) → **Save Link As** to download. (Clicking opens it as text in a new tab.)
   </Step>
   <Step title="Open Claude Design">
     Start a new chat at [claude.ai](https://claude.ai) with Claude Design enabled.
@@ -38,7 +38,7 @@ Claude Design produces a **valid first draft** of a HyperFrames video — brand 
 
 | Surface                     | Recommended setup                                                                                                             |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Claude Design               | Download [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) and attach it to your chat |
+| Claude Design               | Right-click [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) → Save Link As, then attach to your chat |
 | Claude Code                 | `npx skills add heygen-com/hyperframes`, then use `/hyperframes`                                                              |
 | Cursor / Codex / Gemini CLI | `npx skills add heygen-com/hyperframes`                                                                                       |
 

--- a/docs/guides/prompting.mdx
+++ b/docs/guides/prompting.mdx
@@ -29,7 +29,7 @@ In Claude Code, restart the session after installing. Skills register as **slash
 
 ## Claude Design
 
-Claude Design uses a different setup. Download [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) and **attach it to your chat** (don't paste the URL — file attachments produce better output):
+Claude Design uses a different setup. Right-click [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/skills/claude-design-hyperframes/SKILL.md) → **Save Link As** to download, then **attach it to your chat** (don't paste the URL — file attachments produce better output):
 
 ```text
 Use the attached skill. 25-second LinkedIn video for my startup.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,7 +16,7 @@ npx skills add heygen-com/hyperframes
 This teaches your agent (Claude Code, Cursor, Gemini CLI, Codex) how to write correct compositions and GSAP animations. In Claude Code the skills register as slash commands — `/hyperframes` for composition authoring, `/hyperframes-cli` for CLI commands, and `/gsap` for animation help. Invoking the slash command loads the skill context explicitly, which produces correct output the first time.
 
 <Note>
-  Claude Design uses a different entry path. Download [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) and attach it to your Claude Design chat. It produces a valid first draft you can refine in any AI coding agent. See the [Claude Design guide](/guides/claude-design).
+  Claude Design uses a different entry path. Open [`skills/claude-design-hyperframes/SKILL.md`](https://github.com/heygen-com/hyperframes/blob/main/skills/claude-design-hyperframes/SKILL.md) on GitHub, click the download button (↓) to save it, then attach to your Claude Design chat. It produces a valid first draft you can refine in any AI coding agent. See the [Claude Design guide](/guides/claude-design).
 </Note>
 
 ### Try it: example prompts


### PR DESCRIPTION
## What

Fix the SKILL.md download links across all 4 files (5 references total) so users actually download the file instead of opening a text tab.

## Why

Raw GitHub URLs (`raw.githubusercontent.com`) serve files as `text/plain`. Clicking the link opens a new tab with raw text instead of triggering a download. Users need the file saved locally to attach it to Claude Design.

## How

- `claude-design.mdx` (2 refs): Added "right-click → Save Link As" instruction
- `prompting.mdx` (1 ref): Added "right-click → Save Link As" instruction
- `README.md` (1 ref): Changed to "open on GitHub, click download button (↓)"
- `quickstart.mdx` (1 ref): Changed to "open on GitHub, click download button (↓)"

## Test plan

- [x] Verified all 5 references updated
- [x] No other references to the SKILL.md download link exist in the repo
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)