### PR TITLE
fix(studio): canvas border expands when zooming — switch from CSS zoom to transform scale

### DIFF
--- a/packages/player/src/iframe-dom.ts
+++ b/packages/player/src/iframe-dom.ts
@@ -64,9 +64,13 @@ export function scaleIframeToFit(
   compositionWidth: number,
   compositionHeight: number,
 ): void {
-  const rect = playerElement.getBoundingClientRect();
-  if (rect.width === 0 || rect.height === 0) return;
-  const scale = Math.min(rect.width / compositionWidth, rect.height / compositionHeight);
+  // Use offsetWidth/offsetHeight (layout dimensions) instead of getBoundingClientRect(),
+  // which returns visual dimensions inflated by ancestor CSS zoom. Using the zoomed rect
+  // would double-scale the iframe when an ancestor has CSS zoom applied.
+  const width = playerElement.offsetWidth;
+  const height = playerElement.offsetHeight;
+  if (width === 0 || height === 0) return;
+  const scale = Math.min(width / compositionWidth, height / compositionHeight);
   iframe.style.width = `${compositionWidth}px`;
   iframe.style.height = `${compositionHeight}px`;
   iframe.style.transform = `translate(-50%, -50%) scale(${scale})`;

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -90,8 +90,8 @@ export const NLEPreview = memo(function NLEPreview({
     const s = toDomPrecision(state.zoomPercent / 100);
     const px = toDomPrecision(state.panX);
     const py = toDomPrecision(state.panY);
-    stage.style.zoom = String(s);
-    stage.style.transform = `translate(${px}px, ${py}px)`;
+    stage.style.zoom = "";
+    stage.style.transform = `translate(${px}px, ${py}px) scale(${s})`;
   }, []);
 
   const applyZoom = useCallback(
@@ -276,12 +276,11 @@ export const NLEPreview = memo(function NLEPreview({
           ref={stageRef}
           className="absolute inset-2"
           style={{
-            zoom: toDomPrecision(initial.zoomPercent / 100),
-            transform: `translate(${toDomPrecision(initial.panX)}px, ${toDomPrecision(initial.panY)}px)`,
-            transformOrigin: "0 0",
-            outline: "1px solid rgba(255,255,255,0.12)",
+            transform: `translate(${toDomPrecision(initial.panX)}px, ${toDomPrecision(initial.panY)}px) scale(${toDomPrecision(initial.zoomPercent / 100)})`,
+            transformOrigin: "50% 50%",
+            outline: "1px solid rgba(255,255,255,0.3)",
             outlineOffset: "0px",
-            boxShadow: "0 4px 32px rgba(0,0,0,0.55)",
+            boxShadow: "0 4px 32px rgba(0,0,0,0.7)",
           }}
           data-testid="preview-zoom-stage"
         >

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -90,7 +90,8 @@ export const NLEPreview = memo(function NLEPreview({
     const s = toDomPrecision(state.zoomPercent / 100);
     const px = toDomPrecision(state.panX);
     const py = toDomPrecision(state.panY);
-    stage.style.transform = `translate(${px}px, ${py}px) scale(${s})`;
+    stage.style.zoom = String(s);
+    stage.style.transform = `translate(${px}px, ${py}px)`;
   }, []);
 
   const applyZoom = useCallback(
@@ -275,9 +276,9 @@ export const NLEPreview = memo(function NLEPreview({
           ref={stageRef}
           className="absolute inset-2"
           style={{
-            transform: `translate(${toDomPrecision(initial.panX)}px, ${toDomPrecision(initial.panY)}px) scale(${toDomPrecision(initial.zoomPercent / 100)})`,
-            transformOrigin: "50% 50%",
-            willChange: "transform",
+            zoom: toDomPrecision(initial.zoomPercent / 100),
+            transform: `translate(${toDomPrecision(initial.panX)}px, ${toDomPrecision(initial.panY)}px)`,
+            transformOrigin: "0 0",
             outline: "1px solid rgba(255,255,255,0.3)",
             outlineOffset: "0px",
             boxShadow: "0 4px 32px rgba(0,0,0,0.7)",

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -90,7 +90,6 @@ export const NLEPreview = memo(function NLEPreview({
     const s = toDomPrecision(state.zoomPercent / 100);
     const px = toDomPrecision(state.panX);
     const py = toDomPrecision(state.panY);
-    stage.style.zoom = "";
     stage.style.transform = `translate(${px}px, ${py}px) scale(${s})`;
   }, []);
 
@@ -278,6 +277,7 @@ export const NLEPreview = memo(function NLEPreview({
           style={{
             transform: `translate(${toDomPrecision(initial.panX)}px, ${toDomPrecision(initial.panY)}px) scale(${toDomPrecision(initial.zoomPercent / 100)})`,
             transformOrigin: "50% 50%",
+            willChange: "transform",
             outline: "1px solid rgba(255,255,255,0.3)",
             outlineOffset: "0px",
             boxShadow: "0 4px 32px rgba(0,0,0,0.7)",

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -264,7 +264,7 @@ export const NLEPreview = memo(function NLEPreview({
     <div className="flex flex-col h-full min-h-0">
       <div
         ref={viewportRef}
-        className="relative flex-1 flex items-center justify-center p-2 overflow-hidden min-h-0 outline-none focus:ring-1 focus:ring-studio-accent/40 bg-neutral-900"
+        className="relative flex-1 flex items-center justify-center p-2 overflow-hidden min-h-0 outline-none focus-visible:ring-1 focus-visible:ring-studio-accent/40 bg-neutral-900"
         tabIndex={0}
         aria-label="Composition preview"
         onPointerDown={handlePointerDown}

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -264,7 +264,7 @@ export const NLEPreview = memo(function NLEPreview({
     <div className="flex flex-col h-full min-h-0">
       <div
         ref={viewportRef}
-        className="relative flex-1 flex items-center justify-center p-2 overflow-hidden min-h-0 outline-none focus:ring-1 focus:ring-studio-accent/40"
+        className="relative flex-1 flex items-center justify-center p-2 overflow-hidden min-h-0 outline-none focus:ring-1 focus:ring-studio-accent/40 bg-neutral-900"
         tabIndex={0}
         aria-label="Composition preview"
         onPointerDown={handlePointerDown}
@@ -279,6 +279,9 @@ export const NLEPreview = memo(function NLEPreview({
             zoom: toDomPrecision(initial.zoomPercent / 100),
             transform: `translate(${toDomPrecision(initial.panX)}px, ${toDomPrecision(initial.panY)}px)`,
             transformOrigin: "0 0",
+            outline: "1px solid rgba(255,255,255,0.12)",
+            outlineOffset: "0px",
+            boxShadow: "0 4px 32px rgba(0,0,0,0.55)",
           }}
           data-testid="preview-zoom-stage"
         >


### PR DESCRIPTION
## Summary

- Replaces `stage.style.zoom` with `CSS transform: scale()` on the preview stage element
- Changes `transformOrigin` from `"0 0"` (top-left) to `"50% 50%"` (centre) to match the existing pan-clamping formula

## Root cause

CSS `zoom` is a layout property. Changing it at runtime triggers `ResizeObserver` on descendant elements, which causes `scaleIframeToFit` to re-run with `getBoundingClientRect()` values that are already inflated by the zoom factor. The iframe ends up scaled too small relative to the player's visual bounds, and the visible letterbox grows as zoom increases — the "canvas border expands inward" symptom reported in #752.

CSS `transform: scale()` is visual-only. `ResizeObserver` never fires on scale changes, so `scaleIframeToFit` keeps the scale it computed on initial mount (based on layout dimensions). The parent transform then magnifies the player and composition uniformly, so the composition always fills the player's visual bounds at any zoom level.

## Test plan

- [ ] Open Studio preview, zoom in and out with Ctrl+scroll or the zoom buttons — no visible letterbox should appear at any zoom level
- [ ] Reload the page with a non-default stored zoom — composition should fill correctly on mount
- [ ] Pan while zoomed in — pan clamping should feel symmetrical (previously it was asymmetric because origin was top-left)

Closes #752