### PR TITLE
fix(producer): treat 4xx from Google Fonts as deterministic "not served", not as failClosed trigger

### DIFF
--- a/packages/producer/src/services/deterministicFonts-failClosed.test.ts
+++ b/packages/producer/src/services/deterministicFonts-failClosed.test.ts
@@ -4,8 +4,12 @@
  * Production callers (the in-process `htmlCompiler`) call the function
  * without options and get the legacy behavior: external font fetch failures
  * are swallowed and a warning is logged. Distributed callers pass
- * `failClosedFontFetch: true` so missing fonts surface as typed
- * non-retryable failures before any chunk is rendered.
+ * `failClosedFontFetch: true` so non-deterministic infrastructure failures
+ * (5xx, network errors, DNS) surface as typed non-retryable failures before
+ * any chunk is rendered. 4xx responses are treated as a *deterministic*
+ * "Google Fonts does not serve this family" answer — same outcome on every
+ * retry — and pass through to the embedded-face fallback without
+ * tripping `failClosedFontFetch` in either mode.
  *
  * The tests inject `fetchImpl` so no real network call happens.
  */
@@ -38,6 +42,19 @@ function makeHttp404Fetch(): typeof fetch {
     new Response("", { status: 404, statusText: "Not Found" })) as unknown as typeof fetch;
 }
 
