### PR TITLE
ci: add fallow audit job (PR-scoped, new-only gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,29 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run lint
 
+  # `fallow audit` runs dead-code + complexity + duplication analysis scoped to
+  # the changed files. The default `--gate new-only` means existing legacy
+  # findings don't fail the build — only NEW issues introduced by the PR do.
+  # This stops bleeding while letting incremental cleanup land separately.
+  fallow:
+    name: Fallow audit
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Full history so `--base origin/main` can diff against the merge
+          # base on stacked PRs, not just the shallow tip.
+          fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      # Pinned version — bumps land via a deliberate PR. Keep in sync with
+      # the version that produced the current `.fallowrc.jsonc` config.
+      - run: npx -y fallow@2.75.0 audit --base origin/main --fail-on-issues
+
   format:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `Fallow audit` job to CI that runs on PRs and fails when **new** dead-code, complexity, or duplication issues are introduced into the changed files.

## Why

After [#938](https://github.com/heygen-com/hyperframes/pull/938) landed a fallow config + the first round of cleanup, the codebase still has ~276 inherited dead-code findings, ~482 clone groups, and ~680 functions above complexity thresholds. Fixing those is a multi-PR effort. Until then, we want to **stop bleeding**: prevent new debt from sneaking in via PRs.

## How

`fallow audit --base origin/main --fail-on-issues` uses the default `--gate new-only`, which compares the PR's findings against the base-snapshot and only counts findings *introduced* by the changeset. Inherited findings still appear in the log for visibility but don't fail the build.

Behavior verified locally:
- Clean PR (no findings) → exit 0, "✓ No issues in N changed files"
- PR introduces a new unused file → exit 1, "✗ 1 file"
- PR only touches a file with existing complexity finding (no new finding) → exit 0, "audit gate excluded 1 inherited finding"

Pinned to `fallow@2.75.0` — the same version that produced the current `.fallowrc.jsonc`. Bumps will land via deliberate PRs, not transitive `latest` shifts.

The job runs only on PRs (`github.event_name == 'pull_request'`) since audit needs a base to diff against, and is gated behind the existing `Detect changes` job so docs-only PRs skip it.

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Audit exits 0 on clean diff
- [x] Audit exits 1 when a new unused file is introduced
- [x] Audit exits 0 when only touching a file with legacy complexity findings (inherited-finding exclusion confirmed)
- [ ] Verify in CI on this PR — should exit 0 since this PR only adds workflow YAML

## Follow-ups

- **Auto-fix existing exports** — `fallow fix --auto-fixable` covers the bulk of the 228 unused-export findings; stacked PR will land next
- **Producer renderOrchestrator hub cycle** — 8 circular deps converging on one orchestrator; a real refactor PR
- **Per-PR comment** — once we trust the signal, can add `--format pr-comment-github` for inline review comments