### PR TITLE
chore(lambda): publish-readiness for @hyperframes/aws-lambda

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,6 +130,7 @@ jobs:
           publish_pkg "@hyperframes/producer" "@hyperframes/producer"
           publish_pkg "@hyperframes/shader-transitions" "@hyperframes/shader-transitions"
           publish_pkg "@hyperframes/studio" "@hyperframes/studio"
+          publish_pkg "@hyperframes/aws-lambda" "@hyperframes/aws-lambda"
 
           # CLI is @hyperframes/cli in the monorepo but published as unscoped "hyperframes" on npm.
           # Rewrite the name in package.json before publishing, then use npm publish directly

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run studio",
-    "build": "bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions}' build && bun run --filter @hyperframes/cli build",
+    "build": "bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions,aws-lambda}' build && bun run --filter @hyperframes/cli build",
     "build:producer": "bun run --filter @hyperframes/producer build",
     "studio": "bun run --filter @hyperframes/studio dev",
     "build:hyperframes-runtime": "bun run --filter @hyperframes/core build:hyperframes-runtime",

--- a/packages/aws-lambda/build.mjs
+++ b/packages/aws-lambda/build.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Build script for @hyperframes/aws-lambda (public OSS package).
+ *
+ * Bundles each subpath barrel via esbuild → dist/, then emits .d.ts via tsc.
+ *
+ * Subpaths (each gets its own dist entry so adopters that import one path
+ * don't load the others' transitive graphs at module-load time):
+ *
+ *   .         (the umbrella barrel: handler + sdk + cdk types re-exported)
+ *   ./handler (the Lambda runtime entry — what `scripts/build-zip.ts` ZIPs)
+ *   ./sdk     (client-side helpers — AWS-SDK only, no chromium/puppeteer)
+ *   ./cdk     (CDK L2 construct — aws-cdk-lib is a peer dep)
+ *
+ * All production deps and peer deps are kept external so consumers resolve
+ * them via their own node_modules.
+ */
+
+import { build } from "esbuild";
+import { execSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+
+rmSync("dist", { recursive: true, force: true });
+mkdirSync("dist", { recursive: true });
+
+const sharedOpts = {
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  format: "esm",
+  minify: false,
+  sourcemap: true,
+  external: [
+    "@aws-sdk/client-s3",
+    "@aws-sdk/client-sfn",
+    "@hyperframes/producer",
+    "@hyperframes/producer/distributed",
+    "@sparticuz/chromium",
+    "aws-cdk-lib",
+    "constructs",
+    "ffmpeg-static",
+    "ffprobe-static",
+    "puppeteer-core",
+    "tar",
+  ],
+};
+
+await Promise.all([
+  build({ ...sharedOpts, entryPoints: ["src/index.ts"], outfile: "dist/index.js" }),
+  build({ ...sharedOpts, entryPoints: ["src/handler.ts"], outfile: "dist/handler.js" }),
+  build({ ...sharedOpts, entryPoints: ["src/sdk/index.ts"], outfile: "dist/sdk/index.js" }),
+  build({ ...sharedOpts, entryPoints: ["src/cdk/index.ts"], outfile: "dist/cdk/index.js" }),
+]);
+
+// esbuild doesn't emit .d.ts. tsc does, with a build-only tsconfig that
+// drops the workspace `paths` overrides so `@hyperframes/producer` resolves
+// through node_modules to the sibling package's already-built `dist/`
+// types instead of pulling its full source tree into emit (which would
+// violate rootDir).
+execSync("tsc -p tsconfig.build.json --emitDeclarationOnly", { stdio: "inherit" });
+
+console.log("[Build] Complete: dist/{index,handler,sdk/index,cdk/index}.js + .d.ts");

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.6.18",
+  "version": "0.6.20",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.0.1",
+  "version": "0.6.18",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",
@@ -8,25 +8,37 @@
     "directory": "packages/aws-lambda"
   },
   "files": [
-    "src/",
+    "dist/",
     "scripts/",
     "README.md"
   ],
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./handler": "./src/handler.ts",
-    "./sdk": "./src/sdk/index.ts",
-    "./cdk": "./src/cdk/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./handler": {
+      "import": "./dist/handler.js",
+      "types": "./dist/handler.d.ts"
+    },
+    "./sdk": {
+      "import": "./dist/sdk/index.js",
+      "types": "./dist/sdk/index.d.ts"
+    },
+    "./cdk": {
+      "import": "./dist/cdk/index.js",
+      "types": "./dist/cdk/index.d.ts"
+    }
   },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "tsc --noEmit",
