### PR TITLE
fix: read refs inside setTimeout to prevent stale closure in debounced save

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -637,7 +637,10 @@ export function StudioApp() {
     // Debounce the server write (600ms)
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      fetch(`/api/projects/${pid}/files/${encodeURIComponent(path)}`, {
+      const currentPid = projectIdRef.current;
+      const currentPath = editingPathRef.current;
+      if (!currentPid || !currentPath) return;
+      fetch(`/api/projects/${currentPid}/files/${encodeURIComponent(currentPath)}`, {
         method: "PUT",
         headers: { "Content-Type": "text/plain" },
         body: content,


### PR DESCRIPTION
## Summary
- Fix stale closure bug in `handleContentChange` where the debounced save writes content to the wrong file
- `projectId` and `filePath` were captured from refs at scheduling time; if the user switches files during the 600ms debounce window, the save writes to the previous file

## Details

**Affected file:** `packages/studio/src/App.tsx` (lines 631-651)

The `setTimeout` closure captured `pid` and `path` from the outer scope at the time the timeout was scheduled. If the user edits file A, then switches to file B within 600ms, the debounced save would write file B's content to file A's path.

The fix moves the ref reads inside the `setTimeout` callback so they always reflect the current state at execution time.

## Test plan
- [ ] Edit file A, quickly switch to file B (< 600ms), verify file A is unchanged and file B has the new content
- [ ] Verify normal editing and saving still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)