### PR TITLE
chore: release v0.4.45

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.4.45 — patch bump of all `@hyperframes/*` packages (and `hyperframes` CLI) from v0.4.44.

Merging this PR triggers the publish workflow, which tags `v0.4.45` and publishes to npm under the `latest` dist-tag.

## Changes since v0.4.44

### Render robustness (#627)

- fix(engine): wait for first frame decode + drop B-frames so renders play in every player (`0e541673`) — `readyState >= 2` on `<video>` readiness checks (was >= 1) so slow-decoding clips don't paint a black first frame; `-bf 0` for libx264/nvenc/qsv/vaapi h264 paths to eliminate negative-DTS freezes in VS Code preview, several browser `<video>` impls, and some HW decoders.
- fix(engine,producer): URL-clamp sub-comp src paths and warn on silent extraction misses (`2f96d5c7`) — `path.join(projectDir, "../assets/foo")` previously escaped the project root and silently froze sub-comp `<video>` at frame 0; now mirrors browser-style `..` clamping with a stderr warning on extraction misses.
- fix(engine): detect VP9 alpha tag case-insensitively in ffprobe (`b836941f`, `39bc3749`, `6fb782fc`) — newer libavformat builds (and our own `hyperframes remove-background`) write the alpha sidecar tag as `ALPHA_MODE` (uppercase), which we previously misclassified as no-alpha. Default to codec-based alpha capability when the tag is missing.
- fix(engine,cli,producer): address PR #627 review feedback (`f4ecf969`) — extend `-bf 0` to GPU h264 paths, detect mid-path `..` traversal in sub-comp sources, dedupe stderr warnings, replace `startsWith("/")` with `isAbsolute()` for Windows compatibility in the HDR probe path.

### `remove-background` quality (#627)

- fix(cli): correct sharp 3-channel mask + BT.709 + quality presets in `remove-background` (`688052d3`).
- docs(remove-background): document compositing patterns, pitfalls, and broaden framing from avatar-specific to any person video (`5fca4bec`, `b8b82fa8`).

### Test infrastructure

- fix(producer): sample PSNR checkpoints from common duration of rendered + snapshot (`7d1d8ead`) — symmetric PSNR comparison should always sample within the duration both videos cover; previously the harness used the rendered duration alone, which could land the last checkpoint on a frame that didn't exist in the snapshot when encoder/mux flags shifted container metadata duration. Repaired the regression run after the encoder change above.

### Skills (does not ship to npm)

- refactor(skills): split asset preprocessing out of `hyperframes-cli` into a new `hyperframes-media` skill (#619) — TTS / transcribe / remove-background guidance moved out of the CLI dev-loop skill so agents auto-load only what's relevant to the task.

All commits since v0.4.44 are fixes or internal changes — no public API changes.