### PR TITLE
docs: correct Codex sparse install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ For Claude Design, open [`docs/guides/claude-design-hyperframes.md`](https://git
 For Codex specifically, the same skills are also exposed as an [OpenAI Codex plugin](./.codex-plugin/plugin.json) — sparse-install just the plugin surface:
 
 ```bash
-codex plugin marketplace add heygen-com/hyperframes --sparse .codex-plugin --sparse skills --sparse assets
+codex plugin marketplace add heygen-com/hyperframes \
+  --sparse .claude-plugin \
+  --sparse .codex-plugin \
+  --sparse skills \
+  --sparse assets
 ```
 
 For Claude Code, the repo also ships a [Claude Code plugin manifest](./.claude-plugin/plugin.json): test it locally with `claude --plugin-dir .`. The manifest intentionally omits `skills` because Claude Code auto-discovers the root `skills/` directory by convention, and for marketplace submission use the title `HyperFrames by HeyGen` plus the black/white icon assets at [`assets/claude-code-icon-dark.svg`](./assets/claude-code-icon-dark.svg) and [`assets/claude-code-icon-light.svg`](./assets/claude-code-icon-light.svg) for the two theme slots.


### PR DESCRIPTION
## Changes

This updates the README Codex plugin install command to include both `.claude-plugin` and `.codex-plugin` sparse paths.

```bash
codex plugin marketplace add heygen-com/hyperframes \
  --sparse .claude-plugin \
  --sparse .codex-plugin \
  --sparse skills \
  --sparse assets
```

## Why

The previous README command omitted `.claude-plugin`, which can lead to incomplete install surfaces for users who want both skill and CLI plugin metadata.
