### PR TITLE
fix(skills): load helper dependencies outside repo installs

### DIFF
--- a/skills/hyperframes/scripts/animation-map.mjs
+++ b/skills/hyperframes/scripts/animation-map.mjs
@@ -11,7 +11,7 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve, join } from "node:path";
-import { importPackagesOrBootstrap } from "./package-loader.mjs";
+import { hyperframesPackageSpec, importPackagesOrBootstrap } from "./package-loader.mjs";
 
 const {
   createFileServer,
@@ -19,7 +19,11 @@ const {
   initializeSession,
   closeCaptureSession,
   getCompositionDuration,
-} = (await importPackagesOrBootstrap(["@hyperframes/producer"]))["@hyperframes/producer"];
+} = (
+  await importPackagesOrBootstrap(["@hyperframes/producer"], {
+    npmPackages: [hyperframesPackageSpec("@hyperframes/producer")],
+  })
+)["@hyperframes/producer"];
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 

--- a/skills/hyperframes/scripts/animation-map.mjs
+++ b/skills/hyperframes/scripts/animation-map.mjs
@@ -11,14 +11,15 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve, join } from "node:path";
+import { importPackagesOrBootstrap } from "./package-loader.mjs";
 
-import {
+const {
   createFileServer,
   createCaptureSession,
   initializeSession,
   closeCaptureSession,
   getCompositionDuration,
-} from "@hyperframes/producer";
+} = (await importPackagesOrBootstrap(["@hyperframes/producer"]))["@hyperframes/producer"];
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 

--- a/skills/hyperframes/scripts/contrast-report.mjs
+++ b/skills/hyperframes/scripts/contrast-report.mjs
@@ -18,11 +18,13 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { importPackagesOrBootstrap } from "./package-loader.mjs";
+import { hyperframesPackageSpec, importPackagesOrBootstrap } from "./package-loader.mjs";
 
 // Use the producer's file server — it auto-injects the HyperFrames runtime
 // and render-seek bridge, so raw authoring HTML works without a build step.
