### PR TITLE
fix(producer): serve symlinked render assets

### DIFF
--- a/packages/producer/src/services/fileServer.test.ts
+++ b/packages/producer/src/services/fileServer.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path, { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  createFileServer,
   HF_BRIDGE_SCRIPT,
   HF_EARLY_STUB,
   injectScriptsAtHeadStart,
@@ -148,6 +149,45 @@ describe("isPathInside", () => {
     it("rejects paths on a different drive letter", () => {
       expect(isPathInside("D:\\foo\\bar", "C:\\foo", win32)).toBe(false);
     });
+  });
+});
+
+describe("createFileServer", () => {
+  it("serves asset files through project-root symlinked directories", async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "hf-file-server-symlink-assets-"));
+    const adsDir = join(workspaceDir, "Ads");
+    const projectDir = join(adsDir, "annual-upsell-2");
+    const sharedDir = join(adsDir, "shared");
+
+    try {
+      mkdirSync(projectDir, { recursive: true });
+      mkdirSync(sharedDir, { recursive: true });
+      writeFileSync(join(projectDir, "index.html"), "<!doctype html><html></html>");
+      writeFileSync(
+        join(sharedDir, "brand.css"),
+        ".aisplus-glass { backdrop-filter: blur(28px); }",
+      );
+      symlinkSync("../shared", join(projectDir, "shared"));
+
+      const server = await createFileServer({
+        projectDir,
+        preHeadScripts: [],
+        headScripts: [],
+        bodyScripts: [],
+      });
+
+      try {
+        const response = await fetch(`${server.url}/shared/brand.css`);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toContain("text/css");
+        expect(await response.text()).toContain(".aisplus-glass");
+      } finally {
+        server.close();
+      }
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/producer/src/services/fileServer.ts
+++ b/packages/producer/src/services/fileServer.ts
@@ -31,8 +31,8 @@ type IsPathInsideOptions = {
 
 /**
  * Returns true iff `child` is the same as, or nested inside, `parent` after
- * symlink-free path normalization. Used to reject path-traversal attempts
- * (e.g. GET `/../etc/passwd`) before opening any file.
+ * path normalization. Used to reject path-traversal attempts (e.g.
+ * GET `/../etc/passwd`) before opening any file.
  *
  * `path.join(root, "..")` normalizes traversal segments and can escape `root`
  * entirely, so the join return value alone is not a safe guard. Callers must
@@ -537,13 +537,14 @@ export function createFileServer(options: FileServerOptions): Promise<FileServer
     // Each candidate is rejected if `..` segments push it outside the
     // intended root: `path.join` normalizes traversal but does not enforce
     // containment, so a request like `GET /../etc/passwd` would otherwise
-    // be served straight off the filesystem.
+    // be served straight off the filesystem. Keep this lexical so project
+    // symlinks to sibling asset directories behave like preview mode.
     let filePath: string | null = null;
     if (compiledDir) {
       const candidate = join(compiledDir, relativePath);
       if (
         existsSync(candidate) &&
-        isPathInside(candidate, compiledDir, { resolveSymlinks: true }) &&
+        isPathInside(candidate, compiledDir) &&
         statSync(candidate).isFile()
       ) {
         filePath = candidate;
@@ -553,7 +554,7 @@ export function createFileServer(options: FileServerOptions): Promise<FileServer
       const candidate = join(projectDir, relativePath);
       if (
         existsSync(candidate) &&
-        isPathInside(candidate, projectDir, { resolveSymlinks: true }) &&
+        isPathInside(candidate, projectDir) &&
         statSync(candidate).isFile()
       ) {
         filePath = candidate;


### PR DESCRIPTION
## Problem

The AIS ads repro exposed a render-mode parity bug around shared project assets.

Those compositions can keep `shared/` inside each ad folder as a symlink to a sibling `../shared/` directory. `hyperframes preview` follows that symlink, so `shared/brand.css` loads and the authored glass cards, reveal wrappers, and layout primitives render correctly.

`hyperframes render` was different. The producer FileServer resolved the requested file through `realpath` before checking containment under the project root. For `shared -> ../shared`, that turned a project-local request like `/shared/brand.css` into a real path outside the ad folder, so the FileServer returned `404 Not Found`.

Without `brand.css`, the visual result is not a small styling drift: the AIS card chrome disappears, centered reveal layout breaks, and dark callouts can render as blunt overlays on top of the source video.

## What this fixes

- keeps producer FileServer traversal protection for requested paths under `compiledDir` and `projectDir`
- changes the render serving check back to lexical containment before opening the file, so valid project-root symlinked asset directories behave like preview mode
- still rejects `..` requests that normalize outside the intended root
- adds a regression test for the AIS-style `shared -> ../shared` asset layout by serving `brand.css` through the symlinked directory

## Root cause

The previous hardening mixed two separate concerns:

1. reject URL path traversal before serving files
2. reject symlink targets whose real path is outside the project directory

The second behavior is stricter than preview mode and broke a real composition-authoring pattern. The request path itself was still inside the project root (`shared/brand.css`), but the real path pointed at the sibling shared folder, so render rejected an asset the browser preview could load.

This PR keeps the URL traversal guard at the request-path layer and lets the filesystem follow the symlink when reading the file.

## Verification

### Local checks

- `bun test packages/producer/src/services/fileServer.test.ts`
- `bun run build:hyperframes-runtime:modular`
- `bun run --filter @hyperframes/producer typecheck`
- `bunx oxlint packages/producer/src/services/fileServer.ts packages/producer/src/services/fileServer.test.ts`
- `bunx oxfmt --check packages/producer/src/services/fileServer.ts packages/producer/src/services/fileServer.test.ts`
- pre-commit hook: `lint`, `format`, `typecheck`

### Repro verification

Verified against the cloned private repro `aidan785/ais-ads-hyperframes-bug-repro` with `annual-upsell-2/shared -> ../shared`:

- before the fix, producer FileServer returned `404` for `/shared/brand.css`
- after the fix, the same request returns `200` and includes the expected `.aisplus-glass` stylesheet content

### Render / browser verification

- rendered a 1s symlinked-CSS composition through the producer render path: `/Users/miguel07code/.codex/artifacts/ais-ads-render-fix/symlink-render-check.mp4`
- extracted a first-frame proof showing the symlinked CSS applied: `/Users/miguel07code/.codex/artifacts/ais-ads-render-fix/symlink-render-frame.png`
- used `agent-browser` against a local render-mode FileServer page and confirmed computed styles from the symlinked stylesheet (`backgroundColor: rgb(33, 197, 93)`, text `SYMLINK CSS`)
- saved agent-browser screenshot and recording:
  - `/Users/miguel07code/.codex/artifacts/ais-ads-render-fix/agent-browser-symlink-css.png`
  - `/Users/miguel07code/.codex/artifacts/ais-ads-render-fix/agent-browser-symlink-css.webm`

## Notes

- this PR intentionally does not copy the AIS repro assets into the HyperFrames repo
- the local render/browser artifacts are verification-only and are not part of this PR
- the scope is limited to FileServer serving parity for valid project-root symlinked assets; it does not broaden into general outside-root asset allowlisting
