### PR TITLE
docs: sharpen agent skill guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ This repo ships AI agent skills via [vercel-labs/skills](https://github.com/verc
 npx skills add heygen-com/hyperframes
 ```
 
+**Always invoke the relevant HyperFrames skill before writing or modifying compositions.**
+If skills are not available, stop and ask the user to run `npx skills add heygen-com/hyperframes` before composition work continues.
+
 ## Build & Test
 
 ```bash

--- a/packages/cli/src/templates/_shared/AGENTS.md
+++ b/packages/cli/src/templates/_shared/AGENTS.md
@@ -1,6 +1,6 @@
 # HyperFrames Composition Project
 
-## Skills
+## Skills — Use These First
 
 This project uses AI agent skills for framework-specific patterns. Install them if not already present:
 
@@ -8,7 +8,9 @@ This project uses AI agent skills for framework-specific patterns. Install them 
 npx skills add heygen-com/hyperframes
 ```
 
-Skills encode patterns like `window.__timelines` registration, `data-*` attribute semantics, and shader-compatible CSS rules that are not in generic web docs. Using them produces correct compositions from the start.
+**Always invoke the relevant HyperFrames skill before writing or modifying compositions.** Skills encode patterns like `window.__timelines` registration, `data-*` attribute semantics, and shader-compatible CSS rules that are not in generic web docs. Skipping them produces broken compositions.
+
+**Skills not available?** Stop and ask the user to run `npx hyperframes skills` and restart their agent session, or install manually with `npx skills add heygen-com/hyperframes`.
 
 ## Commands
 


### PR DESCRIPTION
## Problem

The generated project `AGENTS.md` described HyperFrames skills as useful context, but it was softer than the generated `CLAUDE.md` guidance. Agents could read it as optional advice instead of a required precondition for composition work.

## What this fixes

- Sharpens the root `AGENTS.md` skills section with a direct requirement to invoke relevant HyperFrames skills before composition edits.
- Sharpens the generated project `AGENTS.md` template with the same prescriptive line.
- Adds an explicit missing-skills fallback: stop and ask the user to install/run the HyperFrames skills setup before composition work continues.
- Leaves generated `CLAUDE.md` unchanged because it already carries the stricter wording.

## Root cause

The generated `CLAUDE.md` had been upgraded to “use these first” language, while `AGENTS.md` still used descriptive wording. That created inconsistent guidance between agent config surfaces even though both files are copied by `hyperframes init`.

## Verification

### Local checks

- `bunx oxfmt --check AGENTS.md packages/cli/src/templates/_shared/AGENTS.md`
- `git diff --check`
- Lefthook pre-commit: format
- Lefthook commit-msg: commitlint

Generated-project smoke at `/tmp/hf-agents-guidance-proof`:

- `bun packages/cli/src/cli.ts init /tmp/hf-agents-guidance-proof --example blank --non-interactive --skip-skills`
- `rg -n "Always invoke|Skills not available|npx hyperframes skills|npx skills add" /tmp/hf-agents-guidance-proof/AGENTS.md AGENTS.md packages/cli/src/templates/_shared/AGENTS.md`

### Browser verification

- Not applicable: this is agent guidance text only and has no browser-exercisable flow.

## Notes

- This PR intentionally touches only `AGENTS.md` surfaces. `CLAUDE.md` already had the stronger prescriptive guidance.
