### PR TITLE
chore: ignore Claude session summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,9 +72,10 @@ packages/studio/data/
 # Playwright MCP browser cache
 .playwright-mcp/
 
-# Installed skills (user-specific)
+# Installed skills and generated Claude session summaries (user-specific)
 .agents/
 .claude/skills/
+.claude/session-summaries/
 skills-lock.json
 
 # Skills from other PRs (not managed here)


### PR DESCRIPTION
## Summary
- Add `.claude/session-summaries/` to `.gitignore` so generated local Claude session summary files are not accidentally committed.
- Keep this intentionally narrow after the previous wholesale Claude Project Kit PR was declined.

## Test Plan
- `git diff --check`
- Independent pre-commit review: no blockers; one-file `.gitignore` diff only, no secrets, no rejected kit content included.

Refs #553
