### PR TITLE
fix(runtime): add setter to delegated __player properties

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -282,4 +282,33 @@ describe("initSandboxRuntimeModular", () => {
     expect(video.paused).toBe(true);
     expect(video.currentTime).toBe(0);
   });
+
+  it("allows external code to reassign delegated __player methods", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+      main: createMockTimeline(10),
+    };
+
+    initSandboxRuntimeModular();
+
+    const player = (
+      window as Window & {
+        __player?: { renderSeek: (timeSeconds: number) => void };
+      }
+    ).__player;
+    expect(player).toBeDefined();
+    if (!player) return;
+
+    const original = player.renderSeek;
+    expect(() => {
+      player.renderSeek = (t: number) => original(t);
+    }).not.toThrow();
+  });
 });

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1955,6 +1955,9 @@ export function initSandboxRuntimeModular(): void {
     for (const key of delegated) {
       Object.defineProperty(playerApi, key, {
         get: () => player[key],
+        set: (v: unknown) => {
+          (player as Record<string, unknown>)[key] = v;
+        },
         configurable: true,
       });
     }


### PR DESCRIPTION
## Summary
- Adds a `set` accessor to the `Object.defineProperty` delegation on `window.__player` methods
- Adds regression test verifying `__player.renderSeek` can be reassigned after init

## Problem
The property delegation on `window.__player` (init.ts:1956) used `Object.defineProperty` with only a `get` accessor. When Studio's motion-wrapping code tried to reassign `__player.renderSeek` with a wrapped version, it threw:

```
Uncaught TypeError: Cannot set property renderSeek of [object Object] which has only a getter
```

This cascaded into an infinite error loop — the timeline kept "dancing" (being modified without user input), the preview stuck on "Loading composition", and the console filled with hundreds of repeated errors.

## Root cause
```typescript
// Before — getter only, no setter
Object.defineProperty(playerApi, key, {
  get: () => player[key],
  configurable: true,
});
```

Studio's motion wrapper reads `__player.renderSeek`, wraps it with additional behavior, then tries to SET the wrapped version back. The missing setter caused this assignment to throw in strict mode.

## Fix
```typescript
// After — getter + setter proxy
Object.defineProperty(playerApi, key, {
  get: () => player[key],
  set: (v) => { player[key] = v; },
  configurable: true,
});
```

The setter proxies assignments back to the internal `player` object, so the delegation pattern still works (reads go through `player`, writes update `player`).

## Test plan
- [x] New regression test: `allows external code to reassign delegated __player methods`
- [x] All 6 init tests pass
- [x] All 29 player tests pass
- [x] Lint + typecheck + commitlint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)