### PR TITLE
fix(cli): publish projects through staged uploads

### DIFF
--- a/packages/cli/src/utils/publishProject.test.ts
+++ b/packages/cli/src/utils/publishProject.test.ts
@@ -54,7 +54,8 @@ describe("publishProjectArchive", () => {
         new Response(
           JSON.stringify({
             data: {
-              upload_url: "https://s3.example.com/upload",
+              upload_url:
+                "https://s3.example.com/upload?X-Amz-SignedHeaders=content-length;content-type;host;x-amz-server-side-encryption",
               upload_key: "ephemeral_store/hyperframes/project_uploads/upload-1/demo.zip",
               upload_headers: {
                 "content-type": "application/zip",
@@ -106,10 +107,11 @@ describe("publishProjectArchive", () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        "https://s3.example.com/upload",
+        "https://s3.example.com/upload?X-Amz-SignedHeaders=content-length;content-type;host;x-amz-server-side-encryption",
         expect.objectContaining({
           method: "PUT",
           headers: {
+            "content-length": expect.any(String),
             "content-type": "application/zip",
             "x-amz-server-side-encryption": "AES256",
           },

--- a/packages/cli/src/utils/publishProject.test.ts
+++ b/packages/cli/src/utils/publishProject.test.ts
@@ -37,9 +37,37 @@ describe("createPublishArchive", () => {
 
 describe("publishProjectArchive", () => {
   beforeEach(() => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
+    vi.stubEnv("HYPERFRAMES_PUBLISHED_PROJECTS_API_URL", "");
+    vi.stubEnv("HEYGEN_API_URL", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("uploads through the staged publish flow and returns the stable project URL", async () => {
+    const dir = makeProjectDir();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              upload_url: "https://s3.example.com/upload",
+              upload_key: "ephemeral_store/hyperframes/project_uploads/upload-1/demo.zip",
+              upload_headers: {
+                "content-type": "application/zip",
+                "x-amz-server-side-encryption": "AES256",
+              },
+              content_type: "application/zip",
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
             data: {
@@ -52,16 +80,9 @@ describe("publishProjectArchive", () => {
           }),
           { status: 200 },
         ),
-      ),
-    );
-  });
+      );
+    vi.stubGlobal("fetch", fetchMock);
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("uploads the archive and returns the stable project URL", async () => {
-    const dir = makeProjectDir();
     try {
       writeFileSync(join(dir, "index.html"), "<html></html>", "utf-8");
       writeFileSync(join(dir, "styles.css"), "body {}", "utf-8");
@@ -73,8 +94,72 @@ describe("publishProjectArchive", () => {
         projectId: "hfp_123",
         url: "https://hyperframes.dev/p/hfp_123",
       });
-      expect(fetch).toHaveBeenCalledTimes(1);
-      expect(fetch).toHaveBeenCalledWith(
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://api2.heygen.com/v1/hyperframes/projects/publish/upload",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "content-type": "application/json", heygen_route: "canary" },
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        "https://s3.example.com/upload",
+        expect.objectContaining({
+          method: "PUT",
+          headers: {
+            "content-type": "application/zip",
+            "x-amz-server-side-encryption": "AES256",
+          },
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        "https://api2.heygen.com/v1/hyperframes/projects/publish/complete",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "content-type": "application/json", heygen_route: "canary" },
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the legacy multipart endpoint when staged publish is not deployed", async () => {
+    const dir = makeProjectDir();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project_id: "hfp_123",
+              title: "demo",
+              file_count: 2,
+              url: "https://hyperframes.dev/p/hfp_123",
+              claim_token: "claim-token",
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      writeFileSync(join(dir, "index.html"), "<html></html>", "utf-8");
+
+      const result = await publishProjectArchive(dir);
+
+      expect(result.projectId).toBe("hfp_123");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
         "https://api2.heygen.com/v1/hyperframes/projects/publish",
         expect.objectContaining({
           method: "POST",
@@ -82,6 +167,39 @@ describe("publishProjectArchive", () => {
           signal: expect.any(AbortSignal),
         }),
       );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not fall back to multipart when a staged S3 upload fails", async () => {
+    const dir = makeProjectDir();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              upload_url: "https://s3.example.com/upload",
+              upload_key: "ephemeral_store/hyperframes/project_uploads/upload-1/demo.zip",
+              upload_headers: {
+                "content-type": "application/zip",
+                "x-amz-server-side-encryption": "AES256",
+              },
+              content_type: "application/zip",
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("denied", { status: 403 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      writeFileSync(join(dir, "index.html"), "<html></html>", "utf-8");
+
+      await expect(publishProjectArchive(dir)).rejects.toThrow("Failed to upload project archive");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/utils/publishProject.ts
+++ b/packages/cli/src/utils/publishProject.ts
@@ -63,7 +63,10 @@ function parsePublishedProjectResponse(payload: unknown): PublishedProjectRespon
   };
 }
 
-function parseStagedUploadResponse(payload: unknown): StagedUploadResponse | null {
+function parseStagedUploadResponse(
+  payload: unknown,
+  archiveByteLength: number,
+): StagedUploadResponse | null {
   const data = dataRecord(payload);
   if (!data) return null;
   const uploadUrl = stringField(data, "upload_url");
@@ -74,7 +77,7 @@ function parseStagedUploadResponse(payload: unknown): StagedUploadResponse | nul
     uploadUrl,
     uploadKey,
     contentType,
-    uploadHeaders: getUploadHeaders(data, uploadUrl, contentType),
+    uploadHeaders: getUploadHeaders(data, uploadUrl, contentType, archiveByteLength),
   };
 }
 
@@ -82,6 +85,7 @@ function getUploadHeaders(
   data: JsonRecord,
   uploadUrl: string,
   contentType: string,
+  archiveByteLength: number,
 ): Record<string, string> {
   const headers: Record<string, string> = {};
   const uploadHeaders = data["upload_headers"];
@@ -103,6 +107,12 @@ function getUploadHeaders(
     !Object.keys(headers).some((key) => key.toLowerCase() === "x-amz-server-side-encryption")
   ) {
     headers["x-amz-server-side-encryption"] = "AES256";
+  }
+  if (
+    signedHeaders?.split(";").includes("content-length") &&
+    !Object.keys(headers).some((key) => key.toLowerCase() === "content-length")
+  ) {
+    headers["content-length"] = String(archiveByteLength);
   }
 
   return headers;
@@ -241,7 +251,7 @@ async function publishProjectArchiveStaged(
   }
 
   const uploadPayload = await readJson(uploadResponse);
-  const stagedUpload = parseStagedUploadResponse(uploadPayload);
+  const stagedUpload = parseStagedUploadResponse(uploadPayload, archive.buffer.byteLength);
   if (!uploadResponse.ok || !stagedUpload) {
     throw new Error(await readErrorMessage(uploadResponse, "Failed to prepare project upload"));
   }

--- a/packages/cli/src/utils/publishProject.ts
+++ b/packages/cli/src/utils/publishProject.ts
@@ -4,6 +4,8 @@ import AdmZip from "adm-zip";
 
 const IGNORED_DIRS = new Set([".git", "node_modules", "dist", ".next", "coverage"]);
 const IGNORED_FILES = new Set([".DS_Store", "Thumbs.db"]);
+const PUBLISH_CONTENT_TYPE = "application/zip";
+const PUBLISH_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface PublishArchiveResult {
   buffer: Buffer;
@@ -16,6 +18,118 @@ export interface PublishedProjectResponse {
   fileCount: number;
   url: string;
   claimToken: string;
+}
+
+interface StagedUploadResponse {
+  uploadUrl: string;
+  uploadKey: string;
+  contentType: string;
+  uploadHeaders: Record<string, string>;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function dataRecord(payload: unknown): JsonRecord | null {
+  if (!isRecord(payload) || !isRecord(payload["data"])) return null;
+  return payload["data"];
+}
+
+function stringField(record: JsonRecord, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function parsePublishedProjectResponse(payload: unknown): PublishedProjectResponse | null {
+  const data = dataRecord(payload);
+  if (!data) return null;
+  const projectId = stringField(data, "project_id");
+  const title = stringField(data, "title");
+  const url = stringField(data, "url");
+  const claimToken = stringField(data, "claim_token");
+  const fileCount = data["file_count"];
+  if (!projectId || !title || !url || !claimToken || typeof fileCount !== "number") {
+    return null;
+  }
+  return {
+    projectId,
+    title,
+    fileCount,
+    url,
+    claimToken,
+  };
+}
+
+function parseStagedUploadResponse(payload: unknown): StagedUploadResponse | null {
+  const data = dataRecord(payload);
+  if (!data) return null;
+  const uploadUrl = stringField(data, "upload_url");
+  const uploadKey = stringField(data, "upload_key");
+  const contentType = stringField(data, "content_type") || PUBLISH_CONTENT_TYPE;
+  if (!uploadUrl || !uploadKey) return null;
+  return {
+    uploadUrl,
+    uploadKey,
+    contentType,
+    uploadHeaders: getUploadHeaders(data, uploadUrl, contentType),
+  };
+}
+
+function getUploadHeaders(
+  data: JsonRecord,
+  uploadUrl: string,
+  contentType: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const uploadHeaders = data["upload_headers"];
+  if (isRecord(uploadHeaders)) {
+    for (const [key, value] of Object.entries(uploadHeaders)) {
+      if (typeof value === "string" && key.trim()) {
+        headers[key] = value;
+      }
+    }
+  }
+
+  if (!Object.keys(headers).some((key) => key.toLowerCase() === "content-type")) {
+    headers["content-type"] = contentType;
+  }
+
+  const signedHeaders = new URL(uploadUrl).searchParams.get("X-Amz-SignedHeaders");
+  if (
+    signedHeaders?.split(";").includes("x-amz-server-side-encryption") &&
+    !Object.keys(headers).some((key) => key.toLowerCase() === "x-amz-server-side-encryption")
+  ) {
+    headers["x-amz-server-side-encryption"] = "AES256";
+  }
+
+  return headers;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return response
+    .clone()
+    .json()
+    .catch(() => null);
+}
+
+async function readErrorMessage(response: Response, fallback: string): Promise<string> {
+  const contentType = response.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    const payload = await readJson(response);
+    if (isRecord(payload) && typeof payload["message"] === "string") {
+      return payload["message"];
+    }
+  }
+
+  if (response.status === 403 && response.headers.get("cf-mitigated") === "challenge") {
+    return "Publish upload was blocked before reaching HyperFrames. Please retry after staged uploads are available.";
+  }
+
+  const text = await response.text().catch(() => "");
+  return text.trim() ? `${fallback}: ${text.trim().slice(0, 180)}` : fallback;
 }
 
 function shouldIgnoreSegment(segment: string): boolean {
@@ -65,37 +179,111 @@ export function getPublishApiBaseUrl(): string {
   ).replace(/\/$/, "");
 }
 
-export async function publishProjectArchive(projectDir: string): Promise<PublishedProjectResponse> {
-  const title = basename(projectDir);
-  const archive = createPublishArchive(projectDir);
-  const archiveBytes = new Uint8Array(archive.buffer.byteLength);
-  archiveBytes.set(archive.buffer);
+function archiveArrayBuffer(archive: PublishArchiveResult): ArrayBuffer {
+  const arrayBuffer = new ArrayBuffer(archive.buffer.byteLength);
+  new Uint8Array(arrayBuffer).set(archive.buffer);
+  return arrayBuffer;
+}
+
+async function publishProjectArchiveDirect(
+  apiBaseUrl: string,
+  title: string,
+  archive: PublishArchiveResult,
+): Promise<PublishedProjectResponse> {
   const body = new FormData();
   body.set("title", title);
-  body.set("file", new File([archiveBytes], `${title}.zip`, { type: "application/zip" }));
+  body.set(
+    "file",
+    new File([archiveArrayBuffer(archive)], `${title}.zip`, { type: PUBLISH_CONTENT_TYPE }),
+  );
   const headers: Record<string, string> = {
     heygen_route: "canary",
   };
 
-  const response = await fetch(`${getPublishApiBaseUrl()}/v1/hyperframes/projects/publish`, {
+  const response = await fetch(`${apiBaseUrl}/v1/hyperframes/projects/publish`, {
     method: "POST",
     body,
     headers,
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(PUBLISH_REQUEST_TIMEOUT_MS),
   });
 
-  const payload = await response.json().catch(() => null);
-  const message =
-    typeof payload?.message === "string" ? payload.message : "Failed to publish project";
-  if (!response.ok || !payload?.data) {
-    throw new Error(message);
+  const payload = await readJson(response);
+  const publishedProject = parsePublishedProjectResponse(payload);
+  if (!response.ok || !publishedProject) {
+    throw new Error(await readErrorMessage(response, "Failed to publish project"));
   }
 
-  return {
-    projectId: String(payload.data.project_id),
-    title: String(payload.data.title),
-    fileCount: Number(payload.data.file_count),
-    url: String(payload.data.url),
-    claimToken: String(payload.data.claim_token),
-  };
+  return publishedProject;
+}
+
+async function publishProjectArchiveStaged(
+  apiBaseUrl: string,
+  title: string,
+  archive: PublishArchiveResult,
+): Promise<PublishedProjectResponse | null> {
+  const fileName = `${title}.zip`;
+  const uploadResponse = await fetch(`${apiBaseUrl}/v1/hyperframes/projects/publish/upload`, {
+    method: "POST",
+    body: JSON.stringify({
+      file_name: fileName,
+      content_type: PUBLISH_CONTENT_TYPE,
+      content_length: archive.buffer.byteLength,
+    }),
+    headers: {
+      "content-type": "application/json",
+      heygen_route: "canary",
+    },
+    signal: AbortSignal.timeout(PUBLISH_REQUEST_TIMEOUT_MS),
+  });
+
+  if (uploadResponse.status === 404 || uploadResponse.status === 405) {
+    return null;
+  }
+
+  const uploadPayload = await readJson(uploadResponse);
+  const stagedUpload = parseStagedUploadResponse(uploadPayload);
+  if (!uploadResponse.ok || !stagedUpload) {
+    throw new Error(await readErrorMessage(uploadResponse, "Failed to prepare project upload"));
+  }
+
+  const s3Response = await fetch(stagedUpload.uploadUrl, {
+    method: "PUT",
+    body: new Blob([archiveArrayBuffer(archive)], { type: stagedUpload.contentType }),
+    headers: stagedUpload.uploadHeaders,
+    signal: AbortSignal.timeout(PUBLISH_REQUEST_TIMEOUT_MS),
+  });
+  if (!s3Response.ok) {
+    throw new Error(await readErrorMessage(s3Response, "Failed to upload project archive"));
+  }
+
+  const completeResponse = await fetch(`${apiBaseUrl}/v1/hyperframes/projects/publish/complete`, {
+    method: "POST",
+    body: JSON.stringify({
+      upload_key: stagedUpload.uploadKey,
+      file_name: fileName,
+      title,
+    }),
+    headers: {
+      "content-type": "application/json",
+      heygen_route: "canary",
+    },
+    signal: AbortSignal.timeout(PUBLISH_REQUEST_TIMEOUT_MS),
+  });
+
+  const completePayload = await readJson(completeResponse);
+  const publishedProject = parsePublishedProjectResponse(completePayload);
+  if (!completeResponse.ok || !publishedProject) {
+    throw new Error(await readErrorMessage(completeResponse, "Failed to publish project"));
+  }
+
+  return publishedProject;
+}
+
+export async function publishProjectArchive(projectDir: string): Promise<PublishedProjectResponse> {
+  const title = basename(projectDir);
+  const archive = createPublishArchive(projectDir);
+  const apiBaseUrl = getPublishApiBaseUrl();
+  const stagedResult = await publishProjectArchiveStaged(apiBaseUrl, title, archive);
+  if (stagedResult) return stagedResult;
+  return publishProjectArchiveDirect(apiBaseUrl, title, archive);
 }


### PR DESCRIPTION
## Problem

`hyperframes publish` uploads the project ZIP through the API edge. Valid projects with binary/high-entropy media can be challenged before they reach Flask, so publish fails even when the archive is valid.

While validating the staged backend flow on devbox, the client also exposed a second contract issue: S3 PUTs must send every header signed into the presigned URL. The backend signs `x-amz-server-side-encryption`, so a client that only sends `content-type` gets `SignatureDoesNotMatch` from S3.

A backend review follow-up now signs the archive byte length too. The CLI already sends `content_length` when requesting the upload; this PR also honors `content-length` when it appears in `X-Amz-SignedHeaders`, so the PUT request does not rely on runtime-specific implicit header behavior.

## Reproduction

1. Use a project with HTML plus real binary assets, e.g. `/Users/miguel07code/Downloads/apple-presentation`.
2. Run `hyperframes publish --yes /Users/miguel07code/Downloads/apple-presentation` against the existing direct multipart endpoint.
3. The publish fails before backend validation. Inspecting the response shows HTTP 403 with `cf-mitigated: challenge` and Cloudflare HTML.
4. Against the first staged backend draft, the upload endpoint returned a URL signed with `x-amz-server-side-encryption`, but the CLI PUT only sent `content-type`; S3 returned `SignatureDoesNotMatch`.

## Root Cause

The CLI was sending binary ZIP bytes through the API edge instead of uploading directly to object storage. The staged path also needs to treat presigned upload headers as part of the API contract: every signed header must be sent with the S3 PUT.

## What This Fixes

- Builds the publish archive once, then requests a staged upload from `/v1/hyperframes/projects/publish/upload`.
- Sends the archive byte length to the backend as `content_length`.
- Uploads the ZIP directly to the returned presigned URL with backend-provided upload headers.
- Adds defensive signed-header inference for older/incomplete staged responses:
  - `x-amz-server-side-encryption: AES256` when that header is signed but missing from `upload_headers`
  - `content-length: <archive byte length>` when `content-length` is signed
- Completes publish via `/v1/hyperframes/projects/publish/complete`.
- Falls back to the legacy multipart endpoint when staged endpoints are not deployed yet.
- Improves the legacy Cloudflare challenge error so it no longer looks like a generic publish failure.
- Covers staged success, legacy fallback, and S3 upload failure with CLI tests.

## Verification

### Local checks

- `bunx oxfmt --check packages/cli/src/utils/publishProject.ts packages/cli/src/utils/publishProject.test.ts`
- `bunx oxlint packages/cli/src/utils/publishProject.ts packages/cli/src/utils/publishProject.test.ts`
- `bun run --filter @hyperframes/cli test -- src/utils/publishProject.test.ts` -> 4 tests pass
- `bun run --filter @hyperframes/cli typecheck`
- `git diff --check`
- pre-commit hook: `lint`, `format`, `typecheck`, `commitlint`

### Devbox integration

Before the later `content-length` review follow-up, I verified the staged upload flow on devbox:

- Started EF PR #35557 in an isolated devbox worktree on `127.0.0.1:8029`, leaving the existing `byos`/local_dev stack on `8019` untouched.
- Verified `POST /v1/hyperframes/projects/publish/upload` returns `upload_headers` with `content-type` and `x-amz-server-side-encryption`.
- Ran the CLI through an SSH tunnel against that server:
  - `HYPERFRAMES_PUBLISHED_PROJECTS_API_URL=http://127.0.0.1:18029 bun run --filter @hyperframes/cli dev publish --yes /Users/miguel07code/Downloads/apple-presentation`
- Result: publish succeeded through the staged flow. Server logs show:
  - `POST /v1/hyperframes/projects/publish/upload 200 OK` for `apple-presentation.zip` with `content_length: 56888466`
  - `POST /v1/hyperframes/projects/publish/complete 200 OK`
- The CLI returned project id `hfp_8b56d135d0cf` and a claim URL.

The later signed `content-length` client hardening was validated with local checks only.

## Notes

- Requires backend PR https://github.com/heygen-com/experiment-framework/pull/35557 for the staged endpoints and explicit upload-header contract.
- The legacy multipart fallback keeps the CLI compatible with environments where staged endpoints are not deployed yet.
