### PR TITLE
fix(cli): preload render.js once in renderLocal test suite (Windows CI)

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -26,6 +26,19 @@ vi.mock("../telemetry/events.js", () => ({
 
 describe("renderLocal browser GPU config", () => {
   const savedEnv = new Map<string, string | undefined>();
+  // Pre-resolve once. The first dynamic `import("./render.js")` in this file
+  // takes >5 s on Windows runners (cold module load) — long enough to blow
+  // vitest's default 5 s timeout in whichever test happens to be first. When
+  // that test times out, its leaked late `createRenderJob` call lands AFTER
+  // the next test's `beforeEach` clears `producerState.createdJobs`, shifting
+  // index 0 and corrupting unrelated assertions. Importing once in
+  // `beforeAll` keeps every test fast and isolated.
+  let renderLocal: typeof import("./render.js").renderLocal;
+  let resolveBrowserGpuForCli: typeof import("./render.js").resolveBrowserGpuForCli;
+
+  beforeAll(async () => {
+    ({ renderLocal, resolveBrowserGpuForCli } = await import("./render.js"));
+  });
 
   function setEnv(key: string, value: string) {
     savedEnv.set(key, process.env[key]);
@@ -54,7 +67,6 @@ describe("renderLocal browser GPU config", () => {
   it("passes an explicit software override for --no-browser-gpu even when env requests hardware", async () => {
     setEnv("PRODUCER_BROWSER_GPU_MODE", "hardware");
 
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,
       quality: "standard",
@@ -73,7 +85,6 @@ describe("renderLocal browser GPU config", () => {
   });
 
   it("forwards browserGpuMode='auto' into producer config (probe-then-choose)", async () => {
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,
       quality: "standard",
@@ -92,7 +103,6 @@ describe("renderLocal browser GPU config", () => {
   });
 
   it("passes an explicit hardware override for default local browser GPU", async () => {
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,
       quality: "standard",
@@ -110,9 +120,7 @@ describe("renderLocal browser GPU config", () => {
     });
   });
 
-  it("resolves browser GPU from CLI flags, Docker mode, and env fallback", async () => {
-    const { resolveBrowserGpuForCli } = await import("./render.js");
-
+  it("resolves browser GPU from CLI flags, Docker mode, and env fallback", () => {
     // Default (no flag, no env): auto — engine probes and chooses.
     expect(resolveBrowserGpuForCli(false, undefined, undefined)).toBe("auto");
     // Env override
@@ -128,7 +136,6 @@ describe("renderLocal browser GPU config", () => {
   });
 
   it("forwards parsed --variables payload to createRenderJob", async () => {
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,
       quality: "standard",
@@ -144,7 +151,6 @@ describe("renderLocal browser GPU config", () => {
   });
 
   it("forwards format: png-sequence through to createRenderJob", async () => {
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/frames", {
       fps: 30,
       quality: "standard",
@@ -159,7 +165,6 @@ describe("renderLocal browser GPU config", () => {
   });
 
   it("omits variables from createRenderJob when not provided", async () => {
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,
       quality: "standard",
@@ -174,7 +179,6 @@ describe("renderLocal browser GPU config", () => {
   });
 
   it("forwards entryFile to createRenderJob when --composition is set", async () => {
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,
       quality: "standard",
@@ -190,7 +194,6 @@ describe("renderLocal browser GPU config", () => {
   });
 
   it("omits entryFile from createRenderJob when --composition is not set", async () => {
-    const { renderLocal } = await import("./render.js");
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,
       quality: "standard",
@@ -211,7 +214,6 @@ describe("renderLocal browser GPU config", () => {
       .mockImplementation((code?: string | number | null): never => {
         throw new Error(`process.exit:${code ?? ""}`);
       });
-    const { renderLocal } = await import("./render.js");
 
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: 30,


### PR DESCRIPTION
## What

Hoist the dynamic `await import("./render.js")` out of every test in
`renderLocal browser GPU config` and into a `beforeAll`. Same pattern the
`parseVariablesArg` and `validateVariablesAgainstProject` describe blocks
in this file already use.

## Why

The Windows render verification workflow has been red on `main` since the
merge of #642 (auto-detect-browser-gpu) — most recent failure on main:
https://github.com/heygen-com/hyperframes/actions/runs/25470257972/job/74732502915.

The first dynamic `await import("./render.js")` in this file cold-loads in
>5 s on Windows runners, which blows vitest's default 5 s test timeout in
whichever test happens to run it first. Subsequent imports take <10 ms
because the module is cached, so only test #1 ever times out.

The downstream failure was more subtle. When test #1 timed out, vitest
moved on, but its leaked async function eventually hit the synchronous
`producer.createRenderJob(...)` line and pushed a stale config to
`producerState.createdJobs`. That push landed AFTER test #2's `beforeEach`
cleared the array, so test #2's `createdJobs[0]` was the leaked test #1
entry instead of its own — which is why test #2 reported
`browserGpuMode: 'software'` when it expected `'auto'`. Both failures had
a single cause.

The reason this passed on PR #642's branch but failed once merged: PR #642
was the run that first introduced "forwards browserGpuMode='auto'" as
test #2 in this describe block. On its own branch, the previously-first
test ran without the per-iteration import latency stacking. After merge,
the test ordering plus full-build module graph put it past the 5 s edge
on every push.

## How

`beforeAll` resolves the import once outside any test's timeout window,
then the typed `renderLocal` / `resolveBrowserGpuForCli` references are
reused by every `it(...)` in the block. Cold-load happens once, every
test stays fast, no leaked promise can corrupt state. Behaviour identical
on Linux/macOS — local `bun run --cwd packages/cli test` is still 22/22
passing in <1 s.

## Test plan

- [x] Unit tests added/updated — restructured the existing tests to share a single import; assertions unchanged
- [x] Manual testing performed — `bun run --cwd packages/cli test` → 277/277 passing locally
- [ ] Documentation updated (if applicable)