### PR TITLE
fix(studio,player,core): eliminate double audio and manifest polling loop

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1304,7 +1304,7 @@ export function initSandboxRuntimeModular(): void {
       timeSeconds: state.currentTime,
       playing: state.isPlaying,
       playbackRate: state.playbackRate,
-      outputMuted: state.mediaOutputMuted,
+      outputMuted: state.mediaOutputMuted || webAudio.isActive(),
       userMuted: state.bridgeMuted,
       userVolume: state.bridgeVolume,
       forceSync,

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -7,7 +7,6 @@ export type ScheduledSource = {
   compositionStart: number;
   mediaStart: number;
   scheduledAt: number;
-  priorMuted: boolean;
 };
 
 export class WebAudioTransport {
@@ -102,7 +101,6 @@ export class WebAudioTransport {
         sourceNode.start(scheduledAt + delay, mediaStart);
       }
 
-      const priorMuted = el.muted;
       el.muted = true;
 
       const scheduled: ScheduledSource = {
@@ -112,7 +110,6 @@ export class WebAudioTransport {
         compositionStart,
         mediaStart,
         scheduledAt,
-        priorMuted,
       };
       this._activeSources.push(scheduled);
       this._paused = false;
@@ -132,7 +129,10 @@ export class WebAudioTransport {
       } catch {
         // already stopped
       }
-      source.el.muted = source.priorMuted;
+      // Keep the element muted — syncRuntimeMedia will unmute on the next
+      // tick if appropriate. Restoring priorMuted here races with el.play()
+      // in the media sync loop, briefly producing audio from both the HTML
+      // element and the Web Audio buffer on pause/resume transitions.
     }
     this._activeSources = [];
     this._paused = true;

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -1401,6 +1401,19 @@ class HyperframesPlayer extends HTMLElement {
   private _promoteToParentProxy() {
     if (this._audioOwner === "parent") return;
     this._audioOwner = "parent";
+    // Synchronously mute iframe media to close the race window where a
+    // user gesture could let the runtime's el.play() succeed before the
+    // async bridge mute lands.
+    try {
+      const doc = this.iframe.contentDocument;
+      if (doc) {
+        for (const el of doc.querySelectorAll<HTMLMediaElement>("video, audio")) {
+          el.muted = true;
+        }
+      }
+    } catch {
+      /* cross-origin */
+    }
     // `_sendControl` is async — the iframe won't see the mute for ~one
     // message-loop tick. In that narrow window the runtime's next
     // `syncRuntimeMedia` pass may still try `el.play()` on the iframe

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -2207,11 +2207,12 @@ export function StudioApp() {
       iframe: HTMLIFrameElement | null = previewIframeRef.current,
       options?: { forceFromDisk?: boolean; readFromDiskFirst?: boolean },
     ) => {
-      const readRevision = studioManualEditRevisionRef.current;
       const readFromDiskFirst = Boolean(options?.forceFromDisk || options?.readFromDiskFirst);
       if (!readFromDiskFirst) {
         applyCurrentStudioManualEditsToPreview(iframe);
+        return;
       }
+      const readRevision = studioManualEditRevisionRef.current;
       let content: string;
       try {
         content = await readOptionalProjectFile(STUDIO_MANUAL_EDITS_PATH);
@@ -2219,30 +2220,18 @@ export function StudioApp() {
         const message =
           error instanceof Error ? error.message : "Failed to read manual edit manifest";
         showToast(message);
-        if (readFromDiskFirst) {
-          applyCurrentStudioManualEditsToPreview(iframe);
-        }
+        applyCurrentStudioManualEditsToPreview(iframe);
         return;
       }
       if (options?.forceFromDisk || readRevision === studioManualEditRevisionRef.current) {
         studioManualEditManifestRef.current = parseStudioManualEditManifest(content);
         if (options?.forceFromDisk) studioManualEditRevisionRef.current += 1;
-        applyCurrentStudioManualEditsToPreview(iframe);
-        return;
       }
-      if (readFromDiskFirst) {
-        applyCurrentStudioManualEditsToPreview(iframe);
-      }
+      applyCurrentStudioManualEditsToPreview(iframe);
     },
     [applyCurrentStudioManualEditsToPreview, readOptionalProjectFile, showToast],
   );
   applyStudioManualEditsToPreviewRef.current = applyStudioManualEditsToPreview;
-
-  const applyStudioManualEditsToPreviewAfterRefresh = useCallback(
-    (iframe: HTMLIFrameElement | null = previewIframeRef.current) =>
-      applyStudioManualEditsToPreview(iframe, { readFromDiskFirst: true }),
-    [applyStudioManualEditsToPreview],
-  );
 
   const applyCurrentStudioMotionToPreview = useCallback(
     (iframe: HTMLIFrameElement | null = previewIframeRef.current) => {
@@ -2282,42 +2271,31 @@ export function StudioApp() {
       iframe: HTMLIFrameElement | null = previewIframeRef.current,
       options?: { forceFromDisk?: boolean; readFromDiskFirst?: boolean },
     ) => {
-      const readRevision = studioMotionRevisionRef.current;
       const readFromDiskFirst = Boolean(options?.forceFromDisk || options?.readFromDiskFirst);
       if (!readFromDiskFirst) {
         applyCurrentStudioMotionToPreview(iframe);
+        return;
       }
+      const readRevision = studioMotionRevisionRef.current;
       let content: string;
       try {
         content = await readOptionalProjectFile(STUDIO_MOTION_PATH);
       } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to read motion manifest";
         showToast(message);
-        if (readFromDiskFirst) {
-          applyCurrentStudioMotionToPreview(iframe);
-        }
+        applyCurrentStudioMotionToPreview(iframe);
         return;
       }
       if (options?.forceFromDisk || readRevision === studioMotionRevisionRef.current) {
         studioMotionManifestRef.current = parseStudioMotionManifest(content);
         if (options?.forceFromDisk) studioMotionRevisionRef.current += 1;
         setStudioMotionRevision((revision) => revision + 1);
-        applyCurrentStudioMotionToPreview(iframe);
-        return;
       }
-      if (readFromDiskFirst) {
-        applyCurrentStudioMotionToPreview(iframe);
-      }
+      applyCurrentStudioMotionToPreview(iframe);
     },
     [applyCurrentStudioMotionToPreview, readOptionalProjectFile, showToast],
   );
   applyStudioMotionToPreviewRef.current = applyStudioMotionToPreview;
-
-  const applyStudioMotionToPreviewAfterRefresh = useCallback(
-    (iframe: HTMLIFrameElement | null = previewIframeRef.current) =>
-      applyStudioMotionToPreview(iframe, { readFromDiskFirst: true }),
-    [applyStudioMotionToPreview],
-  );
 
   const commitStudioManualEditManifestOptimistically = useCallback(
     (
@@ -3558,8 +3536,8 @@ export function StudioApp() {
     attachErrorCapture();
     syncPreviewHistoryHotkey(previewIframe);
     void (async () => {
-      await applyStudioManualEditsToPreviewAfterRefresh(previewIframe);
-      await applyStudioMotionToPreviewAfterRefresh(previewIframe);
+      await applyStudioManualEditsToPreviewRef.current(previewIframe);
+      await applyStudioMotionToPreviewRef.current(previewIframe);
     })();
     syncSelectionFromDocument();
     refreshPreviewDocumentVersion();
@@ -3570,8 +3548,8 @@ export function StudioApp() {
       attachErrorCapture();
       syncPreviewHistoryHotkey(previewIframe);
       void (async () => {
-        await applyStudioManualEditsToPreviewAfterRefresh(previewIframe);
-        await applyStudioMotionToPreviewAfterRefresh(previewIframe);
+        await applyStudioManualEditsToPreviewRef.current(previewIframe);
+        await applyStudioMotionToPreviewRef.current(previewIframe);
       })();
       syncSelectionFromDocument();
       refreshPreviewDocumentVersion();
@@ -3584,8 +3562,6 @@ export function StudioApp() {
   }, [
     activeCompPath,
     applyDomSelection,
-    applyStudioManualEditsToPreviewAfterRefresh,
-    applyStudioMotionToPreviewAfterRefresh,
     buildDomSelectionFromTarget,
     captionEditMode,
     previewIframe,


### PR DESCRIPTION
## Summary

Fixes three bugs that compound in Studio preview, causing double audio on pause/resume and a 60fps manifest polling loop.

### 1. Double audio on pause/resume (core/runtime)

`syncRuntimeMedia` played audio through the HTML `<audio>` element while `WebAudioTransport` simultaneously played the same source through `AudioBufferSourceNode`. Both unmuted, both active — constant double audio on every resume.

**Root cause:** `WebAudioTransport.schedulePlayback()` mutes the HTML element and routes audio through Web Audio. But `syncRuntimeMedia` runs synchronously before the async schedule resolves, calling `el.play()` with `el.muted = false`. Additionally, `stopAll()` restored `el.muted = priorMuted` (false) on pause, so the next play cycle started with the element unmuted.

**Fix:**
- Pass `webAudio.isActive()` as `outputMuted` to `syncRuntimeMedia` so HTML elements stay muted when Web Audio owns playback
- Remove the `priorMuted` restore in `stopAll()` and the now-dead `priorMuted` field from `ScheduledSource` — `syncRuntimeMedia` is the single source of truth for element mute state

### 2. Manifest polling loop (studio)

`applyStudioManualEditsToPreview` and `applyStudioMotionToPreview` unconditionally fetched `.hyperframes/studio-manual-edits.json` and `.hyperframes/studio-motion.json` from disk on every call — even when `forceFromDisk` was false. The runtime posts `state` messages every frame via `postMessage`, triggering React re-renders that re-invoked these functions ~60x/second.

**Root cause:** The functions always called `readOptionalProjectFile()` regardless of options. The `readFromDiskFirst` flag only controlled whether to apply the in-memory manifest first, but the disk read happened unconditionally. Combined with unstable callback deps in the iframe load `useEffect`, every runtime frame message triggered a re-render → effect re-run → disk fetch.

**Fix:**
- Early return when `forceFromDisk`/`readFromDiskFirst` are both false — apply in-memory manifest only, skip disk read
- Use refs instead of callback identities in the iframe load `useEffect` deps to prevent re-runs on re-renders
- Remove now-unused `applyStudio*AfterRefresh` wrappers

### 3. Parent proxy promotion race (player)

Synchronously mute iframe media in `_promoteToParentProxy()` to close the async race window where `el.play()` could succeed before the bridge mute message lands. Parent proxies are still preloaded for the autoplay-blocked fallback path — only the mute timing changed.

## Test plan

- [ ] Open Studio preview with a composition that has `<audio>` elements
- [ ] Play, pause, resume — verify single audio source, no echo/doubling
- [ ] Scrub timeline — verify no audio blips on seek
- [ ] Open browser DevTools Network tab — verify no polling of `.hyperframes/studio-manual-edits.json` or `.hyperframes/studio-motion.json`
- [ ] Make a manual edit (drag element in Studio) — verify edits still persist and reload correctly
- [ ] Test on mobile/Safari where autoplay is blocked — verify parent proxy fallback still works (audio plays after user gesture)
- [ ] Verify Studio motion features still work after removing the `AfterRefresh` wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)