-const packages = await importPackagesOrBootstrap(["@hyperframes/producer", "sharp"]);
+const packages = await importPackagesOrBootstrap(["@hyperframes/producer", "sharp"], {
+  npmPackages: [hyperframesPackageSpec("@hyperframes/producer"), "sharp@0.34.5"],
+});
 const sharp = packages.sharp.default;
 const {
   createFileServer,

--- a/skills/hyperframes/scripts/contrast-report.mjs
+++ b/skills/hyperframes/scripts/contrast-report.mjs
@@ -18,19 +18,20 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
-
-import sharp from "sharp";
+import { importPackagesOrBootstrap } from "./package-loader.mjs";
 
 // Use the producer's file server — it auto-injects the HyperFrames runtime
 // and render-seek bridge, so raw authoring HTML works without a build step.
-import {
+const packages = await importPackagesOrBootstrap(["@hyperframes/producer", "sharp"]);
+const sharp = packages.sharp.default;
+const {
   createFileServer,
   createCaptureSession,
   initializeSession,
   closeCaptureSession,
   captureFrameToBuffer,
   getCompositionDuration,
-} from "@hyperframes/producer";
+} = packages["@hyperframes/producer"];
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 

--- a/skills/hyperframes/scripts/package-loader.mjs
+++ b/skills/hyperframes/scripts/package-loader.mjs
@@ -3,10 +3,12 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, delimiter, dirname, join, parse, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BOOTSTRAP_ENV = "HYPERFRAMES_SKILL_DEPS_BOOTSTRAPPED";
+const BOOTSTRAP_CONFIRM_ENV = "HYPERFRAMES_SKILL_BOOTSTRAP_DEPS";
 const NODE_MODULES_ENV = "HYPERFRAMES_SKILL_NODE_MODULES";
 
 export async function importPackagesOrBootstrap(packageNames, options = {}) {
@@ -20,7 +22,10 @@ export async function importPackagesOrBootstrap(packageNames, options = {}) {
   }
 
   if (missing.length > 0 && !process.env[BOOTSTRAP_ENV]) {
-    bootstrapWithNpmInstall(options.npmPackages ?? missing);
+    const npmPackages = options.npmPackages ?? missing;
+    assertPinnedPackageSpecs(npmPackages);
+    await confirmBootstrap(npmPackages);
+    bootstrapWithNpmInstall(npmPackages);
   }
 
   if (missing.length > 0) {
@@ -38,6 +43,19 @@ export async function importPackagesOrBootstrap(packageNames, options = {}) {
     modules[packageName] = await import(pathToFileURL(entry).href);
   }
   return modules;
+}
+
+export function hyperframesPackageSpec(packageName) {
+  const version = readBundledHyperframesVersion();
+  if (!version) {
+    throw new Error(
+      [
+        `Could not determine the bundled HyperFrames version for ${packageName}.`,
+        "Install the package yourself or pass a pinned options.npmPackages entry.",
+      ].join("\n"),
+    );
+  }
+  return `${packageName}@${version}`;
 }
 
 function resolvePackageEntry(packageName) {
@@ -60,6 +78,31 @@ function resolvePackageEntry(packageName) {
     }
   }
 
+  return null;
+}
+
+function readBundledHyperframesVersion() {
+  for (const ancestor of ancestors(HERE)) {
+    const directVersion = readPackageVersion(join(ancestor, "package.json"));
+    if (directVersion) return directVersion;
+
+    const monorepoCliVersion = readPackageVersion(
+      join(ancestor, "packages", "cli", "package.json"),
+    );
+    if (monorepoCliVersion) return monorepoCliVersion;
+  }
+  return null;
+}
+
+function readPackageVersion(packageJsonPath) {
+  try {
+    const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    if (manifest.name === "hyperframes" || manifest.name === "@hyperframes/cli") {
+      return typeof manifest.version === "string" ? manifest.version : null;
+    }
+  } catch {
+    // Keep searching ancestor package manifests.
+  }
   return null;
 }
 
@@ -115,6 +158,60 @@ function exportEntry(exports) {
   return null;
 }
 
+function assertPinnedPackageSpecs(packageSpecs) {
+  const unpinned = packageSpecs.filter((spec) => !hasVersionSpec(spec));
+  if (unpinned.length === 0) return;
+  throw new Error(
+    [
+      `Refusing to bootstrap unpinned package spec(s): ${unpinned.join(", ")}`,
+      "Pass pinned npm package specs, for example:",
+      `  ${packageSpecs.map((spec) => (hasVersionSpec(spec) ? spec : `${spec}@<version>`)).join(" ")}`,
+    ].join("\n"),
+  );
+}
+
+function hasVersionSpec(packageSpec) {
+  if (packageSpec.startsWith("@")) {
+    const slash = packageSpec.indexOf("/");
+    return slash !== -1 && packageSpec.indexOf("@", slash + 1) !== -1;
+  }
+  return packageSpec.includes("@");
+}
+
+async function confirmBootstrap(packageSpecs) {
+  if (process.env[BOOTSTRAP_CONFIRM_ENV] === "1") return;
+
+  const installLine = `npm install --ignore-scripts --no-save ${packageSpecs.map(shellQuote).join(" ")}`;
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      [
+        "Required helper package(s) are missing.",
+        "To allow a one-time temporary dependency bootstrap for this run, set:",
+        `  ${BOOTSTRAP_CONFIRM_ENV}=1`,
+        "The bootstrap command will be:",
+        `  ${installLine}`,
+      ].join("\n"),
+    );
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question(
+      [
+        "HyperFrames helper package(s) are missing.",
+        `Run a temporary install with lifecycle scripts disabled?`,
+        `  ${installLine}`,
+        "Proceed? [y/N] ",
+      ].join("\n"),
+    );
+    if (!/^(y|yes)$/i.test(answer.trim())) {
+      throw new Error("Dependency bootstrap cancelled.");
+    }
+  } finally {
+    rl.close();
+  }
+}
+
 function ancestors(start) {
   const dirs = [];
   let current = resolve(start);
@@ -136,6 +233,7 @@ function bootstrapWithNpmInstall(packageNames) {
       "--silent",
       "--no-audit",
       "--no-fund",
+      "--ignore-scripts",
       "--no-save",
       "--prefix",
       installRoot,

--- a/skills/hyperframes/scripts/package-loader.mjs
+++ b/skills/hyperframes/scripts/package-loader.mjs
@@ -1,0 +1,171 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { basename, delimiter, dirname, join, parse, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BOOTSTRAP_ENV = "HYPERFRAMES_SKILL_DEPS_BOOTSTRAPPED";
+const NODE_MODULES_ENV = "HYPERFRAMES_SKILL_NODE_MODULES";
+
+export async function importPackagesOrBootstrap(packageNames, options = {}) {
+  const entries = new Map();
+  const missing = [];
+
+  for (const packageName of packageNames) {
+    const entry = resolvePackageEntry(packageName);
+    if (entry) entries.set(packageName, entry);
+    else missing.push(packageName);
+  }
+
+  if (missing.length > 0 && !process.env[BOOTSTRAP_ENV]) {
+    bootstrapWithNpmInstall(options.npmPackages ?? missing);
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      [
+        `Could not resolve required package(s): ${missing.join(", ")}`,
+        "Install them in this project, for example:",
+        `  npm install --save-dev ${packageNames.map(shellQuote).join(" ")}`,
+      ].join("\n"),
+    );
+  }
+
+  const modules = {};
+  for (const [packageName, entry] of entries) {
+    modules[packageName] = await import(pathToFileURL(entry).href);
+  }
+  return modules;
+}
+
+function resolvePackageEntry(packageName) {
+  const bases = [process.cwd(), HERE, ...envNodeModulesDirs(), ...nodeModulesDirsFromPath()];
+
+  const seen = new Set();
+  for (const base of bases) {
+    const normalized = resolve(base);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+
+    try {
+      return createRequire(join(normalized, "__hyperframes_skill_loader__.cjs")).resolve(
+        packageName,
+      );
+    } catch {
+      const packageDir = findPackageDir(normalized, packageName);
+      const packageEntry = packageDir ? readPackageEntry(packageDir) : null;
+      if (packageEntry) return packageEntry;
+    }
+  }
+
+  return null;
+}
+
+function envNodeModulesDirs() {
+  return (process.env[NODE_MODULES_ENV] ?? "").split(delimiter).filter(Boolean);
+}
+
+function nodeModulesDirsFromPath() {
+  const dirs = [];
+  for (const entry of (process.env.PATH ?? "").split(delimiter)) {
+    if (!entry.endsWith(`${join("node_modules", ".bin")}`)) continue;
+    dirs.push(dirname(entry));
+  }
+  return dirs;
+}
+
+function findPackageDir(base, packageName) {
+  const packageSegments = packageName.split("/");
+  const roots =
+    basename(base) === "node_modules"
+      ? [base]
+      : ancestors(base).map((ancestor) => join(ancestor, "node_modules"));
+
+  for (const root of roots) {
+    const packageDir = join(root, ...packageSegments);
+    if (existsSync(join(packageDir, "package.json"))) return packageDir;
+  }
+  return null;
+}
+
+function readPackageEntry(packageDir) {
+  try {
+    const manifest = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+    const entry = exportEntry(manifest.exports) ?? manifest.module ?? manifest.main ?? "index.js";
+    const entryPath = join(packageDir, entry);
+    return existsSync(entryPath) ? entryPath : null;
+  } catch {
+    return null;
+  }
+}
+
+function exportEntry(exports) {
+  const root =
+    typeof exports === "object" && exports !== null ? (exports["."] ?? exports) : exports;
+  if (typeof root === "string") return root;
+  if (typeof root !== "object" || root === null) return null;
+  if (typeof root.import === "string") return root.import;
+  if (typeof root.default === "string") return root.default;
+  if (typeof root.node === "string") return root.node;
+  if (typeof root.node === "object" && root.node !== null) {
+    return root.node.import ?? root.node.default ?? null;
+  }
+  return null;
+}
+
+function ancestors(start) {
+  const dirs = [];
+  let current = resolve(start);
+  const root = parse(current).root;
+  while (current && current !== root) {
+    dirs.push(current);
+    current = dirname(current);
+  }
+  dirs.push(root);
+  return dirs;
+}
+
+function bootstrapWithNpmInstall(packageNames) {
+  const installRoot = mkdtempSync(join(tmpdir(), "hyperframes-skill-deps-"));
+  const installResult = spawnSync(
+    process.platform === "win32" ? "npm.cmd" : "npm",
+    [
+      "install",
+      "--silent",
+      "--no-audit",
+      "--no-fund",
+      "--no-save",
+      "--prefix",
+      installRoot,
+      ...packageNames,
+    ],
+    { stdio: "inherit" },
+  );
+
+  if (installResult.error) throw installResult.error;
+  if (installResult.status !== 0) {
+    rmSync(installRoot, { recursive: true, force: true });
+    process.exit(installResult.status ?? 1);
+  }
+
+  const args = [...process.argv.slice(1)];
+  const result = spawnSync(process.execPath, args, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      [BOOTSTRAP_ENV]: "1",
+      [NODE_MODULES_ENV]: join(installRoot, "node_modules"),
+    },
+  });
+
+  rmSync(installRoot, { recursive: true, force: true });
+  if (result.error) throw result.error;
+  process.exit(result.status ?? 1);
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:@=-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}


