### PR TITLE
feat(elevenlabs): add ElevenLabs TTS provider (CLI + Studio API)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -40,6 +40,7 @@ const subCommands = {
   browser: () => import("./commands/browser.js").then((m) => m.default),
   transcribe: () => import("./commands/transcribe.js").then((m) => m.default),
   tts: () => import("./commands/tts.js").then((m) => m.default),
+  "el-tts": () => import("./commands/el-tts.js").then((m) => m.default),
   docs: () => import("./commands/docs.js").then((m) => m.default),
   doctor: () => import("./commands/doctor.js").then((m) => m.default),
   upgrade: () => import("./commands/upgrade.js").then((m) => m.default),

--- a/packages/cli/src/commands/el-tts.ts
+++ b/packages/cli/src/commands/el-tts.ts
@@ -1,0 +1,273 @@
+import { defineCommand } from "citty";
+import type { Example } from "./_examples.js";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, extname, dirname } from "node:path";
+import * as clack from "@clack/prompts";
+import { c } from "../ui/colors.js";
+import { errorBox } from "../ui/format.js";
+import {
+  loadElevenLabsKey,
+  listVoices,
+  synthesize,
+  fileExtensionForFormat,
+  ELEVENLABS_KEY_NAME,
+  ElevenLabsError,
+  type SynthesizeOptions,
+} from "@hyperframes/core/elevenlabs";
+
+export const examples: Example[] = [
+  ["Generate speech", 'hyperframes el-tts "Welcome to HyperFrames" --voice 21m00Tcm4TlvDq8ikWAM'],
+  ["Read text from a file", "hyperframes el-tts script.txt --voice <id>"],
+  ["Save to a specific file", 'hyperframes el-tts "Intro" --voice <id> --output narration.mp3'],
+  [
+    "Tweak voice settings",
+    'hyperframes el-tts "Calm tone" --voice <id> --stability 0.7 --similarity-boost 0.85',
+  ],
+  [
+    "Use a different model",
+    'hyperframes el-tts "Hello" --voice <id> --model eleven_multilingual_v2',
+  ],
+  ["List available voices", "hyperframes el-tts --list"],
+];
+
+const VALID_FORMATS: ReadonlyArray<NonNullable<SynthesizeOptions["outputFormat"]>> = [
+  "mp3_44100_128",
+  "mp3_44100_192",
+  "pcm_16000",
+  "pcm_22050",
+  "pcm_44100",
+];
+
+function isValidFormat(value: string): value is NonNullable<SynthesizeOptions["outputFormat"]> {
+  return (VALID_FORMATS as readonly string[]).includes(value);
+}
+
+export default defineCommand({
+  meta: {
+    name: "el-tts",
+    description:
+      "Generate speech audio with ElevenLabs (cloud, multi-voice). Reads ELEVENLABS_API_KEY from .env",
+  },
+  args: {
+    input: {
+      type: "positional",
+      description: "Text to speak, or path to a .txt file",
+      required: false,
+    },
+    output: {
+      type: "string",
+      description: "Output file path (default: speech.<ext> in current directory)",
+      alias: "o",
+    },
+    voice: {
+      type: "string",
+      description: "ElevenLabs voice_id (use --list to browse). Required unless --list",
+      alias: "v",
+    },
+    model: {
+      type: "string",
+      description: "Model ID (default: eleven_turbo_v2_5)",
+    },
+    stability: {
+      type: "string",
+      description: "Voice stability 0-1 (default: 0.5)",
+    },
+    "similarity-boost": {
+      type: "string",
+      description: "Voice similarity boost 0-1 (default: 0.75)",
+    },
+    style: {
+      type: "string",
+      description: "Style exaggeration 0-1 (default: 0)",
+    },
+    format: {
+      type: "string",
+      description: `Output format. One of: ${VALID_FORMATS.join(", ")} (default: mp3_44100_128)`,
+    },
+    list: {
+      type: "boolean",
+      description: "List available voices and exit",
+      default: false,
+    },
+    json: {
+      type: "boolean",
+      description: "Output result as JSON",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const apiKey = loadElevenLabsKey(process.cwd());
+    if (!apiKey) {
+      errorBox(
+        "ElevenLabs API key not found",
+        `Set ${ELEVENLABS_KEY_NAME} in one of:\n  - <project>/.env\n  - ~/.hyperframes/.env\n  - process environment`,
+      );
+      process.exit(1);
+    }
+
+    if (args.list) {
+      return runListVoices(apiKey, Boolean(args.json));
+    }
+
+    if (!args.voice) {
+      console.error(c.error("--voice <id> is required. Run with --list to browse voices."));
+      process.exit(1);
+    }
+    if (!args.input) {
+      console.error(c.error("Provide text to speak, or use --list to see available voices."));
+      process.exit(1);
+    }
+
+    let text: string;
+    const maybeFile = resolve(args.input);
+    if (existsSync(maybeFile) && extname(maybeFile).toLowerCase() === ".txt") {
+      text = readFileSync(maybeFile, "utf-8").trim();
+      if (!text) {
+        console.error(c.error("File is empty."));
+        process.exit(1);
+      }
+    } else {
+      text = args.input;
+    }
+
+    if (!text.trim()) {
+      console.error(c.error("No text provided."));
+      process.exit(1);
+    }
+
+    const stability = parseOptionalNumber(args.stability, "--stability", 0, 1);
+    const similarityBoost = parseOptionalNumber(
+      args["similarity-boost"],
+      "--similarity-boost",
+      0,
+      1,
+    );
+    const style = parseOptionalNumber(args.style, "--style", 0, 1);
+
+    let format: NonNullable<SynthesizeOptions["outputFormat"]> = "mp3_44100_128";
+    if (args.format) {
+      if (!isValidFormat(args.format)) {
+        errorBox(
+          "Invalid --format",
+          `Got "${args.format}". Must be one of: ${VALID_FORMATS.join(", ")}`,
+        );
+        process.exit(1);
+      }
+      format = args.format;
+    }
+
+    const ext = fileExtensionForFormat(format);
+    const output = resolve(args.output ?? `speech.${ext}`);
+
+    const spin = args.json ? null : clack.spinner();
+    spin?.start(
+      `Generating speech with ${c.accent(args.voice)} (${args.model ?? "eleven_turbo_v2_5"})...`,
+    );
+
+    try {
+      const { bytes } = await synthesize(apiKey, text, args.voice, {
+        modelId: args.model,
+        stability,
+        similarityBoost,
+        style,
+        outputFormat: format,
+      });
+
+      mkdirSync(dirname(output), { recursive: true });
+      writeFileSync(output, bytes);
+
+      if (args.json) {
+        console.log(
+          JSON.stringify({
+            ok: true,
+            voice: args.voice,
+            model: args.model ?? "eleven_turbo_v2_5",
+            format,
+            bytes: bytes.byteLength,
+            outputPath: output,
+          }),
+        );
+      } else {
+        spin?.stop(
+          c.success(`Generated ${c.accent(formatBytes(bytes.byteLength))} → ${c.accent(output)}`),
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const status = err instanceof ElevenLabsError ? err.status : undefined;
+      if (args.json) {
+        console.log(JSON.stringify({ ok: false, error: message, status }));
+      } else {
+        spin?.stop(c.error(`ElevenLabs synthesis failed: ${message}`));
+      }
+      process.exit(1);
+    }
+  },
+});
+
+function parseOptionalNumber(
+  raw: string | undefined,
+  label: string,
+  min: number,
+  max: number,
+): number | undefined {
+  if (raw == null) return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < min || value > max) {
+    errorBox(`Invalid ${label}`, `Must be a number between ${min} and ${max}. Got "${raw}".`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+async function runListVoices(apiKey: string, json: boolean): Promise<void> {
+  const spin = json ? null : clack.spinner();
+  spin?.start("Fetching voices…");
+  try {
+    const voices = await listVoices(apiKey);
+    spin?.stop();
+
+    if (json) {
+      console.log(JSON.stringify(voices));
+      return;
+    }
+
+    if (voices.length === 0) {
+      console.log(c.dim("No voices available on this account."));
+      return;
+    }
+
+    console.log(`\n${c.bold("ElevenLabs voices")} (${voices.length})\n`);
+    console.log(
+      `  ${c.dim("voice_id")}                            ${c.dim("Name")}                 ${c.dim("Category")}     ${c.dim("Labels")}`,
+    );
+    console.log(`  ${c.dim("─".repeat(100))}`);
+    for (const v of voices) {
+      const id = v.voice_id.padEnd(34);
+      const name = (v.name ?? "").padEnd(20);
+      const category = (v.category ?? "").padEnd(12);
+      const labels = v.labels
+        ? Object.entries(v.labels)
+            .map(([k, val]) => `${k}=${val}`)
+            .join(" ")
+        : "";
+      console.log(`  ${c.accent(id)} ${name} ${category} ${c.dim(labels)}`);
+    }
+    console.log();
+  } catch (err) {
+    spin?.stop(c.error("Failed to fetch voices"));
+    const message = err instanceof Error ? err.message : String(err);
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: message }));
+    } else {
+      console.error(c.dim(message));
+    }
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -60,6 +60,7 @@ const GROUPS: Group[] = [
         "Transcribe audio/video to word-level timestamps, or import an existing transcript",
       ],
       ["tts", "Generate speech audio from text using a local AI model (Kokoro-82M)"],
+      ["el-tts", "Generate speech audio with ElevenLabs (cloud, multi-voice)"],
     ],
   },
   {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,10 @@
       "import": "./src/registry/index.ts",
       "types": "./src/registry/index.ts"
     },
+    "./elevenlabs": {
+      "import": "./src/elevenlabs/index.ts",
+      "types": "./src/elevenlabs/index.ts"
+    },
     "./schemas/registry.json": "./schemas/registry.json",
     "./schemas/registry-item.json": "./schemas/registry-item.json"
   },
