### PR TITLE
docs: replace README demo GIF with higher-quality MP4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center"><b>Write HTML. Render video. Built for agents.</b></p>
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/c56cdc28-d2f7-4bca-9c03-58389a87d99c" alt="HyperFrames demo — HTML code on the left transforms into a rendered video on the right" autoplay loop muted playsinline width="800"></video>
+  <img src="https://static.heygen.ai/hyperframes-oss/docs/images/hfgif-1280.webp" alt="HyperFrames demo — HTML code on the left transforms into a rendered video on the right" width="800">
 </p>
 
 Hyperframes is an open-source video rendering framework that lets you create, preview, and render HTML-based video compositions — with first-class support for AI agents.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center"><b>Write HTML. Render video. Built for agents.</b></p>
 
 <p align="center">
-  <img src="https://static.heygen.ai/hyperframes-oss/docs/images/readme-demo.gif" alt="HyperFrames demo — HTML code on the left transforms into a rendered video on the right" width="800">
+  <video src="https://github.com/user-attachments/assets/c56cdc28-d2f7-4bca-9c03-58389a87d99c" alt="HyperFrames demo — HTML code on the left transforms into a rendered video on the right" autoplay loop muted playsinline width="800"></video>
 </p>
 
 Hyperframes is an open-source video rendering framework that lets you create, preview, and render HTML-based video compositions — with first-class support for AI agents.


### PR DESCRIPTION
## Summary
- Replaces the `readme-demo.gif` `<img>` with a `<video>` tag pointing at a GitHub `user-attachments` MP4 — higher quality than the GIF, autoplay-loops on github.com like a GIF would.

## Test plan
- [ ] Verify the video renders inline on the github.com README page (autoplays, loops, muted)
- [ ] Sanity-check on a phone (the `playsinline` attr should keep it from going fullscreen on iOS)
- [ ] Note: most non-GitHub markdown renderers (npmjs.com etc.) strip `<video>` — if that matters for the npm package page we can revisit

🤖 Generated with [Claude Code](https://claude.com/claude-code)