### PR TITLE
feat(studio): add Design panel

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -2797,6 +2797,7 @@ export function StudioApp() {
                   selection={
                     !rightCollapsed && rightPanelTab === "design" ? domEditSelection : null
                   }
+                  allowCanvasMovement={false}
                   onCanvasMouseDown={handlePreviewCanvasMouseDown}
                   onCanvasDoubleClick={handlePreviewCanvasDoubleClick}
                   onSelectedDoubleClick={handleSelectedOverlayDoubleClick}
@@ -2891,6 +2892,7 @@ export function StudioApp() {
                         onImportAssets={handleImportFiles}
                         fontAssets={fontAssets}
                         onImportFonts={handleImportFonts}
+                        allowLayoutDetach={false}
                       />
                     ) : (
                       <RenderQueue

--- a/packages/studio/src/components/editor/DomEditOverlay.tsx
+++ b/packages/studio/src/components/editor/DomEditOverlay.tsx
@@ -14,6 +14,7 @@ interface OverlayRect {
 interface DomEditOverlayProps {
   iframeRef: RefObject<HTMLIFrameElement | null>;
   selection: DomEditSelection | null;
+  allowCanvasMovement?: boolean;
   onCanvasMouseDown: (
     event: React.MouseEvent<HTMLDivElement>,
     options?: { preferClipAncestor?: boolean },
@@ -125,6 +126,7 @@ interface BlockedMoveState {
 export const DomEditOverlay = memo(function DomEditOverlay({
   iframeRef,
   selection,
+  allowCanvasMovement = true,
   onCanvasMouseDown,
   onCanvasDoubleClick,
   onSelectedDoubleClick,
@@ -403,9 +405,10 @@ export const DomEditOverlay = memo(function DomEditOverlay({
               top: overlayRect.top,
               width: overlayRect.width,
               height: overlayRect.height,
-              cursor: selection.capabilities.canMove ? "move" : "default",
+              cursor: allowCanvasMovement && selection.capabilities.canMove ? "move" : "default",
             }}
             onPointerDown={(e) => {
+              if (!allowCanvasMovement) return;
               if (selection.capabilities.canMove) {
                 startGesture("drag", e);
                 return;
@@ -424,7 +427,7 @@ export const DomEditOverlay = memo(function DomEditOverlay({
             onDoubleClick={onSelectedDoubleClick}
           >
             {/* Resize handle — bottom-right corner */}
-            {selection.capabilities.canResize && (
+            {allowCanvasMovement && selection.capabilities.canResize && (
               <div
                 className="absolute -right-1.5 -bottom-1.5 w-3 h-3 rounded-sm bg-studio-accent border border-studio-accent/60"
                 style={{ cursor: "se-resize", touchAction: "none" }}

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -64,6 +64,7 @@ interface PropertyPanelProps {
   onImportAssets?: (files: FileList) => Promise<string[]>;
   fontAssets?: ImportedFontAsset[];
   onImportFonts?: (files: FileList | File[]) => Promise<ImportedFontAsset[]>;
+  allowLayoutDetach?: boolean;
 }
 
 const FIELD =
@@ -1984,6 +1985,7 @@ export const PropertyPanel = memo(function PropertyPanel({
   onImportAssets,
   fontAssets = [],
   onImportFonts,
+  allowLayoutDetach = true,
 }: PropertyPanelProps) {
   const styles = element?.computedStyles ?? EMPTY_STYLES;
   const selectionColors = useMemo(() => collectSelectionColors(styles), [styles]);
@@ -2020,7 +2022,7 @@ export const PropertyPanel = memo(function PropertyPanel({
         <p className="text-sm font-medium text-neutral-200">Select an element in the preview.</p>
         <p className="mt-2 max-w-[260px] text-xs leading-5 text-neutral-500">
           The inspector is tuned for direct DOM edits with safer geometry controls, color picking,
-          and cleaner Paper-style grouping.
+          and cleaner grouped layer controls.
         </p>
       </div>
     );
@@ -2036,7 +2038,9 @@ export const PropertyPanel = memo(function PropertyPanel({
   const sourceLabel = element.id ? `#${element.id}` : element.selector;
   const showEditableSections = element.capabilities.canEditStyles;
   const disabledMoveReason =
-    element.capabilities.reasonIfDisabled && !element.capabilities.canDetachFromLayout
+    allowLayoutDetach &&
+    element.capabilities.reasonIfDisabled &&
+    !element.capabilities.canDetachFromLayout
       ? element.capabilities.reasonIfDisabled
       : null;
 
@@ -2131,7 +2135,7 @@ export const PropertyPanel = memo(function PropertyPanel({
               </button>
             </div>
           )}
-          {element.capabilities.canDetachFromLayout && (
+          {allowLayoutDetach && element.capabilities.canDetachFromLayout && (
             <div className="mt-4 flex min-w-0 flex-wrap items-center justify-between gap-3 border-l border-amber-500/40 pl-3">
               <div className="min-w-0 text-[11px] leading-5 text-neutral-400">
                 <div className="font-medium text-neutral-200">


### PR DESCRIPTION
## Problem

The manual editing work on `next` is broader than the first rollout should be. We want to keep the inspector, Design panel, and tab polish, but avoid shipping direct canvas movement/resize affordances yet.

## What this fixes

- Keeps the existing Inspector entry point and `Design` / `Renders` right-panel tabs on `next`.
- Disables direct canvas drag movement and resize handles for DOM selections.
- Keeps preview click selection and the Design inspector panel available.
- Hides the layout-detach / “Make movable” paths from the Design panel for this rollout.
- Removes the remaining Paper wording from Studio TSX copy only.

## Root cause

The `next` branch’s manual-editing surface bundled inspector selection, Design-panel editing, layout detach, and direct canvas drag/resize together. Canvas movement is the riskiest part of that bundle, so the launch branch needs an explicit gate that leaves inspection enabled while preventing movement affordances from rendering or committing.

## Verification

### Local checks

- `bunx oxlint packages/studio/src/App.tsx packages/studio/src/components/editor/DomEditOverlay.tsx packages/studio/src/components/editor/PropertyPanel.tsx`
- `bunx oxfmt --check packages/studio/src/App.tsx packages/studio/src/components/editor/DomEditOverlay.tsx packages/studio/src/components/editor/PropertyPanel.tsx`
- `bun run --filter @hyperframes/studio typecheck`
- `rg -n "Paper\\.Design|paper\\.design|\\bPaper\\b" packages/studio/src --glob '!node_modules/**'` returned no matches
- `git diff --check`
- `bun run --filter @hyperframes/studio build`
- Pre-commit hook passed `lint`, `format`, repo `typecheck`, and `commitlint`.

### Browser verification

- Ran Studio at `http://127.0.0.1:5177/#project/inspector-demo` with a local ignored fixture.
- Opened Inspector and selected the demo headline into the Design panel.
- Verified selection still shows Design inspector fields.
- Simulated a drag on the selected overlay box and verified computed `left` stayed `140px` before and after.
- Verified the overlay cursor is `default`, resize handle count is `0`, the panel does not include `Make movable`, and the visible Studio panel does not include `Paper`.
- Screenshot: `qa-artifacts/studio-inspector-next/inspector-selection-no-move.png`
- Recording: `qa-artifacts/studio-inspector-next/inspector-no-canvas-move.webm`

## Notes

This PR is intentionally based on `next`, not `main`. It does not remove the inspector or Design panel work; it only holds back direct canvas movement/layout-detach affordances for the first rollout. The local fixture and QA artifacts are untracked and not part of the PR.
