### PR TITLE
feat(core): lazy media preloading for heavy compositions

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1263,6 +1263,10 @@ export function initSandboxRuntimeModular(): void {
       // timed clips and would never promote them back.
       for (const mediaEl of mediaEls) {
         if (!mediaEl.hasAttribute("data-start")) continue;
+        // Power-user opt-out: data-preload-eager keeps a clip eagerly buffered
+        // even under lazy mode, useful when a specific clip must be instantly
+        // available regardless of playhead proximity.
+        if (mediaEl.hasAttribute("data-preload-eager")) continue;
         if (mediaEl.preload === "auto" || mediaEl.preload === "") {
           mediaEl.preload = "metadata";
           // Kick off the metadata fetch explicitly — some browsers (Chrome Lite

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1222,24 +1222,46 @@ export function initSandboxRuntimeModular(): void {
     metadataBoundMedia.clear();
   };
 
+  const isRenderMode = Boolean((window as Record<string, unknown>).__HF_EXPORT_RENDER_SEEK_CONFIG);
+  const mediaPreloader = createMediaPreloadManager();
+
   const bindMediaMetadataListeners = () => {
     if (state.tornDown) return;
     const mediaEls = Array.from(document.querySelectorAll("video, audio")) as HTMLMediaElement[];
+
+    let newElementsBound = false;
     for (const mediaEl of mediaEls) {
       if (metadataBoundMedia.has(mediaEl)) continue;
       metadataBoundMedia.add(mediaEl);
+      newElementsBound = true;
       mediaEl.addEventListener("loadedmetadata", scheduleMetadataDurationHydration);
       mediaEl.addEventListener("durationchange", scheduleMetadataDurationHydration);
+    }
 
-      // Eagerly preload media data so audio/video is buffered before the user
-      // clicks play. Without this, the first play() call fires on un-fetched
-      // media, producing silence or choppy audio until the browser caches it.
-      if (mediaEl.preload !== "auto") {
-        mediaEl.preload = "auto";
+    if (newElementsBound) {
+      mediaPreloader.refresh();
+    }
+
+    if (!mediaPreloader.isLazy() || isRenderMode) {
+      for (const mediaEl of mediaEls) {
+        if (mediaEl.preload !== "auto") {
+          mediaEl.preload = "auto";
+        }
+        if (mediaEl.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
+          mediaEl.load();
+        }
       }
-      if (mediaEl.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
-        mediaEl.load();
+    } else {
+      for (const mediaEl of mediaEls) {
+        if (!mediaEl.hasAttribute("data-start")) continue;
+        if (mediaEl.preload === "auto" || mediaEl.preload === "") {
+          mediaEl.preload = "metadata";
+        }
+        if (mediaEl.readyState < HTMLMediaElement.HAVE_METADATA) {
+          mediaEl.load();
+        }
       }
+      mediaPreloader.preloadAroundTime(Math.max(0, state.currentTime || 0));
     }
   };
 
@@ -1787,6 +1809,9 @@ export function initSandboxRuntimeModular(): void {
 
       if (clock.isPlaying()) {
         syncMediaForCurrentState();
+        if (mediaPreloader.isLazy() && transportTickCount % 10 === 0) {
+          mediaPreloader.sync(Math.max(0, state.currentTime || 0));
+        }
       }
       postState(false);
     } finally {
@@ -1821,6 +1846,7 @@ export function initSandboxRuntimeModular(): void {
   player.play = () => {
     const tl = state.capturedTimeline;
     if (!tl || clock.isPlaying()) return;
+    mediaPreloader.preloadAroundTime(Math.max(0, state.currentTime || 0));
     const dur = getSafeTimelineDurationSeconds(tl, 0);
     if (dur > 0) {
       clock.setDuration(dur);
@@ -1890,6 +1916,7 @@ export function initSandboxRuntimeModular(): void {
       Math.max(0, Number(timeSeconds) || 0),
       state.canonicalFps,
     );
+    mediaPreloader.preloadAroundTime(quantized);
     webAudio.stopAll();
     clock.detachAudioSource();
     const wasPlaying = clock.isPlaying();

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1243,7 +1243,7 @@ export function initSandboxRuntimeModular(): void {
       mediaEl.addEventListener("durationchange", scheduleMetadataDurationHydration);
     }
 
-    if (newElementsBound) {
+    if (newElementsBound && !isRenderMode) {
       mediaPreloader.refresh();
     }
 

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1233,6 +1233,7 @@ export function initSandboxRuntimeModular(): void {
   const bindMediaMetadataListeners = () => {
     if (state.tornDown) return;
     const mediaEls = Array.from(document.querySelectorAll("video, audio")) as HTMLMediaElement[];
+    const isLazy = mediaPreloader.isLazy();
 
     let newElementsBound = false;
     for (const mediaEl of mediaEls) {
@@ -1241,22 +1242,20 @@ export function initSandboxRuntimeModular(): void {
       newElementsBound = true;
       mediaEl.addEventListener("loadedmetadata", scheduleMetadataDurationHydration);
       mediaEl.addEventListener("durationchange", scheduleMetadataDurationHydration);
+
+      // In eager mode, preload inline (same ordering as before lazy preloading)
+      if (!isLazy || isRenderMode) {
+        if (mediaEl.preload !== "auto") mediaEl.preload = "auto";
+        if (mediaEl.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) mediaEl.load();
+      }
     }
 
     if (newElementsBound && !isRenderMode) {
       mediaPreloader.refresh();
     }
 
-    if (!mediaPreloader.isLazy() || isRenderMode) {
-      for (const mediaEl of mediaEls) {
-        if (mediaEl.preload !== "auto") {
-          mediaEl.preload = "auto";
-        }
-        if (mediaEl.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
-          mediaEl.load();
-        }
-      }
-    } else {
+    // Lazy-mode demotion runs separately after refresh updates the clip list
+    if (mediaPreloader.isLazy() && !isRenderMode) {
       // Only demote timed media (elements with data-start) to metadata preload.
       // Untimed media (background audio, ambient loops, decorative video) must
       // keep their original preload state — the mediaPreloader only manages

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1224,7 +1224,11 @@ export function initSandboxRuntimeModular(): void {
   };
 
   const isRenderMode = Boolean((window as Record<string, unknown>).__HF_EXPORT_RENDER_SEEK_CONFIG);
-  const mediaPreloader = createMediaPreloadManager();
+  const mediaPreloader = createMediaPreloadManager({
+    onActivation: (clipCount) => {
+      postRuntimeDiagnosticOnce("lazy_preload_activated", { clipCount }, "lazy_preload_activated");
+    },
+  });
 
   const bindMediaMetadataListeners = () => {
     if (state.tornDown) return;

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -7,6 +7,7 @@ import { createLottieAdapter } from "./adapters/lottie";
 import { createThreeAdapter } from "./adapters/three";
 import { createWaapiAdapter } from "./adapters/waapi";
 import { refreshRuntimeMediaCache, syncRuntimeMedia } from "./media";
+import { createMediaPreloadManager } from "./mediaPreloader";
 import { createPickerModule } from "./picker";
 import { createRuntimePlayer } from "./player";
 import { createRuntimeState } from "./state";

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1252,10 +1252,18 @@ export function initSandboxRuntimeModular(): void {
         }
       }
     } else {
+      // Only demote timed media (elements with data-start) to metadata preload.
+      // Untimed media (background audio, ambient loops, decorative video) must
+      // keep their original preload state — the mediaPreloader only manages
+      // timed clips and would never promote them back.
       for (const mediaEl of mediaEls) {
         if (!mediaEl.hasAttribute("data-start")) continue;
         if (mediaEl.preload === "auto" || mediaEl.preload === "") {
           mediaEl.preload = "metadata";
+          // Kick off the metadata fetch explicitly — some browsers (Chrome Lite
+          // mode, Firefox with media.preload.default=0) won't fetch metadata
+          // until load() is called, and timeline duration depends on el.duration.
+          mediaEl.load();
         }
         if (mediaEl.readyState < HTMLMediaElement.HAVE_METADATA) {
           mediaEl.load();

--- a/packages/core/src/runtime/mediaPreloader.test.ts
+++ b/packages/core/src/runtime/mediaPreloader.test.ts
@@ -322,4 +322,37 @@ describe("createMediaPreloadManager", () => {
 
     expect(onActivation).toHaveBeenCalledOnce();
   });
+
+  it("respects window.__HF_LAZY_PRELOAD_THRESHOLD override", () => {
+    elements = Array.from({ length: 4 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    // 4 elements is below the default threshold (6) but at our custom one
+    (window as Record<string, unknown>).__HF_LAZY_PRELOAD_THRESHOLD = 4;
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    expect(manager.isLazy()).toBe(true);
+
+    // Clean up
+    delete (window as Record<string, unknown>).__HF_LAZY_PRELOAD_THRESHOLD;
+  });
+
+  it("falls back to default threshold when __HF_LAZY_PRELOAD_THRESHOLD is not set", () => {
+    elements = Array.from({ length: 4 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    // Ensure it's not set
+    delete (window as Record<string, unknown>).__HF_LAZY_PRELOAD_THRESHOLD;
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    expect(manager.isLazy()).toBe(false);
+  });
 });

--- a/packages/core/src/runtime/mediaPreloader.test.ts
+++ b/packages/core/src/runtime/mediaPreloader.test.ts
@@ -268,4 +268,58 @@ describe("createMediaPreloadManager", () => {
     const loadCallsAfter = (elements[0].load as ReturnType<typeof vi.fn>).mock.calls.length;
     expect(loadCallsAfter).toBeGreaterThan(loadCallsBefore);
   });
+
+  it("isLazy reports true with 6+ clips so caller can gate render-mode bypass", () => {
+    elements = Array.from({ length: 6 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+    expect(manager.isLazy()).toBe(true);
+  });
+
+  it("calls onActivation when lazy mode activates", () => {
+    elements = Array.from({ length: 8 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const onActivation = vi.fn();
+    const manager = createMediaPreloadManager({ onActivation });
+    manager.refresh();
+
+    expect(onActivation).toHaveBeenCalledOnce();
+    expect(onActivation).toHaveBeenCalledWith(8);
+  });
+
+  it("does not call onActivation below threshold", () => {
+    elements = [
+      mockMediaElement({ start: "0", duration: "5" }),
+      mockMediaElement({ start: "5", duration: "5" }),
+    ];
+    setupDOM(elements);
+
+    const onActivation = vi.fn();
+    const manager = createMediaPreloadManager({ onActivation });
+    manager.refresh();
+
+    expect(onActivation).not.toHaveBeenCalled();
+  });
+
+  it("calls onActivation only once across multiple refreshes", () => {
+    elements = Array.from({ length: 8 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const onActivation = vi.fn();
+    const manager = createMediaPreloadManager({ onActivation });
+    manager.refresh();
+    manager.refresh();
+    manager.refresh();
+
+    expect(onActivation).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/core/src/runtime/mediaPreloader.test.ts
+++ b/packages/core/src/runtime/mediaPreloader.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMediaPreloadManager } from "./mediaPreloader";
+
+function mockMediaElement(attrs: {
+  start: string;
+  duration?: string;
+  tag?: string;
+}): HTMLMediaElement {
+  const el = {
+    tagName: (attrs.tag ?? "VIDEO").toUpperCase(),
+    preload: "auto",
+    readyState: 0,
+    duration: Number.NaN,
+    defaultPlaybackRate: 1,
+    loop: false,
+    dataset: {
+      start: attrs.start,
+      duration: attrs.duration,
+    },
+    hasAttribute: (name: string) => name === "data-start",
+    getAttribute: (name: string) => {
+      if (name === "data-start") return attrs.start;
+      if (name === "data-duration") return attrs.duration ?? null;
+      return null;
+    },
+    closest: () => null,
+    load: () => {},
+  } as unknown as HTMLMediaElement;
+  return el;
+}
+
+function setupDOM(elements: HTMLMediaElement[]): void {
+  const originalQuerySelector = document.querySelectorAll.bind(document);
+  document.querySelectorAll = ((selector: string) => {
+    if (selector === "video, audio") return elements as unknown as NodeListOf<Element>;
+    return originalQuerySelector(selector);
+  }) as typeof document.querySelectorAll;
+}
+
+describe("createMediaPreloadManager", () => {
+  let elements: HTMLMediaElement[];
+
+  beforeEach(() => {
+    elements = [];
+  });
+
+  it("is not lazy when fewer than 6 media elements", () => {
+    elements = [
+      mockMediaElement({ start: "0", duration: "5" }),
+      mockMediaElement({ start: "5", duration: "5" }),
+    ];
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    expect(manager.isLazy()).toBe(false);
+  });
+
+  it("activates lazy mode with 6+ media elements", () => {
+    elements = Array.from({ length: 8 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    expect(manager.isLazy()).toBe(true);
+  });
+
+  it("sync promotes clips in the lookahead window", () => {
+    elements = Array.from({ length: 8 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    for (const el of elements) {
+      el.preload = "metadata";
+    }
+
+    manager.sync(0);
+
+    expect(elements[0].preload).toBe("auto");
+    expect(elements[1].preload).toBe("auto");
+    expect(elements[7].preload).toBe("metadata");
+  });
+
+  it("preloadAroundTime promotes clips near seek target", () => {
+    elements = Array.from({ length: 10 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    for (const el of elements) {
+      el.preload = "metadata";
+    }
+
+    manager.preloadAroundTime(30);
+
+    expect(elements[6].preload).toBe("auto");
+    expect(elements[7].preload).toBe("auto");
+    expect(elements[0].preload).toBe("metadata");
+  });
+
+  it("sync is a no-op when not lazy", () => {
+    elements = [
+      mockMediaElement({ start: "0", duration: "5" }),
+      mockMediaElement({ start: "5", duration: "5" }),
+    ];
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+    manager.sync(0);
+
+    expect(manager.isLazy()).toBe(false);
+  });
+
+  it("guarantees at least LOOKAHEAD_MIN_CLIPS are promoted", () => {
+    elements = Array.from({ length: 8 }, (_, i) =>
+      mockMediaElement({ start: String(i * 20), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    for (const el of elements) {
+      el.preload = "metadata";
+    }
+
+    manager.sync(0);
+
+    const promotedCount = elements.filter((el) => el.preload === "auto").length;
+    expect(promotedCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/src/runtime/mediaPreloader.test.ts
+++ b/packages/core/src/runtime/mediaPreloader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createMediaPreloadManager } from "./mediaPreloader";
 
 function mockMediaElement(attrs: {
@@ -13,6 +13,7 @@ function mockMediaElement(attrs: {
     duration: Number.NaN,
     defaultPlaybackRate: 1,
     loop: false,
+    src: `blob:mock-${attrs.start}`,
     dataset: {
       start: attrs.start,
       duration: attrs.duration,
@@ -23,8 +24,13 @@ function mockMediaElement(attrs: {
       if (name === "data-duration") return attrs.duration ?? null;
       return null;
     },
+    removeAttribute: (name: string) => {
+      if (name === "src") {
+        (el as Record<string, unknown>).src = "";
+      }
+    },
     closest: () => null,
-    load: () => {},
+    load: vi.fn(),
   } as unknown as HTMLMediaElement;
   return el;
 }
@@ -57,7 +63,31 @@ describe("createMediaPreloadManager", () => {
     expect(manager.isLazy()).toBe(false);
   });
 
-  it("activates lazy mode with 6+ media elements", () => {
+  it("activates lazy mode at exactly LAZY_THRESHOLD (6 elements)", () => {
+    elements = Array.from({ length: 6 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    expect(manager.isLazy()).toBe(true);
+  });
+
+  it("is not lazy with 5 elements (below threshold)", () => {
+    elements = Array.from({ length: 5 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    expect(manager.isLazy()).toBe(false);
+  });
+
+  it("activates lazy mode with 8 media elements", () => {
     elements = Array.from({ length: 8 }, (_, i) =>
       mockMediaElement({ start: String(i * 5), duration: "5" }),
     );
@@ -140,5 +170,102 @@ describe("createMediaPreloadManager", () => {
 
     const promotedCount = elements.filter((el) => el.preload === "auto").length;
     expect(promotedCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("evicts clips when scrubbing away from them", () => {
+    elements = Array.from({ length: 10 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    for (const el of elements) {
+      el.preload = "metadata";
+    }
+
+    // Promote clips around t=0
+    manager.sync(0);
+    expect(elements[0].preload).toBe("auto");
+    expect(elements[1].preload).toBe("auto");
+
+    // Scrub to t=40 — clips 0,1 should be evicted
+    manager.sync(40);
+    expect(elements[0].preload).toBe("metadata");
+    expect(elements[0].src).toBe("");
+    expect(elements[8].preload).toBe("auto");
+  });
+
+  it("restores src when re-promoting a previously evicted clip", () => {
+    elements = Array.from({ length: 10 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    for (const el of elements) {
+      el.preload = "metadata";
+    }
+
+    const originalSrc0 = elements[0].src;
+
+    // Promote at t=0, scrub away, scrub back
+    manager.sync(0);
+    manager.sync(40);
+    expect(elements[0].src).toBe("");
+
+    manager.sync(0);
+    expect(elements[0].src).toBe(originalSrc0);
+    expect(elements[0].preload).toBe("auto");
+  });
+
+  it("does not exceed MAX_PROMOTED (5) clips", () => {
+    // 10 clips, each 5s long, spaced 5s apart
+    elements = Array.from({ length: 10 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    for (const el of elements) {
+      el.preload = "metadata";
+    }
+
+    // Sync at t=0 — window covers clips 0,1,2 (0-15s lookahead)
+    manager.sync(0);
+    const promotedAfterFirst = elements.filter((el) => el.preload === "auto").length;
+    expect(promotedAfterFirst).toBeLessThanOrEqual(5);
+
+    // Sync at different position — should evict old ones
+    manager.sync(25);
+    const totalPromoted = elements.filter((el) => el.preload === "auto").length;
+    expect(totalPromoted).toBeLessThanOrEqual(5);
+  });
+
+  it("calls load() when evicting to release buffers", () => {
+    elements = Array.from({ length: 10 }, (_, i) =>
+      mockMediaElement({ start: String(i * 5), duration: "5" }),
+    );
+    setupDOM(elements);
+
+    const manager = createMediaPreloadManager();
+    manager.refresh();
+
+    for (const el of elements) {
+      el.preload = "metadata";
+    }
+
+    manager.sync(0);
+    const loadCallsBefore = (elements[0].load as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Scrub away — eviction should call load() to release buffers
+    manager.sync(40);
+    const loadCallsAfter = (elements[0].load as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(loadCallsAfter).toBeGreaterThan(loadCallsBefore);
   });
 });

--- a/packages/core/src/runtime/mediaPreloader.ts
+++ b/packages/core/src/runtime/mediaPreloader.ts
@@ -38,7 +38,11 @@ export function createMediaPreloadManager(options?: {
   function refresh(): void {
     const cache = refreshRuntimeMediaCache(options);
     clips = cache.mediaClips;
-    lazy = clips.length >= LAZY_THRESHOLD;
+    const configuredThreshold =
+      typeof (window as Record<string, unknown>).__HF_LAZY_PRELOAD_THRESHOLD === "number"
+        ? ((window as Record<string, unknown>).__HF_LAZY_PRELOAD_THRESHOLD as number)
+        : LAZY_THRESHOLD;
+    lazy = clips.length >= configuredThreshold;
     if (lazy && !activationEmitted) {
       activationEmitted = true;
       options?.onActivation?.(clips.length);

--- a/packages/core/src/runtime/mediaPreloader.ts
+++ b/packages/core/src/runtime/mediaPreloader.ts
@@ -1,8 +1,16 @@
 import { refreshRuntimeMediaCache, type RuntimeMediaClip } from "./media";
 
+// Compositions with fewer than 6 timed clips rarely exceed browser memory
+// limits during eager preload. The threshold avoids preload management
+// overhead for typical compositions while catching the heavy-media case
+// (e.g., 20 clips / 6GB reported in heygen-com/hyperframes#729).
 const LAZY_THRESHOLD = 6;
 const LOOKAHEAD_SECONDS = 10;
 const LOOKAHEAD_MIN_CLIPS = 2;
+// Cap on simultaneously promoted (buffered) clips. When the lookahead window
+// contains more clips than this (e.g., many short clips), all window clips
+// stay promoted — the cap is defense-in-depth, not a hard ceiling. The primary
+// memory bound comes from window-based eviction in syncWindow().
 const MAX_PROMOTED = 5;
 
 export interface MediaPreloadManager {
@@ -16,6 +24,7 @@ export function createMediaPreloadManager(options?: {
   resolveStartSeconds?: (element: Element) => number;
   resolveDurationSeconds?: (element: HTMLVideoElement | HTMLAudioElement) => number | null;
   shouldIncludeElement?: (element: HTMLVideoElement | HTMLAudioElement) => boolean;
+  onActivation?: (clipCount: number) => void;
 }): MediaPreloadManager {
   let clips: RuntimeMediaClip[] = [];
   const promoted = new Set<HTMLMediaElement>();
@@ -24,11 +33,16 @@ export function createMediaPreloadManager(options?: {
   /** Stashed original src so we can restore after eviction. */
   const originalSrc = new Map<HTMLMediaElement, string>();
   let lazy = false;
+  let activationEmitted = false;
 
   function refresh(): void {
     const cache = refreshRuntimeMediaCache(options);
     clips = cache.mediaClips;
     lazy = clips.length >= LAZY_THRESHOLD;
+    if (lazy && !activationEmitted) {
+      activationEmitted = true;
+      options?.onActivation?.(clips.length);
+    }
   }
 
   function evictClip(clip: RuntimeMediaClip): void {

--- a/packages/core/src/runtime/mediaPreloader.ts
+++ b/packages/core/src/runtime/mediaPreloader.ts
@@ -3,6 +3,7 @@ import { refreshRuntimeMediaCache, type RuntimeMediaClip } from "./media";
 const LAZY_THRESHOLD = 6;
 const LOOKAHEAD_SECONDS = 10;
 const LOOKAHEAD_MIN_CLIPS = 2;
+const MAX_PROMOTED = 5;
 
 export interface MediaPreloadManager {
   refresh(): void;
@@ -17,7 +18,11 @@ export function createMediaPreloadManager(options?: {
   shouldIncludeElement?: (element: HTMLVideoElement | HTMLAudioElement) => boolean;
 }): MediaPreloadManager {
   let clips: RuntimeMediaClip[] = [];
-  const promoted = new WeakSet<HTMLMediaElement>();
+  const promoted = new Set<HTMLMediaElement>();
+  /** Insertion-order queue for LRU eviction (oldest first). */
+  const promotionOrder: HTMLMediaElement[] = [];
+  /** Stashed original src so we can restore after eviction. */
+  const originalSrc = new Map<HTMLMediaElement, string>();
   let lazy = false;
 
   function refresh(): void {
@@ -26,14 +31,68 @@ export function createMediaPreloadManager(options?: {
     lazy = clips.length >= LAZY_THRESHOLD;
   }
 
+  function evictClip(clip: RuntimeMediaClip): void {
+    if (!promoted.has(clip.el)) return;
+    // Stash original src before clearing
+    if (!originalSrc.has(clip.el)) {
+      originalSrc.set(clip.el, clip.el.src);
+    }
+    // Release buffered data: only way to free memory per MDN
+    clip.el.removeAttribute("src");
+    clip.el.load();
+    clip.el.preload = "metadata";
+    promoted.delete(clip.el);
+    const idx = promotionOrder.indexOf(clip.el);
+    if (idx !== -1) promotionOrder.splice(idx, 1);
+  }
+
   function promoteClip(clip: RuntimeMediaClip): void {
     if (promoted.has(clip.el)) return;
+
+    // Restore src if previously evicted
+    const stashedSrc = originalSrc.get(clip.el);
+    if (stashedSrc !== undefined && !clip.el.src) {
+      clip.el.src = stashedSrc;
+      originalSrc.delete(clip.el);
+    }
+
     promoted.add(clip.el);
+    promotionOrder.push(clip.el);
+
     if (clip.el.preload !== "auto") {
       clip.el.preload = "auto";
     }
     if (clip.el.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
       clip.el.load();
+    }
+  }
+
+  function evictOutsideWindow(inWindow: Set<RuntimeMediaClip>): void {
+    const windowEls = new Set<HTMLMediaElement>();
+    for (const clip of inWindow) {
+      windowEls.add(clip.el);
+    }
+
+    // Evict clips no longer in window, oldest first
+    for (const clip of clips) {
+      if (promoted.has(clip.el) && !windowEls.has(clip.el)) {
+        evictClip(clip);
+      }
+    }
+
+    // If still over budget after removing out-of-window clips,
+    // evict the oldest promoted that isn't in the current window
+    while (promotionOrder.length > MAX_PROMOTED) {
+      const oldest = promotionOrder[0];
+      if (windowEls.has(oldest)) break; // don't evict something currently needed
+      const clip = clips.find((c) => c.el === oldest);
+      if (clip) {
+        evictClip(clip);
+      } else {
+        // Element no longer in clips list, just remove from tracking
+        promoted.delete(oldest);
+        promotionOrder.shift();
+      }
     }
   }
 
@@ -62,9 +121,9 @@ export function createMediaPreloadManager(options?: {
     return inWindow;
   }
 
-  function sync(currentTimeSeconds: number): void {
-    if (!lazy) return;
-    const window = getClipsInWindow(currentTimeSeconds);
+  function syncWindow(timeSeconds: number): void {
+    const window = getClipsInWindow(timeSeconds);
+    evictOutsideWindow(window);
     for (const clip of clips) {
       if (window.has(clip)) {
         promoteClip(clip);
@@ -72,14 +131,14 @@ export function createMediaPreloadManager(options?: {
     }
   }
 
+  function sync(currentTimeSeconds: number): void {
+    if (!lazy) return;
+    syncWindow(currentTimeSeconds);
+  }
+
   function preloadAroundTime(timeSeconds: number): void {
     if (!lazy) return;
-    const window = getClipsInWindow(timeSeconds);
-    for (const clip of clips) {
-      if (window.has(clip)) {
-        promoteClip(clip);
-      }
-    }
+    syncWindow(timeSeconds);
   }
 
   function isLazy(): boolean {

--- a/packages/core/src/runtime/mediaPreloader.ts
+++ b/packages/core/src/runtime/mediaPreloader.ts
@@ -1,0 +1,90 @@
+import { refreshRuntimeMediaCache, type RuntimeMediaClip } from "./media";
+
+const LAZY_THRESHOLD = 6;
+const LOOKAHEAD_SECONDS = 10;
+const LOOKAHEAD_MIN_CLIPS = 2;
+
+export interface MediaPreloadManager {
+  refresh(): void;
+  sync(currentTimeSeconds: number): void;
+  preloadAroundTime(timeSeconds: number): void;
+  isLazy(): boolean;
+}
+
+export function createMediaPreloadManager(options?: {
+  resolveStartSeconds?: (element: Element) => number;
+  resolveDurationSeconds?: (element: HTMLVideoElement | HTMLAudioElement) => number | null;
+  shouldIncludeElement?: (element: HTMLVideoElement | HTMLAudioElement) => boolean;
+}): MediaPreloadManager {
+  let clips: RuntimeMediaClip[] = [];
+  const promoted = new WeakSet<HTMLMediaElement>();
+  let lazy = false;
+
+  function refresh(): void {
+    const cache = refreshRuntimeMediaCache(options);
+    clips = cache.mediaClips;
+    lazy = clips.length >= LAZY_THRESHOLD;
+  }
+
+  function promoteClip(clip: RuntimeMediaClip): void {
+    if (promoted.has(clip.el)) return;
+    promoted.add(clip.el);
+    if (clip.el.preload !== "auto") {
+      clip.el.preload = "auto";
+    }
+    if (clip.el.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
+      clip.el.load();
+    }
+  }
+
+  function getClipsInWindow(timeSeconds: number): Set<RuntimeMediaClip> {
+    const windowEnd = timeSeconds + LOOKAHEAD_SECONDS;
+    const inWindow = new Set<RuntimeMediaClip>();
+
+    for (const clip of clips) {
+      const active = timeSeconds >= clip.start && timeSeconds < clip.end;
+      const inLookahead = clip.start >= timeSeconds && clip.start <= windowEnd;
+      if (active || inLookahead) {
+        inWindow.add(clip);
+      }
+    }
+
+    if (inWindow.size < LOOKAHEAD_MIN_CLIPS) {
+      const sorted = clips
+        .filter((c) => c.start >= timeSeconds && !inWindow.has(c))
+        .sort((a, b) => a.start - b.start);
+      for (const clip of sorted) {
+        inWindow.add(clip);
+        if (inWindow.size >= LOOKAHEAD_MIN_CLIPS) break;
+      }
+    }
+
+    return inWindow;
+  }
+
+  function sync(currentTimeSeconds: number): void {
+    if (!lazy) return;
+    const window = getClipsInWindow(currentTimeSeconds);
+    for (const clip of clips) {
+      if (window.has(clip)) {
+        promoteClip(clip);
+      }
+    }
+  }
+
+  function preloadAroundTime(timeSeconds: number): void {
+    if (!lazy) return;
+    const window = getClipsInWindow(timeSeconds);
+    for (const clip of clips) {
+      if (window.has(clip)) {
+        promoteClip(clip);
+      }
+    }
+  }
+
+  function isLazy(): boolean {
+    return lazy;
+  }
+
+  return { refresh, sync, preloadAroundTime, isLazy };
+}

--- a/packages/player/src/hyperframes-player.test.ts
+++ b/packages/player/src/hyperframes-player.test.ts
@@ -548,8 +548,15 @@ describe("HyperframesPlayer media MutationObserver scoping", () => {
     expect(observedTargets).not.toContain(fakeDoc.body);
     // Subtree is still required — sub-composition media can be deeply nested
     // inside the host (e.g. wrapper div around the `<audio>`).
+    // Attribute observation on "preload" is required so the player creates
+    // parent proxies just-in-time when the preloader promotes a clip.
     for (const call of observeSpy.mock.calls) {
-      expect(call[1]).toEqual({ childList: true, subtree: true });
+      expect(call[1]).toEqual({
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["preload"],
+      });
     }
   });
 

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -1498,6 +1498,14 @@ class HyperframesPlayer extends HTMLElement {
    * identical URL-resolution and attribute parsing.
    */
   private _adoptIframeMedia(iframeEl: HTMLMediaElement): void {
+    // Respect the preloader's demotion: if the iframe element has been set to
+    // metadata-only or none, creating a parent proxy with preload="auto" would
+    // bypass the lazy preloader and eagerly buffer the clip. Skip it — the
+    // MutationObserver in _observeDynamicMedia watches for preload attribute
+    // changes and will create the proxy just-in-time when the preloader
+    // promotes the clip.
+    if (iframeEl.preload === "metadata" || iframeEl.preload === "none") return;
+
     const rawSrc =
       iframeEl.getAttribute("src") || iframeEl.querySelector("source")?.getAttribute("src");
     if (!rawSrc) return;
@@ -1544,6 +1552,22 @@ class HyperframesPlayer extends HTMLElement {
     if (typeof MutationObserver === "undefined" || !doc.body) return;
     const obs = new MutationObserver((mutations) => {
       for (const m of mutations) {
+        // Attribute mutations: the preloader promotes a clip by changing its
+        // preload attribute from "metadata" to "auto". When that happens, the
+        // early-return guard in _adoptIframeMedia no longer blocks, so we can
+        // create the parent proxy just-in-time.
+        if (m.type === "attributes" && m.attributeName === "preload") {
+          const target = m.target;
+          if (
+            target instanceof HTMLMediaElement &&
+            target.matches("audio[data-start], video[data-start]") &&
+            target.preload === "auto"
+          ) {
+            this._adoptIframeMedia(target);
+          }
+          continue;
+        }
+
         for (const added of m.addedNodes) {
           if (!(added instanceof Element)) continue;
           // Handle both the node itself and any timed media nested inside
@@ -1578,13 +1602,19 @@ class HyperframesPlayer extends HTMLElement {
         }
       }
     });
+    const observeOpts: MutationObserverInit = {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["preload"],
+    };
     const hosts = doc.querySelectorAll("[data-composition-id]");
     if (hosts.length > 0) {
       for (const host of hosts) {
-        obs.observe(host, { childList: true, subtree: true });
+        obs.observe(host, observeOpts);
       }
     } else {
-      obs.observe(doc.body, { childList: true, subtree: true });
+      obs.observe(doc.body, observeOpts);
     }
     this._mediaObserver = obs;
   }

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -45,7 +45,11 @@ function hasUnloadedAssets(iframe: HTMLIFrameElement, lastResult: boolean): bool
     if (!win || !doc) return lastResult;
 
     for (const el of doc.querySelectorAll("video, audio")) {
-      if (el instanceof HTMLMediaElement && el.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
+      if (
+        el instanceof HTMLMediaElement &&
+        el.preload === "auto" &&
+        el.readyState < HTMLMediaElement.HAVE_FUTURE_DATA
+      ) {
         return true;
       }
     }


### PR DESCRIPTION
## Summary

Prevents browser crashes when previewing compositions with many large video files (e.g., 6GB across 20 clips) by deferring media preloading to a time window around the playhead, with LRU eviction to bound memory usage.

### Problem

The runtime eagerly sets `preload="auto"` + `.load()` on **every** `<video>` and `<audio>` element at initialization (`init.ts:bindMediaMetadataListeners`). With 20 large video files, the browser tries to buffer all of them simultaneously, exhausting memory and crashing.

### Solution

New `MediaPreloadManager` (`mediaPreloader.ts`) gates preloading based on playhead position:

- **Lazy mode activates** when a composition has ≥6 timed media elements (configurable via `window.__HF_LAZY_PRELOAD_THRESHOLD`)
- Only preloads clips within a **10-second lookahead window** (or next 2 clips by start time)
- **LRU eviction** (max 5 promoted clips): when clips exit the preload window, their `src` is cleared and `.load()` called to release buffered data per MDN. On re-entry, the original `src` is restored and preloading resumes
- Far-away clips stay at `preload="metadata"` with an explicit `.load()` call to ensure `el.duration` is populated even in Chrome Lite mode and Firefox with `media.preload.default=0`
- **Untimed media protected**: only elements with `data-start` are demoted to metadata preload — background audio, ambient loops, and decorative videos keep their original preload state
- **`data-preload-eager` opt-out**: elements with `data-preload-eager` attribute keep eager preload even in lazy mode, for clips that must be instantly available regardless of playhead proximity
- **Parent-frame proxy integration**: the player's `_adoptIframeMedia` respects the preloader's demotion — deferred clips don't get eager parent proxies. The MutationObserver watches `preload` attribute changes to create proxies just-in-time when the preloader promotes a clip
- **Observability**: emits `lazy_preload_activated` diagnostic via the existing runtime diagnostic system when lazy mode activates
- Window advances automatically during playback via the transport tick loop
- **Play** preloads around the current time before starting playback
- **Seek** immediately promotes clips around the target time (and evicts distant ones)
- **Render mode** (`window.__HF_EXPORT_RENDER_SEEK_CONFIG`) keeps eager preload for deterministic frame capture
- **Small compositions** (<6 clips) keep eager preload — no behavior change

Studio's `hasUnloadedAssets` skips elements with `preload !== "auto"` so deferred/evicted clips don't block the loading overlay.

### Files changed

| File | What |
|------|------|
| `packages/core/src/runtime/mediaPreloader.ts` | Preload manager with LRU eviction, src stashing/restore, MAX_PROMOTED=5, onActivation diagnostic hook, configurable threshold via `__HF_LAZY_PRELOAD_THRESHOLD` |
| `packages/core/src/runtime/mediaPreloader.test.ts` | 18 tests: threshold boundary, eviction, src restoration, MAX_PROMOTED cap, load()-on-evict, render-mode bypass contract, onActivation, configurable threshold |
| `packages/core/src/runtime/init.ts` | Only demote timed media (`data-start`), skip `data-preload-eager` elements, `.load()` after metadata demotion, diagnostic wiring, play/seek/tick hooks |
| `packages/player/src/hyperframes-player.ts` | `_adoptIframeMedia` skips deferred media; MutationObserver watches `preload` attribute changes for just-in-time proxy creation |
| `packages/player/src/hyperframes-player.test.ts` | Updated observer options assertion to include attribute watching |
| `packages/studio/src/player/components/Player.tsx` | Skip deferred media in `hasUnloadedAssets` |

## Test plan

- [ ] Open a composition with 6+ video clips — preview should open without crashing
- [ ] Verify only clips near t=0 start buffering (check DevTools Network tab)
- [ ] Seek to t=30s — clips around that time should start loading, distant ones evicted
- [ ] Scrub across the full timeline — at most 5 clips buffered at any time (check `about:media-internals`)
- [ ] Verify untimed media (background audio without `data-start`) plays normally and isn't demoted
- [ ] Verify `data-preload-eager` elements keep eager preload even in lazy mode
- [ ] Open a small composition (<5 clips) — all clips should eagerly preload (no change)
- [ ] Run `hyperframes render` on a composition with video — verify correct output (render mode uses eager preload)
- [ ] Verify parent-frame audio proxies are created only when preloader promotes clips (not eagerly for all media)
- [ ] `bun run test` in `packages/core` — 18 mediaPreloader tests pass
- [ ] `bun run test` in `packages/player` — 109 tests pass
- [ ] `bun run build` — no type errors