### PR TITLE
ci: run fallow audit in lefthook pre-commit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@hyperframes/player": "workspace:*",
         "@types/node": "^25.0.10",
         "concurrently": "^8.2.0",
+        "fallow": "^2.75.0",
         "happy-dom": "^20.9.0",
         "knip": "^6.0.3",
         "lefthook": "^2.1.4",
@@ -516,6 +517,22 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@fallow-cli/darwin-arm64": ["@fallow-cli/darwin-arm64@2.75.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-izJTjYPNdiWPbf7QjVwje0JwJeVQJAUuncjPkuAO9hRM3t4oJ9fqAvyEXyyRq4dAJS4NO4DMEsPsN82QOF8fGw=="],
+
+    "@fallow-cli/darwin-x64": ["@fallow-cli/darwin-x64@2.75.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-hZzaSidHYKFC82bjP/L+xKOp67ESgNjSUX3U2HzaBg/dKFVcyMFxub3O7r3SBFBU2zY5wsZK1qmfpw/oC01vsg=="],
+
+    "@fallow-cli/linux-arm64-gnu": ["@fallow-cli/linux-arm64-gnu@2.75.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-K5ymLWqR6NJUV+wVDFK0+bKK4YSzYo9Lr2Xla5YptW6FnlpEAvRDdcr3lGdf3Ge1T14fKU3ys8dKHDHkJSeyeA=="],
+
+    "@fallow-cli/linux-arm64-musl": ["@fallow-cli/linux-arm64-musl@2.75.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-FRBz19XQ6pPjnhsIry0w0cRqUEYGZH6rEDCau3SGa2DNgts/i4573HJOn7ZRAzgSNMtgoh3KKTyUNOEzNLTl0A=="],
+
+    "@fallow-cli/linux-x64-gnu": ["@fallow-cli/linux-x64-gnu@2.75.0", "", { "os": "linux", "cpu": "x64" }, "sha512-81xmIf9G8hVTKbQGRGV6oTbu9W5XQPpKFpfXS3KFu16bbdgfwEaKzr5E7Y7dxECYsskhIiff5zdHcEPOFv29Wg=="],
+
+    "@fallow-cli/linux-x64-musl": ["@fallow-cli/linux-x64-musl@2.75.0", "", { "os": "linux", "cpu": "x64" }, "sha512-lVPjmM+dGy3NG6nJ9PaZfkUClZC6OyfwyqVZdQFhq+6Xl/2c2jZI9vgmwIDBIGBhL9TU+V8NdSM7Xy85ifeOyw=="],
+
+    "@fallow-cli/win32-arm64-msvc": ["@fallow-cli/win32-arm64-msvc@2.75.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-HbIXLbte8pzNX0XlbyRlRQA2+y8kfJ4O6XxB2VR2dE6q5LrNhG4fl0QRR/P9x8r3CNn9fw/25kk+WxULfbHu1w=="],
+
+    "@fallow-cli/win32-x64-msvc": ["@fallow-cli/win32-x64-msvc@2.75.0", "", { "os": "win32", "cpu": "x64" }, "sha512-h8W+qEOPvyolBQO2Y0H4/pz2XXw/1yHA8/XRPo3/tYRovmN2zoNjDrvaGjjodzFt6fBVLus+T0uo+U4pMgOu/w=="],
 
     "@fontsource/archivo-black": ["@fontsource/archivo-black@5.2.8", "", {}, "sha512-3zNj/o9LzWyDl/UEpY5IOHpAQyUtFr3hQaFS7NSKwCLLkXOfH/CMCt1L2b2Z+OF25OURtOYenCadgAebALz7/A=="],
 
