### PR TITLE
fix(studio): pin user-agent color scheme to dark

### DIFF
--- a/packages/studio/src/styles/studio.css
+++ b/packages/studio/src/styles/studio.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Studio is a dark-only UI — pin the user-agent color scheme to dark so that
+ * browser-native chrome (scrollbars, form controls, focus rings) picks the
+ * matching palette instead of defaulting to light against our #0a0a0a body.
+ */
+:root {
+  color-scheme: dark;
+}
+
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary

Studio paints a #0a0a0a body but never declares a `color-scheme`, so the browser leaves its native chrome (scrollbars, form controls, focus rings) in the light palette. The mismatch is most visible on scrollbars, which render as a light track on a near-black panel.

## Root cause

`packages/studio/src/styles/studio.css` sets body background/foreground but nothing sets `color-scheme`, and `index.html` has no `<meta name="color-scheme">`. Computed value on both `<html>` and `<body>` is `normal`, which defers to the browser default (light on most platforms).

Studio has no theme toggle — the UI is deliberately dark-only — so declaring a static `color-scheme: dark` is safe and matches how the rest of the chrome is styled.

## Fix

Add `color-scheme: dark` to `:root` at the top of `studio.css`, next to the existing body reset. No other files need to change; `<meta name="color-scheme">` in `index.html` would work too but the CSS entry is already the canonical place for global styling decisions in this project.

## Test plan

- [x] Verified locally by injecting `:root { color-scheme: dark }` into the built `studio/assets/index-*.css` in `node_modules` — scrollbars, text selection, and range inputs all switch to the dark UA palette.
- [x] `bunx oxlint packages/studio/src/styles/studio.css` — clean (no lint rules apply to CSS; exits 0)
- [x] `bunx oxfmt --check packages/studio/src/styles/studio.css` — clean
- [x] `bun run --filter @hyperframes/studio typecheck` — clean
