### PR TITLE
feat(studio): enable inspector layers by default

### DIFF
--- a/packages/studio/src/components/editor/manualEditingAvailability.test.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.test.ts
@@ -16,16 +16,16 @@ describe("manual editing availability", () => {
     vi.resetModules();
   });
 
-  it("keeps alpha inspector and manual editing surfaces disabled by default", async () => {
+  it("enables inspector panels by default while manual editing stays opt-in", async () => {
     const availability = await loadAvailabilityWithEnv({});
 
     expect(availability.STUDIO_PREVIEW_MANUAL_EDITING_ENABLED).toBe(false);
-    expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(false);
-    expect(availability.STUDIO_MOTION_PANEL_ENABLED).toBe(false);
-    expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(false);
+    expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(true);
+    expect(availability.STUDIO_MOTION_PANEL_ENABLED).toBe(true);
+    expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(true);
   });
 
-  it("enables inspector layers only through explicit opt-in flags", async () => {
+  it("keeps explicit truthy inspector env flags enabled", async () => {
     const availability = await loadAvailabilityWithEnv({
       VITE_STUDIO_ENABLE_INSPECTOR_PANELS: "1",
       VITE_STUDIO_ENABLE_TIMELINE_LAYER_INSPECTOR: "true",
@@ -33,6 +33,17 @@ describe("manual editing availability", () => {
 
     expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(true);
     expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(true);
+  });
+
+  it("allows explicit env flags to disable default-on inspector panels", async () => {
+    const availability = await loadAvailabilityWithEnv({
+      VITE_STUDIO_ENABLE_MOTION_PANEL: "0",
+      VITE_STUDIO_ENABLE_TIMELINE_LAYER_INSPECTOR: "off",
+    });
+
+    expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(true);
+    expect(availability.STUDIO_MOTION_PANEL_ENABLED).toBe(false);
+    expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(false);
   });
 
   it("keeps timeline layer inspection off when the parent inspector flag is off", async () => {

--- a/packages/studio/src/components/editor/manualEditingAvailability.test.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.test.ts
@@ -16,12 +16,12 @@ describe("manual editing availability", () => {
     vi.resetModules();
   });
 
-  it("enables inspector panels by default while manual editing stays opt-in", async () => {
+  it("enables inspector layers by default while motion and manual editing stay opt-in", async () => {
     const availability = await loadAvailabilityWithEnv({});
 
     expect(availability.STUDIO_PREVIEW_MANUAL_EDITING_ENABLED).toBe(false);
     expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(true);
-    expect(availability.STUDIO_MOTION_PANEL_ENABLED).toBe(true);
+    expect(availability.STUDIO_MOTION_PANEL_ENABLED).toBe(false);
     expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(true);
   });
 
@@ -35,14 +35,12 @@ describe("manual editing availability", () => {
     expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(true);
   });
 
-  it("allows explicit env flags to disable default-on inspector panels", async () => {
+  it("allows explicit env flags to disable default-on inspector layers", async () => {
     const availability = await loadAvailabilityWithEnv({
-      VITE_STUDIO_ENABLE_MOTION_PANEL: "0",
       VITE_STUDIO_ENABLE_TIMELINE_LAYER_INSPECTOR: "off",
     });
 
     expect(availability.STUDIO_INSPECTOR_PANELS_ENABLED).toBe(true);
-    expect(availability.STUDIO_MOTION_PANEL_ENABLED).toBe(false);
     expect(availability.STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED).toBe(false);
   });
 

--- a/packages/studio/src/components/editor/manualEditingAvailability.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.ts
@@ -38,13 +38,13 @@ export const STUDIO_PREVIEW_MANUAL_EDITING_ENABLED = resolveStudioBooleanEnvFlag
 export const STUDIO_INSPECTOR_PANELS_ENABLED = resolveStudioBooleanEnvFlag(
   env,
   [STUDIO_INSPECTOR_PANELS_ENV, "VITE_STUDIO_INSPECTOR_PANELS_ENABLED"],
-  false,
+  true,
 );
 
 export const STUDIO_MOTION_PANEL_ENABLED = resolveStudioBooleanEnvFlag(
   env,
   [STUDIO_MOTION_PANEL_ENV, "VITE_STUDIO_MOTION_PANEL_ENABLED"],
-  false,
+  true,
 );
 
 export const STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED =
@@ -52,7 +52,7 @@ export const STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED =
   resolveStudioBooleanEnvFlag(
     env,
     [STUDIO_TIMELINE_LAYER_INSPECTOR_ENV, "VITE_STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED"],
-    false,
+    true,
   );
 
 export const STUDIO_MANUAL_EDITING_ENABLED = STUDIO_PREVIEW_MANUAL_EDITING_ENABLED;

--- a/packages/studio/src/components/editor/manualEditingAvailability.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.ts
@@ -44,7 +44,7 @@ export const STUDIO_INSPECTOR_PANELS_ENABLED = resolveStudioBooleanEnvFlag(
 export const STUDIO_MOTION_PANEL_ENABLED = resolveStudioBooleanEnvFlag(
   env,
   [STUDIO_MOTION_PANEL_ENV, "VITE_STUDIO_MOTION_PANEL_ENABLED"],
-  true,
+  false,
 );
 
 export const STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED =


### PR DESCRIPTION
## Problem

The new Studio inspector layer surfaces on `next` still required local env overrides before they appeared. To test the next-branch editor stack by default, developers had to set:

- `VITE_STUDIO_ENABLE_INSPECTOR_PANELS=true`
- `VITE_STUDIO_ENABLE_TIMELINE_LAYER_INSPECTOR=true`

The Motion panel should remain opt-in behind `VITE_STUDIO_ENABLE_MOTION_PANEL=true`.

## What this fixes

- Defaults the Studio Inspector panel flag on.
- Defaults the timeline layer inspector flag on when the parent Inspector flag is enabled.
- Keeps the Motion panel disabled by default and explicitly opt-in.
- Preserves explicit falsy env values like `0` / `off` so the default-on inspector layers can still be disabled locally.
- Keeps preview manual editing/direct dragging opt-in.

## Root cause

The alpha editor layer work introduced Vite env-backed feature flags with `false` fallbacks for the inspector panel, timeline layer inspector, and motion panel. That made the next-branch layer inspector UI depend on local `.env` setup. Only the inspection surfaces should be available by default; motion authoring is still an alpha control that needs an explicit env flag.

## Verification

### Local checks

- `bun run --filter @hyperframes/studio test -- src/components/editor/manualEditingAvailability.test.ts`
- `bun run --filter @hyperframes/studio typecheck`
- `bunx oxfmt --check packages/studio/src/components/editor/manualEditingAvailability.ts packages/studio/src/components/editor/manualEditingAvailability.test.ts`
- `bunx oxlint packages/studio/src/components/editor/manualEditingAvailability.ts packages/studio/src/components/editor/manualEditingAvailability.test.ts`
- `git diff --check`
- `bun run --filter @hyperframes/studio test`
- `bun run --filter @hyperframes/studio build`
- Pre-commit hook passed lint, format, and typecheck; commit-msg hook passed commitlint.

### Browser verification

Verified with `agent-browser` against `http://127.0.0.1:5178/#project/data-visualization` without the Studio env vars set.

- Inspector button is enabled by default.
- Motion tab is hidden by default.
- Timeline clip layer inspector opens and shows nested selectable layers by default.
- Page errors were empty.

Local proof artifacts:

- `qa-artifacts/studio-default-inspector/default-motion-opt-in-layer-inspector.png`
- `qa-artifacts/studio-default-inspector/default-on-layer-inspector.png`
- `qa-artifacts/studio-default-inspector/default-on-inspector-flow.webm`

## Notes

- `qa-artifacts/` remains local/untracked and is not part of this PR.
- Vite build still emits the existing large chunk warning.
