### PR TITLE
fix(studio): adapt sidebar thumbnail container to composition aspect ratio

### DIFF
--- a/packages/studio/src/components/sidebar/CompositionsTab.tsx
+++ b/packages/studio/src/components/sidebar/CompositionsTab.tsx
@@ -55,9 +55,12 @@ function CompCard({
   const name = comp.replace(/^compositions\//, "").replace(/\.html$/, "");
   const thumbnailUrl = `/api/projects/${projectId}/thumbnail/${comp}?t=2`;
   const previewUrl = `/api/projects/${projectId}/preview/comp/${comp}`;
+  const isPortrait = stageSize.height > stageSize.width;
+  const cardWidth = isPortrait ? Math.round((45 * stageSize.width) / stageSize.height) : 80;
+  const cardHeight = isPortrait ? 45 : Math.round((80 * stageSize.height) / stageSize.width);
   const previewScale = resolveCompositionPreviewScale({
-    cardWidth: 80,
-    cardHeight: 45,
+    cardWidth,
+    cardHeight,
     stageWidth: stageSize.width,
     stageHeight: stageSize.height,
   });
@@ -73,7 +76,10 @@ function CompCard({
           : "border-l-2 border-transparent hover:bg-neutral-800/50"
       }`}
     >
-      <div className="w-20 h-[45px] rounded overflow-hidden bg-neutral-900 flex-shrink-0 relative">
+      <div
+        className="rounded overflow-hidden bg-neutral-900 flex-shrink-0 relative"
+        style={{ width: cardWidth, height: cardHeight }}
+      >
         {/* Live iframe preview on hover */}
         {hovered && (
           <iframe


### PR DESCRIPTION
## Summary

Portrait compositions (1080x1920) rendered pillarboxed inside a fixed 80x45px landscape container, wasting space with black bars on both sides.

The thumbnail container now derives its dimensions from the composition's stage size: landscape compositions get 80px wide (height from aspect ratio), portrait compositions get 45px tall (width from aspect ratio). The preview scale calculation uses the matching card dimensions so the iframe fills the container without letterboxing.

## Test plan

- [ ] Open a project with portrait compositions (1080x1920) — thumbnail should be tall and narrow, no black bars
- [ ] Open a project with landscape compositions (1920x1080) — thumbnail unchanged (80x45)
- [ ] Open a project with square compositions (1080x1080) — thumbnail should be square
- [ ] Hover over thumbnails — live preview iframe should fill the container correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)