### PR TITLE
fix: speed up video frame injection renders

### DIFF
--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -74,6 +74,47 @@ export interface CaptureSession {
 // Circular buffer for browser console messages dumped on render failure diagnostics.
 // Complex compositions produce 100+ messages; 50 was too small to capture relevant errors.
 const BROWSER_CONSOLE_BUFFER_SIZE = 200;
+const CAPTURE_SESSION_CLOSE_TIMEOUT_MS = 5_000;
+
+async function waitForCloseWithTimeout(promise: Promise<unknown>): Promise<boolean> {
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    promise.then(
+      () => undefined,
+      () => undefined,
+    ),
+    new Promise<void>((resolve) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+        resolve();
+      }, CAPTURE_SESSION_CLOSE_TIMEOUT_MS);
+    }),
+  ]);
+  if (timer) clearTimeout(timer);
+  return !timedOut;
+}
+
+function forceKillBrowserProcess(browser: Browser): void {
+  const browserProcess = (
+    browser as unknown as {
+      process?: () => { kill: (signal?: NodeJS.Signals) => boolean; killed?: boolean } | null;
+    }
+  ).process?.();
+
+  if (browserProcess && !browserProcess.killed) {
+    try {
+      browserProcess.kill("SIGKILL");
+    } catch {
+      // Best-effort cleanup after Puppeteer close has already timed out.
+    }
+  }
+  try {
+    browser.disconnect();
+  } catch {
+    // Best-effort cleanup after Puppeteer close has already timed out.
+  }
+}
 
 export async function createCaptureSession(
   serverUrl: string,
@@ -674,11 +715,21 @@ export async function closeCaptureSession(session: CaptureSession): Promise<void
   // but browserReleased=false → second call no-ops on page and retries browser.
   // This matches the orchestrator's intent for HDR cleanup.
   if (!session.pageReleased && session.page) {
-    await session.page.close().catch(() => {});
+    const pageClosed = await waitForCloseWithTimeout(session.page.close());
+    if (!pageClosed) {
+      console.warn("[FrameCapture] Timed out closing page; forcing browser process shutdown");
+      forceKillBrowserProcess(session.browser);
+    }
     session.pageReleased = true;
   }
   if (!session.browserReleased && session.browser) {
-    await releaseBrowser(session.browser, session.config);
+    const browserClosed = await waitForCloseWithTimeout(
+      releaseBrowser(session.browser, session.config),
+    );
+    if (!browserClosed) {
+      console.warn("[FrameCapture] Timed out closing browser; forcing browser process shutdown");
+      forceKillBrowserProcess(session.browser);
+    }
     session.browserReleased = true;
   }
   session.isInitialized = false;

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -446,13 +446,15 @@ export async function injectVideoFramesBatch(
           }
         }
         img.decoding = "sync";
-        img.src = item.dataUri;
-        pendingDecodes.push(
-          img
-            .decode()
-            .catch(() => undefined)
-            .then(() => undefined),
-        );
+        if (img.getAttribute("src") !== item.dataUri) {
+          img.src = item.dataUri;
+          pendingDecodes.push(
+            img
+              .decode()
+              .catch(() => undefined)
+              .then(() => undefined),
+          );
+        }
         img.style.opacity = String(computedOpacity);
         img.style.visibility = "visible";
         // Hide the native <video> with visibility only — never clobber inline

--- a/packages/engine/src/services/videoFrameInjector.ts
+++ b/packages/engine/src/services/videoFrameInjector.ts
@@ -14,7 +14,16 @@ import { injectVideoFramesBatch, syncVideoFrameVisibility } from "./screenshotSe
 import { type BeforeCaptureHook } from "./frameCapture.js";
 import { DEFAULT_CONFIG, type EngineConfig } from "../config.js";
 
