### PR TITLE
fix(core): thread playback rate into WebAudio audio sources

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1589,6 +1589,7 @@ export function initSandboxRuntimeModular(): void {
     onSetPlaybackRate: (rate) => {
       applyPlaybackRate(rate);
       if (state.transportClock) state.transportClock.setRate(state.playbackRate);
+      webAudio.setRate(state.playbackRate);
     },
     onEnablePickMode: () => picker.enablePickMode(),
     onDisablePickMode: () => picker.disablePickMode(),
@@ -1858,6 +1859,7 @@ export function initSandboxRuntimeModular(): void {
             clock.now(),
             vol * state.bridgeVolume,
             gen,
+            state.playbackRate,
           );
         });
       }

--- a/packages/core/src/runtime/webAudioTransport.test.ts
+++ b/packages/core/src/runtime/webAudioTransport.test.ts
@@ -1,6 +1,49 @@
 import { describe, it, expect, vi } from "vitest";
 import { WebAudioTransport } from "./webAudioTransport";
 
+function createMockAudioContext(currentTime = 100) {
+  const startFn = vi.fn();
+  const sourceNode = {
+    buffer: null as AudioBuffer | null,
+    playbackRate: { value: 1 },
+    start: startFn,
+    stop: vi.fn(),
+    disconnect: vi.fn(),
+    connect: vi.fn(),
+  };
+  const gainNode = {
+    gain: { value: 1 },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+  const masterGain = {
+    gain: { value: 1 },
+    connect: vi.fn(),
+  };
+  const ctx = {
+    currentTime,
+    state: "running",
+    resume: vi.fn(),
+    createBufferSource: vi.fn(() => sourceNode),
+    createGain: vi.fn(() => gainNode),
+    destination: {},
+    close: vi.fn(),
+  };
+  return { ctx, sourceNode, gainNode, masterGain, startFn };
+}
+
+function setupTransport(currentTime = 100) {
+  const transport = new WebAudioTransport();
+  const mock = createMockAudioContext(currentTime);
+  (transport as unknown as { _ctx: unknown })._ctx = mock.ctx;
+  (transport as unknown as { _masterGain: unknown })._masterGain = mock.masterGain;
+  const gen = transport.startGeneration();
+  return { transport, mock, gen };
+}
+
+const mockBuffer = {} as AudioBuffer;
+const mockEl = { muted: false } as HTMLMediaElement;
+
 describe("WebAudioTransport", () => {
   it("tracks play generation for async race prevention", () => {
     const transport = new WebAudioTransport();
@@ -82,49 +125,6 @@ describe("WebAudioTransport", () => {
   });
 
   describe("schedulePlayback timing", () => {
-    function createMockAudioContext(currentTime = 100) {
-      const startFn = vi.fn();
-      const sourceNode = {
-        buffer: null as AudioBuffer | null,
-        playbackRate: { value: 1 },
-        start: startFn,
-        stop: vi.fn(),
-        disconnect: vi.fn(),
-        connect: vi.fn(),
-      };
-      const gainNode = {
-        gain: { value: 1 },
-        connect: vi.fn(),
-        disconnect: vi.fn(),
-      };
-      const masterGain = {
-        gain: { value: 1 },
-        connect: vi.fn(),
-      };
-      const ctx = {
-        currentTime,
-        state: "running",
-        resume: vi.fn(),
-        createBufferSource: vi.fn(() => sourceNode),
-        createGain: vi.fn(() => gainNode),
-        destination: {},
-        close: vi.fn(),
-      };
-      return { ctx, sourceNode, gainNode, masterGain, startFn };
-    }
-
-    function setupTransport(currentTime = 100) {
-      const transport = new WebAudioTransport();
-      const mock = createMockAudioContext(currentTime);
-      (transport as unknown as { _ctx: unknown })._ctx = mock.ctx;
-      (transport as unknown as { _masterGain: unknown })._masterGain = mock.masterGain;
-      const gen = transport.startGeneration();
-      return { transport, mock, gen };
-    }
-
-    const mockBuffer = {} as AudioBuffer;
-    const mockEl = { muted: false } as HTMLMediaElement;
-
     it("starts in-progress clips immediately with correct buffer offset", async () => {
       const { transport, mock, gen } = setupTransport(100);
 
@@ -167,49 +167,6 @@ describe("WebAudioTransport", () => {
   });
 
   describe("playback rate", () => {
-    function createMockAudioContext(currentTime = 100) {
-      const startFn = vi.fn();
-      const sourceNode = {
-        buffer: null as AudioBuffer | null,
-        playbackRate: { value: 1 },
-        start: startFn,
-        stop: vi.fn(),
-        disconnect: vi.fn(),
-        connect: vi.fn(),
-      };
-      const gainNode = {
-        gain: { value: 1 },
-        connect: vi.fn(),
-        disconnect: vi.fn(),
-      };
-      const masterGain = {
-        gain: { value: 1 },
-        connect: vi.fn(),
-      };
-      const ctx = {
-        currentTime,
-        state: "running",
-        resume: vi.fn(),
-        createBufferSource: vi.fn(() => sourceNode),
-        createGain: vi.fn(() => gainNode),
-        destination: {},
-        close: vi.fn(),
-      };
-      return { ctx, sourceNode, gainNode, masterGain, startFn };
-    }
-
-    function setupTransport(currentTime = 100) {
-      const transport = new WebAudioTransport();
-      const mock = createMockAudioContext(currentTime);
-      (transport as unknown as { _ctx: unknown })._ctx = mock.ctx;
-      (transport as unknown as { _masterGain: unknown })._masterGain = mock.masterGain;
-      const gen = transport.startGeneration();
-      return { transport, mock, gen };
-    }
-
-    const mockBuffer = {} as AudioBuffer;
-    const mockEl = { muted: false } as HTMLMediaElement;
-
     it("sets sourceNode.playbackRate.value when rate is provided", async () => {
       const { transport, mock, gen } = setupTransport(100);
 
@@ -236,10 +193,6 @@ describe("WebAudioTransport", () => {
     });
 
     it("keeps in-progress buffer offset at elapsed + mediaStart regardless of rate", async () => {
-      // Audio that has been playing for `elapsed` composition seconds at rate r:
-      //   wallclock elapsed = elapsed / r
-      //   buffer advanced  = (elapsed / r) × r = elapsed
-      // so the buffer offset is `elapsed + mediaStart` for any rate.
       const { transport, mock, gen } = setupTransport(100);
 
       await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 2);
@@ -263,16 +216,34 @@ describe("WebAudioTransport", () => {
       expect(() => transport.setRate(2)).not.toThrow();
     });
 
+    it("setRate is a no-op when the rate is unchanged", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 2);
+
+      mock.ctx.currentTime = 100.5;
+      const timeBefore = transport.getTime();
+      transport.setRate(2);
+      const timeAfter = transport.getTime();
+
+      expect(timeAfter).toBe(timeBefore);
+      // No re-anchor, so the next 0.5s of wallclock still maps to 1s of comp time.
+      mock.ctx.currentTime = 101;
+      expect(transport.getTime()).toBeCloseTo(10, 10);
+    });
+
     it("setRate clamps non-finite or non-positive values to 1", async () => {
       const { transport, mock, gen } = setupTransport(100);
-      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 1);
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 2);
+      expect(mock.sourceNode.playbackRate.value).toBe(2);
 
       transport.setRate(Number.NaN);
       expect(mock.sourceNode.playbackRate.value).toBe(1);
 
+      transport.setRate(2);
       transport.setRate(0);
       expect(mock.sourceNode.playbackRate.value).toBe(1);
 
+      transport.setRate(2);
       transport.setRate(-1);
       expect(mock.sourceNode.playbackRate.value).toBe(1);
     });

--- a/packages/core/src/runtime/webAudioTransport.test.ts
+++ b/packages/core/src/runtime/webAudioTransport.test.ts
@@ -86,12 +86,16 @@ describe("WebAudioTransport", () => {
       const startFn = vi.fn();
       const sourceNode = {
         buffer: null as AudioBuffer | null,
+        playbackRate: { value: 1 },
         start: startFn,
+        stop: vi.fn(),
+        disconnect: vi.fn(),
         connect: vi.fn(),
       };
       const gainNode = {
         gain: { value: 1 },
         connect: vi.fn(),
+        disconnect: vi.fn(),
       };
       const masterGain = {
         gain: { value: 1 },
@@ -159,6 +163,151 @@ describe("WebAudioTransport", () => {
       await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 5, 1, gen);
 
       expect(mock.startFn).toHaveBeenCalledWith(0, 0);
+    });
+  });
+
+  describe("playback rate", () => {
+    function createMockAudioContext(currentTime = 100) {
+      const startFn = vi.fn();
+      const sourceNode = {
+        buffer: null as AudioBuffer | null,
+        playbackRate: { value: 1 },
+        start: startFn,
+        stop: vi.fn(),
+        disconnect: vi.fn(),
+        connect: vi.fn(),
+      };
+      const gainNode = {
+        gain: { value: 1 },
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      const masterGain = {
+        gain: { value: 1 },
+        connect: vi.fn(),
+      };
+      const ctx = {
+        currentTime,
+        state: "running",
+        resume: vi.fn(),
+        createBufferSource: vi.fn(() => sourceNode),
+        createGain: vi.fn(() => gainNode),
+        destination: {},
+        close: vi.fn(),
+      };
+      return { ctx, sourceNode, gainNode, masterGain, startFn };
+    }
+
+    function setupTransport(currentTime = 100) {
+      const transport = new WebAudioTransport();
+      const mock = createMockAudioContext(currentTime);
+      (transport as unknown as { _ctx: unknown })._ctx = mock.ctx;
+      (transport as unknown as { _masterGain: unknown })._masterGain = mock.masterGain;
+      const gen = transport.startGeneration();
+      return { transport, mock, gen };
+    }
+
+    const mockBuffer = {} as AudioBuffer;
+    const mockEl = { muted: false } as HTMLMediaElement;
+
+    it("sets sourceNode.playbackRate.value when rate is provided", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 2);
+
+      expect(mock.sourceNode.playbackRate.value).toBe(2);
+    });
+
+    it("defaults rate to 1 when not provided", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen);
+
+      expect(mock.sourceNode.playbackRate.value).toBe(1);
+    });
+
+    it("scales delay by rate for future clips so they fire at the right wallclock", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      // compStart=10, compositionTime=2, rate=2 → 8s of comp time = 4s wallclock
+      await transport.schedulePlayback(mockEl, mockBuffer, 10, 0, 2, 1, gen, 2);
+
+      expect(mock.startFn).toHaveBeenCalledWith(104, 0);
+    });
+
+    it("keeps in-progress buffer offset at elapsed + mediaStart regardless of rate", async () => {
+      // Audio that has been playing for `elapsed` composition seconds at rate r:
+      //   wallclock elapsed = elapsed / r
+      //   buffer advanced  = (elapsed / r) × r = elapsed
+      // so the buffer offset is `elapsed + mediaStart` for any rate.
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 2);
+
+      expect(mock.startFn).toHaveBeenCalledWith(0, 3);
+    });
+
+    it("setRate updates active sources in place", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 1);
+      expect(mock.sourceNode.playbackRate.value).toBe(1);
+
+      transport.setRate(2);
+
+      expect(mock.sourceNode.playbackRate.value).toBe(2);
+    });
+
+    it("setRate before any sources are scheduled does not throw", () => {
+      const transport = new WebAudioTransport();
+      expect(() => transport.setRate(2)).not.toThrow();
+    });
+
+    it("setRate clamps non-finite or non-positive values to 1", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 1);
+
+      transport.setRate(Number.NaN);
+      expect(mock.sourceNode.playbackRate.value).toBe(1);
+
+      transport.setRate(0);
+      expect(mock.sourceNode.playbackRate.value).toBe(1);
+
+      transport.setRate(-1);
+      expect(mock.sourceNode.playbackRate.value).toBe(1);
+    });
+
+    it("getTime advances at the configured rate", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 2);
+
+      // At schedule time, ctx.currentTime=100, compositionTime=8.
+      expect(transport.getTime()).toBeCloseTo(8, 10);
+
+      // Advance the audio-context clock by 0.5 wallclock seconds; at rate=2,
+      // composition time should have advanced 1s.
+      mock.ctx.currentTime = 100.5;
+      expect(transport.getTime()).toBeCloseTo(9, 10);
+    });
+
+    it("getTime tracks composition time after a mid-playback setRate", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen, 1);
+      expect(transport.getTime()).toBeCloseTo(8, 10);
+
+      // 0.5s passes at rate=1 → composition time = 8.5
+      mock.ctx.currentTime = 100.5;
+      expect(transport.getTime()).toBeCloseTo(8.5, 10);
+
+      // Bump rate to 2 — composition time should NOT jump.
+      transport.setRate(2);
+      expect(transport.getTime()).toBeCloseTo(8.5, 10);
+
+      // Another 0.5s wallclock at rate=2 → composition time = 9.5
+      mock.ctx.currentTime = 101;
+      expect(transport.getTime()).toBeCloseTo(9.5, 10);
     });
   });
 });

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -1,5 +1,10 @@
 import { swallow } from "./diagnostics";
 
