### PR TITLE
docs: add WadydX to ADOPTERS evaluating list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -24,6 +24,6 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 _Open a PR to add your organization here if you're trying HyperFrames in a non-production context._
 
-| Organization | Contact | How HyperFrames is used |
-| --- | --- | --- |
-| WadydX | [@WadydX](https://github.com/WadydX) | Personal testing for promotional video workflows; active contributor via issues and PRs. |
+| Organization | Contact                                  | How HyperFrames is used                                                             |
+| ------------ | ---------------------------------------- | ----------------------------------------------------------------------------------- |
+| WadydX       | [@WadydX](https://github.com/WadydX)     | Personal testing for promotional video workflows; active contributor via issues and PRs. |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -23,3 +23,7 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 ## Evaluating
 
 _Open a PR to add your organization here if you're trying HyperFrames in a non-production context._
+
+| Organization | Contact | How HyperFrames is used |
+| --- | --- | --- |
+| WadydX | [@WadydX](https://github.com/WadydX) | Personal testing for promotional video workflows; active contributor via issues and PRs. |


### PR DESCRIPTION
## Summary
- add WadydX to the Evaluating section in ADOPTERS.md
- include concise usage context and GitHub contact

## Why
- reflects real-world personal evaluation and ongoing OSS contribution activity

## Changes
- ADOPTERS.md: add one Evaluating table row for WadydX