### PR TITLE
fix(runtime): composition loading stuck indefinitely on multi-slide decks

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -932,6 +932,15 @@ export function initSandboxRuntimeModular(): void {
     if (typeof state.capturedTimeline.timeScale === "function") {
       state.capturedTimeline.timeScale(state.playbackRate);
     }
+    const boundDuration = getSafeTimelineDurationSeconds(state.capturedTimeline, 0);
+    if (boundDuration > 0) {
+      try {
+        clock.setDuration(boundDuration);
+      } catch {
+        // clock not yet initialized — duration will be set during TransportClock setup
+      }
+      state.capturedTimeline.pause();
+    }
     if (resolution.diagnostics) {
       postRuntimeMessage({
         source: "hf-preview",


### PR DESCRIPTION
## Problem

The apple-presentation (and any composition with external sub-compositions loaded via `data-composition-src`) shows "Loading composition — Preparing the Studio preview" indefinitely in the Studio.

## Root cause

Multi-slide compositions load child compositions via `fetch()` in `loadExternalCompositions`. The root GSAP timeline is only available after all children finish loading. But the `TransportClock` duration was only set once during initial runtime setup (line 1978):

```ts
if (state.capturedTimeline) {
  const dur = getSafeTimelineDurationSeconds(state.capturedTimeline, 0);
  if (dur > 0) clock.setDuration(dur);
}
```

At this point, `state.capturedTimeline` is null (external compositions haven't loaded yet), so `clock.getDuration()` stays at 0.

When `loadExternalCompositions` finally resolves and `bindRootTimelineIfAvailable()` captures the root timeline, it sets `state.capturedTimeline` but never updates the clock. `player.getDuration()` continues returning 0, so the player's probe interval never fires the `ready` event (which requires `adapter.getDuration() > 0`), and the loading overlay stays forever.

## Fix

`bindRootTimelineIfAvailable` now calls `clock.setDuration(boundDuration)` when it late-binds the root timeline. Guarded with try/catch for the early call site (line 1403) where `clock` is in the temporal dead zone.

## Test plan
- [x] All 6 runtime init tests pass
- [x] Core typecheck clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)