### PR TITLE
refactor(producer): extract compileStage from executeRenderJob

### DIFF
--- a/packages/producer/src/services/render/stages/compileStage.ts
+++ b/packages/producer/src/services/render/stages/compileStage.ts
@@ -70,6 +70,11 @@ export async function runCompileStage(input: CompileStageInput): Promise<Compile
   const compiled = await compileForRender(projectDir, htmlPath, join(workDir, "downloads"));
   assertNotAborted();
   const compileOnlyMs = Date.now() - compileStart;
+  // TODO(distributed-render): `applyRenderModeHints` mutates `cfg.forceScreenshot`
+  // on a caller-owned object. Before freezePlan wires up, this side-effect
+  // needs to move into the result (e.g. `forceScreenshot: boolean` on
+  // `CompileStageResult`) so the value can be baked into `LockedRenderConfig`
+  // and survive across processes / replays.
   applyRenderModeHints(cfg, compiled, log);
   writeCompiledArtifacts(compiled, workDir, Boolean(job.config.debug));
 

--- a/packages/producer/src/services/render/stages/compileStage.ts
+++ b/packages/producer/src/services/render/stages/compileStage.ts
@@ -1,0 +1,116 @@
+/**
+ * compileStage — pure compile pass of `executeRenderJob`.
+ *
+ * Runs `compileForRender` on the entry HTML, applies render-mode hints
+ * (which may flip `cfg.forceScreenshot` on for compositions that need it),
+ * writes compiled artifacts to `workDir/compiled/`, builds the
+ * `CompositionMetadata` view of the result, and resolves the
+ * `deviceScaleFactor` for supersampling.
+ *
+ * The probe sub-stage (browser launch, duration discovery, recompile,
+ * media reconciliation) is extracted separately in PR 1.3. This stage
+ * stops at the point where the in-process renderer formerly entered the
+ * `if (needsBrowser)` branch.
+ *
+ * Hard constraints preserved verbatim from the in-process renderer:
+ *   - `applyRenderModeHints(cfg, ...)` is allowed to mutate `cfg.forceScreenshot`.
+ *   - `perfStages.compileOnlyMs` is set to wall-clock ms around the
+ *     `compileForRender` call only.
+ *   - The `log.info("Compiled composition metadata", ...)` line is emitted
+ *     after writing artifacts, with the same payload shape as before.
+ *   - The `log.info("Supersampling composition via deviceScaleFactor", ...)`
+ *     line is emitted only when `deviceScaleFactor > 1`.
+ */
+
+import { join } from "node:path";
+import type { EngineConfig } from "@hyperframes/engine";
+import type { CompiledComposition } from "../../htmlCompiler.js";
+import { compileForRender } from "../../htmlCompiler.js";
+import type { ProducerLogger } from "../../../logger.js";
+import {
+  applyRenderModeHints,
+  resolveDeviceScaleFactor,
+  writeCompiledArtifacts,
+  type CompositionMetadata,
+  type RenderJob,
+} from "../../renderOrchestrator.js";
+
+export interface CompileStageInput {
+  projectDir: string;
+  workDir: string;
+  /** Absolute path to the entry HTML (already resolved to standalone-entry if needed). */
+  htmlPath: string;
+  /** The relative `entryFile` string, used only for log payloads. */
+  entryFile: string;
+  job: RenderJob;
+  /** EngineConfig — may be mutated via `cfg.forceScreenshot = true`. */
+  cfg: EngineConfig;
+  /** True when the output format requires an alpha channel (webm/mov/png-sequence). */
+  needsAlpha: boolean;
+  log: ProducerLogger;
+  /** Cooperative-cancellation probe; throws `RenderCancelledError` when aborted. */
+  assertNotAborted: () => void;
+}
+
+export interface CompileStageResult {
+  compiled: CompiledComposition;
+  composition: CompositionMetadata;
+  deviceScaleFactor: number;
+  outputWidth: number;
+  outputHeight: number;
+  /** Wall-clock ms for the pure `compileForRender` call only (excludes artifact writes). */
+  compileOnlyMs: number;
+}
+
+export async function runCompileStage(input: CompileStageInput): Promise<CompileStageResult> {
+  const { projectDir, workDir, htmlPath, entryFile, job, cfg, needsAlpha, log, assertNotAborted } =
+    input;
+
+  const compileStart = Date.now();
+  const compiled = await compileForRender(projectDir, htmlPath, join(workDir, "downloads"));
+  assertNotAborted();
+  const compileOnlyMs = Date.now() - compileStart;
+  applyRenderModeHints(cfg, compiled, log);
+  writeCompiledArtifacts(compiled, workDir, Boolean(job.config.debug));
+
+  log.info("Compiled composition metadata", {
+    entryFile,
+    staticDuration: compiled.staticDuration,
+    width: compiled.width,
+    height: compiled.height,
+    videoCount: compiled.videos.length,
+    audioCount: compiled.audios.length,
+    renderModeHints: compiled.renderModeHints,
+  });
+
+  const composition: CompositionMetadata = {
+    duration: compiled.staticDuration,
+    videos: compiled.videos,
+    audios: compiled.audios,
+    images: compiled.images,
+    width: compiled.width,
+    height: compiled.height,
+  };
+  const { width, height } = composition;
+  const deviceScaleFactor = resolveDeviceScaleFactor({
+    compositionWidth: width,
+    compositionHeight: height,
+    outputResolution: job.config.outputResolution,
+    hdrRequested: job.config.hdrMode === "force-hdr",
+    alphaRequested: needsAlpha,
+  });
+  const outputWidth = width * deviceScaleFactor;
+  const outputHeight = height * deviceScaleFactor;
+  if (deviceScaleFactor > 1) {
+    log.info("Supersampling composition via deviceScaleFactor", {
+      compositionWidth: width,
+      compositionHeight: height,
+      outputResolution: job.config.outputResolution,
+      outputWidth,
+      outputHeight,
+      deviceScaleFactor,
+    });
+  }
+
+  return { compiled, composition, deviceScaleFactor, outputWidth, outputHeight, compileOnlyMs };
+}

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -109,7 +109,6 @@ import { freemem } from "os";
 import { fileURLToPath } from "url";
 import { createFileServer, type FileServerHandle, VIRTUAL_TIME_SHIM } from "./fileServer.js";
 import {
-  compileForRender,
   resolveCompositionDurations,
   recompileWithResolutions,
   discoverMediaFromBrowser,
@@ -121,6 +120,7 @@ import {
   type HdrImageTransferCache,
   createHdrImageTransferCache,
 } from "./hdrImageTransferCache.js";
+import { runCompileStage } from "./render/stages/compileStage.js";
 
 /**
  * Wrap a cleanup operation so it never throws, but logs any failure.
@@ -2125,51 +2125,22 @@ export async function executeRenderJob(
     const stage1Start = Date.now();
     updateJobStatus(job, "preprocessing", "Compiling composition", 5, onProgress);
 
-    const compileStart = Date.now();
-    let compiled = await compileForRender(projectDir, htmlPath, join(workDir, "downloads"));
-    assertNotAborted();
-    perfStages.compileOnlyMs = Date.now() - compileStart;
-    applyRenderModeHints(cfg, compiled, log);
-    writeCompiledArtifacts(compiled, workDir, Boolean(job.config.debug));
-
-    log.info("Compiled composition metadata", {
+    const compileResult = await runCompileStage({
+      projectDir,
+      workDir,
+      htmlPath,
       entryFile,
-      staticDuration: compiled.staticDuration,
-      width: compiled.width,
-      height: compiled.height,
-      videoCount: compiled.videos.length,
-      audioCount: compiled.audios.length,
-      renderModeHints: compiled.renderModeHints,
+      job,
+      cfg,
+      needsAlpha,
+      log,
+      assertNotAborted,
     });
-
-    const composition: CompositionMetadata = {
-      duration: compiled.staticDuration,
-      videos: compiled.videos,
-      audios: compiled.audios,
-      images: compiled.images,
-      width: compiled.width,
-      height: compiled.height,
-    };
+    let compiled = compileResult.compiled;
+    const composition = compileResult.composition;
+    const { deviceScaleFactor, outputWidth, outputHeight } = compileResult;
     const { width, height } = composition;
-    const deviceScaleFactor = resolveDeviceScaleFactor({
-      compositionWidth: width,
-      compositionHeight: height,
-      outputResolution: job.config.outputResolution,
-      hdrRequested: job.config.hdrMode === "force-hdr",
-      alphaRequested: needsAlpha,
-    });
-    const outputWidth = width * deviceScaleFactor;
-    const outputHeight = height * deviceScaleFactor;
-    if (deviceScaleFactor > 1) {
-      log.info("Supersampling composition via deviceScaleFactor", {
-        compositionWidth: width,
-        compositionHeight: height,
-        outputResolution: job.config.outputResolution,
-        outputWidth,
-        outputHeight,
-        deviceScaleFactor,
-      });
-    }
+    perfStages.compileOnlyMs = compileResult.compileOnlyMs;
 
     const probeStart = Date.now();
     const needsBrowser = composition.duration <= 0 || compiled.unresolvedCompositions.length > 0;


### PR DESCRIPTION
> Stacked on #717 (PR 1.1). Rebase to `main` once that merges.

## What

Phase 1 PR 1.2 of the distributed-render refactor. Moves the pure compile sub-stage of `executeRenderJob` into a new file `packages/producer/src/services/render/stages/compileStage.ts`. The sequencer now calls `runCompileStage` at the same code point with identical inputs and outputs.

Source range moved: `renderOrchestrator.ts:2128-2172` (the block between the \"── Stage 1: Compile ──\" comment and the start of `if (needsBrowser)`).

## Why

This is the first real extraction in the Phase 1 stack that mechanically splits the ~2000-line `executeRenderJob` function into 8 stage functions plus a thin sequencer. Phase 1 ships zero new functionality — it's purely a reviewable refactor that sets up the codebase for follow-on determinism hardening (Phase 2) and the new distributed primitives (Phase 3).

## How

- New file `compileStage.ts` exports `runCompileStage(input)` which:
  - Calls `compileForRender` and measures the wall-clock around it for `compileOnlyMs`.
  - Applies render-mode hints (which can mutate `cfg.forceScreenshot`).
  - Writes compiled artifacts via `writeCompiledArtifacts`.
  - Emits the same \"Compiled composition metadata\" log line.
  - Builds the `CompositionMetadata` view and resolves `deviceScaleFactor`.
  - Emits the \"Supersampling composition via deviceScaleFactor\" log line only when `deviceScaleFactor > 1`.
- `executeRenderJob` is updated to call `runCompileStage` at the same point. The `stage1Start = Date.now()`, the `updateJobStatus(...)` progress call, and the `perfStages.compileOnlyMs` assignment all remain in the sequencer.
- Removes the now-unused `compileForRender` import from `renderOrchestrator.ts` (oxlint caught it).

## Preserved invariants

- `cfg.forceScreenshot` mutation by `applyRenderModeHints` is unchanged.
- `perfStages.compileOnlyMs` is set to the same wall-clock interval (around `compileForRender` only, not around artifact writes).
- All `log.info(...)` calls fire at the same code points with the same payload shapes.
- The probe block (`if (needsBrowser)`) is untouched. `recompileWithResolutions` still lives inside probe because it depends on browser-resolved durations.

## Test plan

- [x] `bunx oxlint packages/producer/src/services/render/stages/ packages/producer/src/services/renderOrchestrator.ts` — clean.
- [x] `bunx oxfmt --check packages/producer/src/services/render/stages/ packages/producer/src/services/renderOrchestrator.ts` — clean.
- [x] `bun run --filter @hyperframes/producer typecheck` — clean.
- [x] `bun run --filter @hyperframes/producer build` — clean.
- [x] `bun test packages/producer/src/services/` — 76 pass, 1 pre-existing failure (`writeCompiledArtifacts — rejects a maliciously crafted key`) that also fails on `main` and is unrelated to this PR.
- [ ] Producer regression harness in `Dockerfile.test` — relying on the `regression` workflow on CI for the full PSNR-equivalence run across all fixture shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)