@@ -1242,6 +1259,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fallow": ["fallow@2.75.0", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@fallow-cli/darwin-arm64": "2.75.0", "@fallow-cli/darwin-x64": "2.75.0", "@fallow-cli/linux-arm64-gnu": "2.75.0", "@fallow-cli/linux-arm64-musl": "2.75.0", "@fallow-cli/linux-x64-gnu": "2.75.0", "@fallow-cli/linux-x64-musl": "2.75.0", "@fallow-cli/win32-arm64-msvc": "2.75.0", "@fallow-cli/win32-x64-msvc": "2.75.0" }, "bin": { "fallow": "bin/fallow", "fallow-lsp": "bin/fallow-lsp", "fallow-mcp": "bin/fallow-mcp" } }, "sha512-0/2cquNI/cDLP/LzcCbkwI4hMzkX4tE0VY3/69n3PBBeqFpbM2oai+2Cb0sB8dXB8MDUGPVoPJjDW5GiUo7a1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,6 +12,14 @@ pre-commit:
     typecheck:
       glob: "*.{ts,tsx}"
       run: cd packages/core && bunx tsc --noEmit && cd ../studio && bunx tsc --noEmit
+    # Mirrors the CI gate (same `--base origin/main` so the local hook can't
+    # pass on a branch CI would fail). Audits the working tree, which means
+    # unstaged WIP in `packages/**` is part of the diff — stash before
+    # committing if that surprises you. `--gate new-only` (the default) only
+    # fails on issues introduced by the branch, not inherited findings.
+    fallow:
+      glob: "packages/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"
+      run: bunx fallow audit --base origin/main --fail-on-issues
     filesize:
       # Scoped to packages/studio — the 500 LOC limit is a studio architecture
       # standard enforced as part of the App.tsx decomposition work. Player and

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@hyperframes/player": "workspace:*",
     "@types/node": "^25.0.10",
     "concurrently": "^8.2.0",
+    "fallow": "^2.75.0",
     "happy-dom": "^20.9.0",
     "knip": "^6.0.3",
     "lefthook": "^2.1.4",


### PR DESCRIPTION
## What

Adds `fallow audit` to the lefthook pre-commit hook so the same check that gates PRs in CI also runs locally before the commit is created.

## Why

Without this, the CI fallow audit (added in #942) catches new findings only on push — a ~5-minute round-trip per attempted fix. Pre-commit gives the feedback before the push (~1s locally with bunx).

## How

Adds `fallow@^2.75.0` as a root devDep so the binary resolves from `node_modules` instead of being re-downloaded by `npx` on every commit. New lefthook block in the existing `parallel: true` group:

```yaml
fallow:
  glob: "packages/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"
  run: bunx fallow audit --base origin/main --fail-on-issues
```

- `--base origin/main` matches the CI gate exactly (originally `--base HEAD`, switched per Vance's review — diffing against the last commit lets the hook approve a branch that CI rejects because CI audits the cumulative diff)
- `--fail-on-issues` is required for non-zero exit (audit normally exits 0 even with findings)
- Default `--gate new-only` matches CI behavior — inherited findings don't block commits
- Glob scopes to package source files; doc/config edits skip the hook
- `bunx` (not `npx -y`) resolves the pinned devDep, no per-commit fetch

## Test plan

- [x] Hook fires on `packages/**` edits — measured ~0.8s with bunx, parallel with existing lint/format/typecheck so wall-clock unchanged (typecheck ~11s is the long pole)
- [x] Hook correctly skips for non-package edits (README, top-level configs)
- [x] Hook passes when only inherited findings exist
- [x] Hook fails when a new finding is introduced (same gate as CI)

## Known sharp edges (documented for follow-up, not fixed here)

- **Working-tree vs staged-index**: `fallow audit --base origin/main` audits the working tree, not just the staged subset. So unstaged WIP in `packages/**` is part of the diff. If that surprises you, stash before committing. Fallow doesn't expose a `--staged` flag today; if it becomes a pattern of false positives, can wire `git stash` + `git stash pop` around the hook.

## Notes

Pinned `fallow@^2.75.0` matches the CI workflow pin. Bumps land via a deliberate PR that updates both `package.json` and the workflow together — the lockfile is the source of truth for both.