### PR TITLE
fix(studio): auto-reconnect when preview server is not running

### DIFF
--- a/packages/cli/src/templates/_shared/AGENTS.md
+++ b/packages/cli/src/templates/_shared/AGENTS.md
@@ -13,12 +13,16 @@ Skills encode patterns like `window.__timelines` registration, `data-*` attribut
 ## Commands
 
 ```bash
-npm run dev          # preview in browser (studio editor)
+npm run dev          # start the preview server (long-running — keep it alive in background)
 npm run check        # lint + validate + inspect
 npm run render       # render to MP4
 npm run publish      # publish and get a shareable link
 npx hyperframes docs <topic> # reference docs in terminal
 ```
+
+> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
+> Always run it as a background process so it stays alive while you edit compositions.
+> Running it in the foreground will time out and kill the server, breaking the browser preview.
 
 ## Project Structure
 

--- a/packages/cli/src/templates/_shared/CLAUDE.md
+++ b/packages/cli/src/templates/_shared/CLAUDE.md
@@ -25,7 +25,7 @@
 ## Commands
 
 ```bash
-npm run dev          # preview in browser (studio editor)
+npm run dev          # start the preview server (long-running — keep it alive in background)
 npm run check        # lint + validate + inspect
 npm run render       # render to MP4
 npm run publish      # publish and get a shareable link
@@ -33,6 +33,10 @@ npx hyperframes lint --verbose  # include info-level findings
 npx hyperframes lint --json     # machine-readable output for CI
 npx hyperframes docs <topic> # reference docs in terminal
 ```
+
+> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
+> In Claude Code, always run it with `run_in_background: true`. Never run it as a foreground
+> command — it will time out and the server will die, breaking the browser preview.
 
 ## Documentation
 

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -38,10 +38,12 @@ import { StudioProvider, type StudioContextValue } from "./contexts/StudioContex
 import { PanelLayoutProvider } from "./contexts/PanelLayoutContext";
 import { FileManagerProvider } from "./contexts/FileManagerContext";
 import { DomEditProvider } from "./contexts/DomEditContext";
