### PR TITLE
fix: pass full tar path to verify-packed-manifests

### DIFF
--- a/scripts/verify-packed-manifests.mjs
+++ b/scripts/verify-packed-manifests.mjs
@@ -53,7 +53,7 @@ function main() {
     const [{ filename }] = parsePackJson(packOutput, workspace);
 
     try {
-      const packedPackageJson = execFileSync("tar", ["-xOf", filename, "package/package.json"], {
+      const packedPackageJson = execFileSync("tar", ["-xOf", join(packDir, filename), "package/package.json"], {
         cwd: ROOT,
         encoding: "utf8",
       });


### PR DESCRIPTION
## Summary
- Fix `verify-packed-manifests.mjs` script that always fails because `tar` cannot find the packed tarball
- `pnpm pack` writes to `packDir` (temp directory) but `tar` was invoked with only the bare filename relative to the repo root

## Details

**Affected file:** `scripts/verify-packed-manifests.mjs` (line 56)

The script packs packages into a temp directory (`packDir`), then tries to extract `package.json` from the tarball. But `tar -xOf` was given just the filename (e.g., `hyperframes-core-0.1.0.tgz`) with `cwd: ROOT`, so it looks for the file at the repo root instead of in `packDir`.

## Test plan
- [ ] Run `bun run verify:packed-manifests` and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)