### PR TITLE
docs: add Launch Videos page linking to hyperframes-launches repo

### DIFF
--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -28,6 +28,8 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 | -------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
 
+The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.
+
 ## Evaluating
 
 _Open a PR to add your organization here if you're trying HyperFrames in a non-production context._

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,7 +54,8 @@
             "pages": [
               "introduction",
               "quickstart",
-              "examples"
+              "examples",
+              "launch-videos"
             ]
           },
           {

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -258,13 +258,13 @@ npx hyperframes lint
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Create, preview, and render your first video
   </Card>
+  <Card title="Launch Videos" icon="github" href="/launch-videos">
+    Real production projects from HeyGen's launches — open-source for you to read and remix.
+  </Card>
   <Card title="GSAP Animation" icon="wand-magic-sparkles" href="/guides/gsap-animation">
     Add animations to your example
   </Card>
   <Card title="Compositions" icon="layer-group" href="/concepts/compositions">
     Understand the composition data model
-  </Card>
-  <Card title="Rendering" icon="film" href="/guides/rendering">
-    Render your composition to MP4
   </Card>
 </CardGroup>

--- a/docs/launch-videos.mdx
+++ b/docs/launch-videos.mdx
@@ -1,0 +1,76 @@
+---
+title: "Launch Videos"
+description: "Open-source HyperFrames compositions behind HeyGen's product launch videos — real production projects you can read, run, and remix."
+---
+
+The HeyGen team builds its launch videos in HyperFrames. Every composition — including the original HyperFrames announcement, the Timeline Editor reveal, and the Website-to-Video demo — lives in a public repository you can read, run, and remix.
+
+<Card title="hyperframes-launches" icon="github" href="https://github.com/heygen-com/hyperframes-launches">
+  Open-source HyperFrames compositions behind HeyGen's product launch videos.
+</Card>
+
+## What's in there
+
+Each subdirectory is a standalone HyperFrames project — `index.html`, `compositions/`, `assets/`, and a rendered output you can compare against:
+
+| Project | What it shows | Source |
+| --- | --- | --- |
+| **HyperFrames launch** | The original announcement video — 49.7 s, glass-frame intro, CSS / GSAP / Lottie / shader / Three.js flex section, full narrative arc. | [`hyperframes-launch/`](https://github.com/heygen-com/hyperframes-launches/tree/main/hyperframes-launch) |
+| **Website → HyperFrames** | Companion to the [website-to-video](/guides/website-to-video) workflow — captures a site and animates it. | [`website-to-hyperframes/`](https://github.com/heygen-com/hyperframes-launches/tree/main/website-to-hyperframes) |
+| **Timeline Editor launch** | 60 fps reveal video for the HyperFrames Timeline Editor: late-SFX cold open, chat-spiral of fine-tune prompts, editor reveal. | [`timeline-launch/`](https://github.com/heygen-com/hyperframes-launches/tree/main/timeline-launch) |
+| **Texture launch** | Texture-mask text + shader-driven background, used as a launch teaser. | [`texture-launch-video/`](https://github.com/heygen-com/hyperframes-launches/tree/main/texture-launch-video) |
+| **VFX × HeyGen combined** | Multi-act video chaining a VFX text-cursor scene with the HeyGen iPhone canvas test — useful as a reference for combining two existing projects into one render. | [`vfx-heygen-combined/`](https://github.com/heygen-com/hyperframes-launches/tree/main/vfx-heygen-combined) |
+
+Storyboards (`STORYBOARD.md`), design notes (`DESIGN.md`), and handoff docs (`HANDOFF.md`) sit next to the source so you can see not just the code but the production thinking — VO direction, beat timing, color/style decisions.
+
+## Why these are useful
+
+These aren't toy examples. They're the same compositions HeyGen ships in public launch videos, structured the way real production work is structured:
+
+- **Multi-composition projects.** Most launches are 4-8 sub-compositions wired into one root timeline — useful when your `npx hyperframes init --example` starter outgrows a single file.
+- **Real adapter mix.** GSAP timelines, Lottie animations, custom shaders, Three.js scenes, and CSS keyframes all coexisting in one render. See how the team [boots multiple adapters](/guides/gsap-animation) inside a single composition.
+- **Production-grade timing.** ElevenLabs VO + per-beat SFX + underscore mixed against frame-accurate motion. The storyboards describe the timing decisions; the source shows them executed.
+- **No proprietary plugins.** Everything renders with the same `hyperframes render` you have locally — there's no internal-only branch of the engine.
+
+## Cloning
+
+The repo uses Git LFS for video, audio, image, and font assets:
+
+```bash Terminal
+brew install git-lfs   # macOS — or your platform's git-lfs install
+git lfs install
+git clone https://github.com/heygen-com/hyperframes-launches.git
+cd hyperframes-launches/hyperframes-launch
+hyperframes preview    # opens the studio for that launch
+```
+
+To clone just the source (skip large LFS assets and pull on demand):
+
+```bash Terminal
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/heygen-com/hyperframes-launches.git
+cd hyperframes-launches
+git lfs pull --include="hyperframes-launch/assets/*"
+```
+
+## Adding your own video
+
+Built something you'd like to show alongside these? The contribution flow is the same as adding to [Adopters](/community/adopters) — open a PR adding a new subdirectory to the [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) repo. The README has the layout and contribution steps.
+
+If you'd rather share informally first, drop it in [Discord](https://discord.gg/EbK98HBPdk) — that's actually where the request to publish this page came from.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Examples" icon="layer-group" href="/examples">
+    Starter templates — what `npx hyperframes init --example` gives you.
+  </Card>
+  <Card title="Compositions" icon="diagram-project" href="/concepts/compositions">
+    The composition data model these launches build on.
+  </Card>
+  <Card title="GSAP Animation" icon="wand-magic-sparkles" href="/guides/gsap-animation">
+    Timeline patterns these projects use.
+  </Card>
+  <Card title="Adopters" icon="users" href="/community/adopters">
+    Other organizations shipping with HyperFrames.
+  </Card>
+</CardGroup>

--- a/docs/launch-videos.mdx
+++ b/docs/launch-videos.mdx
@@ -52,12 +52,6 @@ cd hyperframes-launches
 git lfs pull --include="hyperframes-launch/assets/*"
 ```
 
-## Adding your own video
-
-Built something you'd like to show alongside these? The contribution flow is the same as adding to [Adopters](/community/adopters) — open a PR adding a new subdirectory to the [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) repo. The README has the layout and contribution steps.
-
-If you'd rather share informally first, drop it in [Discord](https://discord.gg/EbK98HBPdk) — that's actually where the request to publish this page came from.
-
 ## Next steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## What

Adds a new docs page at `docs/launch-videos.mdx`, slotted under *Getting Started* in the Documentation tab, that links to the [heygen-com/hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) repo — the open-source HyperFrames compositions behind HeyGen's product launch videos. Cross-linked from `docs/examples.mdx`'s Next Steps and from `docs/community/adopters.mdx`.

Page contents:
- One-liner intro plus a card linking to the repo
- Catalog of the 5 projects currently in there:
  - **HyperFrames launch** (`hyperframes-launch/`) — original announcement, 49.7 s, glass-frame intro + CSS/GSAP/Lottie/shader/Three.js section
  - **Website → HyperFrames** (`website-to-hyperframes/`) — companion to the existing website-to-video guide
  - **Timeline Editor launch** (`timeline-launch/`) — 60 fps reveal video
  - **Texture launch** (`texture-launch-video/`) — texture-mask text + shader background
  - **VFX × HeyGen combined** (`vfx-heygen-combined/`) — multi-act video chaining two existing projects
- "Why these are useful" framing: multi-composition shape, real adapter mix, production-grade timing
- LFS-aware clone recipe (the repo uses Git LFS for video/audio/image/font assets)
- Contribution path mirroring the Adopters flow

## Why

Came from a Discord ask via `blackNoir` (forwarded by James in DM):

> Thanks @James Russo the example launch videos are of huge help. You can directly add this to the docs so that users coming in to get to see how the internal team does their own videos through HyperFrames.

Users discovering the project from quickstart / examples don't have an obvious next step into "what does a real production project look like." The CLI starter examples (`--example warm-grain`, etc.) are minimal scaffolds; the launch-videos repo is the team's full production source. Surfacing it in one click closes that gap.

## How

- **New page** (`docs/launch-videos.mdx`) — Mintlify markdown with frontmatter, project catalog table, and a Next Steps card group pointing back into `/examples`, `/concepts/compositions`, `/guides/gsap-animation`, and `/community/adopters`.
- **Nav** (`docs/docs.json`) — added `"launch-videos"` to the Getting Started group right after `"examples"`.
- **Cross-links** — added a card to `docs/examples.mdx`'s Next Steps and a one-line pointer in `docs/community/adopters.mdx`.

No code touched. Mintlify preview should pick up automatically.

## Test plan

- [x] `python3 -c "import json; json.load(open('docs/docs.json'))"` — JSON valid
- [x] All five GitHub URLs in the new page resolve to live tree pages on `heygen-com/hyperframes-launches`
- [x] Cross-link from `examples.mdx` and `adopters.mdx` use existing `/launch-videos` route shape
- [ ] Mintlify preview rendering looks right on landscape + portrait — flag if anything looks off; happy to iterate

— Rames Jusso