### PR TITLE
feat: cache shader transition preview frames

### DIFF
--- a/packages/cli/src/server/fileWatcher.test.ts
+++ b/packages/cli/src/server/fileWatcher.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldWatchProjectFile } from "./fileWatcher.js";
+
+describe("shouldWatchProjectFile", () => {
+  it("watches files that can affect the project signature", () => {
+    expect(shouldWatchProjectFile("index.html")).toBe(true);
+    expect(shouldWatchProjectFile("src/scene.tsx")).toBe(true);
+    expect(shouldWatchProjectFile("assets/hero.png")).toBe(true);
+    expect(shouldWatchProjectFile("Dockerfile")).toBe(true);
+  });
+
+  it("skips generated and dependency directories excluded from signatures", () => {
+    expect(shouldWatchProjectFile("node_modules/pkg/index.js")).toBe(false);
+    expect(shouldWatchProjectFile("renders/output.mp4")).toBe(false);
+    expect(shouldWatchProjectFile("dist/index.html")).toBe(false);
+    expect(shouldWatchProjectFile(".hyperframes/cache.json")).toBe(false);
+  });
+});

--- a/packages/cli/src/server/fileWatcher.ts
+++ b/packages/cli/src/server/fileWatcher.ts
@@ -8,8 +8,26 @@ export interface ProjectWatcher {
   close(): void;
 }
 
-const WATCHED_EXTENSIONS = new Set([".html", ".css", ".js", ".json"]);
+const WATCHER_EXCLUDED_DIRS = new Set([
+  ".cache",
+  ".git",
+  ".hyperframes",
+  ".next",
+  ".vite",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "outputs",
+  "renders",
+]);
 const DEBOUNCE_MS = 300;
+
+export function shouldWatchProjectFile(filename: string): boolean {
+  if (!filename) return false;
+  const parts = filename.split(/[\\/]+/);
+  return !parts.some((part) => WATCHER_EXCLUDED_DIRS.has(part));
+}
 
 export function createProjectWatcher(projectDir: string): ProjectWatcher {
   const listeners = new Set<FileChangeListener>();
@@ -19,13 +37,13 @@ export function createProjectWatcher(projectDir: string): ProjectWatcher {
   try {
     watcher = watch(projectDir, { recursive: true }, (_event, filename) => {
       if (!filename) return;
-      const ext = "." + filename.split(".").pop()?.toLowerCase();
-      if (!WATCHED_EXTENSIONS.has(ext)) return;
+      const relativePath = filename.toString();
+      if (!shouldWatchProjectFile(relativePath)) return;
 
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         for (const fn of listeners) {
-          fn(filename);
+          fn(relativePath);
         }
       }, DEBOUNCE_MS);
     });

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -14,6 +14,7 @@ import { loadRuntimeSource } from "./runtimeSource.js";
 import { VERSION as version } from "../version.js";
 import {
   createStudioApi,
+  createProjectSignature,
   getMimeType,
   type StudioApiAdapter,
   type ResolvedProject,
@@ -144,6 +145,10 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
   // ── CLI adapter for the shared studio API ──────────────────────────────
 
   const project: ResolvedProject = { id: projectId, dir: projectDir, title: projectId };
+  let cachedProjectSignature: string | null = null;
+  watcher.addListener(() => {
+    cachedProjectSignature = null;
+  });
 
   const adapter: StudioApiAdapter = {
     listProjects: () => [project],
@@ -164,6 +169,12 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
         console.error("[studio] Bundle failed:", err);
         return null;
       }
+    },
+
+    getProjectSignature(dir: string): string {
+      if (resolve(dir) !== resolve(projectDir)) return createProjectSignature(dir);
+      cachedProjectSignature ??= createProjectSignature(projectDir);
+      return cachedProjectSignature;
     },
 
     async lint(html: string, opts?: { filePath?: string }) {

--- a/packages/core/src/runtime/picker.test.ts
+++ b/packages/core/src/runtime/picker.test.ts
@@ -95,6 +95,37 @@ describe("createPickerModule", () => {
       expect(api.getCandidatesAtPoint(Infinity, 0)).toEqual([]);
     });
 
+    it("does not pick through blocking loading overlays", () => {
+      const picker = createPickerModule({ postMessage: createMockPostMessage() });
+      picker.installPickerApi();
+      const scene = document.createElement("div");
+      scene.id = "scene-title";
+      scene.textContent = "Scene title";
+      const overlay = document.createElement("div");
+      overlay.setAttribute("data-hyper-shader-loading", "");
+      const overlayLabel = document.createElement("span");
+      overlayLabel.textContent = "Preparing scene transitions";
+      overlay.appendChild(overlayLabel);
+      document.body.appendChild(scene);
+      document.body.appendChild(overlay);
+
+      const originalElementsFromPoint = document.elementsFromPoint;
+      Object.defineProperty(document, "elementsFromPoint", {
+        configurable: true,
+        value: vi.fn(() => [overlayLabel, overlay, scene]),
+      });
+
+      const api = (window as any).__HF_PICKER_API;
+      try {
+        expect(api.getCandidatesAtPoint(10, 10)).toEqual([]);
+      } finally {
+        Object.defineProperty(document, "elementsFromPoint", {
+          configurable: true,
+          value: originalElementsFromPoint,
+        });
+      }
+    });
+
     it("pickAtPoint returns null for invalid coords", () => {
       const picker = createPickerModule({ postMessage: createMockPostMessage() });
       picker.installPickerApi();

--- a/packages/core/src/runtime/picker.ts
+++ b/packages/core/src/runtime/picker.ts
@@ -4,6 +4,19 @@ type PickerModuleDeps = {
   postMessage: (payload: RuntimeOutboundMessage) => void;
 };
 
+const PICKER_IGNORE_SELECTOR = [
+  "[data-hyperframes-ignore]",
+  "[data-hyperframes-picker-ignore]",
+  "[data-hf-ignore]",
+  "[data-no-inspect]",
+  "[data-no-pick]",
+  "[data-hyper-shader-loading]",
+].join(",");
+const PICKER_BLOCK_SELECTOR = [
+  "[data-hyperframes-picker-block]",
+  "[data-hyper-shader-loading]",
+].join(",");
+
 export type PickerModule = {
   enablePickMode: () => void;
   disablePickMode: () => void;
@@ -48,7 +61,12 @@ export function createPickerModule(deps: PickerModuleDeps): PickerModule {
     const tag = el.tagName.toLowerCase();
     if (tag === "script" || tag === "style" || tag === "link" || tag === "meta") return false;
     if (el.classList.contains("__hf-pick-highlight")) return false;
+    if (el.closest(PICKER_IGNORE_SELECTOR)) return false;
     return true;
+  }
+
+  function blocksPickerAtPoint(el: Element | null): boolean {
+    return Boolean(el?.closest(PICKER_BLOCK_SELECTOR));
   }
 
   function buildElementSelector(el: Element): string {
@@ -97,6 +115,7 @@ export function createPickerModule(deps: PickerModuleDeps): PickerModule {
       const single = document.elementFromPoint(clientX, clientY);
       raw = single ? [single] : [];
     }
+    if (blocksPickerAtPoint(raw[0] ?? null)) return [];
     const dedupe: Record<string, true> = {};
     const candidates: Element[] = [];
     for (let i = 0; i < raw.length; i += 1) {

--- a/packages/core/src/studio-api/helpers/projectSignature.ts
+++ b/packages/core/src/studio-api/helpers/projectSignature.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, readdirSync } from "node:fs";
+import { extname, isAbsolute, relative, resolve } from "node:path";
+
+const SIGNATURE_TEXT_EXTENSIONS = new Set([
+  ".cjs",
+  ".css",
+  ".html",
+  ".js",
+  ".json",
+  ".jsx",
+  ".mjs",
+  ".svg",
+  ".ts",
+  ".tsx",
+]);
+const SIGNATURE_EXCLUDED_DIRS = new Set([
+  ".cache",
+  ".git",
+  ".hyperframes",
+  ".next",
+  ".vite",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "outputs",
+  "renders",
+]);
+const MAX_SIGNATURE_TEXT_BYTES = 2_000_000;
+
+interface ProjectSignatureFile {
+  file: string;
+  mtimeMs: number;
+  size: number;
+  textContentEligible: boolean;
+}
+
+interface ProjectSignatureCacheEntry {
+  fingerprint: string;
+  signature: string;
+}
+
+const projectSignatureCache = new Map<string, ProjectSignatureCacheEntry>();
+
+function isPathWithin(parentDir: string, childPath: string): boolean {
+  const childRelativePath = relative(parentDir, childPath);
+  return (
+    childRelativePath === "" ||
+    (!childRelativePath.startsWith("..") && !isAbsolute(childRelativePath))
+  );
+}
+
+function isTextContentEligible(file: string, size: number): boolean {
+  return (
+    SIGNATURE_TEXT_EXTENSIONS.has(extname(file).toLowerCase()) && size <= MAX_SIGNATURE_TEXT_BYTES
+  );
+}
+
+function collectProjectSignatureFiles(
+  projectDir: string,
+  dir: string,
+  files: ProjectSignatureFile[],
+): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir).sort();
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (SIGNATURE_EXCLUDED_DIRS.has(entry)) continue;
+    const file = resolve(dir, entry);
+    if (!isPathWithin(projectDir, file)) continue;
+    let stat: ReturnType<typeof lstatSync>;
+    try {
+      stat = lstatSync(file);
+    } catch {
+      continue;
+    }
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) {
+      collectProjectSignatureFiles(projectDir, file, files);
+    } else if (stat.isFile()) {
+      files.push({
+        file,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+        textContentEligible: isTextContentEligible(file, stat.size),
+      });
+    }
+  }
+}
+
+function createProjectFingerprint(projectDir: string, files: ProjectSignatureFile[]): string {
+  const hash = createHash("sha256");
+  for (const entry of files) {
+    hash.update(relative(projectDir, entry.file));
+    hash.update("\0");
+    hash.update(String(entry.size));
+    hash.update("\0");
+    hash.update(String(entry.mtimeMs));
+    hash.update("\0");
+    hash.update(entry.textContentEligible ? "text" : "binary");
+    hash.update("\0");
+  }
+  return hash.digest("hex").slice(0, 24);
+}
+
+export function createProjectSignature(projectDir: string): string {
+  const normalizedProjectDir = resolve(projectDir);
+  const files: ProjectSignatureFile[] = [];
+  collectProjectSignatureFiles(normalizedProjectDir, normalizedProjectDir, files);
+  files.sort((a, b) => a.file.localeCompare(b.file));
+
+  const fingerprint = createProjectFingerprint(normalizedProjectDir, files);
+  const cached = projectSignatureCache.get(normalizedProjectDir);
+  if (cached?.fingerprint === fingerprint) return cached.signature;
+
+  const hash = createHash("sha256");
+  for (const entry of files) {
+    const relativePath = relative(normalizedProjectDir, entry.file);
+    hash.update(relativePath);
+    hash.update("\0");
+    hash.update(String(entry.size));
+    hash.update("\0");
+    if (entry.textContentEligible) {
+      try {
+        hash.update(readFileSync(entry.file));
+      } catch {
+        hash.update(String(entry.mtimeMs));
+      }
+    } else {
+      hash.update(String(entry.mtimeMs));
+    }
+    hash.update("\0");
+  }
+  const signature = hash.digest("hex").slice(0, 24);
+  projectSignatureCache.set(normalizedProjectDir, { fingerprint, signature });
+  return signature;
+}

--- a/packages/core/src/studio-api/index.ts
+++ b/packages/core/src/studio-api/index.ts
@@ -1,4 +1,5 @@
 export { createStudioApi } from "./createStudioApi.js";
+export { createProjectSignature } from "./helpers/projectSignature.js";
 export type { StudioApiAdapter, ResolvedProject, RenderJobState, LintResult } from "./types.js";
 export { isSafePath, walkDir } from "./helpers/safePath.js";
 export { getMimeType, MIME_TYPES } from "./helpers/mime.js";

--- a/packages/core/src/studio-api/routes/preview.test.ts
+++ b/packages/core/src/studio-api/routes/preview.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerPreviewRoutes } from "./preview";
+import type { StudioApiAdapter } from "../types";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createProjectDir(): string {
+  const projectDir = mkdtempSync(join(tmpdir(), "hf-preview-test-"));
+  tempDirs.push(projectDir);
+  writeFileSync(join(projectDir, "index.html"), "<html><head></head><body>Preview</body></html>");
+  return projectDir;
+}
+
+function createAdapter(
+  projectDir: string,
+  overrides: Partial<StudioApiAdapter> = {},
+): StudioApiAdapter {
+  return {
+    listProjects: () => [],
+    resolveProject: async (id: string) => ({ id, dir: projectDir }),
+    bundle: async () => null,
+    lint: async () => ({ findings: [] }),
+    runtimeUrl: "/api/runtime.js",
+    rendersDir: () => "/tmp/renders",
+    startRender: () => ({
+      id: "job-1",
+      status: "rendering",
+      progress: 0,
+      outputPath: "/tmp/out.mp4",
+    }),
+    ...overrides,
+  };
+}
+
+function tryCreateSymlink(target: string, path: string, type: "dir" | "file"): boolean {
+  try {
+    symlinkSync(target, path, type);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getPreviewSignature(projectDir: string): Promise<string> {
+  const app = new Hono();
+  registerPreviewRoutes(app, createAdapter(projectDir));
+
+  const response = await app.request("http://localhost/projects/demo/preview");
+  expect(response.status).toBe(200);
+  const html = await response.text();
+  const match = /<meta name="hyperframes-project-signature" content="([^"]+)">/.exec(html);
+  expect(match?.[1]).toBeTruthy();
+  return match![1]!;
+}
+
+describe("registerPreviewRoutes", () => {
+  it("uses the adapter project signature when available", async () => {
+    const projectDir = createProjectDir();
+    const getProjectSignature = vi.fn(() => "cached-signature");
+    const app = new Hono();
+    registerPreviewRoutes(app, createAdapter(projectDir, { getProjectSignature }));
+
+    const response = await app.request("http://localhost/projects/demo/preview");
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(getProjectSignature).toHaveBeenCalledWith(projectDir);
+    expect(html).toContain(
+      '<meta name="hyperframes-project-signature" content="cached-signature">',
+    );
+  });
+
+  it("updates the preview signature after project text edits", async () => {
+    const projectDir = createProjectDir();
+    const file = join(projectDir, "scene.js");
+    writeFileSync(file, "export const label = 'first';");
+
+    const firstSignature = await getPreviewSignature(projectDir);
+    expect(await getPreviewSignature(projectDir)).toBe(firstSignature);
+
+    writeFileSync(file, "export const label = 'second with changed size';");
+
+    await expect(getPreviewSignature(projectDir)).resolves.not.toBe(firstSignature);
+  });
+
+  it("skips symlinked files when creating the preview signature", async () => {
+    const projectDir = createProjectDir();
+    const firstSignature = await getPreviewSignature(projectDir);
+
+    const externalDir = mkdtempSync(join(tmpdir(), "hf-preview-external-"));
+    tempDirs.push(externalDir);
+    const externalFile = join(externalDir, "external.js");
+    writeFileSync(externalFile, "export const external = true;");
+
+    if (!tryCreateSymlink(externalFile, join(projectDir, "external.js"), "file")) return;
+
+    await expect(getPreviewSignature(projectDir)).resolves.toBe(firstSignature);
+  });
+
+  it("skips symlinked directories when creating the preview signature", async () => {
+    const projectDir = createProjectDir();
+    if (!tryCreateSymlink(projectDir, join(projectDir, "loop"), "dir")) return;
+
+    const signature = await getPreviewSignature(projectDir);
+
+    expect(signature).toMatch(/^[a-f0-9]{24}$/);
+  });
+});

--- a/packages/core/src/studio-api/routes/preview.ts
+++ b/packages/core/src/studio-api/routes/preview.ts
@@ -5,6 +5,25 @@ import type { StudioApiAdapter } from "../types.js";
 import { isSafePath } from "../helpers/safePath.js";
 import { getMimeType } from "../helpers/mime.js";
 import { buildSubCompositionHtml } from "../helpers/subComposition.js";
+import { createProjectSignature } from "../helpers/projectSignature.js";
+
+const PROJECT_SIGNATURE_META = "hyperframes-project-signature";
+
+function resolveProjectSignature(adapter: StudioApiAdapter, projectDir: string): string {
+  return adapter.getProjectSignature?.(projectDir) ?? createProjectSignature(projectDir);
+}
+
+function injectProjectSignature(html: string, signature: string): string {
+  const tag = `<meta name="${PROJECT_SIGNATURE_META}" content="${signature}">`;
+  if (html.includes(`name="${PROJECT_SIGNATURE_META}"`)) {
+    return html.replace(
+      new RegExp(`<meta\\s+name=["']${PROJECT_SIGNATURE_META}["'][^>]*>`, "i"),
+      tag,
+    );
+  }
+  if (html.includes("</head>")) return html.replace("</head>", `${tag}\n</head>`);
+  return `${tag}\n${html}`;
+}
 
 export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): void {
   // Bundled composition preview
@@ -37,10 +56,18 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
         bundled = bundled.replace(/<head>/i, `<head><base href="${baseHref}">`);
       }
 
+      bundled = injectProjectSignature(bundled, resolveProjectSignature(adapter, project.dir));
       return c.html(bundled);
     } catch {
       const file = resolve(project.dir, "index.html");
-      if (existsSync(file)) return c.html(readFileSync(file, "utf-8"));
+      if (existsSync(file)) {
+        return c.html(
+          injectProjectSignature(
+            readFileSync(file, "utf-8"),
+            resolveProjectSignature(adapter, project.dir),
+          ),
+        );
+      }
       return c.text("not found", 404);
     }
   });
@@ -63,7 +90,7 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
     const baseHref = `/api/projects/${project.id}/preview/`;
     const html = buildSubCompositionHtml(project.dir, compPath, adapter.runtimeUrl, baseHref);
     if (!html) return c.text("not found", 404);
-    return c.html(html);
+    return c.html(injectProjectSignature(html, resolveProjectSignature(adapter, project.dir)));
   });
 
   // Static asset serving (with range request support for audio/video seeking)