### PR DESCRIPTION
## What

Fix the HyperFrames skill helper scripts that ship inside the `hyperframes` CLI package so they can run from standalone composition projects, not only from the monorepo, while keeping helper-only dependency bootstrap explicit and pinned.

This changes:

- `skills/hyperframes/scripts/animation-map.mjs`
- `skills/hyperframes/scripts/contrast-report.mjs`
- a shared `skills/hyperframes/scripts/package-loader.mjs`

## Why

This does affect the CLI distribution, but the affected surface is the CLI-bundled skill helper scripts, not the core `hyperframes render`, `hyperframes lint`, or `hyperframes validate` commands.

The published `hyperframes` package includes the skill helpers under `dist/skills/...`, so agents can call them from an installed CLI or copied skill bundle. But those helpers used static top-level imports for packages that are not runtime dependencies of the `hyperframes` package:

- `animation-map.mjs` imports `@hyperframes/producer`
- `contrast-report.mjs` imports `@hyperframes/producer` and `sharp`

That works inside the monorepo because workspace dev dependencies are available. It fails outside the monorepo because the published CLI package does not install `@hyperframes/producer` as a dependency.

## Repro

From a clean install of the published CLI package:

```bash
tmp=$(mktemp -d -t hf-cli-install-repro)
npm install --silent --no-audit --no-fund --prefix "$tmp" hyperframes@0.4.30

test -f "$tmp/node_modules/hyperframes/dist/skills/hyperframes/scripts/animation-map.mjs" \
  && echo "animation-map shipped in hyperframes package"

test ! -d "$tmp/node_modules/@hyperframes/producer" \
  && echo "@hyperframes/producer is not installed as a hyperframes dependency"

node "$tmp/node_modules/hyperframes/dist/skills/hyperframes/scripts/animation-map.mjs" \
  /Users/miguel07code/dev/yc-revenue-truth-video \
  --out "$tmp/anim-map" \
  --frames 1
```

