### PR TITLE
fix(studio): prevent NLE timeline scrollbar from clipping below viewport

### DIFF
--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -392,7 +392,12 @@ export const NLELayout = memo(function NLELayout({
           <div className="flex flex-col flex-shrink-0" style={{ height: timelineH }}>
             {/* Timeline tracks */}
             <div
-              className="flex-1 min-h-0 overflow-hidden bg-neutral-950"
+              // flex flex-col so the toolbar takes its natural height and the
+              // Timeline below fills the remainder. Without it, both children
+              // are block-laid and Timeline's `h-full` grabs the parent's full
+              // height, pushing the bottom edge of the scroll area below the
+              // viewport and clipping its scrollbar.
+              className="flex flex-col flex-1 min-h-0 overflow-hidden bg-neutral-950"
               onDoubleClick={(e) => {
                 if ((e.target as HTMLElement).closest("[data-clip]")) return;
                 if (compositionStack.length > 1) {

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -392,11 +392,7 @@ export const NLELayout = memo(function NLELayout({
           <div className="flex flex-col flex-shrink-0" style={{ height: timelineH }}>
             {/* Timeline tracks */}
             <div
-              // flex flex-col so the toolbar takes its natural height and the
-              // Timeline below fills the remainder. Without it, both children
-              // are block-laid and Timeline's `h-full` grabs the parent's full
-              // height, pushing the bottom edge of the scroll area below the
-              // viewport and clipping its scrollbar.
+              // flex-col: toolbar takes natural height, Timeline fills remainder.
               className="flex flex-col flex-1 min-h-0 overflow-hidden bg-neutral-950"
               onDoubleClick={(e) => {
                 if ((e.target as HTMLElement).closest("[data-clip]")) return;
@@ -405,7 +401,7 @@ export const NLELayout = memo(function NLELayout({
                 }
               }}
             >
-              {timelineToolbar}
+              <div className="flex-shrink-0">{timelineToolbar}</div>
               <Timeline
                 onSeek={seek}
                 onDrillDown={handleDrillDown}


### PR DESCRIPTION
## Summary

The scroll area in the NLE's right-side timeline panel is offset below the
visible region by the toolbar's height, so its bottom edge and scrollbar
get clipped beneath the viewport.

## Root cause

`NLELayout.tsx` lays the timeline panel out as a fixed-height container
(`style={{ height: timelineH }}`, default 220px at the moment I saw it)
with two children:

1. The toolbar strip (`<div className="border-b ...">`, ~45px)
2. `<Timeline />`, which has `h-full overflow-hidden` on its root

The intermediate wrapper is declared as:

```jsx
<div className="flex-1 min-h-0 overflow-hidden bg-neutral-950">
  {timelineToolbar}
  <Timeline ... />
</div>
```

Without `flex flex-col`, both children stack as block elements. The
toolbar occupies its ~45px of normal flow, and `<Timeline>`'s `h-full`
then measures against the *wrapper's* height (the full 220px) rather
than the remaining space after the toolbar. Net result: the scroll area
extends 45px past the bottom of its visible region, and that tail — which
includes the scrollbar's track — is clipped off-viewport.

Observed layout (timeline height 220px, viewport 678px):

|          | wrapper → toolbar | wrapper → scroll area                         |
| -------- | ----------------- | --------------------------------------------- |
| Before   | top=458, h=45     | top=503, h=220 (**bottom=723, viewport=678**) |
| After    | top=458, h=45     | top=503, h=175 (bottom=678 ✓)                 |

## Fix

Add `flex flex-col` to the wrapper so the toolbar takes its natural
height and the Timeline fills the remaining space. One-line change plus
a comment explaining the invariant for future maintainers.

## Test plan

- [x] Verified fix locally by patching the built `studio/assets/index-*.js`
      in `node_modules` — clipped scrollbar resolves immediately, behaves
      correctly under timeline-section resize.
- [x] `bunx oxlint packages/studio/src/components/nle/NLELayout.tsx` — clean
- [x] `bunx oxfmt --check packages/studio/src/components/nle/NLELayout.tsx` — clean
- [x] `bun run --filter @hyperframes/studio typecheck` — clean
