### PR TITLE
fix(docs): use claude.ai/design link, remove raw download option

### DIFF
--- a/docs/guides/claude-design.mdx
+++ b/docs/guides/claude-design.mdx
@@ -9,10 +9,10 @@ Claude Design produces a **valid first draft** of a HyperFrames video — brand 
 
 <Steps>
   <Step title="Download the instruction file">
-    Open [`claude-design-hyperframes.md`](https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md) on GitHub and click the download button (↓) to save it. Or right-click [`this raw link`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/docs/guides/claude-design-hyperframes.md) → **Save Link As**.
+    Open [`claude-design-hyperframes.md`](https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md) on GitHub and click the download button (↓) to save it.
   </Step>
   <Step title="Open Claude Design">
-    Start a new chat at [claude.ai](https://claude.ai) with Claude Design enabled.
+    Start a new chat at [claude.ai/design](https://claude.ai/design).
   </Step>
   <Step title="Attach the file + describe your video">
     Drag the `claude-design-hyperframes.md` file into the chat. Describe what you want — include screenshots, brand assets, or a palette if you have them.
@@ -38,7 +38,7 @@ Claude Design produces a **valid first draft** of a HyperFrames video — brand 
 
 | Surface                     | Recommended setup                                                                                                             |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Claude Design               | Download [`claude-design-hyperframes.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/docs/guides/claude-design-hyperframes.md) and attach to your chat |
+| Claude Design               | Download [`claude-design-hyperframes.md`](https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md) from GitHub and attach to your chat |
 | Claude Code                 | `npx skills add heygen-com/hyperframes`, then use `/hyperframes`                                                              |
 | Cursor / Codex / Gemini CLI | `npx skills add heygen-com/hyperframes`                                                                                       |
 

--- a/docs/guides/prompting.mdx
+++ b/docs/guides/prompting.mdx
@@ -29,7 +29,7 @@ In Claude Code, restart the session after installing. Skills register as **slash
 
 ## Claude Design
 
-Claude Design uses a different setup. Right-click [`SKILL.md`](https://raw.githubusercontent.com/heygen-com/hyperframes/main/docs/guides/claude-design-hyperframes.md) → **Save Link As** to download, then **attach it to your chat** (don't paste the URL — file attachments produce better output):
+Claude Design uses a different setup. Download [`claude-design-hyperframes.md`](https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md) from GitHub (click the ↓ button), then **attach it to your chat** (don't paste the URL — file attachments produce better output):
 
 ```text
 Use the attached skill. 25-second LinkedIn video for my startup.


### PR DESCRIPTION
## What

Fix Claude Design docs links.

## Why

- `claude.ai` should link directly to `claude.ai/design`
- Raw GitHub download links opened as text tabs — use the GitHub blob page with download button instead
- Stale `SKILL.md` link text in prompting guide

## How

- `claude.ai` → `claude.ai/design` in the get-started steps
- Removed all `raw.githubusercontent.com` download links
- Fixed link text `SKILL.md` → `claude-design-hyperframes.md` in prompting guide

## Test plan

- [x] No raw.githubusercontent links remain
- [x] claude.ai/design link correct
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)