### PR TITLE
feat(cli): add --composition flag to render specific compositions

### DIFF
--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -129,6 +129,10 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
     ```bash
     npx hyperframes render --output output.mp4
     ```
+    Render a specific composition instead of `index.html`:
+    ```bash
+    npx hyperframes render -c compositions/intro.html -o intro.mp4
+    ```
     For deterministic output, add `--docker`:
     ```bash
     npx hyperframes render --docker --output output.mp4

--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -133,6 +133,37 @@ describe("renderLocal browser GPU config", () => {
     expect(producerState.createdJobs[0]?.variables).toBeUndefined();
   });
 
+  it("forwards entryFile to createRenderJob when --composition is set", async () => {
+    const { renderLocal } = await import("./render.js");
+    await renderLocal("/tmp/project", "/tmp/out.mp4", {
+      fps: 30,
+      quality: "standard",
+      format: "mp4",
+      gpu: false,
+      browserGpu: false,
+      hdrMode: "auto",
+      quiet: true,
+      entryFile: "compositions/intro.html",
+    });
+
+    expect(producerState.createdJobs[0]?.entryFile).toBe("compositions/intro.html");
+  });
+
+  it("omits entryFile from createRenderJob when --composition is not set", async () => {
+    const { renderLocal } = await import("./render.js");
+    await renderLocal("/tmp/project", "/tmp/out.mp4", {
+      fps: 30,
+      quality: "standard",
+      format: "mp4",
+      gpu: false,
+      browserGpu: false,
+      hdrMode: "auto",
+      quiet: true,
+    });
+
+    expect(producerState.createdJobs[0]?.entryFile).toBeUndefined();
+  });
+
   it("can force the CLI process to exit after a successful local render", async () => {
     vi.useFakeTimers();
     const exit = vi

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -4,6 +4,7 @@ import { mkdirSync, readFileSync, statSync, writeFileSync, rmSync } from "node:f
 
 export const examples: Example[] = [
   ["Render to MP4", "hyperframes render --output output.mp4"],
+  ["Render a specific composition", "hyperframes render -c compositions/intro.html -o intro.mp4"],
   ["Render transparent overlay (ProRes)", "hyperframes render --format mov --output overlay.mov"],
   ["Render transparent WebM overlay", "hyperframes render --format webm --output overlay.webm"],
   ["High quality at 60fps", "hyperframes render --fps 60 --quality high --output hd.mp4"],
@@ -61,6 +62,12 @@ export default defineCommand({
       type: "positional",
       description: "Project directory",
       required: false,
+    },
+    composition: {
+      type: "string",
+      alias: "c",
+      description:
+        "Render a specific composition file instead of index.html (e.g. compositions/intro.html)",
     },
     output: {
       type: "string",
@@ -263,16 +270,30 @@ export default defineCommand({
       process.exit(1);
     }
 
+    // ── Validate composition entry file ──────────────────────────────────
+    const entryFile = args.composition?.trim() || undefined;
+    if (entryFile) {
+      const entryPath = resolve(project.dir, entryFile);
+      try {
+        statSync(entryPath);
+      } catch {
+        errorBox(
+          "Composition not found",
+          `"${entryFile}" does not exist in the project directory.`,
+          "Use 'hyperframes compositions' to list available compositions.",
+        );
+        process.exit(1);
+      }
+    }
+
     // ── Print render plan ─────────────────────────────────────────────────
     if (!quiet) {
       const workerLabel =
         workers != null ? `${workers} workers` : `auto workers (${CPU_CORE_COUNT} cores detected)`;
       console.log("");
+      const nameLabel = entryFile ? project.name + "/" + entryFile : project.name;
       console.log(
-        c.accent("\u25C6") +
-          "  Rendering " +
-          c.accent(project.name) +
-          c.dim(" \u2192 " + outputPath),
+        c.accent("\u25C6") + "  Rendering " + c.accent(nameLabel) + c.dim(" \u2192 " + outputPath),
       );
       console.log(c.dim("   " + fps + "fps \u00B7 " + quality + " \u00B7 " + workerLabel));
       if (useGpu || useBrowserGpu) {
@@ -403,6 +424,7 @@ export default defineCommand({
         videoBitrate,
         quiet,
         variables,
+        entryFile,
         exitAfterComplete: true,
       });
     } else {
@@ -419,6 +441,7 @@ export default defineCommand({
         quiet,
         browserPath,
         variables,
+        entryFile,
         exitAfterComplete: true,
       });
     }
@@ -438,6 +461,7 @@ interface RenderOptions {
   quiet: boolean;
   browserPath?: string;
   variables?: Record<string, unknown>;
+  entryFile?: string;
   exitAfterComplete?: boolean;
 }
 
@@ -713,6 +737,7 @@ async function renderDocker(
       videoBitrate: options.videoBitrate,
       quiet: options.quiet,
       variables: options.variables,
+      entryFile: options.entryFile,
     },
   });
 
@@ -783,6 +808,7 @@ export async function renderLocal(
     crf: options.crf,
     videoBitrate: options.videoBitrate,
     variables: options.variables,
+    entryFile: options.entryFile,
   });
 
   const onProgress = options.quiet

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -67,7 +67,8 @@ export default defineCommand({
       type: "string",
       alias: "c",
       description:
-        "Render a specific composition file instead of index.html (e.g. compositions/intro.html)",
+        "Render a specific composition file instead of index.html (e.g. compositions/intro.html). " +
+        "Sub-compositions using <template> wrappers must be referenced from index.html via data-composition-src.",
     },
     output: {
       type: "string",
@@ -271,16 +272,24 @@ export default defineCommand({
     }
 
     // ── Validate composition entry file ──────────────────────────────────
-    const entryFile = args.composition?.trim() || undefined;
+    const entryFile = args.composition?.trim().replace(/^\.\//, "") || undefined;
     if (entryFile) {
-      const entryPath = resolve(project.dir, entryFile);
+      const absProjectDir = resolve(project.dir);
+      const entryPath = resolve(absProjectDir, entryFile);
+      if (!entryPath.startsWith(absProjectDir)) {
+        errorBox(
+          "Invalid composition path",
+          `Entry file must stay inside the project directory: ${entryFile}`,
+        );
+        process.exit(1);
+      }
       try {
         statSync(entryPath);
       } catch {
         errorBox(
           "Composition not found",
           `"${entryFile}" does not exist in the project directory.`,
-          "Use 'hyperframes compositions' to list available compositions.",
+          "Pass a path to a .html file relative to the project root (e.g. compositions/intro.html).",
         );
         process.exit(1);
       }

--- a/packages/cli/src/utils/dockerRunArgs.test.ts
+++ b/packages/cli/src/utils/dockerRunArgs.test.ts
@@ -210,4 +210,19 @@ describe("buildDockerRunArgs", () => {
     });
     expect(args).not.toContain("--variables");
   });
+
+  it("forwards --composition to the container when entryFile is set", () => {
+    const args = buildDockerRunArgs({
+      ...FIXED_INPUT,
+      options: { ...BASE, entryFile: "compositions/intro.html" },
+    });
+    const idx = args.indexOf("--composition");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("compositions/intro.html");
+  });
+
+  it("omits --composition when entryFile is not set", () => {
+    const args = buildDockerRunArgs({ ...FIXED_INPUT, options: BASE });
+    expect(args).not.toContain("--composition");
+  });
 });

--- a/packages/cli/src/utils/dockerRunArgs.test.ts
+++ b/packages/cli/src/utils/dockerRunArgs.test.ts
@@ -161,6 +161,7 @@ describe("buildDockerRunArgs", () => {
         crf: 16,
         videoBitrate: undefined,
         quiet: true,
+        entryFile: "compositions/intro.html",
       },
     });
     // Each value must reach the container exactly once. If a future option
@@ -176,6 +177,8 @@ describe("buildDockerRunArgs", () => {
     expect(args).toContain("--gpu");
     expect(args).toContain("--no-browser-gpu");
     expect(args).toContain("--hdr");
+    expect(args).toContain("--composition");
+    expect(args).toContain("compositions/intro.html");
   });
 
   it("forwards --video-bitrate to the container when set", () => {

--- a/packages/cli/src/utils/dockerRunArgs.ts
+++ b/packages/cli/src/utils/dockerRunArgs.ts
@@ -30,6 +30,7 @@ export interface DockerRenderOptions {
   videoBitrate?: string;
   quiet: boolean;
   variables?: Record<string, unknown>;
+  entryFile?: string;
 }
 
 export function buildDockerRunArgs(input: DockerRunArgsInput): string[] {
@@ -67,5 +68,6 @@ export function buildDockerRunArgs(input: DockerRunArgsInput): string[] {
     ...(options.variables && Object.keys(options.variables).length > 0
       ? ["--variables", JSON.stringify(options.variables)]
       : []),
+    ...(options.entryFile ? ["--composition", options.entryFile] : []),
   ];
 }


### PR DESCRIPTION
## Summary

- Add `--composition` / `-c` flag to `hyperframes render` to render a specific composition file instead of `index.html`
- Threads through both local and Docker render paths
- Validates the file exists before starting the render with a clear error message
- Leverages the existing `entryFile` config in the producer — no engine changes needed

## Usage

```bash
# Render a specific sub-composition
hyperframes render -c compositions/intro.html -o intro.mp4

