### PR TITLE
ci: fast-fail regression matrix + preflight gate before expensive jobs

### DIFF
--- a/.github/actions/preflight/action.yml
+++ b/.github/actions/preflight/action.yml
@@ -1,0 +1,31 @@
+name: Preflight
+description: |
+  Cheap lint + format gate that runs before expensive CI jobs (regression
+  shards, perf shards, parity renders, Windows renders, catalog previews).
+  Single source of truth for the gate's bun/node/cache/lint/format steps —
+  tweak here and every preflight job picks it up.
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: 22
+
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          bun-${{ runner.os }}-
+
+    - shell: bash
+      run: bun install --frozen-lockfile
+
+    - shell: bash
+      run: bun run lint
+
+    - shell: bash
+      run: bun run format:check

--- a/.github/workflows/catalog-previews.yml
+++ b/.github/workflows/catalog-previews.yml
@@ -17,8 +17,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    name: Preflight (lint + format)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run format:check
+
   render-previews:
     name: Render catalog previews
+    needs: preflight
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/catalog-previews.yml
+++ b/.github/workflows/catalog-previews.yml
@@ -27,6 +27,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run format:check

--- a/.github/workflows/catalog-previews.yml
+++ b/.github/workflows/catalog-previews.yml
@@ -23,19 +23,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-      - run: bun run lint
-      - run: bun run format:check
+      - uses: ./.github/actions/preflight
 
   render-previews:
     name: Render catalog previews

--- a/.github/workflows/player-perf.yml
+++ b/.github/workflows/player-perf.yml
@@ -37,14 +37,30 @@ jobs:
               - "bun.lock"
               - ".github/workflows/player-perf.yml"
 
+  preflight:
+    name: Preflight (lint + format)
+    needs: changes
+    if: needs.changes.outputs.perf == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run format:check
+
   perf-shards:
     name: "Perf: ${{ matrix.shard }}"
-    needs: changes
+    needs: [changes, preflight]
     if: needs.changes.outputs.perf == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - shard: load

--- a/.github/workflows/player-perf.yml
+++ b/.github/workflows/player-perf.yml
@@ -45,19 +45,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-      - run: bun run lint
-      - run: bun run format:check
+      - uses: ./.github/actions/preflight
 
   perf-shards:
     name: "Perf: ${{ matrix.shard }}"

--- a/.github/workflows/player-perf.yml
+++ b/.github/workflows/player-perf.yml
@@ -49,6 +49,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run format:check

--- a/.github/workflows/preview-regression.yml
+++ b/.github/workflows/preview-regression.yml
@@ -41,9 +41,25 @@ jobs:
               - "bun.lock"
               - ".github/workflows/preview-regression.yml"
 
+  preflight:
+    name: Preflight (lint + format)
+    needs: changes
+    if: needs.changes.outputs.preview == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run format:check
+
   preview-parity:
     name: Preview parity
-    needs: changes
+    needs: [changes, preflight]
     if: needs.changes.outputs.preview == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/preview-regression.yml
+++ b/.github/workflows/preview-regression.yml
@@ -53,6 +53,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run format:check

--- a/.github/workflows/preview-regression.yml
+++ b/.github/workflows/preview-regression.yml
@@ -49,19 +49,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-      - run: bun run lint
-      - run: bun run format:check
+      - uses: ./.github/actions/preflight
 
   preview-parity:
     name: Preview parity

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,13 +34,29 @@ jobs:
               - "packages/engine/**"
               - "Dockerfile*"
 
-  regression-shards:
+  preflight:
+    name: Preflight (lint + format)
     needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run format:check
+
+  regression-shards:
+    needs: [changes, preflight]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         # Shards are bin-packed by measured per-test duration (LPT heuristic on
         # CI run 25893372795) so each row carries ~15-16 min of work. When a

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -46,6 +46,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run format:check

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -42,19 +42,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-      - run: bun run lint
-      - run: bun run format:check
+      - uses: ./.github/actions/preflight
 
   regression-shards:
     needs: [changes, preflight]

--- a/.github/workflows/windows-render.yml
+++ b/.github/workflows/windows-render.yml
@@ -57,9 +57,27 @@ jobs:
               - "bun.lock"
               - ".github/workflows/windows-render.yml"
 
+  preflight:
+    name: Preflight (lint + format)
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run format:check
+
   render-windows:
     name: Render on windows-latest
-    needs: changes
+    needs: [changes, preflight]
     if: needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     timeout-minutes: 30
@@ -344,7 +362,7 @@ jobs:
   # -------------------------------------------------------------------
   test-windows:
     name: Tests on windows-latest
-    needs: changes
+    needs: [changes, preflight]
     if: needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     timeout-minutes: 20

--- a/.github/workflows/windows-render.yml
+++ b/.github/workflows/windows-render.yml
@@ -71,6 +71,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run format:check

--- a/.github/workflows/windows-render.yml
+++ b/.github/workflows/windows-render.yml
@@ -67,19 +67,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.inputs.ref }}
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-      - run: bun run lint
-      - run: bun run format:check
+      - uses: ./.github/actions/preflight
 
   render-windows:
     name: Render on windows-latest


### PR DESCRIPTION
## Summary

Stop burning 60+ runner-minutes on expensive jobs (Docker regression shards, Chrome perf/parity renders, Windows-latest renders, catalog-preview renders) when the PR is already failing lint or format.

## Changes

- **`regression.yml`** — matrix `fail-fast: false` → `true` so the first failing render-regression shard cancels the other 9. New `preflight` job (lint + `oxfmt --check`) gates `regression-shards`.
- **`player-perf.yml`** — matrix `fail-fast: false` → `true`. New `preflight` job gates `perf-shards`.
- **`preview-regression.yml`** — new `preflight` job gates `preview-parity`.
- **`windows-render.yml`** — new `preflight` job (runs on `ubuntu-latest`) gates both `render-windows` and `test-windows` (each on `windows-latest`).
- **`catalog-previews.yml`** — new `preflight` job gates `render-previews`.

Each preflight installs deps, runs `bun run lint`, and `bun run format:check`. Typecheck is intentionally **not** in preflight — it's slow (~10 min) and any TS error will still surface in each heavy job's own `bun run build` step.

## Net effect

- Lint/format-broken PR: dies at ~2 min of preflight instead of waiting 30–60 min for all the heavy renders to complete.
- Green PR: ~2 min added to critical path (preflight runs in parallel with `ci.yml`'s own lint/format/typecheck before heavy jobs kick off).
- First failing regression or perf shard now cancels its siblings — faster signal at the cost of "see every failing shard at once".

## Test plan

- [ ] CI runs on this PR and the preflight gates appear before the heavy jobs in the Checks tab.
- [ ] Confirm `regression` and `player-perf` summary required-check names are unchanged (still match branch protection).
- [ ] On a deliberate lint-breaking PR (smoke test off this branch), confirm `regression-shards` / `perf-shards` / etc. don't start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)