### PR TITLE
feat(core): add video adapter support video seek

### DIFF
--- a/packages/core/src/runtime/adapters/video.ts
+++ b/packages/core/src/runtime/adapters/video.ts
@@ -1,0 +1,49 @@
+import type { RuntimeDeterministicAdapter } from "../types";
+
+export function createVideoAdapter(): RuntimeDeterministicAdapter {
+  let videos: HTMLVideoElement[] = [];
+  return {
+    name: "video",
+    discover(): void {
+      videos = Array.from(
+        document.querySelectorAll<HTMLVideoElement>("video.clip, video[class*='clip']"),
+      );
+    },
+    pause(): void {
+      for (const el of videos) {
+        if (el.isConnected && !el.paused) {
+          try {
+            el.pause();
+          } catch {}
+        }
+      }
+    },
+    seek({ time }: { time: number }): void {
+      for (const el of videos) {
+        if (!el.isConnected) continue;
+        const hasStart = el.hasAttribute("data-start");
+        const start = hasStart ? parseFloat(el.dataset.start ?? "") || 0 : 0;
+        const mediaStart =
+          parseFloat(el.dataset.playbackStart ?? el.dataset.mediaStart ?? "0") || 0;
+        const rawDuration = parseFloat(el.dataset.duration ?? "");
+        const sourceDuration = isFinite(el.duration) && el.duration > 0 ? el.duration : null;
+        const duration =
+          isFinite(rawDuration) && rawDuration > 0
+            ? rawDuration
+            : sourceDuration != null
+              ? Math.max(0, sourceDuration - mediaStart)
+              : Infinity;
+        const end = isFinite(duration) && duration > 0 ? start + duration : Infinity;
+        const relTime = time - start + mediaStart;
+        const isActive = time >= start && time < end && relTime >= 0;
+        if (!isActive) continue;
+        const drift = Math.abs((el.currentTime || 0) - relTime);
+        if (drift > 0.05) {
+          try {
+            el.currentTime = relTime;
+          } catch {}
+        }
+      }
+    },
+  };
+}

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -5,6 +5,7 @@ import { createGsapAdapter } from "./adapters/gsap";
 import { createLottieAdapter } from "./adapters/lottie";
 import { createThreeAdapter } from "./adapters/three";
 import { createWaapiAdapter } from "./adapters/waapi";
+import { createVideoAdapter } from "./adapters/video";
 import { refreshRuntimeMediaCache, syncRuntimeMedia } from "./media";
 import { createPickerModule } from "./picker";
 import { createRuntimePlayer } from "./player";
@@ -1553,6 +1554,7 @@ export function initSandboxRuntimeModular(): void {
     createLottieAdapter(),
     createThreeAdapter(),
     createGsapAdapter({ getTimeline: () => state.capturedTimeline }),
+    createVideoAdapter(),
   ] as RuntimeDeterministicAdapter[];
   installRuntimeErrorDiagnostics();
   runAdapters("discover");


### PR DESCRIPTION
Wire createVideoAdapter into the deterministic adapter pipeline support video seek

## What

add createVideoAdapter function support video seek

## Why

Currently, when modifying the timeline, if the current rendered content is a video clip, seek will not take effect

## How

create video adapter into the deterministic adapter pipeline

## Test plan

How was this tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
