### PR TITLE
fix(tsconfig): silence TS 7.0 baseUrl + rootDir deprecation warnings

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@hyperframes/producer": ["../producer/src/index.ts"]
@@ -12,7 +13,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "./dist",
-    "declaration": true
+    "declaration": true,
+    "rootDir": ".."
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@hyperframes/player": ["../player/src/hyperframes-player.ts"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

TypeScript 7.0 deprecates the `baseUrl` compiler option unless `ignoreDeprecations` is set, and also flags tsconfigs whose computed common source directory differs from an explicit `rootDir`. Both conditions currently trigger warnings in `packages/cli/tsconfig.json` and `packages/studio/tsconfig.json`:

- `packages/cli/tsconfig.json` — `baseUrl` deprecation **and** "common source directory is '..'" because `paths` maps `@hyperframes/producer` to `../producer/src/index.ts`, pulling the compiler's root above `./src`.
- `packages/studio/tsconfig.json` — `baseUrl` deprecation only (rootDir is already `".."`).

The other six package tsconfigs (`core`, `engine`, `player`, `player/tests/perf`, `producer`, `shader-transitions`) set `rootDir` explicitly and don't use `baseUrl`, so they don't trip either warning.

## Changes

**`packages/cli/tsconfig.json`** — add `ignoreDeprecations: "5.0"` and `rootDir: ".."` (matches studio's pattern; covers both `cli/src` and the resolved `paths` target under `packages/`):

```diff
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@hyperframes/producer": ["../producer/src/index.ts"]
     },
     ...
     "outDir": "./dist",
-    "declaration": true
+    "declaration": true,
+    "rootDir": ".."
   },
```

**`packages/studio/tsconfig.json`** — add `ignoreDeprecations: "5.0"` only:

```diff
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@hyperframes/player": ["../player/src/hyperframes-player.ts"]
     },
```

## Rationale

- `ignoreDeprecations: "5.0"` is the only value TypeScript 5.x accepts — TS 5.9.3's `getIgnoreDeprecationsVersion()` explicitly rejects every other value (including `"6.0"`) with `Invalid value for '--ignoreDeprecations'`. Newer editor LS versions suggest `"6.0"` in their warning text, but that fails typecheck on this repo's pinned compiler. It leaves `baseUrl`/`paths` behavior unchanged while silencing the warning until a future refactor is ready to drop `paths` in favor of bun workspace resolution.
- Setting `rootDir: ".."` on the CLI matches the existing pattern in `packages/studio/tsconfig.json`, and keeps the resolved `@hyperframes/producer` file under `rootDir` so no TS6059 is introduced.

## Test plan

- [ ] `bun install` — clean.
- [ ] `bun run build` — builds successfully with no new errors.
- [ ] `bunx oxlint packages/cli/tsconfig.json packages/studio/tsconfig.json` — clean.
- [ ] `bunx oxfmt --check packages/cli/tsconfig.json packages/studio/tsconfig.json` — clean.
- [ ] Editor verification: both deprecation warnings disappear in VS Code / Cursor / any editor running TS ≥ 5.5 LS.

No runtime changes. No emit-layout changes — the CLI builds via `tsup` (`packages/cli/package.json` `"build": "bun run build:fonts && tsup && ..."`) and studio via `vite build`; the `typecheck` script is `tsc --noEmit`. An explicit `rootDir` *would* shift emit paths if tsc were doing the emit (it overrides the auto-computed common source directory), but here it only feeds the typechecker, which doesn't write files. Packages that emit via `tsc -b` (e.g. `core`, `engine`) are untouched by this PR.