### PR TITLE
fix(cli): shut down preview embedded-mode server on Ctrl+C

### DIFF
--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -397,11 +397,12 @@ async function runEmbeddedMode(
   // Node as a SIGINT at all — the process just sits there. Run a readline
   // interface on stdin so the keystroke is observed at the TTY layer and
   // re-emit it as SIGINT. No-op on platforms where the signal already arrives.
+  let rl: import("node:readline").Interface | undefined;
   if (process.platform === "win32") {
     const readline = await import("node:readline");
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     rl.on("SIGINT", () => {
-      process.emit("SIGINT");
+      process.emit("SIGINT", "SIGINT");
     });
   }
 
@@ -412,6 +413,10 @@ async function runEmbeddedMode(
       shuttingDown = true;
       process.off("SIGINT", shutdown);
       process.off("SIGTERM", shutdown);
+      // Close the readline interface so a second Ctrl+C during the grace
+      // period below doesn't re-emit SIGINT and trigger Node's default
+      // exit-130 behaviour, contradicting our intent to exit cleanly.
+      rl?.close();
       // `server.close()` can take a second or two to drain keep-alive
       // connections; surface progress so the terminal doesn't look frozen.
       console.log();

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -387,7 +387,42 @@ async function runEmbeddedMode(
   console.log();
   import("open").then((mod) => mod.default(`${url}#project/${pName}`)).catch(() => {});
 
-  // Block until the process is killed. Ctrl+C (SIGINT) uses Node's default
-  // behavior — exit immediately. The OS reclaims the port and file handles.
-  return new Promise<void>(() => {});
+  // Block until Ctrl+C. Node would normally exit on SIGINT, but the listening
+  // HTTP server keeps handles open, so the event loop stays alive after the
+  // signal handler fires. Close the server explicitly and resolve the promise
+  // so `run()` returns cleanly instead of requiring a second Ctrl+C (or,
+  // worse, the user force-killing the terminal).
+  //
+  // Windows wrinkle: Ctrl+C in some terminals (Git Bash / MSYS) doesn't reach
+  // Node as a SIGINT at all — the process just sits there. Run a readline
+  // interface on stdin so the keystroke is observed at the TTY layer and
+  // re-emit it as SIGINT. No-op on platforms where the signal already arrives.
+  if (process.platform === "win32") {
+    const readline = await import("node:readline");
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.on("SIGINT", () => {
+      process.emit("SIGINT");
+    });
+  }
+
+  return new Promise<void>((resolveRun) => {
+    let shuttingDown = false;
+    const shutdown = (): void => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      process.off("SIGINT", shutdown);
+      process.off("SIGTERM", shutdown);
+      // `server.close()` can take a second or two to drain keep-alive
+      // connections; surface progress so the terminal doesn't look frozen.
+      console.log();
+      console.log(`  ${c.dim("Shutting down studio...")}`);
+      result.server.close(() => resolveRun());
+      // If close() hangs on an open connection, force exit after a short
+      // grace period. Exit 0 because user-initiated Ctrl+C isn't an error
+      // — a non-zero code makes pnpm / npm print ELIFECYCLE.
+      setTimeout(() => process.exit(0), 2000).unref();
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
 }


### PR DESCRIPTION
## Summary

`hyperframes preview` in embedded mode prints "Press Ctrl+C to stop", but the first Ctrl+C doesn't stop it. The terminal becomes unresponsive until the user hits Ctrl+C a second time or kills the shell. On Windows (Git Bash / MSYS) it doesn't respond at all.

## Root causes

The tail of `runEmbeddedMode` was:

```ts
// Block until the process is killed. Ctrl+C (SIGINT) uses Node's default
// behavior — exit immediately. The OS reclaims the port and file handles.
return new Promise<void>(() => {});
```

The comment is optimistic on both counts:

1. **The listening HTTP server keeps the event loop alive after SIGINT fires.** `result.server` from `@hono/node-server` holds an open TCP handle — Node's default SIGINT handler runs, but because the loop still has a pending handle, the process stays up. This is distinct from `runDevMode` / `runLocalStudioMode`, which `spawn()` Vite and await the child's `close` event; Ctrl+C naturally propagates through the terminal's process group to the child and the parent's promise settles.

2. **On Windows, Ctrl+C is sometimes never delivered as SIGINT in the first place.** Git Bash / MSYS handle the keystroke in their own TTY layer and don't always forward it to attached Node processes. Observed locally: no SIGINT listener fires, no exit, no message — the preview just hangs.

## Fix

Replace the never-resolving promise with an explicit shutdown path:

1. **Register `SIGINT` and `SIGTERM` handlers** that close `result.server` and resolve the promise cleanly. This alone fixes the POSIX case and Windows shells that do forward the signal (PowerShell, cmd).

2. **Print `Shutting down studio...` immediately.** `server.close()` takes ~1–2 seconds to drain keep-alive connections, and without a message that gap reads as the previous hang, even though the fix has already started. A one-liner tells the user the signal was received.

3. **Force-exit after 2 seconds** with `setTimeout(...).unref()` in case a keep-alive connection blocks `close()`. Exit 0 because a user-initiated Ctrl+C isn't an error — non-zero codes make pnpm / npm print `ELIFECYCLE Command failed with exit code N` right on top of a normal shutdown.

4. **Windows readline fallback.** On `process.platform === "win32"` only, create a `readline` interface on stdin — `readline` observes Ctrl+C at the TTY layer regardless of whether the hosting terminal forwards it as a signal, and emits its own `"SIGINT"` event. Re-emit `process.emit("SIGINT")` from there so the same handler runs. This is the conventional Node workaround for this platform gap.

`runDevMode` and `runLocalStudioMode` are unchanged — the spawned-Vite pattern there already shuts down correctly via the child's process group.

## Test plan

- [x] `bunx oxlint packages/cli/src/commands/preview.ts` — clean
- [x] `bunx oxfmt --check packages/cli/src/commands/preview.ts` — clean
- [x] `bun run --filter @hyperframes/cli typecheck` — clean
- [x] Verified locally by hand-patching the bundled `dist/cli.js` in node_modules (the CLI is a single esbuild bundle, so the `runEmbeddedMode` tail can be swapped in place for testing without a full rebuild). Reproduced the original hang on `hyperframes preview` in Git Bash on Windows; after the patch, Ctrl+C prints "Shutting down studio..." and the process exits within ~1 second with a clean prompt (no ELIFECYCLE, no second press needed).
