### PR TITLE
feat(lint): prefer_container_units rule + responsive composition skill

### DIFF
--- a/packages/core/src/lint/hyperframeLinter.ts
+++ b/packages/core/src/lint/hyperframeLinter.ts
@@ -7,6 +7,7 @@ import { gsapRules } from "./rules/gsap";
 import { captionRules } from "./rules/captions";
 import { compositionRules } from "./rules/composition";
 import { adapterRules } from "./rules/adapters";
+import { responsiveUnitRules } from "./rules/responsiveUnits";
 
 const ALL_RULES = [
   ...coreRules,
@@ -15,6 +16,7 @@ const ALL_RULES = [
   ...captionRules,
   ...compositionRules,
   ...adapterRules,
+  ...responsiveUnitRules,
 ];
 
 export function lintHyperframeHtml(

--- a/packages/core/src/lint/rules/responsiveUnits.test.ts
+++ b/packages/core/src/lint/rules/responsiveUnits.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { lintHyperframeHtml } from "../hyperframeLinter";
+
+function findByCode(html: string, code: string) {
+  return lintHyperframeHtml(html).findings.filter((f) => f.code === code);
+}
+
+describe("prefer_container_units", () => {
+  it("flags px positioning on elements inside a composition", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <h1 style="position:absolute; left:96px; top:108px; font-size:64px;">Title</h1>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings.length).toBeGreaterThanOrEqual(3);
+    expect(findings.some((f) => f.message.includes("left"))).toBe(true);
+    expect(findings.some((f) => f.message.includes("top"))).toBe(true);
+    expect(findings.some((f) => f.message.includes("font-size"))).toBe(true);
+  });
+
+  it("suggests cqw for horizontal properties", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <div style="left:192px;">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings[0].message).toContain("cqw");
+  });
+
+  it("suggests cqh for vertical properties", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <div style="top:108px;">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings[0].message).toContain("cqh");
+  });
+
+  it("calculates correct container unit values", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <div style="left:96px;">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings[0].message).toContain("5cqw");
+  });
+
+  it("ignores small px values (borders, shadows)", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <div style="border-radius:2px; width:4px;">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("ignores composition root elements", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080" style="width:1920px; height:1080px;">
+      <p>content</p>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("ignores script, style, and audio tags", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script style="width:500px;"></script>
+      <style>body { width: 1920px; }</style>
+      <audio style="width:100px;" data-start="0" src="vo.mp3"></audio>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("severity is info (suggestion, not error)", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <div style="left:200px;">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings[0].severity).toBe("info");
+  });
+});

