### PR TITLE
fix: use JSON.stringify for caption text escaping in generated JS

### DIFF
--- a/packages/studio/src/captions/generator.ts
+++ b/packages/studio/src/captions/generator.ts
@@ -303,14 +303,14 @@ function generateJs(model: CaptionModel): string {
 
     // Build word spans
     const wordLines: string[] = groupSegments.map((seg) => {
-      const escaped = seg.text.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+      const escaped = JSON.stringify(seg.text);
       const segVar = `w_${seg.id.replace(/[^a-zA-Z0-9_]/g, "_")}`;
       const idLine = seg.wordId ? `\n  ${segVar}.id = ${JSON.stringify(seg.wordId)};` : "";
       return (
         `  const ${segVar} = document.createElement('span');` +
         `\n  ${segVar}.className = 'word clip';` +
         idLine +
-        `\n  ${segVar}.textContent = '${escaped}';` +
+        `\n  ${segVar}.textContent = ${escaped};` +
         `\n  ${segVar}.dataset.start = '${seg.start}';` +
         `\n  ${segVar}.dataset.end = '${seg.end}';` +
         `\n  groupEl_${groupVar}.appendChild(${segVar});`


### PR DESCRIPTION
## Summary
- Replace manual single-quote escaping with `JSON.stringify()` in caption JS generation
- Manual escaping only handled backslash and single quotes, missing newlines, carriage returns, and other special characters that break generated JavaScript syntax

## Details

**Affected file:** `packages/studio/src/captions/generator.ts` (lines 306-313)

A caption segment containing a literal newline (e.g. from a multiline caption) would produce broken JS like:
```js
segVar.textContent = 'line1
line2';  // SyntaxError: Invalid or unexpected token
```

`JSON.stringify` handles all special characters correctly and produces a double-quoted string literal that is always valid JS.

## Test plan
- [ ] Create captions with special characters (newlines, quotes, backslashes) and verify the generated HTML is valid
- [ ] Verify existing single-line captions still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)