### PR TITLE
chore(engine): observability for sub-composition timeline poll

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -50,7 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
-      fail-fast: true
+      # Temporarily disabled for the regression-flake investigation on
+      # chore/regression-poll-observability — we need every shard to emit
+      # its pollSubCompositionTimelines log even when an early shard fails.
+      # Restore to `true` before merging this PR (or before reverting it).
+      fail-fast: false
       matrix:
         # Shards are bin-packed by measured per-test duration (LPT heuristic on
         # CI run 25893372795) so each row carries ~15-16 min of work. When a

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -365,20 +365,46 @@ async function pollSubCompositionTimelines(
     }
     return true;
   })()`;
-  const timelinesBeforePoll = Number(
-    await page.evaluate(`Object.keys(window.__timelines || {}).length`),
-  );
+  // Observability snapshot: capture host IDs + timeline IDs before and after
+  // the poll so flaky CI runs can be correlated with whether the count-based
+  // rebind heuristic fired. Temporary — drop once the race condition behind
+  // the regression flakes is confirmed and patched.
+  const beforeSnapshot = (await page.evaluate(`(function() {
+    var hosts = document.querySelectorAll("[data-composition-id]");
+    var hostIds = [];
+    for (var i = 0; i < hosts.length; i++) {
+      var id = hosts[i].getAttribute("data-composition-id");
+      if (id) hostIds.push(id);
+    }
+    return { hostIds: hostIds, timelineIds: Object.keys(window.__timelines || {}) };
+  })()`)) as { hostIds: string[]; timelineIds: string[] };
+  const pollStart = Date.now();
   const ready = await pollPageExpression(page, expression, timeoutMs, intervalMs);
-  const timelinesAfterPoll = Number(
-    await page.evaluate(`Object.keys(window.__timelines || {}).length`),
-  );
-  if (ready && timelinesAfterPoll > timelinesBeforePoll) {
+  const pollMs = Date.now() - pollStart;
+  const afterTimelineIds = (await page.evaluate(
+    `Object.keys(window.__timelines || {})`,
+  )) as string[];
+  const beforeSet = new Set(beforeSnapshot.timelineIds);
+  const addedDuringPoll = afterTimelineIds.filter((id) => !beforeSet.has(id));
+  const rebindFired = ready && addedDuringPoll.length > 0;
+  if (rebindFired) {
     await page.evaluate(`(function() {
       if (typeof window.__hfForceTimelineRebind === "function") {
         window.__hfForceTimelineRebind();
       }
     })()`);
   }
+  console.log(
+    `[FrameCapture] pollSubCompositionTimelines ${JSON.stringify({
+      hostIds: beforeSnapshot.hostIds,
+      timelineIdsBefore: beforeSnapshot.timelineIds,
+      timelineIdsAfter: afterTimelineIds,
+      addedDuringPoll,
+      pollMs,
+      ready,
+      rebindFired,
+    })}`,
+  );
   if (!ready) {
     const missing = await page.evaluate(`(function() {
       var hosts = document.querySelectorAll("[data-composition-id]");


### PR DESCRIPTION
## What

Adds a single structured log line per render in `pollSubCompositionTimelines` (`packages/engine/src/services/frameCapture.ts`) capturing:

- `hostIds` — every `[data-composition-id]` host on the page
- `timelineIdsBefore` / `timelineIdsAfter` — `window.__timelines` keys around the poll
- `addedDuringPoll` — the diff (which timelines registered while we waited)
- `pollMs` — wall-clock time spent polling
- `ready` — whether all host timelines were present at the deadline
- `rebindFired` — whether `__hfForceTimelineRebind()` was invoked

## Why

Regression CI has been flaky on `main` and PRs since the 2026-05-18 renderer stack for async-loaded map blocks (#928 → main). Different fixtures fail on different runs:

- main `27efcd0f` (v0.6.22): shard-3 `style-7-prod`, 60 failed frames
- main `8163f380` (v0.6.21): shard-3 `style-7-prod`, 60 failed frames
- PR #926: shard-8 `gsap-letters-render-compat`, 86 failed frames
- fallow PR: shard-1 `style-3-prod`, 7 failed frames

PSNR drops are 18–30 dB across animation-heavy intervals — the fingerprint of render time shifted ~1-2 frames vs. baseline. Hypothesis: the count-based rebind heuristic in `pollSubCompositionTimelines` (introduced 2c84c9a5, amended 4bf2fa5c) is racy. On slow CI runners, sub-composition scripts register their timelines *between* the before-snapshot and the end of the poll → rebind fires → seek timing shifts → PSNR drops. On fast runners, the same fixture registers everything synchronously → no rebind → baseline matches.

This PR doesn't fix the race — it adds the observability needed to **confirm** the hypothesis before reverting/redesigning. Once correlation is established between failing runs and `rebindFired=true`, this PR is reverted and a real fix follows.

## How

Replaces the `timelinesBeforePoll`/`timelinesAfterPoll` count comparison with a set-difference computed from explicit ID lists. Behavior is unchanged: `addedDuringPoll.length > 0` is mathematically equivalent to `after > before` under the invariant that `window.__timelines` keys are never removed mid-poll.

The log line is unconditional — we want it on every CI shard, regardless of pass/fail.

## Test plan

- [ ] Trigger regression workflow (auto, on PR open) and grep CI logs for `pollSubCompositionTimelines` JSON lines
- [ ] Re-run regression 3-4 times via empty commits or shard rerun
- [ ] Verify correlation: failing shards' fixtures should show `rebindFired:true` and a non-empty `addedDuringPoll`; passing shards should show `rebindFired:false`
- [ ] No baseline regen needed — render output is unchanged

This PR is intentionally landing as **draft** and is intended to be reverted once the investigation completes.