### PR TITLE
fix(runtime): fall back to setInterval when rAF is throttled in nested iframes

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1644,6 +1644,7 @@ export function initSandboxRuntimeModular(): void {
   });
   let transportTickCount = 0;
   let inTransportTick = false;
+  let lastRafMs = performance.now();
 
   const seekTimelineAndAdapters = (t: number) => {
     const tl = state.capturedTimeline;
@@ -1674,11 +1675,14 @@ export function initSandboxRuntimeModular(): void {
     }
   };
 
-  const transportTick = () => {
+  const transportTick = (fromInterval: boolean) => {
     if (state.tornDown || inTransportTick) return;
+    if (!fromInterval) {
+      lastRafMs = performance.now();
+      state.transportRafId = window.requestAnimationFrame(() => transportTick(false));
+    }
     inTransportTick = true;
     try {
-      state.transportRafId = window.requestAnimationFrame(transportTick);
       transportTickCount += 1;
 
       // Slower operations: timeline binding (~every 60 frames / ~1s at 60fps)
@@ -1965,8 +1969,18 @@ export function initSandboxRuntimeModular(): void {
     }
   }
 
-  // Start the rAF tick loop
-  state.transportRafId = window.requestAnimationFrame(transportTick);
+  // Start the rAF tick loop (primary) with a setInterval fallback.
+  // Chromium throttles rAF in deeply nested cross-origin iframes — e.g. an MCP
+  // widget iframe inside Electron (Claude desktop). The interval is a no-op when
+  // rAF is healthy; it takes over after RAF_STARVATION_MS of silence so that
+  // playback works in throttled environments without changing normal-browser behavior.
+  const RAF_STARVATION_MS = 100;
+  state.transportRafId = window.requestAnimationFrame(() => transportTick(false));
+  state.transportIntervalId = window.setInterval(() => {
+    if (!state.tornDown && performance.now() - lastRafMs > RAF_STARVATION_MS) {
+      transportTick(true);
+    }
+  }, 16);
   postTimeline();
   postState(true);
 
@@ -1976,6 +1990,10 @@ export function initSandboxRuntimeModular(): void {
     if (state.transportRafId != null) {
       window.cancelAnimationFrame(state.transportRafId);
       state.transportRafId = null;
+    }
+    if (state.transportIntervalId != null) {
+      window.clearInterval(state.transportIntervalId);
+      state.transportIntervalId = null;
     }
     state.transportClock = null;
     webAudio.destroy();

--- a/packages/core/src/runtime/state.ts
+++ b/packages/core/src/runtime/state.ts
@@ -82,6 +82,8 @@ export type RuntimeState = {
   transportClock: TransportClock | null;
   /** rAF ID for the single-clock tick loop. */
   transportRafId: number | null;
+  /** setInterval ID for the RAF-starvation fallback tick loop. */
+  transportIntervalId: number | null;
 };
 
 export function createRuntimeState(): RuntimeState {
@@ -119,5 +121,6 @@ export function createRuntimeState(): RuntimeState {
     nativeVisualWatchdogTick: 0,
     transportClock: null,
     transportRafId: null,
+    transportIntervalId: null,
   };
 }


### PR DESCRIPTION
## Problem

The HyperFrames composition preview widget works correctly on claude.ai but fails in Claude desktop (Electron):

- **No autoplay** — composition stays frozen
- **Play button does nothing** — pressing it has no effect
- **Scrubbing works** — dragging the timeline shows the correct frame at each position

## Root Cause

Two-layer failure:

**Layer 1 — RAF throttling (the real cause):** The HyperFrames runtime drives all animation by seeking GSAP on every `requestAnimationFrame` tick (`transportTick`). GSAP is always paused; the runtime never lets it free-run. In Claude desktop (Electron), Chromium throttles RAF in deeply nested cross-origin iframes. The composition iframe's RAF loop stalls, so `seekTimelineAndAdapters(clock.now())` is never called and animation never advances — even when `TransportClock.isPlaying()` is `true`.

**Layer 2 — "already playing" guard:** On mount, autoplay calls `player.play()` which sets `clock.isPlaying() = true`. When the user then clicks the play button, `player.play()` hits the `if (!tl || clock.isPlaying()) return` guard and exits immediately, because the clock already thinks it's playing. This is why the button appears to do nothing.

Scrubbing works because `player.seek(t)` calls `seekTimelineAndAdapters(t)` **synchronously** via `window.__player.seek()` — no RAF loop needed.

## Fix

Add a `setInterval` fallback at 16 ms alongside the primary RAF loop.

```
RAF healthy  → lastRafMs updated every tick → interval check fails → interval is a no-op
RAF starved  → lastRafMs goes stale → interval detects >100ms gap → calls transportTick(true)
```

Key invariants:
- **Interval-driven ticks do not reschedule RAF** (`fromInterval: boolean` flag separates the two paths). This prevents RAF handle accumulation when Electron has a queue of throttled-but-pending RAF callbacks.
- **Interval-driven ticks do not update `lastRafMs`**, so the interval continues firing until RAF genuinely resumes.
- **When RAF resumes**, the first RAF tick updates `lastRafMs` and the interval immediately goes dormant.
- In normal browser environments (claude.ai), RAF fires every ~16 ms and `performance.now() - lastRafMs` never exceeds 100 ms, so the interval is a true no-op.

## Changes

- `packages/core/src/runtime/state.ts` — add `transportIntervalId: number | null` field
- `packages/core/src/runtime/init.ts` — `transportTick(fromInterval)`, `lastRafMs` tracking, interval setup + teardown

## Test Plan

- [ ] Open a HyperFrames composition in the Claude desktop MCP widget — verify autoplay works
- [ ] Press play button — verify it works
- [ ] Scrub then press play — verify it works
- [ ] Open same composition on claude.ai — verify no regression (autoplay and play button still work, no double-ticking)
- [ ] `bun run --cwd packages/core test` — 347 runtime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)