+function makeHttp400Fetch(): typeof fetch {
+  return (async () =>
+    new Response("", { status: 400, statusText: "Bad Request" })) as unknown as typeof fetch;
+}
+
+function makeHttp503Fetch(): typeof fetch {
+  return (async () =>
+    new Response("", {
+      status: 503,
+      statusText: "Service Unavailable",
+    })) as unknown as typeof fetch;
+}
+
 describe("injectDeterministicFontFaces — failClosedFontFetch: false (default)", () => {
   it("swallows a network failure and returns the original HTML (no throw)", async () => {
     const result = await injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {
@@ -53,6 +70,14 @@ describe("injectDeterministicFontFaces — failClosedFontFetch: false (default)"
     const result = await injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {
       failClosedFontFetch: false,
       fetchImpl: makeHttp404Fetch(),
+    });
+    expect(result.includes("data-hyperframes-deterministic-fonts")).toBe(false);
+  });
+
+  it("swallows a 5xx response and returns the original HTML (no throw)", async () => {
+    const result = await injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {
+      failClosedFontFetch: false,
+      fetchImpl: makeHttp503Fetch(),
     });
     expect(result.includes("data-hyperframes-deterministic-fonts")).toBe(false);
   });
@@ -84,28 +109,50 @@ describe("injectDeterministicFontFaces — failClosedFontFetch: true", () => {
     expect((caught as Error).message).toContain("simulated network failure");
   });
 
-  it("throws FontFetchError on a 404 response", async () => {
+  it("does NOT throw on a 4xx response — 4xx means 'Google Fonts does not serve this family', a deterministic answer", async () => {
+    // Google Fonts returns HTTP 400 for non-Google families like
+    // "Segoe UI", "Arial", "Futura". Same response on every retry, so it
+    // doesn't violate the byte-identical-retry contract — the render
+    // falls back to embedded faces / the composition's font-family chain.
+    // No FONT_FETCH_FAILED.
+    const result = await injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {
+      failClosedFontFetch: true,
+      fetchImpl: makeHttp400Fetch(),
+    });
+    // No @font-face was injected (no faces returned), but the call resolves.
+    expect(result.includes("data-hyperframes-deterministic-fonts")).toBe(false);
+  });
+
+  it("does NOT throw on a 404 response either — same reasoning as 4xx generally", async () => {
+    const result = await injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {
+      failClosedFontFetch: true,
+      fetchImpl: makeHttp404Fetch(),
+    });
+    expect(result.includes("data-hyperframes-deterministic-fonts")).toBe(false);
+  });
+
+  it("throws FontFetchError on a 5xx response — non-deterministic, could differ on retry", async () => {
     let caught: unknown;
     try {
       await injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {
         failClosedFontFetch: true,
-        fetchImpl: makeHttp404Fetch(),
+        fetchImpl: makeHttp503Fetch(),
       });
     } catch (err) {
       caught = err;
     }
     expect(caught).toBeInstanceOf(FontFetchError);
     expect((caught as FontFetchError).code).toBe(FONT_FETCH_FAILED);
-    expect((caught as Error).message).toContain("HTTP 404");
+    expect((caught as Error).message).toContain("HTTP 503");
     expect((caught as Error).message).toContain("NotARealFontFamilyForTest");
   });
 
-  it("includes the requested URL in the error", async () => {
+  it("includes the requested URL in 5xx errors", async () => {
     let caught: unknown;
     try {
       await injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {
         failClosedFontFetch: true,
-        fetchImpl: makeHttp404Fetch(),
+        fetchImpl: makeHttp503Fetch(),
       });
     } catch (err) {
       caught = err;
@@ -114,15 +161,19 @@ describe("injectDeterministicFontFaces — failClosedFontFetch: true", () => {
     expect((caught as FontFetchError).url).toContain("NotARealFontFamilyForTest");
   });
 
-  it("does NOT throw when the HTML uses a pre-bundled font (no fetch happens)", async () => {
-    // "Inter" is in FONT_ALIASES → uses bundled font data, never reaches
-    // the Google Fonts path → failClosedFontFetch=true is irrelevant here
-    // and shouldn't trip. (The full <html><head> wrap is required because
+  it("does NOT throw when bundled-font Google Fonts supplement returns no extra faces", async () => {
+    // "Inter" is in FONT_ALIASES → uses the embedded font bundle. Since
+    // c8e8fdcf, the resolver also queries Google Fonts to supplement any
+    // weights not in the embedded bundle. A successful empty CSS response
+    // means the bundle was sufficient — `failClosedFontFetch` doesn't
+    // trip. (The full <html><head> wrap is required because
     // injectDeterministicFontFaces injects into <head>.)
     const html = `<!doctype html><html><head><style>body { font-family: "Inter", sans-serif; }</style></head><body></body></html>`;
+    const fetchImpl = (async () =>
+      new Response("/* no faces */", { status: 200 })) as unknown as typeof fetch;
     const result = await injectDeterministicFontFaces(html, {
       failClosedFontFetch: true,
-      fetchImpl: makeFailingFetch(),
+      fetchImpl,
     });
     expect(result).toContain("data-hyperframes-deterministic-fonts");
   });

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -430,15 +430,24 @@ async function fetchGoogleFont(
       headers: { "User-Agent": WOFF2_USER_AGENT },
     });
     if (!res.ok) {
-      if (options.failClosedFontFetch) {
+      // 4xx is a *deterministic* answer from Google Fonts that this
+      // family is not served (e.g. HTTP 400 for "Segoe UI", "Arial",
+      // "Futura" — names absent from Google's catalog) or is misnamed.
+      // The render falls back to embedded faces / the composition's
+      // font-family chain; we return [] in both modes. 5xx (and other
+      // transient upstream failures) could return faces on retry, which
+      // would break the byte-identical-retry contract distributed
+      // renders rely on — those still fail closed when requested.
+      if (res.status >= 500 && options.failClosedFontFetch) {
         throw fontFetchError(familyName, url, "Google Fonts CSS", { status: res.status });
       }
       return [];
     }
     cssText = await res.text();
   } catch (err) {
-    // Rethrow typed error untouched. Other errors (network, DNS) get wrapped
-    // when failClosed is on, swallowed otherwise.
+    // Rethrow typed error untouched. Network / DNS / fetch-throws are
+    // non-deterministic infrastructure failures — wrapped when failClosed
+    // is on, swallowed otherwise.
     if (err instanceof FontFetchError) throw err;
     if (options.failClosedFontFetch) {
       throw fontFetchError(familyName, url, "Google Fonts CSS", { error: err });
@@ -467,7 +476,10 @@ async function fetchGoogleFont(
       try {
         const fontRes = await options.fetchImpl(woff2Url);
         if (!fontRes.ok) {
-          if (options.failClosedFontFetch) {
+          // Same 4xx vs 5xx split as the CSS fetch above: 4xx = the
+          // font's woff2 isn't served, skip silently; 5xx = transient
+          // upstream failure, may fail closed.
+          if (fontRes.status >= 500 && options.failClosedFontFetch) {
             throw fontFetchError(familyName, woff2Url, woff2What, { status: fontRes.status });
           }
           continue;


### PR DESCRIPTION
## Summary

After c8e8fdcf added a Google Fonts supplement-fetch to the Path 1 (bundled-font) branch of `buildFontFaceCss`, every `plan()` call against a composition whose CSS named a non-Google family that Google Fonts 400s on (`\"Segoe UI\"`, `\"Arial\"`, `\"Futura\"`, …) started failing on distributed renders with `FONT_FETCH_FAILED`. Distributed defaults `failClosedFontFetch: true`, and the existing code treated *all* non-2xx responses the same way — throw if failClosed, swallow otherwise. That conflates two very different failure modes.

Confirmed via curl against Google Fonts:

| Family | HTTP | Notes |
|---|---|---|
| Inter | 200 | 4 faces — self-aliased canonical |
| Helvetica Neue | 200 | 2 faces — Google serves real Helvetica glyphs |
| Helvetica | 200 | 2 faces — same |
| Arial | 400 | Not served |
| Segoe UI | 400 | Not served |

## Fix

Split the `!res.ok` branch in `fetchGoogleFont` (both CSS fetch and woff2 fetch):

- **4xx**: a *deterministic* \"Google Fonts doesn't serve this family\" answer. Same outcome on every retry → no risk to the byte-identical-retry contract. Return `[]` in both modes; render falls back to embedded faces / the composition's font-family chain (which is what it would have done pre-c8e8fdcf anyway).
- **5xx** (plus network / DNS / fetch exceptions): *non-deterministic* infrastructure failure. A retry might succeed and produce different pixels than the first attempt — exactly what `failClosedFontFetch` is meant to guard against. Keep failing closed in this mode.

3-line change in error handling; no call-site or `FONT_ALIASES` changes; no behavior change for any composition that wasn't previously broken.

## Why this and not [fix at the call site]

Earlier revisions of this PR tried two other shapes that I rejected:

1. **Pass `canonical.googleName` to `fetchGoogleFont`** (fetch Inter for Helvetica). Drifted `style-7-prod`'s baseline by 67 frames because it silently bound Inter's 50+ Google weights to `font-family: \"Helvetica\"`, expanding the weight palette beyond what the baseline captured.
2. **Skip supplement-fetch for cross-aliases** (canonicalKey !== normalizedFamily). Still drifted `style-7-prod` by 60 frames — because Google Fonts actually serves real Helvetica glyphs under the `\"Helvetica Neue\"` and `\"Helvetica\"` names, and the current baseline depends on those real glyphs. Skipping the fetch fell back to embedded Inter, which is a different render.

The right fix is the error-semantics one: `failClosedFontFetch` should protect against non-determinism, not against \"font doesn't exist on Google\" (which is itself deterministic). With this fix, every existing composition keeps the exact behavior it has today — what changes is only that **distributed renders no longer crash on 4xx**.

## Test plan

`bun test packages/producer/src/services/deterministicFonts-failClosed.test.ts` — 12/12 pass:

- 2 new cases on `failClosedFontFetch: true`: 400 and 404 responses no longer throw, render resolves cleanly.
- 2 new cases on `failClosedFontFetch: true`: 503 throws `FONT_FETCH_FAILED`, error includes URL + family.
- 1 new case on `failClosedFontFetch: false`: 5xx swallowed as before.
- Pre-existing \"does NOT throw when bundled-font\" test was broken by c8e8fdcf (the supplement-fetch always fires for self-aliased bundled fonts now). Updated to use a successful empty CSS response, which is the actual invariant we want.

`bun run --cwd packages/producer build` clean. `bunx oxlint` + `bunx oxfmt --check` clean.

## Unblocks

Distributed renders against compositions that name any non-Google family Google Fonts 400s on (Segoe UI, Arial, Courier New, Futura). Pairs with the c=3 worker-0-only SwiftShader probe fix shipped in #956 — the texture-launch validation bench was blocked on this issue (Segoe UI in the fixture's CSS); we ran validation on a Space-Mono fixture instead and confirmed the worker-0 fix works.

## Followup (not in this PR)

Should `FONT_ALIASES` exist at all in a deterministic cloud renderer? Today `font-family: \"Helvetica\"` silently produces real Helvetica glyphs (via Google Fonts' undocumented alias serving) and `font-family: \"Segoe UI\"` silently produces embedded Roboto, with no warning to the author. That's a WYSIWYG violation worth its own proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)