### PR TITLE
fix(core): scope getElementById inside compositions

### DIFF
--- a/packages/core/src/compiler/compositionScoping.test.ts
+++ b/packages/core/src/compiler/compositionScoping.test.ts
@@ -158,6 +158,56 @@ window.__timelines.scene = tl;
     expect(gsapTargets).toEqual([["Scene"], ["Scene"]]);
   });
 
+  it("scopes getElementById when duplicate IDs exist across composition roots", () => {
+    const { document } = parseHTML(`
+      <div data-composition-id="scene-a"><canvas id="gl-canvas"></canvas></div>
+      <div data-composition-id="scene-b"><canvas id="gl-canvas"></canvas></div>
+    `);
+    const fakeWindow = {
+      document,
+      __selectedComp: "",
+      __timelines: {},
+    };
+    const wrapped = wrapScopedCompositionScript(
+      `
+window.__selectedComp =
+  document.getElementById("gl-canvas")
+    ?.closest("[data-composition-id]")
+    ?.getAttribute("data-composition-id") || "null";
+`,
+      "scene-b",
+    );
+
+    new Function("window", wrapped)(fakeWindow);
+
+    expect(fakeWindow.__selectedComp).toBe("scene-b");
+  });
+
+  it("scopes getElementById for IDs that need CSS selector escaping", () => {
+    const { document } = parseHTML(`
+      <div data-composition-id="scene-a"><div id="clip:1"></div></div>
+      <div data-composition-id="scene-b"><div id="clip:1"></div></div>
+    `);
+    const fakeWindow = {
+      document,
+      __selectedComp: "",
+      __timelines: {},
+    };
+    const wrapped = wrapScopedCompositionScript(
+      `
+window.__selectedComp =
+  document.getElementById("clip:1")
+    ?.closest("[data-composition-id]")
+    ?.getAttribute("data-composition-id") || "null";
+`,
+      "scene-b",
+    );
+
+    new Function("window", wrapped)(fakeWindow);
+
+    expect(fakeWindow.__selectedComp).toBe("scene-b");
+  });
+
   it("reads scoped proxy accessors with the original target receiver", () => {
     const root = {
       contains(node: unknown) {

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -141,17 +141,30 @@ export function wrapScopedCompositionScript(
     var matches = __hfQueryAll(selector);
     return matches[0] || null;
   };
+  var __hfGetElementById = function(id) {
+    var found = window.document.getElementById(id);
+    if (found && __hfContains(found)) return found;
+    var root = __hfFindRoot();
+    if (!root) return found || null;
+    var idValue = id + "";
+    if (root.id === idValue) return root;
+    if (typeof root.querySelector !== "function") return null;
+    if (typeof CSS !== "undefined" && CSS && typeof CSS.escape === "function") {
+      try {
+        return root.querySelector("#" + CSS.escape(idValue)) || null;
+      } catch {}
+    }
+    try {
+      return root.querySelector('[id="' + __hfEscapeAttr(idValue) + '"]') || null;
+    } catch {}
+    return null;
+  };
   var __hfScopedDocument = typeof Proxy === "function"
     ? new Proxy(window.document, {
         get: function(target, prop, receiver) {
           if (prop === "querySelector") return __hfQueryOne;
           if (prop === "querySelectorAll") return __hfQueryAll;
-          if (prop === "getElementById") {
-            return function(id) {
-              var found = target.getElementById(id);
-              return found && __hfContains(found) ? found : null;
-            };
-          }
+          if (prop === "getElementById") return __hfGetElementById;
           var value = Reflect.get(target, prop, target);
           return typeof value === "function" ? value.bind(target) : value;
         },


### PR DESCRIPTION
## Problem

Fixes #646.

When sibling sub-compositions contain the same element IDs, scoped `document.getElementById()` can return `null` for every composition after the first. This breaks blocks that reuse IDs like `<canvas id="gl-canvas">` and then call `document.getElementById("gl-canvas").getContext(...)` from their scoped script.

### How to reproduce

Create two composition roots with the same ID-bearing child, then execute the scoped wrapper for the second composition:

```html
<div data-composition-id="scene-a"><canvas id="gl-canvas"></canvas></div>
<div data-composition-id="scene-b"><canvas id="gl-canvas"></canvas></div>
```

```js
window.__selectedComp =
  document.getElementById("gl-canvas")
    ?.closest("[data-composition-id]")
    ?.getAttribute("data-composition-id") || "null";
```

Before this patch, wrapping that script with `wrapScopedCompositionScript(..., "scene-b")` produces `"null"` because the global DOM lookup finds `scene-a` first and the scoping containment check rejects it.

## What this fixes

- Keeps `document.getElementById()` scoped to the active composition root when duplicate IDs exist across sibling sub-compositions.
- Preserves the fast path when the browser's global `getElementById()` already returns an element inside the active root.
- Handles IDs that need selector escaping, such as `clip:1`, instead of relying on a fragile `"#" + id` selector.
- Adds regression coverage for duplicate WebGL-style IDs and selector-special IDs.

## Root cause

`wrapScopedCompositionScript()` proxied `document.getElementById()` by calling the real document's global `getElementById(id)` first and then checking whether that one result lived inside the scoped composition root.

That works only when the first global match is inside the active composition. With duplicate IDs, the browser returns the first match in document order, so the second composition sees the first composition's element, rejects it during containment filtering, and returns `null` without searching inside its own root.

The fix falls back to the scoped root when the global result is outside the active composition: it checks the root element itself, then queries inside the root using `CSS.escape()` when available and a quoted `[id="..."]` fallback for non-browser/test environments.

## Verification

### Local checks

- `bun test packages/core/src/compiler/compositionScoping.test.ts`
  - Saw the two new regression tests fail before the fix with `Expected: "scene-b" / Received: "null"`.
  - Passed after the fix: 11 tests.
- `bunx oxlint packages/core/src/compiler/compositionScoping.ts packages/core/src/compiler/compositionScoping.test.ts`
- `bunx oxfmt --check packages/core/src/compiler/compositionScoping.ts packages/core/src/compiler/compositionScoping.test.ts`
- `bun run --filter @hyperframes/core build:hyperframes-runtime`
- `bun run --filter @hyperframes/core test` after generating the runtime inline module: 47 files, 665 tests passed.
- `bun run --filter @hyperframes/core typecheck` after generating the runtime inline module.
- `bun run --filter @hyperframes/core build`.
- Lefthook pre-commit: lint, format, typecheck.

### Browser verification

Used `agent-browser` against a generated proof page that embeds the actual patched `wrapScopedCompositionScript()` output and duplicates both `gl-canvas` and `clip:1` across `scene-a` and `scene-b`.

The browser page reported:

```json
{
  "byIdRoot": "scene-b",
  "specialIdRoot": "scene-b",
  "queryRoot": "scene-b"
}
```

Saved local proof artifacts:

- `qa-artifacts/issue-646/proof.html`
- `qa-artifacts/issue-646/proof.png`
- `qa-artifacts/issue-646/proof.webm`

`ffprobe` confirmed the recording is a VP8 WebM at 1440x1000.

## Notes

- The proof artifacts are local QA artifacts and are intentionally not committed.
- I checked that issue #646 has no linked closing PR and open PR searches for `646` / `getElementById compositionScoping` did not find an existing fix.
