### PR TITLE
feat(studio): add alpha editor layer inspector

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -54,16 +54,14 @@ import {
   getTimelineZoomPercent,
 } from "./player/components/timelineZoom";
 import {
-  TIMELINE_TOGGLE_SHORTCUT_LABEL,
-  getTimelineEditorHintDismissed,
   getTimelineToggleTitle,
-  setTimelineEditorHintDismissed,
   shouldHandleTimelineToggleHotkey,
 } from "./utils/timelineDiscovery";
 import { buildFrameCaptureFilename, buildFrameCaptureUrl } from "./utils/frameCapture";
 import { buildProjectHash, parseProjectIdFromHash } from "./utils/projectRouting";
 import { Camera } from "./icons/SystemIcons";
 import { PropertyPanel } from "./components/editor/PropertyPanel";
+import { MotionPanel } from "./components/editor/MotionPanel";
 import { googleFontStylesheetUrl } from "./components/editor/fontCatalog";
 import {
   fontFamilyFromAssetPath,
@@ -74,16 +72,29 @@ import {
   DomEditOverlay,
   type DomEditGroupPathOffsetCommit,
 } from "./components/editor/DomEditOverlay";
+import { TimelineLayerPanel } from "./components/editor/TimelineLayerPanel";
+import {
+  STUDIO_INSPECTOR_PANELS_ENABLED,
+  STUDIO_MANUAL_EDITING_DISABLED_TITLE,
+  STUDIO_MOTION_PANEL_ENABLED,
+  STUDIO_PREVIEW_MANUAL_EDITING_ENABLED,
+  STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED,
+} from "./components/editor/manualEditingAvailability";
 import {
   buildDefaultDomEditTextField,
   buildDomEditStylePatchOperation,
   buildDomEditTextPatchOperation,
   buildElementAgentPrompt,
+  collectDomEditLayerItems,
+  countDomEditChildLayers,
   findElementForSelection,
+  findElementForTimelineElement,
+  getDomEditLayerKey,
   getDomEditTargetKey,
   isTextEditableSelection,
   serializeDomEditTextFields,
   resolveDomEditSelection,
+  type DomEditLayerItem,
   type DomEditTextField,
   type DomEditSelection,
 } from "./components/editor/domEditing";
@@ -102,7 +113,29 @@ import {
   upsertStudioPathOffsetEdit,
   upsertStudioRotationEdit,
 } from "./components/editor/manualEdits";
+import {
+  STUDIO_MOTION_PATH,
+  applyStudioMotionManifest,
+  emptyStudioMotionManifest,
+  getStudioMotionForSelection,
+  installStudioMotionSeekReapply,
+  isStudioMotionManifestPath,
+  parseStudioMotionManifest,
+  removeStudioMotionForSelection,
+  serializeStudioMotionManifest,
+  type StudioGsapMotion,
+  type StudioMotionManifest,
+  upsertStudioGsapMotion,
+} from "./components/editor/studioMotion";
 import { saveProjectFilesWithHistory } from "./utils/studioFileHistory";
+import {
+  canInspectTimelineElement,
+  getTimelineElementKey,
+  getTimelineLayerVisibilityInPreview,
+  isTimelineElementActiveAtTime,
+  isTimelineLayerVisibleInPreview,
+  shouldShowTimelineInspectorBounds,
+} from "./utils/timelineInspector";
 
 interface EditingFile {
   path: string;
@@ -118,7 +151,7 @@ function getTimelineElementLabel(element: TimelineElement): string {
   return element.label || element.id || element.tag;
 }
 
-type RightPanelTab = "design" | "renders";
+type RightPanelTab = "design" | "motion" | "renders";
 
 const GENERIC_FONT_FAMILIES = new Set([
   "inherit",
@@ -242,7 +275,10 @@ function normalizeDomEditStyleValue(property: string, value: string): string {
   const trimmed = value.trim();
   if (!trimmed) return trimmed;
 
-  if (["border-radius", "font-size"].includes(property) && /^-?\d+(\.\d+)?$/.test(trimmed)) {
+  if (
+    ["border-radius", "border-width", "font-size", "letter-spacing"].includes(property) &&
+    /^-?\d+(\.\d+)?$/.test(trimmed)
+  ) {
     return `${trimmed}px`;
   }
 
@@ -424,6 +460,105 @@ function readPlaybackTime(target: object | null, key: string): number | null {
   } catch {
     return null;
   }
+}
+
+interface PreviewPlayerCompat {
+  getTime: () => number;
+  renderSeek: (timeSeconds: number) => void;
+}
+
+function getPreviewPlayer(win: Window | null | undefined): PreviewPlayerCompat | null {
+  const player = objectLike(win ? Reflect.get(win, "__player") : null);
+  if (!player) return null;
+  const getTime = Reflect.get(player, "getTime");
+  const renderSeek = Reflect.get(player, "renderSeek");
+  if (typeof getTime !== "function" || typeof renderSeek !== "function") return null;
+  return {
+    getTime: () => {
+      const value = getTime.call(player);
+      return typeof value === "number" && Number.isFinite(value) ? value : 0;
+    },
+    renderSeek: (timeSeconds: number) => {
+      renderSeek.call(player, timeSeconds);
+    },
+  };
+}
+
+function seekStudioPreview(iframe: HTMLIFrameElement | null, timeSeconds: number): boolean {
+  const player = getPreviewPlayer(iframe?.contentWindow);
+  if (!player) return false;
+  const nextTime = Math.max(0, timeSeconds);
+  player.renderSeek(nextTime);
+  usePlayerStore.getState().setCurrentTime(nextTime);
+  liveTime.notify(nextTime);
+  return true;
+}
+
+function parseFiniteSeconds(value: string | null): number | null {
+  if (value == null || value.trim() === "") return null;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveLayerVisibleSeekTime(
+  layerElement: HTMLElement,
+  timelineElement: TimelineElement | null,
+  player: PreviewPlayerCompat | null,
+): number | null {
+  if (!timelineElement || !player) return null;
+  const originalTime = player.getTime();
+
+  const clipStart = Math.max(0, timelineElement.start);
+  const clipEnd = Math.max(clipStart, clipStart + Math.max(0, timelineElement.duration));
+  const authoredStart = parseFiniteSeconds(
+    layerElement.getAttribute("data-start") ??
+      layerElement.closest<HTMLElement>("[data-start]")?.getAttribute("data-start") ??
+      null,
+  );
+  const preferredTime =
+    authoredStart == null
+      ? clipStart
+      : Math.min(clipEnd, Math.max(clipStart, clipStart + authoredStart));
+  const candidates = [preferredTime, clipStart];
+  const duration = clipEnd - clipStart;
+  if (duration > 0) {
+    const maxSamples = 24;
+    const frameStep = 1 / 24;
+    const step = Math.max(frameStep, duration / maxSamples);
+    for (let time = clipStart; time <= clipEnd + 0.0001; time += step) {
+      candidates.push(Math.min(clipEnd, time));
+    }
+  }
+  candidates.push(clipEnd);
+
+  let lastTried = preferredTime;
+  let clearestVisibleTime: number | null = null;
+  let clearestVisibleOpacity = 0;
+  let resolvedTime: number | null = null;
+  const seen = new Set<string>();
+  try {
+    for (const candidate of candidates) {
+      const time = Math.min(clipEnd, Math.max(clipStart, candidate));
+      const key = time.toFixed(4);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      lastTried = time;
+      player.renderSeek(time);
+      const visibility = getTimelineLayerVisibilityInPreview(layerElement);
+      if (visibility.visible && visibility.compositeOpacity > clearestVisibleOpacity) {
+        clearestVisibleTime = time;
+        clearestVisibleOpacity = visibility.compositeOpacity;
+      }
+      if (isTimelineLayerVisibleInPreview(layerElement, { minCompositeOpacity: 0.9 })) {
+        resolvedTime = time;
+        break;
+      }
+    }
+  } finally {
+    player.renderSeek(originalTime);
+  }
+
+  return resolvedTime ?? clearestVisibleTime ?? lastTried;
 }
 
 function pauseStudioPreviewPlayback(iframe: HTMLIFrameElement | null): number | null {
@@ -642,6 +777,16 @@ export function StudioApp() {
   const [copiedAgentPrompt, setCopiedAgentPrompt] = useState(false);
   const [agentModalOpen, setAgentModalOpen] = useState(false);
   const [previewIframe, setPreviewIframe] = useState<HTMLIFrameElement | null>(null);
+  const [inspectedTimelineElementId, setInspectedTimelineElementId] = useState<string | null>(null);
+  const [thumbnailedTimelineElementIds, setThumbnailedTimelineElementIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [previewDocumentVersion, setPreviewDocumentVersion] = useState(0);
+  const refreshPreviewDocumentVersion = useCallback(() => {
+    setPreviewDocumentVersion((version) => version + 1);
+    window.setTimeout(() => setPreviewDocumentVersion((version) => version + 1), 80);
+    window.setTimeout(() => setPreviewDocumentVersion((version) => version + 1), 300);
+  }, []);
   // Auto-enter caption edit mode when the iframe contains .caption-group elements.
   // This is a subscription to external events (postMessage from runtime) — useEffect
   // is appropriate here. The runtime fires "state"/"timeline" messages after all
@@ -765,9 +910,6 @@ export function StudioApp() {
   const [appToast, setAppToast] = useState<AppToast | null>(null);
   const [timelineVisible, setTimelineVisible] = useState(true);
   const [captureFrameTime, setCaptureFrameTime] = useState(0);
-  const [timelineEditorHintDismissed, setTimelineEditorHintState] = useState(
-    getTimelineEditorHintDismissed,
-  );
   const dragCounterRef = useRef(0);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastBlockedTimelineToastAtRef = useRef(0);
@@ -792,6 +934,7 @@ export function StudioApp() {
   const setManualZoomPercent = usePlayerStore((s) => s.setManualZoomPercent);
   const currentTime = usePlayerStore((s) => s.currentTime);
   const timelineElements = usePlayerStore((s) => s.elements);
+  const selectedTimelineElementId = usePlayerStore((s) => s.selectedElementId);
   const setSelectedTimelineElementId = usePlayerStore((s) => s.setSelectedElementId);
   const timelineDuration = usePlayerStore((s) => s.duration);
   const effectiveTimelineDuration = useMemo(() => {
@@ -831,10 +974,6 @@ export function StudioApp() {
   useMountEffect(() => () => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
   });
-  const dismissTimelineEditorHint = useCallback(() => {
-    setTimelineEditorHintState(true);
-    setTimelineEditorHintDismissed(true);
-  }, []);
   const handleTimelineToggleHotkey = useCallback(
     (event: KeyboardEvent) => {
       if (!shouldHandleTimelineToggleHotkey(event)) return;
@@ -989,31 +1128,6 @@ export function StudioApp() {
   );
   const timelineToolbar = (
     <div className="border-b border-neutral-800/40 bg-neutral-950/96">
-      {timelineVisible && timelineElements.length > 0 && !timelineEditorHintDismissed && (
-        <div className="px-3 pt-3">
-          <div className="flex items-start justify-between gap-3 rounded-xl border border-studio-accent/20 bg-studio-accent/[0.07] px-3 py-3">
-            <div className="min-w-0">
-              <div className="text-[11px] font-semibold text-neutral-100">Timeline editor</div>
-              <p className="mt-1 text-[11px] leading-5 text-neutral-300">
-                Drag clips to move timing, and drag clip edges to resize them when handles are
-                available. Hide the panel anytime and bring it back with{" "}
-                <span className="font-mono text-[10px] text-studio-accent">
-                  {TIMELINE_TOGGLE_SHORTCUT_LABEL}
-                </span>
-                .
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={dismissTimelineEditorHint}
-              className="flex-shrink-0 rounded-md border border-neutral-700 px-2 py-1 text-[10px] font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-100"
-            >
-              Dismiss
-            </button>
-          </div>
-        </div>
-      )}
-
       <div className="flex items-center justify-between px-3 py-2">
         <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-neutral-500">
           Timeline
@@ -1086,6 +1200,7 @@ export function StudioApp() {
   const [consoleErrors, setConsoleErrors] = useState<LintFinding[] | null>(null);
   const [linting, setLinting] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [, setStudioMotionRevision] = useState(0);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const projectIdRef = useRef(projectId);
@@ -1102,7 +1217,15 @@ export function StudioApp() {
     emptyStudioManualEditManifest(),
   );
   const studioManualEditRevisionRef = useRef(0);
+  const studioMotionManifestRef = useRef<StudioMotionManifest>(emptyStudioMotionManifest());
+  const studioMotionRevisionRef = useRef(0);
   const applyStudioManualEditsToPreviewRef = useRef<
+    (
+      iframe?: HTMLIFrameElement | null,
+      options?: { forceFromDisk?: boolean; readFromDiskFirst?: boolean },
+    ) => Promise<void>
+  >(async () => {});
+  const applyStudioMotionToPreviewRef = useRef<
     (
       iframe?: HTMLIFrameElement | null,
       options?: { forceFromDisk?: boolean; readFromDiskFirst?: boolean },
@@ -1142,6 +1265,14 @@ export function StudioApp() {
         }
         return;
       }
+      if (isStudioMotionManifestPath(changedPath)) {
+        if (!recentDomEditSave) {
+          void applyStudioMotionToPreviewRef.current(previewIframeRef.current, {
+            forceFromDisk: true,
+          });
+        }
+        return;
+      }
       if (recentDomEditSave) return;
       if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
       refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), 400);
@@ -1167,6 +1298,9 @@ export function StudioApp() {
     if (!previousProjectId || previousProjectId === projectId) return;
     studioManualEditManifestRef.current = emptyStudioManualEditManifest();
     studioManualEditRevisionRef.current += 1;
+    studioMotionManifestRef.current = emptyStudioMotionManifest();
+    studioMotionRevisionRef.current += 1;
+    setStudioMotionRevision((revision) => revision + 1);
   }, [projectId]);
 
   // Load file tree when projectId changes.
@@ -1646,6 +1780,14 @@ export function StudioApp() {
         setSelectedTimelineElementId(null);
         return;
       }
+      if (!STUDIO_INSPECTOR_PANELS_ENABLED) {
+        domEditSelectionRef.current = null;
+        domEditGroupSelectionsRef.current = [];
+        setDomEditSelection(null);
+        setDomEditGroupSelections([]);
+        setSelectedTimelineElementId(null);
+        return;
+      }
 
       const isAdditiveSelection = Boolean(options?.additive);
       const currentSelection = domEditSelectionRef.current;
@@ -1698,7 +1840,7 @@ export function StudioApp() {
 
   const readHistoryProjectFile = useCallback(
     async (path: string): Promise<string> => {
-      return path === STUDIO_MANUAL_EDITS_PATH
+      return path === STUDIO_MANUAL_EDITS_PATH || path === STUDIO_MOTION_PATH
         ? readOptionalProjectFile(path)
         : readProjectFile(path);
     },
@@ -1708,7 +1850,7 @@ export function StudioApp() {
   const writeHistoryProjectFile = useCallback(
     async (path: string, content: string): Promise<void> => {
       await writeProjectFile(path, content);
-      if (path === STUDIO_MANUAL_EDITS_PATH) {
+      if (path === STUDIO_MANUAL_EDITS_PATH || path === STUDIO_MOTION_PATH) {
         domEditSaveTimestampRef.current = Date.now();
       }
     },
@@ -1795,6 +1937,81 @@ export function StudioApp() {
     [applyStudioManualEditsToPreview],
   );
 
+  const applyCurrentStudioMotionToPreview = useCallback(
+    (iframe: HTMLIFrameElement | null = previewIframeRef.current) => {
+      if (!iframe) return;
+      let doc: Document | null = null;
+      try {
+        doc = iframe.contentDocument;
+      } catch {
+        return;
+      }
+      if (!doc) return;
+      const previewDoc = doc;
+
+      const applyManifest = () => {
+        applyStudioMotionManifest(
+          previewDoc,
+          studioMotionManifestRef.current,
+          activeCompPathRef.current,
+        );
+      };
+      const applyAndInstallSeekHooks = () => {
+        applyManifest();
+        if (iframe.contentWindow) {
+          installStudioMotionSeekReapply(iframe.contentWindow, applyManifest);
+        }
+      };
+
+      const win = iframe.contentWindow;
+      win?.requestAnimationFrame?.(applyAndInstallSeekHooks);
+      win?.setTimeout?.(applyAndInstallSeekHooks, 120);
+    },
+    [],
+  );
+
+  const applyStudioMotionToPreview = useCallback(
+    async (
+      iframe: HTMLIFrameElement | null = previewIframeRef.current,
+      options?: { forceFromDisk?: boolean; readFromDiskFirst?: boolean },
+    ) => {
+      const readRevision = studioMotionRevisionRef.current;
+      const readFromDiskFirst = Boolean(options?.forceFromDisk || options?.readFromDiskFirst);
+      if (!readFromDiskFirst) {
+        applyCurrentStudioMotionToPreview(iframe);
+      }
+      let content: string;
+      try {
+        content = await readOptionalProjectFile(STUDIO_MOTION_PATH);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to read motion manifest";
+        showToast(message);
+        if (readFromDiskFirst) {
+          applyCurrentStudioMotionToPreview(iframe);
+        }
+        return;
+      }
+      if (options?.forceFromDisk || readRevision === studioMotionRevisionRef.current) {
+        studioMotionManifestRef.current = parseStudioMotionManifest(content);
+        if (options?.forceFromDisk) studioMotionRevisionRef.current += 1;
+        setStudioMotionRevision((revision) => revision + 1);
+        applyCurrentStudioMotionToPreview(iframe);
+        return;
+      }
+      if (readFromDiskFirst) {
+        applyCurrentStudioMotionToPreview(iframe);
+      }
+    },
+    [applyCurrentStudioMotionToPreview, readOptionalProjectFile, showToast],
+  );
+  applyStudioMotionToPreviewRef.current = applyStudioMotionToPreview;
+
+  const applyStudioMotionToPreviewAfterRefresh = useCallback(
+    (iframe: HTMLIFrameElement | null = previewIframeRef.current) =>
+      applyStudioMotionToPreview(iframe, { readFromDiskFirst: true }),
+    [applyStudioMotionToPreview],
+  );
+
   const commitStudioManualEditManifestOptimistically = useCallback(
     (
       updateManifest: (manifest: StudioManualEditManifest) => StudioManualEditManifest,
@@ -1863,20 +2080,97 @@ export function StudioApp() {
     ],
   );
 
+  const commitStudioMotionManifestOptimistically = useCallback(
+    (
+      updateManifest: (manifest: StudioMotionManifest) => StudioMotionManifest,
+      options: { label: string; coalesceKey: string },
+    ) => {
+      const previousManifest = studioMotionManifestRef.current;
+      const nextManifest = updateManifest(previousManifest);
+      const previousContent = serializeStudioMotionManifest(previousManifest);
+      const nextContent = serializeStudioMotionManifest(nextManifest);
+      if (nextContent === previousContent) {
+        return;
+      }
+
+      const revision = studioMotionRevisionRef.current + 1;
+      studioMotionRevisionRef.current = revision;
+      studioMotionManifestRef.current = nextManifest;
+      setStudioMotionRevision((current) => current + 1);
+      applyCurrentStudioMotionToPreview(previewIframeRef.current);
+
+      const save = async () => {
+        const originalContent = await readOptionalProjectFile(STUDIO_MOTION_PATH);
+        const diskManifest = parseStudioMotionManifest(originalContent);
+        const nextDiskManifest = updateManifest(diskManifest);
+        const nextDiskContent = serializeStudioMotionManifest(nextDiskManifest);
+        if (nextDiskContent === originalContent) {
+          return;
+        }
+
+        const pid = projectIdRef.current;
+        if (!pid) throw new Error("No active project");
+        domEditSaveTimestampRef.current = Date.now();
+        await saveProjectFilesWithHistory({
+          projectId: pid,
+          label: options.label,
+          kind: "motion",
+          coalesceKey: options.coalesceKey,
+          files: { [STUDIO_MOTION_PATH]: nextDiskContent },
+          readFile: async () => originalContent,
+          writeFile: writeProjectFile,
+          recordEdit: editHistory.recordEdit,
+        });
+        domEditSaveTimestampRef.current = Date.now();
+
+        if (studioMotionRevisionRef.current === revision) {
+          studioMotionManifestRef.current = nextDiskManifest;
+          setStudioMotionRevision((current) => current + 1);
+          applyCurrentStudioMotionToPreview(previewIframeRef.current);
+        }
+      };
+
+      void queueDomEditSave(save).catch((error) => {
+        if (studioMotionRevisionRef.current === revision) {
+          studioMotionRevisionRef.current += 1;
+          studioMotionManifestRef.current = previousManifest;
+          setStudioMotionRevision((current) => current + 1);
+          applyCurrentStudioMotionToPreview(previewIframeRef.current);
+        }
+        const message = error instanceof Error ? error.message : "Failed to save motion edit";
+        showToast(message);
+      });
+    },
+    [
+      applyCurrentStudioMotionToPreview,
+      editHistory.recordEdit,
+      queueDomEditSave,
+      readOptionalProjectFile,
+      showToast,
+      writeProjectFile,
+    ],
+  );
+
   const syncHistoryPreviewAfterApply = useCallback(
     async (paths: string[] | undefined) => {
       const changedPaths = paths ?? [];
       const manualManifestOnly =
         changedPaths.length > 0 && changedPaths.every((path) => path === STUDIO_MANUAL_EDITS_PATH);
+      const motionManifestOnly =
+        changedPaths.length > 0 && changedPaths.every((path) => path === STUDIO_MOTION_PATH);
 
       if (manualManifestOnly) {
         await applyStudioManualEditsToPreview(previewIframeRef.current, { forceFromDisk: true });
         return;
       }
+      if (motionManifestOnly) {
+        await applyStudioMotionToPreview(previewIframeRef.current, { forceFromDisk: true });
+        return;
+      }
 
       setRefreshKey((key) => key + 1);
     },
-    [applyStudioManualEditsToPreview],
+    [applyStudioManualEditsToPreview, applyStudioMotionToPreview],
   );
 
   const handleUndo = useCallback(async () => {
@@ -2015,6 +2309,169 @@ export function StudioApp() {
     if (domEditSelectionsTargetSame(domEditHoverSelectionRef.current, selection)) return;
     domEditHoverSelectionRef.current = selection;
     setDomEditHoverSelection(selection);
+  }, []);
+
+  const buildDomSelectionForTimelineElement = useCallback(
+    (element: TimelineElement): DomEditSelection | null => {
+      const iframe = previewIframeRef.current;
+      let doc: Document | null = null;
+      try {
+        doc = iframe?.contentDocument ?? null;
+      } catch {
+        return null;
+      }
+      if (!doc) return null;
+
+      const targetElement = findElementForTimelineElement(doc, element, {
+        activeCompositionPath: activeCompPath,
+        compIdToSrc,
+        isMasterView,
+      });
+      return targetElement
+        ? buildDomSelectionFromTarget(targetElement, { preferClipAncestor: false })
+        : null;
+    },
+    [activeCompPath, buildDomSelectionFromTarget, compIdToSrc, isMasterView],
+  );
+
+  const inspectedTimelineElement = useMemo(
+    () =>
+      timelineElements.find(
+        (element) => getTimelineElementKey(element) === inspectedTimelineElementId,
+      ) ?? null,
+    [inspectedTimelineElementId, timelineElements],
+  );
+
+  const timelineLayerChildCounts = useMemo(() => {
+    void previewDocumentVersion;
+    const counts = new Map<string, number>();
+    if (!STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED || !inspectedTimelineElement) return counts;
+
+    const key = getTimelineElementKey(inspectedTimelineElement);
+    if (key) {
+      const selection = buildDomSelectionForTimelineElement(inspectedTimelineElement);
+      const count = countDomEditChildLayers(selection?.element, {
+        activeCompositionPath: activeCompPath,
+        isMasterView,
+      });
+      if (count > 0) counts.set(key, count);
+    }
+
+    return counts;
+  }, [
+    activeCompPath,
+    buildDomSelectionForTimelineElement,
+    inspectedTimelineElement,
+    isMasterView,
+    previewDocumentVersion,
+  ]);
+
+  const inspectedTimelineLayers = useMemo(() => {
+    void previewDocumentVersion;
+    if (!STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED || !inspectedTimelineElement) return [];
+    const selection = buildDomSelectionForTimelineElement(inspectedTimelineElement);
+    return collectDomEditLayerItems(selection?.element, {
+      activeCompositionPath: activeCompPath,
+      isMasterView,
+    });
+  }, [
+    activeCompPath,
+    buildDomSelectionForTimelineElement,
+    inspectedTimelineElement,
+    isMasterView,
+    previewDocumentVersion,
+  ]);
+
+  const selectedTimelineLayerKey = useMemo(
+    () => (domEditSelection ? getDomEditLayerKey(domEditSelection) : null),
+    [domEditSelection],
+  );
+
+  const handleTimelineElementSelect = useCallback(
+    (element: TimelineElement | null) => {
+      if (!STUDIO_INSPECTOR_PANELS_ENABLED) return;
+      if (!element) {
+        applyDomSelection(null, { revealPanel: false });
+        setInspectedTimelineElementId(null);
+        return;
+      }
+
+      const selection = buildDomSelectionForTimelineElement(element);
+      if (selection) applyDomSelection(selection);
+    },
+    [applyDomSelection, buildDomSelectionForTimelineElement],
+  );
+
+  const handleTimelineElementInspect = useCallback(
+    (element: TimelineElement) => {
+      if (!STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED || !STUDIO_INSPECTOR_PANELS_ENABLED) return;
+      if (!canInspectTimelineElement(element)) {
+        showToast("Audio clips do not have visual layers.", "info");
+        return;
+      }
+
+      const key = getTimelineElementKey(element);
+      if (!key) return;
+      setInspectedTimelineElementId((current) => (current === key ? null : key));
+      setLeftCollapsed(false);
+
+      const iframe = previewIframeRef.current;
+      if (!shouldShowTimelineInspectorBounds(currentTime, element)) {
+        seekStudioPreview(iframe, element.start);
+      }
+
+      const selection = buildDomSelectionForTimelineElement(element);
+      if (selection) applyDomSelection(selection);
+    },
+    [applyDomSelection, buildDomSelectionForTimelineElement, currentTime, showToast],
+  );
+
+  const handleToggleTimelineElementThumbnail = useCallback((element: TimelineElement) => {
+    const key = getTimelineElementKey(element);
+    if (!key) return;
+    setThumbnailedTimelineElementIds((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const handleTimelineLayerSelect = useCallback(
+    (layer: DomEditLayerItem) => {
+      if (!STUDIO_INSPECTOR_PANELS_ENABLED) return;
+
+      const iframe = previewIframeRef.current;
+      const player = getPreviewPlayer(iframe?.contentWindow);
+      const visibleTime = resolveLayerVisibleSeekTime(
+        layer.element,
+        inspectedTimelineElement,
+        player,
+      );
+      if (visibleTime != null) {
+        seekStudioPreview(iframe, visibleTime);
+      }
+
+      const selection = buildDomSelectionFromTarget(layer.element, { preferClipAncestor: false });
+      if (!selection) {
+        showToast("Studio could not resolve this nested layer.", "error");
+        return;
+      }
+
+      applyDomSelection(selection);
+      requestAnimationFrame(refreshPreviewDocumentVersion);
+    },
+    [
+      applyDomSelection,
+      buildDomSelectionFromTarget,
+      inspectedTimelineElement,
+      refreshPreviewDocumentVersion,
+      showToast,
+    ],
+  );
+
+  const handleTimelineLayerPanelClose = useCallback(() => {
+    setInspectedTimelineElementId(null);
   }, []);
 
   const preloadAgentPromptSnippet = useCallback(
@@ -2286,6 +2743,42 @@ export function StudioApp() {
     [
       applyCurrentStudioManualEditsToPreview,
       commitStudioManualEditManifestOptimistically,
+      refreshDomEditSelectionFromPreview,
+    ],
+  );
+
+  const handleDomMotionCommit = useCallback(
+    (
+      selection: DomEditSelection,
+      motion: Omit<StudioGsapMotion, "kind" | "target" | "updatedAt">,
+    ) => {
+      commitStudioMotionManifestOptimistically(
+        (manifest) => upsertStudioGsapMotion(manifest, selection, motion),
+        {
+          label: "Set GSAP motion",
+          coalesceKey: `motion:${getDomEditTargetKey(selection)}`,
+        },
+      );
+      refreshDomEditSelectionFromPreview(selection);
+    },
+    [commitStudioMotionManifestOptimistically, refreshDomEditSelectionFromPreview],
+  );
+
+  const handleDomMotionClear = useCallback(
+    (selection: DomEditSelection) => {
+      commitStudioMotionManifestOptimistically(
+        (manifest) => removeStudioMotionForSelection(manifest, selection),
+        {
+          label: "Clear GSAP motion",
+          coalesceKey: `motion:${getDomEditTargetKey(selection)}`,
+        },
+      );
+      applyCurrentStudioMotionToPreview(previewIframeRef.current);
+      refreshDomEditSelectionFromPreview(selection);
+    },
+    [
+      applyCurrentStudioMotionToPreview,
+      commitStudioMotionManifestOptimistically,
       refreshDomEditSelectionFromPreview,
     ],
   );
@@ -2570,13 +3063,14 @@ export function StudioApp() {
       syncPreviewHistoryHotkey(iframe);
       consoleErrorsRef.current = [];
       setConsoleErrors(null);
+      refreshPreviewDocumentVersion();
     },
-    [syncPreviewHistoryHotkey, syncPreviewTimelineHotkey],
+    [refreshPreviewDocumentVersion, syncPreviewHistoryHotkey, syncPreviewTimelineHotkey],
   );
 
   const handlePreviewCanvasMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>, options?: { preferClipAncestor?: boolean }) => {
-      if (captionEditMode) return;
+      if (!STUDIO_PREVIEW_MANUAL_EDITING_ENABLED || captionEditMode) return;
       const nextSelection = resolveDomSelectionFromPreviewPoint(e.clientX, e.clientY, {
         preferClipAncestor: options?.preferClipAncestor ?? true,
       });
@@ -2593,7 +3087,7 @@ export function StudioApp() {
 
   const handlePreviewCanvasPointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>, options?: { preferClipAncestor?: boolean }) => {
-      if (captionEditMode) {
+      if (!STUDIO_PREVIEW_MANUAL_EDITING_ENABLED || captionEditMode) {
         updateDomEditHoverSelection(null);
         return null;
       }
@@ -2653,7 +3147,7 @@ export function StudioApp() {
     if (!previewIframe) return;
 
     const syncSelectionFromDocument = () => {
-      if (captionEditMode) return;
+      if (!STUDIO_INSPECTOR_PANELS_ENABLED || captionEditMode) return;
       const currentSelection = domEditSelectionRef.current;
       if (!currentSelection) return;
       let doc: Document | null = null;
@@ -2708,16 +3202,24 @@ export function StudioApp() {
 
     attachErrorCapture();
     syncPreviewHistoryHotkey(previewIframe);
-    void applyStudioManualEditsToPreviewAfterRefresh(previewIframe);
+    void (async () => {
+      await applyStudioManualEditsToPreviewAfterRefresh(previewIframe);
+      await applyStudioMotionToPreviewAfterRefresh(previewIframe);
+    })();
     syncSelectionFromDocument();
+    refreshPreviewDocumentVersion();
 
     const handleLoad = () => {
       consoleErrorsRef.current = [];
       setConsoleErrors(null);
       attachErrorCapture();
       syncPreviewHistoryHotkey(previewIframe);
-      void applyStudioManualEditsToPreviewAfterRefresh(previewIframe);
+      void (async () => {
+        await applyStudioManualEditsToPreviewAfterRefresh(previewIframe);
+        await applyStudioMotionToPreviewAfterRefresh(previewIframe);
+      })();
       syncSelectionFromDocument();
+      refreshPreviewDocumentVersion();
     };
 
     previewIframe.addEventListener("load", handleLoad);
@@ -2728,9 +3230,11 @@ export function StudioApp() {
     activeCompPath,
     applyDomSelection,
     applyStudioManualEditsToPreviewAfterRefresh,
+    applyStudioMotionToPreviewAfterRefresh,
     buildDomSelectionFromTarget,
     captionEditMode,
     previewIframe,
+    refreshPreviewDocumentVersion,
     syncPreviewHistoryHotkey,
   ]);
 
@@ -2739,6 +3243,14 @@ export function StudioApp() {
     if (!captionEditMode) return;
     applyDomSelection(null, { revealPanel: false });
   }, [applyDomSelection, captionEditMode]);
+
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    if (STUDIO_INSPECTOR_PANELS_ENABLED) return;
+    updateDomEditHoverSelection(null);
+    applyDomSelection(null, { revealPanel: false });
+    if (rightPanelTab !== "renders") setRightPanelTab("renders");
+  }, [applyDomSelection, rightPanelTab, updateDomEditHoverSelection]);
 
   // eslint-disable-next-line no-restricted-syntax
   useEffect(
@@ -3169,6 +3681,42 @@ export function StudioApp() {
         })),
     [assets, projectId],
   );
+  const selectedStudioMotion =
+    STUDIO_INSPECTOR_PANELS_ENABLED && domEditSelection
+      ? getStudioMotionForSelection(studioMotionManifestRef.current, domEditSelection)
+      : null;
+  const selectedTimelineElement = useMemo(
+    () =>
+      selectedTimelineElementId
+        ? (timelineElements.find(
+            (element) => getTimelineElementKey(element) === selectedTimelineElementId,
+          ) ?? null)
+        : null,
+    [selectedTimelineElementId, timelineElements],
+  );
+  const designPanelActive = STUDIO_INSPECTOR_PANELS_ENABLED && rightPanelTab === "design";
+  const motionPanelActive =
+    STUDIO_INSPECTOR_PANELS_ENABLED && STUDIO_MOTION_PANEL_ENABLED && rightPanelTab === "motion";
+  const inspectorPanelActive = designPanelActive || motionPanelActive;
+  const shouldShowSelectedDomBounds =
+    inspectorPanelActive &&
+    !rightCollapsed &&
+    (!selectedTimelineElement ||
+      isTimelineElementActiveAtTime(currentTime, selectedTimelineElement));
+  const inspectorButtonActive =
+    STUDIO_INSPECTOR_PANELS_ENABLED && !rightCollapsed && inspectorPanelActive;
+  const timelineLayerPanel =
+    STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED &&
+    inspectedTimelineElement &&
+    inspectedTimelineLayers.length > 0 ? (
+      <TimelineLayerPanel
+        clipLabel={getTimelineElementLabel(inspectedTimelineElement)}
+        layers={inspectedTimelineLayers}
+        selectedLayerKey={selectedTimelineLayerKey}
+        onSelectLayer={handleTimelineLayerSelect}
+        onClose={handleTimelineLayerPanelClose}
+      />
+    ) : null;
 
   if (resolving || !projectId) {
     return (
@@ -3264,8 +3812,10 @@ export function StudioApp() {
             <span>Capture</span>
           </a>
           <button
+            type="button"
             onClick={() => {
-              if (rightCollapsed || rightPanelTab !== "design") {
+              if (!STUDIO_INSPECTOR_PANELS_ENABLED) return;
+              if (rightCollapsed || !inspectorPanelActive) {
                 setRightPanelTab("design");
                 setRightCollapsed(false);
                 return;
@@ -3273,11 +3823,20 @@ export function StudioApp() {
               clearDomSelection();
               setRightCollapsed(true);
             }}
+            disabled={!STUDIO_INSPECTOR_PANELS_ENABLED}
             className={`h-7 flex items-center gap-1.5 px-2.5 rounded-md text-[11px] font-medium border transition-colors ${
-              !rightCollapsed
+              inspectorButtonActive
                 ? "text-studio-accent bg-studio-accent/10 border-studio-accent/30"
-                : "text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800 border-transparent"
+                : STUDIO_INSPECTOR_PANELS_ENABLED
+                  ? "text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800 border-transparent"
+                  : "cursor-not-allowed border-transparent text-neutral-700"
             }`}
+            title={
+              STUDIO_INSPECTOR_PANELS_ENABLED ? "Inspector" : STUDIO_MANUAL_EDITING_DISABLED_TITLE
+            }
+            aria-label={
+              STUDIO_INSPECTOR_PANELS_ENABLED ? "Inspector" : STUDIO_MANUAL_EDITING_DISABLED_TITLE
+            }
           >
             <svg
               width="12"
@@ -3371,6 +3930,7 @@ export function StudioApp() {
             onLint={handleLint}
             linting={linting}
             onToggleCollapse={toggleLeftSidebar}
+            takeoverContent={timelineLayerPanel}
           />
         )}
 
@@ -3401,28 +3961,36 @@ export function StudioApp() {
             onMoveElement={handleTimelineElementMove}
             onResizeElement={handleTimelineElementResize}
             onBlockedEditAttempt={handleBlockedTimelineEdit}
+            onSelectTimelineElement={handleTimelineElementSelect}
+            onInspectTimelineElement={handleTimelineElementInspect}
+            inspectedTimelineElementId={inspectedTimelineElementId}
+            timelineLayerChildCounts={timelineLayerChildCounts}
+            thumbnailedTimelineElementIds={thumbnailedTimelineElementIds}
+            onToggleTimelineElementThumbnail={handleToggleTimelineElementThumbnail}
             onCompIdToSrcChange={setCompIdToSrc}
             onCompositionChange={(compPath) => {
               // Sync activeCompPath when user drills down via timeline double-click
               // or navigates back via breadcrumb — keeps sidebar + thumbnails in sync.
               setActiveCompPath(compPath);
+              setInspectedTimelineElementId(null);
+              refreshPreviewDocumentVersion();
             }}
             onIframeRef={handlePreviewIframeRef}
             previewOverlay={
               captionEditMode ? (
                 <CaptionOverlay iframeRef={previewIframeRef} />
-              ) : (
+              ) : STUDIO_INSPECTOR_PANELS_ENABLED ? (
                 <DomEditOverlay
                   iframeRef={previewIframeRef}
                   activeCompositionPath={activeCompPath}
-                  hoverSelection={captionEditMode ? null : domEditHoverSelection}
-                  selection={
-                    !rightCollapsed && rightPanelTab === "design" ? domEditSelection : null
+                  hoverSelection={
+                    STUDIO_PREVIEW_MANUAL_EDITING_ENABLED && !captionEditMode
+                      ? domEditHoverSelection
+                      : null
                   }
-                  groupSelections={
-                    !rightCollapsed && rightPanelTab === "design" ? domEditGroupSelections : []
-                  }
-                  allowCanvasMovement
+                  selection={shouldShowSelectedDomBounds ? domEditSelection : null}
+                  groupSelections={shouldShowSelectedDomBounds ? domEditGroupSelections : []}
+                  allowCanvasMovement={STUDIO_PREVIEW_MANUAL_EDITING_ENABLED}
                   onCanvasMouseDown={handlePreviewCanvasMouseDown}
                   onCanvasPointerMove={handlePreviewCanvasPointerMove}
                   onCanvasPointerLeave={handlePreviewCanvasPointerLeave}
@@ -3434,7 +4002,7 @@ export function StudioApp() {
                   onBoxSizeCommit={handleDomBoxSizeCommit}
                   onRotationCommit={handleDomRotationCommit}
                 />
-              )
+              ) : null
             }
             timelineFooter={
               captionEditMode ? (
@@ -3477,17 +4045,34 @@ export function StudioApp() {
               ) : (
                 <>
                   <div className="flex items-center gap-1 border-b border-neutral-800 px-3 py-2">
-                    <button
-                      type="button"
-                      onClick={() => setRightPanelTab("design")}
-                      className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
-                        rightPanelTab === "design"
-                          ? "bg-neutral-800 text-white"
-                          : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
-                      }`}
-                    >
-                      Design
-                    </button>
+                    {STUDIO_INSPECTOR_PANELS_ENABLED && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => setRightPanelTab("design")}
+                          className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
+                            rightPanelTab === "design"
+                              ? "bg-neutral-800 text-white"
+                              : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
+                          }`}
+                        >
+                          Design
+                        </button>
+                        {STUDIO_MOTION_PANEL_ENABLED && (
+                          <button
+                            type="button"
+                            onClick={() => setRightPanelTab("motion")}
+                            className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
+                              rightPanelTab === "motion"
+                                ? "bg-neutral-800 text-white"
+                                : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
+                            }`}
+                          >
+                            Motion
+                          </button>
+                        )}
+                      </>
+                    )}
                     <button
                       type="button"
                       onClick={() => setRightPanelTab("renders")}
@@ -3503,7 +4088,7 @@ export function StudioApp() {
                     </button>
                   </div>
                   <div className="min-h-0 flex-1">
-                    {rightPanelTab === "design" ? (
+                    {designPanelActive ? (
                       <PropertyPanel
                         projectId={projectId}
                         assets={assets}
@@ -3522,6 +4107,14 @@ export function StudioApp() {
                         onImportAssets={handleImportFiles}
                         fontAssets={fontAssets}
                         onImportFonts={handleImportFonts}
+                      />
+                    ) : motionPanelActive ? (
+                      <MotionPanel
+                        element={domEditGroupSelections.length > 1 ? null : domEditSelection}
+                        motion={selectedStudioMotion}
+                        onClearSelection={clearDomSelection}
+                        onSetMotion={handleDomMotionCommit}
+                        onClearMotion={handleDomMotionClear}
                       />
                     ) : (
                       <RenderQueue

--- a/packages/studio/src/components/editor/MotionPanel.tsx
+++ b/packages/studio/src/components/editor/MotionPanel.tsx
@@ -1,0 +1,651 @@
+import {
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+import { RotateCcw, X, Zap } from "../../icons/SystemIcons";
+import type { DomEditSelection } from "./domEditing";
+import {
+  STUDIO_GSAP_EASE_OPTIONS,
+  buildStudioGsapPresetMotion,
+  clampStudioCustomEasePoints,
+  controlPointsForGsapEase,
+  parseStudioCustomEaseData,
+  serializeStudioCustomEaseData,
+  type StudioCustomEaseControlPoints,
+  type StudioGsapMotion,
+  type StudioGsapMotionDirection,
+  type StudioGsapMotionPreset,
+} from "./studioMotion";
+
+interface MotionPanelProps {
+  element: DomEditSelection | null;
+  motion: StudioGsapMotion | null;
+  onClearSelection: () => void;
+  onSetMotion: (
+    element: DomEditSelection,
+    motion: Omit<StudioGsapMotion, "kind" | "target" | "updatedAt">,
+  ) => void;
+  onClearMotion: (element: DomEditSelection) => void;
+}
+
+const FIELD =
+  "min-w-0 rounded-xl border border-neutral-800 bg-neutral-900/95 px-3 py-2 text-neutral-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-colors focus-within:border-neutral-600";
+const LABEL = "text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500";
+const RESPONSIVE_GRID = "grid grid-cols-[repeat(auto-fit,minmax(118px,1fr))] gap-3";
+
+const MOTION_PRESET_OPTIONS: Array<{ label: string; value: StudioGsapMotionPreset }> = [
+  { label: "Fade Up", value: "fade-up" },
+  { label: "Slide", value: "slide" },
+  { label: "Pop", value: "pop" },
+];
+
+const MOTION_DIRECTION_OPTIONS: StudioGsapMotionDirection[] = ["up", "down", "left", "right"];
+
+function formatNumericValue(value: number): string {
+  const rounded = Math.round(value * 100) / 100;
+  return Number.isInteger(rounded)
+    ? `${rounded}`
+    : rounded.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function clampMotionNumber(
+  value: number | null,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (value == null || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+function parsePlainNumber(value: string): number | null {
+  const parsed = Number.parseFloat(value.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function motionValueDistance(motion: StudioGsapMotion | null): number {
+  if (!motion) return 32;
+  return Math.max(Math.abs(motion.from.x ?? 0), Math.abs(motion.from.y ?? 0), 1);
+}
+
+function inferMotionPreset(motion: StudioGsapMotion | null): StudioGsapMotionPreset {
+  if (!motion) return "fade-up";
+  if (motion.from.scale != null || motion.to.scale != null) return "pop";
+  if (motion.from.x != null || motion.to.x != null) return "slide";
+  return "fade-up";
+}
+
+function inferMotionDirection(motion: StudioGsapMotion | null): StudioGsapMotionDirection {
+  if (!motion) return "up";
+  const x = motion.from.x ?? 0;
+  const y = motion.from.y ?? 0;
+  if (Math.abs(x) > Math.abs(y)) return x < 0 ? "right" : "left";
+  return y < 0 ? "down" : "up";
+}
+
+function buildStudioCustomEaseId(element: DomEditSelection): string {
+  const source = element.id || element.selector || element.label || "layer";
+  const normalized = source
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `studio-${normalized || "layer"}-ease`;
+}
+
+function CommitField({
+  value,
+  disabled,
+  onCommit,
+}: {
+  value: string;
+  disabled?: boolean;
+  onCommit: (nextValue: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  const focusedRef = useRef(false);
+
+  useEffect(() => {
+    if (!focusedRef.current) setDraft(value);
+  }, [value]);
+
+  const commitDraft = () => {
+    focusedRef.current = false;
+    const next = draft.trim();
+    if (next !== value) onCommit(next);
+  };
+
+  return (
+    <input
+      type="text"
+      value={draft}
+      disabled={disabled}
+      onFocus={() => {
+        focusedRef.current = true;
+      }}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commitDraft}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") (event.target as HTMLInputElement).blur();
+      }}
+      className="w-full min-w-0 bg-transparent text-[11px] font-medium text-neutral-100 outline-none disabled:cursor-not-allowed disabled:text-neutral-600"
+    />
+  );
+}
+
+function DetailField({
+  label,
+  value,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  value: string;
+  disabled?: boolean;
+  onCommit: (nextValue: string) => void;
+}) {
+  return (
+    <label className="grid min-w-0 gap-1.5">
+      <span className={LABEL}>{label}</span>
+      <div className={FIELD}>
+        <CommitField value={value} disabled={disabled} onCommit={onCommit} />
+      </div>
+    </label>
+  );
+}
+
+function SegmentedControl({
+  value,
+  options,
+  onChange,
+}: {
+  value: string;
+  options: Array<{ label: string; value: string }>;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-1 rounded-2xl border border-neutral-800 bg-neutral-950 p-1">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          className={`h-9 rounded-xl text-[11px] font-semibold transition-colors ${
+            option.value === value
+              ? "bg-neutral-800 text-white shadow-sm"
+              : "text-neutral-500 hover:bg-neutral-900 hover:text-neutral-200"
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SelectField({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="grid min-w-0 gap-1.5">
+      <span className={LABEL}>{label}</span>
+      <div className={FIELD}>
+        <select
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="w-full min-w-0 appearance-none bg-transparent text-[11px] font-medium text-neutral-100 outline-none"
+        >
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </div>
+    </label>
+  );
+}
+
+function MotionSection({
+  title,
+  children,
+  accessory,
+}: {
+  title: string;
+  children: ReactNode;
+  accessory?: ReactNode;
+}) {
+  return (
+    <section className="border-b border-neutral-800 px-4 py-5">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Zap size={15} className="text-neutral-500" />
+          <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-300">
+            {title}
+          </h3>
+        </div>
+        {accessory}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function cubicBezierPoint(t: number, p1: StudioCustomEaseControlPoints): { x: number; y: number } {
+  const inv = 1 - t;
+  const inv2 = inv * inv;
+  const t2 = t * t;
+  return {
+    x: 3 * inv2 * t * p1.x1 + 3 * inv * t2 * p1.x2 + t2 * t,
+    y: 3 * inv2 * t * p1.y1 + 3 * inv * t2 * p1.y2 + t2 * t,
+  };
+}
+
+function buildCurvePath(
+  points: StudioCustomEaseControlPoints,
+  map: (point: { x: number; y: number }) => { x: number; y: number },
+): string {
+  const commands: string[] = [];
+  for (let index = 0; index <= 48; index += 1) {
+    const point = map(cubicBezierPoint(index / 48, points));
+    commands.push(`${index === 0 ? "M" : "L"}${point.x.toFixed(2)},${point.y.toFixed(2)}`);
+  }
+  return commands.join(" ");
+}
+
+function EaseCurveEditor({
+  points,
+  onCommit,
+}: {
+  points: StudioCustomEaseControlPoints;
+  onCommit: (points: StudioCustomEaseControlPoints) => void;
+}) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [draft, setDraft] = useState(points);
+  const draggingRef = useRef<"p1" | "p2" | null>(null);
+
+  useEffect(() => {
+    setDraft(points);
+  }, [points]);
+
+  const width = 324;
+  const height = 214;
+  const plot = { left: 46, top: 24, width: 242, height: 146 };
+  const yMin = -0.4;
+  const yMax = 1.4;
+
+  const mapPoint = (point: { x: number; y: number }) => ({
+    x: plot.left + point.x * plot.width,
+    y: plot.top + ((yMax - point.y) / (yMax - yMin)) * plot.height,
+  });
+
+  const unmapPointer = (event: PointerEvent<SVGSVGElement>) => {
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect) return null;
+    const x = ((event.clientX - rect.left) / rect.width) * width;
+    const y = ((event.clientY - rect.top) / rect.height) * height;
+    return clampStudioCustomEasePoints({
+      x1: draggingRef.current === "p1" ? (x - plot.left) / plot.width : draft.x1,
+      y1:
+        draggingRef.current === "p1"
+          ? yMax - ((y - plot.top) / plot.height) * (yMax - yMin)
+          : draft.y1,
+      x2: draggingRef.current === "p2" ? (x - plot.left) / plot.width : draft.x2,
+      y2:
+        draggingRef.current === "p2"
+          ? yMax - ((y - plot.top) / plot.height) * (yMax - yMin)
+          : draft.y2,
+    });
+  };
+
+  const start = mapPoint({ x: 0, y: 0 });
+  const end = mapPoint({ x: 1, y: 1 });
+  const p1 = mapPoint({ x: draft.x1, y: draft.y1 });
+  const p2 = mapPoint({ x: draft.x2, y: draft.y2 });
+  const curvePath = buildCurvePath(draft, mapPoint);
+
+  const handlePointerMove = (event: PointerEvent<SVGSVGElement>) => {
+    if (!draggingRef.current) return;
+    event.preventDefault();
+    const next = unmapPointer(event);
+    if (next) setDraft(next);
+  };
+
+  const endDrag = () => {
+    if (!draggingRef.current) return;
+    draggingRef.current = null;
+    onCommit(draft);
+  };
+
+  const startDrag = (handle: "p1" | "p2", event: PointerEvent<SVGCircleElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    draggingRef.current = handle;
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-neutral-800 bg-black/40">
+      <div className="flex items-center justify-between gap-3 border-b border-neutral-800 px-3 py-2">
+        <div>
+          <div className={LABEL}>CustomEase</div>
+          <div className="mt-1 font-mono text-[10px] text-neutral-500">
+            {serializeStudioCustomEaseData(draft)}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            const reset = controlPointsForGsapEase("power3.out");
+            setDraft(reset);
+            onCommit(reset);
+          }}
+          className="inline-flex h-8 items-center justify-center gap-2 rounded-xl border border-neutral-800 bg-neutral-950 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-100"
+        >
+          <RotateCcw size={13} />
+          Reset
+        </button>
+      </div>
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${width} ${height}`}
+        className="block w-full select-none touch-none"
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        <rect x="0" y="0" width={width} height={height} fill="transparent" />
+        {[0, 0.5, 1].map((value) => {
+          const mapped = mapPoint({ x: 0, y: value });
+          return (
+            <g key={value}>
+              <line
+                x1={plot.left}
+                x2={plot.left + plot.width}
+                y1={mapped.y}
+                y2={mapped.y}
+                stroke="rgba(255,255,255,0.12)"
+                strokeDasharray="5 8"
+              />
+              <text
+                x={plot.left - 12}
+                y={mapped.y + 4}
+                textAnchor="end"
+                className="fill-neutral-500 text-[10px] font-semibold"
+              >
+                {value}
+              </text>
+            </g>
+          );
+        })}
+        <line
+          x1={plot.left}
+          x2={plot.left + plot.width}
+          y1={plot.top + plot.height}
+          y2={plot.top + plot.height}
+          stroke="rgba(255,255,255,0.18)"
+        />
+        <line
+          x1={plot.left}
+          x2={plot.left}
+          y1={plot.top}
+          y2={plot.top + plot.height}
+          stroke="rgba(255,255,255,0.18)"
+        />
+        <line x1={start.x} y1={start.y} x2={p1.x} y2={p1.y} stroke="rgba(255,221,87,0.34)" />
+        <line x1={end.x} y1={end.y} x2={p2.x} y2={p2.y} stroke="rgba(255,221,87,0.34)" />
+        <path d={curvePath} fill="none" stroke="#ffdd57" strokeWidth="4" strokeLinecap="round" />
+        <circle cx={start.x} cy={start.y} r="5" fill="#ffdd57" />
+        <circle cx={end.x} cy={end.y} r="5" fill="#ffdd57" />
+        <circle
+          cx={p1.x}
+          cy={p1.y}
+          r="9"
+          fill="#141414"
+          stroke="#ffdd57"
+          strokeWidth="4"
+          className="cursor-grab active:cursor-grabbing"
+          onPointerDown={(event) => startDrag("p1", event)}
+        />
+        <circle
+          cx={p2.x}
+          cy={p2.y}
+          r="9"
+          fill="#141414"
+          stroke="#ffdd57"
+          strokeWidth="4"
+          className="cursor-grab active:cursor-grabbing"
+          onPointerDown={(event) => startDrag("p2", event)}
+        />
+        <text x={p1.x + 12} y={p1.y - 10} className="fill-neutral-400 text-[10px] font-semibold">
+          P1
+        </text>
+        <text x={p2.x + 12} y={p2.y - 10} className="fill-neutral-400 text-[10px] font-semibold">
+          P2
+        </text>
+      </svg>
+      <div className="grid grid-cols-2 gap-2 border-t border-neutral-800 p-3">
+        <div className="rounded-xl border border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-[10px] text-neutral-400">
+          P1 {formatNumericValue(draft.x1)}, {formatNumericValue(draft.y1)}
+        </div>
+        <div className="rounded-xl border border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-[10px] text-neutral-400">
+          P2 {formatNumericValue(draft.x2)}, {formatNumericValue(draft.y2)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const MotionPanel = memo(function MotionPanel({
+  element,
+  motion,
+  onClearSelection,
+  onSetMotion,
+  onClearMotion,
+}: MotionPanelProps) {
+  const activeMotionPreset = inferMotionPreset(motion);
+  const activeMotionDirection = inferMotionDirection(motion);
+  const activeMotionStart = motion?.start ?? 0;
+  const activeMotionDuration = motion?.duration ?? 0.6;
+  const activeMotionDistance = motionValueDistance(motion);
+  const activeMotionEase = motion?.ease ?? "power3.out";
+  const customEaseData = motion?.customEase?.data ?? "";
+  const customEaseActive = customEaseData.trim().length > 0;
+  const activeCustomEasePoints = useMemo(
+    () =>
+      parseStudioCustomEaseData(customEaseData) ??
+      controlPointsForGsapEase(
+        STUDIO_GSAP_EASE_OPTIONS.includes(
+          activeMotionEase as (typeof STUDIO_GSAP_EASE_OPTIONS)[number],
+        )
+          ? activeMotionEase
+          : "power3.out",
+      ),
+    [activeMotionEase, customEaseData],
+  );
+
+  if (!element) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-neutral-900 px-6 text-center">
+        <Zap size={18} className="mb-3 text-neutral-600" />
+        <p className="text-sm font-medium text-neutral-200">Select an element for motion.</p>
+        <p className="mt-2 max-w-[260px] text-xs leading-5 text-neutral-500">
+          Timeline layers and inspector selections can receive Studio-authored GSAP motion.
+        </p>
+      </div>
+    );
+  }
+
+  const sourceLabel = element.id ? `#${element.id}` : element.selector;
+  const easeSelectValue = customEaseActive
+    ? "CustomEase"
+    : STUDIO_GSAP_EASE_OPTIONS.includes(
+          activeMotionEase as (typeof STUDIO_GSAP_EASE_OPTIONS)[number],
+        )
+      ? activeMotionEase
+      : "power3.out";
+  const easeSelectOptions = customEaseActive
+    ? ["CustomEase", ...STUDIO_GSAP_EASE_OPTIONS]
+    : STUDIO_GSAP_EASE_OPTIONS;
+
+  const commitMotion = (
+    overrides: Partial<{
+      preset: StudioGsapMotionPreset;
+      direction: StudioGsapMotionDirection;
+      start: number;
+      duration: number;
+      distance: number;
+      ease: string;
+      customEaseData: string;
+    }>,
+  ) => {
+    const customEaseText = overrides.customEaseData ?? customEaseData;
+    const customEase = customEaseText.trim()
+      ? {
+          id: motion?.customEase?.id ?? buildStudioCustomEaseId(element),
+          data: customEaseText.trim(),
+        }
+      : undefined;
+    const nextEase = customEase
+      ? customEase.id
+      : (overrides.ease ?? activeMotionEase).trim() || "none";
+    onSetMotion(
+      element,
+      buildStudioGsapPresetMotion(overrides.preset ?? activeMotionPreset, {
+        start: clampMotionNumber(overrides.start ?? activeMotionStart, 0, 3600, 0),
+        duration: clampMotionNumber(overrides.duration ?? activeMotionDuration, 0.01, 3600, 0.6),
+        distance: clampMotionNumber(overrides.distance ?? activeMotionDistance, 1, 2000, 32),
+        direction: overrides.direction ?? activeMotionDirection,
+        ease: nextEase,
+        customEase,
+      }),
+    );
+  };
+
+  const commitCustomEase = (points: StudioCustomEaseControlPoints) => {
+    commitMotion({
+      ease: buildStudioCustomEaseId(element),
+      customEaseData: serializeStudioCustomEaseData(points),
+    });
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-neutral-900 text-neutral-100">
+      <div className="border-b border-neutral-800 px-4 py-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className={LABEL}>Motion Target</div>
+            <div className="mt-3 truncate text-[12px] font-semibold text-neutral-100">
+              {element.label}
+            </div>
+            <div className="mt-1 truncate text-[11px] text-neutral-500">{sourceLabel}</div>
+          </div>
+          <button
+            type="button"
+            aria-label="Clear selection"
+            onClick={onClearSelection}
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-neutral-700 bg-neutral-950 text-neutral-500 shadow-[0_1px_2px_rgba(0,0,0,0.2)] transition-colors hover:border-neutral-600 hover:text-neutral-200"
+          >
+            <X size={13} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <MotionSection
+          title="GSAP Motion"
+          accessory={
+            <div className="rounded-full border border-studio-accent/40 bg-studio-accent/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-studio-accent">
+              GSAP
+            </div>
+          }
+        >
+          <div className="space-y-4">
+            <SegmentedControl
+              value={activeMotionPreset}
+              onChange={(next) => commitMotion({ preset: next as StudioGsapMotionPreset })}
+              options={MOTION_PRESET_OPTIONS}
+            />
+            <div className={RESPONSIVE_GRID}>
+              <SelectField
+                label="Direction"
+                value={activeMotionDirection}
+                onChange={(next) => commitMotion({ direction: next as StudioGsapMotionDirection })}
+                options={MOTION_DIRECTION_OPTIONS}
+              />
+              <SelectField
+                label="Ease"
+                value={easeSelectValue}
+                onChange={(next) => {
+                  if (next === "CustomEase") return;
+                  commitMotion({ ease: next, customEaseData: "" });
+                }}
+                options={easeSelectOptions}
+              />
+            </div>
+            <div className={RESPONSIVE_GRID}>
+              <DetailField
+                label="Start"
+                value={formatNumericValue(activeMotionStart)}
+                onCommit={(next) => commitMotion({ start: parsePlainNumber(next) ?? 0 })}
+              />
+              <DetailField
+                label="Duration"
+                value={formatNumericValue(activeMotionDuration)}
+                onCommit={(next) => commitMotion({ duration: parsePlainNumber(next) ?? 0.6 })}
+              />
+              <DetailField
+                label="Distance"
+                value={formatNumericValue(activeMotionDistance)}
+                onCommit={(next) => commitMotion({ distance: parsePlainNumber(next) ?? 32 })}
+              />
+            </div>
+          </div>
+        </MotionSection>
+
+        <MotionSection
+          title="Ease Curve"
+          accessory={
+            <div className="rounded-full border border-yellow-400/30 bg-yellow-400/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-yellow-300">
+              CustomEase
+            </div>
+          }
+        >
+          <div className="space-y-4">
+            <EaseCurveEditor points={activeCustomEasePoints} onCommit={commitCustomEase} />
+            <DetailField
+              label="CustomEase path"
+              value={customEaseData}
+              onCommit={(next) => {
+                const parsed = parseStudioCustomEaseData(next);
+                if (parsed) commitCustomEase(parsed);
+              }}
+            />
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => onClearMotion(element)}
+                disabled={!motion}
+                className="inline-flex h-8 items-center rounded-xl border border-neutral-700 bg-neutral-950 px-3 text-[11px] font-medium text-neutral-300 transition-colors hover:border-neutral-600 hover:text-white disabled:cursor-not-allowed disabled:border-neutral-800 disabled:text-neutral-600"
+              >
+                Clear motion
+              </button>
+            </div>
+          </div>
+        </MotionSection>
+      </div>
+    </div>
+  );
+});

--- a/packages/studio/src/components/editor/PropertyPanel.test.ts
+++ b/packages/studio/src/components/editor/PropertyPanel.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStrokeStyleUpdates,
+  buildStrokeWidthStyleUpdates,
+  getClipPathInsetPx,
+  getCssFilterFunctionPx,
+  inferBoxShadowPreset,
+  inferClipPathPreset,
+  normalizePanelPxValue,
+  setCssFilterFunctionPx,
+} from "./PropertyPanel";
+
+describe("PropertyPanel style helpers", () => {
+  it("normalizes bounded pixel values without accepting incompatible units", () => {
+    expect(normalizePanelPxValue("12", { min: 0, max: 40 })).toBe("12px");
+    expect(normalizePanelPxValue("12.50px", { min: 0, max: 40 })).toBe("12.5px");
+    expect(normalizePanelPxValue("-8", { min: 0, max: 40 })).toBe("0px");
+    expect(normalizePanelPxValue("80px", { min: 0, max: 40 })).toBe("40px");
+    expect(normalizePanelPxValue("1.2rem", { min: 0, max: 40 })).toBeNull();
+    expect(normalizePanelPxValue("auto", { min: 0, max: 40 })).toBeNull();
+  });
+
+  it("adds, replaces, and removes a named filter function while preserving other filters", () => {
+    expect(setCssFilterFunctionPx("none", "blur", 12)).toBe("blur(12px)");
+    expect(setCssFilterFunctionPx("brightness(1.08)", "blur", 4.5)).toBe(
+      "brightness(1.08) blur(4.5px)",
+    );
+    expect(setCssFilterFunctionPx("brightness(1.08) blur(12px) saturate(1.2)", "blur", 2)).toBe(
+      "brightness(1.08) saturate(1.2) blur(2px)",
+    );
+    expect(setCssFilterFunctionPx("brightness(1.08) blur(12px)", "blur", 0)).toBe(
+      "brightness(1.08)",
+    );
+    expect(setCssFilterFunctionPx("blur(12px)", "blur", 0)).toBe("none");
+    expect(getCssFilterFunctionPx("brightness(1.08) blur(3.5px)", "blur")).toBe(3.5);
+    expect(getCssFilterFunctionPx("drop-shadow(0 2px 8px black)", "blur")).toBe(0);
+  });
+
+  it("infers shadow and clip presets without losing custom values", () => {
+    expect(inferBoxShadowPreset("none")).toBe("none");
+    expect(inferBoxShadowPreset("0 12px 36px rgba(0, 0, 0, 0.28)")).toBe("soft");
+    expect(inferBoxShadowPreset("0 2px 4px red")).toBe("custom");
+
+    expect(inferClipPathPreset(undefined)).toBe("none");
+    expect(inferClipPathPreset("inset(12px round 8px)")).toBe("inset");
+    expect(inferClipPathPreset("circle(50% at 50% 50%)")).toBe("circle");
+    expect(inferClipPathPreset("polygon(0 0, 100% 0, 100% 100%)")).toBe("custom");
+    expect(getClipPathInsetPx("inset(12.5px round 8px)")).toBe(12.5);
+    expect(getClipPathInsetPx("circle(50% at 50% 50%)")).toBe(0);
+  });
+
+  it("keeps stroke width and style edits visually effective", () => {
+    expect(buildStrokeWidthStyleUpdates("3px", "none")).toEqual([
+      ["border-width", "3px"],
+      ["border-style", "solid"],
+    ]);
+    expect(buildStrokeWidthStyleUpdates("0px", "none")).toEqual([["border-width", "0px"]]);
+    expect(buildStrokeWidthStyleUpdates("3px", "dashed")).toEqual([["border-width", "3px"]]);
+
+    expect(buildStrokeStyleUpdates("dashed", "0px")).toEqual([
+      ["border-style", "dashed"],
+      ["border-width", "1px"],
+    ]);
+    expect(buildStrokeStyleUpdates("none", "4px")).toEqual([["border-style", "none"]]);
+    expect(buildStrokeStyleUpdates("solid", "4px")).toEqual([["border-style", "solid"]]);
+  });
+});

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -18,8 +18,10 @@ import {
   Plus,
   RotateCcw,
   Settings,
+  Square,
   Type,
   X,
+  Zap,
 } from "../../icons/SystemIcons";
 import {
   formatCssColor,
@@ -54,7 +56,7 @@ interface PropertyPanelProps {
   element: DomEditSelection | null;
   copiedAgentPrompt: boolean;
   onClearSelection: () => void;
-  onSetStyle: (prop: string, value: string) => void;
+  onSetStyle: (prop: string, value: string) => void | Promise<void>;
   onSetManualOffset: (element: DomEditSelection, next: { x: number; y: number }) => void;
   onSetManualSize: (element: DomEditSelection, next: { width: number; height: number }) => void;
   onSetText: (value: string, fieldKey?: string) => void;
@@ -100,7 +102,6 @@ const DEFAULT_FONT_FAMILIES = [
   "serif",
   "monospace",
 ];
-
 interface LocalFontData {
   family: string;
   fullName?: string;
@@ -117,6 +118,15 @@ interface FontOption {
 }
 
 const COLOR_PICKER_SIZE = { width: 292, height: 386 };
+const EMPTY_FILTER_VALUE = "none";
+const BOX_SHADOW_PRESETS = {
+  none: "none",
+  soft: "0 12px 36px rgba(0, 0, 0, 0.28)",
+  lift: "0 18px 54px rgba(0, 0, 0, 0.38)",
+  glow: "0 0 0 1px rgba(60, 230, 172, 0.34), 0 18px 56px rgba(60, 230, 172, 0.2)",
+} as const;
+
+type BoxShadowPreset = keyof typeof BOX_SHADOW_PRESETS | "custom";
 
 function colorFromCss(value: string): ParsedColor {
   return parseCssColor(value) ?? { red: 0, green: 0, blue: 0, alpha: 1 };
@@ -181,8 +191,166 @@ function parsePxMetricValue(value: string): number | null {
   return token.value;
 }
 
+export function clampPanelNumber(
+  value: number,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, value));
+}
+
+export function normalizePanelPxValue(
+  value: string,
+  options: { min?: number; max?: number; fallback?: number } = {},
+): string | null {
+  const token = parseNumericToken(value.trim());
+  if (!token) return null;
+  if (token.unit && token.unit.toLowerCase() !== "px") return null;
+  const next = clampPanelNumber(
+    token.value,
+    options.min ?? Number.NEGATIVE_INFINITY,
+    options.max ?? Number.POSITIVE_INFINITY,
+    options.fallback ?? 0,
+  );
+  return `${formatNumericValue(next)}px`;
+}
+
 function formatPxMetricValue(value: number): string {
   return `${formatNumericValue(value)}px`;
+}
+
+function normalizeTextMetricValue(property: "letter-spacing" | "line-height", value: string) {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "normal") return trimmed || "normal";
+  const token = parseNumericToken(trimmed);
+  if (!token) return trimmed;
+  if (property === "letter-spacing") {
+    return token.unit ? trimmed : `${formatNumericValue(token.value)}px`;
+  }
+  if (token.unit) return trimmed;
+  return token.value > 4 ? `${formatNumericValue(token.value)}px` : formatNumericValue(token.value);
+}
+
+function splitCssFunctions(value: string): string[] {
+  const functions: string[] = [];
+  let current = "";
+  let depth = 0;
+
+  for (const char of value.trim()) {
+    if (char === "(") depth += 1;
+    if (char === ")") depth = Math.max(0, depth - 1);
+    if (/\s/.test(char) && depth === 0) {
+      if (current.trim()) functions.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.trim()) functions.push(current.trim());
+  return functions;
+}
+
+export function getCssFilterFunctionPx(value: string | undefined, name: string): number {
+  const normalized = value?.trim();
+  if (!normalized || normalized === EMPTY_FILTER_VALUE) return 0;
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(?:^|\\s)${escapedName}\\((-?\\d+(?:\\.\\d+)?)px\\)`, "i").exec(
+    normalized,
+  );
+  if (!match) return 0;
+  const parsed = Number.parseFloat(match[1]);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+export function setCssFilterFunctionPx(
+  value: string | undefined,
+  name: string,
+  nextPx: number,
+): string {
+  const nextValue = clampPanelNumber(nextPx, 0, 200, 0);
+  const functions = splitCssFunctions(value && value.trim() !== EMPTY_FILTER_VALUE ? value : "");
+  const lowerName = name.toLowerCase();
+  const filtered = functions.filter((entry) => !entry.toLowerCase().startsWith(`${lowerName}(`));
+  if (nextValue > 0) filtered.push(`${name}(${formatNumericValue(nextValue)}px)`);
+  return filtered.length > 0 ? filtered.join(" ") : EMPTY_FILTER_VALUE;
+}
+
+export function inferBoxShadowPreset(value: string | undefined): BoxShadowPreset {
+  const normalized = value?.trim() || "none";
+  for (const [preset, shadow] of Object.entries(BOX_SHADOW_PRESETS)) {
+    if (normalized === shadow) return preset as BoxShadowPreset;
+  }
+  return normalized === "none" ? "none" : "custom";
+}
+
+function buildBoxShadowPresetValue(preset: BoxShadowPreset, fallback: string | undefined): string {
+  if (preset === "custom") return fallback?.trim() || "none";
+  return BOX_SHADOW_PRESETS[preset];
+}
+
+export function inferClipPathPreset(
+  value: string | undefined,
+): "none" | "inset" | "circle" | "custom" {
+  const normalized = value?.trim();
+  if (!normalized || normalized === "none") return "none";
+  if (/^inset\(/i.test(normalized)) return "inset";
+  if (/^circle\(/i.test(normalized)) return "circle";
+  return "custom";
+}
+
+export function getClipPathInsetPx(value: string | undefined): number {
+  const match = /^inset\(\s*(-?\d+(?:\.\d+)?)px\b/i.exec(value?.trim() ?? "");
+  if (!match) return 0;
+  const parsed = Number.parseFloat(match[1]);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+export function buildStrokeWidthStyleUpdates(
+  nextWidth: string,
+  currentBorderStyle: string | undefined,
+): Array<[property: string, value: string]> {
+  const updates: Array<[property: string, value: string]> = [["border-width", nextWidth]];
+  const token = parseNumericToken(nextWidth);
+  const style = currentBorderStyle?.trim().toLowerCase() || "none";
+  if (token && token.value > 0 && (style === "none" || style === "hidden")) {
+    updates.push(["border-style", "solid"]);
+  }
+  return updates;
+}
+
+export function buildStrokeStyleUpdates(
+  nextStyle: string,
+  currentBorderWidth: string | undefined,
+): Array<[property: string, value: string]> {
+  const updates: Array<[property: string, value: string]> = [["border-style", nextStyle]];
+  const style = nextStyle.trim().toLowerCase();
+  if (!style || style === "none" || style === "hidden") return updates;
+
+  const token = parseNumericToken(currentBorderWidth?.trim() || "0");
+  if (!token || token.value <= 0) {
+    updates.push(["border-width", "1px"]);
+  }
+  return updates;
+}
+
+function buildClipPathValue(
+  preset: "none" | "inset" | "circle" | "custom",
+  radiusValue: number,
+  fallback: string | undefined,
+) {
+  if (preset === "custom") return fallback?.trim() || "none";
+  if (preset === "circle") return "circle(50% at 50% 50%)";
+  if (preset === "inset") {
+    return `inset(0 round ${formatNumericValue(Math.max(0, radiusValue))}px)`;
+  }
+  return "none";
+}
+
+function buildInsetClipPathValue(insetPx: number, radiusValue: number): string {
+  return `inset(${formatNumericValue(Math.max(0, insetPx))}px round ${formatNumericValue(Math.max(0, radiusValue))}px)`;
 }
 
 function adjustNumericToken(
@@ -1058,6 +1226,75 @@ function FontFamilyField({
   );
 }
 
+function getTextStyleValue(
+  field: DomEditSelection["textFields"][number],
+  inheritedStyles: Record<string, string>,
+  property: string,
+  fallback: string,
+): string {
+  return field.computedStyles[property] || inheritedStyles[property] || fallback;
+}
+
+function AdvancedTextControls({
+  field,
+  inheritedStyles,
+  disabled,
+  onCommit,
+}: {
+  field: DomEditSelection["textFields"][number];
+  inheritedStyles: Record<string, string>;
+  disabled?: boolean;
+  onCommit: (property: string, value: string) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className={RESPONSIVE_GRID}>
+        <MetricField
+          label="Line"
+          value={getTextStyleValue(field, inheritedStyles, "line-height", "normal")}
+          disabled={disabled}
+          liveCommit
+          onCommit={(next) =>
+            onCommit("line-height", normalizeTextMetricValue("line-height", next))
+          }
+        />
+        <MetricField
+          label="Track"
+          value={getTextStyleValue(field, inheritedStyles, "letter-spacing", "0px")}
+          disabled={disabled}
+          liveCommit
+          onCommit={(next) =>
+            onCommit("letter-spacing", normalizeTextMetricValue("letter-spacing", next))
+          }
+        />
+      </div>
+      <div className={RESPONSIVE_GRID}>
+        <SelectField
+          label="Align"
+          value={getTextStyleValue(field, inheritedStyles, "text-align", "start")}
+          disabled={disabled}
+          onChange={(next) => onCommit("text-align", next)}
+          options={["start", "left", "center", "right", "justify", "end"]}
+        />
+        <SelectField
+          label="Case"
+          value={getTextStyleValue(field, inheritedStyles, "text-transform", "none")}
+          disabled={disabled}
+          onChange={(next) => onCommit("text-transform", next)}
+          options={["none", "uppercase", "lowercase", "capitalize"]}
+        />
+      </div>
+      <SelectField
+        label="Style"
+        value={getTextStyleValue(field, inheritedStyles, "font-style", "normal")}
+        disabled={disabled}
+        onChange={(next) => onCommit("font-style", next)}
+        options={["normal", "italic", "oblique"]}
+      />
+    </div>
+  );
+}
+
 function ColorField({
   label,
   value,
@@ -1896,6 +2133,8 @@ function SelectField({
   options: string[];
   onChange: (nextValue: string) => void;
 }) {
+  const renderedOptions = value && !options.includes(value) ? [value, ...options] : options;
+
   return (
     <label className="grid min-w-0 gap-1.5">
       <span className={LABEL}>{label}</span>
@@ -1906,7 +2145,7 @@ function SelectField({
           onChange={(e) => onChange(e.target.value)}
           className="min-w-0 w-full appearance-none bg-transparent text-[11px] font-medium text-neutral-100 outline-none disabled:cursor-not-allowed disabled:text-neutral-600"
         >
-          {options.map((option) => (
+          {renderedOptions.map((option) => (
             <option key={option} value={option}>
               {option}
             </option>
@@ -2035,7 +2274,19 @@ export const PropertyPanel = memo(function PropertyPanel({
   const isFlex = styles.display === "flex" || styles.display === "inline-flex";
   const radiusValue = parseNumericValue(styles["border-radius"]) ?? 0;
   const opacityValue = Math.round((parseNumericValue(styles.opacity) ?? 1) * 100);
-  const clipContent = ["hidden", "clip"].includes((styles.overflow ?? "").trim());
+  const borderWidthValue =
+    parsePxMetricValue(styles["border-width"] ?? "") ??
+    parsePxMetricValue(styles["border-top-width"] ?? "") ??
+    0;
+  const borderStyleValue = styles["border-style"] || styles["border-top-style"] || "none";
+  const borderColorValue =
+    styles["border-color"] || styles["border-top-color"] || "rgba(255, 255, 255, 0.18)";
+  const boxShadowPreset = inferBoxShadowPreset(styles["box-shadow"]);
+  const filterBlurValue = getCssFilterFunctionPx(styles.filter, "blur");
+  const backdropBlurValue = getCssFilterFunctionPx(styles["backdrop-filter"], "blur");
+  const clipPathValue = styles["clip-path"] || "none";
+  const clipPathPreset = inferClipPathPreset(clipPathValue);
+  const clipInsetValue = getClipPathInsetPx(clipPathValue);
   const sourceLabel = element.id ? `#${element.id}` : element.selector;
   const showEditableSections = element.capabilities.canEditStyles;
   const manualOffset = readStudioPathOffset(element.element);
@@ -2203,16 +2454,6 @@ export const PropertyPanel = memo(function PropertyPanel({
                 disabled={styleEditingDisabled}
                 onCommit={(next) => onSetStyle("gap", next.endsWith("px") ? next : `${next}px`)}
               />
-              <label className="flex items-center gap-3 rounded-2xl border border-neutral-800 bg-neutral-900 px-3 py-3 text-[12px] text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-                <input
-                  type="checkbox"
-                  checked={clipContent}
-                  disabled={styleEditingDisabled}
-                  onChange={(e) => onSetStyle("overflow", e.target.checked ? "hidden" : "visible")}
-                  className="h-4 w-4 rounded border-neutral-700 bg-neutral-950 text-[#3ce6ac] focus:ring-[#3ce6ac]"
-                />
-                <span>Clip content</span>
-              </label>
             </div>
           </Section>
         )}
@@ -2230,6 +2471,163 @@ export const PropertyPanel = memo(function PropertyPanel({
                 formatDisplayValue={(next) => `${formatNumericValue(next)}px`}
                 onCommit={(next) => onSetStyle("border-radius", `${formatNumericValue(next)}px`)}
               />
+            </Section>
+
+            <Section title="Stroke" icon={<Square size={15} />}>
+              <div className="space-y-4">
+                <div className={RESPONSIVE_GRID}>
+                  <MetricField
+                    label="Width"
+                    value={formatPxMetricValue(borderWidthValue)}
+                    disabled={styleEditingDisabled}
+                    liveCommit
+                    onCommit={async (next) => {
+                      const normalized = normalizePanelPxValue(next, {
+                        min: 0,
+                        max: 200,
+                        fallback: borderWidthValue,
+                      });
+                      if (!normalized) return;
+                      for (const [property, value] of buildStrokeWidthStyleUpdates(
+                        normalized,
+                        borderStyleValue,
+                      )) {
+                        await onSetStyle(property, value);
+                      }
+                    }}
+                  />
+                  <SelectField
+                    label="Style"
+                    value={borderStyleValue}
+                    disabled={styleEditingDisabled}
+                    onChange={async (next) => {
+                      for (const [property, value] of buildStrokeStyleUpdates(
+                        next,
+                        formatPxMetricValue(borderWidthValue),
+                      )) {
+                        await onSetStyle(property, value);
+                      }
+                    }}
+                    options={[
+                      "none",
+                      "solid",
+                      "dashed",
+                      "dotted",
+                      "double",
+                      "hidden",
+                      "groove",
+                      "ridge",
+                      "inset",
+                      "outset",
+                    ]}
+                  />
+                </div>
+                <ColorField
+                  label="Stroke color"
+                  value={borderColorValue}
+                  disabled={styleEditingDisabled}
+                  onCommit={(next) => onSetStyle("border-color", next)}
+                />
+              </div>
+            </Section>
+
+            <Section title="Effects" icon={<Zap size={15} />}>
+              <div className="space-y-4">
+                <SelectField
+                  label="Shadow"
+                  value={boxShadowPreset}
+                  disabled={styleEditingDisabled}
+                  onChange={(next) => {
+                    if (next === "custom") return;
+                    onSetStyle(
+                      "box-shadow",
+                      buildBoxShadowPresetValue(next as BoxShadowPreset, styles["box-shadow"]),
+                    );
+                  }}
+                  options={["custom", "none", "soft", "lift", "glow"]}
+                />
+                <div className={RESPONSIVE_GRID}>
+                  <div className="grid min-w-0 gap-1.5">
+                    <span className={LABEL}>Layer blur</span>
+                    <SliderControl
+                      value={filterBlurValue}
+                      min={0}
+                      max={Math.max(40, Math.ceil(filterBlurValue))}
+                      step={1}
+                      disabled={styleEditingDisabled}
+                      displayValue={`${formatNumericValue(filterBlurValue)}px`}
+                      formatDisplayValue={(next) => `${formatNumericValue(next)}px`}
+                      onCommit={(next) =>
+                        onSetStyle("filter", setCssFilterFunctionPx(styles.filter, "blur", next))
+                      }
+                    />
+                  </div>
+                  <div className="grid min-w-0 gap-1.5">
+                    <span className={LABEL}>Backdrop</span>
+                    <SliderControl
+                      value={backdropBlurValue}
+                      min={0}
+                      max={Math.max(60, Math.ceil(backdropBlurValue))}
+                      step={1}
+                      disabled={styleEditingDisabled}
+                      displayValue={`${formatNumericValue(backdropBlurValue)}px`}
+                      formatDisplayValue={(next) => `${formatNumericValue(next)}px`}
+                      onCommit={(next) =>
+                        onSetStyle(
+                          "backdrop-filter",
+                          setCssFilterFunctionPx(styles["backdrop-filter"], "blur", next),
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+            </Section>
+
+            <Section title="Clip" icon={<Layers size={15} />}>
+              <div className="space-y-4">
+                <div className={RESPONSIVE_GRID}>
+                  <SelectField
+                    label="Overflow"
+                    value={styles.overflow || "visible"}
+                    disabled={styleEditingDisabled}
+                    onChange={(next) => onSetStyle("overflow", next)}
+                    options={["visible", "hidden", "clip", "auto", "scroll"]}
+                  />
+                  <SelectField
+                    label="Mask"
+                    value={clipPathPreset}
+                    disabled={styleEditingDisabled}
+                    onChange={(next) => {
+                      if (next === "custom") return;
+                      onSetStyle(
+                        "clip-path",
+                        buildClipPathValue(
+                          next as "none" | "inset" | "circle",
+                          radiusValue,
+                          clipPathValue,
+                        ),
+                      );
+                    }}
+                    options={["custom", "none", "inset", "circle"]}
+                  />
+                </div>
+                <div className="grid min-w-0 gap-1.5">
+                  <span className={LABEL}>Mask inset</span>
+                  <SliderControl
+                    value={clipInsetValue}
+                    min={0}
+                    max={Math.max(120, Math.ceil(clipInsetValue))}
+                    step={1}
+                    disabled={styleEditingDisabled}
+                    displayValue={`${formatNumericValue(clipInsetValue)}px`}
+                    formatDisplayValue={(next) => `${formatNumericValue(next)}px`}
+                    onCommit={(next) =>
+                      onSetStyle("clip-path", buildInsetClipPathValue(next, radiusValue))
+                    }
+                  />
+                </div>
+              </div>
             </Section>
 
             <Section title="Blending" icon={<Eye size={15} />}>
@@ -2389,6 +2787,15 @@ export const PropertyPanel = memo(function PropertyPanel({
                             onSetTextFieldStyle(activeField.key, "font-family", next)
                           }
                         />
+
+                        <AdvancedTextControls
+                          field={activeField}
+                          inheritedStyles={styles}
+                          disabled={false}
+                          onCommit={(property, value) =>
+                            onSetTextFieldStyle(activeField.key, property, value)
+                          }
+                        />
                       </div>
                     );
                   }
@@ -2512,6 +2919,15 @@ export const PropertyPanel = memo(function PropertyPanel({
                           onImportFonts={onImportFonts}
                           onCommit={(next) =>
                             onSetTextFieldStyle(activeField.key, "font-family", next)
+                          }
+                        />
+
+                        <AdvancedTextControls
+                          field={activeField}
+                          inheritedStyles={styles}
+                          disabled={false}
+                          onCommit={(property, value) =>
+                            onSetTextFieldStyle(activeField.key, property, value)
                           }
                         />
                       </div>

--- a/packages/studio/src/components/editor/TimelineLayerPanel.test.ts
+++ b/packages/studio/src/components/editor/TimelineLayerPanel.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { Window } from "happy-dom";
+import type { DomEditLayerItem } from "./domEditing";
+import { getTimelineLayerPanelSummary } from "./TimelineLayerPanel";
+
+function createLayer(overrides: Partial<DomEditLayerItem> = {}): DomEditLayerItem {
+  const window = new Window();
+  return {
+    childCount: 0,
+    depth: 0,
+    element: window.document.createElement(overrides.tagName ?? "div"),
+    key: "layer",
+    label: "Layer",
+    sourceFile: "index.html",
+    tagName: "div",
+    ...overrides,
+  };
+}
+
+describe("TimelineLayerPanel", () => {
+  it("describes a leaf media clip as a single selectable layer", () => {
+    expect(
+      getTimelineLayerPanelSummary([
+        createLayer({ key: "alpha-video", label: "Alpha Video", tagName: "video" }),
+      ]),
+    ).toBe("Single selectable media layer");
+  });
+
+  it("describes real nested layers with the nested count", () => {
+    expect(
+      getTimelineLayerPanelSummary([
+        createLayer({ key: "root", childCount: 2 }),
+        createLayer({ key: "title", depth: 1 }),
+        createLayer({ key: "subtitle", depth: 1 }),
+      ]),
+    ).toBe("2 nested selectable layers");
+  });
+
+  it("keeps empty layer lists explicit", () => {
+    expect(getTimelineLayerPanelSummary([])).toBe("No selectable layers");
+  });
+});

--- a/packages/studio/src/components/editor/TimelineLayerPanel.tsx
+++ b/packages/studio/src/components/editor/TimelineLayerPanel.tsx
@@ -1,0 +1,113 @@
+import { memo } from "react";
+import type { DomEditLayerItem } from "./domEditing";
+
+interface TimelineLayerPanelProps {
+  clipLabel: string;
+  layers: DomEditLayerItem[];
+  selectedLayerKey: string | null;
+  onSelectLayer: (layer: DomEditLayerItem) => void;
+  onClose: () => void;
+}
+
+const MEDIA_LAYER_TAGS = new Set(["audio", "canvas", "img", "picture", "svg", "video"]);
+
+export function getTimelineLayerPanelSummary(layers: readonly DomEditLayerItem[]): string {
+  const childCount = Math.max(0, layers.length - 1);
+  if (childCount > 0) {
+    return `${childCount} nested selectable layer${childCount === 1 ? "" : "s"}`;
+  }
+  const layer = layers[0];
+  if (!layer) return "No selectable layers";
+  return MEDIA_LAYER_TAGS.has(layer.tagName.trim().toLowerCase())
+    ? "Single selectable media layer"
+    : "Single selectable layer";
+}
+
+export const TimelineLayerPanel = memo(function TimelineLayerPanel({
+  clipLabel,
+  layers,
+  selectedLayerKey,
+  onSelectLayer,
+  onClose,
+}: TimelineLayerPanelProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-neutral-950">
+      <div className="flex items-start justify-between gap-3 border-b border-white/10 px-3 py-3">
+        <div className="min-w-0">
+          <div className="text-[9px] font-semibold uppercase tracking-[0.18em] text-neutral-500">
+            Clip layers
+          </div>
+          <div className="mt-1 truncate text-sm font-semibold text-neutral-100">{clipLabel}</div>
+        </div>
+        <button
+          type="button"
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+          onClick={onClose}
+          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-white/10 bg-black/20 text-neutral-500 transition-colors hover:border-white/20 hover:text-neutral-200"
+          aria-label="Close clip layers"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      </div>
+      <div className="border-b border-white/10 px-3 py-2 text-[11px] text-neutral-500">
+        {getTimelineLayerPanelSummary(layers)}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {layers.map((layer) => {
+          const selected = layer.key === selectedLayerKey;
+          return (
+            <button
+              key={layer.key}
+              type="button"
+              data-timeline-layer-row={layer.key}
+              onPointerDown={(event) => {
+                event.stopPropagation();
+                onSelectLayer(layer);
+              }}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectLayer(layer);
+              }}
+              className={`group flex w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors ${
+                selected
+                  ? "bg-studio-accent/14 text-studio-accent"
+                  : "text-neutral-300 hover:bg-white/[0.04] hover:text-neutral-100"
+              }`}
+              style={{ paddingLeft: 10 + layer.depth * 14 }}
+            >
+              <span
+                className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md border text-[9px] font-bold uppercase ${
+                  selected
+                    ? "border-studio-accent/50 bg-studio-accent/18"
+                    : "border-white/10 bg-black/20 text-neutral-500 group-hover:text-neutral-300"
+                }`}
+              >
+                {layer.tagName.slice(0, 2)}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-xs font-medium">{layer.label}</span>
+              {layer.childCount > 0 && (
+                <span className="rounded-full border border-white/10 bg-black/25 px-1.5 py-0.5 text-[9px] font-semibold tabular-nums text-neutral-500">
+                  {layer.childCount}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/packages/studio/src/components/editor/domEditing.test.ts
+++ b/packages/studio/src/components/editor/domEditing.test.ts
@@ -3,7 +3,10 @@ import { Window } from "happy-dom";
 import {
   buildDomEditStylePatchOperation,
   buildElementAgentPrompt,
+  collectDomEditLayerItems,
+  countDomEditChildLayers,
   findElementForSelection,
+  findElementForTimelineElement,
   getDomEditNonEditableReason,
   getDomEditTargetKey,
   isTextEditableSelection,
@@ -355,6 +358,66 @@ describe("resolveDomEditSelection", () => {
     expect(findElementForSelection(document, selection!, null)).toBe(nestedCard);
   });
 
+  it("does not throw when a generated timeline identity is passed as a selector", () => {
+    const document = createDocument(`
+      <div data-composition-id="main">
+        <div class="topline">Logo</div>
+      </div>
+    `);
+
+    expect(() =>
+      findElementForSelection(
+        document,
+        {
+          id: "index.html:Hyperframes Logo Light:0",
+          selector:
+            '[data-composition-id="index.html:Hyperframes Logo Light:0"],#index.html:Hyperframes Logo Light:0',
+          sourceFile: "index.html",
+        },
+        null,
+      ),
+    ).not.toThrow();
+    expect(
+      findElementForSelection(
+        document,
+        {
+          id: "index.html:Hyperframes Logo Light:0",
+          selector:
+            '[data-composition-id="index.html:Hyperframes Logo Light:0"],#index.html:Hyperframes Logo Light:0',
+          sourceFile: "index.html",
+        },
+        null,
+      ),
+    ).toBeNull();
+  });
+
+  it("escapes ids and composition ids when creating stable selectors", () => {
+    const document = createDocument(`
+      <div data-composition-id="main">
+        <div id="logo:light">Logo</div>
+        <div data-composition-id="scene:one">Scene</div>
+      </div>
+    `);
+    const logo = document.getElementById("logo:light") as HTMLElement;
+    const scene = Array.from(document.querySelectorAll("[data-composition-id]")).find(
+      (element) => element.getAttribute("data-composition-id") === "scene:one",
+    ) as HTMLElement;
+
+    const logoSelection = resolveDomEditSelection(logo, {
+      activeCompositionPath: null,
+      isMasterView: true,
+    });
+    const sceneSelection = resolveDomEditSelection(scene, {
+      activeCompositionPath: null,
+      isMasterView: true,
+    });
+
+    expect(logoSelection?.selector).not.toBe("#logo:light");
+    expect(findElementForSelection(document, logoSelection!, null)).toBe(logo);
+    expect(sceneSelection?.selector).toBe('[data-composition-id="scene:one"]');
+    expect(findElementForSelection(document, sceneSelection!, null)).toBe(scene);
+  });
+
   it("prefers the nearest clip ancestor on single-click style selection", () => {
     const document = createDocument(`
       <section id="card" class="clip" style="left: 10px; top: 20px; width: 200px; height: 100px; position: absolute;">
@@ -514,6 +577,90 @@ describe("resolveDomEditSelection", () => {
 
     expect(first).not.toBe(second);
   });
+
+  it("resolves generated timeline ids without throwing", () => {
+    const document = createDocument(`
+      <div data-composition-id="hook">
+        <div class="topline">Topline</div>
+      </div>
+    `);
+
+    expect(
+      findElementForTimelineElement(
+        document,
+        { id: "index.html:Hyperframes Logo Light:0", sourceFile: "index.html" },
+        {
+          activeCompositionPath: null,
+          isMasterView: true,
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to the root composition for standalone manifest clips without DOM targets", () => {
+    const document = createDocument(`
+      <div data-composition-id="hook">
+        <div class="topline">Topline</div>
+        <div class="scene-shell">Scene</div>
+      </div>
+    `);
+    const root = document.querySelector("[data-composition-id]") as HTMLElement;
+
+    expect(
+      findElementForTimelineElement(
+        document,
+        { id: "compositions/hook.html:Hyperframes Logo Light:0" },
+        {
+          activeCompositionPath: "compositions/hook.html",
+          isMasterView: false,
+        },
+      ),
+    ).toBe(root);
+  });
+
+  it("resolves the standalone composition root when the fallback clip carries source metadata", () => {
+    const document = createDocument(`
+      <div data-composition-id="manual">
+        <div class="scene-shell">Scene</div>
+      </div>
+    `);
+    const root = document.querySelector("[data-composition-id]") as HTMLElement;
+
+    expect(
+      findElementForTimelineElement(
+        document,
+        {
+          id: "manual",
+          compositionSrc: "compositions/manual.html",
+          selector: '[data-composition-id="manual"]',
+          sourceFile: "compositions/manual.html",
+        },
+        {
+          activeCompositionPath: "compositions/manual.html",
+          isMasterView: false,
+        },
+      ),
+    ).toBe(root);
+  });
+
+  it("does not fall back to the root composition when an explicit timeline selector misses", () => {
+    const document = createDocument(`
+      <div data-composition-id="hook">
+        <div class="topline">Topline</div>
+      </div>
+    `);
+
+    expect(
+      findElementForTimelineElement(
+        document,
+        { selector: ".missing", sourceFile: "compositions/hook.html" },
+        {
+          activeCompositionPath: "compositions/hook.html",
+          isMasterView: false,
+        },
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("patch builders and prompt builder", () => {
@@ -665,5 +812,61 @@ describe("patch builders and prompt builder", () => {
     ).toBe(
       '<strong data-hf-text-key="child:0:strong" style="font-size: 22px">Headline &lt;1&gt;</strong><span data-hf-text-key="child:1:span">Details &amp; more</span>',
     );
+  });
+
+  it("collects nested timeline layers with stable keys and child counts", () => {
+    const doc = createDocument(`
+      <div data-composition-id="hook" data-composition-file="compositions/hook.html">
+        <section class="scene-shell">
+          <div class="topline">
+            <span class="brand">HyperFrames</span>
+            <span class="badge">Alpha</span>
+          </div>
+        </section>
+      </div>
+    `);
+    const root = doc.querySelector(".scene-shell") as HTMLElement;
+    const layers = collectDomEditLayerItems(root, {
+      activeCompositionPath: "compositions/hook.html",
+      isMasterView: false,
+    });
+
+    expect(
+      countDomEditChildLayers(root, {
+        activeCompositionPath: "compositions/hook.html",
+        isMasterView: false,
+      }),
+    ).toBe(3);
+    expect(layers.map((layer) => layer.label)).toEqual([
+      "Scene Shell",
+      "Topline",
+      "Brand",
+      "Badge",
+    ]);
+    expect(layers[0]?.childCount).toBe(1);
+    expect(layers.find((layer) => layer.label === "Brand")?.key).toBe(
+      "compositions/hook.html:.brand:0",
+    );
+  });
+
+  it("collects timeline layers with SVG descendants without crashing", () => {
+    const doc = createDocument(`
+      <div data-composition-id="hook" data-composition-file="compositions/hook.html">
+        <section class="scene-shell">
+          <svg class="brand-mark" viewBox="0 0 24 24">
+            <path class="brand-path" d="M0 0h24v24H0z"></path>
+          </svg>
+          <div class="title">HyperFrames</div>
+        </section>
+      </div>
+    `);
+    const root = doc.querySelector(".scene-shell") as HTMLElement;
+
+    expect(() =>
+      collectDomEditLayerItems(root, {
+        activeCompositionPath: "compositions/hook.html",
+        isMasterView: false,
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/studio/src/components/editor/domEditing.ts
+++ b/packages/studio/src/components/editor/domEditing.ts
@@ -16,18 +16,31 @@ const CURATED_STYLE_PROPERTIES = [
   "align-items",
   "flex-direction",
   "font-size",
+  "font-style",
   "font-weight",
   "font-family",
+  "line-height",
+  "letter-spacing",
+  "text-align",
+  "text-transform",
   "color",
   "background-color",
   "background-image",
   "opacity",
   "mix-blend-mode",
   "border-radius",
+  "border-width",
+  "border-style",
   "border-color",
+  "border-top-width",
+  "border-top-style",
+  "border-top-color",
   "outline-color",
   "overflow",
+  "clip-path",
   "box-shadow",
+  "filter",
+  "backdrop-filter",
   "z-index",
   "transform",
 ] as const;
@@ -73,10 +86,38 @@ export interface DomEditSelection extends PatchTarget {
   capabilities: DomEditCapabilities;
 }
 
+export interface DomEditLayerItem {
+  key: string;
+  element: HTMLElement;
+  label: string;
+  tagName: string;
+  depth: number;
+  childCount: number;
+  id?: string;
+  selector?: string;
+  selectorIndex?: number;
+  sourceFile: string;
+}
+
 export interface DomEditContextOptions {
   activeCompositionPath: string | null;
   isMasterView: boolean;
   preferClipAncestor?: boolean;
+}
+
+export interface TimelineElementDomTarget {
+  id?: string;
+  domId?: string;
+  selector?: string;
+  selectorIndex?: number;
+  sourceFile?: string;
+  compositionSrc?: string;
+}
+
+export interface TimelineElementDomTargetOptions {
+  activeCompositionPath: string | null;
+  compIdToSrc?: ReadonlyMap<string, string>;
+  isMasterView: boolean;
 }
 
 function isHtmlElement(value: unknown): value is HTMLElement {
@@ -198,14 +239,64 @@ function getSelectionCandidate(startEl: HTMLElement, options: DomEditContextOpti
 }
 
 function getPreferredClassSelector(el: HTMLElement): string | undefined {
-  const classes = el.className
-    .split(/\s+/)
+  const classes = Array.from(el.classList)
     .map((value) => value.trim())
     .filter(Boolean);
   if (classes.length === 0) return undefined;
   const preferred =
     classes.find((value) => value !== "clip" && !value.startsWith("__hf-")) ?? classes[0];
-  return preferred ? `.${preferred}` : undefined;
+  return preferred ? `.${escapeCssIdentifier(preferred)}` : undefined;
+}
+
+function escapeCssIdentifier(value: string): string {
+  const css = globalThis.CSS as { escape?: (input: string) => string } | undefined;
+  if (typeof css?.escape === "function") return css.escape(value);
+
+  if (value === "-") return "\\-";
+
+  let escaped = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index] ?? "";
+    const code = char.charCodeAt(0);
+    if (code === 0) {
+      escaped += "\uFFFD";
+      continue;
+    }
+
+    const isDigit = code >= 48 && code <= 57;
+    const isUpperAlpha = code >= 65 && code <= 90;
+    const isLowerAlpha = code >= 97 && code <= 122;
+    const isControl = (code >= 1 && code <= 31) || code === 127;
+    const isLeadingDigit = index === 0 && isDigit;
+    const isSecondDigitAfterDash = index === 1 && value.startsWith("-") && isDigit;
+    if (isControl || isLeadingDigit || isSecondDigitAfterDash) {
+      escaped += `\\${code.toString(16)} `;
+      continue;
+    }
+    if (isUpperAlpha || isLowerAlpha || isDigit || char === "-" || char === "_" || code >= 128) {
+      escaped += char;
+      continue;
+    }
+    escaped += `\\${char}`;
+  }
+  return escaped;
+}
+
+function escapeCssString(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\a ")
+    .replace(/\r/g, "\\d ")
+    .replace(/\f/g, "\\c ");
+}
+
+function querySelectorAllSafely(doc: Document, selector: string): Element[] {
+  try {
+    return Array.from(doc.querySelectorAll(selector));
+  } catch {
+    return [];
+  }
 }
 
 function humanizeIdentifier(value: string): string {
@@ -221,10 +312,10 @@ function humanizeIdentifier(value: string): string {
 }
 
 function buildStableSelector(el: HTMLElement): string | undefined {
-  if (el.id) return `#${el.id}`;
+  if (el.id) return `#${escapeCssIdentifier(el.id)}`;
 
   const compositionId = el.getAttribute("data-composition-id");
-  if (compositionId) return `[data-composition-id="${compositionId}"]`;
+  if (compositionId) return `[data-composition-id="${escapeCssString(compositionId)}"]`;
 
   return getPreferredClassSelector(el);
 }
@@ -238,13 +329,20 @@ function getSelectorIndex(
 ): number | undefined {
   if (!selector?.startsWith(".")) return undefined;
 
-  const candidates = Array.from(doc.querySelectorAll(selector)).filter(
+  const candidates = querySelectorAllSafely(doc, selector).filter(
     (candidate): candidate is HTMLElement =>
       isHtmlElement(candidate) &&
       getSourceFileForElement(candidate, activeCompositionPath).sourceFile === sourceFile,
   );
   const index = candidates.indexOf(el);
   return index >= 0 ? index : undefined;
+}
+
+export function getDomEditLayerKey(
+  target: Pick<DomEditSelection, "id" | "selector" | "selectorIndex" | "sourceFile">,
+): string {
+  const selectorIndex = target.selectorIndex ?? 0;
+  return `${target.sourceFile}:${target.id ?? target.selector ?? "layer"}:${selectorIndex}`;
 }
 
 function buildElementLabel(el: HTMLElement): string {
@@ -269,6 +367,123 @@ function buildElementLabel(el: HTMLElement): string {
   const text = (el.textContent ?? "").trim().replace(/\s+/g, " ");
   if (text) return text.length > 40 ? `${text.slice(0, 39)}…` : text;
   return el.tagName.toLowerCase();
+}
+
+const DOM_LAYER_IGNORED_TAGS = new Set([
+  "base",
+  "br",
+  "link",
+  "meta",
+  "script",
+  "source",
+  "style",
+  "template",
+  "track",
+  "wbr",
+]);
+
+function isInspectableLayerElement(el: HTMLElement): boolean {
+  const tagName = el.tagName.toLowerCase();
+  if (DOM_LAYER_IGNORED_TAGS.has(tagName)) return false;
+
+  const computed = el.ownerDocument.defaultView?.getComputedStyle(el);
+  if (computed?.display === "none" || computed?.visibility === "hidden") return false;
+
+  return true;
+}
+
+function getDomLayerPatchTarget(
+  el: HTMLElement,
+  activeCompositionPath: string | null,
+): Pick<DomEditSelection, "id" | "selector" | "selectorIndex" | "sourceFile"> | null {
+  if (!isInspectableLayerElement(el)) return null;
+
+  const selector = buildStableSelector(el);
+  if (!selector) return null;
+
+  const { sourceFile } = getSourceFileForElement(el, activeCompositionPath);
+  return {
+    id: el.id || undefined,
+    selector,
+    selectorIndex: getSelectorIndex(
+      el.ownerDocument,
+      el,
+      selector,
+      sourceFile,
+      activeCompositionPath,
+    ),
+    sourceFile,
+  };
+}
+
+function getDirectLayerChildren(el: HTMLElement, options: DomEditContextOptions): HTMLElement[] {
+  return Array.from(el.children).filter(
+    (child): child is HTMLElement =>
+      isHtmlElement(child) && getDomLayerPatchTarget(child, options.activeCompositionPath) !== null,
+  );
+}
+
+export function countDomEditChildLayers(
+  root: HTMLElement | null | undefined,
+  options: DomEditContextOptions,
+  maxCount = 99,
+): number {
+  if (!root) return 0;
+
+  let count = 0;
+  const visit = (el: HTMLElement) => {
+    for (const child of Array.from(el.children)) {
+      if (!isHtmlElement(child)) continue;
+      if (getDomLayerPatchTarget(child, options.activeCompositionPath)) {
+        count += 1;
+        if (count >= maxCount) return;
+      }
+      visit(child);
+      if (count >= maxCount) return;
+    }
+  };
+
+  visit(root);
+  return count;
+}
+
+export function collectDomEditLayerItems(
+  root: HTMLElement | null | undefined,
+  options: DomEditContextOptions,
+  maxItems = 80,
+): DomEditLayerItem[] {
+  if (!root) return [];
+
+  const items: DomEditLayerItem[] = [];
+  const visit = (el: HTMLElement, depth: number) => {
+    if (items.length >= maxItems) return;
+
+    const target = getDomLayerPatchTarget(el, options.activeCompositionPath);
+    if (target) {
+      items.push({
+        key: getDomEditLayerKey(target),
+        element: el,
+        label: buildElementLabel(el),
+        tagName: el.tagName.toLowerCase(),
+        depth,
+        childCount: getDirectLayerChildren(el, options).length,
+        id: target.id ?? undefined,
+        selector: target.selector ?? undefined,
+        selectorIndex: target.selectorIndex,
+        sourceFile: target.sourceFile,
+      });
+    }
+
+    const nextDepth = target ? depth + 1 : depth;
+    for (const child of Array.from(el.children)) {
+      if (!isHtmlElement(child)) continue;
+      visit(child, nextDepth);
+      if (items.length >= maxItems) return;
+    }
+  };
+
+  visit(root, 0);
+  return items;
 }
 
 function getDataAttributes(el: HTMLElement): Record<string, string> {
@@ -607,7 +822,7 @@ export function findElementForSelection(
   if (!selection.selector) return null;
 
   if (selection.selector.startsWith(".") && selection.selectorIndex != null) {
-    const matches = Array.from(doc.querySelectorAll(selection.selector)).filter(
+    const matches = querySelectorAllSafely(doc, selection.selector).filter(
       (candidate): candidate is HTMLElement =>
         isHtmlElement(candidate) &&
         (!selection.sourceFile ||
@@ -617,7 +832,7 @@ export function findElementForSelection(
     return matches[selection.selectorIndex] ?? null;
   }
 
-  const matches = Array.from(doc.querySelectorAll(selection.selector)).filter(
+  const matches = querySelectorAllSafely(doc, selection.selector).filter(
     (candidate): candidate is HTMLElement =>
       isHtmlElement(candidate) &&
       (!selection.sourceFile ||
@@ -625,6 +840,51 @@ export function findElementForSelection(
           selection.sourceFile),
   );
   return matches[0] ?? null;
+}
+
+export function findElementForTimelineElement(
+  doc: Document,
+  element: TimelineElementDomTarget,
+  options: TimelineElementDomTargetOptions,
+): HTMLElement | null {
+  const elementId = typeof element.id === "string" ? element.id : "";
+  const compositionSource = element.compositionSrc ?? options.compIdToSrc?.get(elementId);
+  const sourceFile =
+    compositionSource ?? element.sourceFile ?? options.activeCompositionPath ?? "index.html";
+  const escapedElementId = escapeCssString(elementId);
+  const escapedCompositionSource = compositionSource ? escapeCssString(compositionSource) : null;
+  const selector =
+    element.selector ??
+    (compositionSource
+      ? `[data-composition-src="${escapedCompositionSource}"],[data-composition-file="${escapedCompositionSource}"],[data-composition-id="${escapedElementId}"]`
+      : escapedElementId
+        ? `[data-composition-id="${escapedElementId}"]`
+        : undefined);
+
+  if (selector || element.domId) {
+    const targetElement = findElementForSelection(
+      doc,
+      {
+        id: element.domId ?? undefined,
+        selector,
+        selectorIndex: element.selectorIndex,
+        sourceFile,
+      },
+      options.activeCompositionPath,
+    );
+    if (targetElement) return targetElement;
+  }
+
+  const hasExplicitDomTarget = Boolean(element.domId || element.selector || compositionSource);
+  if (options.isMasterView || hasExplicitDomTarget || !options.activeCompositionPath) {
+    return null;
+  }
+
+  const root = doc.querySelector("[data-composition-id]");
+  if (!isHtmlElement(root)) return null;
+  return getSourceFileForElement(root, options.activeCompositionPath).sourceFile === sourceFile
+    ? root
+    : null;
 }
 
 export function buildDomEditStylePatchOperation(property: string, value: string): PatchOperation {

--- a/packages/studio/src/components/editor/manualEditingAvailability.test.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveStudioBooleanEnvFlag } from "./manualEditingAvailability";
+
+async function loadAvailabilityWithEnv(env: Record<string, string | undefined>) {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) vi.stubEnv(key, value);
+  }
+  return import("./manualEditingAvailability");
+}
+
+describe("manual editing availability", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("keeps alpha inspector and manual editing surfaces disabled by default", async () => {
+    const availability = await loadAvailabilityWithEnv({});
+
+    expect(availability.STUDIO_PREVIEW_MANUAL_EDITING_ENABLED).toBe(false);
+    expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(false);
+    expect(availability.STUDIO_MOTION_PANEL_ENABLED).toBe(false);
+    expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(false);
+  });
+
+  it("enables inspector layers only through explicit opt-in flags", async () => {
+    const availability = await loadAvailabilityWithEnv({
+      VITE_STUDIO_ENABLE_INSPECTOR_PANELS: "1",
+      VITE_STUDIO_ENABLE_TIMELINE_LAYER_INSPECTOR: "true",
+    });
+
+    expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(true);
+    expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(true);
+  });
+
+  it("keeps timeline layer inspection off when the parent inspector flag is off", async () => {
+    const availability = await loadAvailabilityWithEnv({
+      VITE_STUDIO_ENABLE_INSPECTOR_PANELS: "0",
+      VITE_STUDIO_ENABLE_TIMELINE_LAYER_INSPECTOR: "true",
+    });
+
+    expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(false);
+    expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(false);
+  });
+
+  it("enables feature flags with explicit truthy env values", () => {
+    expect(
+      resolveStudioBooleanEnvFlag(
+        { VITE_STUDIO_ENABLE_PREVIEW_MANUAL_DRAGGING: "true" },
+        ["VITE_STUDIO_ENABLE_PREVIEW_MANUAL_DRAGGING"],
+        false,
+      ),
+    ).toBe(true);
+    expect(
+      resolveStudioBooleanEnvFlag(
+        { VITE_STUDIO_ENABLE_MOTION_PANEL: "1" },
+        ["VITE_STUDIO_ENABLE_MOTION_PANEL"],
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("disables feature flags with explicit falsy env values", () => {
+    expect(
+      resolveStudioBooleanEnvFlag(
+        { VITE_STUDIO_ENABLE_PREVIEW_MANUAL_DRAGGING: "off" },
+        ["VITE_STUDIO_ENABLE_PREVIEW_MANUAL_DRAGGING"],
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      resolveStudioBooleanEnvFlag(
+        { VITE_STUDIO_ENABLE_MOTION_PANEL: "0" },
+        ["VITE_STUDIO_ENABLE_MOTION_PANEL"],
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("supports legacy flag aliases after the preferred name", () => {
+    expect(
+      resolveStudioBooleanEnvFlag(
+        { VITE_STUDIO_PREVIEW_MANUAL_EDITING_ENABLED: "yes" },
+        [
+          "VITE_STUDIO_ENABLE_PREVIEW_MANUAL_DRAGGING",
+          "VITE_STUDIO_PREVIEW_MANUAL_EDITING_ENABLED",
+        ],
+        false,
+      ),
+    ).toBe(true);
+    expect(
+      resolveStudioBooleanEnvFlag(
+        { VITE_STUDIO_MOTION_PANEL_ENABLED: "enabled" },
+        ["VITE_STUDIO_ENABLE_MOTION_PANEL", "VITE_STUDIO_MOTION_PANEL_ENABLED"],
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("lets preferred flag values override legacy aliases", () => {
+    expect(
+      resolveStudioBooleanEnvFlag(
+        {
+          VITE_STUDIO_ENABLE_INSPECTOR_PANELS: "off",
+          VITE_STUDIO_INSPECTOR_PANELS_ENABLED: "on",
+        },
+        ["VITE_STUDIO_ENABLE_INSPECTOR_PANELS", "VITE_STUDIO_INSPECTOR_PANELS_ENABLED"],
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back for missing, empty, or unknown env values", () => {
+    expect(resolveStudioBooleanEnvFlag({}, ["MISSING"], false)).toBe(false);
+    expect(resolveStudioBooleanEnvFlag({ EMPTY: "" }, ["EMPTY"], true)).toBe(true);
+    expect(resolveStudioBooleanEnvFlag({ UNKNOWN: "maybe" }, ["UNKNOWN"], false)).toBe(false);
+  });
+});

--- a/packages/studio/src/components/editor/manualEditingAvailability.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.ts
@@ -1,0 +1,60 @@
+export type StudioFeatureFlagEnv = Record<string, boolean | string | undefined>;
+
+export const STUDIO_PREVIEW_MANUAL_DRAGGING_ENV = "VITE_STUDIO_ENABLE_PREVIEW_MANUAL_DRAGGING";
+export const STUDIO_INSPECTOR_PANELS_ENV = "VITE_STUDIO_ENABLE_INSPECTOR_PANELS";
+export const STUDIO_MOTION_PANEL_ENV = "VITE_STUDIO_ENABLE_MOTION_PANEL";
+export const STUDIO_TIMELINE_LAYER_INSPECTOR_ENV = "VITE_STUDIO_ENABLE_TIMELINE_LAYER_INSPECTOR";
+
+const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "on", "enabled"]);
+const FALSY_ENV_VALUES = new Set(["0", "false", "no", "off", "disabled"]);
+
+export function resolveStudioBooleanEnvFlag(
+  env: StudioFeatureFlagEnv,
+  names: string[],
+  fallback: boolean,
+): boolean {
+  for (const name of names) {
+    const value = env[name];
+    if (typeof value === "boolean") return value;
+    if (typeof value !== "string") continue;
+
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) continue;
+    if (TRUTHY_ENV_VALUES.has(normalized)) return true;
+    if (FALSY_ENV_VALUES.has(normalized)) return false;
+  }
+
+  return fallback;
+}
+
+const env = import.meta.env as StudioFeatureFlagEnv;
+
+export const STUDIO_PREVIEW_MANUAL_EDITING_ENABLED = resolveStudioBooleanEnvFlag(
+  env,
+  [STUDIO_PREVIEW_MANUAL_DRAGGING_ENV, "VITE_STUDIO_PREVIEW_MANUAL_EDITING_ENABLED"],
+  false,
+);
+
+export const STUDIO_INSPECTOR_PANELS_ENABLED = resolveStudioBooleanEnvFlag(
+  env,
+  [STUDIO_INSPECTOR_PANELS_ENV, "VITE_STUDIO_INSPECTOR_PANELS_ENABLED"],
+  false,
+);
+
+export const STUDIO_MOTION_PANEL_ENABLED = resolveStudioBooleanEnvFlag(
+  env,
+  [STUDIO_MOTION_PANEL_ENV, "VITE_STUDIO_MOTION_PANEL_ENABLED"],
+  false,
+);
+
+export const STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED =
+  STUDIO_INSPECTOR_PANELS_ENABLED &&
+  resolveStudioBooleanEnvFlag(
+    env,
+    [STUDIO_TIMELINE_LAYER_INSPECTOR_ENV, "VITE_STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED"],
+    false,
+  );
+
+export const STUDIO_MANUAL_EDITING_ENABLED = STUDIO_PREVIEW_MANUAL_EDITING_ENABLED;
+
+export const STUDIO_MANUAL_EDITING_DISABLED_TITLE = "Manual editing is temporarily disabled";

--- a/packages/studio/src/components/editor/studioMotion.test.ts
+++ b/packages/studio/src/components/editor/studioMotion.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+import { Window } from "happy-dom";
+import type { DomEditSelection } from "./domEditing";
+import {
+  STUDIO_MOTION_TIMELINE_ID,
+  applyStudioMotionManifest,
+  buildStudioGsapPresetMotion,
+  clampStudioCustomEasePoints,
+  controlPointsForGsapEase,
+  emptyStudioMotionManifest,
+  getStudioMotionForSelection,
+  isStudioMotionManifestPath,
+  parseStudioCustomEaseData,
+  parseStudioMotionManifest,
+  removeStudioMotionForSelection,
+  serializeStudioCustomEaseData,
+  serializeStudioMotionManifest,
+  upsertStudioGsapMotion,
+} from "./studioMotion";
+
+function createSelection(): DomEditSelection {
+  return {
+    element: {} as HTMLElement,
+    id: "card",
+    selector: "#card",
+    selectorIndex: undefined,
+    sourceFile: "index.html",
+    compositionPath: "index.html",
+    compositionSrc: undefined,
+    isCompositionHost: false,
+    label: "Card",
+    tagName: "div",
+    boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+    textContent: null,
+    dataAttributes: {},
+    inlineStyles: {},
+    computedStyles: {},
+    textFields: [],
+    capabilities: {
+      canSelect: true,
+      canEditStyles: true,
+      canMove: false,
+      canResize: false,
+      canApplyManualOffset: true,
+      canApplyManualSize: true,
+      canApplyManualRotation: true,
+    },
+  };
+}
+
+function createDocument(markup: string): Document {
+  const window = new Window();
+  window.document.body.innerHTML = markup;
+  return window.document;
+}
+
+function installFakeGsap(window: Window): {
+  fromToCalls: Array<{
+    target: HTMLElement;
+    from: Record<string, unknown>;
+    to: Record<string, unknown>;
+    at: number;
+  }>;
+  timeCalls: number[];
+  customEaseCalls: Array<{ id: string; data: string }>;
+  killCalls: number;
+} {
+  const state = {
+    fromToCalls: [] as Array<{
+      target: HTMLElement;
+      from: Record<string, unknown>;
+      to: Record<string, unknown>;
+      at: number;
+    }>,
+    timeCalls: [] as number[],
+    customEaseCalls: [] as Array<{ id: string; data: string }>,
+    killCalls: 0,
+  };
+  const timeline = {
+    fromTo(
+      target: HTMLElement,
+      from: Record<string, unknown>,
+      to: Record<string, unknown>,
+      at: number,
+    ) {
+      state.fromToCalls.push({ target, from, to, at });
+      return timeline;
+    },
+    time(value: number) {
+      state.timeCalls.push(value);
+      return timeline;
+    },
+    pause() {
+      return timeline;
+    },
+    kill() {
+      state.killCalls += 1;
+    },
+    duration() {
+      return 3;
+    },
+  };
+  (
+    window as unknown as {
+      gsap: {
+        timeline: () => typeof timeline;
+        set: (target: HTMLElement, vars: Record<string, unknown>) => void;
+      };
+      CustomEase: { create: (id: string, data: string) => void };
+      __timelines?: Record<string, unknown>;
+    }
+  ).gsap = {
+    timeline: () => timeline,
+    set(target, vars) {
+      if (vars.clearProps === "transform,opacity,visibility") {
+        target.style.removeProperty("transform");
+        target.style.removeProperty("opacity");
+        target.style.removeProperty("visibility");
+      }
+    },
+  };
+  (
+    window as unknown as {
+      CustomEase: { create: (id: string, data: string) => void };
+    }
+  ).CustomEase = {
+    create(id, data) {
+      state.customEaseCalls.push({ id, data });
+    },
+  };
+  return state;
+}
+
+describe("studio motion manifest", () => {
+  it("round-trips draggable GSAP CustomEase control points", () => {
+    const points = parseStudioCustomEaseData("M0,0 C0.18,0.9 0.32,1.2 1,1");
+
+    expect(points).toEqual({ x1: 0.18, y1: 0.9, x2: 0.32, y2: 1.2 });
+    expect(serializeStudioCustomEaseData(points!)).toBe("M0,0 C0.18,0.9 0.32,1.2 1,1");
+    expect(parseStudioCustomEaseData("cubic-bezier(0.1, 0.2, 0.3, 1)")).toBeNull();
+  });
+
+  it("clamps custom ease handles to a safe GSAP range and exposes preset previews", () => {
+    expect(
+      clampStudioCustomEasePoints({
+        x1: -2,
+        y1: -2,
+        x2: 2,
+        y2: 3,
+      }),
+    ).toEqual({ x1: 0, y1: -0.6, x2: 1, y2: 1.6 });
+    expect(controlPointsForGsapEase("power3.out")).toEqual({
+      x1: 0.165,
+      y1: 0.84,
+      x2: 0.44,
+      y2: 1,
+    });
+  });
+
+  it("creates preset GSAP motions with deterministic from/to lanes", () => {
+    expect(
+      buildStudioGsapPresetMotion("fade-up", {
+        start: 0.2,
+        duration: 0.9,
+        distance: 44,
+        ease: "power3.out",
+      }),
+    ).toMatchObject({
+      start: 0.2,
+      duration: 0.9,
+      ease: "power3.out",
+      from: { y: 44, autoAlpha: 0 },
+      to: { y: 0, autoAlpha: 1 },
+    });
+    expect(
+      buildStudioGsapPresetMotion("slide", {
+        start: 0,
+        duration: 0.7,
+        distance: 60,
+        direction: "right",
+        ease: "back.out(1.4)",
+      }),
+    ).toMatchObject({
+      from: { x: -60, autoAlpha: 0 },
+      to: { x: 0, autoAlpha: 1 },
+    });
+    expect(
+      buildStudioGsapPresetMotion("pop", {
+        start: 0,
+        duration: 0.5,
+        distance: 30,
+        ease: "elastic.out(1, 0.45)",
+      }),
+    ).toMatchObject({
+      from: { scale: 0.88, autoAlpha: 0 },
+      to: { scale: 1, autoAlpha: 1 },
+    });
+  });
+
+  it("upserts and serializes GSAP motion by stable target", () => {
+    const selection = createSelection();
+    const manifest = upsertStudioGsapMotion(emptyStudioMotionManifest(), selection, {
+      start: 0.25,
+      duration: 0.8,
+      ease: "power3.out",
+      from: { x: 0, y: 44, scale: 1, autoAlpha: 0 },
+      to: { x: 0, y: 0, scale: 1, autoAlpha: 1 },
+    });
+    const updated = upsertStudioGsapMotion(manifest, selection, {
+      start: 0.5,
+      duration: 1.2,
+      ease: "back.out(1.7)",
+      from: { x: -20, y: 0, scale: 0.92, autoAlpha: 0 },
+      to: { x: 0, y: 0, scale: 1, autoAlpha: 1 },
+    });
+
+    expect(updated.motions).toHaveLength(1);
+    expect(updated.motions[0]).toMatchObject({
+      kind: "gsap-motion",
+      target: { sourceFile: "index.html", selector: "#card", id: "card" },
+      start: 0.5,
+      duration: 1.2,
+      ease: "back.out(1.7)",
+      from: { x: -20, y: 0, scale: 0.92, autoAlpha: 0 },
+      to: { x: 0, y: 0, scale: 1, autoAlpha: 1 },
+    });
+    expect(parseStudioMotionManifest(serializeStudioMotionManifest(updated))).toEqual(updated);
+    expect(getStudioMotionForSelection(updated, selection)?.duration).toBe(1.2);
+  });
+
+  it("rejects malformed motions without throwing and removes selected motion", () => {
+    const parsed = parseStudioMotionManifest(`{
+      "motions": [
+        { "kind": "gsap-motion", "target": { "sourceFile": "index.html", "id": "card" }, "start": 0, "duration": 0 },
+        { "kind": "gsap-motion", "target": { "sourceFile": "index.html", "id": "card" }, "start": 0, "duration": 1, "ease": "power2.out", "from": { "x": 0 }, "to": { "x": 20 } }
+      ]
+    }`);
+
+    expect(parsed.motions).toHaveLength(1);
+    expect(removeStudioMotionForSelection(parsed, createSelection()).motions).toEqual([]);
+    expect(isStudioMotionManifestPath(".hyperframes/studio-motion.json")).toBe(true);
+    expect(isStudioMotionManifestPath("index.html")).toBe(false);
+  });
+
+  it("builds a paused GSAP timeline, registers it, and restores Studio-owned props on rebuild", () => {
+    const document = createDocument(
+      '<div id="card" style="transform: rotate(5deg); opacity: 0.8"></div>',
+    );
+    const win = document.defaultView;
+    if (!win) throw new Error("window fixture missing");
+    const gsapState = installFakeGsap(win as Window);
+    const card = document.getElementById("card");
+    if (!(card instanceof win.HTMLElement)) throw new Error("card fixture missing");
+    const manifest = upsertStudioGsapMotion(emptyStudioMotionManifest(), createSelection(), {
+      start: 0.25,
+      duration: 0.8,
+      ease: "power3.out",
+      from: { x: 0, y: 44, scale: 1, autoAlpha: 0 },
+      to: { x: 0, y: 0, scale: 1, autoAlpha: 1 },
+    });
+
+    expect(applyStudioMotionManifest(document, manifest, "index.html", 0.4)).toBe(1);
+    expect(gsapState.fromToCalls[0]).toMatchObject({
+      target: card,
+      from: { x: 0, y: 44, scale: 1, autoAlpha: 0 },
+      to: { x: 0, y: 0, scale: 1, autoAlpha: 1, duration: 0.8, ease: "power3.out" },
+      at: 0.25,
+    });
+    expect(gsapState.timeCalls).toContain(0.4);
+    expect(
+      (win as unknown as { __timelines?: Record<string, unknown> }).__timelines?.[
+        STUDIO_MOTION_TIMELINE_ID
+      ],
+    ).toBeTruthy();
+
+    card.style.setProperty("transform", "matrix(1, 0, 0, 1, 10, 20)");
+    card.style.setProperty("opacity", "0.1");
+    expect(applyStudioMotionManifest(document, emptyStudioMotionManifest(), "index.html", 0)).toBe(
+      0,
+    );
+    expect(gsapState.killCalls).toBe(1);
+    expect(card.style.getPropertyValue("transform")).toBe("rotate(5deg)");
+    expect(card.style.getPropertyValue("opacity")).toBe("0.8");
+    expect(
+      (win as unknown as { __timelines?: Record<string, unknown> }).__timelines?.[
+        STUDIO_MOTION_TIMELINE_ID
+      ],
+    ).toBeUndefined();
+  });
+
+  it("rebuilds from the latest in-memory manifest when a second layer is added", () => {
+    const document = createDocument('<div id="card"></div><div id="badge"></div>');
+    const win = document.defaultView;
+    if (!win) throw new Error("window fixture missing");
+    const gsapState = installFakeGsap(win as Window);
+    const badgeSelection = {
+      ...createSelection(),
+      id: "badge",
+      selector: "#badge",
+      label: "Badge",
+    };
+    const firstManifest = upsertStudioGsapMotion(emptyStudioMotionManifest(), createSelection(), {
+      start: 0,
+      duration: 0.6,
+      ease: "power3.out",
+      from: { y: 32, autoAlpha: 0 },
+      to: { y: 0, autoAlpha: 1 },
+    });
+    const nextManifest = upsertStudioGsapMotion(firstManifest, badgeSelection, {
+      start: 0,
+      duration: 0.6,
+      ease: "power3.out",
+      customEase: {
+        id: "studio-badge-ease",
+        data: "M0,0 C0.2,0.9 0.28,1 1,1",
+      },
+      from: { x: -32, autoAlpha: 0 },
+      to: { x: 0, autoAlpha: 1 },
+    });
+
+    expect(applyStudioMotionManifest(document, firstManifest, "index.html", 0.3)).toBe(1);
+    expect(applyStudioMotionManifest(document, nextManifest, "index.html", 0.3)).toBe(2);
+    expect(gsapState.fromToCalls.at(-2)?.target.id).toBe("card");
+    expect(gsapState.fromToCalls.at(-1)).toMatchObject({
+      target: document.getElementById("badge"),
+      from: { x: -32, autoAlpha: 0 },
+      to: { x: 0, autoAlpha: 1, duration: 0.6, ease: "studio-badge-ease" },
+      at: 0,
+    });
+  });
+
+  it("registers CustomEase data when the selected GSAP plugin is available", () => {
+    const document = createDocument('<div id="card"></div>');
+    const win = document.defaultView;
+    if (!win) throw new Error("window fixture missing");
+    const gsapState = installFakeGsap(win as Window);
+    const manifest = upsertStudioGsapMotion(emptyStudioMotionManifest(), createSelection(), {
+      start: 0,
+      duration: 1,
+      ease: "studio-card-bounce",
+      customEase: {
+        id: "studio-card-bounce",
+        data: "M0,0 C0.18,0.9 0.32,1 1,1",
+      },
+      from: { y: 44 },
+      to: { y: 0 },
+    });
+
+    expect(applyStudioMotionManifest(document, manifest, "index.html", 0)).toBe(1);
+    expect(gsapState.customEaseCalls).toEqual([
+      { id: "studio-card-bounce", data: "M0,0 C0.18,0.9 0.32,1 1,1" },
+    ]);
+    expect(gsapState.fromToCalls[0]?.to.ease).toBe("studio-card-bounce");
+  });
+});

--- a/packages/studio/src/components/editor/studioMotion.ts
+++ b/packages/studio/src/components/editor/studioMotion.ts
@@ -1,0 +1,632 @@
+import type { DomEditSelection } from "./domEditing";
+
+export const STUDIO_MOTION_PATH = ".hyperframes/studio-motion.json";
+export const STUDIO_MOTION_TIMELINE_ID = "studio-motion";
+
+const STUDIO_MOTION_ATTR = "data-hf-studio-motion";
+const STUDIO_MOTION_ORIGINAL_TRANSFORM_ATTR = "data-hf-studio-motion-original-transform";
+const STUDIO_MOTION_ORIGINAL_OPACITY_ATTR = "data-hf-studio-motion-original-opacity";
+const STUDIO_MOTION_ORIGINAL_VISIBILITY_ATTR = "data-hf-studio-motion-original-visibility";
+
+export interface StudioMotionTarget {
+  sourceFile: string;
+  selector?: string;
+  selectorIndex?: number;
+  id?: string;
+}
+
+export interface StudioGsapMotionValues {
+  x?: number;
+  y?: number;
+  scale?: number;
+  rotation?: number;
+  opacity?: number;
+  autoAlpha?: number;
+}
+
+export interface StudioGsapCustomEase {
+  id: string;
+  data: string;
+}
+
+export interface StudioCustomEaseControlPoints {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface StudioGsapMotion {
+  kind: "gsap-motion";
+  target: StudioMotionTarget;
+  start: number;
+  duration: number;
+  ease: string;
+  customEase?: StudioGsapCustomEase;
+  from: StudioGsapMotionValues;
+  to: StudioGsapMotionValues;
+  updatedAt?: string;
+}
+
+export type StudioGsapMotionPreset = "fade-up" | "slide" | "pop";
+export type StudioGsapMotionDirection = "up" | "down" | "left" | "right";
+
+export const STUDIO_GSAP_EASE_OPTIONS = [
+  "none",
+  "power1.in",
+  "power1.out",
+  "power1.inOut",
+  "power2.in",
+  "power2.out",
+  "power2.inOut",
+  "power3.in",
+  "power3.out",
+  "power3.inOut",
+  "power4.in",
+  "power4.out",
+  "power4.inOut",
+  "sine.in",
+  "sine.out",
+  "sine.inOut",
+  "expo.in",
+  "expo.out",
+  "expo.inOut",
+  "circ.in",
+  "circ.out",
+  "circ.inOut",
+  "back.in(1.7)",
+  "back.out(1.7)",
+  "back.inOut(1.7)",
+  "elastic.out(1, 0.45)",
+  "bounce.out",
+] as const;
+
+const DEFAULT_CUSTOM_EASE_POINTS: StudioCustomEaseControlPoints = {
+  x1: 0.215,
+  y1: 0.61,
+  x2: 0.355,
+  y2: 1,
+};
+
+const GSAP_EASE_CONTROL_POINTS: Record<string, StudioCustomEaseControlPoints> = {
+  none: { x1: 0, y1: 0, x2: 1, y2: 1 },
+  "power1.in": { x1: 0.55, y1: 0.085, x2: 0.68, y2: 0.53 },
+  "power1.out": { x1: 0.25, y1: 0.46, x2: 0.45, y2: 0.94 },
+  "power1.inOut": { x1: 0.455, y1: 0.03, x2: 0.515, y2: 0.955 },
+  "power2.in": { x1: 0.55, y1: 0.055, x2: 0.675, y2: 0.19 },
+  "power2.out": { x1: 0.215, y1: 0.61, x2: 0.355, y2: 1 },
+  "power2.inOut": { x1: 0.645, y1: 0.045, x2: 0.355, y2: 1 },
+  "power3.in": { x1: 0.895, y1: 0.03, x2: 0.685, y2: 0.22 },
+  "power3.out": { x1: 0.165, y1: 0.84, x2: 0.44, y2: 1 },
+  "power3.inOut": { x1: 0.77, y1: 0, x2: 0.175, y2: 1 },
+  "power4.in": { x1: 0.755, y1: 0.05, x2: 0.855, y2: 0.06 },
+  "power4.out": { x1: 0.23, y1: 1, x2: 0.32, y2: 1 },
+  "power4.inOut": { x1: 0.86, y1: 0, x2: 0.07, y2: 1 },
+  "sine.in": { x1: 0.47, y1: 0, x2: 0.745, y2: 0.715 },
+  "sine.out": { x1: 0.39, y1: 0.575, x2: 0.565, y2: 1 },
+  "sine.inOut": { x1: 0.445, y1: 0.05, x2: 0.55, y2: 0.95 },
+  "expo.in": { x1: 0.95, y1: 0.05, x2: 0.795, y2: 0.035 },
+  "expo.out": { x1: 0.19, y1: 1, x2: 0.22, y2: 1 },
+  "expo.inOut": { x1: 1, y1: 0, x2: 0, y2: 1 },
+  "circ.in": { x1: 0.6, y1: 0.04, x2: 0.98, y2: 0.335 },
+  "circ.out": { x1: 0.075, y1: 0.82, x2: 0.165, y2: 1 },
+  "circ.inOut": { x1: 0.785, y1: 0.135, x2: 0.15, y2: 0.86 },
+  "back.in(1.7)": { x1: 0.6, y1: -0.28, x2: 0.735, y2: 0.045 },
+  "back.out(1.7)": { x1: 0.175, y1: 0.885, x2: 0.32, y2: 1.275 },
+  "back.inOut(1.7)": { x1: 0.68, y1: -0.55, x2: 0.265, y2: 1.55 },
+  "elastic.out(1, 0.45)": { x1: 0.16, y1: 1.32, x2: 0.28, y2: 0.86 },
+  "bounce.out": { x1: 0.34, y1: 1.56, x2: 0.64, y2: 0.74 },
+};
+
+const CUSTOM_EASE_DATA_PATTERN =
+  /^M\s*0\s*,\s*0\s*C\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s+1\s*,\s*1\s*$/i;
+
+export interface StudioGsapPresetMotionOptions {
+  start: number;
+  duration: number;
+  distance: number;
+  ease: string;
+  direction?: StudioGsapMotionDirection;
+  customEase?: StudioGsapCustomEase;
+}
+
+export interface StudioMotionManifest {
+  version: 1;
+  motions: StudioGsapMotion[];
+}
+
+interface StudioGsapTimeline {
+  fromTo?: (
+    target: HTMLElement,
+    from: Record<string, unknown>,
+    to: Record<string, unknown>,
+    at: number,
+  ) => StudioGsapTimeline;
+  time?: (time: number) => StudioGsapTimeline;
+  totalTime?: (time: number, suppressEvents?: boolean) => StudioGsapTimeline;
+  pause?: () => StudioGsapTimeline;
+  kill?: () => void;
+  duration?: () => number;
+}
+
+type StudioMotionWindow = Window & {
+  gsap?: {
+    timeline?: (vars?: Record<string, unknown>) => StudioGsapTimeline;
+    set?: (target: HTMLElement, vars: Record<string, unknown>) => void;
+    registerPlugin?: (...plugins: unknown[]) => void;
+  };
+  CustomEase?: { create?: (id: string, data: string) => void };
+  __player?: {
+    getTime?: () => number;
+    renderSeek?: (time: number) => void;
+    seek?: (time: number) => void;
+  };
+  __timeline?: { time?: () => number };
+  __timelines?: Record<string, StudioGsapTimeline | undefined>;
+  __hfStudioMotionApply?: () => number;
+  __hfStudioMotionWrapped?: boolean;
+};
+
+export function emptyStudioMotionManifest(): StudioMotionManifest {
+  return { version: 1, motions: [] };
+}
+
+function clampPositiveNumber(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function clampNonNegativeNumber(value: number, fallback: number): number {
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function sanitizeEase(value: string): string {
+  return value.trim() || "none";
+}
+
+function roundEaseNumber(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function clampRange(value: number, min: number, max: number, fallback: number): number {
+  return Number.isFinite(value) ? Math.min(max, Math.max(min, value)) : fallback;
+}
+
+export function clampStudioCustomEasePoints(
+  points: Partial<StudioCustomEaseControlPoints>,
+): StudioCustomEaseControlPoints {
+  return {
+    x1: roundEaseNumber(clampRange(points.x1 ?? DEFAULT_CUSTOM_EASE_POINTS.x1, 0, 1, 0.215)),
+    y1: roundEaseNumber(clampRange(points.y1 ?? DEFAULT_CUSTOM_EASE_POINTS.y1, -0.6, 1.6, 0.61)),
+    x2: roundEaseNumber(clampRange(points.x2 ?? DEFAULT_CUSTOM_EASE_POINTS.x2, 0, 1, 0.355)),
+    y2: roundEaseNumber(clampRange(points.y2 ?? DEFAULT_CUSTOM_EASE_POINTS.y2, -0.6, 1.6, 1)),
+  };
+}
+
+export function parseStudioCustomEaseData(
+  data: string | undefined,
+): StudioCustomEaseControlPoints | null {
+  if (!data) return null;
+  const match = data.trim().match(CUSTOM_EASE_DATA_PATTERN);
+  if (!match) return null;
+  const points = {
+    x1: Number.parseFloat(match[1] ?? ""),
+    y1: Number.parseFloat(match[2] ?? ""),
+    x2: Number.parseFloat(match[3] ?? ""),
+    y2: Number.parseFloat(match[4] ?? ""),
+  };
+  if (!Object.values(points).every(Number.isFinite)) return null;
+  return clampStudioCustomEasePoints(points);
+}
+
+function formatEaseNumber(value: number): string {
+  const rounded = roundEaseNumber(value);
+  if (Object.is(rounded, -0)) return "0";
+  return `${rounded}`;
+}
+
+export function serializeStudioCustomEaseData(points: StudioCustomEaseControlPoints): string {
+  const clamped = clampStudioCustomEasePoints(points);
+  return `M0,0 C${formatEaseNumber(clamped.x1)},${formatEaseNumber(clamped.y1)} ${formatEaseNumber(clamped.x2)},${formatEaseNumber(clamped.y2)} 1,1`;
+}
+
+export function controlPointsForGsapEase(ease: string): StudioCustomEaseControlPoints {
+  return GSAP_EASE_CONTROL_POINTS[ease] ?? DEFAULT_CUSTOM_EASE_POINTS;
+}
+
+export function buildStudioGsapPresetMotion(
+  preset: StudioGsapMotionPreset,
+  options: StudioGsapPresetMotionOptions,
+): Omit<StudioGsapMotion, "kind" | "target" | "updatedAt"> {
+  const start = clampNonNegativeNumber(options.start, 0);
+  const duration = clampPositiveNumber(options.duration, 0.6);
+  const distance = clampPositiveNumber(options.distance, 32);
+  const ease = sanitizeEase(options.ease);
+  const direction = options.direction ?? "up";
+  const base = { start, duration, ease, customEase: options.customEase };
+
+  if (preset === "pop") {
+    return {
+      ...base,
+      from: { scale: 0.88, autoAlpha: 0 },
+      to: { scale: 1, autoAlpha: 1 },
+    };
+  }
+
+  if (preset === "slide") {
+    const x = direction === "right" ? -distance : direction === "left" ? distance : 0;
+    const y = direction === "down" ? -distance : direction === "up" ? distance : 0;
+    return {
+      ...base,
+      from: { x, y, autoAlpha: 0 },
+      to: { x: 0, y: 0, autoAlpha: 1 },
+    };
+  }
+
+  return {
+    ...base,
+    from: { y: direction === "down" ? -distance : distance, autoAlpha: 0 },
+    to: { y: 0, autoAlpha: 1 },
+  };
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseMotionValues(value: unknown): StudioGsapMotionValues | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const parsed: StudioGsapMotionValues = {};
+  for (const key of ["x", "y", "scale", "rotation", "opacity", "autoAlpha"] as const) {
+    const next = finiteNumber(record[key]);
+    if (next != null) parsed[key] = next;
+  }
+  return Object.keys(parsed).length > 0 ? parsed : null;
+}
+
+function parseTarget(value: unknown): StudioMotionTarget | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const sourceFile = typeof record.sourceFile === "string" ? record.sourceFile : "";
+  if (!sourceFile) return null;
+  const selector = typeof record.selector === "string" ? record.selector : undefined;
+  const id = typeof record.id === "string" ? record.id : undefined;
+  if (!selector && !id) return null;
+  return {
+    sourceFile,
+    selector,
+    selectorIndex: finiteNumber(record.selectorIndex) ?? undefined,
+    id,
+  };
+}
+
+function parseCustomEase(value: unknown): StudioGsapCustomEase | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id.trim() : "";
+  const data = typeof record.data === "string" ? record.data.trim() : "";
+  if (!id || !data) return undefined;
+  return { id, data };
+}
+
+function parseGsapMotion(value: unknown): StudioGsapMotion | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "gsap-motion") return null;
+  const target = parseTarget(record.target);
+  if (!target) return null;
+  const start = finiteNumber(record.start);
+  const duration = finiteNumber(record.duration);
+  if (start == null || duration == null || start < 0 || duration <= 0) return null;
+  const ease = typeof record.ease === "string" && record.ease.trim() ? record.ease.trim() : "none";
+  const from = parseMotionValues(record.from);
+  const to = parseMotionValues(record.to);
+  if (!from || !to) return null;
+  return {
+    kind: "gsap-motion",
+    target,
+    start,
+    duration,
+    ease,
+    customEase: parseCustomEase(record.customEase),
+    from,
+    to,
+    updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : undefined,
+  };
+}
+
+export function parseStudioMotionManifest(content: string): StudioMotionManifest {
+  if (!content.trim()) return emptyStudioMotionManifest();
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (!parsed || typeof parsed !== "object") return emptyStudioMotionManifest();
+    const motions = (parsed as { motions?: unknown }).motions;
+    if (!Array.isArray(motions)) return emptyStudioMotionManifest();
+    return {
+      version: 1,
+      motions: motions
+        .map(parseGsapMotion)
+        .filter((motion): motion is StudioGsapMotion => motion !== null),
+    };
+  } catch {
+    return emptyStudioMotionManifest();
+  }
+}
+
+export function serializeStudioMotionManifest(manifest: StudioMotionManifest): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function normalizeStudioFileChangePath(path: string): string {
+  return path
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\.?\//, "");
+}
+
+export function isStudioMotionManifestPath(path: string | null): boolean {
+  if (!path) return false;
+  const normalized = normalizeStudioFileChangePath(path);
+  return normalized === STUDIO_MOTION_PATH || normalized.endsWith(`/${STUDIO_MOTION_PATH}`);
+}
+
+function selectionTarget(selection: DomEditSelection): StudioMotionTarget {
+  return {
+    sourceFile: selection.sourceFile || "index.html",
+    selector: selection.selector,
+    selectorIndex: selection.selectorIndex,
+    id: selection.id ?? undefined,
+  };
+}
+
+function targetKey(target: StudioMotionTarget): string {
+  return [
+    target.sourceFile,
+    target.id ? `id:${target.id}` : "",
+    target.selector ? `selector:${target.selector}` : "",
+    target.selectorIndex != null ? `index:${target.selectorIndex}` : "",
+  ].join("|");
+}
+
+function sameSelectionTarget(motion: StudioGsapMotion, selection: DomEditSelection): boolean {
+  const target = selectionTarget(selection);
+  if (motion.target.sourceFile !== target.sourceFile) return false;
+  if (motion.target.id && target.id && motion.target.id === target.id) return true;
+  return targetKey(motion.target) === targetKey(target);
+}
+
+export function upsertStudioGsapMotion(
+  manifest: StudioMotionManifest,
+  selection: DomEditSelection,
+  motion: Omit<StudioGsapMotion, "kind" | "target" | "updatedAt">,
+): StudioMotionManifest {
+  const target = selectionTarget(selection);
+  const nextMotion: StudioGsapMotion = {
+    kind: "gsap-motion",
+    target,
+    ...motion,
+    updatedAt: new Date().toISOString(),
+  };
+  return {
+    version: 1,
+    motions: [
+      ...manifest.motions.filter((existing) => targetKey(existing.target) !== targetKey(target)),
+      nextMotion,
+    ],
+  };
+}
+
+export function removeStudioMotionForSelection(
+  manifest: StudioMotionManifest,
+  selection: DomEditSelection,
+): StudioMotionManifest {
+  return {
+    version: 1,
+    motions: manifest.motions.filter((motion) => !sameSelectionTarget(motion, selection)),
+  };
+}
+
+export function getStudioMotionForSelection(
+  manifest: StudioMotionManifest,
+  selection: DomEditSelection,
+): StudioGsapMotion | null {
+  return manifest.motions.find((motion) => sameSelectionTarget(motion, selection)) ?? null;
+}
+
+function sourceFileForElement(element: HTMLElement, activeCompositionPath: string | null): string {
+  let current: HTMLElement | null = element;
+  while (current) {
+    const sourceFile =
+      current.getAttribute("data-composition-file") ?? current.getAttribute("data-composition-src");
+    if (sourceFile) return sourceFile;
+    current = current.parentElement;
+  }
+  return activeCompositionPath ?? "index.html";
+}
+
+function elementMatchesSourceFile(
+  element: HTMLElement,
+  sourceFile: string,
+  activeCompositionPath: string | null,
+): boolean {
+  return sourceFileForElement(element, activeCompositionPath) === sourceFile;
+}
+
+function querySelectorCandidates(document: Document, selector: string): HTMLElement[] {
+  const isCandidate = (element: Element): element is HTMLElement => {
+    const HTMLElementCtor = element.ownerDocument.defaultView?.HTMLElement;
+    return Boolean(HTMLElementCtor && element instanceof HTMLElementCtor);
+  };
+  const className = selector.match(/^\.([A-Za-z0-9_-]+)$/)?.[1];
+  if (className) {
+    return Array.from(document.getElementsByTagName("*")).filter(
+      (element): element is HTMLElement =>
+        isCandidate(element) && element.classList.contains(className),
+    );
+  }
+  if (/^[A-Za-z][A-Za-z0-9-]*$/.test(selector)) {
+    return Array.from(document.getElementsByTagName(selector)).filter(isCandidate);
+  }
+  return Array.from(document.querySelectorAll(selector)).filter(isCandidate);
+}
+
+function resolveTarget(
+  document: Document,
+  target: StudioMotionTarget,
+  activeCompositionPath: string | null,
+): HTMLElement | null {
+  const HTMLElementCtor = document.defaultView?.HTMLElement;
+  if (target.id) {
+    const byId = document.getElementById(target.id);
+    if (
+      HTMLElementCtor &&
+      byId instanceof HTMLElementCtor &&
+      elementMatchesSourceFile(byId, target.sourceFile, activeCompositionPath)
+    ) {
+      return byId;
+    }
+  }
+  if (!target.selector) return null;
+  try {
+    const matches = querySelectorCandidates(document, target.selector).filter((element) =>
+      elementMatchesSourceFile(element, target.sourceFile, activeCompositionPath),
+    );
+    return matches[Math.max(0, Math.floor(target.selectorIndex ?? 0))] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function captureOriginalMotionStyles(element: HTMLElement): void {
+  if (element.hasAttribute(STUDIO_MOTION_ATTR)) return;
+  element.setAttribute(STUDIO_MOTION_ORIGINAL_TRANSFORM_ATTR, element.style.transform);
+  element.setAttribute(STUDIO_MOTION_ORIGINAL_OPACITY_ATTR, element.style.opacity);
+  element.setAttribute(STUDIO_MOTION_ORIGINAL_VISIBILITY_ATTR, element.style.visibility);
+}
+
+function restoreStudioMotionElement(element: HTMLElement, gsap: StudioMotionWindow["gsap"]): void {
+  if (!element.hasAttribute(STUDIO_MOTION_ATTR)) return;
+  gsap?.set?.(element, { clearProps: "transform,opacity,visibility" });
+  element.style.transform = element.getAttribute(STUDIO_MOTION_ORIGINAL_TRANSFORM_ATTR) ?? "";
+  element.style.opacity = element.getAttribute(STUDIO_MOTION_ORIGINAL_OPACITY_ATTR) ?? "";
+  element.style.visibility = element.getAttribute(STUDIO_MOTION_ORIGINAL_VISIBILITY_ATTR) ?? "";
+  element.removeAttribute(STUDIO_MOTION_ATTR);
+  element.removeAttribute(STUDIO_MOTION_ORIGINAL_TRANSFORM_ATTR);
+  element.removeAttribute(STUDIO_MOTION_ORIGINAL_OPACITY_ATTR);
+  element.removeAttribute(STUDIO_MOTION_ORIGINAL_VISIBILITY_ATTR);
+}
+
+function restoreStudioMotionElements(document: Document, gsap: StudioMotionWindow["gsap"]): void {
+  const HTMLElementCtor = document.defaultView?.HTMLElement;
+  if (!HTMLElementCtor) return;
+  for (const element of Array.from(document.querySelectorAll(`[${STUDIO_MOTION_ATTR}]`))) {
+    if (element instanceof HTMLElementCtor) restoreStudioMotionElement(element, gsap);
+  }
+}
+
+function resolveGsapEase(win: StudioMotionWindow, motion: StudioGsapMotion): string {
+  const customEase = motion.customEase;
+  if (!customEase) return motion.ease;
+  const customEasePlugin = win.CustomEase;
+  if (typeof customEasePlugin?.create !== "function") return motion.ease;
+  try {
+    win.gsap?.registerPlugin?.(customEasePlugin);
+    customEasePlugin.create(customEase.id, customEase.data);
+    return customEase.id;
+  } catch {
+    return motion.ease;
+  }
+}
+
+function readCurrentTime(win: StudioMotionWindow, fallback?: number): number {
+  if (typeof fallback === "number" && Number.isFinite(fallback)) return Math.max(0, fallback);
+  try {
+    const playerTime = win.__player?.getTime?.();
+    if (typeof playerTime === "number" && Number.isFinite(playerTime))
+      return Math.max(0, playerTime);
+  } catch {
+    // fall through
+  }
+  try {
+    const timelineTime = win.__timeline?.time?.();
+    if (typeof timelineTime === "number" && Number.isFinite(timelineTime)) {
+      return Math.max(0, timelineTime);
+    }
+  } catch {
+    // fall through
+  }
+  return 0;
+}
+
+export function applyStudioMotionManifest(
+  document: Document,
+  manifest: StudioMotionManifest,
+  activeCompositionPath: string | null = null,
+  currentTime?: number,
+): number {
+  const win = document.defaultView as StudioMotionWindow | null;
+  if (!win) return 0;
+  const gsap = win.gsap;
+  win.__timelines = win.__timelines ?? {};
+  win.__timelines[STUDIO_MOTION_TIMELINE_ID]?.kill?.();
+  delete win.__timelines[STUDIO_MOTION_TIMELINE_ID];
+  restoreStudioMotionElements(document, gsap);
+  if (!gsap?.timeline || manifest.motions.length === 0) return 0;
+
+  const timeline = gsap.timeline({
+    paused: true,
+    defaults: { overwrite: "auto" },
+  });
+  let applied = 0;
+  for (const motion of manifest.motions) {
+    const element = resolveTarget(document, motion.target, activeCompositionPath);
+    if (!element || !timeline.fromTo) continue;
+    captureOriginalMotionStyles(element);
+    element.setAttribute(STUDIO_MOTION_ATTR, "true");
+    const fromVars: Record<string, unknown> = { ...motion.from };
+    const toVars: Record<string, unknown> = {
+      ...motion.to,
+      duration: motion.duration,
+      ease: resolveGsapEase(win, motion),
+      overwrite: "auto",
+      immediateRender: false,
+    };
+    timeline.fromTo(element, fromVars, toVars, motion.start);
+    applied += 1;
+  }
+
+  if (applied === 0) {
+    timeline.kill?.();
+    return 0;
+  }
+  win.__timelines[STUDIO_MOTION_TIMELINE_ID] = timeline;
+  timeline.pause?.();
+  const safeTime = readCurrentTime(win, currentTime);
+  if (timeline.totalTime) timeline.totalTime(safeTime, false);
+  else timeline.time?.(safeTime);
+  return applied;
+}
+
+export function installStudioMotionSeekReapply(win: Window, apply: () => void): boolean {
+  const studioWin = win as StudioMotionWindow;
+  studioWin.__hfStudioMotionApply = () => {
+    apply();
+    return 0;
+  };
+  if (studioWin.__hfStudioMotionWrapped) return false;
+  const player = studioWin.__player;
+  if (!player) return false;
+
+  const wrapPlayerMethod = (key: "renderSeek" | "seek") => {
+    const original = player[key];
+    if (typeof original !== "function") return;
+    player[key] = (time: number) => {
+      original.call(player, time);
+      studioWin.__hfStudioMotionApply?.();
+    };
+  };
+  wrapPlayerMethod("renderSeek");
+  wrapPlayerMethod("seek");
+  studioWin.__hfStudioMotionWrapped = true;
+  return true;
+}

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -51,6 +51,12 @@ interface NLELayoutProps {
     updates: Pick<TimelineElement, "start" | "duration" | "playbackStart">,
   ) => Promise<void> | void;
   onBlockedEditAttempt?: (element: TimelineElement, intent: BlockedTimelineEditIntent) => void;
+  onSelectTimelineElement?: (element: TimelineElement | null) => void;
+  onInspectTimelineElement?: (element: TimelineElement) => void;
+  inspectedTimelineElementId?: string | null;
+  timelineLayerChildCounts?: ReadonlyMap<string, number>;
+  thumbnailedTimelineElementIds?: ReadonlySet<string>;
+  onToggleTimelineElementThumbnail?: (element: TimelineElement) => void;
   /** Exposes the compIdToSrc map for parent components (e.g., useRenderClipContent) */
   onCompIdToSrcChange?: (map: Map<string, string>) => void;
   /** Whether the timeline panel is visible (default: true) */
@@ -80,6 +86,12 @@ export const NLELayout = memo(function NLELayout({
   onMoveElement,
   onResizeElement,
   onBlockedEditAttempt,
+  onSelectTimelineElement,
+  onInspectTimelineElement,
+  inspectedTimelineElementId,
+  timelineLayerChildCounts,
+  thumbnailedTimelineElementIds,
+  onToggleTimelineElementThumbnail,
   onCompIdToSrcChange,
   timelineVisible,
   onToggleTimeline,
@@ -417,6 +429,12 @@ export const NLELayout = memo(function NLELayout({
                 onMoveElement={onMoveElement}
                 onResizeElement={onResizeElement}
                 onBlockedEditAttempt={onBlockedEditAttempt}
+                onSelectElement={onSelectTimelineElement}
+                onInspectElement={onInspectTimelineElement}
+                inspectedElementId={inspectedTimelineElementId}
+                layerChildCounts={timelineLayerChildCounts}
+                thumbnailedElementIds={thumbnailedTimelineElementIds}
+                onToggleElementThumbnail={onToggleTimelineElementThumbnail}
               />
             </div>
             {timelineFooter && <div className="flex-shrink-0">{timelineFooter}</div>}

--- a/packages/studio/src/components/sidebar/LeftSidebar.tsx
+++ b/packages/studio/src/components/sidebar/LeftSidebar.tsx
@@ -36,6 +36,7 @@ interface LeftSidebarProps {
   onLint?: () => void;
   linting?: boolean;
   onToggleCollapse?: () => void;
+  takeoverContent?: ReactNode;
 }
 
 export const LeftSidebar = memo(function LeftSidebar({
@@ -59,6 +60,7 @@ export const LeftSidebar = memo(function LeftSidebar({
   onLint,
   linting,
   onToggleCollapse,
+  takeoverContent,
 }: LeftSidebarProps) {
   const [tab, setTab] = useState<SidebarTab>(getPersistedTab);
 
@@ -89,142 +91,148 @@ export const LeftSidebar = memo(function LeftSidebar({
       className="flex flex-col h-full bg-neutral-950 border-r border-neutral-800/50"
       style={{ width }}
     >
-      {/* Tabs — Code first */}
-      <div className="border-b border-neutral-800/50 px-3 py-3 flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <div
-            className="grid min-w-0 flex-1 gap-1 rounded-[18px] bg-neutral-900 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
-            style={{ gridTemplateColumns: "0.9fr 1.25fr 0.9fr" }}
-          >
-            <button
-              type="button"
-              onClick={() => selectTab("code")}
-              className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
-                tab === "code"
-                  ? "bg-neutral-800 text-white"
-                  : "text-neutral-500 hover:text-neutral-200"
-              }`}
-            >
-              Code
-            </button>
-            <button
-              type="button"
-              onClick={() => selectTab("compositions")}
-              className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
-                tab === "compositions"
-                  ? "bg-neutral-800 text-white"
-                  : "text-neutral-500 hover:text-neutral-200"
-              }`}
-            >
-              Compositions
-            </button>
-            <button
-              type="button"
-              onClick={() => selectTab("assets")}
-              className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
-                tab === "assets"
-                  ? "bg-neutral-800 text-white"
-                  : "text-neutral-500 hover:text-neutral-200"
-              }`}
-            >
-              Assets
-            </button>
-          </div>
-          {onToggleCollapse && (
-            <button
-              type="button"
-              onClick={onToggleCollapse}
-              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md border border-transparent text-neutral-500 transition-colors hover:border-neutral-800 hover:bg-neutral-900 hover:text-neutral-300"
-              title="Hide sidebar"
-              aria-label="Hide sidebar"
-            >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
+      {takeoverContent ? (
+        <div className="flex min-h-0 flex-1">{takeoverContent}</div>
+      ) : (
+        <>
+          {/* Tabs — Code first */}
+          <div className="border-b border-neutral-800/50 px-3 py-3 flex-shrink-0">
+            <div className="flex items-center gap-2">
+              <div
+                className="grid min-w-0 flex-1 gap-1 rounded-[18px] bg-neutral-900 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+                style={{ gridTemplateColumns: "0.9fr 1.25fr 0.9fr" }}
               >
-                <path d="m14 7-5 5 5 5" />
-                <path d="M19 4v16" />
-              </svg>
-            </button>
-          )}
-        </div>
-      </div>
+                <button
+                  type="button"
+                  onClick={() => selectTab("code")}
+                  className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
+                    tab === "code"
+                      ? "bg-neutral-800 text-white"
+                      : "text-neutral-500 hover:text-neutral-200"
+                  }`}
+                >
+                  Code
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectTab("compositions")}
+                  className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
+                    tab === "compositions"
+                      ? "bg-neutral-800 text-white"
+                      : "text-neutral-500 hover:text-neutral-200"
+                  }`}
+                >
+                  Compositions
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectTab("assets")}
+                  className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
+                    tab === "assets"
+                      ? "bg-neutral-800 text-white"
+                      : "text-neutral-500 hover:text-neutral-200"
+                  }`}
+                >
+                  Assets
+                </button>
+              </div>
+              {onToggleCollapse && (
+                <button
+                  type="button"
+                  onClick={onToggleCollapse}
+                  className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md border border-transparent text-neutral-500 transition-colors hover:border-neutral-800 hover:bg-neutral-900 hover:text-neutral-300"
+                  title="Hide sidebar"
+                  aria-label="Hide sidebar"
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="m14 7-5 5 5 5" />
+                    <path d="M19 4v16" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
 
-      {/* Tab content */}
-      {tab === "compositions" && (
-        <CompositionsTab
-          projectId={projectId}
-          compositions={compositions}
-          activeComposition={activeComposition}
-          onSelect={onSelectComposition}
-        />
-      )}
-      {tab === "assets" && (
-        <AssetsTab
-          projectId={projectId}
-          assets={assets}
-          onImport={onImportFiles}
-          onDelete={onDeleteFile}
-          onRename={onRenameFile}
-        />
-      )}
-      {tab === "code" && (
-        <div className="flex flex-1 min-h-0">
-          {(fileProp?.length ?? 0) > 0 && (
-            <div className="w-[160px] flex-shrink-0 border-r border-neutral-800 overflow-y-auto">
-              <FileTree
-                files={fileProp ?? []}
-                activeFile={editingFile?.path ?? null}
-                onSelectFile={onSelectFile ?? (() => {})}
-                onCreateFile={onCreateFile}
-                onCreateFolder={onCreateFolder}
-                onDeleteFile={onDeleteFile}
-                onRenameFile={onRenameFile}
-                onDuplicateFile={onDuplicateFile}
-                onMoveFile={onMoveFile}
-                onImportFiles={onImportFiles}
-              />
+          {/* Tab content */}
+          {tab === "compositions" && (
+            <CompositionsTab
+              projectId={projectId}
+              compositions={compositions}
+              activeComposition={activeComposition}
+              onSelect={onSelectComposition}
+            />
+          )}
+          {tab === "assets" && (
+            <AssetsTab
+              projectId={projectId}
+              assets={assets}
+              onImport={onImportFiles}
+              onDelete={onDeleteFile}
+              onRename={onRenameFile}
+            />
+          )}
+          {tab === "code" && (
+            <div className="flex flex-1 min-h-0">
+              {(fileProp?.length ?? 0) > 0 && (
+                <div className="w-[160px] flex-shrink-0 border-r border-neutral-800 overflow-y-auto">
+                  <FileTree
+                    files={fileProp ?? []}
+                    activeFile={editingFile?.path ?? null}
+                    onSelectFile={onSelectFile ?? (() => {})}
+                    onCreateFile={onCreateFile}
+                    onCreateFolder={onCreateFolder}
+                    onDeleteFile={onDeleteFile}
+                    onRenameFile={onRenameFile}
+                    onDuplicateFile={onDuplicateFile}
+                    onMoveFile={onMoveFile}
+                    onImportFiles={onImportFiles}
+                  />
+                </div>
+              )}
+              <div className="flex-1 overflow-hidden min-w-0">
+                {codeChildren ?? (
+                  <div className="flex items-center justify-center h-full text-neutral-600 text-sm">
+                    Select a file to edit
+                  </div>
+                )}
+              </div>
             </div>
           )}
-          <div className="flex-1 overflow-hidden min-w-0">
-            {codeChildren ?? (
-              <div className="flex items-center justify-center h-full text-neutral-600 text-sm">
-                Select a file to edit
-              </div>
-            )}
-          </div>
-        </div>
-      )}
 
-      {/* Lint button pinned at the bottom */}
-      {onLint && (
-        <div className="border-t border-neutral-800 p-2 flex-shrink-0">
-          <button
-            onClick={onLint}
-            disabled={linting}
-            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-medium text-neutral-500 hover:text-amber-300 hover:bg-neutral-800 transition-colors disabled:opacity-40"
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M9 11l3 3L22 4" />
-              <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
-            </svg>
-            {linting ? "Linting…" : "Lint"}
-          </button>
-        </div>
+          {/* Lint button pinned at the bottom */}
+          {onLint && (
+            <div className="border-t border-neutral-800 p-2 flex-shrink-0">
+              <button
+                onClick={onLint}
+                disabled={linting}
+                className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-medium text-neutral-500 hover:text-amber-300 hover:bg-neutral-800 transition-colors disabled:opacity-40"
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="M9 11l3 3L22 4" />
+                  <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
+                </svg>
+                {linting ? "Linting…" : "Lint"}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/studio/src/components/ui/HyperframesLoader.tsx
+++ b/packages/studio/src/components/ui/HyperframesLoader.tsx
@@ -1,0 +1,104 @@
+export interface HyperframesLoaderProps {
+  /** Status text shown below the mark. */
+  title: string;
+  /** Optional secondary detail line. */
+  detail?: string;
+  /** Optional monospace third line for IDs, counts, or percentages. */
+  mono?: string;
+  /** Pixel size of the mark itself; status text scales independently. */
+  size?: number;
+  /** Optional normalized progress value from 0 to 1. */
+  progress?: number;
+}
+
+export function HyperframesLoader({
+  title,
+  detail,
+  mono,
+  size = 64,
+  progress,
+}: HyperframesLoaderProps) {
+  const boundedProgress =
+    typeof progress === "number" && Number.isFinite(progress)
+      ? Math.min(1, Math.max(0, progress))
+      : undefined;
+  const markFrameSize = Math.round(size * 1.16);
+
+  return (
+    <div className="hf-loader" draggable={false}>
+      <div
+        className="hf-loader-mark-frame"
+        style={{ width: markFrameSize, height: markFrameSize }}
+        draggable={false}
+      >
+        <svg
+          className="hf-loader-mark"
+          width={size}
+          height={size}
+          viewBox="0 0 100 100"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <g className="hf-loader-mark__mark" transform="translate(50 50)">
+            <g className="hf-loader-mark__core" transform="scale(1)" opacity=".92">
+              <g transform="translate(-50 -50)">
+                <path
+                  d="M10.1851 57.8021L33.1145 73.8313C36.2202 75.9978 41.5173 73.5433 42.4816 69.4984L51.7611 30.4271C52.7253 26.3822 48.5802 23.9277 44.4602 26.0942L13.917 42.1235C6.96677 45.7676 4.97564 54.1579 10.1851 57.8021Z"
+                  fill="url(#hf-loader-grad-left)"
+                />
+                <path
+                  d="M87.5129 57.5141L56.9696 73.5433C52.8371 75.7098 48.7046 73.2553 49.6688 69.2104L58.9483 30.1391C59.9125 26.0942 65.2097 23.6397 68.3154 25.8062L91.2447 41.8354C96.4668 45.4796 94.4631 53.8699 87.5129 57.5141Z"
+                  fill="url(#hf-loader-grad-right)"
+                />
+              </g>
+            </g>
+          </g>
+          <defs>
+            <linearGradient
+              id="hf-loader-grad-left"
+              x1="48.5676"
+              y1="25"
+              x2="44.7804"
+              y2="71.9384"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop stopColor="#06E3FA" />
+              <stop offset="1" stopColor="#4FDB5E" />
+            </linearGradient>
+            <linearGradient
+              id="hf-loader-grad-right"
+              x1="54.8282"
+              y1="73.8392"
+              x2="72.0989"
+              y2="32.8932"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop stopColor="#06E3FA" />
+              <stop offset="1" stopColor="#4FDB5E" />
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+      <div className="hf-loader-title">{title}</div>
+      {detail && <div className="hf-loader-detail">{detail}</div>}
+      {boundedProgress !== undefined && (
+        <div className="hf-loader-progress" aria-hidden="true">
+          <div
+            className="hf-loader-progress__fill"
+            style={{ transform: `scaleX(${boundedProgress})` }}
+          />
+        </div>
+      )}
+      {mono && <div className="hf-loader-mono">{mono}</div>}
+    </div>
+  );
+}
+
+export function StatusFrame(props: HyperframesLoaderProps) {
+  return (
+    <div className="hf-frame">
+      <HyperframesLoader {...props} />
+    </div>
+  );
+}

--- a/packages/studio/src/components/ui/index.ts
+++ b/packages/studio/src/components/ui/index.ts
@@ -1,2 +1,4 @@
 // Minimal UI primitives for studio canvas components
 export { Button, IconButton } from "./Button";
+export { HyperframesLoader, StatusFrame } from "./HyperframesLoader";
+export type { HyperframesLoaderProps } from "./HyperframesLoader";

--- a/packages/studio/src/player/components/CompositionThumbnail.tsx
+++ b/packages/studio/src/player/components/CompositionThumbnail.tsx
@@ -16,6 +16,7 @@ interface CompositionThumbnailProps {
 
 const CLIP_HEIGHT = 66;
 const THUMBNAIL_URL_VERSION = "v3";
+export const COMPOSITION_THUMBNAIL_LABEL_Z_INDEX = 10;
 
 export function buildCompositionThumbnailUrl({
   previewUrl,
@@ -143,7 +144,10 @@ export const CompositionThumbnail = memo(function CompositionThumbnail({
         }}
       />
 
-      <div className="absolute left-2 top-2 z-10">
+      <div
+        className="absolute left-2 top-2"
+        style={{ zIndex: COMPOSITION_THUMBNAIL_LABEL_Z_INDEX }}
+      >
         <span
           className="block max-w-full truncate rounded-md px-1.5 py-0.5 text-[9px] font-semibold uppercase leading-none"
           style={{
@@ -157,8 +161,9 @@ export const CompositionThumbnail = memo(function CompositionThumbnail({
       </div>
 
       <div
-        className="absolute bottom-0 left-0 right-0 z-10 px-1.5 pb-0.5 pt-3"
+        className="absolute bottom-0 left-0 right-0 px-1.5 pb-0.5 pt-3"
         style={{
+          zIndex: COMPOSITION_THUMBNAIL_LABEL_Z_INDEX,
           background:
             "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)",
         }}

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -1,6 +1,7 @@
-import { forwardRef, useRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import { isLottieAnimationLoaded } from "@hyperframes/core/runtime/lottie-readiness";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import { HyperframesLoader } from "../../components/ui";
 // NOTE: importing "@hyperframes/player" registers a class extending HTMLElement
 // at module load, which throws under SSR. Defer the import to the mount effect
 // so it only runs in the browser.
@@ -15,6 +16,19 @@ interface PlayerProps {
 
 interface HyperframesPlayerElement extends HTMLElement {
   iframeElement: HTMLIFrameElement;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getShaderTransitionLoading(event: Event): boolean | null {
+  if (!(event instanceof CustomEvent)) return null;
+  const detail: unknown = event.detail;
+  if (!isRecord(detail)) return null;
+  const state = detail.state;
+  if (!isRecord(state)) return null;
+  return state.loading === true && state.ready !== true;
 }
 
 function enableInteractiveIframe(player: HyperframesPlayerElement): void {
@@ -74,7 +88,11 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
     const containerRef = useRef<HTMLDivElement>(null);
     const loadCountRef = useRef(0);
     const assetPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const assetFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [assetsLoading, setAssetsLoading] = useState(false);
+    const [assetOverlayVisible, setAssetOverlayVisible] = useState(false);
+    const [assetOverlayFading, setAssetOverlayFading] = useState(false);
+    const [shaderTransitionLoading, setShaderTransitionLoading] = useState(false);
 
     useMountEffect(() => {
       const container = containerRef.current;
@@ -90,6 +108,8 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
         // Create the web component imperatively to avoid JSX custom-element typing.
         const player = document.createElement("hyperframes-player") as HyperframesPlayerElement;
         const src = directUrl || `/api/projects/${projectId}/preview`;
+        player.setAttribute("shader-capture-scale", "1");
+        player.setAttribute("shader-loading", "player");
         player.setAttribute("src", src);
         player.setAttribute("width", String(portrait ? 1080 : 1920));
         player.setAttribute("height", String(portrait ? 1920 : 1080));
@@ -112,9 +132,16 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
         const preventToggle = (e: Event) => e.stopImmediatePropagation();
         player.addEventListener("click", preventToggle, { capture: true });
 
+        const handleShaderTransitionState = (event: Event) => {
+          const loading = getShaderTransitionLoading(event);
+          if (loading !== null) setShaderTransitionLoading(loading);
+        };
+        player.addEventListener("shadertransitionstate", handleShaderTransitionState);
+
         // Forward the iframe's native load event to the studio's onIframeLoad.
         const handleLoad = () => {
           loadCountRef.current++;
+          setShaderTransitionLoading(false);
           // Reveal animation on reload (hot-reload, composition switch)
           if (loadCountRef.current > 1) {
             container.classList.remove("preview-revealing");
@@ -164,6 +191,7 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
         cleanup = () => {
           iframe.removeEventListener("load", handleLoad);
           player.removeEventListener("click", preventToggle, { capture: true });
+          player.removeEventListener("shadertransitionstate", handleShaderTransitionState);
           if (assetPollRef.current) clearInterval(assetPollRef.current);
           assetPollRef.current = null;
           container.removeChild(player);
@@ -182,16 +210,60 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
       };
     });
 
+    useEffect(() => {
+      if (assetFadeRef.current) {
+        clearTimeout(assetFadeRef.current);
+        assetFadeRef.current = null;
+      }
+
+      if (assetsLoading) {
+        setAssetOverlayVisible(true);
+        setAssetOverlayFading(false);
+        return;
+      }
+
+      setAssetOverlayFading(true);
+      assetFadeRef.current = setTimeout(() => {
+        setAssetOverlayVisible(false);
+        setAssetOverlayFading(false);
+        assetFadeRef.current = null;
+      }, 240);
+
+      return () => {
+        if (assetFadeRef.current) {
+          clearTimeout(assetFadeRef.current);
+          assetFadeRef.current = null;
+        }
+      };
+    }, [assetsLoading]);
+
+    const showAssetOverlay = assetOverlayVisible && !shaderTransitionLoading;
+
     return (
       <div
         className="relative w-full h-full max-w-full max-h-full overflow-hidden bg-black flex items-center justify-center"
         style={style}
       >
         <div ref={containerRef} className="w-full h-full" />
-        {assetsLoading && (
-          <div className="absolute inset-0 bg-black/80 flex flex-col items-center justify-center z-20 pointer-events-none">
-            <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
-            <span className="text-white/60 text-xs mt-3">Loading assets…</span>
+        {showAssetOverlay && (
+          <div
+            className="absolute inset-0 bg-black flex items-center justify-center z-20 select-none"
+            data-hyperframes-ignore=""
+            draggable={false}
+            style={{
+              opacity: assetOverlayFading ? 0 : 1,
+              pointerEvents: assetOverlayFading ? "none" : "auto",
+              transition: "opacity 240ms ease-out",
+            }}
+            onDragStart={(event) => event.preventDefault()}
+            onMouseDown={(event) => event.preventDefault()}
+            onPointerDown={(event) => event.preventDefault()}
+          >
+            <HyperframesLoader
+              title="Preparing preview assets"
+              detail="Waiting for media and motion assets before playback starts."
+              size={56}
+            />
           </div>
         )}
       </div>

--- a/packages/studio/src/player/components/Timeline.test.ts
+++ b/packages/studio/src/player/components/Timeline.test.ts
@@ -12,6 +12,8 @@ import {
   shouldHandleTimelineDeleteKey,
   shouldAutoScrollTimeline,
 } from "./Timeline";
+import { TIMELINE_CLIP_CONTROL_Z_INDEX } from "./TimelineClip";
+import { COMPOSITION_THUMBNAIL_LABEL_Z_INDEX } from "./CompositionThumbnail";
 import { formatTime } from "../lib/time";
 
 describe("generateTicks", () => {
@@ -161,6 +163,12 @@ describe("shouldAutoScrollTimeline", () => {
 
   it("auto-scrolls in manual mode when horizontal overflow exists", () => {
     expect(shouldAutoScrollTimeline("manual", 1200, 800)).toBe(true);
+  });
+});
+
+describe("timeline clip controls", () => {
+  it("renders layer controls above composition thumbnail chrome", () => {
+    expect(TIMELINE_CLIP_CONTROL_Z_INDEX).toBeGreaterThan(COMPOSITION_THUMBNAIL_LABEL_Z_INDEX);
   });
 });
 

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -28,6 +28,11 @@ import {
 } from "./timelineTheme";
 import { getPinchTimelineZoomPercent, getTimelinePixelsPerSecond } from "./timelineZoom";
 import { TIMELINE_ASSET_MIME } from "../../utils/timelineAssetDrop";
+import {
+  canInspectTimelineElement,
+  getTimelineElementKey,
+  isAudioTimelineElement,
+} from "../../utils/timelineInspector";
 
 /* ── Layout ─────────────────────────────────────────────────────── */
 const GUTTER = 32;
@@ -329,6 +334,12 @@ interface TimelineProps {
     element: import("../store/playerStore").TimelineElement,
     intent: BlockedTimelineEditIntent,
   ) => void;
+  onSelectElement?: (element: import("../store/playerStore").TimelineElement | null) => void;
+  onInspectElement?: (element: import("../store/playerStore").TimelineElement) => void;
+  inspectedElementId?: string | null;
+  layerChildCounts?: ReadonlyMap<string, number>;
+  thumbnailedElementIds?: ReadonlySet<string>;
+  onToggleElementThumbnail?: (element: import("../store/playerStore").TimelineElement) => void;
   theme?: Partial<TimelineTheme>;
 }
 
@@ -376,6 +387,12 @@ export const Timeline = memo(function Timeline({
   onMoveElement,
   onResizeElement,
   onBlockedEditAttempt,
+  onSelectElement,
+  onInspectElement,
+  inspectedElementId,
+  layerChildCounts,
+  thumbnailedElementIds,
+  onToggleElementThumbnail,
   theme: themeOverrides,
 }: TimelineProps = {}) {
   const theme = useMemo(() => ({ ...defaultTimelineTheme, ...themeOverrides }), [themeOverrides]);
@@ -1482,6 +1499,14 @@ export const Timeline = memo(function Timeline({
                     const elementKey = el.key ?? el.id;
                     const capabilities = getTimelineEditCapabilities(el);
                     const isSelected = selectedElementId === elementKey;
+                    const canInspectClip = canInspectTimelineElement(el);
+                    const isInspectorActive =
+                      canInspectClip && inspectedElementId === getTimelineElementKey(el);
+                    const childCount = canInspectClip
+                      ? (layerChildCounts?.get(elementKey) ?? 0)
+                      : 0;
+                    const isThumbnailActive = thumbnailedElementIds?.has(elementKey) ?? false;
+                    const thumbnailLabel = isAudioTimelineElement(el) ? "waveform" : "thumbnail";
                     const isComposition = !!el.compositionSrc;
                     const clipKey = `${elementKey}-${i}`;
                     const isHovered = hoveredClip === clipKey;
@@ -1505,8 +1530,32 @@ export const Timeline = memo(function Timeline({
                         theme={theme}
                         trackStyle={clipStyle}
                         isComposition={isComposition}
+                        isInspectorActive={isInspectorActive}
+                        isThumbnailActive={isThumbnailActive}
+                        thumbnailLabel={thumbnailLabel}
+                        childCount={childCount}
                         onHoverStart={() => setHoveredClip(clipKey)}
                         onHoverEnd={() => setHoveredClip(null)}
+                        onInspectorClick={
+                          canInspectClip && onInspectElement
+                            ? (e) => {
+                                e.stopPropagation();
+                                if (suppressClickRef.current) return;
+                                setSelectedElementId(elementKey);
+                                onSelectElement?.(el);
+                                onInspectElement(el);
+                              }
+                            : undefined
+                        }
+                        onThumbnailClick={
+                          onToggleElementThumbnail && canInspectClip
+                            ? (e) => {
+                                e.stopPropagation();
+                                if (suppressClickRef.current) return;
+                                onToggleElementThumbnail(el);
+                              }
+                            : undefined
+                        }
                         onResizeStart={(edge, e) => {
                           if (e.button !== 0 || e.shiftKey || !onResizeElement) return;
                           if (edge === "start" && !capabilities.canTrimStart) return;
@@ -1579,7 +1628,9 @@ export const Timeline = memo(function Timeline({
                         onClick={(e) => {
                           e.stopPropagation();
                           if (suppressClickRef.current) return;
-                          setSelectedElementId(isSelected ? null : elementKey);
+                          const nextElement = isSelected ? null : el;
+                          setSelectedElementId(nextElement ? elementKey : null);
+                          onSelectElement?.(nextElement);
                         }}
                         onDoubleClick={(e) => {
                           e.stopPropagation();

--- a/packages/studio/src/player/components/TimelineClip.test.ts
+++ b/packages/studio/src/player/components/TimelineClip.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { getTimelineClipControlPresentation } from "./TimelineClip";
+
+describe("getTimelineClipControlPresentation", () => {
+  it("collapses persistent controls for compact clips until the clip is interactive", () => {
+    expect(
+      getTimelineClipControlPresentation({
+        widthPx: 42,
+        isHovered: false,
+        isSelected: false,
+        isInspectorActive: false,
+        isThumbnailActive: false,
+        isDragging: false,
+      }),
+    ).toMatchObject({
+      compact: true,
+      showControls: false,
+    });
+  });
+
+  it("shows compact controls when the clip is hovered, selected, or active", () => {
+    expect(
+      getTimelineClipControlPresentation({
+        widthPx: 42,
+        isHovered: true,
+        isSelected: false,
+        isInspectorActive: false,
+        isThumbnailActive: false,
+        isDragging: false,
+      }),
+    ).toMatchObject({
+      compact: true,
+      showControls: true,
+    });
+
+    expect(
+      getTimelineClipControlPresentation({
+        widthPx: 42,
+        isHovered: false,
+        isSelected: false,
+        isInspectorActive: true,
+        isThumbnailActive: false,
+        isDragging: false,
+      }).showControls,
+    ).toBe(true);
+  });
+
+  it("keeps controls visible on wide clips", () => {
+    expect(
+      getTimelineClipControlPresentation({
+        widthPx: 120,
+        isHovered: false,
+        isSelected: false,
+        isInspectorActive: false,
+        isThumbnailActive: false,
+        isDragging: false,
+      }),
+    ).toMatchObject({
+      compact: false,
+      showControls: true,
+    });
+  });
+
+  it("treats medium-width clips as compact so dense tracks do not turn into icon grids", () => {
+    expect(
+      getTimelineClipControlPresentation({
+        widthPx: 96,
+        isHovered: false,
+        isSelected: false,
+        isInspectorActive: false,
+        isThumbnailActive: false,
+        isDragging: false,
+      }),
+    ).toMatchObject({
+      compact: true,
+      showControls: false,
+    });
+  });
+
+  it("hides controls while dragging", () => {
+    expect(
+      getTimelineClipControlPresentation({
+        widthPx: 120,
+        isHovered: true,
+        isSelected: true,
+        isInspectorActive: true,
+        isThumbnailActive: true,
+        isDragging: true,
+      }).showControls,
+    ).toBe(false);
+  });
+});

--- a/packages/studio/src/player/components/TimelineClip.tsx
+++ b/packages/studio/src/player/components/TimelineClip.tsx
@@ -17,13 +17,65 @@ interface TimelineClipProps {
   theme?: TimelineTheme;
   trackStyle: TimelineTrackStyle;
   isComposition: boolean;
+  isInspectorActive?: boolean;
+  isThumbnailActive?: boolean;
+  thumbnailLabel?: string;
+  childCount?: number;
   onHoverStart: () => void;
   onHoverEnd: () => void;
   onPointerDown?: (e: React.PointerEvent) => void;
   onResizeStart?: (edge: "start" | "end", e: React.PointerEvent) => void;
+  onInspectorClick?: (e: React.MouseEvent) => void;
+  onThumbnailClick?: (e: React.MouseEvent) => void;
   onClick: (e: React.MouseEvent) => void;
   onDoubleClick: (e: React.MouseEvent) => void;
   children?: ReactNode;
+}
+
+export const TIMELINE_CLIP_CONTROL_Z_INDEX = 20;
+
+const COMPACT_CLIP_CONTROL_WIDTH = 112;
+
+interface TimelineClipControlPresentationInput {
+  widthPx: number;
+  isSelected: boolean;
+  isHovered: boolean;
+  isInspectorActive: boolean;
+  isThumbnailActive: boolean;
+  isDragging: boolean;
+}
+
+export interface TimelineClipControlPresentation {
+  compact: boolean;
+  showControls: boolean;
+  containerClassName: string;
+  buttonClassName: string;
+  iconSize: number;
+}
+
+export function getTimelineClipControlPresentation({
+  widthPx,
+  isSelected,
+  isHovered,
+  isInspectorActive,
+  isThumbnailActive,
+  isDragging,
+}: TimelineClipControlPresentationInput): TimelineClipControlPresentation {
+  const compact = widthPx < COMPACT_CLIP_CONTROL_WIDTH;
+  const isInteractive = isHovered || isSelected || isInspectorActive || isThumbnailActive;
+  const showControls = !isDragging && (!compact || isInteractive);
+
+  return {
+    compact,
+    showControls,
+    containerClassName: compact
+      ? "absolute right-1 top-1 flex items-center gap-1"
+      : "absolute right-2 top-2 flex items-center gap-1",
+    buttonClassName: compact
+      ? "flex h-5 w-5 items-center justify-center rounded-[7px]"
+      : "flex h-6 w-6 items-center justify-center rounded-md",
+    iconSize: compact ? 12 : 14,
+  };
 }
 
 export const TimelineClip = memo(function TimelineClip({
@@ -37,10 +89,16 @@ export const TimelineClip = memo(function TimelineClip({
   theme = defaultTimelineTheme,
   trackStyle,
   isComposition,
+  isInspectorActive = false,
+  isThumbnailActive = false,
+  thumbnailLabel = "thumbnail",
+  childCount = 0,
   onHoverStart,
   onHoverEnd,
   onPointerDown,
   onResizeStart,
+  onInspectorClick,
+  onThumbnailClick,
   onClick,
   onDoubleClick,
   children,
@@ -62,8 +120,20 @@ export const TimelineClip = memo(function TimelineClip({
         : theme.clipShadow;
   const capabilities = getTimelineEditCapabilities(el);
   const displayLabel = el.label || el.id || el.tag;
+  const inspectorLabel =
+    childCount > 0
+      ? `${childCount} nested selectable layer${childCount === 1 ? "" : "s"}`
+      : "Inspect clip layer";
   const showHandles = handleOpacity > 0.01;
   const baseBackgroundImage = isSelected ? theme.clipBackgroundActive : theme.clipBackground;
+  const controlPresentation = getTimelineClipControlPresentation({
+    widthPx,
+    isSelected,
+    isHovered,
+    isInspectorActive,
+    isThumbnailActive,
+    isDragging,
+  });
   const glossBackgroundImage = isSelected
     ? "linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0))"
     : "linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0))";
@@ -115,6 +185,157 @@ export const TimelineClip = memo(function TimelineClip({
       onClick={onClick}
       onDoubleClick={onDoubleClick}
     >
+      {childCount > 0 && controlPresentation.showControls && (
+        <button
+          type="button"
+          className={`absolute flex items-center gap-1 rounded-md border border-studio-accent/30 bg-neutral-950/75 text-[10px] font-semibold tabular-nums text-studio-accent shadow-lg shadow-black/25 backdrop-blur transition-colors hover:border-studio-accent/60 hover:bg-studio-accent/15 ${
+            controlPresentation.compact ? "left-1 top-1 h-5 px-1" : "left-2 top-2 h-6 px-1.5"
+          }`}
+          style={{ zIndex: TIMELINE_CLIP_CONTROL_Z_INDEX }}
+          title={inspectorLabel}
+          aria-label={inspectorLabel}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+          onClick={(event) => {
+            event.stopPropagation();
+            onInspectorClick?.(event);
+          }}
+        >
+          <svg
+            width={controlPresentation.compact ? "11" : "13"}
+            height={controlPresentation.compact ? "11" : "13"}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="4" y="4" width="6" height="6" rx="1" />
+            <rect x="14" y="4" width="6" height="6" rx="1" />
+            <rect x="4" y="14" width="6" height="6" rx="1" />
+            <path d="M14 17h6" />
+          </svg>
+          {childCount}
+        </button>
+      )}
+      {onInspectorClick &&
+        controlPresentation.compact &&
+        !controlPresentation.showControls &&
+        !isDragging && (
+          <button
+            type="button"
+            className="group/clip-inspect absolute right-1 top-1/2 flex h-7 w-2 -translate-y-1/2 items-center justify-center rounded-full border border-white/15 bg-neutral-950/70 text-neutral-300 shadow-lg shadow-black/25 backdrop-blur transition-all hover:w-5 hover:border-white/30 hover:bg-neutral-950/90 focus:w-5 focus:border-studio-accent/60 focus:bg-studio-accent/15 focus:outline-none"
+            style={{ zIndex: TIMELINE_CLIP_CONTROL_Z_INDEX }}
+            title={inspectorLabel}
+            aria-label={inspectorLabel}
+            onPointerDown={(event) => {
+              event.stopPropagation();
+            }}
+            onClick={(event) => {
+              event.stopPropagation();
+              onInspectorClick(event);
+            }}
+          >
+            <svg
+              className="opacity-0 transition-opacity group-hover/clip-inspect:opacity-100 group-focus/clip-inspect:opacity-100"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+          </button>
+        )}
+      {(onThumbnailClick || onInspectorClick) && controlPresentation.showControls && (
+        <div
+          className={controlPresentation.containerClassName}
+          style={{ zIndex: TIMELINE_CLIP_CONTROL_Z_INDEX }}
+        >
+          {onThumbnailClick && (
+            <button
+              type="button"
+              className={`${controlPresentation.buttonClassName} border shadow-lg shadow-black/25 backdrop-blur transition-colors ${
+                isThumbnailActive
+                  ? "border-studio-accent/60 bg-studio-accent/18 text-studio-accent"
+                  : "border-white/12 bg-neutral-950/70 text-neutral-400 hover:border-white/24 hover:text-neutral-100"
+              }`}
+              title={
+                isThumbnailActive ? `Hide clip ${thumbnailLabel}` : `Show clip ${thumbnailLabel}`
+              }
+              aria-label={
+                isThumbnailActive ? `Hide clip ${thumbnailLabel}` : `Show clip ${thumbnailLabel}`
+              }
+              onPointerDown={(event) => {
+                event.stopPropagation();
+              }}
+              onClick={(event) => {
+                event.stopPropagation();
+                onThumbnailClick(event);
+              }}
+            >
+              <svg
+                width={controlPresentation.iconSize}
+                height={controlPresentation.iconSize}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3" y="5" width="18" height="14" rx="2" />
+                <circle cx="8" cy="10" r="1.5" />
+                <path d="m4 17 5-5 4 4 2-2 5 5" />
+              </svg>
+            </button>
+          )}
+          {onInspectorClick && (
+            <button
+              type="button"
+              className={`${controlPresentation.buttonClassName} border shadow-lg shadow-black/25 backdrop-blur transition-colors ${
+                isInspectorActive
+                  ? "border-studio-accent/60 bg-studio-accent/18 text-studio-accent"
+                  : "border-white/12 bg-neutral-950/70 text-neutral-400 hover:border-white/24 hover:text-neutral-100"
+              }`}
+              title={inspectorLabel}
+              aria-label={inspectorLabel}
+              onPointerDown={(event) => {
+                event.stopPropagation();
+              }}
+              onClick={(event) => {
+                event.stopPropagation();
+                onInspectorClick(event);
+              }}
+            >
+              <svg
+                width={controlPresentation.iconSize}
+                height={controlPresentation.iconSize}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
       <div
         aria-hidden="true"
         role="presentation"

--- a/packages/studio/src/player/components/timelineEditing.test.ts
+++ b/packages/studio/src/player/components/timelineEditing.test.ts
@@ -262,6 +262,21 @@ describe("getTimelineEditCapabilities", () => {
     });
   });
 
+  it("keeps implicit layout layers selectable but not timeline-editable", () => {
+    expect(
+      getTimelineEditCapabilities({
+        duration: 8,
+        selector: ".scene-shell",
+        tag: "div",
+        timingSource: "implicit",
+      }),
+    ).toEqual({
+      canMove: false,
+      canTrimStart: false,
+      canTrimEnd: false,
+    });
+  });
+
   it("allows move and both trims for patchable media clips with offset support", () => {
     expect(
       getTimelineEditCapabilities({

--- a/packages/studio/src/player/components/timelineEditing.ts
+++ b/packages/studio/src/player/components/timelineEditing.ts
@@ -228,7 +228,16 @@ export function getTimelineEditCapabilities(input: {
   playbackStart?: number;
   playbackStartAttr?: "media-start" | "playback-start";
   sourceDuration?: number;
+  timingSource?: "authored" | "implicit";
 }): TimelineEditCapabilities {
+  if (input.timingSource === "implicit") {
+    return {
+      canMove: false,
+      canTrimStart: false,
+      canTrimEnd: false,
+    };
+  }
+
   const canPatch = hasPatchableTimelineTarget(input);
   const hasFiniteDuration = Number.isFinite(input.duration) && input.duration > 0;
   const hasDeterministicWindow = isDeterministicTimelineWindow(input);

--- a/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { Window } from "happy-dom";
 import {
   buildStandaloneRootTimelineElement,
+  createStaticSeekPlaybackAdapter,
   createTimelineElementFromManifestClip,
   findTimelineDomNodeForClip,
   getTimelineElementSelector,
   parseTimelineFromDOM,
+  readTimelineDurationFromDocument,
   type ClipManifestClip,
   mergeTimelineElementsPreservingDowngrades,
   resolveStandaloneRootCompositionSrc,
@@ -56,6 +58,102 @@ function mockKeyboardEvent(
     ...overrides,
   };
 }
+
+function createManualAnimationClock() {
+  let now = 0;
+  let nextId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  return {
+    now: () => now,
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      nextId += 1;
+      callbacks.set(nextId, callback);
+      return nextId;
+    },
+    cancelAnimationFrame: (id: number) => {
+      callbacks.delete(id);
+    },
+    step: (milliseconds: number) => {
+      now += milliseconds;
+      const pending = Array.from(callbacks.entries());
+      callbacks.clear();
+      for (const [, callback] of pending) {
+        callback(now);
+      }
+    },
+    scheduledCount: () => callbacks.size,
+  };
+}
+
+describe("readTimelineDurationFromDocument", () => {
+  it("prefers the root composition duration", () => {
+    const doc = createDocument(`
+      <div data-composition-id="main" data-duration="3">
+        <section data-start="0" data-duration="8"></section>
+      </div>
+    `);
+
+    expect(readTimelineDurationFromDocument(doc)).toBe(3);
+  });
+
+  it("falls back to the maximum child end time", () => {
+    const doc = createDocument(`
+      <div data-composition-id="main">
+        <section data-start="1" data-duration="2"></section>
+        <section data-start="4" data-duration="1.5"></section>
+      </div>
+    `);
+
+    expect(readTimelineDurationFromDocument(doc)).toBe(5.5);
+  });
+});
+
+describe("createStaticSeekPlaybackAdapter", () => {
+  it("drives renderSeek while playing a duration-only composition", () => {
+    const clock = createManualAnimationClock();
+    const renderedTimes: number[] = [];
+    const adapter = createStaticSeekPlaybackAdapter(
+      {
+        getTime: () => 0,
+        renderSeek: (time: number) => {
+          renderedTimes.push(time);
+        },
+      },
+      3,
+      clock,
+    );
+
+    adapter.seek(1);
+    adapter.play();
+    clock.step(500);
+    clock.step(2_000);
+
+    expect(renderedTimes).toEqual([1, 1.5, 3]);
+    expect(adapter.getTime()).toBe(3);
+    expect(adapter.isPlaying()).toBe(false);
+    expect(clock.scheduledCount()).toBe(0);
+  });
+
+  it("clamps explicit seeks to the fallback duration", () => {
+    const clock = createManualAnimationClock();
+    const renderedTimes: number[] = [];
+    const adapter = createStaticSeekPlaybackAdapter(
+      {
+        getTime: () => 0,
+        renderSeek: (time: number) => {
+          renderedTimes.push(time);
+        },
+      },
+      2,
+      clock,
+    );
+
+    adapter.seek(9);
+
+    expect(renderedTimes).toEqual([2]);
+    expect(adapter.getTime()).toBe(2);
+  });
+});
 
 describe("buildStandaloneRootTimelineElement", () => {
   it("includes selector and source metadata for standalone composition fallback clips", () => {
@@ -151,6 +249,36 @@ describe("findTimelineDomNodeForClip", () => {
 });
 
 describe("anonymous timeline identity", () => {
+  it("adds root-level untimed DOM layers as implicit full-duration layers", () => {
+    const doc = createDocument(`
+      <div data-composition-id="compare" data-start="0" data-duration="18">
+        <link rel="stylesheet" href="styles.css" />
+        <div class="scene-shell">
+          <div class="topline">Title</div>
+        </div>
+        <video id="main-video" class="clip main-video" data-start="0" data-duration="18" data-track-index="1"></video>
+        <script></script>
+      </div>
+    `);
+
+    const elements = parseTimelineFromDOM(doc, 18);
+
+    expect(elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          duration: 18,
+          label: "Scene Shell",
+          selector: ".scene-shell",
+          start: 0,
+          tag: "div",
+          timingSource: "implicit",
+        }),
+      ]),
+    );
+    expect(elements.find((element) => element.tag === "link")).toBeUndefined();
+    expect(elements.find((element) => element.tag === "script")).toBeUndefined();
+  });
+
   it("keeps fallback-parsed anonymous clips distinct when labels match", () => {
     const doc = createDocument(`
       <div data-composition-id="main" data-start="0" data-duration="8">

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -4,13 +4,23 @@ import { useMountEffect } from "../../hooks/useMountEffect";
 import { stepFrameTime, STUDIO_PREVIEW_FPS } from "../lib/time";
 import { useCaptionStore } from "../../captions/store";
 
-interface PlaybackAdapter {
+export interface PlaybackAdapter {
   play: () => void;
   pause: () => void;
   seek: (time: number) => void;
   getTime: () => number;
   getDuration: () => number;
   isPlaying: () => boolean;
+}
+
+type RuntimePlaybackAdapter = PlaybackAdapter & {
+  renderSeek?: (time: number) => void;
+};
+
+interface StaticSeekPlaybackClock {
+  now: () => number;
+  requestAnimationFrame: (callback: FrameRequestCallback) => number;
+  cancelAnimationFrame: (handle: number) => void;
 }
 
 interface TimelineLike {
@@ -43,11 +53,132 @@ interface ClipManifest {
 }
 
 type IframeWindow = Window & {
-  __player?: PlaybackAdapter;
+  __player?: RuntimePlaybackAdapter;
   __timeline?: TimelineLike;
   __timelines?: Record<string, TimelineLike>;
   __clipManifest?: ClipManifest;
 };
+
+function isFinitePositive(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function clampTime(time: number, duration: number): number {
+  const safeDuration = Math.max(0, Number.isFinite(duration) ? duration : 0);
+  const safeTime = Math.max(0, Number.isFinite(time) ? time : 0);
+  return safeDuration > 0 ? Math.min(safeTime, safeDuration) : safeTime;
+}
+
+function readDurationAttribute(el: Element | null | undefined): number {
+  if (!el) return 0;
+  const duration =
+    Number.parseFloat(el.getAttribute("data-duration") ?? "") ||
+    Number.parseFloat(el.getAttribute("data-hf-authored-duration") ?? "");
+  return isFinitePositive(duration) ? duration : 0;
+}
+
+export function readTimelineDurationFromDocument(doc: Document | null | undefined): number {
+  if (!doc) return 0;
+  const rootDuration = readDurationAttribute(doc.querySelector("[data-composition-id]"));
+  if (rootDuration > 0) return rootDuration;
+
+  let maxEnd = 0;
+  for (const node of Array.from(doc.querySelectorAll("[data-start]"))) {
+    const start = Number.parseFloat(node.getAttribute("data-start") ?? "");
+    const duration = readDurationAttribute(node);
+    if (!Number.isFinite(start) || start < 0 || duration <= 0) continue;
+    maxEnd = Math.max(maxEnd, start + duration);
+  }
+  return maxEnd;
+}
+
+function getAdapterDuration(adapter: PlaybackAdapter | null | undefined): number {
+  if (!adapter) return 0;
+  try {
+    const duration = Number(adapter.getDuration());
+    return isFinitePositive(duration) ? duration : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function getDefaultStaticSeekPlaybackClock(win: Window): StaticSeekPlaybackClock {
+  return {
+    now: () => win.performance.now(),
+    requestAnimationFrame: (callback) => win.requestAnimationFrame(callback),
+    cancelAnimationFrame: (handle) => win.cancelAnimationFrame(handle),
+  };
+}
+
+export function createStaticSeekPlaybackAdapter(
+  player: Pick<RuntimePlaybackAdapter, "getTime"> &
+    Partial<Pick<RuntimePlaybackAdapter, "renderSeek" | "seek">>,
+  duration: number,
+  clock: StaticSeekPlaybackClock,
+  getPlaybackRate: () => number = () => 1,
+): PlaybackAdapter {
+  const safeDuration = Math.max(0, Number.isFinite(duration) ? duration : 0);
+  let currentTime = clampTime(Number(player.getTime?.() ?? 0), safeDuration);
+  let playing = false;
+  let rafId = 0;
+  let playStartTime = currentTime;
+  let playStartNow = clock.now();
+
+  const renderSeek = (time: number) => {
+    currentTime = clampTime(time, safeDuration);
+    if (typeof player.renderSeek === "function") {
+      player.renderSeek(currentTime);
+      return;
+    }
+    player.seek?.(currentTime);
+  };
+
+  const stopTicker = () => {
+    if (rafId) {
+      clock.cancelAnimationFrame(rafId);
+      rafId = 0;
+    }
+  };
+
+  const tick: FrameRequestCallback = (now) => {
+    if (!playing) return;
+    const playbackRate = Math.max(0.1, Number(getPlaybackRate()) || 1);
+    const elapsed = ((now - playStartNow) / 1000) * playbackRate;
+    renderSeek(playStartTime + elapsed);
+    if (currentTime >= safeDuration) {
+      playing = false;
+      rafId = 0;
+      return;
+    }
+    rafId = clock.requestAnimationFrame(tick);
+  };
+
+  return {
+    play: () => {
+      if (playing || safeDuration <= 0) return;
+      if (currentTime >= safeDuration) renderSeek(0);
+      playing = true;
+      playStartTime = currentTime;
+      playStartNow = clock.now();
+      stopTicker();
+      rafId = clock.requestAnimationFrame(tick);
+    },
+    pause: () => {
+      playing = false;
+      stopTicker();
+    },
+    seek: (time) => {
+      renderSeek(time);
+      if (playing) {
+        playStartTime = currentTime;
+        playStartNow = clock.now();
+      }
+    },
+    getTime: () => currentTime,
+    getDuration: () => safeDuration,
+    isPlaying: () => playing,
+  };
+}
 
 function wrapTimeline(tl: TimelineLike): PlaybackAdapter {
   return {
@@ -183,6 +314,100 @@ function getTimelineElementDisplayLabel(input: {
   return tag ? `${tag} clip` : "Timeline clip";
 }
 
+const IMPLICIT_TIMELINE_LAYER_SKIP_TAGS = new Set([
+  "base",
+  "link",
+  "meta",
+  "noscript",
+  "script",
+  "style",
+  "template",
+]);
+
+function humanizeTimelineIdentifier(value: string): string {
+  return value
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function getImplicitTimelineLayerLabel(el: HTMLElement): string {
+  const explicitLabel =
+    el.getAttribute("data-timeline-label") ??
+    el.getAttribute("data-label") ??
+    el.getAttribute("aria-label");
+  if (explicitLabel?.trim()) return explicitLabel.trim();
+  if (el.id.trim()) return humanizeTimelineIdentifier(el.id);
+  const classes = el.className.split(/\s+/).filter(Boolean);
+  const className = classes.find((value) => value !== "clip") ?? classes[0];
+  if (className) return humanizeTimelineIdentifier(className);
+  return getTimelineElementDisplayLabel({ tag: el.tagName });
+}
+
+function isImplicitTimelineLayerCandidate(root: Element, el: Element): el is HTMLElement {
+  if (!isHtmlElement(el)) return false;
+  if (el.parentElement !== root) return false;
+  const tagName = el.tagName.toLowerCase();
+  if (IMPLICIT_TIMELINE_LAYER_SKIP_TAGS.has(tagName)) return false;
+  if (el.hasAttribute("data-start") || el.hasAttribute("data-track-index")) return false;
+  return Boolean(getTimelineElementSelector(el));
+}
+
+export function createImplicitTimelineLayersFromDOM(
+  doc: Document,
+  rootDuration: number,
+  existingElements: readonly TimelineElement[] = [],
+): TimelineElement[] {
+  if (!Number.isFinite(rootDuration) || rootDuration <= 0) return [];
+  const rootComp = doc.querySelector("[data-composition-id]");
+  if (!rootComp) return [];
+
+  const existingKeys = new Set(existingElements.map(getTimelineElementIdentity));
+  const maxTrack = existingElements.reduce(
+    (max, element) => Math.max(max, Number.isFinite(element.track) ? element.track : 0),
+    -1,
+  );
+  const layers: TimelineElement[] = [];
+
+  for (const child of Array.from(rootComp.children)) {
+    if (!isImplicitTimelineLayerCandidate(rootComp, child)) continue;
+
+    const selector = getTimelineElementSelector(child);
+    if (!selector) continue;
+    const selectorIndex = getTimelineElementSelectorIndex(doc, child, selector);
+    const sourceFile = getTimelineElementSourceFile(child);
+    const label = getImplicitTimelineLayerLabel(child);
+    const identity = buildTimelineElementIdentity({
+      preferredId: child.id || null,
+      label,
+      fallbackIndex: existingElements.length + layers.length,
+      domId: child.id || undefined,
+      selector,
+      selectorIndex,
+      sourceFile,
+    });
+    if (existingKeys.has(identity.key) || existingKeys.has(identity.id)) continue;
+
+    layers.push({
+      domId: child.id || undefined,
+      duration: rootDuration,
+      id: identity.id,
+      key: identity.key,
+      label,
+      selector,
+      selectorIndex,
+      sourceFile,
+      start: 0,
+      tag: child.tagName.toLowerCase(),
+      timingSource: "implicit",
+      track: maxTrack + 1 + layers.length,
+    });
+  }
+
+  return layers;
+}
+
 /**
  * Parse [data-start] elements from a Document into TimelineElement[].
  * Shared helper — used by onIframeLoad fallback, handleMessage, and enrichMissingCompositions.
@@ -244,6 +469,7 @@ export function parseTimelineFromDOM(doc: Document, rootDuration: number): Timel
       selector,
       selectorIndex,
       sourceFile,
+      timingSource: "authored",
     };
 
     const mediaEl = resolveMediaElement(el);
@@ -275,7 +501,7 @@ export function parseTimelineFromDOM(doc: Document, rootDuration: number): Timel
     els.push(entry);
   });
 
-  return els;
+  return [...els, ...createImplicitTimelineLayersFromDOM(doc, rootDuration, els)];
 }
 
 function isHtmlElement(el: Element): el is HTMLElement {
@@ -680,6 +906,11 @@ export function useTimelinePlayer() {
   const iframeShortcutCleanupRef = useRef<(() => void) | null>(null);
   const playbackKeyDownRef = useRef<(e: KeyboardEvent) => void>(() => {});
   const playbackKeyUpRef = useRef<(e: KeyboardEvent) => void>(() => {});
+  const staticSeekAdapterRef = useRef<{
+    player: RuntimePlaybackAdapter;
+    duration: number;
+    adapter: PlaybackAdapter;
+  } | null>(null);
 
   // ZERO store subscriptions — this hook never causes re-renders.
   // All reads use getState() (point-in-time), all writes use the stable setters.
@@ -708,13 +939,18 @@ export function useTimelinePlayer() {
     try {
       const iframe = iframeRef.current;
       const win = iframe?.contentWindow as IframeWindow | null;
-      if (!win) return null;
+      if (!iframe || !win) return null;
 
-      if (win.__player && typeof win.__player.play === "function") {
-        return win.__player;
+      const playerAdapter =
+        win.__player && typeof win.__player.play === "function" ? win.__player : null;
+      if (getAdapterDuration(playerAdapter) > 0) {
+        return playerAdapter;
       }
 
-      if (win.__timeline) return wrapTimeline(win.__timeline);
+      if (win.__timeline) {
+        const adapter = wrapTimeline(win.__timeline);
+        if (getAdapterDuration(adapter) > 0) return adapter;
+      }
 
       if (win.__timelines) {
         const keys = Object.keys(win.__timelines);
@@ -727,11 +963,40 @@ export function useTimelinePlayer() {
             ?.querySelector("[data-composition-id]")
             ?.getAttribute("data-composition-id");
           const key = rootId && rootId in win.__timelines ? rootId : keys[keys.length - 1];
-          return wrapTimeline(win.__timelines[key]);
+          const adapter = wrapTimeline(win.__timelines[key]);
+          if (getAdapterDuration(adapter) > 0) return adapter;
         }
       }
 
-      return null;
+      const fallbackDuration = Math.max(
+        usePlayerStore.getState().duration,
+        readTimelineDurationFromDocument(iframe.contentDocument),
+      );
+      if (
+        playerAdapter &&
+        fallbackDuration > 0 &&
+        (typeof playerAdapter.renderSeek === "function" || typeof playerAdapter.seek === "function")
+      ) {
+        const cached = staticSeekAdapterRef.current;
+        if (cached?.player === playerAdapter && cached.duration === fallbackDuration) {
+          return cached.adapter;
+        }
+        cached?.adapter.pause();
+        const adapter = createStaticSeekPlaybackAdapter(
+          playerAdapter,
+          fallbackDuration,
+          getDefaultStaticSeekPlaybackClock(win),
+          () => usePlayerStore.getState().playbackRate,
+        );
+        staticSeekAdapterRef.current = {
+          player: playerAdapter,
+          duration: fallbackDuration,
+          adapter,
+        };
+        return adapter;
+      }
+
+      return playerAdapter;
     } catch (err) {
       console.warn("[useTimelinePlayer] Could not get playback adapter (cross-origin)", err);
       return null;
@@ -1064,8 +1329,15 @@ export function useTimelinePlayer() {
               }))
               .filter((element) => element.duration > 0)
           : els;
-      if (clampedEls.length > 0) {
-        syncTimelineElements(clampedEls, newDuration > 0 ? newDuration : undefined);
+      const timelineEls =
+        iframeDoc && effectiveDuration > 0
+          ? [
+              ...clampedEls,
+              ...createImplicitTimelineLayersFromDOM(iframeDoc, effectiveDuration, clampedEls),
+            ]
+          : clampedEls;
+      if (timelineEls.length > 0) {
+        syncTimelineElements(timelineEls, newDuration > 0 ? newDuration : undefined);
       }
     },
     [syncTimelineElements],

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -23,6 +23,8 @@ export interface TimelineElement {
   volume?: number;
   /** Path from data-composition-src — identifies sub-composition elements */
   compositionSrc?: string;
+  /** Whether this row came from authored clip timing or Studio's full-duration layer fallback. */
+  timingSource?: "authored" | "implicit";
 }
 
 export type ZoomMode = "fit" | "manual";

--- a/packages/studio/src/styles/studio.css
+++ b/packages/studio/src/styles/studio.css
@@ -49,3 +49,115 @@ body {
 .cm-editor.cm-focused {
   outline: none;
 }
+
+/*
+ * HyperFrames brand loader. Shared by preview overlays that need a calm,
+ * branded loading state instead of a generic spinner.
+ */
+.hf-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  width: min(34rem, 100%);
+  padding: 1.5rem;
+  box-sizing: border-box;
+  text-align: center;
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hf-frame {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 12rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.52);
+}
+
+.hf-loader-mark-frame {
+  display: grid;
+  place-items: center;
+  overflow: visible;
+  transform-origin: 50% 50%;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hf-loader-mark {
+  display: block;
+  overflow: visible;
+  filter: drop-shadow(0 0 7px rgba(79, 219, 94, 0.2));
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hf-loader-title {
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--hf-heading, #f4f4f5);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hf-loader-detail {
+  max-width: 32rem;
+  min-height: 2.5rem;
+  overflow: hidden;
+  color: var(--hf-text-secondary, rgba(244, 244, 245, 0.68));
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.hf-loader-mono {
+  width: min(36rem, 100%);
+  min-height: 1.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--hf-text-tertiary, rgba(244, 244, 245, 0.46));
+  font-family: "IBM Plex Mono", "SF Mono", "Fira Code", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.hf-loader-progress {
+  width: min(18rem, 72vw);
+  height: 0.375rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.hf-loader-progress__fill {
+  width: 100%;
+  height: 100%;
+  transform: scaleX(0);
+  transform-origin: left center;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #06e3fa, #4fdb5e);
+  transition: transform 160ms ease;
+}

--- a/packages/studio/src/utils/editHistory.ts
+++ b/packages/studio/src/utils/editHistory.ts
@@ -1,4 +1,4 @@
-export type EditHistoryKind = "manual" | "timeline" | "source";
+export type EditHistoryKind = "manual" | "motion" | "timeline" | "source";
 
 export interface EditHistoryFileSnapshot {
   before: string;

--- a/packages/studio/src/utils/timelineInspector.test.ts
+++ b/packages/studio/src/utils/timelineInspector.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { Window } from "happy-dom";
+import {
+  canInspectTimelineElement,
+  getTimelineLayerVisibilityInPreview,
+  getTimelineElementKey,
+  isAudioTimelineElement,
+  isTimelineElementActiveAtTime,
+  isTimelineLayerVisibleInPreview,
+  shouldShowTimelineInspectorBounds,
+} from "./timelineInspector";
+
+function createDocument(markup: string): Document {
+  const window = new Window();
+  window.document.body.innerHTML = markup;
+  return window.document;
+}
+
+function attachVisibleBox(element: HTMLElement) {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      bottom: 34,
+      height: 24,
+      left: 10,
+      right: 90,
+      top: 10,
+      width: 80,
+      x: 10,
+      y: 10,
+      toJSON: () => ({}),
+    }),
+  });
+}
+
+describe("timeline inspector", () => {
+  it("keeps visual clips inspectable and audio-only clips out of the visual panel", () => {
+    expect(canInspectTimelineElement({ tag: "section" })).toBe(true);
+    expect(canInspectTimelineElement({ tag: "video", src: "assets/demo.mp4" })).toBe(true);
+    expect(canInspectTimelineElement({ tag: "audio" })).toBe(false);
+    expect(canInspectTimelineElement({ tag: "div", src: "assets/narration.mp3" })).toBe(false);
+    expect(isAudioTimelineElement({ tag: "sfx" })).toBe(true);
+  });
+
+  it("uses stable timeline keys and only shows bounds at clip edges", () => {
+    expect(getTimelineElementKey({ id: "card", key: "index.html#card" })).toBe("index.html#card");
+    expect(shouldShowTimelineInspectorBounds(2, { start: 2, duration: 4 })).toBe(true);
+    expect(shouldShowTimelineInspectorBounds(6, { start: 2, duration: 4 })).toBe(true);
+    expect(shouldShowTimelineInspectorBounds(4, { start: 2, duration: 4 })).toBe(false);
+  });
+
+  it("keeps selected layer bounds visible only while the clip is active", () => {
+    expect(isTimelineElementActiveAtTime(1.99, { start: 2, duration: 4 }, 0)).toBe(false);
+    expect(isTimelineElementActiveAtTime(2, { start: 2, duration: 4 }, 0)).toBe(true);
+    expect(isTimelineElementActiveAtTime(4, { start: 2, duration: 4 }, 0)).toBe(true);
+    expect(isTimelineElementActiveAtTime(6, { start: 2, duration: 4 }, 0)).toBe(true);
+    expect(isTimelineElementActiveAtTime(6.01, { start: 2, duration: 4 }, 0)).toBe(false);
+  });
+
+  it("uses composite visibility for nested layers", () => {
+    const hiddenDoc = createDocument(`<div style="opacity: 0"><span id="label">Label</span></div>`);
+    const hiddenLabel = hiddenDoc.getElementById("label") as HTMLElement;
+    attachVisibleBox(hiddenLabel);
+    expect(isTimelineLayerVisibleInPreview(hiddenLabel)).toBe(false);
+
+    const visibleDoc = createDocument(
+      `<div style="opacity: 1"><span id="label">Label</span></div>`,
+    );
+    const visibleLabel = visibleDoc.getElementById("label") as HTMLElement;
+    attachVisibleBox(visibleLabel);
+    expect(isTimelineLayerVisibleInPreview(visibleLabel)).toBe(true);
+    expect(getTimelineLayerVisibilityInPreview(visibleLabel)).toMatchObject({
+      compositeOpacity: 1,
+      hasBox: true,
+      inViewport: true,
+      visible: true,
+    });
+  });
+});

--- a/packages/studio/src/utils/timelineInspector.ts
+++ b/packages/studio/src/utils/timelineInspector.ts
@@ -1,0 +1,116 @@
+import type { TimelineElement } from "../player";
+
+export const TIMELINE_INSPECTOR_BOUNDARY_EPSILON_SECONDS = 0.08;
+
+const AUDIO_TIMELINE_TAGS = new Set(["audio", "music", "sfx", "sound", "narration"]);
+const AUDIO_SOURCE_EXT_RE = /\.(aac|flac|m4a|mp3|ogg|opus|wav)(?:[?#].*)?$/i;
+
+export function getTimelineElementKey(
+  element: Pick<TimelineElement, "id" | "key"> | null | undefined,
+): string | null {
+  if (!element) return null;
+  return element.key ?? element.id;
+}
+
+export function isAudioTimelineElement(
+  element: Pick<TimelineElement, "tag" | "src"> | null | undefined,
+): boolean {
+  if (!element) return false;
+  const tag = element.tag.trim().toLowerCase();
+  if (AUDIO_TIMELINE_TAGS.has(tag)) return true;
+  return Boolean(element.src && AUDIO_SOURCE_EXT_RE.test(element.src));
+}
+
+export function canInspectTimelineElement(
+  element: Pick<TimelineElement, "tag" | "src"> | null | undefined,
+): boolean {
+  return !isAudioTimelineElement(element);
+}
+
+export function shouldShowTimelineInspectorBounds(
+  currentTime: number,
+  element: Pick<TimelineElement, "start" | "duration"> | null | undefined,
+  epsilonSeconds = TIMELINE_INSPECTOR_BOUNDARY_EPSILON_SECONDS,
+): boolean {
+  if (!element) return false;
+  if (!Number.isFinite(currentTime)) return false;
+  if (!Number.isFinite(element.start) || !Number.isFinite(element.duration)) return false;
+  const start = Math.max(0, element.start);
+  const end = Math.max(start, start + Math.max(0, element.duration));
+  const epsilon = Math.max(0, epsilonSeconds);
+  return Math.abs(currentTime - start) <= epsilon || Math.abs(currentTime - end) <= epsilon;
+}
+
+export function isTimelineElementActiveAtTime(
+  currentTime: number,
+  element: Pick<TimelineElement, "start" | "duration"> | null | undefined,
+  epsilonSeconds = TIMELINE_INSPECTOR_BOUNDARY_EPSILON_SECONDS,
+): boolean {
+  if (!element) return false;
+  if (!Number.isFinite(currentTime)) return false;
+  if (!Number.isFinite(element.start) || !Number.isFinite(element.duration)) return false;
+  const start = Math.max(0, element.start);
+  const end = Math.max(start, start + Math.max(0, element.duration));
+  const epsilon = Math.max(0, epsilonSeconds);
+  return currentTime >= start - epsilon && currentTime <= end + epsilon;
+}
+
+export interface TimelineLayerVisibility {
+  visible: boolean;
+  compositeOpacity: number;
+  hasBox: boolean;
+  inViewport: boolean;
+}
+
+export function getTimelineLayerVisibilityInPreview(
+  element: HTMLElement,
+  options: { minCompositeOpacity?: number } = {},
+): TimelineLayerVisibility {
+  const hidden: TimelineLayerVisibility = {
+    visible: false,
+    compositeOpacity: 0,
+    hasBox: false,
+    inViewport: false,
+  };
+  if (!element.isConnected) return hidden;
+  const doc = element.ownerDocument;
+  const win = doc.defaultView;
+  if (!win) return hidden;
+
+  const minCompositeOpacity = options.minCompositeOpacity ?? 0.01;
+  let compositeOpacity = 1;
+  let current: HTMLElement | null = element;
+  while (current && current !== doc.body && current !== doc.documentElement) {
+    const style = win.getComputedStyle(current);
+    if (style.display === "none" || style.visibility === "hidden") {
+      return { ...hidden, compositeOpacity };
+    }
+    compositeOpacity *= Number.parseFloat(style.opacity || "1");
+    if (compositeOpacity <= minCompositeOpacity) {
+      return { ...hidden, compositeOpacity };
+    }
+    current = current.parentElement;
+  }
+
+  const rect = element.getBoundingClientRect();
+  const hasBox = rect.width > 0.5 && rect.height > 0.5;
+  if (!hasBox) return { visible: false, compositeOpacity, hasBox, inViewport: false };
+
+  const viewportWidth = win.innerWidth || doc.documentElement.clientWidth;
+  const viewportHeight = win.innerHeight || doc.documentElement.clientHeight;
+  const inViewport =
+    rect.right > 0 && rect.bottom > 0 && rect.left < viewportWidth && rect.top < viewportHeight;
+  return {
+    visible: inViewport,
+    compositeOpacity,
+    hasBox,
+    inViewport,
+  };
+}
+
+export function isTimelineLayerVisibleInPreview(
+  element: HTMLElement,
+  options: { minCompositeOpacity?: number } = {},
+): boolean {
+  return getTimelineLayerVisibilityInPreview(element, options).visible;
+}

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -8,16 +8,21 @@ import {
   lstatSync,
   realpathSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { createHash } from "node:crypto";
 import {
   type ResolvedProject,
   type RenderJobState,
   type StudioApiAdapter,
 } from "@hyperframes/core/studio-api";
-import { createStudioManualEditsRenderBodyScript } from "@hyperframes/core/studio-api/manual-edits-render-script";
+import { createProjectSignature } from "../core/src/studio-api/helpers/projectSignature";
 import { createRetryingModuleLoader, ensureProducerDist } from "./vite.producer";
 import { readNodeRequestBody } from "./vite.request-body.js";
+import {
+  createStudioDevRenderBodyScripts,
+  readStudioDevManualEditManifestContent,
+  readStudioDevMotionManifestContent,
+} from "./vite.studioMotion";
 import { seekThumbnailPreview } from "./vite.thumbnail";
 
 // ── Shared Puppeteer browser ─────────────────────────────────────────────────
@@ -49,8 +54,7 @@ async function getSharedBrowser(): Promise<import("puppeteer-core").Browser | nu
 
 // In-flight thumbnail dedup
 const _thumbnailInflight = new Map<string, Promise<Buffer>>();
-const THUMBNAIL_CACHE_VERSION = "v3";
-const STUDIO_MANUAL_EDITS_PATH = ".hyperframes/studio-manual-edits.json";
+const THUMBNAIL_CACHE_VERSION = "v4";
 
 interface ScreenshotClip {
   x: number;
@@ -59,43 +63,51 @@ interface ScreenshotClip {
   height: number;
 }
 
-function readStudioManualEditManifestContent(projectDir: string): string {
-  const manifestPath = join(projectDir, STUDIO_MANUAL_EDITS_PATH);
-  if (!existsSync(manifestPath)) return "";
-  try {
-    return readFileSync(manifestPath, "utf-8");
-  } catch {
-    return "";
+async function applyStudioRenderBodyScriptsToThumbnailPage(
+  page: import("puppeteer-core").Page,
+  projectDir: string,
+  activeCompositionPath: string,
+): Promise<void> {
+  const scripts = createStudioDevRenderBodyScripts(projectDir, {
+    activeCompositionPath,
+  });
+  for (const script of scripts) {
+    await page.addScriptTag({ content: script });
   }
 }
 
-async function applyStudioManualEditsToThumbnailPage(
-  page: import("puppeteer-core").Page,
-  manifestContent: string,
-  activeCompositionPath: string,
-): Promise<void> {
-  const script = createStudioManualEditsRenderBodyScript(manifestContent, {
-    activeCompositionPath,
-  });
-  if (!script) return;
-  await page.addScriptTag({ content: script });
-}
-
-async function reapplyStudioManualEditsToThumbnailPage(
+async function reapplyStudioRenderBodyScriptsToThumbnailPage(
   page: import("puppeteer-core").Page,
 ): Promise<void> {
   await page.evaluate(() => {
-    const apply = (window as Window & { __hfStudioManualEditsApply?: () => number })
-      .__hfStudioManualEditsApply;
-    if (typeof apply === "function") apply();
+    const runtimeWindow = window as Window & {
+      __hfStudioManualEditsApply?: () => number;
+      __hfStudioMotionApply?: () => number;
+    };
+    if (typeof runtimeWindow.__hfStudioManualEditsApply === "function") {
+      runtimeWindow.__hfStudioManualEditsApply();
+    }
+    if (typeof runtimeWindow.__hfStudioMotionApply === "function") {
+      runtimeWindow.__hfStudioMotionApply();
+    }
   });
+}
+
+function isPathWithin(parentDir: string, childPath: string): boolean {
+  const childRelativePath = relative(resolve(parentDir), resolve(childPath));
+  return (
+    childRelativePath === "" ||
+    (!childRelativePath.startsWith("..") && !isAbsolute(childRelativePath))
+  );
 }
 
 // ── Vite adapter for the shared studio API ───────────────────────────────────
 
 function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAdapter {
   // Lazy-load the bundler via Vite's SSR module loader
-  let _bundler: ((dir: string) => Promise<string>) | null = null;
+  let _bundler:
+    | ((dir: string, options?: { runtime?: "inline" | "placeholder" }) => Promise<string>)
+    | null = null;
   let _producerModuleLoader:
     | (() => Promise<{
         createRenderJob: (config: {
@@ -112,11 +124,17 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
         ) => Promise<void>;
       }>)
     | null = null;
+  const projectSignatureCache = new Map<string, string>();
+  server.watcher.on("all", (_event, file) => {
+    for (const projectDir of projectSignatureCache.keys()) {
+      if (isPathWithin(projectDir, file)) projectSignatureCache.delete(projectDir);
+    }
+  });
   const getBundler = async () => {
     if (!_bundler) {
       try {
         const mod = await server.ssrLoadModule("@hyperframes/core/compiler");
-        _bundler = (dir: string) => mod.bundleToSingleHtml(dir);
+        _bundler = (dir, options) => mod.bundleToSingleHtml(dir, options);
       } catch (err) {
         console.warn("[Studio] Failed to load compiler, previews will use raw HTML:", err);
         _bundler = null as never;
@@ -209,13 +227,25 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
     async bundle(dir: string) {
       const bundler = await getBundler();
       if (!bundler) return null;
-      let html = await bundler(dir);
-      // Fix empty runtime src from bundler — point to the CDN runtime
+      // Studio vite preview: bundler emits an empty `src=""` placeholder so we
+      // can point it at the local /api/runtime.js endpoint. Cached by the browser
+      // across composition hot-reloads instead of being inlined fresh each time.
+      let html = await bundler(dir, { runtime: "placeholder" });
       html = html.replace(
         'data-hyperframes-preview-runtime="1" src=""',
         `data-hyperframes-preview-runtime="1" src="${this.runtimeUrl}"`,
       );
       return html;
+    },
+
+    getProjectSignature(projectDir: string): string {
+      const cacheKey = resolve(projectDir);
+      const cached = projectSignatureCache.get(cacheKey);
+      if (cached) return cached;
+
+      const signature = createProjectSignature(cacheKey);
+      projectSignatureCache.set(cacheKey, signature);
+      return signature;
     },
 
     async lint(html: string, opts?: { filePath?: string }) {
@@ -249,13 +279,12 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
             if (systemChrome) process.env.PRODUCER_HEADLESS_SHELL_PATH = systemChrome;
           }
           const { createRenderJob, executeRenderJob } = await getProducerModule();
-          const manifestContent = readStudioManualEditManifestContent(opts.project.dir);
-          const manualEditsRenderScript = createStudioManualEditsRenderBodyScript(manifestContent);
+          const renderBodyScripts = createStudioDevRenderBodyScripts(opts.project.dir);
           const job = createRenderJob({
             fps: opts.fps as 24 | 30 | 60,
             quality: opts.quality as "draft" | "standard" | "high",
             format: opts.format,
-            ...(manualEditsRenderScript ? { renderBodyScripts: [manualEditsRenderScript] } : {}),
+            ...(renderBodyScripts.length > 0 ? { renderBodyScripts } : {}),
           });
           const onProgress = (j: { progress: number; currentStage?: string }) => {
             state.progress = j.progress;
@@ -288,11 +317,15 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
       const selectorKey = opts.selector
         ? `_${opts.selector.replace(/[^a-zA-Z0-9_-]+/g, "_").slice(0, 80)}_${opts.selectorIndex ?? 0}`
         : "";
-      const manifestContent = readStudioManualEditManifestContent(opts.project.dir);
-      const manifestKey = manifestContent.trim()
-        ? `_${createHash("sha1").update(manifestContent).digest("hex").slice(0, 16)}`
+      const manualManifestContent = readStudioDevManualEditManifestContent(opts.project.dir);
+      const manualManifestKey = manualManifestContent.trim()
+        ? `_${createHash("sha1").update(manualManifestContent).digest("hex").slice(0, 16)}`
         : "";
-      const cacheKey = `${THUMBNAIL_CACHE_VERSION}${manifestKey}_${opts.compPath.replace(/\//g, "_")}_${opts.seekTime.toFixed(2)}${selectorKey}.${opts.format === "png" ? "png" : "jpg"}`;
+      const motionManifestContent = readStudioDevMotionManifestContent(opts.project.dir);
+      const motionManifestKey = motionManifestContent.trim()
+        ? `_${createHash("sha1").update(motionManifestContent).digest("hex").slice(0, 16)}`
+        : "";
+      const cacheKey = `${THUMBNAIL_CACHE_VERSION}${manualManifestKey}${motionManifestKey}_${opts.compPath.replace(/\//g, "_")}_${opts.seekTime.toFixed(2)}${selectorKey}.${opts.format === "png" ? "png" : "jpg"}`;
 
       let bufferPromise = _thumbnailInflight.get(cacheKey);
       if (!bufferPromise) {
@@ -319,10 +352,10 @@ function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAda
             )
             .catch(() => {});
           await seekThumbnailPreview(page, opts.seekTime);
-          await applyStudioManualEditsToThumbnailPage(page, manifestContent, opts.compPath);
+          await applyStudioRenderBodyScriptsToThumbnailPage(page, opts.project.dir, opts.compPath);
           await page.evaluate("document.fonts?.ready");
           await new Promise((r) => setTimeout(r, 200));
-          await reapplyStudioManualEditsToThumbnailPage(page);
+          await reapplyStudioRenderBodyScriptsToThumbnailPage(page);
           let clip: ScreenshotClip | undefined;
           if (opts.selector) {
             clip = await page.evaluate(

--- a/packages/studio/vite.studioMotion.test.ts
+++ b/packages/studio/vite.studioMotion.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createStudioDevRenderBodyScripts } from "./vite.studioMotion";
+
+describe("createStudioDevRenderBodyScripts", () => {
+  let projectDir: string | null = null;
+
+  afterEach(() => {
+    if (!projectDir) return;
+    rmSync(projectDir, { recursive: true, force: true });
+    projectDir = null;
+  });
+
+  function createProject(): string {
+    projectDir = mkdtempSync(join(tmpdir(), "hf-studio-motion-"));
+    mkdirSync(join(projectDir, ".hyperframes"), { recursive: true });
+    return projectDir;
+  }
+
+  it("injects both manual edit and Studio GSAP motion render scripts in dev", () => {
+    const dir = createProject();
+    writeFileSync(
+      join(dir, ".hyperframes/studio-manual-edits.json"),
+      JSON.stringify({
+        version: 1,
+        edits: [{ kind: "text", target: { sourceFile: "index.html" } }],
+      }),
+    );
+    writeFileSync(
+      join(dir, ".hyperframes/studio-motion.json"),
+      JSON.stringify({
+        version: 1,
+        motions: [
+          {
+            kind: "gsap-motion",
+            target: { sourceFile: "index.html", selector: ".card" },
+            start: 0,
+            duration: 0.6,
+            ease: "power3.out",
+            from: { y: 32, autoAlpha: 0 },
+            to: { y: 0, autoAlpha: 1 },
+          },
+        ],
+      }),
+    );
+
+    const scripts = createStudioDevRenderBodyScripts(dir, {
+      activeCompositionPath: "compositions/scene.html",
+    });
+
+    expect(scripts).toHaveLength(2);
+    expect(scripts[0]).toContain("__hfStudioManualEditsApply");
+    expect(scripts[1]).toContain("__hfStudioMotionApply");
+    expect(scripts.join("\n")).toContain("compositions/scene.html");
+  });
+});

--- a/packages/studio/vite.studioMotion.ts
+++ b/packages/studio/vite.studioMotion.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createStudioManualEditsRenderBodyScript,
+  type StudioManualEditsRenderScriptOptions,
+} from "@hyperframes/core/studio-api/manual-edits-render-script";
+import {
+  createStudioMotionRenderBodyScript,
+  STUDIO_MOTION_PATH,
+} from "@hyperframes/core/studio-api/studio-motion-render-script";
+
+const STUDIO_MANUAL_EDITS_PATH = ".hyperframes/studio-manual-edits.json";
+
+function readManifestContent(projectDir: string, manifestPath: string): string {
+  const resolvedPath = join(projectDir, manifestPath);
+  if (!existsSync(resolvedPath)) return "";
+  try {
+    return readFileSync(resolvedPath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+export function readStudioDevManualEditManifestContent(projectDir: string): string {
+  return readManifestContent(projectDir, STUDIO_MANUAL_EDITS_PATH);
+}
+
+export function readStudioDevMotionManifestContent(projectDir: string): string {
+  return readManifestContent(projectDir, STUDIO_MOTION_PATH);
+}
+
+export function createStudioDevRenderBodyScripts(
+  projectDir: string,
+  options: StudioManualEditsRenderScriptOptions = {},
+): string[] {
+  const manualEditsRenderScript = createStudioManualEditsRenderBodyScript(
+    readStudioDevManualEditManifestContent(projectDir),
+    options,
+  );
+  const motionRenderScript = createStudioMotionRenderBodyScript(
+    readStudioDevMotionManifestContent(projectDir),
+    options,
+  );
+  return [manualEditsRenderScript, motionRenderScript].filter(
+    (script): script is string => typeof script === "string",
+  );
+}


### PR DESCRIPTION
## Problem

The Studio animation/manual-editing alpha had grown into one oversized PR. Reviewers need the actual user-facing editor changes separated from the lower-level preview API support, and the alpha controls need safer defaults while we keep testing manual dragging and the motion panel.

## What this fixes

- Moves Clip Layers into the left sidebar as a takeover surface so it no longer looks like part of the video canvas.
- Hides the normal left-panel tabs while Clip Layers is open, keeps nested layer counts visible, and keeps timeline clip inspector buttons available.
- Keeps Motion and preview manual dragging behind env flags: `VITE_STUDIO_ENABLE_MOTION_PANEL` and `VITE_STUDIO_ENABLE_PREVIEW_MANUAL_DRAGGING`.
- Keeps the default inspector focused on Design/Renders while preserving the opt-in GSAP motion panel for alpha testing.
- Carries the timeline thumbnail/player performance work and selection timing fixes needed for the layer inspector flow.
- Adds/updates tests for layer inspection, motion availability, DOM editing, timeline behavior, and player seeking.

## Root cause

The old overlay-based layer picker competed visually with the preview content, and the motion/manual-dragging alpha controls were always present even when the team wanted to test the design panel without those experimental surfaces. Splitting this into a Graphite stack also avoids reviewing Core API changes and Studio UI changes in one giant diff.

## Verification

### Local checks

- `bun run --filter @hyperframes/studio test -- src/components/editor/TimelineLayerPanel.test.ts src/components/editor/manualEditingAvailability.test.ts src/components/editor/PropertyPanel.test.ts src/components/editor/domEditing.test.ts src/components/editor/studioMotion.test.ts src/utils/timelineInspector.test.ts src/player/components/Timeline.test.ts src/player/components/timelineEditing.test.ts src/player/hooks/useTimelinePlayer.test.ts`
- `bun run --filter @hyperframes/core test -- src/studio-api/routes/preview.test.ts src/studio-api/routes/thumbnail.test.ts src/studio-api/helpers/studioMotionRenderScript.test.ts`
- `bun run --filter @hyperframes/core build`
- `bun run --filter @hyperframes/studio build`

### Browser verification

Tested with `agent-browser` against `hf-manual-editing-demo` on the split stack.

- Default flags on `http://127.0.0.1:5298/?v=graphite-default-proof#project/hf-manual-editing-demo`: Clip Layers opens in the left sidebar, Design/Renders remain visible, and Motion is hidden.
- Env flags on `http://127.0.0.1:5299/?v=graphite-env-proof#project/hf-manual-editing-demo`: Inspector exposes the Motion tab.
- Screenshots: `qa-artifacts/graphite-stack/default-loaded.png`, `qa-artifacts/graphite-stack/default-layer-panel.png`, `qa-artifacts/graphite-stack/env-enabled-inspector.png`, `qa-artifacts/graphite-stack/env-enabled-motion-tab.png`.
- Recording: `qa-artifacts/graphite-stack/default-layer-panel-flow.webm`.

## Notes

- This PR intentionally depends on #682 for the Core Studio API support.
- `qa-artifacts/` remains local/untracked.
- Existing PR #680 is superseded by this Graphite stack.