### PR TITLE
fix(studio): prevent composition switch loop on sub-composition navigation

### DIFF
--- a/packages/studio/src/components/StudioPreviewArea.tsx
+++ b/packages/studio/src/components/StudioPreviewArea.tsx
@@ -108,8 +108,12 @@ export function StudioPreviewArea({
         onCompositionChange={(compPath) => {
           // Sync activeCompPath when user drills down via timeline double-click
           // or navigates back via breadcrumb — keeps sidebar + thumbnails in sync.
-          setActiveCompPath(compPath);
-          refreshPreviewDocumentVersion();
+          // Guard against no-op updates to prevent circular refresh cascades
+          // between activeCompPath → compositionStack → onCompositionChange.
+          if (compPath !== activeCompPath) {
+            setActiveCompPath(compPath);
+            refreshPreviewDocumentVersion();
+          }
         }}
         onIframeRef={handlePreviewIframeRef}
         previewOverlay={

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -203,8 +203,11 @@ export const NLELayout = memo(function NLELayout({
   const updateCompositionStack: typeof setCompositionStack = useCallback((action) => {
     setCompositionStack((prev) => {
       const next = typeof action === "function" ? action(prev) : action;
-      const id = next[next.length - 1]?.id;
-      queueMicrotask(() => onCompositionChangeRef.current?.(id === "master" ? null : id));
+      const prevId = prev[prev.length - 1]?.id;
+      const nextId = next[next.length - 1]?.id;
+      if (prevId !== nextId) {
+        queueMicrotask(() => onCompositionChangeRef.current?.(nextId === "master" ? null : nextId));
+      }
       return next;
     });
   }, []);


### PR DESCRIPTION
## Summary

Circular state update between `activeCompPath` and `compositionStack` caused the preview to flicker when navigating to sub-compositions and scrubbing.

**The cycle:** `activeCompPath` change → useEffect updates `compositionStack` → `onCompositionChange` fires → `setActiveCompPath` + `refreshPreviewDocumentVersion` → re-render → effect re-evaluates → repeat.

**Fix:** Guard both sides of the cycle:
1. `onCompositionChange` in `StudioPreviewArea` skips if `compPath === activeCompPath`
2. `updateCompositionStack` in `NLELayout` skips `onCompositionChange` notification if top-of-stack ID unchanged

## Test plan

- [ ] Open a composition with sub-compositions (e.g., captions loaded via `data-composition-src`)
- [ ] Click into the sub-composition in the sidebar or timeline
- [ ] Scrub the timeline — preview should NOT flicker or reload
- [ ] Navigate back to master — should work without flicker
- [ ] Double-click a sub-composition clip in timeline to drill down — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)