@@ -72,6 +76,10 @@
       "./registry": {
         "import": "./dist/registry/index.js",
         "types": "./dist/registry/index.d.ts"
+      },
+      "./elevenlabs": {
+        "import": "./dist/elevenlabs/index.js",
+        "types": "./dist/elevenlabs/index.d.ts"
       },
       "./schemas/registry.json": "./schemas/registry.json",
       "./schemas/registry-item.json": "./schemas/registry-item.json"

--- a/packages/core/src/elevenlabs/client.ts
+++ b/packages/core/src/elevenlabs/client.ts
@@ -1,0 +1,121 @@
+export interface ElevenLabsVoice {
+  voice_id: string;
+  name: string;
+  category?: string;
+  preview_url?: string;
+  labels?: Record<string, string>;
+  description?: string;
+}
+
+export interface SynthesizeOptions {
+  modelId?: string;
+  stability?: number;
+  similarityBoost?: number;
+  style?: number;
+  useSpeakerBoost?: boolean;
+  outputFormat?: "mp3_44100_128" | "mp3_44100_192" | "pcm_16000" | "pcm_22050" | "pcm_44100";
+}
+
+const API_BASE = "https://api.elevenlabs.io/v1";
+const DEFAULT_MODEL = "eleven_turbo_v2_5";
+
+export class ElevenLabsError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ElevenLabsError";
+    this.status = status;
+  }
+}
+
+function authHeaders(apiKey: string, accept?: string): HeadersInit {
+  const h: Record<string, string> = { "xi-api-key": apiKey };
+  if (accept) h.Accept = accept;
+  return h;
+}
+
+async function ensureOk(res: Response, label: string): Promise<void> {
+  if (res.ok) return;
+  let detail = "";
+  try {
+    const text = await res.text();
+    detail = text.length > 500 ? text.slice(0, 500) + "…" : text;
+  } catch {
+    /* ignore */
+  }
+  throw new ElevenLabsError(
+    `${label}: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ""}`,
+    res.status,
+  );
+}
+
+export async function listVoices(apiKey: string): Promise<ElevenLabsVoice[]> {
+  const res = await fetch(`${API_BASE}/voices`, {
+    headers: authHeaders(apiKey, "application/json"),
+  });
+  await ensureOk(res, "listVoices");
+  const data = (await res.json()) as { voices?: ElevenLabsVoice[] };
+  return data.voices ?? [];
+}
+
+/** Stream the short preview MP3 for a voice. */
+export async function fetchVoicePreview(
+  apiKey: string,
+  voiceId: string,
+): Promise<{ body: ReadableStream<Uint8Array>; contentType: string } | null> {
+  const voices = await listVoices(apiKey);
+  const voice = voices.find((v) => v.voice_id === voiceId);
+  if (!voice?.preview_url) return null;
+
+  const res = await fetch(voice.preview_url);
+  await ensureOk(res, "fetchVoicePreview");
+  if (!res.body) return null;
+  return {
+    body: res.body,
+    contentType: res.headers.get("content-type") ?? "audio/mpeg",
+  };
+}
+
+/**
+ * Synthesize speech. Returns the audio bytes plus the chosen output format
+ * so callers can pick the right file extension.
+ */
+export async function synthesize(
+  apiKey: string,
+  text: string,
+  voiceId: string,
+  opts: SynthesizeOptions = {},
+): Promise<{ bytes: Uint8Array; format: NonNullable<SynthesizeOptions["outputFormat"]> }> {
+  const format = opts.outputFormat ?? "mp3_44100_128";
+  const url = new URL(`${API_BASE}/text-to-speech/${encodeURIComponent(voiceId)}`);
+  url.searchParams.set("output_format", format);
+
+  const body = {
+    text,
+    model_id: opts.modelId ?? DEFAULT_MODEL,
+    voice_settings: {
+      stability: opts.stability ?? 0.5,
+      similarity_boost: opts.similarityBoost ?? 0.75,
+      style: opts.style ?? 0,
+      use_speaker_boost: opts.useSpeakerBoost ?? true,
+    },
+  };
+
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      ...authHeaders(apiKey),
+      "Content-Type": "application/json",
+      Accept: format.startsWith("mp3") ? "audio/mpeg" : "audio/wav",
+    },
+    body: JSON.stringify(body),
+  });
+  await ensureOk(res, "synthesize");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  return { bytes: buf, format };
+}
+
+export function fileExtensionForFormat(format: SynthesizeOptions["outputFormat"]): string {
+  if (!format || format.startsWith("mp3")) return "mp3";
+  return "wav";
+}

