### PR TITLE
fix(studio): copy absolute paths in agent prompts

### DIFF
--- a/packages/core/src/studio-api/routes/projects.ts
+++ b/packages/core/src/studio-api/routes/projects.ts
@@ -25,6 +25,6 @@ export function registerProjectRoutes(api: Hono, adapter: StudioApiAdapter): voi
     const project = await adapter.resolveProject(c.req.param("id"));
     if (!project) return c.json({ error: "not found" }, 404);
     const files = walkDir(project.dir);
-    return c.json({ id: project.id, files });
+    return c.json({ id: project.id, dir: project.dir, title: project.title, files });
   });
 }

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -166,6 +166,23 @@ function toRelativeProjectAssetPath(sourceFile: string, assetPath: string): stri
   return [...fromParts.map(() => ".."), ...targetParts].join("/") || assetPath;
 }
 
+function isAbsoluteFilePath(value: string): boolean {
+  return /^(?:\/|[A-Za-z]:[\\/]|\\\\)/.test(value);
+}
+
+function toProjectAbsolutePath(projectDir: string | null, sourceFile: string): string | undefined {
+  const trimmedSource = sourceFile.trim();
+  if (!trimmedSource) return undefined;
+
+  const normalizedSource = trimmedSource.replace(/\\/g, "/");
+  if (isAbsoluteFilePath(normalizedSource)) return normalizedSource;
+
+  const normalizedRoot = projectDir?.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!normalizedRoot) return undefined;
+
+  return `${normalizedRoot}/${normalizedSource.replace(/^\.?\//, "")}`;
+}
+
 function ensureImportedFontFace(
   html: string,
   asset: ImportedFontAsset,
@@ -574,6 +591,7 @@ export function StudioApp() {
   });
 
   const [editingFile, setEditingFile] = useState<EditingFile | null>(null);
+  const [projectDir, setProjectDir] = useState<string | null>(null);
   const [activeCompPath, setActiveCompPath] = useState<string | null>(null);
   const [fileTree, setFileTree] = useState<string[]>([]);
   const [compIdToSrc, setCompIdToSrc] = useState<Map<string, string>>(new Map());
