### PR TITLE
docs: add adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -22,4 +22,8 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Evaluating
 
-_Open a PR to add your organization here if you're trying HyperFrames in a non-production context._
+| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
+| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -32,4 +32,20 @@ The HeyGen team's actual launch-video sources (the ones featured in product anno
 
 ## Evaluating
 
-_Open a PR to add your organization here if you're trying HyperFrames in a non-production context._
+<CardGroup cols={3}>
+  <Card title="HeyGen" href="https://www.heygen.com">
+    Powers AI-generated video composition and rendering across HeyGen's video product surface.
+  </Card>
+  <Card title="TanStack" href="https://tanstack.com">
+    Exploring HyperFrames for video content and documentation.
+  </Card>
+  <Card title="OptinMonster" href="https://optinmonster.com">
+    Exploring HyperFrames for marketing and product video content.
+  </Card>
+</CardGroup>
+
+| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
+| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |


### PR DESCRIPTION
Adds [TanStack](https://tanstack.com) to the adopters list (Evaluating), with contact [@AlemTuzlak](https://github.com/AlemTuzlak).

Alem greenlit this on X:

<details>
<summary>Screenshot reference</summary>

![Screenshot 2026-05-13 at 16.19.05.png](https://app.graphite.com/user-attachments/assets/adeb1c5d-dce8-40a6-9f3b-b5bed2dac908.png)

</details>

Changes:

- `ADOPTERS.md` — new row in the Evaluating table
- `docs/community/adopters.mdx` — same row in the docs page