### PR TITLE
Fix Studio DOM picking and timeline thumbnails

### DIFF
--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -260,23 +260,34 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
         await new Promise((r) => setTimeout(r, 200));
         let clip: { x: number; y: number; width: number; height: number } | undefined;
         if (opts.selector) {
-          clip = await page.evaluate((selector: string) => {
-            const el = document.querySelector(selector);
-            if (!(el instanceof HTMLElement)) return undefined;
-            const rect = el.getBoundingClientRect();
-            if (rect.width < 4 || rect.height < 4) return undefined;
-            const pad = 8;
-            const x = Math.max(0, rect.left - pad);
-            const y = Math.max(0, rect.top - pad);
-            const maxWidth = window.innerWidth - x;
-            const maxHeight = window.innerHeight - y;
-            return {
-              x,
-              y,
-              width: Math.max(1, Math.min(rect.width + pad * 2, maxWidth)),
-              height: Math.max(1, Math.min(rect.height + pad * 2, maxHeight)),
-            };
-          }, opts.selector);
+          clip = await page.evaluate(
+            (selector: string, selectorIndex: number | undefined) => {
+              const matches = Array.from(document.querySelectorAll(selector)).filter(
+                (el): el is HTMLElement => el instanceof HTMLElement,
+              );
+              const safeIndex = Math.max(
+                0,
+                Math.min(matches.length - 1, Math.floor(selectorIndex ?? 0)),
+              );
+              const el = matches[safeIndex] ?? null;
+              if (!(el instanceof HTMLElement)) return undefined;
+              const rect = el.getBoundingClientRect();
+              if (rect.width < 4 || rect.height < 4) return undefined;
+              const pad = 8;
+              const x = Math.max(0, rect.left - pad);
+              const y = Math.max(0, rect.top - pad);
+              const maxWidth = window.innerWidth - x;
+              const maxHeight = window.innerHeight - y;
+              return {
+                x,
+                y,
+                width: Math.max(1, Math.min(rect.width + pad * 2, maxWidth)),
+                height: Math.max(1, Math.min(rect.height + pad * 2, maxHeight)),
+              };
+            },
+            opts.selector,
+            opts.selectorIndex,
+          );
         }
         const screenshot = (await page.screenshot({
           type: "jpeg",

--- a/packages/core/src/lint/rules/captions.test.ts
+++ b/packages/core/src/lint/rules/captions.test.ts
@@ -50,6 +50,28 @@ describe("caption rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does not warn for generic GSAP opacity exits in non-caption loops", () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080">
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+      var sceneCaption = document.querySelector("#scene-caption");
+      CARDS.forEach(function(group, gi) {
+        var groupEl = document.createElement("div");
+        groupEl.id = "card-" + gi;
+        tl.to(groupEl, { opacity: 0, duration: 0.12 }, 2);
+      });
+      window.__timelines["main"] = tl;
+    </script>
+  </div>
+</body></html>`;
+    const result = lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "caption_exit_missing_hard_kill");
+    expect(finding).toBeUndefined();
+  });
+
   it("warns when caption group has nowrap without max-width", () => {
     const html = `
 <html><body>

--- a/packages/core/src/lint/rules/captions.ts
+++ b/packages/core/src/lint/rules/captions.ts
@@ -12,7 +12,8 @@ export const captionRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> 
           content,
         );
       const hasCaptionLoop =
-        /forEach|\.forEach\s*\(/.test(content) && /createElement|caption|group|cg-/.test(content);
+        /forEach|\.forEach\s*\(/.test(content) &&
+        /karaoke|caption[-_]?(?:group|word|line|block)|cg-/.test(content);
       if (hasCaptionLoop && hasExitTween && !hasHardKill) {
         findings.push({
           code: "caption_exit_missing_hard_kill",

--- a/packages/core/src/studio-api/routes/thumbnail.test.ts
+++ b/packages/core/src/studio-api/routes/thumbnail.test.ts
@@ -55,6 +55,24 @@ describe("registerThumbnailRoutes", () => {
     );
   });
 
+  it("forwards selector occurrence indexes to thumbnail generation", async () => {
+    const adapter = createAdapter();
+    const app = new Hono();
+    registerThumbnailRoutes(app, adapter);
+
+    const response = await app.request(
+      "http://localhost/projects/demo/thumbnail/index.html?t=1.2&selector=.card&selectorIndex=2",
+    );
+
+    expect(response.status).toBe(200);
+    expect(adapter.generateThumbnail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: ".card",
+        selectorIndex: 2,
+      }),
+    );
+  });
+
   it("keeps url thumbnail versions separated in the disk cache", async () => {
     const adapter = createAdapter();
     const app = new Hono();

--- a/packages/core/src/studio-api/routes/thumbnail.ts
+++ b/packages/core/src/studio-api/routes/thumbnail.ts
@@ -23,6 +23,9 @@ export function registerThumbnailRoutes(api: Hono, adapter: StudioApiAdapter): v
     const vpWidth = parseInt(url.searchParams.get("w") || "0") || 0;
     const vpHeight = parseInt(url.searchParams.get("h") || "0") || 0;
     const selector = url.searchParams.get("selector") || undefined;
+    const rawSelectorIndex = Number.parseInt(url.searchParams.get("selectorIndex") || "0", 10);
+    const selectorIndex =
+      Number.isFinite(rawSelectorIndex) && rawSelectorIndex > 0 ? rawSelectorIndex : undefined;
     const urlVersion = url.searchParams.get("v") || "";
 
     // Determine composition dimensions from HTML
@@ -49,7 +52,7 @@ export function registerThumbnailRoutes(api: Hono, adapter: StudioApiAdapter): v
     // Cache
     const cacheDir = join(project.dir, ".thumbnails");
     const selectorKey = selector
-      ? `_${selector.replace(/[^a-zA-Z0-9_-]+/g, "_").slice(0, 80)}`
+      ? `_${selector.replace(/[^a-zA-Z0-9_-]+/g, "_").slice(0, 80)}_${selectorIndex ?? 0}`
       : "";
     const urlVersionKey = urlVersion
       ? `_${urlVersion.replace(/[^a-zA-Z0-9_-]+/g, "_").slice(0, 32)}`
@@ -71,6 +74,7 @@ export function registerThumbnailRoutes(api: Hono, adapter: StudioApiAdapter): v
         height: compH,
         previewUrl,
         selector,
+        selectorIndex,
       });
       if (!buffer) {
         return c.json({ error: "Thumbnail generation returned null" }, 500);

--- a/packages/core/src/studio-api/types.ts
+++ b/packages/core/src/studio-api/types.ts
@@ -72,6 +72,7 @@ export interface StudioApiAdapter {
     height: number;
     previewUrl: string;
     selector?: string;
+    selectorIndex?: number;
   }) => Promise<Buffer | null>;
 
   /** Optional: resolve session ID to project (multi-project mode). */

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -841,6 +841,8 @@ export function StudioApp() {
             label={el.id || el.tag}
             labelColor={style.label}
             accentColor={style.clip}
+            selector={el.selector}
+            selectorIndex={el.selectorIndex}
             seekTime={el.start}
             duration={el.duration}
           />
@@ -901,6 +903,8 @@ export function StudioApp() {
             label={el.id || el.tag}
             labelColor={style.label}
             accentColor={style.clip}
+            selector={el.selector}
+            selectorIndex={el.selectorIndex}
             seekTime={el.start}
             duration={el.duration}
           />
@@ -1947,7 +1951,7 @@ export function StudioApp() {
   );
 
   const handlePreviewCanvasMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: React.MouseEvent<HTMLDivElement>, options?: { preferClipAncestor?: boolean }) => {
       const iframe = previewIframeRef.current;
       if (!iframe || captionEditMode) return;
       const target = getPreviewTargetFromPointer(iframe, e.clientX, e.clientY);
@@ -1959,7 +1963,7 @@ export function StudioApp() {
       e.preventDefault();
       e.stopPropagation();
       const nextSelection = buildDomSelectionFromTarget(target, {
-        preferClipAncestor: true,
+        preferClipAncestor: options?.preferClipAncestor ?? true,
       });
       if (!nextSelection) {
         lastPreviewClickRef.current = null;

--- a/packages/studio/src/components/editor/DomEditOverlay.tsx
+++ b/packages/studio/src/components/editor/DomEditOverlay.tsx
@@ -14,7 +14,10 @@ interface OverlayRect {
 interface DomEditOverlayProps {
   iframeRef: RefObject<HTMLIFrameElement | null>;
   selection: DomEditSelection | null;
-  onCanvasMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onCanvasMouseDown: (
+    event: React.MouseEvent<HTMLDivElement>,
+    options?: { preferClipAncestor?: boolean },
+  ) => void;
   onCanvasDoubleClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   onSelectedDoubleClick: () => void;
   onBlockedMove: (selection: DomEditSelection) => void;
@@ -85,10 +88,21 @@ function selectionCacheKey(
   ].join("|");
 }
 
+function restoreInlineStyle(
+  element: HTMLElement,
+  property: "left" | "top" | "width" | "height",
+  value: string,
+) {
+  if (value) element.style.setProperty(property, value);
+  else element.style.removeProperty(property);
+}
+
 interface GestureState {
   kind: GestureKind;
   startX: number;
   startY: number;
+  initialStyleLeft: string;
+  initialStyleTop: string;
   originLeft: number;
   originTop: number;
   originWidth: number;
@@ -226,6 +240,8 @@ export const DomEditOverlay = memo(function DomEditOverlay({
       kind,
       startX: e.clientX,
       startY: e.clientY,
+      initialStyleLeft: sel.element.style.left,
+      initialStyleTop: sel.element.style.top,
       originLeft: rect.left,
       originTop: rect.top,
       originWidth: rect.width,
@@ -277,9 +293,10 @@ export const DomEditOverlay = memo(function DomEditOverlay({
     }
   };
 
-  const onPointerUp = () => {
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
     const g = gestureRef.current;
     const sel = selectionRef.current;
+    const box = boxRef.current;
     blockedMoveRef.current = null;
     if (!g || !sel) {
       gestureRef.current = null;
@@ -289,6 +306,21 @@ export const DomEditOverlay = memo(function DomEditOverlay({
 
     gestureRef.current = null;
     rafPausedRef.current = false;
+
+    const movedDistance = Math.hypot(e.clientX - g.startX, e.clientY - g.startY);
+    if (g.kind === "drag" && movedDistance < BLOCKED_MOVE_THRESHOLD_PX) {
+      restoreInlineStyle(sel.element, "left", g.initialStyleLeft);
+      restoreInlineStyle(sel.element, "top", g.initialStyleTop);
+      if (box) {
+        box.style.left = `${g.originLeft}px`;
+        box.style.top = `${g.originTop}px`;
+      }
+      suppressNextBoxClickRef.current = true;
+      onCanvasMouseDown(e as unknown as React.MouseEvent<HTMLDivElement>, {
+        preferClipAncestor: false,
+      });
+      return;
+    }
 
     if (g.kind === "drag") {
       const finalLeft = Number.parseFloat(sel.element.style.left) || g.actualLeft;
@@ -320,7 +352,7 @@ export const DomEditOverlay = memo(function DomEditOverlay({
   const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement | null;
     if (target?.closest('[data-dom-edit-selection-box="true"]')) return;
-    onCanvasMouseDown(event);
+    onCanvasMouseDown(event, { preferClipAncestor: false });
   };
 
   const handleOverlayDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -339,7 +371,7 @@ export const DomEditOverlay = memo(function DomEditOverlay({
       event.stopPropagation();
       return;
     }
-    onCanvasMouseDown(event);
+    onCanvasMouseDown(event, { preferClipAncestor: false });
   };
 
   const clearPointerState = () => {

--- a/packages/studio/src/components/editor/domEditing.test.ts
+++ b/packages/studio/src/components/editor/domEditing.test.ts
@@ -108,6 +108,61 @@ describe("resolveDomEditCapabilities", () => {
     });
   });
 
+  it("treats identity transforms left behind by animation libraries as movable", () => {
+    expect(
+      resolveDomEditCapabilities({
+        selector: "#card",
+        inlineStyles: {
+          left: "120px",
+          top: "80px",
+          width: "240px",
+          height: "140px",
+        },
+        computedStyles: {
+          position: "absolute",
+          left: "120px",
+          top: "80px",
+          width: "240px",
+          height: "140px",
+          transform: "matrix(1, 0, 0, 1, 0, 0)",
+        },
+        isCompositionHost: false,
+        isMasterView: false,
+      }),
+    ).toMatchObject({
+      canMove: true,
+      canResize: true,
+      canDetachFromLayout: false,
+    });
+  });
+
+  it("treats identity matrix3d transforms as movable", () => {
+    expect(
+      resolveDomEditCapabilities({
+        selector: "#card",
+        inlineStyles: {
+          left: "120px",
+          top: "80px",
+          width: "240px",
+          height: "140px",
+        },
+        computedStyles: {
+          position: "absolute",
+          left: "120px",
+          top: "80px",
+          width: "240px",
+          height: "140px",
+          transform: "matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)",
+        },
+        isCompositionHost: false,
+        isMasterView: false,
+      }),
+    ).toMatchObject({
+      canMove: true,
+      canResize: true,
+    });
+  });
+
   it("allows imported absolute media to resize from computed px geometry", () => {
     expect(
       resolveDomEditCapabilities({
@@ -226,6 +281,24 @@ describe("resolveDomEditSelection", () => {
 
     expect(selection?.id).toBe("card");
     expect(selection?.selector).toBe("#card");
+  });
+
+  it("can resolve the exact child when clip-ancestor preference is disabled", () => {
+    const document = createDocument(`
+      <section id="card" class="clip" style="left: 10px; top: 20px; width: 200px; height: 100px; position: absolute;">
+        <p id="copy">Hello</p>
+      </section>
+    `);
+
+    const child = document.getElementById("copy") as HTMLElement;
+    const selection = resolveDomEditSelection(child, {
+      activeCompositionPath: null,
+      isMasterView: false,
+      preferClipAncestor: false,
+    });
+
+    expect(selection?.id).toBe("copy");
+    expect(selection?.selector).toBe("#copy");
   });
 
   it("collects simple child text blocks as separate editable fields", () => {

--- a/packages/studio/src/components/editor/domEditing.ts
+++ b/packages/studio/src/components/editor/domEditing.ts
@@ -93,6 +93,32 @@ function parsePx(value: string | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function isIdentityTransform(value: string | undefined): boolean {
+  const transform = (value ?? "none").trim();
+  if (!transform || transform === "none") return true;
+
+  const matrix = transform.match(/^matrix\(([^)]+)\)$/i);
+  if (matrix) {
+    const values = matrix[1].split(",").map((part) => Number.parseFloat(part.trim()));
+    if (values.length !== 6 || values.some((part) => !Number.isFinite(part))) return false;
+    return (
+      Math.abs(values[0] - 1) < 0.0001 &&
+      Math.abs(values[1]) < 0.0001 &&
+      Math.abs(values[2]) < 0.0001 &&
+      Math.abs(values[3] - 1) < 0.0001 &&
+      Math.abs(values[4]) < 0.0001 &&
+      Math.abs(values[5]) < 0.0001
+    );
+  }
+
+  const matrix3d = transform.match(/^matrix3d\(([^)]+)\)$/i);
+  if (!matrix3d) return false;
+  const values = matrix3d[1].split(",").map((part) => Number.parseFloat(part.trim()));
+  if (values.length !== 16 || values.some((part) => !Number.isFinite(part))) return false;
+  const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  return values.every((part, index) => Math.abs(part - identity[index]) < 0.0001);
+}
+
 function isClipClassName(className: string | undefined): boolean {
   return Boolean(className?.split(/\s+/).includes("clip"));
 }
@@ -426,13 +452,13 @@ export function resolveDomEditCapabilities(args: {
   const top = parsePx(args.inlineStyles.top) ?? parsePx(args.computedStyles.top);
   const width = parsePx(args.inlineStyles.width) ?? parsePx(args.computedStyles.width);
   const height = parsePx(args.inlineStyles.height) ?? parsePx(args.computedStyles.height);
-  const transform = (args.computedStyles.transform ?? "none").trim();
+  const hasTransformDrivenGeometry = !isIdentityTransform(args.computedStyles.transform);
 
   const canMove =
     (position === "absolute" || position === "fixed") &&
     left != null &&
     top != null &&
-    transform === "none";
+    !hasTransformDrivenGeometry;
 
   const canResize = canMove && (width != null || height != null);
   const isBlockishLayer =
@@ -442,7 +468,7 @@ export function resolveDomEditCapabilities(args: {
     isBlockishDisplay(args.computedStyles.display);
   const canDetachFromLayout =
     !canMove &&
-    transform === "none" &&
+    !hasTransformDrivenGeometry &&
     isBlockishLayer &&
     (!isInlineTextTag(args.tagName) || isClipClassName(args.className));
   const reasonIfDisabled = !canMove

--- a/packages/studio/src/player/components/CompositionThumbnail.test.ts
+++ b/packages/studio/src/player/components/CompositionThumbnail.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildCompositionThumbnailUrl } from "./CompositionThumbnail";
+
+describe("buildCompositionThumbnailUrl", () => {
+  it("includes selector and occurrence index for precise element thumbnails", () => {
+    expect(
+      buildCompositionThumbnailUrl({
+        previewUrl: "/api/projects/demo/preview",
+        seekTime: 1,
+        duration: 2,
+        selector: ".card",
+        selectorIndex: 2,
+        origin: "http://localhost:3000",
+      }),
+    ).toBe(
+      "http://localhost:3000/api/projects/demo/thumbnail/index.html?t=2.00&v=v2&selector=.card&selectorIndex=2",
+    );
+  });
+});

--- a/packages/studio/src/player/components/CompositionThumbnail.tsx
+++ b/packages/studio/src/player/components/CompositionThumbnail.tsx
@@ -7,6 +7,7 @@ interface CompositionThumbnailProps {
   labelColor: string;
   accentColor?: string;
   selector?: string;
+  selectorIndex?: number;
   seekTime?: number;
   duration?: number;
   width?: number;
@@ -16,12 +17,44 @@ interface CompositionThumbnailProps {
 const CLIP_HEIGHT = 66;
 const THUMBNAIL_URL_VERSION = "v2";
 
+export function buildCompositionThumbnailUrl({
+  previewUrl,
+  seekTime = 2,
+  duration = 5,
+  selector,
+  selectorIndex,
+  origin,
+}: {
+  previewUrl: string;
+  seekTime?: number;
+  duration?: number;
+  selector?: string;
+  selectorIndex?: number;
+  origin: string;
+}): string {
+  const thumbnailBase = previewUrl
+    .replace("/preview/comp/", "/thumbnail/")
+    .replace(/\/preview$/, "/thumbnail/index.html");
+  const midTime = seekTime + duration / 2;
+  const thumbnailUrl = new URL(thumbnailBase, origin);
+  thumbnailUrl.searchParams.set("t", midTime.toFixed(2));
+  thumbnailUrl.searchParams.set("v", THUMBNAIL_URL_VERSION);
+  if (selector) {
+    thumbnailUrl.searchParams.set("selector", selector);
+    if (selectorIndex != null && selectorIndex > 0) {
+      thumbnailUrl.searchParams.set("selectorIndex", String(selectorIndex));
+    }
+  }
+  return thumbnailUrl.toString();
+}
+
 export const CompositionThumbnail = memo(function CompositionThumbnail({
   previewUrl,
   label,
   labelColor,
   accentColor = "#6B7280",
   selector,
+  selectorIndex,
   seekTime = 2,
   duration = 5,
 }: CompositionThumbnailProps) {
@@ -48,15 +81,14 @@ export const CompositionThumbnail = memo(function CompositionThumbnail({
     roRef.current?.disconnect();
   });
 
-  const thumbnailBase = previewUrl
-    .replace("/preview/comp/", "/thumbnail/")
-    .replace(/\/preview$/, "/thumbnail/index.html");
-  const midTime = seekTime + duration / 2;
-  const thumbnailUrl = new URL(thumbnailBase, window.location.origin);
-  thumbnailUrl.searchParams.set("t", midTime.toFixed(2));
-  thumbnailUrl.searchParams.set("v", THUMBNAIL_URL_VERSION);
-  if (selector) thumbnailUrl.searchParams.set("selector", selector);
-  const url = thumbnailUrl.toString();
+  const url = buildCompositionThumbnailUrl({
+    previewUrl,
+    seekTime,
+    duration,
+    selector,
+    selectorIndex,
+    origin: window.location.origin,
+  });
   const frameW = Math.max(48, Math.round(CLIP_HEIGHT * aspect));
   const frameCount = containerWidth > 0 ? Math.max(1, Math.ceil(containerWidth / frameW)) : 1;
 
@@ -66,7 +98,7 @@ export const CompositionThumbnail = memo(function CompositionThumbnail({
         src={url}
         alt=""
         draggable={false}
-        loading="lazy"
+        loading="eager"
         onLoad={(e) => {
           const img = e.currentTarget;
           if (img.naturalWidth > 0 && img.naturalHeight > 0) {

--- a/packages/studio/src/player/components/timelineEditing.test.ts
+++ b/packages/studio/src/player/components/timelineEditing.test.ts
@@ -248,7 +248,7 @@ describe("getTimelineEditCapabilities", () => {
     });
   });
 
-  it("disables move and trims for generic motion clips even when patchable", () => {
+  it("allows moving generic motion clips while keeping trims blocked", () => {
     expect(
       getTimelineEditCapabilities({
         tag: "section",
@@ -256,7 +256,7 @@ describe("getTimelineEditCapabilities", () => {
         selector: ".feature-card",
       }),
     ).toEqual({
-      canMove: false,
+      canMove: true,
       canTrimStart: false,
       canTrimEnd: false,
     });

--- a/packages/studio/src/player/components/timelineEditing.ts
+++ b/packages/studio/src/player/components/timelineEditing.ts
@@ -233,7 +233,7 @@ export function getTimelineEditCapabilities(input: {
   const hasFiniteDuration = Number.isFinite(input.duration) && input.duration > 0;
   const hasDeterministicWindow = isDeterministicTimelineWindow(input);
   return {
-    canMove: canPatch && hasDeterministicWindow,
+    canMove: canPatch && (hasDeterministicWindow || hasFiniteDuration),
     canTrimEnd: canPatch && hasFiniteDuration && hasDeterministicWindow,
     canTrimStart: canPatch && hasFiniteDuration && canOffsetTrimClipStart(input),
   };

--- a/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
@@ -1,9 +1,36 @@
 import { describe, expect, it } from "vitest";
+import { Window } from "happy-dom";
 import {
   buildStandaloneRootTimelineElement,
+  findTimelineDomNodeForClip,
+  getTimelineElementSelector,
+  type ClipManifestClip,
   mergeTimelineElementsPreservingDowngrades,
   resolveStandaloneRootCompositionSrc,
 } from "./useTimelinePlayer";
+
+function createDocument(markup: string): Document {
+  const window = new Window();
+  window.document.body.innerHTML = markup;
+  return window.document;
+}
+
+function createClip(overrides: Partial<ClipManifestClip>): ClipManifestClip {
+  return {
+    id: null,
+    label: "",
+    start: 0,
+    duration: 4,
+    track: 0,
+    kind: "element",
+    tagName: "div",
+    compositionId: null,
+    parentCompositionId: null,
+    compositionSrc: null,
+    assetUrl: null,
+    ...overrides,
+  };
+}
 
 describe("buildStandaloneRootTimelineElement", () => {
   it("includes selector and source metadata for standalone composition fallback clips", () => {
@@ -62,6 +89,38 @@ describe("resolveStandaloneRootCompositionSrc", () => {
     expect(
       resolveStandaloneRootCompositionSrc("http://127.0.0.1:4173/api/projects/demo/preview"),
     ).toBe(undefined);
+  });
+});
+
+describe("findTimelineDomNodeForClip", () => {
+  it("matches anonymous manifest clips back to repeated DOM nodes in timeline order", () => {
+    const doc = createDocument(`
+      <div data-composition-id="main" data-start="0" data-duration="8">
+        <section id="identity-card" class="clip identity-card" data-start="0" data-duration="4" data-track-index="0"></section>
+        <div class="clip duplicate-card first" data-start="0" data-duration="4" data-track-index="1"></div>
+        <div class="clip duplicate-card second" data-start="0" data-duration="4" data-track-index="2"></div>
+      </div>
+    `);
+    const used = new Set<Element>();
+
+    const first = findTimelineDomNodeForClip(
+      doc,
+      createClip({ id: "__node__index_2", track: 1 }),
+      1,
+      used,
+    ) as HTMLElement;
+    used.add(first);
+    const second = findTimelineDomNodeForClip(
+      doc,
+      createClip({ id: "__node__index_3", track: 2 }),
+      2,
+      used,
+    ) as HTMLElement;
+
+    expect(first.className).toBe("clip duplicate-card first");
+    expect(second.className).toBe("clip duplicate-card second");
+    expect(getTimelineElementSelector(first)).toBe(".duplicate-card");
+    expect(getTimelineElementSelector(second)).toBe(".duplicate-card");
   });
 });
 

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -20,7 +20,7 @@ interface TimelineLike {
   isActive: () => boolean;
 }
 
-interface ClipManifestClip {
+export interface ClipManifestClip {
   id: string | null;
   label: string;
   start: number;
@@ -193,12 +193,18 @@ function parseTimelineFromDOM(doc: Document, rootDuration: number): TimelineElem
   return els;
 }
 
-function getTimelineElementSelector(el: Element): string | undefined {
-  if (el instanceof HTMLElement && el.id) return `#${el.id}`;
+function isHtmlElement(el: Element): el is HTMLElement {
+  const HtmlElementCtor = el.ownerDocument.defaultView?.HTMLElement ?? globalThis.HTMLElement;
+  return typeof HtmlElementCtor !== "undefined" && el instanceof HtmlElementCtor;
+}
+
+export function getTimelineElementSelector(el: Element): string | undefined {
+  if (isHtmlElement(el) && el.id) return `#${el.id}`;
   const compId = el.getAttribute("data-composition-id");
   if (compId) return `[data-composition-id="${compId}"]`;
-  if (el instanceof HTMLElement) {
-    const firstClass = el.className.split(/\s+/).find(Boolean);
+  if (isHtmlElement(el)) {
+    const classes = el.className.split(/\s+/).filter(Boolean);
+    const firstClass = classes.find((className) => className !== "clip") ?? classes[0];
     if (firstClass) return `.${firstClass}`;
   }
   return undefined;
@@ -244,6 +250,48 @@ function buildTimelineElementKey(params: {
   if (params.selector) return `${scope}:${params.selector}:${params.selectorIndex ?? 0}`;
   return `${scope}:${params.id}:${params.fallbackIndex}`;
 }
+
+function getTimelineDomNodes(doc: Document): Element[] {
+  const rootComp = doc.querySelector("[data-composition-id]");
+  return Array.from(doc.querySelectorAll("[data-start]")).filter((node) => node !== rootComp);
+}
+
+function numbersNearlyEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) < 0.001;
+}
+
+function nodeMatchesManifestClip(node: Element, clip: ClipManifestClip): boolean {
+  const tagName = clip.tagName?.toLowerCase();
+  if (tagName && node.tagName.toLowerCase() !== tagName) return false;
+
+  const start = Number.parseFloat(node.getAttribute("data-start") ?? "");
+  if (Number.isFinite(start) && !numbersNearlyEqual(start, clip.start)) return false;
+
+  const duration = Number.parseFloat(node.getAttribute("data-duration") ?? "");
+  if (Number.isFinite(duration) && !numbersNearlyEqual(duration, clip.duration)) return false;
+
+  const track = Number.parseInt(node.getAttribute("data-track-index") ?? "", 10);
+  if (Number.isFinite(track) && track !== clip.track) return false;
+
+  return true;
+}
+
+export function findTimelineDomNodeForClip(
+  doc: Document,
+  clip: ClipManifestClip,
+  fallbackIndex: number,
+  usedNodes = new Set<Element>(),
+): Element | null {
+  const byIdentity = clip.id ? findTimelineDomNode(doc, clip.id) : null;
+  if (byIdentity && !usedNodes.has(byIdentity)) return byIdentity;
+
+  const candidates = getTimelineDomNodes(doc).filter((node) => !usedNodes.has(node));
+  const exact = candidates.find((node) => nodeMatchesManifestClip(node, clip));
+  if (exact) return exact;
+
+  return candidates[fallbackIndex] ?? null;
+}
+
 function findTimelineDomNode(doc: Document, id: string): Element | null {
   return (
     doc.getElementById(id) ??
@@ -571,8 +619,18 @@ export function useTimelinePlayer() {
       const filtered = data.clips.filter(
         (clip) => !clip.parentCompositionId || !clipCompositionIds.has(clip.parentCompositionId),
       );
+      let iframeDoc: Document | null = null;
+      try {
+        iframeDoc = iframeRef.current?.contentDocument ?? null;
+      } catch {
+        iframeDoc = null;
+      }
+      const usedHostEls = new Set<Element>();
       const els: TimelineElement[] = filtered.map((clip, index) => {
-        let hostEl: Element | null = null;
+        let hostEl = iframeDoc
+          ? findTimelineDomNodeForClip(iframeDoc, clip, index, usedHostEls)
+          : null;
+        if (hostEl) usedHostEls.add(hostEl);
         const id = clip.id || clip.label || clip.tagName || "element";
         const entry: TimelineElement = {
           id,
@@ -581,16 +639,7 @@ export function useTimelinePlayer() {
           duration: clip.duration,
           track: clip.track,
         };
-        try {
-          const iframeDoc = iframeRef.current?.contentDocument;
-          if (iframeDoc && entry.id) {
-            hostEl = findTimelineDomNode(iframeDoc, entry.id);
-          }
-        } catch {
-          /* cross-origin */
-        }
         if (hostEl) {
-          const iframeDoc = iframeRef.current?.contentDocument;
           entry.domId = hostEl.id || undefined;
           entry.selector = getTimelineElementSelector(hostEl);
           entry.selectorIndex =
@@ -606,19 +655,13 @@ export function useTimelinePlayer() {
           // after inlining, so the clip manifest may not have compositionSrc.
           // Fall back to reading data-composition-file from the DOM.
           let resolvedSrc = clip.compositionSrc;
-          let hostEl: Element | null = null;
           if (!resolvedSrc) {
-            try {
-              const iframeDoc = iframeRef.current?.contentDocument;
-              hostEl =
-                iframeDoc?.querySelector(`[data-composition-id="${clip.compositionId}"]`) ?? hostEl;
-              resolvedSrc =
-                hostEl?.getAttribute("data-composition-src") ??
-                hostEl?.getAttribute("data-composition-file") ??
-                null;
-            } catch {
-              /* cross-origin */
-            }
+            hostEl =
+              iframeDoc?.querySelector(`[data-composition-id="${clip.compositionId}"]`) ?? hostEl;
+            resolvedSrc =
+              hostEl?.getAttribute("data-composition-src") ??
+              hostEl?.getAttribute("data-composition-file") ??
+              null;
           }
           if (resolvedSrc) {
             entry.compositionSrc = resolvedSrc;

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -237,7 +237,7 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
 
     async generateThumbnail(opts) {
       const selectorKey = opts.selector
-        ? `_${opts.selector.replace(/[^a-zA-Z0-9_-]+/g, "_").slice(0, 80)}`
+        ? `_${opts.selector.replace(/[^a-zA-Z0-9_-]+/g, "_").slice(0, 80)}_${opts.selectorIndex ?? 0}`
         : "";
       const cacheKey = `${THUMBNAIL_CACHE_VERSION}_${opts.compPath.replace(/\//g, "_")}_${opts.seekTime.toFixed(2)}${selectorKey}.jpg`;
 
@@ -289,23 +289,34 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
           await new Promise((r) => setTimeout(r, 200));
           let clip: { x: number; y: number; width: number; height: number } | undefined;
           if (opts.selector) {
-            clip = await page.evaluate((selector: string) => {
-              const el = document.querySelector(selector);
-              if (!(el instanceof HTMLElement)) return undefined;
-              const rect = el.getBoundingClientRect();
-              if (rect.width < 4 || rect.height < 4) return undefined;
-              const pad = 8;
-              const x = Math.max(0, rect.left - pad);
-              const y = Math.max(0, rect.top - pad);
-              const maxWidth = window.innerWidth - x;
-              const maxHeight = window.innerHeight - y;
-              return {
-                x,
-                y,
-                width: Math.max(1, Math.min(rect.width + pad * 2, maxWidth)),
-                height: Math.max(1, Math.min(rect.height + pad * 2, maxHeight)),
-              };
-            }, opts.selector);
+            clip = await page.evaluate(
+              (selector: string, selectorIndex: number | undefined) => {
+                const matches = Array.from(document.querySelectorAll(selector)).filter(
+                  (el): el is HTMLElement => el instanceof HTMLElement,
+                );
+                const safeIndex = Math.max(
+                  0,
+                  Math.min(matches.length - 1, Math.floor(selectorIndex ?? 0)),
+                );
+                const el = matches[safeIndex] ?? null;
+                if (!(el instanceof HTMLElement)) return undefined;
+                const rect = el.getBoundingClientRect();
+                if (rect.width < 4 || rect.height < 4) return undefined;
+                const pad = 8;
+                const x = Math.max(0, rect.left - pad);
+                const y = Math.max(0, rect.top - pad);
+                const maxWidth = window.innerWidth - x;
+                const maxHeight = window.innerHeight - y;
+                return {
+                  x,
+                  y,
+                  width: Math.max(1, Math.min(rect.width + pad * 2, maxWidth)),
+                  height: Math.max(1, Math.min(rect.height + pad * 2, maxHeight)),
+                };
+              },
+              opts.selector,
+              opts.selectorIndex,
+            );
           }
           const buf = await page.screenshot({
             type: "jpeg",


### PR DESCRIPTION
## Problem

Manual DOM editing in Studio had a few rough edges that showed up when testing the latest alpha like a video editor would:

- Elements with identity transforms such as `matrix(1, 0, 0, 1, 0, 0)` were treated as transform-driven and could not be moved/resized directly, even when their layout was otherwise absolute px geometry.
- Clicking inside an already-selected parent layer could keep selecting the parent instead of the exact child under the pointer, which made last-mile visual edits feel imprecise.
- Timeline thumbnails for DOM clips were generated from the full composition too often, so repeated/anonymous elements were hard to distinguish.
- Runtime manifest clips with anonymous ids like `__node__index_*` could lose their connection back to the real DOM node, which also blocked precise selector thumbnails and reliable timeline patch targets.
- Generic finite-duration DOM clips were more constrained than needed in timeline drag operations.
- The caption lint rule could false-positive on non-caption code that merely used caption-like names.

## What this fixes

- Treats `none`, identity `matrix(...)`, and identity `matrix3d(...)` transforms as directly editable for DOM move/resize capability checks.
- Lets selected-box clicks re-pick the exact child element under the pointer, while preserving normal drag behavior for real movement.
- Allows finite-duration patchable DOM clips to move on the timeline, while keeping trim behavior conservative.
- Carries `selector` and `selectorIndex` through Studio timeline thumbnails and the core thumbnail API.
- Uses `querySelectorAll(selector)[selectorIndex]` when generating cropped thumbnails in both Vite Studio preview and the CLI Studio server.
- Reconnects anonymous runtime manifest clips back to their DOM nodes using tag/start/duration/track matching and avoids generic `.clip` selectors when a more specific class exists.
- Makes the thumbnail preload eager so hidden preload images actually load before the visible filmstrip is mounted.
- Narrows the caption lint marker detection so ordinary variables/classes containing `caption` do not trigger caption-runtime warnings.

## Root cause

The DOM editor was using a strict `transform === "none"` check. GSAP and browsers commonly leave identity transforms as computed matrices, so visually untransformed absolute elements were incorrectly downgraded into the layout-controlled path.

The selected-box picker also mixed two intents on the same pointer path: click-to-repick and drag-to-move. Movable boxes started a gesture on pointerdown, which could suppress the normal click path before the exact child picker ran.

For thumbnails, Studio had the backend cropper but did not consistently pass enough identity information from timeline clips to the thumbnail route. Runtime manifests can emit synthetic ids for anonymous DOM clips, so the Studio side needed a DOM fallback to recover the actual element, selector, and occurrence index.

## Verification

### Local checks

- `bun run --filter @hyperframes/studio test src/components/editor/domEditing.test.ts src/player/components/timelineEditing.test.ts src/player/components/CompositionThumbnail.test.ts src/player/hooks/useTimelinePlayer.test.ts` -> 66 tests pass
- `bun run --filter @hyperframes/core test src/lint/rules/captions.test.ts src/studio-api/routes/thumbnail.test.ts` -> 10 tests pass
- `bun run --filter @hyperframes/studio typecheck`
- `bun run --filter @hyperframes/core typecheck`
- `bun run --filter @hyperframes/cli typecheck`
- `bunx oxlint packages/cli/src/server/studioServer.ts packages/core/src/lint/rules/captions.test.ts packages/core/src/lint/rules/captions.ts packages/core/src/studio-api/routes/thumbnail.test.ts packages/core/src/studio-api/routes/thumbnail.ts packages/core/src/studio-api/types.ts packages/studio/src/App.tsx packages/studio/src/components/editor/DomEditOverlay.tsx packages/studio/src/components/editor/domEditing.test.ts packages/studio/src/components/editor/domEditing.ts packages/studio/src/player/components/CompositionThumbnail.tsx packages/studio/src/player/components/CompositionThumbnail.test.ts packages/studio/src/player/components/timelineEditing.test.ts packages/studio/src/player/components/timelineEditing.ts packages/studio/src/player/hooks/useTimelinePlayer.test.ts packages/studio/src/player/hooks/useTimelinePlayer.ts packages/studio/vite.config.ts` -> 0 warnings, 0 errors
- `git diff --check`
- `bun run --filter @hyperframes/studio build`
- Lefthook pre-commit -> lint, format, typecheck pass
- Lefthook commit-msg -> commitlint pass

### Browser verification

- Started Studio preview against a scratch project for DOM/timeline edge cases.
- Used `agent-browser` to select an absolute layer with computed `matrix(1, 0, 0, 1, 0, 0)` and verify normal X/Y/W/H controls were available.
- Dragged that identity-transform card and verified the preview updated and Studio persisted the file through the project file API.
- Re-picked a child text element from inside the selected parent box and verified selection changed from `#identity-card` to `#identity-title`.
- Verified repeated DOM timeline thumbnails emitted distinct URLs with `selector` and `selectorIndex`, loaded successfully, and returned distinct cropped JPEGs.
- Dragged a timeline DOM clip and verified `data-start` / track changes were written back.
- Added two local sub-compositions (`matrix-visual`, `matrix-code`) to the scratch project and verified:
  - `hyperframes lint /tmp/hf-dom-edit-fix-verify` -> 0 errors, 0 warnings
  - `hyperframes compositions /tmp/hf-dom-edit-fix-verify` listed `main`, `matrix-visual`, and `matrix-code`
  - root timeline showed both composition clips
  - composition thumbnails loaded from `/thumbnail/compositions/...`
  - sidebar drill-in to `matrix-visual` showed its inner clips and selector-specific thumbnails
- Recorded the tested Studio flow with `agent-browser`.

## Notes

- The scratch verification project lives at `/tmp/hf-dom-edit-fix-verify` and is intentionally not committed.
- Local screenshots/recordings are kept under `qa-artifacts/` and are intentionally not committed.
- While testing sub-compositions, `agent-browser dblclick` did not reliably trigger timeline composition drill-in; sidebar composition navigation worked and verified the drilled-in composition path.
