### PR TITLE
docs(guides): refresh video editor cheatsheet with I/O work-area shortcuts

### DIFF
--- a/docs/guides/video-editor-cheatsheet.mdx
+++ b/docs/guides/video-editor-cheatsheet.mdx
@@ -81,17 +81,50 @@ Use a different port if `3002` is already busy:
 npx hyperframes preview --port 4567
 ```
 
-Inside the Studio:
+Inside the Studio, shortcuts are grouped the same way the playbar's `⌨` panel groups them — playback first, then work-area markers, view controls, and app-level commands. Open the `⌨` panel in the playbar for an in-app cheatsheet, a frame-jump input, and live readouts of the in/out points.
 
-| Shortcut | Use |
+### Playback
+
+| Shortcut | Action |
 | --- | --- |
-| `Space` | Play or pause (focus on the page body) |
-| `Left Arrow` / `Right Arrow` | Nudge seek bar by 1 second (seek bar focused) |
-| `Shift+Left Arrow` / `Shift+Right Arrow` | Nudge seek bar by 5 seconds (seek bar focused) |
+| `Space` | Play or pause |
+| `K` | Stop |
+| `J` | Play backward (press again to shuttle faster) |
+| `L` | Play forward (press again to shuttle faster) |
+| `←` / `→` | Step 1 frame |
+| `Shift+←` / `Shift+→` | Step 10 frames |
+
+`J` and `L` build the classic NLE shuttle: each repeat ramps the playback rate up. Tap `K` between shuttle bursts to stop. With `K` held, tapping `J` or `L` steps one frame in that direction.
+
+### Work area (in / out points)
+
+| Shortcut | Action |
+| --- | --- |
+| `I` | Set in-point at the playhead |
+| `Shift+I` | Clear in-point |
+| `O` | Set out-point at the playhead |
+| `Shift+O` | Clear out-point |
+| `A` | Jump to in-point (or composition start if unset) |
+| `E` | Jump to out-point (or composition end if unset) |
+
+The in and out points define a **work area**. When loop is on, both forward and backward playback loop within those boundaries — useful for tightening a transition or scrubbing a single clip without trimming it. The seek bar renders a teal band between in and out, with tick markers at each point. Clear the markers from the `⌨` panel or with `Shift+I` and `Shift+O`.
+
+### View
+
+| Shortcut | Action |
+| --- | --- |
+| `Cmd+Scroll` / `Ctrl+Scroll` over the preview | Zoom the preview at the cursor |
+
+### Application
+
+| Shortcut | Action |
+| --- | --- |
 | `Shift+T` | Show or hide the timeline editor |
-| `Cmd+1` / `Ctrl+1` | Switch to Compositions |
-| `Cmd+2` / `Ctrl+2` | Switch to Assets |
-| `Delete` / `Backspace` | Delete the selected timeline clip (when not typing in an editor) |
+| `Cmd+1` / `Ctrl+1` | Switch sidebar to Compositions |
+| `Cmd+2` / `Ctrl+2` | Switch sidebar to Assets |
+| `Cmd+Z` / `Ctrl+Z` | Undo |
+| `Cmd+Shift+Z` / `Ctrl+Shift+Z` / `Ctrl+Y` | Redo |
+| `Delete` / `Backspace` | Delete the selected timeline clip or DOM element (when not typing in an editor) |
 | `Escape` | Leave a sub-composition or close editor dialogs |
 
 <Tip>


### PR DESCRIPTION
## Summary

Refreshes `docs/guides/video-editor-cheatsheet.mdx` so the Preview Shortcuts section matches what's actually wired up in the Studio today. The single flat table is split into the same four groups the in-app `⌨` panel uses (Playback, Work area, View, Application), with each row traced to the source handler so the doc stays in sync with the code.

**New rows (previously undocumented)**

- Playback shuttle: `J` / `K` / `L`, including the "press again to shuttle faster" semantics from `usePlaybackKeyboard.ts`.
- Work-area markers from #811: `I` / `⇧I` / `O` / `⇧O` to set and clear in/out, `A` / `E` to jump (with fallback to composition start / end when unset).
- View: `Cmd/Ctrl+Scroll` over the preview to zoom at the cursor (`NLEPreview.tsx` wheel handler).
- App: `Cmd/Ctrl+Z` undo and `Cmd/Ctrl+Shift+Z` / `Ctrl+Y` redo, exposed by #710.

**Corrections to existing rows**

- Arrow keys step **1 frame** and `Shift+Arrow` steps **10 frames** — the previous "1 second" / "5 seconds" wording was wrong (see `stepFrames(e.shiftKey ? -10 : -1)` in `usePlaybackKeyboard.ts`).
- "Seek bar focused" qualifier dropped — the keydown listener is window + iframe-level, gated only by `shouldIgnorePlaybackShortcutEvent` for editable targets.

**Narrative additions**

- Short paragraph explaining the work area concept and that loop respects the in/out band when set, matching the #811 description.
- Mention of the in-app `⌨` panel (frame jump + live in/out readouts) as the discoverable home for these shortcuts.

Closes #812.

## Test plan

- [x] `npx mint validate` — success build validation passed.
- [x] `npx mint broken-links` — no broken links found.
- [x] `npx tsx scripts/sync-schemas.ts --check` — registry schemas in sync.
- [x] Cross-checked every row against the source: `usePlaybackKeyboard.ts`, `useAppHotkeys.ts`, `PlayerControls.tsx` (`SHORTCUT_SECTIONS`), `NLEPreview.tsx`.
- [x] Conventional commit + lefthook commitlint pass.

Happy to adjust grouping, naming (e.g. "Work area" vs "Range"), or table density if the maintainers prefer a different style.