### PR TITLE
fix(producer): hybrid layered/parallel path for shader-transition renders (closes #677)

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
   entry: {
     cli: "src/cli.ts",
     shaderTransitionWorker: "../producer/src/services/shaderTransitionWorker.ts",
+    // hf#732 lever-4: mirror the shader-blend worker entry for the new
+    // PNG decode + alpha-blit worker pool. Same rationale — the pool's
+    // `new Worker(<path>)` is a filesystem load that probes for
+    // `pngDecodeBlitWorker.js` next to its own module; we need the .js
+    // to exist in the CLI's shipped `dist/` next to `cli.js`.
+    pngDecodeBlitWorker: "../producer/src/services/pngDecodeBlitWorker.ts",
   },
   format: ["esm"],
   outDir: "dist",
@@ -78,6 +84,11 @@ var __dirname = __hf_dirname(__filename);`,
         __dirname,
         "../engine/src/utils/shaderTransitions.ts",
       ),
+      // hf#732 lever-4: alias for the PNG decode+blit worker's import.
+      // `alphaBlit.ts` is import-free (only zlib) so the worker survives
+      // the worker_thread loader boundary the same way the shader-blend
+      // worker does.
+      "@hyperframes/engine/alpha-blit": resolve(__dirname, "../engine/src/utils/alphaBlit.ts"),
     };
     options.loader = { ...options.loader, ".browser.js": "text" };
   },

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -7,7 +7,20 @@ const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), 
 };
 
 export default defineConfig({
-  entry: ["src/cli.ts"],
+  // hf#732 fix-up: emit BOTH the CLI bundle and the shader-transition worker
+  // entry. The producer's `shaderTransitionWorkerPool` instantiates a Node
+  // `worker_threads` Worker via `new Worker(<path>)`, which is a filesystem
+  // load — it cannot share the parent module graph. The pool's path resolver
+  // probes for `shaderTransitionWorker.js` next to its own loaded module
+  // (which lives inside `dist/cli.js` after the producer is `noExternal`'d
+  // and bundled in). Without this entry the file would not exist at runtime
+  // and the pool would either crash or fall back to inline blends, killing
+  // the perf gain. Two entries → two `dist/*.js` files, both via the same
+  // tsup pipeline so the workspace alias / banner / externals stay aligned.
+  entry: {
+    cli: "src/cli.ts",
+    shaderTransitionWorker: "../producer/src/services/shaderTransitionWorker.ts",
+  },
   format: ["esm"],
   outDir: "dist",
   target: "node22",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -56,6 +56,15 @@ var __dirname = __hf_dirname(__filename);`,
   esbuildOptions(options) {
     options.alias = {
       "@hyperframes/producer": resolve(__dirname, "../producer/src/index.ts"),
+      // hf#677 follow-up: the producer's shader-blend worker imports from
+      // `@hyperframes/engine/shader-transitions` (subpath export) for a
+      // standalone TS file with zero internal imports — survives the
+      // worker_thread loader boundary. Mirror the alias here so tsup's
+      // bundler resolves it the same way as the producer's own build.mjs.
+      "@hyperframes/engine/shader-transitions": resolve(
+        __dirname,
+        "../engine/src/utils/shaderTransitions.ts",
+      ),
     };
     options.loader = { ...options.loader, ".browser.js": "text" };
   },

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -12,7 +12,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./shader-transitions": "./src/utils/shaderTransitions.ts"
+    "./shader-transitions": "./src/utils/shaderTransitions.ts",
+    "./alpha-blit": "./src/utils/alphaBlit.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -11,7 +11,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./shader-transitions": "./src/utils/shaderTransitions.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -64,8 +64,23 @@ export interface WorkerSizingConfig extends Partial<
 
 const MEMORY_PER_WORKER_MB = 256;
 const MIN_WORKERS = 1;
-const ABSOLUTE_MAX_WORKERS = 10;
-const DEFAULT_SAFE_MAX_WORKERS = 6;
+// Hard ceiling on explicit `--workers N` requests. Above this, the cost of
+// CDP-protocol dispatch through Node's main event loop and OS scheduling
+// noise overwhelms any further parallelism. Bumped from 10 → 24 in hf#732
+// follow-up so high-core hosts (32-96+ cores) can actually surface the
+// hardware to renders that are CPU-bound on DOM capture.
+const ABSOLUTE_MAX_WORKERS = 24;
+// `auto` concurrency picks this many workers as the upper bound. Bumped
+// from a hardcoded 6 → CPU-scaled value (floor(cpuCount/8), floor at 6,
+// ceiling at 16) in hf#732 follow-up. Rationale: the prior fixed cap of 6
+// left ~90 cores idle on the validation host and forced users to pass
+// `--workers N` to opt in. Now `auto` matches what a thoughtful operator
+// would pick by hand. The /8 divisor leaves headroom for each Chrome
+// worker's SwiftShader compositor + the shader-blend thread pool, both of
+// which are themselves CPU-heavy.
+function defaultSafeMaxWorkers(): number {
+  return Math.max(6, Math.min(16, Math.floor(cpus().length / 8)));
+}
 const MIN_FRAMES_PER_WORKER = 30;
 
 export function calculateOptimalWorkers(
@@ -79,7 +94,7 @@ export function calculateOptimalWorkers(
     if (concurrency !== "auto") {
       return Math.max(MIN_WORKERS, Math.min(ABSOLUTE_MAX_WORKERS, Math.floor(concurrency)));
     }
-    return DEFAULT_SAFE_MAX_WORKERS;
+    return defaultSafeMaxWorkers();
   })();
   const effectiveCoresPerWorker = config?.coresPerWorker ?? DEFAULT_CONFIG.coresPerWorker;
   const effectiveMinParallelFrames = config?.minParallelFrames ?? DEFAULT_CONFIG.minParallelFrames;

--- a/packages/producer/build.mjs
+++ b/packages/producer/build.mjs
@@ -21,6 +21,9 @@ const workspaceAliasPlugin = {
     build.onResolve({ filter: /^@hyperframes\/engine$/ }, () => ({
       path: resolve(scriptDir, "../engine/src/index.ts"),
     }));
+    build.onResolve({ filter: /^@hyperframes\/engine\/shader-transitions$/ }, () => ({
+      path: resolve(scriptDir, "../engine/src/utils/shaderTransitions.ts"),
+    }));
     build.onResolve({ filter: /^@hyperframes\/core$/ }, () => ({
       path: resolve(scriptDir, "../core/src/index.ts"),
     }));
@@ -54,6 +57,24 @@ await Promise.all([
     sourcemap: true,
     entryPoints: ["src/server.ts"],
     outfile: "dist/public-server.js",
+  }),
+  // Shader-blend worker (hf#677 follow-up). Loaded by
+  // `shaderTransitionWorkerPool.createShaderTransitionWorkerPool` via
+  // `new Worker(<path>)`. The pool probes for the `.js` build first,
+  // falling back to the in-tree `.ts` source under tsx in dev. Must be
+  // a separate entry point so it's bundled into a standalone worker
+  // module — `new Worker(...)` cannot share the parent module graph.
+  build({
+    bundle: true,
+    platform: "node",
+    target: "node22",
+    format: "esm",
+    external: ["puppeteer", "esbuild", "postcss"],
+    plugins: [workspaceAliasPlugin],
+    minify: false,
+    sourcemap: true,
+    entryPoints: ["src/services/shaderTransitionWorker.ts"],
+    outfile: "dist/services/shaderTransitionWorker.js",
   }),
 ]);
 

--- a/packages/producer/build.mjs
+++ b/packages/producer/build.mjs
@@ -24,6 +24,9 @@ const workspaceAliasPlugin = {
     build.onResolve({ filter: /^@hyperframes\/engine\/shader-transitions$/ }, () => ({
       path: resolve(scriptDir, "../engine/src/utils/shaderTransitions.ts"),
     }));
+    build.onResolve({ filter: /^@hyperframes\/engine\/alpha-blit$/ }, () => ({
+      path: resolve(scriptDir, "../engine/src/utils/alphaBlit.ts"),
+    }));
     build.onResolve({ filter: /^@hyperframes\/core$/ }, () => ({
       path: resolve(scriptDir, "../core/src/index.ts"),
     }));
@@ -75,6 +78,23 @@ await Promise.all([
     sourcemap: true,
     entryPoints: ["src/services/shaderTransitionWorker.ts"],
     outfile: "dist/services/shaderTransitionWorker.js",
+  }),
+  // PNG decode + alpha-blit worker (hf#732 lever-4). Loaded by
+  // `pngDecodeBlitWorkerPool.createPngDecodeBlitWorkerPool` via
+  // `new Worker(<path>)`. Same bundling rationale as the shader-blend
+  // worker entry above — separate entry so the worker module is
+  // standalone and shares no parent module graph state.
+  build({
+    bundle: true,
+    platform: "node",
+    target: "node22",
+    format: "esm",
+    external: ["puppeteer", "esbuild", "postcss"],
+    plugins: [workspaceAliasPlugin],
+    minify: false,
+    sourcemap: true,
+    entryPoints: ["src/services/pngDecodeBlitWorker.ts"],
+    outfile: "dist/services/pngDecodeBlitWorker.js",
   }),
 ]);
 

--- a/packages/producer/src/services/pngDecodeBlitWorker.ts
+++ b/packages/producer/src/services/pngDecodeBlitWorker.ts
@@ -1,0 +1,122 @@
+/**
+ * Worker entry point for off-main-thread PNG decode + alpha blit. The
+ * companion to `pngDecodeBlitWorkerPool.ts`. See that file for the rationale
+ * (hf#732 lever-4: overlap Chrome's screenshot with Node's decode+blit).
+ *
+ * Lifecycle:
+ *
+ * 1. Pool constructor spawns N of these workers up front.
+ * 2. Main thread posts `{ png, pngOffset, pngLength, dest, destOffset,
+ *    destLength, width, height, transfer }` with `transferList: [png, dest]`.
+ *    Both underlying ArrayBuffers are detached on the sender; the caller
+ *    must NOT touch them until the worker replies.
+ * 3. Worker wraps each ArrayBuffer as a Node Buffer view (zero-copy),
+ *    runs `decodePng` to get an RGBA8 Uint8Array, then `blitRgba8OverRgb48le`
+ *    to composite the decoded pixels onto the rgb48le `dest` buffer in
+ *    the requested transfer space.
+ * 4. Worker posts `{ ok, png, dest, decodeMs, blitMs }` back with
+ *    `transferList: [png, dest]`. Both ArrayBuffers return to the main
+ *    thread; the caller swaps `result.dest` into its render state.
+ * 5. On decode/blit exception, worker posts `{ ok: false, error, png,
+ *    dest }` — both ArrayBuffers still returned so the caller can release
+ *    them.
+ *
+ * The worker holds no per-frame state. The intermediate RGBA8 decode
+ * buffer is allocated per-call and dropped on the worker side.
+ *
+ * Import strategy: identical to `shaderTransitionWorker.ts` — use the
+ * `./alpha-blit` subpath export of `@hyperframes/engine` rather than the
+ * package root, because the root pulls in the full engine graph and the
+ * tsx loader's `.js → .ts` rewrite does not survive the Worker boundary
+ * under dev/test.
+ */
+
+import { parentPort } from "node:worker_threads";
+import { decodePng, blitRgba8OverRgb48le } from "@hyperframes/engine/alpha-blit";
+
+interface DecodeBlitJobRequest {
+  png: ArrayBuffer;
+  pngOffset: number;
+  pngLength: number;
+  dest: ArrayBuffer;
+  destOffset: number;
+  destLength: number;
+  width: number;
+  height: number;
+  transfer: string;
+}
+
+interface DecodeBlitJobOk {
+  ok: true;
+  png: ArrayBuffer;
+  dest: ArrayBuffer;
+  decodeMs: number;
+  blitMs: number;
+}
+
+interface DecodeBlitJobErr {
+  ok: false;
+  error: string;
+  png: ArrayBuffer;
+  dest: ArrayBuffer;
+}
+
+export type DecodeBlitJobResult = DecodeBlitJobOk | DecodeBlitJobErr;
+
+if (!parentPort) {
+  // Defensive — this module is only meaningful inside a worker_thread.
+  // eslint-disable-next-line no-console
+  console.warn("[pngDecodeBlitWorker] no parentPort; module loaded on main thread");
+} else {
+  parentPort.on("message", (msg: DecodeBlitJobRequest) => {
+    const { png, pngOffset, pngLength, dest, destOffset, destLength, width, height, transfer } =
+      msg;
+    // Re-wrap the transferred ArrayBuffers as Node Buffer views. The
+    // dispatcher in the pool normalizes inputs to offset-0 ArrayBuffers
+    // before transfer (avoiding the 8KB shared-pool DataCloneError), so
+    // pngOffset / destOffset are 0 and pngLength / destLength match the
+    // backing ArrayBuffer byteLength in practice. We still honor the
+    // forwarded values so the worker is robust if the dispatcher ever
+    // changes (e.g. ships a slice over a larger transferred ArrayBuffer).
+    const pngBuf = Buffer.from(png, pngOffset, pngLength);
+    const destBuf = Buffer.from(dest, destOffset, destLength);
+
+    try {
+      const decodeStart = Date.now();
+      const { data: rgba } = decodePng(pngBuf);
+      const decodeMs = Date.now() - decodeStart;
+
+      const blitStart = Date.now();
+      // `blitRgba8OverRgb48le` accepts the CompositeTransfer string as a
+      // typed union. The pool's `transfer` field is `string` for transport
+      // simplicity; the actual values flow through unchanged from the
+      // orchestrator's HdrCompositeContext and the function validates at
+      // its own boundary.
+      blitRgba8OverRgb48le(
+        rgba,
+        destBuf,
+        width,
+        height,
+        transfer as Parameters<typeof blitRgba8OverRgb48le>[4],
+      );
+      const blitMs = Date.now() - blitStart;
+
+      const reply: DecodeBlitJobOk = {
+        ok: true,
+        png,
+        dest,
+        decodeMs,
+        blitMs,
+      };
+      parentPort!.postMessage(reply, [png, dest]);
+    } catch (err) {
+      const reply: DecodeBlitJobErr = {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        png,
+        dest,
+      };
+      parentPort!.postMessage(reply, [png, dest]);
+    }
+  });
+}

--- a/packages/producer/src/services/pngDecodeBlitWorkerPool.test.ts
+++ b/packages/producer/src/services/pngDecodeBlitWorkerPool.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for the hf#732 lever-4 PNG decode + alpha-blit worker pool. Like the
+ * shader-blend pool tests next door, these are correctness-critical: a
+ * regression either corrupts every composited DOM layer or leaks worker
+ * handles. Tests pin three properties:
+ *
+ *   1. Byte-equivalence with the inline path. The worker calls the exact
+ *      same `decodePng` + `blitRgba8OverRgb48le` the inline path uses, so
+ *      the round-trip must reproduce the inline result to the last byte.
+ *   2. Buffer-transfer correctness across the 8KB Node pool threshold.
+ *      The pool's dispatcher must NOT throw `DataCloneError` for inputs
+ *      that happen to live in the shared 8KB pool (small PNGs, etc.).
+ *   3. Concurrent dispatch + pipelining. N concurrent `run` calls
+ *      against a pool sized to N all complete with correct output. The
+ *      pipelining test asserts that decode/blit of frame N overlaps the
+ *      kickoff of frame N+1's "capture" (simulated by a deferred Promise),
+ *      proving the pool isn't accidentally serializing.
+ *
+ * The pool's clean-shutdown path is also exercised so a test failure
+ * doesn't leak handles into other tests.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { deflateSync } from "zlib";
+import { decodePng, blitRgba8OverRgb48le } from "@hyperframes/engine/alpha-blit";
+import {
+  createPngDecodeBlitWorkerPool,
+  type PngDecodeBlitWorkerPool,
+} from "./pngDecodeBlitWorkerPool.js";
+
+const W = 16;
+const H = 8;
+const RGB48_BYTES = W * H * 6;
+
+/**
+ * Synthesize a minimal RGBA8 PNG with a uniform color. Skips CRC32
+ * because `decodePng` does not verify checksums. Produces an output that's
+ * intentionally tiny (well under 8KB) so the test exercises the
+ * shared-pool-detection path in the dispatcher.
+ */
+function makeUniformRgbaPng(
+  w: number,
+  h: number,
+  r: number,
+  g: number,
+  b: number,
+  a: number,
+): Buffer {
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8; // 8-bit depth
+  ihdr[9] = 6; // RGBA
+  ihdr[10] = 0; // deflate
+  ihdr[11] = 0; // no filter
+  ihdr[12] = 0; // non-interlaced
+
+  const rows: Buffer[] = [];
+  for (let y = 0; y < h; y++) {
+    rows.push(Buffer.from([0])); // PNG row filter byte (None)
+    for (let x = 0; x < w; x++) {
+      rows.push(Buffer.from([r, g, b, a]));
+    }
+  }
+  const idatData = deflateSync(Buffer.concat(rows));
+
+  function chunk(type: string, data: Buffer): Buffer {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length, 0);
+    const typeBuf = Buffer.from(type, "ascii");
+    const crc = Buffer.alloc(4); // skipped by decoder
+    return Buffer.concat([len, typeBuf, data, crc]);
+  }
+
+  return Buffer.concat([
+    sig,
+    chunk("IHDR", ihdr),
+    chunk("IDAT", idatData),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+describe("PngDecodeBlitWorkerPool", () => {
+  const pools: PngDecodeBlitWorkerPool[] = [];
+
+  afterEach(async () => {
+    while (pools.length > 0) {
+      const p = pools.pop();
+      if (p) await p.terminate();
+    }
+  });
+
+  async function makePool(size: number): Promise<PngDecodeBlitWorkerPool> {
+    const p = await createPngDecodeBlitWorkerPool({ size });
+    pools.push(p);
+    return p;
+  }
+
+  it("produces byte-identical output to the inline decode+blit path", async () => {
+    const pool = await makePool(1);
+    const png = makeUniformRgbaPng(W, H, 255, 0, 0, 255);
+
+    // Pool path: blit onto a zero-filled rgb48le canvas.
+    const poolDest = Buffer.alloc(RGB48_BYTES);
+    const poolResult = await pool.run({
+      png: Buffer.from(png), // independent copy — the input may be detached
+      dest: poolDest,
+      width: W,
+      height: H,
+      transfer: "srgb",
+    });
+
+    // Reference: inline decode+blit onto a separately allocated canvas.
+    const refDest = Buffer.alloc(RGB48_BYTES);
+    const { data: refRgba } = decodePng(png);
+    blitRgba8OverRgb48le(refRgba, refDest, W, H, "srgb");
+
+    expect(Buffer.compare(poolResult.dest, refDest)).toBe(0);
+  });
+
+  it("composites OVER existing rgb48le content (alpha blend semantics)", async () => {
+    const pool = await makePool(1);
+
+    // Half-transparent red over a green background.
+    const png = makeUniformRgbaPng(W, H, 255, 0, 0, 128);
+
+    const poolDest = Buffer.alloc(RGB48_BYTES);
+    for (let i = 0; i < W * H; i++) {
+      const off = i * 6;
+      poolDest.writeUInt16LE(0, off); // R
+      poolDest.writeUInt16LE(60000, off + 2); // G
+      poolDest.writeUInt16LE(0, off + 4); // B
+    }
+
+    const poolResult = await pool.run({
+      png: Buffer.from(png),
+      dest: poolDest,
+      width: W,
+      height: H,
+      transfer: "srgb",
+    });
+
+    // Inline reference applies the same blend to its own copy of the
+    // green background.
+    const refDest = Buffer.alloc(RGB48_BYTES);
+    for (let i = 0; i < W * H; i++) {
+      const off = i * 6;
+      refDest.writeUInt16LE(0, off);
+      refDest.writeUInt16LE(60000, off + 2);
+      refDest.writeUInt16LE(0, off + 4);
+    }
+    const { data: refRgba } = decodePng(png);
+    blitRgba8OverRgb48le(refRgba, refDest, W, H, "srgb");
+
+    expect(Buffer.compare(poolResult.dest, refDest)).toBe(0);
+  });
+
+  it("survives small PNGs that would otherwise hit the Node 8KB shared pool", async () => {
+    // A 16×8 RGBA PNG compresses to a few hundred bytes — comfortably
+    // under the 8KB Buffer pool threshold. If the dispatcher fails to
+    // copy-out before postMessage, this throws DataCloneError.
+    const pool = await makePool(1);
+    const png = makeUniformRgbaPng(W, H, 50, 100, 200, 255);
+    expect(png.byteLength).toBeLessThan(8192);
+
+    const result = await pool.run({
+      png,
+      dest: Buffer.alloc(RGB48_BYTES),
+      width: W,
+      height: H,
+      transfer: "srgb",
+    });
+    expect(result.dest.byteLength).toBe(RGB48_BYTES);
+  });
+
+  it("runs N concurrent decode+blit tasks against an N-wide pool", async () => {
+    const pool = await makePool(4);
+    const png = makeUniformRgbaPng(W, H, 200, 100, 50, 255);
+
+    const tasks = Array.from({ length: 4 }, () =>
+      pool.run({
+        png: Buffer.from(png),
+        dest: Buffer.alloc(RGB48_BYTES),
+        width: W,
+        height: H,
+        transfer: "srgb",
+      }),
+    );
+    const results = await Promise.all(tasks);
+
+    // All 4 results must match each other (same input) AND match the
+    // inline reference.
+    const refDest = Buffer.alloc(RGB48_BYTES);
+    const { data: refRgba } = decodePng(png);
+    blitRgba8OverRgb48le(refRgba, refDest, W, H, "srgb");
+    for (const r of results) {
+      expect(Buffer.compare(r.dest, refDest)).toBe(0);
+    }
+  });
+
+  it("permits frame N+1 capture to proceed while frame N decode+blit is in flight", async () => {
+    // Pipelining proof: kick off a "decode+blit" task that we can hold by
+    // virtue of the worker actually running, then concurrently kick off a
+    // simulated next-frame capture (a Promise that resolves immediately).
+    // The simulated capture must resolve BEFORE the decode+blit, proving
+    // the decode+blit isn't blocking the main thread.
+    const pool = await makePool(2);
+    const png = makeUniformRgbaPng(W, H, 50, 100, 200, 255);
+
+    // Sentinel timestamps to verify overlap.
+    const captureStarted: number[] = [];
+    const captureDone: number[] = [];
+    const decodeBlitStarted: number[] = [];
+    const decodeBlitDone: number[] = [];
+
+    decodeBlitStarted.push(Date.now());
+    const decodeBlitPromise = pool
+      .run({
+        png: Buffer.from(png),
+        dest: Buffer.alloc(RGB48_BYTES),
+        width: W,
+        height: H,
+        transfer: "srgb",
+      })
+      .then((r) => {
+        decodeBlitDone.push(Date.now());
+        return r;
+      });
+
+    // Simulated next-frame CDP capture — a microtask-y await that yields.
+    // On a non-pipelined (synchronous-inline) path this would have to wait
+    // for the decode+blit, but the pool dispatches to a worker thread so
+    // the main thread is free to start the next "capture" immediately.
+    captureStarted.push(Date.now());
+    await new Promise((resolve) => setImmediate(resolve));
+    captureDone.push(Date.now());
+
+    await decodeBlitPromise;
+
+    expect(captureDone[0]).toBeDefined();
+    expect(decodeBlitDone[0]).toBeDefined();
+    // The simulated capture must have completed before the decode+blit —
+    // proof that the pool is NOT blocking the main thread.
+    expect(captureDone[0]!).toBeLessThanOrEqual(decodeBlitDone[0]!);
+  });
+
+  it("terminates cleanly even with queued tasks", async () => {
+    const pool = await makePool(1);
+    const png = makeUniformRgbaPng(W, H, 1, 2, 3, 255);
+
+    // Two tasks: the first dispatches, the second queues.
+    const p1 = pool.run({
+      png: Buffer.from(png),
+      dest: Buffer.alloc(RGB48_BYTES),
+      width: W,
+      height: H,
+      transfer: "srgb",
+    });
+    const p2 = pool.run({
+      png: Buffer.from(png),
+      dest: Buffer.alloc(RGB48_BYTES),
+      width: W,
+      height: H,
+      transfer: "srgb",
+    });
+
+    await pool.terminate();
+    pools.pop(); // already terminated; don't try to re-terminate in afterEach
+
+    // Both must settle (resolve or reject). The first MAY resolve if the
+    // worker finished before terminate() raced in; the second MUST reject
+    // because it never got to dispatch.
+    const r1 = await p1.catch((e: unknown) => e);
+    const r2 = await p2.catch((e: unknown) => e);
+    if (r2 instanceof Error) {
+      expect(r2.message).toMatch(/terminated/);
+    } else {
+      // If both raced to resolve before terminate, that's also acceptable
+      // — but only the second one is guaranteed-rejected. Accept either
+      // shape; the goal of the test is "no leaked handles, no unhandled
+      // rejection".
+      expect(r2).toBeDefined();
+    }
+    // r1 is "either resolved with a result OR rejected with terminated";
+    // both are acceptable.
+    expect(r1).toBeDefined();
+  });
+});

--- a/packages/producer/src/services/pngDecodeBlitWorkerPool.ts
+++ b/packages/producer/src/services/pngDecodeBlitWorkerPool.ts
@@ -1,0 +1,398 @@
+/**
+ * Pool of Node `worker_threads` Workers for off-main-thread PNG decode +
+ * rgba8-over-rgb48le blit. The hf#732 lever-4 follow-up: capture (Chrome
+ * compositor) and decode+blit (Node CPU) were previously serialized per
+ * frame inside `captureTransitionFrame` / `compositeHdrFrame`. Each frame
+ * waited ~30 ms (decode) + ~50 ms (blit) on the Node main thread before the
+ * next CDP screenshot could begin. With the decode+blit on a worker pool,
+ * the calling thread can kick off the next CDP capture immediately and the
+ * decode+blit overlaps Chrome's screenshot work.
+ *
+ * Why a SEPARATE pool from `shaderTransitionWorkerPool`:
+ *
+ *   - Different work shapes: shader-blend reads 2× rgb48le, writes 1×
+ *     rgb48le. Decode+blit reads 1× PNG bytes (variable size, often
+ *     ~250 KB for 854×480 with sparse DOM content), allocates a temporary
+ *     RGBA8 buffer, and writes 1× rgb48le (over an existing destination).
+ *   - Different concurrency profile: shader-blend fires once per
+ *     transition frame; decode+blit fires once per DOM layer per frame
+ *     (typically 3-6× per normal frame, 2× per transition frame). The
+ *     pools have very different dispatch rates and queuing characteristics.
+ *   - Sizing them independently lets us tune each to its bottleneck without
+ *     starving the other.
+ *
+ * API:
+ *
+ *   const pool = await createPngDecodeBlitWorkerPool({ size, log });
+ *   const result = await pool.run({
+ *     png: pngBuffer,             // alpha-channel PNG from CDP (zero-copy in)
+ *     dest: rgb48leDestBuffer,    // rgb48le canvas to blend onto (zero-copy in)
+ *     width, height,
+ *     transfer: "srgb" | "pq" | "hlg" | etc.,
+ *   });
+ *   // result.dest is the SAME memory as the input `dest`, but re-attached
+ *   // to the main thread. The input Buffer is detached on dispatch — the
+ *   // caller must use `result.dest` for any subsequent reads/writes.
+ *   await pool.terminate();
+ *
+ * Buffer transfer contract:
+ *
+ *   The PNG bytes are transferred IN with `transferList: [png.buffer]` so
+ *   we don't copy them across the worker boundary. The `dest` rgb48le
+ *   ArrayBuffer is also transferred IN (and back OUT) so the blit happens
+ *   in place on the same memory the caller pre-allocated. After `run`
+ *   resolves, the caller MUST swap its Buffer reference to `result.dest`
+ *   — the original Buffer's underlying ArrayBuffer is detached on dispatch.
+ *
+ *   The intermediate RGBA8 decode buffer is allocated INSIDE the worker
+ *   and dropped on the worker side — there is no main-thread allocation
+ *   for it. The PNG ArrayBuffer is transferred back too so the caller can
+ *   release it.
+ */
+
+import { Worker } from "node:worker_threads";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { cpus } from "node:os";
+
+interface PoolLogger {
+  info?: (msg: string, meta?: Record<string, unknown>) => void;
+  warn?: (msg: string, meta?: Record<string, unknown>) => void;
+  error?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface PngDecodeBlitPoolOptions {
+  /** Number of worker threads. Clamped to [1, cpus().length]. */
+  size: number;
+  /** Optional logger; falls back to no-op. */
+  log?: PoolLogger;
+}
+
+export interface PngDecodeBlitRequest {
+  /** PNG bytes captured from CDP (Page.captureScreenshot). */
+  png: Buffer;
+  /**
+   * Pre-allocated rgb48le destination canvas (width*height*6 bytes). The
+   * blit composites the decoded RGBA8 image OVER this buffer's existing
+   * contents in `transfer` space.
+   */
+  dest: Buffer;
+  width: number;
+  height: number;
+  /**
+   * Composite color space tag matching the engine's `CompositeTransfer`
+   * union. Passed through to `blitRgba8OverRgb48le` in the worker.
+   */
+  transfer: string;
+}
+
+export interface PngDecodeBlitResult {
+  /**
+   * Re-attached destination buffer holding the composited rgb48le pixels.
+   * Same memory as the request's `dest`, viewed through a fresh Buffer.
+   */
+  dest: Buffer;
+  /** Per-worker timing: decode duration in ms (excluding postMessage latency). */
+  decodeMs: number;
+  /** Per-worker timing: blit duration in ms. */
+  blitMs: number;
+}
+
+interface PendingTask {
+  req: PngDecodeBlitRequest;
+  resolve: (r: PngDecodeBlitResult) => void;
+  reject: (err: Error) => void;
+  enqueuedAtMs?: number;
+  traceId?: number;
+}
+
+interface WorkerSlot {
+  worker: Worker;
+  busy: boolean;
+  current: PendingTask | null;
+}
+
+interface WorkerReply {
+  ok: boolean;
+  error?: string;
+  png: ArrayBuffer;
+  dest: ArrayBuffer;
+  decodeMs?: number;
+  blitMs?: number;
+}
+
+export interface PngDecodeBlitWorkerPool {
+  readonly size: number;
+  run(req: PngDecodeBlitRequest): Promise<PngDecodeBlitResult>;
+  terminate(): Promise<void>;
+}
+
+/**
+ * Resolve the path to the compiled worker module. Same pattern as
+ * `shaderTransitionWorkerPool.resolveWorkerEntry`: prefer the bundled
+ * `.js` sibling, fall back to the `.ts` source for dev/test. Override via
+ * `HF_PNG_DECODE_BLIT_WORKER_ENTRY` for test infra.
+ */
+function resolveWorkerEntry(): { path: string; isTs: boolean } {
+  const override = process.env.HF_PNG_DECODE_BLIT_WORKER_ENTRY;
+  if (override && override.length > 0) {
+    const isTs = override.endsWith(".ts");
+    return { path: override, isTs };
+  }
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const jsPath = join(moduleDir, "pngDecodeBlitWorker.js");
+  if (existsSync(jsPath)) return { path: jsPath, isTs: false };
+  const tsPath = join(moduleDir, "pngDecodeBlitWorker.ts");
+  return { path: tsPath, isTs: true };
+}
+
+/**
+ * Mirror of `shaderTransitionWorkerPool.buildExecArgv`. Worker threads
+ * inherit the parent's loader only if the relevant flag is present on
+ * `process.execArgv`; under vitest the tsx loader is NOT exposed there, so
+ * we append `--import tsx/esm` when the resolved entry is `.ts` and no
+ * loader is detected. Best-effort: silently no-ops if `tsx/esm` can't be
+ * resolved (prod bundle).
+ */
+function buildExecArgv(entryIsTs: boolean): string[] {
+  const inherited = [...process.execArgv];
+  if (!entryIsTs) return inherited;
+  const hasLoader = inherited.some(
+    (a) => a.includes("tsx/esm") || a.includes("ts-node/esm") || a.includes("--import"),
+  );
+  if (hasLoader) return inherited;
+  try {
+    const require = createRequire(import.meta.url);
+    const tsxEsm = require.resolve("tsx/esm");
+    inherited.push("--import", pathToFileURL(tsxEsm).href);
+  } catch {
+    // tsx not installed (prod) — leave execArgv as-is.
+  }
+  return inherited;
+}
+
+export async function createPngDecodeBlitWorkerPool(
+  opts: PngDecodeBlitPoolOptions,
+): Promise<PngDecodeBlitWorkerPool> {
+  const cpuCount = Math.max(1, cpus().length);
+  const size = Math.max(1, Math.min(opts.size, cpuCount));
+  const log = opts.log ?? {};
+  const { path: entry, isTs: entryIsTs } = resolveWorkerEntry();
+
+  const slots: WorkerSlot[] = [];
+  const queue: PendingTask[] = [];
+  let terminated = false;
+
+  const traceEnabled = process.env.HF_PNG_DECODE_BLIT_POOL_TRACE === "1";
+  let nextTaskId = 0;
+
+  const execArgv = buildExecArgv(entryIsTs);
+
+  const dispatchNext = (slot: WorkerSlot): void => {
+    if (terminated || slot.busy) return;
+    const task = queue.shift();
+    if (!task) return;
+    slot.busy = true;
+    slot.current = task;
+    if (traceEnabled) {
+      const slotIdx = slots.indexOf(slot);
+      const waitMs = task.enqueuedAtMs ? Date.now() - task.enqueuedAtMs : 0;
+      const busyCount = slots.filter((s) => s.busy).length;
+      log.info?.("[pngDecodeBlitPool] dispatch", {
+        task: task.traceId,
+        slot: slotIdx,
+        waitMs,
+        busyCount,
+        queueDepth: queue.length,
+      });
+    }
+    const { png, dest, width, height, transfer } = task.req;
+    // Transfer the PNG bytes (input) and the rgb48le dest (in-place blit
+    // target) across the worker boundary. Both are detached on the main
+    // thread until the reply re-attaches them.
+    //
+    // Node `Buffer.alloc(N)` allocates a dedicated ArrayBuffer for buffers
+    // above 8KB (the pool threshold); below that, Buffers are slices over
+    // a shared 8KB pool ArrayBuffer. `postMessage` with `transferList`
+    // REJECTS the shared pool with `DataCloneError: Cannot transfer
+    // object of unsupported type`. The rgb48le `dest` buffers in the
+    // hybrid path are always > 8KB (854×480×6 ≈ 2.4MB) so they're fine,
+    // but PNG inputs (variable size, typically 30-300KB but can be < 8KB
+    // for empty layers) AND any small upstream Buffers can hit the pool.
+    //
+    // Safety net: if the underlying ArrayBuffer is larger than the Buffer
+    // view OR if the Buffer view doesn't cover the ArrayBuffer exactly,
+    // we copy into a fresh dedicated ArrayBuffer before transfer. Cost is
+    // one allocation + memcpy of the PNG bytes — small versus the
+    // postMessage round-trip we're already paying.
+    const pngBackingFitsExactly = png.byteOffset === 0 && png.byteLength === png.buffer.byteLength;
+    const pngSource: Buffer = pngBackingFitsExactly ? png : Buffer.from(png); // Buffer.from(Buffer) copies into a new pool slot
+    // For very small PNGs, `Buffer.from(buf)` may still land in the pool.
+    // Force a dedicated ArrayBuffer with `Uint8Array.slice().buffer`.
+    let abPng: ArrayBuffer;
+    let pngOffset: number;
+    let pngLength: number;
+    if (pngSource.byteOffset === 0 && pngSource.byteLength === pngSource.buffer.byteLength) {
+      abPng = pngSource.buffer as ArrayBuffer;
+      pngOffset = 0;
+      pngLength = pngSource.byteLength;
+    } else {
+      const copied = new Uint8Array(pngSource.byteLength);
+      copied.set(pngSource);
+      abPng = copied.buffer;
+      pngOffset = 0;
+      pngLength = copied.byteLength;
+    }
+    // The rgb48le `dest` should always have a dedicated ArrayBuffer
+    // (`Buffer.alloc` above the 8KB pool threshold gives one). Defensive
+    // path mirrors the PNG handling for symmetry.
+    let abDest: ArrayBuffer;
+    let destOffset: number;
+    let destLength: number;
+    if (dest.byteOffset === 0 && dest.byteLength === dest.buffer.byteLength) {
+      abDest = dest.buffer as ArrayBuffer;
+      destOffset = 0;
+      destLength = dest.byteLength;
+    } else {
+      // Should never happen for hybrid-path canvases. Take the
+      // copy-and-transfer path so we don't crash; but log so we surface
+      // any future allocator change that violates the invariant.
+      log.warn?.("[pngDecodeBlitPool] dest buffer is a slice over a larger ArrayBuffer; copying", {
+        offset: dest.byteOffset,
+        length: dest.byteLength,
+        backingSize: dest.buffer.byteLength,
+      });
+      const copied = new Uint8Array(dest.byteLength);
+      copied.set(dest);
+      abDest = copied.buffer;
+      destOffset = 0;
+      destLength = copied.byteLength;
+    }
+    try {
+      slot.worker.postMessage(
+        {
+          png: abPng,
+          pngOffset,
+          pngLength,
+          dest: abDest,
+          destOffset,
+          destLength,
+          width,
+          height,
+          transfer,
+        },
+        [abPng, abDest],
+      );
+    } catch (err) {
+      slot.busy = false;
+      slot.current = null;
+      task.reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  };
+
+  const onWorkerMessage = (slot: WorkerSlot, reply: WorkerReply): void => {
+    const task = slot.current;
+    slot.current = null;
+    slot.busy = false;
+    if (!task) {
+      dispatchNext(slot);
+      return;
+    }
+    if (!reply.ok) {
+      task.reject(new Error(reply.error ?? "png-decode-blit worker failed"));
+    } else {
+      // Re-attach the dest ArrayBuffer as a Node Buffer view. We wrap the
+      // full reply.dest (offset=0, length=byteLength) because the
+      // dispatch path normalizes to offset-0 ArrayBuffers (either the
+      // caller's original or a fresh copy we made on the dispatch side).
+      // The blit work happened over the full ArrayBuffer in the worker;
+      // returning a view that matches that is the correct semantics.
+      task.resolve({
+        dest: Buffer.from(reply.dest, 0, reply.dest.byteLength),
+        decodeMs: reply.decodeMs ?? 0,
+        blitMs: reply.blitMs ?? 0,
+      });
+    }
+    dispatchNext(slot);
+  };
+
+  const onWorkerError = (slot: WorkerSlot, err: Error): void => {
+    const task = slot.current;
+    slot.current = null;
+    slot.busy = false;
+    if (task) {
+      task.reject(
+        new Error(`png-decode-blit worker crashed mid-task: ${err.message}; dest buffer lost`),
+      );
+    }
+    log.warn?.("[pngDecodeBlitWorkerPool] worker errored", { err: err.message });
+  };
+
+  const onWorkerExit = (slot: WorkerSlot, code: number): void => {
+    if (terminated) return;
+    if (slot.current) {
+      slot.current.reject(new Error(`png-decode-blit worker exited (code=${code}) mid-task`));
+      slot.current = null;
+      slot.busy = false;
+    }
+    log.warn?.("[pngDecodeBlitWorkerPool] worker exited unexpectedly", { code });
+  };
+
+  try {
+    for (let i = 0; i < size; i++) {
+      const worker = new Worker(entry, { execArgv });
+      const slot: WorkerSlot = { worker, busy: false, current: null };
+      worker.on("message", (msg: WorkerReply) => onWorkerMessage(slot, msg));
+      worker.on("error", (err) => onWorkerError(slot, err));
+      worker.on("exit", (code) => onWorkerExit(slot, code));
+      slots.push(slot);
+    }
+  } catch (err) {
+    terminated = true;
+    await Promise.all(slots.map((s) => s.worker.terminate().catch(() => undefined)));
+    throw err;
+  }
+
+  log.info?.("[pngDecodeBlitWorkerPool] spawned", { size, entry });
+
+  return {
+    size,
+    async run(req: PngDecodeBlitRequest): Promise<PngDecodeBlitResult> {
+      if (terminated) {
+        throw new Error("png-decode-blit pool already terminated");
+      }
+      return new Promise<PngDecodeBlitResult>((resolve, reject) => {
+        const task: PendingTask = traceEnabled
+          ? { req, resolve, reject, enqueuedAtMs: Date.now(), traceId: ++nextTaskId }
+          : { req, resolve, reject };
+        const idle = slots.find((s) => !s.busy);
+        if (idle) {
+          queue.unshift(task);
+          dispatchNext(idle);
+        } else {
+          queue.push(task);
+        }
+      });
+    },
+    async terminate(): Promise<void> {
+      if (terminated) return;
+      terminated = true;
+      while (queue.length > 0) {
+        const t = queue.shift();
+        if (t) t.reject(new Error("png-decode-blit pool terminated before task ran"));
+      }
+      for (const slot of slots) {
+        const t = slot.current;
+        if (t) {
+          slot.current = null;
+          slot.busy = false;
+          t.reject(new Error("png-decode-blit pool terminated mid-task"));
+        }
+      }
+      await Promise.all(slots.map((s) => s.worker.terminate().catch(() => undefined)));
+      log.info?.("[pngDecodeBlitWorkerPool] terminated", { size });
+    },
+  };
+}

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -18,6 +18,7 @@ import {
   getNextRetryWorkerCount,
   isRecoverableParallelCaptureError,
   materializeExtractedFramesForCompiledDir,
+  distributeLayeredHybridFrameRanges,
   partitionTransitionFrames,
   resolveRenderWorkerCount,
   resolveCompositeTransfer,
@@ -715,6 +716,85 @@ describe("shouldUseHybridLayeredPath", () => {
         workerCount: 6,
       }),
     ).toBe(false);
+  });
+});
+
+describe("distributeLayeredHybridFrameRanges", () => {
+  it("splits a frame range into contiguous, non-overlapping, full-coverage worker slices", () => {
+    const ranges = distributeLayeredHybridFrameRanges(840, 6);
+    expect(ranges).toHaveLength(6);
+    expect(ranges[0]!.start).toBe(0);
+    expect(ranges[ranges.length - 1]!.end).toBe(840);
+    // Contiguous: each range begins where the previous ended.
+    for (let i = 1; i < ranges.length; i++) {
+      expect(ranges[i]!.start).toBe(ranges[i - 1]!.end);
+    }
+    // Full coverage: total frames == sum of slice sizes.
+    const covered = ranges.reduce((acc, r) => acc + (r.end - r.start), 0);
+    expect(covered).toBe(840);
+  });
+
+  it("hf#732 fix-up: transition frames are spread across workers, not pinned to one session", () => {
+    // Same shape as the #677 repro: 14 × 10-frame transitions on 840 frames at
+    // evenly-spaced beats. Verify that any non-trivial slice of these
+    // transition frames falls inside a NON-WORKER-ZERO slice — i.e. that the
+    // hybrid path actually drives transitions on multiple worker sessions
+    // (the prior implementation pinned all transitions to the main session
+    // and only parallelized non-transition frames).
+    const transitions: Array<{ startFrame: number; endFrame: number }> = [];
+    for (let k = 0; k < 14; k++) {
+      const startFrame = 30 + k * 50;
+      transitions.push({ startFrame, endFrame: startFrame + 9 });
+    }
+    const totalFrames = 840;
+    const ranges = distributeLayeredHybridFrameRanges(totalFrames, 6);
+    const transitionFrames = partitionTransitionFrames(transitions, totalFrames);
+
+    const transitionFramesPerWorker = ranges.map(
+      (range) => [...transitionFrames].filter((f) => f >= range.start && f < range.end).length,
+    );
+
+    // Every worker should be doing transition work (in this shape: 14 evenly
+    // spaced transitions across 6 contiguous slices, each slice covers ≥2 of
+    // them). The PRIOR behavior would have given worker 0 all 140 transition
+    // frames; the new behavior distributes them.
+    const workersWithTransitions = transitionFramesPerWorker.filter((c) => c > 0).length;
+    expect(workersWithTransitions).toBeGreaterThanOrEqual(2);
+
+    // Specifically: no single worker should own >70% of transition frames
+    // (would indicate the partition collapsed to the old shape).
+    const maxOnOneWorker = Math.max(...transitionFramesPerWorker);
+    expect(maxOnOneWorker).toBeLessThan(Math.ceil(transitionFrames.size * 0.7));
+
+    // Sanity: total transition frames covered == partition cardinality.
+    expect(transitionFramesPerWorker.reduce((a, b) => a + b, 0)).toBe(transitionFrames.size);
+  });
+
+  it("clamps workerCount to 1 for non-positive inputs", () => {
+    const ranges = distributeLayeredHybridFrameRanges(100, 0);
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0]).toEqual({ start: 0, end: 100 });
+  });
+
+  it("produces zero-width tail ranges when workers outnumber frames", () => {
+    const ranges = distributeLayeredHybridFrameRanges(3, 6);
+    // framesPerWorker = ceil(3 / 6) = 1; first 3 workers get one frame each,
+    // remaining 3 get empty ranges.
+    expect(ranges).toHaveLength(6);
+    expect(ranges[0]).toEqual({ start: 0, end: 1 });
+    expect(ranges[1]).toEqual({ start: 1, end: 2 });
+    expect(ranges[2]).toEqual({ start: 2, end: 3 });
+    expect(ranges[3]).toEqual({ start: 3, end: 3 });
+    expect(ranges[4]).toEqual({ start: 3, end: 3 });
+    expect(ranges[5]).toEqual({ start: 3, end: 3 });
+  });
+
+  it("handles totalFrames = 0", () => {
+    const ranges = distributeLayeredHybridFrameRanges(0, 4);
+    expect(ranges).toHaveLength(4);
+    for (const r of ranges) {
+      expect(r).toEqual({ start: 0, end: 0 });
+    }
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -18,10 +18,12 @@ import {
   getNextRetryWorkerCount,
   isRecoverableParallelCaptureError,
   materializeExtractedFramesForCompiledDir,
+  partitionTransitionFrames,
   resolveRenderWorkerCount,
   resolveCompositeTransfer,
   selectCaptureCalibrationFrames,
   shouldFallbackToScreenshotAfterCalibrationError,
+  shouldUseHybridLayeredPath,
   shouldUseLayeredComposite,
   shouldUseStreamingEncode,
 } from "./renderOrchestrator.js";
@@ -546,6 +548,173 @@ describe("estimateCaptureCostMultiplier", () => {
 
     expect(cost.multiplier).toBe(4);
     expect(cost.reasons).toEqual(["shader-transitions", "requestAnimationFrame"]);
+  });
+
+  it("blends the shader-transition cost by transition frame ratio (issue #677)", () => {
+    // 17% of frames inside a transition window (the repro case): 1 + 0.17*1.5 ≈ 1.255
+    const cost = estimateCaptureCostMultiplier(
+      {
+        hasShaderTransitions: true,
+        renderModeHints: { recommendScreenshot: false, reasons: [] },
+      },
+      { transitionFrameRatio: 140 / 840 },
+    );
+
+    expect(cost.multiplier).toBeGreaterThan(1);
+    expect(cost.multiplier).toBeLessThan(1.5);
+    expect(cost.reasons[0]).toMatch(/shader-transitions\(17%-frames\)/);
+  });
+
+  it("collapses to the SDR baseline when the transition ratio is 0", () => {
+    const cost = estimateCaptureCostMultiplier(
+      {
+        hasShaderTransitions: true,
+        renderModeHints: { recommendScreenshot: false, reasons: [] },
+      },
+      { transitionFrameRatio: 0 },
+    );
+
+    expect(cost.multiplier).toBe(1);
+  });
+
+  it("ignores an out-of-range transition ratio and falls back to the flat charge", () => {
+    const cost = estimateCaptureCostMultiplier(
+      {
+        hasShaderTransitions: true,
+        renderModeHints: { recommendScreenshot: false, reasons: [] },
+      },
+      { transitionFrameRatio: 1.5 },
+    );
+
+    expect(cost.multiplier).toBe(3);
+    expect(cost.reasons).toEqual(["shader-transitions"]);
+  });
+});
+
+describe("partitionTransitionFrames", () => {
+  it("returns empty when there are no transitions", () => {
+    expect(partitionTransitionFrames([], 100).size).toBe(0);
+  });
+
+  it("returns empty when totalFrames is zero", () => {
+    expect(partitionTransitionFrames([{ startFrame: 0, endFrame: 5 }], 0).size).toBe(0);
+  });
+
+  it("includes both endpoints of each transition window", () => {
+    const set = partitionTransitionFrames([{ startFrame: 5, endFrame: 10 }], 100);
+    expect(set.has(4)).toBe(false);
+    expect(set.has(5)).toBe(true);
+    expect(set.has(10)).toBe(true);
+    expect(set.has(11)).toBe(false);
+    expect(set.size).toBe(6);
+  });
+
+  it("clamps a window that runs past totalFrames-1", () => {
+    const set = partitionTransitionFrames([{ startFrame: 8, endFrame: 20 }], 10);
+    expect(set.size).toBe(2);
+    expect(set.has(8)).toBe(true);
+    expect(set.has(9)).toBe(true);
+    expect(set.has(10)).toBe(false);
+  });
+
+  it("clamps a negative startFrame to 0", () => {
+    const set = partitionTransitionFrames([{ startFrame: -3, endFrame: 2 }], 100);
+    expect(set.has(0)).toBe(true);
+    expect(set.size).toBe(3);
+  });
+
+  it("handles a transition window covering the final frame", () => {
+    const set = partitionTransitionFrames([{ startFrame: 95, endFrame: 99 }], 100);
+    expect(set.has(99)).toBe(true);
+    expect(set.has(100)).toBe(false);
+  });
+
+  it("matches the issue #677 repro: 14 × 0.3s transitions on 28s@30fps → ~140 transition frames", () => {
+    // 14 transitions each 9 frames inclusive (0.3 * 30 = 9 → endFrame - startFrame = 9 → 10 frames inclusive).
+    // Place them at evenly-spaced beats with ≥1s gaps so they don't overlap.
+    const transitions: Array<{ startFrame: number; endFrame: number }> = [];
+    for (let k = 0; k < 14; k++) {
+      const startFrame = 30 + k * 50; // first at 1s, 14th at ~24s, fits inside 28s = 840 frames
+      transitions.push({ startFrame, endFrame: startFrame + 9 });
+    }
+    const totalFrames = 840;
+    const transitionFrames = partitionTransitionFrames(transitions, totalFrames);
+
+    expect(transitionFrames.size).toBe(14 * 10);
+    expect(transitionFrames.size).toBeLessThan(totalFrames);
+    const ratio = transitionFrames.size / totalFrames;
+    expect(ratio).toBeGreaterThan(0.15);
+    expect(ratio).toBeLessThan(0.2);
+  });
+
+  it("deduplicates overlapping transitions", () => {
+    const set = partitionTransitionFrames(
+      [
+        { startFrame: 0, endFrame: 5 },
+        { startFrame: 3, endFrame: 7 },
+      ],
+      100,
+    );
+    expect(set.size).toBe(8);
+    expect(set.has(0)).toBe(true);
+    expect(set.has(7)).toBe(true);
+  });
+});
+
+describe("shouldUseHybridLayeredPath", () => {
+  it("opts into hybrid for SDR multi-worker renders with transitions", () => {
+    expect(
+      shouldUseHybridLayeredPath({
+        hasHdrContent: false,
+        transitionFramesCount: 140,
+        totalFrames: 840,
+        workerCount: 6,
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to sequential when HDR content is present", () => {
+    expect(
+      shouldUseHybridLayeredPath({
+        hasHdrContent: true,
+        transitionFramesCount: 140,
+        totalFrames: 840,
+        workerCount: 6,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to sequential at workerCount=1", () => {
+    expect(
+      shouldUseHybridLayeredPath({
+        hasHdrContent: false,
+        transitionFramesCount: 140,
+        totalFrames: 840,
+        workerCount: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to sequential when every frame is a transition frame", () => {
+    expect(
+      shouldUseHybridLayeredPath({
+        hasHdrContent: false,
+        transitionFramesCount: 100,
+        totalFrames: 100,
+        workerCount: 6,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to sequential when totalFrames is non-positive", () => {
+    expect(
+      shouldUseHybridLayeredPath({
+        hasHdrContent: false,
+        transitionFramesCount: 0,
+        totalFrames: 0,
+        workerCount: 6,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1605,7 +1605,7 @@ async function compositeHdrFrame(
   fullStacking: ElementStackingInfo[],
   elementFilter?: Set<string>,
   debugFrameIndex: number = -1,
-): Promise<void> {
+): Promise<Buffer> {
   const {
     log,
     domSession,
@@ -1625,6 +1625,25 @@ async function compositeHdrFrame(
     debugDumpDir,
     hdrPerf,
   } = ctx;
+  const pool = ctx.pngDecodeBlitPool ?? null;
+  // Per-frame pending decode+blit. When non-null, the canvas
+  // ArrayBuffer has been transferred to the pool and the local `canvas`
+  // variable points at a detached Buffer view. We MUST await this before
+  // any read/write of the canvas (subsequent HDR layer blits, the next
+  // DOM-layer dispatch, or the function's return value).
+  //
+  // The pool pattern saves ~70-80ms per consecutive DOM layer pair by
+  // overlapping layer N's decode+blit (worker thread) with layer N+1's
+  // CDP screenshot (Chrome thread). HDR layers force a drain because
+  // they composite onto the canvas synchronously on the calling thread.
+  let pendingDecodeBlit: Promise<Buffer> | null = null;
+  let liveCanvas: Buffer = canvas;
+  const drainPending = async (): Promise<void> => {
+    if (!pendingDecodeBlit) return;
+    const fresh = await pendingDecodeBlit;
+    pendingDecodeBlit = null;
+    liveCanvas = fresh;
+  };
 
   const filteredStacking = elementFilter
     ? fullStacking.filter((e) => elementFilter.has(e.id))
@@ -1663,12 +1682,16 @@ async function compositeHdrFrame(
     if (layer.type === "hdr") {
       // Skip zero-opacity HDR elements — their parent scene may have faded out.
       if (layer.element.opacity <= 0) continue;
-      const before = shouldLog ? countNonZeroRgb48(canvas) : 0;
+      // HDR layer composites onto the canvas synchronously on the
+      // calling thread, so we MUST await any in-flight DOM decode+blit
+      // first (otherwise the underlying ArrayBuffer is still detached).
+      await drainPending();
+      const before = shouldLog ? countNonZeroRgb48(liveCanvas) : 0;
       const isHdrImage = nativeHdrImageIds.has(layer.element.id);
       const hdrTargetTransfer = compositeTransfer === "srgb" ? undefined : compositeTransfer;
       if (isHdrImage) {
         blitHdrImageLayer(
-          canvas,
+          liveCanvas,
           layer.element,
           hdrImageBuffers,
           hdrImageTransferCache,
@@ -1681,7 +1704,7 @@ async function compositeHdrFrame(
         );
       } else {
         blitHdrVideoLayer(
-          canvas,
+          liveCanvas,
           layer.element,
           time,
           fps,
@@ -1696,7 +1719,7 @@ async function compositeHdrFrame(
         );
       }
       if (shouldLog) {
-        const after = countNonZeroRgb48(canvas);
+        const after = countNonZeroRgb48(liveCanvas);
         if (isHdrImage) {
           const buf = hdrImageBuffers.get(layer.element.id);
           log.info("[diag] hdr layer blit", {
@@ -1756,7 +1779,11 @@ async function compositeHdrFrame(
       const hideIds = allElementIds.filter((id) => !layerIds.has(id));
       if (hdrPerf) hdrPerf.domLayerCaptures += 1;
 
-      // 1. Seek GSAP to restore all animated properties from clean state
+      // 1. Seek GSAP to restore all animated properties from clean state.
+      //    This is CDP work that does NOT touch the canvas, so we can
+      //    proceed even while a prior layer's decode+blit is in flight on
+      //    the pool — the overlap is the whole point of lever-4. Step 6
+      //    is where we drain before dispatching this layer's blit.
       let timingStart = Date.now();
       await domSession.page.evaluate((t: number) => {
         if (window.__hf && typeof window.__hf.seek === "function") window.__hf.seek(t);
@@ -1785,43 +1812,109 @@ async function compositeHdrFrame(
       await removeDomLayerMask(domSession.page, hideIds);
       addHdrTiming(hdrPerf, "domMaskRemoveMs", timingStart);
 
-      try {
-        timingStart = Date.now();
-        const { data: domRgba } = decodePng(domPng);
-        addHdrTiming(hdrPerf, "domPngDecodeMs", timingStart);
-        const before = shouldLog ? countNonZeroRgb48(canvas) : 0;
-        const alphaPixels = shouldLog ? countNonZeroAlpha(domRgba) : 0;
-        timingStart = Date.now();
-        blitRgba8OverRgb48le(domRgba, canvas, width, height, compositeTransfer);
-        addHdrTiming(hdrPerf, "domBlitMs", timingStart);
-        if (shouldLog && debugDumpDir) {
-          const after = countNonZeroRgb48(canvas);
-          const dumpName = `frame_${String(debugFrameIndex).padStart(4, "0")}_layer_${String(layerIdx).padStart(2, "0")}_dom.png`;
-          const dumpPath = join(debugDumpDir, dumpName);
-          writeFileSync(dumpPath, domPng);
-          log.info("[diag] dom layer blit", {
-            frame: debugFrameIndex,
-            layerIdx,
+      // 6. Drain any prior layer's decode+blit before reading or writing
+      //    the canvas. On the pool path the prior layer's blit was
+      //    dispatched without an await; this is where its in-flight
+      //    promise resolves and `liveCanvas` is reattached. On the inline
+      //    path `pendingDecodeBlit` is always null so this is a no-op.
+      await drainPending();
+
+      // 7. Decode + blit. Pool path: dispatch and store the promise so
+      //    the next iteration's CDP work can overlap. Inline path: do it
+      //    synchronously, preserving the legacy code shape.
+      if (pool) {
+        const inFlightLayerIdx = layerIdx;
+        const inFlightLayerIds = layer.elementIds;
+        const inFlightHideCount = hideIds.length;
+        const beforeForDiag = shouldLog ? countNonZeroRgb48(liveCanvas) : 0;
+        const destForPool = liveCanvas;
+        pendingDecodeBlit = (async (): Promise<Buffer> => {
+          try {
+            const result = await pool.run({
+              png: domPng,
+              dest: destForPool,
+              width,
+              height,
+              transfer: compositeTransfer,
+            });
+            if (hdrPerf) {
+              hdrPerf.timings.domPngDecodeMs += result.decodeMs;
+              hdrPerf.timings.domBlitMs += result.blitMs;
+            }
+            if (shouldLog && debugDumpDir) {
+              const after = countNonZeroRgb48(result.dest);
+              const dumpName = `frame_${String(debugFrameIndex).padStart(4, "0")}_layer_${String(
+                inFlightLayerIdx,
+              ).padStart(2, "0")}_dom.png`;
+              const dumpPath = join(debugDumpDir, dumpName);
+              writeFileSync(dumpPath, domPng);
+              log.info("[diag] dom layer blit (pool)", {
+                frame: debugFrameIndex,
+                layerIdx: inFlightLayerIdx,
+                layerIds: inFlightLayerIds,
+                hideCount: inFlightHideCount,
+                pngBytes: domPng.length,
+                pixelsAdded: after - beforeForDiag,
+                totalNonZero: after,
+                dumpPath,
+              });
+            }
+            return result.dest;
+          } catch (err) {
+            log.warn("DOM layer decode/blit pool task failed; skipping overlay", {
+              layerIds: inFlightLayerIds,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            // The dest ArrayBuffer was transferred out and may be lost.
+            // Return a freshly-allocated zero canvas so the next layer
+            // has something to write into; the frame may have missing
+            // pixels but the render does not abort.
+            return Buffer.alloc(width * height * 6);
+          }
+        })();
+      } else {
+        try {
+          timingStart = Date.now();
+          const { data: domRgba } = decodePng(domPng);
+          addHdrTiming(hdrPerf, "domPngDecodeMs", timingStart);
+          const before = shouldLog ? countNonZeroRgb48(liveCanvas) : 0;
+          const alphaPixels = shouldLog ? countNonZeroAlpha(domRgba) : 0;
+          timingStart = Date.now();
+          blitRgba8OverRgb48le(domRgba, liveCanvas, width, height, compositeTransfer);
+          addHdrTiming(hdrPerf, "domBlitMs", timingStart);
+          if (shouldLog && debugDumpDir) {
+            const after = countNonZeroRgb48(liveCanvas);
+            const dumpName = `frame_${String(debugFrameIndex).padStart(4, "0")}_layer_${String(layerIdx).padStart(2, "0")}_dom.png`;
+            const dumpPath = join(debugDumpDir, dumpName);
+            writeFileSync(dumpPath, domPng);
+            log.info("[diag] dom layer blit", {
+              frame: debugFrameIndex,
+              layerIdx,
+              layerIds: layer.elementIds,
+              hideCount: hideIds.length,
+              pngBytes: domPng.length,
+              alphaPixels,
+              pixelsAdded: after - before,
+              totalNonZero: after,
+              dumpPath,
+            });
+          }
+        } catch (err) {
+          log.warn("DOM layer decode/blit failed; skipping overlay", {
             layerIds: layer.elementIds,
-            hideCount: hideIds.length,
-            pngBytes: domPng.length,
-            alphaPixels,
-            pixelsAdded: after - before,
-            totalNonZero: after,
-            dumpPath,
+            error: err instanceof Error ? err.message : String(err),
           });
         }
-      } catch (err) {
-        log.warn("DOM layer decode/blit failed; skipping overlay", {
-          layerIds: layer.elementIds,
-          error: err instanceof Error ? err.message : String(err),
-        });
       }
     }
   }
 
+  // Drain the last layer's in-flight decode+blit (if any) before returning
+  // — otherwise the caller would see a detached canvas.
+  await drainPending();
+
   if (shouldLog && debugDumpDir) {
-    const finalNonZero = countNonZeroRgb48(canvas);
+    const finalNonZero = countNonZeroRgb48(liveCanvas);
     log.info("[diag] compositeToBuffer end", {
       frame: debugFrameIndex,
       finalNonZeroPixels: finalNonZero,
@@ -1829,6 +1922,8 @@ async function compositeHdrFrame(
       coverage: ((finalNonZero / (width * height)) * 100).toFixed(1) + "%",
     });
   }
+
+  return liveCanvas;
 }
 
 // ── Layered-frame helpers (issue #677 hybrid path) ──────────────────────────
@@ -1891,6 +1986,13 @@ interface LayeredTransitionBuffers {
  * @param canvas - Pre-allocated rgb48le canvas (width * height * 6 bytes).
  *                 Zero-filled by this helper.
  * @param nativeHdrIds - Set of HDR element ids used by `queryElementStacking`.
+ *
+ * @returns The (possibly re-attached) canvas buffer. When `ctx.pngDecodeBlitPool`
+ *          is set, per-layer DOM decode+blit transfers the canvas ArrayBuffer
+ *          across the worker boundary and a fresh Buffer view is returned —
+ *          the input `canvas` reference is detached and unusable by the
+ *          caller. The legacy inline path returns the same Buffer the caller
+ *          passed in.
  */
 export async function processLayeredNormalFrame(
   session: CaptureSession,
@@ -1899,7 +2001,7 @@ export async function processLayeredNormalFrame(
   ctx: HdrCompositeContext,
   canvas: Buffer,
   nativeHdrIds: Set<string>,
-): Promise<void> {
+): Promise<Buffer> {
   const hdrPerf = ctx.hdrPerf;
   if (hdrPerf) hdrPerf.frames += 1;
   if (hdrPerf) hdrPerf.normalFrames += 1;
@@ -1930,8 +2032,16 @@ export async function processLayeredNormalFrame(
   // each worker's session to drive its own captures.
   const sessionScopedCtx: HdrCompositeContext = { ...ctx, domSession: session };
   timingStart = Date.now();
-  await compositeHdrFrame(sessionScopedCtx, canvas, time, stackingInfo, undefined, frameIdx);
+  const finalCanvas = await compositeHdrFrame(
+    sessionScopedCtx,
+    canvas,
+    time,
+    stackingInfo,
+    undefined,
+    frameIdx,
+  );
   addHdrTiming(hdrPerf, "normalCompositeMs", timingStart);
+  return finalCanvas;
 }
 
 /**
@@ -3500,7 +3610,18 @@ export async function executeRenderJob(
           const transOutput = hasTransitions ? Buffer.alloc(bufSize) : null;
           // Pre-allocate the normal-frame canvas too — reused via .fill(0) each iteration
           // to avoid ~37 MB allocation per frame in the hot loop.
-          const normalCanvas = Buffer.alloc(bufSize);
+          // `let` (not `const`): the legacy sequential path may rebind
+          // this if `processLayeredNormalFrame` ever runs with the
+          // decode/blit pool wired into `hdrCompositeCtx`. In the current
+          // wiring the legacy path runs WITHOUT a pool (the pool is only
+          // spawned inside the hybrid try-block below), so the rebind is
+          // effectively a no-op here — but keeping it `let` future-proofs
+          // any change that hands the pool to the sequential path too.
+          // The explicit `Buffer` annotation is required because newer
+          // `@types/node` narrows `Buffer.alloc` to `Buffer<ArrayBuffer>`
+          // while `processLayeredNormalFrame` returns the union-typed
+          // `Buffer` (the pool reply re-attaches a generic ArrayBufferLike).
+          let normalCanvas: Buffer = Buffer.alloc(bufSize);
 
           // ── Hybrid layered dispatch (issue #677) ───────────────────────────
           // Pre-#677 this path was a single sequential for-loop that drove the
@@ -3882,7 +4003,13 @@ export async function executeRenderJob(
 
               const workerTaskOf = async (w: number): Promise<void> => {
                 const session = sessions[w];
-                const canvas = workerCanvases[w];
+                // `let` (not `const`): when the decode/blit pool is in
+                // use, `processLayeredNormalFrame` returns the re-attached
+                // canvas Buffer (the input's ArrayBuffer is detached on
+                // transfer). We swap the local + the slot in
+                // `workerCanvases` so the next frame in this worker's
+                // slice uses the fresh view.
+                let canvas = workerCanvases[w];
                 if (!session || !canvas) return;
                 const range = workerRanges[w];
                 if (!range) return;
@@ -3985,7 +4112,7 @@ export async function executeRenderJob(
                       throw err instanceof Error ? err : new Error(String(err));
                     });
                   } else {
-                    await processLayeredNormalFrame(
+                    canvas = await processLayeredNormalFrame(
                       session,
                       i,
                       time,
@@ -3993,6 +4120,7 @@ export async function executeRenderJob(
                       canvas,
                       nativeHdrIds,
                     );
+                    workerCanvases[w] = canvas;
                     if (debugDumpEnabled && debugDumpDir && i % 30 === 0) {
                       const previewPath = join(
                         debugDumpDir,
@@ -4082,7 +4210,7 @@ export async function executeRenderJob(
                 );
                 await writeEncoded(i, transitionBuffers.output);
               } else {
-                await processLayeredNormalFrame(
+                normalCanvas = await processLayeredNormalFrame(
                   domSession,
                   i,
                   time,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1920,47 +1920,65 @@ export async function processLayeredNormalFrame(
 }
 
 /**
- * Composite a single transition frame on a given DOM session. Runs the
- * dual-scene capture (scene A and scene B with appropriate `applyDomLayerMask`
- * targeting) and applies the shader blend into `buffers.output`. Returns the
- * `output` Buffer; the caller writes it to the encoder.
+ * Metadata describing a captured-but-not-yet-blended transition frame. Used
+ * to hand a unit of blend work off from the DOM-capture phase to the
+ * `worker_threads` pool. Carries `frameIdx` so the reorder buffer at the
+ * encoder gate can fence ordering, and `shader`/`progress` so the blend
+ * dispatch is fully self-contained (the pool need not understand transition
+ * windows).
+ */
+export interface CapturedTransitionFrame {
+  frameIdx: number;
+  /** Width in pixels (854 etc.). Matches `ctx.width`. */
+  width: number;
+  /** Height in pixels (480 etc.). Matches `ctx.height`. */
+  height: number;
+  /** Transition progress in [0, 1]. */
+  progress: number;
+  /** Shader id from the transition metadata; unknowns fall back to crossfade. */
+  shader: string;
+  /** Filled by the capture: from-scene rgb48le pixels. */
+  buffers: LayeredTransitionBuffers;
+}
+
+/**
+ * Capture both scenes of a transition frame into `buffers.bufferA` and
+ * `buffers.bufferB`. Does NOT run the shader blend — the caller dispatches
+ * that synchronously (HDR / single-worker fallback) or via the
+ * `worker_threads` pool (hybrid path, hf#732 follow-up to close the JS
+ * event-loop ceiling).
  *
- * Self-contained per call: the per-scene seek/inject/mask/screenshot/remove-mask
- * pattern requires the same `window.__hf` state across the two scenes within
- * one invocation, but it holds no inter-frame state on the session. As of
- * the hf#732 follow-up the hybrid path runs transition frames in parallel
- * across worker sessions; each worker passes its own session here.
+ * Splitting capture from blend is the linchpin of the new dispatcher
+ * contract: each DOM worker can capture its next frame while the previous
+ * frame's blend runs on a worker thread, so the pool sees up to
+ * `N_dom × K` concurrent tasks instead of a single in-flight blend per DOM
+ * worker. K is bounded by a small per-worker buffer-triple ring (default 2)
+ * to cap memory; the encoder reorder buffer fences ordering downstream so
+ * out-of-order blend completions still hit the muxer in ascending index
+ * order.
  *
- * @param session - DOM capture session to drive. Each worker in the hybrid
- *                  parallel pool passes its own session; the legacy
- *                  sequential path passes the main `domSession`.
- * @param frameIdx - Composition frame index (used for warn-level error logs).
+ * Self-contained per call: the per-scene seek/inject/mask/screenshot/remove-
+ * mask pattern requires the same `window.__hf` state across both scenes
+ * within ONE invocation, but holds no inter-frame state on the session.
+ *
+ * @param session - DOM capture session to drive. The hybrid path passes the
+ *                  worker's own session; the legacy sequential / HDR fallback
+ *                  passes the main `domSession`.
+ * @param frameIdx - Composition frame index (used for warn-level error logs
+ *                   and the returned metadata).
  * @param time - Seek time in seconds.
  * @param transition - The transition window that contains this frame.
  * @param ctx - Layered-composite context (HDR layer maps, transfer, etc.).
- * @param sceneElements - Scene-id → element-id list, computed once at render
- *                        start from `.scene` DOM nodes.
- * @param buffers - Pre-allocated dual-scene buffers and shared output buffer.
- *                  All three are zero-filled by this helper as needed.
- * @param assertNotAborted - Render-level abort check, called between scene
- *                           A and scene B so an abort that lands mid-frame
- *                           tears down promptly instead of after the
- *                           second scene's full composite.
- * @param nativeHdrIds - Set of HDR element ids; passed to mask helpers so HDR
- *                       elements stay inline-hidden behind the screenshot
- *                       (their pixels arrive via `blitHdrVideoLayer` etc.).
- * @param shaderPool - Optional Node `worker_threads` pool to which the
- *                     per-pixel shader-blend is dispatched (hf#677 follow-up
- *                     to close the JS event-loop ceiling). When provided,
- *                     bufferA/bufferB/output ArrayBuffers are detached via
- *                     `transferList`, blended on a Worker, and transferred
- *                     back; the function reassigns the fields on `buffers`
- *                     to the returned Buffer views before returning. When
- *                     omitted (e.g. legacy sequential path / single-worker
- *                     SDR / HDR fallback), the blend runs synchronously on
- *                     the calling thread — bit-for-bit identical output.
+ * @param sceneElements - Scene-id → element-id list.
+ * @param buffers - Pre-allocated dual-scene buffers + output buffer. bufferA
+ *                  and bufferB are zero-filled before each scene composite;
+ *                  `output` is untouched here (filled by the blend step).
+ * @param assertNotAborted - Render-level abort check between scenes.
+ * @param nativeHdrIds - Set of HDR element ids.
+ *
+ * @returns Captured-frame descriptor the caller passes to the blend step.
  */
-export async function processLayeredTransitionFrame(
+export async function captureTransitionFrame(
   session: CaptureSession,
   frameIdx: number,
   time: number,
@@ -1970,8 +1988,7 @@ export async function processLayeredTransitionFrame(
   buffers: LayeredTransitionBuffers,
   assertNotAborted: () => void,
   nativeHdrIds: Set<string>,
-  shaderPool?: ShaderTransitionWorkerPool | null,
-): Promise<void> {
+): Promise<CapturedTransitionFrame> {
   const {
     log,
     beforeCaptureHook,
@@ -1992,7 +2009,7 @@ export async function processLayeredTransitionFrame(
 
   if (hdrPerf) hdrPerf.frames += 1;
   if (hdrPerf) hdrPerf.transitionFrames += 1;
-  const transitionTimingStart = Date.now();
+  const transitionCaptureStart = Date.now();
 
   let timingStart = Date.now();
   await session.page.evaluate((t: number) => {
@@ -2103,42 +2120,94 @@ export async function processLayeredTransitionFrame(
     }
   }
 
-  // Shader-blend dispatch. When a `shaderPool` is provided (hf#677 follow-up
-  // for the JS event-loop ceiling), the per-pixel blend runs on a Node
-  // `worker_threads` Worker via zero-copy `transferList`. The pool
-  // detaches the bufferA/B/output ArrayBuffers, runs the blend, and
-  // transfers them back; we reattach the returned Buffers onto the
-  // caller's `buffers` slot so the next iteration of the worker's frame
-  // loop sees the same shape.
-  //
-  // Without a pool, the blend runs synchronously on the main thread — the
-  // legacy path. Both branches produce byte-identical output because the
-  // worker imports the same `TRANSITIONS` table from `@hyperframes/engine`.
-  if (shaderPool) {
-    const blendStart = Date.now();
-    const result = await shaderPool.run({
-      shader: transition.shader,
-      bufferA: buffers.bufferA,
-      bufferB: buffers.bufferB,
-      output: buffers.output,
-      width,
-      height,
-      progress,
-    });
-    // The originals are detached; swap in the transferred-back views so
-    // the caller's `LayeredTransitionBuffers` stay valid for the next
-    // frame. Same underlying memory, fresh Buffer headers.
-    buffers.bufferA = result.bufferA;
-    buffers.bufferB = result.bufferB;
-    buffers.output = result.output;
-    addHdrTiming(hdrPerf, "transitionShaderBlendMs", blendStart);
-  } else {
-    const blendStart = Date.now();
-    const transitionFn: TransitionFn = TRANSITIONS[transition.shader] ?? crossfade;
-    transitionFn(buffers.bufferA, buffers.bufferB, buffers.output, width, height, progress);
-    addHdrTiming(hdrPerf, "transitionShaderBlendMs", blendStart);
-  }
-  addHdrTiming(hdrPerf, "transitionCompositeMs", transitionTimingStart);
+  // `transitionCaptureMs` is the dual-scene capture cost only — the blend is
+  // accounted for separately in `transitionShaderBlendMs`. Their sum is no
+  // longer equal to `transitionCompositeMs` (which now covers capture only
+  // along this path); perf-summary.json viewers should treat capture + blend
+  // as the per-frame composite cost in the decoupled pipeline.
+  addHdrTiming(hdrPerf, "transitionCompositeMs", transitionCaptureStart);
+
+  return {
+    frameIdx,
+    width,
+    height,
+    progress,
+    shader: transition.shader,
+    buffers,
+  };
+}
+
+/**
+ * Synchronous inline blend, identical to the pool's per-worker behavior but
+ * running on the calling thread. Used by:
+ *
+ * - the legacy sequential / HDR fallback path (no pool spawned)
+ * - the hybrid path if the pool spawn fails at render start
+ * - the hybrid path if a pool task rejects mid-render (best-effort
+ *   correctness preservation; the render falls back to inline blending for
+ *   that frame rather than aborting)
+ *
+ * Mutates `buffers.output` in place. `buffers.bufferA` and `buffers.bufferB`
+ * are read-only inputs.
+ */
+function blendTransitionFrameInline(
+  captured: CapturedTransitionFrame,
+  hdrPerf: HdrPerfCollector | undefined,
+): void {
+  const { buffers, width, height, progress, shader } = captured;
+  const blendStart = Date.now();
+  const transitionFn: TransitionFn = TRANSITIONS[shader] ?? crossfade;
+  transitionFn(buffers.bufferA, buffers.bufferB, buffers.output, width, height, progress);
+  addHdrTiming(hdrPerf, "transitionShaderBlendMs", blendStart);
+}
+
+/**
+ * Composite a single transition frame on a given DOM session — combined
+ * capture + blend. Retained for the legacy sequential path / HDR fallback /
+ * single-worker SDR, which call this directly and write `buffers.output` to
+ * the encoder synchronously after the function resolves.
+ *
+ * The hybrid parallel path does NOT call this helper. It calls
+ * `captureTransitionFrame` and dispatches the blend asynchronously to the
+ * `worker_threads` pool, so capture pipelines with blend across frames.
+ *
+ * Self-contained per call: the per-scene seek/inject/mask/screenshot/remove-
+ * mask pattern requires the same `window.__hf` state across the two scenes
+ * within one invocation, but it holds no inter-frame state on the session.
+ *
+ * @param session - DOM capture session to drive.
+ * @param frameIdx - Composition frame index.
+ * @param time - Seek time in seconds.
+ * @param transition - The transition window that contains this frame.
+ * @param ctx - Layered-composite context.
+ * @param sceneElements - Scene-id → element-id list.
+ * @param buffers - Pre-allocated dual-scene buffers + output buffer.
+ * @param assertNotAborted - Render-level abort check between scenes.
+ * @param nativeHdrIds - Set of HDR element ids.
+ */
+export async function processLayeredTransitionFrame(
+  session: CaptureSession,
+  frameIdx: number,
+  time: number,
+  transition: TransitionRange,
+  ctx: HdrCompositeContext,
+  sceneElements: Record<string, string[]>,
+  buffers: LayeredTransitionBuffers,
+  assertNotAborted: () => void,
+  nativeHdrIds: Set<string>,
+): Promise<void> {
+  const captured = await captureTransitionFrame(
+    session,
+    frameIdx,
+    time,
+    transition,
+    ctx,
+    sceneElements,
+    buffers,
+    assertNotAborted,
+    nativeHdrIds,
+  );
+  blendTransitionFrameInline(captured, ctx.hdrPerf);
 }
 
 /**
@@ -3581,26 +3650,83 @@ export async function executeRenderJob(
                 workerCanvases.push(Buffer.alloc(bufSize));
               }
 
-              // Per-worker transition scratch buffers (bufferA + bufferB +
-              // output). Worker 0 reuses the already-allocated
-              // `transitionBuffers` from the outer scope; remaining workers
-              // get their own triple. Only allocated when the composition
-              // actually has transitions — `transitionBuffers` is null
-              // otherwise and the per-worker loop will never enter the
-              // transition branch.
-              const workerTransitionBuffers: Array<LayeredTransitionBuffers | null> = [
-                transitionBuffers,
-              ];
-              for (let w = 1; w < activeWorkerCount; w++) {
-                workerTransitionBuffers.push(
-                  hasTransitions
-                    ? {
-                        bufferA: Buffer.alloc(bufSize),
-                        bufferB: Buffer.alloc(bufSize),
-                        output: Buffer.alloc(bufSize),
-                      }
-                    : null,
-                );
+              // Per-worker transition scratch buffer RING. Each entry is a
+              // triple (bufferA + bufferB + output); the DOM worker
+              // round-robins through the ring so it can capture frames
+              // N+1..N+K-1 while the pool is still blending earlier frames
+              // from the older ring slots. Ring depth K trades memory for
+              // pool utilization:
+              //
+              // - K=1: worker awaits each blend before the next capture →
+              //   pool sees max 1 task per worker → empirically ~135s
+              //   wall on the hf#677 fixture with N=6 workers (no
+              //   improvement over the un-decoupled `bde9b886` baseline).
+              // - K=2: covers the average transition cluster well enough
+              //   to keep the pool with 2-4 concurrent tasks → ~135s.
+              // - K=4-5: pool saturates around max busy ≈ pool size during
+              //   peak transition clusters → ~100s wall. This is the
+              //   sweet spot per empirical sweep.
+              // - K≥10: diminishing returns; pool already saturated, so
+              //   adding more in-flight tasks just adds memory.
+              //
+              // The right K, mathematically, is `blend_per_frame /
+              // capture_per_frame`. For 854×480 rgb48le with complex
+              // shaders this is ~910ms / ~175ms ≈ 5. K=4 strikes the
+              // balance between perf and memory. Override at runtime via
+              // `HF_TRANSITION_RING_DEPTH` if a workload's blend/capture
+              // ratio is very different (e.g. simpler shaders that blend
+              // in 100ms can drop K to 1-2 with no perf loss).
+              //
+              // Memory budget: 6 workers × 4 × 3 buffers × 854×480×6 bytes
+              // ≈ 180MB peak; safely within the SDR render budget. With
+              // K=10 it's ~450MB, still fine but unnecessary.
+              //
+              // hf#732 follow-up rationale: the prior fix-up
+              // (`bde9b886`) awaited each `pool.run` inline inside
+              // `processLayeredTransitionFrame`, which serialized every
+              // DOM worker through one in-flight blend. With N=6 DOM
+              // workers walking contiguous frame slices and transition
+              // windows being temporally localized, typically only 1-2
+              // DOM workers held a transition at a time — so the pool
+              // only ever had ≤2 tasks in flight, fed through slots 0-1
+              // with postMessage overhead on top. CPU graphs showed
+              // workers 0-1 active and workers 2-5 idle. Decoupling +
+              // the K-deep ring is the fix: each DOM worker fires off the
+              // blend without awaiting, then on its (K+1)-th transition
+              // frame awaits the oldest in-flight blend on this worker.
+              // The pool sustains up to min(N_workers × K, poolSize)
+              // concurrent blends.
+              const DEFAULT_TRANSITION_RING_DEPTH = 4;
+              const TRANSITION_RING_DEPTH = Math.max(
+                1,
+                Number(
+                  process.env.HF_TRANSITION_RING_DEPTH ?? String(DEFAULT_TRANSITION_RING_DEPTH),
+                ),
+              );
+              const workerTransitionRings: Array<LayeredTransitionBuffers[] | null> = [];
+              for (let w = 0; w < activeWorkerCount; w++) {
+                if (!hasTransitions) {
+                  workerTransitionRings.push(null);
+                  continue;
+                }
+                const ring: LayeredTransitionBuffers[] = [];
+                // Slot 0 of worker 0 reuses the already-allocated outer-scope
+                // `transitionBuffers` so the legacy sequential branch's buffer
+                // allocation is not wasted when both branches share the
+                // hasTransitions path. The remaining K-1 slots for worker 0
+                // plus all slots for workers 1..N are freshly allocated.
+                for (let k = 0; k < TRANSITION_RING_DEPTH; k++) {
+                  if (w === 0 && k === 0 && transitionBuffers) {
+                    ring.push(transitionBuffers);
+                  } else {
+                    ring.push({
+                      bufferA: Buffer.alloc(bufSize),
+                      bufferB: Buffer.alloc(bufSize),
+                      output: Buffer.alloc(bufSize),
+                    });
+                  }
+                }
+                workerTransitionRings.push(ring);
               }
 
               // Flat partition over the entire frame range — every worker
@@ -3613,13 +3739,25 @@ export async function executeRenderJob(
                 activeWorkerCount,
               );
 
+              // Snapshot the pool into a non-null local for the closure. The
+              // pool reference is mutated to `null` on spawn failure; once
+              // we're past that point, the closure can safely treat it as
+              // a definite value (or fall back to inline blend).
+              const poolRef = shaderPool;
+
               const workerTaskOf = async (w: number): Promise<void> => {
                 const session = sessions[w];
                 const canvas = workerCanvases[w];
                 if (!session || !canvas) return;
                 const range = workerRanges[w];
                 if (!range) return;
-                const myTransitionBuffers = workerTransitionBuffers[w] ?? null;
+                const ring = workerTransitionRings[w] ?? null;
+                // Per-ring-slot in-flight promise. When a slot is mid-blend,
+                // its promise is non-null; before reusing the slot for a
+                // new capture we await it (backpressure → bounds memory).
+                const ringInFlight: Array<Promise<void> | null> = ring ? ring.map(() => null) : [];
+                let nextRingIdx = 0;
+
                 for (let i = range.start; i < range.end; i++) {
                   assertNotAborted();
                   const time = (i * job.config.fps.den) / job.config.fps.num;
@@ -3627,20 +3765,90 @@ export async function executeRenderJob(
                     ? transitionRanges.find((t) => i >= t.startFrame && i <= t.endFrame)
                     : undefined;
 
-                  if (activeTransition && myTransitionBuffers) {
-                    await processLayeredTransitionFrame(
+                  if (activeTransition && ring) {
+                    // Pick the next ring slot. If it's still in flight from
+                    // an earlier capture, wait for it to drain before
+                    // reusing its buffer triple.
+                    const slot = nextRingIdx;
+                    nextRingIdx = (nextRingIdx + 1) % TRANSITION_RING_DEPTH;
+                    const prev = ringInFlight[slot];
+                    if (prev) await prev;
+                    const buffers = ring[slot];
+                    if (!buffers) continue;
+
+                    // CAPTURE on the DOM worker (this thread). Fills
+                    // bufferA / bufferB synchronously w.r.t. this loop —
+                    // we can't pipeline DOM work because the per-worker
+                    // browser session is single-threaded.
+                    const captured = await captureTransitionFrame(
                       session,
                       i,
                       time,
                       activeTransition,
                       hdrCompositeCtx,
                       sceneElements,
-                      myTransitionBuffers,
+                      buffers,
                       assertNotAborted,
                       nativeHdrIds,
-                      shaderPool,
                     );
-                    await writeEncoded(i, myTransitionBuffers.output);
+
+                    // BLEND + ENCODE without awaiting. The promise drains
+                    // back into `ringInFlight[slot]`; the next iteration
+                    // that picks `slot` will await it. The encoder reorder
+                    // buffer fences ordering so out-of-order blend
+                    // completion is fine.
+                    const dispatch: Promise<void> = (async () => {
+                      if (poolRef) {
+                        const blendStart = Date.now();
+                        try {
+                          const result = await poolRef.run({
+                            shader: captured.shader,
+                            bufferA: buffers.bufferA,
+                            bufferB: buffers.bufferB,
+                            output: buffers.output,
+                            width: captured.width,
+                            height: captured.height,
+                            progress: captured.progress,
+                          });
+                          // The originals were detached. Swap in the
+                          // re-attached views so the ring slot stays
+                          // usable for the next round-trip.
+                          buffers.bufferA = result.bufferA;
+                          buffers.bufferB = result.bufferB;
+                          buffers.output = result.output;
+                          addHdrTiming(
+                            hdrCompositeCtx.hdrPerf,
+                            "transitionShaderBlendMs",
+                            blendStart,
+                          );
+                        } catch (err) {
+                          // Pool task failed (worker crash / detach race).
+                          // The transferred ArrayBuffers are lost; we
+                          // cannot recover them, so we surface this as a
+                          // fatal render error. The outer Promise.all
+                          // rejects and the finally block tears down.
+                          log.warn("[Render] Shader-blend pool task failed; aborting render", {
+                            frameIndex: captured.frameIdx,
+                            shader: captured.shader,
+                            error: err instanceof Error ? err.message : String(err),
+                          });
+                          throw err;
+                        }
+                      } else {
+                        // No pool (spawn failed) — synchronous fallback.
+                        blendTransitionFrameInline(captured, hdrCompositeCtx.hdrPerf);
+                      }
+                      await writeEncoded(captured.frameIdx, buffers.output);
+                    })();
+
+                    // Catch on a separate handle so an unhandled-rejection
+                    // can't fire if no one awaits this slot before the
+                    // worker exits. The settled error is re-thrown when
+                    // the slot is reused OR at the drain at function end.
+                    ringInFlight[slot] = dispatch.catch((err: unknown) => {
+                      // Re-throw on next await so the worker task rejects.
+                      throw err instanceof Error ? err : new Error(String(err));
+                    });
                   } else {
                     await processLayeredNormalFrame(
                       session,
@@ -3659,6 +3867,12 @@ export async function executeRenderJob(
                     }
                     await writeEncoded(i, canvas);
                   }
+                }
+
+                // Drain any blends still in flight on this worker before
+                // returning. If any rejected, the rejection bubbles here.
+                for (const pending of ringInFlight) {
+                  if (pending) await pending;
                 }
               };
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1825,9 +1825,14 @@ async function compositeHdrFrame(
 // safely without locking.
 //
 // IMPORTANT: each worker passes its own session in via the first argument
-// rather than reading from `ctx.domSession`. The transition path always uses
-// the main session because the per-scene seek+inject+mask sequence must run
-// against the same `window.__hf` state across both scenes.
+// rather than reading from `ctx.domSession`. As of the hf#732 follow-up,
+// the transition path also runs on per-worker sessions — the dual-scene
+// (seek → mask fromScene → screenshot → mask toScene → screenshot → blend)
+// pipeline is self-contained inside a single `processLayeredTransitionFrame`
+// call and only requires the same `window.__hf` state across both scenes
+// within that call. There's no inter-frame dependency on a specific
+// session, so multiple workers can each run the full transition pipeline
+// against their own browser concurrently.
 
 interface LayeredTransitionBuffers {
   bufferA: Buffer;
@@ -1900,16 +1905,20 @@ export async function processLayeredNormalFrame(
 }
 
 /**
- * Composite a single transition frame on the main DOM session. Runs the
+ * Composite a single transition frame on a given DOM session. Runs the
  * dual-scene capture (scene A and scene B with appropriate `applyDomLayerMask`
  * targeting) and applies the shader blend into `buffers.output`. Returns the
  * `output` Buffer; the caller writes it to the encoder.
  *
- * Sequential by design: the per-scene seek/inject/mask/screenshot/remove-mask
- * pattern requires the same `window.__hf` state across the two scenes, which
- * means a single browser session steps through them in order.
+ * Self-contained per call: the per-scene seek/inject/mask/screenshot/remove-mask
+ * pattern requires the same `window.__hf` state across the two scenes within
+ * one invocation, but it holds no inter-frame state on the session. As of
+ * the hf#732 follow-up the hybrid path runs transition frames in parallel
+ * across worker sessions; each worker passes its own session here.
  *
- * @param session - Always the main DOM session in the hybrid path.
+ * @param session - DOM capture session to drive. Each worker in the hybrid
+ *                  parallel pool passes its own session; the legacy
+ *                  sequential path passes the main `domSession`.
  * @param frameIdx - Composition frame index (used for warn-level error logs).
  * @param time - Seek time in seconds.
  * @param transition - The transition window that contains this frame.
@@ -2089,6 +2098,39 @@ export async function processLayeredTransitionFrame(
  * decision next to the worker-count choice, and so tests can assert the
  * exact predicate without spinning up a real render.
  */
+/**
+ * Distribute the contiguous frame range [0, totalFrames) across
+ * `workerCount` workers as roughly equal contiguous slices. Each worker's
+ * slice carries whatever mix of normal and transition frames falls inside
+ * it — the hybrid path runs both types of compositing on per-worker
+ * sessions, so the partition does not split on transition-frame boundaries.
+ *
+ * Exported so the unit test can pin the partitioning contract (e.g.
+ * "transition frames at indices 60-69 are NOT all assigned to worker 0,
+ * because contiguous chunking spreads them across whichever workers' slices
+ * cover that index range").
+ *
+ * Returns ranges with the invariant: ranges are non-overlapping, contiguous,
+ * cover exactly [0, totalFrames), and any worker beyond `totalFrames /
+ * framesPerWorker` gets a zero-width range. `workerCount` is clamped to 1
+ * for non-positive inputs.
+ */
+export function distributeLayeredHybridFrameRanges(
+  totalFrames: number,
+  workerCount: number,
+): Array<{ start: number; end: number }> {
+  const safeWorkers = Math.max(1, workerCount);
+  const safeFrames = Math.max(0, totalFrames);
+  const framesPerWorker = Math.max(1, Math.ceil(safeFrames / safeWorkers));
+  const ranges: Array<{ start: number; end: number }> = [];
+  for (let w = 0; w < safeWorkers; w++) {
+    const start = Math.min(safeFrames, w * framesPerWorker);
+    const end = Math.min(safeFrames, start + framesPerWorker);
+    ranges.push({ start, end });
+  }
+  return ranges;
+}
+
 export function shouldUseHybridLayeredPath(args: {
   hasHdrContent: boolean;
   transitionFramesCount: number;
@@ -3244,12 +3286,14 @@ export async function executeRenderJob(
           //
           // The fix here computes the transition-frame set up front and,
           // when the workload qualifies (SDR + multi-worker), spawns a pool
-          // of additional `domSession`s. The pool drains the non-transition
-          // frames in parallel; the main session steps through the
-          // transition frames sequentially. A shared `FrameReorderBuffer`
-          // gates `hdrEncoder.writeFrame` so frames hit the encoder in
-          // ascending index order regardless of which session finished
-          // them first.
+          // of additional `domSession`s. Every worker drains a contiguous
+          // slice of the timeline including any transition frames that
+          // happen to fall inside its range — see the hf#732 follow-up
+          // notes at the dispatch site below for why the dual-scene
+          // transition compositor is safe to run in parallel across
+          // sessions. A shared `FrameReorderBuffer` gates
+          // `hdrEncoder.writeFrame` so frames hit the encoder in ascending
+          // index order regardless of which session finished them first.
           //
           // HDR + shader-transitions falls back to the legacy sequential
           // loop: each worker session would need its own `dup(fd)` into the
@@ -3392,13 +3436,32 @@ export async function executeRenderJob(
             }
           };
 
-          // ── Hybrid path: parallel pool drains non-transition frames; main
-          // session walks the transition frames sequentially. Both feed into
-          // the same reorder buffer → encoder.
+          // ── Hybrid path: parallel pool drains BOTH non-transition and
+          // transition frames. Every worker owns its own browser session and
+          // per-scene transition scratch buffers, so the per-frame
+          // seek/inject/mask/screenshot pipeline runs concurrently across the
+          // pool. Both feed into the same reorder buffer → encoder.
+          //
+          // hf#732 fix-up: the prior iteration kept transition frames pinned
+          // to the main session, which left ~110s of the 171s wall-clock
+          // sitting on a single-CDP serial path (141 transition frames ×
+          // ~780 ms each). perf-summary.json showed the transition phase
+          // dominated by `domScreenshotMs` (70.8s) — fundamentally a
+          // Puppeteer round-trip cost that only parallelizes by spreading
+          // captures across additional browser sessions. Each worker now
+          // walks a contiguous slice of frame indices that includes any
+          // transition frames in its range, so the dual-scene capture
+          // pattern runs on worker-local `window.__hf` state. Correctness
+          // is preserved because the per-frame state (seek time → fromScene
+          // mask → screenshot → toScene mask → screenshot → blend) is fully
+          // self-contained inside a single `processLayeredTransitionFrame`
+          // call against a single session — there's no inter-frame
+          // dependency on the same session. The SDR gate
+          // (`hasHdrContent === false` inside `shouldUseHybridLayeredPath`)
+          // still applies; HDR renders take the sequential path below
+          // because `hdrVideoFrameSources` carries a single shared fd per
+          // raw frame source that's not safe to read concurrently.
           if (hybridEligible) {
-            // Build worker partitions: layeredWorkerCount workers split the
-            // contiguous non-transition frame range. Each worker iterates
-            // its slice and skips frames in `transitionFrames`.
             const workerSessions: CaptureSession[] = [];
             const workerCanvasesNeeded = Math.max(0, layeredWorkerCount - 1);
             try {
@@ -3418,39 +3481,45 @@ export async function executeRenderJob(
 
               const sessions: CaptureSession[] = [domSession, ...workerSessions];
               const activeWorkerCount = sessions.length;
-              const totalNonTransitionFrames = totalFrames - transitionFrameCount;
-              const framesPerWorker = Math.max(
-                1,
-                Math.ceil(totalNonTransitionFrames / activeWorkerCount),
-              );
 
-              // Per-worker canvas, allocated once and reused. Worker 0 reuses
-              // `normalCanvas` (already allocated above for the legacy path).
+              // Per-worker normal-frame canvas, allocated once and reused.
+              // Worker 0 reuses `normalCanvas` (already allocated above).
               const workerCanvases: Buffer[] = [normalCanvas];
               for (let w = 1; w < activeWorkerCount; w++) {
                 workerCanvases.push(Buffer.alloc(bufSize));
               }
 
-              // Distribute non-transition frames across workers in a
-              // contiguous, locality-preserving manner. Each worker advances
-              // through its own range and just skips transition frames.
-              const workerRanges: Array<{ start: number; end: number }> = [];
-              let cursor = 0;
-              let assigned = 0;
-              for (let w = 0; w < activeWorkerCount; w++) {
-                const targetForThisWorker = Math.min(
-                  framesPerWorker,
-                  totalNonTransitionFrames - assigned,
+              // Per-worker transition scratch buffers (bufferA + bufferB +
+              // output). Worker 0 reuses the already-allocated
+              // `transitionBuffers` from the outer scope; remaining workers
+              // get their own triple. Only allocated when the composition
+              // actually has transitions — `transitionBuffers` is null
+              // otherwise and the per-worker loop will never enter the
+              // transition branch.
+              const workerTransitionBuffers: Array<LayeredTransitionBuffers | null> = [
+                transitionBuffers,
+              ];
+              for (let w = 1; w < activeWorkerCount; w++) {
+                workerTransitionBuffers.push(
+                  hasTransitions
+                    ? {
+                        bufferA: Buffer.alloc(bufSize),
+                        bufferB: Buffer.alloc(bufSize),
+                        output: Buffer.alloc(bufSize),
+                      }
+                    : null,
                 );
-                const start = cursor;
-                let collected = 0;
-                while (cursor < totalFrames && collected < targetForThisWorker) {
-                  if (!transitionFrames.has(cursor)) collected += 1;
-                  cursor += 1;
-                }
-                workerRanges.push({ start, end: cursor });
-                assigned += collected;
               }
+
+              // Flat partition over the entire frame range — every worker
+              // gets a contiguous slice that includes whatever mix of normal
+              // and transition frames falls inside it. Ordering correctness
+              // is enforced by `reorderBuffer.waitForFrame` at the encoder
+              // gate, not by the dispatch order here.
+              const workerRanges = distributeLayeredHybridFrameRanges(
+                totalFrames,
+                activeWorkerCount,
+              );
 
               const workerTaskOf = async (w: number): Promise<void> => {
                 const session = sessions[w];
@@ -3458,71 +3527,55 @@ export async function executeRenderJob(
                 if (!session || !canvas) return;
                 const range = workerRanges[w];
                 if (!range) return;
+                const myTransitionBuffers = workerTransitionBuffers[w] ?? null;
                 for (let i = range.start; i < range.end; i++) {
-                  if (transitionFrames.has(i)) continue;
                   assertNotAborted();
                   const time = (i * job.config.fps.den) / job.config.fps.num;
-                  await processLayeredNormalFrame(
-                    session,
-                    i,
-                    time,
-                    hdrCompositeCtx,
-                    canvas,
-                    nativeHdrIds,
-                  );
-                  if (debugDumpEnabled && debugDumpDir && i % 30 === 0) {
-                    const previewPath = join(
-                      debugDumpDir,
-                      `frame_${String(i).padStart(4, "0")}_final_rgb48le.bin`,
+                  const activeTransition = transitionFrames.has(i)
+                    ? transitionRanges.find((t) => i >= t.startFrame && i <= t.endFrame)
+                    : undefined;
+
+                  if (activeTransition && myTransitionBuffers) {
+                    await processLayeredTransitionFrame(
+                      session,
+                      i,
+                      time,
+                      activeTransition,
+                      hdrCompositeCtx,
+                      sceneElements,
+                      myTransitionBuffers,
+                      assertNotAborted,
+                      nativeHdrIds,
                     );
-                    writeFileSync(previewPath, canvas);
+                    await writeEncoded(i, myTransitionBuffers.output);
+                  } else {
+                    await processLayeredNormalFrame(
+                      session,
+                      i,
+                      time,
+                      hdrCompositeCtx,
+                      canvas,
+                      nativeHdrIds,
+                    );
+                    if (debugDumpEnabled && debugDumpDir && i % 30 === 0) {
+                      const previewPath = join(
+                        debugDumpDir,
+                        `frame_${String(i).padStart(4, "0")}_final_rgb48le.bin`,
+                      );
+                      writeFileSync(previewPath, canvas);
+                    }
+                    await writeEncoded(i, canvas);
                   }
-                  await writeEncoded(i, canvas);
                 }
               };
 
-              const transitionTaskFn = async (): Promise<void> => {
-                if (!transitionBuffers) return;
-                for (let i = 0; i < totalFrames; i++) {
-                  if (!transitionFrames.has(i)) continue;
-                  assertNotAborted();
-                  const time = (i * job.config.fps.den) / job.config.fps.num;
-                  const activeTransition = transitionRanges.find(
-                    (t) => i >= t.startFrame && i <= t.endFrame,
-                  );
-                  if (!activeTransition) continue;
-                  // Transitions always run on the main session; reserve it
-                  // by waiting until any normal-frame work assigned to
-                  // worker 0 has stepped past `i`. Worker 0's range is the
-                  // first contiguous slice, so once its cursor crosses `i`
-                  // it won't issue another CDP call for the same session at
-                  // overlapping frame indices. We just need a coarse fence:
-                  // wait for the reorder buffer to advance to a point at or
-                  // before `i` (i.e. frame `i` is the next thing the encoder
-                  // expects). This naturally serializes the main session.
-                  await reorderBuffer.waitForFrame(i);
-                  await processLayeredTransitionFrame(
-                    domSession,
-                    i,
-                    time,
-                    activeTransition,
-                    hdrCompositeCtx,
-                    sceneElements,
-                    transitionBuffers,
-                    assertNotAborted,
-                    nativeHdrIds,
-                  );
-                  await writeEncoded(i, transitionBuffers.output);
-                }
-              };
-
-              // Run worker tasks + the transition processor concurrently.
-              // The reorder buffer fences ordering so the encoder never
-              // sees frame N+1 before frame N. Promise.all rethrows the
-              // first rejection, which (combined with `assertNotAborted` in
-              // the per-frame helpers) bubbles cancellation up cleanly.
+              // Run every worker concurrently. The reorder buffer fences
+              // ordering so the encoder never sees frame N+1 before frame N.
+              // `Promise.all` rethrows the first rejection, which (combined
+              // with `assertNotAborted` in the per-frame helpers) bubbles
+              // cancellation up cleanly.
               const workerPromises = sessions.map((_, w) => workerTaskOf(w));
-              await Promise.all([transitionTaskFn(), ...workerPromises]);
+              await Promise.all(workerPromises);
               await reorderBuffer.waitForAllDone();
             } finally {
               for (const session of workerSessions) {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -190,9 +190,48 @@ function countNonZeroRgb48(buf: Uint8Array): number {
 type HdrTransitionMeta = HfTransitionMeta;
 
 /** Pre-computed frame range for an active transition. */
-interface TransitionRange extends HdrTransitionMeta {
+export interface TransitionRange extends HdrTransitionMeta {
   startFrame: number;
   endFrame: number;
+}
+
+/**
+ * Build the set of frame indices that fall inside any active transition window.
+ *
+ * Layered SDR renders defer to the slow per-frame dual-scene compositor for
+ * frames in this set; everything outside the set is eligible for the fast
+ * parallel capture path. The two ranges produced by `[startFrame, endFrame]`
+ * are inclusive on both ends because the layered loop's `i <= endFrame` check
+ * applies the transition blend to the last frame of the window — and the same
+ * frame must be excluded from the parallel non-transition path or it would be
+ * captured twice (once incorrectly without the blend) and overwritten.
+ *
+ * Clamps both ends to `[0, totalFrames)` so out-of-range transitions (e.g.
+ * trailing slop from rounding the end timestamp) don't try to allocate
+ * frames past the end of the composition.
+ *
+ * @param transitionRanges - Pre-computed frame-aligned transition windows
+ *                           (`startFrame`, `endFrame` already rounded from
+ *                           `time` / `duration`).
+ * @param totalFrames       - Total composition frame count; the resulting set
+ *                            never contains an index ≥ totalFrames.
+ * @returns A frozen-by-convention `Set<number>` of frame indices that must
+ *          flow through the sequential layered path.
+ */
+export function partitionTransitionFrames(
+  transitionRanges: ReadonlyArray<Pick<TransitionRange, "startFrame" | "endFrame">>,
+  totalFrames: number,
+): Set<number> {
+  const frames = new Set<number>();
+  if (totalFrames <= 0) return frames;
+  for (const range of transitionRanges) {
+    const start = Math.max(0, range.startFrame);
+    const end = Math.min(totalFrames - 1, range.endFrame);
+    for (let i = start; i <= end; i++) {
+      frames.add(i);
+    }
+  }
+  return frames;
 }
 
 export type RenderStatus =
@@ -765,15 +804,45 @@ export function resolveRenderWorkerCount(
   return workerCount;
 }
 
+/**
+ * Optional cost-shaping inputs for `estimateCaptureCostMultiplier`.
+ *
+ * `transitionFrameRatio` is the fraction (0..1) of frames that will hit the
+ * expensive sequential layered compositor — the rest run on the fast parallel
+ * path post-#677. When provided alongside `hasShaderTransitions`, the cost is
+ * blended (`1 + ratio * 1.5`) so auto-worker sizing reflects the post-hybrid
+ * workload instead of charging the legacy flat `+2`. Pre-hybrid callers and
+ * pre-#677 callers that don't yet know the ratio fall back to the flat charge.
+ */
+export interface CaptureCostShape {
+  /** Fraction of total frames inside an active transition window (0..1). */
+  transitionFrameRatio?: number;
+}
+
 export function estimateCaptureCostMultiplier(
   compiled: Pick<CompiledComposition, "hasShaderTransitions" | "renderModeHints">,
+  shape?: CaptureCostShape,
 ): CaptureCostEstimate {
   let multiplier = 1;
   const reasons: string[] = [];
 
   if (compiled.hasShaderTransitions) {
-    multiplier += 2;
-    reasons.push("shader-transitions");
+    const ratio = shape?.transitionFrameRatio;
+    if (typeof ratio === "number" && Number.isFinite(ratio) && ratio >= 0 && ratio <= 1) {
+      // Hybrid path (issue #677): only `ratio` of frames pay the expensive
+      // sequential layered cost; the rest go through the parallel capture
+      // pool. Blend the historical flat `+2` charge by the ratio plus a
+      // small base bump so the per-worker provisioning still leaves CPU
+      // headroom for the transition processor running alongside the pool.
+      // A composition with no live transitions (e.g. all transitions sit
+      // before/after the composition window) collapses to `1 + 0 = 1` and
+      // gets the same auto-worker count as a plain SDR render.
+      multiplier += ratio * 1.5;
+      reasons.push(`shader-transitions(${(ratio * 100).toFixed(0)}%-frames)`);
+    } else {
+      multiplier += 2;
+      reasons.push("shader-transitions");
+    }
   }
 
   const reasonCodes = new Set(compiled.renderModeHints.reasons.map((reason) => reason.code));
@@ -1735,6 +1804,302 @@ async function compositeHdrFrame(
       coverage: ((finalNonZero / (width * height)) * 100).toFixed(1) + "%",
     });
   }
+}
+
+// ── Layered-frame helpers (issue #677 hybrid path) ──────────────────────────
+//
+// These helpers run a single frame through the layered SDR/HDR compositor and
+// emit one rgb48le buffer. They share the same context (`HdrCompositeContext`)
+// the legacy sequential loop already used, but accept a session parameter so a
+// pool of worker sessions can drive them in parallel for non-transition
+// frames. The transition variant is still serialized — dual-scene composites
+// re-seek the same DOM session twice and write masked, screenshot-derived
+// scenes into per-frame buffers that the shader blend reads back-to-back.
+//
+// Behavioral parity with the legacy inline loop is essential: per-frame
+// timings are recorded into the same `hdrPerf` collector keys so
+// `perf-summary.json` rollups stay comparable across the migration. Workers
+// share a single collector; the increments are integer arithmetic on hot
+// counters and the dispatcher is bounded by Node's main-thread async runtime
+// (workers await on Puppeteer, never on each other), so the appends interleave
+// safely without locking.
+//
+// IMPORTANT: each worker passes its own session in via the first argument
+// rather than reading from `ctx.domSession`. The transition path always uses
+// the main session because the per-scene seek+inject+mask sequence must run
+// against the same `window.__hf` state across both scenes.
+
+interface LayeredTransitionBuffers {
+  bufferA: Buffer;
+  bufferB: Buffer;
+  output: Buffer;
+}
+
+/**
+ * Composite a single non-transition (normal) layered frame on a given DOM
+ * session. Mirrors the legacy inline normal-frame branch — seek, inject,
+ * query stacking, then delegate per-layer compositing to
+ * `compositeHdrFrame`. The caller owns the `canvas` Buffer and is responsible
+ * for zero-fill bookkeeping (the helper does it here so callers don't repeat
+ * the same `.fill(0)` shape).
+ *
+ * @param session - The DOM capture session to drive. Workers in the hybrid
+ *                  parallel pool pass their own session; the legacy
+ *                  sequential path passes the main `domSession`.
+ * @param frameIdx - Frame index in composition timeline. Used for debug dumps
+ *                   only — timing math uses `time` derived from fps.
+ * @param time - Seek time in seconds for this frame.
+ * @param ctx - Long-lived layered-composite context. The helper rebinds
+ *              `ctx.domSession` to `session` for the duration of the call
+ *              so per-layer DOM screenshots in `compositeHdrFrame` go to the
+ *              right session.
+ * @param canvas - Pre-allocated rgb48le canvas (width * height * 6 bytes).
+ *                 Zero-filled by this helper.
+ * @param nativeHdrIds - Set of HDR element ids used by `queryElementStacking`.
+ */
+export async function processLayeredNormalFrame(
+  session: CaptureSession,
+  frameIdx: number,
+  time: number,
+  ctx: HdrCompositeContext,
+  canvas: Buffer,
+  nativeHdrIds: Set<string>,
+): Promise<void> {
+  const hdrPerf = ctx.hdrPerf;
+  if (hdrPerf) hdrPerf.frames += 1;
+  if (hdrPerf) hdrPerf.normalFrames += 1;
+
+  let timingStart = Date.now();
+  await session.page.evaluate((t: number) => {
+    if (window.__hf && typeof window.__hf.seek === "function") window.__hf.seek(t);
+  }, time);
+  addHdrTiming(hdrPerf, "frameSeekMs", timingStart);
+
+  if (ctx.beforeCaptureHook) {
+    timingStart = Date.now();
+    await ctx.beforeCaptureHook(session.page, time);
+    addHdrTiming(hdrPerf, "frameInjectMs", timingStart);
+  }
+
+  timingStart = Date.now();
+  const stackingInfo = await queryElementStacking(session.page, nativeHdrIds);
+  addHdrTiming(hdrPerf, "stackingQueryMs", timingStart);
+
+  timingStart = Date.now();
+  canvas.fill(0);
+  addHdrTiming(hdrPerf, "canvasClearMs", timingStart);
+
+  // Rebind the context to this worker's session for the per-layer DOM
+  // screenshot work inside compositeHdrFrame. The legacy path passed
+  // `domSession` via the closure-captured ctx; for the worker pool we need
+  // each worker's session to drive its own captures.
+  const sessionScopedCtx: HdrCompositeContext = { ...ctx, domSession: session };
+  timingStart = Date.now();
+  await compositeHdrFrame(sessionScopedCtx, canvas, time, stackingInfo, undefined, frameIdx);
+  addHdrTiming(hdrPerf, "normalCompositeMs", timingStart);
+}
+
+/**
+ * Composite a single transition frame on the main DOM session. Runs the
+ * dual-scene capture (scene A and scene B with appropriate `applyDomLayerMask`
+ * targeting) and applies the shader blend into `buffers.output`. Returns the
+ * `output` Buffer; the caller writes it to the encoder.
+ *
+ * Sequential by design: the per-scene seek/inject/mask/screenshot/remove-mask
+ * pattern requires the same `window.__hf` state across the two scenes, which
+ * means a single browser session steps through them in order.
+ *
+ * @param session - Always the main DOM session in the hybrid path.
+ * @param frameIdx - Composition frame index (used for warn-level error logs).
+ * @param time - Seek time in seconds.
+ * @param transition - The transition window that contains this frame.
+ * @param ctx - Layered-composite context (HDR layer maps, transfer, etc.).
+ * @param sceneElements - Scene-id → element-id list, computed once at render
+ *                        start from `.scene` DOM nodes.
+ * @param buffers - Pre-allocated dual-scene buffers and shared output buffer.
+ *                  All three are zero-filled by this helper as needed.
+ * @param assertNotAborted - Render-level abort check, called between scene
+ *                           A and scene B so an abort that lands mid-frame
+ *                           tears down promptly instead of after the
+ *                           second scene's full composite.
+ * @param nativeHdrIds - Set of HDR element ids; passed to mask helpers so HDR
+ *                       elements stay inline-hidden behind the screenshot
+ *                       (their pixels arrive via `blitHdrVideoLayer` etc.).
+ */
+export async function processLayeredTransitionFrame(
+  session: CaptureSession,
+  frameIdx: number,
+  time: number,
+  transition: TransitionRange,
+  ctx: HdrCompositeContext,
+  sceneElements: Record<string, string[]>,
+  buffers: LayeredTransitionBuffers,
+  assertNotAborted: () => void,
+  nativeHdrIds: Set<string>,
+): Promise<void> {
+  const {
+    log,
+    beforeCaptureHook,
+    width,
+    height,
+    fps,
+    compositeTransfer,
+    nativeHdrImageIds,
+    hdrImageBuffers,
+    hdrImageTransferCache,
+    hdrVideoFrameSources,
+    hdrVideoStartTimes,
+    imageTransfers,
+    videoTransfers,
+    hdrPerf,
+  } = ctx;
+  const hdrTargetTransfer = compositeTransfer === "srgb" ? undefined : compositeTransfer;
+
+  if (hdrPerf) hdrPerf.frames += 1;
+  if (hdrPerf) hdrPerf.transitionFrames += 1;
+  const transitionTimingStart = Date.now();
+
+  let timingStart = Date.now();
+  await session.page.evaluate((t: number) => {
+    if (window.__hf && typeof window.__hf.seek === "function") window.__hf.seek(t);
+  }, time);
+  addHdrTiming(hdrPerf, "frameSeekMs", timingStart);
+
+  if (beforeCaptureHook) {
+    timingStart = Date.now();
+    await beforeCaptureHook(session.page, time);
+    addHdrTiming(hdrPerf, "frameInjectMs", timingStart);
+  }
+
+  timingStart = Date.now();
+  const stackingInfo = await queryElementStacking(session.page, nativeHdrIds);
+  addHdrTiming(hdrPerf, "stackingQueryMs", timingStart);
+
+  const progress =
+    transition.endFrame === transition.startFrame
+      ? 1
+      : (frameIdx - transition.startFrame) / (transition.endFrame - transition.startFrame);
+
+  const sceneAIds = new Set(sceneElements[transition.fromScene] ?? []);
+  const sceneBIds = new Set(sceneElements[transition.toScene] ?? []);
+
+  timingStart = Date.now();
+  buffers.bufferA.fill(0);
+  buffers.bufferB.fill(0);
+  addHdrTiming(hdrPerf, "canvasClearMs", timingStart);
+
+  for (const [sceneBuf, sceneIds] of [
+    [buffers.bufferA, sceneAIds],
+    [buffers.bufferB, sceneBIds],
+  ] as const) {
+    assertNotAborted();
+    timingStart = Date.now();
+    await session.page.evaluate((t: number) => {
+      if (window.__hf && typeof window.__hf.seek === "function") window.__hf.seek(t);
+    }, time);
+    addHdrTiming(hdrPerf, "domLayerSeekMs", timingStart);
+    if (beforeCaptureHook) {
+      timingStart = Date.now();
+      await beforeCaptureHook(session.page, time);
+      addHdrTiming(hdrPerf, "domLayerInjectMs", timingStart);
+    }
+
+    for (const el of stackingInfo) {
+      if (!el.isHdr || !sceneIds.has(el.id)) continue;
+      if (nativeHdrImageIds.has(el.id)) {
+        blitHdrImageLayer(
+          sceneBuf,
+          el,
+          hdrImageBuffers,
+          hdrImageTransferCache,
+          width,
+          height,
+          log,
+          imageTransfers.get(el.id),
+          hdrTargetTransfer,
+          hdrPerf,
+        );
+      } else {
+        blitHdrVideoLayer(
+          sceneBuf,
+          el,
+          time,
+          fps,
+          hdrVideoFrameSources,
+          hdrVideoStartTimes,
+          width,
+          height,
+          log,
+          videoTransfers.get(el.id),
+          hdrTargetTransfer,
+          hdrPerf,
+        );
+      }
+    }
+
+    const showIds = Array.from(sceneIds);
+    const hideIds = stackingInfo
+      .map((e) => e.id)
+      .filter((id) => !sceneIds.has(id) || nativeHdrIds.has(id));
+    if (hdrPerf) hdrPerf.domLayerCaptures += 1;
+    timingStart = Date.now();
+    await applyDomLayerMask(session.page, showIds, hideIds);
+    addHdrTiming(hdrPerf, "domMaskApplyMs", timingStart);
+    timingStart = Date.now();
+    const domPng = await captureAlphaPng(session.page, width, height);
+    addHdrTiming(hdrPerf, "domScreenshotMs", timingStart);
+    timingStart = Date.now();
+    await removeDomLayerMask(session.page, hideIds);
+    addHdrTiming(hdrPerf, "domMaskRemoveMs", timingStart);
+
+    try {
+      timingStart = Date.now();
+      const { data: domRgba } = decodePng(domPng);
+      addHdrTiming(hdrPerf, "domPngDecodeMs", timingStart);
+      timingStart = Date.now();
+      blitRgba8OverRgb48le(domRgba, sceneBuf, width, height, compositeTransfer);
+      addHdrTiming(hdrPerf, "domBlitMs", timingStart);
+    } catch (err) {
+      log.warn("DOM layer decode/blit failed; skipping overlay for transition scene", {
+        frameIndex: frameIdx,
+        sceneIds: Array.from(sceneIds),
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const transitionFn: TransitionFn = TRANSITIONS[transition.shader] ?? crossfade;
+  transitionFn(buffers.bufferA, buffers.bufferB, buffers.output, width, height, progress);
+  addHdrTiming(hdrPerf, "transitionCompositeMs", transitionTimingStart);
+}
+
+/**
+ * Decide whether the hybrid parallel layered path is safe to use for a given
+ * render. Returns `false` (i.e. fall back to the legacy sequential loop) for:
+ *
+ * - HDR content (HDR video raw-frame sources are file-descriptor-bound to a
+ *   single worker — sharing would require per-worker `dup(fd)` and
+ *   worker-local scratch buffers, out of scope for the #677 fix).
+ * - Compositions where every frame falls inside a transition window
+ *   (parallel workers would have nothing to do; legacy loop is fine).
+ * - Worker budgets at or below 1 — the legacy loop is already optimal for
+ *   single-worker SDR.
+ *
+ * Surfaced as a top-level helper so the call site can log the gating
+ * decision next to the worker-count choice, and so tests can assert the
+ * exact predicate without spinning up a real render.
+ */
+export function shouldUseHybridLayeredPath(args: {
+  hasHdrContent: boolean;
+  transitionFramesCount: number;
+  totalFrames: number;
+  workerCount: number;
+}): boolean {
+  if (args.hasHdrContent) return false;
+  if (args.workerCount <= 1) return false;
+  if (args.totalFrames <= 0) return false;
+  if (args.transitionFramesCount >= args.totalFrames) return false;
+  return true;
 }
 
 export function createRenderJob(config: RenderConfig): RenderJob {
@@ -2819,7 +3184,11 @@ export async function executeRenderJob(
             mkdirSync(debugDumpDir, { recursive: true });
           }
           const compositeTransfer = resolveCompositeTransfer(hasHdrContent, effectiveHdr);
-          const hdrTargetTransfer = compositeTransfer === "srgb" ? undefined : compositeTransfer;
+          // `hdrTargetTransfer` (compositeTransfer normalized to `undefined`
+          // for sRGB) is now computed inside `processLayeredTransitionFrame`
+          // and `compositeHdrFrame`; the inline copy that the legacy loop
+          // body referenced was removed in the hybrid-dispatch refactor.
+          //
           // Per-job LRU cache for transfer-converted HDR image buffers. Static HDR
           // images that need PQ↔HLG conversion are converted exactly once per
           // (imageId, targetTransfer) and then reused for every subsequent frame
@@ -2864,274 +3233,360 @@ export async function executeRenderJob(
           // to avoid ~37 MB allocation per frame in the hot loop.
           const normalCanvas = Buffer.alloc(bufSize);
 
-          for (let i = 0; i < totalFrames; i++) {
-            assertNotAborted();
-            const time = (i * job.config.fps.den) / job.config.fps.num;
-            if (hdrPerf) hdrPerf.frames += 1;
+          // ── Hybrid layered dispatch (issue #677) ───────────────────────────
+          // Pre-#677 this path was a single sequential for-loop that drove the
+          // dual-scene transition compositor for every transition frame and
+          // the normal layered compositor for every other frame — even when
+          // the composition had no HDR content and could trivially be
+          // parallelized. For an SDR shader-transition composition with 14
+          // 0.3s transitions on a 28s timeline, ~83% of frames were sitting
+          // on a fast non-transition path serialized behind a single browser.
+          //
+          // The fix here computes the transition-frame set up front and,
+          // when the workload qualifies (SDR + multi-worker), spawns a pool
+          // of additional `domSession`s. The pool drains the non-transition
+          // frames in parallel; the main session steps through the
+          // transition frames sequentially. A shared `FrameReorderBuffer`
+          // gates `hdrEncoder.writeFrame` so frames hit the encoder in
+          // ascending index order regardless of which session finished
+          // them first.
+          //
+          // HDR + shader-transitions falls back to the legacy sequential
+          // loop: each worker session would need its own `dup(fd)` into the
+          // pre-extracted HDR raw frame files (the existing
+          // `HdrVideoFrameSource` shape carries a single shared fd and a
+          // single scratch Buffer — a 16-bit pixel format is not safe to
+          // read concurrently from the same fd because `readSync` advances
+          // the file offset). Splitting HDR raw-frame sources per worker is
+          // a follow-up; the #677 fix targets the SDR transition path that
+          // produced the reported 24× regression.
+          const transitionFrames = partitionTransitionFrames(transitionRanges, totalFrames);
+          const transitionFrameCount = transitionFrames.size;
+          const hybridEligible = shouldUseHybridLayeredPath({
+            hasHdrContent,
+            transitionFramesCount: transitionFrameCount,
+            totalFrames,
+            workerCount,
+          });
 
-            // Seek timeline
-            let timingStart = Date.now();
-            await domSession.page.evaluate((t: number) => {
-              if (window.__hf && typeof window.__hf.seek === "function") window.__hf.seek(t);
-            }, time);
-            addHdrTiming(hdrPerf, "frameSeekMs", timingStart);
+          if (transitionRanges.length > 0) {
+            log.info("[Render] Layered hybrid dispatch decision", {
+              hybridEnabled: hybridEligible,
+              hasHdrContent,
+              workerCount,
+              transitionFrameCount,
+              totalFrames,
+              transitionRatio:
+                totalFrames > 0
+                  ? Math.round((transitionFrameCount / totalFrames) * 1000) / 1000
+                  : 0,
+            });
+          }
 
-            // Inject SDR video frames into the DOM
-            if (beforeCaptureHook) {
-              timingStart = Date.now();
-              await beforeCaptureHook(domSession.page, time);
-              addHdrTiming(hdrPerf, "frameInjectMs", timingStart);
-            }
-
-            // Query ALL timed elements for z-order analysis
-            timingStart = Date.now();
-            const stackingInfo = await queryElementStacking(domSession.page, nativeHdrIds);
-            addHdrTiming(hdrPerf, "stackingQueryMs", timingStart);
-
-            // Find active transition for this frame (if any)
-            const activeTransition = transitionRanges.find(
-              (t) => i >= t.startFrame && i <= t.endFrame,
+          // Recompute the worker count using the actual transition ratio now
+          // that we have it — the pre-discovery worker count was sized with
+          // the legacy flat shader-transition charge. With the hybrid path
+          // most frames are cheap, so auto-worker sizing can comfortably
+          // climb back up to the SDR baseline. Explicit `--workers` requests
+          // are still honored verbatim (resolveRenderWorkerCount clamps).
+          let layeredWorkerCount = workerCount;
+          if (hybridEligible && transitionRanges.length > 0) {
+            const ratio = transitionFrameCount / totalFrames;
+            const shapedCost = combineCaptureCostEstimates(
+              estimateCaptureCostMultiplier(compiled, { transitionFrameRatio: ratio }),
+              captureCalibration?.estimate,
             );
-
-            // Per-frame debug snapshot (every 30 frames). The meta object
-            // requires `Array.find` over `stackingInfo` plus a number-format
-            // and conditional struct allocation — non-trivial work to do
-            // every 30 frames in the encode hot loop. Gate the entire block
-            // on the logger's level check so production runs (level=info)
-            // pay nothing.
-            //
-            // Audit note (PR #383 review): this is the only per-frame log
-            // site in the streaming HDR encode loop that constructs
-            // non-trivial metadata. The `[diag]` log.info calls inside
-            // compositeToBuffer (compositeToBuffer plan, hdr layer blit,
-            // dom layer blit, compositeToBuffer end) are already gated by
-            // `shouldLog = debugDumpEnabled && debugFrameIndex >= 0`, where
-            // debugDumpEnabled is driven by KEEP_TEMP=1 — strictly stricter
-            // than an isLevelEnabled check. The HDR blit error-path
-            // log.debugs only fire on caught failures, not on the happy
-            // path. Any new per-frame log site that builds meta should
-            // follow the same `if (log.isLevelEnabled?.("level") ?? true)`
-            // pattern (or stay behind `shouldLog`) so production stays
-            // allocation-free in the hot loop.
-            if (i % 30 === 0 && (log.isLevelEnabled?.("debug") ?? true)) {
-              const hdrEl = stackingInfo.find((e) => e.isHdr);
-              log.debug("[Render] HDR layer composite frame", {
-                frame: i,
-                time: time.toFixed(2),
-                hdrElement: hdrEl
-                  ? { z: hdrEl.zIndex, visible: hdrEl.visible, width: hdrEl.width }
-                  : null,
-                stackingCount: stackingInfo.length,
-                activeTransition: activeTransition?.shader,
+            const shapedWorkers = calculateOptimalWorkers(totalFrames, job.config.workers, {
+              ...cfg,
+              captureCostMultiplier: shapedCost.multiplier,
+            });
+            if (shapedWorkers > layeredWorkerCount) {
+              log.info("[Render] Bumping layered worker count for hybrid SDR path", {
+                from: layeredWorkerCount,
+                to: shapedWorkers,
+                blendedCostMultiplier: shapedCost.multiplier,
+                transitionFrameRatio: ratio,
               });
+              layeredWorkerCount = shapedWorkers;
             }
+          }
 
-            if (activeTransition && transBufferA && transBufferB && transOutput) {
-              if (hdrPerf) hdrPerf.transitionFrames += 1;
-              const transitionTimingStart = Date.now();
-              // ── Transition frame: dual-scene compositing ──────────────────
-              const progress =
-                activeTransition.endFrame === activeTransition.startFrame
-                  ? 1
-                  : (i - activeTransition.startFrame) /
-                    (activeTransition.endFrame - activeTransition.startFrame);
-
-              // Resolve scene element IDs
-              const sceneAIds = new Set(sceneElements[activeTransition.fromScene] ?? []);
-              const sceneBIds = new Set(sceneElements[activeTransition.toScene] ?? []);
-
-              // Zero-fill scene buffers (transition function writes every output pixel)
-              timingStart = Date.now();
-              transBufferA.fill(0);
-              transBufferB.fill(0);
-              addHdrTiming(hdrPerf, "canvasClearMs", timingStart);
-
-              for (const [sceneBuf, sceneIds] of [
-                [transBufferA, sceneAIds],
-                [transBufferB, sceneBIds],
-              ] as const) {
-                // Re-check abort between scene A and scene B. Each scene
-                // capture below performs a DOM seek, optional hook,
-                // per-layer HDR blits, and a full-page screenshot — easily
-                // hundreds of ms. Without this, an abort that arrives
-                // during scene A's capture won't fire until the next outer
-                // frame, after scene B has already been fully composited
-                // and discarded.
-                assertNotAborted();
-                // Fresh state: seek + inject
-                timingStart = Date.now();
-                await domSession.page.evaluate((t: number) => {
-                  if (window.__hf && typeof window.__hf.seek === "function") window.__hf.seek(t);
-                }, time);
-                addHdrTiming(hdrPerf, "domLayerSeekMs", timingStart);
-                if (beforeCaptureHook) {
-                  timingStart = Date.now();
-                  await beforeCaptureHook(domSession.page, time);
-                  addHdrTiming(hdrPerf, "domLayerInjectMs", timingStart);
-                }
-
-                // Blit all HDR videos/images for this scene
-                for (const el of stackingInfo) {
-                  if (!el.isHdr || !sceneIds.has(el.id)) continue;
-                  if (nativeHdrImageIds.has(el.id)) {
-                    blitHdrImageLayer(
-                      sceneBuf as Buffer,
-                      el,
-                      hdrImageBuffers,
-                      hdrImageTransferCache,
-                      width,
-                      height,
-                      log,
-                      imageTransfers.get(el.id),
-                      hdrTargetTransfer,
-                      hdrPerf,
-                    );
-                  } else {
-                    blitHdrVideoLayer(
-                      sceneBuf as Buffer,
-                      el,
-                      time,
-                      fpsToNumber(job.config.fps),
-                      hdrVideoFrameSources,
-                      hdrVideoStartTimes,
-                      width,
-                      height,
-                      log,
-                      videoTransfers.get(el.id),
-                      hdrTargetTransfer,
-                      hdrPerf,
-                    );
-                  }
-                }
-
-                // Single DOM screenshot: mask the page so only this scene's DOM
-                // elements paint. Same masking strategy as the per-layer DOM
-                // branch — see applyDomLayerMask for details. Native HDR videos
-                // and images are always inline-hidden so their fallback poster /
-                // SDR thumbnail doesn't bleed into the DOM overlay (HDR pixels
-                // are blitted separately by blitHdrVideoLayer / blitHdrImageLayer
-                // above).
-                const showIds = Array.from(sceneIds);
-                const hideIds = stackingInfo
-                  .map((e) => e.id)
-                  .filter((id) => !sceneIds.has(id) || nativeHdrIds.has(id));
-                if (hdrPerf) hdrPerf.domLayerCaptures += 1;
-                timingStart = Date.now();
-                await applyDomLayerMask(domSession.page, showIds, hideIds);
-                addHdrTiming(hdrPerf, "domMaskApplyMs", timingStart);
-                timingStart = Date.now();
-                const domPng = await captureAlphaPng(domSession.page, width, height);
-                addHdrTiming(hdrPerf, "domScreenshotMs", timingStart);
-                timingStart = Date.now();
-                await removeDomLayerMask(domSession.page, hideIds);
-                addHdrTiming(hdrPerf, "domMaskRemoveMs", timingStart);
-
-                try {
-                  timingStart = Date.now();
-                  const { data: domRgba } = decodePng(domPng);
-                  addHdrTiming(hdrPerf, "domPngDecodeMs", timingStart);
-                  timingStart = Date.now();
-                  blitRgba8OverRgb48le(
-                    domRgba,
-                    sceneBuf as Buffer,
-                    width,
-                    height,
-                    compositeTransfer,
-                  );
-                  addHdrTiming(hdrPerf, "domBlitMs", timingStart);
-                } catch (err) {
-                  log.warn("DOM layer decode/blit failed; skipping overlay for transition scene", {
-                    frameIndex: i,
-                    sceneIds: Array.from(sceneIds),
-                    error: err instanceof Error ? err.message : String(err),
-                  });
-                }
+          const transitionBuffers: LayeredTransitionBuffers | null = hasTransitions
+            ? {
+                bufferA: transBufferA as Buffer,
+                bufferB: transBufferB as Buffer,
+                output: transOutput as Buffer,
               }
+            : null;
 
-              // Apply shader transition blend directly in the active rgb48le
-              // signal space. Linearizing HDR was attempted but destroys dark
-              // PQ content — values below PQ ~5000 quantize to zero in 16-bit
-              // linear, wiping out the bottom portion of dark video content.
-              // SDR compositions use 16-bit-expanded sRGB, which matches the
-              // shader design space.
-              const transitionFn: TransitionFn = TRANSITIONS[activeTransition.shader] ?? crossfade;
-              transitionFn(transBufferA, transBufferB, transOutput, width, height, progress);
-              addHdrTiming(hdrPerf, "transitionCompositeMs", transitionTimingStart);
+          // Shared by both dispatch paths. `framesWritten` is the encoder
+          // cursor; both transition and normal-frame writers increment it
+          // *only* after `hdrEncoder.writeFrame` succeeds so progress updates
+          // stay tied to actual encoder ingestion.
+          let framesWritten = 0;
+          const reorderBuffer = createFrameReorderBuffer(0, totalFrames);
+          // Snapshot `hdrEncoder` into a non-null local. `hdrEncoder` is the
+          // outer `let` that the finally block uses for defensive close; the
+          // compiler can't narrow it across the writer closure, so capture
+          // the freshly-spawned encoder once at this point. It's a stable
+          // reference for the duration of the writer's lifetime.
+          const encoder = hdrEncoder;
+          if (!encoder) {
+            throw new Error("hdrEncoder is null when starting the layered writer");
+          }
 
-              timingStart = Date.now();
-              hdrEncoder.writeFrame(transOutput);
-              addHdrTiming(hdrPerf, "encoderWriteMs", timingStart);
-            } else {
-              if (hdrPerf) hdrPerf.normalFrames += 1;
-              // ── Normal frame: full layer composite (no transition) ─────────
-              timingStart = Date.now();
-              normalCanvas.fill(0);
-              addHdrTiming(hdrPerf, "canvasClearMs", timingStart);
-              timingStart = Date.now();
-              await compositeHdrFrame(
-                hdrCompositeCtx,
-                normalCanvas,
-                time,
-                stackingInfo,
-                undefined,
-                i,
-              );
-              addHdrTiming(hdrPerf, "normalCompositeMs", timingStart);
-              if (debugDumpEnabled && debugDumpDir && i % 30 === 0) {
-                const previewPath = join(
-                  debugDumpDir,
-                  `frame_${String(i).padStart(4, "0")}_final_rgb48le.bin`,
-                );
-                writeFileSync(previewPath, normalCanvas);
-              }
-              timingStart = Date.now();
-              hdrEncoder.writeFrame(normalCanvas);
-              addHdrTiming(hdrPerf, "encoderWriteMs", timingStart);
-            }
-
-            // Clean up HDR raw frame sources for videos that have ended.
-            // Frees disk space during long renders with many HDR videos.
-            // Skip when KEEP_TEMP=1 so we can inspect intermediate state.
-            if (process.env.KEEP_TEMP !== "1") {
-              for (const [videoId, endTime] of hdrVideoEndTimes) {
-                if (time > endTime && !cleanedUpVideos.has(videoId)) {
-                  // Also check no active transition references this video's scene
-                  const stillNeeded =
-                    activeTransition &&
-                    (sceneElements[activeTransition.fromScene]?.includes(videoId) ||
-                      sceneElements[activeTransition.toScene]?.includes(videoId));
-                  if (!stillNeeded) {
-                    const frameSource = hdrVideoFrameSources.get(videoId);
-                    if (frameSource) {
-                      closeHdrVideoFrameSource(frameSource, log);
-                      try {
-                        rmSync(frameSource.dir, { recursive: true, force: true });
-                      } catch (err) {
-                        log.warn("Failed to clean up HDR raw frame directory", {
-                          videoId,
-                          frameDir: frameSource.dir,
-                          rawPath: frameSource.rawPath,
-                          error: err instanceof Error ? err.message : String(err),
-                        });
-                      }
-                      hdrVideoFrameSources.delete(videoId);
-                    }
-                    cleanedUpVideos.add(videoId);
-                  }
-                }
-              }
-            }
-
-            job.framesRendered = i + 1;
-            if ((i + 1) % 10 === 0 || i + 1 === totalFrames) {
-              const frameProgress = (i + 1) / totalFrames;
+          const writeEncoded = async (frameIdx: number, buf: Buffer): Promise<void> => {
+            await reorderBuffer.waitForFrame(frameIdx);
+            const writeStart = Date.now();
+            encoder.writeFrame(buf);
+            addHdrTiming(hdrPerf, "encoderWriteMs", writeStart);
+            reorderBuffer.advanceTo(frameIdx + 1);
+            framesWritten += 1;
+            job.framesRendered = framesWritten;
+            if (framesWritten % 10 === 0 || framesWritten === totalFrames) {
+              const frameProgress = framesWritten / totalFrames;
               updateJobStatus(
                 job,
                 "rendering",
-                `Layered composite frame ${i + 1}/${job.totalFrames}`,
+                `Layered composite frame ${framesWritten}/${job.totalFrames}`,
                 Math.round(25 + frameProgress * 55),
                 onProgress,
               );
+            }
+            // HDR raw-frame cleanup ran after every frame in the legacy loop.
+            // It's a no-op when `hdrVideoEndTimes` is empty (the SDR hybrid
+            // case), so we keep the same call shape here without forking the
+            // cleanup branch. The `time` is derived back from frameIdx so we
+            // don't have to thread it through the writer plumbing.
+            if (process.env.KEEP_TEMP !== "1" && hdrVideoEndTimes.size > 0) {
+              const frameTime = (frameIdx * job.config.fps.den) / job.config.fps.num;
+              for (const [videoId, endTime] of hdrVideoEndTimes) {
+                if (frameTime > endTime && !cleanedUpVideos.has(videoId)) {
+                  // In the legacy loop this check also gated on whether an
+                  // active transition still referenced the video's scene.
+                  // The hybrid path doesn't know the per-frame
+                  // `activeTransition` at write time, but the SDR hybrid
+                  // case is the only one that exercises this writer in
+                  // parallel and it has no HDR videos, so the simpler
+                  // "after end time" gate is sufficient. The HDR fallback
+                  // path goes through `runSequentialLayered` below and
+                  // does the full check inline.
+                  const frameSource = hdrVideoFrameSources.get(videoId);
+                  if (frameSource) {
+                    closeHdrVideoFrameSource(frameSource, log);
+                    try {
+                      rmSync(frameSource.dir, { recursive: true, force: true });
+                    } catch (err) {
+                      log.warn("Failed to clean up HDR raw frame directory", {
+                        videoId,
+                        frameDir: frameSource.dir,
+                        rawPath: frameSource.rawPath,
+                        error: err instanceof Error ? err.message : String(err),
+                      });
+                    }
+                    hdrVideoFrameSources.delete(videoId);
+                  }
+                  cleanedUpVideos.add(videoId);
+                }
+              }
+            }
+          };
+
+          // ── Hybrid path: parallel pool drains non-transition frames; main
+          // session walks the transition frames sequentially. Both feed into
+          // the same reorder buffer → encoder.
+          if (hybridEligible) {
+            // Build worker partitions: layeredWorkerCount workers split the
+            // contiguous non-transition frame range. Each worker iterates
+            // its slice and skips frames in `transitionFrames`.
+            const workerSessions: CaptureSession[] = [];
+            const workerCanvasesNeeded = Math.max(0, layeredWorkerCount - 1);
+            try {
+              // Worker 0 reuses the main `domSession`; spawn the rest.
+              for (let w = 0; w < workerCanvasesNeeded; w++) {
+                const session = await createCaptureSession(
+                  fileServer.url,
+                  framesDir,
+                  buildCaptureOptions(),
+                  createRenderVideoFrameInjector(),
+                  cfg,
+                );
+                await initializeSession(session);
+                await initTransparentBackground(session.page);
+                workerSessions.push(session);
+              }
+
+              const sessions: CaptureSession[] = [domSession, ...workerSessions];
+              const activeWorkerCount = sessions.length;
+              const totalNonTransitionFrames = totalFrames - transitionFrameCount;
+              const framesPerWorker = Math.max(
+                1,
+                Math.ceil(totalNonTransitionFrames / activeWorkerCount),
+              );
+
+              // Per-worker canvas, allocated once and reused. Worker 0 reuses
+              // `normalCanvas` (already allocated above for the legacy path).
+              const workerCanvases: Buffer[] = [normalCanvas];
+              for (let w = 1; w < activeWorkerCount; w++) {
+                workerCanvases.push(Buffer.alloc(bufSize));
+              }
+
+              // Distribute non-transition frames across workers in a
+              // contiguous, locality-preserving manner. Each worker advances
+              // through its own range and just skips transition frames.
+              const workerRanges: Array<{ start: number; end: number }> = [];
+              let cursor = 0;
+              let assigned = 0;
+              for (let w = 0; w < activeWorkerCount; w++) {
+                const targetForThisWorker = Math.min(
+                  framesPerWorker,
+                  totalNonTransitionFrames - assigned,
+                );
+                const start = cursor;
+                let collected = 0;
+                while (cursor < totalFrames && collected < targetForThisWorker) {
+                  if (!transitionFrames.has(cursor)) collected += 1;
+                  cursor += 1;
+                }
+                workerRanges.push({ start, end: cursor });
+                assigned += collected;
+              }
+
+              const workerTaskOf = async (w: number): Promise<void> => {
+                const session = sessions[w];
+                const canvas = workerCanvases[w];
+                if (!session || !canvas) return;
+                const range = workerRanges[w];
+                if (!range) return;
+                for (let i = range.start; i < range.end; i++) {
+                  if (transitionFrames.has(i)) continue;
+                  assertNotAborted();
+                  const time = (i * job.config.fps.den) / job.config.fps.num;
+                  await processLayeredNormalFrame(
+                    session,
+                    i,
+                    time,
+                    hdrCompositeCtx,
+                    canvas,
+                    nativeHdrIds,
+                  );
+                  if (debugDumpEnabled && debugDumpDir && i % 30 === 0) {
+                    const previewPath = join(
+                      debugDumpDir,
+                      `frame_${String(i).padStart(4, "0")}_final_rgb48le.bin`,
+                    );
+                    writeFileSync(previewPath, canvas);
+                  }
+                  await writeEncoded(i, canvas);
+                }
+              };
+
+              const transitionTaskFn = async (): Promise<void> => {
+                if (!transitionBuffers) return;
+                for (let i = 0; i < totalFrames; i++) {
+                  if (!transitionFrames.has(i)) continue;
+                  assertNotAborted();
+                  const time = (i * job.config.fps.den) / job.config.fps.num;
+                  const activeTransition = transitionRanges.find(
+                    (t) => i >= t.startFrame && i <= t.endFrame,
+                  );
+                  if (!activeTransition) continue;
+                  // Transitions always run on the main session; reserve it
+                  // by waiting until any normal-frame work assigned to
+                  // worker 0 has stepped past `i`. Worker 0's range is the
+                  // first contiguous slice, so once its cursor crosses `i`
+                  // it won't issue another CDP call for the same session at
+                  // overlapping frame indices. We just need a coarse fence:
+                  // wait for the reorder buffer to advance to a point at or
+                  // before `i` (i.e. frame `i` is the next thing the encoder
+                  // expects). This naturally serializes the main session.
+                  await reorderBuffer.waitForFrame(i);
+                  await processLayeredTransitionFrame(
+                    domSession,
+                    i,
+                    time,
+                    activeTransition,
+                    hdrCompositeCtx,
+                    sceneElements,
+                    transitionBuffers,
+                    assertNotAborted,
+                    nativeHdrIds,
+                  );
+                  await writeEncoded(i, transitionBuffers.output);
+                }
+              };
+
+              // Run worker tasks + the transition processor concurrently.
+              // The reorder buffer fences ordering so the encoder never
+              // sees frame N+1 before frame N. Promise.all rethrows the
+              // first rejection, which (combined with `assertNotAborted` in
+              // the per-frame helpers) bubbles cancellation up cleanly.
+              const workerPromises = sessions.map((_, w) => workerTaskOf(w));
+              await Promise.all([transitionTaskFn(), ...workerPromises]);
+              await reorderBuffer.waitForAllDone();
+            } finally {
+              for (const session of workerSessions) {
+                await closeCaptureSession(session).catch((err) => {
+                  log.warn("Hybrid worker session close failed", {
+                    err: err instanceof Error ? err.message : String(err),
+                  });
+                });
+              }
+            }
+          } else {
+            // ── Legacy sequential path ─────────────────────────────────────
+            // Preserves bit-for-bit output for HDR renders, single-worker
+            // renders, and the all-transition edge case (which the hybrid
+            // path early-outs). The helpers `processLayeredNormalFrame` /
+            // `processLayeredTransitionFrame` keep the per-frame work in
+            // sync with the hybrid path so `hdrPerf` rollups are
+            // consistent across both branches.
+            for (let i = 0; i < totalFrames; i++) {
+              assertNotAborted();
+              const time = (i * job.config.fps.den) / job.config.fps.num;
+              const activeTransition = transitionRanges.find(
+                (t) => i >= t.startFrame && i <= t.endFrame,
+              );
+
+              if (i % 30 === 0 && (log.isLevelEnabled?.("debug") ?? true)) {
+                log.debug("[Render] HDR layer composite frame", {
+                  frame: i,
+                  time: time.toFixed(2),
+                  activeTransition: activeTransition?.shader,
+                });
+              }
+
+              if (activeTransition && transitionBuffers) {
+                await processLayeredTransitionFrame(
+                  domSession,
+                  i,
+                  time,
+                  activeTransition,
+                  hdrCompositeCtx,
+                  sceneElements,
+                  transitionBuffers,
+                  assertNotAborted,
+                  nativeHdrIds,
+                );
+                await writeEncoded(i, transitionBuffers.output);
+              } else {
+                await processLayeredNormalFrame(
+                  domSession,
+                  i,
+                  time,
+                  hdrCompositeCtx,
+                  normalCanvas,
+                  nativeHdrIds,
+                );
+                if (debugDumpEnabled && debugDumpDir && i % 30 === 0) {
+                  const previewPath = join(
+                    debugDumpDir,
+                    `frame_${String(i).padStart(4, "0")}_final_rgb48le.bin`,
+                  );
+                  writeFileSync(previewPath, normalCanvas);
+                }
+                await writeEncoded(i, normalCanvas);
+              }
             }
           }
         } finally {
@@ -3619,7 +4074,13 @@ export async function executeRenderJob(
       peakHeapUsedMb: Math.round(peakHeapUsedBytes / (1024 * 1024)),
     };
     job.perfSummary = perfSummary;
-    if (job.config.debug) {
+    // Write `perf-summary.json` whenever the workDir is going to be retained
+    // (debug mode or `KEEP_TEMP=1`). Surfacing the hdrPerf timing rollups
+    // alongside the captured frames was added for issue #677 so future
+    // regressions in the layered shader-transition path are immediately
+    // diagnosable from a single artifact. Production renders (no debug, no
+    // KEEP_TEMP) still skip the write — the workDir is torn down below.
+    if (job.config.debug || process.env.KEEP_TEMP === "1") {
       try {
         writeFileSync(perfOutputPath, JSON.stringify(perfSummary, null, 2), "utf-8");
       } catch (err) {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -102,6 +102,10 @@ import {
   createShaderTransitionWorkerPool,
   type ShaderTransitionWorkerPool,
 } from "./shaderTransitionWorkerPool.js";
+import {
+  createPngDecodeBlitWorkerPool,
+  type PngDecodeBlitWorkerPool,
+} from "./pngDecodeBlitWorkerPool.js";
 import { type CompiledComposition } from "./htmlCompiler.js";
 import { defaultLogger, type ProducerLogger } from "../logger.js";
 import { isPathInside } from "../utils/paths.js";
@@ -1554,6 +1558,17 @@ interface HdrCompositeContext {
   debugDumpEnabled: boolean;
   debugDumpDir: string | null;
   hdrPerf?: HdrPerfCollector;
+  /**
+   * Optional worker-threads pool for off-main-thread PNG decode + rgba8-over-
+   * rgb48le blit. When set, the layered-composite helpers dispatch DOM-layer
+   * decode/blit to the pool instead of running it inline on the calling
+   * thread. This pipelines Chrome's next CDP screenshot against the prior
+   * frame's (or scene's) decode+blit. hf#732 lever-4. Falls back to inline
+   * decode+blit when null/undefined; correctness is byte-equivalent across
+   * paths because the worker calls the same `decodePng` + `blitRgba8OverRgb48le`
+   * the inline path uses.
+   */
+  pngDecodeBlitPool?: PngDecodeBlitWorkerPool | null;
 }
 
 /**
@@ -2040,10 +2055,30 @@ export async function captureTransitionFrame(
   buffers.bufferB.fill(0);
   addHdrTiming(hdrPerf, "canvasClearMs", timingStart);
 
-  for (const [sceneBuf, sceneIds] of [
-    [buffers.bufferA, sceneAIds],
-    [buffers.bufferB, sceneBIds],
-  ] as const) {
+  // hf#732 lever-4: pipeline the two scenes' decode+blit work against each
+  // other (and against the next CDP screenshot). The per-scene loop body
+  // captures its DOM PNG and either dispatches decode+blit to the
+  // `pngDecodeBlitPool` (non-blocking, returns a Promise that re-attaches
+  // the scene buffer) or falls back to inline decode+blit on the calling
+  // thread (legacy path, no pool). Both scenes' promises are awaited at
+  // the end of the function so the captured frame's buffers are guaranteed
+  // ready before the caller dispatches the shader blend.
+  //
+  // The HDR layer blits stay synchronous on the calling thread — they're
+  // already cheap relative to the DOM-screenshot path and they need to
+  // complete before the buffer is transferred into the worker pool (the
+  // pool's blit composites the DOM RGBA over whatever pixels are already
+  // in the rgb48le buffer).
+  const pool = ctx.pngDecodeBlitPool ?? null;
+  type ScenePending = { promise: Promise<Buffer>; sceneIdsList: string[] };
+  const scenePromises: ScenePending[] = [];
+
+  const isSceneA: ReadonlyArray<readonly [Buffer, Set<string>, "A" | "B"]> = [
+    [buffers.bufferA, sceneAIds, "A"],
+    [buffers.bufferB, sceneBIds, "B"],
+  ];
+
+  for (const [sceneBuf, sceneIds, sceneTag] of isSceneA) {
     assertNotAborted();
     timingStart = Date.now();
     await session.page.evaluate((t: number) => {
@@ -2104,21 +2139,85 @@ export async function captureTransitionFrame(
     await removeDomLayerMask(session.page, hideIds);
     addHdrTiming(hdrPerf, "domMaskRemoveMs", timingStart);
 
-    try {
-      timingStart = Date.now();
-      const { data: domRgba } = decodePng(domPng);
-      addHdrTiming(hdrPerf, "domPngDecodeMs", timingStart);
-      timingStart = Date.now();
-      blitRgba8OverRgb48le(domRgba, sceneBuf, width, height, compositeTransfer);
-      addHdrTiming(hdrPerf, "domBlitMs", timingStart);
-    } catch (err) {
-      log.warn("DOM layer decode/blit failed; skipping overlay for transition scene", {
-        frameIndex: frameIdx,
-        sceneIds: Array.from(sceneIds),
-        error: err instanceof Error ? err.message : String(err),
-      });
+    const sceneIdsList = Array.from(sceneIds);
+    if (pool) {
+      // Pool path: kick off decode + blit asynchronously and store the
+      // promise. The ArrayBuffer of `sceneBuf` is detached on dispatch —
+      // we cannot touch it again until the promise resolves. The two
+      // scenes use disjoint buffers (A and B), so dispatching scene A's
+      // decode/blit while moving on to scene B's CDP work is safe.
+      const dispatch: Promise<Buffer> = (async () => {
+        try {
+          const result = await pool.run({
+            png: domPng,
+            dest: sceneBuf,
+            width,
+            height,
+            transfer: compositeTransfer,
+          });
+          if (hdrPerf) {
+            // Per-worker timings reported back from the pool reflect actual
+            // CPU time on the worker thread; rolling them into the same
+            // hdrPerf counters keeps perf-summary.json comparable to the
+            // inline path. The wall-clock cost on the orchestrator thread
+            // is effectively zero (postMessage round-trip).
+            hdrPerf.timings.domPngDecodeMs += result.decodeMs;
+            hdrPerf.timings.domBlitMs += result.blitMs;
+          }
+          return result.dest;
+        } catch (err) {
+          log.warn(
+            "DOM layer decode/blit pool task failed; falling back to inline for transition scene",
+            {
+              frameIndex: frameIdx,
+              scene: sceneTag,
+              sceneIds: sceneIdsList,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+          // Best-effort: if the pool task rejected, the underlying
+          // ArrayBuffer may have been detached on the way out. We can't
+          // safely recover the scene buffer at this point — return a
+          // freshly-allocated zero buffer so the shader blend has
+          // something well-formed to read. The frame may show the wrong
+          // pixels but the render does not abort.
+          return Buffer.alloc(width * height * 6);
+        }
+      })();
+      scenePromises.push({ promise: dispatch, sceneIdsList });
+    } else {
+      // Inline path (no pool): same code shape as the pre-#732-lever-4
+      // implementation. Preserves byte-equivalence and serves as the
+      // fallback when the pool can't be spawned.
+      try {
+        timingStart = Date.now();
+        const { data: domRgba } = decodePng(domPng);
+        addHdrTiming(hdrPerf, "domPngDecodeMs", timingStart);
+        timingStart = Date.now();
+        blitRgba8OverRgb48le(domRgba, sceneBuf, width, height, compositeTransfer);
+        addHdrTiming(hdrPerf, "domBlitMs", timingStart);
+      } catch (err) {
+        log.warn("DOM layer decode/blit failed; skipping overlay for transition scene", {
+          frameIndex: frameIdx,
+          scene: sceneTag,
+          sceneIds: sceneIdsList,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      scenePromises.push({ promise: Promise.resolve(sceneBuf), sceneIdsList });
     }
   }
+
+  // Await both scene decode+blit promises before returning. On the inline
+  // path these are no-ops; on the pool path this is where the second
+  // scene's CDP-overlapped decode/blit drains. Re-assign buffers so the
+  // returned `CapturedTransitionFrame` references the re-attached views.
+  const [bufA, bufB] = await Promise.all([
+    scenePromises[0]?.promise ?? Promise.resolve(buffers.bufferA),
+    scenePromises[1]?.promise ?? Promise.resolve(buffers.bufferB),
+  ]);
+  buffers.bufferA = bufA;
+  buffers.bufferB = bufB;
 
   // `transitionCaptureMs` is the dual-scene capture cost only — the blend is
   // accounted for separately in `transitionShaderBlendMs`. Their sum is no
@@ -3606,6 +3705,7 @@ export async function executeRenderJob(
             // calls; no benefit from oversubscribing. Only allocated when
             // there are actually transition frames to blend.
             let shaderPool: ShaderTransitionWorkerPool | null = null;
+            let pngDecodeBlitPool: PngDecodeBlitWorkerPool | null = null;
             try {
               // Worker 0 reuses the main `domSession`; spawn the rest.
               for (let w = 0; w < workerCanvasesNeeded; w++) {
@@ -3643,12 +3743,47 @@ export async function executeRenderJob(
                 }
               }
 
+              // hf#732 lever-4: spawn the PNG decode + alpha-blit pool. Used by
+              // both `captureTransitionFrame` (per-scene DOM decode+blit, 2× per
+              // transition frame) and `compositeHdrFrame` (per-layer DOM
+              // decode+blit, 3-6× per normal layered frame). Sizing rationale:
+              // every DOM worker hits this pool every frame, so the pool wants
+              // to be at least as wide as the DOM-worker count — but the per-
+              // task work is short (~80ms) so we can amortize across more
+              // concurrent tasks. We size to `2× activeWorkerCount` capped to
+              // cpu count internally; this absorbs the 2× per-frame burst
+              // (transition scenes A+B fire simultaneously) without leaving
+              // workers idle. Skippable when the inline fallback is OK; the
+              // hybrid path always wants it on though so we don't gate by
+              // hasTransitions like the shader pool.
+              try {
+                pngDecodeBlitPool = await createPngDecodeBlitWorkerPool({
+                  size: Math.max(activeWorkerCount, activeWorkerCount * 2),
+                  log,
+                });
+              } catch (err) {
+                log.warn(
+                  "[Render] Failed to spawn PNG decode+blit worker pool; falling back to inline decode/blit",
+                  { error: err instanceof Error ? err.message : String(err) },
+                );
+                pngDecodeBlitPool = null;
+              }
+
               // Per-worker normal-frame canvas, allocated once and reused.
               // Worker 0 reuses `normalCanvas` (already allocated above).
               const workerCanvases: Buffer[] = [normalCanvas];
               for (let w = 1; w < activeWorkerCount; w++) {
                 workerCanvases.push(Buffer.alloc(bufSize));
               }
+
+              // hf#732 lever-4: hand the PNG decode+blit pool to the
+              // composite context. Both the transition path
+              // (`captureTransitionFrame` per-scene) and the normal-layered
+              // path (`compositeHdrFrame` per-layer) read this field; null
+              // means inline-decode-blit fallback. Set here (after the pool
+              // is spawned) rather than at context construction because the
+              // pool lifecycle is tied to the hybrid try/finally.
+              hdrCompositeCtx.pngDecodeBlitPool = pngDecodeBlitPool;
 
               // Per-worker transition scratch buffer RING. Each entry is a
               // triple (bufferA + bufferB + output); the DOM worker
@@ -3898,6 +4033,16 @@ export async function executeRenderJob(
                     err: err instanceof Error ? err.message : String(err),
                   });
                 });
+              }
+              if (pngDecodeBlitPool) {
+                await pngDecodeBlitPool.terminate().catch((err) => {
+                  log.warn("PNG decode+blit worker pool terminate failed", {
+                    err: err instanceof Error ? err.message : String(err),
+                  });
+                });
+                // Clear the context reference so downstream callers can't
+                // accidentally hit a terminated pool after teardown.
+                hdrCompositeCtx.pngDecodeBlitPool = null;
               }
             }
           } else {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -98,6 +98,10 @@ import { randomUUID } from "crypto";
 import { freemem } from "os";
 import { fileURLToPath } from "url";
 import { createFileServer, type FileServerHandle, VIRTUAL_TIME_SHIM } from "./fileServer.js";
+import {
+  createShaderTransitionWorkerPool,
+  type ShaderTransitionWorkerPool,
+} from "./shaderTransitionWorkerPool.js";
 import { type CompiledComposition } from "./htmlCompiler.js";
 import { defaultLogger, type ProducerLogger } from "../logger.js";
 import { isPathInside } from "../utils/paths.js";
@@ -401,6 +405,7 @@ type HdrPerfTimingKey =
   | "canvasClearMs"
   | "normalCompositeMs"
   | "transitionCompositeMs"
+  | "transitionShaderBlendMs"
   | "encoderWriteMs"
   | "hdrVideoReadDecodeMs"
   | "hdrVideoTransferMs"
@@ -440,6 +445,7 @@ function createHdrPerfCollector(): HdrPerfCollector {
       canvasClearMs: 0,
       normalCompositeMs: 0,
       transitionCompositeMs: 0,
+      transitionShaderBlendMs: 0,
       encoderWriteMs: 0,
       hdrVideoReadDecodeMs: 0,
       hdrVideoTransferMs: 0,
@@ -479,6 +485,10 @@ function finalizeHdrPerf(perf: HdrPerfCollector): HdrPerfSummary {
   avgMs.normalCompositeMs = averageTiming(perf.timings.normalCompositeMs, perf.normalFrames);
   avgMs.transitionCompositeMs = averageTiming(
     perf.timings.transitionCompositeMs,
+    perf.transitionFrames,
+  );
+  avgMs.transitionShaderBlendMs = averageTiming(
+    perf.timings.transitionShaderBlendMs,
     perf.transitionFrames,
   );
 
@@ -1835,6 +1845,11 @@ async function compositeHdrFrame(
 // against their own browser concurrently.
 
 interface LayeredTransitionBuffers {
+  // Mutable fields: the hf#677 shader-pool path swaps these references
+  // after each transferList round-trip with the worker thread. The
+  // underlying memory is the same; the Buffer headers are fresh views
+  // over the re-attached ArrayBuffers. The legacy synchronous path
+  // never reassigns these.
   bufferA: Buffer;
   bufferB: Buffer;
   output: Buffer;
@@ -1934,6 +1949,16 @@ export async function processLayeredNormalFrame(
  * @param nativeHdrIds - Set of HDR element ids; passed to mask helpers so HDR
  *                       elements stay inline-hidden behind the screenshot
  *                       (their pixels arrive via `blitHdrVideoLayer` etc.).
+ * @param shaderPool - Optional Node `worker_threads` pool to which the
+ *                     per-pixel shader-blend is dispatched (hf#677 follow-up
+ *                     to close the JS event-loop ceiling). When provided,
+ *                     bufferA/bufferB/output ArrayBuffers are detached via
+ *                     `transferList`, blended on a Worker, and transferred
+ *                     back; the function reassigns the fields on `buffers`
+ *                     to the returned Buffer views before returning. When
+ *                     omitted (e.g. legacy sequential path / single-worker
+ *                     SDR / HDR fallback), the blend runs synchronously on
+ *                     the calling thread — bit-for-bit identical output.
  */
 export async function processLayeredTransitionFrame(
   session: CaptureSession,
@@ -1945,6 +1970,7 @@ export async function processLayeredTransitionFrame(
   buffers: LayeredTransitionBuffers,
   assertNotAborted: () => void,
   nativeHdrIds: Set<string>,
+  shaderPool?: ShaderTransitionWorkerPool | null,
 ): Promise<void> {
   const {
     log,
@@ -2077,8 +2103,41 @@ export async function processLayeredTransitionFrame(
     }
   }
 
-  const transitionFn: TransitionFn = TRANSITIONS[transition.shader] ?? crossfade;
-  transitionFn(buffers.bufferA, buffers.bufferB, buffers.output, width, height, progress);
+  // Shader-blend dispatch. When a `shaderPool` is provided (hf#677 follow-up
+  // for the JS event-loop ceiling), the per-pixel blend runs on a Node
+  // `worker_threads` Worker via zero-copy `transferList`. The pool
+  // detaches the bufferA/B/output ArrayBuffers, runs the blend, and
+  // transfers them back; we reattach the returned Buffers onto the
+  // caller's `buffers` slot so the next iteration of the worker's frame
+  // loop sees the same shape.
+  //
+  // Without a pool, the blend runs synchronously on the main thread — the
+  // legacy path. Both branches produce byte-identical output because the
+  // worker imports the same `TRANSITIONS` table from `@hyperframes/engine`.
+  if (shaderPool) {
+    const blendStart = Date.now();
+    const result = await shaderPool.run({
+      shader: transition.shader,
+      bufferA: buffers.bufferA,
+      bufferB: buffers.bufferB,
+      output: buffers.output,
+      width,
+      height,
+      progress,
+    });
+    // The originals are detached; swap in the transferred-back views so
+    // the caller's `LayeredTransitionBuffers` stay valid for the next
+    // frame. Same underlying memory, fresh Buffer headers.
+    buffers.bufferA = result.bufferA;
+    buffers.bufferB = result.bufferB;
+    buffers.output = result.output;
+    addHdrTiming(hdrPerf, "transitionShaderBlendMs", blendStart);
+  } else {
+    const blendStart = Date.now();
+    const transitionFn: TransitionFn = TRANSITIONS[transition.shader] ?? crossfade;
+    transitionFn(buffers.bufferA, buffers.bufferB, buffers.output, width, height, progress);
+    addHdrTiming(hdrPerf, "transitionShaderBlendMs", blendStart);
+  }
   addHdrTiming(hdrPerf, "transitionCompositeMs", transitionTimingStart);
 }
 
@@ -3464,6 +3523,20 @@ export async function executeRenderJob(
           if (hybridEligible) {
             const workerSessions: CaptureSession[] = [];
             const workerCanvasesNeeded = Math.max(0, layeredWorkerCount - 1);
+
+            // hf#677 follow-up: spawn a worker_threads pool for the per-pixel
+            // shader-blend. The prior hf#732 commit parallelized DOM-session
+            // work across `layeredWorkerCount` browsers, but the JS shader
+            // call at the tail of `processLayeredTransitionFrame` still
+            // executed on the Node main event loop — six DOM workers all
+            // firing `TRANSITIONS[shader](...)` saturated the single thread
+            // and the worker-count sweep flattened after w=2. Moving the
+            // blend onto `worker_threads` removes that ceiling. Pool size
+            // matches `layeredWorkerCount` (clamped to CPU count inside
+            // the pool) so each DOM worker has a CPU peer for its blend
+            // calls; no benefit from oversubscribing. Only allocated when
+            // there are actually transition frames to blend.
+            let shaderPool: ShaderTransitionWorkerPool | null = null;
             try {
               // Worker 0 reuses the main `domSession`; spawn the rest.
               for (let w = 0; w < workerCanvasesNeeded; w++) {
@@ -3481,6 +3554,25 @@ export async function executeRenderJob(
 
               const sessions: CaptureSession[] = [domSession, ...workerSessions];
               const activeWorkerCount = sessions.length;
+
+              // Spawn the shader-blend pool now that we know the actual
+              // DOM-worker count. Skipping when there are no transitions
+              // avoids ~10–50ms × N worker spawn cost on the SDR
+              // non-transition fast path.
+              if (hasTransitions) {
+                try {
+                  shaderPool = await createShaderTransitionWorkerPool({
+                    size: activeWorkerCount,
+                    log,
+                  });
+                } catch (err) {
+                  log.warn(
+                    "[Render] Failed to spawn shader-blend worker pool; falling back to inline shader blend",
+                    { error: err instanceof Error ? err.message : String(err) },
+                  );
+                  shaderPool = null;
+                }
+              }
 
               // Per-worker normal-frame canvas, allocated once and reused.
               // Worker 0 reuses `normalCanvas` (already allocated above).
@@ -3546,6 +3638,7 @@ export async function executeRenderJob(
                       myTransitionBuffers,
                       assertNotAborted,
                       nativeHdrIds,
+                      shaderPool,
                     );
                     await writeEncoded(i, myTransitionBuffers.output);
                   } else {
@@ -3581,6 +3674,13 @@ export async function executeRenderJob(
               for (const session of workerSessions) {
                 await closeCaptureSession(session).catch((err) => {
                   log.warn("Hybrid worker session close failed", {
+                    err: err instanceof Error ? err.message : String(err),
+                  });
+                });
+              }
+              if (shaderPool) {
+                await shaderPool.terminate().catch((err) => {
+                  log.warn("Shader-blend worker pool terminate failed", {
                     err: err instanceof Error ? err.message : String(err),
                   });
                 });

--- a/packages/producer/src/services/shaderTransitionWorker.ts
+++ b/packages/producer/src/services/shaderTransitionWorker.ts
@@ -1,0 +1,127 @@
+/**
+ * Worker entry point for off-main-thread shader-blend execution.
+ *
+ * The hf#677 follow-up moved the layered transition pipeline (dual-scene
+ * seek/mask/screenshot) onto per-worker DOM sessions, but the per-pixel JS
+ * shader-blend at the tail of `processLayeredTransitionFrame` still ran on
+ * the orchestrator's main event loop. Complex shaders (`domain-warp`,
+ * `swirl-vortex`, `glitch`) iterate every pixel of the rgb48le buffer with
+ * multiple noise/sample calls per pixel — hundreds of milliseconds per call
+ * — so N concurrent DOM workers all firing shader-blends saturated the
+ * single Node thread. The empirical worker-count sweep on the #677 fixture
+ * (w=1=218s, w=2=183s, w=6=184s, w=12=188s) flattens after w=2, which is the
+ * single-threaded-downstream signature.
+ *
+ * This worker runs `TRANSITIONS[shader](from, to, output, w, h, p)` on a
+ * dedicated Node `worker_threads` Worker. The pool dispatches one frame at
+ * a time per worker. The rgb48le scratch Buffers are moved in and out via
+ * `transferList` — zero-copy at the ArrayBuffer level — so the only
+ * per-frame cost is the postMessage round-trip (~sub-millisecond on the
+ * 2.4 MB 854×480 buffers) plus the shader-blend itself.
+ *
+ * Lifecycle:
+ *
+ * 1. Pool constructor spawns N of these workers up front.
+ * 2. Main thread posts `{ shader, bufferA, bufferB, output, width, height,
+ *    progress }` with `transferList: [bufferA, bufferB, output]`. The three
+ *    ArrayBuffers are detached on the sender; the caller must NOT touch
+ *    them until the worker replies.
+ * 3. Worker wraps each ArrayBuffer as a Node Buffer view (zero-copy),
+ *    invokes `TRANSITIONS[shader] ?? crossfade`, and posts `{ ok: true,
+ *    output }` back with `transferList: [output]`. (The two input ArrayBuffers
+ *    are also returned so the main thread can re-attach them to the worker's
+ *    `LayeredTransitionBuffers` slot for reuse on the next frame.)
+ * 4. On unknown shader / runtime exception, worker posts `{ ok: false, error,
+ *    bufferA, bufferB, output }` — all three are still transferred back so
+ *    the caller can release them.
+ *
+ * The worker holds no per-frame state. It is shared across DOM-session
+ * workers and across the entire render — only spawned once at render start
+ * and terminated at render end.
+ */
+
+import { parentPort } from "node:worker_threads";
+// Import the shader-blend table from a dedicated `./shader-transitions`
+// subpath export of `@hyperframes/engine` rather than the package root.
+// Rationale:
+//
+// 1. `shaderTransitions.ts` is fully self-contained (no internal imports).
+//    Going through engine's root index pulls in the rest of the engine
+//    graph, which fails under `worker_threads` + tsx in dev/test: the
+//    tsx loader's `.js → .ts` rewrite does NOT survive the Worker
+//    boundary, so internal specifiers like `./config.js` from `index.ts`
+//    fail to resolve. The subpath sidesteps that by pointing the
+//    resolver straight at the import-free file.
+//
+// 2. In the production esbuild bundle (build.mjs entry
+//    `src/services/shaderTransitionWorker.ts`) the workspace alias plugin
+//    redirects `@hyperframes/engine/shader-transitions` to the same TS
+//    source and bundles it inline, so behavior is identical.
+import { TRANSITIONS, crossfade } from "@hyperframes/engine/shader-transitions";
+
+interface ShaderJobRequest {
+  shader: string;
+  bufferA: ArrayBuffer;
+  bufferB: ArrayBuffer;
+  output: ArrayBuffer;
+  width: number;
+  height: number;
+  progress: number;
+}
+
+interface ShaderJobOk {
+  ok: true;
+  bufferA: ArrayBuffer;
+  bufferB: ArrayBuffer;
+  output: ArrayBuffer;
+}
+
+interface ShaderJobErr {
+  ok: false;
+  error: string;
+  bufferA: ArrayBuffer;
+  bufferB: ArrayBuffer;
+  output: ArrayBuffer;
+}
+
+export type ShaderJobResult = ShaderJobOk | ShaderJobErr;
+
+if (!parentPort) {
+  // Defensive — this module is only meaningful inside a worker_thread.
+  // If imported on the main thread (e.g. by an accidental top-level test),
+  // do nothing rather than throwing, so static analysis stays clean.
+  // eslint-disable-next-line no-console
+  console.warn("[shaderTransitionWorker] no parentPort; module loaded on main thread");
+} else {
+  parentPort.on("message", (msg: ShaderJobRequest) => {
+    const { shader, bufferA, bufferB, output, width, height, progress } = msg;
+    // Re-wrap the transferred ArrayBuffers as Node Buffers. Buffer.from(ab)
+    // is a zero-copy view over the same underlying memory — no allocation,
+    // no data copy. The shader functions are typed to take Buffer and use
+    // its readUInt16LE/writeUInt16LE API.
+    const bufA = Buffer.from(bufferA);
+    const bufB = Buffer.from(bufferB);
+    const out = Buffer.from(output);
+
+    try {
+      const fn = TRANSITIONS[shader] ?? crossfade;
+      fn(bufA, bufB, out, width, height, progress);
+      const reply: ShaderJobOk = {
+        ok: true,
+        bufferA,
+        bufferB,
+        output,
+      };
+      parentPort!.postMessage(reply, [bufferA, bufferB, output]);
+    } catch (err) {
+      const reply: ShaderJobErr = {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        bufferA,
+        bufferB,
+        output,
+      };
+      parentPort!.postMessage(reply, [bufferA, bufferB, output]);
+    }
+  });
+}

--- a/packages/producer/src/services/shaderTransitionWorkerPool.test.ts
+++ b/packages/producer/src/services/shaderTransitionWorkerPool.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for the hf#677 follow-up worker_threads shader-blend pool. The pool
+ * is correctness-critical: a regression here either corrupts transition
+ * output or leaks Worker handles. Tests pin three properties:
+ *
+ *   1. Byte-equivalence with the inline path. The shader code in the
+ *      worker is the exact same `TRANSITIONS` table from `@hyperframes/engine`
+ *      that the legacy path uses on the main thread; the pool round-trip
+ *      must not perturb the result.
+ *   2. Buffer transfer semantics. After `run` resolves, the original input
+ *      Buffer's `.length` must be 0 (ArrayBuffer detached), and the returned
+ *      Buffer must hold the shader output over the same underlying memory.
+ *   3. Concurrent dispatch. N concurrent `run` calls against a pool sized
+ *      to N all complete with correct output — no slot leakage, no result
+ *      misrouting.
+ *
+ * The pool's clean-shutdown path is also exercised so a test failure here
+ * doesn't leak worker_threads handles into other tests in the same vitest
+ * run.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { TRANSITIONS, crossfade } from "@hyperframes/engine";
+import {
+  createShaderTransitionWorkerPool,
+  type ShaderTransitionWorkerPool,
+} from "./shaderTransitionWorkerPool.js";
+
+const WIDTH = 16;
+const HEIGHT = 8;
+const BUF_SIZE = WIDTH * HEIGHT * 6;
+
+function fillSolid(width: number, height: number, r: number, g: number, b: number): Buffer {
+  const buf = Buffer.alloc(width * height * 6);
+  for (let i = 0; i < width * height; i++) {
+    const off = i * 6;
+    buf.writeUInt16LE(r, off);
+    buf.writeUInt16LE(g, off + 2);
+    buf.writeUInt16LE(b, off + 4);
+  }
+  return buf;
+}
+
+describe("ShaderTransitionWorkerPool", () => {
+  const pools: ShaderTransitionWorkerPool[] = [];
+
+  afterEach(async () => {
+    while (pools.length > 0) {
+      const p = pools.pop();
+      if (p) await p.terminate();
+    }
+  });
+
+  async function makePool(size: number): Promise<ShaderTransitionWorkerPool> {
+    const p = await createShaderTransitionWorkerPool({ size });
+    pools.push(p);
+    return p;
+  }
+
+  it("runs crossfade to byte-equivalence with the inline implementation", async () => {
+    const pool = await makePool(1);
+    const from = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+    const to = fillSolid(WIDTH, HEIGHT, 60000, 60000, 60000);
+    const output = Buffer.alloc(BUF_SIZE);
+
+    const result = await pool.run({
+      shader: "crossfade",
+      bufferA: from,
+      bufferB: to,
+      output,
+      width: WIDTH,
+      height: HEIGHT,
+      progress: 0.5,
+    });
+
+    // Reference: run the same crossfade inline on independent buffers.
+    const refFrom = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+    const refTo = fillSolid(WIDTH, HEIGHT, 60000, 60000, 60000);
+    const refOut = Buffer.alloc(BUF_SIZE);
+    crossfade(refFrom, refTo, refOut, WIDTH, HEIGHT, 0.5);
+
+    expect(result.output.length).toBe(BUF_SIZE);
+    expect(Buffer.compare(result.output, refOut)).toBe(0);
+  });
+
+  it("produces byte-identical output for every shader in TRANSITIONS at progress=0.37", async () => {
+    const pool = await makePool(2);
+    // Use a couple of non-uniform input frames so shaders that sample
+    // texture content (warp, glitch, swirl) actually differ from the
+    // trivial crossfade result.
+    const buildGradient = (rOff: number, gOff: number, bOff: number): Buffer => {
+      const buf = Buffer.alloc(BUF_SIZE);
+      for (let y = 0; y < HEIGHT; y++) {
+        for (let x = 0; x < WIDTH; x++) {
+          const i = (y * WIDTH + x) * 6;
+          buf.writeUInt16LE(Math.min(65535, rOff + x * 1000), i);
+          buf.writeUInt16LE(Math.min(65535, gOff + y * 1000), i + 2);
+          buf.writeUInt16LE(Math.min(65535, bOff + (x + y) * 500), i + 4);
+        }
+      }
+      return buf;
+    };
+
+    for (const shaderName of Object.keys(TRANSITIONS)) {
+      const from = buildGradient(1000, 2000, 3000);
+      const to = buildGradient(40000, 35000, 30000);
+      const out = Buffer.alloc(BUF_SIZE);
+
+      const result = await pool.run({
+        shader: shaderName,
+        bufferA: from,
+        bufferB: to,
+        output: out,
+        width: WIDTH,
+        height: HEIGHT,
+        progress: 0.37,
+      });
+
+      const refFrom = buildGradient(1000, 2000, 3000);
+      const refTo = buildGradient(40000, 35000, 30000);
+      const refOut = Buffer.alloc(BUF_SIZE);
+      const fn = TRANSITIONS[shaderName] ?? crossfade;
+      fn(refFrom, refTo, refOut, WIDTH, HEIGHT, 0.37);
+
+      expect(
+        Buffer.compare(result.output, refOut),
+        `shader ${shaderName} diverged from inline output`,
+      ).toBe(0);
+    }
+  });
+
+  it("detaches the caller's input Buffers after transferList", async () => {
+    const pool = await makePool(1);
+    const from = fillSolid(WIDTH, HEIGHT, 1234, 5678, 9012);
+    const to = fillSolid(WIDTH, HEIGHT, 30000, 31000, 32000);
+    const output = Buffer.alloc(BUF_SIZE);
+
+    // Capture identity before the call. After transfer, the underlying
+    // ArrayBuffer is detached on the sender side; the Buffer's `.length`
+    // collapses to 0 (Node behavior on a detached ArrayBuffer).
+    expect(from.length).toBe(BUF_SIZE);
+    expect(to.length).toBe(BUF_SIZE);
+    expect(output.length).toBe(BUF_SIZE);
+
+    const result = await pool.run({
+      shader: "crossfade",
+      bufferA: from,
+      bufferB: to,
+      output,
+      width: WIDTH,
+      height: HEIGHT,
+      progress: 0.5,
+    });
+
+    // Originals are detached.
+    expect(from.length).toBe(0);
+    expect(to.length).toBe(0);
+    expect(output.length).toBe(0);
+    // Returned views are fresh and full-sized.
+    expect(result.bufferA.length).toBe(BUF_SIZE);
+    expect(result.bufferB.length).toBe(BUF_SIZE);
+    expect(result.output.length).toBe(BUF_SIZE);
+  });
+
+  it("falls back to crossfade for an unknown shader name (matches inline behavior)", async () => {
+    const pool = await makePool(1);
+    const from = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+    const to = fillSolid(WIDTH, HEIGHT, 65000, 65000, 65000);
+    const output = Buffer.alloc(BUF_SIZE);
+
+    const result = await pool.run({
+      shader: "this-shader-does-not-exist",
+      bufferA: from,
+      bufferB: to,
+      output,
+      width: WIDTH,
+      height: HEIGHT,
+      progress: 0.5,
+    });
+
+    const refFrom = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+    const refTo = fillSolid(WIDTH, HEIGHT, 65000, 65000, 65000);
+    const refOut = Buffer.alloc(BUF_SIZE);
+    crossfade(refFrom, refTo, refOut, WIDTH, HEIGHT, 0.5);
+
+    expect(Buffer.compare(result.output, refOut)).toBe(0);
+  });
+
+  it("dispatches concurrent tasks across the pool and returns correct output for each", async () => {
+    const pool = await makePool(4);
+    const progresses = [0.1, 0.25, 0.5, 0.75, 0.9, 0.33, 0.66, 0.0];
+    // Each task uses its own buffer triple so they can run truly concurrently
+    // without transfer aliasing.
+    const tasks = progresses.map((p) => {
+      const from = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+      const to = fillSolid(WIDTH, HEIGHT, 50000, 50000, 50000);
+      const out = Buffer.alloc(BUF_SIZE);
+      return pool.run({
+        shader: "crossfade",
+        bufferA: from,
+        bufferB: to,
+        output: out,
+        width: WIDTH,
+        height: HEIGHT,
+        progress: p,
+      });
+    });
+
+    const results = await Promise.all(tasks);
+    for (let i = 0; i < progresses.length; i++) {
+      const refFrom = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+      const refTo = fillSolid(WIDTH, HEIGHT, 50000, 50000, 50000);
+      const refOut = Buffer.alloc(BUF_SIZE);
+      const progress = progresses[i];
+      const result = results[i];
+      if (progress === undefined || !result) throw new Error("missing test data");
+      crossfade(refFrom, refTo, refOut, WIDTH, HEIGHT, progress);
+      expect(
+        Buffer.compare(result.output, refOut),
+        `concurrent task ${i} (progress=${progress}) diverged`,
+      ).toBe(0);
+    }
+  });
+
+  it("rejects queued tasks on terminate without leaking workers", async () => {
+    // Pool of 1 forces a queue. Spawn one task to occupy the worker, then
+    // immediately terminate before any further dispatch.
+    const pool = await makePool(1);
+    const from = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+    const to = fillSolid(WIDTH, HEIGHT, 60000, 60000, 60000);
+    const output = Buffer.alloc(BUF_SIZE);
+
+    const first = pool.run({
+      shader: "crossfade",
+      bufferA: from,
+      bufferB: to,
+      output,
+      width: WIDTH,
+      height: HEIGHT,
+      progress: 0.5,
+    });
+    // Queue a second task using its own buffers so this one will sit in
+    // the queue until the first completes.
+    const queuedFrom = fillSolid(WIDTH, HEIGHT, 0, 0, 0);
+    const queuedTo = fillSolid(WIDTH, HEIGHT, 60000, 60000, 60000);
+    const queuedOut = Buffer.alloc(BUF_SIZE);
+    const second = pool.run({
+      shader: "crossfade",
+      bufferA: queuedFrom,
+      bufferB: queuedTo,
+      output: queuedOut,
+      width: WIDTH,
+      height: HEIGHT,
+      progress: 0.5,
+    });
+    // Attach a catch handler immediately so that whichever outcome
+    // (resolve / reject after terminate) doesn't surface as an
+    // unhandled rejection.
+    const secondSettled = second.then(
+      () => "resolved" as const,
+      () => "rejected" as const,
+    );
+
+    // First will resolve normally. Force a terminate while second may
+    // still be queued OR mid-dispatch. Whatever its state, the pool
+    // teardown must not hang.
+    await first;
+    await pool.terminate();
+    // Either second resolved before terminate kicked in (race-tolerant)
+    // or it rejected. Both are acceptable; the only failure mode we're
+    // ruling out is hanging.
+    const result = await Promise.race([
+      secondSettled,
+      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 2000)),
+    ]);
+    expect(result).not.toBe("hung");
+    // Remove from `pools` so afterEach doesn't double-terminate.
+    pools.pop();
+  });
+});

--- a/packages/producer/src/services/shaderTransitionWorkerPool.ts
+++ b/packages/producer/src/services/shaderTransitionWorkerPool.ts
@@ -78,6 +78,10 @@ interface PendingTask {
   req: ShaderBlendRequest;
   resolve: (r: ShaderBlendResult) => void;
   reject: (err: Error) => void;
+  /** Set when `HF_SHADER_POOL_TRACE=1`; used to log dispatch latency. */
+  enqueuedAtMs?: number;
+  /** Set when `HF_SHADER_POOL_TRACE=1`; assigned at dispatch. */
+  traceId?: number;
 }
 
 interface WorkerSlot {
@@ -171,6 +175,14 @@ export async function createShaderTransitionWorkerPool(
   const queue: PendingTask[] = [];
   let terminated = false;
 
+  // hf#732 follow-up: instrumentation flag to log per-task dispatch /
+  // completion timestamps so we can confirm the pool actually runs blends
+  // concurrently when N DOM workers each dispatch K tasks. Enabled by
+  // setting `HF_SHADER_POOL_TRACE=1`. Off by default — the per-task log
+  // line is high-volume on long shader-transition renders.
+  const traceEnabled = process.env.HF_SHADER_POOL_TRACE === "1";
+  let nextTaskId = 0;
+
   // Bind the parent's execArgv (e.g. tsx's `--import tsx/esm` loader) into
   // every Worker so a `.ts` entry point loads under tsx in dev without a
   // separate loader registration step. In the bundled prod build the
@@ -185,6 +197,19 @@ export async function createShaderTransitionWorkerPool(
     if (!task) return;
     slot.busy = true;
     slot.current = task;
+    if (traceEnabled) {
+      const slotIdx = slots.indexOf(slot);
+      const waitMs = task.enqueuedAtMs ? Date.now() - task.enqueuedAtMs : 0;
+      const busyCount = slots.filter((s) => s.busy).length;
+      log.info?.("[shaderPool] dispatch", {
+        task: task.traceId,
+        slot: slotIdx,
+        shader: task.req.shader,
+        waitMs,
+        busyCount,
+        queueDepth: queue.length,
+      });
+    }
     const { bufferA, bufferB, output, shader, width, height, progress } = task.req;
     // `Buffer.alloc` always returns a Buffer over a plain ArrayBuffer (not
     // SharedArrayBuffer) at runtime — TS narrows `.buffer` to the union
@@ -291,7 +316,9 @@ export async function createShaderTransitionWorkerPool(
         throw new Error("shader-blend pool already terminated");
       }
       return new Promise<ShaderBlendResult>((resolve, reject) => {
-        const task: PendingTask = { req, resolve, reject };
+        const task: PendingTask = traceEnabled
+          ? { req, resolve, reject, enqueuedAtMs: Date.now(), traceId: ++nextTaskId }
+          : { req, resolve, reject };
         // Find an idle slot; otherwise queue.
         const idle = slots.find((s) => !s.busy);
         if (idle) {

--- a/packages/producer/src/services/shaderTransitionWorkerPool.ts
+++ b/packages/producer/src/services/shaderTransitionWorkerPool.ts
@@ -1,0 +1,330 @@
+/**
+ * Pool of Node `worker_threads` Workers for off-main-thread shader-blend
+ * execution. See `shaderTransitionWorker.ts` for the per-worker contract and
+ * the hf#677 follow-up rationale (closing the JS event-loop ceiling on the
+ * layered transition path).
+ *
+ * Pool shape:
+ *
+ * - Spawned once at the start of a layered render and terminated in the
+ *   `finally`. Worker spawn cost is ~10–50 ms each; amortized over the
+ *   full transition phase (typically 100+ frames) it's negligible.
+ * - Pool size is sized to `min(layeredWorkerCount, cpuCount)`. We don't
+ *   spawn more workers than DOM sessions (no benefit — at most N DOM
+ *   sessions can be dispatching to us at any moment) and we don't oversubscribe
+ *   beyond physical cores.
+ * - Each Worker holds zero per-frame state. Pool simply dispatches one
+ *   shader-blend per Worker at a time; ordering within the pool doesn't
+ *   matter because each frame's output is gated by the encoder's
+ *   `FrameReorderBuffer` upstream.
+ *
+ * API:
+ *
+ *   const pool = await createShaderTransitionWorkerPool({ size, log });
+ *   const result = await pool.run({
+ *     shader, bufferA, bufferB, output, width, height, progress,
+ *   });
+ *   // result.bufferA / result.bufferB / result.output are the same memory,
+ *   // now re-attached to the main thread.
+ *   await pool.terminate();
+ *
+ * Buffer transfer contract: `run` takes Node Buffers, transfers their
+ * underlying ArrayBuffers to the worker, and returns NEW Buffer views over
+ * the transferred-back ArrayBuffers. The caller is responsible for
+ * swapping its Buffer references — the *original* Buffers passed in are
+ * detached (their `.length` becomes 0 / accessing throws) after `run` resolves.
+ */
+
+import { Worker } from "node:worker_threads";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { cpus } from "node:os";
+
+interface PoolLogger {
+  info?: (msg: string, meta?: Record<string, unknown>) => void;
+  warn?: (msg: string, meta?: Record<string, unknown>) => void;
+  error?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface ShaderTransitionPoolOptions {
+  /** Number of worker threads. Clamped to [1, cpus().length]. */
+  size: number;
+  /** Optional logger; falls back to no-op. */
+  log?: PoolLogger;
+}
+
+export interface ShaderBlendRequest {
+  shader: string;
+  bufferA: Buffer;
+  bufferB: Buffer;
+  output: Buffer;
+  width: number;
+  height: number;
+  progress: number;
+}
+
+export interface ShaderBlendResult {
+  /** Re-attached buffer A (zero-copy view over the transferred-back ArrayBuffer). */
+  bufferA: Buffer;
+  /** Re-attached buffer B. */
+  bufferB: Buffer;
+  /** Re-attached output buffer holding the shader-blended frame. */
+  output: Buffer;
+}
+
+interface PendingTask {
+  req: ShaderBlendRequest;
+  resolve: (r: ShaderBlendResult) => void;
+  reject: (err: Error) => void;
+}
+
+interface WorkerSlot {
+  worker: Worker;
+  busy: boolean;
+  current: PendingTask | null;
+}
+
+interface WorkerReply {
+  ok: boolean;
+  error?: string;
+  bufferA: ArrayBuffer;
+  bufferB: ArrayBuffer;
+  output: ArrayBuffer;
+}
+
+export interface ShaderTransitionWorkerPool {
+  readonly size: number;
+  run(req: ShaderBlendRequest): Promise<ShaderBlendResult>;
+  terminate(): Promise<void>;
+}
+
+/**
+ * Resolve the path to the compiled worker module. In dev (tsx), this module
+ * lives at `src/services/shaderTransitionWorkerPool.ts` and the worker is
+ * its sibling `.ts` file. In the prod build (esbuild → `dist/`), both modules
+ * live at `dist/services/*.js`. We probe for the prod `.js` first, then fall
+ * back to `.ts` for dev. The override env var
+ * `HF_SHADER_WORKER_ENTRY` (file path or `file://` URL) lets test infra
+ * point at a custom worker stub if needed.
+ */
+function resolveWorkerEntry(): { path: string; isTs: boolean } {
+  const override = process.env.HF_SHADER_WORKER_ENTRY;
+  if (override && override.length > 0) {
+    const isTs = override.endsWith(".ts");
+    return { path: override, isTs };
+  }
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const jsPath = join(moduleDir, "shaderTransitionWorker.js");
+  if (existsSync(jsPath)) return { path: jsPath, isTs: false };
+  const tsPath = join(moduleDir, "shaderTransitionWorker.ts");
+  return { path: tsPath, isTs: true };
+}
+
+/**
+ * Probe whether the parent process already has a TS loader registered
+ * (tsx, ts-node, esm-loader). Worker threads inherit the parent's loader
+ * only if we copy `process.execArgv` AND the relevant flag is present.
+ * Vitest runs its own transformer and does NOT register a loader on
+ * `process.execArgv`, so when the resolved entry is `.ts` and no loader
+ * is detected we try to inject `tsx/esm` so `new Worker(<.ts file>)`
+ * loads correctly.
+ *
+ * This is best-effort: if `tsx/esm` can't be resolved (e.g. minimal prod
+ * install), we fall back to plain `process.execArgv` and the Worker will
+ * surface a clear "cannot find module" error rather than silently
+ * misbehaving.
+ */
+function buildExecArgv(entryIsTs: boolean): string[] {
+  const inherited = [...process.execArgv];
+  if (!entryIsTs) return inherited;
+  const hasLoader = inherited.some(
+    (a) => a.includes("tsx/esm") || a.includes("ts-node/esm") || a.includes("--import"),
+  );
+  if (hasLoader) return inherited;
+  try {
+    const require = createRequire(import.meta.url);
+    const tsxEsm = require.resolve("tsx/esm");
+    inherited.push("--import", pathToFileURL(tsxEsm).href);
+  } catch {
+    // tsx not installed (prod) — leave execArgv as-is. The caller will
+    // get a clear error if the .ts entry can't be loaded.
+  }
+  return inherited;
+}
+
+/**
+ * Spawn a worker pool ready to run shader-blends. The returned pool is
+ * usable as soon as the function resolves. If any worker fails to spawn,
+ * all already-spawned workers are terminated and the error is propagated.
+ */
+export async function createShaderTransitionWorkerPool(
+  opts: ShaderTransitionPoolOptions,
+): Promise<ShaderTransitionWorkerPool> {
+  const cpuCount = Math.max(1, cpus().length);
+  const size = Math.max(1, Math.min(opts.size, cpuCount));
+  const log = opts.log ?? {};
+  const { path: entry, isTs: entryIsTs } = resolveWorkerEntry();
+
+  const slots: WorkerSlot[] = [];
+  const queue: PendingTask[] = [];
+  let terminated = false;
+
+  // Bind the parent's execArgv (e.g. tsx's `--import tsx/esm` loader) into
+  // every Worker so a `.ts` entry point loads under tsx in dev without a
+  // separate loader registration step. In the bundled prod build the
+  // entry is `.js` and execArgv is typically empty — passing it is a no-op.
+  // Under vitest the parent has no tsx loader on execArgv; `buildExecArgv`
+  // appends one so the `.ts` worker entry still loads.
+  const execArgv = buildExecArgv(entryIsTs);
+
+  const dispatchNext = (slot: WorkerSlot): void => {
+    if (terminated || slot.busy) return;
+    const task = queue.shift();
+    if (!task) return;
+    slot.busy = true;
+    slot.current = task;
+    const { bufferA, bufferB, output, shader, width, height, progress } = task.req;
+    // `Buffer.alloc` always returns a Buffer over a plain ArrayBuffer (not
+    // SharedArrayBuffer) at runtime — TS narrows `.buffer` to the union
+    // `ArrayBuffer | SharedArrayBuffer`, so cast at the boundary. The pool
+    // would not work with SharedArrayBuffer-backed Buffers anyway because
+    // transferList rejects them.
+    const abA = bufferA.buffer as ArrayBuffer;
+    const abB = bufferB.buffer as ArrayBuffer;
+    const abOut = output.buffer as ArrayBuffer;
+    try {
+      slot.worker.postMessage(
+        {
+          shader,
+          bufferA: abA,
+          bufferB: abB,
+          output: abOut,
+          width,
+          height,
+          progress,
+        },
+        [abA, abB, abOut],
+      );
+    } catch (err) {
+      // postMessage can throw if the ArrayBuffer was already detached
+      // (e.g. caller reused a buffer mid-flight). Surface clearly.
+      slot.busy = false;
+      slot.current = null;
+      task.reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  };
+
+  const onWorkerMessage = (slot: WorkerSlot, reply: WorkerReply): void => {
+    const task = slot.current;
+    slot.current = null;
+    slot.busy = false;
+    if (!task) {
+      // Spurious message; nothing to resolve. Drain queue anyway.
+      dispatchNext(slot);
+      return;
+    }
+    if (!reply.ok) {
+      task.reject(new Error(reply.error ?? "shader-blend worker failed"));
+    } else {
+      task.resolve({
+        bufferA: Buffer.from(reply.bufferA),
+        bufferB: Buffer.from(reply.bufferB),
+        output: Buffer.from(reply.output),
+      });
+    }
+    dispatchNext(slot);
+  };
+
+  const onWorkerError = (slot: WorkerSlot, err: Error): void => {
+    const task = slot.current;
+    slot.current = null;
+    slot.busy = false;
+    if (task) {
+      // The in-flight task's buffers were transferred to the worker. They're
+      // lost on the worker crash — the caller's original Buffers are
+      // already detached. Reject so the render fails fast rather than
+      // continuing with corrupted state.
+      task.reject(new Error(`shader-blend worker crashed mid-task: ${err.message}; buffers lost`));
+    }
+    log.warn?.("[shaderTransitionWorkerPool] worker errored", { err: err.message });
+  };
+
+  const onWorkerExit = (slot: WorkerSlot, code: number): void => {
+    if (terminated) return;
+    // Unexpected exit — fail any in-flight task and drop the slot. We don't
+    // auto-respawn in the middle of a render because the lost transferList
+    // buffers can't be reconstructed, and silently shrinking the pool would
+    // mask the real failure. Pool teardown handles graceful shutdown.
+    if (slot.current) {
+      slot.current.reject(new Error(`shader-blend worker exited (code=${code}) mid-task`));
+      slot.current = null;
+      slot.busy = false;
+    }
+    log.warn?.("[shaderTransitionWorkerPool] worker exited unexpectedly", { code });
+  };
+
+  // Spawn workers. If any throws synchronously we still want to terminate
+  // the partially-spawned set before rejecting.
+  try {
+    for (let i = 0; i < size; i++) {
+      const worker = new Worker(entry, { execArgv });
+      const slot: WorkerSlot = { worker, busy: false, current: null };
+      worker.on("message", (msg: WorkerReply) => onWorkerMessage(slot, msg));
+      worker.on("error", (err) => onWorkerError(slot, err));
+      worker.on("exit", (code) => onWorkerExit(slot, code));
+      slots.push(slot);
+    }
+  } catch (err) {
+    terminated = true;
+    await Promise.all(slots.map((s) => s.worker.terminate().catch(() => undefined)));
+    throw err;
+  }
+
+  log.info?.("[shaderTransitionWorkerPool] spawned", { size, entry });
+
+  return {
+    size,
+    async run(req: ShaderBlendRequest): Promise<ShaderBlendResult> {
+      if (terminated) {
+        throw new Error("shader-blend pool already terminated");
+      }
+      return new Promise<ShaderBlendResult>((resolve, reject) => {
+        const task: PendingTask = { req, resolve, reject };
+        // Find an idle slot; otherwise queue.
+        const idle = slots.find((s) => !s.busy);
+        if (idle) {
+          queue.unshift(task);
+          dispatchNext(idle);
+        } else {
+          queue.push(task);
+        }
+      });
+    },
+    async terminate(): Promise<void> {
+      if (terminated) return;
+      terminated = true;
+      // Reject any queued (not-yet-dispatched) tasks. Their buffers are
+      // still attached on the main thread — caller can recover.
+      while (queue.length > 0) {
+        const t = queue.shift();
+        if (t) t.reject(new Error("shader-blend pool terminated before task ran"));
+      }
+      // Reject any in-flight tasks before worker.terminate() races with
+      // the message reply. Calling Worker.terminate() forcefully stops
+      // the worker; if a task was mid-execution its parentPort.postMessage
+      // never lands, so the `current` task promise would otherwise leak.
+      for (const slot of slots) {
+        const t = slot.current;
+        if (t) {
+          slot.current = null;
+          slot.busy = false;
+          t.reject(new Error("shader-blend pool terminated mid-task"));
+        }
+      }
+      await Promise.all(slots.map((s) => s.worker.terminate().catch(() => undefined)));
+      log.info?.("[shaderTransitionWorkerPool] terminated", { size });
+    },
+  };
+}


### PR DESCRIPTION
## What

Routes shader-transition renders through a pool of additional Chrome sessions, offloads the per-pixel shader blend to a Node `worker_threads` pool, **AND** pipelines per-scene/per-layer PNG decode+blit on a second `worker_threads` pool so Chrome's CDP screenshot and Node's decode+blit overlap instead of serializing per frame. The fix lands in six commits on the same branch:

1. **Initial hybrid path (`cc80f91b`)**: parallelize non-transition frames; transition frames pinned to main session.
2. **First fix-up (`42229718`)**: parallelize transition frames too — every worker walks a contiguous frame range and handles both normal and transition frames on its own session.
3. **Worker_threads shader-blend pool, naive integration (`bde9b886`)**: move per-pixel shader blend onto `worker_threads`. Functionally correct but routes via `await pool.run(...)` inline inside each DOM worker — only 1-2 pool slots ever active. Empirically *regressed* wall to 207s.
4. **Decouple capture from blend (`74adf6dc`)**: extract `captureTransitionFrame` from `processLayeredTransitionFrame`. DOM workers maintain a K-deep ring of transition buffer triples, fire off blends as chained promises without awaiting, then back-pressure on slot reuse. Pool sustains up to `N × K` concurrent tasks. **Got to ~108s (1.93× over baseline).**
5. **Scale worker caps (`76d9c3dc`)**: bump explicit-worker cap 10→24 and auto-cap CPU-scaled. Surfaces the hardware on multi-core hosts.
6. **Lever 4: pipeline capture and decode/blit (`a9ee0330` + `302fa5de` + `04ec949e`, this PR's head)**: introduce `pngDecodeBlitWorkerPool` — a second `worker_threads` pool that runs `decodePng` + `blitRgba8OverRgb48le` off the main thread. `captureTransitionFrame` pipelines scene-A's decode/blit against scene-B's CDP screenshot. `compositeHdrFrame` pipelines layer-N's decode/blit against layer-N+1's CDP. Applies to BOTH the transition path AND the normal-layered path — every layered render benefits.

## Why

Issue #677: a 28s 30fps composition with 14 × 0.3s shader transitions took ~2m 15s to render; the same timeline with hard cuts rendered in 13.9s — ~10× slower in the bug report, ~24× slower in the deeper repro the bug led us to.

Root cause was multi-layered. Commits 1-5 closed the layered-composite serialization, the shader-blend ceiling, and the DOM-worker count cap. The remaining bottleneck (called out at the bottom of commit 4's PR description) was **DOM-capture serialization through Node's main event loop**: each DOM worker captured a PNG via CDP (~70 ms, Chrome thread), then ran `decodePng` (~30 ms) and `blitRgba8OverRgb48le` (~50 ms) on the Node main thread before the next CDP screenshot could start. Across 6 workers and the dual-scene transition pipeline, this serialized ~70 % of the wall time. Lever 4 closes it.

## How (lever-4 commits, this PR's head)

* **`pngDecodeBlitWorkerPool`**: a dedicated `worker_threads` pool mirroring the shader-blend pool. `decodePng` + `blitRgba8OverRgb48le` run inside the worker; the rgb48le destination ArrayBuffer is transferred IN and back OUT via `transferList` (zero-copy at the ArrayBuffer level). The PNG input is also transferred IN. Dispatcher copies inputs out of Node's 8KB shared `Buffer` pool when necessary — prevents `DataCloneError` for small PNGs / `Buffer.concat` outputs. Pool size = `2× activeWorkerCount` capped to `cpus().length`.
* **`captureTransitionFrame` (transition path)**: scene-A captures its PNG, then *kicks off* decode+blit on the pool without awaiting. Scene-B's seek/inject/mask/screenshot/unmask runs on Chrome WHILE scene-A's decode+blit runs on the worker. Both scene promises drain at the function tail; the returned `CapturedTransitionFrame.buffers.bufferA/.bufferB` are the re-attached views the caller hands to the shader-blend dispatch.
* **`compositeHdrFrame` (normal-layered path)**: per-DOM-layer decode+blit dispatches to the pool, returns a pending Promise. The loop continues to layer N+1's CDP screenshot. Before the next canvas read/write (an HDR-layer blit, the next DOM-layer dispatch, or the function return), the prior layer's promise is awaited. Saves ~70 ms per consecutive DOM-layer pair while preserving z-order semantics.
* **Buffer detach plumbing**: the pool transfers `dest` out, so the caller's Buffer reference is detached on dispatch. `compositeHdrFrame` and `processLayeredNormalFrame` now return the (potentially new) canvas Buffer; the hybrid worker loop reassigns `workerCanvases[w]` after each frame. The transition path mutates the existing `LayeredTransitionBuffers` struct (matching the existing shader-pool pattern).
* **Inline fallback**: when the pool can't be spawned (or `hdrCompositeCtx.pngDecodeBlitPool` is null), every helper falls back to the synchronous `decodePng` + `blitRgba8OverRgb48le` path. Byte-equivalent because the worker calls the exact same functions.
* **CLI / build wiring**: `pngDecodeBlitWorker.ts` is bundled as a separate esbuild + tsup entry next to `pngDecodeBlitWorkerPool.ts` (same pattern as the shader-blend worker in `74adf6dc`). The `@hyperframes/engine/alpha-blit` subpath export is added so the worker's `decodePng` / `blitRgba8OverRgb48le` imports survive the worker_thread loader boundary (the package root pulls in the full engine graph; the import-free `alphaBlit.ts` does not).

## Empirical results

**Validation environment caveat:** I could not reproduce the original hf#677 28s @ 30fps, 14 × 0.3s shader-transition fixture in the validation sandbox (external CDN audio assets are CORS-blocked; the producer's regression-harness needs network access the sandbox lacks). The architectural change is validated by:

- **Unit tests** (added in `a9ee0330`): byte-equivalence with the inline path, small-PNG handling (8KB shared-pool path), N-concurrent dispatch, and an explicit overlap test that asserts simulated next-frame capture completes before the in-flight decode+blit on the same pool.
- **Multi-layer byte-equivalence smoke test**: 3 sequential alpha-blits over a 320×240 PNG through the pool produce a buffer that is byte-identical to the inline `decodePng` + `blitRgba8OverRgb48le` reference.
- **Typecheck / lint / format / commitlint**: clean on all three new commits.

**Predicted speedup** (per the lever-4 brief): each DOM worker saves ~70-80 ms per transition frame (scene B's CDP overlapping scene A's decode/blit, plus cross-frame K-deep ring overlap). On the original repro that's ~141 transition frames × ~75 ms / 6 workers ≈ ~1.8 s wall improvement on the transition phase alone, plus the normal-layered pipelining cuts ~50-200 ms per normal frame (layer count varies). End-to-end target: ~108 s → ~70-80 s (~3× over baseline). The validation gap is empirical, not architectural — re-running the hf#677 fixture on the prior validation host is the right way to confirm.

## Test plan

Unit tests:

- `partitionTransitionFrames`, `shouldUseHybridLayeredPath`, `estimateCaptureCostMultiplier`, `distributeLayeredHybridFrameRanges` (existing).
- `shaderTransitionWorkerPool.test.ts` (existing 6 tests, unchanged).
- `pngDecodeBlitWorkerPool.test.ts` (NEW, 6 tests):
  - Byte-equivalence with the inline decode+blit path.
  - Composite-over-existing-content alpha blend semantics.
  - Small PNGs (sub-8KB pool) survive the dispatcher.
  - N concurrent decode+blit tasks against an N-wide pool, all byte-equivalent.
  - Pipelining proof: simulated next-frame capture completes before in-flight decode+blit.
  - Clean shutdown with queued tasks (no leaked handles).

`bun run --filter @hyperframes/producer typecheck`: clean.
`bun run --filter @hyperframes/engine typecheck`: clean.
`oxlint` / `oxfmt --check`: clean.
Lefthook pre-commit: passing on all three lever-4 commits.

- [x] Unit tests added (byte-equivalence + pipelining proof + concurrent dispatch)
- [x] Inline fallback preserved when the pool can't spawn
- [x] CLI bundling mirrored for the new worker entry (same pattern as `74adf6dc`)
- [ ] End-to-end empirical re-validation on the hf#677 28s 14-transition fixture (sandbox can't reach external audio assets; needs the original validation host)
- [x] Typecheck / lint / format / commitlint

Closes #677

— Vai
