### PR TITLE
fix: resolve build race condition by ensuring core builds first

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run studio",
-    "build": "bun run --filter '!@hyperframes/cli' build && bun run --filter @hyperframes/cli build",
+    "build": "bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions}' build && bun run --filter @hyperframes/cli build",
     "build:producer": "bun run --filter @hyperframes/producer build",
     "studio": "bun run --filter @hyperframes/studio dev",
     "build:hyperframes-runtime": "bun run --filter @hyperframes/core build:hyperframes-runtime",


### PR DESCRIPTION
## Summary
- Fix intermittent build failure when running `bun run build`
- Ensure `@hyperframes/core` completes building (including generating `src/generated/runtime-inline.ts`) before dependent packages start TypeScript compilation

## Problem
`bun run build` uses concurrent package execution by default. This caused a race condition where:
1. Multiple packages start building simultaneously
2. `@hyperframes/engine` begins TypeScript compilation
3. TypeScript tries to resolve `../core/src/index.ts` which imports `./generated/runtime-inline`
4. But `runtime-inline.ts` hasn't been generated yet (still running in `@hyperframes/core`'s build script)
5. Error: `Cannot find module './generated/runtime-inline'`

## Solution
Changed build order in root `package.json` from:
```json
"build": "bun run --filter '!@hyperframes/cli' build && ..."
```

To staged execution:
```json
"build": "bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions}' build && ..."
```

This ensures core builds first (including runtime artifacts), then other packages can safely depend on its generated files.

## Test plan
- [x] Run `rm -f packages/core/src/generated/runtime-inline.ts && bun run build` - builds successfully
- [x] Verify all packages compile without errors
- [x] Check `runtime-inline.ts` is generated before engine compilation starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)