+import { StudioSplash } from "./components/StudioSplash";
 
 export function StudioApp() {
   const [projectId, setProjectId] = useState<string | null>(null);
   const [resolving, setResolving] = useState(true);
+  const [waitingForServer, setWaitingForServer] = useState(false);
   useMountEffect(() => {
     const hashProjectId = parseProjectIdFromHash(window.location.hash);
     if (hashProjectId) {
@@ -49,17 +51,29 @@ export function StudioApp() {
       setResolving(false);
       return;
     }
-    fetch("/api/projects")
-      .then((r) => r.json())
-      .then((data) => {
-        const first = (data.projects ?? [])[0];
-        if (first) {
-          setProjectId(first.id);
-          window.location.hash = buildProjectHash(first.id);
-        }
-      })
-      .catch(() => {})
-      .finally(() => setResolving(false));
+
+    function tryConnect() {
+      fetch("/api/projects")
+        .then((r) => r.json())
+        .then((data) => {
+          const first = (data.projects ?? [])[0];
+          if (first) {
+            setProjectId(first.id);
+            setWaitingForServer(false);
+            window.location.hash = buildProjectHash(first.id);
+          } else {
+            scheduleRetry();
+          }
+        })
+        .catch(() => scheduleRetry())
+        .finally(() => setResolving(false));
+    }
+
+    function scheduleRetry() {
+      setWaitingForServer(true);
+      window.setTimeout(tryConnect, 2000);
+    }
+    tryConnect();
   });
 
   const [activeCompPath, setActiveCompPath] = useState<string | null>(null);
@@ -341,12 +355,8 @@ export function StudioApp() {
     toggleTimelineVisibility,
   };
 
-  if (resolving || !projectId) {
-    return (
-      <div className="h-full w-full bg-neutral-950 flex items-center justify-center">
-        <div className="w-4 h-4 rounded-full bg-studio-accent animate-pulse" />
-      </div>
-    );
+  if (resolving || waitingForServer || !projectId) {
+    return <StudioSplash waiting={waitingForServer} />;
   }
 
   const timelineToolbar = <TimelineToolbar toggleTimelineVisibility={toggleTimelineVisibility} />;

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useRef, useMemo } from "react";
-import { useMountEffect } from "./hooks/useMountEffect";
 import type { LeftSidebarHandle } from "./components/sidebar/LeftSidebar";
 import { useRenderQueue } from "./components/renders/useRenderQueue";
 import { usePlayerStore } from "./player";
@@ -21,7 +20,6 @@ import { useFrameCapture } from "./hooks/useFrameCapture";
 import { useLintModal } from "./hooks/useLintModal";
 import { useCompositionDimensions } from "./hooks/useCompositionDimensions";
 import { useToast } from "./hooks/useToast";
-import { buildProjectHash, parseProjectIdFromHash } from "./utils/projectRouting";
 import {
   STUDIO_INSPECTOR_PANELS_ENABLED,
   STUDIO_MOTION_PANEL_ENABLED,
@@ -39,42 +37,10 @@ import { PanelLayoutProvider } from "./contexts/PanelLayoutContext";
 import { FileManagerProvider } from "./contexts/FileManagerContext";
 import { DomEditProvider } from "./contexts/DomEditContext";
 import { StudioSplash } from "./components/StudioSplash";
+import { useServerConnection } from "./hooks/useServerConnection";
 
 export function StudioApp() {
-  const [projectId, setProjectId] = useState<string | null>(null);
-  const [resolving, setResolving] = useState(true);
-  const [waitingForServer, setWaitingForServer] = useState(false);
-  useMountEffect(() => {
-    const hashProjectId = parseProjectIdFromHash(window.location.hash);
-    if (hashProjectId) {
-      setProjectId(hashProjectId);
-      setResolving(false);
-      return;
-    }
-
-    function tryConnect() {
-      fetch("/api/projects")
-        .then((r) => r.json())
-        .then((data) => {
-          const first = (data.projects ?? [])[0];
-          if (first) {
-            setProjectId(first.id);
-            setWaitingForServer(false);
-            window.location.hash = buildProjectHash(first.id);
-          } else {
-            scheduleRetry();
-          }
-        })
-        .catch(() => scheduleRetry())
-        .finally(() => setResolving(false));
-    }
-
-    function scheduleRetry() {
-      setWaitingForServer(true);
-      window.setTimeout(tryConnect, 2000);
-    }
-    tryConnect();
-  });
+  const { projectId, resolving, waitingForServer } = useServerConnection();
 
   const [activeCompPath, setActiveCompPath] = useState<string | null>(null);
   const [compIdToSrc, setCompIdToSrc] = useState<Map<string, string>>(new Map());

--- a/packages/studio/src/components/StudioSplash.tsx
+++ b/packages/studio/src/components/StudioSplash.tsx
@@ -1,0 +1,17 @@
+export function StudioSplash({ waiting }: { waiting?: boolean }) {
+  return (
+    <div className="h-full w-full bg-neutral-950 flex items-center justify-center">
+      {waiting ? (
+        <div className="flex flex-col items-center gap-3 text-center px-6">
+          <div className="w-4 h-4 rounded-full border-2 border-neutral-700 border-t-neutral-500 animate-spin" />
+          <p className="text-xs text-neutral-600">
+            Waiting for preview server… run{" "}
+            <code className="text-neutral-500 font-mono">npm run dev</code>
+          </p>
+        </div>
+      ) : (
+        <div className="w-4 h-4 rounded-full bg-studio-accent animate-pulse" />
+      )}
+    </div>
+  );
+}

--- a/packages/studio/src/hooks/useServerConnection.ts
+++ b/packages/studio/src/hooks/useServerConnection.ts
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { buildProjectHash, parseProjectIdFromHash } from "../utils/projectRouting";
+import { useMountEffect } from "./useMountEffect";
+
+interface ServerConnectionState {
+  projectId: string | null;
+  resolving: boolean;
+  waitingForServer: boolean;
+}
+
+/**
+ * Resolves the active project ID by pinging /api/projects.
+ *
+ * If the hash contains a project ID the server is still contacted — this
+ * ensures a dead server (bookmark-reload case) enters the waiting state
+ * rather than mounting the full Studio against a non-responsive API.
+ *
+ * Polls every 2 s until the server responds, then transitions automatically.
+ * Cleans up pending timers on unmount so it is safe under React StrictMode.
+ */
+export function useServerConnection(): ServerConnectionState {
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(true);
+  const [waitingForServer, setWaitingForServer] = useState(false);
+
+  useMountEffect(() => {
+    const hashProjectId = parseProjectIdFromHash(window.location.hash);
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof window.setTimeout> | null = null;
+
+    function scheduleRetry() {
+      setWaitingForServer(true);
+      retryTimer = window.setTimeout(tryConnect, 2000);
+    }
+
+    function tryConnect() {
+      fetch("/api/projects")
+        .then((r) => r.json())
+        .then((data) => {
+          if (cancelled) return;
+          if (hashProjectId) {
+            setProjectId(hashProjectId);
+            setWaitingForServer(false);
+          } else {
+            const first = (data.projects ?? [])[0];
+            if (first) {
+              setProjectId(first.id);
+              setWaitingForServer(false);
+              window.location.hash = buildProjectHash(first.id);
+            } else {
+              scheduleRetry();
+            }
+          }
+        })
+        .catch(() => {
+          if (!cancelled) scheduleRetry();
+        })
+        .finally(() => {
+          if (!cancelled) setResolving(false);
+        });
+    }
+
+    tryConnect();
+    return () => {
+      cancelled = true;
+      if (retryTimer !== null) clearTimeout(retryTimer);
+    };
+  });
+
+  return { projectId, resolving, waitingForServer };
+}


### PR DESCRIPTION
## Problem

Two things combined to produce the "reloading the tab kills the whole" experience reported by users:

**1. Agents were silently killing the server**

`CLAUDE.md` and `AGENTS.md` listed `npm run dev` with the same terse comment as other one-shot commands. Agents (Opus 4.7 and others) read this and ran it in foreground mode. The Bash tool timed out after ~2 minutes and killed the process. The browser preview appeared to work briefly, then died — and the next reload showed nothing useful.

**2. The Studio had no recovery UX**

When `/api/projects` failed, the `.catch(() => {})` swallowed the error silently and the component rendered the same loading spinner it shows during initial resolve. Users saw a pulsing dot forever with no indication of what happened or how to fix it.

## Fix

**Studio auto-reconnects** (`App.tsx`, `StudioSplash.tsx`): instead of a dead end, the Studio now polls `/api/projects` every 2 seconds. When the server comes back up, the editor loads automatically — no manual reload required. The waiting state shows a subtle spinner and a one-line hint, but the user doesn't need to act.

**Agents instructed correctly** (`_shared/CLAUDE.md`, `_shared/AGENTS.md`): added an explicit note that `npm run dev` is a long-running blocking server that must be started as a background process. Claude Code agents are told to use `run_in_background: true`.

## Does this address the Reddit complaint?

The user said: *"reloading the tab kills the whole"* and *"hard to consistently display Compositions."*

- If an agent started the server: agents now know to keep it running in background → server survives the session
- If the server dies for any reason: Studio auto-reconnects when it comes back, instead of staying blank forever
- The experience goes from "broken, no recovery" to "waiting, auto-recovers"