### PR TITLE
fix(player): drive composition ticks from widget-frame rAF via postMessage

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.6.0-alpha.13",
+  "version": "0.6.0-alpha.14",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.6.0-alpha.13",
+  "version": "0.6.0-alpha.14",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/core/src/runtime/bridge.test.ts
+++ b/packages/core/src/runtime/bridge.test.ts
@@ -6,6 +6,7 @@ function createMockDeps() {
     onPlay: vi.fn(),
     onPause: vi.fn(),
     onSeek: vi.fn(),
+    onTick: vi.fn(),
     onSetMuted: vi.fn(),
     onSetVolume: vi.fn(),
     onSetMediaOutputMuted: vi.fn(),
@@ -108,6 +109,13 @@ describe("installRuntimeControlBridge", () => {
     const handler = installRuntimeControlBridge(deps);
     handler(makeControlMessage("set-playback-rate"));
     expect(deps.onSetPlaybackRate).toHaveBeenCalledWith(1);
+  });
+
+  it("dispatches tick command", () => {
+    const deps = createMockDeps();
+    const handler = installRuntimeControlBridge(deps);
+    handler(makeControlMessage("tick"));
+    expect(deps.onTick).toHaveBeenCalledOnce();
   });
 
   it("dispatches enable-pick-mode", () => {

--- a/packages/core/src/runtime/bridge.ts
+++ b/packages/core/src/runtime/bridge.ts
@@ -5,6 +5,7 @@ type BridgeDeps = {
   onPlay: () => void;
   onPause: () => void;
   onSeek: (frame: number, seekMode: "drag" | "commit") => void;
+  onTick: () => void;
   onSetMuted: (muted: boolean) => void;
   onSetVolume: (volume: number) => void;
   onSetMediaOutputMuted: (muted: boolean) => void;
@@ -37,6 +38,10 @@ export function installRuntimeControlBridge(deps: BridgeDeps): (event: MessageEv
     }
     if (action === "seek") {
       deps.onSeek(Number(data.frame ?? 0), data.seekMode ?? "commit");
+      return;
+    }
+    if (action === "tick") {
+      deps.onTick();
       return;
     }
     if (action === "set-muted") {

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1605,6 +1605,21 @@ export function initSandboxRuntimeModular(): void {
       const t = clock.now();
       state.currentTime = t;
       seekTimelineAndAdapters(t);
+      if (clock.reachedEnd()) {
+        webAudio.stopAll();
+        clock.detachAudioSource();
+        clock.pause();
+        state.isPlaying = false;
+        const dur = clock.getDuration();
+        if (Number.isFinite(dur)) {
+          clock.seek(dur);
+          state.currentTime = dur;
+          seekTimelineAndAdapters(dur);
+        }
+        runAdapters("pause");
+        syncMediaForCurrentState();
+        postState(true);
+      }
     },
     onEnablePickMode: () => picker.enablePickMode(),
     onDisablePickMode: () => picker.disablePickMode(),

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1600,6 +1600,12 @@ export function initSandboxRuntimeModular(): void {
       applyPlaybackRate(rate);
       if (state.transportClock) state.transportClock.setRate(state.playbackRate);
     },
+    onTick: () => {
+      if (state.tornDown || !clock.isPlaying()) return;
+      const t = clock.now();
+      state.currentTime = t;
+      seekTimelineAndAdapters(t);
+    },
     onEnablePickMode: () => picker.enablePickMode(),
     onDisablePickMode: () => picker.disablePickMode(),
   });

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -10,6 +10,7 @@ export type RuntimeBridgeControlAction =
   | "play"
   | "pause"
   | "seek"
+  | "tick"
   | "set-muted"
   | "set-volume"
   | "set-media-output-muted"

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.6.0-alpha.13",
+  "version": "0.6.0-alpha.14",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.6.0-alpha.13",
+  "version": "0.6.0-alpha.14",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -209,6 +209,7 @@ class HyperframesPlayer extends HTMLElement {
   private _lastUpdateMs = 0;
   private _directTimelineAdapter: DirectTimelineAdapter | null = null;
   private _directTimelineRaf: number | null = null;
+  private _parentTickRaf: number | null = null;
 
   /**
    * Parent-frame audio/video proxies, preloaded mirror copies of the iframe's
@@ -346,6 +347,7 @@ class HyperframesPlayer extends HTMLElement {
     this.iframe.removeEventListener("load", this._onIframeLoad);
     if (this._probeInterval) clearInterval(this._probeInterval);
     this._stopDirectTimelineClock();
+    this._stopParentTickClock();
     this._directTimelineAdapter = null;
     if (this.shaderLoaderHideTimeout) clearTimeout(this.shaderLoaderHideTimeout);
     this.shaderLoaderHideTimeout = null;
@@ -461,7 +463,10 @@ class HyperframesPlayer extends HTMLElement {
     // compositions can expose only `window.__timelines`, so they use a direct
     // timeline adapter instead of a postMessage bridge nobody is listening to.
     const directTimelineStarted = this._tryDirectTimelinePlay();
-    if (!directTimelineStarted) this._sendControl("play");
+    if (!directTimelineStarted) {
+      this._sendControl("play");
+      this._startParentTickClock();
+    }
     if (this._audioOwner === "parent") this._playParentMedia();
     this._paused = false;
     this.controlsApi?.updatePlaying(true);
@@ -472,6 +477,7 @@ class HyperframesPlayer extends HTMLElement {
   pause() {
     if (!this._tryDirectTimelinePause()) this._sendControl("pause");
     this._stopDirectTimelineClock();
+    this._stopParentTickClock();
     if (this._audioOwner === "parent") this._pauseParentMedia();
     this._paused = true;
     this.controlsApi?.updatePlaying(false);
@@ -957,6 +963,33 @@ class HyperframesPlayer extends HTMLElement {
     this._directTimelineRaf = null;
   }
 
+  /**
+   * Widget-frame RAF loop that sends "tick" postMessages to the composition
+   * iframe on every frame. Used for the runtime bridge path so that animation
+   * advances even when the composition iframe's own rAF is throttled by
+   * Chromium (e.g. deeply nested cross-origin iframes in Electron / Claude desktop).
+   * The runtime's own rAF loop still runs — ticking GSAP twice per frame is
+   * harmless because seekTimelineAndAdapters is idempotent.
+   */
+  private _startParentTickClock(): void {
+    this._stopParentTickClock();
+    const tick = () => {
+      if (this._paused) {
+        this._parentTickRaf = null;
+        return;
+      }
+      this._sendControl("tick");
+      this._parentTickRaf = requestAnimationFrame(tick);
+    };
+    this._parentTickRaf = requestAnimationFrame(tick);
+  }
+
+  private _stopParentTickClock(): void {
+    if (this._parentTickRaf === null) return;
+    cancelAnimationFrame(this._parentTickRaf);
+    this._parentTickRaf = null;
+  }
+
   private _resolveDirectTimelineAdapter(): DirectTimelineAdapter | null {
     try {
       const win = this.iframe.contentWindow;
@@ -1107,6 +1140,7 @@ class HyperframesPlayer extends HTMLElement {
     this._runtimeInjected = false;
     this._directTimelineAdapter = null;
     this._stopDirectTimelineClock();
+    this._stopParentTickClock();
     this._resetShaderLoader();
     // A fresh iframe means a fresh runtime — `mediaOutputMuted` and the
     // autoplay-blocked latch are both reset inside it. The web component's

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -459,16 +459,24 @@ class HyperframesPlayer extends HTMLElement {
     if (this._duration > 0 && this._currentTime >= this._duration) {
       this.seek(0);
     }
+    // Must be set before _startParentTickClock so the RAF loop's `_paused`
+    // check doesn't immediately self-terminate on the first callback.
+    this._paused = false;
     // Drive the iframe runtime when present. Same-origin standalone GSAP
     // compositions can expose only `window.__timelines`, so they use a direct
     // timeline adapter instead of a postMessage bridge nobody is listening to.
     const directTimelineStarted = this._tryDirectTimelinePlay();
     if (!directTimelineStarted) {
       this._sendControl("play");
-      this._startParentTickClock();
+      // Only start the parent tick clock once the composition is ready and
+      // confirmed on the runtime bridge path (not the direct-timeline path).
+      // Guards against firing ticks into an uninitialized iframe when play()
+      // is called before the probe has resolved.
+      if (this._ready && !this._directTimelineAdapter) {
+        this._startParentTickClock();
+      }
     }
     if (this._audioOwner === "parent") this._playParentMedia();
-    this._paused = false;
     this.controlsApi?.updatePlaying(true);
     this.dispatchEvent(new Event("play"));
     if (directTimelineStarted) this._startDirectTimelineClock();
@@ -514,6 +522,7 @@ class HyperframesPlayer extends HTMLElement {
       this._sendControl("seek", { frame });
     }
     this._stopDirectTimelineClock();
+    this._stopParentTickClock();
     this._currentTime = timeInSeconds;
 
     // Mirror parent proxy currentTime only while parent owns audible output.

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.6.0-alpha.13",
+  "version": "0.6.0-alpha.14",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.6.0-alpha.13",
+  "version": "0.6.0-alpha.14",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.6.0-alpha.13",
+  "version": "0.6.0-alpha.14",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

The HyperFrames composition preview widget works on claude.ai but fails in Claude desktop (Electron):
- No autoplay — composition stays frozen
- Play button does nothing
- Scrubbing works correctly

## Root Cause

The runtime drives all animation by calling `seekTimelineAndAdapters(clock.now())` on every `requestAnimationFrame` tick. GSAP is always paused; the runtime manually seeks it each frame. Chromium throttles RAF in deeply nested cross-origin iframes, so in Claude desktop the composition iframe's tick loop stalls — animation never advances even when `TransportClock.isPlaying()` is true.

Scrubbing works because `player.seek(t)` calls `seekTimelineAndAdapters(t)` **synchronously** via `window.__player.seek()` — no RAF needed.

## Fix

Drive ticks from the **widget-frame RAF**, which lives one level above the composition iframe and is not subject to the same throttling.

When `play()` takes the runtime bridge path (no direct timeline adapter), `<hyperframes-player>` starts a parent-frame RAF loop that sends `"tick"` postMessages to the composition iframe on every frame. The runtime's control bridge handles `"tick"` by calling `seekTimelineAndAdapters(clock.now())` — exactly what `transportTick` does on each RAF, just driven from outside.

```
Widget iframe RAF (unthrottled)
  → postMessage("tick") every frame
    → composition iframe control bridge
      → seekTimelineAndAdapters(clock.now())  ← animation advances
```

The composition iframe's own RAF loop is **unchanged** — it keeps running normally in standard browsers. Seeking GSAP twice per frame is idempotent, so there is no regression on claude.ai or any non-throttled environment.

## Changes

| File | Change |
|------|--------|
| `packages/player/src/hyperframes-player.ts` | `_startParentTickClock()` / `_stopParentTickClock()` wired into `play()`, `pause()`, `seek()`, `disconnectedCallback()`, `_onIframeLoad()`; `_paused` set before clock starts; readiness guard before starting ticks |
| `packages/core/src/runtime/init.ts` | `onTick` in control bridge: seeks GSAP to current clock time when playing; includes full end-of-composition handling (`reachedEnd` → pause, seek-to-end, `postState`) |
| `packages/core/src/runtime/bridge.ts` | `onTick` added to `BridgeDeps`; `action === "tick"` handler |
| `packages/core/src/runtime/types.ts` | `"tick"` added to `RuntimeBridgeControlAction` union |
| `packages/core/src/runtime/bridge.test.ts` | `onTick` added to mock deps; tick dispatch test added |

## Test Plan

- [ ] Open a HyperFrames composition in Claude desktop MCP widget — verify autoplay works
- [ ] Press play — verify animation advances
- [ ] Scrub then press play — verify it works
- [ ] Open same composition on claude.ai — verify no regression (autoplay and play still work, no double-ticking visible)
- [ ] `bun run --cwd packages/core test` — 379 tests pass
- [ ] `bun run --cwd packages/player test` — 109 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)