### PR TITLE
feat(registry): 11 caption style blocks

### DIFF
--- a/registry/blocks/cap-bounce/cap-bounce.html
+++ b/registry/blocks/cap-bounce/cap-bounce.html
@@ -1,172 +1,213 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@700;800&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #111; overflow: hidden; }
-#root-cap-bounce {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #111;
-}
-.cap-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.cg {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  max-width: 1700px; overflow: visible;
-  opacity: 0;
-  visibility: hidden;
-}
-.cw {
-  font-family: 'Figtree', sans-serif;
-  font-weight: 800;
-  font-size: 112px;
-  color: #FFFFFF;
-  line-height: 1;
-  display: inline-block;
-  -webkit-text-stroke: 3px rgba(0,0,0,0.7);
-  paint-order: stroke fill;
-  text-shadow: 0 4px 10px rgba(0,0,0,0.5);
-  opacity: 0;
-}
-</style>
-</head>
-<body>
-<div id="root-cap-bounce" data-composition-id="cap-bounce" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="cap-container" id="cc-bounce"></div>
-  <div id="drv-cap-bounce" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("cc-bounce");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "bn-cg-" + gi;
-    groupEl.className = "cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "bn-cw-" + wi;
-      wordEl.className = "cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
-        fontFamily: "Figtree",
-        fontWeight: 800,
-        maxWidth: 1550,
-        baseFontSize: 112,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 112) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Figtree:wght@700;800&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #111;
+        overflow: hidden;
+      }
+      #root-cap-bounce {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #111;
+      }
+      .cap-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .cg {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 20px;
+        max-width: 1700px;
+        overflow: visible;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .cw {
+        font-family: "Figtree", sans-serif;
+        font-weight: 800;
+        font-size: 112px;
+        color: #ffffff;
+        line-height: 1;
+        display: inline-block;
+        -webkit-text-stroke: 3px rgba(0, 0, 0, 0.7);
+        paint-order: stroke fill;
+        text-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+        opacity: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-bounce"
+      data-composition-id="cap-bounce"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="cap-container" id="cc-bounce"></div>
+      <div
+        id="drv-cap-bounce"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("bn-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group container (words bounce in individually)
-    tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+        var container = document.getElementById("cc-bounce");
 
-    // Each word bounces in at its own start time
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("bn-cw-" + wi);
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "bn-cg-" + gi;
+          groupEl.className = "cg";
 
-      // Elastic bounce entrance
-      tl.to(wordEl, {
-        y: 0,
-        opacity: 1,
-        scale: 1,
-        duration: 0.4,
-        ease: "elastic.out(1, 0.35)"
-      }, WORDS[wi].start);
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "bn-cw-" + wi;
+            wordEl.className = "cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-      // Activate: cyan + scale up
-      tl.to(wordEl, {
-        color: "#00E5FF",
-        scale: 1.1,
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+              fontFamily: "Figtree",
+              fontWeight: 800,
+              maxWidth: 1550,
+              baseFontSize: 112,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 112) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
 
-      // Deactivate: dim and shrink
-      tl.to(wordEl, {
-        color: "rgba(255,255,255,0.4)",
-        scale: 0.95,
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+        var tl = gsap.timeline({ paused: true });
 
-    // EXIT: stagger slide down
-    tl.to(groupEl, { y: 50, opacity: 1, duration: 0.15, ease: "power2.in" }, g.end - 0.15);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 1, visibility: "hidden" }, g.end);
-  });
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("bn-cg-" + gi);
 
-  window.__timelines["cap-bounce"] = tl;
-})();</script>
-</body>
+          // SHOW group container (words bounce in individually)
+          tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+
+          // Each word bounces in at its own start time
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("bn-cw-" + wi);
+
+            // Elastic bounce entrance
+            tl.to(
+              wordEl,
+              {
+                y: 0,
+                opacity: 1,
+                scale: 1,
+                duration: 0.4,
+                ease: "elastic.out(1, 0.35)",
+              },
+              WORDS[wi].start,
+            );
+
+            // Activate: cyan + scale up
+            tl.to(
+              wordEl,
+              {
+                color: "#00E5FF",
+                scale: 1.1,
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+
+            // Deactivate: dim and shrink
+            tl.to(
+              wordEl,
+              {
+                color: "rgba(255,255,255,0.4)",
+                scale: 0.95,
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT: stagger slide down
+          tl.to(groupEl, { y: 50, opacity: 1, duration: 0.15, ease: "power2.in" }, g.end - 0.15);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 1, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-bounce"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-bounce/cap-bounce.html
+++ b/registry/blocks/cap-bounce/cap-bounce.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@700;800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #111; overflow: hidden; }
+#root-cap-bounce {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #111;
+}
+.cap-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cg {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  max-width: 1700px; overflow: visible;
+  opacity: 0;
+  visibility: hidden;
+}
+.cw {
+  font-family: 'Figtree', sans-serif;
+  font-weight: 800;
+  font-size: 112px;
+  color: #FFFFFF;
+  line-height: 1;
+  display: inline-block;
+  -webkit-text-stroke: 3px rgba(0,0,0,0.7);
+  paint-order: stroke fill;
+  text-shadow: 0 4px 10px rgba(0,0,0,0.5);
+  opacity: 0;
+}
+</style>
+</head>
+<body>
+<div id="root-cap-bounce" data-composition-id="cap-bounce" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="cap-container" id="cc-bounce"></div>
+  <div id="drv-cap-bounce" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("cc-bounce");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "bn-cg-" + gi;
+    groupEl.className = "cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "bn-cw-" + wi;
+      wordEl.className = "cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+        fontFamily: "Figtree",
+        fontWeight: 800,
+        maxWidth: 1550,
+        baseFontSize: 112,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 112) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("bn-cg-" + gi);
+
+    // SHOW group container (words bounce in individually)
+    tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+
+    // Each word bounces in at its own start time
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("bn-cw-" + wi);
+
+      // Elastic bounce entrance
+      tl.to(wordEl, {
+        y: 0,
+        opacity: 1,
+        scale: 1,
+        duration: 0.4,
+        ease: "elastic.out(1, 0.35)"
+      }, WORDS[wi].start);
+
+      // Activate: cyan + scale up
+      tl.to(wordEl, {
+        color: "#00E5FF",
+        scale: 1.1,
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+
+      // Deactivate: dim and shrink
+      tl.to(wordEl, {
+        color: "rgba(255,255,255,0.4)",
+        scale: 0.95,
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT: stagger slide down
+    tl.to(groupEl, { y: 50, opacity: 1, duration: 0.15, ease: "power2.in" }, g.end - 0.15);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 1, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-bounce"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-bounce/registry-item.json
+++ b/registry/blocks/cap-bounce/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-bounce",
+  "type": "hyperframes:block",
+  "title": "Bounce Word",
+  "description": "Elastic bounce per word — Figtree 800, words enter with spring physics, cyan highlight",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "playful", "energetic", "bounce"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-bounce.mp4",
+  "files": [
+    {
+      "path": "cap-bounce.html",
+      "target": "compositions/cap-bounce.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-boxed/cap-boxed.html
+++ b/registry/blocks/cap-boxed/cap-boxed.html
@@ -1,162 +1,199 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@700;800&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: transparent; overflow: hidden; }
-#root-cap-boxed {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-}
-.cap-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  padding-bottom: 200px;
-}
-.cg {
-  position: absolute;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  max-width: 1700px; overflow: visible;
-  opacity: 0;
-  visibility: hidden;
-  background: rgba(0,0,0,0.75);
-  padding: 18px 40px;
-  border-radius: 6px;
-}
-.cw {
-  font-family: 'Albert Sans', sans-serif;
-  font-weight: 700;
-  font-size: 64px;
-  color: #FFFFFF;
-  line-height: 1;
-  display: inline-block;
-  text-shadow: 0 1px 4px rgba(0,0,0,0.3);
-}
-</style>
-</head>
-<body>
-<div id="root-cap-boxed" data-composition-id="cap-boxed" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="cap-container" id="cc-boxed"></div>
-  <div id="drv-cap-boxed" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("cc-boxed");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "bx-cg-" + gi;
-    groupEl.className = "cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "bx-cw-" + wi;
-      wordEl.className = "cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
-        fontFamily: "Albert Sans",
-        fontWeight: 700,
-        maxWidth: 1700,
-        baseFontSize: 64,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 64) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@700;800&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      #root-cap-boxed {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+      }
+      .cap-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
+        padding-bottom: 200px;
+      }
+      .cg {
+        position: absolute;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        max-width: 1700px;
+        overflow: visible;
+        opacity: 0;
+        visibility: hidden;
+        background: rgba(0, 0, 0, 0.75);
+        padding: 18px 40px;
+        border-radius: 6px;
+      }
+      .cw {
+        font-family: "Albert Sans", sans-serif;
+        font-weight: 700;
+        font-size: 64px;
+        color: #ffffff;
+        line-height: 1;
+        display: inline-block;
+        text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-boxed"
+      data-composition-id="cap-boxed"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="cap-container" id="cc-boxed"></div>
+      <div
+        id="drv-cap-boxed"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("bx-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group with subtle slide-up
-    tl.set(groupEl, { opacity: 1, visibility: "visible", y: 10 }, g.start);
-    tl.to(groupEl, { opacity: 1, y: 10, duration: 0.25, ease: "power2.out" }, g.start);
+        var container = document.getElementById("cc-boxed");
 
-    // Karaoke: gold highlight on active word
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("bx-cw-" + wi);
-      // Activate
-      tl.to(wordEl, {
-        color: "#FFD700",
-        fontWeight: 800,
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-      // Deactivate
-      tl.to(wordEl, {
-        color: "#FFFFFF",
-        fontWeight: 700,
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "bx-cg-" + gi;
+          groupEl.className = "cg";
 
-    // EXIT fade
-    tl.to(groupEl, { opacity: 0, duration: 0.15 }, g.end - 0.15);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
-  });
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "bx-cw-" + wi;
+            wordEl.className = "cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-  window.__timelines["cap-boxed"] = tl;
-})();</script>
-</body>
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+              fontFamily: "Albert Sans",
+              fontWeight: 700,
+              maxWidth: 1700,
+              baseFontSize: 64,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 64) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("bx-cg-" + gi);
+
+          // SHOW group with subtle slide-up
+          tl.set(groupEl, { opacity: 1, visibility: "visible", y: 10 }, g.start);
+          tl.to(groupEl, { opacity: 1, y: 10, duration: 0.25, ease: "power2.out" }, g.start);
+
+          // Karaoke: gold highlight on active word
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("bx-cw-" + wi);
+            // Activate
+            tl.to(
+              wordEl,
+              {
+                color: "#FFD700",
+                fontWeight: 800,
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+            // Deactivate
+            tl.to(
+              wordEl,
+              {
+                color: "#FFFFFF",
+                fontWeight: 700,
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT fade
+          tl.to(groupEl, { opacity: 0, duration: 0.15 }, g.end - 0.15);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-boxed"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-boxed/cap-boxed.html
+++ b/registry/blocks/cap-boxed/cap-boxed.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@700;800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: transparent; overflow: hidden; }
+#root-cap-boxed {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+}
+.cap-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 200px;
+}
+.cg {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  max-width: 1700px; overflow: visible;
+  opacity: 0;
+  visibility: hidden;
+  background: rgba(0,0,0,0.75);
+  padding: 18px 40px;
+  border-radius: 6px;
+}
+.cw {
+  font-family: 'Albert Sans', sans-serif;
+  font-weight: 700;
+  font-size: 64px;
+  color: #FFFFFF;
+  line-height: 1;
+  display: inline-block;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.3);
+}
+</style>
+</head>
+<body>
+<div id="root-cap-boxed" data-composition-id="cap-boxed" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="cap-container" id="cc-boxed"></div>
+  <div id="drv-cap-boxed" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("cc-boxed");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "bx-cg-" + gi;
+    groupEl.className = "cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "bx-cw-" + wi;
+      wordEl.className = "cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+        fontFamily: "Albert Sans",
+        fontWeight: 700,
+        maxWidth: 1700,
+        baseFontSize: 64,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 64) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("bx-cg-" + gi);
+
+    // SHOW group with subtle slide-up
+    tl.set(groupEl, { opacity: 1, visibility: "visible", y: 10 }, g.start);
+    tl.to(groupEl, { opacity: 1, y: 10, duration: 0.25, ease: "power2.out" }, g.start);
+
+    // Karaoke: gold highlight on active word
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("bx-cw-" + wi);
+      // Activate
+      tl.to(wordEl, {
+        color: "#FFD700",
+        fontWeight: 800,
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+      // Deactivate
+      tl.to(wordEl, {
+        color: "#FFFFFF",
+        fontWeight: 700,
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT fade
+    tl.to(groupEl, { opacity: 0, duration: 0.15 }, g.end - 0.15);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-boxed"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-boxed/registry-item.json
+++ b/registry/blocks/cap-boxed/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-boxed",
+  "type": "hyperframes:block",
+  "title": "Boxed Subtitle",
+  "description": "Netflix/YouTube boxed subtitle — semi-transparent dark box, gold word highlight, lower-third",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "professional", "netflix", "boxed"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-boxed.mp4",
+  "files": [
+    {
+      "path": "cap-boxed.html",
+      "target": "compositions/cap-boxed.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-clean/cap-clean.html
+++ b/registry/blocks/cap-clean/cap-clean.html
@@ -1,160 +1,198 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@700&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #111; overflow: hidden; }
-#root-cap-clean {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #111;
-}
-.cl-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.cl-cg {
-  position: absolute;
-  top: 830px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 18px;
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-}
-.cl-cw {
-  font-family: 'Albert Sans', sans-serif;
-  font-weight: 700;
-  font-size: 108px;
-  color: rgba(255,255,255,0.5);
-  line-height: 1;
-  display: inline-block;
-  text-shadow: 0 2px 8px rgba(0,0,0,0.5); -webkit-text-stroke: 1px rgba(0,0,0,0.3); paint-order: stroke fill;
-}
-</style>
-</head>
-<body>
-<div id="root-cap-clean" data-composition-id="cap-clean" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="cl-container" id="cl-container"></div>
-  <div id="drv-cap-clean" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("cl-container");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "cl-cg-" + gi;
-    groupEl.className = "cl-cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "cl-cw-" + wi;
-      wordEl.className = "cl-cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
-        fontFamily: "Albert Sans",
-        fontWeight: 700,
-        maxWidth: 1550,
-        baseFontSize: 108,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 108) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #111;
+        overflow: hidden;
+      }
+      #root-cap-clean {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #111;
+      }
+      .cl-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .cl-cg {
+        position: absolute;
+        top: 830px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 18px;
+        white-space: nowrap;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .cl-cw {
+        font-family: "Albert Sans", sans-serif;
+        font-weight: 700;
+        font-size: 108px;
+        color: rgba(255, 255, 255, 0.5);
+        line-height: 1;
+        display: inline-block;
+        text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+        -webkit-text-stroke: 1px rgba(0, 0, 0, 0.3);
+        paint-order: stroke fill;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-clean"
+      data-composition-id="cap-clean"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="cl-container" id="cl-container"></div>
+      <div
+        id="drv-cap-clean"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("cl-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group — smooth fade only
-    tl.set(groupEl, { visibility: "visible" }, g.start);
-    tl.to(groupEl, { opacity: 1, duration: 0.3, ease: "power1.inOut" }, g.start);
+        var container = document.getElementById("cl-container");
 
-    // Word highlights: dim → white → stay bright
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("cl-cw-" + wi);
-      // Activate — smooth to pure white
-      tl.to(wordEl, {
-        color: "#FFFFFF",
-        duration: 0.1,
-        ease: "power1.out"
-      }, WORDS[wi].start);
-      // Deactivate — stay bright (already spoken)
-      tl.to(wordEl, {
-        color: "rgba(255,255,255,0.85)",
-        duration: 0.1,
-        ease: "power1.out"
-      }, WORDS[wi].end);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "cl-cg-" + gi;
+          groupEl.className = "cl-cg";
 
-    // EXIT — smooth fade
-    tl.to(groupEl, { opacity: 0, duration: 0.2, ease: "power1.inOut" }, g.end - 0.2);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
-  });
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "cl-cw-" + wi;
+            wordEl.className = "cl-cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-  window.__timelines["cap-clean"] = tl;
-})();</script>
-</body>
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+              fontFamily: "Albert Sans",
+              fontWeight: 700,
+              maxWidth: 1550,
+              baseFontSize: 108,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 108) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("cl-cg-" + gi);
+
+          // SHOW group — smooth fade only
+          tl.set(groupEl, { visibility: "visible" }, g.start);
+          tl.to(groupEl, { opacity: 1, duration: 0.3, ease: "power1.inOut" }, g.start);
+
+          // Word highlights: dim → white → stay bright
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("cl-cw-" + wi);
+            // Activate — smooth to pure white
+            tl.to(
+              wordEl,
+              {
+                color: "#FFFFFF",
+                duration: 0.1,
+                ease: "power1.out",
+              },
+              WORDS[wi].start,
+            );
+            // Deactivate — stay bright (already spoken)
+            tl.to(
+              wordEl,
+              {
+                color: "rgba(255,255,255,0.85)",
+                duration: 0.1,
+                ease: "power1.out",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT — smooth fade
+          tl.to(groupEl, { opacity: 0, duration: 0.2, ease: "power1.inOut" }, g.end - 0.2);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-clean"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-clean/cap-clean.html
+++ b/registry/blocks/cap-clean/cap-clean.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@700&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #111; overflow: hidden; }
+#root-cap-clean {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #111;
+}
+.cl-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cl-cg {
+  position: absolute;
+  top: 830px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+}
+.cl-cw {
+  font-family: 'Albert Sans', sans-serif;
+  font-weight: 700;
+  font-size: 108px;
+  color: rgba(255,255,255,0.5);
+  line-height: 1;
+  display: inline-block;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.5); -webkit-text-stroke: 1px rgba(0,0,0,0.3); paint-order: stroke fill;
+}
+</style>
+</head>
+<body>
+<div id="root-cap-clean" data-composition-id="cap-clean" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="cl-container" id="cl-container"></div>
+  <div id="drv-cap-clean" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("cl-container");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "cl-cg-" + gi;
+    groupEl.className = "cl-cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "cl-cw-" + wi;
+      wordEl.className = "cl-cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+        fontFamily: "Albert Sans",
+        fontWeight: 700,
+        maxWidth: 1550,
+        baseFontSize: 108,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 108) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("cl-cg-" + gi);
+
+    // SHOW group — smooth fade only
+    tl.set(groupEl, { visibility: "visible" }, g.start);
+    tl.to(groupEl, { opacity: 1, duration: 0.3, ease: "power1.inOut" }, g.start);
+
+    // Word highlights: dim → white → stay bright
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("cl-cw-" + wi);
+      // Activate — smooth to pure white
+      tl.to(wordEl, {
+        color: "#FFFFFF",
+        duration: 0.1,
+        ease: "power1.out"
+      }, WORDS[wi].start);
+      // Deactivate — stay bright (already spoken)
+      tl.to(wordEl, {
+        color: "rgba(255,255,255,0.85)",
+        duration: 0.1,
+        ease: "power1.out"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT — smooth fade
+    tl.to(groupEl, { opacity: 0, duration: 0.2, ease: "power1.inOut" }, g.end - 0.2);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-clean"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-clean/registry-item.json
+++ b/registry/blocks/cap-clean/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-clean",
+  "type": "hyperframes:block",
+  "title": "Clean Fade",
+  "description": "Ali Abdaal clean fade — zero decoration, smooth opacity transitions, maximum professionalism",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "minimal", "professional", "clean"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-clean.mp4",
+  "files": [
+    {
+      "path": "cap-clean.html",
+      "target": "compositions/cap-clean.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-emoji/cap-emoji.html
+++ b/registry/blocks/cap-emoji/cap-emoji.html
@@ -1,205 +1,254 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800;900&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #111; overflow: hidden; }
-#root-cap-emoji {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #111;
-}
-.cap-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.cg {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 32px;
-  max-width: 1700px;
-  overflow: visible;
-  opacity: 0;
-  visibility: hidden;
-}
-.cw {
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 900;
-  font-size: 112px;
-  color: #FFFFFF;
-  text-transform: uppercase;
-  line-height: 1.2;
-  display: inline-block;
-  -webkit-text-stroke: 3px rgba(0,0,0,0.8);
-  paint-order: stroke fill;
-  text-shadow: 0 4px 12px rgba(0,0,0,0.5);
-}
-.emoji-pop {
-  display: inline-block;
-  font-size: 96px;
-  -webkit-text-stroke: 0;
-  text-shadow: none;
-  text-transform: none;
-  vertical-align: middle;
-  margin-left: 8px;
-}
-</style>
-</head>
-<body>
-<div id="root-cap-emoji" data-composition-id="cap-emoji" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="cap-container" id="cc-emoji"></div>
-  <div id="drv-cap-emoji" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4, emoji: "\u{1F680}" },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15, emoji: "\u{1F3AC}" },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9, emoji: "\u{1F525}" },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0, emoji: "\u{1F4AA}" },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9, emoji: "\u{1F3AF}" },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6, emoji: "\u{1F4A5}" }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.3, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.6, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 3.8, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.4, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 6.8, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("cc-emoji");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "em-cg-" + gi;
-    groupEl.className = "cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordWrap = document.createElement("span");
-      wordWrap.style.display = "inline-block";
-
-      var wordEl = document.createElement("span");
-      wordEl.id = "em-cw-" + wi;
-      wordEl.className = "cw";
-      wordEl.textContent = WORDS[wi].text;
-      wordWrap.appendChild(wordEl);
-
-      if (WORDS[wi].emoji) {
-        var emojiEl = document.createElement("span");
-        emojiEl.id = "em-ej-" + wi;
-        emojiEl.className = "emoji-pop";
-        emojiEl.textContent = WORDS[wi].emoji;
-        emojiEl.style.opacity = "0";
-        emojiEl.style.display = "inline-block";
-        wordWrap.appendChild(emojiEl);
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800;900&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-
-      groupEl.appendChild(wordWrap);
-    }
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
-        fontFamily: "Montserrat",
-        fontWeight: 900,
-        maxWidth: 1400,
-        baseFontSize: 112,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 112) {
-        var allWords = groupEl.querySelectorAll(".cw");
-        for (var _fi = 0; _fi < allWords.length; _fi++) {
-          allWords[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+      body {
+        background: #111;
+        overflow: hidden;
       }
-    }
-    container.appendChild(groupEl);
-  });
-
-  var tl = gsap.timeline({ paused: true });
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("em-cg-" + gi);
-
-    tl.set(groupEl, { opacity: 1, visibility: "visible", scale: 1.5 }, g.start);
-    tl.to(groupEl, { scale: 1, duration: 0.15, ease: "back.out(2.5)" }, g.start);
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("em-cw-" + wi);
-      var emojiEl = document.getElementById("em-ej-" + wi);
-
-      // Word highlight
-      tl.to(wordEl, {
-        color: "#FFD700",
-        scale: 1.1,
-        textShadow: "0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5)",
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-
-      // Emoji pops in when its word activates
-      if (emojiEl) {
-        tl.to(emojiEl, {
-          opacity: 1,
-          scale: 1,
-          duration: 0.2,
-          ease: "back.out(3)"
-        }, WORDS[wi].start);
-        tl.from(emojiEl, {
-          scale: 2.5,
-          rotation: -20,
-          duration: 0.3,
-          ease: "elastic.out(1, 0.4)"
-        }, WORDS[wi].start);
+      #root-cap-emoji {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #111;
       }
+      .cap-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .cg {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 32px;
+        max-width: 1700px;
+        overflow: visible;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .cw {
+        font-family: "Montserrat", sans-serif;
+        font-weight: 900;
+        font-size: 112px;
+        color: #ffffff;
+        text-transform: uppercase;
+        line-height: 1.2;
+        display: inline-block;
+        -webkit-text-stroke: 3px rgba(0, 0, 0, 0.8);
+        paint-order: stroke fill;
+        text-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+      }
+      .emoji-pop {
+        display: inline-block;
+        font-size: 96px;
+        -webkit-text-stroke: 0;
+        text-shadow: none;
+        text-transform: none;
+        vertical-align: middle;
+        margin-left: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-emoji"
+      data-composition-id="cap-emoji"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="cap-container" id="cc-emoji"></div>
+      <div
+        id="drv-cap-emoji"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-      // Word deactivate
-      tl.to(wordEl, {
-        color: "#FFFFFF",
-        scale: 1,
-        textShadow: "0 4px 12px rgba(0,0,0,0.5)",
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4, emoji: "\u{1F680}" },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15, emoji: "\u{1F3AC}" },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9, emoji: "\u{1F525}" },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0, emoji: "\u{1F4AA}" },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9, emoji: "\u{1F3AF}" },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6, emoji: "\u{1F4A5}" },
+        ];
 
