### PR TITLE
fix(lint): rephrase too-large composition warnings to give actionable reasoning

### DIFF
--- a/packages/core/src/lint/rules/composition.ts
+++ b/packages/core/src/lint/rules/composition.ts
@@ -49,7 +49,7 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
       {
         code: "composition_file_too_large",
         severity: "warning",
-        message: `This HTML composition file has ${lineCount} lines. Agents produce better results when large scenes are split into smaller sub-compositions.`,
+        message: `This HTML composition file has ${lineCount} lines. Smaller sub-compositions are easier to read, iterate on, and diff.`,
         fixHint: `${splitTarget}, then mount them from the parent with data-composition-src so each file stays small enough to inspect, revise, and validate independently.`,
       },
     ];
@@ -77,7 +77,7 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
       findings.push({
         code: "timeline_track_too_dense",
         severity: "warning",
-        message: `Track ${track} has ${count} timed elements in this HTML file. Agents produce better timelines when dense tracks are split into smaller sub-compositions.`,
+        message: `Track ${track} has ${count} timed elements in this HTML file. Smaller sub-compositions keep timelines easier to read, iterate on, and diff.`,
         fixHint: `${splitTarget} and mount them from the parent with data-composition-src so the timeline stays easier to inspect, revise, and validate.`,
       });
     }


### PR DESCRIPTION
## Problem

Both `composition_file_too_large` and `timeline_track_too_dense` lint warnings led with audience-flavored framing — *"Agents produce better results when large scenes are split into smaller sub-compositions."* That doesn't tell a reader (agent or human) **why** smaller is better.

Per Abhay in #C0ACCNHLG3U:
> "an agent reading 'Agents produce better results' sounds weird. We should give the agent an actual reason why smaller is better for them."

## What this fixes

Reframe both messages to concrete properties of smaller compositions: easier to read, iterate on, and diff. The existing `fixHint` already covers the inspect/revise/validate detail and the data-composition-src mounting recipe — the message now leads with a tight reason that works for any reader.

```diff
-message: `This HTML composition file has ${lineCount} lines. Agents produce better results when large scenes are split into smaller sub-compositions.`
+message: `This HTML composition file has ${lineCount} lines. Smaller sub-compositions are easier to read, iterate on, and diff.`
```

```diff
-message: `Track ${track} has ${count} timed elements in this HTML file. Agents produce better timelines when dense tracks are split into smaller sub-compositions.`
+message: `Track ${track} has ${count} timed elements in this HTML file. Smaller sub-compositions keep timelines easier to read, iterate on, and diff.`
```

No code-path changes; only message text. `fixHint`s untouched.

## Verification

- `bun run --filter @hyperframes/core test src/lint/rules/composition.test.ts` — *48/48 passed* (no test asserts against the changed tail of the message string; both rules continue to fire on their existing thresholds with no behavior change).
- `bunx oxfmt --check` — clean.
- `bunx oxlint` — 0 warnings, 0 errors.
- `bun run --filter @hyperframes/core typecheck` — clean (after `bun run build:hyperframes-runtime` to populate `runtime-inline.ts` per the fresh-worktree gotcha).
- Lefthook pre-commit: format / lint / typecheck all pass.

## Notes

Wording rationale — the four candidates I considered:

| Property | Why it matters |
|---|---|
| Easier to *read* | Smaller files fit in one viewport / one mental load |
| Easier to *iterate on* | Faster lint + render loop on a small file vs the whole project |
| Easier to *diff* | Cleaner PRs / git history when a change touches one composition |
| (Lower coupling risk) | Less likely for a sub-composition's local change to ripple into another |

Picked the first three for the message — punchy + concrete. The fourth (decoupling) is implicit in the fixHint's "validate independently" framing. The longer-form tradeoff between message conciseness and reason coverage is documented here so reviewers can suggest a different blend if they prefer.

— Rames Jusso