### PR TITLE
fix(producer): handle no-audio source files in resolveMediaDuration

### DIFF
--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -167,10 +167,19 @@ async function resolveMediaDuration(
     return { duration: 0, resolvedPath: filePath };
   }
 
-  const metadata =
-    tagName === "video"
-      ? await extractMediaMetadata(filePath)
-      : await extractAudioMetadata(filePath);
+  let metadata: { durationSeconds: number };
+  if (tagName === "video") {
+    metadata = await extractMediaMetadata(filePath);
+  } else {
+    try {
+      metadata = await extractAudioMetadata(filePath);
+    } catch {
+      // Source file has no audio stream (e.g. a silent video used as an audio src).
+      // Return duration 0 so the element is excluded from the composition gracefully,
+      // matching how missing files and failed downloads are already handled above.
+      return { duration: 0, resolvedPath: filePath };
+    }
+  }
 
   const fileDuration = metadata.durationSeconds;
   const effectiveDuration = fileDuration - mediaStart;


### PR DESCRIPTION
## Problem

When an `<audio>` element referenced a file with no audio stream (e.g. a silent video used as an audio src), `resolveMediaDuration` called `extractAudioMetadata` without a guard. `ffprobe` threw `[FFmpeg] No audio stream found`, which propagated uncaught through `Promise.all` in `compileHtmlFile` and crashed the entire render.

## What this fixes

Wraps the `extractAudioMetadata` probe in a try-catch inside `resolveMediaDuration`. On failure the function returns `{ duration: 0 }`, so the element is excluded from the composition gracefully — the same pattern already used for missing files and failed HTTP downloads.

## How

`packages/producer/src/services/htmlCompiler.ts` — `resolveMediaDuration()`:

```typescript
// Before — throws and crashes the render:
const metadata =
  tagName === "video"
    ? await extractMediaMetadata(filePath)
    : await extractAudioMetadata(filePath);

// After — skips gracefully with duration 0:
} else {
  try {
    metadata = await extractAudioMetadata(filePath);
  } catch {
    return { duration: 0, resolvedPath: filePath };
  }
}
```