### PR TITLE
feat(studio): add build:dev mode with source maps and React dev warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,20 @@ bun run test    # Run tests
 
 **This repo uses bun**, not pnpm. Do NOT run `pnpm install` — it creates a `pnpm-lock.yaml` that should not exist. Workspace linking relies on bun's resolution from `"workspaces"` in root `package.json`.
 
+### Studio Build
+
+Always use the dev build locally — source maps, no minification, React dev-mode warnings:
+
+```bash
+bun run --cwd packages/studio build:dev
+```
+
+The production build (`build` without `:dev`) is only run by GitHub Actions for publish. After building, copy to CLI:
+
+```bash
+rm -rf packages/cli/dist/studio && cp -r packages/studio/dist packages/cli/dist/studio
+```
+
 ### Linting & Formatting
 
 This project uses **oxlint** and **oxfmt** (not biome, not eslint, not prettier).

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:dev": "vite build --mode development",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -615,18 +615,26 @@ function devProjectApi(): Plugin {
   };
 }
 
-export default defineConfig({
-  plugins: [react(), devProjectApi()],
-  resolve: {
-    alias: {
-      "@hyperframes/player": resolve(__dirname, "../player/src/hyperframes-player.ts"),
+export default defineConfig(({ mode }) => {
+  const isDev = mode === "development";
+  return {
+    plugins: [react(), devProjectApi()],
+    resolve: {
+      alias: {
+        "@hyperframes/player": resolve(__dirname, "../player/src/hyperframes-player.ts"),
+      },
     },
-  },
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-  },
-  server: {
-    port: 5190,
-  },
+    ...(isDev && {
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    }),
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      sourcemap: isDev,
+      minify: !isDev,
+    },
+    server: {
+      port: 5190,
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- Add `build:dev` script to Studio that builds with source maps, no minification, and React dev-mode warnings
- Vite config now accepts `--mode development` to conditionally enable `process.env.NODE_ENV`, sourcemaps, and disable minify
- CLAUDE.md updated: always use `build:dev` locally, production build is GHA-only

## Test plan
- [ ] `bun run --cwd packages/studio build:dev` produces unminified output with `.map` files
- [ ] `bun run --cwd packages/studio build` still produces minified output without maps
- [ ] React dev-mode warnings appear in browser console with dev build

🤖 Generated with [Claude Code](https://claude.com/claude-code)