### PR TITLE
ci(regression): rebalance matrix via measured per-test durations

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -42,27 +42,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Shards are bin-packed by measured per-test duration (LPT heuristic on
+        # CI run 25893372795) so each row carries ~15-16 min of work. When a
+        # new fixture lands, drop it into the currently-lightest shard or
+        # re-balance against fresh `test_suite_summary` timings. Worst-shard
+        # work time was 19.3 min under the old tag-based split (styles-e);
+        # the rebalance brings every shard within ~40s of the others.
         include:
-          - shard: fast
-            args: "--sequential --exclude-tags slow,render-compat,hdr"
-          - shard: render-compat
-            args: "--sequential gsap-letters-render-compat css-spinner-render-compat raf-ball-render-compat iframe-render-compat"
-          - shard: hdr
-            args: "--sequential hdr-regression hdr-hlg-regression"
-          - shard: styles-a
-            args: "style-1-prod style-2-prod style-3-prod"
-          - shard: styles-b
-            args: "style-4-prod style-5-prod style-6-prod"
-          - shard: styles-c
-            args: "style-7-prod style-8-prod style-9-prod"
-          - shard: styles-d
-            args: "style-10-prod style-11-prod style-12-prod"
-          - shard: styles-e
-            args: "style-13-prod style-15-prod style-16-prod"
-          - shard: styles-f
-            args: "style-17-prod style-18-prod"
-          - shard: styles-g
-            args: "overlay-montage-prod"
+          - shard: shard-1
+            args: "hdr-regression style-5-prod style-3-prod mov-prores"
+          - shard: shard-2
+            args: "style-15-prod hdr-hlg-regression style-1-prod many-cuts vfr-screen-recording render-symlinked-assets"
+          - shard: shard-3
+            args: "style-7-prod style-8-prod style-10-prod css-spinner-render-compat webm-transparency mp4-h264-sdr"
+          - shard: shard-4
+            args: "style-16-prod style-9-prod style-17-prod iframe-render-compat variables-prod mp4-h265-sdr"
+          - shard: shard-5
+            args: "style-4-prod style-11-prod style-2-prod animejs-adapter typegpu-adapter"
+          - shard: shard-6
+            args: "overlay-montage-prod style-12-prod chat missing-host-comp-id png-sequence"
+          - shard: shard-7
+            args: "sub-composition-video style-18-prod raf-ball-render-compat font-variant-numeric"
+          - shard: shard-8
+            args: "style-13-prod style-6-prod vignelli-stacking gsap-letters-render-compat"
     steps:
       - name: Checkout (with LFS)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -94,7 +96,7 @@ jobs:
           load: true
           tags: hyperframes-producer:test
           cache-from: type=gha,scope=regression-test-image
-          cache-to: type=gha,mode=min,scope=regression-test-image
+          cache-to: type=gha,mode=max,scope=regression-test-image
 
       - name: "Run regression shard: ${{ matrix.shard }}"
         run: |

--- a/packages/producer/tests/sub-composition-video/meta.json
+++ b/packages/producer/tests/sub-composition-video/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "Sub-composition video in photo area",
   "description": "Tests that video elements inside sub-compositions (lacking explicit id attributes) render correctly. Regression for: parseVideoElements selector only matched video[id][src], silently dropping id-less videos; end derived from data-end only (not data-duration); compiled HTML did not persist auto-assigned ids.",
-  "tags": ["video", "sub-composition", "regression"],
+  "tags": ["video", "sub-composition", "regression", "slow"],
   "minPsnr": 25,
   "maxFrameFailures": 5,
   "minAudioCorrelation": 0.0,


### PR DESCRIPTION
## What

Rebalance the `regression.yml` matrix using measured per-test durations from a recent CI run, and tag `sub-composition-video` as `slow` to match its actual ~9.6 min runtime.

## Why

The current matrix is badly imbalanced. Pulling per-test timings from run [25893372795](https://github.com/heygen-com/hyperframes/actions/runs/25893372795):

| shard | work time | wall clock |
| --- | --- | --- |
| `styles-e` | 19.3 min | 23.6 min ← gates everything |
| `fast` | 17.1 min | 21.3 min |
| `styles-c` | 15.1 min | 21.1 min |
| `render-compat` | 3.0 min | 7.2 min |

Total work is ~123 min across 37 tests. Two outliers — `sub-composition-video` (9.6 min) and `overlay-montage-prod` (9.1 min) — drive most of the skew. `sub-composition-video` is also untagged, so it slips into the `fast` shard (`--exclude-tags slow,...`) and turns "fast" into 21 min.

## How

**1. Bin-pack the matrix.** Replaced the tag-based split with 8 explicit shards generated by a Longest-Processing-Time-first pass over measured durations. Every shard now carries ~15-16 min of work (within ~40s of each other):

```
shard-1 (15.9m): hdr-regression, style-5-prod, style-3-prod, mov-prores
shard-2 (15.4m): style-15-prod, hdr-hlg-regression, style-1-prod, many-cuts, vfr-screen-recording, render-symlinked-assets
shard-3 (15.4m): style-7-prod, style-8-prod, style-10-prod, css-spinner-render-compat, webm-transparency, mp4-h264-sdr
shard-4 (15.9m): style-16-prod, style-9-prod, style-17-prod, iframe-render-compat, variables-prod, mp4-h265-sdr
shard-5 (15.4m): style-4-prod, style-11-prod, style-2-prod, animejs-adapter, typegpu-adapter
shard-6 (15.8m): overlay-montage-prod, style-12-prod, chat, missing-host-comp-id, png-sequence
shard-7 (15.3m): sub-composition-video, style-18-prod, raf-ball-render-compat, font-variant-numeric
shard-8 (15.3m): style-13-prod, style-6-prod, vignelli-stacking, gsap-letters-render-compat
```

8 shards (down from 10) and the worst-shard work time drops from **19.3 min → 15.9 min**. Wall clock target ~20 min vs ~24 min today.

**2. Docker layer cache.** Flipped `cache-to: type=gha,mode=min` → `mode=max`. The current cached build still re-extracts apt layers for ~3 min of its 4-min "cached" run because `mode=min` only caches the final image. `mode=max` caches all intermediate layers; expected to drop the Docker step to ~30s per shard and trim another ~2-3 min off the wall clock.

**3. Tag `sub-composition-video` slow.** Existing prod-style fixtures at 3-9 min runtime are all tagged `slow`; sub-composition-video at 9.6 min was a misclassification that fell through into the `fast` shard.

## Test plan

- [x] Workflow YAML parses (matrix is structurally identical to the existing one, just different `args:` strings)
- [ ] CI run shows balanced shard durations (~15-16 min work each, ~20 min wall clock total)
- [ ] Docker build step drops from ~4 min to ~30s on cache hit after first run on a PR
- [ ] All 37 in-matrix fixtures still get executed (every test from the old matrix appears exactly once in the new matrix)

### Follow-ups (not in this PR)

- `dogs-captions`, `heygen-promo-preview-assets`, `spanish-empire-cdn-inline`, `css-import-scoping` have `meta.json` but aren't listed in any shard — they currently don't run in CI at all. Worth confirming whether that's intentional.
- Emit a `durations.json` artifact from `test_suite_summary` and generate the matrix dynamically from it, so this balance doesn't drift as new fixtures land.