### PR TITLE
feat: auto-open timeline clip layers

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -2398,8 +2398,21 @@ export function StudioApp() {
 
       const selection = buildDomSelectionForTimelineElement(element);
       if (selection) applyDomSelection(selection);
+
+      const key = getTimelineElementKey(element);
+      if (STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED && key && canInspectTimelineElement(element)) {
+        setInspectedTimelineElementId(key);
+        setLeftCollapsed(false);
+
+        const iframe = previewIframeRef.current;
+        if (!shouldShowTimelineInspectorBounds(currentTime, element)) {
+          seekStudioPreview(iframe, element.start);
+        }
+      } else {
+        setInspectedTimelineElementId(null);
+      }
     },
-    [applyDomSelection, buildDomSelectionForTimelineElement],
+    [applyDomSelection, buildDomSelectionForTimelineElement, currentTime],
   );
 
   const handleTimelineElementInspect = useCallback(


### PR DESCRIPTION
## Problem

Timeline clip layers were hidden behind the small layer/eye button on each clip. That made the layer inspector hard to discover even though selecting a clip already implies the user is inspecting or editing that clip.

## What this fixes

- Opens the `Clip layers` left-sidebar panel automatically when a visual timeline clip is selected.
- Keeps the existing layer/eye button as an explicit control, but no longer requires it for the normal path.
- Seeks the preview into the selected clip when needed, matching the previous explicit inspect behavior so nested layers resolve against the visible clip DOM.
- Clears the inspected clip when a non-inspectable/non-visual timeline item is selected.

## Root cause

The layer panel was only wired to `handleTimelineElementInspect`, which runs from the clip layer/eye button. Normal clip selection applied the DOM selection, but never set `inspectedTimelineElementId`, so `timelineLayerPanel` stayed null and the left sidebar kept showing the normal file/composition tabs.

## Verification

### Local

- `bunx oxfmt --check packages/studio/src/App.tsx`
- `bunx oxlint packages/studio/src/App.tsx`
- `bun run --filter @hyperframes/studio typecheck`
- `git diff --check`
- Pre-commit hook: lint, format, typecheck

### Browser

- Ran Studio at `http://127.0.0.1:5174/?auto-layers-pr=1#project/app-trailer`.
- Clicked the `S3` timeline clip body, not the layer/eye icon.
- Verified the left sidebar changed to `Clip layers` and showed `15 nested selectable layers`.
- Saved local proof artifacts under `qa-artifacts/timeline-layers-default/`, including an `agent-browser` recording.

## Notes

- Browser proof artifacts are local only and are not committed.
- The local `app-trailer` fixture still emits its existing static-guard warnings; this PR only changes the Studio selection behavior.