--- a/packages/core/src/elevenlabs/env.ts
+++ b/packages/core/src/elevenlabs/env.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const KEY_NAME = "ELEVENLABS_API_KEY";
+
+function parseDotenv(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function readEnvFile(path: string): string | null {
+  if (!existsSync(path)) return null;
+  try {
+    const env = parseDotenv(readFileSync(path, "utf-8"));
+    return env[KEY_NAME] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Look up the ElevenLabs API key. Resolution order:
+ *   1. process.env.ELEVENLABS_API_KEY
+ *   2. <projectDir>/.env (if projectDir provided)
+ *   3. ~/.hyperframes/.env
+ */
+export function loadElevenLabsKey(projectDir?: string): string | null {
+  const fromProcess = process.env[KEY_NAME];
+  if (fromProcess) return fromProcess;
+
+  if (projectDir) {
+    const fromProject = readEnvFile(join(projectDir, ".env"));
+    if (fromProject) return fromProject;
+  }
+
+  return readEnvFile(join(homedir(), ".hyperframes", ".env"));
+}
+
+export const ELEVENLABS_KEY_NAME = KEY_NAME;

--- a/packages/core/src/elevenlabs/index.ts
+++ b/packages/core/src/elevenlabs/index.ts
@@ -1,0 +1,9 @@
+export { loadElevenLabsKey, ELEVENLABS_KEY_NAME } from "./env.js";
+export {
+  listVoices,
+  fetchVoicePreview,
+  synthesize,
+  fileExtensionForFormat,
+  ElevenLabsError,
+} from "./client.js";
+export type { ElevenLabsVoice, SynthesizeOptions } from "./client.js";

--- a/packages/core/src/studio-api/createStudioApi.ts
+++ b/packages/core/src/studio-api/createStudioApi.ts
@@ -6,6 +6,7 @@ import { registerPreviewRoutes } from "./routes/preview.js";
 import { registerLintRoutes } from "./routes/lint.js";
 import { registerRenderRoutes } from "./routes/render.js";
 import { registerThumbnailRoutes } from "./routes/thumbnail.js";
+import { registerElevenLabsRoutes } from "./routes/elevenlabs.js";
 
 /**
  * Create a Hono sub-app with all studio API routes.
@@ -22,6 +23,7 @@ export function createStudioApi(adapter: StudioApiAdapter): Hono {
   registerLintRoutes(api, adapter);
   registerRenderRoutes(api, adapter);
   registerThumbnailRoutes(api, adapter);
+  registerElevenLabsRoutes(api, adapter);
 
   return api;
 }

--- a/packages/core/src/studio-api/routes/elevenlabs.ts
+++ b/packages/core/src/studio-api/routes/elevenlabs.ts
@@ -1,0 +1,185 @@
+import type { Hono } from "hono";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import type { StudioApiAdapter } from "../types.js";
+import { isSafePath } from "../helpers/safePath.js";
+import {
+  loadElevenLabsKey,
+  listVoices,
+  fetchVoicePreview,
+  synthesize,
+  fileExtensionForFormat,
+  ElevenLabsError,
+  type SynthesizeOptions,
+} from "../../elevenlabs/index.js";
+
+const VALID_FORMATS: readonly string[] = [
+  "mp3_44100_128",
+  "mp3_44100_192",
+  "pcm_16000",
+  "pcm_22050",
+  "pcm_44100",
+];
+
+interface GenerateBody {
+  text?: string;
+  voiceId?: string;
+  filename?: string;
+  modelId?: string;
+  stability?: number;
+  similarityBoost?: number;
+  style?: number;
+  outputFormat?: string;
+}
+
+function keyMissingResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error:
+        "ELEVENLABS_API_KEY not set. Add it to <project>/.env, ~/.hyperframes/.env, or the process environment.",
+    }),
+    { status: 401, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function elevenLabsError(err: unknown): Response {
+  const message = err instanceof Error ? err.message : String(err);
+  const status = err instanceof ElevenLabsError && err.status ? err.status : 502;
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function registerElevenLabsRoutes(api: Hono, adapter: StudioApiAdapter): void {
+  // Voice list — uses project-scoped key when a project is supplied via query param.
+  api.get("/elevenlabs/voices", async (c) => {
+    const projectId = c.req.query("project");
+    let projectDir: string | undefined;
+    if (projectId) {
+      const project = await adapter.resolveProject(projectId);
+      if (project) projectDir = project.dir;
+    }
+    const apiKey = loadElevenLabsKey(projectDir);
+    if (!apiKey) return keyMissingResponse();
+
+    try {
+      const voices = await listVoices(apiKey);
+      return c.json({
+        voices: voices.map((v) => ({
+          voice_id: v.voice_id,
+          name: v.name,
+          category: v.category,
+          labels: v.labels ?? {},
+          description: v.description,
+          // Browser-safe preview URL — hits our proxy so the API key never leaves the server.
+          preview_url: `/api/elevenlabs/voices/${encodeURIComponent(v.voice_id)}/preview${
+            projectId ? `?project=${encodeURIComponent(projectId)}` : ""
+          }`,
+        })),
+      });
+    } catch (err) {
+      return elevenLabsError(err);
+    }
+  });
+
+  // Stream the short preview clip for one voice.
+  api.get("/elevenlabs/voices/:voiceId/preview", async (c) => {
+    const projectId = c.req.query("project");
+    let projectDir: string | undefined;
+    if (projectId) {
+      const project = await adapter.resolveProject(projectId);
+      if (project) projectDir = project.dir;
+    }
+    const apiKey = loadElevenLabsKey(projectDir);
+    if (!apiKey) return keyMissingResponse();
+
+    try {
+      const result = await fetchVoicePreview(apiKey, c.req.param("voiceId"));
+      if (!result) {
+        return c.json({ error: "preview not available" }, 404);
+      }
+      return new Response(result.body, {
+        status: 200,
+        headers: {
+          "Content-Type": result.contentType,
+          "Cache-Control": "public, max-age=3600",
+        },
+      });
+    } catch (err) {
+      return elevenLabsError(err);
+    }
+  });
+
+  // Synthesize speech and write it into the project's assets/voice directory.
+  api.post("/projects/:id/elevenlabs/generate", async (c) => {
+    const project = await adapter.resolveProject(c.req.param("id"));
+    if (!project) return c.json({ error: "not found" }, 404);
+
+    const apiKey = loadElevenLabsKey(project.dir);
+    if (!apiKey) return keyMissingResponse();
+
+    let body: GenerateBody;
+    try {
+      body = (await c.req.json()) as GenerateBody;
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+
+    const text = body.text?.trim();
+    const voiceId = body.voiceId?.trim();
+    if (!text) return c.json({ error: "text is required" }, 400);
+    if (!voiceId) return c.json({ error: "voiceId is required" }, 400);
+
+    let outputFormat: NonNullable<SynthesizeOptions["outputFormat"]> = "mp3_44100_128";
+    if (body.outputFormat) {
+      if (!VALID_FORMATS.includes(body.outputFormat)) {
+        return c.json({ error: `invalid outputFormat. valid: ${VALID_FORMATS.join(", ")}` }, 400);
+      }
+      outputFormat = body.outputFormat as typeof outputFormat;
+    }
+
+    const ext = fileExtensionForFormat(outputFormat);
+    const safeFilename = sanitizeFilename(body.filename) ?? `voice/scene-${Date.now()}.${ext}`;
+    const relativePath = safeFilename.endsWith(`.${ext}`) ? safeFilename : `${safeFilename}.${ext}`;
+    const finalRelative = relativePath.startsWith("assets/")
+      ? relativePath
+      : `assets/${relativePath}`;
+    const absPath = resolve(project.dir, finalRelative);
+    if (!isSafePath(project.dir, absPath)) {
+      return c.json({ error: "forbidden" }, 403);
+    }
+
+    try {
+      const { bytes } = await synthesize(apiKey, text, voiceId, {
+        modelId: body.modelId,
+        stability: body.stability,
+        similarityBoost: body.similarityBoost,
+        style: body.style,
+        outputFormat,
+      });
+      mkdirSync(dirname(absPath), { recursive: true });
+      writeFileSync(absPath, bytes);
+      return c.json({
+        ok: true,
+        path: finalRelative,
+        bytes: bytes.byteLength,
+        format: outputFormat,
+      });
+    } catch (err) {
+      return elevenLabsError(err);
+    }
+  });
+}
+
+function sanitizeFilename(value: string | undefined): string | null {
+  if (!value) return null;
+  // Allow forward slashes for subdirectory hints, strip everything else risky.
+  const cleaned = value
+    .replace(/\\/g, "/")
+    .replace(/\.\.+/g, ".")
+    .replace(/[^a-zA-Z0-9._\-/]/g, "_")
+    .replace(/^\/+/, "")
+    .trim();
+  return cleaned.length > 0 ? cleaned : null;
+}


### PR DESCRIPTION
Adds first-class ElevenLabs support so projects can use cloud voices alongside the existing local Kokoro pipeline.

- @hyperframes/core/elevenlabs: client (listVoices, synthesize, fetchVoicePreview) and dotenv-based key loader (process env → <project>/.env → ~/.hyperframes/.env). API key never leaves the server — the studio routes proxy preview audio.
- CLI: new `hyperframes el-tts` command (--voice, --list, --stability, --similarity-boost, --style, --format, --json). Registered in cli.ts and help.ts under "AI & Integrations".
- Studio API: GET /elevenlabs/voices, GET /elevenlabs/voices/:id/preview (proxied stream), POST /projects/:id/elevenlabs/generate (writes into <project>/assets/voice/, validated via isSafePath).

No new runtime dependencies — uses node:fetch.

## What

Brief description of the change.

## Why

Why is this change needed?

## How

How was this implemented? Any notable design decisions?

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)
