### PR TITLE
test: cover sub-composition audio extraction

### DIFF
--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -494,6 +494,7 @@ describe("template-wrapped sub-composition media offsets", () => {
   function writeTemplateWrappedProject(
     hostAttrs: string,
     mediaAttrs: string = 'data-start="0" data-duration="4"',
+    extraMediaMarkup: string = "",
   ): {
     projectDir: string;
     indexPath: string;
@@ -547,6 +548,7 @@ describe("template-wrapped sub-composition media offsets", () => {
       ${mediaAttrs}
       data-track-index="0"
     ></video>
+    ${extraMediaMarkup}
     <script>
       window.__timelines = window.__timelines || {};
       window.__timelines["scene"] = { duration: () => 4 };
@@ -628,6 +630,30 @@ describe("template-wrapped sub-composition media offsets", () => {
       start: 21.5,
       end: 25.5,
     });
+  });
+
+  it("includes explicit audio from template-wrapped sub-compositions", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-duration="6" data-width="640" data-height="360"',
+      'data-start="1" data-duration="4"',
+      `<audio
+        id="scene-audio"
+        src="../assets/narration.wav"
+        data-start="2"
+        data-duration="3"
+        data-track-index="1"
+      ></audio>`,
+    );
+
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+
+    expect(compiled.audios).toContainEqual(
+      expect.objectContaining({
+        id: "scene-audio",
+        start: 7,
+        end: 10,
+      }),
+    );
   });
 
   it("flattens the sub-composition root onto the host in compiled render HTML", async () => {


### PR DESCRIPTION
## Problem

PR #525 was merged before the final review-follow-up coverage patch could attach to it. James's review specifically called out sub-composition audio coverage as a useful guardrail for the worker-cost path.

## What this fixes

- Adds an explicit template-wrapped sub-composition `<audio>` fixture to `htmlCompiler.test.ts`.
- Verifies compiled audio metadata is preserved on the host timeline after sub-composition offsetting.

## Root cause

The merged PR already covered video-derived sub-composition audio, but there was no direct test proving authored nested `<audio>` clips stay in `compiled.audios` after template wrapping and host-time projection.

## Verification

### Local checks

- `bun test packages/producer/src/services/htmlCompiler.test.ts` -> 36 pass
- `bunx oxlint packages/producer/src/services/htmlCompiler.test.ts` -> 0 warnings, 0 errors
- `bunx oxfmt --check packages/producer/src/services/htmlCompiler.test.ts` -> clean
- `bun run --filter @hyperframes/producer typecheck` -> pass
- `git diff --check` -> clean
- Lefthook during commit -> lint, format, typecheck, commitlint pass

## Notes

- Follow-up to #525 review comments.
