### PR TITLE
fix(runtime): respect keepPlaying option in player seek

### DIFF
--- a/packages/core/src/core.types.ts
+++ b/packages/core/src/core.types.ts
@@ -399,7 +399,7 @@ export interface CompositionAPI {
 export interface PlayerAPI {
   play(): void;
   pause(): void;
-  seek(time: number): void;
+  seek(time: number, options?: { keepPlaying?: boolean }): void;
   getTime(): number;
   getDuration(): number;
   isPlaying(): boolean;

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -84,7 +84,7 @@ export function initSandboxRuntimeModular(): void {
     _timeline: RuntimeTimelineLike | null;
     play: () => void;
     pause: () => void;
-    seek: (timeSeconds: number) => void;
+    seek: (timeSeconds: number, options?: { keepPlaying?: boolean }) => void;
     getTime: () => number;
     getDuration: () => number;
     isPlaying: () => boolean;

--- a/packages/core/src/runtime/player.test.ts
+++ b/packages/core/src/runtime/player.test.ts
@@ -368,6 +368,91 @@ describe("createRuntimePlayer", () => {
       expect(deps.onDeterministicSeek).toHaveBeenCalledWith(8);
       expect(deps.onSyncMedia).toHaveBeenCalledWith(8, false);
     });
+
+    // Regression: A/E Jump-to-in/out shortcuts (PR #842) send
+    // `{ keepPlaying: true }` so playback survives the seek. Before this fix the
+    // runtime always called setIsPlaying(false), so the shortcut paused playback
+    // on every press in compositions backed by the `__player` runtime adapter.
+    describe("keepPlaying option", () => {
+      it("preserves play state when keepPlaying is true and playback was active", () => {
+        const timeline = createMockTimeline({ duration: 10 });
+        const deps = createMockDeps(timeline);
+        deps.getIsPlaying.mockReturnValue(true);
+        const player = createRuntimePlayer(deps);
+        player.seek(3, { keepPlaying: true });
+        expect(deps.setIsPlaying).not.toHaveBeenCalledWith(false);
+        expect(deps.onDeterministicPlay).toHaveBeenCalled();
+        expect(deps.onShowNativeVideos).toHaveBeenCalled();
+        expect(deps.onSyncMedia).toHaveBeenCalledWith(expect.any(Number), true);
+      });
+
+      it("resumes the master timeline after the deterministic seek pauses it", () => {
+        const timeline = createMockTimeline({ duration: 10 });
+        const deps = createMockDeps(timeline);
+        deps.getIsPlaying.mockReturnValue(true);
+        const player = createRuntimePlayer(deps);
+        player.seek(3, { keepPlaying: true });
+        // The helper pauses then seeks; the keep-playing branch must call
+        // play() afterwards so the timeline is left running.
+        const playMock = timeline.play as ReturnType<typeof vi.fn>;
+        const pauseMock = timeline.pause as ReturnType<typeof vi.fn>;
+        expect(playMock).toHaveBeenCalledTimes(1);
+        expect(pauseMock).toHaveBeenCalled();
+        expect(playMock.mock.invocationCallOrder[0]).toBeGreaterThan(
+          pauseMock.mock.invocationCallOrder[pauseMock.mock.invocationCallOrder.length - 1],
+        );
+      });
+
+      it("applies playbackRate to master and siblings on resume", () => {
+        const master = createMockTimeline({ duration: 10 });
+        const scene1 = createMockTimeline();
+        const deps = createMockDeps(master);
+        deps.getIsPlaying.mockReturnValue(true);
+        deps.getPlaybackRate.mockReturnValue(2);
+        const player = createRuntimePlayer({
+          ...deps,
+          getTimelineRegistry: () => ({ main: master, scene1 }),
+        });
+        player.seek(3, { keepPlaying: true });
+        expect(master.timeScale).toHaveBeenCalledWith(2);
+        expect(scene1.timeScale).toHaveBeenCalledWith(2);
+        expect(scene1.play).toHaveBeenCalled();
+      });
+
+      it("stays paused when keepPlaying is true but playback was not active", () => {
+        const timeline = createMockTimeline({ duration: 10 });
+        const deps = createMockDeps(timeline);
+        deps.getIsPlaying.mockReturnValue(false);
+        const player = createRuntimePlayer(deps);
+        player.seek(3, { keepPlaying: true });
+        expect(deps.setIsPlaying).toHaveBeenCalledWith(false);
+        expect(deps.onSyncMedia).toHaveBeenCalledWith(expect.any(Number), false);
+        expect(deps.onDeterministicPlay).not.toHaveBeenCalled();
+        expect(deps.onShowNativeVideos).not.toHaveBeenCalled();
+      });
+
+      it("pauses on seek when keepPlaying is false (explicit)", () => {
+        const timeline = createMockTimeline({ duration: 10 });
+        const deps = createMockDeps(timeline);
+        deps.getIsPlaying.mockReturnValue(true);
+        const player = createRuntimePlayer(deps);
+        player.seek(3, { keepPlaying: false });
+        expect(deps.setIsPlaying).toHaveBeenCalledWith(false);
+        expect(deps.onSyncMedia).toHaveBeenCalledWith(expect.any(Number), false);
+        expect(deps.onDeterministicPlay).not.toHaveBeenCalled();
+      });
+
+      it("pauses on seek when no options are passed (default behavior unchanged)", () => {
+        const timeline = createMockTimeline({ duration: 10 });
+        const deps = createMockDeps(timeline);
+        deps.getIsPlaying.mockReturnValue(true);
+        const player = createRuntimePlayer(deps);
+        player.seek(3);
+        expect(deps.setIsPlaying).toHaveBeenCalledWith(false);
+        expect(deps.onSyncMedia).toHaveBeenCalledWith(expect.any(Number), false);
+        expect(deps.onDeterministicPlay).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("renderSeek", () => {

--- a/packages/core/src/runtime/player.ts
+++ b/packages/core/src/runtime/player.ts
@@ -144,10 +144,11 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
       deps.onRenderFrameSeek(time);
       deps.onStatePost(true);
     },
-    seek: (timeSeconds: number) => {
+    seek: (timeSeconds: number, options?: { keepPlaying?: boolean }) => {
       const timeline = deps.getTimeline();
       if (!timeline) return;
       const safeTime = Math.max(0, Number(timeSeconds) || 0);
+      const wasPlaying = deps.getIsPlaying();
       const quantized = seekMasterAndSiblingTimelinesDeterministically(
         deps.getTimelineRegistry?.(),
         timeline,
@@ -155,8 +156,24 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
         deps.getCanonicalFps(),
       );
       deps.onDeterministicSeek(quantized);
-      deps.setIsPlaying(false);
-      deps.onSyncMedia(quantized, false);
+      if (options?.keepPlaying && wasPlaying) {
+        // The deterministic seek helper pauses the master and rearmed siblings.
+        // Resume them so the caller's playback state survives the seek.
+        if (typeof timeline.timeScale === "function") {
+          timeline.timeScale(deps.getPlaybackRate());
+        }
+        timeline.play();
+        forEachSiblingTimeline(deps.getTimelineRegistry?.(), timeline, (tl) => {
+          if (typeof tl.timeScale === "function") tl.timeScale(deps.getPlaybackRate());
+          tl.play();
+        });
+        deps.onDeterministicPlay();
+        deps.onShowNativeVideos();
+        deps.onSyncMedia(quantized, true);
+      } else {
+        deps.setIsPlaying(false);
+        deps.onSyncMedia(quantized, false);
+      }
       deps.onRenderFrameSeek(quantized);
       deps.onStatePost(true);
     },

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -206,7 +206,7 @@ export type RuntimePlayer = {
   _timeline: RuntimeTimelineLike | null;
   play: () => void;
   pause: () => void;
-  seek: (timeSeconds: number) => void;
+  seek: (timeSeconds: number, options?: { keepPlaying?: boolean }) => void;
   renderSeek: (timeSeconds: number) => void;
   getTime: () => number;
   getDuration: () => number;


### PR DESCRIPTION
## Summary

Closes the follow-up I promised in [#842 (comment)](https://github.com/heygen-com/hyperframes/pull/842#issuecomment-4454801238): the `__player` runtime adapter ignored the `{ keepPlaying: true }` option that A/E Jump-to-in/out shortcuts send, so playback pauses on every press even though the caller asked to preserve it. Only the `wrapTimeline` (GSAP) path honoured the option.

## Background

PR #842 added `seek: (time, options?: { keepPlaying?: boolean })` to `PlaybackAdapter` and wired the A/E shortcuts in `usePlaybackKeyboard` to pass `{ keepPlaying: true }`. The fix landed correctly for compositions backed by `__timeline` / `__timelines` (GSAP), because `wrapTimeline` reads the option and skips its internal `tl.pause()`.

For compositions backed by `window.__player` (`packages/core/src/runtime/init.ts:1529`), `useTimelinePlayer.getAdapter()` returns the runtime adapter directly without a wrapper. That adapter's `seek` is `basePlayer.seek` from `createRuntimePlayer` (`packages/core/src/runtime/player.ts:147`), and the implementation was:

```ts
seek: (timeSeconds: number) => {
  // ...quantize + deterministic seek...
  deps.setIsPlaying(false);
  deps.onSyncMedia(quantized, false);
  // ...
},
```

`setIsPlaying(false)` runs unconditionally, so A/E pauses the moment the shortcut fires. The option that the Studio sends never reaches the implementation because both the local `basePlayer` shape in `createPlayerApiCompat` and the public `PlayerAPI.seek` / `RuntimePlayer.seek` types only declared `(time: number) => void`.

## Fix

1. Extend the type contract from end to end so the option is preserved through `createPlayerApiCompat`:
   - `core.types.ts` — `PlayerAPI.seek(time, options?: { keepPlaying?: boolean })`
   - `runtime/types.ts` — `RuntimePlayer.seek` signature
   - `runtime/init.ts:88` — local `basePlayer` shape in `createPlayerApiCompat`

2. Implement the behaviour in `createRuntimePlayer.seek`:
   - Capture `wasPlaying` before the deterministic seek helper pauses the master and rearmed siblings.
   - When `options.keepPlaying && wasPlaying`, resume the master + siblings, reapply `playbackRate` via `timeScale`, and emit `onDeterministicPlay` + `onShowNativeVideos` + `onSyncMedia(t, true)` so media and analytics stay in sync.
   - Default branch (no options, explicit `keepPlaying: false`, or `wasPlaying === false`) keeps the existing `setIsPlaying(false)` + `onSyncMedia(t, false)` path. No back-compat change.

## Test plan

Added 6 new tests in `packages/core/src/runtime/player.test.ts` under `describe(\"keepPlaying option\")`:

- [x] Preserves play state when `keepPlaying: true` and playback was active (no `setIsPlaying(false)`, emits `onDeterministicPlay` + `onSyncMedia(t, true)`).
- [x] Resumes the master timeline after the deterministic seek pauses it (asserts `play()` is invoked after the last internal `pause()` via `invocationCallOrder`).
- [x] Applies `playbackRate` to master and siblings on resume.
- [x] Stays paused when `keepPlaying: true` but playback was not active (intent is preserve, not force).
- [x] Explicit `keepPlaying: false` matches default behaviour.
- [x] No options matches default behaviour (back-compat).

Other validations:

- [x] `bun run --cwd packages/core test` → 868/868 passing (was 862, +6 new).
- [x] `bun run --cwd packages/studio test` → 514/514 passing, no regression in the consuming side.
- [x] `bun run --cwd packages/core typecheck` and `bun run --cwd packages/studio typecheck` clean.
- [x] `bunx oxlint` and `bunx oxfmt --check` clean on touched files.
- [x] Lefthook pre-commit ran lint + format + typecheck + commitlint.

## Out of scope

`createStaticSeekPlaybackAdapter` in `packages/studio/src/player/lib/playbackAdapter.ts` still has `seek: (time) => void` (no options). Its current behaviour happens to preserve playback by accident (the `playing` flag drives the RAF ticker independently), but the contract is mismatched. Happy to follow up if a maintainer wants the static-seek adapter brought in line with the same shape.

## Related

- PR #842 (the original fix, GSAP path).
- jrusso's review on #842 raising the `__player` path concern.
- Issue #834 (the originating I/O markers bug list).