-function createFrameDataUriCache(cacheLimit: number) {
+export interface VideoFrameInjectorOptions extends Partial<
+  Pick<EngineConfig, "frameDataUriCacheLimit">
+> {
+  frameSrcResolver?: (framePath: string) => string | null;
+}
+
+function createFrameSourceCache(
+  cacheLimit: number,
+  frameSrcResolver?: (framePath: string) => string | null,
+) {
   const cache = new Map<string, string>();
   const inFlight = new Map<string, Promise<string>>();
 
@@ -33,6 +42,9 @@ function createFrameDataUriCache(cacheLimit: number) {
   }
 
   async function get(framePath: string): Promise<string> {
+    const servedSrc = frameSrcResolver?.(framePath);
+    if (servedSrc) return servedSrc;
+
     const cached = cache.get(framePath);
     if (cached) {
       remember(framePath, cached);
@@ -67,7 +79,7 @@ function createFrameDataUriCache(cacheLimit: number) {
  */
 export function createVideoFrameInjector(
   frameLookup: FrameLookupTable | null,
-  config?: Partial<Pick<EngineConfig, "frameDataUriCacheLimit">>,
+  config?: VideoFrameInjectorOptions,
 ): BeforeCaptureHook | null {
   if (!frameLookup) return null;
 
@@ -75,7 +87,7 @@ export function createVideoFrameInjector(
     32,
     config?.frameDataUriCacheLimit ?? DEFAULT_CONFIG.frameDataUriCacheLimit,
   );
-  const frameCache = createFrameDataUriCache(cacheLimit);
+  const frameCache = createFrameSourceCache(cacheLimit, config?.frameSrcResolver);
   const lastInjectedFrameByVideo = new Map<string, number>();
 
   return async (page: Page, time: number) => {

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -416,6 +416,30 @@ describe("resolveRenderWorkerCount", () => {
 
     expect(workers).toBe(1);
   });
+
+  it("keeps baseline auto workers after screenshot fallback when measured capture is cheap", () => {
+    const log = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    const workers = resolveRenderWorkerCount(
+      180,
+      undefined,
+      { ...cfg, forceScreenshot: true },
+      {
+        hasShaderTransitions: false,
+        renderModeHints: { recommendScreenshot: false, reasons: [] },
+      },
+      log,
+      { multiplier: 1, reasons: [], p95Ms: 180 },
+    );
+
+    expect(workers).toBe(6);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
 });
 
 describe("estimateCaptureCostMultiplier", () => {

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -11,6 +11,7 @@ import {
   collectVideoMetadataHints,
   collectVideoReadinessSkipIds,
   createCaptureCalibrationConfig,
+  createCompiledFrameSrcResolver,
   estimateMeasuredCaptureCostMultiplier,
   estimateCaptureCostMultiplier,
   extractStandaloneEntryFromIndex,
@@ -122,6 +123,22 @@ describe("shouldUseStreamingEncode", () => {
         120.001,
       ),
     ).toBe(false);
+  });
+});
+
+describe("createCompiledFrameSrcResolver", () => {
+  it("maps extracted frame paths under compiledDir to encoded server URLs", () => {
+    const resolver = createCompiledFrameSrcResolver("/tmp/hf job/compiled");
+
+    expect(
+      resolver("/tmp/hf job/compiled/__hyperframes_video_frames/video 1/frame_00001.jpg"),
+    ).toBe("/__hyperframes_video_frames/video%201/frame_00001.jpg");
+  });
+
+  it("returns null for paths outside compiledDir", () => {
+    const resolver = createCompiledFrameSrcResolver("/tmp/hf-job/compiled");
+
+    expect(resolver("/tmp/hf-job/video-frames/frame_00001.jpg")).toBeNull();
   });
 });
 
@@ -337,15 +354,6 @@ describe("collectVideoMetadataHints", () => {
 
 describe("resolveRenderWorkerCount", () => {
   const cfg = { ...createConfig(), coresPerWorker: 100 };
-  const audio = {
-    id: "narration",
-    src: "narration.wav",
-    start: 0,
-    end: 3,
-    mediaStart: 0,
-    layer: 9,
-    type: "audio" as const,
-  };
 
   it("reduces auto workers for expensive capture workloads", () => {
     const log = {
@@ -363,7 +371,6 @@ describe("resolveRenderWorkerCount", () => {
         hasShaderTransitions: true,
         renderModeHints: { recommendScreenshot: false, reasons: [] },
       },
-      { videos: [], audios: [audio] },
       log,
     );
 
@@ -387,7 +394,6 @@ describe("resolveRenderWorkerCount", () => {
         hasShaderTransitions: true,
         renderModeHints: { recommendScreenshot: false, reasons: [] },
       },
-      { videos: [], audios: [audio] },
       log,
     );
 
@@ -404,7 +410,6 @@ describe("resolveRenderWorkerCount", () => {
         hasShaderTransitions: false,
         renderModeHints: { recommendScreenshot: false, reasons: [] },
       },
-      { videos: [], audios: [] },
       undefined,
       { multiplier: 4, reasons: ["calibration-p95=2400ms"] },
     );
@@ -414,33 +419,17 @@ describe("resolveRenderWorkerCount", () => {
 });
 
 describe("estimateCaptureCostMultiplier", () => {
-  it("weights shader transitions, media, and render mode hints", () => {
-    const cost = estimateCaptureCostMultiplier(
-      {
-        hasShaderTransitions: true,
-        renderModeHints: {
-          recommendScreenshot: true,
-          reasons: [{ code: "requestAnimationFrame", message: "raw rAF" }],
-        },
+  it("weights shader transitions and render mode hints without charging static media cost", () => {
+    const cost = estimateCaptureCostMultiplier({
+      hasShaderTransitions: true,
+      renderModeHints: {
+        recommendScreenshot: true,
+        reasons: [{ code: "requestAnimationFrame", message: "raw rAF" }],
       },
-      {
-        videos: [],
-        audios: [
-          {
-            id: "narration",
-            src: "narration.wav",
-            start: 0,
-            end: 3,
-            mediaStart: 0,
-            layer: 9,
-            type: "audio" as const,
-          },
-        ],
-      },
-    );
+    });
 
-    expect(cost.multiplier).toBe(4.75);
-    expect(cost.reasons).toEqual(["shader-transitions", "requestAnimationFrame", "1 audio"]);
+    expect(cost.multiplier).toBe(4);
+    expect(cost.reasons).toEqual(["shader-transitions", "requestAnimationFrame"]);
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -989,6 +989,37 @@ async function measureCaptureCostFromSession(
   };
 }
 
+function logCaptureCalibrationResult(
+  calibration: { estimate: CaptureCostEstimate; samples: CaptureCalibrationSample[] },
+  log: ProducerLogger,
+): void {
+  if (calibration.estimate.multiplier > 1) {
+    log.warn("[Render] Measured slow frame capture during auto-worker calibration.", {
+      multiplier: calibration.estimate.multiplier,
+      p95Ms: calibration.estimate.p95Ms,
+      sampledFrames: calibration.samples.map((sample) => sample.frameIndex),
+    });
+  } else {
+    log.debug("[Render] Auto-worker calibration kept baseline capture cost.", {
+      p95Ms: calibration.estimate.p95Ms,
+      sampledFrames: calibration.samples.map((sample) => sample.frameIndex),
+    });
+  }
+}
+
+function createFailedCaptureCalibrationEstimate(reason: string): {
+  estimate: CaptureCostEstimate;
+  samples: CaptureCalibrationSample[];
+} {
+  return {
+    estimate: {
+      multiplier: MAX_MEASURED_CAPTURE_COST_MULTIPLIER,
+      reasons: [reason],
+    },
+    samples: [],
+  };
+}
+
 async function executeDiskCaptureWithAdaptiveRetry(options: {
   serverUrl: string;
   workDir: string;
@@ -2439,7 +2470,6 @@ export async function executeRenderJob(
           samples: CaptureCalibrationSample[];
         }
       | undefined;
-    let switchedToScreenshotAfterCalibration = false;
 
     if (job.config.workers === undefined && totalFrames >= 60) {
       const calibrationDir = join(workDir, "capture-calibration");
@@ -2464,48 +2494,66 @@ export async function executeRenderJob(
           totalFrames,
           job.config.fps,
         );
-        if (captureCalibration.estimate.multiplier > 1) {
-          log.warn("[Render] Measured slow frame capture during auto-worker calibration.", {
-            multiplier: captureCalibration.estimate.multiplier,
-            p95Ms: captureCalibration.estimate.p95Ms,
-            sampledFrames: captureCalibration.samples.map((sample) => sample.frameIndex),
-          });
-        } else {
-          log.debug("[Render] Auto-worker calibration kept baseline capture cost.", {
-            p95Ms: captureCalibration.estimate.p95Ms,
-            sampledFrames: captureCalibration.samples.map((sample) => sample.frameIndex),
-          });
-        }
+        logCaptureCalibrationResult(captureCalibration, log);
       } catch (error) {
         const shouldFallbackToScreenshot =
           !cfg.forceScreenshot && shouldFallbackToScreenshotAfterCalibrationError(error);
         if (shouldFallbackToScreenshot) {
           cfg.forceScreenshot = true;
-          switchedToScreenshotAfterCalibration = true;
           if (probeSession) {
             lastBrowserConsole = probeSession.browserConsoleBuffer;
             await closeCaptureSession(probeSession).catch(() => {});
             probeSession = null;
           }
-        }
-        captureCalibration = {
-          estimate: {
-            multiplier: MAX_MEASURED_CAPTURE_COST_MULTIPLIER,
-            reasons: shouldFallbackToScreenshot
-              ? ["calibration-beginframe-timeout", "screenshot-fallback"]
-              : ["calibration-failed"],
-          },
-          samples: [],
-        };
-        if (shouldFallbackToScreenshot) {
+          if (calibrationSession) {
+            lastBrowserConsole = calibrationSession.browserConsoleBuffer;
+            await closeCaptureSession(calibrationSession).catch(() => {});
+            calibrationSession = null;
+          }
+
           log.warn(
-            "[Render] BeginFrame auto-worker calibration timed out; falling back to screenshot capture mode.",
+            "[Render] BeginFrame auto-worker calibration timed out; retrying calibration in screenshot capture mode.",
             {
               protocolTimeout: calibrationCfg.protocolTimeout,
               error: error instanceof Error ? error.message : String(error),
             },
           );
+
+          const screenshotCalibrationCfg = createCaptureCalibrationConfig(cfg);
+          try {
+            calibrationSession = await createCaptureSession(
+              fileServer.url,
+              join(workDir, "capture-calibration-screenshot"),
+              buildCaptureOptions(),
+              createRenderVideoFrameInjector(),
+              screenshotCalibrationCfg,
+            );
+            if (!calibrationSession.isInitialized) {
+              await initializeSession(calibrationSession);
+            }
+            assertNotAborted();
+
+            captureCalibration = await measureCaptureCostFromSession(
+              calibrationSession,
+              totalFrames,
+              job.config.fps,
+            );
+            logCaptureCalibrationResult(captureCalibration, log);
+          } catch (fallbackError) {
+            captureCalibration = createFailedCaptureCalibrationEstimate(
+              "calibration-screenshot-failed",
+            );
+            log.warn(
+              "[Render] Screenshot auto-worker calibration failed after BeginFrame fallback; using conservative worker budget.",
+              {
+                protocolTimeout: screenshotCalibrationCfg.protocolTimeout,
+                error:
+                  fallbackError instanceof Error ? fallbackError.message : String(fallbackError),
+              },
+            );
+          }
         } else {
+          captureCalibration = createFailedCaptureCalibrationEstimate("calibration-failed");
           log.warn("[Render] Auto-worker calibration failed; using conservative worker budget.", {
             protocolTimeout: calibrationCfg.protocolTimeout,
             error: error instanceof Error ? error.message : String(error),
@@ -2527,10 +2575,6 @@ export async function executeRenderJob(
       log,
       captureCalibration?.estimate,
     );
-
-    if (switchedToScreenshotAfterCalibration && workerCount > 1) {
-      workerCount = 1;
-    }
 
     if (workerCount > 1 && probeSession) {
       lastBrowserConsole = probeSession.browserConsoleBuffer;

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -93,7 +93,7 @@ import {
   type ElementStackingInfo,
   type HfTransitionMeta,
 } from "@hyperframes/engine";
-import { join, dirname, resolve } from "path";
+import { join, dirname, resolve, relative, isAbsolute } from "path";
 import { randomUUID } from "crypto";
 import { freemem } from "os";
 import { fileURLToPath } from "url";
@@ -665,6 +665,26 @@ export function writeCompiledArtifacts(
   }
 }
 
+export function createCompiledFrameSrcResolver(
+  compiledDir: string,
+): (framePath: string) => string | null {
+  const compiledRoot = resolve(compiledDir);
+  return (framePath: string): string | null => {
+    const resolvedFramePath = resolve(framePath);
+    if (!isPathInside(resolvedFramePath, compiledRoot)) return null;
+
+    const relativePath = relative(compiledRoot, resolvedFramePath);
+    if (!relativePath || relativePath.startsWith("..") || isAbsolute(relativePath)) {
+      return null;
+    }
+
+    return `/${relativePath
+      .split(/[\\/]+/)
+      .map((segment) => encodeURIComponent(segment))
+      .join("/")}`;
+  };
+}
+
 export function applyRenderModeHints(
   cfg: EngineConfig,
   compiled: CompiledComposition,
@@ -728,12 +748,11 @@ export function resolveRenderWorkerCount(
   requestedWorkers: number | undefined,
   cfg: EngineConfig,
   compiled: Pick<CompiledComposition, "hasShaderTransitions" | "renderModeHints">,
-  composition: Pick<CompositionMetadata, "videos" | "audios">,
   log: ProducerLogger = defaultLogger,
   measuredCaptureCost?: CaptureCostEstimate,
 ): number {
   const captureCost = combineCaptureCostEstimates(
-    estimateCaptureCostMultiplier(compiled, composition),
+    estimateCaptureCostMultiplier(compiled),
     measuredCaptureCost,
   );
   const workerCount = calculateOptimalWorkers(totalFrames, requestedWorkers, {
@@ -763,7 +782,6 @@ export function resolveRenderWorkerCount(
 
 export function estimateCaptureCostMultiplier(
   compiled: Pick<CompiledComposition, "hasShaderTransitions" | "renderModeHints">,
-  composition: Pick<CompositionMetadata, "videos" | "audios">,
 ): CaptureCostEstimate {
   let multiplier = 1;
   const reasons: string[] = [];
@@ -781,16 +799,6 @@ export function estimateCaptureCostMultiplier(
   if (reasonCodes.has("iframe")) {
     multiplier += 0.5;
     reasons.push("iframe");
-  }
-
-  if (composition.videos.length > 0) {
-    multiplier += Math.min(2, composition.videos.length * 0.75);
-    reasons.push(`${composition.videos.length} video${composition.videos.length === 1 ? "" : "s"}`);
-  }
-
-  if (composition.audios.length > 0) {
-    multiplier += Math.min(1, composition.audios.length * 0.75);
-    reasons.push(`${composition.audios.length} audio${composition.audios.length === 1 ? "" : "s"}`);
   }
 
   return {
@@ -2248,7 +2256,7 @@ export async function executeRenderJob(
       extractionResult = await extractAllVideoFrames(
         composition.videos,
         projectDir,
-        { fps: job.config.fps, outputDir: join(workDir, "video-frames") },
+        { fps: job.config.fps, outputDir: join(compiledDir, "__hyperframes_video_frames") },
         abortSignal,
         { extractCacheDir: cfg.extractCacheDir },
         compiledDir,
@@ -2418,6 +2426,12 @@ export async function executeRenderJob(
       videoMetadataHints,
       skipReadinessVideoIds: videoReadinessSkipIds,
     });
+    const frameSrcResolver = createCompiledFrameSrcResolver(compiledDir);
+    const createRenderVideoFrameInjector = (): BeforeCaptureHook | null =>
+      createVideoFrameInjector(frameLookup, {
+        frameDataUriCacheLimit: cfg.frameDataUriCacheLimit,
+        frameSrcResolver,
+      });
 
     let captureCalibration:
       | {
@@ -2430,7 +2444,7 @@ export async function executeRenderJob(
     if (job.config.workers === undefined && totalFrames >= 60) {
       const calibrationDir = join(workDir, "capture-calibration");
       const calibrationCfg = createCaptureCalibrationConfig(cfg);
-      const videoInjector = createVideoFrameInjector(frameLookup);
+      const videoInjector = createRenderVideoFrameInjector();
       let calibrationSession: CaptureSession | null = null;
       try {
         calibrationSession = await createCaptureSession(
@@ -2510,7 +2524,6 @@ export async function executeRenderJob(
       job.config.workers,
       cfg,
       compiled,
-      composition,
       log,
       captureCalibration?.estimate,
     );
@@ -2646,7 +2659,7 @@ export async function executeRenderJob(
         fileServer.url,
         framesDir,
         buildCaptureOptions(),
-        createVideoFrameInjector(frameLookup),
+        createRenderVideoFrameInjector(),
         cfg,
       );
       // Track lifecycle of resources spawned during HDR rendering so the
@@ -3411,7 +3424,7 @@ export async function executeRenderJob(
               workDir,
               tasks,
               buildCaptureOptions(),
-              () => createVideoFrameInjector(frameLookup),
+              createRenderVideoFrameInjector,
               abortSignal,
               (progress) => {
                 job.framesRendered = progress.capturedFrames;
@@ -3443,7 +3456,7 @@ export async function executeRenderJob(
           } else {
             // Sequential capture → streaming encode
 
-            const videoInjector = createVideoFrameInjector(frameLookup);
+            const videoInjector = createRenderVideoFrameInjector();
             const session =
               probeSession ??
               (await createCaptureSession(
@@ -3515,7 +3528,7 @@ export async function executeRenderJob(
               allowRetry: job.config.workers === undefined,
               frameExt: needsAlpha ? "png" : "jpg",
               captureOptions: buildCaptureOptions(),
-              createBeforeCaptureHook: () => createVideoFrameInjector(frameLookup),
+              createBeforeCaptureHook: createRenderVideoFrameInjector,
               abortSignal,
               onProgress: (progress) => {
                 job.framesRendered = progress.capturedFrames;
@@ -3551,7 +3564,7 @@ export async function executeRenderJob(
           } else {
             // Sequential capture
 
-            const videoInjector = createVideoFrameInjector(frameLookup);
+            const videoInjector = createRenderVideoFrameInjector();
             const session =
               probeSession ??
               (await createCaptureSession(


### PR DESCRIPTION
## Problem

A real HyperFrames wrapper project with a 19-second video asset was rendering much slower than expected on local macOS. On the reproduced fixture, auto calibration became extremely expensive, the renderer reduced itself to one worker, and the render path fell far behind an equivalent Remotion implementation.

A Linux repro later showed a second path to the same bad outcome: BeginFrame calibration can time out, switch the job to screenshot mode, and still leave the worker budget clamped to one even when screenshot capture itself is healthy.

## What this fixes

- Serves extracted video frames from the compiled render file server instead of converting every injected frame to a base64 data URI.
- Reuses an already-applied frame source in the browser instead of reassigning and decoding the same image source repeatedly.
- Stops treating ordinary static video/audio presence as a reason to reduce auto worker count; measured calibration still reduces workers for genuinely expensive captures.
- Retries auto-worker calibration in screenshot mode after BeginFrame calibration timeout, instead of immediately assigning the maximum measured capture cost.
- Removes the hard one-worker clamp after BeginFrame fallback; screenshot fallback now uses the measured screenshot calibration result.
- Adds bounded browser/page close handling so a timed-out Puppeteer close cannot leave the CLI hanging after a successful render.

## Root cause

The video-frame injection path forced extracted frames through disk reads and base64 data URIs during capture. On high-resolution video-wrapper compositions, that made calibration look dramatically slower than the actual visual workload, so auto worker selection collapsed from the expected parallel path to a single worker.

Separately, BeginFrame calibration failures were treated as proof that the whole capture workload was expensive. That was too conservative after switching to screenshot mode: the fallback mode may be perfectly capable of parallel capture, but the old logic assigned multiplier `8` and then hard-clamped workers to `1` before measuring it.

## Verification

### Local

- `bunx oxlint packages/engine/src/services/frameCapture.ts packages/engine/src/services/screenshotService.ts packages/engine/src/services/videoFrameInjector.ts packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/renderOrchestrator.test.ts`
- `bunx oxfmt --check packages/engine/src/services/frameCapture.ts packages/engine/src/services/screenshotService.ts packages/engine/src/services/videoFrameInjector.ts packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/renderOrchestrator.test.ts`
- `bunx vitest run packages/producer/src/services/renderOrchestrator.test.ts packages/engine/src/config.test.ts`
- `bun run --filter @hyperframes/engine typecheck`
- `bun run --filter @hyperframes/producer typecheck`
- `bun run --filter @hyperframes/producer build`
- `bun run --filter @hyperframes/cli build`
- Built CLI smoke render of the shortened external fixture produced a valid 1080x1920 H.264/AAC MP4 and left no Puppeteer Chrome process behind.
- After the fallback-calibration follow-up, the same shortened built-CLI smoke completed in `12.85s` on macOS screenshot mode.

### Browser

- Used `agent-browser` to open the full patched render output in Chrome, play it through to `18.9s`, and verify the browser-reported video dimensions were `1080x1920`.
- Saved a browser screenshot and recording from that pass locally.

## Notes

Reproduced against `iswangwenbin/hyperframes-video-wrapper` at commit `f04c3dd`.

Measured on the same machine before the Linux follow-up:

- Current HyperFrames main with explicit `workers:5`: about `410s`.
- Patched HyperFrames auto-worker producer render: about `129s` internal render time, with 5 workers selected.
- Equivalent Remotion fixture using `@remotion/cli@4.0.455`, `OffthreadVideo`, and concurrency 7: about `374s` wall time.

Follow-up Linux repro feedback showed that the initial patch did remove false video/audio worker-cost terms, but BeginFrame timeout plus screenshot fallback still dominated there. This PR now handles that path by recalibrating in screenshot mode and only using the conservative multiplier if screenshot calibration also fails.

The source fixture still warns about sparse keyframes (`max interval: 8.33s`), so re-encoding the input remains recommended for reliable seeking, but this PR removes the renderer-side bottlenecks exposed by that project.
