### PR TITLE
fix(cli): snapshot resolves runtime from own dist, not monorepo layout

### DIFF
--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -102,16 +102,11 @@ async function captureSnapshots(
   // 1. Bundle
   let html = await bundleToSingleHtml(projectDir);
 
-  // Inject local runtime if available
-  const runtimePath = resolve(
-    __dirname,
-    "..",
-    "..",
-    "..",
-    "core",
-    "dist",
-    "hyperframe.runtime.iife.js",
-  );
+  // Inject local runtime if available.
+  // The runtime IIFE is copied into the CLI dist during build (build:runtime),
+  // so it lives alongside cli.js. The old ../../../core/dist/ path only worked
+  // in the monorepo dev layout and broke for published/npx installs.
+  const runtimePath = resolve(__dirname, "hyperframe.runtime.iife.js");
   if (existsSync(runtimePath)) {
     const runtimeSource = readFileSync(runtimePath, "utf-8");
     html = html.replace(


### PR DESCRIPTION
## What

Fix snapshot command failing to seek into sub-compositions — all beats rendered beat-1 content regardless of timestamp.

## Why

The snapshot command resolved the HyperFrames runtime IIFE via a path that walks up 3 directories from the CLI dist folder to `core/dist/`. This only worked during tsx source development — the built CLI and npm/npx installs have the runtime IIFE right next to `cli.js` in the same `dist/` folder.

Without the runtime, `window.__player` was never created. Snapshot fell back to seeking every `__timelines` entry to the same absolute time. Sub-composition timelines expect relative time (offset from `data-start`), so all beats rendered beat-1 content.

## How

One-line fix — resolve the runtime from `__dirname` (the dist/ folder itself):

Before: `resolve(__dirname, "..", "..", "..", "core", "dist", "hyperframe.runtime.iife.js")`
After: `resolve(__dirname, "hyperframe.runtime.iife.js")`

## Test plan

- [x] Snapshot 6 projects (heygen, railway, raycast — with/without GSAP rules) — all beats render distinct content
- [x] Verified runtime IIFE is in npm tarball via `npm pack --dry-run`
- [x] Path resolves correctly in monorepo dev, npm install, and npx contexts
- [x] Before: all timestamps show beat-1 (20-28KB uniform). After: varied content (44-1724KB)

