### PR TITLE
docs(readme): add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://www.npmjs.com/package/hyperframes"><img src="https://img.shields.io/npm/dm/hyperframes.svg?style=flat" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node.js"></a>
+  <a href="https://discord.gg/EbK98HBPdk"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center"><b>Write HTML. Render video. Built for agents.</b></p>


### PR DESCRIPTION
## What

Adds a Discord badge to the README badges row linking to the HeyGen for Developers Discord server (`#hyperframes` channel).

## Why

Give users and contributors a place to ask questions, share work, and chat with maintainers. Currently there's no community channel surfaced from the README.

## How

Single-line addition to the existing `<p align="center">` badges block in `README.md`. Uses a static shields.io badge in Discord blurple (`#5865F2`) with the Discord logo. The invite is non-expiring and was generated from the `#hyperframes` channel, so clicks land users directly there.

## Test plan

- [ ] Unit tests added/updated — N/A (docs only)
- [x] Manual testing performed — verified badge renders correctly via shields.io URL; confirmed invite link is non-expiring and channel-scoped
- [x] Documentation updated (if applicable) — this PR is the doc update