### PR TITLE
docs: clarify alpha PR target branch

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -123,6 +123,8 @@ All of the following must pass before your PR can be merged:
 
 - PRs require at least 1 approval from a maintainer
 - Keep PRs focused — one feature or fix per PR
+- Target alpha-only PRs at `next` instead of `main`; see
+  [Release channels](/contributing/release-channels) for branch policy details
 - Include a clear description of what changed and why
 - Add tests for new features and bug fixes
 


### PR DESCRIPTION
## Problem

The contributing guide did not explicitly tell contributors where alpha-only pull requests should be targeted, which made it easy to aim prerelease work at the stable `main` branch.

## What this fixes

Adds a short Review Process bullet telling contributors to target alpha-only PRs at `next` instead of `main`, and links to the release-channel branch policy for the full explanation.

## Root cause

The detailed release-channel policy existed under `docs/contributing/release-channels.mdx`, but the top-level contributing page did not surface the alpha PR target rule in the normal PR checklist.

## Verification

### Local checks

- `./node_modules/.bin/oxfmt --check --no-error-on-unmatched-pattern docs/contributing.mdx` -> no matching MDX files for oxfmt, command exits 0
- `git diff --check`
- `bunx mintlify validate` from clean verification worktree -> success build validation passed
- Lefthook pre-commit -> lint, typecheck, and format skipped because no inspectable staged files; commitlint passed

### Browser verification

- Ran `bunx mintlify dev --no-open` from a clean detached worktree at `http://localhost:3001`.
- Used `agent-browser` to open `/contributing`, verify the new alpha-only PR guidance rendered in the Review Process list, and save a screenshot.
- Recorded the verified docs page state with `agent-browser`.

## Notes

- Local proof artifacts are not committed:
  - `/tmp/hyperframes-oss-alpha-docs-verify.EdOXDL/qa-artifacts/contributing-alpha-pr-guidance.png`
  - `/tmp/hyperframes-oss-alpha-docs-verify.EdOXDL/qa-artifacts/contributing-alpha-pr-guidance.webm`