--- a/packages/core/src/studio-api/types.ts
+++ b/packages/core/src/studio-api/types.ts
@@ -41,6 +41,9 @@ export interface StudioApiAdapter {
   /** Bundle a project directory into a single HTML string. Returns null if unavailable. */
   bundle(projectDir: string): Promise<string | null>;
 
+  /** Optional: cached signature for project files that should invalidate preview frame caches. */
+  getProjectSignature?: (projectDir: string) => string;
+
   /** Lint a single HTML string. */
   lint(html: string, opts?: { filePath?: string }): Promise<LintResult> | LintResult;
 

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -52,18 +52,35 @@ Show a static image before playback starts:
 
 ## Attributes
 
-| Attribute       | Type    | Default | Description                                  |
-| --------------- | ------- | ------- | -------------------------------------------- |
-| `src`           | string  | —       | URL to the composition HTML file             |
-| `audio-src`     | string  | —       | Audio URL for parent-frame playback (mobile) |
-| `width`         | number  | 1920    | Composition width in pixels (aspect ratio)   |
-| `height`        | number  | 1080    | Composition height in pixels (aspect ratio)  |
-| `controls`      | boolean | false   | Show play/pause, scrubber, and time display  |
-| `muted`         | boolean | false   | Mute audio playback                          |
-| `poster`        | string  | —       | Image URL shown before playback starts       |
-| `playback-rate` | number  | 1       | Speed multiplier (0.5 = half, 2 = double)    |
-| `autoplay`      | boolean | false   | Start playing when ready                     |
-| `loop`          | boolean | false   | Restart when the composition ends            |
+| Attribute              | Type                            | Default       | Description                                                                 |
+| ---------------------- | ------------------------------- | ------------- | --------------------------------------------------------------------------- |
+| `src`                  | string                          | —             | URL to the composition HTML file                                            |
+| `audio-src`            | string                          | —             | Audio URL for parent-frame playback (mobile)                                |
+| `width`                | number                          | 1920          | Composition width in pixels (aspect ratio)                                  |
+| `height`               | number                          | 1080          | Composition height in pixels (aspect ratio)                                 |
+| `controls`             | boolean                         | false         | Show play/pause, scrubber, and time display                                 |
+| `muted`                | boolean                         | false         | Mute audio playback                                                         |
+| `poster`               | string                          | —             | Image URL shown before playback starts                                      |
+| `playback-rate`        | number                          | 1             | Speed multiplier (0.5 = half, 2 = double)                                   |
+| `autoplay`             | boolean                         | false         | Start playing when ready                                                    |
+| `loop`                 | boolean                         | false         | Restart when the composition ends                                           |
+| `shader-capture-scale` | number                          | —             | Shader transition snapshot scale forwarded to browser previews (`0.25`-`1`) |
+| `shader-loading`       | `composition \| player \| none` | `composition` | Controls shader transition prep loading UI ownership                        |
+
+### Shader transition previews
+
+When a composition uses `@hyperframes/shader-transitions`, the player can own preview-only shader capture settings:
+
+```html
+<hyperframes-player
+  src="./composition/index.html"
+  shader-capture-scale="1"
+  shader-loading="player"
+  controls
+></hyperframes-player>
+```
+
+`shader-loading="player"` shows the player-owned transition-prep overlay from shader progress messages. `composition` leaves direct composition fallback behavior alone, and `none` suppresses the loader.
 
 ### Mobile audio
 
@@ -98,6 +115,8 @@ player.ready; // boolean (read-only)
 player.playbackRate; // number (read/write)
 player.muted; // boolean (read/write)
 player.loop; // boolean (read/write)
+player.shaderCaptureScale; // number (read/write)
+player.shaderLoading; // "composition" | "player" | "none" (read/write)
 
 // Inner iframe access (for advanced consumers — see "Advanced: iframe access" below)
 player.iframeElement; // HTMLIFrameElement (read-only)
@@ -157,14 +176,15 @@ function StudioPreview({ src }: { src: string }) {
 
 ## Events
 
-| Event        | Detail            | Fired when                                 |
-| ------------ | ----------------- | ------------------------------------------ |
-| `ready`      | `{ duration }`    | Composition loaded and duration determined |
-| `play`       | —                 | Playback started                           |
-| `pause`      | —                 | Playback paused                            |
-| `timeupdate` | `{ currentTime }` | Playback position changed (~10 fps)        |
-| `ended`      | —                 | Reached the end (when not looping)         |
-| `error`      | `{ message }`     | Composition failed to load                 |
+| Event                   | Detail                     | Fired when                                 |
+| ----------------------- | -------------------------- | ------------------------------------------ |
+| `ready`                 | `{ duration }`             | Composition loaded and duration determined |
+| `play`                  | —                          | Playback started                           |
+| `pause`                 | —                          | Playback paused                            |
+| `timeupdate`            | `{ currentTime }`          | Playback position changed (~10 fps)        |
+| `ended`                 | —                          | Reached the end (when not looping)         |
+| `error`                 | `{ message }`              | Composition failed to load                 |
+| `shadertransitionstate` | `{ compositionId, state }` | Shader transition cache/capture progress   |
 
 ```js
 player.addEventListener("ready", (e) => {

--- a/packages/player/src/hyperframes-player.test.ts
+++ b/packages/player/src/hyperframes-player.test.ts
@@ -323,6 +323,137 @@ describe("HyperframesPlayer parent-frame media", () => {
   });
 });
 
+// ── Shader transition preview controls ──
+//
+// Shader transition capture scale and loading UI ownership are player-level
+// preview concerns. The player forwards those options into the iframe before
+// the composition runs, then renders transition-prep progress from runtime
+// messages when `shader-loading="player"` is enabled.
+
+describe("HyperframesPlayer shader transition options", () => {
+  type PlayerWithIframe = HTMLElement & {
+    iframeElement: HTMLIFrameElement;
+  };
+
+  beforeEach(async () => {
+    await import("./hyperframes-player.js");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("observes shader capture scale and loading attributes", () => {
+    const player = document.createElement("hyperframes-player");
+    const Ctor = player.constructor as typeof HTMLElement & {
+      observedAttributes: string[];
+    };
+
+    expect(Ctor.observedAttributes).toContain("shader-capture-scale");
+    expect(Ctor.observedAttributes).toContain("shader-loading");
+  });
+
+  it("passes shader options through src query parameters", () => {
+    const player = document.createElement("hyperframes-player") as PlayerWithIframe;
+    player.setAttribute("shader-capture-scale", "0.5");
+    player.setAttribute("shader-loading", "player");
+    player.setAttribute("src", "/api/projects/demo/preview?x=1#stage");
+
+    const url = new URL(player.iframeElement.src);
+    expect(url.pathname).toBe("/api/projects/demo/preview");
+    expect(url.searchParams.get("x")).toBe("1");
+    expect(url.searchParams.get("__hf_shader_capture_scale")).toBe("0.5");
+    expect(url.searchParams.get("__hf_shader_loading")).toBe("player");
+    expect(url.hash).toBe("#stage");
+  });
+
+  it("injects shader options into srcdoc before composition scripts run", () => {
+    const player = document.createElement("hyperframes-player") as PlayerWithIframe;
+    player.setAttribute("shader-capture-scale", "0.5");
+    player.setAttribute("shader-loading", "player");
+    player.setAttribute(
+      "srcdoc",
+      '<!doctype html><html><head><script src="composition.js"></script></head><body></body></html>',
+    );
+
+    const srcdoc = player.iframeElement.srcdoc;
+    expect(srcdoc).toContain('window.__HF_SHADER_CAPTURE_SCALE="0.5";');
+    expect(srcdoc).toContain('window.__HF_SHADER_LOADING="player";');
+    expect(srcdoc.indexOf("data-hyperframes-player-shader-options")).toBeLessThan(
+      srcdoc.indexOf("composition.js"),
+    );
+  });
+
+  it("shows and hides the player-owned shader loader from transition state messages", () => {
+    vi.useFakeTimers();
+    const player = document.createElement("hyperframes-player") as PlayerWithIframe;
+    player.setAttribute("shader-loading", "player");
+    document.body.appendChild(player);
+
+    const iframeWindow = player.iframeElement.contentWindow;
+    expect(iframeWindow).toBeTruthy();
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframeWindow,
+        data: {
+          source: "hf-preview",
+          type: "shader-transition-state",
+          compositionId: "main",
+          state: {
+            loading: true,
+            progress: 3,
+            total: 10,
+            currentTransition: 1,
+            transitionTotal: 2,
+            transitionFrame: 3,
+            transitionFrames: 5,
+            phase: "capturing",
+          },
+        },
+      }),
+    );
+
+    const loader = player.shadowRoot?.querySelector(".hfp-shader-loader");
+    expect(loader?.classList.contains("hfp-visible")).toBe(true);
+    expect(loader?.textContent).toContain("1/2");
+    expect(loader?.textContent).toContain("3/5");
+
+    const playEvents: Event[] = [];
+    player.addEventListener("play", (event) => playEvents.push(event));
+    loader?.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    expect(playEvents).toHaveLength(0);
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframeWindow,
+        data: {
+          source: "hf-preview",
+          type: "shader-transition-state",
+          compositionId: "main",
+          state: { loading: false, ready: true },
+        },
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframeWindow,
+        data: {
+          source: "hf-preview",
+          type: "shader-transition-state",
+          compositionId: "main",
+          state: { loading: false, ready: true },
+        },
+      }),
+    );
+    expect(loader?.classList.contains("hfp-visible")).toBe(false);
+    expect(loader?.classList.contains("hfp-hiding")).toBe(true);
+    vi.advanceTimersByTime(420);
+    expect(loader?.classList.contains("hfp-hiding")).toBe(false);
+    vi.useRealTimers();
+  });
+});
+
 // ── Shared stylesheet (adoptedStyleSheets) ──
 //
 // Every player constructed in the same document should adopt the *same*

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -20,6 +20,114 @@ function getSharedSheet(): CSSStyleSheet | null {
 const DEFAULT_FPS = 30;
 const RUNTIME_CDN_URL =
   "https://cdn.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js";
+const SHADER_CAPTURE_SCALE_ATTR = "shader-capture-scale";
+const SHADER_LOADING_ATTR = "shader-loading";
+const SHADER_CAPTURE_SCALE_PARAM = "__hf_shader_capture_scale";
+const SHADER_LOADING_PARAM = "__hf_shader_loading";
+
+export type ShaderLoadingMode = "composition" | "player" | "none";
+
+interface ShaderTransitionState {
+  ready?: boolean;
+  progress?: number;
+  total?: number;
+  currentTransition?: number;
+  transitionTotal?: number;
+  transitionFrame?: number;
+  transitionFrames?: number;
+  phase?: "cached" | "capturing" | "finalizing";
+  loading?: boolean;
+}
+
+interface ShaderLoaderElements {
+  root: HTMLDivElement;
+  fill: HTMLDivElement;
+  title: HTMLSpanElement;
+  detail: HTMLDivElement;
+  transitionValue: HTMLSpanElement;
+  frameLabel: HTMLSpanElement;
+  frameValue: HTMLSpanElement;
+  frameRow: HTMLDivElement;
+}
+
+const SHADER_LOADING_PHRASES = [
+  "Preparing scene transitions",
+  "Sampling outgoing scene motion",
+  "Sampling incoming scene motion",
+  "Caching transition frames",
+  "Finalizing transition preview",
+];
+
+function normalizeShaderCaptureScale(value: string | null): string | null {
+  if (value === null) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return String(Math.min(1, Math.max(0.25, parsed)));
+}
+
+function normalizeShaderLoadingMode(value: string | null): ShaderLoadingMode {
+  if (value === null || value.trim() === "") return "composition";
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === "none" ||
+    normalized === "false" ||
+    normalized === "0" ||
+    normalized === "off"
+  ) {
+    return "none";
+  }
+  if (
+    normalized === "player" ||
+    normalized === "true" ||
+    normalized === "1" ||
+    normalized === "on"
+  ) {
+    return "player";
+  }
+  return "composition";
+}
+
+function setQueryParam(params: URLSearchParams, key: string, value: string | null): void {
+  if (value === null) params.delete(key);
+  else params.set(key, value);
+}
+
+function withShaderQueryParams(
+  src: string,
+  scale: string | null,
+  loadingMode: ShaderLoadingMode,
+): string {
+  const hashIndex = src.indexOf("#");
+  const beforeHash = hashIndex >= 0 ? src.slice(0, hashIndex) : src;
+  const hash = hashIndex >= 0 ? src.slice(hashIndex) : "";
+  const queryIndex = beforeHash.indexOf("?");
+  const path = queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash;
+  const query = queryIndex >= 0 ? beforeHash.slice(queryIndex + 1) : "";
+  const params = new URLSearchParams(query);
+  setQueryParam(params, SHADER_CAPTURE_SCALE_PARAM, scale);
+  setQueryParam(params, SHADER_LOADING_PARAM, loadingMode === "composition" ? null : loadingMode);
+  const nextQuery = params.toString();
+  return `${path}${nextQuery ? `?${nextQuery}` : ""}${hash}`;
+}
+
+function injectShaderOptionsIntoSrcdoc(
+  html: string,
+  scale: string | null,
+  loadingMode: ShaderLoadingMode,
+): string {
+  if (scale === null && loadingMode === "composition") return html;
+  const lines: string[] = [];
+  if (scale !== null) lines.push(`window.__HF_SHADER_CAPTURE_SCALE=${JSON.stringify(scale)};`);
+  if (loadingMode !== "composition") {
+    lines.push(`window.__HF_SHADER_LOADING=${JSON.stringify(loadingMode)};`);
+  }
+  const script = `<script data-hyperframes-player-shader-options>${lines.join("")}</script>`;
+  if (/<head\b[^>]*>/i.test(html))
+    return html.replace(/<head\b[^>]*>/i, (match) => `${match}${script}`);
+  if (/<html\b[^>]*>/i.test(html))
+    return html.replace(/<html\b[^>]*>/i, (match) => `${match}${script}`);
+  return `${script}${html}`;
+}
 
 class HyperframesPlayer extends HTMLElement {
   static get observedAttributes() {
@@ -33,6 +141,8 @@ class HyperframesPlayer extends HTMLElement {
       "poster",
       "playback-rate",
       "audio-src",
+      SHADER_CAPTURE_SCALE_ATTR,
+      SHADER_LOADING_ATTR,
     ];
   }
 
@@ -42,6 +152,15 @@ class HyperframesPlayer extends HTMLElement {
   private posterEl: HTMLImageElement | null = null;
   private controlsApi: ReturnType<typeof createControls> | null = null;
   private resizeObserver: ResizeObserver;
+  private shaderLoaderEl: HTMLDivElement;
+  private shaderLoaderFillEl: HTMLDivElement;
+  private shaderLoaderTitleEl: HTMLSpanElement;
+  private shaderLoaderDetailEl: HTMLDivElement;
+  private shaderLoaderTransitionValueEl: HTMLSpanElement;
+  private shaderLoaderFrameLabelEl: HTMLSpanElement;
+  private shaderLoaderFrameValueEl: HTMLSpanElement;
+  private shaderLoaderFrameRowEl: HTMLDivElement;
+  private shaderLoaderHideTimeout: ReturnType<typeof setTimeout> | null = null;
 
   private _ready = false;
   private _duration = 0;
@@ -141,6 +260,16 @@ class HyperframesPlayer extends HTMLElement {
 
     this.container.appendChild(this.iframe);
     this.shadow.appendChild(this.container);
+    const shaderLoader = this._createShaderLoader();
+    this.shaderLoaderEl = shaderLoader.root;
+    this.shaderLoaderFillEl = shaderLoader.fill;
+    this.shaderLoaderTitleEl = shaderLoader.title;
+    this.shaderLoaderDetailEl = shaderLoader.detail;
+    this.shaderLoaderTransitionValueEl = shaderLoader.transitionValue;
+    this.shaderLoaderFrameLabelEl = shaderLoader.frameLabel;
+    this.shaderLoaderFrameValueEl = shaderLoader.frameValue;
+    this.shaderLoaderFrameRowEl = shaderLoader.frameRow;
+    this.shadow.appendChild(this.shaderLoaderEl);
 
     // Clicking the bare player surface toggles play/pause.
     // Ignore shadow-DOM control interactions so overlay clicks don't double-handle.
@@ -167,8 +296,9 @@ class HyperframesPlayer extends HTMLElement {
       this._setupParentAudioFromUrl(this.getAttribute("audio-src")!);
     // srcdoc wins over src per HTML spec when both are set; mirror both attributes
     // so the browser applies the standard precedence rules.
-    if (this.hasAttribute("srcdoc")) this.iframe.srcdoc = this.getAttribute("srcdoc")!;
-    if (this.hasAttribute("src")) this.iframe.src = this.getAttribute("src")!;
+    if (this.hasAttribute("srcdoc"))
+      this.iframe.srcdoc = this._prepareSrcdoc(this.getAttribute("srcdoc")!);
+    if (this.hasAttribute("src")) this.iframe.src = this._prepareSrc(this.getAttribute("src")!);
   }
 
   disconnectedCallback() {
@@ -176,6 +306,8 @@ class HyperframesPlayer extends HTMLElement {
     window.removeEventListener("message", this._onMessage);
     this.iframe.removeEventListener("load", this._onIframeLoad);
     if (this._probeInterval) clearInterval(this._probeInterval);
+    if (this.shaderLoaderHideTimeout) clearTimeout(this.shaderLoaderHideTimeout);
+    this.shaderLoaderHideTimeout = null;
     this._teardownMediaObserver();
     this.controlsApi?.destroy();
     for (const m of this._parentMedia) {
@@ -190,7 +322,7 @@ class HyperframesPlayer extends HTMLElement {
       case "src":
         if (val) {
           this._ready = false;
-          this.iframe.src = val;
+          this.iframe.src = this._prepareSrc(val);
         }
         break;
       case "srcdoc":
@@ -198,7 +330,7 @@ class HyperframesPlayer extends HTMLElement {
         // srcdoc and let src take over. Always reset readiness; the iframe will
         // load a new document either way.
         this._ready = false;
-        if (val !== null) this.iframe.srcdoc = val;
+        if (val !== null) this.iframe.srcdoc = this._prepareSrcdoc(val);
         else this.iframe.removeAttribute("srcdoc");
         break;
       case "width":
@@ -233,6 +365,10 @@ class HyperframesPlayer extends HTMLElement {
         break;
       case "audio-src":
         if (val) this._setupParentAudioFromUrl(val);
+        break;
+      case SHADER_CAPTURE_SCALE_ATTR:
+      case SHADER_LOADING_ATTR:
+        this._reloadShaderOptions();
         break;
     }
   }
@@ -355,6 +491,21 @@ class HyperframesPlayer extends HTMLElement {
     this.setAttribute("playback-rate", String(r));
   }
 
+  get shaderCaptureScale() {
+    return Number(normalizeShaderCaptureScale(this.getAttribute(SHADER_CAPTURE_SCALE_ATTR)) ?? "1");
+  }
+  set shaderCaptureScale(scale: number) {
+    this.setAttribute(SHADER_CAPTURE_SCALE_ATTR, String(scale));
+  }
+
+  get shaderLoading() {
+    return normalizeShaderLoadingMode(this.getAttribute(SHADER_LOADING_ATTR));
+  }
+  set shaderLoading(mode: ShaderLoadingMode) {
+    if (mode === "composition") this.removeAttribute(SHADER_LOADING_ATTR);
+    else this.setAttribute(SHADER_LOADING_ATTR, mode);
+  }
+
   get muted() {
     return this.hasAttribute("muted");
   }
@@ -382,6 +533,236 @@ class HyperframesPlayer extends HTMLElement {
     } catch {
       /* cross-origin */
     }
+  }
+
+  private _shaderCaptureScaleParam(): string | null {
+    return normalizeShaderCaptureScale(this.getAttribute(SHADER_CAPTURE_SCALE_ATTR));
+  }
+
+  private _shaderLoadingMode(): ShaderLoadingMode {
+    return normalizeShaderLoadingMode(this.getAttribute(SHADER_LOADING_ATTR));
+  }
+
+  private _prepareSrc(src: string): string {
+    return withShaderQueryParams(src, this._shaderCaptureScaleParam(), this._shaderLoadingMode());
+  }
+
+  private _prepareSrcdoc(srcdoc: string): string {
+    return injectShaderOptionsIntoSrcdoc(
+      srcdoc,
+      this._shaderCaptureScaleParam(),
+      this._shaderLoadingMode(),
+    );
+  }
+
+  private _reloadShaderOptions(): void {
+    if (this._shaderLoadingMode() !== "player") {
+      this._resetShaderLoader();
+    }
+    if (this.hasAttribute("srcdoc")) {
+      this.iframe.srcdoc = this._prepareSrcdoc(this.getAttribute("srcdoc") || "");
+      return;
+    }
+    if (this.hasAttribute("src")) {
+      this.iframe.src = this._prepareSrc(this.getAttribute("src") || "");
+    }
+  }
+
+  private _createShaderLoader(): ShaderLoaderElements {
+    const root = document.createElement("div");
+    root.className = "hfp-shader-loader";
+    root.setAttribute("role", "status");
+    root.setAttribute("aria-live", "polite");
+    root.setAttribute("aria-label", "Preparing scene transitions");
+    root.setAttribute("data-hyperframes-ignore", "");
+    root.draggable = false;
+
+    const blockOverlayInteraction = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    for (const eventName of [
+      "selectstart",
+      "dragstart",
+      "pointerdown",
+      "mousedown",
+      "click",
+      "dblclick",
+      "contextmenu",
+      "touchstart",
+    ]) {
+      root.addEventListener(eventName, blockOverlayInteraction, { capture: true });
+    }
+
+    const panel = document.createElement("div");
+    panel.className = "hfp-shader-loader-panel";
+    panel.draggable = false;
+
+    const markFrame = document.createElement("div");
+    markFrame.className = "hfp-shader-loader-mark";
+    markFrame.draggable = false;
+    markFrame.innerHTML = [
+      '<svg width="78" height="78" viewBox="0 0 100 100" fill="none" aria-hidden="true" draggable="false">',
+      '<path d="M10.1851 57.8021L33.1145 73.8313C36.2202 75.9978 41.5173 73.5433 42.4816 69.4984L51.7611 30.4271C52.7253 26.3822 48.5802 23.9277 44.4602 26.0942L13.917 42.1235C6.96677 45.7676 4.97564 54.1579 10.1851 57.8021Z" fill="url(#hfp-shader-loader-grad-left)"/>',
+      '<path d="M87.5129 57.5141L56.9696 73.5433C52.8371 75.7098 48.7046 73.2553 49.6688 69.2104L58.9483 30.1391C59.9125 26.0942 65.2097 23.6397 68.3154 25.8062L91.2447 41.8354C96.4668 45.4796 94.4631 53.8699 87.5129 57.5141Z" fill="url(#hfp-shader-loader-grad-right)"/>',
+      "<defs>",
+      '<linearGradient id="hfp-shader-loader-grad-left" x1="48.5676" y1="25" x2="44.7804" y2="71.9384" gradientUnits="userSpaceOnUse">',
+      '<stop stop-color="#06E3FA"/>',
+      '<stop offset="1" stop-color="#4FDB5E"/>',
+      "</linearGradient>",
+      '<linearGradient id="hfp-shader-loader-grad-right" x1="54.8282" y1="73.8392" x2="72.0989" y2="32.8932" gradientUnits="userSpaceOnUse">',
+      '<stop stop-color="#06E3FA"/>',
+      '<stop offset="1" stop-color="#4FDB5E"/>',
+      "</linearGradient>",
+      "</defs>",
+      "</svg>",
+    ].join("");
+
+    const title = document.createElement("div");
+    title.className = "hfp-shader-loader-title";
+    const titleText = document.createElement("span");
+    titleText.className = "hfp-shader-loader-title-text";
+    titleText.textContent = SHADER_LOADING_PHRASES[0] || "Preparing scene transitions";
+    title.appendChild(titleText);
+
+    const detail = document.createElement("div");
+    detail.className = "hfp-shader-loader-detail";
+    detail.textContent = "Rendering animated scene samples for shader transitions.";
+
+    const track = document.createElement("div");
+    track.className = "hfp-shader-loader-track";
+    track.setAttribute("aria-hidden", "true");
+    const fill = document.createElement("div");
+    fill.className = "hfp-shader-loader-fill";
+    track.appendChild(fill);
+
+    const progress = document.createElement("div");
+    progress.className = "hfp-shader-loader-progress";
+    const createProgressRow = (labelText: string) => {
+      const row = document.createElement("div");
+      row.className = "hfp-shader-loader-row";
+      const label = document.createElement("span");
+      label.className = "hfp-shader-loader-label";
+      label.textContent = labelText;
+      const value = document.createElement("span");
+      value.className = "hfp-shader-loader-value";
+      row.appendChild(label);
+      row.appendChild(value);
+      progress.appendChild(row);
+      return { row, label, value };
+    };
+    const transitionStatus = createProgressRow("transition");
+    const frameStatus = createProgressRow("transition frame");
+
+    panel.appendChild(markFrame);
+    panel.appendChild(title);
+    panel.appendChild(detail);
+    panel.appendChild(track);
+    panel.appendChild(progress);
+    root.appendChild(panel);
+
+    return {
+      root,
+      fill,
+      title: titleText,
+      detail,
+      transitionValue: transitionStatus.value,
+      frameLabel: frameStatus.label,
+      frameValue: frameStatus.value,
+      frameRow: frameStatus.row,
+    };
+  }
+
+  private _showShaderLoader(): void {
+    if (this.shaderLoaderHideTimeout) {
+      clearTimeout(this.shaderLoaderHideTimeout);
+      this.shaderLoaderHideTimeout = null;
+    }
+    this.shaderLoaderEl.classList.remove("hfp-hiding");
+    this.shaderLoaderEl.classList.add("hfp-visible");
+  }
+
+  private _hideShaderLoader(): void {
+    if (this.shaderLoaderEl.classList.contains("hfp-hiding")) {
+      if (!this.shaderLoaderHideTimeout) this._scheduleShaderLoaderHideCleanup();
+      return;
+    }
+    if (!this.shaderLoaderEl.classList.contains("hfp-visible")) return;
+    this.shaderLoaderEl.classList.add("hfp-hiding");
+    this.shaderLoaderEl.classList.remove("hfp-visible");
+    this._scheduleShaderLoaderHideCleanup();
+  }
+
+  private _scheduleShaderLoaderHideCleanup(): void {
+    if (this.shaderLoaderHideTimeout) clearTimeout(this.shaderLoaderHideTimeout);
+    this.shaderLoaderHideTimeout = setTimeout(() => {
+      this.shaderLoaderEl.classList.remove("hfp-hiding");
+      this.shaderLoaderHideTimeout = null;
+    }, 420);
+  }
+
+  private _resetShaderLoader(): void {
+    if (this.shaderLoaderHideTimeout) {
+      clearTimeout(this.shaderLoaderHideTimeout);
+      this.shaderLoaderHideTimeout = null;
+    }
+    this.shaderLoaderEl.classList.remove("hfp-visible", "hfp-hiding");
+    this.shaderLoaderFillEl.style.transform = "scaleX(0)";
+    this.shaderLoaderTransitionValueEl.textContent = "";
+    this.shaderLoaderFrameValueEl.textContent = "";
+    this.shaderLoaderFrameRowEl.style.visibility = "hidden";
+  }
+
+  private _updateShaderLoader(status: ShaderTransitionState): void {
+    if (this._shaderLoadingMode() !== "player") {
+      this._resetShaderLoader();
+      return;
+    }
+    if (status.ready || !status.loading) {
+      this._hideShaderLoader();
+      return;
+    }
+
+    const progress =
+      typeof status.progress === "number" && Number.isFinite(status.progress) ? status.progress : 0;
+    const total =
+      typeof status.total === "number" && Number.isFinite(status.total) ? status.total : 0;
+    const ratio = total > 0 ? Math.min(1, Math.max(0, progress / total)) : 0;
+    const phraseIndex = Math.min(
+      SHADER_LOADING_PHRASES.length - 1,
+      Math.floor(ratio * SHADER_LOADING_PHRASES.length),
+    );
+    this.shaderLoaderTitleEl.textContent =
+      SHADER_LOADING_PHRASES[phraseIndex] || "Preparing scene transitions";
+    this.shaderLoaderDetailEl.textContent =
+      status.phase === "cached"
+        ? "Loading cached transition frames before playback."
+        : status.phase === "finalizing"
+          ? "Uploading transition textures for smooth playback."
+          : "Rendering animated scene samples for shader transitions.";
+    this.shaderLoaderFillEl.style.transform = `scaleX(${ratio})`;
+
+    this.shaderLoaderTransitionValueEl.textContent =
+      status.currentTransition !== undefined && status.transitionTotal !== undefined
+        ? `${status.currentTransition}/${status.transitionTotal}`
+        : total > 0
+          ? `${progress}/${total}`
+          : "";
+
+    const frameValue =
+      status.transitionFrame !== undefined && status.transitionFrames !== undefined
+        ? `${status.transitionFrame}/${status.transitionFrames}`
+        : "";
+    this.shaderLoaderFrameLabelEl.textContent =
+      status.phase === "cached"
+        ? "cached transition frames"
+        : status.phase === "finalizing"
+          ? "finalizing transition frames"
+          : "rendering transition frames";
+    this.shaderLoaderFrameValueEl.textContent = frameValue;
+    this.shaderLoaderFrameRowEl.style.visibility = frameValue ? "visible" : "hidden";
+    this.shaderLoaderEl.setAttribute("aria-valuenow", String(Math.round(ratio * 100)));
+    this._showShaderLoader();
   }
 
   /**
@@ -425,6 +806,18 @@ class HyperframesPlayer extends HTMLElement {
     if (e.source !== this.iframe.contentWindow) return;
     const data = e.data;
     if (!data || data.source !== "hf-preview") return;
+
+    if (data.type === "shader-transition-state") {
+      const state: ShaderTransitionState =
+        data.state && typeof data.state === "object" ? data.state : {};
+      this._updateShaderLoader(state);
+      this.dispatchEvent(
+        new CustomEvent("shadertransitionstate", {
+          detail: { compositionId: data.compositionId, state },
+        }),
+      );
+      return;
+    }
 
     if (data.type === "state") {
       this._currentTime = (data.frame ?? 0) / DEFAULT_FPS;
@@ -501,6 +894,7 @@ class HyperframesPlayer extends HTMLElement {
   private _onIframeLoad() {
     let attempts = 0;
     this._runtimeInjected = false;
+    this._resetShaderLoader();
     // A fresh iframe means a fresh runtime — `mediaOutputMuted` and the
     // autoplay-blocked latch are both reset inside it. The web component's
     // `_audioOwner` must reset to match, otherwise a composition switch on

--- a/packages/player/src/styles.ts
+++ b/packages/player/src/styles.ts
@@ -31,6 +31,161 @@ export const PLAYER_STYLES = /* css */ `
     pointer-events: none;
   }
 
+  .hfp-shader-loader {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    display: grid;
+    place-items: center;
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    background: #030504;
+    color: #f4f7fb;
+    cursor: default;
+    user-select: none;
+    -webkit-user-select: none;
+    transition: opacity 420ms ease-out, visibility 420ms ease-out;
+  }
+
+  .hfp-shader-loader.hfp-visible,
+  .hfp-shader-loader.hfp-hiding {
+    visibility: visible;
+  }
+
+  .hfp-shader-loader.hfp-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .hfp-shader-loader.hfp-hiding {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .hfp-shader-loader-panel {
+    display: grid;
+    grid-template-rows: 86px 40px 26px 12px 44px;
+    justify-items: center;
+    align-items: center;
+    gap: 8px;
+    width: min(620px, 82%);
+    text-align: center;
+    font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  .hfp-shader-loader-mark {
+    width: 86px;
+    height: 86px;
+    display: grid;
+    place-items: center;
+    overflow: visible;
+  }
+
+  .hfp-shader-loader-mark svg {
+    display: block;
+    overflow: visible;
+    filter: drop-shadow(0 0 5px rgba(79, 219, 94, 0.16));
+    pointer-events: none;
+  }
+
+  .hfp-shader-loader-title {
+    width: 100%;
+    height: 40px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: 26px;
+    line-height: 40px;
+    font-weight: 700;
+    letter-spacing: 0;
+  }
+
+  .hfp-shader-loader-title-text {
+    color: transparent;
+    background: linear-gradient(
+      90deg,
+      rgba(244, 247, 251, 0.84) 0%,
+      #ffffff 42%,
+      #80efe4 52%,
+      #ffffff 62%,
+      rgba(244, 247, 251, 0.84) 100%
+    );
+    background-size: 220% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    animation: hfp-shader-loader-sheen 1.9s linear infinite;
+  }
+
+  .hfp-shader-loader-detail {
+    width: 100%;
+    height: 26px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: rgba(244, 247, 251, 0.62);
+    font-size: 15px;
+    line-height: 26px;
+    font-weight: 500;
+  }
+
+  .hfp-shader-loader-track {
+    width: min(360px, 100%);
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .hfp-shader-loader-fill {
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #06e3fa, #4fdb5e);
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 160ms ease;
+  }
+
+  .hfp-shader-loader-progress {
+    width: min(420px, 100%);
+    height: 44px;
+    display: grid;
+    grid-template-rows: repeat(2, 22px);
+    color: rgba(244, 247, 251, 0.48);
+    font: 600 13px/22px "IBM Plex Mono", "SF Mono", "Fira Code", "Courier New", monospace;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .hfp-shader-loader-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 74px;
+    align-items: center;
+    column-gap: 20px;
+    width: 100%;
+    white-space: nowrap;
+  }
+
+  .hfp-shader-loader-label {
+    min-width: 0;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+  }
+
+  .hfp-shader-loader-value {
+    text-align: right;
+  }
+
+  @keyframes hfp-shader-loader-sheen {
+    from {
+      background-position: 140% 0;
+    }
+    to {
+      background-position: -140% 0;
+    }
+  }
+
   /* ── Theming via CSS custom properties ──
    *
    * Override from outside the shadow DOM:

--- a/packages/shader-transitions/README.md
+++ b/packages/shader-transitions/README.md
@@ -30,7 +30,7 @@ const tl = init({
 });
 ```
 
-The `init()` function captures each scene to a WebGL texture at transition time, crossfades between them using the selected shader, and returns a GSAP timeline. If WebGL is unavailable, it falls back to hard cuts.
+The `init()` function pre-captures animated scene samples for every transition, composites cached samples with the selected shader during playback, and returns a GSAP timeline. Scene animations keep advancing through shader transitions without running DOM captures in the playback loop. If WebGL is unavailable, it falls back to normal timeline playback without shader compositing.
 
 ### With an existing timeline
 
@@ -74,14 +74,19 @@ init({
 
 ### `init(config): GsapTimeline`
 
-| Option          | Type                 | Required | Description                                                                                                                                                   |
-| --------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bgColor`       | `string`             | yes      | Fallback background color (hex) for scene capture. Use the composition's body/canvas background — individual scenes set their own `background-color` via CSS. |
-| `accentColor`   | `string`             | no       | Accent color (hex) for shader glow effects                                                                                                                    |
-| `scenes`        | `string[]`           | yes      | Element IDs of each scene, in order                                                                                                                           |
-| `transitions`   | `TransitionConfig[]` | yes      | Transition definitions (see below)                                                                                                                            |
-| `timeline`      | `GsapTimeline`       | no       | Existing timeline to attach transitions to                                                                                                                    |
-| `compositionId` | `string`             | no       | Override the `data-composition-id` for timeline registration                                                                                                  |
+| Option                | Type                 | Required | Description                                                                                                                                                   |
+| --------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bgColor`             | `string`             | yes      | Fallback background color (hex) for scene capture. Use the composition's body/canvas background — individual scenes set their own `background-color` via CSS. |
+| `accentColor`         | `string`             | no       | Accent color (hex) for shader glow effects                                                                                                                    |
+| `scenes`              | `string[]`           | yes      | Element IDs of each scene, in order                                                                                                                           |
+| `transitions`         | `TransitionConfig[]` | yes      | Transition definitions (see below)                                                                                                                            |
+| `timeline`            | `GsapTimeline`       | no       | Existing timeline to attach transitions to                                                                                                                    |
+| `compositionId`       | `string`             | no       | Override the `data-composition-id` for timeline registration                                                                                                  |
+| `previewCaptureFps`   | `number`             | no       | Browser preview pre-capture samples per transition second. Defaults to `30`; rendering uses deterministic per-frame compositing instead.                      |
+| `previewCaptureScale` | `number`             | no       | Browser preview pre-capture scale from `0.25` to `1`. Defaults to `1` for full-fidelity snapshots; lower it for faster lower-resolution preview captures.     |
+| `showPreviewLoading`  | `boolean`            | no       | Cover the preview with a loading phrase and progress bar while browser snapshots are being pre-captured. Defaults to `true`.                                  |
+
+Browser previews store captured transition snapshots in IndexedDB using a key derived from composition ID, scene DOM/style signatures, transition timing, capture FPS, scale, and dimensions. On refresh, matching snapshots are reloaded into WebGL textures instead of being captured again. Runtime scene or stylesheet edits mark only adjacent transition caches dirty; recapture is deferred until playback so editing stays responsive.
 
 ### `TransitionConfig`
 

--- a/packages/shader-transitions/README.md
+++ b/packages/shader-transitions/README.md
@@ -74,17 +74,17 @@ init({
 
 ### `init(config): GsapTimeline`
 
-| Option                | Type                 | Required | Description                                                                                                                                                   |
-| --------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bgColor`             | `string`             | yes      | Fallback background color (hex) for scene capture. Use the composition's body/canvas background — individual scenes set their own `background-color` via CSS. |
-| `accentColor`         | `string`             | no       | Accent color (hex) for shader glow effects                                                                                                                    |
-| `scenes`              | `string[]`           | yes      | Element IDs of each scene, in order                                                                                                                           |
-| `transitions`         | `TransitionConfig[]` | yes      | Transition definitions (see below)                                                                                                                            |
-| `timeline`            | `GsapTimeline`       | no       | Existing timeline to attach transitions to                                                                                                                    |
-| `compositionId`       | `string`             | no       | Override the `data-composition-id` for timeline registration                                                                                                  |
-| `previewCaptureFps`   | `number`             | no       | Browser preview pre-capture samples per transition second. Defaults to `30`; rendering uses deterministic per-frame compositing instead.                      |
-| `previewCaptureScale` | `number`             | no       | Browser preview pre-capture scale from `0.25` to `1`. Defaults to `1` for full-fidelity snapshots; lower it for faster lower-resolution preview captures.     |
-| `showPreviewLoading`  | `boolean`            | no       | Cover the preview with a loading phrase and progress bar while browser snapshots are being pre-captured. Defaults to `true`.                                  |
+| Option              | Type                 | Required | Description                                                                                                                                                   |
+| ------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bgColor`           | `string`             | yes      | Fallback background color (hex) for scene capture. Use the composition's body/canvas background — individual scenes set their own `background-color` via CSS. |
+| `accentColor`       | `string`             | no       | Accent color (hex) for shader glow effects                                                                                                                    |
+| `scenes`            | `string[]`           | yes      | Element IDs of each scene, in order                                                                                                                           |
+| `transitions`       | `TransitionConfig[]` | yes      | Transition definitions (see below)                                                                                                                            |
+| `timeline`          | `GsapTimeline`       | no       | Existing timeline to attach transitions to                                                                                                                    |
+| `compositionId`     | `string`             | no       | Override the `data-composition-id` for timeline registration                                                                                                  |
+| `previewCaptureFps` | `number`             | no       | Browser preview pre-capture samples per transition second. Defaults to `30`; rendering uses deterministic per-frame compositing instead.                      |
+
+Browser preview capture scale and transition-prep loading UI ownership are controlled by `<hyperframes-player>` (`shader-capture-scale`, `shader-loading`) instead of composition code. Direct non-player previews keep the built-in full-fidelity loading fallback.
 
 Browser previews store captured transition snapshots in IndexedDB using a key derived from composition ID, scene DOM/style signatures, transition timing, capture FPS, scale, and dimensions. On refresh, matching snapshots are reloaded into WebGL textures instead of being captured again. Runtime scene or stylesheet edits mark only adjacent transition caches dirty; recapture is deferred until playback so editing stays responsive.
 

--- a/packages/shader-transitions/src/capture.ts
+++ b/packages/shader-transitions/src/capture.ts
@@ -2,6 +2,22 @@ import html2canvas from "html2canvas";
 import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from "./webgl.js";
 
 let patched = false;
+const VOID_ELEMENT_TAGS = new Set([
+  "AREA",
+  "BASE",
+  "BR",
+  "COL",
+  "EMBED",
+  "HR",
+  "IMG",
+  "INPUT",
+  "LINK",
+  "META",
+  "PARAM",
+  "SOURCE",
+  "TRACK",
+  "WBR",
+]);
 
 function patchCreatePattern(): void {
   if (patched) return;
@@ -27,94 +43,113 @@ export function initCapture(): void {
   patchCreatePattern();
 }
 
+export interface CaptureSceneOptions {
+  forceVisible?: boolean;
+  preferBrowserPaint?: boolean;
+  scale?: number;
+}
+
+function forceSceneVisibleInClone(source: HTMLElement, cloneDoc: Document): void {
+  if (!source.id) return;
+  const clone = cloneDoc.getElementById(source.id);
+  if (!(clone instanceof HTMLElement)) return;
+
+  clone.style.opacity = "1";
+  clone.style.visibility = "visible";
+  clone.querySelectorAll<HTMLElement>("[data-start]").forEach((el) => {
+    el.style.visibility = "visible";
+  });
+}
+
+function stabilizeTransformedBoxShadows(root: HTMLElement): void {
+  const view = root.ownerDocument.defaultView;
+  if (!view) return;
+
+  [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))].forEach((el) => {
+    if (VOID_ELEMENT_TAGS.has(el.tagName)) return;
+    const styles = view.getComputedStyle(el);
+    if (styles.boxShadow === "none" || styles.transform === "none") return;
+
+    const shadow = root.ownerDocument.createElement("div");
+    shadow.setAttribute("data-hyper-shader-shadow-shim", "");
+    shadow.style.cssText = [
+      "position:absolute",
+      "inset:0",
+      "border-radius:inherit",
+      `box-shadow:${styles.boxShadow}`,
+      "background:transparent",
+      "pointer-events:none",
+      "z-index:0",
+    ].join(";");
+
+    if (styles.position === "static") {
+      el.style.position = "relative";
+    }
+    el.style.boxShadow = "none";
+    el.insertBefore(shadow, el.firstChild);
+  });
+}
+
 export function captureScene(
   sceneEl: HTMLElement,
   bgColor: string,
   width: number = DEFAULT_WIDTH,
   height: number = DEFAULT_HEIGHT,
+  options: CaptureSceneOptions = {},
 ): Promise<HTMLCanvasElement> {
-  return html2canvas(sceneEl, {
-    width,
-    height,
-    scale: 1,
-    backgroundColor: bgColor,
-    logging: false,
-    // Safari applies stricter canvas-taint rules than Chrome. SVG data URLs
-    // with <filter> elements (e.g. feTurbulence grain backgrounds), certain
-    // cross-origin images, and mask/clip-path url() refs can taint the
-    // output canvas on WebKit. Without these flags, html2canvas throws
-    // `SecurityError: The operation is insecure` during its own read-back
-    // path and every shader transition falls through to the catch handler
-    // — observed in Safari + Claude Design's cross-origin iframe sandbox.
-    //
-    // useCORS:    send CORS headers on image fetches so cross-origin images
-    //             with proper `Access-Control-Allow-Origin` don't taint the
-    //             canvas in the first place. Strict improvement.
-    // allowTaint: let html2canvas complete and return a canvas even when it
-    //             becomes tainted (instead of throwing). Important caveat:
-    //             a tainted canvas CANNOT be uploaded to WebGL via
-    //             `gl.texImage2D` — WebGL spec requires SecurityError on
-    //             non-origin-clean sources, with no opt-out. So this flag
-    //             only moves the failure point from html2canvas to the
-    //             texImage2D call in webgl.ts. In both cases `hyper-shader.ts`
-    //             catches the rejected promise and runs the CSS crossfade
-    //             fallback. Net effect: the end-user UX is the same (smooth
-    //             CSS fade in either case), but we get a cleaner, more
-    //             predictable error site and the flag is defensively
-    //             correct for the non-taint branches where it genuinely
-    //             helps (e.g., `crossOrigin="anonymous"` image fetches
-    //             that already had CORS headers).
-    useCORS: true,
-    allowTaint: true,
-    ignoreElements: (el: Element) => el.tagName === "CANVAS" || el.hasAttribute("data-no-capture"),
-  });
-}
-
-/**
- * Capture the incoming scene with .scene-content hidden (background + decoratives only).
- * Shows the scene behind the outgoing scene via z-index, waits 2 rAFs for font rendering,
- * captures, then restores.
- *
- * IMPORTANT: We force `visibility: visible` during capture because the HyperFrames runtime's
- * time-based visibility gate (in `packages/core/src/runtime/init.ts`) sets `style.visibility
- * = "hidden"` on every `[data-start]` element that's outside its current playback window —
- * every frame. When a shader transition fires *before* the incoming scene's `data-start`
- * boundary (the recommended "transition.time = boundary - duration/2" centered placement),
- * the runtime has `visibility: hidden` on the incoming scene. Without the visibility override
- * here, `html2canvas` captures the element as blank → shader transitions from the real
- * outgoing scene to a blank incoming texture → users see content fade/morph into the
- * background color mid-transition (a visible "blink"). Forcing `visibility: visible` only
- * for the duration of the capture fixes this without affecting what the user sees during
- * normal playback.
- */
-export function captureIncomingScene(
-  toScene: HTMLElement,
-  bgColor: string,
-  width: number = DEFAULT_WIDTH,
-  height: number = DEFAULT_HEIGHT,
-): Promise<HTMLCanvasElement> {
-  return new Promise<HTMLCanvasElement>((resolve, reject) => {
-    const origZ = toScene.style.zIndex;
-    const origOpacity = toScene.style.opacity;
-    const origVisibility = toScene.style.visibility;
-    toScene.style.zIndex = "-1";
-    toScene.style.opacity = "1";
-    toScene.style.visibility = "visible";
-
-    const contentEl = toScene.querySelector<HTMLElement>(".scene-content");
-    if (contentEl) contentEl.style.visibility = "hidden";
-
-    const restore = () => {
-      if (contentEl) contentEl.style.visibility = "";
-      toScene.style.visibility = origVisibility;
-      toScene.style.opacity = origOpacity;
-      toScene.style.zIndex = origZ;
-    };
-
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        captureScene(toScene, bgColor, width, height).then(resolve, reject).finally(restore);
-      });
+  const captureWithRenderer = (foreignObjectRendering: boolean): Promise<HTMLCanvasElement> => {
+    return html2canvas(sceneEl, {
+      width,
+      height,
+      scale: options.scale ?? 1,
+      backgroundColor: bgColor,
+      logging: false,
+      foreignObjectRendering,
+      // Safari applies stricter canvas-taint rules than Chrome. SVG data URLs
+      // with <filter> elements (e.g. feTurbulence grain backgrounds), certain
+      // cross-origin images, and mask/clip-path url() refs can taint the
+      // output canvas on WebKit. Without these flags, html2canvas throws
+      // `SecurityError: The operation is insecure` during its own read-back
+      // path and every shader transition falls through to the catch handler
+      // — observed in Safari + Claude Design's cross-origin iframe sandbox.
+      //
+      // useCORS:    send CORS headers on image fetches so cross-origin images
+      //             with proper `Access-Control-Allow-Origin` don't taint the
+      //             canvas in the first place. Strict improvement.
+      // allowTaint: let html2canvas complete and return a canvas even when it
+      //             becomes tainted (instead of throwing). Important caveat:
+      //             a tainted canvas CANNOT be uploaded to WebGL via
+      //             `gl.texImage2D` — WebGL spec requires SecurityError on
+      //             non-origin-clean sources, with no opt-out. So this flag
+      //             only moves the failure point from html2canvas to the
+      //             texImage2D call in webgl.ts. The caller catches the
+      //             rejected promise and keeps the DOM fallback visible. Net
+      //             effect: the end-user UX avoids blank frames either way,
+      //             but we get a cleaner, more predictable error site and the
+      //             flag is defensively correct for the non-taint branches
+      //             where it genuinely helps (e.g.,
+      //             `crossOrigin="anonymous"` image fetches that already had
+      //             CORS headers).
+      useCORS: true,
+      allowTaint: true,
+      onclone: (cloneDoc) => {
+        if (!sceneEl.id) return;
+        const clone = cloneDoc.getElementById(sceneEl.id);
+        if (clone instanceof HTMLElement) {
+          stabilizeTransformedBoxShadows(clone);
+        }
+        if (options.forceVisible) {
+          forceSceneVisibleInClone(sceneEl, cloneDoc);
+        }
+      },
+      ignoreElements: (el: Element) =>
+        el.tagName === "CANVAS" || el.hasAttribute("data-no-capture"),
     });
-  });
+  };
+
+  if (options.preferBrowserPaint === true) {
+    return captureWithRenderer(true).catch(() => captureWithRenderer(false));
+  }
+
+  return captureWithRenderer(false);
 }

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -64,8 +64,6 @@ export interface HyperShaderConfig {
   timeline?: GsapTimeline;
   compositionId?: string;
   previewCaptureFps?: number;
-  previewCaptureScale?: number;
-  showPreviewLoading?: boolean;
 }
 
 interface TransState {
@@ -196,6 +194,33 @@ function clampNumber(value: number, min: number, max: number): number {
 function resolvePositiveNumber(value: number | undefined, fallback: number): number {
   if (value === undefined) return fallback;
   return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+const PLAYER_CAPTURE_SCALE_PARAM = "__hf_shader_capture_scale";
+const PLAYER_LOADING_PARAM = "__hf_shader_loading";
+
+function readPlayerOption(globalName: string, queryName: string): string | null {
+  const globalValue = (window as unknown as Record<string, unknown>)[globalName];
+  if (typeof globalValue === "string") return globalValue;
+  if (typeof globalValue === "number" && Number.isFinite(globalValue)) return String(globalValue);
+  try {
+    return new URLSearchParams(window.location.search).get(queryName);
+  } catch {
+    return null;
+  }
+}
+
+function resolvePlayerCaptureScale(): number {
+  const raw = readPlayerOption("__HF_SHADER_CAPTURE_SCALE", PLAYER_CAPTURE_SCALE_PARAM);
+  const parsed = raw === null ? NaN : Number(raw);
+  return clampNumber(Number.isFinite(parsed) && parsed > 0 ? parsed : 1, 0.25, 1);
+}
+
+function resolvePlayerLoadingMode(): "internal" | "player" | "none" {
+  const raw = readPlayerOption("__HF_SHADER_LOADING", PLAYER_LOADING_PARAM)?.trim().toLowerCase();
+  if (raw === "player" || raw === "true" || raw === "1") return "player";
+  if (raw === "none" || raw === "false" || raw === "0" || raw === "off") return "none";
+  return "internal";
 }
 
 function stableHash(input: string): string {
@@ -886,12 +911,8 @@ export function init(config: HyperShaderConfig): GsapTimeline {
 
   const canvasEl = glCanvas;
   const previewCaptureFps = clampNumber(resolvePositiveNumber(config.previewCaptureFps, 30), 1, 60);
-  const defaultCaptureScale = 1;
-  const previewCaptureScale = clampNumber(
-    resolvePositiveNumber(config.previewCaptureScale, defaultCaptureScale),
-    0.25,
-    1,
-  );
+  const previewCaptureScale = resolvePlayerCaptureScale();
+  const loadingMode = resolvePlayerLoadingMode();
   const previewTextureWidth = Math.max(1, Math.round(compWidth * previewCaptureScale));
   const previewTextureHeight = Math.max(1, Math.round(compHeight * previewCaptureScale));
   const cachedTransitions: CachedTransition[] = [];
@@ -921,7 +942,7 @@ export function init(config: HyperShaderConfig): GsapTimeline {
   const interpolatedToFbo = createFramebuffer(gl, interpolatedToTex);
   let loadingOverlay: SnapshotLoadingOverlay | null = null;
   const getLoadingOverlay = (): SnapshotLoadingOverlay | null => {
-    if (config.showPreviewLoading === false) return null;
+    if (loadingMode !== "internal") return null;
     loadingOverlay = loadingOverlay || createSnapshotLoadingOverlay(root, compWidth, compHeight);
     return loadingOverlay;
   };
@@ -1500,6 +1521,15 @@ export function init(config: HyperShaderConfig): GsapTimeline {
     const next = { ...current, ...status };
     next.dirtyTransitions = cachedTransitions.filter((cache) => cache.dirty || !cache.ready).length;
     hfWin.__hf.shaderTransitions[compId] = next;
+    window.parent?.postMessage(
+      {
+        source: "hf-preview",
+        type: "shader-transition-state",
+        compositionId: compId,
+        state: next,
+      },
+      "*",
+    );
     if (next.loading) {
       const overlay = getLoadingOverlay();
       overlay?.show();

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -2,15 +2,16 @@ import {
   createContext,
   setupQuad,
   createProgram,
+  createProgramWithVertex,
   createTexture,
-  uploadTexture,
+  uploadTextureSource,
   renderShader,
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
   type AccentColors,
 } from "./webgl.js";
 import { getFragSource, type ShaderName } from "./shaders/registry.js";
-import { initCapture, captureScene, captureIncomingScene } from "./capture.js";
+import { initCapture, captureScene } from "./capture.js";
 
 declare const gsap: {
   timeline: (opts: Record<string, unknown>) => GsapTimeline;
@@ -24,9 +25,13 @@ declare const gsap: {
 
 interface GsapTimeline {
   paused: () => boolean;
-  play: () => GsapTimeline;
-  pause: () => GsapTimeline;
-  time: () => number;
+  play: (from?: number, suppressEvents?: boolean) => GsapTimeline;
+  pause: (atTime?: number, suppressEvents?: boolean) => GsapTimeline;
+  time: {
+    (): number;
+    (value: number, suppressEvents?: boolean): GsapTimeline;
+  };
+  seek?: (position: number | string, suppressEvents?: boolean) => GsapTimeline;
   call: (fn: () => void, args: null, position: number) => GsapTimeline;
   to: (
     target: Record<string, unknown>,
@@ -58,14 +63,86 @@ export interface HyperShaderConfig {
   transitions: TransitionConfig[];
   timeline?: GsapTimeline;
   compositionId?: string;
+  previewCaptureFps?: number;
+  previewCaptureScale?: number;
+  showPreviewLoading?: boolean;
 }
 
 interface TransState {
   active: boolean;
   prog: WebGLProgram | null;
+  progress: number;
+  transitionIndex: number;
+}
+
+interface CachedTransitionFrame {
+  sampleIndex: number;
+  fromBlob: Blob | null;
+  toBlob: Blob | null;
+  fromTex: WebGLTexture | null;
+  toTex: WebGLTexture | null;
+}
+
+interface TexturedTransitionFrame extends CachedTransitionFrame {
+  fromTex: WebGLTexture;
+  toTex: WebGLTexture;
+}
+
+interface CachedTransitionFrameBlend {
+  a: TexturedTransitionFrame;
+  b: TexturedTransitionFrame;
+  mix: number;
+}
+
+interface CachedTransition {
+  index: number;
+  time: number;
+  duration: number;
   fromId: string;
   toId: string;
+  prog: WebGLProgram;
+  frames: CachedTransitionFrame[];
+  cacheKey: string;
+  dirty: boolean;
+  ready: boolean;
+  fallback: boolean;
+  persisted: boolean;
+  textureReady: boolean;
+  texturePromise: Promise<boolean> | null;
+  textureGeneration: number;
+  textureAccess: number;
+  lastError?: string;
+}
+
+interface SnapshotLoadingOverlay {
+  show: () => void;
+  update: (status: SnapshotLoadingStatus) => void;
+  hide: () => void;
+}
+
+interface SnapshotLoadingStatus {
   progress: number;
+  total: number;
+  currentTransition?: number;
+  transitionTotal?: number;
+  transitionFrame?: number;
+  transitionFrames?: number;
+  phase?: "cached" | "capturing" | "finalizing";
+}
+
+interface SnapshotCacheEntry {
+  key: string;
+  blob: Blob;
+  width: number;
+  height: number;
+  updatedAt: number;
+}
+
+interface SceneStyleState {
+  scene: HTMLElement | null;
+  opacity: string;
+  visibility: string;
+  pointerEvents: string;
 }
 
 // Defaults for transition duration/ease. Used by every fallback site in this
@@ -75,6 +152,23 @@ interface TransState {
 // producer reads to plan compositing.
 const DEFAULT_DURATION = 0.7;
 const DEFAULT_EASE = "power2.inOut";
+const NO_FLIP_VERT_SRC =
+  "attribute vec2 a_pos; varying vec2 v_uv; void main(){" +
+  "v_uv=a_pos*0.5+0.5; gl_Position=vec4(a_pos,0,1);}";
+const SNAPSHOT_LOADING_PHRASES = [
+  "Preparing scene transitions",
+  "Sampling outgoing scene motion",
+  "Sampling incoming scene motion",
+  "Caching transition frames",
+  "Finalizing transition preview",
+];
+const SNAPSHOT_CACHE_DB = "hyper-shader-preview-cache";
+const SNAPSHOT_CACHE_STORE = "frames";
+const SNAPSHOT_CACHE_VERSION = 1;
+const SNAPSHOT_CACHE_SCHEMA = "v1";
+const MAX_TEXTURED_TRANSITIONS = 2;
+const TEXTURE_PRELOAD_LOOKAHEAD_SECONDS = 1.25;
+const MAX_SNAPSHOT_CACHE_ENTRIES = 1200;
 
 function parseHex(hex: string): [number, number, number] {
   const h = hex.replace("#", "");
@@ -92,6 +186,576 @@ function deriveAccentColors(hex: string): AccentColors {
     accent: [r, g, b],
     dark: [r * 0.35, g * 0.35, b * 0.35],
     bright: [Math.min(1, r * 1.5 + 0.2), Math.min(1, g * 1.5 + 0.2), Math.min(1, b * 1.5 + 0.2)],
+  };
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function resolvePositiveNumber(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function stableHash(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function getDocumentStyleSignature(doc: Document): string {
+  const styleText = Array.from(doc.querySelectorAll("style"))
+    .map((style) => style.textContent || "")
+    .join("\n");
+  const linkedStyles = Array.from(doc.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"]'))
+    .map((link) => `${link.href}:${link.getAttribute("integrity") || ""}`)
+    .join("\n");
+  return stableHash(`${styleText}\n${linkedStyles}`);
+}
+
+function getDocumentScriptSignature(doc: Document): string {
+  const projectSignature = Array.from(
+    doc.querySelectorAll<HTMLMetaElement>('meta[name="hyperframes-project-signature"]'),
+  )
+    .map((meta) => meta.getAttribute("content") || "")
+    .join("\n");
+  const scriptText = Array.from(doc.querySelectorAll<HTMLScriptElement>("script"))
+    .map((script) => {
+      const attrs = [
+        script.type,
+        script.src,
+        script.getAttribute("integrity") || "",
+        script.getAttribute("crossorigin") || "",
+        script.getAttribute("data-hyperframes-runtime") || "",
+      ].join(":");
+      return `${attrs}\n${script.src ? "" : script.textContent || ""}`;
+    })
+    .join("\n");
+  return stableHash(`${projectSignature}\n${scriptText}`);
+}
+
+function getSceneSignature(sceneId: string): string {
+  const scene = document.getElementById(sceneId);
+  if (!scene) return "missing";
+  return stableHash(
+    `${getDocumentStyleSignature(document)}\n${getDocumentScriptSignature(document)}\n${getSceneSignatureHtml(scene)}`,
+  );
+}
+
+function removeStyleProperties(el: HTMLElement, properties: string[]): void {
+  for (const property of properties) {
+    el.style.removeProperty(property);
+  }
+  if (el.getAttribute("style")?.trim() === "") {
+    el.removeAttribute("style");
+  }
+}
+
+function getSceneSignatureHtml(scene: HTMLElement): string {
+  const clone = scene.cloneNode(true) as HTMLElement;
+
+  // HyperShader and the core runtime mutate these inline styles during seek and
+  // playback. Cache identity should track authored content, not the last preview
+  // playhead state.
+  removeStyleProperties(clone, ["opacity", "visibility", "pointer-events"]);
+  clone.querySelectorAll<HTMLElement>("[data-start]").forEach((el) => {
+    removeStyleProperties(el, ["visibility"]);
+  });
+
+  return clone.outerHTML;
+}
+
+function makeSnapshotKey(cacheKey: string, sampleIndex: number, side: "from" | "to"): string {
+  return `${cacheKey}:sample:${sampleIndex}:${side}`;
+}
+
+function openSnapshotDb(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const request = indexedDB.open(SNAPSHOT_CACHE_DB, SNAPSHOT_CACHE_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(SNAPSHOT_CACHE_STORE)) {
+        db.createObjectStore(SNAPSHOT_CACHE_STORE, { keyPath: "key" });
+      }
+    };
+    request.onerror = () => resolve(null);
+    request.onblocked = () => resolve(null);
+    request.onsuccess = () => {
+      const db = request.result;
+      db.onversionchange = () => {
+        db.close();
+        snapshotDbPromise = null;
+      };
+      resolve(db);
+    };
+  });
+}
+
+let snapshotDbPromise: Promise<IDBDatabase | null> | null = null;
+
+function resetSnapshotDb(db: IDBDatabase | null): void {
+  try {
+    db?.close();
+  } catch {
+    // Ignore close failures; the next cache operation will reopen the DB.
+  }
+  snapshotDbPromise = null;
+}
+
+function getSnapshotDb(): Promise<IDBDatabase | null> {
+  snapshotDbPromise = snapshotDbPromise || openSnapshotDb();
+  return snapshotDbPromise;
+}
+
+async function getSnapshotEntry(key: string): Promise<SnapshotCacheEntry | null> {
+  const db = await getSnapshotDb();
+  if (!db) return null;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(SNAPSHOT_CACHE_STORE, "readonly");
+      const request = tx.objectStore(SNAPSHOT_CACHE_STORE).get(key);
+      request.onerror = () => resolve(null);
+      request.onsuccess = () => {
+        const result = request.result;
+        if (
+          result &&
+          typeof result === "object" &&
+          "blob" in result &&
+          result.blob instanceof Blob
+        ) {
+          resolve(result as SnapshotCacheEntry);
+        } else {
+          resolve(null);
+        }
+      };
+    } catch {
+      resetSnapshotDb(db);
+      resolve(null);
+    }
+  });
+}
+
+async function putSnapshotEntry(entry: SnapshotCacheEntry): Promise<boolean> {
+  const db = await getSnapshotDb();
+  if (!db) return false;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(SNAPSHOT_CACHE_STORE, "readwrite");
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => resolve(false);
+      tx.objectStore(SNAPSHOT_CACHE_STORE).put(entry);
+    } catch {
+      resetSnapshotDb(db);
+      resolve(false);
+    }
+  });
+}
+
+function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    try {
+      canvas.toBlob((blob) => resolve(blob), "image/png");
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+async function pruneSnapshotCache(
+  compId: string,
+  activeCacheKeys: Set<string>,
+  maxEntries: number = MAX_SNAPSHOT_CACHE_ENTRIES,
+): Promise<void> {
+  const db = await getSnapshotDb();
+  if (!db) return;
+  const entries = await new Promise<Array<{ key: string; updatedAt: number }>>((resolve) => {
+    try {
+      const tx = db.transaction(SNAPSHOT_CACHE_STORE, "readonly");
+      const request = tx.objectStore(SNAPSHOT_CACHE_STORE).getAll();
+      request.onerror = () => resolve([]);
+      request.onsuccess = () => {
+        const rows: Array<{ key: string; updatedAt: number }> = [];
+        for (const result of request.result) {
+          if (
+            result &&
+            typeof result === "object" &&
+            "key" in result &&
+            typeof result.key === "string"
+          ) {
+            const updatedAt =
+              "updatedAt" in result && typeof result.updatedAt === "number" ? result.updatedAt : 0;
+            rows.push({ key: result.key, updatedAt });
+          }
+        }
+        resolve(rows);
+      };
+    } catch {
+      resetSnapshotDb(db);
+      resolve([]);
+    }
+  });
+  const projectPrefix = `${compId}:`;
+  const isActiveSnapshot = (key: string): boolean => {
+    for (const cacheKey of activeCacheKeys) {
+      if (key.startsWith(`${cacheKey}:sample:`)) return true;
+    }
+    return false;
+  };
+  const staleProjectKeys = entries
+    .filter((entry) => entry.key.startsWith(projectPrefix) && !isActiveSnapshot(entry.key))
+    .map((entry) => entry.key);
+  const staleProjectKeySet = new Set(staleProjectKeys);
+  const remaining = entries.filter((entry) => !staleProjectKeySet.has(entry.key));
+  const activeCount = remaining.filter((entry) => isActiveSnapshot(entry.key)).length;
+  const removable = remaining
+    .filter((entry) => !isActiveSnapshot(entry.key))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+  const removableBudget = Math.max(0, maxEntries - activeCount);
+  const overflowKeys =
+    removable.length > removableBudget
+      ? removable.slice(removableBudget).map((entry) => entry.key)
+      : [];
+  const keysToDelete = Array.from(new Set([...staleProjectKeys, ...overflowKeys]));
+  if (keysToDelete.length === 0) return;
+  await new Promise<void>((resolve) => {
+    try {
+      const tx = db.transaction(SNAPSHOT_CACHE_STORE, "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+      const store = tx.objectStore(SNAPSHOT_CACHE_STORE);
+      for (const key of keysToDelete) {
+        store.delete(key);
+      }
+    } catch {
+      resetSnapshotDb(db);
+      resolve();
+    }
+  });
+}
+
+function blobToTextureSource(blob: Blob): Promise<TexImageSource> {
+  if (typeof createImageBitmap === "function") {
+    return createImageBitmap(blob);
+  }
+
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("[HyperShader] Failed to decode cached snapshot"));
+    };
+    img.src = url;
+  });
+}
+
+function closeTextureSource(source: TexImageSource): void {
+  if (typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap) {
+    source.close();
+  }
+}
+
+function createRenderTexture(
+  gl: WebGLRenderingContext,
+  width: number,
+  height: number,
+): WebGLTexture {
+  const tex = createTexture(gl);
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  return tex;
+}
+
+function createFramebuffer(gl: WebGLRenderingContext, tex: WebGLTexture): WebGLFramebuffer {
+  const fbo = gl.createFramebuffer();
+  if (!fbo) throw new Error("[HyperShader] Failed to create framebuffer");
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  return fbo;
+}
+
+function createSnapshotLoadingOverlay(
+  root: HTMLElement | null,
+  width: number,
+  height: number,
+): SnapshotLoadingOverlay | null {
+  const doc = root?.ownerDocument || document;
+  const host = root || doc.body;
+  if (!host) return null;
+
+  host.querySelector<HTMLElement>("[data-hyper-shader-loading]")?.remove();
+
+  const overlay = doc.createElement("div");
+  overlay.setAttribute("data-hyper-shader-loading", "");
+  overlay.setAttribute("data-hyperframes-ignore", "");
+  overlay.setAttribute("data-hyperframes-picker-block", "");
+  overlay.setAttribute("data-hf-ignore", "");
+  overlay.setAttribute("data-no-capture", "");
+  overlay.setAttribute("data-no-inspect", "");
+  overlay.setAttribute("data-no-pick", "");
+  overlay.setAttribute("draggable", "false");
+  overlay.setAttribute("role", "status");
+  overlay.setAttribute("aria-label", "Preparing scene transitions");
+  overlay.style.cssText = [
+    "position:absolute",
+    "inset:0",
+    `width:${width}px`,
+    `height:${height}px`,
+    "z-index:2147483647",
+    "display:none",
+    "place-items:center",
+    "opacity:1",
+    "transition:opacity 240ms ease-out",
+    "background:#030504",
+    "pointer-events:auto",
+    "color:#f4f7fb",
+    "cursor:default",
+    "touch-action:none",
+    "user-select:none",
+    "-webkit-user-select:none",
+    "-webkit-user-drag:none",
+  ].join(";");
+  const blockOverlayInteraction = (event: Event): void => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  for (const eventName of ["selectstart", "dragstart", "pointerdown", "mousedown", "touchstart"]) {
+    overlay.addEventListener(eventName, blockOverlayInteraction, { capture: true });
+  }
+
+  const panel = doc.createElement("div");
+  panel.setAttribute("draggable", "false");
+  panel.style.cssText = [
+    "display:grid",
+    "grid-template-rows:172px 72px 44px 44px 54px",
+    "justify-items:center",
+    "align-items:center",
+    "gap:0",
+    "width:min(1040px,82%)",
+    "padding:42px",
+    "box-sizing:border-box",
+    "text-align:center",
+    "font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
+    "user-select:none",
+    "-webkit-user-select:none",
+    "-webkit-user-drag:none",
+  ].join(";");
+
+  const markFrame = doc.createElement("div");
+  markFrame.setAttribute("data-hf-loader-mark-frame", "");
+  markFrame.style.cssText = [
+    "width:172px",
+    "height:172px",
+    "display:grid",
+    "place-items:center",
+    "overflow:visible",
+    "transform-origin:50% 50%",
+    "will-change:transform,opacity",
+    "user-select:none",
+    "-webkit-user-select:none",
+    "-webkit-user-drag:none",
+  ].join(";");
+  markFrame.innerHTML = [
+    '<svg width="156" height="156" viewBox="0 0 100 100" fill="none" aria-hidden="true" draggable="false" style="display:block;overflow:visible;filter:drop-shadow(0 0 7px rgba(79,219,94,.2));user-select:none;-webkit-user-select:none">',
+    '<g data-hf-loader-mark transform="translate(50 50)">',
+    '<g data-hf-loader-core transform="scale(1)" opacity=".92">',
+    '<g transform="translate(-50 -50)">',
+    '<path data-hf-loader-left d="M10.1851 57.8021L33.1145 73.8313C36.2202 75.9978 41.5173 73.5433 42.4816 69.4984L51.7611 30.4271C52.7253 26.3822 48.5802 23.9277 44.4602 26.0942L13.917 42.1235C6.96677 45.7676 4.97564 54.1579 10.1851 57.8021Z" fill="url(#hyper-shader-loader-grad-left)"/>',
+    '<path data-hf-loader-right d="M87.5129 57.5141L56.9696 73.5433C52.8371 75.7098 48.7046 73.2553 49.6688 69.2104L58.9483 30.1391C59.9125 26.0942 65.2097 23.6397 68.3154 25.8062L91.2447 41.8354C96.4668 45.4796 94.4631 53.8699 87.5129 57.5141Z" fill="url(#hyper-shader-loader-grad-right)"/>',
+    "</g>",
+    "</g>",
+    "</g>",
+    "<defs>",
+    '<linearGradient id="hyper-shader-loader-grad-left" x1="48.5676" y1="25" x2="44.7804" y2="71.9384" gradientUnits="userSpaceOnUse">',
+    '<stop stop-color="#06E3FA"/>',
+    '<stop offset="1" stop-color="#4FDB5E"/>',
+    "</linearGradient>",
+    '<linearGradient id="hyper-shader-loader-grad-right" x1="54.8282" y1="73.8392" x2="72.0989" y2="32.8932" gradientUnits="userSpaceOnUse">',
+    '<stop stop-color="#06E3FA"/>',
+    '<stop offset="1" stop-color="#4FDB5E"/>',
+    "</linearGradient>",
+    "</defs>",
+    "</svg>",
+  ].join("");
+  const mark = markFrame.querySelector("svg");
+  if (!mark) return null;
+  mark.setAttribute("draggable", "false");
+
+  const phrase = doc.createElement("div");
+  phrase.style.cssText = [
+    "width:100%",
+    "height:72px",
+    "display:flex",
+    "align-items:center",
+    "justify-content:center",
+    "overflow:hidden",
+    "white-space:nowrap",
+    "text-overflow:ellipsis",
+    "font:600 44px/1.15 Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
+    "letter-spacing:0",
+    "text-align:center",
+    "color:#f4f7fb",
+  ].join(";");
+
+  const phraseText = doc.createElement("span");
+  phraseText.textContent = SNAPSHOT_LOADING_PHRASES[0] ?? "Preparing scene transitions";
+
+  const detail = doc.createElement("div");
+  detail.textContent = "Sampling animated scene frames so shader transitions stay in motion.";
+  detail.style.cssText = [
+    "width:min(760px,100%)",
+    "height:44px",
+    "overflow:hidden",
+    "white-space:nowrap",
+    "text-overflow:ellipsis",
+    "color:rgba(244,247,251,0.64)",
+    "font:400 24px/1.5 Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
+  ].join(";");
+
+  phrase.appendChild(phraseText);
+
+  const track = doc.createElement("div");
+  track.setAttribute("aria-hidden", "true");
+  track.style.cssText = [
+    "width:min(520px,100%)",
+    "height:10px",
+    "overflow:hidden",
+    "border-radius:999px",
+    "background:rgba(255,255,255,0.1)",
+  ].join(";");
+
+  const fill = doc.createElement("div");
+  fill.style.cssText = [
+    "width:100%",
+    "height:100%",
+    "transform:scaleX(0)",
+    "transform-origin:left center",
+    "border-radius:inherit",
+    "background:linear-gradient(90deg,#06e3fa,#4fdb5e)",
+    "transition:transform 160ms ease",
+  ].join(";");
+
+  const progressText = doc.createElement("div");
+  progressText.style.cssText = [
+    "width:min(560px,100%)",
+    "height:54px",
+    "overflow:hidden",
+    "display:grid",
+    "grid-template-rows:repeat(2,27px)",
+    "font:500 18px/27px 'IBM Plex Mono','SF Mono','Fira Code',monospace",
+    "font-variant-numeric:tabular-nums",
+    "color:rgba(244,247,251,0.48)",
+  ].join(";");
+  const createProgressRow = (labelText: string) => {
+    const row = doc.createElement("div");
+    row.style.cssText = [
+      "display:grid",
+      "grid-template-columns:minmax(0,1fr) auto",
+      "align-items:center",
+      "column-gap:28px",
+      "width:100%",
+      "height:27px",
+      "white-space:nowrap",
+    ].join(";");
+
+    const label = doc.createElement("span");
+    label.textContent = labelText;
+    label.style.cssText = [
+      "overflow:hidden",
+      "text-overflow:ellipsis",
+      "text-align:left",
+      "min-width:0",
+    ].join(";");
+
+    const value = doc.createElement("span");
+    value.style.cssText = ["min-width:76px", "text-align:right"].join(";");
+
+    row.appendChild(label);
+    row.appendChild(value);
+    progressText.appendChild(row);
+    return { row, label, value };
+  };
+  const transitionStatus = createProgressRow("transition");
+  const frameStatus = createProgressRow("transition frame");
+
+  track.appendChild(fill);
+  panel.appendChild(markFrame);
+  panel.appendChild(phrase);
+  panel.appendChild(detail);
+  panel.appendChild(track);
+  panel.appendChild(progressText);
+  overlay.appendChild(panel);
+  host.appendChild(overlay);
+
+  let hideTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    show: () => {
+      if (hideTimeout) {
+        clearTimeout(hideTimeout);
+        hideTimeout = null;
+      }
+      overlay.style.display = "grid";
+      overlay.style.opacity = "1";
+      overlay.style.pointerEvents = "auto";
+    },
+    update: (status: SnapshotLoadingStatus) => {
+      const { progress, total } = status;
+      const ratio = total > 0 ? clampNumber(progress / total, 0, 1) : 0;
+      const phraseIndex = Math.min(
+        SNAPSHOT_LOADING_PHRASES.length - 1,
+        Math.floor(ratio * SNAPSHOT_LOADING_PHRASES.length),
+      );
+      const nextPhrase = SNAPSHOT_LOADING_PHRASES[phraseIndex] ?? "Preparing scene transitions";
+      phraseText.textContent = nextPhrase;
+      fill.style.transform = `scaleX(${ratio})`;
+      const transitionValue =
+        status.currentTransition !== undefined && status.transitionTotal !== undefined
+          ? `${status.currentTransition}/${status.transitionTotal}`
+          : total > 0
+            ? `${progress}/${total}`
+            : "";
+      const frameValue =
+        status.transitionFrame !== undefined && status.transitionFrames !== undefined
+          ? `${status.transitionFrame}/${status.transitionFrames}`
+          : "";
+      const phaseLabel =
+        status.phase === "cached"
+          ? "loading cached transition frames"
+          : status.phase === "finalizing"
+            ? "finalizing"
+            : "rendering transition frames";
+
+      transitionStatus.label.textContent =
+        status.currentTransition !== undefined ? "transition" : "transition frames";
+      transitionStatus.value.textContent = transitionValue;
+      frameStatus.label.textContent = phaseLabel;
+      frameStatus.value.textContent = frameValue;
+      frameStatus.row.style.visibility = frameValue ? "visible" : "hidden";
+      overlay.setAttribute("aria-valuenow", String(Math.round(ratio * 100)));
+    },
+    hide: () => {
+      if (hideTimeout) clearTimeout(hideTimeout);
+      if (overlay.style.display === "none") return;
+      overlay.style.opacity = "0";
+      overlay.style.pointerEvents = "none";
+      hideTimeout = setTimeout(() => {
+        overlay.style.display = "none";
+        overlay.style.opacity = "1";
+        overlay.style.pointerEvents = "auto";
+        hideTimeout = null;
+      }, 240);
+    },
   };
 }
 
@@ -183,9 +847,8 @@ export function init(config: HyperShaderConfig): GsapTimeline {
   const state: TransState = {
     active: false,
     prog: null,
-    fromId: "",
-    toId: "",
     progress: 0,
+    transitionIndex: -1,
   };
 
   let glCanvas = document.getElementById("gl-canvas") as HTMLCanvasElement | null;
@@ -221,29 +884,271 @@ export function init(config: HyperShaderConfig): GsapTimeline {
     }
   }
 
-  const textures = new Map<string, WebGLTexture>();
-  for (const id of scenes) {
-    textures.set(id, createTexture(gl));
-  }
+  const canvasEl = glCanvas;
+  const previewCaptureFps = clampNumber(resolvePositiveNumber(config.previewCaptureFps, 30), 1, 60);
+  const defaultCaptureScale = 1;
+  const previewCaptureScale = clampNumber(
+    resolvePositiveNumber(config.previewCaptureScale, defaultCaptureScale),
+    0.25,
+    1,
+  );
+  const previewTextureWidth = Math.max(1, Math.round(compWidth * previewCaptureScale));
+  const previewTextureHeight = Math.max(1, Math.round(compHeight * previewCaptureScale));
+  const cachedTransitions: CachedTransition[] = [];
+  const blendProg = createProgramWithVertex(
+    gl,
+    NO_FLIP_VERT_SRC,
+    [
+      "precision mediump float;",
+      "varying vec2 v_uv;",
+      "uniform sampler2D u_a;",
+      "uniform sampler2D u_b;",
+      "uniform float u_mix;",
+      "void main(){",
+      "gl_FragColor=mix(texture2D(u_a,v_uv),texture2D(u_b,v_uv),u_mix);",
+      "}",
+    ].join(""),
+  );
+  const blendLoc = {
+    a: gl.getUniformLocation(blendProg, "u_a"),
+    b: gl.getUniformLocation(blendProg, "u_b"),
+    mix: gl.getUniformLocation(blendProg, "u_mix"),
+    pos: gl.getAttribLocation(blendProg, "a_pos"),
+  };
+  const interpolatedFromTex = createRenderTexture(gl, previewTextureWidth, previewTextureHeight);
+  const interpolatedToTex = createRenderTexture(gl, previewTextureWidth, previewTextureHeight);
+  const interpolatedFromFbo = createFramebuffer(gl, interpolatedFromTex);
+  const interpolatedToFbo = createFramebuffer(gl, interpolatedToTex);
+  let loadingOverlay: SnapshotLoadingOverlay | null = null;
+  const getLoadingOverlay = (): SnapshotLoadingOverlay | null => {
+    if (config.showPreviewLoading === false) return null;
+    loadingOverlay = loadingOverlay || createSnapshotLoadingOverlay(root, compWidth, compHeight);
+    return loadingOverlay;
+  };
+  let shaderCacheReady = false;
+  let prewarming = false;
+  let sceneMutationSuppressionDepth = 0;
+  let ignoreSceneMutationsUntil = 0;
+  const scenePointerEvents = new WeakMap<HTMLElement, string>();
 
-  const tickShader = () => {
-    if (state.active && state.prog) {
-      const fromTex = textures.get(state.fromId);
-      const toTex = textures.get(state.toId);
-      if (fromTex && toTex) {
-        renderShader(
-          gl,
-          quadBuf,
-          state.prog,
-          fromTex,
-          toTex,
-          state.progress,
-          accentColors,
-          compWidth,
-          compHeight,
-        );
+  const markRuntimeSceneMutation = (): void => {
+    ignoreSceneMutationsUntil = performance.now() + 120;
+  };
+
+  const rememberScenePointerEvents = (scene: HTMLElement): void => {
+    if (!scenePointerEvents.has(scene)) {
+      scenePointerEvents.set(scene, scene.style.pointerEvents);
+    }
+  };
+
+  const setScenePlaybackState = (scene: HTMLElement, visible: boolean, opacity: string): void => {
+    rememberScenePointerEvents(scene);
+    markRuntimeSceneMutation();
+    scene.style.opacity = opacity;
+    scene.style.visibility = visible ? "visible" : "hidden";
+    scene.style.pointerEvents = visible ? (scenePointerEvents.get(scene) ?? "") : "none";
+  };
+
+  const paintScenePairState = (
+    fromId: string,
+    toId: string,
+    fromOpacity: string,
+    toOpacity: string,
+  ): void => {
+    scenes.forEach((sceneId) => {
+      const scene = document.getElementById(sceneId);
+      if (!scene) return;
+      if (sceneId === fromId) {
+        setScenePlaybackState(scene, true, fromOpacity);
+      } else if (sceneId === toId) {
+        setScenePlaybackState(scene, true, toOpacity);
+      } else {
+        setScenePlaybackState(scene, false, "0");
+      }
+    });
+  };
+
+  const disposeCaptureCanvas = (canvas: HTMLCanvasElement): void => {
+    canvas.width = 0;
+    canvas.height = 0;
+  };
+
+  const captureLiveScene = (scene: HTMLElement): Promise<HTMLCanvasElement> => {
+    return captureScene(scene, bgColor, compWidth, compHeight, {
+      forceVisible: true,
+      scale: previewCaptureScale,
+    });
+  };
+
+  const waitForPaint = (): Promise<void> => {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+  };
+
+  const hasFrameTextures = (
+    frame: CachedTransitionFrame | undefined,
+  ): frame is TexturedTransitionFrame => {
+    return Boolean(frame?.fromTex && frame.toTex);
+  };
+
+  const selectCachedFrameBlend = (
+    cache: CachedTransition,
+    progress: number,
+  ): CachedTransitionFrameBlend | null => {
+    if (cache.frames.length === 0) return null;
+    const position = clampNumber(progress, 0, 1) * (cache.frames.length - 1);
+    const lowerIndex = Math.floor(position);
+    const upperIndex = Math.ceil(position);
+    const a = cache.frames[lowerIndex] ?? cache.frames[cache.frames.length - 1];
+    const b = cache.frames[upperIndex] ?? a;
+    if (!hasFrameTextures(a) || !hasFrameTextures(b)) return null;
+    return { a, b, mix: position - lowerIndex };
+  };
+
+  const renderTextureBlend = (
+    target: WebGLFramebuffer,
+    texA: WebGLTexture,
+    texB: WebGLTexture,
+    mix: number,
+  ): void => {
+    gl.bindFramebuffer(gl.FRAMEBUFFER, target);
+    gl.viewport(0, 0, previewTextureWidth, previewTextureHeight);
+    gl.useProgram(blendProg);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texA);
+    gl.uniform1i(blendLoc.a, 0);
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, texB);
+    gl.uniform1i(blendLoc.b, 1);
+    gl.uniform1f(blendLoc.mix, mix);
+    gl.bindBuffer(gl.ARRAY_BUFFER, quadBuf);
+    gl.enableVertexAttribArray(blendLoc.pos);
+    gl.vertexAttribPointer(blendLoc.pos, 2, gl.FLOAT, false, 0, 0);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, compWidth, compHeight);
+  };
+
+  const preloadTransitionTextures = (cache: CachedTransition): void => {
+    void ensureTransitionTextures(cache).then((loaded) => {
+      if (!loaded) return;
+      const now = tl.time();
+      if (now >= cache.time && now < cache.time + cache.duration) {
+        tickShader();
+      }
+    });
+  };
+
+  const resolveSettledSceneIndex = (currentTime: number): number => {
+    let index = 0;
+    for (let i = 0; i < cachedTransitions.length; i += 1) {
+      const cache = cachedTransitions[i];
+      if (cache && currentTime >= cache.time + cache.duration) {
+        index = i + 1;
       }
     }
+    return clampNumber(index, 0, scenes.length - 1);
+  };
+
+  const paintSettledSceneState = (currentTime: number): void => {
+    const visibleIndex = resolveSettledSceneIndex(currentTime);
+    scenes.forEach((sceneId, index) => {
+      const scene = document.getElementById(sceneId);
+      if (!scene) return;
+      const visible = index === visibleIndex;
+      setScenePlaybackState(scene, visible, visible ? "1" : "0");
+    });
+  };
+
+  const applyFallbackTransition = (cache: CachedTransition, progress: number): void => {
+    const fromScene = document.getElementById(cache.fromId);
+    const toScene = document.getElementById(cache.toId);
+    if (!fromScene || !toScene) return;
+    const eased = progress * progress * (3 - 2 * progress);
+    canvasEl.style.display = "none";
+    paintScenePairState(cache.fromId, cache.toId, String(1 - eased), String(eased));
+  };
+
+  const tickShader = () => {
+    if (prewarming) {
+      return;
+    }
+
+    const currentTime = tl.time();
+    const upcoming = cachedTransitions.find((cache) => {
+      return (
+        !cache.fallback &&
+        cache.ready &&
+        !cache.dirty &&
+        !cache.textureReady &&
+        currentTime >= cache.time - TEXTURE_PRELOAD_LOOKAHEAD_SECONDS &&
+        currentTime < cache.time + cache.duration
+      );
+    });
+    if (upcoming) {
+      preloadTransitionTextures(upcoming);
+    }
+
+    const activeIndex = cachedTransitions.findIndex((cache) => {
+      return currentTime >= cache.time && currentTime < cache.time + cache.duration;
+    });
+    if (activeIndex < 0) {
+      state.active = false;
+      state.transitionIndex = -1;
+      canvasEl.style.display = "none";
+      paintSettledSceneState(currentTime);
+      return;
+    }
+
+    const cache = cachedTransitions[activeIndex];
+    if (!cache || cache.dirty || !cache.ready) {
+      canvasEl.style.display = "none";
+      return;
+    }
+    if (cache.fallback) {
+      state.active = true;
+      state.transitionIndex = activeIndex;
+      state.prog = null;
+      state.progress = clampNumber((currentTime - cache.time) / cache.duration, 0, 1);
+      applyFallbackTransition(cache, state.progress);
+      return;
+    }
+    if (!cache.textureReady) {
+      preloadTransitionTextures(cache);
+      canvasEl.style.display = "none";
+      return;
+    }
+
+    state.active = true;
+    state.transitionIndex = activeIndex;
+    state.prog = cache.prog;
+    state.progress = clampNumber((currentTime - cache.time) / cache.duration, 0, 1);
+    markTextureAccess(cache);
+
+    const frame = selectCachedFrameBlend(cache, state.progress);
+    if (!frame) {
+      canvasEl.style.display = "none";
+      return;
+    }
+    paintScenePairState(cache.fromId, cache.toId, "1", "1");
+    renderTextureBlend(interpolatedFromFbo, frame.a.fromTex, frame.b.fromTex, frame.mix);
+    renderTextureBlend(interpolatedToFbo, frame.a.toTex, frame.b.toTex, frame.mix);
+
+    canvasEl.style.display = "block";
+    renderShader(
+      gl,
+      quadBuf,
+      state.prog,
+      interpolatedFromTex,
+      interpolatedToTex,
+      state.progress,
+      accentColors,
+      compWidth,
+      compHeight,
+    );
   };
 
   let tl: GsapTimeline;
@@ -255,10 +1160,109 @@ export function init(config: HyperShaderConfig): GsapTimeline {
     tl = gsap.timeline({ paused: true, onUpdate: tickShader });
   }
 
+  const originalPlay = tl.play.bind(tl) as (...args: unknown[]) => GsapTimeline;
+  const originalPause = tl.pause.bind(tl) as (...args: unknown[]) => GsapTimeline;
+  const originalTime = tl.time.bind(tl) as (...args: unknown[]) => GsapTimeline | number;
+  const originalSeek =
+    typeof tl.seek === "function"
+      ? (tl.seek.bind(tl) as (...args: unknown[]) => GsapTimeline)
+      : null;
+  const readActualTimelineTime = (): number => {
+    const value = originalTime();
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  };
+  let publicTimelineTime = readActualTimelineTime();
+  const updatePublicTimelineTime = (value: unknown): void => {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      publicTimelineTime = value;
+    }
+  };
+  const getPlaybackRequestTime = (args: unknown[], fallback: number): number => {
+    const requestedTime = args[0];
+    return typeof requestedTime === "number" && Number.isFinite(requestedTime)
+      ? requestedTime
+      : fallback;
+  };
+  const setActualTimelineTime = (time: number, suppressEvents: boolean): GsapTimeline => {
+    const result = originalTime(time, suppressEvents);
+    return typeof result === "number" ? tl : result;
+  };
+  const suppressSceneMutationTracking = <T>(fn: () => T): T => {
+    sceneMutationSuppressionDepth += 1;
+    try {
+      return fn();
+    } finally {
+      sceneMutationSuppressionDepth -= 1;
+      ignoreSceneMutationsUntil = performance.now() + 120;
+    }
+  };
+  let pendingPlay = false;
+  let pendingPlayArgs: unknown[] = [];
+  let cancelResumeAfterPrewarm = false;
+  tl.play = ((...args: unknown[]) => {
+    updatePublicTimelineTime(args[0]);
+    const requestedTime = getPlaybackRequestTime(args, publicTimelineTime);
+    if (!areAllCachesReady() || !arePlaybackTexturesReady(requestedTime)) {
+      cancelResumeAfterPrewarm = false;
+      pendingPlay = true;
+      pendingPlayArgs = args;
+      void ensureTransitionCachesReady();
+      return tl;
+    }
+    const result = suppressSceneMutationTracking(() => originalPlay(...args));
+    publicTimelineTime = readActualTimelineTime();
+    return result;
+  }) as GsapTimeline["play"];
+  tl.pause = ((...args: unknown[]) => {
+    pendingPlay = false;
+    pendingPlayArgs = [];
+    updatePublicTimelineTime(args[0]);
+    if (prewarming) {
+      cancelResumeAfterPrewarm = true;
+      return tl;
+    }
+    const result = suppressSceneMutationTracking(() => originalPause(...args));
+    publicTimelineTime = readActualTimelineTime();
+    if (args.length > 0) {
+      tickShader();
+    }
+    return result;
+  }) as GsapTimeline["pause"];
+  tl.time = ((...args: unknown[]) => {
+    if (args.length === 0) {
+      if (!prewarming) {
+        publicTimelineTime = readActualTimelineTime();
+      }
+      return publicTimelineTime;
+    }
+    updatePublicTimelineTime(args[0]);
+    if (prewarming) {
+      return tl;
+    }
+    const result = suppressSceneMutationTracking(() => originalTime(...args));
+    if (!prewarming) {
+      publicTimelineTime = readActualTimelineTime();
+    }
+    tickShader();
+    return result;
+  }) as GsapTimeline["time"];
+  if (originalSeek) {
+    tl.seek = ((...args: unknown[]) => {
+      updatePublicTimelineTime(args[0]);
+      if (prewarming) {
+        return tl;
+      }
+      const result = suppressSceneMutationTracking(() => originalSeek(...args));
+      if (!prewarming) {
+        publicTimelineTime = readActualTimelineTime();
+      }
+      tickShader();
+      return result;
+    }) as NonNullable<GsapTimeline["seek"]>;
+  }
+
   initCapture();
   glCanvas.style.display = "none";
-
-  const canvasEl = glCanvas;
 
   for (let i = 0; i < transitions.length; i++) {
     const t = transitions[i];
@@ -272,85 +1276,46 @@ export function init(config: HyperShaderConfig): GsapTimeline {
     const dur = t.duration ?? DEFAULT_DURATION;
     const ease = t.ease ?? DEFAULT_EASE;
     const T = t.time;
+    const cacheIndex = cachedTransitions.length;
+    cachedTransitions.push({
+      index: cacheIndex,
+      time: T,
+      duration: dur,
+      fromId,
+      toId,
+      prog,
+      frames: [],
+      cacheKey: "",
+      dirty: true,
+      ready: false,
+      fallback: false,
+      persisted: false,
+      textureReady: false,
+      texturePromise: null,
+      textureGeneration: 0,
+      textureAccess: 0,
+    });
 
-    // Pause timeline during async capture to prevent the progress tween
-    // from running ahead. Resume once textures are uploaded.
     tl.call(
       () => {
-        const fromScene = document.getElementById(fromId);
-        const toScene = document.getElementById(toId);
-        if (!fromScene || !toScene) return;
+        suppressSceneMutationTracking(() => {
+          const fromScene = document.getElementById(fromId);
+          const toScene = document.getElementById(toId);
+          if (!fromScene || !toScene) return;
 
-        const wasPlaying = !tl.paused();
-        if (wasPlaying) tl.pause();
-
-        captureScene(fromScene, bgColor, compWidth, compHeight)
-          .then((fromCanvas) => {
-            const fromTex = textures.get(fromId);
-            if (fromTex) uploadTexture(gl, fromTex, fromCanvas);
-            return captureIncomingScene(toScene, bgColor, compWidth, compHeight);
-          })
-          .then((toCanvas) => {
-            const toTex = textures.get(toId);
-            if (toTex) uploadTexture(gl, toTex, toCanvas);
-
-            // Guard: only apply transition-state DOM changes if the playhead
-            // is STILL inside this transition's [T, T+dur] window. Without
-            // this, a seek that crosses multiple transitions launches several
-            // async captures in parallel; each resolves ~80-200ms later and
-            // unconditionally calls querySelectorAll(".scene").opacity = "0"
-            // + canvas.display = "block" + state.active = true. The last one
-            // to resolve wins, so after seeking past a transition, state gets
-            // stuck pointing at the wrong transition and every scene is
-            // hidden — manifesting as the "scrub blanks until the next scene
-            // begins" bug. Checking tl.time() against the transition window
-            // keeps async capture completions from corrupting state the
-            // end-callback (at T+dur) or the next transition's start-callback
-            // has already set correctly.
-            const nowTime = tl.time();
-            const inWindow = nowTime >= T && nowTime < T + dur;
-            if (inWindow) {
-              document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
-                s.style.opacity = "0";
-              });
-              canvasEl.style.display = "block";
-              state.prog = prog;
-              state.fromId = fromId;
-              state.toId = toId;
-              state.progress = 0;
-              state.active = true;
-            }
-
-            if (wasPlaying) tl.play();
-          })
-          .catch((e) => {
-            // Graceful fallback for unavoidable capture failures. The most
-            // common cause is Safari's stricter canvas-taint rules combined
-            // with SVG-filter-based background images (e.g. inline
-            // `<feTurbulence>` grain data URLs): html2canvas returns a
-            // tainted canvas, then `gl.texImage2D` throws SecurityError
-            // with no framework opt-out (WebGL spec). In Chrome this path
-            // rarely fires, but when it does (CORS-less cross-origin
-            // images, iframe sandbox restrictions, etc.) the old hard-cut
-            // was jarring. A CSS crossfade is strictly better UX.
-            console.warn("[HyperShader] Capture failed, CSS crossfade fallback:", e);
-            const nowTime = tl.time();
-            const inWindow = nowTime >= T && nowTime < T + dur;
-            if (inWindow) {
-              const fromEl = document.getElementById(fromId);
-              const toEl = document.getElementById(toId);
-              if (fromEl && toEl) {
-                gsap.to(fromEl, { opacity: 0, duration: dur, ease });
-                gsap.fromTo(toEl, { opacity: 0 }, { opacity: 1, duration: dur, ease });
-              } else {
-                document.querySelectorAll<HTMLElement>(".scene").forEach((s) => {
-                  s.style.opacity = "0";
-                });
-                if (toEl) toEl.style.opacity = "1";
-              }
-            }
-            if (wasPlaying) tl.play();
-          });
+          state.prog = prog;
+          state.transitionIndex = cacheIndex;
+          state.progress = 0;
+          state.active = true;
+          const cache = cachedTransitions[cacheIndex];
+          if (cache?.fallback) {
+            applyFallbackTransition(cache, 0);
+            return;
+          }
+          canvasEl.style.display =
+            !prewarming && cache?.ready && !cache.dirty && cache.textureReady ? "block" : "none";
+          paintScenePairState(fromId, toId, "1", "1");
+        });
       },
       null,
       T,
@@ -372,15 +1337,784 @@ export function init(config: HyperShaderConfig): GsapTimeline {
 
     tl.call(
       () => {
-        state.active = false;
-        canvasEl.style.display = "none";
-        const scene = document.getElementById(toId);
-        if (scene) scene.style.opacity = "1";
+        suppressSceneMutationTracking(() => {
+          state.active = false;
+          state.transitionIndex = -1;
+          canvasEl.style.display = "none";
+          paintSettledSceneState(T + dur);
+        });
       },
       null,
       T + dur,
     );
   }
+
+  type ShaderReadyState = {
+    ready: boolean;
+    progress: number;
+    total: number;
+    currentTransition?: number;
+    transitionTotal?: number;
+    transitionFrame?: number;
+    transitionFrames?: number;
+    phase?: SnapshotLoadingStatus["phase"];
+    dirtyTransitions: number;
+    captureScale: number;
+    textureWidth: number;
+    textureHeight: number;
+    fps: number;
+    loading: boolean;
+    error?: string;
+  };
+
+  const sampleCountForCache = (cache: CachedTransition): number => {
+    return Math.max(2, Math.ceil(cache.duration * previewCaptureFps) + 1);
+  };
+
+  const areAllCachesReady = (): boolean => {
+    return cachedTransitions.every((cache) => cache.ready && !cache.dirty);
+  };
+
+  const getPlaybackTextureWindow = (currentTime: number): CachedTransition[] => {
+    const selected: CachedTransition[] = [];
+    const selectedIndexes = new Set<number>();
+    const addIfNeeded = (cache: CachedTransition): void => {
+      if (selectedIndexes.has(cache.index)) return;
+      if (cache.fallback || cache.dirty || !cache.ready) return;
+      selected.push(cache);
+      selectedIndexes.add(cache.index);
+    };
+
+    for (const cache of cachedTransitions) {
+      if (currentTime >= cache.time && currentTime < cache.time + cache.duration) {
+        addIfNeeded(cache);
+      }
+    }
+
+    const nextUpcoming = cachedTransitions.find((cache) => cache.time >= currentTime);
+    if (nextUpcoming) {
+      addIfNeeded(nextUpcoming);
+    }
+
+    for (const cache of cachedTransitions) {
+      if (
+        cache.time >= currentTime &&
+        cache.time - currentTime <= TEXTURE_PRELOAD_LOOKAHEAD_SECONDS
+      ) {
+        addIfNeeded(cache);
+      }
+    }
+    return selected.slice(0, MAX_TEXTURED_TRANSITIONS);
+  };
+
+  const arePlaybackTexturesReady = (currentTime: number): boolean => {
+    return getPlaybackTextureWindow(currentTime).every((cache) => cache.textureReady);
+  };
+
+  let textureAccessCounter = 0;
+
+  const disposeTransitionTextures = (cache: CachedTransition): void => {
+    cache.textureGeneration += 1;
+    for (const frame of cache.frames) {
+      if (frame.fromTex) {
+        gl.deleteTexture(frame.fromTex);
+        frame.fromTex = null;
+      }
+      if (frame.toTex) {
+        gl.deleteTexture(frame.toTex);
+        frame.toTex = null;
+      }
+    }
+    cache.textureReady = false;
+  };
+
+  const disposeCachedTransition = (cache: CachedTransition): void => {
+    disposeTransitionTextures(cache);
+    cache.texturePromise = null;
+    cache.frames = [];
+    cache.ready = false;
+    cache.fallback = false;
+    cache.persisted = false;
+    cache.textureReady = false;
+    cache.lastError = undefined;
+  };
+
+  const markTextureAccess = (cache: CachedTransition): void => {
+    textureAccessCounter += 1;
+    cache.textureAccess = textureAccessCounter;
+  };
+
+  const enforceTextureBudget = (keep: CachedTransition): void => {
+    const loaded = cachedTransitions
+      .filter((cache) => cache !== keep && cache.textureReady)
+      .sort((a, b) => a.textureAccess - b.textureAccess);
+    while (loaded.length >= MAX_TEXTURED_TRANSITIONS) {
+      const evict = loaded.shift();
+      if (!evict) break;
+      disposeTransitionTextures(evict);
+    }
+  };
+
+  const buildTransitionCacheKey = (cache: CachedTransition, sampleCount: number): string => {
+    const source = [
+      SNAPSHOT_CACHE_SCHEMA,
+      compId,
+      cache.index,
+      cache.fromId,
+      getSceneSignature(cache.fromId),
+      cache.toId,
+      getSceneSignature(cache.toId),
+      transitions[cache.index]?.shader || "unknown",
+      cache.time,
+      cache.duration,
+      sampleCount,
+      previewCaptureFps,
+      previewCaptureScale,
+      previewTextureWidth,
+      previewTextureHeight,
+      compWidth,
+      compHeight,
+    ].join("|");
+    return `${compId}:${cache.index}:${stableHash(source)}`;
+  };
+
+  const setShaderReadyState = (status: Partial<ShaderReadyState>) => {
+    const hfWin = window as unknown as {
+      __hf?: {
+        shaderTransitions?: Record<string, ShaderReadyState>;
+      };
+    };
+    hfWin.__hf = hfWin.__hf || {};
+    hfWin.__hf.shaderTransitions = hfWin.__hf.shaderTransitions || {};
+    const current = hfWin.__hf.shaderTransitions[compId] || {
+      ready: false,
+      progress: 0,
+      total: 0,
+      dirtyTransitions: cachedTransitions.length,
+      captureScale: previewCaptureScale,
+      textureWidth: previewTextureWidth,
+      textureHeight: previewTextureHeight,
+      fps: previewCaptureFps,
+      loading: true,
+    };
+    const next = { ...current, ...status };
+    next.dirtyTransitions = cachedTransitions.filter((cache) => cache.dirty || !cache.ready).length;
+    hfWin.__hf.shaderTransitions[compId] = next;
+    if (next.loading) {
+      const overlay = getLoadingOverlay();
+      overlay?.show();
+      overlay?.update({
+        progress: next.progress,
+        total: next.total,
+        currentTransition: next.currentTransition,
+        transitionTotal: next.transitionTotal,
+        transitionFrame: next.transitionFrame,
+        transitionFrames: next.transitionFrames,
+        phase: next.phase,
+      });
+    }
+    if (next.ready) {
+      loadingOverlay?.hide();
+    } else if (!next.loading) {
+      loadingOverlay?.hide();
+    }
+  };
+
+  const shouldIgnoreSceneMutation = (): boolean => {
+    return (
+      prewarming ||
+      sceneMutationSuppressionDepth > 0 ||
+      performance.now() < ignoreSceneMutationsUntil ||
+      !tl.paused()
+    );
+  };
+
+  const markScenesDirty = (sceneIds: Set<string>): void => {
+    if (sceneIds.size === 0) return;
+    let changed = false;
+    for (const cache of cachedTransitions) {
+      if (!sceneIds.has(cache.fromId) && !sceneIds.has(cache.toId)) continue;
+      disposeCachedTransition(cache);
+      cache.dirty = true;
+      cache.cacheKey = "";
+      changed = true;
+    }
+    if (!changed) return;
+    shaderCacheReady = areAllCachesReady();
+    setShaderReadyState({
+      ready: shaderCacheReady,
+      progress: 0,
+      total: 0,
+      currentTransition: undefined,
+      transitionTotal: undefined,
+      transitionFrame: undefined,
+      transitionFrames: undefined,
+      phase: undefined,
+      loading: false,
+    });
+    window.dispatchEvent(
+      new CustomEvent("hyperShader:dirty", {
+        detail: { compositionId: compId, scenes: Array.from(sceneIds) },
+      }),
+    );
+  };
+
+  const observeSceneEdits = (): MutationObserver[] => {
+    const sceneElements = scenes
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el instanceof HTMLElement);
+    const observers: MutationObserver[] = [];
+    for (const scene of sceneElements) {
+      const observer = new MutationObserver((mutations) => {
+        if (shouldIgnoreSceneMutation()) return;
+        const affected = new Set<string>();
+        for (const mutation of mutations) {
+          const target =
+            mutation.target instanceof Element ? mutation.target : mutation.target.parentElement;
+          if (!target) continue;
+          for (const candidate of sceneElements) {
+            if (candidate === target || candidate.contains(target)) {
+              affected.add(candidate.id);
+            }
+          }
+        }
+        markScenesDirty(affected);
+      });
+      observer.observe(scene, {
+        attributes: true,
+        characterData: true,
+        childList: true,
+        subtree: true,
+      });
+      observers.push(observer);
+    }
+
+    const styleObserver = new MutationObserver(() => {
+      if (shouldIgnoreSceneMutation()) return;
+      markScenesDirty(new Set(scenes));
+    });
+    styleObserver.observe(document.head, {
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+    observers.push(styleObserver);
+    return observers;
+  };
+
+  const hydrateTransitionCache = async (
+    cache: CachedTransition,
+    sampleCount: number,
+    onProgress: (transitionFrame: number) => void,
+  ): Promise<boolean> => {
+    const hydratedFrames: CachedTransitionFrame[] = [];
+    for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
+      const [fromEntry, toEntry] = await Promise.all([
+        getSnapshotEntry(makeSnapshotKey(cache.cacheKey, sampleIndex, "from")),
+        getSnapshotEntry(makeSnapshotKey(cache.cacheKey, sampleIndex, "to")),
+      ]);
+      if (!fromEntry || !toEntry) {
+        for (const frame of hydratedFrames) {
+          gl.deleteTexture(frame.fromTex);
+          gl.deleteTexture(frame.toTex);
+        }
+        return false;
+      }
+
+      hydratedFrames.push({
+        sampleIndex,
+        fromBlob: fromEntry.blob,
+        toBlob: toEntry.blob,
+        fromTex: null,
+        toTex: null,
+      });
+      onProgress(sampleIndex + 1);
+    }
+    cache.frames = hydratedFrames;
+    cache.ready = true;
+    cache.dirty = false;
+    cache.fallback = false;
+    cache.persisted = true;
+    cache.textureReady = false;
+    return true;
+  };
+
+  const ensureTransitionTextures = (cache: CachedTransition): Promise<boolean> => {
+    if (cache.fallback || cache.dirty || !cache.ready) return Promise.resolve(false);
+    if (cache.textureReady) {
+      markTextureAccess(cache);
+      return Promise.resolve(true);
+    }
+    if (cache.texturePromise) return cache.texturePromise;
+
+    const generation = cache.textureGeneration;
+    const frames = cache.frames;
+    const uploadedTextures: WebGLTexture[] = [];
+    const isStaleTextureJob = (): boolean => {
+      return cache.textureGeneration !== generation || cache.dirty || cache.frames !== frames;
+    };
+    const disposeUploadedTextures = (): void => {
+      const deleted = new Set<WebGLTexture>();
+      for (const tex of uploadedTextures) {
+        if (!deleted.has(tex)) {
+          gl.deleteTexture(tex);
+          deleted.add(tex);
+        }
+      }
+      for (const frame of frames) {
+        if (frame.fromTex && !deleted.has(frame.fromTex)) {
+          gl.deleteTexture(frame.fromTex);
+          deleted.add(frame.fromTex);
+        }
+        if (frame.toTex && !deleted.has(frame.toTex)) {
+          gl.deleteTexture(frame.toTex);
+          deleted.add(frame.toTex);
+        }
+        frame.fromTex = null;
+        frame.toTex = null;
+      }
+    };
+    const getFrameBlob = async (
+      frame: CachedTransitionFrame,
+      side: "from" | "to",
+    ): Promise<Blob> => {
+      const cached = side === "from" ? frame.fromBlob : frame.toBlob;
+      if (cached) return cached;
+      const entry = await getSnapshotEntry(
+        makeSnapshotKey(cache.cacheKey, frame.sampleIndex, side),
+      );
+      if (entry?.blob) return entry.blob;
+      throw new Error("[HyperShader] Cached transition snapshot blob is unavailable");
+    };
+
+    let texturePromise = Promise.resolve(false);
+    texturePromise = (async () => {
+      for (const frame of frames) {
+        if (isStaleTextureJob()) {
+          disposeUploadedTextures();
+          return false;
+        }
+        if (!frame.fromTex) {
+          const fromBlob = await getFrameBlob(frame, "from");
+          if (isStaleTextureJob()) {
+            disposeUploadedTextures();
+            return false;
+          }
+          const source = await blobToTextureSource(fromBlob);
+          const tex = createTexture(gl);
+          uploadedTextures.push(tex);
+          try {
+            uploadTextureSource(gl, tex, source);
+            if (isStaleTextureJob()) {
+              disposeUploadedTextures();
+              return false;
+            }
+            frame.fromTex = tex;
+          } finally {
+            closeTextureSource(source);
+          }
+        }
+        if (!frame.toTex) {
+          const toBlob = await getFrameBlob(frame, "to");
+          if (isStaleTextureJob()) {
+            disposeUploadedTextures();
+            return false;
+          }
+          const source = await blobToTextureSource(toBlob);
+          const tex = createTexture(gl);
+          uploadedTextures.push(tex);
+          try {
+            uploadTextureSource(gl, tex, source);
+            if (isStaleTextureJob()) {
+              disposeUploadedTextures();
+              return false;
+            }
+            frame.toTex = tex;
+          } finally {
+            closeTextureSource(source);
+          }
+        }
+        if (cache.persisted) {
+          frame.fromBlob = null;
+          frame.toBlob = null;
+        }
+      }
+      if (isStaleTextureJob()) {
+        disposeUploadedTextures();
+        return false;
+      }
+      cache.textureReady = frames.every((frame) => Boolean(frame.fromTex && frame.toTex));
+      if (cache.textureReady) {
+        markTextureAccess(cache);
+        enforceTextureBudget(cache);
+      }
+      return cache.textureReady;
+    })()
+      .catch((e) => {
+        disposeUploadedTextures();
+        if (isStaleTextureJob()) {
+          return false;
+        }
+        disposeTransitionTextures(cache);
+        cache.fallback = true;
+        cache.ready = true;
+        cache.dirty = false;
+        cache.lastError = e instanceof Error ? e.message : String(e);
+        setShaderReadyState({
+          ready: areAllCachesReady(),
+          loading: false,
+          error: cache.lastError,
+        });
+        return false;
+      })
+      .finally(() => {
+        if (cache.texturePromise === texturePromise) {
+          cache.texturePromise = null;
+        }
+      });
+
+    cache.texturePromise = texturePromise;
+    return texturePromise;
+  };
+
+  const ensurePlaybackTextureWindow = async (currentTime: number): Promise<void> => {
+    for (const cache of getPlaybackTextureWindow(currentTime)) {
+      await ensureTransitionTextures(cache);
+    }
+  };
+
+  const persistSnapshot = async (
+    cache: CachedTransition,
+    sampleIndex: number,
+    side: "from" | "to",
+    blob: Blob | null,
+  ): Promise<boolean> => {
+    if (!blob) return false;
+    return putSnapshotEntry({
+      key: makeSnapshotKey(cache.cacheKey, sampleIndex, side),
+      blob,
+      width: previewTextureWidth,
+      height: previewTextureHeight,
+      updatedAt: cache.index * 1_000_000 + sampleIndex * 2 + (side === "to" ? 1 : 0),
+    });
+  };
+
+  const captureTransitionCache = async (
+    cache: CachedTransition,
+    sampleCount: number,
+    onProgress: (transitionFrame: number) => void,
+  ): Promise<void> => {
+    disposeCachedTransition(cache);
+    let allPersisted = true;
+    for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
+      const progress = sampleIndex / (sampleCount - 1);
+      suppressSceneMutationTracking(() => {
+        originalTime(cache.time + cache.duration * progress, false);
+      });
+      await waitForPaint();
+
+      const fromScene = document.getElementById(cache.fromId);
+      const toScene = document.getElementById(cache.toId);
+      if (!fromScene || !toScene) continue;
+
+      const [fromCanvas, toCanvas] = await Promise.all([
+        captureLiveScene(fromScene),
+        captureLiveScene(toScene),
+      ]);
+      const [fromBlob, toBlob] = await Promise.all([
+        canvasToPngBlob(fromCanvas),
+        canvasToPngBlob(toCanvas),
+      ]);
+      disposeCaptureCanvas(fromCanvas);
+      disposeCaptureCanvas(toCanvas);
+      if (!fromBlob || !toBlob) {
+        throw new Error("[HyperShader] Failed to encode transition snapshot");
+      }
+
+      cache.frames.push({ sampleIndex, fromBlob, toBlob, fromTex: null, toTex: null });
+      const persisted = await Promise.all([
+        persistSnapshot(cache, sampleIndex, "from", fromBlob),
+        persistSnapshot(cache, sampleIndex, "to", toBlob),
+      ]);
+      if (!persisted.every(Boolean)) {
+        allPersisted = false;
+        cache.lastError = "[HyperShader] Failed to persist one or more transition snapshots";
+      }
+      onProgress(sampleIndex + 1);
+    }
+    cache.ready = true;
+    cache.dirty = false;
+    cache.fallback = false;
+    cache.persisted = allPersisted;
+    cache.textureReady = false;
+  };
+
+  let transitionCachePromise: Promise<void> | null = null;
+
+  const ensureTransitionCachesReady = (): Promise<void> => {
+    if (transitionCachePromise) return transitionCachePromise;
+
+    transitionCachePromise = (async () => {
+      const work = cachedTransitions.filter((cache) => cache.dirty || !cache.ready);
+      const workItems = work.map((cache) => ({
+        cache,
+        sampleCount: sampleCountForCache(cache),
+      }));
+      for (const item of workItems) {
+        item.cache.cacheKey = buildTransitionCacheKey(item.cache, item.sampleCount);
+      }
+      const total = workItems.reduce((sum, item) => sum + item.sampleCount, 0);
+      const firstItem = workItems[0];
+      let showLoadingOverlay = false;
+      setShaderReadyState({
+        ready: false,
+        progress: 0,
+        total,
+        currentTransition: firstItem ? 1 : undefined,
+        transitionTotal: workItems.length || undefined,
+        transitionFrame: firstItem ? 0 : undefined,
+        transitionFrames: firstItem?.sampleCount,
+        phase: firstItem ? "cached" : undefined,
+        loading: showLoadingOverlay,
+      });
+
+      if (work.length === 0) {
+        shaderCacheReady = true;
+        setShaderReadyState({
+          ready: true,
+          progress: 0,
+          total: 0,
+          currentTransition: undefined,
+          transitionTotal: undefined,
+          transitionFrame: undefined,
+          transitionFrames: undefined,
+          phase: undefined,
+          loading: false,
+        });
+        if (pendingPlay) {
+          const resumeArgs = pendingPlayArgs;
+          const resumeTime = getPlaybackRequestTime(resumeArgs, publicTimelineTime);
+          await ensurePlaybackTextureWindow(resumeTime);
+          if (pendingPlay) {
+            pendingPlay = false;
+            pendingPlayArgs = [];
+            cancelResumeAfterPrewarm = false;
+            suppressSceneMutationTracking(() => originalPlay(...resumeArgs));
+            publicTimelineTime = readActualTimelineTime();
+          }
+        }
+        transitionCachePromise = null;
+        return;
+      }
+
+      publicTimelineTime = readActualTimelineTime();
+      const wasPaused = tl.paused();
+      const originalSceneStyles: SceneStyleState[] = scenes.map((id) => {
+        const scene = document.getElementById(id);
+        return {
+          scene,
+          opacity: scene?.style.opacity ?? "",
+          visibility: scene?.style.visibility ?? "",
+          pointerEvents: scene?.style.pointerEvents ?? "",
+        };
+      });
+
+      prewarming = true;
+      canvasEl.style.display = "none";
+      originalPause();
+
+      let completed = 0;
+      try {
+        for (let workIndex = 0; workIndex < workItems.length; workIndex += 1) {
+          const item = workItems[workIndex];
+          if (!item) continue;
+          const { cache, sampleCount } = item;
+          const currentTransition = workIndex + 1;
+          const completedBeforeTransition = completed;
+          disposeCachedTransition(cache);
+          try {
+            setShaderReadyState({
+              ready: false,
+              progress: completedBeforeTransition,
+              total,
+              currentTransition,
+              transitionTotal: workItems.length,
+              transitionFrame: 0,
+              transitionFrames: sampleCount,
+              phase: "cached",
+              loading: showLoadingOverlay,
+            });
+            const hydrated = await hydrateTransitionCache(cache, sampleCount, (transitionFrame) => {
+              completed = completedBeforeTransition + transitionFrame;
+              setShaderReadyState({
+                ready: false,
+                progress: completed,
+                total,
+                currentTransition,
+                transitionTotal: workItems.length,
+                transitionFrame,
+                transitionFrames: sampleCount,
+                phase: "cached",
+                loading: showLoadingOverlay,
+              });
+            });
+            if (!hydrated) {
+              completed = completedBeforeTransition;
+              showLoadingOverlay = true;
+              setShaderReadyState({
+                ready: false,
+                progress: completed,
+                total,
+                currentTransition,
+                transitionTotal: workItems.length,
+                transitionFrame: 0,
+                transitionFrames: sampleCount,
+                phase: "capturing",
+                loading: true,
+              });
+              await captureTransitionCache(cache, sampleCount, (transitionFrame) => {
+                completed = completedBeforeTransition + transitionFrame;
+                setShaderReadyState({
+                  ready: false,
+                  progress: completed,
+                  total,
+                  currentTransition,
+                  transitionTotal: workItems.length,
+                  transitionFrame,
+                  transitionFrames: sampleCount,
+                  phase: "capturing",
+                  loading: true,
+                });
+              });
+              if (!cache.persisted && cache.lastError) {
+                setShaderReadyState({
+                  ready: false,
+                  loading: showLoadingOverlay,
+                  error: cache.lastError,
+                });
+              }
+            }
+          } catch (e) {
+            completed = completedBeforeTransition + sampleCount;
+            cache.fallback = true;
+            cache.ready = true;
+            cache.dirty = false;
+            cache.lastError = e instanceof Error ? e.message : String(e);
+            console.warn("[HyperShader] Transition capture failed; using CSS fallback:", e);
+            setShaderReadyState({
+              ready: false,
+              progress: completed,
+              total,
+              currentTransition,
+              transitionTotal: workItems.length,
+              transitionFrame: sampleCount,
+              transitionFrames: sampleCount,
+              phase: "finalizing",
+              loading: showLoadingOverlay,
+              error: cache.lastError,
+            });
+          }
+          completed = completedBeforeTransition + sampleCount;
+        }
+        void pruneSnapshotCache(
+          compId,
+          new Set(cachedTransitions.map((cache) => cache.cacheKey).filter(Boolean)),
+        );
+        shaderCacheReady = areAllCachesReady();
+        const finalItem = workItems[workItems.length - 1];
+        setShaderReadyState({
+          ready: shaderCacheReady,
+          progress: completed,
+          total,
+          currentTransition: workItems.length,
+          transitionTotal: workItems.length,
+          transitionFrame: finalItem?.sampleCount,
+          transitionFrames: finalItem?.sampleCount,
+          phase: "finalizing",
+          loading: false,
+        });
+      } catch (e) {
+        console.warn("[HyperShader] Pre-capture failed, keeping DOM fallback visible:", e);
+        shaderCacheReady = areAllCachesReady();
+        setShaderReadyState({
+          ready: shaderCacheReady,
+          progress: completed,
+          total,
+          phase: "finalizing",
+          loading: false,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        const restoreTimelineTime = publicTimelineTime;
+        let shouldResume = (pendingPlay || !wasPaused) && !cancelResumeAfterPrewarm;
+        let resumeArgs = pendingPlay ? pendingPlayArgs : [];
+        let resumeTime = getPlaybackRequestTime(resumeArgs, restoreTimelineTime);
+        let hydratedTextureTime: number | null = null;
+        if (shouldResume) {
+          await ensurePlaybackTextureWindow(resumeTime);
+          hydratedTextureTime = resumeTime;
+        }
+        shouldResume = (pendingPlay || !wasPaused) && !cancelResumeAfterPrewarm;
+        resumeArgs = pendingPlay ? pendingPlayArgs : [];
+        resumeTime = getPlaybackRequestTime(resumeArgs, restoreTimelineTime);
+        if (shouldResume && resumeTime !== hydratedTextureTime) {
+          await ensurePlaybackTextureWindow(resumeTime);
+        }
+        prewarming = false;
+        state.active = false;
+        state.transitionIndex = -1;
+        canvasEl.style.display = "none";
+        suppressSceneMutationTracking(() => {
+          setActualTimelineTime(restoreTimelineTime, false);
+        });
+        publicTimelineTime = restoreTimelineTime;
+        for (const item of originalSceneStyles) {
+          if (!item.scene) continue;
+          item.scene.style.opacity = item.opacity;
+          item.scene.style.visibility = item.visibility;
+          item.scene.style.pointerEvents = item.pointerEvents;
+        }
+        tickShader();
+        window.dispatchEvent(
+          new CustomEvent("hyperShader:ready", {
+            detail: { compositionId: compId, progress: completed, total },
+          }),
+        );
+        transitionCachePromise = null;
+        if (shouldResume) {
+          pendingPlay = false;
+          pendingPlayArgs = [];
+          cancelResumeAfterPrewarm = false;
+          suppressSceneMutationTracking(() => originalPlay(...resumeArgs));
+          publicTimelineTime = readActualTimelineTime();
+        } else {
+          pendingPlay = false;
+          pendingPlayArgs = [];
+          cancelResumeAfterPrewarm = false;
+          originalPause();
+        }
+      }
+    })();
+
+    return transitionCachePromise;
+  };
+
+  const sceneEditObservers = observeSceneEdits();
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      for (const observer of sceneEditObservers) {
+        observer.disconnect();
+      }
+    },
+    { once: true },
+  );
+
+  const prewarmPromise = Promise.resolve().then(() => ensureTransitionCachesReady());
+  const hfWin = window as unknown as { __hf?: { shaderTransitionsReady?: Promise<void> } };
+  hfWin.__hf = hfWin.__hf || {};
+  hfWin.__hf.shaderTransitionsReady = prewarmPromise;
 
   registerTimeline(compId, tl, config.timeline);
   return tl;

--- a/packages/shader-transitions/src/webgl.ts
+++ b/packages/shader-transitions/src/webgl.ts
@@ -36,19 +36,35 @@ function compileShader(gl: WebGLRenderingContext, src: string, type: number): We
   return s;
 }
 
-export function createProgram(gl: WebGLRenderingContext, fragSrc: string): WebGLProgram {
-  if (!cachedVertexShader) {
-    cachedVertexShader = compileShader(gl, vertSrc, gl.VERTEX_SHADER);
-  }
+function linkProgram(
+  gl: WebGLRenderingContext,
+  vertexShader: WebGLShader,
+  fragSrc: string,
+): WebGLProgram {
   const p = gl.createProgram();
   if (!p) throw new Error("[HyperShader] Failed to create program");
-  gl.attachShader(p, cachedVertexShader);
+  gl.attachShader(p, vertexShader);
   gl.attachShader(p, compileShader(gl, fragSrc, gl.FRAGMENT_SHADER));
   gl.linkProgram(p);
   if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
     throw new Error(`[HyperShader] Program link: ${gl.getProgramInfoLog(p) || "unknown"}`);
   }
   return p;
+}
+
+export function createProgram(gl: WebGLRenderingContext, fragSrc: string): WebGLProgram {
+  if (!cachedVertexShader) {
+    cachedVertexShader = compileShader(gl, vertSrc, gl.VERTEX_SHADER);
+  }
+  return linkProgram(gl, cachedVertexShader, fragSrc);
+}
+
+export function createProgramWithVertex(
+  gl: WebGLRenderingContext,
+  vertexSrc: string,
+  fragSrc: string,
+): WebGLProgram {
+  return linkProgram(gl, compileShader(gl, vertexSrc, gl.VERTEX_SHADER), fragSrc);
 }
 
 export interface AccentColors {
@@ -136,8 +152,16 @@ export function uploadTexture(
   tex: WebGLTexture,
   canvas: HTMLCanvasElement,
 ): void {
-  gl.bindTexture(gl.TEXTURE_2D, tex);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, canvas);
+  uploadTextureSource(gl, tex, canvas);
   canvas.width = 0;
   canvas.height = 0;
+}
+
+export function uploadTextureSource(
+  gl: WebGLRenderingContext,
+  tex: WebGLTexture,
+  source: TexImageSource,
+): void {
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
 }

--- a/packages/studio/src/components/ui/HyperframesLoader.tsx
+++ b/packages/studio/src/components/ui/HyperframesLoader.tsx
@@ -1,0 +1,104 @@
+export interface HyperframesLoaderProps {
+  /** Status text shown below the mark. */
+  title: string;
+  /** Optional secondary detail line. */
+  detail?: string;
+  /** Optional monospace third line for IDs, counts, or percentages. */
+  mono?: string;
+  /** Pixel size of the mark itself; status text scales independently. */
+  size?: number;
+  /** Optional normalized progress value from 0 to 1. */
+  progress?: number;
+}
+
+export function HyperframesLoader({
+  title,
+  detail,
+  mono,
+  size = 64,
+  progress,
+}: HyperframesLoaderProps) {
+  const boundedProgress =
+    typeof progress === "number" && Number.isFinite(progress)
+      ? Math.min(1, Math.max(0, progress))
+      : undefined;
+  const markFrameSize = Math.round(size * 1.16);
+
+  return (
+    <div className="hf-loader" draggable={false}>
+      <div
+        className="hf-loader-mark-frame"
+        style={{ width: markFrameSize, height: markFrameSize }}
+        draggable={false}
+      >
+        <svg
+          className="hf-loader-mark"
+          width={size}
+          height={size}
+          viewBox="0 0 100 100"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <g className="hf-loader-mark__mark" transform="translate(50 50)">
+            <g className="hf-loader-mark__core" transform="scale(1)" opacity=".92">
+              <g transform="translate(-50 -50)">
+                <path
+                  d="M10.1851 57.8021L33.1145 73.8313C36.2202 75.9978 41.5173 73.5433 42.4816 69.4984L51.7611 30.4271C52.7253 26.3822 48.5802 23.9277 44.4602 26.0942L13.917 42.1235C6.96677 45.7676 4.97564 54.1579 10.1851 57.8021Z"
+                  fill="url(#hf-loader-grad-left)"
+                />
+                <path
+                  d="M87.5129 57.5141L56.9696 73.5433C52.8371 75.7098 48.7046 73.2553 49.6688 69.2104L58.9483 30.1391C59.9125 26.0942 65.2097 23.6397 68.3154 25.8062L91.2447 41.8354C96.4668 45.4796 94.4631 53.8699 87.5129 57.5141Z"
+                  fill="url(#hf-loader-grad-right)"
+                />
+              </g>
+            </g>
+          </g>
+          <defs>
+            <linearGradient
+              id="hf-loader-grad-left"
+              x1="48.5676"
+              y1="25"
+              x2="44.7804"
+              y2="71.9384"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop stopColor="#06E3FA" />
+              <stop offset="1" stopColor="#4FDB5E" />
+            </linearGradient>
+            <linearGradient
+              id="hf-loader-grad-right"
+              x1="54.8282"
+              y1="73.8392"
+              x2="72.0989"
+              y2="32.8932"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop stopColor="#06E3FA" />
+              <stop offset="1" stopColor="#4FDB5E" />
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+      <div className="hf-loader-title">{title}</div>
+      {detail && <div className="hf-loader-detail">{detail}</div>}
+      {boundedProgress !== undefined && (
+        <div className="hf-loader-progress" aria-hidden="true">
+          <div
+            className="hf-loader-progress__fill"
+            style={{ transform: `scaleX(${boundedProgress})` }}
+          />
+        </div>
+      )}
+      {mono && <div className="hf-loader-mono">{mono}</div>}
+    </div>
+  );
+}
+
+export function StatusFrame(props: HyperframesLoaderProps) {
+  return (
+    <div className="hf-frame">
+      <HyperframesLoader {...props} />
+    </div>
+  );
+}

--- a/packages/studio/src/components/ui/index.ts
+++ b/packages/studio/src/components/ui/index.ts
@@ -1,2 +1,4 @@
 // Minimal UI primitives for studio canvas components
 export { Button, IconButton } from "./Button";
+export { HyperframesLoader, StatusFrame } from "./HyperframesLoader";
+export type { HyperframesLoaderProps } from "./HyperframesLoader";

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -1,6 +1,7 @@
-import { forwardRef, useRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import { isLottieAnimationLoaded } from "@hyperframes/core/runtime/lottie-readiness";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import { HyperframesLoader } from "../../components/ui";
 // NOTE: importing "@hyperframes/player" registers a class extending HTMLElement
 // at module load, which throws under SSR. Defer the import to the mount effect
 // so it only runs in the browser.
@@ -62,7 +63,10 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
     const containerRef = useRef<HTMLDivElement>(null);
     const loadCountRef = useRef(0);
     const assetPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const assetFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [assetsLoading, setAssetsLoading] = useState(false);
+    const [assetOverlayVisible, setAssetOverlayVisible] = useState(false);
+    const [assetOverlayFading, setAssetOverlayFading] = useState(false);
 
     useMountEffect(() => {
       const container = containerRef.current;
@@ -169,13 +173,55 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
       };
     });
 
+    useEffect(() => {
+      if (assetFadeRef.current) {
+        clearTimeout(assetFadeRef.current);
+        assetFadeRef.current = null;
+      }
+
+      if (assetsLoading) {
+        setAssetOverlayVisible(true);
+        setAssetOverlayFading(false);
+        return;
+      }
+
+      setAssetOverlayFading(true);
+      assetFadeRef.current = setTimeout(() => {
+        setAssetOverlayVisible(false);
+        setAssetOverlayFading(false);
+        assetFadeRef.current = null;
+      }, 240);
+
+      return () => {
+        if (assetFadeRef.current) {
+          clearTimeout(assetFadeRef.current);
+          assetFadeRef.current = null;
+        }
+      };
+    }, [assetsLoading]);
+
     return (
       <div className="relative w-full h-full max-w-full max-h-full overflow-hidden bg-black flex items-center justify-center">
         <div ref={containerRef} className="w-full h-full" />
-        {assetsLoading && (
-          <div className="absolute inset-0 bg-black/80 flex flex-col items-center justify-center z-20 pointer-events-none">
-            <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
-            <span className="text-white/60 text-xs mt-3">Loading assets…</span>
+        {assetOverlayVisible && (
+          <div
+            className="absolute inset-0 bg-black flex items-center justify-center z-20 select-none"
+            data-hyperframes-ignore=""
+            draggable={false}
+            style={{
+              opacity: assetOverlayFading ? 0 : 1,
+              pointerEvents: assetOverlayFading ? "none" : "auto",
+              transition: "opacity 240ms ease-out",
+            }}
+            onDragStart={(event) => event.preventDefault()}
+            onMouseDown={(event) => event.preventDefault()}
+            onPointerDown={(event) => event.preventDefault()}
+          >
+            <HyperframesLoader
+              title="Preparing preview assets"
+              detail="Waiting for media and motion assets before playback starts."
+              size={56}
+            />
           </div>
         )}
       </div>

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -17,6 +17,19 @@ interface HyperframesPlayerElement extends HTMLElement {
   iframeElement: HTMLIFrameElement;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getShaderTransitionLoading(event: Event): boolean | null {
+  if (!(event instanceof CustomEvent)) return null;
+  const detail: unknown = event.detail;
+  if (!isRecord(detail)) return null;
+  const state = detail.state;
+  if (!isRecord(state)) return null;
+  return state.loading === true && state.ready !== true;
+}
+
 // Assets are considered ready when every `<video>`/`<audio>` has enough data
 // to play through without buffering, and every registered Lottie animation has
 // finished loading.
@@ -67,6 +80,7 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
     const [assetsLoading, setAssetsLoading] = useState(false);
     const [assetOverlayVisible, setAssetOverlayVisible] = useState(false);
     const [assetOverlayFading, setAssetOverlayFading] = useState(false);
+    const [shaderTransitionLoading, setShaderTransitionLoading] = useState(false);
 
     useMountEffect(() => {
       const container = containerRef.current;
@@ -82,6 +96,8 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
         // Create the web component imperatively to avoid JSX custom-element typing.
         const player = document.createElement("hyperframes-player") as HyperframesPlayerElement;
         const src = directUrl || `/api/projects/${projectId}/preview`;
+        player.setAttribute("shader-capture-scale", "1");
+        player.setAttribute("shader-loading", "player");
         player.setAttribute("src", src);
         player.setAttribute("width", String(portrait ? 1080 : 1920));
         player.setAttribute("height", String(portrait ? 1920 : 1080));
@@ -103,9 +119,16 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
         const preventToggle = (e: Event) => e.stopImmediatePropagation();
         player.addEventListener("click", preventToggle, { capture: true });
 
+        const handleShaderTransitionState = (event: Event) => {
+          const loading = getShaderTransitionLoading(event);
+          if (loading !== null) setShaderTransitionLoading(loading);
+        };
+        player.addEventListener("shadertransitionstate", handleShaderTransitionState);
+
         // Forward the iframe's native load event to the studio's onIframeLoad.
         const handleLoad = () => {
           loadCountRef.current++;
+          setShaderTransitionLoading(false);
           // Reveal animation on reload (hot-reload, composition switch)
           if (loadCountRef.current > 1) {
             container.classList.remove("preview-revealing");
@@ -155,6 +178,7 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
         cleanup = () => {
           iframe.removeEventListener("load", handleLoad);
           player.removeEventListener("click", preventToggle, { capture: true });
+          player.removeEventListener("shadertransitionstate", handleShaderTransitionState);
           if (assetPollRef.current) clearInterval(assetPollRef.current);
           assetPollRef.current = null;
           container.removeChild(player);
@@ -200,10 +224,12 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
       };
     }, [assetsLoading]);
 
+    const showAssetOverlay = assetOverlayVisible && !shaderTransitionLoading;
+
     return (
       <div className="relative w-full h-full max-w-full max-h-full overflow-hidden bg-black flex items-center justify-center">
         <div ref={containerRef} className="w-full h-full" />
-        {assetOverlayVisible && (
+        {showAssetOverlay && (
           <div
             className="absolute inset-0 bg-black flex items-center justify-center z-20 select-none"
             data-hyperframes-ignore=""

--- a/packages/studio/src/styles/studio.css
+++ b/packages/studio/src/styles/studio.css
@@ -49,3 +49,115 @@ body {
 .cm-editor.cm-focused {
   outline: none;
 }
+
+/*
+ * HyperFrames brand loader. Shared by preview overlays that need a calm,
+ * branded loading state instead of a generic spinner.
+ */
+.hf-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  width: min(34rem, 100%);
+  padding: 1.5rem;
+  box-sizing: border-box;
+  text-align: center;
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hf-frame {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 12rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.52);
+}
+
+.hf-loader-mark-frame {
+  display: grid;
+  place-items: center;
+  overflow: visible;
+  transform-origin: 50% 50%;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hf-loader-mark {
+  display: block;
+  overflow: visible;
+  filter: drop-shadow(0 0 7px rgba(79, 219, 94, 0.2));
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hf-loader-title {
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--hf-heading, #f4f4f5);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hf-loader-detail {
+  max-width: 32rem;
+  min-height: 2.5rem;
+  overflow: hidden;
+  color: var(--hf-text-secondary, rgba(244, 244, 245, 0.68));
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.hf-loader-mono {
+  width: min(36rem, 100%);
+  min-height: 1.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--hf-text-tertiary, rgba(244, 244, 245, 0.46));
+  font-family: "IBM Plex Mono", "SF Mono", "Fira Code", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.hf-loader-progress {
+  width: min(18rem, 72vw);
+  height: 0.375rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.hf-loader-progress__fill {
+  width: 100%;
+  height: 100%;
+  transform: scaleX(0);
+  transform-origin: left center;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #06e3fa, #4fdb5e);
+  transition: transform 160ms ease;
+}

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -8,12 +8,13 @@ import {
   lstatSync,
   realpathSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import type {
   StudioApiAdapter,
   ResolvedProject,
   RenderJobState,
 } from "@hyperframes/core/studio-api";
+import { createProjectSignature } from "../core/src/studio-api/helpers/projectSignature";
 import { createRetryingModuleLoader, ensureProducerDist } from "./vite.producer";
 import { readNodeRequestBody } from "./vite.request-body.js";
 import { seekThumbnailPreview } from "./vite.thumbnail";
@@ -56,6 +57,14 @@ interface ScreenshotClip {
   height: number;
 }
 
+function isPathWithin(parentDir: string, childPath: string): boolean {
+  const childRelativePath = relative(resolve(parentDir), resolve(childPath));
+  return (
+    childRelativePath === "" ||
+    (!childRelativePath.startsWith("..") && !isAbsolute(childRelativePath))
+  );
+}
+
 // ── Vite adapter for the shared studio API ───────────────────────────────────
 
 function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAdapter {
@@ -74,6 +83,12 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
       onProgress?: (job: { progress: number; currentStage?: string }) => void,
     ) => Promise<void>;
   }> | null = null;
+  const projectSignatureCache = new Map<string, string>();
+  server.watcher.on("all", (_event, file) => {
+    for (const projectDir of projectSignatureCache.keys()) {
+      if (isPathWithin(projectDir, file)) projectSignatureCache.delete(projectDir);
+    }
+  });
   const getBundler = async () => {
     if (!_bundler) {
       try {
@@ -178,6 +193,16 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
         `data-hyperframes-preview-runtime="1" src="${this.runtimeUrl}"`,
       );
       return html;
+    },
+
+    getProjectSignature(projectDir: string): string {
+      const cacheKey = resolve(projectDir);
+      const cached = projectSignatureCache.get(cacheKey);
+      if (cached) return cached;
+
+      const signature = createProjectSignature(cacheKey);
+      projectSignatureCache.set(cacheKey, signature);
+      return signature;
     },
 
     async lint(html: string, opts?: { filePath?: string }) {


### PR DESCRIPTION
## Summary
- Cache animated shader transition frame pairs in IndexedDB so browser previews can play outgoing and incoming scene motion through transitions instead of freezing snapshots.
- Include project/file signatures and normalized scene/style signatures in transition cache keys so edits invalidate only affected adjacent transitions and refreshes can reuse valid captures.
- Keep cached snapshots as blobs and upload only a bounded transition texture window, with stale-generation guards and cleanup so invalidated async uploads cannot overwrite newer state or leak textures.
- Gate playback on the active/upcoming transition texture window and repaint settled scene state outside transitions so scrub/playback cannot leave a hidden scene stack or black shader canvas.
- Move preview capture scale and transition-prep loading ownership to `<hyperframes-player>` via `shader-capture-scale` and `shader-loading`; HyperShader now reads player-provided preview options instead of composition config flags.
- Add the player-owned opaque transition loader with stable progress rows, shimmer title treatment, click/selection blocking, fade-out cleanup, and `shadertransitionstate` events.
- Coordinate Studio’s asset-loading overlay with the player-owned shader loader so the two overlays do not compete while transition captures are active.
- Default Studio shader previews to full-fidelity snapshots (`shader-capture-scale="1"`) while leaving direct non-player composition previews on the internal loading fallback.

## Verification
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bun run test src/hyperframes-player.test.ts` (packages/player)
- `bun run typecheck` (packages/player)
- `bun run typecheck` (packages/studio)
- `bun run typecheck` (packages/shader-transitions)
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bunx oxlint packages/player/src/hyperframes-player.ts packages/player/src/hyperframes-player.test.ts packages/studio/src/player/components/Player.tsx`
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bunx oxfmt --check packages/player/src/hyperframes-player.ts packages/player/src/hyperframes-player.test.ts packages/studio/src/player/components/Player.tsx`
- `git diff --check`
- `git diff --cached --check`
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bun run build` (packages/player)
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bun run build` (packages/studio)
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bun run build` (packages/cli)
- Browser smoke: cleared `hyper-shader-preview-cache` on the `localhost:3003` origin, confirmed Studio passes `shader-capture-scale="1"` and `shader-loading="player"`, confirmed iframe preview params/globals are injected, confirmed the player-owned loader appears during capture, and confirmed the internal HyperShader overlay is absent.
- Browser cache smoke: after capture completed, refresh showed no loader flash with `ready:true`, `dirtyTransitions:0`, and cached full-fidelity textures.
- Browser scrub smoke: seeking into and out of transitions restored settled scenes with the shader canvas hidden outside active transitions.
