### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# Normalize text files to LF on checkout and in the repo, regardless of the
+# contributor's OS. Without this, files saved on Windows can land in PRs with
+# CRLF endings or a UTF-8 BOM, which makes every line differ at the byte level
+# and trips GitHub's "Binary file not shown" diff heuristic.
+* text=auto eol=lf
+
 # Golden baseline videos for regression tests
 packages/producer/tests/*/output/output.mp4 filter=lfs diff=lfs merge=lfs -text
 


### PR DESCRIPTION
## Summary
- Add `* text=auto eol=lf` to `.gitattributes` so text files are checked in with LF regardless of the contributor's OS.

## Why
On #840, a TypeScript file landed in the PR saved as UTF-8-with-BOM + CRLF, while `main` has it as UTF-8 + LF. Every line then differed at the byte level even though the actual code change was ~30 lines, which tripped GitHub's "Binary file not shown" diff heuristic and made the PR unreviewable.

`.editorconfig` already declares `end_of_line = lf` and `charset = utf-8`, but that's a hint to editors — Git doesn't enforce it. Adding the rule at the `.gitattributes` layer means Git itself normalizes on checkin, so this class of mistake can't reach a PR diff again.

Existing LFS rules (`packages/producer/tests/.../*.mp4`, `.png`) already carry `-text` and remain unaffected by the new top-level rule.

## Test plan
- [ ] CI green
- [ ] After merge, contributors with `core.autocrlf=true` on Windows will have CRLF in their working tree but the repo will still store LF — confirm by inspecting a freshly-cloned `.gitattributes`-aware checkout (`git ls-files --eol`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)