### PR TITLE
fix(studio): serve favicon.svg from embedded preview server

### DIFF
--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -420,6 +420,7 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
   };
   app.get("/assets/*", serveStudioStaticFile);
   app.get("/icons/*", serveStudioStaticFile);
+  app.get("/favicon.svg", serveStudioStaticFile);
 
   // SPA fallback
   app.get("*", (c) => {


### PR DESCRIPTION
Closes #804

## Problem

`/favicon.svg` was not listed as a static route in the embedded preview server (`studioServer.ts`). Requests for it fell through to the SPA catch-all, which returns `index.html`. The browser received HTML where it expected an SVG and silently ignored it, leaving the tab with no icon.

The file itself (`public/favicon.svg` → `dist/studio/favicon.svg`) was already correct and present — it just wasn't being served.

## Fix

One-line addition: explicit route for `/favicon.svg` alongside the existing `/assets/*` and `/icons/*` static routes.