Observed output:

```text
animation-map shipped in hyperframes package
@hyperframes/producer is not installed as a hyperframes dependency
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@hyperframes/producer' imported from .../node_modules/hyperframes/dist/skills/hyperframes/scripts/animation-map.mjs
```

So the failure is real for the installed CLI package shape: the helper script is shipped, but its dependency is not present.

## How

Add a small shared package loader for skill scripts:

- First try normal resolution from the current project, helper bundle, explicit bootstrap paths, and `node_modules/.bin` parents.
- Require callers to pass pinned npm specs for helper-only dependency bootstrap.
- Pin `@hyperframes/producer` to the bundled HyperFrames CLI/package version, and pin `sharp` for the contrast helper.
- Refuse non-interactive bootstrap by default unless `HYPERFRAMES_SKILL_BOOTSTRAP_DEPS=1` is set; interactive runs ask before installing.
- If bootstrap is explicitly allowed, install into a temporary npm prefix with `--ignore-scripts`, re-exec the same Node script with that temporary `node_modules` path, and clean it up after the helper exits.

The helper dependency stays lazy: normal CLI installs do not pull `@hyperframes/producer` or `sharp` unless the script actually needs them, and missing dependencies are no longer installed implicitly without consent.

## Verification

### Local checks

- Reproduced the published CLI-package failure above with `hyperframes@0.4.30`.
- `node skills/hyperframes/scripts/animation-map.mjs /Users/miguel07code/dev/yc-revenue-truth-video --out /tmp/hf-anim-map-pr-test --frames 2`
  - Succeeded and wrote `animation-map.json` from the standalone composition project.
- `node skills/hyperframes/scripts/contrast-report.mjs /Users/miguel07code/dev/yc-revenue-truth-video --out /tmp/hf-contrast-pr-test --samples 1`
  - Reached the normal contrast-audit result path and wrote report artifacts.
  - Exited `1` because that sample composition has expected WCAG AA failures, not because dependency loading failed.
- `node --check skills/hyperframes/scripts/package-loader.mjs && node --check skills/hyperframes/scripts/animation-map.mjs && node --check skills/hyperframes/scripts/contrast-report.mjs`
- `bunx oxlint skills/hyperframes/scripts/package-loader.mjs skills/hyperframes/scripts/animation-map.mjs skills/hyperframes/scripts/contrast-report.mjs`
- `bunx tsx scripts/lint-skills.ts`

### Review follow-up checks

- Confirmed `hyperframesPackageSpec("@hyperframes/producer")` resolves to `@hyperframes/producer@0.4.30` in this checkout.
- Confirmed unpinned bootstrap specs are rejected before install.
- Confirmed missing dependencies in non-interactive mode refuse to install unless `HYPERFRAMES_SKILL_BOOTSTRAP_DEPS=1` is set, and print the exact `npm install --ignore-scripts --no-save ...` command.
- Ran a fake-`npm` bootstrap simulation and confirmed the loader invokes `npm install --ignore-scripts --no-save --prefix <tmp> fake-pkg@1.2.3`, then re-execs and imports from the temporary `node_modules` path.

### Browser verification

No browser verification is applicable for this PR because it only changes standalone Node helper scripts, not a user-facing Studio or player flow.

## Notes

The dependency bootstrap remains a helper-script fallback only. It does not add `@hyperframes/producer` or `sharp` to the normal `hyperframes` CLI install path.
