### PR TITLE
fix(studio): keep preview selection overlay visible for selected item

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -26,7 +26,6 @@ import {
   STUDIO_MOTION_PANEL_ENABLED,
 } from "./components/editor/manualEditingAvailability";
 import { getStudioMotionForSelection } from "./components/editor/studioMotion";
-import { getTimelineElementKey, isTimelineElementActiveAtTime } from "./utils/timelineInspector";
 import type { DomEditSelection } from "./components/editor/domEditing";
 import { AskAgentModal } from "./components/AskAgentModal";
 import { StudioHeader } from "./components/StudioHeader";
@@ -79,7 +78,6 @@ export function StudioApp() {
   const captionSync = useCaptionSync(projectId);
   const currentTime = usePlayerStore((s) => s.currentTime);
   const timelineElements = usePlayerStore((s) => s.elements);
-  const selectedTimelineElementId = usePlayerStore((s) => s.selectedElementId);
   const setSelectedTimelineElementId = usePlayerStore((s) => s.setSelectedElementId);
   const timelineDuration = usePlayerStore((s) => s.duration);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -284,14 +282,6 @@ export function StudioApp() {
           domEditSession.domEditSelection,
         )
       : null;
-  const selectedTimelineElement = useMemo(
-    () =>
-      selectedTimelineElementId
-        ? (timelineElements.find((el) => getTimelineElementKey(el) === selectedTimelineElementId) ??
-          null)
-        : null,
-    [selectedTimelineElementId, timelineElements],
-  );
   const designPanelActive =
     STUDIO_INSPECTOR_PANELS_ENABLED && panelLayout.rightPanelTab === "design";
   const motionPanelActive =
@@ -300,11 +290,7 @@ export function StudioApp() {
     panelLayout.rightPanelTab === "motion";
   const inspectorPanelActive = designPanelActive || motionPanelActive;
   const shouldShowSelectedDomBounds =
-    inspectorPanelActive &&
-    !panelLayout.rightCollapsed &&
-    !isPlaying &&
-    (!selectedTimelineElement ||
-      isTimelineElementActiveAtTime(currentTime, selectedTimelineElement));
+    inspectorPanelActive && !panelLayout.rightCollapsed && !isPlaying;
   const inspectorButtonActive =
     STUDIO_INSPECTOR_PANELS_ENABLED && !panelLayout.rightCollapsed && inspectorPanelActive;
 


### PR DESCRIPTION
## What

Keep the Studio preview selection overlay visible while an element is still selected

## Why

The overlay can disappear evenn though the element is still selected. Because overlay visibility was tied to timeline active state.

## How

Remove the timeline active-state check from `shouldShowSelectedDomBounds`. The overlay should be visible based on selection and inspector state, not timeline activity.

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