+function normalizeRate(rate: number): number {
+  if (!Number.isFinite(rate) || rate <= 0) return 1;
+  return rate;
+}
+
 export type ScheduledSource = {
   el: HTMLMediaElement;
   sourceNode: AudioBufferSourceNode;
@@ -15,7 +20,12 @@ export class WebAudioTransport {
   private _bufferCache = new Map<string, AudioBuffer>();
   private _activeSources: ScheduledSource[] = [];
   private _masterGain: GainNode | null = null;
-  private _scheduleOffset = 0;
+  // Composition-time reference frame: at AudioContext time `_rateAnchorCtx`,
+  // composition time was `_rateAnchorComp`, and time has been advancing at
+  // `_rate` composition-seconds per wallclock-second since.
+  private _rateAnchorCtx = 0;
+  private _rateAnchorComp = 0;
+  private _rate = 1;
   private _paused = true;
   private _playGeneration = 0;
 
@@ -36,7 +46,7 @@ export class WebAudioTransport {
 
   getTime(): number {
     if (!this._ctx || this._paused) return -1;
-    return this._ctx.currentTime - this._scheduleOffset;
+    return this._rateAnchorComp + (this._ctx.currentTime - this._rateAnchorCtx) * this._rate;
   }
 
   async decodeAudioElement(el: HTMLMediaElement): Promise<AudioBuffer | null> {
@@ -73,6 +83,7 @@ export class WebAudioTransport {
     compositionTime: number,
     volume: number,
     generation: number,
+    rate = 1,
   ): Promise<ScheduledSource | null> {
     if (!this._ctx || !this._masterGain) return null;
     if (generation !== this._playGeneration) return null;
@@ -83,8 +94,11 @@ export class WebAudioTransport {
       }
       if (generation !== this._playGeneration) return null;
 
+      const safeRate = normalizeRate(rate);
+
       const sourceNode = this._ctx.createBufferSource();
       sourceNode.buffer = buffer;
+      sourceNode.playbackRate.value = safeRate;
 
       const gainNode = this._ctx.createGain();
       gainNode.gain.value = volume;
@@ -93,12 +107,20 @@ export class WebAudioTransport {
 
       const elapsed = compositionTime - compositionStart;
       const scheduledAt = this._ctx.currentTime;
-      this._scheduleOffset = scheduledAt - compositionTime;
+      this._rate = safeRate;
+      this._rateAnchorCtx = scheduledAt;
+      this._rateAnchorComp = compositionTime;
 
       if (elapsed >= 0) {
+        // Audio that has already been "playing" for `elapsed` composition
+        // seconds at rate r has advanced exactly `elapsed` buffer seconds —
+        // wallclock elapsed is `elapsed / r` and the source plays at rate r,
+        // so buffer advance = (elapsed / r) × r = elapsed.
         sourceNode.start(0, elapsed + mediaStart);
       } else {
-        const delay = -elapsed;
+        // Future clip: composition time will reach `compositionStart` after
+        // `-elapsed` composition seconds, which is `-elapsed / r` wallclock.
+        const delay = -elapsed / safeRate;
         sourceNode.start(scheduledAt + delay, mediaStart);
       }
 
@@ -120,6 +142,33 @@ export class WebAudioTransport {
     } catch (err) {
       swallow("webAudioTransport.schedule", err);
       return null;
+    }
+  }
+
+  /**
+   * Change the playback rate of every currently-active source in place.
+   *
+   * Also rebases the composition-time reference frame so `getTime()` keeps
+   * returning the same value across the rate change (i.e. the clock doesn't
+   * jump, it just advances at a different slope from here on).
+   *
+   * Note: sources scheduled to start in the future via `sourceNode.start(when)`
+   * keep their original wallclock start time. Callers that need rate-correct
+   * future-start times should `stopAll()` and reschedule.
+   */
+  setRate(rate: number): void {
+    const safeRate = normalizeRate(rate);
+    if (this._ctx && !this._paused) {
+      this._rateAnchorComp = this.getTime();
+      this._rateAnchorCtx = this._ctx.currentTime;
+    }
+    this._rate = safeRate;
+    for (const source of this._activeSources) {
+      try {
+        source.sourceNode.playbackRate.value = safeRate;
+      } catch (err) {
+        swallow("webAudioTransport.setRate", err);
+      }
     }
   }
 

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -112,14 +112,8 @@ export class WebAudioTransport {
       this._rateAnchorComp = compositionTime;
 
       if (elapsed >= 0) {
-        // Audio that has already been "playing" for `elapsed` composition
-        // seconds at rate r has advanced exactly `elapsed` buffer seconds —
-        // wallclock elapsed is `elapsed / r` and the source plays at rate r,
-        // so buffer advance = (elapsed / r) × r = elapsed.
         sourceNode.start(0, elapsed + mediaStart);
       } else {
-        // Future clip: composition time will reach `compositionStart` after
-        // `-elapsed` composition seconds, which is `-elapsed / r` wallclock.
         const delay = -elapsed / safeRate;
         sourceNode.start(scheduledAt + delay, mediaStart);
       }
@@ -146,18 +140,14 @@ export class WebAudioTransport {
   }
 
   /**
-   * Change the playback rate of every currently-active source in place.
-   *
-   * Also rebases the composition-time reference frame so `getTime()` keeps
-   * returning the same value across the rate change (i.e. the clock doesn't
-   * jump, it just advances at a different slope from here on).
-   *
-   * Note: sources scheduled to start in the future via `sourceNode.start(when)`
-   * keep their original wallclock start time. Callers that need rate-correct
-   * future-start times should `stopAll()` and reschedule.
+   * Rebases the composition-time reference frame before swapping rate so
+   * `getTime()` stays continuous across the change. Sources scheduled to
+   * start in the future keep their original wallclock start time — callers
+   * that need rate-correct future starts should `stopAll()` and reschedule.
    */
   setRate(rate: number): void {
     const safeRate = normalizeRate(rate);
+    if (safeRate === this._rate) return;
     if (this._ctx && !this._paused) {
       this._rateAnchorComp = this.getTime();
       this._rateAnchorCtx = this._ctx.currentTime;


### PR DESCRIPTION
## What

Threads the transport playback rate into `WebAudioTransport` so audio clips routed through it advance at the same rate as the rest of the player (transport clock, GSAP timelines, native `<video>` elements).

Closes #713.

## Why

The player exposes a `playback-rate` attribute and a speed selector. At non-1× rates, the transport clock, GSAP timelines, and native `<video>` elements all advance at the new rate — but `<audio>` clips routed through `WebAudioTransport` kept playing at 1× because `AudioBufferSourceNode.playbackRate` was never set. Result: visuals run at 2×, audio plays at 1×, hard desync within seconds.

## How

- `schedulePlayback(...)` now accepts an optional `rate` (default 1):
  - Sets `sourceNode.playbackRate.value = rate` on the buffer source.
  - Scales the future-clip start `delay` by `1 / rate` so a future clip still fires at the right composition-time boundary (composition time advances `rate ×` wallclock).
  - In-progress buffer offset stays `elapsed + mediaStart` — that quantity is rate-independent (wallclock-elapsed × rate = composition-elapsed).
- New `setRate(rate)`:
  - Updates `playbackRate.value` on every active source in place.
  - Rebases the composition-time reference frame (`_rateAnchorCtx` / `_rateAnchorComp`) so `getTime()` stays continuous across the rate change — the audio-master clock keeps reporting the same composition time at the moment of the change, then advances at the new slope.
- Runtime wiring (`packages/core/src/runtime/init.ts`):
  - `onSetPlaybackRate` now also calls `webAudio.setRate(state.playbackRate)` after `applyPlaybackRate` and `transportClock.setRate`.
  - `player.play()` schedules each audio clip with `state.playbackRate`, so playback that starts after a non-1× rate has been chosen begins at the right rate.

Non-finite / non-positive rates are normalized to 1, matching the existing `applyPlaybackRate` policy.

Known limitation (called out in the JSDoc on `setRate`): sources scheduled to start in the future via `start(when, ...)` retain their original wallclock start time. Callers that need rate-correct rescheduling for future-start clips should `stopAll()` and reschedule; for the in-tree paths, future audio is rescheduled on every `play()` / `pause()` / `seek()` so this is currently a non-issue.

## Test plan

Used TDD — wrote the failing tests first, then implemented.

- [x] Unit tests added/updated — 8 new tests in `webAudioTransport.test.ts`:
  - `schedulePlayback` sets `sourceNode.playbackRate.value` from the rate arg
  - Defaults to 1 when not provided
  - Future-clip delay is scaled by `1 / rate`
  - In-progress buffer offset is rate-invariant
  - `setRate` updates active sources in place
  - `setRate` before any sources is a no-op
  - `setRate` clamps `NaN` / `0` / negative to 1
  - `getTime` advances at the configured rate, and stays continuous across a mid-playback `setRate`
- [x] All 771 tests in `packages/core` pass.
- [x] All 109 tests in `packages/player` pass.
- [x] `bunx oxlint` and `bunx oxfmt --check` clean on touched files.
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)