### PR TITLE
fix: prevent SourceEditor recreation on every keystroke

### DIFF
--- a/packages/studio/src/components/editor/SourceEditor.tsx
+++ b/packages/studio/src/components/editor/SourceEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, memo } from "react";
+import { useRef, useCallback, useEffect, memo } from "react";
 import {
   EditorView,
   keymap,
@@ -69,6 +69,9 @@ export const SourceEditor = memo(function SourceEditor({
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
+  const contentRef = useRef(content);
+  contentRef.current = content;
+
   const mountEditor = useCallback(
     (node: HTMLDivElement | null) => {
       if (editorRef.current) {
@@ -87,7 +90,7 @@ export const SourceEditor = memo(function SourceEditor({
       });
 
       const state = EditorState.create({
-        doc: content,
+        doc: contentRef.current,
         extensions: [
           lineNumbers(),
           highlightActiveLine(),
@@ -112,8 +115,22 @@ export const SourceEditor = memo(function SourceEditor({
 
       editorRef.current = new EditorView({ state, parent: node });
     },
-    [content, filePath, language, readOnly],
+    [filePath, language, readOnly],
   );
+
+  // Sync external content changes into the editor without recreating it.
+  // Only applies when the new content differs from the current document
+  // (e.g. file switch or server refresh), not on every keystroke.
+  useEffect(() => {
+    const view = editorRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current !== content) {
+      view.dispatch({
+        changes: { from: 0, to: current.length, insert: content },
+      });
+    }
+  }, [content]);
 
   return <div ref={mountEditor} className="h-full w-full overflow-hidden" />;
 });


### PR DESCRIPTION
## Summary
- Fix SourceEditor being destroyed and recreated on every content change, losing cursor position, undo history, and focus
- The `mountEditor` callback had `content` in its dependency array and was used as a React ref callback — every keystroke changed `content`, giving `mountEditor` a new identity and triggering full editor recreation

## Details

**Affected file:** `packages/studio/src/components/editor/SourceEditor.tsx`

The fix:
1. Removes `content` from the `mountEditor` dependency array — the editor is now only recreated when `filePath`, `language`, or `readOnly` change
2. Uses a `contentRef` to pass initial content to the editor without subscribing to changes
3. Adds a `useEffect` that syncs external content changes (file switches, server refreshes) into the existing editor via `view.dispatch()`, without recreating it

## Test plan
- [ ] Open a file in the source editor and type — verify cursor position is maintained between keystrokes
- [ ] Verify undo/redo (Ctrl+Z/Ctrl+Y) still works
- [ ] Switch files and verify the editor content updates correctly
- [ ] Verify syntax highlighting works after file switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)