@@ -1036,10 +1054,13 @@ export function StudioApp() {
     let cancelled = false;
     fetch(`/api/projects/${projectId}`)
       .then((r) => r.json())
-      .then((data: { files?: string[] }) => {
+      .then((data: { files?: string[]; dir?: string }) => {
         if (!cancelled && data.files) setFileTree(data.files);
+        if (!cancelled) setProjectDir(typeof data.dir === "string" ? data.dir : null);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setProjectDir(null);
+      });
     return () => {
       cancelled = true;
     };
@@ -1915,6 +1936,7 @@ export function StudioApp() {
         currentTime,
         tagSnippet,
         userInstruction,
+        sourceFilePath: toProjectAbsolutePath(projectDir, targetPath),
       });
 
       try {
@@ -1936,7 +1958,7 @@ export function StudioApp() {
       setCopiedAgentPrompt(true);
       copiedAgentTimerRef.current = setTimeout(() => setCopiedAgentPrompt(false), 1600);
     },
-    [activeCompPath, currentTime, domEditSelection],
+    [activeCompPath, currentTime, domEditSelection, projectDir],
   );
 
   const handlePreviewIframeRef = useCallback(

--- a/packages/studio/src/components/editor/domEditing.test.ts
+++ b/packages/studio/src/components/editor/domEditing.test.ts
@@ -467,6 +467,43 @@ describe("patch builders and prompt builder", () => {
     expect(prompt).toContain("Do not modify other elements' data-* attributes or positioning.");
   });
 
+  it("uses an absolute source path in copied agent prompts when provided", () => {
+    const selection = {
+      element: {} as HTMLElement,
+      id: "editable-card",
+      selector: "#editable-card",
+      selectorIndex: undefined,
+      sourceFile: "index.html",
+      compositionPath: "index.html",
+      compositionSrc: undefined,
+      isCompositionHost: false,
+      label: "Drag me first",
+      tagName: "div",
+      boundingBox: { x: 108, y: 112, width: 380, height: 196 },
+      textContent: "Drag me first",
+      dataAttributes: {},
+      inlineStyles: {},
+      computedStyles: {},
+      textFields: [],
+      capabilities: {
+        canSelect: true,
+        canEditStyles: true,
+        canMove: true,
+        canResize: true,
+        canDetachFromLayout: false,
+      },
+    } satisfies DomEditSelection;
+
+    const prompt = buildElementAgentPrompt({
+      selection,
+      currentTime: 1.25,
+      sourceFilePath: "/tmp/hf-studio-project/index.html",
+    });
+
+    expect(prompt).toContain("Source file: /tmp/hf-studio-project/index.html");
+    expect(prompt).not.toContain("Source file: index.html");
+  });
+
   it("serializes child text fields back into HTML", () => {
     expect(
       serializeDomEditTextFields([

--- a/packages/studio/src/components/editor/domEditing.ts
+++ b/packages/studio/src/components/editor/domEditing.ts
@@ -697,12 +697,15 @@ export function buildElementAgentPrompt({
   currentTime,
   tagSnippet,
   userInstruction,
+  sourceFilePath,
 }: {
   selection: DomEditSelection;
   currentTime: number;
   tagSnippet?: string;
   userInstruction?: string;
+  sourceFilePath?: string;
 }): string {
+  const displayedSourceFile = sourceFilePath?.trim() || selection.sourceFile;
   const lines = [
     "## HyperFrames element edit request v1",
     "Schema version: 1",
@@ -711,7 +714,7 @@ export function buildElementAgentPrompt({
     "",
     `Composition: ${selection.compositionPath}`,
     `Playback time: ${formatTime(currentTime)}`,
-    `Source file: ${selection.sourceFile}`,
+    `Source file: ${displayedSourceFile}`,
     `DOM id: ${selection.id ?? "(none)"}`,
     `Selector: ${selection.selector ?? "(none)"}`,
     `Selector index: ${selection.selectorIndex ?? 0}`,


### PR DESCRIPTION
## Problem

Studio's design-panel Ask agent flow had the right selected-element context, but the copied prompt still pointed agents at project-relative source paths such as `index.html`.

That is fine for Studio's internal file API, but it makes the external agent loop slower: after pasting the prompt, the agent still has to infer which project root the relative file belongs to before making the edit.

## What this fixes

- returns the resolved project directory from the Studio project metadata endpoint
- keeps that project directory in `StudioApp` alongside the file tree
- renders the selected source file as an absolute path in copied Ask agent prompts
- keeps Studio's existing relative paths for file reads, writes, and source patching
- preserves the previous prompt-builder fallback when a host cannot provide a project directory
- adds prompt coverage so absolute source paths stay wired into the copy flow

## Root cause

The DOM selection model intentionally stores `sourceFile` as a project-relative path because the same value is used to fetch and patch files through `/api/projects/:id/files/...`.

The Ask agent prompt reused that internal path directly. For human- and agent-facing copy, Studio needed a separate display path that joins the resolved project directory with the selected source file without changing the relative path contract used by the editor APIs.

## Verification

### Local checks

- `bun run --filter @hyperframes/studio test src/components/editor/domEditing.test.ts` -> 21 tests pass
- `bun run --filter @hyperframes/studio typecheck`
- `bun run build:hyperframes-runtime`
- `bun run --filter @hyperframes/core typecheck`
- `bunx oxlint packages/core/src/studio-api/routes/projects.ts packages/studio/src/App.tsx packages/studio/src/components/editor/domEditing.ts packages/studio/src/components/editor/domEditing.test.ts` -> 0 warnings, 0 errors
- `bunx oxfmt --check packages/core/src/studio-api/routes/projects.ts packages/studio/src/App.tsx packages/studio/src/components/editor/domEditing.ts packages/studio/src/components/editor/domEditing.test.ts`
- `bun run --filter @hyperframes/studio build`
- `git diff --check`
- Lefthook pre-commit -> lint, format, typecheck pass
- Lefthook commit-msg -> commitlint pass

### Browser verification

- Started Studio against the real `warm-grain` example project.
- Used `agent-browser` to open the design panel, select a preview layer, open Ask agent, enter an instruction, and copy the prompt.
- Verified the copied prompt contains the absolute selected source path:
  `/Users/miguel07code/.codex/worktrees/925c/hyperframes-oss/packages/studio/data/projects/warm-grain/index.html`
- Recorded the tested Ask agent flow with `agent-browser`.

## Notes

- Local screenshots and recordings are kept under `qa-artifacts/studio-copy-agent-absolute-path/` and are intentionally not committed.
- The browser proof used a symlinked Studio example project, matching the preview flow used by local Studio development.
- Browser clipboard readback was blocked by Chrome permissions, so the copied payload was verified by capturing the page-local `navigator.clipboard.writeText` argument during the same `agent-browser`-driven flow.