### PR TITLE
feat(shader-transitions): support any aspect ratio (vertical, square)

### DIFF
--- a/docs/guides/claude-design.mdx
+++ b/docs/guides/claude-design.mdx
@@ -115,7 +115,7 @@ The more specific your prompt, the better the output. Include palette, fonts, du
 
 - **In-pane preview** — scrubbing is unreliable in Claude Design's iframe sandbox. Download and use `npx hyperframes preview` locally for reliable playback.
 - **No linting** — Claude Design can't run `npx hyperframes lint`. The template-first skeletons handle structural validity, but the self-review checklist is the only QA before download.
-- **No shaders on vertical** — HyperShader's WebGL canvas is hardcoded to 1920x1080. Vertical (1080x1920) compositions use hard cuts only.
+- **Shaders work at any aspect ratio** — vertical (1080x1920), landscape (1920x1080), and square (1080x1080) all supported. HyperShader reads dimensions from `data-width`/`data-height` on the composition root.
 - **3 fetch limit** — Claude Design limits web fetches per turn. All critical rules are inlined in the skill; external references are for edge cases only.
 - **Seeking backwards** — scrubbing backwards in the in-pane preview can show blank frames (async capture race condition). Forward seeking usually works.
 

--- a/packages/shader-transitions/src/capture.ts
+++ b/packages/shader-transitions/src/capture.ts
@@ -1,4 +1,5 @@
 import html2canvas from "html2canvas";
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from "./webgl.js";
 
 let patched = false;
 
