### PR TITLE
ci(security): add advanced CodeQL setup with path-scoped query filters

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,56 @@
+name: "Hyperframes CodeQL config"
+
+# Use GitHub's default security-extended suite — it's a strict superset of the
+# default suite (more queries, slightly higher false-positive rate). Pair it with
+# the query-filters below so the extra queries don't drown the dashboard.
+queries:
+  - uses: security-extended
+
+# Per-rule path filters. The intent is to silence rules that have known false
+# positives on specific file shapes (generated test artifacts, CDN-script test
+# fixtures, functional-cleanup regex) WITHOUT excluding those paths from all
+# analysis — a malicious contributor adding e.g. a command-injection sink into
+# a "test fixture" would still get caught.
+#
+# To audit what changed: look at PR diffs touching this file. Reviewers should
+# treat it like CODEOWNERS — adding a new path exclusion is a policy change.
+query-filters:
+  # Generated test artifacts (golden baselines written by the producer test
+  # harness). Every compiled.html re-rasterizes the regex-stripped composition;
+  # the same alerts fire on every fixture and on every re-render.
+  - exclude:
+      id: js/incomplete-sanitization
+      paths:
+        - "packages/producer/tests/**/output/compiled.html"
+        - "packages/producer/tests/**/failures/*.html"
+
+  # Test fixtures and skill test corpora intentionally load CDN scripts without
+  # SRI — pinning hashes there would fight the test's purpose (we want the test
+  # to use whatever the registry hands back, the same way a composition would).
+  - exclude:
+      id: js/functionality-from-untrusted-source
+      paths:
+        - "packages/producer/tests/**"
+        - "skills/**/test-corpus/**"
+        - "skills/**/assets/test-corpus/**"
+
+  # The hand-rolled HTML cleanup regex in our build-time tooling looks like a
+  # sanitizer to CodeQL but isn't one — it strips framework bootstraps from
+  # captured pages before they're fed back into our own renderer (Puppeteer,
+  # not a user-facing DOM). Same for the text normalizer in the whisper path
+  # (caption text → SRT/VTT, no DOM emission). Scope these exclusions to the
+  # exact files that contain functional regex, not to whole directories, so
+  # any new code in cli/, core/, or producer/ that LOOKS like a sanitizer
+  # still trips the rules.
+  - exclude:
+      id: js/bad-tag-filter
+      paths:
+        - "packages/cli/src/capture/index.ts"
+        - "packages/cli/src/whisper/normalize.ts"
+        - "packages/core/src/lint/utils.ts"
+        - "packages/producer/src/services/htmlCompiler.ts"
+  - exclude:
+      id: js/incomplete-multi-character-sanitization
+      paths:
+        - "packages/cli/src/capture/index.ts"
+        - "packages/cli/src/whisper/normalize.ts"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+# CodeQL advanced setup. Replaces GitHub's default code-scanning setup; the
+# repo must have default setup disabled in Security → Code scanning → "Set up"
+# before this workflow can run.
+#
+# Languages were taken from the existing default-setup config (JS/TS, Python,
+# Actions). Triggers mirror what default setup ran: push to main, every PR
+# against main, and a weekly schedule.
+#
+# The rules and path filters live in .github/codeql/codeql-config.yml so policy
+# changes show up as a normal PR diff.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays at 14:39 UTC — matches the cadence default setup was running on.
+    - cron: "39 14 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Switch CodeQL from default setup to advanced setup, with two new files:

- `.github/workflows/codeql.yml` — workflow scanning `javascript-typescript`, `python`, and `actions` (mirroring what default setup was configured with).
- `.github/codeql/codeql-config.yml` — per-rule path filters that silence the known-noisy rules on the file shapes where they're always false positives, *without* excluding those paths from analysis entirely.

Stacked on top of #856 (the actual code fixes for the critical + 2 medium findings).

## Why

The CodeQL dashboard hit **170 open alerts**, and ~157 of them were duplicates of the same 4 patterns across either generated test fixtures or functional regex that CodeQL misreads as sanitizers. That noise level made it nearly impossible to spot a real finding land — which is exactly the regression mode we don't want for an OSS repo that takes external contributions.

Naive fix: `paths-ignore` for `packages/producer/tests/`. That would also blind CodeQL to a malicious contributor smuggling a real `execSync(user_input)` into a "test fixture." Wrong tradeoff.

