### PR TITLE
docs: add tldraw adopter and company logos

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,15 +16,9 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Production
 
-| Organization                     | Contact                                        | How HyperFrames is used                                                                                     |
-| -------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                  |
-| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
-
-## Evaluating
-
-| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
-| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |
+| Organization                             | Contact                                        | How HyperFrames is used                                                                                     |
+| ---------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                  |
+| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.                                                  |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.                                              |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -20,5 +20,5 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 | ---------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                  |
 | [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.                                                  |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for short-form code demo videos and documentation.                                    |
 | [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.                                              |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -22,8 +22,8 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Evaluating
 
-| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
-| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |
+| Organization                             | Contact                                        | How HyperFrames is used                                              |
+| ---------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.           |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.       |
+| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export. |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,10 +16,10 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Production
 
-| Organization                     | Contact                                        | How HyperFrames is used                                                                    |
-| -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
-| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export.                       |
+| Organization                     | Contact                                        | How HyperFrames is used                                                                                     |
+| -------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                  |
+| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
 
 ## Evaluating
 

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,14 +16,15 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Production
 
-| Organization                     | Contact                                      | How HyperFrames is used                                                                    |
-| -------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| Organization                     | Contact                                        | How HyperFrames is used                                                                    |
+| -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export.                       |
 
 ## Evaluating
 
-| Organization                             | Contact                                        | How HyperFrames is used                                              |
-| ---------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.           |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.       |
-| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export. |
+| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
+| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -27,21 +27,21 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
     [@jrusso1020](https://github.com/jrusso1020)
   </Card>
   <Card title="tldraw" href="https://tldraw.com">
-    <img src="https://tldraw.com/apple-touch-icon.png" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
+    <img src="https://www.google.com/s2/favicons?domain=tldraw.com&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
     Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.
 
     [@steveruizok](https://github.com/steveruizok)
   </Card>
   <Card title="TanStack" href="https://tanstack.com">
-    <img src="https://tanstack.com/apple-touch-icon.png" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
+    <img src="https://www.google.com/s2/favicons?domain=tanstack.com&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
     Exploring HyperFrames for video content and documentation.
 
     [@AlemTuzlak](https://github.com/AlemTuzlak)
   </Card>
   <Card title="OptinMonster" href="https://optinmonster.com">
-    <img src="https://cdn.optinmonster.com/wp-content/uploads/2024/05/cropped-archie-1-180x180.png" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
+    <img src="https://www.google.com/s2/favicons?domain=optinmonster.com&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
     Exploring HyperFrames for marketing and product video content.
 

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -26,21 +26,6 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
     Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration,
     and captions.
   </Card>
-</CardGroup>
-
-| Organization                     | Contact                                        | How HyperFrames is used                                                                                     |
-| -------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                  |
-| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
-
-The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.
-
-## Evaluating
-
-<CardGroup cols={3}>
-  <Card title="HeyGen" href="https://www.heygen.com" img="https://logo.clearbit.com/heygen.com">
-    Powers AI-generated video composition and rendering across HeyGen's video product surface.
-  </Card>
   <Card title="TanStack" href="https://tanstack.com" img="https://logo.clearbit.com/tanstack.com">
     Exploring HyperFrames for video content and documentation.
   </Card>
@@ -53,8 +38,11 @@ The HeyGen team's actual launch-video sources (the ones featured in product anno
   </Card>
 </CardGroup>
 
-| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
-| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |
+| Organization                             | Contact                                        | How HyperFrames is used                                                                                      |
+| ---------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                   |
+| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.                                                   |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.                                               |
+
+The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -19,7 +19,7 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 ## Production
 
 <CardGroup cols={3}>
-  <Card title="HeyGen" href="https://www.heygen.com">
+  <Card title="HeyGen" href="https://www.heygen.com" img="https://logo.clearbit.com/heygen.com">
     Powers AI-generated video composition and rendering across HeyGen's video product surface.
   </Card>
 </CardGroup>
@@ -33,19 +33,19 @@ The HeyGen team's actual launch-video sources (the ones featured in product anno
 ## Evaluating
 
 <CardGroup cols={3}>
-  <Card title="HeyGen" href="https://www.heygen.com">
-    Powers AI-generated video composition and rendering across HeyGen's video product surface.
-  </Card>
-  <Card title="TanStack" href="https://tanstack.com">
+  <Card title="TanStack" href="https://tanstack.com" img="https://logo.clearbit.com/tanstack.com">
     Exploring HyperFrames for video content and documentation.
   </Card>
-  <Card title="OptinMonster" href="https://optinmonster.com">
+  <Card title="OptinMonster" href="https://optinmonster.com" img="https://logo.clearbit.com/optinmonster.com">
     Exploring HyperFrames for marketing and product video content.
+  </Card>
+  <Card title="tldraw" href="https://tldraw.com" img="https://logo.clearbit.com/tldraw.com">
+    Exploring HyperFrames for diagramming and canvas-based video export.
   </Card>
 </CardGroup>
 
-| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
-| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |
+| Organization                             | Contact                                        | How HyperFrames is used                                               |
+| ---------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.            |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.        |
+| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export.  |

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -19,7 +19,7 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 ## Production
 
 <CardGroup cols={3}>
-  <Card title="HeyGen" href="https://www.heygen.com" img="https://logo.clearbit.com/heygen.com">
+  <Card title="HeyGen" href="https://www.heygen.com" img="https://app.heygen.com/apple-touch-icon.png">
     Powers AI-generated video composition and rendering across HeyGen's video product surface.
   </Card>
   <Card title="tldraw" href="https://tldraw.com" img="https://logo.clearbit.com/tldraw.com">

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -22,30 +22,34 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
   <Card title="HeyGen" href="https://www.heygen.com" img="https://logo.clearbit.com/heygen.com">
     Powers AI-generated video composition and rendering across HeyGen's video product surface.
   </Card>
+  <Card title="tldraw" href="https://tldraw.com" img="https://logo.clearbit.com/tldraw.com">
+    Exploring HyperFrames for diagramming and canvas-based video export.
+  </Card>
 </CardGroup>
 
-| Organization                     | Contact                                      | How HyperFrames is used                                                                    |
-| -------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| Organization                     | Contact                                        | How HyperFrames is used                                                                    |
+| -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export.                       |
 
 The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.
 
 ## Evaluating
 
 <CardGroup cols={3}>
+  <Card title="HeyGen" href="https://www.heygen.com" img="https://logo.clearbit.com/heygen.com">
+    Powers AI-generated video composition and rendering across HeyGen's video product surface.
+  </Card>
   <Card title="TanStack" href="https://tanstack.com" img="https://logo.clearbit.com/tanstack.com">
     Exploring HyperFrames for video content and documentation.
   </Card>
   <Card title="OptinMonster" href="https://optinmonster.com" img="https://logo.clearbit.com/optinmonster.com">
     Exploring HyperFrames for marketing and product video content.
   </Card>
-  <Card title="tldraw" href="https://tldraw.com" img="https://logo.clearbit.com/tldraw.com">
-    Exploring HyperFrames for diagramming and canvas-based video export.
-  </Card>
 </CardGroup>
 
-| Organization                             | Contact                                        | How HyperFrames is used                                               |
-| ---------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.            |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.        |
-| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export.  |
+| Organization                             | Contact                                      | How HyperFrames is used                                                                    |
+| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020) | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak) | Exploring HyperFrames for video content and documentation.                                 |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                 | Exploring HyperFrames for marketing and product video content.                             |

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -20,36 +20,32 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 
 <CardGroup cols={2}>
   <Card title="HeyGen" href="https://www.heygen.com">
-    <img src="https://app.heygen.com/apple-touch-icon.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+    <img src="https://app.heygen.com/apple-touch-icon.png" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
     Powers AI-generated video composition and rendering across HeyGen's video product surface.
 
     [@jrusso1020](https://github.com/jrusso1020)
-
   </Card>
   <Card title="tldraw" href="https://tldraw.com">
-    <img src="https://tldraw.com/apple-touch-icon.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+    <img src="https://tldraw.com/apple-touch-icon.png" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
     Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.
 
     [@steveruizok](https://github.com/steveruizok)
-
   </Card>
   <Card title="TanStack" href="https://tanstack.com">
-    <img src="https://tanstack.com/apple-touch-icon.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+    <img src="https://tanstack.com/apple-touch-icon.png" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
     Exploring HyperFrames for video content and documentation.
 
     [@AlemTuzlak](https://github.com/AlemTuzlak)
-
   </Card>
   <Card title="OptinMonster" href="https://optinmonster.com">
-    <img src="https://cdn.optinmonster.com/wp-content/uploads/2024/05/cropped-archie-1-180x180.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+    <img src="https://cdn.optinmonster.com/wp-content/uploads/2024/05/cropped-archie-1-180x180.png" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
     Exploring HyperFrames for marketing and product video content.
 
     Angie Meeker
-
   </Card>
 </CardGroup>
 

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -23,14 +23,15 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
     Powers AI-generated video composition and rendering across HeyGen's video product surface.
   </Card>
   <Card title="tldraw" href="https://tldraw.com" img="https://logo.clearbit.com/tldraw.com">
-    Exploring HyperFrames for diagramming and canvas-based video export.
+    Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration,
+    and captions.
   </Card>
 </CardGroup>
 
-| Organization                     | Contact                                        | How HyperFrames is used                                                                    |
-| -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface. |
-| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Exploring HyperFrames for diagramming and canvas-based video export.                       |
+| Organization                     | Contact                                        | How HyperFrames is used                                                                                     |
+| -------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [HeyGen](https://www.heygen.com) | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                  |
+| [tldraw](https://tldraw.com)     | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
 
 The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.
 
@@ -43,7 +44,11 @@ The HeyGen team's actual launch-video sources (the ones featured in product anno
   <Card title="TanStack" href="https://tanstack.com" img="https://logo.clearbit.com/tanstack.com">
     Exploring HyperFrames for video content and documentation.
   </Card>
-  <Card title="OptinMonster" href="https://optinmonster.com" img="https://logo.clearbit.com/optinmonster.com">
+  <Card
+    title="OptinMonster"
+    href="https://optinmonster.com"
+    img="https://logo.clearbit.com/optinmonster.com"
+  >
     Exploring HyperFrames for marketing and product video content.
   </Card>
 </CardGroup>

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -36,7 +36,7 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
   <Card title="TanStack" href="https://tanstack.com">
     <img src="https://www.google.com/s2/favicons?domain=tanstack.com&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
-    Exploring HyperFrames for video content and documentation.
+    Exploring HyperFrames for short-form code demo videos and documentation.
 
     [@AlemTuzlak](https://github.com/AlemTuzlak)
   </Card>

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -18,31 +18,39 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 
 ## Production
 
-<CardGroup cols={3}>
-  <Card title="HeyGen" href="https://www.heygen.com" img="https://app.heygen.com/apple-touch-icon.png">
+<CardGroup cols={2}>
+  <Card title="HeyGen" href="https://www.heygen.com">
+    <img src="https://app.heygen.com/apple-touch-icon.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+
     Powers AI-generated video composition and rendering across HeyGen's video product surface.
+
+    [@jrusso1020](https://github.com/jrusso1020)
+
   </Card>
-  <Card title="tldraw" href="https://tldraw.com" img="https://logo.clearbit.com/tldraw.com">
-    Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration,
-    and captions.
+  <Card title="tldraw" href="https://tldraw.com">
+    <img src="https://tldraw.com/apple-touch-icon.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+
+    Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.
+
+    [@steveruizok](https://github.com/steveruizok)
+
   </Card>
-  <Card title="TanStack" href="https://tanstack.com" img="https://logo.clearbit.com/tanstack.com">
+  <Card title="TanStack" href="https://tanstack.com">
+    <img src="https://tanstack.com/apple-touch-icon.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+
     Exploring HyperFrames for video content and documentation.
+
+    [@AlemTuzlak](https://github.com/AlemTuzlak)
+
   </Card>
-  <Card
-    title="OptinMonster"
-    href="https://optinmonster.com"
-    img="https://logo.clearbit.com/optinmonster.com"
-  >
+  <Card title="OptinMonster" href="https://optinmonster.com">
+    <img src="https://cdn.optinmonster.com/wp-content/uploads/2024/05/cropped-archie-1-180x180.png" width="48" height="48" style="border-radius: 10px; margin-bottom: 12px;" />
+
     Exploring HyperFrames for marketing and product video content.
+
+    Angie Meeker
+
   </Card>
 </CardGroup>
-
-| Organization                             | Contact                                        | How HyperFrames is used                                                                                      |
-| ---------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                   |
-| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for video content and documentation.                                                   |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.                                               |
 
 The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.


### PR DESCRIPTION
## Summary

- Added tldraw (Steve Ruiz, @steveruizok) to the Evaluating section in both ADOPTERS.md and docs/community/adopters.mdx
- Removed erroneously duplicated HeyGen entry from the Evaluating section (it belongs only in Production)
- Added Clearbit logo images to all company cards in adopters.mdx