### PR TITLE
Fix Studio timeline cutoff with many tracks

### DIFF
--- a/packages/studio/src/player/components/Timeline.test.ts
+++ b/packages/studio/src/player/components/Timeline.test.ts
@@ -6,6 +6,7 @@ import {
   resolveTimelineAssetDrop,
   getTimelinePlayheadLeft,
   getTimelineScrollLeftForZoomTransition,
+  shouldShowTimelineShortcutHint,
   shouldHandleTimelineDeleteKey,
   shouldAutoScrollTimeline,
 } from "./Timeline";
@@ -162,6 +163,17 @@ describe("getTimelineCanvasHeight", () => {
 
   it("still keeps ruler space when there are no tracks", () => {
     expect(getTimelineCanvasHeight(0)).toBeGreaterThan(24);
+  });
+});
+
+describe("shouldShowTimelineShortcutHint", () => {
+  it("shows the hint when the timeline does not vertically overflow", () => {
+    expect(shouldShowTimelineShortcutHint(220, 220)).toBe(true);
+    expect(shouldShowTimelineShortcutHint(220.5, 220)).toBe(true);
+  });
+
+  it("hides the hint when timeline tracks need vertical scrolling", () => {
+    expect(shouldShowTimelineShortcutHint(221.5, 220)).toBe(false);
   });
 });
 

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -35,7 +35,7 @@ const TRACK_H = 72;
 const RULER_H = 24;
 const CLIP_Y = 3; // vertical inset inside track
 const CLIP_HANDLE_W = 18;
