### PR TITLE
fix: copy Studio agent prompts in Safari

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -28,6 +28,7 @@ import { CaptionTimeline } from "./captions/components/CaptionTimeline";
 import { useCaptionStore } from "./captions/store";
 import { useCaptionSync } from "./captions/hooks/useCaptionSync";
 import { parseCaptionComposition } from "./captions/parser";
+import { copyTextToClipboard } from "./utils/clipboard";
 import {
   applyPatchByTarget,
   readAttributeByTarget,
@@ -607,6 +608,7 @@ export function StudioApp() {
   const [rightCollapsed, setRightCollapsed] = useState(true);
   const [rightPanelTab, setRightPanelTab] = useState<RightPanelTab>("renders");
   const [domEditSelection, setDomEditSelection] = useState<DomEditSelection | null>(null);
+  const [agentPromptTagSnippet, setAgentPromptTagSnippet] = useState<string | undefined>();
   const [copiedAgentPrompt, setCopiedAgentPrompt] = useState(false);
   const [agentModalOpen, setAgentModalOpen] = useState(false);
   const [previewIframe, setPreviewIframe] = useState<HTMLIFrameElement | null>(null);
@@ -1449,6 +1451,7 @@ export function StudioApp() {
   const applyDomSelection = useCallback(
     (selection: DomEditSelection | null, options?: { revealPanel?: boolean }) => {
       setDomEditSelection(selection);
+      setAgentPromptTagSnippet(undefined);
       setCopiedAgentPrompt(false);
       if (selection) {
         if (options?.revealPanel !== false) {
@@ -1509,6 +1512,34 @@ export function StudioApp() {
       });
     },
     [activeCompPath, compIdToSrc, fileTree, isMasterView, timelineElements],
+  );
+
+  const preloadAgentPromptSnippet = useCallback(
+    async (selection: DomEditSelection) => {
+      const pid = projectIdRef.current;
+      if (!pid) return;
+
+      const targetPath = selection.sourceFile || activeCompPath || "index.html";
+      try {
+        const response = await fetch(
+          `/api/projects/${pid}/files/${encodeURIComponent(targetPath)}`,
+        );
+        if (!response.ok) return;
+
+        const data = (await response.json()) as { content?: string };
+        const html = data.content;
+        const tagSnippet =
+          typeof html === "string" ? readTagSnippetByTarget(html, selection) : undefined;
+
+        setAgentPromptTagSnippet((current) => {
+          if (domEditSelectionRef.current !== selection) return current;
+          return tagSnippet;
+        });
+      } catch {
+        // Runtime outerHTML is still available as a synchronous copy fallback.
+      }
+    },
+    [activeCompPath],
   );
 
   const resolveImportedFontAsset = useCallback(
@@ -1913,24 +1944,17 @@ export function StudioApp() {
 
   const handleAskAgent = useCallback(() => {
     if (!domEditSelection) return;
+    setAgentPromptTagSnippet(undefined);
+    void preloadAgentPromptSnippet(domEditSelection);
     setAgentModalOpen(true);
-  }, [domEditSelection]);
+  }, [domEditSelection, preloadAgentPromptSnippet]);
 
   const handleAgentModalSubmit = useCallback(
     async (userInstruction: string) => {
       if (!domEditSelection) return;
 
-      const pid = projectIdRef.current;
-      if (!pid) return;
-
       const targetPath = domEditSelection.sourceFile || activeCompPath || "index.html";
-      const response = await fetch(`/api/projects/${pid}/files/${encodeURIComponent(targetPath)}`);
-      if (!response.ok) throw new Error(`Failed to read ${targetPath}`);
-
-      const data = (await response.json()) as { content?: string };
-      const html = data.content;
-      const tagSnippet =
-        typeof html === "string" ? readTagSnippetByTarget(html, domEditSelection) : undefined;
+      const tagSnippet = agentPromptTagSnippet ?? domEditSelection.element.outerHTML;
       const prompt = buildElementAgentPrompt({
         selection: domEditSelection,
         currentTime,
@@ -1939,18 +1963,10 @@ export function StudioApp() {
         sourceFilePath: toProjectAbsolutePath(projectDir, targetPath),
       });
 
-      try {
-        await navigator.clipboard.writeText(prompt);
-      } catch {
-        const textarea = document.createElement("textarea");
-        textarea.value = prompt;
-        textarea.setAttribute("readonly", "true");
-        textarea.style.position = "fixed";
-        textarea.style.opacity = "0";
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textarea);
+      const copied = await copyTextToClipboard(prompt);
+      if (!copied) {
+        showToast("Could not copy prompt to clipboard.", "error");
+        return;
       }
 
       setAgentModalOpen(false);
@@ -1958,7 +1974,7 @@ export function StudioApp() {
       setCopiedAgentPrompt(true);
       copiedAgentTimerRef.current = setTimeout(() => setCopiedAgentPrompt(false), 1600);
     },
-    [activeCompPath, currentTime, domEditSelection, projectDir],
+    [activeCompPath, agentPromptTagSnippet, currentTime, domEditSelection, projectDir, showToast],
   );
 
   const handlePreviewIframeRef = useCallback(

--- a/packages/studio/src/components/LintModal.tsx
+++ b/packages/studio/src/components/LintModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { XIcon, WarningIcon, CheckCircleIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { copyTextToClipboard } from "../utils/clipboard";
 
 export interface LintFinding {
   severity: "error" | "warning";
@@ -30,12 +31,10 @@ export function LintModal({
       return line;
     });
     const text = `Fix these HyperFrames lint issues for project "${projectId}":\n\nProject path: ${window.location.href}\n\n${lines.join("\n\n")}`;
-    try {
-      await navigator.clipboard.writeText(text);
+    const copiedText = await copyTextToClipboard(text);
+    if (copiedText) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // ignore
     }
   };
 

--- a/packages/studio/src/components/sidebar/AssetsTab.tsx
+++ b/packages/studio/src/components/sidebar/AssetsTab.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useCallback, useRef } from "react";
 import { VideoFrameThumbnail } from "../ui/VideoFrameThumbnail";
 import { MEDIA_EXT, IMAGE_EXT, VIDEO_EXT, AUDIO_EXT } from "../../utils/mediaTypes";
 import { TIMELINE_ASSET_MIME } from "../../utils/timelineAssetDrop";
+import { copyTextToClipboard } from "../../utils/clipboard";
 
 interface AssetsTabProps {
   projectId: string;
@@ -298,12 +299,10 @@ export const AssetsTab = memo(function AssetsTab({
   );
 
   const handleCopyPath = useCallback(async (path: string) => {
-    try {
-      await navigator.clipboard.writeText(path);
+    const copied = await copyTextToClipboard(path);
+    if (copied) {
       setCopiedPath(path);
       setTimeout(() => setCopiedPath(null), 1500);
-    } catch {
-      // ignore
     }
   }, []);
 

--- a/packages/studio/src/player/components/EditModal.tsx
+++ b/packages/studio/src/player/components/EditModal.tsx
@@ -3,6 +3,7 @@ import { useMountEffect } from "../../hooks/useMountEffect";
 import { usePlayerStore } from "../store/playerStore";
 import { formatTime } from "../lib/time";
 import { buildPromptCopyText, buildTimelineAgentPrompt } from "./timelineEditing";
+import { copyTextToClipboard } from "../../utils/clipboard";
 
 interface EditPopoverProps {
   rangeStart: number;
@@ -62,16 +63,8 @@ export function EditPopover({ rangeStart, rangeEnd, anchorX, anchorY, onClose }:
   }, [start, end, elementsInRange, prompt]);
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(buildClipboardText());
-    } catch {
-      const ta = document.createElement("textarea");
-      ta.value = buildClipboardText();
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand("copy");
-      document.body.removeChild(ta);
-    }
+    const copied = await copyTextToClipboard(buildClipboardText());
+    if (!copied) return;
     setCopiedAgentPrompt(true);
     setTimeout(() => {
       setCopiedAgentPrompt(false);
@@ -82,16 +75,8 @@ export function EditPopover({ rangeStart, rangeEnd, anchorX, anchorY, onClose }:
   const handleCopyPrompt = useCallback(async () => {
     const promptText = buildPromptCopyText(prompt);
     if (!promptText) return;
-    try {
-      await navigator.clipboard.writeText(promptText);
-    } catch {
-      const ta = document.createElement("textarea");
-      ta.value = promptText;
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand("copy");
-      document.body.removeChild(ta);
-    }
+    const copied = await copyTextToClipboard(promptText);
+    if (!copied) return;
     setCopiedPromptOnly(true);
     setTimeout(() => {
       setCopiedPromptOnly(false);

--- a/packages/studio/src/utils/clipboard.test.ts
+++ b/packages/studio/src/utils/clipboard.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Window } from "happy-dom";
+import { copyTextToClipboard } from "./clipboard";
+
+function installDocument(execCommand: (command: string) => boolean): void {
+  const window = new Window();
+  Object.defineProperty(window.document, "execCommand", {
+    configurable: true,
+    value: execCommand,
+  });
+  vi.stubGlobal("document", window.document);
+}
+
+function installNavigator(
+  writeText: (text: string) => Promise<void>,
+  userAgent = "Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36",
+): void {
+  vi.stubGlobal("navigator", {
+    clipboard: { writeText },
+    userAgent,
+  });
+}
+
+describe("copyTextToClipboard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the synchronous selection copy path first in Safari", async () => {
+    const execCommand = vi.fn((command: string) => command === "copy");
+    const writeText = vi.fn((_text: string) => Promise.resolve());
+
+    installDocument(execCommand);
+    installNavigator(
+      writeText,
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+    );
+
+    await expect(copyTextToClipboard("copy me")).resolves.toBe(true);
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(writeText).not.toHaveBeenCalled();
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("uses navigator.clipboard first outside Safari", async () => {
+    const execCommand = vi.fn((command: string) => command === "copy");
+    const writeText = vi.fn((_text: string) => Promise.resolve());
+
+    installDocument(execCommand);
+    installNavigator(writeText);
+
+    await expect(copyTextToClipboard("copy me")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("copy me");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to selection copy outside Safari when navigator.clipboard fails", async () => {
+    const execCommand = vi.fn((command: string) => command === "copy");
+    const writeText = vi.fn((_text: string) => Promise.reject(new Error("blocked")));
+
+    installDocument(execCommand);
+    installNavigator(writeText);
+
+    await expect(copyTextToClipboard("copy me")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("copy me");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("reports failure when both copy paths fail", async () => {
+    const execCommand = vi.fn(() => false);
+    const writeText = vi.fn((_text: string) => Promise.reject(new Error("blocked")));
+
+    installDocument(execCommand);
+    installNavigator(
+      writeText,
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+    );
+
+    await expect(copyTextToClipboard("copy me")).resolves.toBe(false);
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(writeText).toHaveBeenCalledWith("copy me");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/packages/studio/src/utils/clipboard.ts
+++ b/packages/studio/src/utils/clipboard.ts
@@ -1,0 +1,57 @@
+function copyWithSelection(text: string): boolean {
+  if (typeof document === "undefined" || !document.body || !document.execCommand) {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.width = "1px";
+  textarea.style.height = "1px";
+  textarea.style.padding = "0";
+  textarea.style.border = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+
+  document.body.appendChild(textarea);
+  textarea.focus({ preventScroll: true });
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+function shouldCopyWithSelectionFirst(): boolean {
+  if (typeof navigator === "undefined") return false;
+
+  const userAgent = navigator.userAgent;
+  return /Safari/i.test(userAgent) && !/Chrome|Chromium|CriOS|FxiOS|Edg|OPR/i.test(userAgent);
+}
+
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  const useSelectionFirst = shouldCopyWithSelectionFirst();
+  if (useSelectionFirst && copyWithSelection(text)) {
+    return true;
+  }
+
+  const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back below when the browser still allows synchronous copy.
+    }
+  }
+
+  return !useSelectionFirst && copyWithSelection(text);
+}


### PR DESCRIPTION
## Problem

The Design panel's Ask agent flow could fail to copy prompts in Safari. The modal looked like it completed the action from the user's point of view, but Safari's clipboard permission is more tightly coupled to the original user gesture than Chromium's.

The submit handler was doing an async project-file fetch before calling `navigator.clipboard.writeText()`. In Safari, that can lose the trusted click/key gesture by the time the copy runs, so the prompt never reaches the system clipboard.

## What this fixes

- Adds a shared Studio clipboard helper that handles browser-specific copy ordering.
- Uses the synchronous selection copy path first in Safari, where preserving the user gesture matters most.
- Keeps Chromium on `navigator.clipboard.writeText()` first, avoiding the automation/system-clipboard mismatch from using `execCommand` too eagerly there.
- Preloads the selected element's source snippet when the Ask agent modal opens instead of waiting until submit.
- Falls back to the selected runtime element's `outerHTML` if the source snippet has not loaded yet.
- Routes the other Studio copy affordances through the shared helper so prompt, lint, timeline, and asset-path copy behavior stay consistent.
- Shows a Studio toast if the Design panel prompt copy fails instead of closing the modal with a false success state.

## Root cause

The Design panel Ask agent submit path mixed two operations with different timing requirements: it fetched the project source asynchronously, then tried to copy the generated prompt. Safari can reject clipboard writes after that async boundary because the write is no longer directly attached to the user's click or `Cmd+Enter` gesture.

The older fallback also only ran after `navigator.clipboard.writeText()` failed, which is too late for Safari's stricter gesture handling in this flow. Moving source lookup ahead of the submit action and preferring a synchronous copy path in Safari keeps the actual copy inside the trusted interaction.

## Verification

### Local checks

- `bun run --filter @hyperframes/studio test -- src/utils/clipboard.test.ts` -> 4 tests pass
- `bun run --filter @hyperframes/studio test` -> 23 files pass, 278 tests pass
- `bun run --filter @hyperframes/studio typecheck`
- `bun run --filter @hyperframes/studio build`
- `bunx oxlint packages/studio/src/utils/clipboard.ts packages/studio/src/utils/clipboard.test.ts packages/studio/src/App.tsx packages/studio/src/components/LintModal.tsx packages/studio/src/player/components/EditModal.tsx packages/studio/src/components/sidebar/AssetsTab.tsx` -> 0 warnings, 0 errors
- `bunx oxfmt --check packages/studio/src/utils/clipboard.ts packages/studio/src/utils/clipboard.test.ts packages/studio/src/App.tsx packages/studio/src/components/LintModal.tsx packages/studio/src/player/components/EditModal.tsx packages/studio/src/components/sidebar/AssetsTab.tsx`
- `git diff --check`
- Lefthook pre-commit -> lint, format, typecheck pass
- Lefthook commit-msg -> commitlint pass

### Browser verification

- Started Studio locally from this branch against a scratch `safari-copy-agent` project.
- Used `agent-browser` to load Studio, select a layer from the preview into the Design panel, open Ask agent, enter an instruction, and run the copy flow.
- Recorded the agent-browser-driven flow.
- Opened the same local Studio project in Safari.
- Selected the layer in the Design panel, opened Ask agent, typed `Make the headline larger`, clicked `Copy prompt`, and verified the Design panel changed to `Prompt copied`.
- Verified the macOS system clipboard with `pbpaste`; it contained the generated `## HyperFrames element edit request v1` prompt and the typed instruction.

## Notes

- Local screenshots and recordings are kept under `qa-artifacts/safari-copy-agent/` and are intentionally not committed.
- Safari WebDriver / Apple Events JavaScript execution were not enabled on this machine, so the Safari pass used macOS UI automation plus `pbpaste` for clipboard verification. The agent-browser recording covers the same Studio flow in the required automation path.
