### PR TITLE
fix(studio): break iframe ref update loop causing flickering

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -261,6 +261,7 @@ export function StudioApp() {
   const { syncPreviewTimelineHotkey, syncPreviewHistoryHotkey } = appHotkeys;
   const handlePreviewIframeRef = useCallback(
     (iframe: HTMLIFrameElement | null) => {
+      if (previewIframeRef.current === iframe) return;
       previewIframeRef.current = iframe;
       setPreviewIframe(iframe);
       syncPreviewTimelineHotkey(iframe);

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -234,9 +234,11 @@ export const NLELayout = memo(function NLELayout({
   const currentLevel = compositionStack[compositionStack.length - 1];
   const directUrl = compositionStack.length > 1 ? currentLevel.previewUrl : undefined;
 
+  const onIframeRefRef = useRef(onIframeRef);
+  onIframeRefRef.current = onIframeRef;
   useEffect(() => {
-    onIframeRef?.(iframeRef.current);
-  }, [compositionStack.length, onIframeRef, refreshKey, iframeRef]);
+    onIframeRefRef.current?.(iframeRef.current);
+  }, [compositionStack.length, refreshKey, iframeRef]);
 
   // Save master seek position before drilling down so we can restore it on back-navigation.
   // saveSeekPosition() sets pendingSeekRef in useTimelinePlayer which onIframeLoad reads.


### PR DESCRIPTION
## Summary
- Break infinite update loop between `handlePreviewIframeRef` (App.tsx) and `onIframeRef` effect (NLELayout.tsx)
- Callback identity change triggered the effect which re-called the callback, causing "Maximum update depth exceeded" in dev mode and intermittent flickering in production
- Guard `setPreviewIframe` with identity check; use ref for `onIframeRef` callback in NLELayout effect deps

## Test plan
- [ ] Studio loads without "Maximum update depth exceeded" error in dev build
- [ ] No flickering in production build
- [ ] Sub-composition drill-down still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)