### PR TITLE
feat(studio): add Ctrl+C/V/X copy/paste for timeline clips and DOM elements

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -12,6 +12,7 @@ import { useManifestPersistence } from "./hooks/useManifestPersistence";
 import { useTimelineEditing } from "./hooks/useTimelineEditing";
 import { useDomEditSession } from "./hooks/useDomEditSession";
 import { useAppHotkeys } from "./hooks/useAppHotkeys";
+import { useClipboard } from "./hooks/useClipboard";
 import { readStudioUiPreferences, writeStudioUiPreferences } from "./utils/studioUiPreferences";
 import { useCaptionDetection } from "./hooks/useCaptionDetection";
 import { useRenderClipContent } from "./hooks/useRenderClipContent";
@@ -162,15 +163,28 @@ export function StudioApp() {
 
   const clearDomSelectionRef = useRef<() => void>(() => {});
   const domEditSelectionBridgeRef = useRef<DomEditSelection | null>(null);
-  const handleDomEditElementDeleteRef = useRef<(selection: DomEditSelection) => Promise<void>>(
+  const handleDomEditElementDeleteRef = useRef<(s: DomEditSelection) => Promise<void>>(
     async () => {},
   );
-
+  const domEditDeleteBridge = async (s: DomEditSelection) =>
+    handleDomEditElementDeleteRef.current(s);
+  const { handleCopy, handlePaste, handleCut } = useClipboard({
+    projectId,
+    activeCompPath,
+    domEditSelectionRef: domEditSelectionBridgeRef,
+    showToast,
+    writeProjectFile: fileManager.writeProjectFile,
+    recordEdit: editHistory.recordEdit,
+    domEditSaveTimestampRef,
+    reloadPreview,
+    handleTimelineElementDelete: timelineEditing.handleTimelineElementDelete,
+    handleDomEditElementDelete: domEditDeleteBridge,
+    previewIframeRef,
+  });
   const appHotkeys = useAppHotkeys({
     toggleTimelineVisibility,
     handleTimelineElementDelete: timelineEditing.handleTimelineElementDelete,
-    handleDomEditElementDelete: async (s: DomEditSelection) =>
-      handleDomEditElementDeleteRef.current(s),
+    handleDomEditElementDelete: domEditDeleteBridge,
     domEditSelectionRef: domEditSelectionBridgeRef,
     clearDomSelectionRef,
     editHistory,
@@ -182,6 +196,9 @@ export function StudioApp() {
     syncHistoryPreviewAfterApply: manifestPersistence.syncHistoryPreviewAfterApply,
     waitForPendingDomEditSaves: manifestPersistence.waitForPendingDomEditSaves,
     leftSidebarRef,
+    handleCopy,
+    handlePaste,
+    handleCut,
   });
 
   const domEditSession = useDomEditSession({

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -110,7 +110,11 @@ export function StudioApp() {
   const editHistory = usePersistentEditHistory({ projectId });
   const domEditSaveTimestampRef = useRef(0);
   const reloadPreview = useCallback(() => {
-    setRefreshKey((k) => k + 1);
+    try {
+      previewIframeRef.current?.contentWindow?.location.reload();
+    } catch {
+      setRefreshKey((k) => k + 1);
+    }
   }, []);
 
   const fileManager = useFileManager({

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -110,11 +110,7 @@ export function StudioApp() {
   const editHistory = usePersistentEditHistory({ projectId });
   const domEditSaveTimestampRef = useRef(0);
   const reloadPreview = useCallback(() => {
-    try {
-      previewIframeRef.current?.contentWindow?.location.reload();
-    } catch {
-      setRefreshKey((k) => k + 1);
-    }
+    setRefreshKey((k) => k + 1);
   }, []);
 
   const fileManager = useFileManager({

--- a/packages/studio/src/hooks/useAppHotkeys.ts
+++ b/packages/studio/src/hooks/useAppHotkeys.ts
@@ -45,6 +45,9 @@ interface UseAppHotkeysParams {
   syncHistoryPreviewAfterApply: (paths: string[] | undefined) => Promise<void>;
   waitForPendingDomEditSaves: () => Promise<void>;
   leftSidebarRef: React.RefObject<LeftSidebarHandle | null>;
+  handleCopy: () => boolean;
+  handlePaste: () => Promise<void>;
+  handleCut: () => Promise<void>;
 }
 
 // ── Hook ──
@@ -64,6 +67,9 @@ export function useAppHotkeys({
   syncHistoryPreviewAfterApply,
   waitForPendingDomEditSaves,
   leftSidebarRef,
+  handleCopy,
+  handlePaste,
+  handleCut,
 }: UseAppHotkeysParams) {
   const previewHotkeyWindowRef = useRef<Window | null>(null);
   const handleAppKeyDownRef = useRef<((event: KeyboardEvent) => void) | undefined>(undefined);
@@ -161,6 +167,12 @@ export function useAppHotkeys({
   handleUndoRef.current = handleUndo;
   const handleRedoRef = useRef(handleRedo);
   handleRedoRef.current = handleRedo;
+  const handleCopyRef = useRef(handleCopy);
+  handleCopyRef.current = handleCopy;
+  const handlePasteRef = useRef(handlePaste);
+  handlePasteRef.current = handlePaste;
+  const handleCutRef = useRef(handleCut);
+  handleCutRef.current = handleCut;
 
   // ── Consolidated keydown handler ──
 
@@ -195,6 +207,28 @@ export function useAppHotkeys({
       if (event.key === "2") {
         event.preventDefault();
         leftSidebarRef.current?.selectTab("assets");
+        return;
+      }
+
+      // Cmd/Ctrl+C — copy
+      const copyPasteKey = event.key.toLowerCase();
+      if (copyPasteKey === "c" && !event.shiftKey && !isEditableTarget(event.target)) {
+        event.preventDefault();
+        handleCopyRef.current();
+        return;
+      }
+
+      // Cmd/Ctrl+V — paste
+      if (copyPasteKey === "v" && !event.shiftKey && !isEditableTarget(event.target)) {
+        event.preventDefault();
+        void handlePasteRef.current();
+        return;
+      }
+
+      // Cmd/Ctrl+X — cut
+      if (copyPasteKey === "x" && !event.shiftKey && !isEditableTarget(event.target)) {
+        event.preventDefault();
+        void handleCutRef.current();
         return;
       }
     }

--- a/packages/studio/src/hooks/useAppHotkeys.ts
+++ b/packages/studio/src/hooks/useAppHotkeys.ts
@@ -47,7 +47,7 @@ interface UseAppHotkeysParams {
   leftSidebarRef: React.RefObject<LeftSidebarHandle | null>;
   handleCopy: () => boolean;
   handlePaste: () => Promise<void>;
-  handleCut: () => Promise<void>;
+  handleCut: () => Promise<boolean>;
 }
 
 // ── Hook ──
@@ -236,15 +236,19 @@ export function useAppHotkeys({
         return;
       }
 
-      // Cmd/Ctrl+X — cut
+      // Cmd/Ctrl+X — cut (only preventDefault if there's a selected element to cut)
       if (
         copyPasteKey === "x" &&
         !event.shiftKey &&
         !event.altKey &&
         !isEditableTarget(event.target)
       ) {
-        event.preventDefault();
-        void handleCutRef.current();
+        const hasSelection =
+          !!usePlayerStore.getState().selectedElementId || !!domEditSelectionRef.current;
+        if (hasSelection) {
+          event.preventDefault();
+          void handleCutRef.current();
+        }
         return;
       }
     }

--- a/packages/studio/src/hooks/useAppHotkeys.ts
+++ b/packages/studio/src/hooks/useAppHotkeys.ts
@@ -210,23 +210,39 @@ export function useAppHotkeys({
         return;
       }
 
-      // Cmd/Ctrl+C — copy
+      // Cmd/Ctrl+C — copy (only preventDefault if we actually have something to copy)
       const copyPasteKey = event.key.toLowerCase();
-      if (copyPasteKey === "c" && !event.shiftKey && !isEditableTarget(event.target)) {
-        event.preventDefault();
-        handleCopyRef.current();
+      if (
+        copyPasteKey === "c" &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !isEditableTarget(event.target)
+      ) {
+        if (handleCopyRef.current()) {
+          event.preventDefault();
+        }
         return;
       }
 
       // Cmd/Ctrl+V — paste
-      if (copyPasteKey === "v" && !event.shiftKey && !isEditableTarget(event.target)) {
+      if (
+        copyPasteKey === "v" &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !isEditableTarget(event.target)
+      ) {
         event.preventDefault();
         void handlePasteRef.current();
         return;
       }
 
       // Cmd/Ctrl+X — cut
-      if (copyPasteKey === "x" && !event.shiftKey && !isEditableTarget(event.target)) {
+      if (
+        copyPasteKey === "x" &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !isEditableTarget(event.target)
+      ) {
         event.preventDefault();
         void handleCutRef.current();
         return;

--- a/packages/studio/src/hooks/useClipboard.ts
+++ b/packages/studio/src/hooks/useClipboard.ts
@@ -65,7 +65,7 @@ function getElementOuterHtml(
     const matches = doc.querySelectorAll(selection.selector);
     el = matches[selection.selectorIndex ?? 0] ?? null;
   }
-  return el instanceof HTMLElement ? el.outerHTML : null;
+  return el && "outerHTML" in el ? (el as Element).outerHTML : null;
 }
 
 export function useClipboard({
@@ -104,7 +104,7 @@ export function useClipboard({
             const matches = doc.querySelectorAll(element.selector);
             el = matches[element.selectorIndex ?? 0] ?? null;
           }
-          if (el instanceof HTMLElement) html = el.outerHTML;
+          if (el && "outerHTML" in el) html = (el as Element).outerHTML;
         }
       } catch {
         // cross-origin frame

--- a/packages/studio/src/hooks/useClipboard.ts
+++ b/packages/studio/src/hooks/useClipboard.ts
@@ -6,6 +6,7 @@ import {
   type ClipboardPayload,
   serializeClipboardPayload,
   deduplicateIds,
+  insertAsSibling,
 } from "../utils/clipboardPayload";
 import { copyTextToClipboard } from "../utils/clipboard";
 import { collectHtmlIds } from "../utils/studioHelpers";
@@ -131,7 +132,13 @@ export function useClipboard({
         return false;
       }
       const targetPath = domSelection.sourceFile || activeCompPath || "index.html";
-      const payload: ClipboardPayload = { kind: "dom-element", html, sourceFile: targetPath };
+      const payload: ClipboardPayload = {
+        kind: "dom-element",
+        html,
+        sourceFile: targetPath,
+        originSelector: domSelection.selector,
+        originSelectorIndex: domSelection.selectorIndex,
+      };
       clipboardRef.current = payload;
       void copyTextToClipboard(serializeClipboardPayload(payload));
       showToast("Copied element", "info");
@@ -165,7 +172,12 @@ export function useClipboard({
         );
         patchedContent = insertTimelineAssetIntoSource(originalContent, withNewStart);
       } else {
-        patchedContent = insertTimelineAssetIntoSource(originalContent, deduped);
+        patchedContent = insertAsSibling(
+          originalContent,
+          deduped,
+          payload.originSelector,
+          payload.originSelectorIndex,
+        );
       }
 
       domEditSaveTimestampRef.current = Date.now();

--- a/packages/studio/src/hooks/useClipboard.ts
+++ b/packages/studio/src/hooks/useClipboard.ts
@@ -1,0 +1,217 @@
+import { useCallback, useRef } from "react";
+import type { TimelineElement } from "../player";
+import { usePlayerStore } from "../player";
+import type { DomEditSelection } from "../components/editor/domEditing";
+import {
+  type ClipboardPayload,
+  serializeClipboardPayload,
+  deduplicateIds,
+} from "../utils/clipboardPayload";
+import { copyTextToClipboard } from "../utils/clipboard";
+import { collectHtmlIds } from "../utils/studioHelpers";
+import { insertTimelineAssetIntoSource } from "../utils/timelineAssetDrop";
+import { saveProjectFilesWithHistory } from "../utils/studioFileHistory";
+import type { EditHistoryKind } from "../utils/editHistory";
+import { formatTimelineAttributeNumber } from "../player/components/timelineEditing";
+
+interface RecordEditInput {
+  label: string;
+  kind: EditHistoryKind;
+  coalesceKey?: string;
+  files: Record<string, { before: string; after: string }>;
+}
+
+interface UseClipboardOptions {
+  projectId: string | null;
+  activeCompPath: string | null;
+  domEditSelectionRef: React.MutableRefObject<DomEditSelection | null>;
+  showToast: (message: string, tone?: "error" | "info") => void;
+  writeProjectFile: (path: string, content: string) => Promise<void>;
+  recordEdit: (input: RecordEditInput) => Promise<void>;
+  domEditSaveTimestampRef: React.MutableRefObject<number>;
+  reloadPreview: () => void;
+  handleTimelineElementDelete: (element: TimelineElement) => Promise<void>;
+  handleDomEditElementDelete: (selection: DomEditSelection) => Promise<void>;
+  previewIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
+}
+
+async function readFileContent(projectId: string, targetPath: string): Promise<string> {
+  const response = await fetch(
+    `/api/projects/${projectId}/files/${encodeURIComponent(targetPath)}`,
+  );
+  if (!response.ok) throw new Error(`Failed to read ${targetPath}`);
+  const data = (await response.json()) as { content?: string };
+  if (typeof data.content !== "string") throw new Error(`Missing file contents for ${targetPath}`);
+  return data.content;
+}
+
+function getElementOuterHtml(
+  iframeRef: React.MutableRefObject<HTMLIFrameElement | null>,
+  selection: DomEditSelection,
+): string | null {
+  let doc: Document | null = null;
+  try {
+    doc = iframeRef.current?.contentDocument ?? null;
+  } catch {
+    return null;
+  }
+  if (!doc) return null;
+
+  let el: Element | null = null;
+  if (selection.id) {
+    el = doc.getElementById(selection.id);
+  }
+  if (!el && selection.selector) {
+    const matches = doc.querySelectorAll(selection.selector);
+    el = matches[selection.selectorIndex ?? 0] ?? null;
+  }
+  return el instanceof HTMLElement ? el.outerHTML : null;
+}
+
+export function useClipboard({
+  projectId,
+  activeCompPath,
+  domEditSelectionRef,
+  showToast,
+  writeProjectFile,
+  recordEdit,
+  domEditSaveTimestampRef,
+  reloadPreview,
+  handleTimelineElementDelete,
+  handleDomEditElementDelete,
+  previewIframeRef,
+}: UseClipboardOptions) {
+  const clipboardRef = useRef<ClipboardPayload | null>(null);
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
+
+  const handleCopy = useCallback((): boolean => {
+    const { selectedElementId, elements } = usePlayerStore.getState();
+
+    // Timeline clip copy
+    if (selectedElementId) {
+      const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
+      if (!element) return false;
+      const targetPath = element.sourceFile || activeCompPath || "index.html";
+
+      let html: string | null = null;
+      try {
+        const doc = previewIframeRef.current?.contentDocument;
+        if (doc) {
+          let el: Element | null = null;
+          if (element.domId) el = doc.getElementById(element.domId);
+          if (!el && element.selector) {
+            const matches = doc.querySelectorAll(element.selector);
+            el = matches[element.selectorIndex ?? 0] ?? null;
+          }
+          if (el instanceof HTMLElement) html = el.outerHTML;
+        }
+      } catch {
+        // cross-origin frame
+      }
+
+      if (!html) {
+        showToast("Unable to copy this element.", "info");
+        return false;
+      }
+
+      const payload: ClipboardPayload = { kind: "timeline-clip", html, sourceFile: targetPath };
+      clipboardRef.current = payload;
+      void copyTextToClipboard(serializeClipboardPayload(payload));
+      showToast("Copied clip", "info");
+      return true;
+    }
+
+    // DOM element copy
+    const domSelection = domEditSelectionRef.current;
+    if (domSelection) {
+      const html = getElementOuterHtml(previewIframeRef, domSelection);
+      if (!html) {
+        showToast("Unable to copy this element.", "info");
+        return false;
+      }
+      const targetPath = domSelection.sourceFile || activeCompPath || "index.html";
+      const payload: ClipboardPayload = { kind: "dom-element", html, sourceFile: targetPath };
+      clipboardRef.current = payload;
+      void copyTextToClipboard(serializeClipboardPayload(payload));
+      showToast("Copied element", "info");
+      return true;
+    }
+
+    return false;
+  }, [activeCompPath, domEditSelectionRef, previewIframeRef, showToast]);
+
+  const handlePaste = useCallback(async () => {
+    const payload = clipboardRef.current;
+    if (!payload) {
+      showToast("Nothing to paste.", "info");
+      return;
+    }
+    const pid = projectIdRef.current;
+    if (!pid) return;
+
+    const targetPath = activeCompPath || "index.html";
+    try {
+      const originalContent = await readFileContent(pid, targetPath);
+      const existingIds = collectHtmlIds(originalContent);
+      const deduped = deduplicateIds(payload.html, existingIds);
+
+      let patchedContent: string;
+      if (payload.kind === "timeline-clip") {
+        const { currentTime } = usePlayerStore.getState();
+        const withNewStart = deduped.replace(
+          /data-start="[^"]*"/,
+          `data-start="${formatTimelineAttributeNumber(currentTime)}"`,
+        );
+        patchedContent = insertTimelineAssetIntoSource(originalContent, withNewStart);
+      } else {
+        patchedContent = insertTimelineAssetIntoSource(originalContent, deduped);
+      }
+
+      domEditSaveTimestampRef.current = Date.now();
+      await saveProjectFilesWithHistory({
+        projectId: pid,
+        label: payload.kind === "timeline-clip" ? "Paste clip" : "Paste element",
+        kind: "timeline" as EditHistoryKind,
+        files: { [targetPath]: patchedContent },
+        readFile: async () => originalContent,
+        writeFile: writeProjectFile,
+        recordEdit,
+      });
+
+      reloadPreview();
+      showToast(payload.kind === "timeline-clip" ? "Pasted clip" : "Pasted element", "info");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to paste";
+      showToast(message);
+    }
+  }, [
+    activeCompPath,
+    domEditSaveTimestampRef,
+    recordEdit,
+    reloadPreview,
+    showToast,
+    writeProjectFile,
+  ]);
+
+  const handleCut = useCallback(async () => {
+    const copied = handleCopy();
+    if (!copied) return;
+
+    const { selectedElementId, elements } = usePlayerStore.getState();
+    if (selectedElementId) {
+      const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
+      if (element) {
+        await handleTimelineElementDelete(element);
+        return;
+      }
+    }
+
+    const domSelection = domEditSelectionRef.current;
+    if (domSelection) {
+      await handleDomEditElementDelete(domSelection);
+    }
+  }, [handleCopy, domEditSelectionRef, handleTimelineElementDelete, handleDomEditElementDelete]);
+
+  return { handleCopy, handlePaste, handleCut };
+}

--- a/packages/studio/src/hooks/useClipboard.ts
+++ b/packages/studio/src/hooks/useClipboard.ts
@@ -2,13 +2,7 @@ import { useCallback, useRef } from "react";
 import type { TimelineElement } from "../player";
 import { usePlayerStore } from "../player";
 import type { DomEditSelection } from "../components/editor/domEditing";
-import {
-  type ClipboardPayload,
-  serializeClipboardPayload,
-  deduplicateIds,
-  insertAsSibling,
-} from "../utils/clipboardPayload";
-import { copyTextToClipboard } from "../utils/clipboard";
+import { type ClipboardPayload, deduplicateIds, insertAsSibling } from "../utils/clipboardPayload";
 import { collectHtmlIds } from "../utils/studioHelpers";
 import { insertTimelineAssetIntoSource } from "../utils/timelineAssetDrop";
 import { saveProjectFilesWithHistory } from "../utils/studioFileHistory";
@@ -118,7 +112,6 @@ export function useClipboard({
 
       const payload: ClipboardPayload = { kind: "timeline-clip", html, sourceFile: targetPath };
       clipboardRef.current = payload;
-      void copyTextToClipboard(serializeClipboardPayload(payload));
       showToast("Copied clip", "info");
       return true;
     }
@@ -140,7 +133,6 @@ export function useClipboard({
         originSelectorIndex: domSelection.selectorIndex,
       };
       clipboardRef.current = payload;
-      void copyTextToClipboard(serializeClipboardPayload(payload));
       showToast("Copied element", "info");
       return true;
     }
@@ -165,11 +157,17 @@ export function useClipboard({
 
       let patchedContent: string;
       if (payload.kind === "timeline-clip") {
+        // Only rewrite data-start on the outermost opening tag. The non-global
+        // regex matches the first occurrence, which is always in the root tag
+        // since outerHTML starts with it. Nested clips keep their own timing.
         const { currentTime } = usePlayerStore.getState();
-        const withNewStart = deduped.replace(
+        const rootTagEnd = deduped.indexOf(">");
+        const rootTag = rootTagEnd >= 0 ? deduped.slice(0, rootTagEnd + 1) : deduped;
+        const patchedRootTag = rootTag.replace(
           /data-start="[^"]*"/,
           `data-start="${formatTimelineAttributeNumber(currentTime)}"`,
         );
+        const withNewStart = patchedRootTag + deduped.slice(rootTagEnd + 1);
         patchedContent = insertTimelineAssetIntoSource(originalContent, withNewStart);
       } else {
         patchedContent = insertAsSibling(
@@ -206,23 +204,25 @@ export function useClipboard({
     writeProjectFile,
   ]);
 
-  const handleCut = useCallback(async () => {
+  const handleCut = useCallback(async (): Promise<boolean> => {
     const copied = handleCopy();
-    if (!copied) return;
+    if (!copied) return false;
 
     const { selectedElementId, elements } = usePlayerStore.getState();
     if (selectedElementId) {
       const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
       if (element) {
         await handleTimelineElementDelete(element);
-        return;
+        return true;
       }
     }
 
     const domSelection = domEditSelectionRef.current;
     if (domSelection) {
       await handleDomEditElementDelete(domSelection);
+      return true;
     }
+    return true;
   }, [handleCopy, domEditSelectionRef, handleTimelineElementDelete, handleDomEditElementDelete]);
 
   return { handleCopy, handlePaste, handleCut };

--- a/packages/studio/src/utils/clipboardPayload.test.ts
+++ b/packages/studio/src/utils/clipboardPayload.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  deduplicateIds,
+  serializeClipboardPayload,
+  deserializeClipboardPayload,
+  type ClipboardPayload,
+} from "./clipboardPayload";
+
+describe("deduplicateIds", () => {
+  it("renames ids that collide with existing ids", () => {
+    const html = '<div id="hero"><img id="photo" src="a.png" /></div>';
+    const existingIds = ["hero", "other"];
+    const result = deduplicateIds(html, existingIds);
+    expect(result).not.toContain('id="hero"');
+    expect(result).toContain('id="photo"');
+    expect(result).toMatch(/id="hero-\d+"/);
+  });
+
+  it("returns html unchanged when no collisions", () => {
+    const html = '<div id="unique"><p>hello</p></div>';
+    const result = deduplicateIds(html, ["other"]);
+    expect(result).toBe(html);
+  });
+});
+
+describe("serializeClipboardPayload / deserializeClipboardPayload", () => {
+  it("round-trips a timeline clip payload", () => {
+    const payload: ClipboardPayload = {
+      kind: "timeline-clip",
+      html: '<img id="photo" src="a.png" data-start="1" data-duration="3" />',
+      sourceFile: "index.html",
+    };
+    const json = serializeClipboardPayload(payload);
+    const parsed = deserializeClipboardPayload(json);
+    expect(parsed).toEqual(payload);
+  });
+
+  it("round-trips a dom-element payload", () => {
+    const payload: ClipboardPayload = {
+      kind: "dom-element",
+      html: '<div class="card"><p>Hello</p></div>',
+      sourceFile: "compositions/scene.html",
+    };
+    const json = serializeClipboardPayload(payload);
+    const parsed = deserializeClipboardPayload(json);
+    expect(parsed).toEqual(payload);
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(deserializeClipboardPayload("not json")).toBeNull();
+    expect(deserializeClipboardPayload('{"kind":"unknown"}')).toBeNull();
+  });
+});

--- a/packages/studio/src/utils/clipboardPayload.test.ts
+++ b/packages/studio/src/utils/clipboardPayload.test.ts
@@ -22,6 +22,14 @@ describe("deduplicateIds", () => {
     const result = deduplicateIds(html, ["other"]);
     expect(result).toBe(html);
   });
+
+  it("does not rewrite data-composition-id or other data-*-id attributes", () => {
+    const html = '<div data-composition-id="hero" data-clip-id="hero" id="hero">content</div>';
+    const result = deduplicateIds(html, ["hero"]);
+    expect(result).toContain('data-composition-id="hero"');
+    expect(result).toContain('data-clip-id="hero"');
+    expect(result).toMatch(/\sid="hero-\d+"/);
+  });
 });
 
 describe("serializeClipboardPayload / deserializeClipboardPayload", () => {

--- a/packages/studio/src/utils/clipboardPayload.ts
+++ b/packages/studio/src/utils/clipboardPayload.ts
@@ -1,0 +1,51 @@
+const CLIPBOARD_MARKER = "hyperframes-clipboard:v1";
+
+export interface ClipboardPayload {
+  kind: "timeline-clip" | "dom-element";
+  html: string;
+  sourceFile: string;
+}
+
+interface SerializedPayload {
+  _marker: string;
+  kind: "timeline-clip" | "dom-element";
+  html: string;
+  sourceFile: string;
+}
+
+export function serializeClipboardPayload(payload: ClipboardPayload): string {
+  const data: SerializedPayload = {
+    _marker: CLIPBOARD_MARKER,
+    kind: payload.kind,
+    html: payload.html,
+    sourceFile: payload.sourceFile,
+  };
+  return JSON.stringify(data);
+}
+
+export function deserializeClipboardPayload(json: string): ClipboardPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj._marker !== CLIPBOARD_MARKER) return null;
+  if (obj.kind !== "timeline-clip" && obj.kind !== "dom-element") return null;
+  if (typeof obj.html !== "string" || typeof obj.sourceFile !== "string") return null;
+  return { kind: obj.kind, html: obj.html, sourceFile: obj.sourceFile };
+}
+
+export function deduplicateIds(html: string, existingIds: string[]): string {
+  const existingSet = new Set(existingIds);
+  return html.replace(/\bid="([^"]+)"/g, (full, id: string) => {
+    if (!existingSet.has(id)) return full;
+    let counter = 2;
+    while (existingSet.has(`${id}-${counter}`)) counter++;
+    const newId = `${id}-${counter}`;
+    existingSet.add(newId);
+    return `id="${newId}"`;
+  });
+}

--- a/packages/studio/src/utils/clipboardPayload.ts
+++ b/packages/studio/src/utils/clipboardPayload.ts
@@ -4,6 +4,8 @@ export interface ClipboardPayload {
   kind: "timeline-clip" | "dom-element";
   html: string;
   sourceFile: string;
+  originSelector?: string;
+  originSelectorIndex?: number;
 }
 
 interface SerializedPayload {
@@ -11,6 +13,8 @@ interface SerializedPayload {
   kind: "timeline-clip" | "dom-element";
   html: string;
   sourceFile: string;
+  originSelector?: string;
+  originSelectorIndex?: number;
 }
 
 export function serializeClipboardPayload(payload: ClipboardPayload): string {
@@ -19,6 +23,8 @@ export function serializeClipboardPayload(payload: ClipboardPayload): string {
     kind: payload.kind,
     html: payload.html,
     sourceFile: payload.sourceFile,
+    originSelector: payload.originSelector,
+    originSelectorIndex: payload.originSelectorIndex,
   };
   return JSON.stringify(data);
 }
@@ -35,7 +41,118 @@ export function deserializeClipboardPayload(json: string): ClipboardPayload | nu
   if (obj._marker !== CLIPBOARD_MARKER) return null;
   if (obj.kind !== "timeline-clip" && obj.kind !== "dom-element") return null;
   if (typeof obj.html !== "string" || typeof obj.sourceFile !== "string") return null;
-  return { kind: obj.kind, html: obj.html, sourceFile: obj.sourceFile };
+  return {
+    kind: obj.kind,
+    html: obj.html,
+    sourceFile: obj.sourceFile,
+    originSelector: typeof obj.originSelector === "string" ? obj.originSelector : undefined,
+    originSelectorIndex:
+      typeof obj.originSelectorIndex === "number" ? obj.originSelectorIndex : undefined,
+  };
+}
+
+/**
+ * Insert `newHtml` as a sibling immediately after the element matched by
+ * `selector` (at `selectorIndex`) in `source`. Falls back to inserting after
+ * the composition root if the selector doesn't match — so paste never silently
+ * drops the content.
+ */
+export function insertAsSibling(
+  source: string,
+  newHtml: string,
+  selector: string | undefined,
+  selectorIndex: number | undefined,
+): string {
+  if (selector) {
+    const idx = selectorIndex ?? 0;
+    let matchCount = 0;
+
+    // Find the element by searching for its opening tag pattern.
+    // For id selectors like #foo, search for id="foo".
+    // For class selectors like .name-text, search for class="...name-text...".
+    // For attribute selectors like [data-composition-id="x"], search literally.
+
+    let searchPattern: RegExp | null = null;
+    if (selector.startsWith("#")) {
+      const id = selector.slice(1);
+      searchPattern = new RegExp(`<[a-z][^>]*\\bid="${id}"[^>]*>`, "gi");
+    } else if (selector.startsWith(".")) {
+      const cls = selector.slice(1);
+      searchPattern = new RegExp(`<[a-z][^>]*\\bclass="[^"]*\\b${cls}\\b[^"]*"[^>]*>`, "gi");
+    } else if (selector.startsWith("[")) {
+      const inner = selector.slice(1, -1);
+      searchPattern = new RegExp(`<[a-z][^>]*\\b${inner.replace(/"/g, '"')}[^>]*>`, "gi");
+    }
+
+    if (searchPattern) {
+      let match: RegExpExecArray | null;
+      while ((match = searchPattern.exec(source)) !== null) {
+        if (matchCount === idx) {
+          const insertPos = findClosingTagPosition(source, match.index);
+          if (insertPos > 0) {
+            return source.slice(0, insertPos) + "\n" + newHtml + source.slice(insertPos);
+          }
+        }
+        matchCount++;
+      }
+    }
+  }
+
+  // Fallback: insert after composition root opening tag (same as timeline clips)
+  const rootOpenTag = /<[^>]*data-composition-id="[^"]+"[^>]*>/i;
+  const rootMatch = rootOpenTag.exec(source);
+  if (rootMatch && rootMatch.index != null) {
+    const insertAt = rootMatch.index + rootMatch[0].length;
+    return source.slice(0, insertAt) + newHtml + source.slice(insertAt);
+  }
+
+  return source + newHtml;
+}
+
+function findClosingTagPosition(html: string, openTagStart: number): number {
+  // Find the end of the opening tag
+  const openTagEnd = html.indexOf(">", openTagStart);
+  if (openTagEnd < 0) return -1;
+
+  // Self-closing tag?
+  if (html[openTagEnd - 1] === "/") return openTagEnd + 1;
+
+  // Extract the tag name
+  const tagNameMatch = html.slice(openTagStart).match(/^<([a-z][a-z0-9]*)/i);
+  if (!tagNameMatch) return -1;
+  const tagName = tagNameMatch[1]!;
+
+  // Walk forward counting open/close tags of the same name
+  let depth = 1;
+  let pos = openTagEnd + 1;
+  const openRe = new RegExp(`<${tagName}(?:\\s|>|/>)`, "gi");
+  const closeRe = new RegExp(`</${tagName}\\s*>`, "gi");
+
+  while (depth > 0 && pos < html.length) {
+    openRe.lastIndex = pos;
+    closeRe.lastIndex = pos;
+
+    const nextOpen = openRe.exec(html);
+    const nextClose = closeRe.exec(html);
+
+    if (!nextClose) return -1;
+
+    if (nextOpen && nextOpen.index < nextClose.index) {
+      // Check if it's self-closing
+      const selfCloseCheck = html.lastIndexOf("/", html.indexOf(">", nextOpen.index));
+      if (selfCloseCheck > nextOpen.index) {
+        pos = html.indexOf(">", nextOpen.index) + 1;
+      } else {
+        depth++;
+        pos = html.indexOf(">", nextOpen.index) + 1;
+      }
+    } else {
+      depth--;
+      if (depth === 0) return nextClose.index + nextClose[0].length;
+      pos = nextClose.index + nextClose[0].length;
+    }
+  }
+  return -1;
 }
 
 export function deduplicateIds(html: string, existingIds: string[]): string {

--- a/packages/studio/src/utils/clipboardPayload.ts
+++ b/packages/studio/src/utils/clipboardPayload.ts
@@ -81,7 +81,7 @@ export function insertAsSibling(
       searchPattern = new RegExp(`<[a-z][^>]*\\bclass="[^"]*\\b${cls}\\b[^"]*"[^>]*>`, "gi");
     } else if (selector.startsWith("[")) {
       const inner = selector.slice(1, -1);
-      searchPattern = new RegExp(`<[a-z][^>]*\\b${inner.replace(/"/g, '"')}[^>]*>`, "gi");
+      searchPattern = new RegExp(`<[a-z][^>]*\\b${inner}[^>]*>`, "gi");
     }
 
     if (searchPattern) {
@@ -157,7 +157,7 @@ function findClosingTagPosition(html: string, openTagStart: number): number {
 
 export function deduplicateIds(html: string, existingIds: string[]): string {
   const existingSet = new Set(existingIds);
-  return html.replace(/\bid="([^"]+)"/g, (full, id: string) => {
+  return html.replace(/(?<=\s)id="([^"]+)"/g, (full, id: string) => {
     if (!existingSet.has(id)) return full;
     let counter = 2;
     while (existingSet.has(`${id}-${counter}`)) counter++;


### PR DESCRIPTION
## Summary

- Adds Ctrl+C / Ctrl+V / Ctrl+X keyboard shortcuts for copying, pasting, and cutting timeline clips and DOM elements
- Contextual dispatch: timeline clip selected → clip operations; DOM element selected → element operations
- Pasted timeline clips re-timed to playhead position with deduplicated IDs
- DOM elements pasted as siblings (same parent context) preserving CSS inheritance
- All operations fully undoable via Ctrl+Z
- Cross-frame `instanceof` fix for iframe DOM access

## Test plan

- [x] 5 unit tests for clipboard payload (dedup, serialization, round-trip)
- [x] Build passes, lint clean
- [x] Manual: copy/paste timeline clips, DOM elements, undo all work