### PR TITLE
fix(studio): only seek layers on selection

### DIFF
--- a/packages/studio/src/components/editor/LayersPanel.tsx
+++ b/packages/studio/src/components/editor/LayersPanel.tsx
@@ -103,13 +103,6 @@ export const LayersPanel = memo(function LayersPanel() {
     }
   }, [compositionLoading, collectLayers]);
 
-  useEffect(() => {
-    const ref = hoverSeekTimerRef;
-    return () => {
-      if (ref.current) clearTimeout(ref.current);
-    };
-  }, []);
-
   const resolveSelection = useCallback(
     (layer: DomEditLayerItem) =>
       resolveDomEditSelection(layer.element, {
@@ -119,8 +112,6 @@ export const LayersPanel = memo(function LayersPanel() {
       }),
     [activeCompPath, isMasterView],
   );
-
-  const hoverSeekTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const seekToLayer = useCallback(
     (layer: DomEditLayerItem) => {
@@ -169,17 +160,13 @@ export const LayersPanel = memo(function LayersPanel() {
   const handleLayerHover = useCallback(
     (layer: DomEditLayerItem | null) => {
       if (!layer) {
-        if (hoverSeekTimerRef.current) clearTimeout(hoverSeekTimerRef.current);
         updateDomEditHoverSelection(null);
         return;
       }
       const selection = resolveSelection(layer);
       updateDomEditHoverSelection(selection);
-      // Debounce hover seeks so brushing past items doesn't thrash the player
-      if (hoverSeekTimerRef.current) clearTimeout(hoverSeekTimerRef.current);
-      hoverSeekTimerRef.current = setTimeout(() => seekToLayer(layer), 300);
     },
-    [resolveSelection, updateDomEditHoverSelection, seekToLayer],
+    [resolveSelection, updateDomEditHoverSelection],
   );
 
   const toggleCollapse = useCallback((key: string, e: React.MouseEvent) => {


### PR DESCRIPTION
## What

Stop the Layers panel from seeking the preview on hover.

## Why

Scrolling the Layers panel could move the preview. This happened because hover on a layer also triggered a seek.

## How

Keep hover for hover state only. Keep seek in the selection path only, so the preview moves when a layer is clicked.

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
