### PR TITLE
feat(registry): add vignette CSS component

### DIFF
--- a/docs/catalog/components/vignette.mdx
+++ b/docs/catalog/components/vignette.mdx
@@ -1,0 +1,38 @@
+---
+title: "Vignette"
+description: "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center"
+---
+
+# Vignette
+
+Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center
+
+`vignette` `overlay` `cinematic` `effect`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add vignette
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `vignette.html` | `compositions/components/vignette.html` | hyperframes:snippet |
+
+## Usage
+
+Open `compositions/components/vignette.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -180,7 +180,8 @@
               "catalog/components/grain-overlay",
               "catalog/components/grid-pixelate-wipe",
               "catalog/components/shimmer-sweep",
-              "catalog/components/texture-mask-text"
+              "catalog/components/texture-mask-text",
+              "catalog/components/vignette"
             ]
           },
           {

--- a/docs/public/catalog-index.json
+++ b/docs/public/catalog-index.json
@@ -651,6 +651,20 @@
     "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-text-cursor.png"
   },
   {
+    "name": "vignette",
+    "type": "component",
+    "title": "Vignette",
+    "description": "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center",
+    "tags": [
+      "vignette",
+      "overlay",
+      "cinematic",
+      "effect"
+    ],
+    "href": "/catalog/components/vignette",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.png"
+  },
+  {
     "name": "vpn-youtube-spot",
     "type": "block",
     "title": "VPN YouTube Spot",

--- a/packages/studio/src/player/hooks/usePlaybackKeyboard.test.ts
+++ b/packages/studio/src/player/hooks/usePlaybackKeyboard.test.ts
@@ -93,7 +93,7 @@ describe("usePlaybackKeyboard — keyboard layout independence (#834)", () => {
       dispatch(keydown({ code: "KeyA", key: "a" }));
     });
 
-    expect(spies.seek).toHaveBeenCalledWith(1.5);
+    expect(spies.seek).toHaveBeenCalledWith(1.5, { keepPlaying: true });
   });
 
   it("'Jump to in-point' fires on AZERTY (physical KeyQ produces e.key='a')", () => {
@@ -104,7 +104,7 @@ describe("usePlaybackKeyboard — keyboard layout independence (#834)", () => {
       dispatch(keydown({ code: "KeyQ", key: "a" }));
     });
 
-    expect(spies.seek).toHaveBeenCalledWith(2.5);
+    expect(spies.seek).toHaveBeenCalledWith(2.5, { keepPlaying: true });
   });
 
   it("AZERTY 'A' physical key (e.key='q') no longer triggers in-point seek", () => {

--- a/registry/components/vignette/demo.html
+++ b/registry/components/vignette/demo.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>Vignette — Demo</title>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="demo"
+      data-composition-id="vignette-demo"
+      data-width="1920"
+      data-height="1080"
+      data-duration="6"
+    >
+      <div class="demo-bg">
+        <div
+          class="demo-title"
+          style="font-size: 96px; font-weight: 700; color: #f4ecd6; opacity: 0"
+        >
+          Vignette
+        </div>
+        <div
+          class="demo-subtitle"
+          style="
+            font-size: 32px;
+            color: rgba(244, 236, 214, 0.7);
+            margin-top: 16px;
+            letter-spacing: 0.04em;
+            opacity: 0;
+          "
+        >
+          Pulls focus toward the center
+        </div>
+      </div>
+
+      <!-- The vignette component -->
+      <div
+        id="hf-vignette"
+        style="
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          pointer-events: none;
+          z-index: 90;
+        "
+      ></div>
+
+      <style>
+        .demo-bg {
+          width: 1920px;
+          height: 1080px;
+          background: radial-gradient(circle at 30% 30%, #c98a4b, #6d3a18 60%, #2a160a 100%);
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          font-family: "Inter", sans-serif;
+          position: relative;
+        }
+
+        #hf-vignette {
+          background: radial-gradient(
+            var(--vignette-shape, ellipse) at center,
+            transparent var(--vignette-size, 45%),
+            var(--vignette-color, rgba(0, 0, 0, 0.7)) var(--vignette-edge, 100%)
+          );
+        }
+      </style>
+
+      <script>
+        (function () {
+          const tl = gsap.timeline({ paused: true });
+
+          // Fade in title and subtitle
+          tl.to(".demo-title", { opacity: 1, y: -10, duration: 1, ease: "power3.out" }, 0.3);
+          tl.to(".demo-subtitle", { opacity: 1, y: -5, duration: 0.8, ease: "power3.out" }, 0.7);
+
+          // Fade vignette in from transparent
+          tl.fromTo(
+            "#hf-vignette",
+            { "--vignette-color": "rgba(0, 0, 0, 0)" },
+            {
+              "--vignette-color": "rgba(0, 0, 0, 0.75)",
+              duration: 1.5,
+              ease: "power2.out",
+            },
+            1.2,
+          );
+
+          // Breathe the size in and out
+          tl.to(
+            "#hf-vignette",
+            { "--vignette-size": "35%", duration: 1.0, ease: "sine.inOut" },
+            3.0,
+          );
+          tl.to(
+            "#hf-vignette",
+            { "--vignette-size": "45%", duration: 1.0, ease: "sine.inOut" },
+            4.0,
+          );
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines["vignette-demo"] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/components/vignette/demo.html
+++ b/registry/components/vignette/demo.html
@@ -17,6 +17,7 @@
         width: 1920px;
         height: 1080px;
         overflow: hidden;
+        background: #000;
       }
     </style>
   </head>
@@ -26,26 +27,22 @@
       data-composition-id="vignette-demo"
       data-width="1920"
       data-height="1080"
-      data-duration="6"
+      data-duration="5"
     >
+      <!-- Backdrop: a layered "cinematic still" — a warm key light at upper-left,
+           a teal rim light at lower-right, and a soft global glow. The vignette
+           overlay reads against this so the effect is unambiguous. -->
       <div class="demo-bg">
-        <div
-          class="demo-title"
-          style="font-size: 96px; font-weight: 700; color: #f4ecd6; opacity: 0"
-        >
-          Vignette
-        </div>
-        <div
-          class="demo-subtitle"
-          style="
-            font-size: 32px;
-            color: rgba(244, 236, 214, 0.7);
-            margin-top: 16px;
-            letter-spacing: 0.04em;
-            opacity: 0;
-          "
-        >
-          Pulls focus toward the center
+        <!-- Subject shapes — a stylized "moon" centered, with subtle haze rings
+             so the eye has something to anchor on. Without a subject the demo
+             looks like an abstract gradient and the vignette gets lost. -->
+        <div class="demo-haze haze-far"></div>
+        <div class="demo-haze haze-near"></div>
+        <div class="demo-subject"></div>
+
+        <div class="demo-text">
+          <div class="demo-title">VIGNETTE</div>
+          <div class="demo-subtitle">Frame the eye. Hold the moment.</div>
         </div>
       </div>
 
@@ -67,13 +64,101 @@
         .demo-bg {
           width: 1920px;
           height: 1080px;
-          background: radial-gradient(circle at 30% 30%, #c98a4b, #6d3a18 60%, #2a160a 100%);
+          background:
+            radial-gradient(
+              circle at 22% 28%,
+              rgba(255, 196, 130, 0.85),
+              rgba(255, 196, 130, 0) 38%
+            ),
+            radial-gradient(circle at 78% 78%, rgba(64, 175, 200, 0.55), rgba(64, 175, 200, 0) 42%),
+            radial-gradient(circle at 50% 50%, #3b2616 0%, #1a0e07 68%, #060403 100%);
+          position: relative;
+          overflow: hidden;
+          font-family: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        }
+
+        .demo-haze {
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          border-radius: 50%;
+          transform: translate(-50%, -50%) scale(1);
+          pointer-events: none;
+          opacity: 0;
+        }
+        .haze-far {
+          width: 1400px;
+          height: 1400px;
+          background: radial-gradient(
+            circle,
+            rgba(255, 220, 180, 0.18),
+            rgba(255, 220, 180, 0) 65%
+          );
+          filter: blur(40px);
+        }
+        .haze-near {
+          width: 900px;
+          height: 900px;
+          background: radial-gradient(
+            circle,
+            rgba(255, 240, 210, 0.32),
+            rgba(255, 240, 210, 0) 60%
+          );
+          filter: blur(20px);
+        }
+
+        .demo-subject {
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          width: 520px;
+          height: 520px;
+          border-radius: 50%;
+          transform: translate(-50%, -50%);
+          background: radial-gradient(
+            circle at 35% 32%,
+            #fff6e0 0%,
+            #f4c47e 28%,
+            #b87a3f 62%,
+            #6b3d1c 88%,
+            #2a1607 100%
+          );
+          box-shadow:
+            inset -40px -40px 80px rgba(0, 0, 0, 0.55),
+            0 0 120px rgba(255, 180, 100, 0.35);
+          opacity: 0;
+        }
+
+        .demo-text {
+          position: absolute;
+          left: 0;
+          right: 0;
+          bottom: 12%;
           display: flex;
           flex-direction: column;
-          justify-content: center;
           align-items: center;
-          font-family: "Inter", sans-serif;
-          position: relative;
+          gap: 14px;
+          pointer-events: none;
+          /* Sits above the subject in document order; below the vignette in z-index */
+          z-index: 5;
+        }
+
+        .demo-title {
+          font-size: 108px;
+          font-weight: 800;
+          letter-spacing: 0.18em;
+          color: #f6ecd0;
+          text-shadow: 0 4px 24px rgba(0, 0, 0, 0.55);
+          opacity: 0;
+        }
+
+        .demo-subtitle {
+          font-size: 30px;
+          font-weight: 400;
+          letter-spacing: 0.32em;
+          text-transform: uppercase;
+          color: rgba(246, 236, 208, 0.72);
+          opacity: 0;
         }
 
         #hf-vignette {
@@ -89,32 +174,53 @@
         (function () {
           const tl = gsap.timeline({ paused: true });
 
-          // Fade in title and subtitle
-          tl.to(".demo-title", { opacity: 1, y: -10, duration: 1, ease: "power3.out" }, 0.3);
-          tl.to(".demo-subtitle", { opacity: 1, y: -5, duration: 0.8, ease: "power3.out" }, 0.7);
+          // Reveal the backdrop subject and haze first so the vignette has
+          // something to frame. Without a subject the effect reads as a flat
+          // dark gradient — uninteresting in a still preview.
+          tl.to(".haze-far", { opacity: 1, duration: 0.8, ease: "power2.out" }, 0.0);
+          tl.to(".haze-near", { opacity: 1, duration: 0.8, ease: "power2.out" }, 0.15);
+          tl.to(".demo-subject", { opacity: 1, scale: 1, duration: 1.0, ease: "power3.out" }, 0.1);
 
-          // Fade vignette in from transparent
+          // Title + subtitle settle in.
           tl.fromTo(
+            ".demo-title",
+            { opacity: 0, y: 18, letterSpacing: "0.32em" },
+            { opacity: 1, y: 0, letterSpacing: "0.18em", duration: 1.0, ease: "power3.out" },
+            0.6,
+          );
+          tl.to(".demo-subtitle", { opacity: 1, duration: 0.8, ease: "power3.out" }, 1.0);
+
+          // Vignette: start visibly soft (so viewers see the unframed scene),
+          // then ramp to a strong cinematic vignette and hold through the
+          // capture-time peak (~3.0s, picked to match the catalog thumbnail
+          // sampling at `Math.min(3.0, duration * 0.6)` for duration=5).
+          gsap.set("#hf-vignette", {
+            "--vignette-color": "rgba(0, 0, 0, 0.35)",
+            "--vignette-size": "70%",
+            "--vignette-edge": "100%",
+          });
+          tl.to(
             "#hf-vignette",
-            { "--vignette-color": "rgba(0, 0, 0, 0)" },
             {
-              "--vignette-color": "rgba(0, 0, 0, 0.75)",
-              duration: 1.5,
-              ease: "power2.out",
+              "--vignette-color": "rgba(0, 0, 0, 0.92)",
+              "--vignette-size": "26%",
+              duration: 1.6,
+              ease: "power2.inOut",
             },
-            1.2,
+            1.4,
           );
 
-          // Breathe the size in and out
+          // Gentle breathing for the video loop so the effect reads as alive,
+          // not static. Keeps the still-frame at peak intensity around t≈3s.
           tl.to(
             "#hf-vignette",
-            { "--vignette-size": "35%", duration: 1.0, ease: "sine.inOut" },
-            3.0,
+            { "--vignette-size": "32%", duration: 0.9, ease: "sine.inOut" },
+            3.4,
           );
           tl.to(
             "#hf-vignette",
-            { "--vignette-size": "45%", duration: 1.0, ease: "sine.inOut" },
-            4.0,
+            { "--vignette-size": "26%", duration: 0.9, ease: "sine.inOut" },
+            4.3,
           );
 
           window.__timelines = window.__timelines || {};

--- a/registry/components/vignette/registry-item.json
+++ b/registry/components/vignette/registry-item.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "vignette",
+  "type": "hyperframes:component",
+  "title": "Vignette",
+  "description": "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center",
+  "tags": ["vignette", "overlay", "cinematic", "effect"],
+  "files": [
+    {
+      "path": "vignette.html",
+      "target": "compositions/components/vignette.html",
+      "type": "hyperframes:snippet"
+    }
+  ]
+}

--- a/registry/components/vignette/vignette.html
+++ b/registry/components/vignette/vignette.html
@@ -1,0 +1,51 @@
+<!--
+  Vignette — cinematic radial darkening overlay.
+
+  Usage: paste this snippet inside your composition's positioned stage.
+  The overlay covers the full viewport with pointer-events: none so it
+  sits on top of all content without blocking interaction.
+
+  Customize:
+  - --vignette-color: edge color and alpha (default rgba(0, 0, 0, 0.7))
+  - --vignette-size: where the transparent center ends (default 45%)
+  - --vignette-edge: where the color reaches its final stop (default 100%)
+  - --vignette-shape: ellipse | circle (default ellipse)
+  - z-index: defaults to 90 so grain-overlay (100) reads on top
+-->
+
+<div
+  id="hf-vignette"
+  style="
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 90;
+  "
+></div>
+
+<style>
+  #hf-vignette {
+    background: radial-gradient(
+      var(--vignette-shape, ellipse) at center,
+      transparent var(--vignette-size, 45%),
+      var(--vignette-color, rgba(0, 0, 0, 0.7)) var(--vignette-edge, 100%)
+    );
+  }
+</style>
+
+<!--
+  Timeline integration example (add to your composition's GSAP timeline):
+
+  // Fade the vignette in over the first second
+  tl.fromTo("#hf-vignette",
+    { "--vignette-color": "rgba(0, 0, 0, 0)" },
+    { "--vignette-color": "rgba(0, 0, 0, 0.7)", duration: 1, ease: "power2.out" },
+    0,
+  );
+
+  // Or breathe the size in and out (works with any easing)
+  tl.to("#hf-vignette", { "--vignette-size": "35%", duration: 1, ease: "sine.inOut" }, 2);
+-->

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -64,6 +64,10 @@
       "type": "hyperframes:component"
     },
     {
+      "name": "vignette",
+      "type": "hyperframes:component"
+    },
+    {
       "name": "instagram-follow",
       "type": "hyperframes:block"
     },

--- a/scripts/generate-catalog-previews.ts
+++ b/scripts/generate-catalog-previews.ts
@@ -243,7 +243,7 @@ async function generateThumbnail(item: CatalogItem, projectDir: string): Promise
     const session = await createCaptureSession(fileServer.url, framesDir, {
       width,
       height,
-      fps: 30,
+      fps: { num: 30, den: 1 },
       format: "png",
     });
     await initializeSession(session);
@@ -276,7 +276,7 @@ async function generateVideo(item: CatalogItem, projectDir: string): Promise<voi
 
   const outMp4 = join(outDir, `${item.name}.mp4`);
   const job = createRenderJob({
-    fps: 24,
+    fps: { num: 24, den: 1 },
     quality: "draft",
     format: "mp4",
   });


### PR DESCRIPTION
## Summary

Takeover of #825 (community PR can't be merged because catalog additions are restricted to team members) plus the fix that was blocking its CI.

Two commits:

1. **`feat(registry): add vignette CSS component`** — original work by @calcarazgre646. Pure-CSS radial darkening overlay, 4 CSS custom properties (`--vignette-color`, `--vignette-size`, `--vignette-edge`, `--vignette-shape`), `pointer-events: none`, `z-index: 90` so it sits under `grain-overlay`.
2. **`fix(scripts): pass rational fps …`** — the CI fix.

## CI fix details

`scripts/generate-catalog-previews.ts` still called `createCaptureSession({ fps: 30, … })` and `createRenderJob({ fps: 24, … })`. Commit 5dcc89c9 (May 9) made both APIs accept `Fps = { num, den }` rationals — passing a plain number yields:

```ts
beginFrameIntervalMs: (1000 * options.fps.den) / Math.max(1, options.fps.num),
// = (1000 * undefined) / Math.max(1, undefined) = NaN / NaN = NaN
```

After warmup, `session.beginFrameTimeTicks = (baseTickCount + 10) * NaN = NaN`. The next `HeadlessExperimental.beginFrame` CDP call fails with:

```
Protocol error (HeadlessExperimental.beginFrame): Invalid parameters
Failed to deserialize params.frameTimeTicks - BINDINGS: double value expected at position 23
```

— exactly what CI was showing on #825.

This is a regression in the script — not the vignette component. It didn't surface earlier because `catalog-previews.yml` only re-renders **changed** items (path filter on `registry/blocks/**` and `registry/components/**`), so existing components were never exercised against the new fps contract. Vignette is the first new component since the refactor.

Fix is two lines: `fps: { num: 30, den: 1 }` and `fps: { num: 24, den: 1 }`.

## Test plan

- [x] Reproduced the BeginFrame error locally on PR #825 head: `Protocol error … position 23` ✓
- [x] After fix: `npx tsx scripts/generate-catalog-previews.ts --only vignette --skip-video` → `✓ vignette.png (246ms)` ✓
- [x] Sanity-check existing item: `npx tsx scripts/generate-catalog-previews.ts --only grain-overlay --skip-video` → `✓ grain-overlay.png (8611ms)` ✓
- [x] `npx tsx scripts/generate-catalog-pages.ts` → produces no diffs vs PR #825 (docs were already correct)
- [x] `bunx oxfmt scripts/generate-catalog-previews.ts` and `bunx oxlint` clean

## Credit

Vignette component authored by @calcarazgre646 — see commit authorship.

Closes #825.