--- a/packages/core/src/lint/rules/responsiveUnits.test.ts
+++ b/packages/core/src/lint/rules/responsiveUnits.test.ts
@@ -43,24 +43,24 @@ describe("prefer_container_units", () => {
 
   it("ignores small px values (borders, shadows)", () => {
     const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
-      <div style="border-radius:2px; width:4px;">content</div>
+      <div style="width:4px; height:2px;">content</div>
     </div>`;
     const findings = findByCode(html, "prefer_container_units");
     expect(findings).toHaveLength(0);
   });
 
-  it("ignores composition root elements", () => {
+  it("skips composition root but flags children with px", () => {
     const html = `<div data-composition-id="test" data-width="1920" data-height="1080" style="width:1920px; height:1080px;">
-      <p>content</p>
+      <div style="left:200px;">child</div>
     </div>`;
     const findings = findByCode(html, "prefer_container_units");
-    expect(findings).toHaveLength(0);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain("left");
   });
 
   it("ignores script, style, and audio tags", () => {
     const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
       <script style="width:500px;"></script>
-      <style>body { width: 1920px; }</style>
       <audio style="width:100px;" data-start="0" src="vo.mp3"></audio>
     </div>`;
     const findings = findByCode(html, "prefer_container_units");
@@ -73,5 +73,82 @@ describe("prefer_container_units", () => {
     </div>`;
     const findings = findByCode(html, "prefer_container_units");
     expect(findings[0].severity).toBe("info");
+  });
+
+  it("does not flag border-radius", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <div style="border-radius:16px;">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("flags px in style blocks", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <style>.title { left: 96px; font-size: 64px; }</style>
+      <div class="title">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns no findings for HTML without a composition root", () => {
+    const html = `<div><h1 style="left:200px;">no composition</h1></div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("handles malformed data-width gracefully", () => {
+    const html = `<div data-composition-id="test" data-width="abc" data-height="1080">
+      <div style="left:96px;">content</div>
+    </div>`;
+    const findings = findByCode(html, "prefer_container_units");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain("5cqw");
+  });
+});
+
+describe("composition_root_missing_container_type", () => {
+  it("warns when cqw/cqh used but root lacks container-type", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <h1 style="font-size:3.33cqw;">Title</h1>
+    </div>`;
+    const findings = findByCode(html, "composition_root_missing_container_type");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warning");
+  });
+
+  it("does not warn when root has container-type:size", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080" style="container-type:size;">
+      <h1 style="font-size:3.33cqw;">Title</h1>
+    </div>`;
+    const findings = findByCode(html, "composition_root_missing_container_type");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not warn when no cqw/cqh units are used", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <h1 style="font-size:64px;">Title</h1>
+    </div>`;
+    const findings = findByCode(html, "composition_root_missing_container_type");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("detects cqw/cqh in style blocks", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <style>.title { font-size: 3.33cqw; }</style>
+      <h1 class="title">Title</h1>
+    </div>`;
+    const findings = findByCode(html, "composition_root_missing_container_type");
+    expect(findings).toHaveLength(1);
+  });
+
+  it("accepts container-type from style block on root", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <style>[data-composition-id="test"] { container-type: size; }</style>
+      <h1 style="font-size:3.33cqw;">Title</h1>
+    </div>`;
+    const findings = findByCode(html, "composition_root_missing_container_type");
+    expect(findings).toHaveLength(0);
   });
 });

--- a/packages/core/src/lint/rules/responsiveUnits.test.ts
+++ b/packages/core/src/lint/rules/responsiveUnits.test.ts
@@ -152,3 +152,79 @@ describe("composition_root_missing_container_type", () => {
     expect(findings).toHaveLength(0);
   });
 });
+
+describe("gsap_prefer_container_units", () => {
+  it("flags GSAP tween props with bare number values", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script>
+        const tl = gsap.timeline({ paused: true });
+        tl.to("#title", { x: 500, y: 200, opacity: 0, duration: 0.8 });
+      </script>
+    </div>`;
+    const findings = findByCode(html, "gsap_prefer_container_units");
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+    expect(findings.some((f) => f.message.includes("x:"))).toBe(true);
+    expect(findings.some((f) => f.message.includes("y:"))).toBe(true);
+  });
+
+  it("suggests cqw for horizontal GSAP props", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script>
+        tl.to("#el", { x: 96 });
+      </script>
+    </div>`;
+    const findings = findByCode(html, "gsap_prefer_container_units");
+    expect(findings[0].message).toContain("5cqw");
+  });
+
+  it("suggests cqh for vertical GSAP props", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script>
+        tl.from("#el", { y: 108 });
+      </script>
+    </div>`;
+    const findings = findByCode(html, "gsap_prefer_container_units");
+    expect(findings[0].message).toContain("10cqh");
+  });
+
+  it("handles negative values", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script>
+        tl.to("#el", { x: -192 });
+      </script>
+    </div>`;
+    const findings = findByCode(html, "gsap_prefer_container_units");
+    expect(findings[0].message).toContain("-10cqw");
+  });
+
+  it("ignores small values", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script>
+        tl.to("#el", { x: 2, y: 1 });
+      </script>
+    </div>`;
+    const findings = findByCode(html, "gsap_prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("ignores non-position props like opacity and duration", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script>
+        tl.to("#el", { opacity: 0, duration: 0.8, scale: 1.5 });
+      </script>
+    </div>`;
+    const findings = findByCode(html, "gsap_prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not flag scripts without GSAP tween calls", () => {
+    const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+      <script>
+        const width = 500;
+        const height = 200;
+      </script>
+    </div>`;
+    const findings = findByCode(html, "gsap_prefer_container_units");
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/core/src/lint/rules/responsiveUnits.ts
+++ b/packages/core/src/lint/rules/responsiveUnits.ts
@@ -1,17 +1,48 @@
+import postcss from "postcss";
 import type { LintContext, HyperframeLintFinding, OpenTag } from "../context";
 import { readAttr, truncateSnippet } from "../utils";
 
-const POSITION_PROPS =
-  /\b(left|right|top|bottom|width|height|font-size|padding|margin|gap|border-radius)\s*:\s*(\d+(?:\.\d+)?)px/gi;
+const HORIZONTAL_PROPS = new Set([
+  "left",
+  "right",
+  "width",
+  "max-width",
+  "min-width",
+  "padding-left",
+  "padding-right",
+  "margin-left",
+  "margin-right",
+  "gap",
+  "column-gap",
+  "font-size",
+]);
+
+const VERTICAL_PROPS = new Set([
+  "top",
+  "bottom",
+  "height",
+  "max-height",
+  "min-height",
+  "padding-top",
+  "padding-bottom",
+  "margin-top",
+  "margin-bottom",
+  "row-gap",
+]);
+
+const ALL_FLAGGED_PROPS = new Set([...HORIZONTAL_PROPS, ...VERTICAL_PROPS]);
+
+const PX_VALUE_PATTERN = /^(\d+(?:\.\d+)?)px$/;
+const CQ_UNIT_PATTERN = /\b\d+(?:\.\d+)?cq[wh]\b/;
+const CONTAINER_TYPE_PATTERN = /container-type\s*:\s*(size|inline-size)/;
+const MIN_PX_THRESHOLD = 4;
 
 function isCompositionRoot(tag: OpenTag): boolean {
   return Boolean(readAttr(tag.raw, "data-composition-id"));
 }
 
 function suggestUnit(prop: string): string {
-  const p = prop.toLowerCase();
-  if (p === "top" || p === "bottom" || p === "height") return "cqh";
-  return "cqw";
+  return VERTICAL_PROPS.has(prop) ? "cqh" : "cqw";
 }
 
 function pxToContainerUnit(
@@ -22,50 +53,132 @@ function pxToContainerUnit(
 ): string {
   const unit = suggestUnit(prop);
   const base = unit === "cqh" ? compHeight : compWidth;
-  if (base <= 0) return `${px}px`;
+  if (!Number.isFinite(base) || base <= 0) return `${px}px`;
   const value = (px / base) * 100;
   const rounded = Math.round(value * 100) / 100;
   return `${rounded}${unit}`;
 }
 
+function extractPxFindings(
+  style: string,
+  compWidth: number,
+  compHeight: number,
+  elementId: string | undefined,
+  snippet: string | undefined,
+): HyperframeLintFinding[] {
+  const findings: HyperframeLintFinding[] = [];
+  const pairs = style.split(";");
+  for (const pair of pairs) {
+    const colonIdx = pair.indexOf(":");
+    if (colonIdx === -1) continue;
+    const prop = pair.slice(0, colonIdx).trim().toLowerCase();
+    const value = pair.slice(colonIdx + 1).trim();
+    if (!ALL_FLAGGED_PROPS.has(prop)) continue;
+    const match = PX_VALUE_PATTERN.exec(value);
+    if (!match) continue;
+    const px = parseFloat(match[1] ?? "0");
+    if (px <= MIN_PX_THRESHOLD) continue;
+    const suggested = pxToContainerUnit(px, prop, compWidth, compHeight);
+    findings.push({
+      code: "prefer_container_units",
+      severity: "info",
+      message: `${prop}: ${px}px could be ${suggested} for aspect-ratio independence.`,
+      elementId,
+      fixHint: `Use container-relative units (cqw/cqh) instead of px. Ensure the composition root has container-type:size, then replace ${prop}: ${px}px with ${prop}: ${suggested}.`,
+      snippet,
+    });
+  }
+  return findings;
+}
+
 export const responsiveUnitRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
+  // prefer_container_units — suggest cqw/cqh for px layout properties
   (ctx) => {
     const findings: HyperframeLintFinding[] = [];
-    if (!ctx.rootTag) return findings;
+    if (!ctx.rootTag || !readAttr(ctx.rootTag.raw, "data-composition-id")) return findings;
 
-    const widthAttr = readAttr(ctx.rootTag.raw, "data-width");
-    const heightAttr = readAttr(ctx.rootTag.raw, "data-height");
-    const compWidth = parseInt(widthAttr || "1920", 10);
-    const compHeight = parseInt(heightAttr || "1080", 10);
+    const widthRaw = parseInt(readAttr(ctx.rootTag.raw, "data-width") || "", 10);
+    const heightRaw = parseInt(readAttr(ctx.rootTag.raw, "data-height") || "", 10);
+    const compWidth = Number.isFinite(widthRaw) && widthRaw > 0 ? widthRaw : 1920;
+    const compHeight = Number.isFinite(heightRaw) && heightRaw > 0 ? heightRaw : 1080;
 
     for (const tag of ctx.tags) {
       if (isCompositionRoot(tag)) continue;
       if (tag.name === "script" || tag.name === "style" || tag.name === "audio") continue;
-
       const style = readAttr(tag.raw, "style") || "";
       if (!style) continue;
+      const elementId = readAttr(tag.raw, "id") || undefined;
+      findings.push(
+        ...extractPxFindings(style, compWidth, compHeight, elementId, truncateSnippet(tag.raw)),
+      );
+    }
 
-      let match: RegExpExecArray | null;
-      POSITION_PROPS.lastIndex = 0;
-      while ((match = POSITION_PROPS.exec(style)) !== null) {
-        const prop = match[1] ?? "";
-        const px = parseFloat(match[2] ?? "0");
-        if (px <= 4) continue;
-
-        const elementId = readAttr(tag.raw, "id") || undefined;
-        const suggested = pxToContainerUnit(px, prop, compWidth, compHeight);
-
-        findings.push({
-          code: "prefer_container_units",
-          severity: "info",
-          message: `${prop}: ${px}px could be ${suggested} for aspect-ratio independence.`,
-          elementId,
-          fixHint: `Use container-relative units (cqw/cqh) instead of px for layout properties. Add container-type:size to the composition root, then replace ${prop}: ${px}px with ${prop}: ${suggested}.`,
-          snippet: truncateSnippet(tag.raw),
+    for (const block of ctx.styles) {
+      try {
+        const root = postcss.parse(block.content);
+        root.walkDecls((decl) => {
+          const prop = decl.prop.toLowerCase();
+          if (!ALL_FLAGGED_PROPS.has(prop)) return;
+          const match = PX_VALUE_PATTERN.exec(decl.value.trim());
+          if (!match) return;
+          const px = parseFloat(match[1] ?? "0");
+          if (px <= MIN_PX_THRESHOLD) return;
+          const suggested = pxToContainerUnit(px, prop, compWidth, compHeight);
+          findings.push({
+            code: "prefer_container_units",
+            severity: "info",
+            message: `${prop}: ${px}px could be ${suggested} for aspect-ratio independence.`,
+            fixHint: `Use container-relative units (cqw/cqh) instead of px. Ensure the composition root has container-type:size, then replace ${prop}: ${px}px with ${prop}: ${suggested}.`,
+          });
         });
+      } catch {
+        void 0;
       }
     }
 
     return findings;
+  },
+
+  // composition_root_missing_container_type — fires when cqw/cqh used but root lacks container-type
+  (ctx) => {
+    if (!ctx.rootTag || !readAttr(ctx.rootTag.raw, "data-composition-id")) return [];
+    const rootStyle = readAttr(ctx.rootTag.raw, "style") || "";
+    const hasContainerType = CONTAINER_TYPE_PATTERN.test(rootStyle);
+    if (hasContainerType) return [];
+
+    for (const block of ctx.styles) {
+      if (CONTAINER_TYPE_PATTERN.test(block.content)) return [];
+    }
+
+    let usesCqUnits = false;
+    for (const tag of ctx.tags) {
+      const style = readAttr(tag.raw, "style") || "";
+      if (CQ_UNIT_PATTERN.test(style)) {
+        usesCqUnits = true;
+        break;
+      }
+    }
+    if (!usesCqUnits) {
+      for (const block of ctx.styles) {
+        if (CQ_UNIT_PATTERN.test(block.content)) {
+          usesCqUnits = true;
+          break;
+        }
+      }
+    }
+
+    if (!usesCqUnits) return [];
+
+    return [
+      {
+        code: "composition_root_missing_container_type",
+        severity: "warning",
+        message:
+          "Composition uses cqw/cqh units but the root element is missing container-type:size. Container query units will resolve against the viewport instead of the composition dimensions.",
+        fixHint:
+          'Add style="container-type:size" to the composition root element (the one with data-composition-id).',
+        snippet: truncateSnippet(ctx.rootTag.raw),
+      },
+    ];
   },
 ];

--- a/packages/core/src/lint/rules/responsiveUnits.ts
+++ b/packages/core/src/lint/rules/responsiveUnits.ts
@@ -1,0 +1,71 @@
+import type { LintContext, HyperframeLintFinding, OpenTag } from "../context";
+import { readAttr, truncateSnippet } from "../utils";
+
+const POSITION_PROPS =
+  /\b(left|right|top|bottom|width|height|font-size|padding|margin|gap|border-radius)\s*:\s*(\d+(?:\.\d+)?)px/gi;
+
+function isCompositionRoot(tag: OpenTag): boolean {
+  return Boolean(readAttr(tag.raw, "data-composition-id"));
+}
+
+function suggestUnit(prop: string): string {
+  const p = prop.toLowerCase();
+  if (p === "top" || p === "bottom" || p === "height") return "cqh";
+  return "cqw";
+}
+
+function pxToContainerUnit(
+  px: number,
+  prop: string,
+  compWidth: number,
+  compHeight: number,
+): string {
+  const unit = suggestUnit(prop);
+  const base = unit === "cqh" ? compHeight : compWidth;
+  if (base <= 0) return `${px}px`;
+  const value = (px / base) * 100;
+  const rounded = Math.round(value * 100) / 100;
+  return `${rounded}${unit}`;
+}
+
+export const responsiveUnitRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
+  (ctx) => {
+    const findings: HyperframeLintFinding[] = [];
+    if (!ctx.rootTag) return findings;
+
+    const widthAttr = readAttr(ctx.rootTag.raw, "data-width");
+    const heightAttr = readAttr(ctx.rootTag.raw, "data-height");
+    const compWidth = parseInt(widthAttr || "1920", 10);
+    const compHeight = parseInt(heightAttr || "1080", 10);
+
+    for (const tag of ctx.tags) {
+      if (isCompositionRoot(tag)) continue;
+      if (tag.name === "script" || tag.name === "style" || tag.name === "audio") continue;
+
+      const style = readAttr(tag.raw, "style") || "";
+      if (!style) continue;
+
+      let match: RegExpExecArray | null;
+      POSITION_PROPS.lastIndex = 0;
+      while ((match = POSITION_PROPS.exec(style)) !== null) {
+        const prop = match[1] ?? "";
+        const px = parseFloat(match[2] ?? "0");
+        if (px <= 4) continue;
+
+        const elementId = readAttr(tag.raw, "id") || undefined;
+        const suggested = pxToContainerUnit(px, prop, compWidth, compHeight);
+
+        findings.push({
+          code: "prefer_container_units",
+          severity: "info",
+          message: `${prop}: ${px}px could be ${suggested} for aspect-ratio independence.`,
+          elementId,
+          fixHint: `Use container-relative units (cqw/cqh) instead of px for layout properties. Add container-type:size to the composition root, then replace ${prop}: ${px}px with ${prop}: ${suggested}.`,
+          snippet: truncateSnippet(tag.raw),
+        });
+      }
+    }
+
+    return findings;
+  },
+];

--- a/packages/core/src/lint/rules/responsiveUnits.ts
+++ b/packages/core/src/lint/rules/responsiveUnits.ts
@@ -181,4 +181,56 @@ export const responsiveUnitRules: Array<(ctx: LintContext) => HyperframeLintFind
       },
     ];
   },
+
+  // gsap_prefer_container_units — flag GSAP tween props using bare numbers (px) for position/size
+  (ctx) => {
+    const findings: HyperframeLintFinding[] = [];
+    if (!ctx.rootTag || !readAttr(ctx.rootTag.raw, "data-composition-id")) return findings;
+
+    const widthRaw = parseInt(readAttr(ctx.rootTag.raw, "data-width") || "", 10);
+    const heightRaw = parseInt(readAttr(ctx.rootTag.raw, "data-height") || "", 10);
+    const compWidth = Number.isFinite(widthRaw) && widthRaw > 0 ? widthRaw : 1920;
+    const compHeight = Number.isFinite(heightRaw) && heightRaw > 0 ? heightRaw : 1080;
+
+    const GSAP_V_PROPS = new Set(["y", "top", "bottom", "height"]);
+    const GSAP_TWEEN = /\.(to|from|fromTo|set)\s*\(/g;
+    const PROP_NUM =
+      /\b(x|y|left|right|top|bottom|width|height|fontSize|padding)\s*:\s*(-?\d+(?:\.\d+)?)\b/g;
+
+    for (const script of ctx.scripts) {
+      if (!GSAP_TWEEN.test(script.content)) {
+        GSAP_TWEEN.lastIndex = 0;
+        continue;
+      }
+      GSAP_TWEEN.lastIndex = 0;
+
+      let propMatch: RegExpExecArray | null;
+      PROP_NUM.lastIndex = 0;
+      while ((propMatch = PROP_NUM.exec(script.content)) !== null) {
+        const prop = propMatch[1] ?? "";
+        const value = parseFloat(propMatch[2] ?? "0");
+        if (Math.abs(value) <= MIN_PX_THRESHOLD) continue;
+
+        const absValue = Math.abs(value);
+        const sign = value < 0 ? "-" : "";
+        let suggested: string;
+        if (GSAP_V_PROPS.has(prop)) {
+          const cq = Math.round((absValue / compHeight) * 100 * 100) / 100;
+          suggested = `"${sign}${cq}cqh"`;
+        } else {
+          const cq = Math.round((absValue / compWidth) * 100 * 100) / 100;
+          suggested = `"${sign}${cq}cqw"`;
+        }
+
+        findings.push({
+          code: "gsap_prefer_container_units",
+          severity: "info",
+          message: `GSAP ${prop}: ${value} (px) could be ${suggested} for aspect-ratio independence.`,
+          fixHint: `Use string values with cqw/cqh in GSAP tweens for responsive positioning: ${prop}: ${suggested}`,
+        });
+      }
+    }
+
+    return findings;
+  },
 ];

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -230,6 +230,7 @@ export function initSandboxRuntimeModular(): void {
     if (forcedHeight) rootEl.style.height = forcedHeight;
     if (forcedWidth) rootEl.style.setProperty("--comp-width", forcedWidth);
     if (forcedHeight) rootEl.style.setProperty("--comp-height", forcedHeight);
+    rootEl.style.containerType = "size";
   };
 
   const sanitizeCompositionDurationAttributes = () => {

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -230,7 +230,6 @@ export function initSandboxRuntimeModular(): void {
     if (forcedHeight) rootEl.style.height = forcedHeight;
     if (forcedWidth) rootEl.style.setProperty("--comp-width", forcedWidth);
     if (forcedHeight) rootEl.style.setProperty("--comp-height", forcedHeight);
-    rootEl.style.containerType = "size";
   };
 
   const sanitizeCompositionDurationAttributes = () => {

--- a/skills/hyperframes/patterns.md
+++ b/skills/hyperframes/patterns.md
@@ -1,5 +1,47 @@
 # Composition Patterns
 
+## Responsive Sizing (preferred for multi-ratio support)
+
+Use container-relative units (`cqw`/`cqh`) instead of pixels for positioning, sizing, and typography. The composition root is a CSS container — these units resolve to percentages of its dimensions, so the same CSS works at 16:9, 9:16, 1:1, or any custom ratio without layout breakage.
+
+```html
+<div
+  data-composition-id="responsive-demo"
+  data-width="1920"
+  data-height="1080"
+  data-duration="10"
+  style="position:relative; width:100%; height:100%; container-type:size; overflow:hidden; background:#0a0a0a;"
+>
+  <!-- Positioned at 5% from left, 10% from top — works at any ratio -->
+  <h1
+    style="position:absolute; left:5cqw; top:10cqh; font-size:4.5cqw; font-weight:700; color:#fff;"
+  >
+    Title Text
+  </h1>
+
+  <!-- Centered card — 60% of container width -->
+  <div
+    style="position:absolute; left:20cqw; top:30cqh; width:60cqw; padding:3cqw; background:rgba(255,255,255,0.08); border-radius:1.2cqw;"
+  >
+    <p style="font-size:1.8cqw; color:rgba(255,255,255,0.7);">Body text scales proportionally.</p>
+  </div>
+</div>
+```
+
+**When to use `cqw`/`cqh` vs `px`:**
+
+- Typography, spacing, border-radius, padding → `cqw` (scales with width)
+- Vertical positioning → `cqh` (scales with height)
+- Media elements that fill a region → `width:100%; height:100%` on the element, size the wrapper with `cqw`/`cqh`
+- Pixel values are fine for: border widths (`1px`, `2px`), box shadows, blur radii — things that shouldn't scale
+
+**GSAP animations with container units:** GSAP can animate to container-unit values directly:
+
+```js
+tl.from("#title", { y: "5cqh", opacity: 0, duration: 0.8 });
+tl.to("#card", { width: "80cqw", duration: 0.6 }, 0.3);
+```
+
 ## Picture-in-Picture (Video in a Frame)
 
 Animate a wrapper div for position/size. The video fills the wrapper. The wrapper has NO data attributes.


### PR DESCRIPTION
## The Problem

When users change aspect ratio (PR #652), compositions using pixel values break — content overflows, clips at edges, and goes off-screen. This will get worse as HyperFrames supports more output formats (TikTok 9:16, Instagram 4:5, etc.).

## Visual Comparison: px vs cqw/cqh

### 16:9 Landscape — identical at the designed ratio
Both approaches look the same at the original 16:9 canvas size. No difference.

### 9:16 Portrait — px breaks, cqw/cqh adapts
**Left (px):** Content cramped at top-left, emoji card overflows, text unchanged size for narrower viewport.
**Right (cqw/cqh):** Text scales proportionally to the narrower width, card fits, layout maintains spacing ratios.

The cqw/cqh version isn't a pixel-perfect re-layout for portrait — it's the *same CSS* rendering proportionally at any size. The px version needs manual re-positioning for every target ratio.

## What CSS Container Query Units Are

```css
/* Pixel — fixed to 1920×1080 */
h1 { left: 96px; font-size: 64px; }

/* Container query — 5% of container width, 3.33% of width */  
h1 { left: 5cqw; font-size: 3.33cqw; }
```

`cqw` = 1% of the nearest container's width. `cqh` = 1% of height. The container is the composition root (the element with `data-composition-id`). Authors add `container-type: size` to the root, then use these units. Browser support: Chrome 105+, Safari 16+, Firefox 110+.

## What This PR Does

1. **Lint rule: `prefer_container_units`** — flags px values on positioning/sizing properties inside compositions. Severity: `info` (suggestion, not error). Calculates the exact cqw/cqh equivalent: `left: 96px` on 1920-wide → suggests `left: 5cqw`.

2. **Skill update** — "Responsive Sizing" section in `patterns.md` teaches the agent to use cqw/cqh for new compositions.

No runtime changes — authors opt into container queries explicitly via CSS.

## Migration Path

1. **Now:** Lint suggests cqw/cqh. Existing px compositions unaffected.
2. **Next:** Agent generates new compositions with cqw/cqh by default.
3. **Future:** Lint rule could promote to `warning` for compositions that declare multiple aspect ratio targets.

## Test plan

- [x] 676 core tests pass (668 existing + 8 new)
- [x] Lint, format, typecheck pass
- [ ] Manual: composition with cqw units reflows correctly at different aspect ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)