### PR TITLE
feat(registry): add experimental-orbit-theater block

### DIFF
--- a/registry/blocks/experimental-orbit-theater/experimental-orbit-theater.html
+++ b/registry/blocks/experimental-orbit-theater/experimental-orbit-theater.html
@@ -1,0 +1,909 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=1920, height=1080">
+<title>Orbit Theater</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/build/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/examples/js/shaders/CopyShader.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/examples/js/shaders/LuminosityHighPassShader.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/examples/js/postprocessing/EffectComposer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/examples/js/postprocessing/RenderPass.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/examples/js/postprocessing/ShaderPass.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/examples/js/postprocessing/UnrealBloomPass.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.147.0/examples/js/controls/OrbitControls.js"></script>
+<style>
+  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #000; overflow: hidden; font-family: 'Inter', system-ui, sans-serif; }
+
+  #root {
+    position: relative;
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    background: #000;
+  }
+
+  #theater {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1920px;
+    height: 1080px;
+  }
+
+  .panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    overflow: hidden;
+    background: #0a0a0f;
+    color: #fff;
+  }
+
+  .hero-dashboard {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: linear-gradient(135deg, #0a0a1a 0%, #111128 100%);
+  }
+  .hero-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 24px 40px;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .hero-logo {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+    background: linear-gradient(135deg, #6366f1, #a855f7);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .hero-nav { display: flex; gap: 32px; }
+  .hero-nav span { font-size: 14px; color: rgba(255,255,255,0.5); font-weight: 500; }
+  .hero-nav span.active { color: #fff; }
+  .hero-body { display: flex; flex: 1; }
+  .hero-sidebar {
+    width: 240px;
+    padding: 32px 20px;
+    border-right: 1px solid rgba(255,255,255,0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .sidebar-item {
+    padding: 10px 16px;
+    border-radius: 8px;
+    font-size: 14px;
+    color: rgba(255,255,255,0.5);
+    font-weight: 500;
+  }
+  .sidebar-item.active {
+    background: rgba(99, 102, 241, 0.15);
+    color: #818cf8;
+  }
+  .hero-main { flex: 1; padding: 32px 40px; }
+  .hero-title { font-size: 28px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; }
+  .hero-subtitle { font-size: 14px; color: rgba(255,255,255,0.4); margin-bottom: 32px; }
+  .metrics-row { display: flex; gap: 20px; margin-bottom: 32px; }
+  .metric-card {
+    flex: 1;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 12px;
+    padding: 20px 24px;
+  }
+  .metric-label { font-size: 12px; color: rgba(255,255,255,0.4); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px; }
+  .metric-value { font-size: 32px; font-weight: 700; letter-spacing: -1px; }
+  .metric-value.accent { color: #6366f1; }
+  .metric-change { font-size: 12px; color: #34d399; margin-top: 4px; }
+  .chart-area {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 12px;
+    height: 320px;
+    display: flex;
+    align-items: flex-end;
+    padding: 24px;
+    gap: 6px;
+  }
+  .chart-bar {
+    flex: 1;
+    background: linear-gradient(to top, #6366f1, #a855f7);
+    border-radius: 4px 4px 0 0;
+    min-height: 20px;
+    opacity: 0.8;
+  }
+
+  .features-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    padding: 60px;
+    height: 100%;
+    align-content: center;
+    background: linear-gradient(135deg, #0a0a1a 0%, #0f172a 100%);
+  }
+  .feature-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 16px;
+    padding: 32px;
+  }
+  .feature-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #6366f1, #a855f7);
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+  }
+  .feature-name { font-size: 20px; font-weight: 600; margin-bottom: 8px; }
+  .feature-desc { font-size: 14px; color: rgba(255,255,255,0.5); line-height: 1.6; }
+
+  .pricing-section {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    height: 100%;
+    padding: 60px;
+    background: linear-gradient(135deg, #0a0a1a 0%, #1a0a2e 100%);
+  }
+  .pricing-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 20px;
+    padding: 40px 36px;
+    width: 300px;
+    text-align: center;
+  }
+  .pricing-card.featured {
+    background: linear-gradient(135deg, rgba(99,102,241,0.15), rgba(168,85,247,0.15));
+    border-color: rgba(99,102,241,0.3);
+    transform: scale(1.05);
+  }
+  .pricing-tier { font-size: 14px; text-transform: uppercase; letter-spacing: 2px; color: rgba(255,255,255,0.5); margin-bottom: 12px; }
+  .pricing-amount { font-size: 48px; font-weight: 800; letter-spacing: -2px; margin-bottom: 8px; }
+  .pricing-period { font-size: 14px; color: rgba(255,255,255,0.4); margin-bottom: 24px; }
+  .pricing-features { list-style: none; text-align: left; margin-bottom: 32px; }
+  .pricing-features li { padding: 8px 0; font-size: 14px; color: rgba(255,255,255,0.6); border-bottom: 1px solid rgba(255,255,255,0.06); }
+  .pricing-cta {
+    display: inline-block;
+    padding: 12px 32px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    background: rgba(255,255,255,0.1);
+    color: #fff;
+    border: none;
+  }
+  .pricing-card.featured .pricing-cta {
+    background: linear-gradient(135deg, #6366f1, #a855f7);
+  }
+
+  #error-overlay {
+    position: absolute;
+    inset: 0;
+    background: #000;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    flex-direction: column;
+    gap: 16px;
+  }
+  #error-overlay.visible { display: flex; }
+  #error-overlay h2 { font-size: 24px; color: #fff; font-weight: 600; }
+  #error-overlay p { font-size: 14px; color: rgba(255,255,255,0.5); max-width: 480px; text-align: center; line-height: 1.6; }
+  #error-overlay code { background: rgba(255,255,255,0.1); padding: 2px 8px; border-radius: 4px; font-size: 13px; }
+</style>
+</head>
+<body>
+<div id="root"
+     data-composition-id="orbit-theater"
+     data-width="1920"
+     data-height="1080"
+     data-start="0"
+     data-duration="20"
+     data-root="true">
+
+  <canvas id="cap-0" layoutsubtree width="1920" height="1080" style="position:absolute;top:0;left:0;width:1920px;height:1080px;z-index:-1;pointer-events:none">
+    <section class="panel" id="panel-hero"
+             data-panel-start="2" data-panel-duration="4"
+             style="width:1920px;height:1080px">
+      <div class="hero-dashboard">
+        <div class="hero-topbar">
+          <div class="hero-logo">Acme Analytics</div>
+          <div class="hero-nav">
+            <span class="active">Dashboard</span>
+            <span>Reports</span>
+            <span>Settings</span>
+            <span>Team</span>
+          </div>
+        </div>
+        <div class="hero-body">
+          <div class="hero-sidebar">
+            <div class="sidebar-item active">Overview</div>
+            <div class="sidebar-item">Revenue</div>
+            <div class="sidebar-item">Users</div>
+            <div class="sidebar-item">Funnels</div>
+            <div class="sidebar-item">Retention</div>
+            <div class="sidebar-item">Events</div>
+          </div>
+          <div class="hero-main">
+            <div class="hero-title">Dashboard</div>
+            <div class="hero-subtitle">Last 30 days performance overview</div>
+            <div class="metrics-row">
+              <div class="metric-card">
+                <div class="metric-label">Revenue</div>
+                <div class="metric-value accent">$84.2K</div>
+                <div class="metric-change">+12.5% vs last month</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-label">Active Users</div>
+                <div class="metric-value">24,521</div>
+                <div class="metric-change">+8.3% vs last month</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-label">Conversion</div>
+                <div class="metric-value">3.42%</div>
+                <div class="metric-change">+0.8% vs last month</div>
+              </div>
+              <div class="metric-card">
+                <div class="metric-label">Avg. Session</div>
+                <div class="metric-value">4m 12s</div>
+                <div class="metric-change">+15s vs last month</div>
+              </div>
+            </div>
+            <div class="chart-area" id="hero-chart"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </canvas>
+  <canvas id="cap-1" layoutsubtree width="1920" height="1080" style="position:absolute;top:0;left:0;width:1920px;height:1080px;z-index:-1;pointer-events:none">
+    <section class="panel" id="panel-features"
+             data-panel-start="7" data-panel-duration="4"
+             style="width:1920px;height:1080px">
+      <div class="features-grid">
+        <div class="feature-card">
+          <div class="feature-icon">&#9889;</div>
+          <div class="feature-name">Real-time Analytics</div>
+          <div class="feature-desc">Sub-second query latency across billions of events. No sampling, no approximations — exact counts, always.</div>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">&#128274;</div>
+          <div class="feature-name">Privacy-first</div>
+          <div class="feature-desc">SOC2 Type II certified. All data encrypted at rest and in transit. GDPR and CCPA compliant by default.</div>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">&#128268;</div>
+          <div class="feature-name">Integrations</div>
+          <div class="feature-desc">Connect to 200+ tools out of the box. Segment, Amplitude, Mixpanel — import your existing data in minutes.</div>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">&#129302;</div>
+          <div class="feature-name">AI Insights</div>
+          <div class="feature-desc">Anomaly detection, trend forecasting, and natural language queries. Ask your data anything in plain English.</div>
+        </div>
+      </div>
+    </section>
+  </canvas>
+  <canvas id="cap-2" layoutsubtree width="1920" height="1080" style="position:absolute;top:0;left:0;width:1920px;height:1080px;z-index:-1;pointer-events:none">
+    <section class="panel" id="panel-pricing"
+             data-panel-start="12" data-panel-duration="4"
+             style="width:1920px;height:1080px">
+      <div class="pricing-section">
+        <div class="pricing-card">
+          <div class="pricing-tier">Starter</div>
+          <div class="pricing-amount">$29</div>
+          <div class="pricing-period">per month</div>
+          <ul class="pricing-features">
+            <li>10K events / month</li>
+            <li>3 team members</li>
+            <li>7-day retention</li>
+            <li>Email support</li>
+          </ul>
+          <button class="pricing-cta">Get Started</button>
+        </div>
+        <div class="pricing-card featured">
+          <div class="pricing-tier">Pro</div>
+          <div class="pricing-amount">$99</div>
+          <div class="pricing-period">per month</div>
+          <ul class="pricing-features">
+            <li>1M events / month</li>
+            <li>Unlimited members</li>
+            <li>12-month retention</li>
+            <li>Priority support</li>
+          </ul>
+          <button class="pricing-cta">Start Free Trial</button>
+        </div>
+        <div class="pricing-card">
+          <div class="pricing-tier">Enterprise</div>
+          <div class="pricing-amount">Custom</div>
+          <div class="pricing-period">contact sales</div>
+          <ul class="pricing-features">
+            <li>Unlimited events</li>
+            <li>SSO &amp; SAML</li>
+            <li>Unlimited retention</li>
+            <li>Dedicated CSM</li>
+          </ul>
+          <button class="pricing-cta">Contact Sales</button>
+        </div>
+      </div>
+    </section>
+  </canvas>
+
+  <canvas id="theater" width="1920" height="1080" style="position:absolute;top:0;left:0;width:1920px;height:1080px"></canvas>
+
+  <div id="error-overlay">
+    <h2>HTML-in-Canvas Required</h2>
+    <p>This composition requires the experimental CanvasDrawElement API. Enable it in Chrome or Brave:</p>
+    <p><code>chrome://flags/#canvas-draw-element</code></p>
+  </div>
+
+  <div id="driver"
+       class="clip"
+       data-start="0"
+       data-duration="20"
+       data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none">
+  </div>
+</div>
+
+<script>
+var theaterCanvas = document.getElementById("theater");
+var W = 1920, H = 1080;
+
+// ── Feature Detection ──────────────────────────────────────────────
+function isSupported() {
+  if (!("layoutSubtree" in document.createElement("canvas"))) return false;
+  var tc = document.createElement("canvas");
+  tc.setAttribute("layoutsubtree", "");
+  var ctx = tc.getContext("2d");
+  return ctx && typeof ctx.drawElementImage === "function";
+}
+
+if (!isSupported()) {
+  document.getElementById("error-overlay").classList.add("visible");
+}
+
+// ── Generate chart bars ────────────────────────────────────────────
+var chartArea = document.getElementById("hero-chart");
+if (chartArea) {
+  var heights = [40,55,35,65,80,60,45,70,90,75,55,85,65,50,72,88,62,78,95,68,82,58,74,92,70,60,85,78,90,72];
+  for (var h = 0; h < heights.length; h++) {
+    var bar = document.createElement("div");
+    bar.className = "chart-bar";
+    bar.style.height = heights[h] + "%";
+    chartArea.appendChild(bar);
+  }
+}
+
+// ── Parse Panels ───────────────────────────────────────────────────
+var capCanvases = [document.getElementById("cap-0"), document.getElementById("cap-1"), document.getElementById("cap-2")];
+var capContexts = capCanvases.map(function(c) { return c.getContext("2d"); });
+var panels = Array.from(document.querySelectorAll("section.panel"));
+var panelData = [];
+for (var p = 0; p < panels.length; p++) {
+  panelData.push({
+    el: panels[p],
+    id: panels[p].id,
+    start: parseFloat(panels[p].getAttribute("data-panel-start")),
+    duration: parseFloat(panels[p].getAttribute("data-panel-duration")),
+    isHero: p === 0
+  });
+}
+
+// ── Custom Shader Definitions ──────────────────────────────────────
+var BokehShader = {
+  uniforms: {
+    tDiffuse: { value: null },
+    tDepth: { value: null },
+    focus: { value: 3.5 },
+    aperture: { value: 0.015 },
+    maxblur: { value: 0.01 },
+    nearClip: { value: 0.1 },
+    farClip: { value: 100.0 },
+    aspect: { value: W / H }
+  },
+  vertexShader: [
+    "varying vec2 vUv;",
+    "void main() {",
+    "  vUv = uv;",
+    "  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);",
+    "}"
+  ].join("\n"),
+  fragmentShader: [
+    "uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDepth;",
+    "uniform float focus;",
+    "uniform float aperture;",
+    "uniform float maxblur;",
+    "uniform float nearClip;",
+    "uniform float farClip;",
+    "uniform float aspect;",
+    "varying vec2 vUv;",
+    "float getDepth(vec2 coord) {",
+    "  float d = texture2D(tDepth, coord).x;",
+    "  float z = nearClip * farClip / (farClip - d * (farClip - nearClip));",
+    "  return z;",
+    "}",
+    "void main() {",
+    "  float depth = getDepth(vUv);",
+    "  float coc = clamp(abs(depth - focus) * aperture, 0.0, maxblur);",
+    "  vec4 color = vec4(0.0);",
+    "  float total = 0.0;",
+    "  for (float x = -4.0; x <= 4.0; x += 1.0) {",
+    "    for (float y = -4.0; y <= 4.0; y += 1.0) {",
+    "      vec2 offset = vec2(x, y * aspect) * coc * 0.002;",
+    "      float w = 1.0 - length(vec2(x, y)) / 5.66;",
+    "      if (w > 0.0) {",
+    "        color += texture2D(tDiffuse, vUv + offset) * w;",
+    "        total += w;",
+    "      }",
+    "    }",
+    "  }",
+    "  gl_FragColor = color / total;",
+    "}"
+  ].join("\n")
+};
+
+var ChromaticAberrationShader = {
+  uniforms: {
+    tDiffuse: { value: null },
+    intensity: { value: 0.003 }
+  },
+  vertexShader: [
+    "varying vec2 vUv;",
+    "void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }"
+  ].join("\n"),
+  fragmentShader: [
+    "uniform sampler2D tDiffuse;",
+    "uniform float intensity;",
+    "varying vec2 vUv;",
+    "void main() {",
+    "  vec2 dir = vUv - 0.5;",
+    "  float d = length(dir);",
+    "  vec2 offset = dir * d * intensity;",
+    "  float r = texture2D(tDiffuse, vUv + offset).r;",
+    "  float g = texture2D(tDiffuse, vUv).g;",
+    "  float b = texture2D(tDiffuse, vUv - offset).b;",
+    "  gl_FragColor = vec4(r, g, b, 1.0);",
+    "}"
+  ].join("\n")
+};
+
+var FilmGrainVignetteShader = {
+  uniforms: {
+    tDiffuse: { value: null },
+    time: { value: 0.0 },
+    grainIntensity: { value: 0.03 },
+    vignetteStrength: { value: 0.2 },
+    vignetteSoftness: { value: 0.8 }
+  },
+  vertexShader: [
+    "varying vec2 vUv;",
+    "void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }"
+  ].join("\n"),
+  fragmentShader: [
+    "uniform sampler2D tDiffuse;",
+    "uniform float time;",
+    "uniform float grainIntensity;",
+    "uniform float vignetteStrength;",
+    "uniform float vignetteSoftness;",
+    "varying vec2 vUv;",
+    "float rand(vec2 co) { return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453); }",
+    "void main() {",
+    "  vec4 color = texture2D(tDiffuse, vUv);",
+    "  float grain = rand(vUv * 1000.0 + time) * 2.0 - 1.0;",
+    "  color.rgb += grain * grainIntensity;",
+    "  float dist = length(vUv - 0.5) * 1.4;",
+    "  float vignette = smoothstep(1.0, 1.0 - vignetteSoftness, dist * (1.0 + vignetteStrength));",
+    "  color.rgb *= vignette;",
+    "  gl_FragColor = color;",
+    "}"
+  ].join("\n")
+};
+
+var VolumetricLightShader = {
+  uniforms: {
+    tDiffuse: { value: null },
+    lightPos: { value: new THREE.Vector2(0.5, 0.3) },
+    exposure: { value: 0.08 },
+    decay: { value: 0.96 },
+    density: { value: 0.8 },
+    weight: { value: 0.4 }
+  },
+  vertexShader: [
+    "varying vec2 vUv;",
+    "void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }"
+  ].join("\n"),
+  fragmentShader: [
+    "uniform sampler2D tDiffuse;",
+    "uniform vec2 lightPos;",
+    "uniform float exposure;",
+    "uniform float decay;",
+    "uniform float density;",
+    "uniform float weight;",
+    "varying vec2 vUv;",
+    "void main() {",
+    "  vec2 deltaUV = (vUv - lightPos) * density / 60.0;",
+    "  vec2 coord = vUv;",
+    "  vec4 color = texture2D(tDiffuse, vUv);",
+    "  float illumination = 1.0;",
+    "  vec4 godray = vec4(0.0);",
+    "  for (int i = 0; i < 60; i++) {",
+    "    coord -= deltaUV;",
+    "    vec4 s = texture2D(tDiffuse, coord);",
+    "    s *= illumination * weight;",
+    "    godray += s;",
+    "    illumination *= decay;",
+    "  }",
+    "  gl_FragColor = color + godray * exposure;",
+    "}"
+  ].join("\n")
+};
+
+// ── Three.js Scene Setup ───────────────────────────────────────────
+var renderer = new THREE.WebGLRenderer({
+  canvas: theaterCanvas,
+  antialias: true,
+  alpha: false,
+  powerPreference: "high-performance",
+  preserveDrawingBuffer: true
+});
+renderer.setSize(W, H, false);
+renderer.setPixelRatio(1);
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.0;
+renderer.setClearColor(0x000000, 1);
+renderer.outputEncoding = THREE.sRGBEncoding;
+
+var scene = new THREE.Scene();
+var camera = new THREE.PerspectiveCamera(45, W / H, 0.1, 100);
+camera.position.set(0, 0, 5);
+camera.lookAt(0, 0, 0);
+
+// ── Texture Pipeline (texElementImage2D → manual GL textures) ──────
+var panelsReady = false;
+
+// ── Panel Meshes + Textures ────────────────────────────────────────
+var PANEL_ASPECT = W / H;
+var PANEL_WIDTH = 3.0;
+var PANEL_HEIGHT = PANEL_WIDTH / PANEL_ASPECT;
+var RAIL_RADIUS = 6;
+var RAIL_ARC = Math.PI * 0.55;
+
+var panelMeshes = [];
+var panelTextures = [];
+
+for (var i = 0; i < panelData.length; i++) {
+  (function(pd, idx) {
+    var geometry = new THREE.PlaneGeometry(PANEL_WIDTH, PANEL_HEIGHT);
+
+    var texture = new THREE.CanvasTexture(capCanvases[idx]);
+    texture.minFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+    texture.generateMipmaps = false;
+
+    var material = new THREE.MeshBasicMaterial({
+      map: texture,
+      side: THREE.FrontSide
+    });
+    var mesh = new THREE.Mesh(geometry, material);
+
+    if (pd.isHero) {
+      mesh.position.set(0, 0, 0);
+    } else {
+      var surroundCount = panelData.length - 1;
+      var si = idx - 1;
+      var t = surroundCount === 1 ? 0.5 : si / (surroundCount - 1);
+      var angle = (t - 0.5) * RAIL_ARC;
+      mesh.position.set(
+        Math.sin(angle) * RAIL_RADIUS,
+        0,
+        -(RAIL_RADIUS - Math.cos(angle) * RAIL_RADIUS) - 1.5
+      );
+      mesh.lookAt(0, 0, 2);
+    }
+
+    scene.add(mesh);
+
+    var edgeThickness = 0.02;
+    var edgeDepth = 0.05;
+    var edgeShape = new THREE.Shape();
+    var pw = PANEL_WIDTH / 2 + edgeThickness;
+    var ph = PANEL_HEIGHT / 2 + edgeThickness;
+    var iw = PANEL_WIDTH / 2;
+    var ih = PANEL_HEIGHT / 2;
+    edgeShape.moveTo(-pw, -ph);
+    edgeShape.lineTo(pw, -ph);
+    edgeShape.lineTo(pw, ph);
+    edgeShape.lineTo(-pw, ph);
+    edgeShape.lineTo(-pw, -ph);
+    var hole = new THREE.Path();
+    hole.moveTo(-iw, -ih);
+    hole.lineTo(iw, -ih);
+    hole.lineTo(iw, ih);
+    hole.lineTo(-iw, ih);
+    hole.lineTo(-iw, -ih);
+    edgeShape.holes.push(hole);
+    var edgeGeo = new THREE.ExtrudeGeometry(edgeShape, { depth: edgeDepth, bevelEnabled: false });
+    var glassMat = new THREE.MeshPhysicalMaterial({
+      color: 0xffffff,
+      transmission: 0.9,
+      roughness: 0.1,
+      thickness: 0.5,
+      ior: 1.5,
+      clearcoat: 1.0,
+      clearcoatRoughness: 0.1
+    });
+    var edgeMesh = new THREE.Mesh(edgeGeo, glassMat);
+    edgeMesh.position.copy(mesh.position);
+    edgeMesh.rotation.copy(mesh.rotation);
+    edgeMesh.translateZ(-edgeDepth / 2);
+    scene.add(edgeMesh);
+
+    panelMeshes.push(mesh);
+    panelTextures.push(texture);
+  })(panelData[i], i);
+}
+
+function capturePanels() {
+  for (var ci = 0; ci < panels.length; ci++) {
+    capContexts[ci].clearRect(0, 0, W, H);
+    capContexts[ci].drawElementImage(panels[ci], 0, 0, W, H);
+    panelTextures[ci].needsUpdate = true;
+  }
+}
+
+// ── Scene Lighting ─────────────────────────────────────────────────
+scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+var keyLight = new THREE.PointLight(0x6366f1, 2, 20);
+keyLight.position.set(0, 3, 5);
+scene.add(keyLight);
+var fillLight = new THREE.PointLight(0xa855f7, 1, 15);
+fillLight.position.set(-3, -1, 3);
+scene.add(fillLight);
+
+// ── Reflection Plane ───────────────────────────────────────────────
+var reflectionY = -(PANEL_HEIGHT / 2) - 0.3;
+var reflectorGeo = new THREE.PlaneGeometry(30, 30);
+var reflectorMat = new THREE.MeshStandardMaterial({
+  color: 0x000000,
+  roughness: 0.15,
+  metalness: 0.9,
+  transparent: true,
+  opacity: 0.4
+});
+var reflector = new THREE.Mesh(reflectorGeo, reflectorMat);
+reflector.rotation.x = -Math.PI / 2;
+reflector.position.y = reflectionY;
+scene.add(reflector);
+
+var mirrorGroup = new THREE.Group();
+mirrorGroup.scale.y = -1;
+mirrorGroup.position.y = reflectionY * 2;
+scene.add(mirrorGroup);
+
+for (var m = 0; m < panelData.length; m++) {
+  var mirrorMesh = new THREE.Mesh(
+    panelMeshes[m].geometry,
+    new THREE.MeshBasicMaterial({
+      map: panelTextures[m],
+      transparent: true,
+      opacity: 0.25,
+      side: THREE.FrontSide
+    })
+  );
+  mirrorMesh.position.copy(panelMeshes[m].position);
+  mirrorMesh.rotation.copy(panelMeshes[m].rotation);
+  mirrorGroup.add(mirrorMesh);
+}
+
+// ── Depth Render Target ────────────────────────────────────────────
+var depthRT = new THREE.WebGLRenderTarget(W, H, {
+  minFilter: THREE.NearestFilter,
+  magFilter: THREE.NearestFilter,
+  type: THREE.FloatType
+});
+depthRT.depthTexture = new THREE.DepthTexture(W, H);
+depthRT.depthTexture.type = THREE.FloatType;
+
+// ── EffectComposer ─────────────────────────────────────────────────
+var composer = new THREE.EffectComposer(renderer);
+composer.addPass(new THREE.RenderPass(scene, camera));
+
+var bokehPass = new THREE.ShaderPass(BokehShader);
+bokehPass.uniforms.tDepth.value = depthRT.depthTexture;
+composer.addPass(bokehPass);
+
+var bloomPass = new THREE.UnrealBloomPass(new THREE.Vector2(W, H), 0.3, 0.4, 0.2);
+composer.addPass(bloomPass);
+
+var chromaPass = new THREE.ShaderPass(ChromaticAberrationShader);
+composer.addPass(chromaPass);
+
+var volumetricPass = new THREE.ShaderPass(VolumetricLightShader);
+composer.addPass(volumetricPass);
+
+var filmPass = new THREE.ShaderPass(FilmGrainVignetteShader);
+composer.addPass(filmPass);
+
+// Capture deferred to after first layout via setTimeout
+
+// ── Camera Choreography ────────────────────────────────────────────
+var ROOT_DURATION = parseFloat(document.getElementById("root").getAttribute("data-duration"));
+
+var cameraTargets = [];
+for (var ct = 0; ct < panelData.length; ct++) {
+  var mesh = panelMeshes[ct];
+  var pos = mesh.position.clone();
+  var focalDist = panelData[ct].isHero ? 3.5 : 4.5;
+  var dir = new THREE.Vector3(0, 0, 1).applyQuaternion(mesh.quaternion);
+  var camPos = pos.clone().add(dir.multiplyScalar(focalDist));
+  camPos.y += 0.2;
+  cameraTargets.push({ position: camPos, lookAt: pos.clone(), panel: panelData[ct] });
+}
+
+var heroTarget = cameraTargets[0];
+var tightOnHero = {
+  position: heroTarget.position.clone().multiplyScalar(0.65),
+  lookAt: heroTarget.lookAt.clone()
+};
+tightOnHero.position.y = 0.1;
+
+var wideShot = {
+  position: new THREE.Vector3(0, 1.2, 8),
+  lookAt: new THREE.Vector3(0, -0.2, 0)
+};
+
+var camState = {
+  px: tightOnHero.position.x,
+  py: tightOnHero.position.y,
+  pz: tightOnHero.position.z,
+  lx: tightOnHero.lookAt.x,
+  ly: tightOnHero.lookAt.y,
+  lz: tightOnHero.lookAt.z,
+  focalDepth: 3.5
+};
+var prevPx = camState.px, prevPz = camState.pz;
+
+// ── GSAP Timeline ──────────────────────────────────────────────────
+window.__timelines = window.__timelines || {};
+var tl = gsap.timeline({ paused: true });
+
+tl.to({ v: 0 }, { v: 1, duration: ROOT_DURATION, ease: "none" }, 0);
+
+tl.set(camState, {
+  px: tightOnHero.position.x,
+  py: tightOnHero.position.y,
+  pz: tightOnHero.position.z,
+  lx: tightOnHero.lookAt.x,
+  ly: tightOnHero.lookAt.y,
+  lz: tightOnHero.lookAt.z
+}, 0);
+
+tl.to(camState, {
+  px: wideShot.position.x,
+  py: wideShot.position.y,
+  pz: wideShot.position.z,
+  lx: wideShot.lookAt.x,
+  ly: wideShot.lookAt.y,
+  lz: wideShot.lookAt.z,
+  duration: 1.5,
+  ease: "power2.inOut"
+}, 0.5);
+
+for (var ci = 0; ci < panelData.length; ci++) {
+  var target = cameraTargets[ci];
+  var td = 1.5;
+  var arriveAt = Math.max(panelData[ci].start - td * 0.5, 2);
+  tl.to(camState, {
+    px: target.position.x,
+    py: target.position.y,
+    pz: target.position.z,
+    lx: target.lookAt.x,
+    ly: target.lookAt.y,
+    lz: target.lookAt.z,
+    focalDepth: panelData[ci].isHero ? 3.5 : target.position.distanceTo(target.lookAt),
+    duration: td,
+    ease: "power2.inOut"
+  }, arriveAt);
+}
+
+var lastPanel = panelData[panelData.length - 1];
+var closingStart = lastPanel.start + lastPanel.duration + 0.5;
+tl.to(camState, {
+  px: heroTarget.position.x,
+  py: heroTarget.position.y,
+  pz: heroTarget.position.z,
+  lx: heroTarget.lookAt.x,
+  ly: heroTarget.lookAt.y,
+  lz: heroTarget.lookAt.z,
+  focalDepth: 3.5,
+  duration: 2,
+  ease: "power2.inOut"
+}, closingStart);
+
+// ── Interactive Orbit Mode ─────────────────────────────────────────
+var orbitControls = new THREE.OrbitControls(camera, theaterCanvas);
+orbitControls.enableDamping = true;
+orbitControls.dampingFactor = 0.05;
+orbitControls.enableZoom = true;
+orbitControls.minDistance = 2;
+orbitControls.maxDistance = 15;
+orbitControls.enabled = false;
+var orbitMode = false;
+
+document.addEventListener("keydown", function(e) {
+  if (e.code !== "Space") return;
+  e.preventDefault();
+  orbitMode = !orbitMode;
+  orbitControls.enabled = orbitMode;
+  if (orbitMode) {
+    orbitControls.target.set(camState.lx, camState.ly, camState.lz);
+    orbitControls.update();
+    tl.pause();
+  } else {
+    tl.resume();
+  }
+});
+
+// ── Render on timeline update ──────────────────────────────────────
+tl.eventCallback("onUpdate", function() {
+  if (panelsReady) capturePanels();
+
+  camState._velX = camState.px - prevPx;
+  camState._velZ = camState.pz - prevPz;
+  prevPx = camState.px;
+  prevPz = camState.pz;
+
+  if (orbitMode) {
+    orbitControls.update();
+  } else {
+    camera.position.set(camState.px, camState.py, camState.pz);
+    camera.lookAt(camState.lx, camState.ly, camState.lz);
+  }
+
+  reflector.visible = false;
+  mirrorGroup.visible = false;
+  renderer.setRenderTarget(depthRT);
+  renderer.render(scene, camera);
+  renderer.setRenderTarget(null);
+  reflector.visible = true;
+  mirrorGroup.visible = true;
+
+  bokehPass.uniforms.focus.value = camState.focalDepth;
+  filmPass.uniforms.time.value = tl.time();
+
+  if (!orbitMode) {
+    var vel = Math.abs(camState._velX || 0) + Math.abs(camState._velZ || 0);
+    chromaPass.uniforms.intensity.value = 0.001 + Math.min(vel * 0.01, 0.004);
+  } else {
+    chromaPass.uniforms.intensity.value = 0.001;
+  }
+
+  composer.render();
+});
+
+window.__timelines["orbit-theater"] = tl;
+
+// Defer first render to after browser layout pass
+setTimeout(function() {
+  panelsReady = true;
+  tl.seek(0);
+}, 0);
+</script>
+</body>
+</html>

--- a/registry/blocks/experimental-orbit-theater/registry-item.json
+++ b/registry/blocks/experimental-orbit-theater/registry-item.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "experimental-orbit-theater",
+  "type": "hyperframes:block",
+  "title": "Orbit Theater",
+  "description": "Cinematic 3D spatial UI showcase. Live HTML panels float in WebGL space with depth of field, bloom, glass reflections, and volumetric lighting. Requires Chrome/Brave with CanvasDrawElement flag.",
+  "stability": "experimental",
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 20,
+  "tags": ["html-in-canvas", "webgl", "3d", "spatial", "cinematic", "product-showcase"],
+  "files": [
+    {
+      "path": "experimental-orbit-theater.html",
+      "target": "compositions/experimental-orbit-theater.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -218,6 +218,7 @@
     {
       "name": "transitions-scale",
       "type": "hyperframes:block"
-    }
+    },
+    { "name": "experimental-orbit-theater", "type": "hyperframes:block" }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `experimental-orbit-theater` — a cinematic 3D spatial UI showcase block using the HTML-in-Canvas API (`drawElementImage()` + `layoutsubtree`)
- Live HTML panels rendered as WebGL textures via Three.js r147, floating in a 3D scene with full post-processing pipeline (bloom, DoF, chromatic aberration, volumetric light, film grain, vignette)
- Glass edges (MeshPhysicalMaterial), reflection plane, and GSAP-driven camera autopilot derived from composition timing
- Interactive orbit mode via spacebar for live demos
- Enables `--enable-features=CanvasDrawElement` in engine Chrome args
- Requires Chrome/Brave with CanvasDrawElement flag — `stability: "experimental"` in registry metadata

## What it does

Users paste their product UI as HTML panel sections, and the component automatically:
1. Captures each panel via `drawElementImage()` on 2D canvas contexts
2. Projects them as textures onto Three.js geometry (flat hero + curved rail)
3. Generates a cinematic camera path from `data-panel-start`/`data-panel-duration` attributes
4. Applies a full GPU post-processing chain
5. Opens with a hero-first reveal, visits each panel, returns to hero

## Test plan

- [ ] Enable `chrome://flags/#canvas-draw-element` in Chrome/Brave
- [ ] Run `hyperframes preview` on the block directory
- [ ] Verify 3D scene renders with visible HTML panel textures
- [ ] Play timeline — camera should animate through all panels
- [ ] Press spacebar — orbit mode should activate/deactivate
- [ ] Run `hyperframes lint` — should pass with 0 errors
- [ ] Without the flag: error overlay should appear