### PR TITLE
feat: default streaming encode for sequential renders

### DIFF
--- a/packages/engine/src/config.test.ts
+++ b/packages/engine/src/config.test.ts
@@ -31,6 +31,7 @@ describe("resolveConfig", () => {
     expect(config.jpegQuality).toBe(80);
     expect(config.browserGpuMode).toBe("software");
     expect(config.enableStreamingEncode).toBe(true);
+    expect(config.streamingEncodeMaxDurationSeconds).toBe(240);
     expect(config.audioGain).toBe(1);
     expect(config.debug).toBe(false);
   });
@@ -66,6 +67,20 @@ describe("resolveConfig", () => {
 
     const config = resolveConfig();
     expect(config.enableStreamingEncode).toBe(false);
+  });
+
+  it("reads the streaming encode duration cutoff from env", () => {
+    setEnv("PRODUCER_STREAMING_ENCODE_MAX_DURATION_SECONDS", "120");
+
+    const config = resolveConfig();
+    expect(config.streamingEncodeMaxDurationSeconds).toBe(120);
+  });
+
+  it("clamps negative streaming encode duration cutoff env values to zero", () => {
+    setEnv("PRODUCER_STREAMING_ENCODE_MAX_DURATION_SECONDS", "-1");
+
+    const config = resolveConfig();
+    expect(config.streamingEncodeMaxDurationSeconds).toBe(0);
   });
 
   it("treats non-'true' boolean env vars as false", () => {

--- a/packages/engine/src/config.test.ts
+++ b/packages/engine/src/config.test.ts
@@ -30,6 +30,7 @@ describe("resolveConfig", () => {
     expect(config.format).toBe("jpeg");
     expect(config.jpegQuality).toBe(80);
     expect(config.browserGpuMode).toBe("software");
+    expect(config.enableStreamingEncode).toBe(true);
     expect(config.audioGain).toBe(1);
     expect(config.debug).toBe(false);
   });
@@ -58,6 +59,13 @@ describe("resolveConfig", () => {
     const config = resolveConfig();
     expect(config.disableGpu).toBe(true);
     expect(config.enableBrowserPool).toBe(true);
+  });
+
+  it("lets env vars opt out of default streaming encode", () => {
+    setEnv("PRODUCER_ENABLE_STREAMING_ENCODE", "false");
+
+    const config = resolveConfig();
+    expect(config.enableStreamingEncode).toBe(false);
   });
 
   it("treats non-'true' boolean env vars as false", () => {

--- a/packages/engine/src/config.ts
+++ b/packages/engine/src/config.ts
@@ -126,7 +126,7 @@ export const DEFAULT_CONFIG: EngineConfig = {
 
   enableChunkedEncode: false,
   chunkSizeFrames: 360,
-  enableStreamingEncode: false,
+  enableStreamingEncode: true,
 
   ffmpegEncodeTimeout: 600_000,
   ffmpegProcessTimeout: 300_000,

--- a/packages/engine/src/config.ts
+++ b/packages/engine/src/config.ts
@@ -48,6 +48,12 @@ export interface EngineConfig {
   enableChunkedEncode: boolean;
   chunkSizeFrames: number;
   enableStreamingEncode: boolean;
+  /**
+   * Max composition duration eligible for streaming encode (seconds).
+   * Mirrors GSAP rendering's 4-minute streaming guard: production has seen
+   * ffmpeg's streaming pipe hit FFMPEG_STREAMING_TIMEOUT_MS on longer videos.
+   */
+  streamingEncodeMaxDurationSeconds: number;
 
   // ── FFmpeg timeouts ──────────────────────────────────────────────────
   /** Timeout for FFmpeg frame encoding (ms). Default: 600_000 */
@@ -127,6 +133,7 @@ export const DEFAULT_CONFIG: EngineConfig = {
   enableChunkedEncode: false,
   chunkSizeFrames: 360,
   enableStreamingEncode: true,
+  streamingEncodeMaxDurationSeconds: 240,
 
   ffmpegEncodeTimeout: 600_000,
   ffmpegProcessTimeout: 300_000,
@@ -206,6 +213,13 @@ export function resolveConfig(overrides?: Partial<EngineConfig>): EngineConfig {
     enableStreamingEncode: envBool(
       "PRODUCER_ENABLE_STREAMING_ENCODE",
       DEFAULT_CONFIG.enableStreamingEncode,
+    ),
+    streamingEncodeMaxDurationSeconds: Math.max(
+      0,
+      envNum(
+        "PRODUCER_STREAMING_ENCODE_MAX_DURATION_SECONDS",
+        DEFAULT_CONFIG.streamingEncodeMaxDurationSeconds,
+      ),
     ),
 
     ffmpegEncodeTimeout: envNum("FFMPEG_ENCODE_TIMEOUT_MS", DEFAULT_CONFIG.ffmpegEncodeTimeout),

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -21,6 +21,7 @@ import {
   resolveRenderWorkerCount,
   selectCaptureCalibrationFrames,
   shouldFallbackToScreenshotAfterCalibrationError,
+  shouldUseStreamingEncode,
   writeCompiledArtifacts,
 } from "./renderOrchestrator.js";
 import { toExternalAssetKey } from "../utils/paths.js";
@@ -81,6 +82,23 @@ describe("extractStandaloneEntryFromIndex", () => {
     const extracted = extractStandaloneEntryFromIndex(indexHtml, "compositions/outro.html");
 
     expect(extracted).toBeNull();
+  });
+});
+
+describe("shouldUseStreamingEncode", () => {
+  it("enables streaming for default single-worker video renders", () => {
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1)).toBe(true);
+  });
+
+  it("lets config disable streaming encode", () => {
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: false }, "mp4", 1)).toBe(false);
+  });
+
+  it("keeps png-sequence and parallel capture on the non-streaming path", () => {
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "png-sequence", 1)).toBe(
+      false,
+    );
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 2)).toBe(false);
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -87,18 +87,25 @@ describe("extractStandaloneEntryFromIndex", () => {
 
 describe("shouldUseStreamingEncode", () => {
   it("enables streaming for default single-worker video renders", () => {
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1)).toBe(true);
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1, 240)).toBe(true);
   });
 
   it("lets config disable streaming encode", () => {
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: false }, "mp4", 1)).toBe(false);
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: false }, "mp4", 1, 240)).toBe(false);
   });
 
   it("keeps png-sequence and parallel capture on the non-streaming path", () => {
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "png-sequence", 1)).toBe(
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "png-sequence", 1, 240)).toBe(
       false,
     );
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 2)).toBe(false);
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 2, 240)).toBe(false);
+  });
+
+  it("keeps renders over four minutes on normal encoding", () => {
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1, 240)).toBe(true);
+    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1, 240.001)).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -86,26 +86,42 @@ describe("extractStandaloneEntryFromIndex", () => {
 });
 
 describe("shouldUseStreamingEncode", () => {
+  const streamingEnabledConfig = {
+    enableStreamingEncode: true,
+    streamingEncodeMaxDurationSeconds: 240,
+  };
+
   it("enables streaming for default single-worker video renders", () => {
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1, 240)).toBe(true);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 1, 240)).toBe(true);
   });
 
   it("lets config disable streaming encode", () => {
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: false }, "mp4", 1, 240)).toBe(false);
+    expect(
+      shouldUseStreamingEncode(
+        { enableStreamingEncode: false, streamingEncodeMaxDurationSeconds: 240 },
+        "mp4",
+        1,
+        240,
+      ),
+    ).toBe(false);
   });
 
   it("keeps png-sequence and parallel capture on the non-streaming path", () => {
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "png-sequence", 1, 240)).toBe(
-      false,
-    );
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 2, 240)).toBe(false);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "png-sequence", 1, 240)).toBe(false);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 240)).toBe(false);
   });
 