# Still works without the flag (renders index.html as before)
hyperframes render -o output.mp4
```

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/commands/render.ts` | Add `--composition` / `-c` arg, validate file exists, pass `entryFile` to both local and Docker render paths, show composition name in render plan output |
| `packages/cli/src/utils/dockerRunArgs.ts` | Add `entryFile` to `DockerRenderOptions`, forward as `--composition` flag to container |
| `packages/cli/src/utils/dockerRunArgs.test.ts` | 2 new tests: forwards `--composition` when set, omits when not |
| `docs/packages/cli.mdx` | Add composition render example to quickstart |

## Test results

### Automated tests
- All 15 `dockerRunArgs` tests pass (13 existing + 2 new)
- `bunx vitest run packages/cli/src/utils/dockerRunArgs.test.ts` — 15/15 passed

### Manual tests

**Error handling — nonexistent file:**
```
$ hyperframes render -c nonexistent.html -o /tmp/test.mp4 ./my-project

✗  Composition not found

   "nonexistent.html" does not exist in the project directory.
   Use 'hyperframes compositions' to list available compositions.
```

**Happy path — render broadcast-kit composition:**
```
$ hyperframes render -c compositions/broadcast-kit.html -o /tmp/broadcast-test.mp4 -f 30 -q draft ./html-in-canvas-showcase

◆  Rendering html-in-canvas-showcase/compositions/broadcast-kit.html → /tmp/broadcast-test.mp4
   30fps · draft · auto workers (14 cores detected)

   600 frames captured (20s × 30fps — matches data-duration="20")
   561.8 KB · 10.0s · completed
```

**Backwards compatible — no flag renders index.html as before:**
```
$ hyperframes render -o /tmp/default.mp4 ./my-project
# Renders index.html (unchanged behavior)
```