-const TIMELINE_SCROLL_BUFFER = 24;
+const TIMELINE_SCROLL_BUFFER = 20;
 
 interface TrackVisualStyle extends TimelineTrackStyle {
   icon: ReactNode;
@@ -138,6 +138,14 @@ export function getTimelinePlayheadLeft(time: number, pixelsPerSecond: number): 
 
 export function getTimelineCanvasHeight(trackCount: number): number {
   return RULER_H + Math.max(0, trackCount) * TRACK_H + TIMELINE_SCROLL_BUFFER;
+}
+
+export function shouldShowTimelineShortcutHint(
+  scrollHeight: number,
+  clientHeight: number,
+): boolean {
+  if (!Number.isFinite(scrollHeight) || !Number.isFinite(clientHeight)) return true;
+  return scrollHeight - clientHeight <= 1;
 }
 
 export function shouldHandleTimelineDeleteKey(input: {
@@ -348,30 +356,51 @@ export const Timeline = memo(function Timeline({
   onDeleteElementRef.current = onDeleteElement;
   const suppressClickRef = useRef(false);
   const [showPopover, setShowPopover] = useState(false);
+  const [showShortcutHint, setShowShortcutHint] = useState(true);
   const [viewportWidth, setViewportWidth] = useState(0);
   const roRef = useRef<ResizeObserver | null>(null);
+  const shortcutHintRafRef = useRef(0);
+  const syncShortcutHintVisibility = useCallback(() => {
+    const scroll = scrollRef.current;
+    setShowShortcutHint(
+      scroll ? shouldShowTimelineShortcutHint(scroll.scrollHeight, scroll.clientHeight) : true,
+    );
+  }, []);
+  const scheduleShortcutHintVisibilitySync = useCallback(() => {
+    if (shortcutHintRafRef.current) cancelAnimationFrame(shortcutHintRafRef.current);
+    shortcutHintRafRef.current = requestAnimationFrame(() => {
+      shortcutHintRafRef.current = 0;
+      syncShortcutHintVisibility();
+    });
+  }, [syncShortcutHintVisibility]);
 
   // Callback ref: sets up ResizeObserver when the DOM element actually mounts.
   // useMountEffect can't work here because the component returns null on first
   // render (timelineReady=false), so containerRef.current is null when the
   // effect fires and the ResizeObserver is never created.
-  const setContainerRef = useCallback((el: HTMLDivElement | null) => {
-    if (roRef.current) {
-      roRef.current.disconnect();
-      roRef.current = null;
-    }
-    containerRef.current = el;
-    if (!el) return;
-    setViewportWidth(el.clientWidth);
-    roRef.current = new ResizeObserver(([entry]) => {
-      setViewportWidth(entry.contentRect.width);
-    });
-    roRef.current.observe(el);
-  }, []);
+  const setContainerRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (roRef.current) {
+        roRef.current.disconnect();
+        roRef.current = null;
+      }
+      containerRef.current = el;
+      if (!el) return;
+      setViewportWidth(el.clientWidth);
+      scheduleShortcutHintVisibilitySync();
+      roRef.current = new ResizeObserver(([entry]) => {
+        setViewportWidth(entry.contentRect.width);
+        scheduleShortcutHintVisibilitySync();
+      });
+      roRef.current.observe(el);
+    },
+    [scheduleShortcutHintVisibilitySync],
+  );
 
   // Clean up ResizeObserver on unmount
   useMountEffect(() => () => {
     roRef.current?.disconnect();
+    if (shortcutHintRafRef.current) cancelAnimationFrame(shortcutHintRafRef.current);
   });
 
   // Effective duration: max of store duration and the furthest element end.
@@ -416,6 +445,7 @@ export const Timeline = memo(function Timeline({
     }
     return [...trackOrder, draggedClip.previewTrack].sort((a, b) => a - b);
   }, [draggedClip, trackOrder]);
+  const totalH = getTimelineCanvasHeight(displayTrackOrder.length);
   const selectedElement = useMemo(
     () => elements.find((element) => (element.key ?? element.id) === selectedElementId) ?? null,
     [elements, selectedElementId],
@@ -923,6 +953,10 @@ export const Timeline = memo(function Timeline({
   }, []);
 
   const { major, minor } = useMemo(() => generateTicks(effectiveDuration), [effectiveDuration]);
+  useEffect(() => {
+    syncShortcutHintVisibility();
+  }, [syncShortcutHintVisibility, timelineReady, elements.length, totalH]);
+
   const getPreviewElement = useCallback(
     (element: TimelineElement): TimelineElement => {
       if (resizingClip?.element.id === element.id) {
@@ -1096,7 +1130,6 @@ export const Timeline = memo(function Timeline({
     );
   }
 
-  const totalH = getTimelineCanvasHeight(displayTrackOrder.length);
   const draggedElement = draggedClip?.element ?? null;
   const activeDraggedElement =
     draggedClip?.started === true && draggedElement
@@ -1170,7 +1203,7 @@ export const Timeline = memo(function Timeline({
     <div
       ref={setContainerRef}
       aria-label="Timeline"
-      className={`border-t select-none h-full overflow-hidden ${shiftHeld ? "cursor-crosshair" : "cursor-default"}`}
+      className={`relative border-t select-none h-full overflow-hidden ${shiftHeld ? "cursor-crosshair" : "cursor-default"}`}
       style={{
         touchAction: "pan-x pan-y",
         background: theme.shellBackground,
@@ -1509,8 +1542,8 @@ export const Timeline = memo(function Timeline({
         </div>
       </div>
 
-      {/* Keyboard shortcut hint — always visible */}
-      {!showPopover && !rangeSelection && (
+      {/* Keyboard shortcut hint */}
+      {showShortcutHint && !showPopover && !rangeSelection && (
         <div className="absolute bottom-2 right-3 pointer-events-none z-20">
           <div
             className="flex items-center gap-1.5 px-2 py-1 rounded-md border"


### PR DESCRIPTION
## Problem

Studio’s timeline could become hard to inspect when a composition had many tracks:

- the track list needed vertical scrolling, but the bottom shortcut hint stayed pinned over the track canvas
- after scrolling to the bottom, the final visible track could sit behind that overlay and look cut off
- the hint was positioned against the nearest page-level positioning context instead of the timeline shell itself, so its placement depended on the surrounding Studio layout
- this showed up most clearly in a local repro project with 30 separate `data-track-index` rows

## What this fixes

- Makes the timeline shell the positioning context for its bottom shortcut hint.
- Adds an explicit overflow check for the timeline scroll container.
- Hides the shortcut hint when the timeline has vertical track overflow, keeping the final track unobstructed while scrolling.
- Keeps the shortcut hint visible for compact timelines where it does not compete with scrollable track rows.
- Slightly tightens the timeline canvas bottom buffer so the last track can fully align inside short timeline panels.
- Adds focused unit coverage for the hint visibility decision.

## Root cause

The timeline rendered the keyboard shortcut hint as an always-visible absolute overlay near the bottom of the visible timeline area. That works for short timelines, but with many tracks the scroll container and the overlay share the same bottom region.

Because the hint did not account for vertical overflow, Studio could scroll the final row into view and then immediately cover part of it with the hint. The canvas also had a small bottom spacer that left the last row close enough to the bottom overlay to make the cutoff visible.

## Verification

### Local checks

- `bun run --filter @hyperframes/studio test -- Timeline.test.ts` -> 33 tests pass
- `bun run --filter @hyperframes/studio typecheck`
- `bunx oxlint packages/studio/src/player/components/Timeline.tsx packages/studio/src/player/components/Timeline.test.ts` -> 0 warnings, 0 errors
- `bunx oxfmt --check packages/studio/src/player/components/Timeline.tsx packages/studio/src/player/components/Timeline.test.ts`
- `git diff --check`
- Lefthook pre-commit -> lint, format, typecheck pass
- Lefthook commit-msg -> commitlint pass

### Browser verification

- Created a local ignored Studio repro project at `packages/studio/data/projects/timeline-scroll-cutoff-repro/index.html` with 30 separate timeline tracks.
- Started Studio locally at `http://127.0.0.1:5173/#project/timeline-scroll-cutoff-repro`.
- Used `agent-browser` to open the repro, scroll the timeline to the bottom, and verify the measured state:
  - `rowCount: 30`
  - `scrollTop: 2109`
  - `lastFullyVisible: true`
  - `hintVisible: false`
- Saved local browser proof under `artifacts/timeline-scroll-cutoff/after-bottom.png`.
- Recorded the tested scroll flow with `agent-browser` at `artifacts/timeline-scroll-cutoff/after-scroll-flow.webm`.

## Notes

- The 30-track repro project is ignored under `packages/studio/data/projects/` and intentionally not committed.
- Browser screenshots and recordings are local-only proof artifacts under `artifacts/` and intentionally not committed.
- A clean worktree needed the ignored runtime inline artifact for the commit hook, so I ran `bun run --filter @hyperframes/core build:hyperframes-runtime` before committing.
