### PR TITLE
fix(studio): auto-enable loop when work-area markers are set

### DIFF
--- a/packages/studio/src/player/store/playerStore.test.ts
+++ b/packages/studio/src/player/store/playerStore.test.ts
@@ -77,6 +77,100 @@ describe("usePlayerStore", () => {
     });
   });
 
+  describe("setInPoint", () => {
+    it("updates inPoint", () => {
+      usePlayerStore.getState().setInPoint(1.5);
+      expect(usePlayerStore.getState().inPoint).toBe(1.5);
+    });
+
+    it("clears inPoint when given null", () => {
+      usePlayerStore.getState().setInPoint(1.5);
+      usePlayerStore.getState().setInPoint(null);
+      expect(usePlayerStore.getState().inPoint).toBeNull();
+    });
+
+    it("rejects non-finite values", () => {
+      usePlayerStore.getState().setInPoint(Number.NaN);
+      expect(usePlayerStore.getState().inPoint).toBeNull();
+    });
+
+    it("nullifies outPoint when new inPoint is at or past existing outPoint", () => {
+      usePlayerStore.getState().setOutPoint(2);
+      usePlayerStore.getState().setInPoint(3);
+      expect(usePlayerStore.getState().outPoint).toBeNull();
+      expect(usePlayerStore.getState().inPoint).toBe(3);
+    });
+
+    it("preserves outPoint when new inPoint is before it", () => {
+      usePlayerStore.getState().setOutPoint(5);
+      usePlayerStore.getState().setInPoint(2);
+      expect(usePlayerStore.getState().outPoint).toBe(5);
+    });
+
+    it("auto-enables loopEnabled when set to a non-null value", () => {
+      usePlayerStore.getState().setLoopEnabled(false);
+      usePlayerStore.getState().setInPoint(1.5);
+      expect(usePlayerStore.getState().loopEnabled).toBe(true);
+    });
+
+    it("preserves loopEnabled when cleared with null", () => {
+      usePlayerStore.getState().setLoopEnabled(true);
+      usePlayerStore.getState().setInPoint(null);
+      expect(usePlayerStore.getState().loopEnabled).toBe(true);
+
+      usePlayerStore.getState().setLoopEnabled(false);
+      usePlayerStore.getState().setInPoint(null);
+      expect(usePlayerStore.getState().loopEnabled).toBe(false);
+    });
+  });
+
+  describe("setOutPoint", () => {
+    it("updates outPoint", () => {
+      usePlayerStore.getState().setOutPoint(4.2);
+      expect(usePlayerStore.getState().outPoint).toBe(4.2);
+    });
+
+    it("clears outPoint when given null", () => {
+      usePlayerStore.getState().setOutPoint(4.2);
+      usePlayerStore.getState().setOutPoint(null);
+      expect(usePlayerStore.getState().outPoint).toBeNull();
+    });
+
+    it("rejects non-finite values", () => {
+      usePlayerStore.getState().setOutPoint(Number.POSITIVE_INFINITY);
+      expect(usePlayerStore.getState().outPoint).toBeNull();
+    });
+
+    it("nullifies inPoint when new outPoint is at or before existing inPoint", () => {
+      usePlayerStore.getState().setInPoint(5);
+      usePlayerStore.getState().setOutPoint(3);
+      expect(usePlayerStore.getState().inPoint).toBeNull();
+      expect(usePlayerStore.getState().outPoint).toBe(3);
+    });
+
+    it("preserves inPoint when new outPoint is after it", () => {
+      usePlayerStore.getState().setInPoint(2);
+      usePlayerStore.getState().setOutPoint(5);
+      expect(usePlayerStore.getState().inPoint).toBe(2);
+    });
+
+    it("auto-enables loopEnabled when set to a non-null value", () => {
+      usePlayerStore.getState().setLoopEnabled(false);
+      usePlayerStore.getState().setOutPoint(4.2);
+      expect(usePlayerStore.getState().loopEnabled).toBe(true);
+    });
+
+    it("preserves loopEnabled when cleared with null", () => {
+      usePlayerStore.getState().setLoopEnabled(true);
+      usePlayerStore.getState().setOutPoint(null);
+      expect(usePlayerStore.getState().loopEnabled).toBe(true);
+
+      usePlayerStore.getState().setLoopEnabled(false);
+      usePlayerStore.getState().setOutPoint(null);
+      expect(usePlayerStore.getState().loopEnabled).toBe(false);
+    });
+  });
+
   describe("setTimelineReady", () => {
     it("updates timelineReady", () => {
       usePlayerStore.getState().setTimelineReady(true);

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -127,6 +127,9 @@ export const usePlayerStore = create<PlayerState>((set) => ({
         inPoint: t,
         outPoint:
           t !== null && state.outPoint !== null && t >= state.outPoint ? null : state.outPoint,
+        // Setting a work-area marker implies the user wants playback bounded by it.
+        // Auto-enable loop so the playhead respects the marker instead of running past.
+        loopEnabled: t !== null ? true : state.loopEnabled,
       };
     }),
   setOutPoint: (time) =>
@@ -135,6 +138,7 @@ export const usePlayerStore = create<PlayerState>((set) => ({
       return {
         outPoint: t,
         inPoint: t !== null && state.inPoint !== null && t <= state.inPoint ? null : state.inPoint,
+        loopEnabled: t !== null ? true : state.loopEnabled,
       };
     }),
   setManualZoomPercent: (percent) =>


### PR DESCRIPTION
## Summary

Setting an in-point or out-point now auto-enables `loopEnabled`, so the playhead respects the work-area marker instead of running past the out-point. Closes the last open sub-bug of #834.

## Background

PR #811 wired the work-area RAF loop to read `inPoint`/`outPoint` (`useTimelinePlayer.ts:185-201`), but kept the loop branch gated behind `loopEnabled`. Default for that flag is `false` (`playerStore.ts:102`), so users who set markers without first toggling the loop button saw playback sail past the out-point. With the L-key shuttle (multi-x speed), the playhead also overshoots by a few frames before the next RAF tick clamps it.

The original spec for the feature in #807 described markers as logic that *"constrains the playback engine"*. The actual UX did not match that intent until the loop toggle was on, which the issue's reporter flagged as the bug under sub-bug #1.

## Fix

`setInPoint` and `setOutPoint` flip `loopEnabled` to `true` when given a non-null value. This extends the existing "smart setter" pattern already in the store (setting one marker past the other already nullifies the counterpart). Clearing a marker with `null` preserves the current `loopEnabled`, so a user who manually toggles the loop button afterward stays in control.

```ts
setInPoint: (time) =>
  set((state) => {
    const t = time !== null && Number.isFinite(time) ? time : null;
    return {
      inPoint: t,
      outPoint:
        t !== null && state.outPoint !== null && t >= state.outPoint ? null : state.outPoint,
      loopEnabled: t !== null ? true : state.loopEnabled,
    };
  }),
```

Symmetric for `setOutPoint`. The RAF loop body in `useTimelinePlayer` (both forward and reverse paths) already does the right thing once `loopEnabled` is true.

## Tests

`packages/studio/src/player/store/playerStore.test.ts` had no existing coverage for `setInPoint`/`setOutPoint`. Added 14 new tests across both setters covering:

- Basic set / clear / non-finite rejection
- Overlap nullification (existing behavior, was uncovered)
- Auto-enable on non-null set
- Preserve `loopEnabled` on clear (in both directions: was-true stays true, was-false stays false)

Full studio suite: 525/525 ✅, oxlint clean, oxfmt clean, typecheck clean.

## Behavior of edge cases

- **Manual toggle after set:** if the user disables loop manually after setting markers, then updates a marker, loop re-enables. Each "set marker" is treated as a fresh expression of intent ("I want bounded playback here").
- **Clear preserves:** `setInPoint(null)` or `setOutPoint(null)` does not touch `loopEnabled`, so a user who built up a loop-on state by other means keeps it.
- **Reset preserves:** `reset()` continues to preserve `loopEnabled` as before (it bypasses the setters with a direct `set(...)`).

## Issue #834 status after this PR

- Sub-bug #1 (loop at out-point): fixed here.
- Sub-bug #2 (Jump-to-in/out forces pause): fixed in #842.
- Sub-bug #3 (AZERTY layout): fixed in #839.

Issue can be closed once this lands.