-  it("keeps renders over four minutes on normal encoding", () => {
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1, 240)).toBe(true);
-    expect(shouldUseStreamingEncode({ enableStreamingEncode: true }, "mp4", 1, 240.001)).toBe(
-      false,
-    );
+  it("keeps renders over the configured max duration on normal encoding", () => {
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 1, 240)).toBe(true);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 1, 240.001)).toBe(false);
+    expect(
+      shouldUseStreamingEncode(
+        { enableStreamingEncode: true, streamingEncodeMaxDurationSeconds: 120 },
+        "mp4",
+        1,
+        120.001,
+      ),
+    ).toBe(false);
   });
 });
 
@@ -241,9 +257,12 @@ function createConfig(): EngineConfig {
     enableChunkedEncode: false,
     chunkSizeFrames: 360,
     enableStreamingEncode: false,
+    streamingEncodeMaxDurationSeconds: 240,
     ffmpegEncodeTimeout: 600000,
     ffmpegProcessTimeout: 300000,
     ffmpegStreamingTimeout: 600000,
+    hdr: false,
+    hdrAutoDetect: true,
     audioGain: 1,
     frameDataUriCacheLimit: 256,
     playerReadyTimeout: 45000,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1710,6 +1710,34 @@ function normalizeCompositionSrcPath(srcPath: string): string {
   return srcPath.replace(/\\/g, "/").replace(/^\.\//, "");
 }
 
+function createStandaloneEntryRenderClone(root: Element, host: Element): Element {
+  const hostClone = host.cloneNode(true) as Element;
+  hostClone.setAttribute("data-start", "0");
+
+  if (root === host) return hostClone;
+
+  const rootClone = root.cloneNode(false) as Element;
+  rootClone.appendChild(hostClone);
+  return rootClone;
+}
+
+function replaceBodyWithRenderClone(body: HTMLElement, renderClone: Element): void {
+  while (body.firstChild) {
+    body.removeChild(body.firstChild);
+  }
+  body.appendChild(renderClone);
+}
+
+export function shouldUseStreamingEncode(
+  cfg: Pick<EngineConfig, "enableStreamingEncode">,
+  outputFormat: NonNullable<RenderConfig["format"]>,
+  workerCount: number,
+): boolean {
+  if (!cfg.enableStreamingEncode) return false;
+  if (outputFormat === "png-sequence") return false;
+  return workerCount === 1;
+}
+
 /**
  * Main render pipeline
  */
@@ -1737,19 +1765,8 @@ export function extractStandaloneEntryFromIndex(
     ) ?? null;
   if (!root) return null;
 
-  const hostClone = host.cloneNode(true) as Element;
-  hostClone.setAttribute("data-start", "0");
-
-  body.innerHTML = "";
-
-  if (root === host) {
-    body.appendChild(hostClone);
-    return document.toString();
-  }
-
-  const rootClone = root.cloneNode(false) as Element;
-  rootClone.appendChild(hostClone);
-  body.appendChild(rootClone);
+  const renderClone = createStandaloneEntryRenderClone(root, host);
+  replaceBodyWithRenderClone(body, renderClone);
 
   return document.toString();
 }
@@ -1783,7 +1800,7 @@ export async function executeRenderJob(
   let hdrPerf: HdrPerfCollector | undefined;
   const perfOutputPath = join(workDir, "perf-summary.json");
   const cfg = { ...(job.config.producerConfig ?? resolveConfig()) };
-  const outputFormat = (job.config.format ?? "mp4") as "mp4" | "webm" | "mov" | "png-sequence";
+  const outputFormat = (job.config.format ?? "mp4") as NonNullable<RenderConfig["format"]>;
   const isWebm = outputFormat === "webm";
   const isMov = outputFormat === "mov";
   const isPngSequence = outputFormat === "png-sequence";
@@ -1794,12 +1811,6 @@ export async function executeRenderJob(
   }
   const enableChunkedEncode = cfg.enableChunkedEncode;
   const chunkedEncodeSize = cfg.chunkSizeFrames;
-  // Streaming encode pipes captured frames through ffmpeg's stdin to produce
-  // a single video file. png-sequence has no encoded video output — frames go
-  // straight to disk — so the streaming branch is bypassed regardless of the
-  // engine config flag.
-  const enableStreamingEncode = cfg.enableStreamingEncode && !isPngSequence;
-
   // Periodic memory sampler — surfaces peak RSS/heap so the benchmark harness
   // can detect memory regressions (e.g. unbounded image-cache growth) that
   // wall-clock numbers miss. Sampled every 250ms; the interval is `unref`'d so
@@ -2509,6 +2520,13 @@ export async function executeRenderJob(
       await closeCaptureSession(probeSession);
       probeSession = null;
     }
+
+    // Streaming encode pipes captured frames through ffmpeg's stdin to produce
+    // a single video file. Keep the default enabled for sequential capture, but
+    // let auto-parallel renders use disk frames: the current ordered streaming
+    // writer would otherwise stall later workers behind earlier frame ranges.
+    // png-sequence has no encoded video output, so streaming is always bypassed.
+    const enableStreamingEncode = shouldUseStreamingEncode(cfg, outputFormat, workerCount);
 
     const captureAttempts: CaptureAttemptSummary[] = [];
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1728,13 +1728,18 @@ function replaceBodyWithRenderClone(body: HTMLElement, renderClone: Element): vo
   body.appendChild(renderClone);
 }
 
+const STREAMING_ENCODE_MAX_DURATION_SECONDS = 4 * 60;
+
 export function shouldUseStreamingEncode(
   cfg: Pick<EngineConfig, "enableStreamingEncode">,
   outputFormat: NonNullable<RenderConfig["format"]>,
   workerCount: number,
+  durationSeconds: number,
 ): boolean {
   if (!cfg.enableStreamingEncode) return false;
   if (outputFormat === "png-sequence") return false;
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return false;
+  if (durationSeconds > STREAMING_ENCODE_MAX_DURATION_SECONDS) return false;
   return workerCount === 1;
 }
 
@@ -2526,7 +2531,12 @@ export async function executeRenderJob(
     // let auto-parallel renders use disk frames: the current ordered streaming
     // writer would otherwise stall later workers behind earlier frame ranges.
     // png-sequence has no encoded video output, so streaming is always bypassed.
-    const enableStreamingEncode = shouldUseStreamingEncode(cfg, outputFormat, workerCount);
+    const enableStreamingEncode = shouldUseStreamingEncode(
+      cfg,
+      outputFormat,
+      workerCount,
+      job.duration,
+    );
 
     const captureAttempts: CaptureAttemptSummary[] = [];
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1728,18 +1728,17 @@ function replaceBodyWithRenderClone(body: HTMLElement, renderClone: Element): vo
   body.appendChild(renderClone);
 }
 
-const STREAMING_ENCODE_MAX_DURATION_SECONDS = 4 * 60;
-
 export function shouldUseStreamingEncode(
-  cfg: Pick<EngineConfig, "enableStreamingEncode">,
+  cfg: Pick<EngineConfig, "enableStreamingEncode" | "streamingEncodeMaxDurationSeconds">,
   outputFormat: NonNullable<RenderConfig["format"]>,
   workerCount: number,
+  // Composition timeline duration in seconds.
   durationSeconds: number,
 ): boolean {
   if (!cfg.enableStreamingEncode) return false;
   if (outputFormat === "png-sequence") return false;
   if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return false;
-  if (durationSeconds > STREAMING_ENCODE_MAX_DURATION_SECONDS) return false;
+  if (durationSeconds > cfg.streamingEncodeMaxDurationSeconds) return false;
   return workerCount === 1;
 }
 
@@ -2531,12 +2530,15 @@ export async function executeRenderJob(
     // let auto-parallel renders use disk frames: the current ordered streaming
     // writer would otherwise stall later workers behind earlier frame ranges.
     // png-sequence has no encoded video output, so streaming is always bypassed.
-    const enableStreamingEncode = shouldUseStreamingEncode(
-      cfg,
+    let useStreamingEncode = shouldUseStreamingEncode(cfg, outputFormat, workerCount, job.duration);
+    log.info("streaming-encode gate", {
+      enabled: useStreamingEncode,
+      configFlag: cfg.enableStreamingEncode,
       outputFormat,
       workerCount,
-      job.duration,
-    );
+      durationSeconds: job.duration,
+      maxDurationSeconds: cfg.streamingEncodeMaxDurationSeconds,
+    });
 
     const captureAttempts: CaptureAttemptSummary[] = [];
 
@@ -3347,30 +3349,50 @@ export async function executeRenderJob(
       let streamingEncoder: StreamingEncoder | null = null;
       let streamingEncoderClosed = false;
 
-      if (enableStreamingEncode) {
-        streamingEncoder = await spawnStreamingEncoder(
-          videoOnlyPath,
-          {
-            fps: job.config.fps,
-            width,
-            height,
-            codec: preset.codec,
-            preset: preset.preset,
-            quality: effectiveQuality,
-            bitrate: effectiveBitrate,
-            pixelFormat: preset.pixelFormat,
-            useGpu: job.config.useGpu,
-            imageFormat: captureOptions.format || "jpeg",
-            hdr: preset.hdr,
-          },
-          abortSignal,
-        );
-        assertNotAborted();
+      if (useStreamingEncode) {
+        try {
+          streamingEncoder = await spawnStreamingEncoder(
+            videoOnlyPath,
+            {
+              fps: job.config.fps,
+              width,
+              height,
+              codec: preset.codec,
+              preset: preset.preset,
+              quality: effectiveQuality,
+              bitrate: effectiveBitrate,
+              pixelFormat: preset.pixelFormat,
+              useGpu: job.config.useGpu,
+              imageFormat: captureOptions.format || "jpeg",
+              hdr: preset.hdr,
+            },
+            abortSignal,
+          );
+          assertNotAborted();
+        } catch (err) {
+          if (abortSignal?.aborted) {
+            if (streamingEncoder && !streamingEncoderClosed) {
+              await streamingEncoder.close().catch(() => {});
+              streamingEncoderClosed = true;
+            }
+            throw err;
+          }
+          useStreamingEncode = false;
+          streamingEncoder = null;
+          log.warn("[Render] Streaming encoder spawn failed; falling back to disk-frame encode.", {
+            error: err instanceof Error ? err.message : String(err),
+            outputFormat,
+            workerCount,
+            durationSeconds: job.duration,
+          });
+        }
       }
 
       try {
-        if (enableStreamingEncode && streamingEncoder) {
+        if (useStreamingEncode && streamingEncoder) {
           // ── Streaming capture + encode (Stage 4 absorbs Stage 5) ──────────
+          // Streaming encode is locked in here; capture retries may shrink
+          // workerCount later, but must not grow a streaming render past one worker.
           const reorderBuffer = createFrameReorderBuffer(0, totalFrames);
           const currentEncoder = streamingEncoder;
 


### PR DESCRIPTION
## Problem

Streaming encode is available, but `resolveConfig()` still defaulted it off, so sequential renders kept writing every captured frame to disk before encoding.

Production has also seen streaming encode fail on longer videos because the ffmpeg streaming process can hit its timeout. We need the same guard used in GSAP rendering: stream only for videos up to four minutes by default, make that cutoff operator-tunable, and use normal frame-dir encoding for longer videos.

The standalone sub-composition render extraction also mutated `body` before the final render subtree was fully assembled, which made the logic more fragile than necessary.

## What this fixes

- Defaults `enableStreamingEncode` to `true` in engine config while preserving `PRODUCER_ENABLE_STREAMING_ENCODE=false` as the opt-out.
- Adds `streamingEncodeMaxDurationSeconds` to `EngineConfig`, defaulting to `240`, with `PRODUCER_STREAMING_ENCODE_MAX_DURATION_SECONDS` as the env override.
- Logs the structured `streaming-encode gate` decision with config flag, format, worker count, duration seconds, max duration seconds, and result.
- Falls back to disk-frame encoding if spawning the streaming encoder fails before capture starts.
- Uses streaming encode for sequential video renders up to and including the configured max duration.
- Keeps renders over the configured max duration on normal encoding to avoid the long-running ffmpeg streaming timeout failure mode.
- Keeps auto-parallel and `png-sequence` renders on the existing disk-frame path.
- Builds the standalone-entry render clone off-DOM first, then swaps the body contents in one place.
- Adds unit coverage for the default, env opt-out, env cutoff, streaming-path gating, duration cutoff, and render-clone extraction behavior.

## Root cause

Streaming encode was configured as an opt-in experimental path, so default renders could not benefit from it. A straight global flip is not safe without guards:

- the current ordered streaming writer blocks later parallel workers behind earlier frame ranges, which can erase auto-parallel capture throughput
- long videos can keep the streaming ffmpeg process open long enough to trip `FFMPEG_STREAMING_TIMEOUT_MS`
- a failed streaming encoder spawn should not fail the whole render when the existing disk-frame path can still run

## Verification

### Local checks

- `bunx vitest run packages/engine/src/config.test.ts packages/producer/src/services/renderOrchestrator.test.ts`
- `bun run --filter @hyperframes/engine typecheck`
- `bun run --filter @hyperframes/producer typecheck`
- `bunx oxfmt --check packages/engine/src/config.ts packages/engine/src/config.test.ts packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/renderOrchestrator.test.ts`
- `bunx oxlint packages/engine/src/config.ts packages/engine/src/config.test.ts packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/renderOrchestrator.test.ts`
- `bun run --filter /producer build`
- `git diff --check`

### Render / Perf

- Opt-out benchmark: `PRODUCER_ENABLE_STREAMING_ENCODE=false bun run --filter @hyperframes/producer benchmark -- --only css-spinner-render-compat --runs 1`
  - `5719ms total`, `803ms encode`, `201MiB` peak RSS
- Naive global streaming benchmark before the parallel guard:
  - `8768ms total`, `7321ms encode`, `185MiB` peak RSS
- Guarded default benchmark after the fix:
  - `5509ms total`, `761ms encode`, `180MiB` peak RSS
- Default streaming render:
  - `bun packages/cli/src/cli.ts init /tmp/hf-streaming-rollout-proof --example blank --non-interactive --skip-skills`
  - `bun packages/cli/src/cli.ts render /tmp/hf-streaming-rollout-proof --workers 1 --fps 24 --quality draft --output /tmp/hf-streaming-rollout-proof-artifacts/output.mp4`
  - Log included `streaming-encode gate {"enabled":true,"configFlag":true,"outputFormat":"mp4","workerCount":1,"durationSeconds":10,"maxDurationSeconds":240}`
  - CLI displayed `Streaming frame 1/240` through `Streaming frame 240/240`
  - `ffprobe` confirmed H.264, `1920x1080`, `24/1`, `10.000000s`
- Env cutoff disk-frame render:
  - `PRODUCER_STREAMING_ENCODE_MAX_DURATION_SECONDS=1 bun packages/cli/src/cli.ts render /tmp/hf-streaming-rollout-proof --workers 1 --fps 24 --quality draft --output /tmp/hf-streaming-rollout-proof-artifacts/output-env-cutoff.mp4`
  - Log included `streaming-encode gate {"enabled":false,"configFlag":true,"outputFormat":"mp4","workerCount":1,"durationSeconds":10,"maxDurationSeconds":1}`
  - CLI displayed `Capturing frame 1/240` through `Capturing frame 240/240`, then `Encoding video`
  - `ffprobe` confirmed H.264, `1920x1080`, `24/1`, `10.000000s`

### Browser Verification

No browser UI changed. The render proofs exercised the headless browser capture path used by producer renders.

## Notes

The `enableStreamingEncode` gate now runs after auto-worker calibration, so it sees the final post-calibration worker count. The standalone render-clone extraction and `RenderConfig["format"]` type cleanup are readability/refactor pieces bundled with this branch; future changes like those should split out when they are not needed by the behavior change.

This intentionally does not enable streaming for auto-parallel renders yet. The next safe step would be a non-blocking ordered writer that lets parallel workers continue capturing while a single drain loop writes frames to ffmpeg in sequence.
