### PR TITLE
fix(runtime): schedule future WebAudio clips with delay

### DIFF
--- a/packages/core/src/runtime/webAudioTransport.test.ts
+++ b/packages/core/src/runtime/webAudioTransport.test.ts
@@ -80,4 +80,85 @@ describe("WebAudioTransport", () => {
     expect(transport.context).toBeNull();
     expect(transport.isActive()).toBe(false);
   });
+
+  describe("schedulePlayback timing", () => {
+    function createMockAudioContext(currentTime = 100) {
+      const startFn = vi.fn();
+      const sourceNode = {
+        buffer: null as AudioBuffer | null,
+        start: startFn,
+        connect: vi.fn(),
+      };
+      const gainNode = {
+        gain: { value: 1 },
+        connect: vi.fn(),
+      };
+      const masterGain = {
+        gain: { value: 1 },
+        connect: vi.fn(),
+      };
+      const ctx = {
+        currentTime,
+        state: "running",
+        resume: vi.fn(),
+        createBufferSource: vi.fn(() => sourceNode),
+        createGain: vi.fn(() => gainNode),
+        destination: {},
+        close: vi.fn(),
+      };
+      return { ctx, sourceNode, gainNode, masterGain, startFn };
+    }
+
+    function setupTransport(currentTime = 100) {
+      const transport = new WebAudioTransport();
+      const mock = createMockAudioContext(currentTime);
+      (transport as unknown as { _ctx: unknown })._ctx = mock.ctx;
+      (transport as unknown as { _masterGain: unknown })._masterGain = mock.masterGain;
+      const gen = transport.startGeneration();
+      return { transport, mock, gen };
+    }
+
+    const mockBuffer = {} as AudioBuffer;
+    const mockEl = { muted: false } as HTMLMediaElement;
+
+    it("starts in-progress clips immediately with correct buffer offset", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen);
+
+      expect(mock.startFn).toHaveBeenCalledWith(0, 3);
+    });
+
+    it("starts in-progress clips with mediaStart offset", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 2, 8, 1, gen);
+
+      expect(mock.startFn).toHaveBeenCalledWith(0, 5);
+    });
+
+    it("schedules future clips with delay instead of playing immediately", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 10, 0, 2, 1, gen);
+
+      expect(mock.startFn).toHaveBeenCalledWith(108, 0);
+    });
+
+    it("schedules future clips with correct mediaStart", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 10, 1.5, 2, 1, gen);
+
+      expect(mock.startFn).toHaveBeenCalledWith(108, 1.5);
+    });
+
+    it("starts clips at exact composition start time immediately", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 5, 1, gen);
+
+      expect(mock.startFn).toHaveBeenCalledWith(0, 0);
+    });
+  });
 });

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -91,10 +91,16 @@ export class WebAudioTransport {
       sourceNode.connect(gainNode);
       gainNode.connect(this._masterGain);
 
-      const offset = Math.max(0, compositionTime - compositionStart + mediaStart);
+      const elapsed = compositionTime - compositionStart;
       const scheduledAt = this._ctx.currentTime;
       this._scheduleOffset = scheduledAt - compositionTime;
-      sourceNode.start(0, offset);
+
+      if (elapsed >= 0) {
+        sourceNode.start(0, elapsed + mediaStart);
+      } else {
+        const delay = -elapsed;
+        sourceNode.start(scheduledAt + delay, mediaStart);
+      }
 
       const priorMuted = el.muted;
       el.muted = true;


### PR DESCRIPTION
## Summary

- Fixes `schedulePlayback` to use `sourceNode.start(ctx.currentTime + delay, mediaStart)` for clips whose `compositionStart` is ahead of the current timeline position, instead of always passing `when=0` which plays them immediately
- Adds 5 regression tests covering in-progress clips, future clips, mediaStart offsets, and the exact-boundary case

## Root Cause

`sourceNode.start(0, offset)` was called for all clips regardless of timeline position. The WebAudio `start(when)` parameter of `0` means "play now." For clips scheduled in the future, the buffer `offset` clamped to `0` via `Math.max`, so all dialogue clips would play simultaneously on compositions with staggered `data-start` values.

## Fix

```typescript
// Before: all clips start immediately
sourceNode.start(0, offset);

// After: future clips are deferred via WebAudio scheduling
if (elapsed >= 0) {
  sourceNode.start(0, elapsed + mediaStart);
} else {
  sourceNode.start(ctx.currentTime + delay, mediaStart);
}
```

## Test plan

- [x] `webAudioTransport.test.ts` — 5 new timing tests pass
- [x] Full core test suite — 761 tests pass
- [x] All pre-commit hooks (lint, format, typecheck, commitlint) pass
- [ ] Manual QA: composition with multiple staggered `audio[data-start]` clips plays in correct sequence

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)