### PR TITLE
docs: add reap as HyperFrames adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -22,3 +22,4 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 | [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
 | [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for short-form code demo videos and documentation.                                    |
 | [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.                                              |
+| [Reap](https://reap.video)               | [@usamaabid](https://github.com/usamaabid)     | Powers lightweight video edits and renders in an AI-driven video processing pipeline for social content.    |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,10 +16,10 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Production
 
-| Organization                             | Contact                                        | How HyperFrames is used                                                                                     |
-| ---------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                  |
-| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions. |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for short-form code demo videos and documentation.                                    |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.                                              |
-| [Reap](https://reap.video)               | [@usamaabid](https://github.com/usamaabid)     | Powers lightweight video edits and renders in an AI-driven video processing pipeline for social content.    |
+| Organization                             | Contact                                        | How HyperFrames is used                                                                                       |
+| ---------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)   | Powers AI-generated video composition and rendering across HeyGen's video product surface.                    |
+| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok) | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.   |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)   | Exploring HyperFrames for short-form code demo videos and documentation.                                      |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                   | Exploring HyperFrames for marketing and product video content.                                                |
+| [reap](https://reap.video)               | [@usamaabid](https://github.com/usamaabid)     | Powers agent-first AI video clipping, editing, and rendering across reap.video's creator and agent workflows. |

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -47,6 +47,13 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 
     Angie Meeker
   </Card>
+  <Card title="reap" href="https://reap.video">
+    <img src="https://www.google.com/s2/favicons?domain=reap.video&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
+
+    Powers agent-first AI video clipping, editing, and rendering across reap.video's creator and agent workflows.
+
+    [@usamaabid](https://github.com/usamaabid)
+  </Card>
 </CardGroup>
 
 The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.


### PR DESCRIPTION
## What

Adds [reap](https://reap.video) to the `ADOPTERS.md` table.

## Why

reap is an AI-powered video processing platform that clips, captions, transcribes, dubs, and publishes short-form video content at scale for creators and brands. We're integrating HyperFrames as a renderer for **lightweight video edits and renders** within our pipeline, specifically for caption overlays, trim/cut compositions, and template-based clip rendering where HTML-as-video is a clean fit alongside our existing Remotion-based heavy rendering.

## Entry added

| Organization | Contact | How HyperFrames is used |
| --- | --- | --- |
| [reap](https://reap.video) | [@usamaabid](https://github.com/usamaabid) | Powers lightweight video edits and renders in an AI-driven video processing pipeline for social content. |