### PR TITLE
fix(cli): use bun in command hints

### DIFF
--- a/packages/cli/src/commands/play.ts
+++ b/packages/cli/src/commands/play.ts
@@ -25,7 +25,7 @@ export default defineCommand({
     // Resolve runtime path — same logic as studioServer.ts
     const runtimePath = resolveRuntimePath();
     if (!runtimePath) {
-      clack.log.error("HyperFrames runtime not found. Run `pnpm build` first.");
+      clack.log.error("HyperFrames runtime not found. Run `bun run build` first.");
       process.exitCode = 1;
       return;
     }
@@ -33,7 +33,9 @@ export default defineCommand({
     // Resolve player path
     const playerPath = resolvePlayerPath();
     if (!playerPath) {
-      clack.log.error("@hyperframes/player not found. Run `pnpm build` in packages/player first.");
+      clack.log.error(
+        "@hyperframes/player not found. Run `bun run --cwd packages/player build` first.",
+      );
       process.exitCode = 1;
       return;
     }

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -115,7 +115,7 @@ export default defineCommand({
 });
 
 /**
- * Dev mode: spawn pnpm studio from the monorepo (existing behavior).
+ * Dev mode: spawn the studio dev server from the monorepo.
  */
 async function runDevMode(dir: string, projectName?: string): Promise<void> {
   // Find monorepo root by navigating from packages/cli/src/commands/
@@ -159,7 +159,7 @@ async function runDevMode(dir: string, projectName?: string): Promise<void> {
 
   // Run the new consolidated studio (single Vite dev server with API plugin)
   const studioPkgDir = join(repoRoot, "packages", "studio");
-  const child = spawn("pnpm", ["exec", "vite"], {
+  const child = spawn("bun", ["run", "dev"], {
     cwd: studioPkgDir,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -335,7 +335,7 @@ async function runEmbeddedMode(
       console.error(`  ${c.dim("-")} ${checkedPath}`);
     }
     console.error();
-    console.error(`  ${c.dim("Rebuild the CLI package with")} ${c.accent("pnpm run build")}`);
+    console.error(`  ${c.dim("Rebuild the CLI package with")} ${c.accent("bun run build")}`);
     console.error();
     process.exitCode = 1;
     return;

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -409,7 +409,7 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     <main>
       <h1>Studio bundle missing</h1>
       <p>The preview server started, but this CLI build does not contain the Studio assets.</p>
-      <code>pnpm run build</code>
+      <code>bun run build</code>
     </main>
   </body>
 </html>`,


### PR DESCRIPTION
## Summary

- Use the Studio package's bun dev script when `hyperframes preview` runs from the monorepo source path.
- Update stale CLI missing-build guidance from pnpm commands to bun commands.
- Leave release/packaging-related pnpm usage untouched, since that appears to be part of the publish workflow.

## Why

I noticed a few user-facing CLI paths still referenced pnpm while checking the repo setup. CONTRIBUTING.md and AGENTS.md describe bun as the workspace package manager, so this keeps those small hints aligned with the documented development flow.

## Validation

- `bunx oxfmt --check packages/cli/src/commands/play.ts packages/cli/src/commands/preview.ts packages/cli/src/server/studioServer.ts`
- `bunx oxlint packages/cli/src/commands/play.ts packages/cli/src/commands/preview.ts packages/cli/src/server/studioServer.ts`
- `bun run --filter @hyperframes/cli typecheck`
- `bun run --filter @hyperframes/cli test -- src/server/studioServer.test.ts`
