### PR TITLE
fix(engine): suppress benign play()/pause() AbortError spam during render

### DIFF
--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -252,20 +252,9 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     const message = err instanceof Error ? err.message : String(err);
     const text = `[Browser:PAGEERROR] ${message}`;
 
-    // Frame capture pauses → seeks → screenshots → plays audio/video many
-    // times per second. HTMLMediaElement.play() returns a promise that rejects
-    // with AbortError whenever another pause() lands before it resolves —
-    // which it does, every frame. The rejection is benign (output frames are
-    // unaffected) but the message floods the terminal.
-    //
-    // The thrown value is a DOMException whose `name` is literally
-    // "DOMException"; "AbortError" appears as the prefix of its `message`, so
-    // we match against the message rather than err.name. Both "play()" and
-    // "pause()" are required so we don't accidentally swallow unrelated
-    // AbortErrors. Still pushed to browserConsoleBuffer so it's available in
-    // the post-failure diagnostic dump.
+    // Benign play/pause race during frame capture — suppress terminal noise, keep in buffer.
     const isPlayAbort =
-      /^AbortError:/.test(message) && /play\(\)/i.test(message) && /pause\(\)/i.test(message);
+      /^AbortError:/.test(message) && message.includes("play()") && message.includes("pause()");
     if (!isPlayAbort) {
       console.error(text);
     }

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -249,8 +249,27 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   });
 
   page.on("pageerror", (err) => {
-    const text = `[Browser:PAGEERROR] ${err instanceof Error ? err.message : String(err)}`;
-    console.error(text);
+    const message = err instanceof Error ? err.message : String(err);
+    const text = `[Browser:PAGEERROR] ${message}`;
+
+    // Frame capture pauses → seeks → screenshots → plays audio/video many
+    // times per second. HTMLMediaElement.play() returns a promise that rejects
+    // with AbortError whenever another pause() lands before it resolves —
+    // which it does, every frame. The rejection is benign (output frames are
+    // unaffected) but the message floods the terminal.
+    //
+    // The thrown value is a DOMException whose `name` is literally
+    // "DOMException"; "AbortError" appears as the prefix of its `message`, so
+    // we match against the message rather than err.name. Both "play()" and
+    // "pause()" are required so we don't accidentally swallow unrelated
+    // AbortErrors. Still pushed to browserConsoleBuffer so it's available in
+    // the post-failure diagnostic dump.
+    const isPlayAbort =
+      /^AbortError:/.test(message) && /play\(\)/i.test(message) && /pause\(\)/i.test(message);
+    if (!isPlayAbort) {
+      console.error(text);
+    }
+
     session.browserConsoleBuffer.push(text);
     if (session.browserConsoleBuffer.length > BROWSER_CONSOLE_BUFFER_SIZE) {
       session.browserConsoleBuffer.shift();


### PR DESCRIPTION
## Summary

Every render floods the terminal with repetitions of:

```
[Browser:PAGEERROR] AbortError: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22
```

On a ~90-second composition I see 15–25 of these lines over the course of the capture, interleaved with the progress bar. The rejection is benign, the user can't act on it, and it obscures real errors the handler is meant to surface.

## Root cause

In `createCaptureSession` (`packages/engine/src/services/frameCapture.ts`), the pageerror handler logs every page-level exception:

```ts
page.on("pageerror", (err) => {
  const text = `[Browser:PAGEERROR] ${err instanceof Error ? err.message : String(err)}`;
  console.error(text);
  session.browserConsoleBuffer.push(text);
  // …
});
```

The engine drives playback by repeatedly calling `pause()` → `seek()` → screenshot → `play()` once per captured frame. `HTMLMediaElement.play()` returns a promise, and when the next `pause()` fires before it resolves (i.e. every frame at capture cadence), Chrome rejects the promise with a `DOMException` whose message is `"AbortError: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22"`. Scene code that calls `.play()` without attaching a `.catch()` — a common shape, including the `audio.play()` calls in the composition template the current HyperFrames skill produces — surfaces that rejection as an unhandled rejection on the page, which Puppeteer then forwards to `pageerror`. Output frames and the mixed audio track are unaffected.

Note on detection: the thrown value's `err.name` is literally `"DOMException"`, not `"AbortError"` — "AbortError" appears as the prefix of `err.message`. So the filter has to match on the message, not the constructor name.

## Fix

Filter against `err.message` starting with `AbortError:` AND containing both `play()` and `pause()` tokens before logging. All three conditions together are specific enough not to accidentally swallow a legitimate `AbortError` from user code.

The matched error is still pushed to `browserConsoleBuffer`, so if the render later fails and dumps its diagnostic buffer, these lines remain available for analysis.

## Test plan

- [x] `bunx oxlint packages/engine/src/services/frameCapture.ts` — clean
- [x] `bunx oxfmt --check packages/engine/src/services/frameCapture.ts` — clean
- [x] `bun run --filter @hyperframes/engine typecheck` — clean
- [x] Verified locally by hand-patching the bundled `dist/cli.js` (the CLI is a single esbuild bundle, so the `pageerror` handler can be swapped in place for testing). Ran `hyperframes render` on a composition with `audio.play()` calls in its timeline — previously produced ~20 play-abort lines per render; after the patch, none. Confirmed via a debug-logged variant that the same handler still sees the errors and still pushes them to the browser-console buffer; only the `console.error` for this specific shape is skipped.

## Non-goals

- Not changing where or when `play()` is called in user compositions. Compositions authored against the documented runtime (and the `hyperframes.audio-playback` skill) fire-and-forget `.play()` intentionally, and that's compatible with render. Asking every scene author to sprinkle `.catch(() => {})` is a worse fix than filtering one well-known benign error at the boundary.
- Not suppressing any other `AbortError` — fetch aborts, signal aborts, user-thrown errors all continue to log normally.
