### PR TITLE
perf(distributed): parallelize chunk capture across multiple workers

### DIFF
--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -29,6 +29,19 @@ export interface WorkerTask {
   startFrame: number;
   endFrame: number;
   outputDir: string;
+  /**
+   * Offset to subtract from the absolute frame index when computing the
+   * captured file's name. Default 0: file name equals absolute index (the
+   * in-process contract — workers writing into a shared framesDir indexed
+   * `0..totalFrames-1`). Distributed chunks set this to the chunk's
+   * absolute startFrame so file names land 0-indexed within the chunk's
+   * range, matching the sequential chunk-capture contract and the encoder's
+   * expectation that frames are read sequentially without an
+   * `-start_number` override. The per-frame TIME calculation still uses
+   * the absolute frame index so the page's virtual clock matches an
+   * in-process render at that frame.
+   */
+  outputFrameOffset?: number;
 }
 
 export interface WorkerResult {
@@ -148,20 +161,22 @@ export function distributeFrames(
   totalFrames: number,
   workerCount: number,
   workDir: string,
+  rangeStart: number = 0,
 ): WorkerTask[] {
   const tasks: WorkerTask[] = [];
   const framesPerWorker = Math.ceil(totalFrames / workerCount);
 
   for (let i = 0; i < workerCount; i++) {
-    const startFrame = i * framesPerWorker;
-    const endFrame = Math.min((i + 1) * framesPerWorker, totalFrames);
-    if (startFrame >= totalFrames) break;
+    const startFrame = rangeStart + i * framesPerWorker;
+    const endFrame = Math.min(rangeStart + (i + 1) * framesPerWorker, rangeStart + totalFrames);
+    if (startFrame >= rangeStart + totalFrames) break;
 
     tasks.push({
       workerId: i,
       startFrame,
       endFrame,
       outputDir: join(workDir, `worker-${i}`),
+      outputFrameOffset: rangeStart,
     });
   }
 
@@ -196,6 +211,7 @@ async function executeWorkerTask(
     );
     await initializeSession(session);
 
+    const outputOffset = task.outputFrameOffset ?? 0;
     for (let i = task.startFrame; i < task.endFrame; i++) {
       if (signal?.aborted) {
         throw new Error("Parallel worker cancelled");
@@ -204,14 +220,24 @@ async function executeWorkerTask(
       // frame-index → time math. The 1-in-1001 ULP loss for NTSC is invisible
       // at our scales (frame count tops out at single-digit thousands).
       const time = (i * captureOptions.fps.den) / captureOptions.fps.num;
+      // File NAME uses the offset-adjusted index so chunk renders end up with
+      // `frame_0..frame_(chunkSize-1)` in the framesDir (matching the
+      // sequential chunk contract); time uses the absolute index `i` so the
+      // page's virtual clock matches what an in-process render at the same
+      // frame would see. For in-process renders `outputOffset` is 0 so the
+      // file name equals the absolute index — the prior contract is unchanged.
+      const fileFrameIdx = i - outputOffset;
 
       if (onFrameBuffer) {
-        // Streaming mode: capture to buffer and invoke callback
-        const { buffer } = await captureFrameToBuffer(session, i, time);
+        // Streaming mode: capture to buffer and invoke callback. The
+        // callback still receives the absolute index `i` so the streaming
+        // encoder sequences frames against the composition's timeline; only
+        // the disk file name uses the offset.
+        const { buffer } = await captureFrameToBuffer(session, fileFrameIdx, time);
         await onFrameBuffer(i, buffer);
       } else {
         // Disk mode: capture to file
-        await captureFrame(session, i, time);
+        await captureFrame(session, fileFrameIdx, time);
       }
       framesCaptured++;
 

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -30,16 +30,12 @@ export interface WorkerTask {
   endFrame: number;
   outputDir: string;
   /**
-   * Offset to subtract from the absolute frame index when computing the
-   * captured file's name. Default 0: file name equals absolute index (the
-   * in-process contract — workers writing into a shared framesDir indexed
-   * `0..totalFrames-1`). Distributed chunks set this to the chunk's
-   * absolute startFrame so file names land 0-indexed within the chunk's
-   * range, matching the sequential chunk-capture contract and the encoder's
-   * expectation that frames are read sequentially without an
-   * `-start_number` override. The per-frame TIME calculation still uses
-   * the absolute frame index so the page's virtual clock matches an
-   * in-process render at that frame.
+   * Offset subtracted from the absolute frame index when naming the captured
+   * file (`frame_<i - outputFrameOffset>.{ext}`). Default 0. Distributed
+   * chunks set this to the chunk's absolute startFrame so file names land
+   * 0-indexed within the chunk's range — the encoder reads frames
+   * sequentially without an `-start_number` override. The per-frame TIME
+   * calculation still uses the absolute frame index.
    */
   outputFrameOffset?: number;
 }
@@ -220,23 +216,15 @@ async function executeWorkerTask(
       // frame-index → time math. The 1-in-1001 ULP loss for NTSC is invisible
       // at our scales (frame count tops out at single-digit thousands).
       const time = (i * captureOptions.fps.den) / captureOptions.fps.num;
-      // File NAME uses the offset-adjusted index so chunk renders end up with
-      // `frame_0..frame_(chunkSize-1)` in the framesDir (matching the
-      // sequential chunk contract); time uses the absolute index `i` so the
-      // page's virtual clock matches what an in-process render at the same
-      // frame would see. For in-process renders `outputOffset` is 0 so the
-      // file name equals the absolute index — the prior contract is unchanged.
       const fileFrameIdx = i - outputOffset;
 
       if (onFrameBuffer) {
-        // Streaming mode: capture to buffer and invoke callback. The
-        // callback still receives the absolute index `i` so the streaming
-        // encoder sequences frames against the composition's timeline; only
-        // the disk file name uses the offset.
+        // The streaming-encode callback receives the absolute index `i`
+        // (not `fileFrameIdx`) so the encoder sequences frames against the
+        // composition's timeline.
         const { buffer } = await captureFrameToBuffer(session, fileFrameIdx, time);
         await onFrameBuffer(i, buffer);
       } else {
-        // Disk mode: capture to file
         await captureFrame(session, fileFrameIdx, time);
       }
       framesCaptured++;

--- a/packages/producer/src/services/distributed/renderChunk.ts
+++ b/packages/producer/src/services/distributed/renderChunk.ts
@@ -532,35 +532,12 @@ export async function renderChunk(
       // would deadlock Chrome's compositor by issuing a second beginFrame
       // at a `frameTimeTicks` it had just advanced to.
 
-      // ── Capture the chunk's range via runCaptureStage ──
-      //
-      // Auto-size the chunk's intra-pod worker count via the same
-      // `calculateOptimalWorkers` helper the in-process renderer uses. The
-      // distributed primitive previously hardcoded `workerCount: 1`, leaving
-      // ~18 of a typical 22-vCPU pod's cores idle while a single Chrome
-      // session rendered the chunk: chunk-level fan-out at the orchestration
-      // layer (Temporal / Lambda / K8s Jobs) gave each pod one chunk at a
-      // time, but the chunk render itself was single-threaded. Matching the
-      // in-process renderer's worker selection lifts that ceiling and lets
-      // chunks saturate the pod they land on (typically 2-6 workers based on
-      // pod CPU + frame count).
-      //
-      // The framesDir contract is unchanged: the sequential and parallel
-      // branches of `runCaptureStage` both emit a contiguous, 0-indexed
-      // `frame_<i>.{ext}` directory within the chunk's range, so the encoder
-      // downstream is unaffected. The pre-warmed `probeSession` is consumed
-      // only by the sequential branch; the parallel branch closes it during
-      // stage entry and creates its own worker sessions. The ~3-5s warmup is
-      // wasted when the auto-sized worker count is >1 — kept for now because
-      // the per-chunk render-time win dwarfs it; a follow-up can skip
-      // probeSession creation when the resolved workerCount > 1.
-      //
-      // `requestedWorkers` is `undefined` so the auto path computes the
-      // worker count from `framesInChunk` + `cfg.concurrency` (default
-      // "auto") + pod CPU. Capture-cost calibration based on shader
-      // transitions / renderModeHints is not threaded through yet; the
-      // chunk's compiled metadata could be plumbed if heavy shader work
-      // starts trigging compositor contention.
+      // Capture-cost calibration based on shader transitions /
+      // renderModeHints is not threaded through to chunks yet; the in-process
+      // renderer's `resolveRenderWorkerCount` wraps this with that reduction,
+      // but `PlanJson` doesn't carry the compiled hints needed to call it
+      // directly. The existing adaptive-retry path reduces workers if
+      // compositor contention surfaces as CDP timeouts.
       const chunkWorkerCount = calculateOptimalWorkers(framesInChunk, undefined, cfg);
       await runCaptureStage({
         fileServer,
@@ -572,11 +549,9 @@ export async function renderChunk(
         forceScreenshot: encoder.forceScreenshot,
         log,
         workerCount: chunkWorkerCount,
-        // Pass the pre-warmed session through as `probeSession` so captureStage
-        // reuses it via `prepareCaptureSessionForReuse` instead of spinning up
-        // a fresh browser (sequential path only). The stage closes the session
-        // in its `finally`, so we MUST clear our own reference here to avoid
-        // a double-close.
+        // The parallel branch closes this session and spins up its own
+        // worker sessions, wasting the ~3-5s of pre-warmed setup. Worth a
+        // follow-up to skip pre-warmup when the resolved workerCount > 1.
         probeSession: session,
         needsAlpha: plan.dimensions.format !== "mp4",
         captureAttempts: [],

--- a/packages/producer/src/services/distributed/renderChunk.ts
+++ b/packages/producer/src/services/distributed/renderChunk.ts
@@ -532,6 +532,26 @@ export async function renderChunk(
       // at a `frameTimeTicks` it had just advanced to.
 
       // ── Capture the chunk's range via runCaptureStage ──
+      //
+      // `workerCount: 2` parallelizes the chunk's capture across two Chrome
+      // sessions on this worker. Adopters that deploy chunks onto multi-core
+      // hosts (the standard pattern — Temporal pods, Lambda containers, K8s
+      // Jobs at 8-24 vCPU) previously pinned only ~3-4 cores per chunk while
+      // the rest sat idle: chunk-level fan-out at the orchestration layer
+      // gave each pod one chunk at a time, and the chunk render itself was
+      // single-threaded. Doubling to two intra-chunk workers approximately
+      // halves per-chunk wall time on per-frame-heavy compositions (where
+      // the slowest chunk gates total distributed wall-clock), without
+      // changing the chunk's byte-identical-retry contract — the sequential
+      // and parallel branches of `runCaptureStage` both produce a
+      // contiguous, 0-indexed `frame_<i>.{ext}` framesDir within the chunk's
+      // range, so the encoder downstream is unchanged.
+      //
+      // The pre-warmed `probeSession` is consumed only by the sequential
+      // branch; the parallel branch closes it during stage entry and creates
+      // its own worker sessions. The ~3-5s warmup is therefore wasted under
+      // parallel — kept for now because the chunk-render speedup dwarfs it;
+      // a follow-up can skip probeSession creation when workerCount > 1.
       await runCaptureStage({
         fileServer,
         workDir,
@@ -541,11 +561,12 @@ export async function renderChunk(
         cfg,
         forceScreenshot: encoder.forceScreenshot,
         log,
-        workerCount: 1,
+        workerCount: 2,
         // Pass the pre-warmed session through as `probeSession` so captureStage
         // reuses it via `prepareCaptureSessionForReuse` instead of spinning up
-        // a fresh browser. The stage closes the session in its `finally`,
-        // so we MUST clear our own reference here to avoid a double-close.
+        // a fresh browser (sequential path only). The stage closes the session
+        // in its `finally`, so we MUST clear our own reference here to avoid
+        // a double-close.
         probeSession: session,
         needsAlpha: plan.dimensions.format !== "mp4",
         captureAttempts: [],

--- a/packages/producer/src/services/distributed/renderChunk.ts
+++ b/packages/producer/src/services/distributed/renderChunk.ts
@@ -42,6 +42,7 @@ import {
   assertSwiftShader,
   type BeforeCaptureHook,
   BROWSER_GPU_NOT_SOFTWARE,
+  calculateOptimalWorkers,
   type CaptureOptions,
   type CaptureSession,
   closeCaptureSession,
@@ -533,25 +534,34 @@ export async function renderChunk(
 
       // ── Capture the chunk's range via runCaptureStage ──
       //
-      // `workerCount: 2` parallelizes the chunk's capture across two Chrome
-      // sessions on this worker. Adopters that deploy chunks onto multi-core
-      // hosts (the standard pattern — Temporal pods, Lambda containers, K8s
-      // Jobs at 8-24 vCPU) previously pinned only ~3-4 cores per chunk while
-      // the rest sat idle: chunk-level fan-out at the orchestration layer
-      // gave each pod one chunk at a time, and the chunk render itself was
-      // single-threaded. Doubling to two intra-chunk workers approximately
-      // halves per-chunk wall time on per-frame-heavy compositions (where
-      // the slowest chunk gates total distributed wall-clock), without
-      // changing the chunk's byte-identical-retry contract — the sequential
-      // and parallel branches of `runCaptureStage` both produce a
-      // contiguous, 0-indexed `frame_<i>.{ext}` framesDir within the chunk's
-      // range, so the encoder downstream is unchanged.
+      // Auto-size the chunk's intra-pod worker count via the same
+      // `calculateOptimalWorkers` helper the in-process renderer uses. The
+      // distributed primitive previously hardcoded `workerCount: 1`, leaving
+      // ~18 of a typical 22-vCPU pod's cores idle while a single Chrome
+      // session rendered the chunk: chunk-level fan-out at the orchestration
+      // layer (Temporal / Lambda / K8s Jobs) gave each pod one chunk at a
+      // time, but the chunk render itself was single-threaded. Matching the
+      // in-process renderer's worker selection lifts that ceiling and lets
+      // chunks saturate the pod they land on (typically 2-6 workers based on
+      // pod CPU + frame count).
       //
-      // The pre-warmed `probeSession` is consumed only by the sequential
-      // branch; the parallel branch closes it during stage entry and creates
-      // its own worker sessions. The ~3-5s warmup is therefore wasted under
-      // parallel — kept for now because the chunk-render speedup dwarfs it;
-      // a follow-up can skip probeSession creation when workerCount > 1.
+      // The framesDir contract is unchanged: the sequential and parallel
+      // branches of `runCaptureStage` both emit a contiguous, 0-indexed
+      // `frame_<i>.{ext}` directory within the chunk's range, so the encoder
+      // downstream is unaffected. The pre-warmed `probeSession` is consumed
+      // only by the sequential branch; the parallel branch closes it during
+      // stage entry and creates its own worker sessions. The ~3-5s warmup is
+      // wasted when the auto-sized worker count is >1 — kept for now because
+      // the per-chunk render-time win dwarfs it; a follow-up can skip
+      // probeSession creation when the resolved workerCount > 1.
+      //
+      // `requestedWorkers` is `undefined` so the auto path computes the
+      // worker count from `framesInChunk` + `cfg.concurrency` (default
+      // "auto") + pod CPU. Capture-cost calibration based on shader
+      // transitions / renderModeHints is not threaded through yet; the
+      // chunk's compiled metadata could be plumbed if heavy shader work
+      // starts trigging compositor contention.
+      const chunkWorkerCount = calculateOptimalWorkers(framesInChunk, undefined, cfg);
       await runCaptureStage({
         fileServer,
         workDir,
@@ -561,7 +571,7 @@ export async function renderChunk(
         cfg,
         forceScreenshot: encoder.forceScreenshot,
         log,
-        workerCount: 2,
+        workerCount: chunkWorkerCount,
         // Pass the pre-warmed session through as `probeSession` so captureStage
         // reuses it via `prepareCaptureSessionForReuse` instead of spinning up
         // a fresh browser (sequential path only). The stage closes the session

--- a/packages/producer/src/services/render/stages/captureStage.ts
+++ b/packages/producer/src/services/render/stages/captureStage.ts
@@ -96,25 +96,15 @@ export interface CaptureStageInput {
   onProgress?: ProgressCallback;
   /**
    * Capture a sub-range `[startFrame, endFrame)` of the composition's
-   * timeline. Used by distributed `renderChunk` workers to render only
-   * their assigned chunk. Captured frames are written with file names
-   * normalized to start at zero (`frame_000000.{ext}`) so the encoder
-   * doesn't need an `-start_number` override; per-frame TIMES still
-   * reflect the absolute frame index via `(absIdx * fps.den) / fps.num`,
-   * keeping the page's virtual clock identical to what an in-process
-   * render at that frame would see.
+   * timeline. Used by distributed `renderChunk` to render only its chunk.
+   * Captured file names are 0-indexed within the range; per-frame TIMES use
+   * the absolute frame index so the page's virtual clock matches an
+   * in-process render at that frame. Supported on both the sequential and
+   * parallel branches; the parallel branch threads `frameRange.startFrame`
+   * through as `frameRangeStart`. See `WorkerTask.outputFrameOffset`.
    *
-   * Supported on both the sequential (`workerCount === 1`) and parallel
-   * (`workerCount > 1`) branches. The parallel branch forwards
-   * `frameRange.startFrame` to `executeDiskCaptureWithAdaptiveRetry` as
-   * `frameRangeStart` so each worker's `WorkerTask` lands on absolute
-   * composition indices for time and 0-indexed file names within the
-   * chunk range. `mergeWorkerFrames` then stitches each worker's slice
-   * into a contiguous `0..rangeFrames-1` framesDir, matching what the
-   * sequential path already produces.
-   *
-   * Default `undefined`: the stage captures `[0, totalFrames)` (the
-   * in-process contract).
+   * Default `undefined`: capture `[0, totalFrames)` (in-process contract).
+   * When set, `endFrame - startFrame` MUST equal `totalFrames`.
    */
   frameRange?: { startFrame: number; endFrame: number };
 }
@@ -167,6 +157,18 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
       throw new Error(
         `[captureStage] invalid frameRange: ${JSON.stringify(frameRange)}. ` +
           `Expected non-negative startFrame strictly less than endFrame.`,
+      );
+    }
+    // The parallel branch passes `totalFrames` to executeDiskCaptureWithAdaptiveRetry
+    // (which drives `distributeFrames` partitioning and `findMissingFrameRanges`
+    // completion checks) AND `frameRangeStart` separately. They must describe the
+    // same window: callers passing `totalFrames=100, frameRange={50, 200}` would
+    // get a silently wrong distribution.
+    const rangeFrames = frameRange.endFrame - frameRange.startFrame;
+    if (rangeFrames !== totalFrames) {
+      throw new Error(
+        `[captureStage] frameRange size (${rangeFrames}) must equal totalFrames (${totalFrames}). ` +
+          `Received frameRange=${JSON.stringify(frameRange)}.`,
       );
     }
   }

--- a/packages/producer/src/services/render/stages/captureStage.ts
+++ b/packages/producer/src/services/render/stages/captureStage.ts
@@ -104,12 +104,14 @@ export interface CaptureStageInput {
    * keeping the page's virtual clock identical to what an in-process
    * render at that frame would see.
    *
-   * Only honored on the sequential capture branch (workerCount === 1).
-   * The parallel branch in this stage targets in-process renders where
-   * adaptive retry across the whole timeline is the contract, and chunk
-   * workers fan out at the activity layer instead. Passing `frameRange`
-   * with `workerCount > 1` throws — the caller should reduce
-   * `workerCount` to 1.
+   * Supported on both the sequential (`workerCount === 1`) and parallel
+   * (`workerCount > 1`) branches. The parallel branch forwards
+   * `frameRange.startFrame` to `executeDiskCaptureWithAdaptiveRetry` as
+   * `frameRangeStart` so each worker's `WorkerTask` lands on absolute
+   * composition indices for time and 0-indexed file names within the
+   * chunk range. `mergeWorkerFrames` then stitches each worker's slice
+   * into a contiguous `0..rangeFrames-1` framesDir, matching what the
+   * sequential path already produces.
    *
    * Default `undefined`: the stage captures `[0, totalFrames)` (the
    * in-process contract).
@@ -155,12 +157,6 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
   const captureCfg: EngineConfig =
     cfg.forceScreenshot === forceScreenshot ? cfg : { ...cfg, forceScreenshot };
 
-  if (frameRange !== undefined && workerCount > 1) {
-    throw new Error(
-      `[captureStage] frameRange capture requires workerCount === 1 (received workerCount=${workerCount}). ` +
-        `Distributed chunk workers fan out at the activity layer; reduce workerCount to 1 when passing frameRange.`,
-    );
-  }
   if (frameRange !== undefined) {
     if (
       !Number.isFinite(frameRange.startFrame) ||
@@ -176,7 +172,9 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
   }
 
   if (workerCount > 1) {
-    // Parallel capture
+    // Parallel capture. When `frameRange` is set (distributed chunk), pass
+    // `frameRangeStart` so workers land on absolute composition frame indices
+    // for time math while file names stay 0-indexed within the chunk range.
     const attempts = await executeDiskCaptureWithAdaptiveRetry({
       serverUrl: fileServer.url,
       workDir,
@@ -188,6 +186,7 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
       captureOptions: buildCaptureOptions(),
       createBeforeCaptureHook: createRenderVideoFrameInjector,
       abortSignal,
+      frameRangeStart: frameRange?.startFrame,
       onProgress: (progress) => {
         job.framesRendered = progress.capturedFrames;
         const frameProgress = progress.capturedFrames / progress.totalFrames;

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -541,14 +541,11 @@ export function buildMissingFrameRetryBatches(
   const workersPerBatch = Math.max(1, Math.floor(maxWorkers));
   const batches: WorkerTask[][] = [];
 
-  // `ranges` come from `findMissingFrameRanges` which walks file names in
-  // the framesDir — those names are 0-indexed within the chunk's frame range
-  // (or within the in-process render when `rangeStart === 0`). Translate to
-  // ABSOLUTE composition frame indices for `WorkerTask.startFrame/endFrame`
-  // (so the per-frame TIME math `(i * fps.den) / fps.num` lands on the same
-  // virtual clock the page already saw), and set `outputFrameOffset` so the
-  // worker writes the captured file back at the local name the missing-range
-  // scan was looking for.
+  // `ranges` are 0-indexed within the chunk's frame range (or full timeline
+  // when `rangeStart === 0`); translate to absolute composition indices so
+  // `WorkerTask`'s per-frame time math lands on the page's actual virtual
+  // clock, and propagate `outputFrameOffset` so the retry captures back at
+  // the same local file name `findMissingFrameRanges` was looking for.
   for (let i = 0; i < ranges.length; i += workersPerBatch) {
     const batchIndex = batches.length;
     const batch = ranges.slice(i, i + workersPerBatch).map((range, workerId) => ({
@@ -616,14 +613,9 @@ export async function executeDiskCaptureWithAdaptiveRetry(options: {
   cfg: EngineConfig;
   log: ProducerLogger;
   /**
-   * Absolute composition frame index of the first frame this call should
-   * capture. Default 0 (the in-process contract: `[0, totalFrames)`).
-   * Distributed `renderChunk` workers set this to the chunk's startFrame so
-   * the workers' per-frame TIME math lands on the page's actual virtual clock
-   * at that frame, while the captured file names are still 0-indexed within
-   * the chunk's range (so `findMissingFrameRanges` / `countCapturedFrames`
-   * see a contiguous `0..totalFrames-1` namespace and the encoder reads
-   * frames sequentially without an `-start_number` override).
+   * Forwarded to each `WorkerTask`'s `outputFrameOffset` and to the
+   * `buildMissingFrameRetryBatches` translation. Default 0 (in-process
+   * contract: `[0, totalFrames)`). See `WorkerTask.outputFrameOffset`.
    */
   frameRangeStart?: number;
 }): Promise<CaptureAttemptSummary[]> {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -536,17 +536,27 @@ export function buildMissingFrameRetryBatches(
   maxWorkers: number,
   workDir: string,
   attempt: number,
+  rangeStart: number = 0,
 ): WorkerTask[][] {
   const workersPerBatch = Math.max(1, Math.floor(maxWorkers));
   const batches: WorkerTask[][] = [];
 
+  // `ranges` come from `findMissingFrameRanges` which walks file names in
+  // the framesDir — those names are 0-indexed within the chunk's frame range
+  // (or within the in-process render when `rangeStart === 0`). Translate to
+  // ABSOLUTE composition frame indices for `WorkerTask.startFrame/endFrame`
+  // (so the per-frame TIME math `(i * fps.den) / fps.num` lands on the same
+  // virtual clock the page already saw), and set `outputFrameOffset` so the
+  // worker writes the captured file back at the local name the missing-range
+  // scan was looking for.
   for (let i = 0; i < ranges.length; i += workersPerBatch) {
     const batchIndex = batches.length;
     const batch = ranges.slice(i, i + workersPerBatch).map((range, workerId) => ({
       workerId,
-      startFrame: range.startFrame,
-      endFrame: range.endFrame,
+      startFrame: rangeStart + range.startFrame,
+      endFrame: rangeStart + range.endFrame,
       outputDir: join(workDir, `retry-${attempt}-batch-${batchIndex}-worker-${workerId}`),
+      outputFrameOffset: rangeStart,
     }));
     batches.push(batch);
   }
@@ -605,11 +615,23 @@ export async function executeDiskCaptureWithAdaptiveRetry(options: {
   onProgress?: (progress: ParallelProgress) => void;
   cfg: EngineConfig;
   log: ProducerLogger;
+  /**
+   * Absolute composition frame index of the first frame this call should
+   * capture. Default 0 (the in-process contract: `[0, totalFrames)`).
+   * Distributed `renderChunk` workers set this to the chunk's startFrame so
+   * the workers' per-frame TIME math lands on the page's actual virtual clock
+   * at that frame, while the captured file names are still 0-indexed within
+   * the chunk's range (so `findMissingFrameRanges` / `countCapturedFrames`
+   * see a contiguous `0..totalFrames-1` namespace and the encoder reads
+   * frames sequentially without an `-start_number` override).
+   */
+  frameRangeStart?: number;
 }): Promise<CaptureAttemptSummary[]> {
   const attempts: CaptureAttemptSummary[] = [];
   let currentWorkers = options.initialWorkerCount;
   let missingRanges: FrameRange[] | null = null;
   let attempt = 0;
+  const rangeStart = options.frameRangeStart ?? 0;
 
   while (true) {
     const frameCount = missingRanges ? countFrameRanges(missingRanges) : options.totalFrames;
@@ -622,8 +644,14 @@ export async function executeDiskCaptureWithAdaptiveRetry(options: {
 
     const attemptWorkDir = join(options.workDir, `capture-attempt-${attempt}`);
     const batches = missingRanges
-      ? buildMissingFrameRetryBatches(missingRanges, currentWorkers, attemptWorkDir, attempt)
-      : [distributeFrames(options.totalFrames, currentWorkers, attemptWorkDir)];
+      ? buildMissingFrameRetryBatches(
+          missingRanges,
+          currentWorkers,
+          attemptWorkDir,
+          attempt,
+          rangeStart,
+        )
+      : [distributeFrames(options.totalFrames, currentWorkers, attemptWorkDir, rangeStart)];
 
     try {
       for (const tasks of batches) {


### PR DESCRIPTION
## Summary

The distributed `renderChunk` primitive hardcoded `workerCount: 1` and `captureStage` explicitly forbade `workerCount > 1` when `frameRange` was set, with the comment:

> *"Distributed chunk workers fan out at the activity layer; reduce workerCount to 1 when passing frameRange."*

The assumption was that orchestration-layer fan-out (Temporal / Lambda / K8s Jobs / SSH) saturates available CPU on its own. In practice, adopters that deploy chunks onto multi-core hosts (8–24 vCPU is the standard producer-worker pod sizing) end up pinning only ~3-4 cores per chunk while the rest sit idle: chunk-level fan-out at the orchestration layer gives each pod one chunk at a time, but the chunk render itself is single-threaded.

This PR lifts the restriction by plumbing the chunk's frame range through the parallel-capture path. The `frameRange` field already existed on `runCaptureStage`'s input; it just wasn't honored by the parallel branch. Now both branches produce a byte-equivalent framesDir (contiguous 0-indexed `frame_<i>.{ext}` within the chunk's range), and chunks pick up `calculateOptimalWorkers` auto-sizing the same way the in-process renderer already does.

## Validation

Measured against a real 1080p / 30fps / 22-second shader-heavy composition on a 22 vCPU Temporal producer-worker pod. Tested before/after the fix with the same composition, same fixture, same pod sizing:

| | Before (`workerCount: 1`) | After (auto) | Δ |
|---|---|---|---|
| In-process baseline | 83.8s | 83.8s | — |
| Distributed `chunks=1` | 117.0s | 90.6s | **-23%** |
| Distributed `chunks=4` | 70.3s | **59.3s** | **-16% wall** |
| chunk p50 | 40.3s | 35.9s | -11% |
| chunk p95 (gates wall) | 63.6s | 53.2s | -16% |
| chunk total pod-time | 123.8s | 110.9s | -10% |

Distributed `chunks=4` is now **29% faster than in-process** on this real workload — the first wall-clock win for the distributed path on per-frame-heavy compositions ≤1 min.

The deployed bundle's runtime confirms the auto-sized count via the new `chunkWorkerCount` log: on this 22 vCPU pod the chunk now picks 6 workers (the `defaultSafeMaxWorkers` ceiling for that core count) instead of the prior hardcoded 1.

## Wire-up

- **`WorkerTask.outputFrameOffset`** — optional offset subtracted from the absolute frame index when computing the captured file's name. Default 0 (in-process contract; file name == absolute index). Distributed chunks set this to the chunk's `startFrame` so file names land 0-indexed within the chunk's range, matching the sequential chunk-capture contract and the encoder's expectation that frames are read sequentially without an `-start_number` override.

- **`distributeFrames(totalFrames, workerCount, workDir, rangeStart=0)`** — offsets both `startFrame`/`endFrame` (used for per-frame time math on the page's virtual clock) by `rangeStart`, and threads `outputFrameOffset = rangeStart` onto each task. With `rangeStart=0` it is a no-op for in-process renders.

- **`executeWorkerTask`** — uses `i - (task.outputFrameOffset ?? 0)` for the captured file name, leaving the per-frame TIME computation `(i * fps.den) / fps.num` untouched so the page's virtual clock is unchanged. The streaming callback (`onFrameBuffer`) still receives the absolute index `i` so the streaming encoder sequences frames against the composition's timeline; only the disk file name uses the offset.

- **`executeDiskCaptureWithAdaptiveRetry({ frameRangeStart? })`** — accepts the chunk's absolute startFrame and forwards it to `distributeFrames` and `buildMissingFrameRetryBatches`. Default `undefined` preserves the in-process contract.

- **`buildMissingFrameRetryBatches(ranges, ..., rangeStart=0)`** — `findMissingFrameRanges` walks LOCAL 0-indexed file names; the retry batch translates the local missing-range pair back to ABSOLUTE composition indices for `WorkerTask.startFrame/endFrame` and sets `outputFrameOffset = rangeStart` so the retried capture writes back to the same local file name.

- **`captureStage`** — drops the assert; passes `frameRangeStart: frameRange?.startFrame` to the parallel branch so workers land on absolute composition frame indices for time math while file names stay 0-indexed within the chunk range. Docstring updated to reflect that the parallel branch is now supported.

- **`renderChunk`** — `workerCount: 1` → `workerCount: calculateOptimalWorkers(framesInChunk, undefined, cfg)`. Matches the in-process renderer's worker selection (`resolveRenderWorkerCount` → `calculateOptimalWorkers`) minus the capture-cost calibration reduction, which would require plumbing the chunk's compiled metadata through and is left as a follow-up (current code degrades gracefully — heavy shader chunks will still fan out at the configured worker count; the existing adaptive-retry path in `executeDiskCaptureWithAdaptiveRetry` reduces workers if compositor contention surfaces as CDP timeouts).

## Backwards compatibility

Every change is gated on a parameter that defaults to the prior behavior:

- In-process callers (`executeRenderJob`) pass no `frameRangeStart`, so `rangeStart === 0`, `outputFrameOffset` defaults to 0, and the file-name math collapses to `i` (the prior absolute-index contract).
- The framesDir contract (`frame_0..frame_(totalFrames-1)`) and the `WorkerTask` interface are extended, not replaced.
- The sequential chunk-capture branch in `captureStage` was always emitting 0-indexed local file names; the parallel branch now matches.

## Follow-ups

1. **Skip probeSession creation when `workerCount > 1`** — the parallel branch closes the pre-warmed session during stage entry, so the ~3-5s warmup is wasted under auto-sizing. Recovered as a follow-up.
2. **Wire shader-cost calibration through to chunks** — pass the chunk's compiled metadata (`hasShaderTransitions`, `renderModeHints`) so chunks pick up the same reduction the in-process path uses for high-compositor-cost compositions.
3. **Chunk-level work balancing** — the texture-launch benchmark showed chunk1 took 53s while chunk2 took 16s (the slowest chunk gates wall time). Smarter partitioning that balances per-frame cost — not just frame count — would close more of the gap to the theoretical N×-speedup ceiling.

## Test plan

- [x] `bun test packages/engine/src/services/parallelCoordinator.test.ts` — 7/7 pass
- [x] `bun test packages/producer/src/services/distributed/{renderChunk,plan}.test.ts` — 24/24 pass (full distributed suite green — see [renderChunk.test.ts](packages/producer/src/services/distributed/renderChunk.test.ts))
- [x] `bun test packages/producer/src/services/renderOrchestrator.test.ts` — 56/57 (the one fail is a pre-existing Windows-only path-escape test, unrelated to this change)
- [x] `bunx oxlint` + `bunx oxfmt --check` on changed files — clean
- [x] Live end-to-end against dev Temporal Cloud: in-process baseline + `chunks=1,4` distributed runs all produce valid mp4s with byte-equivalent frame counts and resolutions. Numbers above.