-    // Exit
-    tl.to(groupEl, { opacity: 0, scale: 0.85, duration: 0.1, ease: "power2.in" }, g.end - 0.1);
-    tl.set(groupEl, { opacity: 0, visibility: "hidden", scale: 1 }, g.end);
-  });
+        var GROUPS = [
+          { start: 0.3, end: 1.3, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.6, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 3.8, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.4, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 6.8, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-  window.__timelines["cap-emoji"] = tl;
-})();</script>
-</body>
+        var container = document.getElementById("cc-emoji");
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "em-cg-" + gi;
+          groupEl.className = "cg";
+
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordWrap = document.createElement("span");
+            wordWrap.style.display = "inline-block";
+
+            var wordEl = document.createElement("span");
+            wordEl.id = "em-cw-" + wi;
+            wordEl.className = "cw";
+            wordEl.textContent = WORDS[wi].text;
+            wordWrap.appendChild(wordEl);
+
+            if (WORDS[wi].emoji) {
+              var emojiEl = document.createElement("span");
+              emojiEl.id = "em-ej-" + wi;
+              emojiEl.className = "emoji-pop";
+              emojiEl.textContent = WORDS[wi].emoji;
+              emojiEl.style.opacity = "0";
+              emojiEl.style.display = "inline-block";
+              wordWrap.appendChild(emojiEl);
+            }
+
+            groupEl.appendChild(wordWrap);
+          }
+
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+              fontFamily: "Montserrat",
+              fontWeight: 900,
+              maxWidth: 1400,
+              baseFontSize: 112,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 112) {
+              var allWords = groupEl.querySelectorAll(".cw");
+              for (var _fi = 0; _fi < allWords.length; _fi++) {
+                allWords[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("em-cg-" + gi);
+
+          tl.set(groupEl, { opacity: 1, visibility: "visible", scale: 1.5 }, g.start);
+          tl.to(groupEl, { scale: 1, duration: 0.15, ease: "back.out(2.5)" }, g.start);
+
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("em-cw-" + wi);
+            var emojiEl = document.getElementById("em-ej-" + wi);
+
+            // Word highlight
+            tl.to(
+              wordEl,
+              {
+                color: "#FFD700",
+                scale: 1.1,
+                textShadow: "0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5)",
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+
+            // Emoji pops in when its word activates
+            if (emojiEl) {
+              tl.to(
+                emojiEl,
+                {
+                  opacity: 1,
+                  scale: 1,
+                  duration: 0.2,
+                  ease: "back.out(3)",
+                },
+                WORDS[wi].start,
+              );
+              tl.from(
+                emojiEl,
+                {
+                  scale: 2.5,
+                  rotation: -20,
+                  duration: 0.3,
+                  ease: "elastic.out(1, 0.4)",
+                },
+                WORDS[wi].start,
+              );
+            }
+
+            // Word deactivate
+            tl.to(
+              wordEl,
+              {
+                color: "#FFFFFF",
+                scale: 1,
+                textShadow: "0 4px 12px rgba(0,0,0,0.5)",
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // Exit
+          tl.to(
+            groupEl,
+            { opacity: 0, scale: 0.85, duration: 0.1, ease: "power2.in" },
+            g.end - 0.1,
+          );
+          tl.set(groupEl, { opacity: 0, visibility: "hidden", scale: 1 }, g.end);
+        });
+
+        window.__timelines["cap-emoji"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-emoji/cap-emoji.html
+++ b/registry/blocks/cap-emoji/cap-emoji.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800;900&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #111; overflow: hidden; }
+#root-cap-emoji {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #111;
+}
+.cap-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cg {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+  max-width: 1700px;
+  overflow: visible;
+  opacity: 0;
+  visibility: hidden;
+}
+.cw {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 112px;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  line-height: 1.2;
+  display: inline-block;
+  -webkit-text-stroke: 3px rgba(0,0,0,0.8);
+  paint-order: stroke fill;
+  text-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+.emoji-pop {
+  display: inline-block;
+  font-size: 96px;
+  -webkit-text-stroke: 0;
+  text-shadow: none;
+  text-transform: none;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+</style>
+</head>
+<body>
+<div id="root-cap-emoji" data-composition-id="cap-emoji" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="cap-container" id="cc-emoji"></div>
+  <div id="drv-cap-emoji" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4, emoji: "\u{1F680}" },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15, emoji: "\u{1F3AC}" },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9, emoji: "\u{1F525}" },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0, emoji: "\u{1F4AA}" },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9, emoji: "\u{1F3AF}" },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6, emoji: "\u{1F4A5}" }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.3, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.6, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 3.8, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.4, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 6.8, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("cc-emoji");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "em-cg-" + gi;
+    groupEl.className = "cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordWrap = document.createElement("span");
+      wordWrap.style.display = "inline-block";
+
+      var wordEl = document.createElement("span");
+      wordEl.id = "em-cw-" + wi;
+      wordEl.className = "cw";
+      wordEl.textContent = WORDS[wi].text;
+      wordWrap.appendChild(wordEl);
+
+      if (WORDS[wi].emoji) {
+        var emojiEl = document.createElement("span");
+        emojiEl.id = "em-ej-" + wi;
+        emojiEl.className = "emoji-pop";
+        emojiEl.textContent = WORDS[wi].emoji;
+        emojiEl.style.opacity = "0";
+        emojiEl.style.display = "inline-block";
+        wordWrap.appendChild(emojiEl);
+      }
+
+      groupEl.appendChild(wordWrap);
+    }
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+        fontFamily: "Montserrat",
+        fontWeight: 900,
+        maxWidth: 1400,
+        baseFontSize: 112,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 112) {
+        var allWords = groupEl.querySelectorAll(".cw");
+        for (var _fi = 0; _fi < allWords.length; _fi++) {
+          allWords[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("em-cg-" + gi);
+
+    tl.set(groupEl, { opacity: 1, visibility: "visible", scale: 1.5 }, g.start);
+    tl.to(groupEl, { scale: 1, duration: 0.15, ease: "back.out(2.5)" }, g.start);
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("em-cw-" + wi);
+      var emojiEl = document.getElementById("em-ej-" + wi);
+
+      // Word highlight
+      tl.to(wordEl, {
+        color: "#FFD700",
+        scale: 1.1,
+        textShadow: "0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5)",
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+
+      // Emoji pops in when its word activates
+      if (emojiEl) {
+        tl.to(emojiEl, {
+          opacity: 1,
+          scale: 1,
+          duration: 0.2,
+          ease: "back.out(3)"
+        }, WORDS[wi].start);
+        tl.from(emojiEl, {
+          scale: 2.5,
+          rotation: -20,
+          duration: 0.3,
+          ease: "elastic.out(1, 0.4)"
+        }, WORDS[wi].start);
+      }
+
+      // Word deactivate
+      tl.to(wordEl, {
+        color: "#FFFFFF",
+        scale: 1,
+        textShadow: "0 4px 12px rgba(0,0,0,0.5)",
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // Exit
+    tl.to(groupEl, { opacity: 0, scale: 0.85, duration: 0.1, ease: "power2.in" }, g.end - 0.1);
+    tl.set(groupEl, { opacity: 0, visibility: "hidden", scale: 1 }, g.end);
+  });
+
+  window.__timelines["cap-emoji"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-emoji/registry-item.json
+++ b/registry/blocks/cap-emoji/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-emoji",
+  "type": "hyperframes:block",
+  "title": "Emoji Pop",
+  "description": "Hormozi pop with emoji reactions — contextual emoji bounces in next to keyword on activation",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "emoji", "social", "fun"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-emoji.mp4",
+  "files": [
+    {
+      "path": "cap-emoji.html",
+      "target": "compositions/cap-emoji.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-glitch/cap-glitch.html
+++ b/registry/blocks/cap-glitch/cap-glitch.html
@@ -1,167 +1,204 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #0a0a0a; overflow: hidden; }
-#root-cap-glitch {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #0a0a0a;
-}
-.gl-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.gl-cg {
-  position: absolute;
-  top: 480px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-}
-.gl-cw {
-  font-family: 'Chakra Petch', sans-serif;
-  font-weight: 700;
-  font-size: 120px;
-  color: #FFFFFF;
-  text-transform: uppercase;
-  line-height: 1;
-  display: inline-block;
-  -webkit-text-stroke: 2px rgba(0,0,0,0.6);
-  paint-order: stroke fill;
-  text-shadow: 0 3px 8px rgba(0,0,0,0.5);
-}
-</style>
-</head>
-<body>
-<div id="root-cap-glitch" data-composition-id="cap-glitch" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="gl-container" id="gl-container"></div>
-  <div id="drv-cap-glitch" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("gl-container");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "gl-cg-" + gi;
-    groupEl.className = "gl-cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "gl-cw-" + wi;
-      wordEl.className = "gl-cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
-        fontFamily: "Chakra Petch",
-        fontWeight: 700,
-        maxWidth: 1550,
-        baseFontSize: 120,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 120) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #0a0a0a;
+        overflow: hidden;
+      }
+      #root-cap-glitch {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0a0a0a;
+      }
+      .gl-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .gl-cg {
+        position: absolute;
+        top: 480px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 20px;
+        white-space: nowrap;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .gl-cw {
+        font-family: "Chakra Petch", sans-serif;
+        font-weight: 700;
+        font-size: 120px;
+        color: #ffffff;
+        text-transform: uppercase;
+        line-height: 1;
+        display: inline-block;
+        -webkit-text-stroke: 2px rgba(0, 0, 0, 0.6);
+        paint-order: stroke fill;
+        text-shadow: 0 3px 8px rgba(0, 0, 0, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-glitch"
+      data-composition-id="cap-glitch"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="gl-container" id="gl-container"></div>
+      <div
+        id="drv-cap-glitch"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("gl-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // GLITCH entrance — 3 rapid RGB flashes
-    tl.set(groupEl, { opacity: 1, visibility: "visible", x: -6, color: "#FF0000" }, g.start);
-    tl.set(groupEl, { x: 4, color: "#00FF00" }, g.start + 0.03);
-    tl.set(groupEl, { x: 0, color: "#FFFFFF" }, g.start + 0.06);
+        var container = document.getElementById("gl-container");
 
-    // Karaoke: chromatic aberration on active word
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("gl-cw-" + wi);
-      // Activate — matrix green with chromatic split
-      tl.to(wordEl, {
-        color: "#00FF88",
-        textShadow: "3px 0 #FF0000, -3px 0 #0000FF, 0 0 15px #00FF8880, 0 3px 8px rgba(0,0,0,0.5)",
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-      // Deactivate — dim white, no chromatic split
-      tl.to(wordEl, {
-        color: "rgba(255,255,255,0.75)",
-        textShadow: "0 3px 8px rgba(0,0,0,0.5)",
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "gl-cg-" + gi;
+          groupEl.className = "gl-cg";
 
-    // EXIT — reverse glitch
-    tl.set(groupEl, { x: 5, color: "#FF0000" }, g.end - 0.06);
-    tl.set(groupEl, { x: -3, opacity: 0.5 }, g.end - 0.03);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden", x: 0 }, g.end);
-  });
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "gl-cw-" + wi;
+            wordEl.className = "gl-cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-  window.__timelines["cap-glitch"] = tl;
-})();</script>
-</body>
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+              fontFamily: "Chakra Petch",
+              fontWeight: 700,
+              maxWidth: 1550,
+              baseFontSize: 120,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 120) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("gl-cg-" + gi);
+
+          // GLITCH entrance — 3 rapid RGB flashes
+          tl.set(groupEl, { opacity: 1, visibility: "visible", x: -6, color: "#FF0000" }, g.start);
+          tl.set(groupEl, { x: 4, color: "#00FF00" }, g.start + 0.03);
+          tl.set(groupEl, { x: 0, color: "#FFFFFF" }, g.start + 0.06);
+
+          // Karaoke: chromatic aberration on active word
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("gl-cw-" + wi);
+            // Activate — matrix green with chromatic split
+            tl.to(
+              wordEl,
+              {
+                color: "#00FF88",
+                textShadow:
+                  "3px 0 #FF0000, -3px 0 #0000FF, 0 0 15px #00FF8880, 0 3px 8px rgba(0,0,0,0.5)",
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+            // Deactivate — dim white, no chromatic split
+            tl.to(
+              wordEl,
+              {
+                color: "rgba(255,255,255,0.75)",
+                textShadow: "0 3px 8px rgba(0,0,0,0.5)",
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT — reverse glitch
+          tl.set(groupEl, { x: 5, color: "#FF0000" }, g.end - 0.06);
+          tl.set(groupEl, { x: -3, opacity: 0.5 }, g.end - 0.03);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden", x: 0 }, g.end);
+        });
+
+        window.__timelines["cap-glitch"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-glitch/cap-glitch.html
+++ b/registry/blocks/cap-glitch/cap-glitch.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #0a0a0a; overflow: hidden; }
+#root-cap-glitch {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #0a0a0a;
+}
+.gl-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.gl-cg {
+  position: absolute;
+  top: 480px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+}
+.gl-cw {
+  font-family: 'Chakra Petch', sans-serif;
+  font-weight: 700;
+  font-size: 120px;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  line-height: 1;
+  display: inline-block;
+  -webkit-text-stroke: 2px rgba(0,0,0,0.6);
+  paint-order: stroke fill;
+  text-shadow: 0 3px 8px rgba(0,0,0,0.5);
+}
+</style>
+</head>
+<body>
+<div id="root-cap-glitch" data-composition-id="cap-glitch" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="gl-container" id="gl-container"></div>
+  <div id="drv-cap-glitch" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("gl-container");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "gl-cg-" + gi;
+    groupEl.className = "gl-cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "gl-cw-" + wi;
+      wordEl.className = "gl-cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+        fontFamily: "Chakra Petch",
+        fontWeight: 700,
+        maxWidth: 1550,
+        baseFontSize: 120,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 120) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("gl-cg-" + gi);
+
+    // GLITCH entrance — 3 rapid RGB flashes
+    tl.set(groupEl, { opacity: 1, visibility: "visible", x: -6, color: "#FF0000" }, g.start);
+    tl.set(groupEl, { x: 4, color: "#00FF00" }, g.start + 0.03);
+    tl.set(groupEl, { x: 0, color: "#FFFFFF" }, g.start + 0.06);
+
+    // Karaoke: chromatic aberration on active word
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("gl-cw-" + wi);
+      // Activate — matrix green with chromatic split
+      tl.to(wordEl, {
+        color: "#00FF88",
+        textShadow: "3px 0 #FF0000, -3px 0 #0000FF, 0 0 15px #00FF8880, 0 3px 8px rgba(0,0,0,0.5)",
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+      // Deactivate — dim white, no chromatic split
+      tl.to(wordEl, {
+        color: "rgba(255,255,255,0.75)",
+        textShadow: "0 3px 8px rgba(0,0,0,0.5)",
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT — reverse glitch
+    tl.set(groupEl, { x: 5, color: "#FF0000" }, g.end - 0.06);
+    tl.set(groupEl, { x: -3, opacity: 0.5 }, g.end - 0.03);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden", x: 0 }, g.end);
+  });
+
+  window.__timelines["cap-glitch"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-glitch/registry-item.json
+++ b/registry/blocks/cap-glitch/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-glitch",
+  "type": "hyperframes:block",
+  "title": "Glitch",
+  "description": "Digital glitch entrance — RGB chromatic aberration flash, matrix green active word",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "tech", "cyberpunk", "glitch"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-glitch.mp4",
+  "files": [
+    {
+      "path": "cap-glitch.html",
+      "target": "compositions/cap-glitch.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-hormozi/cap-hormozi.html
+++ b/registry/blocks/cap-hormozi/cap-hormozi.html
@@ -1,169 +1,212 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800;900&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #111; overflow: hidden; }
-#root-cap-hormozi {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #111;
-}
-.cap-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.cg {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 40px;
-  max-width: 1700px; overflow: visible;
-  opacity: 0;
-  visibility: hidden;
-}
-.cw {
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 900;
-  font-size: 128px;
-  color: #FFFFFF;
-  text-transform: uppercase;
-  line-height: 1;
-  display: inline-block;
-  -webkit-text-stroke: 3px rgba(0,0,0,0.8);
-  paint-order: stroke fill;
-  text-shadow: 0 4px 12px rgba(0,0,0,0.5);
-}
-.cw-active {
-  color: #FFD700;
-  transform: scale(1.1);
-  text-shadow: 0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5);
-}
-</style>
-</head>
-<body>
-<div id="root-cap-hormozi" data-composition-id="cap-hormozi" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="cap-container" id="cc-hormozi"></div>
-  <div id="drv-cap-hormozi" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.3, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.6, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 3.8, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.4, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 6.8, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("cc-hormozi");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "hz-cg-" + gi;
-    groupEl.className = "cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "hz-cw-" + wi;
-      wordEl.className = "cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
-        fontFamily: "Montserrat",
-        fontWeight: 900,
-        maxWidth: 1550,
-        baseFontSize: 128,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 128) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800;900&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #111;
+        overflow: hidden;
+      }
+      #root-cap-hormozi {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #111;
+      }
+      .cap-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .cg {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 40px;
+        max-width: 1700px;
+        overflow: visible;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .cw {
+        font-family: "Montserrat", sans-serif;
+        font-weight: 900;
+        font-size: 128px;
+        color: #ffffff;
+        text-transform: uppercase;
+        line-height: 1;
+        display: inline-block;
+        -webkit-text-stroke: 3px rgba(0, 0, 0, 0.8);
+        paint-order: stroke fill;
+        text-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+      }
+      .cw-active {
+        color: #ffd700;
+        transform: scale(1.1);
+        text-shadow:
+          0 0 20px rgba(255, 215, 0, 0.4),
+          0 4px 12px rgba(0, 0, 0, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-hormozi"
+      data-composition-id="cap-hormozi"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="cap-container" id="cc-hormozi"></div>
+      <div
+        id="drv-cap-hormozi"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("hz-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.3, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.6, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 3.8, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.4, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 6.8, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group with pop entrance
-    tl.set(groupEl, { opacity: 1, visibility: "visible", scale: 1.6 }, g.start);
-    tl.to(groupEl, { scale: 1, duration: 0.15, ease: "back.out(2.5)" }, g.start);
+        var container = document.getElementById("cc-hormozi");
 
-    // Karaoke: highlight each word as spoken
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("hz-cw-" + wi);
-      // Activate
-      tl.to(wordEl, {
-        color: "#FFD700",
-        scale: 1.12,
-        textShadow: "0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5)",
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-      // Deactivate
-      tl.to(wordEl, {
-        color: "#FFFFFF",
-        scale: 1,
-        textShadow: "0 4px 12px rgba(0,0,0,0.5)",
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "hz-cg-" + gi;
+          groupEl.className = "cg";
 
-    // EXIT with scale-down
-    tl.to(groupEl, { opacity: 0, scale: 0.85, duration: 0.1, ease: "power2.in" }, g.end - 0.1);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden", scale: 1 }, g.end);
-  });
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "hz-cw-" + wi;
+            wordEl.className = "cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-  window.__timelines["cap-hormozi"] = tl;
-})();</script>
-</body>
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+              fontFamily: "Montserrat",
+              fontWeight: 900,
+              maxWidth: 1550,
+              baseFontSize: 128,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 128) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("hz-cg-" + gi);
+
+          // SHOW group with pop entrance
+          tl.set(groupEl, { opacity: 1, visibility: "visible", scale: 1.6 }, g.start);
+          tl.to(groupEl, { scale: 1, duration: 0.15, ease: "back.out(2.5)" }, g.start);
+
+          // Karaoke: highlight each word as spoken
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("hz-cw-" + wi);
+            // Activate
+            tl.to(
+              wordEl,
+              {
+                color: "#FFD700",
+                scale: 1.12,
+                textShadow: "0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5)",
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+            // Deactivate
+            tl.to(
+              wordEl,
+              {
+                color: "#FFFFFF",
+                scale: 1,
+                textShadow: "0 4px 12px rgba(0,0,0,0.5)",
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT with scale-down
+          tl.to(
+            groupEl,
+            { opacity: 0, scale: 0.85, duration: 0.1, ease: "power2.in" },
+            g.end - 0.1,
+          );
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden", scale: 1 }, g.end);
+        });
+
+        window.__timelines["cap-hormozi"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-hormozi/cap-hormozi.html
+++ b/registry/blocks/cap-hormozi/cap-hormozi.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800;900&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #111; overflow: hidden; }
+#root-cap-hormozi {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #111;
+}
+.cap-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cg {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 40px;
+  max-width: 1700px; overflow: visible;
+  opacity: 0;
+  visibility: hidden;
+}
+.cw {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 128px;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  line-height: 1;
+  display: inline-block;
+  -webkit-text-stroke: 3px rgba(0,0,0,0.8);
+  paint-order: stroke fill;
+  text-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+.cw-active {
+  color: #FFD700;
+  transform: scale(1.1);
+  text-shadow: 0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5);
+}
+</style>
+</head>
+<body>
+<div id="root-cap-hormozi" data-composition-id="cap-hormozi" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="cap-container" id="cc-hormozi"></div>
+  <div id="drv-cap-hormozi" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.3, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.6, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 3.8, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.4, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 6.8, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("cc-hormozi");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "hz-cg-" + gi;
+    groupEl.className = "cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "hz-cw-" + wi;
+      wordEl.className = "cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+        fontFamily: "Montserrat",
+        fontWeight: 900,
+        maxWidth: 1550,
+        baseFontSize: 128,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 128) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("hz-cg-" + gi);
+
+    // SHOW group with pop entrance
+    tl.set(groupEl, { opacity: 1, visibility: "visible", scale: 1.6 }, g.start);
+    tl.to(groupEl, { scale: 1, duration: 0.15, ease: "back.out(2.5)" }, g.start);
+
+    // Karaoke: highlight each word as spoken
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("hz-cw-" + wi);
+      // Activate
+      tl.to(wordEl, {
+        color: "#FFD700",
+        scale: 1.12,
+        textShadow: "0 0 20px rgba(255,215,0,0.4), 0 4px 12px rgba(0,0,0,0.5)",
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+      // Deactivate
+      tl.to(wordEl, {
+        color: "#FFFFFF",
+        scale: 1,
+        textShadow: "0 4px 12px rgba(0,0,0,0.5)",
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT with scale-down
+    tl.to(groupEl, { opacity: 0, scale: 0.85, duration: 0.1, ease: "power2.in" }, g.end - 0.1);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden", scale: 1 }, g.end);
+  });
+
+  window.__timelines["cap-hormozi"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-hormozi/registry-item.json
+++ b/registry/blocks/cap-hormozi/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-hormozi",
+  "type": "hyperframes:block",
+  "title": "Hormozi Bold Pop",
+  "description": "Hormozi-style word pop — Montserrat 900, ALL CAPS, gold karaoke highlight with scale bounce entrance",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "viral", "short-form", "hormozi"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-hormozi.mp4",
+  "files": [
+    {
+      "path": "cap-hormozi.html",
+      "target": "compositions/cap-hormozi.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-karaoke-sweep/cap-karaoke-sweep.html
+++ b/registry/blocks/cap-karaoke-sweep/cap-karaoke-sweep.html
@@ -1,165 +1,201 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #111; overflow: hidden; }
-#root-cap-karaoke-sweep {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #111;
-}
-.ks-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.ks-cg {
-  position: absolute;
-  top: 820px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 18px;
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-}
-.ks-cw {
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 800;
-  font-size: 96px;
-  color: rgba(255,255,255,0.35);
-  text-transform: uppercase;
-  line-height: 1;
-  display: inline-block;
-  text-shadow: 0 3px 8px rgba(0,0,0,0.6);
-}
-</style>
-</head>
-<body>
-<div id="root-cap-karaoke-sweep" data-composition-id="cap-karaoke-sweep" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="ks-container" id="ks-container"></div>
-  <div id="drv-cap-karaoke-sweep" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("ks-container");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "ks-cg-" + gi;
-    groupEl.className = "ks-cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "ks-cw-" + wi;
-      wordEl.className = "ks-cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
-        fontFamily: "Montserrat",
-        fontWeight: 800,
-        maxWidth: 1550,
-        baseFontSize: 96,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 96) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #111;
+        overflow: hidden;
+      }
+      #root-cap-karaoke-sweep {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #111;
+      }
+      .ks-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .ks-cg {
+        position: absolute;
+        top: 820px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 18px;
+        white-space: nowrap;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .ks-cw {
+        font-family: "Montserrat", sans-serif;
+        font-weight: 800;
+        font-size: 96px;
+        color: rgba(255, 255, 255, 0.35);
+        text-transform: uppercase;
+        line-height: 1;
+        display: inline-block;
+        text-shadow: 0 3px 8px rgba(0, 0, 0, 0.6);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-karaoke-sweep"
+      data-composition-id="cap-karaoke-sweep"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="ks-container" id="ks-container"></div>
+      <div
+        id="drv-cap-karaoke-sweep"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("ks-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group — slide up with fade
-    tl.set(groupEl, { opacity: 1, visibility: "visible", y: 25 }, g.start);
-    tl.to(groupEl, { y: 0, opacity: 1, duration: 0.2, ease: "power3.out" }, g.start);
+        var container = document.getElementById("ks-container");
 
-    // Karaoke sweep: activate each word, then dim to "spoken" state
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("ks-cw-" + wi);
-      // Activate — pure bright white with glow
-      tl.to(wordEl, {
-        color: "#FFFFFF",
-        scale: 1.06,
-        textShadow: "0 0 15px rgba(255,255,255,0.4), 0 3px 8px rgba(0,0,0,0.6)",
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-      // Deactivate — spoken words stay brighter than unspoken
-      tl.to(wordEl, {
-        color: "rgba(255,255,255,0.8)",
-        scale: 1,
-        textShadow: "0 3px 8px rgba(0,0,0,0.6)",
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "ks-cg-" + gi;
+          groupEl.className = "ks-cg";
 
-    // EXIT — slide up with fade
-    tl.to(groupEl, { y: -15, opacity: 0, duration: 0.12 }, g.end - 0.12);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
-  });
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "ks-cw-" + wi;
+            wordEl.className = "ks-cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-  window.__timelines["cap-karaoke-sweep"] = tl;
-})();</script>
-</body>
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+              fontFamily: "Montserrat",
+              fontWeight: 800,
+              maxWidth: 1550,
+              baseFontSize: 96,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 96) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("ks-cg-" + gi);
+
+          // SHOW group — slide up with fade
+          tl.set(groupEl, { opacity: 1, visibility: "visible", y: 25 }, g.start);
+          tl.to(groupEl, { y: 0, opacity: 1, duration: 0.2, ease: "power3.out" }, g.start);
+
+          // Karaoke sweep: activate each word, then dim to "spoken" state
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("ks-cw-" + wi);
+            // Activate — pure bright white with glow
+            tl.to(
+              wordEl,
+              {
+                color: "#FFFFFF",
+                scale: 1.06,
+                textShadow: "0 0 15px rgba(255,255,255,0.4), 0 3px 8px rgba(0,0,0,0.6)",
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+            // Deactivate — spoken words stay brighter than unspoken
+            tl.to(
+              wordEl,
+              {
+                color: "rgba(255,255,255,0.8)",
+                scale: 1,
+                textShadow: "0 3px 8px rgba(0,0,0,0.6)",
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT — slide up with fade
+          tl.to(groupEl, { y: -15, opacity: 0, duration: 0.12 }, g.end - 0.12);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-karaoke-sweep"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-karaoke-sweep/cap-karaoke-sweep.html
+++ b/registry/blocks/cap-karaoke-sweep/cap-karaoke-sweep.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #111; overflow: hidden; }
+#root-cap-karaoke-sweep {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #111;
+}
+.ks-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ks-cg {
+  position: absolute;
+  top: 820px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+}
+.ks-cw {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 800;
+  font-size: 96px;
+  color: rgba(255,255,255,0.35);
+  text-transform: uppercase;
+  line-height: 1;
+  display: inline-block;
+  text-shadow: 0 3px 8px rgba(0,0,0,0.6);
+}
+</style>
+</head>
+<body>
+<div id="root-cap-karaoke-sweep" data-composition-id="cap-karaoke-sweep" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="ks-container" id="ks-container"></div>
+  <div id="drv-cap-karaoke-sweep" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("ks-container");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "ks-cg-" + gi;
+    groupEl.className = "ks-cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "ks-cw-" + wi;
+      wordEl.className = "ks-cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+        fontFamily: "Montserrat",
+        fontWeight: 800,
+        maxWidth: 1550,
+        baseFontSize: 96,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 96) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("ks-cg-" + gi);
+
+    // SHOW group — slide up with fade
+    tl.set(groupEl, { opacity: 1, visibility: "visible", y: 25 }, g.start);
+    tl.to(groupEl, { y: 0, opacity: 1, duration: 0.2, ease: "power3.out" }, g.start);
+
+    // Karaoke sweep: activate each word, then dim to "spoken" state
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("ks-cw-" + wi);
+      // Activate — pure bright white with glow
+      tl.to(wordEl, {
+        color: "#FFFFFF",
+        scale: 1.06,
+        textShadow: "0 0 15px rgba(255,255,255,0.4), 0 3px 8px rgba(0,0,0,0.6)",
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+      // Deactivate — spoken words stay brighter than unspoken
+      tl.to(wordEl, {
+        color: "rgba(255,255,255,0.8)",
+        scale: 1,
+        textShadow: "0 3px 8px rgba(0,0,0,0.6)",
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT — slide up with fade
+    tl.to(groupEl, { y: -15, opacity: 0, duration: 0.12 }, g.end - 0.12);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-karaoke-sweep"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-karaoke-sweep/registry-item.json
+++ b/registry/blocks/cap-karaoke-sweep/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-karaoke-sweep",
+  "type": "hyperframes:block",
+  "title": "Karaoke Sweep",
+  "description": "CapCut-style full phrase with progressive white glow on active word, dimmed unspoken words",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "karaoke", "capcut", "general"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-karaoke-sweep.mp4",
+  "files": [
+    {
+      "path": "cap-karaoke-sweep.html",
+      "target": "compositions/cap-karaoke-sweep.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-marker/cap-marker.html
+++ b/registry/blocks/cap-marker/cap-marker.html
@@ -1,182 +1,214 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@800&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #F0EDE8; overflow: hidden; }
-#root-cap-marker {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #F0EDE8;
-}
-.mk-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.mk-cg {
-  position: absolute;
-  top: 500px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 18px;
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-}
-.mk-cw {
-  font-family: 'Figtree', sans-serif;
-  font-weight: 800;
-  font-size: 108px;
-  color: #1a1a1a;
-  line-height: 1;
-  display: inline-block;
-}
-.mk-word-wrap {
-  position: relative;
-  display: inline-block;
-}
-.mk-bar {
-  position: absolute;
-  left: -6px;
-  right: -6px;
-  top: 0;
-  bottom: 0;
-  background: #FFE066;
-  transform: scaleX(0);
-  transform-origin: left;
-  border-radius: 4px;
-  z-index: 0;
-}
-.mk-text {
-  position: relative;
-  z-index: 1;
-}
-</style>
-</head>
-<body>
-<div id="root-cap-marker" data-composition-id="cap-marker" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="mk-container" id="mk-container"></div>
-  <div id="drv-cap-marker" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("mk-container");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "mk-cg-" + gi;
-    groupEl.className = "mk-cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wrapEl = document.createElement("span");
-      wrapEl.className = "mk-word-wrap mk-cw";
-      wrapEl.id = "mk-cw-" + wi;
-
-      var barEl = document.createElement("span");
-      barEl.className = "mk-bar";
-      barEl.id = "mk-bar-" + wi;
-
-      var textEl = document.createElement("span");
-      textEl.className = "mk-text";
-      textEl.textContent = WORDS[wi].text;
-
-      wrapEl.appendChild(barEl);
-      wrapEl.appendChild(textEl);
-      groupEl.appendChild(wrapEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
-        fontFamily: "Figtree",
-        fontWeight: 800,
-        maxWidth: 1550,
-        baseFontSize: 108,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 108) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Figtree:wght@800&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #f0ede8;
+        overflow: hidden;
+      }
+      #root-cap-marker {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #f0ede8;
+      }
+      .mk-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .mk-cg {
+        position: absolute;
+        top: 500px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 18px;
+        white-space: nowrap;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .mk-cw {
+        font-family: "Figtree", sans-serif;
+        font-weight: 800;
+        font-size: 108px;
+        color: #1a1a1a;
+        line-height: 1;
+        display: inline-block;
+      }
+      .mk-word-wrap {
+        position: relative;
+        display: inline-block;
+      }
+      .mk-bar {
+        position: absolute;
+        left: -6px;
+        right: -6px;
+        top: 0;
+        bottom: 0;
+        background: #ffe066;
+        transform: scaleX(0);
+        transform-origin: left;
+        border-radius: 4px;
+        z-index: 0;
+      }
+      .mk-text {
+        position: relative;
+        z-index: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-marker"
+      data-composition-id="cap-marker"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="mk-container" id="mk-container"></div>
+      <div
+        id="drv-cap-marker"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("mk-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group — slide up with fade
-    tl.set(groupEl, { visibility: "visible" }, g.start);
-    tl.to(groupEl, { opacity: 1, y: 15, duration: 0.2, ease: "power2.out" }, g.start);
+        var container = document.getElementById("mk-container");
 
-    // Marker sweep: animate highlight bar on each word
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var barEl = document.getElementById("mk-bar-" + wi);
-      tl.to(barEl, {
-        scaleX: 1,
-        duration: 0.12,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "mk-cg-" + gi;
+          groupEl.className = "mk-cg";
 
-    // EXIT — fade out
-    tl.to(groupEl, { opacity: 0, duration: 0.15 }, g.end - 0.15);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
-  });
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wrapEl = document.createElement("span");
+            wrapEl.className = "mk-word-wrap mk-cw";
+            wrapEl.id = "mk-cw-" + wi;
 
-  window.__timelines["cap-marker"] = tl;
-})();</script>
-</body>
+            var barEl = document.createElement("span");
+            barEl.className = "mk-bar";
+            barEl.id = "mk-bar-" + wi;
+
+            var textEl = document.createElement("span");
+            textEl.className = "mk-text";
+            textEl.textContent = WORDS[wi].text;
+
+            wrapEl.appendChild(barEl);
+            wrapEl.appendChild(textEl);
+            groupEl.appendChild(wrapEl);
+          }
+
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+              fontFamily: "Figtree",
+              fontWeight: 800,
+              maxWidth: 1550,
+              baseFontSize: 108,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 108) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("mk-cg-" + gi);
+
+          // SHOW group — slide up with fade
+          tl.set(groupEl, { visibility: "visible" }, g.start);
+          tl.to(groupEl, { opacity: 1, y: 15, duration: 0.2, ease: "power2.out" }, g.start);
+
+          // Marker sweep: animate highlight bar on each word
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var barEl = document.getElementById("mk-bar-" + wi);
+            tl.to(
+              barEl,
+              {
+                scaleX: 1,
+                duration: 0.12,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+          }
+
+          // EXIT — fade out
+          tl.to(groupEl, { opacity: 0, duration: 0.15 }, g.end - 0.15);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-marker"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-marker/cap-marker.html
+++ b/registry/blocks/cap-marker/cap-marker.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #F0EDE8; overflow: hidden; }
+#root-cap-marker {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #F0EDE8;
+}
+.mk-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mk-cg {
+  position: absolute;
+  top: 500px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+}
+.mk-cw {
+  font-family: 'Figtree', sans-serif;
+  font-weight: 800;
+  font-size: 108px;
+  color: #1a1a1a;
+  line-height: 1;
+  display: inline-block;
+}
+.mk-word-wrap {
+  position: relative;
+  display: inline-block;
+}
+.mk-bar {
+  position: absolute;
+  left: -6px;
+  right: -6px;
+  top: 0;
+  bottom: 0;
+  background: #FFE066;
+  transform: scaleX(0);
+  transform-origin: left;
+  border-radius: 4px;
+  z-index: 0;
+}
+.mk-text {
+  position: relative;
+  z-index: 1;
+}
+</style>
+</head>
+<body>
+<div id="root-cap-marker" data-composition-id="cap-marker" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="mk-container" id="mk-container"></div>
+  <div id="drv-cap-marker" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("mk-container");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "mk-cg-" + gi;
+    groupEl.className = "mk-cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wrapEl = document.createElement("span");
+      wrapEl.className = "mk-word-wrap mk-cw";
+      wrapEl.id = "mk-cw-" + wi;
+
+      var barEl = document.createElement("span");
+      barEl.className = "mk-bar";
+      barEl.id = "mk-bar-" + wi;
+
+      var textEl = document.createElement("span");
+      textEl.className = "mk-text";
+      textEl.textContent = WORDS[wi].text;
+
+      wrapEl.appendChild(barEl);
+      wrapEl.appendChild(textEl);
+      groupEl.appendChild(wrapEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+        fontFamily: "Figtree",
+        fontWeight: 800,
+        maxWidth: 1550,
+        baseFontSize: 108,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 108) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("mk-cg-" + gi);
+
+    // SHOW group — slide up with fade
+    tl.set(groupEl, { visibility: "visible" }, g.start);
+    tl.to(groupEl, { opacity: 1, y: 15, duration: 0.2, ease: "power2.out" }, g.start);
+
+    // Marker sweep: animate highlight bar on each word
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var barEl = document.getElementById("mk-bar-" + wi);
+      tl.to(barEl, {
+        scaleX: 1,
+        duration: 0.12,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+    }
+
+    // EXIT — fade out
+    tl.to(groupEl, { opacity: 0, duration: 0.15 }, g.end - 0.15);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-marker"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-marker/registry-item.json
+++ b/registry/blocks/cap-marker/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-marker",
+  "type": "hyperframes:block",
+  "title": "Marker Highlight",
+  "description": "Yellow marker highlight sweep on light background — educational/emphasis style",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "educational", "marker", "highlight"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-marker.mp4",
+  "files": [
+    {
+      "path": "cap-marker.html",
+      "target": "compositions/cap-marker.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-neon/cap-neon.html
+++ b/registry/blocks/cap-neon/cap-neon.html
@@ -1,166 +1,203 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #0a0a0a; overflow: hidden; }
-#root-cap-neon {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #0a0a0a;
-}
-.nn-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.nn-cg {
-  position: absolute;
-  top: 480px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-}
-.nn-cw {
-  font-family: 'Chakra Petch', sans-serif;
-  font-weight: 700;
-  font-size: 120px;
-  color: rgba(255,255,255,0.7);
-  text-transform: uppercase;
-  line-height: 1;
-  display: inline-block;
-  -webkit-text-stroke: 2px rgba(0,0,0,0.5);
-  paint-order: stroke fill;
-}
-</style>
-</head>
-<body>
-<div id="root-cap-neon" data-composition-id="cap-neon" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="nn-container" id="nn-container"></div>
-  <div id="drv-cap-neon" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("nn-container");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "nn-cg-" + gi;
-    groupEl.className = "nn-cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "nn-cw-" + wi;
-      wordEl.className = "nn-cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
-        fontFamily: "Chakra Petch",
-        fontWeight: 700,
-        maxWidth: 1550,
-        baseFontSize: 120,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 120) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #0a0a0a;
+        overflow: hidden;
+      }
+      #root-cap-neon {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0a0a0a;
+      }
+      .nn-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .nn-cg {
+        position: absolute;
+        top: 480px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 20px;
+        white-space: nowrap;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .nn-cw {
+        font-family: "Chakra Petch", sans-serif;
+        font-weight: 700;
+        font-size: 120px;
+        color: rgba(255, 255, 255, 0.7);
+        text-transform: uppercase;
+        line-height: 1;
+        display: inline-block;
+        -webkit-text-stroke: 2px rgba(0, 0, 0, 0.5);
+        paint-order: stroke fill;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-neon"
+      data-composition-id="cap-neon"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="nn-container" id="nn-container"></div>
+      <div
+        id="drv-cap-neon"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("nn-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group — slide from right
-    tl.set(groupEl, { opacity: 1, visibility: "visible", x: 50 }, g.start);
-    tl.to(groupEl, { x: 0, opacity: 1, duration: 0.2, ease: "power3.out" }, g.start);
+        var container = document.getElementById("nn-container");
 
-    // Karaoke: neon glow on active word
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("nn-cw-" + wi);
-      // Activate — neon pink with layered glow
-      tl.to(wordEl, {
-        color: "#FF3366",
-        scale: 1.08,
-        textShadow: "0 0 7px #FF3366, 0 0 20px #FF3366, 0 0 45px #FF336680, 0 0 80px #FF336640",
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-      // Deactivate — spoken words brighter than unspoken
-      tl.to(wordEl, {
-        color: "rgba(255,255,255,0.7)",
-        scale: 1,
-        textShadow: "none",
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "nn-cg-" + gi;
+          groupEl.className = "nn-cg";
 
-    // EXIT — slide left
-    tl.to(groupEl, { x: -30, opacity: 0, duration: 0.12 }, g.end - 0.12);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
-  });
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "nn-cw-" + wi;
+            wordEl.className = "nn-cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-  window.__timelines["cap-neon"] = tl;
-})();</script>
-</body>
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+              fontFamily: "Chakra Petch",
+              fontWeight: 700,
+              maxWidth: 1550,
+              baseFontSize: 120,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 120) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
+
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("nn-cg-" + gi);
+
+          // SHOW group — slide from right
+          tl.set(groupEl, { opacity: 1, visibility: "visible", x: 50 }, g.start);
+          tl.to(groupEl, { x: 0, opacity: 1, duration: 0.2, ease: "power3.out" }, g.start);
+
+          // Karaoke: neon glow on active word
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("nn-cw-" + wi);
+            // Activate — neon pink with layered glow
+            tl.to(
+              wordEl,
+              {
+                color: "#FF3366",
+                scale: 1.08,
+                textShadow:
+                  "0 0 7px #FF3366, 0 0 20px #FF3366, 0 0 45px #FF336680, 0 0 80px #FF336640",
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+            // Deactivate — spoken words brighter than unspoken
+            tl.to(
+              wordEl,
+              {
+                color: "rgba(255,255,255,0.7)",
+                scale: 1,
+                textShadow: "none",
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT — slide left
+          tl.to(groupEl, { x: -30, opacity: 0, duration: 0.12 }, g.end - 0.12);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-neon"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-neon/cap-neon.html
+++ b/registry/blocks/cap-neon/cap-neon.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #0a0a0a; overflow: hidden; }
+#root-cap-neon {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #0a0a0a;
+}
+.nn-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.nn-cg {
+  position: absolute;
+  top: 480px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+}
+.nn-cw {
+  font-family: 'Chakra Petch', sans-serif;
+  font-weight: 700;
+  font-size: 120px;
+  color: rgba(255,255,255,0.7);
+  text-transform: uppercase;
+  line-height: 1;
+  display: inline-block;
+  -webkit-text-stroke: 2px rgba(0,0,0,0.5);
+  paint-order: stroke fill;
+}
+</style>
+</head>
+<body>
+<div id="root-cap-neon" data-composition-id="cap-neon" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="nn-container" id="nn-container"></div>
+  <div id="drv-cap-neon" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("nn-container");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "nn-cg-" + gi;
+    groupEl.className = "nn-cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "nn-cw-" + wi;
+      wordEl.className = "nn-cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+        fontFamily: "Chakra Petch",
+        fontWeight: 700,
+        maxWidth: 1550,
+        baseFontSize: 120,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 120) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("nn-cg-" + gi);
+
+    // SHOW group — slide from right
+    tl.set(groupEl, { opacity: 1, visibility: "visible", x: 50 }, g.start);
+    tl.to(groupEl, { x: 0, opacity: 1, duration: 0.2, ease: "power3.out" }, g.start);
+
+    // Karaoke: neon glow on active word
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("nn-cw-" + wi);
+      // Activate — neon pink with layered glow
+      tl.to(wordEl, {
+        color: "#FF3366",
+        scale: 1.08,
+        textShadow: "0 0 7px #FF3366, 0 0 20px #FF3366, 0 0 45px #FF336680, 0 0 80px #FF336640",
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+      // Deactivate — spoken words brighter than unspoken
+      tl.to(wordEl, {
+        color: "rgba(255,255,255,0.7)",
+        scale: 1,
+        textShadow: "none",
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT — slide left
+    tl.to(groupEl, { x: -30, opacity: 0, duration: 0.12 }, g.end - 0.12);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-neon"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-neon/registry-item.json
+++ b/registry/blocks/cap-neon/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-neon",
+  "type": "hyperframes:block",
+  "title": "Neon Glow",
+  "description": "Neon glow on active word — layered pink text-shadow with chromatic edge, slide entrance",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "neon", "premium", "night"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-neon.mp4",
+  "files": [
+    {
+      "path": "cap-neon.html",
+      "target": "compositions/cap-neon.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-outline/cap-outline.html
+++ b/registry/blocks/cap-outline/cap-outline.html
@@ -1,158 +1,191 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #111; overflow: hidden; }
-#root-cap-outline {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #111;
-}
-.cap-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.cg {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 24px;
-  max-width: 1700px; overflow: visible;
-  opacity: 0;
-  visibility: hidden;
-}
-.cw {
-  font-family: 'Bebas Neue', sans-serif;
-  font-weight: 400;
-  font-size: 128px;
-  color: transparent;
-  text-transform: uppercase;
-  line-height: 1;
-  display: inline-block;
-  -webkit-text-stroke: 3px #FFFFFF;
-  text-shadow: 0 0 20px rgba(255,255,255,0.15);
-}
-</style>
-</head>
-<body>
-<div id="root-cap-outline" data-composition-id="cap-outline" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="cap-container" id="cc-outline"></div>
-  <div id="drv-cap-outline" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("cc-outline");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "ol-cg-" + gi;
-    groupEl.className = "cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "ol-cw-" + wi;
-      wordEl.className = "cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
-        fontFamily: "Bebas Neue",
-        fontWeight: 400,
-        maxWidth: 1550,
-        baseFontSize: 128,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 128) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #111;
+        overflow: hidden;
+      }
+      #root-cap-outline {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #111;
+      }
+      .cap-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .cg {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 24px;
+        max-width: 1700px;
+        overflow: visible;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .cw {
+        font-family: "Bebas Neue", sans-serif;
+        font-weight: 400;
+        font-size: 128px;
+        color: transparent;
+        text-transform: uppercase;
+        line-height: 1;
+        display: inline-block;
+        -webkit-text-stroke: 3px #ffffff;
+        text-shadow: 0 0 20px rgba(255, 255, 255, 0.15);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-outline"
+      data-composition-id="cap-outline"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="cap-container" id="cc-outline"></div>
+      <div
+        id="drv-cap-outline"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("ol-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group with scale entrance
-    tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
-    tl.to(groupEl, { scale: 1, opacity: 1, duration: 0.2, ease: "power2.out" }, g.start);
+        var container = document.getElementById("cc-outline");
 
-    // Reset all words in this group to outline state at group start
-    for (var ri = g.wordStart; ri <= g.wordEnd; ri++) {
-      tl.set(document.getElementById("ol-cw-" + ri), { color: "transparent" }, g.start);
-    }
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "ol-cg-" + gi;
+          groupEl.className = "cg";
 
-    // Outline-to-fill: each word fills when spoken, stays filled
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("ol-cw-" + wi);
-      // Fill on speak
-      tl.to(wordEl, {
-        color: "#FFFFFF",
-        duration: 0.08,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-    }
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "ol-cw-" + wi;
+            wordEl.className = "cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-    // EXIT with scale-down
-    tl.to(groupEl, { opacity: 0, scale: 0.95, duration: 0.12 }, g.end - 0.12);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
-  });
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+              fontFamily: "Bebas Neue",
+              fontWeight: 400,
+              maxWidth: 1550,
+              baseFontSize: 128,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 128) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
 
-  window.__timelines["cap-outline"] = tl;
-})();</script>
-</body>
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("ol-cg-" + gi);
+
+          // SHOW group with scale entrance
+          tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+          tl.to(groupEl, { scale: 1, opacity: 1, duration: 0.2, ease: "power2.out" }, g.start);
+
+          // Reset all words in this group to outline state at group start
+          for (var ri = g.wordStart; ri <= g.wordEnd; ri++) {
+            tl.set(document.getElementById("ol-cw-" + ri), { color: "transparent" }, g.start);
+          }
+
+          // Outline-to-fill: each word fills when spoken, stays filled
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("ol-cw-" + wi);
+            // Fill on speak
+            tl.to(
+              wordEl,
+              {
+                color: "#FFFFFF",
+                duration: 0.08,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+          }
+
+          // EXIT with scale-down
+          tl.to(groupEl, { opacity: 0, scale: 0.95, duration: 0.12 }, g.end - 0.12);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-outline"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-outline/cap-outline.html
+++ b/registry/blocks/cap-outline/cap-outline.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #111; overflow: hidden; }
+#root-cap-outline {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #111;
+}
+.cap-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cg {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  max-width: 1700px; overflow: visible;
+  opacity: 0;
+  visibility: hidden;
+}
+.cw {
+  font-family: 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 128px;
+  color: transparent;
+  text-transform: uppercase;
+  line-height: 1;
+  display: inline-block;
+  -webkit-text-stroke: 3px #FFFFFF;
+  text-shadow: 0 0 20px rgba(255,255,255,0.15);
+}
+</style>
+</head>
+<body>
+<div id="root-cap-outline" data-composition-id="cap-outline" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="cap-container" id="cc-outline"></div>
+  <div id="drv-cap-outline" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("cc-outline");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "ol-cg-" + gi;
+    groupEl.className = "cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "ol-cw-" + wi;
+      wordEl.className = "cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text.toUpperCase(), {
+        fontFamily: "Bebas Neue",
+        fontWeight: 400,
+        maxWidth: 1550,
+        baseFontSize: 128,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 128) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("ol-cg-" + gi);
+
+    // SHOW group with scale entrance
+    tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+    tl.to(groupEl, { scale: 1, opacity: 1, duration: 0.2, ease: "power2.out" }, g.start);
+
+    // Reset all words in this group to outline state at group start
+    for (var ri = g.wordStart; ri <= g.wordEnd; ri++) {
+      tl.set(document.getElementById("ol-cw-" + ri), { color: "transparent" }, g.start);
+    }
+
+    // Outline-to-fill: each word fills when spoken, stays filled
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("ol-cw-" + wi);
+      // Fill on speak
+      tl.to(wordEl, {
+        color: "#FFFFFF",
+        duration: 0.08,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+    }
+
+    // EXIT with scale-down
+    tl.to(groupEl, { opacity: 0, scale: 0.95, duration: 0.12 }, g.end - 0.12);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-outline"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-outline/registry-item.json
+++ b/registry/blocks/cap-outline/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-outline",
+  "type": "hyperframes:block",
+  "title": "Outline Fill",
+  "description": "Stroke-to-fill reveal — Bebas Neue ALL CAPS outline fills to solid white when spoken",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "premium", "brand", "outline"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-outline.mp4",
+  "files": [
+    {
+      "path": "cap-outline.html",
+      "target": "compositions/cap-outline.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/cap-pill/cap-pill.html
+++ b/registry/blocks/cap-pill/cap-pill.html
@@ -1,174 +1,214 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@800&display=swap" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
-<style>
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #111; overflow: hidden; }
-#root-cap-pill {
-  position: relative;
-  width: 1920px;
-  height: 1080px;
-  overflow: hidden;
-  background: #111;
-}
-.pl-container {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.pl-cg {
-  position: absolute;
-  top: 500px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-}
-.pl-cw {
-  font-family: 'Figtree', sans-serif;
-  font-weight: 800;
-  font-size: 96px;
-  color: rgba(255,255,255,0.9);
-  line-height: 1;
-  display: inline-block;
-  background: rgba(0,0,0,0.65);
-  border-radius: 12px;
-  padding: 10px 24px;
-  margin: 0 6px;
-}
-</style>
-</head>
-<body>
-<div id="root-cap-pill" data-composition-id="cap-pill" data-start="0" data-duration="9" data-width="1920" data-height="1080">
-  <div class="pl-container" id="pl-container"></div>
-  <div id="drv-cap-pill" class="clip" data-start="0" data-duration="9" data-track-index="0"
-       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
-</div>
-<script>(function() {
-  window.__timelines = window.__timelines || {};
-
-  var WORDS = [
-    { text: "Welcome", start: 0.3, end: 0.65 },
-    { text: "to", start: 0.65, end: 0.8 },
-    { text: "the", start: 0.8, end: 0.95 },
-    { text: "future", start: 0.95, end: 1.4 },
-    { text: "of", start: 1.6, end: 1.75 },
-    { text: "video", start: 1.75, end: 2.15 },
-    { text: "creation", start: 2.15, end: 2.7 },
-    { text: "where", start: 3.0, end: 3.25 },
-    { text: "every", start: 3.25, end: 3.55 },
-    { text: "frame", start: 3.55, end: 3.9 },
-    { text: "tells", start: 4.1, end: 4.4 },
-    { text: "a", start: 4.4, end: 4.5 },
-    { text: "powerful", start: 4.5, end: 5.0 },
-    { text: "story", start: 5.0, end: 5.5 },
-    { text: "built", start: 5.8, end: 6.1 },
-    { text: "with", start: 6.1, end: 6.3 },
-    { text: "precision", start: 6.3, end: 6.9 },
-    { text: "designed", start: 7.1, end: 7.5 },
-    { text: "for", start: 7.5, end: 7.65 },
-    { text: "maximum", start: 7.65, end: 8.1 },
-    { text: "impact", start: 8.1, end: 8.6 }
-  ];
-
-  var GROUPS = [
-    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
-    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
-    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
-    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
-    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
-    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
-  ];
-
-  var container = document.getElementById("pl-container");
-
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.createElement("div");
-    groupEl.id = "pl-cg-" + gi;
-    groupEl.className = "pl-cg";
-
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.createElement("span");
-      wordEl.id = "pl-cw-" + wi;
-      wordEl.className = "pl-cw";
-      wordEl.textContent = WORDS[wi].text;
-      groupEl.appendChild(wordEl);
-    }
-
-
-    // Pretext overflow prevention
-    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
-      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
-        fontFamily: "Figtree",
-        fontWeight: 800,
-        maxWidth: 1200,
-        baseFontSize: 96,
-        minFontSize: 48
-      });
-      if (_fit.fontSize < 96) {
-        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
-          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
-        }
+  <head>
+    <meta charset="utf-8" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Figtree:wght@800&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
-    container.appendChild(groupEl);
-  });
+      body {
+        background: #111;
+        overflow: hidden;
+      }
+      #root-cap-pill {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #111;
+      }
+      .pl-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .pl-cg {
+        position: absolute;
+        top: 500px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        white-space: nowrap;
+        opacity: 0;
+        visibility: hidden;
+      }
+      .pl-cw {
+        font-family: "Figtree", sans-serif;
+        font-weight: 800;
+        font-size: 96px;
+        color: rgba(255, 255, 255, 0.9);
+        line-height: 1;
+        display: inline-block;
+        background: rgba(0, 0, 0, 0.65);
+        border-radius: 12px;
+        padding: 10px 24px;
+        margin: 0 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root-cap-pill"
+      data-composition-id="cap-pill"
+      data-start="0"
+      data-duration="9"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="pl-container" id="pl-container"></div>
+      <div
+        id="drv-cap-pill"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="0"
+        style="position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
 
-  var tl = gsap.timeline({ paused: true });
+        var WORDS = [
+          { text: "Welcome", start: 0.3, end: 0.65 },
+          { text: "to", start: 0.65, end: 0.8 },
+          { text: "the", start: 0.8, end: 0.95 },
+          { text: "future", start: 0.95, end: 1.4 },
+          { text: "of", start: 1.6, end: 1.75 },
+          { text: "video", start: 1.75, end: 2.15 },
+          { text: "creation", start: 2.15, end: 2.7 },
+          { text: "where", start: 3.0, end: 3.25 },
+          { text: "every", start: 3.25, end: 3.55 },
+          { text: "frame", start: 3.55, end: 3.9 },
+          { text: "tells", start: 4.1, end: 4.4 },
+          { text: "a", start: 4.4, end: 4.5 },
+          { text: "powerful", start: 4.5, end: 5.0 },
+          { text: "story", start: 5.0, end: 5.5 },
+          { text: "built", start: 5.8, end: 6.1 },
+          { text: "with", start: 6.1, end: 6.3 },
+          { text: "precision", start: 6.3, end: 6.9 },
+          { text: "designed", start: 7.1, end: 7.5 },
+          { text: "for", start: 7.5, end: 7.65 },
+          { text: "maximum", start: 7.65, end: 8.1 },
+          { text: "impact", start: 8.1, end: 8.6 },
+        ];
 
-  GROUPS.forEach(function(g, gi) {
-    var groupEl = document.getElementById("pl-cg-" + gi);
+        var GROUPS = [
+          { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+          { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+          { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+          { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+          { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+          { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" },
+        ];
 
-    // SHOW group
-    tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+        var container = document.getElementById("pl-container");
 
-    // Stagger entrance: each word pill bounces in
-    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
-      var wordEl = document.getElementById("pl-cw-" + wi);
-      tl.from(wordEl, {
-        y: 30,
-        opacity: 0,
-        scale: 0.85,
-        duration: 0.15,
-        ease: "back.out(1.4)"
-      }, g.start + (wi - g.wordStart) * 0.06);
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.createElement("div");
+          groupEl.id = "pl-cg-" + gi;
+          groupEl.className = "pl-cg";
 
-      // Activate — red pill pops
-      tl.to(wordEl, {
-        background: "#E63946",
-        color: "#FFFFFF",
-        scale: 1.08,
-        duration: 0.06,
-        ease: "power2.out"
-      }, WORDS[wi].start);
-      // Deactivate — back to dark pill
-      tl.to(wordEl, {
-        background: "rgba(0,0,0,0.65)",
-        color: "rgba(255,255,255,0.9)",
-        scale: 1,
-        duration: 0.08,
-        ease: "power1.in"
-      }, WORDS[wi].end);
-    }
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.createElement("span");
+            wordEl.id = "pl-cw-" + wi;
+            wordEl.className = "pl-cw";
+            wordEl.textContent = WORDS[wi].text;
+            groupEl.appendChild(wordEl);
+          }
 
-    // EXIT — fade up
-    tl.to(groupEl, { opacity: 0, y: -20, duration: 0.12 }, g.end - 0.12);
-    // HARD KILL
-    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
-  });
+          // Pretext overflow prevention
+          if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+            var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+              fontFamily: "Figtree",
+              fontWeight: 800,
+              maxWidth: 1200,
+              baseFontSize: 96,
+              minFontSize: 48,
+            });
+            if (_fit.fontSize < 96) {
+              for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+                groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+              }
+            }
+          }
+          container.appendChild(groupEl);
+        });
 
-  window.__timelines["cap-pill"] = tl;
-})();</script>
-</body>
+        var tl = gsap.timeline({ paused: true });
+
+        GROUPS.forEach(function (g, gi) {
+          var groupEl = document.getElementById("pl-cg-" + gi);
+
+          // SHOW group
+          tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+
+          // Stagger entrance: each word pill bounces in
+          for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+            var wordEl = document.getElementById("pl-cw-" + wi);
+            tl.from(
+              wordEl,
+              {
+                y: 30,
+                opacity: 0,
+                scale: 0.85,
+                duration: 0.15,
+                ease: "back.out(1.4)",
+              },
+              g.start + (wi - g.wordStart) * 0.06,
+            );
+
+            // Activate — red pill pops
+            tl.to(
+              wordEl,
+              {
+                background: "#E63946",
+                color: "#FFFFFF",
+                scale: 1.08,
+                duration: 0.06,
+                ease: "power2.out",
+              },
+              WORDS[wi].start,
+            );
+            // Deactivate — back to dark pill
+            tl.to(
+              wordEl,
+              {
+                background: "rgba(0,0,0,0.65)",
+                color: "rgba(255,255,255,0.9)",
+                scale: 1,
+                duration: 0.08,
+                ease: "power1.in",
+              },
+              WORDS[wi].end,
+            );
+          }
+
+          // EXIT — fade up
+          tl.to(groupEl, { opacity: 0, y: -20, duration: 0.12 }, g.end - 0.12);
+          // HARD KILL
+          tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+        });
+
+        window.__timelines["cap-pill"] = tl;
+      })();
+    </script>
+  </body>
 </html>

--- a/registry/blocks/cap-pill/cap-pill.html
+++ b/registry/blocks/cap-pill/cap-pill.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #111; overflow: hidden; }
+#root-cap-pill {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: #111;
+}
+.pl-container {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pl-cg {
+  position: absolute;
+  top: 500px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+}
+.pl-cw {
+  font-family: 'Figtree', sans-serif;
+  font-weight: 800;
+  font-size: 96px;
+  color: rgba(255,255,255,0.9);
+  line-height: 1;
+  display: inline-block;
+  background: rgba(0,0,0,0.65);
+  border-radius: 12px;
+  padding: 10px 24px;
+  margin: 0 6px;
+}
+</style>
+</head>
+<body>
+<div id="root-cap-pill" data-composition-id="cap-pill" data-start="0" data-duration="9" data-width="1920" data-height="1080">
+  <div class="pl-container" id="pl-container"></div>
+  <div id="drv-cap-pill" class="clip" data-start="0" data-duration="9" data-track-index="0"
+       style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"></div>
+</div>
+<script>(function() {
+  window.__timelines = window.__timelines || {};
+
+  var WORDS = [
+    { text: "Welcome", start: 0.3, end: 0.65 },
+    { text: "to", start: 0.65, end: 0.8 },
+    { text: "the", start: 0.8, end: 0.95 },
+    { text: "future", start: 0.95, end: 1.4 },
+    { text: "of", start: 1.6, end: 1.75 },
+    { text: "video", start: 1.75, end: 2.15 },
+    { text: "creation", start: 2.15, end: 2.7 },
+    { text: "where", start: 3.0, end: 3.25 },
+    { text: "every", start: 3.25, end: 3.55 },
+    { text: "frame", start: 3.55, end: 3.9 },
+    { text: "tells", start: 4.1, end: 4.4 },
+    { text: "a", start: 4.4, end: 4.5 },
+    { text: "powerful", start: 4.5, end: 5.0 },
+    { text: "story", start: 5.0, end: 5.5 },
+    { text: "built", start: 5.8, end: 6.1 },
+    { text: "with", start: 6.1, end: 6.3 },
+    { text: "precision", start: 6.3, end: 6.9 },
+    { text: "designed", start: 7.1, end: 7.5 },
+    { text: "for", start: 7.5, end: 7.65 },
+    { text: "maximum", start: 7.65, end: 8.1 },
+    { text: "impact", start: 8.1, end: 8.6 }
+  ];
+
+  var GROUPS = [
+    { start: 0.3, end: 1.5, wordStart: 0, wordEnd: 3, text: "Welcome to the future" },
+    { start: 1.6, end: 2.8, wordStart: 4, wordEnd: 6, text: "of video creation" },
+    { start: 3.0, end: 4.0, wordStart: 7, wordEnd: 9, text: "where every frame" },
+    { start: 4.1, end: 5.6, wordStart: 10, wordEnd: 13, text: "tells a powerful story" },
+    { start: 5.8, end: 7.0, wordStart: 14, wordEnd: 16, text: "built with precision" },
+    { start: 7.1, end: 8.7, wordStart: 17, wordEnd: 20, text: "designed for maximum impact" }
+  ];
+
+  var container = document.getElementById("pl-container");
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.createElement("div");
+    groupEl.id = "pl-cg-" + gi;
+    groupEl.className = "pl-cg";
+
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.createElement("span");
+      wordEl.id = "pl-cw-" + wi;
+      wordEl.className = "pl-cw";
+      wordEl.textContent = WORDS[wi].text;
+      groupEl.appendChild(wordEl);
+    }
+
+
+    // Pretext overflow prevention
+    if (window.__hyperframes && window.__hyperframes.fitTextFontSize) {
+      var _fit = window.__hyperframes.fitTextFontSize(g.text, {
+        fontFamily: "Figtree",
+        fontWeight: 800,
+        maxWidth: 1200,
+        baseFontSize: 96,
+        minFontSize: 48
+      });
+      if (_fit.fontSize < 96) {
+        for (var _fi = 0; _fi < groupEl.children.length; _fi++) {
+          groupEl.children[_fi].style.fontSize = _fit.fontSize + "px";
+        }
+      }
+    }
+    container.appendChild(groupEl);
+  });
+
+  var tl = gsap.timeline({ paused: true });
+
+  GROUPS.forEach(function(g, gi) {
+    var groupEl = document.getElementById("pl-cg-" + gi);
+
+    // SHOW group
+    tl.set(groupEl, { opacity: 1, visibility: "visible" }, g.start);
+
+    // Stagger entrance: each word pill bounces in
+    for (var wi = g.wordStart; wi <= g.wordEnd; wi++) {
+      var wordEl = document.getElementById("pl-cw-" + wi);
+      tl.from(wordEl, {
+        y: 30,
+        opacity: 0,
+        scale: 0.85,
+        duration: 0.15,
+        ease: "back.out(1.4)"
+      }, g.start + (wi - g.wordStart) * 0.06);
+
+      // Activate — red pill pops
+      tl.to(wordEl, {
+        background: "#E63946",
+        color: "#FFFFFF",
+        scale: 1.08,
+        duration: 0.06,
+        ease: "power2.out"
+      }, WORDS[wi].start);
+      // Deactivate — back to dark pill
+      tl.to(wordEl, {
+        background: "rgba(0,0,0,0.65)",
+        color: "rgba(255,255,255,0.9)",
+        scale: 1,
+        duration: 0.08,
+        ease: "power1.in"
+      }, WORDS[wi].end);
+    }
+
+    // EXIT — fade up
+    tl.to(groupEl, { opacity: 0, y: -20, duration: 0.12 }, g.end - 0.12);
+    // HARD KILL
+    tl.set(groupEl, { opacity: 0, visibility: "hidden" }, g.end);
+  });
+
+  window.__timelines["cap-pill"] = tl;
+})();</script>
+</body>
+</html>

--- a/registry/blocks/cap-pill/registry-item.json
+++ b/registry/blocks/cap-pill/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "cap-pill",
+  "type": "hyperframes:block",
+  "title": "Pill Background",
+  "description": "Instagram Reels pill style — each word in a rounded gradient pill, active pill turns red",
+  "stability": "stable",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 9,
+  "tags": ["captions", "social", "instagram", "pill"],
+  "preview": "https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-pill.mp4",
+  "files": [
+    {
+      "path": "cap-pill.html",
+      "target": "compositions/cap-pill.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

11 production-quality caption/subtitle style blocks for the HyperFrames registry, covering viral short-form to professional lower-thirds.

### Styles

| # | Block | Style | Preview |
|---|-------|-------|---------|
| 1 | `cap-boxed` | Netflix/YouTube dark box subtitle | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-boxed.mp4) |
| 2 | `cap-outline` | Stroke-to-fill reveal (Bebas Neue) | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-outline.mp4) |
| 3 | `cap-karaoke-sweep` | CapCut-style progressive white glow | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-karaoke-sweep.mp4) |
| 4 | `cap-hormozi` | Hormozi word pop, gold highlight | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-hormozi.mp4) |
| 5 | `cap-pill` | Instagram Reels gradient pills | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-pill.mp4) |
| 6 | `cap-marker` | Yellow marker sweep (light bg) | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-marker.mp4) |
| 7 | `cap-clean` | Ali Abdaal smooth fade | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-clean.mp4) |
| 8 | `cap-glitch` | RGB chromatic aberration | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-glitch.mp4) |
| 9 | `cap-neon` | Layered pink neon glow | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-neon.mp4) |
| 10 | `cap-bounce` | Elastic word entrance | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-bounce.mp4) |
| 11 | `cap-emoji` | Hormozi + emoji reactions | [video](https://heygen-public.s3.us-east-2.amazonaws.com/hyperframes/caption-blocks/cap-emoji.mp4) |

### Technical details

- Word-level karaoke sync from transcript timestamps
- Hard kill at every group.end
- Deterministic GSAP timelines, no Math.random()
- 96-128px fonts with text-stroke/shadow for readability over any background
- Font size auto-fitting for long phrases to prevent overflow
- Standalone 1920x1080 compositions (9s each)

## Test plan

- [x] hyperframes validate passes with 0 errors on all 11
- [x] All 11 rendered to MP4 and uploaded to S3
- [ ] Review video previews linked above