### PR TITLE
feat(registry): add vignette CSS component

### DIFF
--- a/docs/catalog/components/vignette.mdx
+++ b/docs/catalog/components/vignette.mdx
@@ -1,0 +1,38 @@
+---
+title: "Vignette"
+description: "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center"
+---
+
+# Vignette
+
+Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center
+
+`vignette` `overlay` `cinematic` `effect`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add vignette
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `vignette.html` | `compositions/components/vignette.html` | hyperframes:snippet |
+
+## Usage
+
+Open `compositions/components/vignette.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -180,7 +180,8 @@
               "catalog/components/grain-overlay",
               "catalog/components/grid-pixelate-wipe",
               "catalog/components/shimmer-sweep",
-              "catalog/components/texture-mask-text"
+              "catalog/components/texture-mask-text",
+              "catalog/components/vignette"
             ]
           },
           {

--- a/docs/public/catalog-index.json
+++ b/docs/public/catalog-index.json
@@ -651,6 +651,20 @@
     "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-text-cursor.png"
   },
   {
+    "name": "vignette",
+    "type": "component",
+    "title": "Vignette",
+    "description": "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center",
+    "tags": [
+      "vignette",
+      "overlay",
+      "cinematic",
+      "effect"
+    ],
+    "href": "/catalog/components/vignette",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.png"
+  },
+  {
     "name": "vpn-youtube-spot",
     "type": "block",
     "title": "VPN YouTube Spot",

--- a/registry/components/vignette/demo.html
+++ b/registry/components/vignette/demo.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>Vignette — Demo</title>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="demo"
+      data-composition-id="vignette-demo"
+      data-width="1920"
+      data-height="1080"
+      data-duration="6"
+    >
+      <div class="demo-bg">
+        <div
+          class="demo-title"
+          style="font-size: 96px; font-weight: 700; color: #f4ecd6; opacity: 0"
+        >
+          Vignette
+        </div>
+        <div
+          class="demo-subtitle"
+          style="
+            font-size: 32px;
+            color: rgba(244, 236, 214, 0.7);
+            margin-top: 16px;
+            letter-spacing: 0.04em;
+            opacity: 0;
+          "
+        >
+          Pulls focus toward the center
+        </div>
+      </div>
+
+      <!-- The vignette component -->
+      <div
+        id="hf-vignette"
+        style="
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          pointer-events: none;
+          z-index: 90;
+        "
+      ></div>
+
+      <style>
+        .demo-bg {
+          width: 1920px;
+          height: 1080px;
+          background: radial-gradient(circle at 30% 30%, #c98a4b, #6d3a18 60%, #2a160a 100%);
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          font-family: "Inter", sans-serif;
+          position: relative;
+        }
+
+        #hf-vignette {
+          background: radial-gradient(
+            var(--vignette-shape, ellipse) at center,
+            transparent var(--vignette-size, 45%),
+            var(--vignette-color, rgba(0, 0, 0, 0.7)) var(--vignette-edge, 100%)
+          );
+        }
+      </style>
+
+      <script>
+        (function () {
+          const tl = gsap.timeline({ paused: true });
+
+          // Fade in title and subtitle
+          tl.to(".demo-title", { opacity: 1, y: -10, duration: 1, ease: "power3.out" }, 0.3);
+          tl.to(".demo-subtitle", { opacity: 1, y: -5, duration: 0.8, ease: "power3.out" }, 0.7);
+
+          // Fade vignette in from transparent
+          tl.fromTo(
+            "#hf-vignette",
+            { "--vignette-color": "rgba(0, 0, 0, 0)" },
+            {
+              "--vignette-color": "rgba(0, 0, 0, 0.75)",
+              duration: 1.5,
+              ease: "power2.out",
+            },
+            1.2,
+          );
+
+          // Breathe the size in and out
+          tl.to(
+            "#hf-vignette",
+            { "--vignette-size": "35%", duration: 1.0, ease: "sine.inOut" },
+            3.0,
+          );
+          tl.to(
+            "#hf-vignette",
+            { "--vignette-size": "45%", duration: 1.0, ease: "sine.inOut" },
+            4.0,
+          );
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines["vignette-demo"] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/components/vignette/registry-item.json
+++ b/registry/components/vignette/registry-item.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "vignette",
+  "type": "hyperframes:component",
+  "title": "Vignette",
+  "description": "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center",
+  "tags": ["vignette", "overlay", "cinematic", "effect"],
+  "files": [
+    {
+      "path": "vignette.html",
+      "target": "compositions/components/vignette.html",
+      "type": "hyperframes:snippet"
+    }
+  ]
+}

--- a/registry/components/vignette/vignette.html
+++ b/registry/components/vignette/vignette.html
@@ -1,0 +1,51 @@
+<!--
+  Vignette — cinematic radial darkening overlay.
+
+  Usage: paste this snippet inside your composition's positioned stage.
+  The overlay covers the full viewport with pointer-events: none so it
+  sits on top of all content without blocking interaction.
+
+  Customize:
+  - --vignette-color: edge color and alpha (default rgba(0, 0, 0, 0.7))
+  - --vignette-size: where the transparent center ends (default 45%)
+  - --vignette-edge: where the color reaches its final stop (default 100%)
+  - --vignette-shape: ellipse | circle (default ellipse)
+  - z-index: defaults to 90 so grain-overlay (100) reads on top
+-->
+
+<div
+  id="hf-vignette"
+  style="
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 90;
+  "
+></div>
+
+<style>
+  #hf-vignette {
+    background: radial-gradient(
+      var(--vignette-shape, ellipse) at center,
+      transparent var(--vignette-size, 45%),
+      var(--vignette-color, rgba(0, 0, 0, 0.7)) var(--vignette-edge, 100%)
+    );
+  }
+</style>
+
+<!--
+  Timeline integration example (add to your composition's GSAP timeline):
+
+  // Fade the vignette in over the first second
+  tl.fromTo("#hf-vignette",
+    { "--vignette-color": "rgba(0, 0, 0, 0)" },
+    { "--vignette-color": "rgba(0, 0, 0, 0.7)", duration: 1, ease: "power2.out" },
+    0,
+  );
+
+  // Or breathe the size in and out (works with any easing)
+  tl.to("#hf-vignette", { "--vignette-size": "35%", duration: 1, ease: "sine.inOut" }, 2);
+-->

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -64,6 +64,10 @@
       "type": "hyperframes:component"
     },
     {
+      "name": "vignette",
+      "type": "hyperframes:component"
+    },
+    {
       "name": "instagram-follow",
       "type": "hyperframes:block"
     },


### PR DESCRIPTION
## Summary

Adds **`vignette`** — a pure-CSS radial darkening overlay — to the components catalog. It absolutely fills its positioned parent with `pointer-events: none`, so it sits over any composition without intercepting interaction, and uses a single `radial-gradient` to pull focus toward the center.

The intent matches the bar set in #779 and the team discussion on #712: a small, generic, model-free primitive in the spirit of a shadcn-style component. No bundled assets, no Three.js, no hardcoded theme.

### Why this fills a real gap

Components currently has four entries (`grain-overlay`, `shimmer-sweep`, `grid-pixelate-wipe`, `texture-mask-text`). None covers the cinematic edge-darken that virtually every cinematographic edit reaches for. With this component a user can do:

```html
<!-- inside the composition stage -->
<div id="hf-vignette" style="--vignette-color: rgba(10,5,20,0.85); --vignette-size: 35%"></div>
```

…and get a configurable cinematic vignette in two lines.

### API

Customizable via CSS custom properties on `#hf-vignette` (or any ancestor):

