### PR TITLE
fix: delay ObjectURL revocation to prevent failed downloads

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -872,7 +872,7 @@ export function StudioApp() {
         document.body.appendChild(link);
         link.click();
         link.remove();
-        setTimeout(() => URL.revokeObjectURL(blobUrl), 0);
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Capture failed";
         showToast(message);


### PR DESCRIPTION
## Summary
- Delay `URL.revokeObjectURL` from 0ms to 1000ms in frame capture download
- `setTimeout(..., 0)` revokes the blob URL before the browser initiates the download, causing empty/failed downloads

## Details

**Affected file:** `packages/studio/src/App.tsx` (line 875)

When capturing a frame, the code creates a blob URL, triggers a download via `link.click()`, then immediately schedules `revokeObjectURL` with `setTimeout(..., 0)`. The 0ms timeout fires on the next microtask, before the browser has started reading from the blob, resulting in a failed or empty download.

## Test plan
- [ ] Capture a frame in the studio and verify the download completes successfully
- [ ] Verify the blob URL is eventually cleaned up (no memory leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)