@@ -29,8 +30,8 @@ export function initCapture(): void {
 export function captureScene(
   sceneEl: HTMLElement,
   bgColor: string,
-  width: number = 1920,
-  height: number = 1080,
+  width: number = DEFAULT_WIDTH,
+  height: number = DEFAULT_HEIGHT,
 ): Promise<HTMLCanvasElement> {
   return html2canvas(sceneEl, {
     width,
@@ -89,8 +90,8 @@ export function captureScene(
 export function captureIncomingScene(
   toScene: HTMLElement,
   bgColor: string,
-  width: number = 1920,
-  height: number = 1080,
+  width: number = DEFAULT_WIDTH,
+  height: number = DEFAULT_HEIGHT,
 ): Promise<HTMLCanvasElement> {
   return new Promise<HTMLCanvasElement>((resolve, reject) => {
     const origZ = toScene.style.zIndex;

--- a/packages/shader-transitions/src/capture.ts
+++ b/packages/shader-transitions/src/capture.ts
@@ -26,10 +26,15 @@ export function initCapture(): void {
   patchCreatePattern();
 }
 
-export function captureScene(sceneEl: HTMLElement, bgColor: string): Promise<HTMLCanvasElement> {
+export function captureScene(
+  sceneEl: HTMLElement,
+  bgColor: string,
+  width: number = 1920,
+  height: number = 1080,
+): Promise<HTMLCanvasElement> {
   return html2canvas(sceneEl, {
-    width: 1920,
-    height: 1080,
+    width,
+    height,
     scale: 1,
     backgroundColor: bgColor,
     logging: false,
@@ -84,6 +89,8 @@ export function captureScene(sceneEl: HTMLElement, bgColor: string): Promise<HTM
 export function captureIncomingScene(
   toScene: HTMLElement,
   bgColor: string,
+  width: number = 1920,
+  height: number = 1080,
 ): Promise<HTMLCanvasElement> {
   return new Promise<HTMLCanvasElement>((resolve, reject) => {
     const origZ = toScene.style.zIndex;
@@ -105,7 +112,7 @@ export function captureIncomingScene(
 
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        captureScene(toScene, bgColor).then(resolve, reject).finally(restore);
+        captureScene(toScene, bgColor, width, height).then(resolve, reject).finally(restore);
       });
     });
   });

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -160,8 +160,10 @@ export function init(config: HyperShaderConfig): GsapTimeline {
 
   const root = document.querySelector<HTMLElement>("[data-composition-id]");
   const compId = config.compositionId || root?.getAttribute("data-composition-id") || "main";
-  const compWidth = Number(root?.getAttribute("data-width") || DEFAULT_WIDTH);
-  const compHeight = Number(root?.getAttribute("data-height") || DEFAULT_HEIGHT);
+  const rawW = Number(root?.getAttribute("data-width"));
+  const rawH = Number(root?.getAttribute("data-height"));
+  const compWidth = Number.isFinite(rawW) && rawW > 0 ? rawW : DEFAULT_WIDTH;
+  const compHeight = Number.isFinite(rawH) && rawH > 0 ? rawH : DEFAULT_HEIGHT;
 
   // The Hyperframes engine injects a virtual-time shim (window.__HF_VIRTUAL_TIME__)
   // during render mode and composites every transition itself from the
@@ -190,11 +192,13 @@ export function init(config: HyperShaderConfig): GsapTimeline {
   if (!glCanvas) {
     glCanvas = document.createElement("canvas");
     glCanvas.id = "gl-canvas";
-    glCanvas.width = compWidth;
-    glCanvas.height = compHeight;
-    glCanvas.style.cssText = `position:absolute;top:0;left:0;width:${compWidth}px;height:${compHeight}px;z-index:100;pointer-events:none;display:none;`;
+    glCanvas.style.cssText = `position:absolute;top:0;left:0;z-index:100;pointer-events:none;display:none;`;
     (root || document.body).appendChild(glCanvas);
   }
+  glCanvas.width = compWidth;
+  glCanvas.height = compHeight;
+  glCanvas.style.width = `${compWidth}px`;
+  glCanvas.style.height = `${compHeight}px`;
 
   const gl = createContext(glCanvas, compWidth, compHeight);
   if (!gl) {

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -5,8 +5,8 @@ import {
   createTexture,
   uploadTexture,
   renderShader,
-  WIDTH,
-  HEIGHT,
+  DEFAULT_WIDTH,
+  DEFAULT_HEIGHT,
   type AccentColors,
 } from "./webgl.js";
 import { getFragSource, type ShaderName } from "./shaders/registry.js";
@@ -160,6 +160,8 @@ export function init(config: HyperShaderConfig): GsapTimeline {
 
   const root = document.querySelector<HTMLElement>("[data-composition-id]");
   const compId = config.compositionId || root?.getAttribute("data-composition-id") || "main";
+  const compWidth = Number(root?.getAttribute("data-width") || DEFAULT_WIDTH);
+  const compHeight = Number(root?.getAttribute("data-height") || DEFAULT_HEIGHT);
 
   // The Hyperframes engine injects a virtual-time shim (window.__HF_VIRTUAL_TIME__)
   // during render mode and composites every transition itself from the
@@ -188,13 +190,13 @@ export function init(config: HyperShaderConfig): GsapTimeline {
   if (!glCanvas) {
     glCanvas = document.createElement("canvas");
     glCanvas.id = "gl-canvas";
-    glCanvas.width = WIDTH;
-    glCanvas.height = HEIGHT;
-    glCanvas.style.cssText = `position:absolute;top:0;left:0;width:${WIDTH}px;height:${HEIGHT}px;z-index:100;pointer-events:none;display:none;`;
+    glCanvas.width = compWidth;
+    glCanvas.height = compHeight;
+    glCanvas.style.cssText = `position:absolute;top:0;left:0;width:${compWidth}px;height:${compHeight}px;z-index:100;pointer-events:none;display:none;`;
     (root || document.body).appendChild(glCanvas);
   }
 
-  const gl = createContext(glCanvas);
+  const gl = createContext(glCanvas, compWidth, compHeight);
   if (!gl) {
     console.warn("[HyperShader] WebGL unavailable — shader transitions disabled.");
     const fallback = config.timeline || gsap.timeline({ paused: true });
@@ -225,7 +227,17 @@ export function init(config: HyperShaderConfig): GsapTimeline {
       const fromTex = textures.get(state.fromId);
       const toTex = textures.get(state.toId);
       if (fromTex && toTex) {
-        renderShader(gl, quadBuf, state.prog, fromTex, toTex, state.progress, accentColors);
+        renderShader(
+          gl,
+          quadBuf,
+          state.prog,
+          fromTex,
+          toTex,
+          state.progress,
+          accentColors,
+          compWidth,
+          compHeight,
+        );
       }
     }
   };
@@ -268,11 +280,11 @@ export function init(config: HyperShaderConfig): GsapTimeline {
         const wasPlaying = !tl.paused();
         if (wasPlaying) tl.pause();
 
-        captureScene(fromScene, bgColor)
+        captureScene(fromScene, bgColor, compWidth, compHeight)
           .then((fromCanvas) => {
             const fromTex = textures.get(fromId);
             if (fromTex) uploadTexture(gl, fromTex, fromCanvas);
-            return captureIncomingScene(toScene, bgColor);
+            return captureIncomingScene(toScene, bgColor, compWidth, compHeight);
           })
           .then((toCanvas) => {
             const toTex = textures.get(toId);

--- a/packages/shader-transitions/src/webgl.ts
+++ b/packages/shader-transitions/src/webgl.ts
@@ -1,12 +1,16 @@
 import { vertSrc } from "./shaders/common.js";
 
-export const WIDTH = 1920;
-export const HEIGHT = 1080;
+export const DEFAULT_WIDTH = 1920;
+export const DEFAULT_HEIGHT = 1080;
 
-export function createContext(canvas: HTMLCanvasElement): WebGLRenderingContext | null {
+export function createContext(
+  canvas: HTMLCanvasElement,
+  width: number = DEFAULT_WIDTH,
+  height: number = DEFAULT_HEIGHT,
+): WebGLRenderingContext | null {
   const gl = canvas.getContext("webgl", { preserveDrawingBuffer: true });
   if (!gl) return null;
-  gl.viewport(0, 0, WIDTH, HEIGHT);
+  gl.viewport(0, 0, width, height);
   gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
   return gl as WebGLRenderingContext;
 }
@@ -91,6 +95,8 @@ export function renderShader(
   texTo: WebGLTexture,
   progress: number,
   colors?: AccentColors,
+  width: number = DEFAULT_WIDTH,
+  height: number = DEFAULT_HEIGHT,
 ): void {
   const loc = getLocations(gl, prog);
   gl.useProgram(prog);
@@ -101,7 +107,7 @@ export function renderShader(
   gl.bindTexture(gl.TEXTURE_2D, texTo);
   gl.uniform1i(loc.to, 1);
   gl.uniform1f(loc.progress, progress);
-  gl.uniform2f(loc.resolution, WIDTH, HEIGHT);
+  gl.uniform2f(loc.resolution, width, height);
   if (colors) {
     gl.uniform3f(loc.accent, ...colors.accent);
     gl.uniform3f(loc.accentDark, ...colors.dark);

--- a/skills/claude-design-hyperframes/SKILL.md
+++ b/skills/claude-design-hyperframes/SKILL.md
@@ -524,7 +524,7 @@ npx hyperframes render index.html -o output.mp4
 
 ### Skeleton A -- Social Reel (1080x1920, 15s, 6 scenes)
 
-All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardcoded to 1920x1080. It does not support vertical (1080x1920) compositions. Shaders render at the wrong aspect ratio and distort. For vertical video, rely on entrance animations and mid-scene activity to carry the energy.
+Transition plan: s1→s2 hard cut, s2→s3 hard cut, **s3→s4 SHADER** (hero reveal), s4→s5 hard cut, s5→s6 hard cut. One shader at the midpoint.
 
 ```html
 <!doctype html>
@@ -534,7 +534,7 @@ All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardco
     <meta name="viewport" content="width=1080, height=1920" />
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js"></script>
-    <!-- No shader-transitions script — shaders are hardcoded to 1920x1080 and don't support vertical -->
+    <script src="https://cdn.jsdelivr.net/npm/@hyperframes/shader-transitions/dist/index.global.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <!-- FILL: Google Fonts link for your chosen typefaces -->
@@ -638,8 +638,6 @@ All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardco
       data-start="0"
       data-duration="15"
     >
-      <!-- ALL HARD CUTS — no shaders on vertical. Entrance animations carry the energy. -->
-
       <!-- SCENE 1 -- visible from t=0 -->
       <div class="scene clip" id="s1" data-start="0" data-duration="2.5" data-track-index="0">
         <div class="grain"></div>
@@ -662,31 +660,33 @@ All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardco
         </div>
       </div>
 
+      <!-- SCENE 3 -- SHADER ANCHOR (opacity:0, HyperShader manages) -->
       <div
         class="scene clip"
         id="s3"
         data-start="5"
         data-duration="2.5"
         data-track-index="0"
-        style="visibility:hidden;"
+        style="opacity:0;"
       >
         <div class="grain"></div>
         <div class="scene-content">
-          <!-- FILL: Scene 3 — feature -->
+          <!-- FILL: Scene 3 — build-up before hero -->
         </div>
       </div>
 
+      <!-- SCENE 4 -- SHADER ANCHOR (opacity:0, HyperShader manages) -->
       <div
         class="scene clip"
         id="s4"
         data-start="7.5"
         data-duration="2.5"
         data-track-index="0"
-        style="visibility:hidden;"
+        style="opacity:0;"
       >
         <div class="grain"></div>
         <div class="scene-content">
-          <!-- FILL: Scene 4 — hero / key stat -->
+          <!-- FILL: Scene 4 — hero / key stat (shader reveals this) -->
         </div>
       </div>
 
@@ -723,14 +723,12 @@ All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardco
       window.__timelines = window.__timelines || {};
       var tl = gsap.timeline({ paused: true });
 
-      // --- Scene toggles (REQUIRED — use autoAlpha, not visibility) ---
+      // --- Non-anchor scene toggles (REQUIRED — use autoAlpha) ---
       tl.set("#s1", { autoAlpha: 0 }, 2.5);
       tl.set("#s2", { autoAlpha: 1 }, 2.5);
       tl.set("#s2", { autoAlpha: 0 }, 5.0);
-      tl.set("#s3", { autoAlpha: 1 }, 5.0);
-      tl.set("#s3", { autoAlpha: 0 }, 7.5);
-      tl.set("#s4", { autoAlpha: 1 }, 7.5);
-      tl.set("#s4", { autoAlpha: 0 }, 10.0);
+      // s3, s4 are shader anchors — HyperShader manages their opacity
+      tl.set("#s3", { opacity: 1 }, 5.0); // first anchor must be explicitly shown
       tl.set("#s5", { autoAlpha: 1 }, 10.0);
       tl.set("#s5", { autoAlpha: 0 }, 12.5);
       tl.set("#s6", { autoAlpha: 1 }, 12.5);
@@ -741,10 +739,10 @@ All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardco
       // === SCENE 2 (2.5-5s) ===
       // FILL: entrance + mid-scene activity
 
-      // === SCENE 3 (5-7.5s) ===
+      // === SCENE 3 (5-7.5s) — SHADER ANCHOR, no exit tweens ===
       // FILL: entrance + mid-scene activity
 
-      // === SCENE 4 (7.5-10s) — hero ===
+      // === SCENE 4 (7.5-10s) — hero (shader reveals this) ===
       // FILL: entrance + mid-scene activity
 
       // === SCENE 5 (10-12.5s) — proof ===
@@ -753,7 +751,15 @@ All hard cuts. **No shader transitions** -- HyperShader's WebGL canvas is hardco
       // === SCENE 6 (12.5-15s) — CTA, final scene, exit OK ===
       // FILL: entrance + mid-scene activity + optional exit
 
-      // No HyperShader — vertical compositions use hard cuts only.
+      // --- Shader: 1 transition at the hero reveal ---
+      window.HyperShader.init({
+        bgColor:
+          getComputedStyle(document.documentElement).getPropertyValue("--bg").trim() || "#0a0a0d",
+        scenes: ["s3", "s4"],
+        timeline: tl,
+        transitions: [{ time: 7.25, shader: "cinematic-zoom", duration: 0.5 }],
+      });
+
       window.__timelines["main"] = tl;
     </script>
   </body>


### PR DESCRIPTION
## What

Shader transitions now work at any aspect ratio — vertical (1080x1920), square (1080x1080), and any custom dimensions. Previously hardcoded to 1920x1080. Also updates the Claude Design skill and docs.

## Why

Vertical compositions (Instagram Reels, TikTok, Stories) are one of the most common video types. Shader transitions on vertical produced distorted effects because the WebGL canvas, viewport, and html2canvas capture were all hardcoded to 1920x1080.

## How

Read `data-width`/`data-height` from the composition root element at `init()` time and pass the dimensions through:

- `webgl.ts`: `WIDTH`/`HEIGHT` constants → `DEFAULT_WIDTH`/`DEFAULT_HEIGHT`. `createContext()` and `renderShader()` accept width/height params.
- `capture.ts`: `captureScene()` and `captureIncomingScene()` accept width/height for html2canvas.
- `hyper-shader.ts`: Reads `data-width`/`data-height` from root, passes to all webgl and capture calls.

GLSL shaders unchanged — they already use `u_resolution` uniform. Engine compositor already takes width/height params. No other packages import from shader-transitions.

Skill + docs:
- Skeleton A (vertical social reel) now has 1 shader at hero reveal (s3→s4)
- Removed "no shaders on vertical" from docs known limitations

All params default to 1920x1080 — fully backwards compatible.

## Test plan

- [x] `bunx oxlint` — 0 warnings, 0 errors
- [x] `bunx oxfmt --check` — passes
- [x] TypeScript type-check clean
- [x] `bun run --cwd packages/shader-transitions build` — ESM/CJS/IIFE/DTS all build
- [x] Manual test: vertical (1080x1920) with cinematic-zoom + cross-warp-morph — correct aspect ratio in preview
- [x] Code review: grep for 1920/1080 across all shader-transitions src — only defaults remain
- [x] Code review: GLSL shaders use u_resolution uniform, no hardcoded dimensions
- [x] Code review: engine compositor already dynamic — no changes needed
- [ ] Existing 1920x1080 compositions unchanged (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)