### PR TITLE
fix(cli): resolve sub-composition <audio> src relative to its own file

### DIFF
--- a/packages/cli/src/utils/lintProject.test.ts
+++ b/packages/cli/src/utils/lintProject.test.ts
@@ -324,6 +324,49 @@ describe("audio_src_not_found", () => {
     const occurrences = (finding?.message.match(/song\.mp3/g) ?? []).length;
     expect(occurrences).toBe(1);
   });
+
+  it("resolves sub-composition src relative to the sub-composition file (../assets/...)", () => {
+    // A sub-composition at compositions/captions.html referencing
+    // ../assets/bgm.mp3 means {projectRoot}/assets/bgm.mp3 — the bundler
+    // rewrites that path before serving, so the lint check has to mirror it.
+    const subComp = `<html><body>
+  <div data-composition-id="captions" data-width="1920" data-height="1080">
+    <audio id="music" src="../assets/bgm.mp3" data-start="0" data-track-index="0" data-volume="1"></audio>
+  </div>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines["captions"] = gsap.timeline({ paused: true });</script>
+</body></html>`;
+    const project = makeProject(validHtml(), { "captions.html": subComp });
+    mkdirSync(join(project.dir, "assets"), { recursive: true });
+    writeFileSync(join(project.dir, "assets", "bgm.mp3"), "fake");
+
+    const { results } = lintProject(project);
+
+    const first = results[0];
+    expect(first).toBeDefined();
+    const finding = first?.result.findings.find((f) => f.code === "audio_src_not_found");
+    expect(finding).toBeUndefined();
+  });
+
+  it("flags sub-composition src that resolves to a missing file via ../", () => {
+    const subComp = `<html><body>
+  <div data-composition-id="captions" data-width="1920" data-height="1080">
+    <audio id="music" src="../assets/missing.mp3" data-start="0" data-track-index="0" data-volume="1"></audio>
+  </div>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines["captions"] = gsap.timeline({ paused: true });</script>
+</body></html>`;
+    const project = makeProject(validHtml(), { "captions.html": subComp });
+    // No assets/ directory at all.
+
+    const { results } = lintProject(project);
+
+    const first = results[0];
+    expect(first).toBeDefined();
+    const finding = first?.result.findings.find((f) => f.code === "audio_src_not_found");
+    expect(finding).toBeDefined();
+    // The original (un-rewritten) src is what surfaces in the message so the
+    // author can grep for it in their HTML.
+    expect(finding?.message).toContain("../assets/missing.mp3");
+  });
 });
 
 describe("multiple_root_compositions", () => {

--- a/packages/cli/src/utils/lintProject.ts
+++ b/packages/cli/src/utils/lintProject.ts
@@ -2,7 +2,21 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join, resolve, extname } from "node:path";
 import { lintHyperframeHtml, type HyperframeLintResult } from "@hyperframes/core/lint";
 import type { HyperframeLintFinding } from "@hyperframes/core/lint";
+import { rewriteAssetPath } from "@hyperframes/core";
 import type { ProjectDir } from "./project.js";
+
+/**
+ * An HTML source paired with the sub-composition path it came from, if any.
+ * Sub-composition relative paths (`../assets/foo.mp3`) need to be resolved
+ * against the sub-composition's directory before checking the filesystem —
+ * the root index.html is the only source where a bare `resolve(projectDir, src)`
+ * is correct.
+ */
+interface HtmlSource {
+  html: string;
+  /** `data-composition-src` value (e.g. "compositions/scene.html"); undefined for the root. */
+  compSrcPath?: string;
+}
 
 export interface ProjectLintResult {
   results: Array<{ file: string; result: HyperframeLintResult }>;
@@ -32,14 +46,14 @@ export function lintProject(project: ProjectDir): ProjectLintResult {
   totalInfos += rootResult.infoCount;
 
   // Lint sub-compositions in compositions/ directory, collecting HTML for project-level checks
-  const allHtmlSources = [rootHtml];
+  const allHtmlSources: HtmlSource[] = [{ html: rootHtml }];
   const compositionsDir = resolve(project.dir, "compositions");
   if (existsSync(compositionsDir)) {
     const files = readdirSync(compositionsDir).filter((f) => f.endsWith(".html"));
     for (const file of files) {
       const filePath = join(compositionsDir, file);
       const html = readFileSync(filePath, "utf-8");
-      allHtmlSources.push(html);
+      allHtmlSources.push({ html, compSrcPath: `compositions/${file}` });
       const result = lintHyperframeHtml(html, { filePath, isSubComposition: true });
       results.push({ file: `compositions/${file}`, result });
       totalErrors += result.errorCount;
@@ -83,7 +97,10 @@ export function lintProject(project: ProjectDir): ProjectLintResult {
  * placing an audio file in the project but forgetting the <audio> tag, which
  * results in a silent render.
  */
-function lintProjectAudioFiles(projectDir: string, htmlSources: string[]): HyperframeLintFinding[] {
+function lintProjectAudioFiles(
+  projectDir: string,
+  htmlSources: HtmlSource[],
+): HyperframeLintFinding[] {
   const findings: HyperframeLintFinding[] = [];
 
   // Scan project root for audio files (non-recursive — only top-level)
@@ -99,7 +116,7 @@ function lintProjectAudioFiles(projectDir: string, htmlSources: string[]): Hyper
   if (audioFiles.length === 0) return findings;
 
   // Check if any HTML source contains an <audio> element
-  const hasAudioElement = htmlSources.some((html) => /<audio\b/i.test(html));
+  const hasAudioElement = htmlSources.some(({ html }) => /<audio\b/i.test(html));
 
   if (!hasAudioElement) {
     findings.push({
@@ -121,19 +138,27 @@ function lintProjectAudioFiles(projectDir: string, htmlSources: string[]): Hyper
  * in the project directory. The renderer will silently skip missing audio,
  * producing a silent video with no indication of what went wrong.
  */
-function lintAudioSrcNotFound(projectDir: string, htmlSources: string[]): HyperframeLintFinding[] {
+function lintAudioSrcNotFound(
+  projectDir: string,
+  htmlSources: HtmlSource[],
+): HyperframeLintFinding[] {
   const findings: HyperframeLintFinding[] = [];
 
   const audioSrcRe = /<audio\b[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
 
   const missingSrcs: string[] = [];
-  for (const html of htmlSources) {
+  for (const { html, compSrcPath } of htmlSources) {
     let match: RegExpExecArray | null;
     while ((match = audioSrcRe.exec(html)) !== null) {
       const src = match[1]!;
       if (/^(https?:|data:|blob:)/i.test(src)) continue;
       if (/^__[A-Z_]+__$/.test(src)) continue; // Skip template placeholders
-      const resolved = resolve(projectDir, src);
+      // Sub-composition srcs are written relative to the sub-composition file
+      // (e.g. "../assets/foo.mp3"); the bundler rewrites them to root-relative
+      // before serving. Mirror that rewrite here so the existence check sees
+      // the same path the renderer will. Root-html srcs pass through unchanged.
+      const rootRelative = compSrcPath ? rewriteAssetPath(compSrcPath, src) : src;
+      const resolved = resolve(projectDir, rootRelative);
       if (!existsSync(resolved)) {
         missingSrcs.push(src);
       }
@@ -192,7 +217,7 @@ function lintMultipleRootCompositions(projectDir: string): HyperframeLintFinding
  * Extracts each attribute independently (order-insensitive) to handle any HTML attribute order.
  * Deduplicates by (src, start, duration) to avoid flagging the same audio reached via sub-compositions.
  */
-function lintDuplicateAudioTracks(htmlSources: string[]): HyperframeLintFinding[] {
+function lintDuplicateAudioTracks(htmlSources: HtmlSource[]): HyperframeLintFinding[] {
   const findings: HyperframeLintFinding[] = [];
   function extractAttr(tag: string, name: string): string | null {
     const re = new RegExp(`\\b${name}\\s*=\\s*["']([^"']+)["']`, "i");
@@ -203,7 +228,7 @@ function lintDuplicateAudioTracks(htmlSources: string[]): HyperframeLintFinding[
   const tracks: Array<{ trackIndex: number; start: number; end: number; src: string }> = [];
   const seen = new Set<string>();
 
-  for (const html of htmlSources) {
+  for (const { html } of htmlSources) {
     // Regex with g flag must be created inside the loop — a shared g-regex
     // carries lastIndex across strings, silently skipping matches.
     const audioTagRe = /<audio\b[^>]*>/gi;


### PR DESCRIPTION
## What

`lintAudioSrcNotFound` was reporting `audio_src_not_found` errors for `<audio>` elements inside sub-compositions whose `src` attribute starts with `../`, even when the file actually exists at the path the bundler rewrites to.

## Why

The pre-render lint check is currently produced by reading every HTML source (root + each `compositions/*.html`) into a single string array, then for each `<audio src>` doing `resolve(projectDir, src)` and checking the filesystem. That's correct for the root index.html but wrong for sub-compositions:

- A sub-composition at `compositions/scene.html` writes `<audio src="../assets/foo.mp3">` because its bundler rewrites paths relative to the sub-composition's own file (see `rewriteAssetPath` in `packages/core/src/compiler/rewriteSubCompPaths.ts`).
- `resolve(projectDir, "../assets/foo.mp3")` walks one level *above* the project — to `{parentOfProject}/assets/foo.mp3` — which does not exist, so the lint check reports the file as missing.

Net effect: a project that follows the documented authoring model (sub-composition assets written relative to the sub-composition file) gets a hard `audio_src_not_found` error from `hyperframes lint`, even though `hyperframes preview` and `hyperframes render` both work correctly.

## How

1. Replace the bare `string[]` of `htmlSources` with `HtmlSource[] = { html, compSrcPath? }`. `compSrcPath` is the `data-composition-src` value (e.g. `compositions/scene.html`); the root index.html leaves it `undefined`.

2. Inside `lintAudioSrcNotFound`, when a sub-composition source's `src` matches the existing rewrite criteria, run it through the bundler's own `rewriteAssetPath(compSrcPath, src)` helper to convert `../assets/foo.mp3` into `assets/foo.mp3`. Then `resolve(projectDir, ...)` against the rewritten path.

3. Keep the original (un-rewritten) `src` in the `missingSrcs` array so the finding message and fix hint remain greppable from the author's HTML — they should see what they wrote, not the rewritten internal form.

4. Update `lintProjectAudioFiles` and `lintDuplicateAudioTracks` signatures to accept the same `HtmlSource[]`, since they read off the same array. Their internal logic doesn't depend on `compSrcPath`, but the type has to match.

`rewriteAssetPath` is already exported from `@hyperframes/core` (used by the producer/preview bundlers). No new dependency, no duplication of path-rewrite logic.

## Test plan

- [x] `bunx oxlint packages/cli/src/utils/lintProject.ts packages/cli/src/utils/lintProject.test.ts` — clean
- [x] `bunx oxfmt --check packages/cli/src/utils/lintProject.ts packages/cli/src/utils/lintProject.test.ts` — clean
- [x] `bun run --filter @hyperframes/cli typecheck` — clean
- [x] `bunx vitest run src/utils/lintProject.test.ts` (in `packages/cli`) — 39 tests pass (37 previous + 2 new)
- [x] Two new tests added to `lintProject.test.ts`:
    - `resolves sub-composition src relative to the sub-composition file (../assets/...)` — sub-comp at `compositions/captions.html` referencing `../assets/bgm.mp3` with the file present at `{project}/assets/bgm.mp3` → no `audio_src_not_found` finding
    - `flags sub-composition src that resolves to a missing file via ../` — same shape but no file on disk → finding raised, message contains the original `../assets/...` src so authors can grep it
- [x] Verified locally by hand-patching the bundled `dist/cli.js` in a real project with a sub-composition that references nine `<audio>` elements via `../assets/narration/*.mp3`. Before the patch: 9 hard errors despite all files existing and `render` succeeding. After the patch: lint clean for those audio sources. Renaming one of the mp3s on disk still produces the expected single error pointing at the un-rewritten path, so the rule still catches genuine misses.

## Non-goals

- Not changing the bundler's path-rewrite rules. This PR uses `rewriteAssetPath` as the source of truth — same behaviour, same edge cases.
- Not changing the `audio_src_not_found` finding message format beyond what already shows up. Authors continue to see the literal `src` they wrote.