Better fix: silence *specific rules* on *specific paths*, scoped narrowly enough that anything outside the pattern still trips the alarms.

## How

The config has four rule-scoped exclusions, with comments explaining why each path-shape is genuinely a false positive for that one rule:

| Rule | Excluded paths | Why |
|---|---|---|
| `js/incomplete-sanitization` | `packages/producer/tests/**/output/compiled.html`, `packages/producer/tests/**/failures/*.html` | Generated golden baselines, not shipped |
| `js/functionality-from-untrusted-source` | `packages/producer/tests/**`, `skills/**/test-corpus/**`, `skills/**/assets/test-corpus/**` | CDN scripts intentionally unpinned in test fixtures |
| `js/bad-tag-filter` | `packages/cli/src/capture/index.ts`, `packages/cli/src/whisper/normalize.ts`, `packages/core/src/lint/utils.ts`, `packages/producer/src/services/htmlCompiler.ts` | Functional HTML cleanup regex, output goes to Puppeteer not a user-facing DOM |
| `js/incomplete-multi-character-sanitization` | `packages/cli/src/capture/index.ts`, `packages/cli/src/whisper/normalize.ts` | Text normalization, no DOM emission |

Key property: **rules stay on for everything else.** `js/command-line-injection`, `js/code-injection`, `js/xss-through-dom`, etc. all still scan `packages/producer/tests/` — so a real exploit slipped into a test fixture would still get caught.

The two cleanup-regex files are named individually, not by glob, so any new file in `cli/`, `core/`, or `producer/` that looks like a sanitizer still trips the rules. Loosening a path means touching this file — which shows up in PR review the same way a CODEOWNERS change does.

## Required action before merge

This repo is currently on CodeQL **default setup**. Both default and advanced setup can't run simultaneously — a maintainer needs to disable default setup before this workflow can take effect:

1. Go to **Settings → Security → Code scanning**.
2. Find the existing "CodeQL analysis" default-setup config and click **Set up → Advanced** (or "Switch to advanced setup").
3. GitHub will note that the repo already has an advanced workflow committed.
4. Confirm and merge this PR.

If we merge before doing the toggle, the workflow file is harmless (it'll just sit unrun) — but the path-filtered scan won't actually start until default setup is off.

## Companion: bulk dismissal of existing noise

In tandem with this PR, **157 of the 170 existing alerts were dismissed via the GitHub Code Scanning API** with per-category reason strings:

- 145 dismissed as `used in tests` (test fixtures, golden baselines, `*.test.ts` files, perf test scenarios)
- 11 dismissed as `false positive` (functional regex, scheme check that already filters `data:`/`javascript:`)

Each dismissal carries a one-line audit comment visible on the Security tab. **Open count: 170 → 13.** The 13 that remain:

- 3 close automatically when #856 merges (the actual code fixes)
- 9 `js/polynomial-redos` (real but lower-risk — build-time regex on developer-authored input, except `studio-api/routes/preview.ts` which is server-facing and worth a closer look)
- 1 `js/incomplete-sanitization` in `studio/src/captions/parser.ts:283` (real but low-risk single-quote → JSON normalization for caption pastes)

These were intentionally left open as a small to-do list visible on the dashboard rather than buried in a comment thread.

## Test plan

- [x] `bunx oxfmt --check` clean on both new files.
- [x] Action SHAs verified against `gh api repos/{actions/checkout,github/codeql-action}/git/refs/tags/{v4,v3}` — using same checkout SHA the rest of the repo pins (`34e114876b…`) and the resolved tip of `codeql-action@v3` (`7fd177fa68…`).
- [ ] CodeQL workflow run on this PR confirms the config parses and the matrix executes (this is the gate that proves nothing's broken).
- [ ] After merge + default-setup toggle: re-scan should produce only 13 open alerts, and any new PR that adds a non-test-path command-injection or xss sink should still trip CodeQL.

## What this PR is *not* doing

- Not changing what queries run (`security-extended` was already enabled by default setup).
- Not adding `paths-ignore` — every path is still analyzed, only specific rules are silenced where they're known false-positive.
- Not auto-resolving alerts — dismissals were a one-time API action with comments, separate from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)