### PR TITLE
fix(cli): bypass stale cache on tag-based registry lookup

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -248,7 +248,7 @@ export default defineCommand({
 
       let items: Awaited<ReturnType<typeof resolveItemsByTag>>;
       try {
-        items = await resolveItemsByTag(args.name, { baseUrl: config.registry });
+        items = await resolveItemsByTag(args.name, { baseUrl: config.registry, skipCache: true });
       } catch {
         items = [];
       }

--- a/packages/cli/src/registry/remote.ts
+++ b/packages/cli/src/registry/remote.ts
@@ -84,10 +84,13 @@ async function fetchJson<T>(url: string): Promise<T> {
  */
 export async function fetchRegistryManifest(
   baseUrl: string = DEFAULT_REGISTRY_URL,
+  options?: { skipCache?: boolean },
 ): Promise<RegistryManifest | undefined> {
   const cacheFile = cachePath(baseUrl, "registry");
-  const cached = readCache<RegistryManifest>(cacheFile);
-  if (cached) return cached;
+  if (!options?.skipCache) {
+    const cached = readCache<RegistryManifest>(cacheFile);
+    if (cached) return cached;
+  }
 
   try {
     const manifest = await fetchJson<RegistryManifest>(`${baseUrl}/registry.json`);

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -9,6 +9,8 @@ import { fetchItemManifest, fetchRegistryManifest, DEFAULT_REGISTRY_URL } from "
 
 export interface ResolveOptions {
   baseUrl?: string;
+  /** Bypass the 24h manifest cache and fetch fresh data from the registry. */
+  skipCache?: boolean;
   /**
    * Called once per item that fails to load inside `loadAllItems`. Defaults
    * to writing a diagnostic line to stderr. Pass a quieter implementation
@@ -30,7 +32,7 @@ export async function listRegistryItems(
   options: ResolveOptions = {},
 ): Promise<RegistryManifestEntry[]> {
   const baseUrl = options.baseUrl ?? DEFAULT_REGISTRY_URL;
-  const manifest = await fetchRegistryManifest(baseUrl);
+  const manifest = await fetchRegistryManifest(baseUrl, { skipCache: options.skipCache });
   if (!manifest) return [];
   if (!filter?.type) return manifest.items;
   return manifest.items.filter((item) => item.type === filter.type);


### PR DESCRIPTION
## Summary

- `hyperframes add html-in-canvas` (tag-based bulk install) was failing because the tag fallback path reused the same 24h cached registry manifest as single-item lookups
- When new blocks are added to the registry, the stale cache returns an incomplete item list, so tag resolution finds zero matches and reports "not found"
- The fix passes `skipCache: true` in the tag fallback path so it always fetches the latest manifest

## Changes

- `remote.ts`: `fetchRegistryManifest` accepts optional `skipCache` flag
- `resolver.ts`: `ResolveOptions` gains `skipCache`, threaded through `listRegistryItems`
- `add.ts`: tag fallback calls `resolveItemsByTag` with `skipCache: true`

## Test plan

- [x] All 257 CLI tests pass
- [x] `npx hyperframes add html-in-canvas` installs 7/7 blocks after cache clear
- [x] Build, lint, format all clean