+    "build": "node build.mjs",
     "build:zip": "tsx scripts/build-zip.ts",
     "probe:beginframe": "tsx scripts/probe-beginframe.ts",
     "probe:beginframe:docker": "docker build -f scripts/probe-beginframe.dockerfile -t hyperframes-lambda-probe:local ../.. && docker run --rm hyperframes-lambda-probe:local",

--- a/packages/aws-lambda/tsconfig.build.json
+++ b/packages/aws-lambda/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}

--- a/packages/aws-lambda/tsconfig.json
+++ b/packages/aws-lambda/tsconfig.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "scripts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__fixtures__/**", "scripts"]
 }

--- a/packages/producer/src/regression-harness-lambda-local-types.ts
+++ b/packages/producer/src/regression-harness-lambda-local-types.ts
@@ -1,0 +1,37 @@
+/**
+ * Public-facing types for `./regression-harness-lambda-local.ts`.
+ *
+ * Kept in its own file because the implementation imports
+ * `@hyperframes/aws-lambda`, which can't be resolved by producer's
+ * tsc emit pass until aws-lambda's own dist/ is built. Splitting the
+ * types out lets producer's regression harness reference the lambda
+ * adapter's shape without pulling the aws-lambda graph into producer's
+ * type-check pass.
+ */
+
+/** Inputs for {@link runLambdaLocalRender}. Same contract as `runDistributedSimulatedRender`. */
+export interface RunLambdaLocalInput {
+  projectDir: string;
+  tempRoot: string;
+  renderedOutputPath: string;
+  fps: 24 | 30 | 60;
+  /**
+   * Width/height from the fixture's renderConfig. Forwarded directly to
+   * the Lambda event so this mode catches drift if the handler ever
+   * starts honouring `Config.width/height` for canvas sizing rather
+   * than reading the composition's `data-width`/`data-height`. The
+   * `distributed-simulated` mode hardcodes 1920×1080 because it
+   * bypasses the event-serialization boundary; lambda-local goes
+   * through it, which is the whole point.
+   */
+  width: number;
+  height: number;
+  format: "mp4" | "mov" | "png-sequence";
+  codec?: "h264" | "h265";
+  chunkSize?: number;
+  maxParallelChunks?: number;
+  variables?: Record<string, unknown>;
+}
+
+/** Public signature of the dynamically-loaded `runLambdaLocalRender`. */
+export type RunLambdaLocalRender = (input: RunLambdaLocalInput) => Promise<void>;

--- a/packages/producer/src/regression-harness-lambda-local.ts
+++ b/packages/producer/src/regression-harness-lambda-local.ts
@@ -46,29 +46,8 @@ import type {
   SerializableDistributedRenderConfig,
 } from "@hyperframes/aws-lambda";
 
-/** Inputs for {@link runLambdaLocalRender}. Same contract as `runDistributedSimulatedRender`. */
-export interface RunLambdaLocalInput {
-  projectDir: string;
-  tempRoot: string;
-  renderedOutputPath: string;
-  fps: 24 | 30 | 60;
-  /**
-   * Width/height from the fixture's renderConfig. Forwarded directly to
-   * the Lambda event so this mode catches drift if the handler ever
-   * starts honouring `Config.width/height` for canvas sizing rather
-   * than reading the composition's `data-width`/`data-height`. The
-   * `distributed-simulated` mode hardcodes 1920×1080 because it
-   * bypasses the event-serialization boundary; lambda-local goes
-   * through it, which is the whole point.
-   */
-  width: number;
-  height: number;
-  format: "mp4" | "mov" | "png-sequence";
-  codec?: "h264" | "h265";
-  chunkSize?: number;
-  maxParallelChunks?: number;
-  variables?: Record<string, unknown>;
-}
+export type { RunLambdaLocalInput } from "./regression-harness-lambda-local-types.js";
+import type { RunLambdaLocalInput } from "./regression-harness-lambda-local-types.js";
 
 const FAKE_BUCKET = "harness-lambda-local";
 

