### PR TITLE
feat(studio): consolidate keyboard shortcuts into single handler + fixes alpha issues

### DIFF
--- a/packages/core/src/studio-api/helpers/sourceMutation.ts
+++ b/packages/core/src/studio-api/helpers/sourceMutation.ts
@@ -17,6 +17,20 @@ function parseSourceDocument(source: string): { document: Document; wrappedFragm
   };
 }
 
+function querySelectorAllWithTemplates(root: Document | Element, selector: string): Element[] {
+  const matches = Array.from(root.querySelectorAll(selector));
+  if (matches.length > 0) return matches;
+  // querySelectorAll doesn't traverse <template> content in linkedom.
+  // Search directly on each template element (NOT .content — removing from
+  // .content's DocumentFragment doesn't update the serialized output).
+  const templates = Array.from(root.querySelectorAll("template"));
+  for (const tmpl of templates) {
+    const inner = tmpl.querySelectorAll(selector);
+    if (inner.length > 0) return Array.from(inner);
+  }
+  return [];
+}
+
 function findTargetElement(document: Document, target: SourceMutationTarget): Element | null {
   if (target.id) {
     const byId = document.getElementById(target.id);
@@ -25,7 +39,7 @@ function findTargetElement(document: Document, target: SourceMutationTarget): El
 
   if (!target.selector) return null;
   try {
-    const matches = Array.from(document.querySelectorAll(target.selector));
+    const matches = querySelectorAllWithTemplates(document, target.selector);
     return matches[target.selectorIndex ?? 0] ?? null;
   } catch {
     return null;

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -11,7 +11,7 @@ import {
 import { useMountEffect } from "./hooks/useMountEffect";
 import { NLELayout } from "./components/nle/NLELayout";
 import { SourceEditor } from "./components/editor/SourceEditor";
-import { LeftSidebar } from "./components/sidebar/LeftSidebar";
+import { LeftSidebar, type LeftSidebarHandle } from "./components/sidebar/LeftSidebar";
 import { RenderQueue } from "./components/renders/RenderQueue";
 import { useRenderQueue } from "./components/renders/useRenderQueue";
 import { CompositionThumbnail, VideoThumbnail, liveTime, usePlayerStore } from "./player";
@@ -56,6 +56,7 @@ import {
 } from "./player/components/timelineZoom";
 import {
   getTimelineToggleTitle,
+  isEditableTarget,
   shouldHandleTimelineToggleHotkey,
 } from "./utils/timelineDiscovery";
 import { buildFrameCaptureFilename, buildFrameCaptureUrl } from "./utils/frameCapture";
@@ -1031,6 +1032,7 @@ export function StudioApp() {
   const lastBlockedDomMoveToastAtRef = useRef(0);
   const importedFontAssetsRef = useRef<ImportedFontAsset[]>([]);
   const previewHotkeyWindowRef = useRef<Window | null>(null);
+  const leftSidebarRef = useRef<LeftSidebarHandle>(null);
   const previewHistoryHotkeyCleanupRef = useRef<(() => void) | null>(null);
   const panelDragRef = useRef<{
     side: "left" | "right";
@@ -1097,13 +1099,6 @@ export function StudioApp() {
     },
     [toggleTimelineVisibility],
   );
-
-  useMountEffect(() => {
-    window.addEventListener("keydown", handleTimelineToggleHotkey);
-    return () => {
-      window.removeEventListener("keydown", handleTimelineToggleHotkey);
-    };
-  });
 
   const syncPreviewTimelineHotkey = useCallback(
     (iframe: HTMLIFrameElement | null) => {
@@ -1856,6 +1851,73 @@ export function StudioApp() {
     [activeCompPath, editHistory.recordEdit, showToast, timelineElements, writeProjectFile],
   );
 
+  // ── Consolidated keyboard shortcuts ────────────────────────────────
+  // All app-level window keydown handlers live here.
+  // Component-scoped shortcuts (playback J/K/L/Space, caption nudge)
+  // stay in their respective hooks.
+  const handleToggleRef = useRef(handleTimelineToggleHotkey);
+  handleToggleRef.current = handleTimelineToggleHotkey;
+  const handleDeleteRef = useRef(handleTimelineElementDelete);
+  handleDeleteRef.current = handleTimelineElementDelete;
+
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    function handleAppKeyDown(event: KeyboardEvent) {
+      // Shift+T — toggle timeline
+      handleToggleRef.current(event);
+
+      // Cmd/Ctrl+Z — undo, Cmd/Ctrl+Shift+Z or Ctrl+Y — redo
+      if (event.metaKey || event.ctrlKey) {
+        if (!shouldIgnoreHistoryShortcut(event.target)) {
+          const key = event.key.toLowerCase();
+          if (key === "z" && !event.shiftKey) {
+            event.preventDefault();
+            void handleUndoRef.current();
+            return;
+          }
+          if ((key === "z" && event.shiftKey) || (event.ctrlKey && !event.metaKey && key === "y")) {
+            event.preventDefault();
+            void handleRedoRef.current();
+            return;
+          }
+        }
+
+        // Cmd/Ctrl+1 — sidebar: Compositions tab
+        if (event.key === "1") {
+          event.preventDefault();
+          leftSidebarRef.current?.selectTab("compositions");
+          return;
+        }
+
+        // Cmd/Ctrl+2 — sidebar: Assets tab
+        if (event.key === "2") {
+          event.preventDefault();
+          leftSidebarRef.current?.selectTab("assets");
+          return;
+        }
+      }
+
+      // Delete / Backspace — remove selected timeline element
+      if (
+        (event.key === "Delete" || event.key === "Backspace") &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !isEditableTarget(event.target)
+      ) {
+        const { selectedElementId, elements } = usePlayerStore.getState();
+        if (!selectedElementId) return;
+        const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
+        if (!element) return;
+        event.preventDefault();
+        void handleDeleteRef.current(element);
+      }
+    }
+
+    window.addEventListener("keydown", handleAppKeyDown, true);
+    return () => window.removeEventListener("keydown", handleAppKeyDown, true);
+  }, []);
+
   const handleBlockedTimelineEdit = useCallback(
     (_element: TimelineElement) => {
       const now = Date.now();
@@ -2345,6 +2407,8 @@ export function StudioApp() {
   handleUndoRef.current = handleUndo;
   handleRedoRef.current = handleRedo;
 
+  // History hotkey — no longer has its own window listener (consolidated
+  // handler covers it), but kept as a named callback for iframe forwarding.
   const handleHistoryHotkey = useCallback((event: KeyboardEvent) => {
     if (!(event.metaKey || event.ctrlKey)) return;
     if (shouldIgnoreHistoryShortcut(event.target)) return;
@@ -2359,12 +2423,6 @@ export function StudioApp() {
       void handleRedoRef.current();
     }
   }, []);
-
-  // eslint-disable-next-line no-restricted-syntax
-  useEffect(() => {
-    window.addEventListener("keydown", handleHistoryHotkey, true);
-    return () => window.removeEventListener("keydown", handleHistoryHotkey, true);
-  }, [handleHistoryHotkey]);
 
   const syncPreviewHistoryHotkey = useCallback(
     (iframe: HTMLIFrameElement | null) => {
@@ -4053,6 +4111,7 @@ export function StudioApp() {
           </div>
         ) : (
           <LeftSidebar
+            ref={leftSidebarRef}
             width={leftWidth}
             projectId={projectId}
             compositions={compositions}

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1503,6 +1503,10 @@ export function StudioApp() {
       // Debounce the server write (600ms)
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
+        // Suppress the file-change watcher echo — the save callback triggers
+        // its own refresh, so a second one from the watcher causes a double-reload
+        // race that can leave the player in a non-playable state.
+        domEditSaveTimestampRef.current = Date.now();
         saveProjectFilesWithHistory({
           projectId: pid,
           label: "Edit source",
@@ -1601,6 +1605,7 @@ export function StudioApp() {
         throw new Error(`Unable to patch timeline element ${element.id} in ${targetPath}`);
       }
 
+      domEditSaveTimestampRef.current = Date.now();
       await saveProjectFilesWithHistory({
         projectId: pid,
         label: "Move timeline clip",
@@ -1685,6 +1690,7 @@ export function StudioApp() {
         throw new Error(`Unable to patch timeline element ${element.id} in ${targetPath}`);
       }
 
+      domEditSaveTimestampRef.current = Date.now();
       await saveProjectFilesWithHistory({
         projectId: pid,
         label: "Resize timeline clip",
@@ -1823,6 +1829,7 @@ export function StudioApp() {
           });
         }
 
+        domEditSaveTimestampRef.current = Date.now();
         await saveProjectFilesWithHistory({
           projectId: pid,
           label: "Delete timeline clip",
@@ -3624,6 +3631,7 @@ export function StudioApp() {
           }),
         );
 
+        domEditSaveTimestampRef.current = Date.now();
         await saveProjectFilesWithHistory({
           projectId: pid,
           label: "Add timeline asset",

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1858,6 +1858,75 @@ export function StudioApp() {
     [activeCompPath, editHistory.recordEdit, showToast, timelineElements, writeProjectFile],
   );
 
+  const handleDomEditElementDelete = useCallback(
+    async (selection: DomEditSelection) => {
+      const pid = projectIdRef.current;
+      if (!pid) return;
+
+      const targetPath = selection.sourceFile || activeCompPath || "index.html";
+      try {
+        const response = await fetch(
+          `/api/projects/${pid}/files/${encodeURIComponent(targetPath)}`,
+        );
+        if (!response.ok) throw new Error(`Failed to read ${targetPath}`);
+
+        const data = (await response.json()) as { content?: string };
+        const originalContent = data.content;
+        if (typeof originalContent !== "string")
+          throw new Error(`Missing file contents for ${targetPath}`);
+
+        const patchTarget: { id?: string; selector?: string; selectorIndex?: number } = selection.id
+          ? {
+              id: selection.id,
+              selector: selection.selector,
+              selectorIndex: selection.selectorIndex,
+            }
+          : selection.selector
+            ? { selector: selection.selector, selectorIndex: selection.selectorIndex }
+            : ({} as never);
+        if (!patchTarget.id && !patchTarget.selector) {
+          throw new Error("Selected element has no patchable target");
+        }
+
+        const removeResponse = await fetch(
+          `/api/projects/${pid}/file-mutations/remove-element/${encodeURIComponent(targetPath)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ target: patchTarget }),
+          },
+        );
+        if (!removeResponse.ok) throw new Error(`Failed to delete element from ${targetPath}`);
+
+        const removeData = (await removeResponse.json()) as { changed?: boolean; content?: string };
+        const patchedContent =
+          typeof removeData.content === "string" ? removeData.content : originalContent;
+
+        domEditSaveTimestampRef.current = Date.now();
+        await saveProjectFilesWithHistory({
+          projectId: pid,
+          label: "Delete element",
+          kind: "timeline",
+          files: { [targetPath]: patchedContent },
+          readFile: async () => originalContent,
+          writeFile: writeProjectFile,
+          recordEdit: editHistory.recordEdit,
+        });
+
+        domEditSelectionRef.current = null;
+        domEditGroupSelectionsRef.current = [];
+        setDomEditSelection(null);
+        setDomEditGroupSelections([]);
+        usePlayerStore.getState().setSelectedElementId(null);
+        setRefreshKey((k) => k + 1);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to delete element";
+        showToast(message);
+      }
+    },
+    [activeCompPath, editHistory.recordEdit, showToast, writeProjectFile],
+  );
+
   // ── Consolidated keyboard shortcuts ────────────────────────────────
   // All app-level window keydown handlers live here.
   // Component-scoped shortcuts (playback J/K/L/Space, caption nudge)
@@ -1866,6 +1935,8 @@ export function StudioApp() {
   handleToggleRef.current = handleTimelineToggleHotkey;
   const handleDeleteRef = useRef(handleTimelineElementDelete);
   handleDeleteRef.current = handleTimelineElementDelete;
+  const handleDomEditDeleteRef = useRef(handleDomEditElementDelete);
+  handleDomEditDeleteRef.current = handleDomEditElementDelete;
 
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
@@ -1904,7 +1975,7 @@ export function StudioApp() {
         }
       }
 
-      // Delete / Backspace — remove selected timeline element
+      // Delete / Backspace — remove selected element (timeline clip or preview selection)
       if (
         (event.key === "Delete" || event.key === "Backspace") &&
         !event.metaKey &&
@@ -1913,11 +1984,19 @@ export function StudioApp() {
         !isEditableTarget(event.target)
       ) {
         const { selectedElementId, elements } = usePlayerStore.getState();
-        if (!selectedElementId) return;
-        const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
-        if (!element) return;
-        event.preventDefault();
-        void handleDeleteRef.current(element);
+        if (selectedElementId) {
+          const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
+          if (element) {
+            event.preventDefault();
+            void handleDeleteRef.current(element);
+            return;
+          }
+        }
+        const domSelection = domEditSelectionRef.current;
+        if (domSelection) {
+          event.preventDefault();
+          void handleDomEditDeleteRef.current(domSelection);
+        }
       }
     }
 

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1032,6 +1032,7 @@ export function StudioApp() {
   const lastBlockedDomMoveToastAtRef = useRef(0);
   const importedFontAssetsRef = useRef<ImportedFontAsset[]>([]);
   const previewHotkeyWindowRef = useRef<Window | null>(null);
+  const handleAppKeyDownRef = useRef<((event: KeyboardEvent) => void) | undefined>(undefined);
   const leftSidebarRef = useRef<LeftSidebarHandle>(null);
   const previewHistoryHotkeyCleanupRef = useRef<(() => void) | null>(null);
   const panelDragRef = useRef<{
@@ -1100,27 +1101,31 @@ export function StudioApp() {
     [toggleTimelineVisibility],
   );
 
+  const previewAppKeyDownHandler = useCallback((event: KeyboardEvent) => {
+    handleAppKeyDownRef.current?.(event);
+  }, []);
+
   const syncPreviewTimelineHotkey = useCallback(
     (iframe: HTMLIFrameElement | null) => {
       const nextWindow = iframe?.contentWindow ?? null;
       if (previewHotkeyWindowRef.current === nextWindow) return;
       if (previewHotkeyWindowRef.current) {
-        previewHotkeyWindowRef.current.removeEventListener("keydown", handleTimelineToggleHotkey);
+        previewHotkeyWindowRef.current.removeEventListener("keydown", previewAppKeyDownHandler);
       }
       previewHotkeyWindowRef.current = nextWindow;
-      nextWindow?.addEventListener("keydown", handleTimelineToggleHotkey);
+      nextWindow?.addEventListener("keydown", previewAppKeyDownHandler, true);
     },
-    [handleTimelineToggleHotkey],
+    [previewAppKeyDownHandler],
   );
 
   useEffect(
     () => () => {
       if (previewHotkeyWindowRef.current) {
-        previewHotkeyWindowRef.current.removeEventListener("keydown", handleTimelineToggleHotkey);
+        previewHotkeyWindowRef.current.removeEventListener("keydown", previewAppKeyDownHandler);
         previewHotkeyWindowRef.current = null;
       }
     },
-    [handleTimelineToggleHotkey],
+    [previewAppKeyDownHandler],
   );
 
   const renderClipContent = useCallback(
@@ -1938,68 +1943,71 @@ export function StudioApp() {
   const handleDomEditDeleteRef = useRef(handleDomEditElementDelete);
   handleDomEditDeleteRef.current = handleDomEditElementDelete;
 
-  // eslint-disable-next-line no-restricted-syntax
-  useEffect(() => {
-    function handleAppKeyDown(event: KeyboardEvent) {
-      // Shift+T — toggle timeline
-      handleToggleRef.current(event);
+  handleAppKeyDownRef.current = (event: KeyboardEvent) => {
+    // Shift+T — toggle timeline
+    handleToggleRef.current(event);
 
-      // Cmd/Ctrl+Z — undo, Cmd/Ctrl+Shift+Z or Ctrl+Y — redo
-      if (event.metaKey || event.ctrlKey) {
-        if (!shouldIgnoreHistoryShortcut(event.target)) {
-          const key = event.key.toLowerCase();
-          if (key === "z" && !event.shiftKey) {
-            event.preventDefault();
-            void handleUndoRef.current();
-            return;
-          }
-          if ((key === "z" && event.shiftKey) || (event.ctrlKey && !event.metaKey && key === "y")) {
-            event.preventDefault();
-            void handleRedoRef.current();
-            return;
-          }
-        }
-
-        // Cmd/Ctrl+1 — sidebar: Compositions tab
-        if (event.key === "1") {
+    // Cmd/Ctrl+Z — undo, Cmd/Ctrl+Shift+Z or Ctrl+Y — redo
+    if (event.metaKey || event.ctrlKey) {
+      if (!shouldIgnoreHistoryShortcut(event.target)) {
+        const key = event.key.toLowerCase();
+        if (key === "z" && !event.shiftKey) {
           event.preventDefault();
-          leftSidebarRef.current?.selectTab("compositions");
+          void handleUndoRef.current();
           return;
         }
-
-        // Cmd/Ctrl+2 — sidebar: Assets tab
-        if (event.key === "2") {
+        if ((key === "z" && event.shiftKey) || (event.ctrlKey && !event.metaKey && key === "y")) {
           event.preventDefault();
-          leftSidebarRef.current?.selectTab("assets");
+          void handleRedoRef.current();
           return;
         }
       }
 
-      // Delete / Backspace — remove selected element (timeline clip or preview selection)
-      if (
-        (event.key === "Delete" || event.key === "Backspace") &&
-        !event.metaKey &&
-        !event.ctrlKey &&
-        !event.altKey &&
-        !isEditableTarget(event.target)
-      ) {
-        const { selectedElementId, elements } = usePlayerStore.getState();
-        if (selectedElementId) {
-          const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
-          if (element) {
-            event.preventDefault();
-            void handleDeleteRef.current(element);
-            return;
-          }
-        }
-        const domSelection = domEditSelectionRef.current;
-        if (domSelection) {
-          event.preventDefault();
-          void handleDomEditDeleteRef.current(domSelection);
-        }
+      // Cmd/Ctrl+1 — sidebar: Compositions tab
+      if (event.key === "1") {
+        event.preventDefault();
+        leftSidebarRef.current?.selectTab("compositions");
+        return;
+      }
+
+      // Cmd/Ctrl+2 — sidebar: Assets tab
+      if (event.key === "2") {
+        event.preventDefault();
+        leftSidebarRef.current?.selectTab("assets");
+        return;
       }
     }
 
+    // Delete / Backspace — remove selected element (timeline clip or preview selection)
+    if (
+      (event.key === "Delete" || event.key === "Backspace") &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !isEditableTarget(event.target)
+    ) {
+      const { selectedElementId, elements } = usePlayerStore.getState();
+      if (selectedElementId) {
+        const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
+        if (element) {
+          event.preventDefault();
+          void handleDeleteRef.current(element);
+          return;
+        }
+      }
+      const domSelection = domEditSelectionRef.current;
+      if (domSelection) {
+        event.preventDefault();
+        void handleDomEditDeleteRef.current(domSelection);
+      }
+    }
+  };
+
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    function handleAppKeyDown(event: KeyboardEvent) {
+      handleAppKeyDownRef.current?.(event);
+    }
     window.addEventListener("keydown", handleAppKeyDown, true);
     return () => window.removeEventListener("keydown", handleAppKeyDown, true);
   }, []);

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -28,7 +28,6 @@ import {
   hsvToRgb,
   parseCssColor,
   rgbToHsv,
-  toColorPickerValue,
   toHexColor,
   type ParsedColor,
 } from "./colorValue";
@@ -367,13 +366,6 @@ function adjustNumericToken(
   return `${formatNumericValue(nextValue)}${token.unit}`;
 }
 
-function formatColorToken(value: string): string {
-  const parsed = parseCssColor(value);
-  if (!parsed) return value;
-  const hex = toColorPickerValue(value).replace(/^#/, "").toUpperCase();
-  return `${hex} / ${Math.round(parsed.alpha * 100)}%`;
-}
-
 function extractBackgroundImageUrl(value: string | undefined): string {
   if (!value) return "";
   const lowerValue = value.toLowerCase();
@@ -452,36 +444,6 @@ function resolveSelectedAsset(
   }
 
   return null;
-}
-
-function collectSelectionColors(styles: Record<string, string>) {
-  const candidates = [
-    { source: "Fill", value: styles["background-color"] },
-    { source: "Text", value: styles.color },
-  ];
-
-  const deduped = new Map<string, { swatch: string; token: string; sources: string[] }>();
-
-  for (const candidate of candidates) {
-    if (!candidate.value) continue;
-    const parsed = parseCssColor(candidate.value);
-    if (!parsed || parsed.alpha <= 0) continue;
-
-    const key = `${toColorPickerValue(candidate.value)}-${Math.round(parsed.alpha * 100)}`;
-    const existing = deduped.get(key);
-    if (existing) {
-      existing.sources.push(candidate.source);
-      continue;
-    }
-
-    deduped.set(key, {
-      swatch: toColorPickerValue(candidate.value),
-      token: formatColorToken(candidate.value),
-      sources: [candidate.source],
-    });
-  }
-
-  return Array.from(deduped.values());
 }
 
 function CommitField({
@@ -2137,22 +2099,20 @@ function SelectField({
   const renderedOptions = value && !options.includes(value) ? [value, ...options] : options;
 
   return (
-    <label className="grid min-w-0 gap-1.5">
-      <span className={LABEL}>{label}</span>
-      <div className={FIELD}>
-        <select
-          value={value}
-          disabled={disabled}
-          onChange={(e) => onChange(e.target.value)}
-          className="min-w-0 w-full appearance-none bg-transparent text-[11px] font-medium text-neutral-100 outline-none disabled:cursor-not-allowed disabled:text-neutral-600"
-        >
-          {renderedOptions.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))}
-        </select>
-      </div>
+    <label className={`${FIELD} flex items-center gap-3`}>
+      <span className="flex-shrink-0 text-[11px] font-medium text-neutral-500">{label}</span>
+      <select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        className="min-w-0 w-full appearance-none bg-transparent text-[11px] font-medium text-neutral-100 outline-none disabled:cursor-not-allowed disabled:text-neutral-600"
+      >
+        {renderedOptions.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
     </label>
   );
 }
@@ -2184,31 +2144,6 @@ function Section({
   );
 }
 
-function SelectionColorRow({
-  swatch,
-  token,
-  sources,
-}: {
-  swatch: string;
-  token: string;
-  sources: string[];
-}) {
-  return (
-    <div className={`${FIELD} flex min-w-0 items-center gap-3`}>
-      <div
-        className="h-7 w-7 flex-shrink-0 rounded-lg border border-neutral-700"
-        style={{ backgroundColor: swatch }}
-      />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-[11px] font-medium text-neutral-100">{token}</div>
-        <div className="truncate text-[11px] uppercase tracking-[0.18em] text-neutral-500">
-          {sources.join(" · ")}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export const PropertyPanel = memo(function PropertyPanel({
   projectId,
   assets,
@@ -2230,7 +2165,6 @@ export const PropertyPanel = memo(function PropertyPanel({
   onImportFonts,
 }: PropertyPanelProps) {
   const styles = element?.computedStyles ?? EMPTY_STYLES;
-  const selectionColors = useMemo(() => collectSelectionColors(styles), [styles]);
   const backgroundImage = styles["background-image"] ?? "none";
   const fillMode =
     backgroundImage && backgroundImage !== "none"
@@ -2403,6 +2337,219 @@ export const PropertyPanel = memo(function PropertyPanel({
       </div>
 
       <div className="flex-1 overflow-y-auto">
+        {hasTextControls && (
+          <Section title="Text" icon={<Type size={15} />}>
+            {(() => {
+              const textFields = element.textFields;
+              const activeField =
+                textFields.find((field) => field.key === activeTextFieldKey) ?? textFields[0];
+              if (!activeField) return null;
+
+              if (textFields.length === 1) {
+                return (
+                  <div className="space-y-4 rounded-xl border border-neutral-800 bg-neutral-900/60 p-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-[11px] font-medium text-neutral-100">
+                        {formatTextFieldPreview(activeField.value) || "Text"}
+                      </div>
+                      <div className="text-[10px] uppercase tracking-[0.12em] text-neutral-500">
+                        {activeField.tagName}
+                      </div>
+                    </div>
+
+                    <TextAreaField
+                      key={activeField.key}
+                      label="Content"
+                      value={activeField.value}
+                      disabled={false}
+                      onCommit={(next) => onSetText(next, activeField.key)}
+                    />
+
+                    <ColorField
+                      label="Text color"
+                      value={getTextFieldColor(activeField, styles)}
+                      disabled={false}
+                      onCommit={(next) => onSetTextFieldStyle(activeField.key, "color", next)}
+                    />
+
+                    <div className={RESPONSIVE_GRID}>
+                      <MetricField
+                        label="Size"
+                        value={
+                          activeField.computedStyles["font-size"] || styles["font-size"] || "16px"
+                        }
+                        disabled={false}
+                        liveCommit
+                        onCommit={(next) => onSetTextFieldStyle(activeField.key, "font-size", next)}
+                      />
+                      <FontWeightField
+                        value={
+                          activeField.computedStyles["font-weight"] ||
+                          styles["font-weight"] ||
+                          "400"
+                        }
+                        disabled={false}
+                        onCommit={(next) =>
+                          onSetTextFieldStyle(activeField.key, "font-weight", next)
+                        }
+                      />
+                    </div>
+
+                    <FontFamilyField
+                      value={
+                        activeField.computedStyles["font-family"] ||
+                        styles["font-family"] ||
+                        "inherit"
+                      }
+                      disabled={false}
+                      importedFonts={fontAssets}
+                      onImportFonts={onImportFonts}
+                      onCommit={(next) => onSetTextFieldStyle(activeField.key, "font-family", next)}
+                    />
+
+                    <AdvancedTextControls
+                      field={activeField}
+                      inheritedStyles={styles}
+                      disabled={false}
+                      onCommit={(property, value) =>
+                        onSetTextFieldStyle(activeField.key, property, value)
+                      }
+                    />
+                  </div>
+                );
+              }
+
+              return (
+                <div className="space-y-4">
+                  <div className="grid gap-1.5">
+                    <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+                      <span className={LABEL}>Text layers</span>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void Promise.resolve(onAddTextField(activeField.key)).then((nextKey) => {
+                            if (nextKey) setActiveTextFieldKey(nextKey);
+                          });
+                        }}
+                        className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-lg border border-neutral-700 bg-neutral-950 px-2.5 text-[11px] font-medium text-neutral-300 transition-colors hover:border-neutral-600 hover:text-white"
+                      >
+                        <Plus size={12} className="flex-shrink-0" />
+                        <span className="truncate">Add text</span>
+                      </button>
+                    </div>
+                    <div className="grid gap-2">
+                      {textFields.map((field, index) => {
+                        const active = field.key === activeField.key;
+                        return (
+                          <button
+                            key={field.key}
+                            type="button"
+                            onClick={() => setActiveTextFieldKey(field.key)}
+                            className={`min-w-0 w-full rounded-xl border px-3 py-2 text-left transition-colors ${
+                              active
+                                ? "border-studio-accent/50 bg-studio-accent/10"
+                                : "border-neutral-800 bg-neutral-900/80 hover:border-neutral-700 hover:bg-neutral-900"
+                            }`}
+                          >
+                            <div className="flex min-w-0 items-center justify-between gap-2">
+                              <div className="flex min-w-0 items-center gap-2">
+                                <span
+                                  className="h-4 w-4 flex-shrink-0 rounded border border-neutral-700 bg-neutral-950"
+                                  style={{ backgroundColor: getTextFieldColor(field, styles) }}
+                                />
+                                <span className="min-w-0 truncate text-[11px] font-medium text-neutral-100">
+                                  {formatTextFieldPreview(field.value) || `Text ${index + 1}`}
+                                </span>
+                              </div>
+                              <span className="flex-shrink-0 rounded-md border border-neutral-700 bg-neutral-950 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em] text-neutral-500">
+                                {field.tagName}
+                              </span>
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="space-y-4 rounded-xl border border-neutral-800 bg-neutral-900/60 p-3">
+                    <div className="flex min-w-0 items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="truncate text-[11px] font-medium text-neutral-100">
+                          {formatTextFieldPreview(activeField.value) || "Text"}
+                        </div>
+                        <div className="text-[10px] uppercase tracking-[0.12em] text-neutral-500">
+                          {activeField.tagName}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => onRemoveTextField(activeField.key)}
+                        className="inline-flex h-7 flex-shrink-0 items-center rounded-lg border border-neutral-700 bg-neutral-950 px-2.5 text-[11px] font-medium text-neutral-300 transition-colors hover:border-neutral-600 hover:text-white"
+                      >
+                        Remove
+                      </button>
+                    </div>
+
+                    <TextAreaField
+                      key={activeField.key}
+                      label="Content"
+                      value={activeField.value}
+                      disabled={false}
+                      autoFocus
+                      onCommit={(next) => onSetText(next, activeField.key)}
+                    />
+
+                    <ColorField
+                      label="Text color"
+                      value={getTextFieldColor(activeField, styles)}
+                      disabled={false}
+                      onCommit={(next) => onSetTextFieldStyle(activeField.key, "color", next)}
+                    />
+
+                    <div className={RESPONSIVE_GRID}>
+                      <MetricField
+                        label="Size"
+                        value={activeField.computedStyles["font-size"] || "16px"}
+                        disabled={false}
+                        liveCommit
+                        onCommit={(next) => onSetTextFieldStyle(activeField.key, "font-size", next)}
+                      />
+                      <FontWeightField
+                        value={activeField.computedStyles["font-weight"] || "400"}
+                        disabled={false}
+                        onCommit={(next) =>
+                          onSetTextFieldStyle(activeField.key, "font-weight", next)
+                        }
+                      />
+                    </div>
+
+                    <FontFamilyField
+                      value={
+                        activeField.computedStyles["font-family"] ||
+                        styles["font-family"] ||
+                        "inherit"
+                      }
+                      disabled={false}
+                      importedFonts={fontAssets}
+                      onImportFonts={onImportFonts}
+                      onCommit={(next) => onSetTextFieldStyle(activeField.key, "font-family", next)}
+                    />
+
+                    <AdvancedTextControls
+                      field={activeField}
+                      inheritedStyles={styles}
+                      disabled={false}
+                      onCommit={(property, value) =>
+                        onSetTextFieldStyle(activeField.key, property, value)
+                      }
+                    />
+                  </div>
+                </div>
+              );
+            })()}
+          </Section>
+        )}
+
         <Section title="Layout" icon={<Move size={15} />}>
           <div className={RESPONSIVE_GRID}>
             <MetricField
@@ -2649,7 +2796,7 @@ export const PropertyPanel = memo(function PropertyPanel({
               </div>
             </Section>
 
-            <Section title="Blending" icon={<Eye size={15} />}>
+            <Section title="Transparency" icon={<Eye size={15} />}>
               <div className="space-y-4">
                 <SliderControl
                   value={opacityValue}
@@ -2730,246 +2877,6 @@ export const PropertyPanel = memo(function PropertyPanel({
                 )}
               </div>
             </Section>
-
-            {hasTextControls && (
-              <Section title="Text" icon={<Type size={15} />}>
-                {(() => {
-                  const textFields = element.textFields;
-                  const activeField =
-                    textFields.find((field) => field.key === activeTextFieldKey) ?? textFields[0];
-                  if (!activeField) return null;
-
-                  if (textFields.length === 1) {
-                    return (
-                      <div className="space-y-4 rounded-xl border border-neutral-800 bg-neutral-900/60 p-3">
-                        <div className="min-w-0">
-                          <div className="truncate text-[11px] font-medium text-neutral-100">
-                            {formatTextFieldPreview(activeField.value) || "Text"}
-                          </div>
-                          <div className="text-[10px] uppercase tracking-[0.12em] text-neutral-500">
-                            {activeField.tagName}
-                          </div>
-                        </div>
-
-                        <TextAreaField
-                          key={activeField.key}
-                          label="Content"
-                          value={activeField.value}
-                          disabled={false}
-                          onCommit={(next) => onSetText(next, activeField.key)}
-                        />
-
-                        <ColorField
-                          label="Text color"
-                          value={getTextFieldColor(activeField, styles)}
-                          disabled={false}
-                          onCommit={(next) => onSetTextFieldStyle(activeField.key, "color", next)}
-                        />
-
-                        <div className={RESPONSIVE_GRID}>
-                          <MetricField
-                            label="Size"
-                            value={
-                              activeField.computedStyles["font-size"] ||
-                              styles["font-size"] ||
-                              "16px"
-                            }
-                            disabled={false}
-                            liveCommit
-                            onCommit={(next) =>
-                              onSetTextFieldStyle(activeField.key, "font-size", next)
-                            }
-                          />
-                          <FontWeightField
-                            value={
-                              activeField.computedStyles["font-weight"] ||
-                              styles["font-weight"] ||
-                              "400"
-                            }
-                            disabled={false}
-                            onCommit={(next) =>
-                              onSetTextFieldStyle(activeField.key, "font-weight", next)
-                            }
-                          />
-                        </div>
-
-                        <FontFamilyField
-                          value={
-                            activeField.computedStyles["font-family"] ||
-                            styles["font-family"] ||
-                            "inherit"
-                          }
-                          disabled={false}
-                          importedFonts={fontAssets}
-                          onImportFonts={onImportFonts}
-                          onCommit={(next) =>
-                            onSetTextFieldStyle(activeField.key, "font-family", next)
-                          }
-                        />
-
-                        <AdvancedTextControls
-                          field={activeField}
-                          inheritedStyles={styles}
-                          disabled={false}
-                          onCommit={(property, value) =>
-                            onSetTextFieldStyle(activeField.key, property, value)
-                          }
-                        />
-                      </div>
-                    );
-                  }
-
-                  return (
-                    <div className="space-y-4">
-                      <div className="grid gap-1.5">
-                        <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
-                          <span className={LABEL}>Text layers</span>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              void Promise.resolve(onAddTextField(activeField.key)).then(
-                                (nextKey) => {
-                                  if (nextKey) setActiveTextFieldKey(nextKey);
-                                },
-                              );
-                            }}
-                            className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-lg border border-neutral-700 bg-neutral-950 px-2.5 text-[11px] font-medium text-neutral-300 transition-colors hover:border-neutral-600 hover:text-white"
-                          >
-                            <Plus size={12} className="flex-shrink-0" />
-                            <span className="truncate">Add text</span>
-                          </button>
-                        </div>
-                        <div className="grid gap-2">
-                          {textFields.map((field, index) => {
-                            const active = field.key === activeField.key;
-                            return (
-                              <button
-                                key={field.key}
-                                type="button"
-                                onClick={() => setActiveTextFieldKey(field.key)}
-                                className={`min-w-0 w-full rounded-xl border px-3 py-2 text-left transition-colors ${
-                                  active
-                                    ? "border-studio-accent/50 bg-studio-accent/10"
-                                    : "border-neutral-800 bg-neutral-900/80 hover:border-neutral-700 hover:bg-neutral-900"
-                                }`}
-                              >
-                                <div className="flex min-w-0 items-center justify-between gap-2">
-                                  <div className="flex min-w-0 items-center gap-2">
-                                    <span
-                                      className="h-4 w-4 flex-shrink-0 rounded border border-neutral-700 bg-neutral-950"
-                                      style={{ backgroundColor: getTextFieldColor(field, styles) }}
-                                    />
-                                    <span className="min-w-0 truncate text-[11px] font-medium text-neutral-100">
-                                      {formatTextFieldPreview(field.value) || `Text ${index + 1}`}
-                                    </span>
-                                  </div>
-                                  <span className="flex-shrink-0 rounded-md border border-neutral-700 bg-neutral-950 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em] text-neutral-500">
-                                    {field.tagName}
-                                  </span>
-                                </div>
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      <div className="space-y-4 rounded-xl border border-neutral-800 bg-neutral-900/60 p-3">
-                        <div className="flex min-w-0 items-center justify-between gap-2">
-                          <div className="min-w-0">
-                            <div className="truncate text-[11px] font-medium text-neutral-100">
-                              {formatTextFieldPreview(activeField.value) || "Text"}
-                            </div>
-                            <div className="text-[10px] uppercase tracking-[0.12em] text-neutral-500">
-                              {activeField.tagName}
-                            </div>
-                          </div>
-                          <button
-                            type="button"
-                            onClick={() => onRemoveTextField(activeField.key)}
-                            className="inline-flex h-7 flex-shrink-0 items-center rounded-lg border border-neutral-700 bg-neutral-950 px-2.5 text-[11px] font-medium text-neutral-300 transition-colors hover:border-neutral-600 hover:text-white"
-                          >
-                            Remove
-                          </button>
-                        </div>
-
-                        <TextAreaField
-                          key={activeField.key}
-                          label="Content"
-                          value={activeField.value}
-                          disabled={false}
-                          autoFocus
-                          onCommit={(next) => onSetText(next, activeField.key)}
-                        />
-
-                        <ColorField
-                          label="Text color"
-                          value={getTextFieldColor(activeField, styles)}
-                          disabled={false}
-                          onCommit={(next) => onSetTextFieldStyle(activeField.key, "color", next)}
-                        />
-
-                        <div className={RESPONSIVE_GRID}>
-                          <MetricField
-                            label="Size"
-                            value={activeField.computedStyles["font-size"] || "16px"}
-                            disabled={false}
-                            liveCommit
-                            onCommit={(next) =>
-                              onSetTextFieldStyle(activeField.key, "font-size", next)
-                            }
-                          />
-                          <FontWeightField
-                            value={activeField.computedStyles["font-weight"] || "400"}
-                            disabled={false}
-                            onCommit={(next) =>
-                              onSetTextFieldStyle(activeField.key, "font-weight", next)
-                            }
-                          />
-                        </div>
-
-                        <FontFamilyField
-                          value={
-                            activeField.computedStyles["font-family"] ||
-                            styles["font-family"] ||
-                            "inherit"
-                          }
-                          disabled={false}
-                          importedFonts={fontAssets}
-                          onImportFonts={onImportFonts}
-                          onCommit={(next) =>
-                            onSetTextFieldStyle(activeField.key, "font-family", next)
-                          }
-                        />
-
-                        <AdvancedTextControls
-                          field={activeField}
-                          inheritedStyles={styles}
-                          disabled={false}
-                          onCommit={(property, value) =>
-                            onSetTextFieldStyle(activeField.key, property, value)
-                          }
-                        />
-                      </div>
-                    </div>
-                  );
-                })()}
-              </Section>
-            )}
-
-            {selectionColors.length > 0 && (
-              <Section title="Selection colors" icon={<Palette size={15} />}>
-                <div className="space-y-3">
-                  {selectionColors.map((entry) => (
-                    <SelectionColorRow
-                      key={`${entry.swatch}-${entry.token}`}
-                      swatch={entry.swatch}
-                      token={entry.token}
-                      sources={entry.sources}
-                    />
-                  ))}
-                </div>
-              </Section>
-            )}
           </>
         )}
       </div>

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -460,12 +460,33 @@ function CommitField({
   const [draft, setDraft] = useState(value);
   const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const valueRef = useRef(value);
+  const draftRef = useRef(draft);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   valueRef.current = value;
+  draftRef.current = draft;
 
   useEffect(() => {
     setDraft(value);
   }, [value]);
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    const handler = (e: WheelEvent) => {
+      if (disabled) return;
+      const delta = e.deltaY === 0 ? e.deltaX : e.deltaY;
+      if (delta === 0) return;
+      const nextDraft = adjustNumericToken(draftRef.current, delta < 0 ? 1 : -1, e);
+      if (!nextDraft) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setDraft(nextDraft);
+      scheduleCommitRef.current(nextDraft);
+    };
+    el.addEventListener("wheel", handler, { passive: false });
+    return () => el.removeEventListener("wheel", handler);
+  }, [disabled]);
 
   useEffect(
     () => () => {
@@ -489,9 +510,12 @@ function CommitField({
       }
     }, 120);
   };
+  const scheduleCommitRef = useRef(scheduleCommit);
+  scheduleCommitRef.current = scheduleCommit;
 
   return (
     <input
+      ref={inputRef}
       type="text"
       value={draft}
       disabled={disabled}
@@ -500,16 +524,6 @@ function CommitField({
         if (liveCommit) scheduleCommit(e.target.value);
       }}
       onBlur={() => commitDraft(draft)}
-      onWheel={(e) => {
-        if (disabled) return;
-        const delta = e.deltaY === 0 ? e.deltaX : e.deltaY;
-        if (delta === 0) return;
-        const nextDraft = adjustNumericToken(draft, delta < 0 ? 1 : -1, e);
-        if (!nextDraft) return;
-        e.preventDefault();
-        setDraft(nextDraft);
-        scheduleCommit(nextDraft);
-      }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           (e.target as HTMLInputElement).blur();

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -217,7 +217,13 @@ export const NLELayout = memo(function NLELayout({
 
   // Resizable timeline height
   const [timelineH, setTimelineH] = useState(DEFAULT_TIMELINE_H);
-  const [compositionLoading, setCompositionLoading] = useState(true);
+  const hasLoadedOnceRef = useRef(false);
+  const [compositionLoading, setCompositionLoadingRaw] = useState(true);
+  const setCompositionLoading = useCallback((loading: boolean) => {
+    if (!loading) hasLoadedOnceRef.current = true;
+    if (loading && hasLoadedOnceRef.current) return;
+    setCompositionLoadingRaw(loading);
+  }, []);
   const timelineDisabled = shouldDisableTimelineWhileCompositionLoading(compositionLoading);
 
   useEffect(() => {
@@ -395,6 +401,7 @@ export const NLELayout = memo(function NLELayout({
             portrait={portrait}
             directUrl={directUrl}
             refreshKey={refreshKey}
+            suppressLoadingOverlay={hasLoadedOnceRef.current}
           />
           {previewOverlay}
         </div>

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -9,6 +9,7 @@ interface NLEPreviewProps {
   portrait?: boolean;
   directUrl?: string;
   refreshKey?: number;
+  suppressLoadingOverlay?: boolean;
 }
 
 export function getPreviewPlayerKey({
@@ -41,6 +42,7 @@ export const NLEPreview = memo(function NLEPreview({
   portrait,
   directUrl,
   refreshKey,
+  suppressLoadingOverlay,
 }: NLEPreviewProps) {
   const baseKey = getPreviewPlayerKey({ projectId, directUrl, refreshKey });
   const prevRefreshKeyRef = useRef(refreshKey);
@@ -93,6 +95,7 @@ export const NLEPreview = memo(function NLEPreview({
           onCompositionLoadingChange={onCompositionLoadingChange}
           portrait={portrait}
           style={retiringKey ? { position: "absolute", inset: 0, zIndex: 1 } : undefined}
+          suppressLoadingOverlay={suppressLoadingOverlay}
         />
       </div>
     </div>

--- a/packages/studio/src/components/sidebar/LeftSidebar.tsx
+++ b/packages/studio/src/components/sidebar/LeftSidebar.tsx
@@ -1,10 +1,13 @@
-import { memo, useState, useCallback, type ReactNode } from "react";
-import { useMountEffect } from "../../hooks/useMountEffect";
+import { memo, useState, useCallback, useImperativeHandle, forwardRef, type ReactNode } from "react";
 import { CompositionsTab } from "./CompositionsTab";
 import { AssetsTab } from "./AssetsTab";
 import { FileTree } from "../editor/FileTree";
 
-type SidebarTab = "compositions" | "assets" | "code";
+export type SidebarTab = "compositions" | "assets" | "code";
+
+export interface LeftSidebarHandle {
+  selectTab: (tab: SidebarTab) => void;
+}
 
 const STORAGE_KEY = "hf-studio-sidebar-tab";
 
@@ -39,7 +42,7 @@ interface LeftSidebarProps {
   takeoverContent?: ReactNode;
 }
 
-export const LeftSidebar = memo(function LeftSidebar({
+export const LeftSidebar = memo(forwardRef<LeftSidebarHandle, LeftSidebarProps>(function LeftSidebar({
   width = 240,
   projectId,
   compositions,
@@ -61,7 +64,7 @@ export const LeftSidebar = memo(function LeftSidebar({
   linting,
   onToggleCollapse,
   takeoverContent,
-}: LeftSidebarProps) {
+}, ref) {
   const [tab, setTab] = useState<SidebarTab>(getPersistedTab);
 
   const selectTab = useCallback((t: SidebarTab) => {
@@ -69,22 +72,7 @@ export const LeftSidebar = memo(function LeftSidebar({
     localStorage.setItem(STORAGE_KEY, t);
   }, []);
 
-  // Keyboard shortcuts: Cmd+1 for Compositions, Cmd+2 for Assets
-  useMountEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (!e.metaKey && !e.ctrlKey) return;
-      if (e.key === "1") {
-        e.preventDefault();
-        selectTab("compositions");
-      }
-      if (e.key === "2") {
-        e.preventDefault();
-        selectTab("assets");
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  });
+  useImperativeHandle(ref, () => ({ selectTab }), [selectTab]);
 
   return (
     <div
@@ -236,4 +224,4 @@ export const LeftSidebar = memo(function LeftSidebar({
       )}
     </div>
   );
-});
+}));

--- a/packages/studio/src/components/sidebar/LeftSidebar.tsx
+++ b/packages/studio/src/components/sidebar/LeftSidebar.tsx
@@ -1,4 +1,11 @@
-import { memo, useState, useCallback, useImperativeHandle, forwardRef, type ReactNode } from "react";
+import {
+  memo,
+  useState,
+  useCallback,
+  useImperativeHandle,
+  forwardRef,
+  type ReactNode,
+} from "react";
 import { CompositionsTab } from "./CompositionsTab";
 import { AssetsTab } from "./AssetsTab";
 import { FileTree } from "../editor/FileTree";
@@ -42,186 +49,191 @@ interface LeftSidebarProps {
   takeoverContent?: ReactNode;
 }
 
-export const LeftSidebar = memo(forwardRef<LeftSidebarHandle, LeftSidebarProps>(function LeftSidebar({
-  width = 240,
-  projectId,
-  compositions,
-  assets,
-  activeComposition,
-  onSelectComposition,
-  onImportFiles,
-  fileTree: fileProp,
-  editingFile,
-  onSelectFile,
-  onCreateFile,
-  onCreateFolder,
-  onDeleteFile,
-  onRenameFile,
-  onDuplicateFile,
-  onMoveFile,
-  codeChildren,
-  onLint,
-  linting,
-  onToggleCollapse,
-  takeoverContent,
-}, ref) {
-  const [tab, setTab] = useState<SidebarTab>(getPersistedTab);
+export const LeftSidebar = memo(
+  forwardRef<LeftSidebarHandle, LeftSidebarProps>(function LeftSidebar(
+    {
+      width = 240,
+      projectId,
+      compositions,
+      assets,
+      activeComposition,
+      onSelectComposition,
+      onImportFiles,
+      fileTree: fileProp,
+      editingFile,
+      onSelectFile,
+      onCreateFile,
+      onCreateFolder,
+      onDeleteFile,
+      onRenameFile,
+      onDuplicateFile,
+      onMoveFile,
+      codeChildren,
+      onLint,
+      linting,
+      onToggleCollapse,
+      takeoverContent,
+    },
+    ref,
+  ) {
+    const [tab, setTab] = useState<SidebarTab>(getPersistedTab);
 
-  const selectTab = useCallback((t: SidebarTab) => {
-    setTab(t);
-    localStorage.setItem(STORAGE_KEY, t);
-  }, []);
+    const selectTab = useCallback((t: SidebarTab) => {
+      setTab(t);
+      localStorage.setItem(STORAGE_KEY, t);
+    }, []);
 
-  useImperativeHandle(ref, () => ({ selectTab }), [selectTab]);
+    useImperativeHandle(ref, () => ({ selectTab }), [selectTab]);
 
-  return (
-    <div
-      className="flex flex-col h-full bg-neutral-950 border-r border-neutral-800/50"
-      style={{ width }}
-    >
-      {takeoverContent ? (
-        <div className="flex min-h-0 flex-1">{takeoverContent}</div>
-      ) : (
-        <>
-          {/* Tabs — Code first */}
-          <div className="border-b border-neutral-800/50 px-3 py-3 flex-shrink-0">
-            <div className="flex items-center gap-2">
-              <div
-                className="grid min-w-0 flex-1 gap-1 rounded-[18px] bg-neutral-900 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
-                style={{ gridTemplateColumns: "0.9fr 1.25fr 0.9fr" }}
-              >
-                <button
-                  type="button"
-                  onClick={() => selectTab("code")}
-                  className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
-                    tab === "code"
-                      ? "bg-neutral-800 text-white"
-                      : "text-neutral-500 hover:text-neutral-200"
-                  }`}
+    return (
+      <div
+        className="flex flex-col h-full bg-neutral-950 border-r border-neutral-800/50"
+        style={{ width }}
+      >
+        {takeoverContent ? (
+          <div className="flex min-h-0 flex-1">{takeoverContent}</div>
+        ) : (
+          <>
+            {/* Tabs — Code first */}
+            <div className="border-b border-neutral-800/50 px-3 py-3 flex-shrink-0">
+              <div className="flex items-center gap-2">
+                <div
+                  className="grid min-w-0 flex-1 gap-0.5 rounded-[18px] bg-neutral-900 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+                  style={{ gridTemplateColumns: "1fr 1fr 1fr" }}
                 >
-                  Code
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectTab("compositions")}
-                  className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
-                    tab === "compositions"
-                      ? "bg-neutral-800 text-white"
-                      : "text-neutral-500 hover:text-neutral-200"
-                  }`}
-                >
-                  Compositions
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectTab("assets")}
-                  className={`rounded-[14px] px-2.5 py-2 text-[10px] font-semibold transition-all ${
-                    tab === "assets"
-                      ? "bg-neutral-800 text-white"
-                      : "text-neutral-500 hover:text-neutral-200"
-                  }`}
-                >
-                  Assets
-                </button>
-              </div>
-              {onToggleCollapse && (
-                <button
-                  type="button"
-                  onClick={onToggleCollapse}
-                  className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md border border-transparent text-neutral-500 transition-colors hover:border-neutral-800 hover:bg-neutral-900 hover:text-neutral-300"
-                  title="Hide sidebar"
-                  aria-label="Hide sidebar"
-                >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
+                  <button
+                    type="button"
+                    onClick={() => selectTab("code")}
+                    className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
+                      tab === "code"
+                        ? "bg-neutral-800 text-white"
+                        : "text-neutral-500 hover:text-neutral-200"
+                    }`}
                   >
-                    <path d="m14 7-5 5 5 5" />
-                    <path d="M19 4v16" />
-                  </svg>
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* Tab content */}
-          {tab === "compositions" && (
-            <CompositionsTab
-              projectId={projectId}
-              compositions={compositions}
-              activeComposition={activeComposition}
-              onSelect={onSelectComposition}
-            />
-          )}
-          {tab === "assets" && (
-            <AssetsTab
-              projectId={projectId}
-              assets={assets}
-              onImport={onImportFiles}
-              onDelete={onDeleteFile}
-              onRename={onRenameFile}
-            />
-          )}
-          {tab === "code" && (
-            <div className="flex flex-1 min-h-0">
-              {(fileProp?.length ?? 0) > 0 && (
-                <div className="w-[160px] flex-shrink-0 border-r border-neutral-800 overflow-y-auto">
-                  <FileTree
-                    files={fileProp ?? []}
-                    activeFile={editingFile?.path ?? null}
-                    onSelectFile={onSelectFile ?? (() => {})}
-                    onCreateFile={onCreateFile}
-                    onCreateFolder={onCreateFolder}
-                    onDeleteFile={onDeleteFile}
-                    onRenameFile={onRenameFile}
-                    onDuplicateFile={onDuplicateFile}
-                    onMoveFile={onMoveFile}
-                    onImportFiles={onImportFiles}
-                  />
+                    Code
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectTab("compositions")}
+                    className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
+                      tab === "compositions"
+                        ? "bg-neutral-800 text-white"
+                        : "text-neutral-500 hover:text-neutral-200"
+                    }`}
+                  >
+                    Comps
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectTab("assets")}
+                    className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
+                      tab === "assets"
+                        ? "bg-neutral-800 text-white"
+                        : "text-neutral-500 hover:text-neutral-200"
+                    }`}
+                  >
+                    Assets
+                  </button>
                 </div>
-              )}
-              <div className="flex-1 overflow-hidden min-w-0">
-                {codeChildren ?? (
-                  <div className="flex items-center justify-center h-full text-neutral-600 text-sm">
-                    Select a file to edit
-                  </div>
+                {onToggleCollapse && (
+                  <button
+                    type="button"
+                    onClick={onToggleCollapse}
+                    className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md border border-transparent text-neutral-500 transition-colors hover:border-neutral-800 hover:bg-neutral-900 hover:text-neutral-300"
+                    title="Hide sidebar"
+                    aria-label="Hide sidebar"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="m14 7-5 5 5 5" />
+                      <path d="M19 4v16" />
+                    </svg>
+                  </button>
                 )}
               </div>
             </div>
-          )}
 
-          {/* Lint button pinned at the bottom */}
-          {onLint && (
-            <div className="border-t border-neutral-800 p-2 flex-shrink-0">
-              <button
-                onClick={onLint}
-                disabled={linting}
-                className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-medium text-neutral-500 hover:text-amber-300 hover:bg-neutral-800 transition-colors disabled:opacity-40"
-              >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
+            {/* Tab content */}
+            {tab === "compositions" && (
+              <CompositionsTab
+                projectId={projectId}
+                compositions={compositions}
+                activeComposition={activeComposition}
+                onSelect={onSelectComposition}
+              />
+            )}
+            {tab === "assets" && (
+              <AssetsTab
+                projectId={projectId}
+                assets={assets}
+                onImport={onImportFiles}
+                onDelete={onDeleteFile}
+                onRename={onRenameFile}
+              />
+            )}
+            {tab === "code" && (
+              <div className="flex flex-1 min-h-0">
+                {(fileProp?.length ?? 0) > 0 && (
+                  <div className="w-[160px] flex-shrink-0 border-r border-neutral-800 overflow-y-auto">
+                    <FileTree
+                      files={fileProp ?? []}
+                      activeFile={editingFile?.path ?? null}
+                      onSelectFile={onSelectFile ?? (() => {})}
+                      onCreateFile={onCreateFile}
+                      onCreateFolder={onCreateFolder}
+                      onDeleteFile={onDeleteFile}
+                      onRenameFile={onRenameFile}
+                      onDuplicateFile={onDuplicateFile}
+                      onMoveFile={onMoveFile}
+                      onImportFiles={onImportFiles}
+                    />
+                  </div>
+                )}
+                <div className="flex-1 overflow-hidden min-w-0">
+                  {codeChildren ?? (
+                    <div className="flex items-center justify-center h-full text-neutral-600 text-sm">
+                      Select a file to edit
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Lint button pinned at the bottom */}
+            {onLint && (
+              <div className="border-t border-neutral-800 p-2 flex-shrink-0">
+                <button
+                  onClick={onLint}
+                  disabled={linting}
+                  className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-medium text-neutral-500 hover:text-amber-300 hover:bg-neutral-800 transition-colors disabled:opacity-40"
                 >
-                  <path d="M9 11l3 3L22 4" />
-                  <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
-                </svg>
-                {linting ? "Linting…" : "Lint"}
-              </button>
-            </div>
-          )}
-        </>
-      )}
-    </div>
-  );
-}));
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M9 11l3 3L22 4" />
+                    <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
+                  </svg>
+                  {linting ? "Linting…" : "Lint"}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    );
+  }),
+);

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -13,6 +13,7 @@ interface PlayerProps {
   onCompositionLoadingChange?: (loading: boolean) => void;
   portrait?: boolean;
   style?: React.CSSProperties;
+  suppressLoadingOverlay?: boolean;
 }
 
 interface HyperframesPlayerElement extends HTMLElement {
@@ -102,7 +103,18 @@ export function hasUnloadedAssets(iframe: HTMLIFrameElement, lastResult: boolean
  * timeline probing, and DOM inspection.
  */
 export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
-  ({ projectId, directUrl, onLoad, onCompositionLoadingChange, portrait, style }, ref) => {
+  (
+    {
+      projectId,
+      directUrl,
+      onLoad,
+      onCompositionLoadingChange,
+      portrait,
+      style,
+      suppressLoadingOverlay,
+    },
+    ref,
+  ) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const loadCountRef = useRef(0);
     const assetPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -268,7 +280,8 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
       };
     }, [assetsLoading]);
 
-    const showCompositionOverlay = shouldShowCompositionLoadingOverlay(compositionLoading);
+    const showCompositionOverlay =
+      !suppressLoadingOverlay && shouldShowCompositionLoadingOverlay(compositionLoading);
     const showAssetOverlay =
       assetOverlayVisible && !shaderTransitionLoading && !showCompositionOverlay;
 

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -976,27 +976,16 @@ export const Timeline = memo(function Timeline({
     };
   });
 
-  useMountEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (disabledRef.current) return;
-      if (!shouldHandleTimelineDeleteKey(event)) return;
-      const selected = selectedElementRef.current;
-      const onDelete = onDeleteElementRef.current;
-      if (!selected || !onDelete || deleteInFlightRef.current) return;
-      event.preventDefault();
-      deleteInFlightRef.current = true;
-      suppressClickRef.current = true;
+  const prevSelectedRef = useRef(selectedElementRef.current);
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    const prev = prevSelectedRef.current;
+    const curr = selectedElementRef.current;
+    prevSelectedRef.current = curr;
+    if (prev && !curr) {
       setShowPopover(false);
       setRangeSelection(null);
-      Promise.resolve(onDelete(selected)).finally(() => {
-        deleteInFlightRef.current = false;
-        requestAnimationFrame(() => {
-          suppressClickRef.current = false;
-        });
-      });
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    }
   });
 
   const handlePointerDown = useCallback(

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -446,7 +446,6 @@ export const Timeline = memo(function Timeline({
   const resizingClipRef = useRef<ResizingClipState | null>(null);
   resizingClipRef.current = resizingClip;
   const blockedClipRef = useRef<BlockedClipState | null>(null);
-  const deleteInFlightRef = useRef(false);
   const onMoveElementRef = useRef(onMoveElement);
   onMoveElementRef.current = onMoveElement;
   const onResizeElementRef = useRef(onResizeElement);
@@ -977,7 +976,7 @@ export const Timeline = memo(function Timeline({
   });
 
   const prevSelectedRef = useRef(selectedElementRef.current);
-  // eslint-disable-next-line no-restricted-syntax
+  // eslint-disable-next-line no-restricted-syntax, react-hooks/exhaustive-deps
   useEffect(() => {
     const prev = prevSelectedRef.current;
     const curr = selectedElementRef.current;

--- a/packages/studio/src/utils/timelineDiscovery.ts
+++ b/packages/studio/src/utils/timelineDiscovery.ts
@@ -13,7 +13,7 @@ interface EditableTargetLike {
   getAttribute?: (name: string) => string | null;
 }
 
-function isEditableTarget(target: EventTarget | null): boolean {
+export function isEditableTarget(target: EventTarget | null): boolean {
   if (!target || typeof target !== "object") return false;
 
   const element = target as EditableTargetLike;


### PR DESCRIPTION
## Summary
- Moves all window-level keyboard shortcuts from 4 separate files into one `handleAppKeyDown` listener in App.tsx
- Adds new Delete/Backspace shortcut for removing selected timeline elements
- All app shortcuts now live in one place for easier testing and discoverability

| Shortcut | Action | Was in |
|---|---|---|
| `Shift+T` | Toggle timeline | App.tsx (separate useMountEffect) |
| `Cmd/Ctrl+Z` | Undo | App.tsx (separate useEffect) |
| `Cmd/Ctrl+Shift+Z` | Redo | App.tsx (separate useEffect) |
| `Cmd/Ctrl+1` | Sidebar → Compositions | LeftSidebar.tsx |
| `Cmd/Ctrl+2` | Sidebar → Assets | LeftSidebar.tsx |
| `Delete/Backspace` | Remove selected element | Timeline.tsx (+ new) |

Playback shortcuts (Space, J/K/L, arrows) and caption nudge stay in their component hooks.

## Test plan
- [x] Select a clip in timeline, press Delete — clip removed
- [x] Select a clip, press Backspace — clip removed
- [x] Press Shift+T — timeline toggles
- [x] Press Cmd+Z after delete — element restored
- [x] Press Cmd+1 / Cmd+2 — sidebar switches tabs
- [x] Click into a text input, press Delete — no clip deleted, text editing works
- [x] Space/J/K/L still control playback
- [x] All shortcuts work from preview iframe focus

loom: https://www.loom.com/share/5854049fdc6a4db5abda09ae6670fa0e