### PR TITLE
fix(security): remove double URL decode enabling path traversal

### DIFF
--- a/packages/core/src/studio-api/routes/files.ts
+++ b/packages/core/src/studio-api/routes/files.ts
@@ -41,7 +41,7 @@ async function resolveProjectFile(
     return { error: c.json({ error: "not found" }, 404) } as const;
   }
 
-  const filePath = decodeURIComponent(c.req.path.replace(`/projects/${project.id}/files/`, ""));
+  const filePath = c.req.path.replace(`/projects/${project.id}/files/`, "");
   if (filePath.includes("\0")) {
     return { error: c.json({ error: "forbidden" }, 403) } as const;
   }
@@ -193,9 +193,8 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
     const project = await adapter.resolveProject(id);
     if (!project) return c.json({ error: "not found" }, 404);
 
-    const filePath = decodeURIComponent(
-      c.req.path.replace(`/projects/${project.id}/file-mutations/remove-element/`, ""),
-    );
+    const filePath =
+      c.req.path.replace(`/projects/${project.id}/file-mutations/remove-element/`, "");
     if (filePath.includes("\0")) {
       return c.json({ error: "forbidden" }, 403);
     }


### PR DESCRIPTION
## Summary
- Remove redundant `decodeURIComponent()` calls in `files.ts` that enable path traversal via double-encoded sequences
- Hono's router already decodes path parameters once; the explicit `decodeURIComponent` decoded a second time, allowing `%252e%252e%252f` to become `../` and bypass `isSafePath`

## Details

**Affected file:** `packages/core/src/studio-api/routes/files.ts` (lines 44, 196)

A request to `/projects/1/files/%252e%252e%252f%252e%252e%252fetc/passwd` would:
1. Be decoded by Hono to `/projects/1/files/%2e%2e%2f%2e%2e%2fetc/passwd`
2. After stripping the prefix, `decodeURIComponent` decodes `%2e%2e%2f%2e%2e%2f` to `../../etc/passwd`
3. The `isSafePath` check passes because the resolved path appears to be `../../etc/passwd` relative to `project.dir`

The same vulnerability exists in the `remove-element` route.

## Test plan
- [ ] Verify normal file operations still work (read, write, delete)
- [ ] Verify double-encoded paths like `%252e%252e%252f` are blocked by isSafePath
- [ ] Verify single-encoded paths like `%2e%2e%2f` are also blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)