### PR TITLE
fix(studio): keep preview selection overlay visible while element selected

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -303,8 +303,7 @@ export function StudioApp() {
     inspectorPanelActive &&
     !panelLayout.rightCollapsed &&
     !isPlaying &&
-    (!selectedTimelineElement ||
-      isTimelineElementActiveAtTime(currentTime, selectedTimelineElement));
+    selectedTimelineElement != null;
   const inspectorButtonActive =
     STUDIO_INSPECTOR_PANELS_ENABLED && !panelLayout.rightCollapsed && inspectorPanelActive;
 


### PR DESCRIPTION
## Summary

The selection overlay in the Studio preview was disappearing even while an element remained selected, because its visibility was tied to the element being active at the current playback time. This caused the overlay to flicker/disappear during playback.

### What changed

**packages/studio/src/App.tsx** - shouldShowSelectedDomBounds now checks selectedTimelineElement != null instead of also requiring the element to be timeline-active. The overlay stays visible whenever something is selected and the inspector panel is open.

Closes #777