### PR TITLE
ci(codeql): bump codeql-action v3 → v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,13 +43,13 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Bump pinned SHA for `github/codeql-action/{init,analyze}` from v3 → v4 in `.github/workflows/codeql.yml`.

Both `init` and `analyze` now point at `9e0d7b8d25671d64c341c19c0152d693099fb5ba` (v4 tag tip, resolved via `gh api repos/github/codeql-action/git/refs/tags/v4`).

## Why

GitHub's deprecation notice landed in the live CodeQL run logs:

> CodeQL Action v3 will be deprecated in December 2026. Please update all occurrences of the CodeQL Action in your workflow files to v4.

> [github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)

v4's other big change is Node.js 24 (v3 still runs on Node 20, which has its own deprecation timer starting June 2026). Bumping now clears both.

## Test plan

- [x] Pinned SHA resolved from the canonical `github/codeql-action` v4 annotated tag at the time of this commit.
- [ ] Next push/PR run of `.github/workflows/codeql.yml` succeeds and no longer emits the v3 deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)