### PR TITLE
fix(studio): block element selection while composition is loading

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -894,6 +894,7 @@ export function StudioApp() {
   const [agentModalOpen, setAgentModalOpen] = useState(false);
   const [previewIframe, setPreviewIframe] = useState<HTMLIFrameElement | null>(null);
   const [inspectedTimelineElementId, setInspectedTimelineElementId] = useState<string | null>(null);
+  const [compositionLoading, setCompositionLoading] = useState(true);
   const [previewDocumentVersion, setPreviewDocumentVersion] = useState(0);
   const refreshPreviewDocumentVersion = useCallback(() => {
     setPreviewDocumentVersion((version) => version + 1);
@@ -3169,7 +3170,7 @@ export function StudioApp() {
 
   const handlePreviewCanvasMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>, options?: { preferClipAncestor?: boolean }) => {
-      if (!STUDIO_PREVIEW_SELECTION_ENABLED || captionEditMode) return;
+      if (!STUDIO_PREVIEW_SELECTION_ENABLED || captionEditMode || compositionLoading) return;
       const nextSelection = resolveDomSelectionFromPreviewPoint(e.clientX, e.clientY, {
         preferClipAncestor: options?.preferClipAncestor ?? false,
       });
@@ -3199,6 +3200,7 @@ export function StudioApp() {
     [
       applyDomSelection,
       captionEditMode,
+      compositionLoading,
       preloadAgentPromptSnippet,
       resolveDomSelectionFromPreviewPoint,
     ],
@@ -3206,7 +3208,7 @@ export function StudioApp() {
 
   const handlePreviewCanvasPointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>, options?: { preferClipAncestor?: boolean }) => {
-      if (!STUDIO_PREVIEW_SELECTION_ENABLED || captionEditMode) {
+      if (!STUDIO_PREVIEW_SELECTION_ENABLED || captionEditMode || compositionLoading) {
         updateDomEditHoverSelection(null);
         return null;
       }
@@ -3217,7 +3219,12 @@ export function StudioApp() {
       updateDomEditHoverSelection(nextSelection);
       return nextSelection;
     },
-    [captionEditMode, resolveDomSelectionFromPreviewPoint, updateDomEditHoverSelection],
+    [
+      captionEditMode,
+      compositionLoading,
+      resolveDomSelectionFromPreviewPoint,
+      updateDomEditHoverSelection,
+    ],
   );
 
   const handlePreviewCanvasPointerLeave = useCallback(() => {
@@ -4085,6 +4092,7 @@ export function StudioApp() {
             inspectedTimelineElementId={inspectedTimelineElementId}
             timelineLayerChildCounts={timelineLayerChildCounts}
             onCompIdToSrcChange={setCompIdToSrc}
+            onCompositionLoadingChange={setCompositionLoading}
             onCompositionChange={(compPath) => {
               // Sync activeCompPath when user drills down via timeline double-click
               // or navigates back via breadcrumb — keeps sidebar + thumbnails in sync.

--- a/packages/studio/src/components/editor/manualEditingAvailability.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.ts
@@ -32,7 +32,7 @@ const env = import.meta.env as StudioFeatureFlagEnv;
 export const STUDIO_PREVIEW_MANUAL_EDITING_ENABLED = resolveStudioBooleanEnvFlag(
   env,
   [STUDIO_PREVIEW_MANUAL_DRAGGING_ENV, "VITE_STUDIO_PREVIEW_MANUAL_EDITING_ENABLED"],
-  true,
+  false,
 );
 
 export const STUDIO_INSPECTOR_PANELS_ENABLED = resolveStudioBooleanEnvFlag(
@@ -44,7 +44,7 @@ export const STUDIO_INSPECTOR_PANELS_ENABLED = resolveStudioBooleanEnvFlag(
 export const STUDIO_MOTION_PANEL_ENABLED = resolveStudioBooleanEnvFlag(
   env,
   [STUDIO_MOTION_PANEL_ENV, "VITE_STUDIO_MOTION_PANEL_ENABLED"],
-  true,
+  false,
 );
 
 export const STUDIO_TIMELINE_LAYER_INSPECTOR_ENABLED =

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -61,6 +61,8 @@ interface NLELayoutProps {
   timelineVisible?: boolean;
   /** Callback to toggle timeline visibility */
   onToggleTimeline?: () => void;
+  /** Notifies parent when composition loading state changes */
+  onCompositionLoadingChange?: (loading: boolean) => void;
 }
 
 const MIN_TIMELINE_H = 100;
@@ -95,6 +97,7 @@ export const NLELayout = memo(function NLELayout({
   onCompIdToSrcChange,
   timelineVisible,
   onToggleTimeline,
+  onCompositionLoadingChange: onCompositionLoadingChangeParent,
 }: NLELayoutProps) {
   const {
     iframeRef,
@@ -216,6 +219,10 @@ export const NLELayout = memo(function NLELayout({
   const [timelineH, setTimelineH] = useState(DEFAULT_TIMELINE_H);
   const [compositionLoading, setCompositionLoading] = useState(true);
   const timelineDisabled = shouldDisableTimelineWhileCompositionLoading(compositionLoading);
+
+  useEffect(() => {
+    onCompositionLoadingChangeParent?.(compositionLoading);
+  }, [compositionLoading, onCompositionLoadingChangeParent]);
   const isTimelineVisible = timelineVisible ?? true;
   const isDragging = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary

- Block element selection and hover highlighting in the preview while the composition is loading. `compositionLoading` state is forwarded from `NLELayout` → `App.tsx` via a new `onCompositionLoadingChange` prop.
- Reverts motion panel and manual drag editing defaults to `false` — these were accidentally set to `true` during the PR #693 merge conflict resolution.

## Test plan
- [x] 472 studio tests pass
- [x] Typecheck clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)