### PR TITLE
refactor(producer): extract audioStage from executeRenderJob

### DIFF
--- a/packages/producer/src/services/render/stages/audioStage.ts
+++ b/packages/producer/src/services/render/stages/audioStage.ts
@@ -1,0 +1,72 @@
+/**
+ * audioStage — mix the composition's audio tracks into `workDir/audio.aac`.
+ *
+ * Trivial wrapper around `processCompositionAudio`. The stage is skipped
+ * (no ffmpeg invocation) when the composition has no audio elements; the
+ * timer is still set so the perf summary stays consistent across renders.
+ *
+ * Hard constraints preserved verbatim:
+ *   - `audioOutputPath` is always `join(workDir, "audio.aac")`, regardless
+ *     of whether any audio was actually produced.
+ *   - `hasAudio` reflects `audioResult.success` from
+ *     `processCompositionAudio`; it is `false` when there are no audio
+ *     elements (skips the call entirely) and also when the call returns
+ *     `success: false`.
+ *   - `perfStages.audioProcessMs` is set whether or not the call ran.
+ */
+
+import { join } from "node:path";
+import { processCompositionAudio } from "@hyperframes/engine";
+import type { RenderJob } from "../../renderOrchestrator.js";
+import type { CompositionMetadata } from "../shared.js";
+
+export interface AudioStageInput {
+  projectDir: string;
+  workDir: string;
+  /** `join(workDir, "compiled")`; passed through to the audio mixer for asset resolution. */
+  compiledDir: string;
+  job: RenderJob;
+  /** Composition duration (post-probe). Must be > 0 — probeStage guarantees this. */
+  duration: number;
+  /** Read-only view of `composition.audios`. */
+  audios: CompositionMetadata["audios"];
+  abortSignal: AbortSignal | undefined;
+  assertNotAborted: () => void;
+}
+
+export interface AudioStageResult {
+  /** Always `join(workDir, "audio.aac")`. */
+  audioOutputPath: string;
+  /** True iff the audio mix actually produced a file. False when there are no audio elements. */
+  hasAudio: boolean;
+  /** Wall-clock ms for the audio mix phase. Zero-elements path is near-zero but always set. */
+  audioProcessMs: number;
+}
+
+export async function runAudioStage(input: AudioStageInput): Promise<AudioStageResult> {
+  const { projectDir, workDir, compiledDir, duration, audios, abortSignal, assertNotAborted } =
+    input;
+
+  const stage3Start = Date.now();
+  const audioOutputPath = join(workDir, "audio.aac");
+  let hasAudio = false;
+
+  if (audios.length > 0) {
+    const audioResult = await processCompositionAudio(
+      audios,
+      projectDir,
+      join(workDir, "audio-work"),
+      audioOutputPath,
+      duration,
+      abortSignal,
+      undefined,
+      compiledDir,
+    );
+    assertNotAborted();
+
+    hasAudio = audioResult.success;
+  }
+  const audioProcessMs = Date.now() - stage3Start;
+
+  return { audioOutputPath, hasAudio, audioProcessMs };
+}

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -53,7 +53,6 @@ import {
   muxVideoWithAudio,
   applyFaststart,
   getEncoderPreset,
-  processCompositionAudio,
   calculateOptimalWorkers,
   distributeFrames,
   executeParallelCapture,
@@ -101,6 +100,7 @@ import {
 import { runCompileStage } from "./render/stages/compileStage.js";
 import { runProbeStage } from "./render/stages/probeStage.js";
 import { runExtractVideosStage } from "./render/stages/extractVideosStage.js";
+import { runAudioStage } from "./render/stages/audioStage.js";
 
 /**
  * Wrap a cleanup operation so it never throws, but logs any failure.
@@ -2076,30 +2076,20 @@ export async function executeRenderJob(
     }
 
     // ── Stage 3: Audio processing ───────────────────────────────────────
-    const stage3Start = Date.now();
     updateJobStatus(job, "preprocessing", "Processing audio tracks", 20, onProgress);
 
-    const audioOutputPath = join(workDir, "audio.aac");
-    let hasAudio = false;
-
-    if (composition.audios.length > 0) {
-      const audioResult = await processCompositionAudio(
-        composition.audios,
-        projectDir,
-        join(workDir, "audio-work"),
-        audioOutputPath,
-        job.duration,
-        abortSignal,
-        undefined,
-        compiledDir,
-      );
-      assertNotAborted();
-
-      hasAudio = audioResult.success;
-      perfStages.audioProcessMs = Date.now() - stage3Start;
-    } else {
-      perfStages.audioProcessMs = Date.now() - stage3Start;
-    }
+    const audioResult = await runAudioStage({
+      projectDir,
+      workDir,
+      compiledDir,
+      job,
+      duration: job.duration,
+      audios: composition.audios,
+      abortSignal,
+      assertNotAborted,
+    });
+    const { audioOutputPath, hasAudio } = audioResult;
+    perfStages.audioProcessMs = audioResult.audioProcessMs;
 
     // ── Stage 4: Frame capture ──────────────────────────────────────────
     const stage4Start = Date.now();


### PR DESCRIPTION
> Stacked on #725 (PR 1.4). Rebase to \`main\` once that merges.

## What

Phase 1 PR 1.5 of the distributed-render refactor. Moves the audio mixing sub-stage of `executeRenderJob` into `packages/producer/src/services/render/stages/audioStage.ts`. Trivial extraction — the body is a thin wrapper around `processCompositionAudio`.

Source range moved: ~25 lines between the "── Stage 3: Audio processing ──" comment and the start of "── Stage 4: Frame capture ──".

## Why

Continues the Phase 1 mechanical extraction. Phase 1 ships zero new functionality.

## How

- New file `audioStage.ts` exports `runAudioStage(input) → AudioStageResult` returning `{ audioOutputPath, hasAudio, audioProcessMs }`.
- Sequencer calls the stage at the same code point with the same inputs.
- Removes the now-unused `processCompositionAudio` import from `renderOrchestrator.ts` (oxlint flagged it).

## Preserved invariants

- `audioOutputPath` is still `join(workDir, "audio.aac")` regardless of whether any audio was produced.
- `hasAudio` reflects `audioResult.success` from `processCompositionAudio`; it is `false` when there are no audio elements (call is skipped) and also when the mixer returns `success: false`.
- `perfStages.audioProcessMs` is set whether or not the mixer ran, at the same code point.
- The 20% "Processing audio tracks" `updateJobStatus` fires at the same point.

## Test plan

- [x] `bunx oxlint` + `bunx oxfmt --check` — clean.
- [x] `bun run --filter @hyperframes/producer typecheck` + `build` — clean.
- [x] `bun test packages/producer/src/services/` — 176 pass, same single pre-existing failure unrelated to this PR.
- [x] `docker run hyperframes-producer:test --sequential font-variant-numeric many-cuts variables-prod` — 3/3 PASS, audio correlations 1.000 / 0.994 / 0.975 (identical to prior PRs in the stack; `font-variant-numeric` and `many-cuts` exercise the audio path).
- [ ] Full regression matrix on CI via the `regression` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)