### PR TITLE
refactor: drop unused exports detected by fallow auto-fix

### DIFF
--- a/packages/cli/src/background-removal/pipeline.ts
+++ b/packages/cli/src/background-removal/pipeline.ts
@@ -20,7 +20,7 @@ import { type Device, type ModelId } from "./manager.js";
 
 export type OutputFormat = "webm" | "mov" | "png";
 
-export const QUALITY_CRF = {
+const QUALITY_CRF = {
   fast: 30,
   balanced: 18,
   best: 12,

--- a/packages/cli/src/commands/compositions.ts
+++ b/packages/cli/src/commands/compositions.ts
@@ -45,7 +45,7 @@ function estimateDurationFromScripts(root: ParentNode): number {
   return duration;
 }
 
-export function parseCompositions(html: string, baseDir: string): CompositionInfo[] {
+function parseCompositions(html: string, baseDir: string): CompositionInfo[] {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, "text/html");
 

--- a/packages/cli/src/commands/lambda/policies.ts
+++ b/packages/cli/src/commands/lambda/policies.ts
@@ -56,7 +56,7 @@ interface TrustPolicyDocument {
  * Actions the CLI needs to deploy/invoke/destroy the stack. Keep this
  * sorted alphabetically inside each service so diffs stay readable.
  */
-export const REQUIRED_ACTIONS = {
+const REQUIRED_ACTIONS = {
   cloudformation: [
     "cloudformation:CreateChangeSet",
     "cloudformation:CreateStack",

--- a/packages/cli/src/commands/lambda/sam.ts
+++ b/packages/cli/src/commands/lambda/sam.ts
@@ -23,7 +23,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 /** Throws with a clear hint when the SAM CLI is not on PATH. */
-export function assertSamAvailable(): void {
+function assertSamAvailable(): void {
   try {
     execFileSync("sam", ["--version"], { stdio: "ignore" });
   } catch {
@@ -34,7 +34,7 @@ export function assertSamAvailable(): void {
 }
 
 /** Throws with a clear hint when the `aws` CLI is not on PATH. */
-export function assertAwsCliAvailable(): void {
+function assertAwsCliAvailable(): void {
   try {
     execFileSync("aws", ["--version"], { stdio: "ignore" });
   } catch {

--- a/packages/cli/src/tts/manager.ts
+++ b/packages/cli/src/tts/manager.ts
@@ -145,4 +145,4 @@ export async function ensureVoices(options?: {
   return voicesPath;
 }
 
-export { MODELS_DIR, VOICES_DIR, DEFAULT_MODEL };
+export { MODELS_DIR, DEFAULT_MODEL };

--- a/packages/cli/src/utils/projectConfig.ts
+++ b/packages/cli/src/utils/projectConfig.ts
@@ -12,7 +12,7 @@ import { join, resolve } from "node:path";
 import { DEFAULT_REGISTRY_URL } from "../registry/index.js";
 
 export const PROJECT_CONFIG_FILENAME = "hyperframes.json";
-export const PROJECT_CONFIG_SCHEMA_URL = "https://hyperframes.heygen.com/schema/hyperframes.json";
+const PROJECT_CONFIG_SCHEMA_URL = "https://hyperframes.heygen.com/schema/hyperframes.json";
 
 export interface ProjectConfigPaths {
   /** Where `hyperframes:block` items land, relative to project root. */

--- a/packages/cli/src/whisper/manager.ts
+++ b/packages/cli/src/whisper/manager.ts
@@ -131,7 +131,7 @@ export function findWhisper(): WhisperResult | undefined {
   return findFromEnv() ?? findFromSystem() ?? findBuiltBinary();
 }
 
-export function getInstallInstructions(): string {
+function getInstallInstructions(): string {
   if (platform() === "darwin") {
     return "brew install whisper-cpp";
   }

--- a/packages/cli/src/whisper/transcribe.ts
+++ b/packages/cli/src/whisper/transcribe.ts
@@ -299,5 +299,3 @@ export async function transcribe(
     speechOnsetSeconds,
   };
 }
-
-export { isAudioFile, isVideoFile };

--- a/packages/core/src/lint/utils.ts
+++ b/packages/core/src/lint/utils.ts
@@ -15,10 +15,10 @@ export type ExtractedBlock = {
   index: number;
 };
 
-export const TAG_PATTERN = /<([a-z][\w:-]*)(\s[^<>]*?)?>/gi;
+const TAG_PATTERN = /<([a-z][\w:-]*)(\s[^<>]*?)?>/gi;
 export const STYLE_BLOCK_PATTERN = /<style\b([^>]*)>([\s\S]*?)<\/style>/gi;
 export const SCRIPT_BLOCK_PATTERN = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
-export const COMPOSITION_ID_IN_CSS_PATTERN = /\[data-composition-id=["']([^"']+)["']\]/g;
+const COMPOSITION_ID_IN_CSS_PATTERN = /\[data-composition-id=["']([^"']+)["']\]/g;
 export const TIMELINE_REGISTRY_INIT_PATTERN =
   /window\.__timelines\s*=\s*window\.__timelines\s*\|\|\s*\{\}|window\.__timelines\s*=\s*\{\}|window\.__timelines\s*\?\?=\s*\{\}/i;
 export const TIMELINE_REGISTRY_ASSIGN_PATTERN = /window\.__timelines\[[^\]]+\]\s*=/i;

--- a/packages/core/src/runtime/adapters/lottie.ts
+++ b/packages/core/src/runtime/adapters/lottie.ts
@@ -1,6 +1,5 @@
 import type { RuntimeDeterministicAdapter } from "../types";
 import { swallow } from "../diagnostics";
-export { isLottieAnimationLoaded } from "../../lottieReadiness";
 
 /**
  * Lottie adapter for HyperFrames

--- a/packages/core/src/studio-api/helpers/waveform.ts
+++ b/packages/core/src/studio-api/helpers/waveform.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 const SAMPLE_RATE = 4000;
 const PEAK_COUNT = 4000;
-export const WAVEFORM_CACHE_VERSION = "v2";
+const WAVEFORM_CACHE_VERSION = "v2";
 
 export function buildWaveformCacheKey(assetPath: string): string {
   return `${WAVEFORM_CACHE_VERSION}_${assetPath.replace(/[/\\]/g, "_")}.json`;

--- a/packages/core/src/studio-api/routes/waveform.ts
+++ b/packages/core/src/studio-api/routes/waveform.ts
@@ -4,9 +4,6 @@ import type { Hono } from "hono";
 import type { StudioApiAdapter } from "../types.js";
 import { decodeAudioPeaks, buildWaveformCacheKey } from "../helpers/waveform.js";
 
-export { isAudioFile } from "../helpers/mime.js";
-export { generateWaveformCache } from "../helpers/waveform.js";
-
 export function registerWaveformRoutes(api: Hono, adapter: StudioApiAdapter): void {
   api.get("/projects/:id/waveform/*", async (c) => {
     const project = await adapter.resolveProject(c.req.param("id"));

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -149,7 +149,7 @@ async function probeBeginFrameSupport(browser: Browser): Promise<boolean> {
  *
  * Exported for tests; production callers go through `resolveBrowserGpuMode`.
  */
-export let _autoBrowserGpuModeCache: Promise<"software" | "hardware"> | undefined;
+let _autoBrowserGpuModeCache: Promise<"software" | "hardware"> | undefined;
 
 /** Test-only: reset the cached probe result. */
 export function _resetAutoBrowserGpuModeCacheForTests(): void {

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -203,7 +203,7 @@ export async function captureScreenshotWithAlpha(
  * video itself is the backdrop, so DOM layers must only contribute their
  * foreground UI pixels — never a page-spanning solid backdrop.
  */
-export const TRANSPARENT_BG_STYLE_ID = "__hf_transparent_bg__";
+const TRANSPARENT_BG_STYLE_ID = "__hf_transparent_bg__";
 
 export async function initTransparentBackground(page: Page): Promise<void> {
   const client = await getCdpSession(page);

--- a/packages/player/src/shader-options.ts
+++ b/packages/player/src/shader-options.ts
@@ -6,8 +6,8 @@
 
 export const SHADER_CAPTURE_SCALE_ATTR = "shader-capture-scale";
 export const SHADER_LOADING_ATTR = "shader-loading";
-export const SHADER_CAPTURE_SCALE_PARAM = "__hf_shader_capture_scale";
-export const SHADER_LOADING_PARAM = "__hf_shader_loading";
+const SHADER_CAPTURE_SCALE_PARAM = "__hf_shader_capture_scale";
+const SHADER_LOADING_PARAM = "__hf_shader_loading";
 
 export const SHADER_LOADING_PHRASES = [
   "Preparing scene transitions",
@@ -31,14 +31,14 @@ export interface ShaderTransitionState {
   loading?: boolean;
 }
 
-export function normalizeShaderCaptureScale(value: string | null): string | null {
+function normalizeShaderCaptureScale(value: string | null): string | null {
   if (value === null) return null;
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return null;
   return String(Math.min(1, Math.max(0.25, parsed)));
 }
 
-export function normalizeShaderLoadingMode(value: string | null): ShaderLoadingMode {
+function normalizeShaderLoadingMode(value: string | null): ShaderLoadingMode {
   if (value === null || value.trim() === "") return "composition";
   const normalized = value.trim().toLowerCase();
   if (
@@ -65,7 +65,7 @@ function setQueryParam(params: URLSearchParams, key: string, value: string | nul
   else params.set(key, value);
 }
 
-export function withShaderQueryParams(
+function withShaderQueryParams(
   src: string,
   scale: string | null,
   loadingMode: ShaderLoadingMode,
@@ -83,7 +83,7 @@ export function withShaderQueryParams(
   return `${path}${nextQuery ? `?${nextQuery}` : ""}${hash}`;
 }
 
-export function injectShaderOptionsIntoSrcdoc(
+function injectShaderOptionsIntoSrcdoc(
   html: string,
   scale: string | null,
   loadingMode: ShaderLoadingMode,

--- a/packages/producer/src/services/compilationTester.ts
+++ b/packages/producer/src/services/compilationTester.ts
@@ -39,7 +39,7 @@ const EPSILON = 0.001; // Tolerance for floating-point timing comparisons
  * Parse HTML and extract all elements with timing attributes.
  * Includes <video>, <audio>, and <div data-composition-src>.
  */
-export function extractTimedElements(html: string): CompiledElement[] {
+function extractTimedElements(html: string): CompiledElement[] {
   const elements: CompiledElement[] = [];
 
   // Extract video elements

--- a/packages/producer/src/services/distributed/shared.ts
+++ b/packages/producer/src/services/distributed/shared.ts
@@ -73,7 +73,7 @@ export async function readFfmpegVersion(): Promise<string> {
 }
 
 /** Test-only: clear the cached ffmpeg version so a fresh probe runs. */
-export function _resetFfmpegVersionCacheForTests(): void {
+function _resetFfmpegVersionCacheForTests(): void {
   cachedFfmpegVersion = null;
 }
 

--- a/packages/producer/src/services/fileServer.ts
+++ b/packages/producer/src/services/fileServer.ts
@@ -15,7 +15,7 @@ import { join, extname, resolve, sep } from "node:path";
 import { injectScriptsAtHeadStart, injectScriptsIntoHtml } from "@hyperframes/core/compiler";
 import { getVerifiedHyperframeRuntimeSource } from "./hyperframeRuntimeLoader.js";
 
-export { injectScriptsAtHeadStart, injectScriptsIntoHtml };
+export { injectScriptsAtHeadStart };
 
 type PathModuleLike = {
   resolve: (...segments: string[]) => string;

--- a/packages/producer/src/services/render/stages/freezePlan.ts
+++ b/packages/producer/src/services/render/stages/freezePlan.ts
@@ -116,7 +116,6 @@ export interface FreezePlanResult {
  * `../runtimeEnvSnapshot.ts` — chunk workers re-apply the snapshot during
  * boot, so it needs to be importable without dragging in the freeze pipeline.
  */
-export { RUNTIME_ENV_PREFIXES, snapshotRuntimeEnv } from "../runtimeEnvSnapshot.js";
 
 /** The relative path inside `<planDir>/` to the compiled HTML. */
 const COMPILED_INDEX_RELATIVE_PATH = "compiled/index.html";

--- a/packages/shader-transitions/src/capture.ts
+++ b/packages/shader-transitions/src/capture.ts
@@ -61,7 +61,7 @@ function forceSceneVisibleInClone(source: HTMLElement, cloneDoc: Document): void
   });
 }
 
-export function stabilizeTransformedBoxShadows(root: HTMLElement): void {
+function stabilizeTransformedBoxShadows(root: HTMLElement): void {
   const view = root.ownerDocument.defaultView;
   if (!view) return;
 

--- a/packages/studio/src/captions/types.ts
+++ b/packages/studio/src/captions/types.ts
@@ -191,7 +191,7 @@ export const DEFAULT_CONTAINER: CaptionContainerStyle = {
   boxShadow: "none",
 };
 
-export const DEFAULT_ANIMATION: CaptionAnimation = {
+const DEFAULT_ANIMATION: CaptionAnimation = {
   preset: "fade",
   duration: 0.2,
   ease: "power2.out",

--- a/packages/studio/src/components/editor/MotionPanelFields.tsx
+++ b/packages/studio/src/components/editor/MotionPanelFields.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, type ReactNode } from "react";
 import { Zap } from "../../icons/SystemIcons";
 
-export const FIELD =
+const FIELD =
   "min-w-0 rounded-xl border border-neutral-800 bg-neutral-900/95 px-3 py-2 text-neutral-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-colors focus-within:border-neutral-600";
 export const LABEL = "text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500";
 export const RESPONSIVE_GRID = "grid grid-cols-[repeat(auto-fit,minmax(118px,1fr))] gap-3";
@@ -30,7 +30,7 @@ export function parsePlainNumber(value: string): number | null {
 
 // ── CommitField ──
 
-export function CommitField({
+function CommitField({
   value,
   disabled,
   onCommit,

--- a/packages/studio/src/components/editor/domEditOverlayGestures.ts
+++ b/packages/studio/src/components/editor/domEditOverlayGestures.ts
@@ -10,7 +10,7 @@ import type { GroupOverlayItem } from "./domEditOverlayGeometry";
 export type GestureKind = "drag" | "resize" | "rotate";
 
 export const BLOCKED_MOVE_THRESHOLD_PX = 4;
-export const MIN_RESIZE_EDGE_PX = 20;
+const MIN_RESIZE_EDGE_PX = 20;
 const ROTATION_COMMIT_EPSILON_DEGREES = 0.05;
 const ROTATION_SNAP_DEGREES = 15;
 

--- a/packages/studio/src/components/editor/domEditingDom.ts
+++ b/packages/studio/src/components/editor/domEditingDom.ts
@@ -163,7 +163,7 @@ export function normalizeTimelineCompositionSource(value: string | undefined): s
 
 // ─── CSS escaping ─────────────────────────────────────────────────────────────
 
-export function escapeCssIdentifier(value: string): string {
+function escapeCssIdentifier(value: string): string {
   const css = globalThis.CSS as { escape?: (input: string) => string } | undefined;
   if (typeof css?.escape === "function") return css.escape(value);
 

--- a/packages/studio/src/components/editor/fontAssets.ts
+++ b/packages/studio/src/components/editor/fontAssets.ts
@@ -8,7 +8,7 @@ const FONT_EXT_RE = /\.(eot|otf|ttc|ttf|woff2?)$/i;
 const FONT_STYLE_SUFFIX_RE =
   /\s+(thin|extralight|extra light|light|regular|roman|medium|semibold|semi bold|bold|extrabold|extra bold|black|italic|oblique|variable)$/i;
 
-export function cssString(value: string): string {
+function cssString(value: string): string {
   return JSON.stringify(value);
 }
 

--- a/packages/studio/src/components/editor/gradientValue.ts
+++ b/packages/studio/src/components/editor/gradientValue.ts
@@ -370,7 +370,7 @@ function formatHex(channel: number): string {
   return channel.toString(16).padStart(2, "0");
 }
 
-export function interpolateGradientStopColor(model: GradientModel, position: number): string {
+function interpolateGradientStopColor(model: GradientModel, position: number): string {
   const clampedPosition = clamp(position, 0, 100);
   const sortedStops = [...model.stops].sort((a, b) => a.position - b.position);
   const exact = sortedStops.find((stop) => Math.abs(stop.position - clampedPosition) < 0.001);

--- a/packages/studio/src/components/editor/manualOffsetDrag.ts
+++ b/packages/studio/src/components/editor/manualOffsetDrag.ts
@@ -256,7 +256,7 @@ export function createManualOffsetDragMember(input: {
   };
 }
 
-export function resolveManualOffsetDragMemberOffset(
+function resolveManualOffsetDragMemberOffset(
   member: ManualOffsetDragMember,
   dx: number,
   dy: number,
@@ -289,7 +289,7 @@ export function applyManualOffsetDragCommit(
   return offset;
 }
 
-export function restoreManualOffsetDragMember(member: ManualOffsetDragMember): void {
+function restoreManualOffsetDragMember(member: ManualOffsetDragMember): void {
   restoreStudioPathOffset(member.element, member.initialPathOffset);
   endStudioManualEditGesture(member.element, member.gestureToken);
 }

--- a/packages/studio/src/components/editor/propertyPanelColor.tsx
+++ b/packages/studio/src/components/editor/propertyPanelColor.tsx
@@ -18,7 +18,7 @@ const COLOR_PICKER_SIZE = { width: 292, height: 386 };
 /*  ColorSlider                                                        */
 /* ------------------------------------------------------------------ */
 
-export function ColorSlider({
+function ColorSlider({
   label,
   value,
   min,

--- a/packages/studio/src/components/editor/propertyPanelPrimitives.tsx
+++ b/packages/studio/src/components/editor/propertyPanelPrimitives.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { adjustNumericToken, FIELD, LABEL, parseNumericToken } from "./propertyPanelHelpers";
 
-export function CommitField({
+function CommitField({
   value,
   disabled,
   liveCommit,

--- a/packages/studio/src/components/editor/studioMotionOps.ts
+++ b/packages/studio/src/components/editor/studioMotionOps.ts
@@ -129,7 +129,7 @@ export function buildStudioGsapPresetMotion(
 
 // ── Manifest parse/serialize ──
 
-export function parseMotionValues(value: unknown): StudioGsapMotionValues | null {
+function parseMotionValues(value: unknown): StudioGsapMotionValues | null {
   if (!value || typeof value !== "object") return null;
   const record = value as Record<string, unknown>;
   const parsed: StudioGsapMotionValues = {};

--- a/packages/studio/src/player/components/CompositionThumbnail.tsx
+++ b/packages/studio/src/player/components/CompositionThumbnail.tsx
@@ -16,7 +16,7 @@ interface CompositionThumbnailProps {
 
 const CLIP_HEIGHT = 66;
 const THUMBNAIL_URL_VERSION = "v3";
-export const COMPOSITION_THUMBNAIL_LABEL_Z_INDEX = 10;
+const COMPOSITION_THUMBNAIL_LABEL_Z_INDEX = 10;
 
 export function buildCompositionThumbnailUrl({
   previewUrl,

--- a/packages/studio/src/player/components/timelineLayout.ts
+++ b/packages/studio/src/player/components/timelineLayout.ts
@@ -7,7 +7,7 @@ export const TRACK_H = 72;
 export const RULER_H = 24;
 export const CLIP_Y = 3;
 export const CLIP_HANDLE_W = 18;
-export const TIMELINE_SCROLL_BUFFER = 20;
+const TIMELINE_SCROLL_BUFFER = 20;
 
 /* ── Tick generation ──────────────────────────────────────────────── */
 function getMajorTickInterval(duration: number, pixelsPerSecond?: number): number {

--- a/packages/studio/src/player/lib/playbackAdapter.ts
+++ b/packages/studio/src/player/lib/playbackAdapter.ts
@@ -20,7 +20,7 @@ export function isFinitePositive(value: number): boolean {
   return Number.isFinite(value) && value > 0;
 }
 
-export function clampTime(time: number, duration: number): number {
+function clampTime(time: number, duration: number): number {
   const safeDuration = Math.max(0, Number.isFinite(duration) ? duration : 0);
   const safeTime = Math.max(0, Number.isFinite(time) ? time : 0);
   return safeDuration > 0 ? Math.min(safeTime, safeDuration) : safeTime;

--- a/packages/studio/src/player/lib/timelineElementHelpers.ts
+++ b/packages/studio/src/player/lib/timelineElementHelpers.ts
@@ -15,7 +15,7 @@ import { isFinitePositive } from "./playbackAdapter";
 // Duration attribute helpers
 // ---------------------------------------------------------------------------
 
-export function readDurationAttribute(el: Element | null | undefined): number {
+function readDurationAttribute(el: Element | null | undefined): number {
   if (!el) return 0;
   const duration =
     Number.parseFloat(el.getAttribute("data-duration") ?? "") ||
@@ -42,7 +42,7 @@ export function readTimelineDurationFromDocument(doc: Document | null | undefine
 // DOM element type guards
 // ---------------------------------------------------------------------------
 
-export function isHtmlElement(el: Element): el is HTMLElement {
+function isHtmlElement(el: Element): el is HTMLElement {
   const HtmlElementCtor = el.ownerDocument.defaultView?.HTMLElement ?? globalThis.HTMLElement;
   return typeof HtmlElementCtor !== "undefined" && el instanceof HtmlElementCtor;
 }
@@ -113,7 +113,7 @@ export function getTimelineElementDisplayLabel(input: {
   return tag ? `${tag} clip` : "Timeline clip";
 }
 
-export const IMPLICIT_TIMELINE_LAYER_SKIP_TAGS = new Set([
+const IMPLICIT_TIMELINE_LAYER_SKIP_TAGS = new Set([
   "base",
   "link",
   "meta",
@@ -123,7 +123,7 @@ export const IMPLICIT_TIMELINE_LAYER_SKIP_TAGS = new Set([
   "template",
 ]);
 
-export function humanizeTimelineIdentifier(value: string): string {
+function humanizeTimelineIdentifier(value: string): string {
   return value
     .trim()
     .replace(/[_-]+/g, " ")
@@ -239,7 +239,7 @@ export function getTimelineElementIdentity(element: TimelineElement): string {
 // DOM node querying
 // ---------------------------------------------------------------------------
 
-export function getTimelineDomNodes(doc: Document): Element[] {
+function getTimelineDomNodes(doc: Document): Element[] {
   const rootComp = doc.querySelector("[data-composition-id]");
   return Array.from(doc.querySelectorAll("[data-start]")).filter((node) => node !== rootComp);
 }

--- a/packages/studio/src/utils/studioFontHelpers.ts
+++ b/packages/studio/src/utils/studioFontHelpers.ts
@@ -22,7 +22,7 @@ const GENERIC_FONT_FAMILIES = new Set([
   "fangsong",
 ]);
 
-export function primaryFontFamilyFromCss(value: string): string {
+function primaryFontFamilyFromCss(value: string): string {
   const first = value.split(",")[0] ?? "";
   return first.trim().replace(/^["']|["']$/g, "");
 }

--- a/packages/studio/src/utils/studioUrlState.ts
+++ b/packages/studio/src/utils/studioUrlState.ts
@@ -80,7 +80,7 @@ function normalizeSelection(params: URLSearchParams): StudioUrlSelectionState | 
   };
 }
 
-export function defaultStudioUrlState(): StudioUrlState {
+function defaultStudioUrlState(): StudioUrlState {
   return {
     activeCompPath: null,
     currentTime: null,

--- a/packages/studio/src/utils/timelineInspector.ts
+++ b/packages/studio/src/utils/timelineInspector.ts
@@ -1,6 +1,6 @@
 import type { TimelineElement } from "../player";
 
-export const TIMELINE_INSPECTOR_BOUNDARY_EPSILON_SECONDS = 0.08;
+const TIMELINE_INSPECTOR_BOUNDARY_EPSILON_SECONDS = 0.08;
 
 const AUDIO_TIMELINE_TAGS = new Set(["audio", "music", "sfx", "sound", "narration"]);
 const AUDIO_SOURCE_EXT_RE = /\.(aac|flac|m4a|mp3|ogg|opus|wav)(?:[?#].*)?$/i;

--- a/packages/studio/vite.browser.ts
+++ b/packages/studio/vite.browser.ts
@@ -20,7 +20,7 @@ const CHROME_PATHS = [
   "/usr/bin/chromium-browser",
 ];
 
-export async function getSharedBrowser(): Promise<import("puppeteer-core").Browser | null> {
+async function getSharedBrowser(): Promise<import("puppeteer-core").Browser | null> {
   if (_browser?.connected) return _browser;
   if (_browserLaunchPromise) return _browserLaunchPromise;
   _browserLaunchPromise = (async () => {


### PR DESCRIPTION
## What

Run `fallow fix --auto-fixable` to drop the `export` keyword from symbols fallow identifies as unreachable from any entry point, restricted to cases where the symbol is still used internally in its own file.

## Why

After #938 + #942 landed the config + CI audit gate, fallow reports 276 dead-code findings. The biggest mechanical chunk is unused exports — symbols exported "in case someone needs them" that nothing currently imports. Removing the `export` keyword makes them module-private, shrinks the public surface, and lets future cleanup catch genuinely-orphaned declarations.

## How

`npx fallow@2.75.0 fix --yes` would have applied 165 de-exports. Inspecting the result against typecheck + lint + the fallow audit surfaced three problem categories:

**False positives (4 files reverted):**
- `captureCost.ts` — `renderOrchestrator.ts` has two separate `import { ... } from "./render/captureCost.js"` blocks. Fallow only saw the first and incorrectly flagged symbols from the second block as unused. (Real bug to file upstream.)
- `propertyPanelHelpers.ts`, `domEditingLayers.ts` — internal uses fallow's reachability missed.
- `render.ts` — exports consumed via `await import("./render.js")` dynamic imports in tests; fallow's static analysis doesn't follow these.

**Cascading dead code (20 files reverted):**
When fallow removed `export` from a symbol that wasn't used in-file either, oxlint immediately surfaces `no-unused-vars`. Those cases are properly cleaned up by **deleting the declaration**, not just dropping `export`. Doing that touches different code shapes (cascading unused imports, dead helpers) and is better as a separate, narrower PR.

**Barrel cascades (4 more files reverted):**
After force-rebasing onto main, fallow audit caught a third pattern: dropping a single re-export from a barrel file or a single export from a tightly-coupled file made the *other* symbols in that file become unused. Examples:
- `Button.tsx` — removing `Button`'s and `IconButton`'s exports orphaned the whole file
- `renderOrchestrator.ts` — removing one captureCost re-export left other dead re-exports
- `telemetry/index.ts`, `portUtils.ts`, `ui/index.ts`, `hyperframeRuntimeLoader.ts` — similar barrel-cleanup cascades

These need a "whole-file cleanup" pass, not a per-symbol auto-fix.

Kept the remaining 38 files where the de-export is purely an access-modifier change — symbol is still used internally, no follow-on findings.

## Result

- Fallow dead-code findings: **276 → 208** (68 fewer unused exports)
- No behavior change — each symbol is still defined and used identically inside its file
- Zero lint / format / typecheck regressions
- Fallow audit passes on this PR (all remaining findings are inherited)

## Test plan

- [x] `bun run --filter '*' typecheck` — clean across all 8 packages
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — clean
- [x] `npx fallow@2.75.0 audit --base origin/main --fail-on-issues` — exit 0 (all 19 remaining changed-file findings are inherited)
- [x] vitest: `packages/cli` 335/335, `packages/core` 917/917, `packages/studio` 576/576, `packages/engine` 605/605

## Follow-ups

- **Delete fully-dead declarations** (the 20 files reverted) — properly clean up code where the export had no consumers internally either
- **Barrel/cascade file cleanup** — `Button.tsx`, `renderOrchestrator.ts` re-export barrel, `telemetry/index.ts`, `ui/index.ts`, etc. Each is its own small whole-file decision.
- **File multi-import-block bug** with fallow upstream
- **Producer `renderOrchestrator` hub cycle** — 8 circular deps, real refactor