| Custom property | Default | Purpose |
| --- | --- | --- |
| `--vignette-color` | `rgba(0, 0, 0, 0.7)` | Color (and alpha) of the darkened edges |
| `--vignette-size` | `45%` | Where the transparent center ends — smaller eats more frame |
| `--vignette-edge` | `100%` | Where the color reaches its final stop — pull inward for a sharper falloff |
| `--vignette-shape` | `ellipse` | `ellipse` \| `circle` |

All four properties can be tweened from a GSAP timeline; the snippet's header comment shows the standard "fade-in over 1s" pattern. Default `z-index: 90` sits below `grain-overlay` (100) so grain reads on top of the darkened corners — inline-overridable if a different layer order is needed.

### Files

- `registry/components/vignette/registry-item.json` — manifest
- `registry/components/vignette/vignette.html` — the snippet (~50 lines incl. the documentation comment)
- `registry/components/vignette/demo.html` — standalone composition that fades the vignette in, then breathes the `--vignette-size` once
- `registry/registry.json` — index entry
- `docs/catalog/components/vignette.mdx`, `docs/docs.json`, `docs/public/catalog-index.json` — regenerated via `scripts/generate-catalog-pages.ts`

## Test plan

- [x] `npx tsx scripts/generate-catalog-previews.ts --only vignette --skip-video` → renders cleanly (564 ms), 1920×1080 PNG matches the intent.
- [x] `npx tsx scripts/generate-catalog-pages.ts` → produces the MDX page, updates `docs.json` and `catalog-index.json` with no other diffs.
- [x] `npx hyperframes lint` against a temp project that includes the snippet → 0 errors, 0 snippet-side warnings.
- [x] `npx hyperframes validate` against the same project → "No console errors · 5 text elements pass WCAG AA".
- [x] `cd docs && npx mint validate` → build validation passed.
- [x] `cd docs && npx mint broken-links` → no broken links.
- [x] `npx tsx scripts/sync-schemas.ts --check` → registry + registry-item schemas in sync.
- [x] Conventional commit + lefthook commitlint pass.

Happy to adjust the API surface (rename properties, drop a knob, reframe the default z-index) or the demo timing if the team wants something different.