### PR TITLE
fix: multi-file timeline drop spacing

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -957,7 +957,11 @@ export function StudioApp() {
   );
 
   const handleTimelineAssetDrop = useCallback(
-    async (assetPath: string, placement: Pick<TimelineElement, "start" | "track">) => {
+    async (
+      assetPath: string,
+      placement: Pick<TimelineElement, "start" | "track">,
+      durationOverride?: number,
+    ) => {
       const pid = projectIdRef.current;
       if (!pid) throw new Error("No active project");
 
@@ -983,9 +987,11 @@ export function StudioApp() {
         }
 
         const normalizedStart = Number(formatTimelineAttributeNumber(placement.start));
-        const normalizedDuration = Number(
-          formatTimelineAttributeNumber(await resolveDroppedAssetDuration(pid, assetPath, kind)),
-        );
+        const duration =
+          Number.isFinite(durationOverride) && durationOverride != null && durationOverride > 0
+            ? durationOverride
+            : await resolveDroppedAssetDuration(pid, assetPath, kind);
+        const normalizedDuration = Number(formatTimelineAttributeNumber(duration));
         const newId = buildTimelineAssetId(assetPath, collectHtmlIds(originalContent));
         const resolvedAssetSrc = resolveTimelineAssetSrc(targetPath, assetPath);
 
@@ -1064,17 +1070,40 @@ export function StudioApp() {
 
   const handleTimelineFileDrop = useCallback(
     async (files: File[], placement?: Pick<TimelineElement, "start" | "track">) => {
+      const pid = projectIdRef.current;
+      if (!pid) return;
       const uploaded = await uploadProjectFiles(files);
       if (uploaded.length === 0) return;
+      const durations: number[] = [];
+      for (const assetPath of uploaded) {
+        const kind = getTimelineAssetKind(assetPath);
+        const duration = kind ? await resolveDroppedAssetDuration(pid, assetPath, kind) : 0;
+        durations.push(Number(formatTimelineAttributeNumber(duration)));
+      }
       const placements = buildTimelineFileDropPlacements(
         placement ?? { start: 0, track: 0 },
-        uploaded.length,
+        durations,
+        timelineElements
+          .filter(
+            (timelineElement) =>
+              (timelineElement.sourceFile || activeCompPath || "index.html") ===
+              (activeCompPath || "index.html"),
+          )
+          .map((timelineElement) => ({
+            start: timelineElement.start,
+            duration: timelineElement.duration,
+            track: timelineElement.track,
+          })),
       );
       for (const [index, assetPath] of uploaded.entries()) {
-        await handleTimelineAssetDrop(assetPath, placements[index] ?? placements[0]);
+        await handleTimelineAssetDrop(
+          assetPath,
+          placements[index] ?? placements[0],
+          durations[index],
+        );
       }
     },
-    [handleTimelineAssetDrop, uploadProjectFiles],
+    [activeCompPath, handleTimelineAssetDrop, timelineElements, uploadProjectFiles],
   );
 
   // ── File Management Handlers ──

--- a/packages/studio/src/utils/timelineAssetDrop.test.ts
+++ b/packages/studio/src/utils/timelineAssetDrop.test.ts
@@ -11,6 +11,8 @@ describe("getTimelineAssetKind", () => {
   it("detects image, video, and audio assets", () => {
     expect(getTimelineAssetKind("assets/photo.png")).toBe("image");
     expect(getTimelineAssetKind("assets/clip.mp4")).toBe("video");
+    expect(getTimelineAssetKind("assets/clip.mov")).toBe("video");
+    expect(getTimelineAssetKind("assets/music.mp3")).toBe("audio");
     expect(getTimelineAssetKind("assets/music.wav")).toBe("audio");
   });
 });
@@ -58,11 +60,69 @@ describe("resolveTimelineAssetSrc", () => {
 });
 
 describe("buildTimelineFileDropPlacements", () => {
-  it("uses the dropped start and stacks multiple files onto successive tracks", () => {
-    expect(buildTimelineFileDropPlacements({ start: 1.5, track: 2 }, 3)).toEqual([
+  it("returns no placements for an empty drop set", () => {
+    expect(buildTimelineFileDropPlacements({ start: 1.5, track: 2 }, [])).toEqual([]);
+  });
+
+  it("uses the dropped start and spaces multiple files by duration on the same track", () => {
+    expect(buildTimelineFileDropPlacements({ start: 1.5, track: 2 }, [1.2, 1.6, 1.1])).toEqual([
       { start: 1.5, track: 2 },
-      { start: 1.5, track: 3 },
-      { start: 1.5, track: 4 },
+      { start: 2.7, track: 2 },
+      { start: 4.3, track: 2 },
+    ]);
+  });
+
+  it("uses fallback spacing when a duration is unavailable", () => {
+    expect(buildTimelineFileDropPlacements({ start: 1.5, track: 2 }, [1.2, 0, 1.1])).toEqual([
+      { start: 1.5, track: 2 },
+      { start: 2.7, track: 2 },
+      { start: 7.7, track: 2 },
+    ]);
+  });
+
+  it("moves the spaced sequence to a clear track when the dropped row is occupied", () => {
+    expect(
+      buildTimelineFileDropPlacements(
+        { start: 1.5, track: 2 },
+        [1.2, 1.6, 1.1],
+        [
+          { start: 0, duration: 8, track: 2 },
+          { start: 0, duration: 4, track: 5 },
+        ],
+      ),
+    ).toEqual([
+      { start: 1.5, track: 6 },
+      { start: 2.7, track: 6 },
+      { start: 4.3, track: 6 },
+    ]);
+  });
+
+  it("keeps a requested track above occupied rows when that track is clear", () => {
+    expect(
+      buildTimelineFileDropPlacements(
+        { start: 1.5, track: 8 },
+        [1.2, 1.6],
+        [
+          { start: 0, duration: 8, track: 2 },
+          { start: 0, duration: 4, track: 5 },
+        ],
+      ),
+    ).toEqual([
+      { start: 1.5, track: 8 },
+      { start: 2.7, track: 8 },
+    ]);
+  });
+
+  it("moves a default-track drop to a clear row when track 0 is occupied at time 0", () => {
+    expect(
+      buildTimelineFileDropPlacements(
+        { start: 0, track: 0 },
+        [1.2, 1.6],
+        [{ start: 0, duration: 8, track: 0 }],
+      ),
+    ).toEqual([
+      { start: 0, track: 1 },
+      { start: 1.2, track: 1 },
     ]);
   });
 });

--- a/packages/studio/src/utils/timelineAssetDrop.ts
+++ b/packages/studio/src/utils/timelineAssetDrop.ts
@@ -1,6 +1,7 @@
 import { AUDIO_EXT, IMAGE_EXT, VIDEO_EXT } from "./mediaTypes";
 
 export const TIMELINE_ASSET_MIME = "application/x-hyperframes-asset";
+const FALLBACK_TIMELINE_FILE_DROP_DURATION = 5;
 
 export type TimelineAssetKind = "image" | "video" | "audio";
 
@@ -46,12 +47,33 @@ export function resolveTimelineAssetSrc(targetPath: string, assetPath: string): 
 
 export function buildTimelineFileDropPlacements(
   placement: { start: number; track: number },
-  count: number,
+  durations: number[],
+  occupiedClips: Array<{ start: number; duration: number; track: number }> = [],
 ): Array<{ start: number; track: number }> {
-  return Array.from({ length: Math.max(0, count) }, (_, index) => ({
-    start: placement.start,
-    track: placement.track + index,
-  }));
+  let nextStart = Math.round(Math.max(0, placement.start) * 100) / 100;
+  const sequenceStart = nextStart;
+  const resolvedDurations = durations.map((duration) =>
+    Number.isFinite(duration) && duration > 0 ? duration : FALLBACK_TIMELINE_FILE_DROP_DURATION,
+  );
+  const sequenceEnd = resolvedDurations.reduce(
+    (end, duration) => Math.round((end + duration) * 100) / 100,
+    sequenceStart,
+  );
+  const overlapsDropTrack = occupiedClips.some((clip) => {
+    if (clip.track !== placement.track) return false;
+    const clipStart = Math.max(0, clip.start);
+    const clipEnd = clipStart + Math.max(0, clip.duration);
+    return sequenceStart < clipEnd && sequenceEnd > clipStart;
+  });
+  const track = overlapsDropTrack
+    ? Math.max(placement.track, ...occupiedClips.map((clip) => clip.track)) + 1
+    : placement.track;
+
+  return resolvedDurations.map((duration) => {
+    const start = nextStart;
+    nextStart = Math.round((nextStart + duration) * 100) / 100;
+    return { start, track };
+  });
 }
 
 export function buildTimelineAssetInsertHtml(input: {


### PR DESCRIPTION
## Problem

Studio could still produce a bad timeline layout when multiple media files were dropped onto the timeline at once.

The files uploaded correctly, but the placement logic treated the group too loosely:

- MP4 / MOV / MP3 files could be inserted with the same drop start instead of being spaced by their actual media durations
- dropping onto a row that already contained a long clip could leave the first new media clip overlapping existing content on that same track
- if duration metadata was unavailable during group placement, the helper could treat a clip as zero-length even though insertion would later write a positive fallback duration
- the saved HTML could therefore look valid at a glance while still creating track collisions during preview / static guard checks

## What this fixes

### Multi-file timeline placement

- resolves each uploaded file's media duration before placing the dropped group
- places the group sequentially from the drop point instead of assigning every file the same start time
- falls back to a finite placement duration when duration metadata is unavailable, keeping placement math aligned with the insert fallback path
- reuses the resolved duration when writing the inserted clip HTML, so the saved `data-duration` matches the placement math when metadata is available
- keeps the whole dropped group on one clear row so the assets read as a sequence instead of scattering across rows

### Occupied-row handling

- keeps the requested drop track when the time range is clear
- if the requested row is already occupied at that time range, moves the whole group to a new clear track below the current timeline rows
- covers the default `{ start: 0, track: 0 }` placement path when track `0` is already occupied
- preserves the existing track / z-index update path so older clips keep rendering predictably after the new clips are inserted

### Media coverage

- keeps MP4 and MOV handled as video assets
- keeps MP3 handled as audio
- adds regression coverage for MOV / MP3 detection, occupied-row fallback, empty drops, clear high-track drops, and mixed positive / missing durations

## Root cause

The multi-file drop helper only knew about the number of uploaded files. It did not know the duration of each uploaded media asset, so it could not build a non-overlapping sequence from the drop point.

The direct file-drop handler also passed placement into each insert independently. That meant the drop could use the same start time repeatedly, and it could target a row that was already occupied by an existing clip.

A smaller edge case existed when a duration resolved to `0` or was otherwise unavailable: placement math did not advance `nextStart`, but the insert path could still write a positive fallback duration later. The helper now uses a finite fallback for placement too.

## Behavior

- dropping a single file still places that file at the dropped time / track when the row is clear
- dropping multiple files now creates a sequential group from the dropped time
- if a file's duration is unavailable during placement, the next file is still spaced forward by a finite fallback
- if the dropped row is occupied, the group moves together to the next clear track
- video and audio durations come from metadata when available, with the existing fallback duration still used when metadata cannot be read quickly
- inserted clips are still persisted into source HTML and the preview refreshes after the drop

## Verification

### Local checks

- `bun run --filter @hyperframes/studio test -- src/utils/timelineAssetDrop.test.ts` -> 12 tests pass
- `bun run --filter @hyperframes/studio test` -> 221 tests pass
- `bun run --filter @hyperframes/studio typecheck`
- `bunx oxlint packages/studio/src/utils/timelineAssetDrop.ts packages/studio/src/utils/timelineAssetDrop.test.ts`
- `bunx oxfmt --check packages/studio/src/utils/timelineAssetDrop.ts packages/studio/src/utils/timelineAssetDrop.test.ts`
- `bun run --filter @hyperframes/studio build`
- `git diff --check`
- pre-commit hook: lint / format / typecheck

### Browser / live verification

Verified against a live local Studio fixture with real media files:

- dropped a group containing MP4, MOV, and MP3 files onto the timeline
- confirmed the saved HTML sequenced them at `2.18s`, `3.38s`, and `4.98s`
- confirmed the existing background clip stayed on track `0` while the new media group moved together to clear track `1`
- confirmed `agent-browser errors` was clean after the drop
- captured an `agent-browser` recording pass for the tested flow

## Notes

- the `timeline-multi-drop-repro` Studio project and generated MP4 / MOV / MP3 files used for browser verification are local-only and are not part of this PR
- this PR is intentionally scoped to multi-file drop placement; it does not add broader timeline editing modes or change drag/move behavior for existing clips
