### PR TITLE
docs: add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,25 @@
+# Adopters
+
+This page lists organizations using HyperFrames in production or actively evaluating it. If your team is shipping with HyperFrames — whether you're rendering hundreds of videos a day, building agent-driven composition tooling, or experimenting with HTML-as-video for the first time — we'd love to hear about it.
+
+Adding your organization helps the community understand how HyperFrames is being used in the wild and makes it easier for new users to find peers solving similar problems.
+
+## How to add your organization
+
+Open a pull request that adds a row to the table below. Keep entries short:
+
+- **Organization** — your company or project name, linked to your website.
+- **Contact** — a GitHub handle or contact person who can answer questions about your usage.
+- **How HyperFrames is used** — one sentence on the use case (e.g., "Personalized video at scale," "Agent-authored marketing assets," "Slides-to-video pipeline").
+
+If you'd rather not be listed publicly, that's fine — drop a note in [our Discord](https://discord.gg/EbK98HBPdk) instead. We always like hearing about how the project is being used.
+
+## Production
+
+| Organization                     | Contact                                      | How HyperFrames is used                                                                    |
+| -------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+
+## Evaluating
+
+_Open a PR to add your organization here if you're trying HyperFrames in a non-production context._

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -1,0 +1,33 @@
+---
+title: Adopters
+description: Organizations using HyperFrames in production or actively evaluating it.
+---
+
+The teams below are shipping with HyperFrames. If your organization uses HyperFrames — in production, in evaluation, or in a side project — we'd love to add you.
+
+## How to add your organization
+
+Open a pull request that adds your team to [`ADOPTERS.md`](https://github.com/heygen-com/hyperframes/blob/main/ADOPTERS.md) at the repository root. The format is intentionally lightweight:
+
+- **Organization** — your company or project name, linked to your website.
+- **Contact** — a GitHub handle so other adopters can reach out.
+- **How HyperFrames is used** — one sentence on the use case.
+- **Logo** _(optional)_ — a square logo or icon to show on this page. If you skip this, your entry still appears in the table below.
+
+If you'd rather not be listed publicly, we'd still love to hear about your usage — drop a note in [our Discord](https://discord.gg/EbK98HBPdk).
+
+## Production
+
+<CardGroup cols={3}>
+  <Card title="HeyGen" href="https://www.heygen.com">
+    Powers AI-generated video composition and rendering across HeyGen's video product surface.
+  </Card>
+</CardGroup>
+
+| Organization                     | Contact                                      | How HyperFrames is used                                                                    |
+| -------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+
+## Evaluating
+
+_Open a PR to add your organization here if you're trying HyperFrames in a non-production context._

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -204,6 +204,12 @@
               "contributing/release-channels",
               "contributing/testing-local-changes"
             ]
+          },
+          {
+            "group": "Community",
+            "pages": [
+              "community/adopters"
+            ]
           }
         ]
       }


### PR DESCRIPTION
## What

Adds a top-level `ADOPTERS.md` listing organizations using HyperFrames in production or actively evaluating it. HeyGen is the first entry.

## Why

Two reasons:

1. *Discoverability for new users.* People evaluating HyperFrames want to know who's actually shipping with it — having a public, low-friction list makes it easier for them to find peers solving similar problems.
2. *Community signal.* Gives the project a visible record of where it's being used in the wild, which helps newcomers calibrate fit and gives existing users a place to see they're not alone.

## How others can add their organization

Open a PR with one row in the table — Organization, Contact, and a one-sentence use case. The format is intentionally lightweight; anyone whose team uses HyperFrames is welcome to self-add. Orgs that prefer not to be listed publicly can reach out via Discord instead.

## Test plan

- [x] `bunx oxfmt --check ADOPTERS.md` passes
- [x] commitlint conventional-commit format passes
- [ ] Reviewer eyeballs the HeyGen entry — wording is open to tweaks before merge

— Rames Jusso