--- a/packages/producer/src/regression-harness.ts
+++ b/packages/producer/src/regression-harness.ts
@@ -44,10 +44,18 @@ import {
 // `@hyperframes/aws-lambda`, whose types come from `dist/index.d.ts` after
 // aws-lambda's build runs — a chicken-and-egg with producer's tsc that
 // would otherwise fail the whole-repo build.
+//
+// The dynamic import path is indirected through a variable so tsc can't
+// statically resolve the target file. Without this indirection tsc still
+// pulls `regression-harness-lambda-local.ts` (and its `@hyperframes/aws-lambda`
+// imports) into the program even though the tsconfig `exclude` list
+// nominally hides it. `tsx` resolves the path normally at runtime.
 import type { RunLambdaLocalRender } from "./regression-harness-lambda-local-types.js";
 
+const LAMBDA_LOCAL_MODULE = "./regression-harness-lambda-local.js";
+
 async function loadLambdaLocalRender(): Promise<RunLambdaLocalRender> {
-  const mod = (await import("./regression-harness-lambda-local.js")) as {
+  const mod = (await import(LAMBDA_LOCAL_MODULE)) as {
     runLambdaLocalRender: RunLambdaLocalRender;
   };
   return mod.runLambdaLocalRender;

--- a/packages/producer/src/regression-harness.ts
+++ b/packages/producer/src/regression-harness.ts
@@ -37,10 +37,19 @@ import {
 // In Dockerfile.test the workspace copy of aws-lambda's src isn't present,
 // so a static import here would fail at module-load time even when
 // running `--mode=in-process`. Load it on demand instead.
-async function loadLambdaLocalRender(): Promise<
-  typeof import("./regression-harness-lambda-local.js").runLambdaLocalRender
-> {
-  const mod = await import("./regression-harness-lambda-local.js");
+//
+// The signature is typed via `RunLambdaLocalRender` (in its own types-only
+// file) instead of `typeof import(...)` so producer's tsc doesn't have to
+// type-check the implementation. The implementation imports
+// `@hyperframes/aws-lambda`, whose types come from `dist/index.d.ts` after
+// aws-lambda's build runs — a chicken-and-egg with producer's tsc that
+// would otherwise fail the whole-repo build.
+import type { RunLambdaLocalRender } from "./regression-harness-lambda-local-types.js";
+
+async function loadLambdaLocalRender(): Promise<RunLambdaLocalRender> {
+  const mod = (await import("./regression-harness-lambda-local.js")) as {
+    runLambdaLocalRender: RunLambdaLocalRender;
+  };
   return mod.runLambdaLocalRender;
 }
 

--- a/packages/producer/tsconfig.json
+++ b/packages/producer/tsconfig.json
@@ -20,5 +20,11 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__test_utils__/**"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/__test_utils__/**",
+    "src/regression-harness-lambda-local.ts"
+  ]
 }

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -25,6 +25,7 @@ const PACKAGES = [
   "packages/shader-transitions",
   "packages/studio",
   "packages/cli",
+  "packages/aws-lambda",
 ];
 
 const ROOT = join(import.meta.dirname, "..");


### PR DESCRIPTION
## What

Wire `@hyperframes/aws-lambda` to publish to npm alongside the other `@hyperframes/*` packages on the next `v*` tag. The Lambda adapter has been on `main` since #909 but its package manifest still shipped raw TypeScript source (`main: ./src/index.ts`, `build: tsc --noEmit`, `version: 0.0.1`) and the publish workflow didn't list it.

## Why

External adopters can't `npm install @hyperframes/aws-lambda` until the package both (a) publishes and (b) ships compiled JS + types. The CLI already shows a friendly install hint when the lambda subverbs can't find it, but that hint resolves to nothing without a published package.

## How

  - **`packages/aws-lambda/build.mjs` (new)** mirrors `packages/producer/build.mjs`: esbuild bundles `src/{index,handler,sdk/index,cdk/index}.ts` → `dist/`, then `tsc --emitDeclarationOnly` emits `.d.ts`. All runtime/peer deps (`@aws-sdk/*`, `@hyperframes/producer*`, `@sparticuz/chromium`, `aws-cdk-lib`, `constructs`, `ffmpeg-static`, `ffprobe-static`, `puppeteer-core`, `tar`) are external so consumers resolve them through their own `node_modules`.
  - **`tsconfig.build.json` (new)** strips the workspace `paths` overrides so `@hyperframes/producer*` resolves through `node_modules` to producer's already-built `dist/` types instead of pulling its full source tree into emit (which would violate `rootDir`).
  - **`tsconfig.json`** keeps `noEmit: true` + workspace `paths` for fast in-place typechecks; excludes `src/**/__fixtures__/**` so test-only helpers (`fakeS3`) don't leak into emitted declarations.
  - **`package.json`** sets `version` to `0.6.20` to align with current `main`'s lockstep release; points `main` / `types` / `exports` at `./dist/...`; sets `files: ["dist/", "scripts/", "README.md"]` (the whole `scripts/` directory is kept because `build-zip.ts` and `verify-zip-size.ts` both import `scripts/_formatBytes.ts`); and sets `scripts.build = node build.mjs`.
  - **Root `package.json`** adds `aws-lambda` to the `build` filter so `bun run build` builds it in topological order after producer.
  - **`scripts/set-version.ts`** adds `packages/aws-lambda` to the `PACKAGES` list so future `chore: release vX.Y.Z` commits bump `aws-lambda` along with the other publishable packages instead of leaving it frozen.
  - **`.github/workflows/publish.yml`** gets one new `publish_pkg "@hyperframes/aws-lambda" "@hyperframes/aws-lambda"` line. First publish is automatic via the `--access public` flag in `publish_pkg`; the `@hyperframes` scope already owns the name.

### Breaking the producer ↔ aws-lambda build cycle

Moving aws-lambda's types from `./src/index.ts` → `./dist/index.d.ts` exposed a circular workspace build dependency: producer's `regression-harness-lambda-local.ts` imports `@hyperframes/aws-lambda`, and aws-lambda imports `@hyperframes/producer/distributed`. Neither side's tsc emit pass can run cleanly without the other side's `dist/` already in place, and bun's `--filter` can't topologically order them out of the cycle.

Three commits stacked on top of the publish-readiness wiring break that cycle:

  - **`regression-harness-lambda-local-types.ts` (new)** — extracts the public surface (`RunLambdaLocalInput`, `RunLambdaLocalRender`) into a no-aws-lambda-imports file. `regression-harness.ts` uses these types instead of `typeof import(...)`.
  - **`regression-harness.ts`** — the dynamic `await import("./regression-harness-lambda-local.js")` is routed through a top-level `const LAMBDA_LOCAL_MODULE` so tsc can't statically resolve the target path. Without this indirection tsc walks into the file via the static-string dynamic import even though `tsconfig.exclude` nominally hides it (TS [docs](https://www.typescriptlang.org/tsconfig#exclude): "TypeScript will always include files referenced by `import` statements... regardless of `exclude`"). `tsx` resolves the path normally at runtime so `--mode=lambda-local` is unchanged.
  - **`packages/producer/tsconfig.json`** — adds `src/regression-harness-lambda-local.ts` to `exclude` so even if tsc somehow reached it, it wouldn't emit declarations for it.

Together these mean producer's tsc never tries to resolve `@hyperframes/aws-lambda` at emit time, which lets the package build cleanly even before aws-lambda's `dist/` exists.

## Test plan

```
bun run build                          # ✅ full root build green, aws-lambda builds after producer
bun run verify:packed-manifests        # ✅ all packages including aws-lambda publish-safe
cd packages/cli && pnpm pack            # ✅ @hyperframes/aws-lambda rewrites workspace:* → 0.6.20
cd packages/cli && npm pack && \
  npm install -g <tgz>                 # ✅ global install smoke flow still works
hyperframes lambda deploy              # ✅ friendly missing-package error still fires when
                                       #    aws-lambda isn't installed alongside the CLI
```

CI status as of `187dfd5b`: required jobs (Build, Typecheck, CLI smoke) all green. Regression shards inherit from main / are running.

### Post-merge: manual first publish

The package isn't on npm yet, so Trusted Publisher can't be pre-configured (npm doesn't surface a "register a not-yet-existing package" path in its UI). Plan after merge: `pnpm publish --access public` from a clean `main` checkout to create `@hyperframes/aws-lambda@0.6.20`, then wire up Trusted Publisher on the now-existing package, then CI takes over for `v0.6.21+`.

- [x] Build / typecheck green on the PR head
- [x] Packed manifest is publish-safe (no `workspace:*` refs)
- [x] CLI global-install smoke flow unaffected
- [x] `scripts/set-version.ts` covers aws-lambda for future lockstep bumps
- [ ] Unit tests added/updated — N/A (CI/build change)
- [ ] Documentation updated — N/A (deploy guide already in #914)