### PR TITLE
perf(producer): skip static render probes

### DIFF
--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -14,8 +14,8 @@ describe("ENCODER_PRESETS", () => {
     expect(ENCODER_PRESETS.draft.codec).toBe("h264");
   });
 
-  it("high uses slow preset with low CRF for better quality", () => {
-    expect(ENCODER_PRESETS.high.preset).toBe("slow");
+  it("high keeps low CRF while using the standard-speed preset", () => {
+    expect(ENCODER_PRESETS.high.preset).toBe("medium");
     expect(ENCODER_PRESETS.high.quality).toBeLessThan(ENCODER_PRESETS.standard.quality);
     expect(ENCODER_PRESETS.high.codec).toBe("h264");
   });
@@ -180,14 +180,14 @@ describe("buildEncoderArgs GPU preset mapping", () => {
     expect(presetArg(args)).toBe("p4");
   });
 
-  it("translates the high slow preset to NVENC p5", () => {
+  it("translates the high medium preset to NVENC p4", () => {
     const args = buildEncoderArgs(
-      { ...baseOptions, codec: "h264", preset: "slow", quality: 15, useGpu: true },
+      { ...baseOptions, codec: "h264", preset: "medium", quality: 15, useGpu: true },
       inputArgs,
       "out.mp4",
       "nvenc",
     );
-    expect(presetArg(args)).toBe("p5");
+    expect(presetArg(args)).toBe("p4");
   });
 
   // hevc_nvenc uses the same p1..p7 preset vocabulary as h264_nvenc, so the

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -24,7 +24,7 @@ export type { EncoderOptions, EncodeResult, MuxResult } from "./chunkEncoder.typ
 export const ENCODER_PRESETS = {
   draft: { preset: "ultrafast", quality: 28, codec: "h264" as const },
   standard: { preset: "medium", quality: 18, codec: "h264" as const },
-  high: { preset: "slow", quality: 15, codec: "h264" as const },
+  high: { preset: "medium", quality: 15, codec: "h264" as const },
 };
 
 export interface EncoderPreset {

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -284,14 +284,78 @@ describe("inlineExternalScripts", () => {
         <script src="https://cdn.example.com/gsap.min.js"></script>
       </body></html>`;
       const result = await inlineExternalScripts(html);
-      // Both identical script tags should be fetched and replaced independently.
-      expect(fetchCount).toBe(2);
+      // Both identical script tags are replaced, but the network fetch is shared.
+      expect(fetchCount).toBe(1);
       expect(
         result.match(/\/\* inlined: https:\/\/cdn\.example\.com\/gsap\.min\.js \*\//g)?.length,
       ).toBe(2);
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe("static sub-composition duration resolution", () => {
+  it("resolves host duration from a declared sub-composition root without a browser probe", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-static-sub-duration-"));
+    const compositionsDir = join(projectDir, "compositions");
+    mkdirSync(compositionsDir, { recursive: true });
+
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!DOCTYPE html>
+<html><body>
+  <div id="root" data-composition-id="root" data-width="640" data-height="360" data-duration="8">
+    <div id="scene-host" data-composition-src="compositions/scene.html" data-start="2"></div>
+  </div>
+</body></html>`,
+    );
+    writeFileSync(
+      join(compositionsDir, "scene.html"),
+      `<template>
+  <div data-composition-id="scene" data-width="640" data-height="360" data-duration="3">
+    <p>Hello</p>
+  </div>
+</template>`,
+    );
+
+    const result = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+
+    expect(result.unresolvedCompositions).toEqual([]);
+    expect(result.html).toContain('id="scene-host"');
+    expect(result.html).toContain('data-duration="3"');
+    expect(result.html).toContain('data-end="5"');
+  });
+
+  it("matches unusual composition ids without selector string escaping", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-static-sub-duration-"));
+    const compositionsDir = join(projectDir, "compositions");
+    const compositionId = 'scene"\\\\host';
+    mkdirSync(compositionsDir, { recursive: true });
+
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!DOCTYPE html>
+<html><body>
+  <div id="root" data-composition-id="root" data-width="640" data-height="360" data-duration="8">
+    <div id='${compositionId}' data-composition-src="compositions/scene.html" data-start="1"></div>
+  </div>
+</body></html>`,
+    );
+    writeFileSync(
+      join(compositionsDir, "scene.html"),
+      `<template>
+  <div data-composition-id='${compositionId}' data-width="640" data-height="360" data-duration="2">
+    <p>Hello</p>
+  </div>
+</template>`,
+    );
+
+    const result = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+
+    expect(result.unresolvedCompositions).toEqual([]);
+    expect(result.html).toContain('data-duration="2"');
+    expect(result.html).toContain('data-end="3"');
   });
 });
 

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -73,6 +73,10 @@ function dedupeElementsById<T extends { id: string }>(elements: T[]): T[] {
   return Array.from(deduped.values());
 }
 
+const externalScriptCache = new Map<
+  string,
+  { fetcher: typeof globalThis.fetch; promise: Promise<string> }
+>();
 const INLINE_SCRIPT_PATTERN = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
 const COMPILER_MOUNT_BLOCK_START = "/* __HF_COMPILER_MOUNT_START__ */";
 const COMPILER_MOUNT_BLOCK_END = "/* __HF_COMPILER_MOUNT_END__ */";
@@ -553,6 +557,65 @@ function coalesceHeadStylesAndBodyScripts(html: string): string {
   return document.toString();
 }
 
+function parseDeclaredDurationFromCompositionHtml(
+  html: string,
+  compositionId: string | null | undefined,
+): number | null {
+  let { document } = parseHTML(html);
+  let root = findCompositionRoot(document, compositionId);
+  if (!root) {
+    const template = document.querySelector("template");
+    if (template) {
+      document = parseHTML(template.innerHTML || "").document;
+      root = findCompositionRoot(document, compositionId);
+    }
+  }
+  if (!root) return null;
+
+  const duration = Number.parseFloat(root.getAttribute("data-duration") ?? "");
+  if (Number.isFinite(duration) && duration > 0) return duration;
+
+  const start = Number.parseFloat(root.getAttribute("data-start") ?? "0") || 0;
+  const end = Number.parseFloat(root.getAttribute("data-end") ?? "");
+  if (Number.isFinite(end) && end > start) return end - start;
+
+  return null;
+}
+
+function findCompositionRoot(
+  document: Document,
+  compositionId: string | null | undefined,
+): Element | null {
+  const roots = Array.from(document.querySelectorAll("[data-composition-id]")) as Element[];
+  if (compositionId) {
+    const exactMatch = roots.find(
+      (root) => root.getAttribute("data-composition-id") === compositionId,
+    );
+    if (exactMatch) return exactMatch;
+  }
+  return roots[0] ?? null;
+}
+
+function resolveStaticCompositionDurations(
+  unresolvedCompositions: UnresolvedElement[],
+  subCompositions: Map<string, string>,
+): ResolvedDuration[] {
+  const resolutions: ResolvedDuration[] = [];
+
+  for (const unresolved of unresolvedCompositions) {
+    const src = unresolved.compositionSrc;
+    if (!src) continue;
+    const subHtml = subCompositions.get(src);
+    if (!subHtml) continue;
+
+    const declaredDuration = parseDeclaredDurationFromCompositionHtml(subHtml, unresolved.id);
+    if (declaredDuration == null) continue;
+    resolutions.push({ id: unresolved.id, duration: declaredDuration });
+  }
+
+  return resolutions;
+}
+
 /**
  * Inline sub-composition HTML into the main document, mirroring what the
  * bundler's step 6 does.  For each host element with `data-composition-src`:
@@ -828,13 +891,7 @@ export async function inlineExternalScripts(html: string): Promise<string> {
   if (externalScripts.length === 0) return html;
 
   const downloads = await Promise.allSettled(
-    externalScripts.map(async ({ src }) => {
-      const response = await fetch(src, {
-        signal: AbortSignal.timeout(15_000),
-      });
-      if (!response.ok) throw new Error(`HTTP ${response.status} for ${src}`);
-      return { src, text: await response.text() };
-    }),
+    externalScripts.map(async ({ src }) => ({ src, text: await fetchExternalScriptText(src) })),
   );
 
   for (let i = 0; i < downloads.length; i++) {
@@ -863,6 +920,30 @@ export async function inlineExternalScripts(html: string): Promise<string> {
   }
 
   return wrappedFragment ? document.body.innerHTML || "" : document.toString();
+}
+
+async function fetchExternalScriptText(src: string): Promise<string> {
+  const cached = externalScriptCache.get(src);
+  if (cached && cached.fetcher === globalThis.fetch) return cached.promise;
+
+  const download = (async () => {
+    const response = await fetch(src, {
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status} for ${src}`);
+    return response.text();
+  })();
+
+  externalScriptCache.set(src, { fetcher: globalThis.fetch, promise: download });
+  try {
+    return await download;
+  } catch (error) {
+    const current = externalScriptCache.get(src);
+    if (current?.promise === download) {
+      externalScriptCache.delete(src);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -964,7 +1045,7 @@ export async function compileForRender(
   downloadDir: string,
 ): Promise<CompiledComposition> {
   const rawHtml = readFileSync(htmlPath, "utf-8");
-  const { html: compiledHtml, unresolvedCompositions } = await compileHtmlFile(
+  let { html: compiledHtml, unresolvedCompositions } = await compileHtmlFile(
     rawHtml,
     projectDir,
     downloadDir,
@@ -977,6 +1058,18 @@ export async function compileForRender(
     images: subImages,
     subCompositions,
   } = await parseSubCompositions(compiledHtml, projectDir, downloadDir);
+
+  const staticCompositionResolutions = resolveStaticCompositionDurations(
+    unresolvedCompositions,
+    subCompositions,
+  );
+  if (staticCompositionResolutions.length > 0) {
+    compiledHtml = injectDurations(compiledHtml, staticCompositionResolutions);
+    const resolvedIds = new Set(staticCompositionResolutions.map((resolution) => resolution.id));
+    unresolvedCompositions = unresolvedCompositions.filter(
+      (composition) => !resolvedIds.has(composition.id),
+    );
+  }
 
   // Ensure the HTML is a full document before inlining sub-compositions.
   // When index.html is a fragment (no <html>/<head>/<body>), linkedom.parseHTML()


### PR DESCRIPTION
## Problem

Renderer speed is mostly won or lost on work that sits before or beside the actual frame loop. This PR removes three pieces of avoidable render-path work:

- Nested `data-composition-src` hosts could still require a browser duration probe even when the compiled sub-composition root already declared a static duration.
- Duplicate remote script tags were fetched once per tag during compilation instead of sharing the same download.
- The `high` quality tier spent CPU on libx264 `slow`, which optimizes compression harder than a render-throughput product should by default.

The competitive read from current renderer docs reinforces the direction: Remotion local rendering is browser-tab screenshot work with concurrency tradeoffs, and its H.264 `x264Preset` default is `medium`, not `slow`. FFmpeg/libx264 exposes `preset` and `crf` as separate controls; keeping CRF low preserves the quality target while moving the speed/size tradeoff back toward throughput.

Sources used while checking the optimization surface:

- https://www.remotion.dev/docs/terminology/concurrency
- https://www.remotion.dev/docs/renderer/render-media#x264preset
- https://ffmpeg.org/ffmpeg-codecs.html#libx264_002c-libx264rgb
- https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot

## Root Cause

The producer already has enough static information after `parseSubCompositions()` to resolve common sub-composition host durations, but it did not use that information before returning `unresolvedCompositions` to the render orchestrator. That leaves Chrome on the critical path for a value that is often already present in the HTML.

Separately, `inlineExternalScripts()` treated every matching `<script src="https://...">` as an independent network request, and `high` encoding tied visual quality to the x264 slow preset instead of to the CRF.

## What Changed

- Resolve statically declared sub-composition durations during `compileForRender()`:
  - reads `data-duration` from the compiled sub root
  - falls back to `data-end - data-start`
  - supports template-wrapped sub-compositions
  - injects `data-duration` / `data-end` into the host
  - removes resolved hosts from the browser-probe queue
- Cache external script downloads by URL and the active `globalThis.fetch`, so duplicate CDN script tags share one in-flight/finished request while tests that replace `fetch` still stay isolated.
- Change the `high` H.264 preset from `slow` to `medium` while keeping CRF `15` unchanged.
- Update the NVENC mapping expectations for the new `high` preset shape.

## Performance

Measured locally against a clean `origin/main` baseline worktree, using 3-run producer benchmark averages.

| Fixture | Baseline | This PR | Delta | Notes |
| --- | ---: | ---: | ---: | --- |
| `chat` | `10150ms` | `9097ms` | `-1053ms` / `-10.4%` | `browserProbeMs: 544ms -> 0ms`, `compileMs: 1477ms -> 956ms` |
| `missing-host-comp-id` | `2283ms` | `2107ms` | `-176ms` / `-7.7%` | `encodeMs: 289ms -> 234ms` |

Isolated encoder proof on the same 450 captured frames:

| x264 preset | Wall time | Output size |
| --- | ---: | ---: |
| `slow` | `2.90s` | `981K` |
| `medium` | `1.86s` | `989K` |

Medium was `35.9%` faster in that isolated encode test, with PSNR `65.37 dB` comparing medium output against slow output.

## What I Tested And Did Not Ship

These were real experiments, but they lost on wall clock and were reverted instead of being hidden behind optimistic code paths:

- Streaming encode by default: slower on the tested fixtures (`chat` around `20s` vs roughly `10s`).
- Shared browser-pool launch path: functionally worked, but regressed `chat` to roughly `12.66s` average.
- Async frame writes: passed tests, but regressed `chat` to roughly `10.25s` average.
- CDP `Runtime.evaluate` seek path: passed tests, but regressed `chat` to roughly `14.47s` average.

## Verification

- [x] `bunx oxfmt --check packages/engine/src/services/chunkEncoder.ts packages/engine/src/services/chunkEncoder.test.ts packages/producer/src/services/htmlCompiler.ts packages/producer/src/services/htmlCompiler.test.ts`
- [x] `bunx oxlint packages/engine/src/services/chunkEncoder.ts packages/engine/src/services/chunkEncoder.test.ts packages/producer/src/services/htmlCompiler.ts packages/producer/src/services/htmlCompiler.test.ts`
- [x] `bun run --filter @hyperframes/producer typecheck`
- [x] `bun run --filter @hyperframes/engine typecheck`
- [x] `bun test packages/producer/src/services/htmlCompiler.test.ts` -> 33 tests pass
- [x] `bun run --filter @hyperframes/engine test -- src/services/chunkEncoder.test.ts src/services/streamingEncoder.test.ts src/utils/gpuEncoder.test.ts src/services/frameCapture.test.ts src/services/frameCapture-namePolyfill.test.ts src/services/parallelCoordinator.test.ts` -> 124 tests pass
- [x] `bun run --filter @hyperframes/producer test -- missing-host-comp-id --sequential` -> compilation, visual, and audio pass; 0 failed visual frames; audio correlation `1.000`
- [x] `ffprobe` on the fresh proof render -> `1080x1920`, `3.000000s`, `72` frames
- [x] `agent-browser` playback proof -> recorded local playback, verified `readyState: 4`, `currentTime: 1.75`, `duration: 3`, `videoWidth: 1080`, `videoHeight: 1920`
- [x] Lefthook pre-commit -> lint, format, typecheck pass
- [x] Lefthook commit-msg -> commitlint pass

Known local harness note: `bun run --filter @hyperframes/producer test -- chat --sequential` still reports 34 visual frame failures in this checkout, but I reproduced the same 34-frame failure on a clean `origin/main` baseline worktree before this patch. The perf benchmark for `chat` is still useful for timing, but that regression-test baseline drift is pre-existing local state rather than a failure introduced here.
