### PR TITLE
feat(skills): design picker UI (Phase 1 templates index + Phase 2 fine-tune)

### DIFF
--- a/skills/hyperframes/templates/design-picker.html
+++ b/skills/hyperframes/templates/design-picker.html
@@ -3,8 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <base href="__BASE_HREF__" />
     <title>Design your visual direction</title>
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/CustomEase.min.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.167.0/build/three.module.js",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.167.0/examples/jsm/"
+        }
+      }
+    </script>
     <style>
       * {
         margin: 0;
@@ -53,26 +63,112 @@
         opacity: 0.25;
         pointer-events: none;
       }
+      .tp-nav {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+      }
+      .tp-nav-arrow {
+        background: transparent;
+        border: 1px solid #2a2a2a;
+        color: #bbb;
+        width: 28px;
+        height: 28px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 18px;
+        line-height: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.15s;
+        padding: 0;
+      }
+      .tp-nav-arrow:hover {
+        background: #1a1a1a;
+        color: #fff;
+        border-color: #444;
+      }
+      .tp-nav-title {
+        font-size: 12px;
+        font-weight: 600;
+        color: #fff;
+        letter-spacing: 0.04em;
+        min-width: 160px;
+        text-align: center;
+      }
 
       /* ── Phases ── */
       .phase {
         display: none;
         flex: 1;
-        overflow: hidden;
+        height: 100%;
+        overflow: auto;
       }
       .phase.active {
         display: flex;
+        animation: phaseIn 0.6s ease;
+      }
+      @keyframes phaseIn {
+        from {
+          opacity: 0;
+          transform: translateY(12px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      /* Periodic shimmer on the Living Background "Configure" affordance —
+         draws the eye to it every 5 seconds. A light gloss sweeps across,
+         text base color stays light (#bbb) — never darker than the surrounding label. */
+      .cfg-shimmer {
+        color: #bbb;
+        background: linear-gradient(
+            90deg,
+            #bbb 0%,
+            #bbb 40%,
+            #ffffff 50%,
+            #bbb 60%,
+            #bbb 100%
+          )
+          0% 0% / 220% 100%;
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        animation: cfgShimmer 5s ease-in-out infinite;
+        animation-delay: 1.5s;
+      }
+      @keyframes cfgShimmer {
+        0%,
+        85%,
+        100% {
+          background-position: 100% 0%;
+        }
+        92% {
+          background-position: 0% 0%;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .cfg-shimmer {
+          animation: none;
+          -webkit-text-fill-color: #bbb;
+        }
       }
 
       /* ── Phase 1: Mood boards ── */
       .mood-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+        grid-template-columns: repeat(3, minmax(0, 420px));
         gap: 16px;
         padding: 20px;
         overflow-y: auto;
         flex: 1;
-        align-content: start;
+        align-content: center;
+        justify-content: center;
       }
       .mood-card {
         border: 1px solid #1e1e1e;
@@ -84,8 +180,6 @@
           transform 0.15s,
           box-shadow 0.15s;
         background: #141414;
-        display: flex;
-        flex-direction: column;
       }
       .mood-card:hover {
         border-color: #333;
@@ -96,16 +190,84 @@
         border-color: #fff;
       }
       .mood-preview {
-        height: 500px;
+        aspect-ratio: 16/9;
         overflow: hidden;
         position: relative;
         background: #0a0a0a;
       }
-      .mood-preview > div {
+      .mood-frame {
         transform-origin: top left;
+        width: 1920px;
+        height: 1080px;
+        position: absolute;
+        top: 0;
+        left: 0;
+        opacity: 0;
+        transition: opacity 0.25s;
+        z-index: 1;
+      }
+      .mood-frame.active {
+        opacity: 1;
+      }
+      .mood-arrow {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 28px;
+        height: 28px;
+        background: rgba(0, 0, 0, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 50%;
+        color: #fff;
+        font-size: 13px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        transition: opacity 0.15s;
+        z-index: 10;
+        -webkit-user-select: none;
+        user-select: none;
+      }
+      .mood-preview:hover .mood-arrow {
+        opacity: 1;
+      }
+      .mood-arrow:hover {
+        background: rgba(0, 0, 0, 0.8);
+        border-color: rgba(255, 255, 255, 0.3);
+      }
+      .mood-arrow.left {
+        left: 8px;
+      }
+      .mood-arrow.right {
+        right: 8px;
+      }
+      .mood-dots {
+        position: absolute;
+        bottom: 8px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        gap: 5px;
+        z-index: 10;
+        opacity: 0;
+        transition: opacity 0.15s;
+      }
+      .mood-preview:hover .mood-dots {
+        opacity: 1;
+      }
+      .mood-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.25);
+      }
+      .mood-dot.active {
+        background: #fff;
       }
       .mood-info {
-        padding: 14px 16px;
+        display: none;
       }
       .mood-name {
         font-size: 14px;
@@ -193,9 +355,287 @@
         overflow-x: hidden;
         background: #0e0e0e;
       }
-      .panel-right * {
+      .panel-right > *:not(.showcase) {
         max-width: 100%;
         box-sizing: border-box;
+      }
+      .showcase *,
+      .showcase *::before,
+      .showcase *::after {
+        box-sizing: border-box;
+      }
+      .scene-frame,
+      .scene-frame * {
+        max-width: none !important;
+      }
+
+      /* ── Showcase ── */
+      .showcase {
+        padding: 0;
+        --sc-bg: #0e0e0e;
+        --sc-fg: #eee;
+        --sc-ac: #888;
+        --sc-mt: #555;
+      }
+      .showcase-section {
+        padding: 48px 40px;
+        border-bottom: 1px solid var(--sc-mt, #1a1a1a);
+        background: var(--sc-bg);
+        color: var(--sc-fg);
+      }
+      .showcase-eyebrow {
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        color: var(--sc-ac);
+        margin: 0 0 12px;
+        font-family: ui-monospace, "SF Mono", monospace;
+      }
+      .showcase-heading {
+        font-size: 22px;
+        font-weight: 600;
+        color: var(--sc-fg);
+        margin: 0 0 8px;
+        letter-spacing: -0.02em;
+      }
+      .showcase-lead {
+        font-size: 13px;
+        line-height: 1.6;
+        color: var(--sc-mt);
+        margin: 0 0 24px;
+        max-width: 600px;
+      }
+
+      /* Palette swatches */
+      .swatch-grid {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .swatch-card {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        background: rgba(128, 128, 128, 0.06);
+        border: 1px solid rgba(128, 128, 128, 0.12);
+        border-radius: 8px;
+        min-width: 180px;
+      }
+      .swatch-chip {
+        width: 36px;
+        height: 36px;
+        border-radius: 6px;
+        flex-shrink: 0;
+        border: 1px solid rgba(128, 128, 128, 0.1);
+      }
+      .swatch-name {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--sc-fg);
+      }
+      .swatch-hex {
+        font-size: 11px;
+        color: var(--sc-mt);
+        font-family: ui-monospace, monospace;
+      }
+      .swatch-role {
+        font-size: 11px;
+        color: var(--sc-mt);
+        margin-top: 2px;
+        opacity: 0.7;
+      }
+
+      /* Type specimens */
+      .type-specimen-row {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 24px 0;
+        border-bottom: 1px solid rgba(128, 128, 128, 0.1);
+      }
+      .type-meta {
+        font-size: 11px;
+        color: var(--sc-mt);
+        font-family: ui-monospace, monospace;
+        line-height: 1.4;
+        display: flex;
+        gap: 12px;
+        align-items: baseline;
+      }
+      .type-sample {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .type-meta strong {
+        color: var(--sc-ac);
+        display: block;
+        margin-bottom: 2px;
+      }
+      .type-sample {
+        flex: 1;
+        color: var(--sc-fg);
+      }
+
+      /* Scene grid */
+      .scene-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 6px;
+      }
+      .specimen-grid {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 6px;
+        margin-top: 12px;
+      }
+      .specimen-cell {
+        position: relative;
+        overflow: hidden;
+        border-radius: 4px;
+        aspect-ratio: 16/9;
+        border: 1px solid rgba(128, 128, 128, 0.1);
+        background: #111;
+        cursor: pointer;
+        transition: border-color 0.15s;
+      }
+      .specimen-cell:hover {
+        border-color: rgba(255, 255, 255, 0.3);
+      }
+      .specimen-cell.active {
+        border-color: #fff;
+        border-width: 2px;
+      }
+      .specimen-cell iframe {
+        width: 1920px;
+        height: 1080px;
+        border: none;
+        transform-origin: top left;
+        pointer-events: none;
+      }
+      .specimen-label {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 4px 8px;
+        font-size: 9px;
+        color: rgba(255, 255, 255, 0.5);
+        background: linear-gradient(transparent, rgba(0, 0, 0, 0.5));
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      .scene-cell {
+        position: relative;
+        overflow: hidden;
+        border-radius: 6px;
+        aspect-ratio: 16/9;
+        border: 1px solid rgba(128, 128, 128, 0.12);
+      }
+      .scene-cell-label {
+        position: absolute;
+        top: 6px;
+        left: 8px;
+        font-size: 9px;
+        color: var(--sc-mt);
+        font-family: ui-monospace, monospace;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        z-index: 2;
+      }
+      .scene-frame {
+        width: 1920px;
+        height: 1080px;
+        transform-origin: top left;
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+
+      /* Motion preview */
+      .ease-preview-track {
+        width: 100%;
+        height: 48px;
+        position: relative;
+      }
+      .ease-preview-dot {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        position: absolute;
+        top: 8px;
+        left: 10px;
+      }
+
+      /* Elevation */
+      .elevation-grid {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .elevation-card {
+        width: 140px;
+        height: 80px;
+        border-radius: 6px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        font-size: 11px;
+      }
+      .elevation-label {
+        font-size: 10px;
+        color: var(--sc-mt);
+      }
+
+      /* Radius */
+      .radius-grid {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        align-items: flex-end;
+      }
+      .radius-chip-preview {
+        width: 48px;
+        height: 48px;
+        border: 1px solid var(--sc-mt);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .radius-label {
+        font-size: 10px;
+        color: var(--sc-mt);
+        text-align: center;
+        margin-top: 4px;
+        font-family: ui-monospace, monospace;
+      }
+
+      .tune-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 4px;
+        padding: 8px;
+        width: 100%;
+        max-height: calc(100vh - 45px);
+        align-content: center;
+      }
+      .tune-cell {
+        position: relative;
+        overflow: hidden;
+        border-radius: 6px;
+        aspect-ratio: 16/9;
+      }
+      .tune-frame {
+        width: 1920px;
+        height: 1080px;
+        transform-origin: top left;
+        position: absolute;
+        top: 0;
+        left: 0;
       }
 
       /* ── Section cards (Neuform-inspired) ── */
@@ -235,11 +675,19 @@
         padding: 6px 16px 16px;
       }
 
+      .opt-grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 6px;
+      }
+      .opt-grid-2 > .opt:last-child:nth-child(odd) {
+        grid-column: 1 / -1;
+      }
+
       /* ── Option cards ── */
       .opt {
         border: 1px solid #1e1e1e;
         border-radius: 10px;
-        margin-bottom: 6px;
         cursor: pointer;
         transition: border-color 0.12s;
         overflow: hidden;
@@ -466,6 +914,128 @@
         font-family: "SF Mono", Consolas, monospace;
         letter-spacing: 0.02em;
       }
+      #shader-editor input[type="color"] {
+        padding: 0;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      .bezier-editor {
+        border: 1px solid #1e1e1e;
+        border-radius: 10px;
+        margin-bottom: 6px;
+        cursor: pointer;
+        background: #141414;
+        padding: 14px;
+        transition: border-color 0.12s;
+        overflow: hidden;
+      }
+      .bezier-editor .bezier-canvas-wrap,
+      .bezier-editor .bezier-hint,
+      .bezier-editor .bezier-track {
+        display: none;
+      }
+      .bezier-editor.selected .bezier-canvas-wrap,
+      .bezier-editor.selected .bezier-hint,
+      .bezier-editor.selected .bezier-track {
+        display: block;
+      }
+      .bezier-header {
+        margin-bottom: 0;
+      }
+      .bezier-editor.selected .bezier-header {
+        margin-bottom: 10px;
+      }
+      .bezier-editor:hover {
+        border-color: #333;
+      }
+      .bezier-editor.selected {
+        border-color: #fff;
+      }
+      .bezier-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0;
+      }
+      .bezier-header .ease-name {
+        font-size: 11px;
+        font-weight: 600;
+      }
+      .bezier-header .ease-value {
+        font-size: 9px;
+        color: #444;
+        font-family: "SF Mono", Consolas, monospace;
+      }
+      .bezier-canvas-wrap {
+        position: relative;
+        width: 100%;
+        aspect-ratio: 1;
+        overflow: visible;
+        cursor: crosshair;
+      }
+      .bezier-canvas-wrap canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      .bezier-handle {
+        position: absolute;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        border: 2px solid #4e7fff;
+        background: #0e0e0e;
+        cursor: grab;
+        transform: translate(-50%, -50%);
+        z-index: 2;
+      }
+      .bezier-handle:hover,
+      .bezier-handle.dragging {
+        background: #4e7fff;
+        cursor: grabbing;
+      }
+      .bezier-anchor {
+        position: absolute;
+        width: 12px;
+        height: 12px;
+        border: 2px solid #4e7fff;
+        background: #fff;
+        cursor: grab;
+        transform: translate(-50%, -50%) rotate(45deg);
+        z-index: 3;
+      }
+      .bezier-anchor:hover,
+      .bezier-anchor.dragging {
+        background: #4e7fff;
+        cursor: grabbing;
+      }
+      .bezier-anchor.selected {
+        background: #4e7fff;
+      }
+      .bezier-hint {
+        font-size: 9px;
+        color: #555;
+        margin-top: 6px;
+        line-height: 1.3;
+      }
+      .bezier-track {
+        position: relative;
+        height: 8px;
+        background: #1a1a1a;
+        border-radius: 4px;
+        margin-top: 10px;
+        overflow: visible;
+      }
+      .bezier-dot {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        left: 0;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: #fff;
+      }
 
       .preview-empty {
         display: flex;
@@ -476,32 +1046,27 @@
         font-size: 13px;
       }
 
-      /* ── FAB + Overlay ── */
-      .fab {
-        position: fixed;
-        bottom: 20px;
-        right: 32px;
-        transform: translateY(60px);
-        opacity: 0;
+      /* ── Header button + Overlay ── */
+      .header-btn {
+        margin-left: auto;
         background: #fff;
         color: #000;
         border: none;
-        padding: 12px 24px;
-        border-radius: 10px;
-        font-size: 13px;
+        padding: 6px 16px;
+        border-radius: 6px;
+        font-size: 12px;
         font-weight: 600;
         cursor: pointer;
-        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
-        transition:
-          transform 0.25s ease,
-          opacity 0.25s ease;
-        z-index: 100;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s;
+        align-self: center;
       }
-      .fab.visible {
-        transform: translateY(0);
+      .header-btn.visible {
         opacity: 1;
+        pointer-events: auto;
       }
-      .fab:hover {
+      .header-btn:hover {
         background: #ddd;
       }
 
@@ -635,50 +1200,563 @@
         font-weight: 500;
         color: #888;
       }
+
+      /* ── Template picker (Phase 1) — editorial index ── */
+      @import url("https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300..700;1,8..60,300..700&family=Hanken+Grotesk:wght@400;500;600&display=swap");
+
+      #phase-mood {
+        --canvas: oklch(0.165 0.005 70);
+        --paper: oklch(0.21 0.006 70);
+        --ink: oklch(0.945 0.008 70);
+        --ink-quiet: oklch(0.68 0.006 70);
+        --ink-faint: oklch(0.46 0.006 70);
+        --rule: oklch(0.32 0.006 70);
+        --rule-soft: oklch(0.255 0.005 70);
+        --accent: oklch(0.78 0.13 65);
+        --f-disp: "Source Serif 4", "Iowan Old Style", Georgia, serif;
+        --f-body: "Hanken Grotesk", system-ui, sans-serif;
+        background: var(--canvas);
+        color: var(--ink);
+        font-family: var(--f-body);
+        font-feature-settings: "ss01", "kern", "liga";
+        --idx-pad-x: clamp(40px, 7vw, 112px);
+      }
+
+      #phase-mood .idx-mast {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: end;
+        column-gap: 32px;
+        padding: clamp(40px, 6vh, 72px) var(--idx-pad-x) clamp(32px, 4vh, 48px);
+        border-bottom: 1px solid var(--rule);
+      }
+      #phase-mood .idx-folio {
+        font: 500 11px/1 var(--f-body);
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-quiet);
+        justify-self: start;
+      }
+      #phase-mood .idx-title {
+        margin: 0;
+        font: 400 clamp(48px, 6.5vw, 96px) / 0.94 var(--f-disp);
+        letter-spacing: -0.015em;
+        text-align: center;
+        color: var(--ink);
+        white-space: nowrap;
+      }
+      #phase-mood .idx-title em {
+        font-style: italic;
+        font-weight: 400;
+        color: var(--ink-quiet);
+      }
+      #phase-mood .idx-meta {
+        font: 500 11px/1 var(--f-body);
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-quiet);
+        justify-self: end;
+        white-space: nowrap;
+      }
+      #phase-mood .idx-meta .idx-sep {
+        margin: 0 0.5em;
+        color: var(--rule);
+      }
+
+      #phase-mood .idx-section {
+        padding: clamp(48px, 7vh, 96px) var(--idx-pad-x);
+      }
+      #phase-mood .idx-specimens {
+        padding-top: clamp(28px, 4vh, 48px);
+        padding-bottom: clamp(64px, 9vh, 128px);
+      }
+
+      #phase-mood .idx-section-head {
+        display: grid;
+        grid-template-columns: 3.5em 1fr;
+        column-gap: 24px;
+        align-items: baseline;
+        padding-bottom: 20px;
+        margin-bottom: clamp(28px, 4vh, 48px);
+        border-bottom: 1px solid var(--rule);
+      }
+      #phase-mood .idx-section-num {
+        font: italic 400 26px/1 var(--f-disp);
+        color: var(--accent);
+      }
+      #phase-mood .idx-section-title {
+        margin: 0;
+        font: 400 clamp(28px, 3.2vw, 40px) / 1 var(--f-disp);
+        letter-spacing: -0.005em;
+      }
+      #phase-mood .idx-section-note {
+        grid-column: 2;
+        margin: 10px 0 0;
+        font: italic 400 16px/1.55 var(--f-disp);
+        color: var(--ink-quiet);
+        max-width: 52ch;
+      }
+
+      /* ── Palette bar (sticky, compact) ── */
+      #phase-mood .idx-palette {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        padding: 14px var(--idx-pad-x);
+        background: color-mix(in oklch, var(--canvas) 92%, transparent);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        border-bottom: 1px solid var(--rule);
+        display: grid;
+        grid-template-columns: auto 1fr;
+        align-items: center;
+        column-gap: clamp(20px, 3vw, 56px);
+      }
+      #phase-mood .idx-palette .idx-section-head {
+        display: flex;
+        align-items: baseline;
+        column-gap: 12px;
+        padding: 0;
+        margin: 0;
+        border: none;
+      }
+      #phase-mood .idx-palette .idx-section-num {
+        font-size: 17px;
+      }
+      #phase-mood .idx-palette .idx-section-title {
+        font-size: clamp(20px, 2vw, 26px);
+      }
+      #phase-mood .idx-palette .idx-section-note {
+        display: none;
+      }
+      #phase-mood .idx-palette-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-wrap: nowrap;
+        gap: clamp(14px, 1.8vw, 28px);
+        overflow-x: auto;
+        scrollbar-width: thin;
+        scrollbar-color: var(--rule) transparent;
+      }
+      #phase-mood .idx-palette-list::-webkit-scrollbar {
+        height: 4px;
+      }
+      #phase-mood .idx-palette-list::-webkit-scrollbar-thumb {
+        background: var(--rule);
+      }
+      #phase-mood .idx-row {
+        flex: 0 0 auto;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        grid-template-rows: auto auto;
+        column-gap: 8px;
+        row-gap: 4px;
+        align-items: baseline;
+        padding: 4px 0;
+        border: none;
+        cursor: pointer;
+      }
+      #phase-mood .idx-row-num {
+        grid-row: 1;
+        grid-column: 1;
+        font: italic 400 13px/1 var(--f-disp);
+        color: var(--ink-faint);
+        transition: color 0.2s ease;
+      }
+      #phase-mood .idx-row:hover .idx-row-num {
+        color: var(--ink-quiet);
+      }
+      #phase-mood .idx-row.on .idx-row-num {
+        color: var(--accent);
+      }
+      #phase-mood .idx-row-name {
+        grid-row: 1;
+        grid-column: 2;
+        font: 500 12.5px/1 var(--f-body);
+        letter-spacing: -0.005em;
+        color: var(--ink-quiet);
+        white-space: nowrap;
+        transition: color 0.2s ease;
+      }
+      #phase-mood .idx-row:hover .idx-row-name {
+        color: var(--ink);
+      }
+      #phase-mood .idx-row.on .idx-row-name {
+        color: var(--ink);
+      }
+      #phase-mood .idx-row-strip {
+        grid-row: 2;
+        grid-column: 2;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        height: 16px;
+        width: 96px;
+        outline: 1px solid var(--rule);
+        outline-offset: 0;
+        transition: outline-color 0.2s ease;
+      }
+      #phase-mood .idx-row:hover .idx-row-strip {
+        outline-color: var(--ink-quiet);
+      }
+      #phase-mood .idx-row.on .idx-row-strip {
+        outline-color: var(--accent);
+      }
+      #phase-mood .idx-row-strip span {
+        display: block;
+      }
+      #phase-mood .idx-row-note {
+        display: none;
+      }
+      #phase-mood .idx-row.idx-row-default .idx-row-strip {
+        background: transparent;
+        outline: 1px dashed var(--rule);
+        position: relative;
+      }
+      #phase-mood .idx-row.idx-row-default .idx-row-strip::after {
+        content: "—";
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        font: italic 400 11px/1 var(--f-disp);
+        color: var(--ink-faint);
+      }
+      #phase-mood .idx-row.idx-row-default.on .idx-row-strip {
+        outline-color: var(--accent);
+      }
+      #phase-mood .idx-row.idx-row-default.on .idx-row-strip::after {
+        color: var(--accent);
+      }
+
+      /* ── Specimen grid ── */
+      #phase-mood .idx-grid {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        column-gap: clamp(28px, 3vw, 48px);
+        row-gap: clamp(48px, 6vh, 80px);
+      }
+      @media (max-width: 1180px) {
+        #phase-mood .idx-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      @media (max-width: 700px) {
+        #phase-mood .idx-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      #phase-mood .idx-spec {
+        display: grid;
+        grid-template-rows: auto auto auto;
+        row-gap: 14px;
+        cursor: pointer;
+      }
+      #phase-mood .idx-spec-num {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        font: italic 400 14px/1 var(--f-disp);
+        color: var(--ink-faint);
+        letter-spacing: 0.01em;
+        transition: color 0.2s ease;
+      }
+      #phase-mood .idx-spec-num .idx-spec-folio {
+        font-family: var(--f-body);
+        font-style: normal;
+        font-weight: 500;
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+      }
+      #phase-mood .idx-spec:hover .idx-spec-num {
+        color: var(--ink-quiet);
+      }
+      #phase-mood .idx-spec.on .idx-spec-num,
+      #phase-mood .idx-spec:hover .idx-spec-num .idx-spec-folio {
+        color: var(--accent);
+      }
+      #phase-mood .idx-spec-preview {
+        position: relative;
+        width: 100%;
+        aspect-ratio: 16/9;
+        background: var(--paper);
+        overflow: hidden;
+        outline: 1px solid var(--rule);
+        outline-offset: 0;
+        transition: outline-color 0.25s ease;
+      }
+      #phase-mood .idx-spec:hover .idx-spec-preview {
+        outline-color: var(--ink-quiet);
+      }
+      #phase-mood .idx-spec.on .idx-spec-preview {
+        outline-color: var(--accent);
+      }
+      #phase-mood .idx-spec-preview iframe {
+        width: 1920px;
+        height: 1080px;
+        border: none;
+        transform-origin: top left;
+        pointer-events: none;
+      }
+      #phase-mood .idx-spec-caption {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        column-gap: 16px;
+        row-gap: 4px;
+        padding-top: 10px;
+        border-top: 1px solid var(--rule-soft);
+      }
+      #phase-mood .idx-spec-name {
+        margin: 0;
+        grid-column: 1;
+        font: 500 17px/1.2 var(--f-disp);
+        letter-spacing: -0.005em;
+        color: var(--ink);
+      }
+      #phase-mood .idx-spec-meta {
+        grid-column: 2;
+        align-self: baseline;
+        font: 500 10px/1.4 var(--f-body);
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+        white-space: nowrap;
+      }
+      #phase-mood .idx-spec-tagline {
+        grid-column: 1 / -1;
+        margin: 0;
+        font: italic 400 13.5px/1.55 var(--f-disp);
+        color: var(--ink-quiet);
+        max-width: 42ch;
+      }
+
+      /* User-provided design specimen ("YOUR DESIGN") */
+      #phase-mood .idx-spec.provided .idx-spec-num::before {
+        content: "Your design";
+        font-family: var(--f-body);
+        font-style: normal;
+        font-weight: 500;
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--accent);
+      }
+      #phase-mood .idx-spec.provided .idx-spec-preview {
+        outline-color: var(--accent);
+      }
+
+      /* Legacy compatibility — keep selectors used by other JS paths */
+      #phase-mood .tp-transition-overlay {
+        position: fixed;
+        inset: 0;
+        background: var(--canvas);
+        opacity: 0;
+        pointer-events: none;
+        z-index: 200;
+        transition: opacity 0.55s cubic-bezier(0.5, 0, 0.1, 1);
+      }
+      #phase-mood .tp-transition-overlay.active {
+        opacity: 1;
+        pointer-events: all;
+      }
+      #phase-mood .idx-spec.selected-exit {
+        position: relative;
+        z-index: 201;
+        animation: tpCardLift 1.4s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+      }
+      @keyframes tpCardLift {
+        0% {
+          transform: scale(1);
+          opacity: 1;
+        }
+        50% {
+          transform: scale(1.04);
+          opacity: 1;
+        }
+        100% {
+          transform: scale(1.06);
+          opacity: 0;
+        }
+      }
     </style>
   </head>
   <body>
     <div class="phase-bar">
-      <div class="phase-tab active" id="tab-mood" onclick="showPhase('mood')">1. Direction</div>
+      <div class="phase-tab active" id="tab-mood" onclick="showPhase('mood')">1. Template</div>
       <div class="phase-tab disabled" id="tab-tune" onclick="showPhase('tune')">2. Fine-tune</div>
+      <div class="tp-nav" id="tp-nav" style="display:none">
+        <button class="tp-nav-arrow" id="tp-nav-prev" onclick="tpNavTo(-1)" title="Previous">&#8249;</button>
+        <span class="tp-nav-title" id="tp-nav-title"></span>
+        <button class="tp-nav-arrow" id="tp-nav-next" onclick="tpNavTo(1)" title="Next">&#8250;</button>
+      </div>
+      <button class="header-btn" id="fab" onclick="showOutput()">Create DESIGN.html</button>
     </div>
 
-    <!-- Phase 1: Mood boards -->
-    <div class="phase active" id="phase-mood" style="flex-direction: column">
-      <div class="mood-header">
-        <h2 id="mood-title">Pick a direction</h2>
-        <p id="mood-subtitle">
-          Each option is a complete visual identity. Pick one, then fine-tune.
-        </p>
-      </div>
-      <div class="pal-bar" id="pal-bar"><span class="pal-bar-label">Palette</span></div>
-      <div class="mood-grid" id="mood-grid"></div>
-      <div class="mood-next">
-        <button class="mood-next-btn" id="mood-next-btn" onclick="goToTune()">
-          Customize this direction →
-        </button>
-      </div>
+    <!-- Phase 1: Template picker (inline) -->
+    <div class="phase active" id="phase-mood" style="flex-direction: column; overflow-y: auto">
+      <section class="idx-section idx-palette">
+        <div class="idx-section-head">
+          <span class="idx-section-num">i.</span>
+          <h2 class="idx-section-title">Palette</h2>
+        </div>
+        <ol id="tp-pchips" class="idx-palette-list"></ol>
+      </section>
+
+      <section class="idx-section idx-specimens">
+        <ol id="tp-grid" class="idx-grid"></ol>
+      </section>
+      <div class="tp-transition-overlay" id="tp-trans-overlay"></div>
     </div>
 
     <!-- Phase 2: Fine-tune -->
     <div class="phase" id="phase-tune" style="flex-direction: row">
       <div class="panel-left">
-        <!-- Theme -->
-        <div class="section-card">
+        <!-- Background / Shader Editor -->
+        <div class="section-card" id="bg-section">
           <div class="section-header">
-            <div class="section-icon">◐</div>
-            <div class="section-title">Theme</div>
+            <div class="section-icon">◈</div>
+            <div class="section-title">Living Background</div>
           </div>
-          <div class="section-body"><div class="chips" id="theme-options"></div></div>
-        </div>
-        <!-- Structure -->
-        <div class="section-card">
-          <div class="section-header">
-            <div class="section-icon">▦</div>
-            <div class="section-title">Structure</div>
-            <div class="section-meta" id="arch-meta"></div>
+          <div class="section-body">
+            <div class="opt-grid-2" id="bg-options"></div>
+            <div id="shader-editor" style="display: none; margin-top: 10px">
+              <div
+                id="shader-editor-toggle"
+                style="
+                  font-size: 11px;
+                  color: #666;
+                  cursor: pointer;
+                  display: flex;
+                  align-items: center;
+                  gap: 6px;
+                  margin-bottom: 8px;
+                "
+                onclick="
+                  var b = document.getElementById('shader-editor-body');
+                  var a = this.querySelector('span');
+                  if (b.style.display === 'none') {
+                    b.style.display = '';
+                    a.textContent = '▾';
+                  } else {
+                    b.style.display = 'none';
+                    a.textContent = '▸';
+                  }
+                "
+              >
+                <span style="font-size: 18px; position: relative; top: -4px">▸</span>
+                <span class="cfg-shimmer">Configure</span>
+              </div>
+              <div id="shader-editor-body" style="display: none">
+                <div
+                  style="
+                    font-size: 9px;
+                    color: #444;
+                    text-transform: uppercase;
+                    letter-spacing: 0.1em;
+                    margin-bottom: 6px;
+                  "
+                >
+                  Colors
+                </div>
+                <div style="display: flex; gap: 8px; margin-bottom: 8px">
+                  <label style="flex: 1; font-size: 10px; color: #666">
+                    Color 1
+                    <input
+                      type="color"
+                      id="se-c1"
+                      value="#f7f4ef"
+                      style="
+                        width: 100%;
+                        height: 24px;
+                        border: none;
+                        background: none;
+                        cursor: pointer;
+                      "
+                    />
+                  </label>
+                  <label style="flex: 1; font-size: 10px; color: #666">
+                    Color 2
+                    <input
+                      type="color"
+                      id="se-c2"
+                      value="#2a9d8f"
+                      style="
+                        width: 100%;
+                        height: 24px;
+                        border: none;
+                        background: none;
+                        cursor: pointer;
+                      "
+                    />
+                  </label>
+                  <label style="flex: 1; font-size: 10px; color: #666">
+                    Color 3
+                    <input
+                      type="color"
+                      id="se-c3"
+                      value="#7a8b8d"
+                      style="
+                        width: 100%;
+                        height: 24px;
+                        border: none;
+                        background: none;
+                        cursor: pointer;
+                      "
+                    />
+                  </label>
+                </div>
+                <label
+                  style="
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    cursor: pointer;
+                    font-size: 10px;
+                    color: #666;
+                    margin-bottom: 8px;
+                  "
+                >
+                  <input type="checkbox" id="se-use-palette" checked style="accent-color: #fff" />
+                  Use palette colors
+                </label>
+                <div
+                  style="
+                    font-size: 9px;
+                    color: #444;
+                    text-transform: uppercase;
+                    letter-spacing: 0.1em;
+                    margin: 10px 0 6px;
+                    border-top: 1px solid #222;
+                    padding-top: 8px;
+                  "
+                >
+                  Grain
+                </div>
+                <label
+                  style="
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    cursor: pointer;
+                    font-size: 10px;
+                    color: #666;
+                    margin-bottom: 8px;
+                  "
+                >
+                  <input type="checkbox" id="se-grain" checked style="accent-color: #fff" /> Enable
+                </label>
+                <div id="se-grain-controls"></div>
+                <div id="se-controls"></div>
+              </div>
+            </div>
           </div>
-          <div class="section-body" id="arch-options"></div>
         </div>
         <!-- Palette -->
         <div class="section-card">
@@ -686,7 +1764,7 @@
             <div class="section-icon">◉</div>
             <div class="section-title">Color</div>
           </div>
-          <div class="section-body" id="pal-options"></div>
+          <div class="section-body"><div class="opt-grid-2" id="pal-options"></div></div>
         </div>
         <!-- Typography -->
         <div class="section-card">
@@ -707,7 +1785,7 @@
         <!-- Density -->
         <div class="section-card">
           <div class="section-header">
-            <div class="section-icon">≡</div>
+            <div class="section-icon">▦</div>
             <div class="section-title">Density</div>
           </div>
           <div class="section-body"><div class="chips" id="density-options"></div></div>
@@ -732,17 +1810,62 @@
       </div>
       <div class="panel-right" id="preview">
         <div class="preview-empty">Pick a structure to preview</div>
+        <iframe
+          id="design-iframe"
+          sandbox="allow-scripts allow-same-origin"
+          style="display: none; border: none; width: 100%; height: 100%"
+        ></iframe>
+        <div class="showcase" id="showcase" style="display: none">
+          <div class="showcase-section" id="sc-overview">
+            <h2 class="showcase-heading" id="sc-overview-title"></h2>
+            <p class="showcase-lead" id="sc-overview-lead"></p>
+          </div>
+
+          <!-- Template hero: first slide, large -->
+          <div class="showcase-section" id="sc-scenes">
+            <div class="scene-grid" id="sc-scene-grid"></div>
+          </div>
+
+          <!-- Slide specimens: remaining slides from the template, rendered small -->
+          <div class="showcase-section" id="sc-specimens">
+            <div class="showcase-eyebrow">/ Slides</div>
+            <div class="specimen-grid" id="sc-specimen-grid"></div>
+          </div>
+
+          <!-- Palette swatches -->
+          <div class="showcase-section" id="sc-palette">
+            <div class="showcase-eyebrow">/ Palette</div>
+            <div class="swatch-grid" id="sc-swatches"></div>
+          </div>
+
+          <!-- Type specimens -->
+          <div class="showcase-section" id="sc-type">
+            <div class="showcase-eyebrow">/ Typography</div>
+            <div id="sc-type-specimens"></div>
+          </div>
+
+          <!-- Hidden containers for renderPreview compatibility -->
+          <div style="display: none">
+            <p id="sc-palette-lead"></p>
+            <p id="sc-type-lead"></p>
+            <p id="sc-elevation-lead"></p>
+            <p id="sc-motion-lead"></p>
+            <div id="sc-ease-preview"></div>
+            <div id="sc-radius-grid"></div>
+            <div id="sc-elevation-grid"></div>
+          </div>
+        </div>
       </div>
     </div>
-
-    <button class="fab" id="fab" onclick="showOutput()">Create design.md</button>
 
     <div class="md-overlay" id="md-overlay">
       <div class="md-card">
         <div class="md-header">
           <div class="md-title">
-            design.md
-            <span style="font-size: 11px; font-weight: 400; color: #555">— edit, then copy</span>
+            DESIGN.html
+            <span style="font-size: 11px; font-weight: 400; color: #555"
+              >— copy and paste back to your agent</span
+            >
           </div>
           <div class="md-actions">
             <button class="copy-btn" id="copy-btn">Copy</button>
@@ -763,9 +1886,57 @@
     <script>
       var ARCHITECTURES = __ARCHITECTURES_JSON__;
       var PALETTES = __PALETTES_JSON__;
+      PALETTES.push({
+        name: "Custom",
+        primary: "#FFFFFF",
+        secondary: "#1A1A2E",
+        tertiary: "#7B6F9E",
+        accent: "#E94560",
+        _custom: true,
+      });
       var TYPEPAIRS = __TYPEPAIRS_JSON__;
       var MOODBOARDS = __MOODBOARDS_JSON__;
       var PROMPT = __PROMPT_JSON__;
+      var ALL_TEMPLATES = __TEMPLATES_JSON__;
+      // Authored native palettes per template — used by both renderDesignIframe (fine-tune)
+      // and tpBuildGrid (templates index hero previews). Lives on window for cross-scope access.
+      window.NATIVE_PALETTES = window.NATIVE_PALETTES || {
+        "8-bit-orbit": ["#F3F2EA", "#0A1429", "#4ADDE5", "#FF52A2"],
+        "biennale-yellow": ["#F3ECDA", "#1B2960", "#C9572A", "#F4E36A"],
+        "block-frame": ["#FFDC8B", "#000000", "#FFFFFF", "#FE90E8"],
+        "blue-professional": ["#F1ECDF", "#11151B", "#444C5A", "#2C5BFF"],
+        "bold-poster": ["#F4ECDB", "#161210", "#6E5B45", "#E53935"],
+        broadside: ["#f0ece5", "#111111", "#282826", "#e85d26"],
+        capsule: ["#F0E9D9", "#1A1A1A", "#C7E1D4", "#F2B5B5"],
+        cartesian: ["#F1EBDC", "#2A241D", "#B89F7F", "#806D52"],
+        "cobalt-grid": ["#F5F4F0", "#0E1116", "#5C6A82", "#1E40FF"],
+        coral: ["#F3E9D2", "#14110E", "#5C4C39", "#F2674E"],
+        "creative-mode": ["#F2EBDD", "#131313", "#7D6F58", "#E26A47"],
+        "daisy-days": ["#FCF1D8", "#2A2624", "#BBD0A4", "#F4B5C9"],
+        "editorial-forest": ["#EDE6D2", "#1B2D24", "#7A8F7E", "#C97E48"],
+        "editorial-tri-tone": ["#F3E1D6", "#5B1A1F", "#D9B86F", "#2B1112"],
+        "emerald-editorial": ["#F8F2E3", "#0D2B23", "#3C7864", "#D4B26A"],
+        grove: ["#F2E9D3", "#1C342B", "#5F8772", "#BD6034"],
+        "long-table": ["#F4ECDA", "#2A2018", "#9C8266", "#B04E2A"],
+        mat: ["#EAE0CC", "#2A3530", "#66796E", "#CB6730"],
+        monochrome: ["#F8F4EA", "#111111", "#5A5752", "#111111"],
+        "neo-grid-bold": ["#F4F1EA", "#1A1A1A", "#6E6E6E", "#E5FF3F"],
+        "peoples-platform": ["#F1ECDF", "#111111", "#112D54", "#E15A2E"],
+        "pin-and-paper": ["#F2DD8A", "#14213B", "#B0903A", "#2E4D8C"],
+        "pink-script": ["#F4ECE0", "#0A0A0A", "#4A4744", "#FF3F8D"],
+        playful: ["#FCE2C2", "#2A1E15", "#B89070", "#F08660"],
+        "raw-grid": ["#EFE5D9", "#1F1B17", "#B8C9A8", "#ECC2D2"],
+        "retro-windows": ["#FFFFFF", "#000000", "#C0C0C0", "#000080"],
+        "retro-zine": ["#ECE3CB", "#1A1815", "#C2A85B", "#3B6E48"],
+        "sakura-chroma": ["#EFE6D3", "#1C1612", "#2880A3", "#E25C58"],
+        scatterbrain: ["#F4EFE2", "#1F1B16", "#B0A693", "#FF8A4C"],
+        signal: ["#EBE2C9", "#14202F", "#6E7780", "#BD9E54"],
+        "soft-editorial": ["#F3EFE3", "#2A2A28", "#9BAA8F", "#D9A6A6"],
+        "stencil-tablet": ["#EAE3D2", "#2B2723", "#8E6E48", "#B85D3A"],
+        studio: ["#FAFAF7", "#050505", "#ABABAB", "#f5d200"],
+        vellum: ["#FCFAF1", "#0F1A2E", "#6D9CA1", "#F4E2A4"],
+      };
+      var PROMPT_TEXT = __PROMPT_TEXT_JSON__;
       var picks = {
         theme: null,
         arch: null,
@@ -775,6 +1946,7 @@
         density: null,
         depth: null,
         easing: null,
+        bg_mode: null,
       };
 
       var EASINGS = [
@@ -797,14 +1969,14 @@
         { name: "Rounded", value: "12px" },
       ];
       var DENSITIES = [
-        { name: "Tight", padding: "8-12px", gap: "8-12px", desc: "Compact" },
-        { name: "Normal", padding: "16-24px", gap: "16-20px", desc: "Balanced" },
-        { name: "Generous", padding: "32-48px", gap: "28-40px", desc: "Spacious" },
+        { name: "Tight", padding: "10px", gap: "10px", desc: "Compact", label: "8–12px" },
+        { name: "Normal", padding: "20px", gap: "16px", desc: "Balanced", label: "16–24px" },
+        { name: "Generous", padding: "40px", gap: "32px", desc: "Spacious", label: "32–48px" },
       ];
       var DEPTHS = [
-        { name: "Flat", desc: "No shadows" },
-        { name: "Subtle", desc: "Faint shadows" },
-        { name: "Layered", desc: "Glows + depth" },
+        { name: "Flat", desc: "No shadows", css: "none" },
+        { name: "Subtle", desc: "Faint shadows", css: "0 2px 8px rgba(0,0,0,0.06)" },
+        { name: "Layered", desc: "Glows + depth", css: "0 8px 24px rgba(0,0,0,0.12)" },
       ];
 
       // Load fonts
@@ -832,26 +2004,30 @@
       }
 
       // Prompt-aware UI
-      if (PROMPT && PROMPT.title)
-        document.getElementById("mood-title").textContent = "Pick a direction for: " + PROMPT.title;
+      if (PROMPT && PROMPT.title) {
+        var _mt = document.getElementById("mood-title");
+        if (_mt) _mt.textContent = "Pick a direction for: " + PROMPT.title;
+      }
 
       // ── Phase 1: Mood boards + Palette bar ──
-      var moodGrid = document.getElementById("mood-grid");
+      var moodGrid = document.getElementById("mood-grid") || document.createElement("div");
       var selectedMood = null;
       var overridePalette = null;
 
       // Build palette bar
-      var palBar = document.getElementById("pal-bar");
+      var palBar = document.getElementById("pal-bar") || document.createElement("div");
       PALETTES.forEach(function (p, i) {
         var chip = document.createElement("div");
-        chip.className = "pal-bar-chip" + (i === 0 ? "" : "");
+        chip.className = "pal-bar-chip";
         chip.innerHTML =
           '<div class="pal-bar-chip-swatches"><div class="pal-bar-chip-swatch" style="background:' +
-          p.background +
+          p.primary +
           ';border:1px solid rgba(255,255,255,0.08);"></div><div class="pal-bar-chip-swatch" style="background:' +
-          p.accent +
+          p.secondary +
           ';"></div><div class="pal-bar-chip-swatch" style="background:' +
-          p.foreground +
+          p.tertiary +
+          ';"></div><div class="pal-bar-chip-swatch" style="background:' +
+          p.accent +
           ';border:1px solid rgba(255,255,255,0.08);"></div></div><span class="pal-bar-chip-name">' +
           p.name +
           "</span>";
@@ -912,40 +2088,93 @@
             "{{prompt_headline}}": (PROMPT && PROMPT.headline) || "Your Headline",
             "{{prompt_sub}}": (PROMPT && PROMPT.subline) || "A subline for your product.",
           };
-          var preview = arch.preview_html || "";
-          Object.keys(tokens).forEach(function (k) {
-            preview = preview.split(k).join(tokens[k]);
-          });
-          var tagHtml = [tp.headline.family, pal.name, CORNERS[mb.corners_index || 1].name]
-            .map(function (t) {
-              return '<span class="mood-token">' + t + "</span>";
+          var frames = arch.preview_frames || [arch.preview_html || ""];
+          var framesHtml = frames
+            .map(function (f, fi) {
+              var resolved = f || "";
+              Object.keys(tokens).forEach(function (k) {
+                resolved = resolved.split(k).join(tokens[k]);
+              });
+              return (
+                '<div class="mood-frame' + (fi === 0 ? " active" : "") + '">' + resolved + "</div>"
+              );
             })
             .join("");
+          var dotsHtml =
+            frames.length > 1
+              ? '<div class="mood-dots">' +
+                frames
+                  .map(function (_, di) {
+                    return '<div class="mood-dot' + (di === 0 ? " active" : "") + '"></div>';
+                  })
+                  .join("") +
+                "</div>"
+              : "";
+          var arrowsHtml =
+            frames.length > 1
+              ? '<div class="mood-arrow left">‹</div><div class="mood-arrow right">›</div>'
+              : "";
           card.innerHTML =
-            '<div class="mood-preview"><div style="transform:scale(0.38);transform-origin:top left;width:263.16%;min-height:263.16%;">' +
-            preview +
-            '</div></div><div class="mood-info"><div class="mood-name">' +
-            mb.name +
-            '</div><div class="mood-desc">' +
-            mb.description +
-            '</div><div class="mood-tokens">' +
-            tagHtml +
-            "</div></div>";
+            '<div class="mood-preview" style="background:' +
+            bg +
+            ';">' +
+            framesHtml +
+            arrowsHtml +
+            dotsHtml +
+            "</div>";
+
+          if (frames.length > 1) {
+            (function (cardEl, count) {
+              var idx = 0;
+              var prev = cardEl.querySelector(".mood-preview");
+              function show(n) {
+                idx = (n + count) % count;
+                prev.querySelectorAll(".mood-frame").forEach(function (f, fi) {
+                  f.classList.toggle("active", fi === idx);
+                });
+                prev.querySelectorAll(".mood-dot").forEach(function (d, di) {
+                  d.classList.toggle("active", di === idx);
+                });
+              }
+              prev.querySelector(".mood-arrow.left").onclick = function (e) {
+                e.stopPropagation();
+                show(idx - 1);
+              };
+              prev.querySelector(".mood-arrow.right").onclick = function (e) {
+                e.stopPropagation();
+                show(idx + 1);
+              };
+            })(card, frames.length);
+          }
           card.onclick = function () {
             moodGrid.querySelectorAll(".mood-card").forEach(function (c) {
               c.classList.remove("selected");
             });
             card.classList.add("selected");
             selectedMood = i;
-            document.getElementById("mood-next-btn").classList.add("visible");
+            var _mnb = document.getElementById("mood-next-btn");
+            if (_mnb) _mnb.classList.add("visible");
           };
           moodGrid.appendChild(card);
         });
+        scaleMoodPreviews();
       }
       renderMoodBoards();
+      function scaleMoodPreviews() {
+        document.querySelectorAll(".mood-preview").forEach(function (p) {
+          var s = p.offsetWidth / 1920;
+          p.querySelectorAll(".mood-frame").forEach(function (f) {
+            f.style.transform = "scale(" + s + ")";
+          });
+        });
+      }
+      window.addEventListener("resize", scaleMoodPreviews);
+
+      // ── Removed: procedural canvas backgrounds ──
 
       var currentPhase = "mood";
       function showPhase(name) {
+        if (name === "tune" && !window._currentTemplateSlug) return;
         currentPhase = name;
         document.querySelectorAll(".phase").forEach(function (p) {
           p.classList.remove("active");
@@ -955,19 +2184,27 @@
         });
         document.getElementById("phase-" + name).classList.add("active");
         document.getElementById("tab-" + name).classList.add("active");
-        if (name === "mood") document.getElementById("fab").classList.remove("visible");
-        else checkReady();
+        var nav = document.getElementById("tp-nav");
+        if (nav) nav.style.display = (name === "tune" && window._currentTemplateSlug) ? "flex" : "none";
+        if (name === "mood") {
+          document.getElementById("fab").classList.remove("visible");
+          document.getElementById("tab-tune").classList.add("disabled");
+          var dif = document.getElementById("design-iframe");
+          if (dif) dif.style.display = "none";
+        } else {
+          checkReady();
+          if (typeof window._redrawBezier === "function") window._redrawBezier();
+        }
       }
 
       function goToTune() {
         if (selectedMood === null) return;
-        var mb = MOODBOARDS[selectedMood];
+        var mb = MOODBOARDS[selectedMood] || {};
         var thIdx = THEMES.findIndex(function (t) {
           return t.id === (mb.theme || "dark");
         });
-        if (thIdx >= 0) chipSel("theme", thIdx, document.getElementById("theme-options"));
-        if (mb.arch_index != null)
-          sel("arch", mb.arch_index, document.getElementById("arch-options"));
+        if (thIdx >= 0) picks.theme = thIdx;
+        picks.arch = mb.arch_index || 0;
         var palIdx = overridePalette !== null ? overridePalette : mb.palette_index;
         if (palIdx != null) sel("palette", palIdx, document.getElementById("pal-options"));
         if (mb.type_index != null)
@@ -978,6 +2215,21 @@
           chipSel("density", mb.density_index, document.getElementById("density-options"));
         if (mb.depth_index != null)
           chipSel("depth", mb.depth_index, document.getElementById("depth-options"));
+        // Pre-fill background from architecture
+        var arch = ARCHITECTURES[mb.arch_index || 0];
+        var bgIdx = 0;
+        if (arch.bg_preset) {
+          for (var si = 0; si < BG_PRESETS.length; si++) {
+            if (BG_PRESETS[si].name === arch.bg_preset) {
+              bgIdx = si;
+              break;
+            }
+          }
+        }
+        sel("bg_mode", bgIdx, document.getElementById("bg-options"));
+        shaderEditor.style.display = bgIdx > 0 ? "block" : "none";
+        renderBgControls(bgIdx > 0 ? BG_PRESETS[bgIdx] : null);
+
         var eIdx = mb.easing_index != null ? mb.easing_index : 0;
         var eOpts = document.getElementById("ease-options");
         eOpts.querySelectorAll(".ease-opt").forEach(function (c) {
@@ -987,112 +2239,251 @@
         picks.easing = eIdx;
         document.getElementById("tab-tune").classList.remove("disabled");
         showPhase("tune");
+        renderPreview();
       }
 
       // ── Phase 2: Build options ──
 
-      // Architecture cards
-      var archOpts = document.getElementById("arch-options");
-      ARCHITECTURES.forEach(function (a, i) {
-        var el = document.createElement("div");
-        el.className = "opt";
-        el.innerHTML =
-          '<div class="opt-inner"><div class="opt-name">' +
-          a.name +
-          '</div><div class="opt-desc">' +
-          a.description +
-          '</div><div class="opt-tag">' +
-          a.tag +
-          "</div></div>";
-        el.onclick = function () {
-          sel("arch", i, archOpts);
-        };
-        archOpts.appendChild(el);
-      });
-
-      // Palette cards with ramp
       var palOpts = document.getElementById("pal-options");
-      PALETTES.forEach(function (p, i) {
-        var el = document.createElement("div");
-        el.className = "opt";
-        el.innerHTML =
-          '<div class="opt-inner"><div class="pal-strip"><div style="background:' +
-          p.background +
-          ';"></div><div style="background:' +
-          (p.muted || p.mid || "#888") +
-          ';"></div><div style="background:' +
-          p.accent +
-          ';"></div><div style="background:' +
-          p.foreground +
-          ';"></div></div><div class="opt-name">' +
-          p.name +
-          '</div><div class="opt-desc">' +
-          p.description +
-          "</div></div>";
-        el.onclick = function () {
-          sel("palette", i, palOpts);
-        };
-        palOpts.appendChild(el);
-      });
+      var customPalIdx = -1;
+      function buildPalOpts() {
+        var prevSelected = picks.palette;
+        palOpts.innerHTML = "";
+        PALETTES.forEach(function (p, i) {
+          var el = document.createElement("div");
+          el.className = "opt" + (i === prevSelected ? " selected" : "");
+          if (p._custom) {
+            customPalIdx = i;
+            el.innerHTML =
+              '<div class="opt-inner">' +
+              '<div class="pal-strip">' +
+              '<div style="background:' +
+              p.primary +
+              ';"></div>' +
+              '<div style="background:' +
+              p.secondary +
+              ';"></div>' +
+              '<div style="background:' +
+              p.tertiary +
+              ';"></div>' +
+              '<div style="background:' +
+              p.accent +
+              ';"></div>' +
+              "</div>" +
+              '<div class="opt-name">Custom</div>' +
+              '<div style="display:flex;gap:6px;margin-top:6px;">' +
+              '<label style="flex:1;font-size:9px;color:#666;text-align:center;">Primary<input type="color" value="' +
+              p.primary +
+              '" data-role="primary" style="width:100%;height:20px;border:none;background:none;cursor:pointer;padding:0;"></label>' +
+              '<label style="flex:1;font-size:9px;color:#666;text-align:center;">Secondary<input type="color" value="' +
+              p.secondary +
+              '" data-role="secondary" style="width:100%;height:20px;border:none;background:none;cursor:pointer;padding:0;"></label>' +
+              '<label style="flex:1;font-size:9px;color:#666;text-align:center;">Tertiary<input type="color" value="' +
+              p.tertiary +
+              '" data-role="tertiary" style="width:100%;height:20px;border:none;background:none;cursor:pointer;padding:0;"></label>' +
+              '<label style="flex:1;font-size:9px;color:#666;text-align:center;">Accent<input type="color" value="' +
+              p.accent +
+              '" data-role="accent" style="width:100%;height:20px;border:none;background:none;cursor:pointer;padding:0;"></label>' +
+              "</div></div>";
+            el.onclick = function (e) {
+              if (e.target.tagName === "INPUT") return;
+              sel("palette", i, palOpts);
+            };
+            el.querySelectorAll ||
+              setTimeout(function () {
+                el.querySelectorAll("input[type=color]").forEach(function (inp) {
+                  inp.addEventListener("input", function () {
+                    PALETTES[i][inp.dataset.role] = inp.value;
+                    var strip = el.querySelector(".pal-strip");
+                    if (strip)
+                      strip.children[
+                        { primary: 0, secondary: 1, tertiary: 2, accent: 3 }[inp.dataset.role]
+                      ].style.background = inp.value;
+                    if (picks.palette === i) renderPreview();
+                  });
+                  inp.addEventListener("click", function (e) {
+                    e.stopPropagation();
+                    if (picks.palette !== i) sel("palette", i, palOpts);
+                  });
+                });
+              }, 0);
+          } else {
+            el.innerHTML =
+              '<div class="opt-inner"><div class="pal-strip"><div style="background:' +
+              p.primary +
+              ';"></div><div style="background:' +
+              p.secondary +
+              ';"></div><div style="background:' +
+              p.tertiary +
+              ';"></div><div style="background:' +
+              p.accent +
+              ';"></div></div><div class="opt-name">' +
+              p.name +
+              '</div><div class="opt-desc">' +
+              (p.desc || "") +
+              "</div></div>";
+            el.onclick = function () {
+              sel("palette", i, palOpts);
+            };
+          }
+          palOpts.appendChild(el);
+        });
+        // Wire up custom palette color inputs after DOM insertion
+        if (customPalIdx >= 0) {
+          var customEl = palOpts.children[customPalIdx];
+          if (customEl) {
+            customEl.querySelectorAll("input[type=color]").forEach(function (inp) {
+              inp.addEventListener("input", function () {
+                PALETTES[customPalIdx][inp.dataset.role] = inp.value;
+                var strip = customEl.querySelector(".pal-strip");
+                if (strip) {
+                  var idx = { primary: 0, secondary: 1, tertiary: 2, accent: 3 }[inp.dataset.role];
+                  strip.children[idx].style.background = inp.value;
+                }
+                if (picks.palette === customPalIdx) renderPreview();
+              });
+              inp.addEventListener("click", function (e) {
+                e.stopPropagation();
+                if (picks.palette !== customPalIdx) sel("palette", customPalIdx, palOpts);
+              });
+            });
+          }
+        }
+      }
+      buildPalOpts();
+
+      function updateDefaultPaletteFromIframe(ifr) {
+        // Skip if NATIVE_PALETTES already set the correct values
+        if (PALETTES[0]._native) return;
+        if (!ifr || !ifr.contentWindow) return;
+        var cs = ifr.contentWindow.getComputedStyle(ifr.contentDocument.documentElement);
+        var primary = cs.getPropertyValue("--tp-primary").trim();
+        var secondary = cs.getPropertyValue("--tp-secondary").trim();
+        var tertiary = cs.getPropertyValue("--tp-tertiary").trim();
+        var accent = cs.getPropertyValue("--tp-accent").trim();
+        if (primary && secondary) {
+          PALETTES[0].primary = primary;
+          PALETTES[0].secondary = secondary;
+          PALETTES[0].tertiary = tertiary || "#555";
+          PALETTES[0].accent = accent || "#888";
+          PALETTES[0].name = "Template Default";
+          buildPalOpts();
+        }
+      }
 
       // Typography cards with specimen
       var typeOpts = document.getElementById("type-options");
-      TYPEPAIRS.forEach(function (tp, i) {
-        var letters = "AaBbCcDdEeFfGgHh";
-        var el = document.createElement("div");
-        el.className = "opt";
-        el.innerHTML =
-          '<div class="type-specimen"><div class="type-headline" style="font-family:\'' +
-          tp.headline.family +
-          "',sans-serif;font-weight:" +
-          tp.headline.weight +
-          ';font-size:24px;">' +
-          tp.preview +
-          '</div><div class="type-body" style="font-family:\'' +
-          tp.body.family +
-          "',monospace;font-weight:" +
-          tp.body.weight +
-          ';">' +
-          tp.body_preview +
-          '</div></div><div class="type-meta"><div class="type-families">' +
-          tp.headline.family +
-          " " +
-          tp.headline.weight +
-          " · " +
-          tp.body.family +
-          " " +
-          tp.body.weight +
-          '</div><div class="type-letters" style="font-family:\'' +
-          tp.headline.family +
-          "',sans-serif;font-weight:" +
-          tp.headline.weight +
-          ';">' +
-          letters +
-          "</div></div>";
-        el.onclick = function () {
-          sel("type", i, typeOpts);
-        };
-        typeOpts.appendChild(el);
-      });
+      function buildTypeOpts() {
+        var prevSelected = picks.type;
+        typeOpts.innerHTML = "";
+        TYPEPAIRS.forEach(function (tp, i) {
+          var letters = "AaBbCcDdEeFfGgHh";
+          var el = document.createElement("div");
+          el.className = "opt" + (i === prevSelected ? " selected" : "");
+          el.innerHTML =
+            '<div class="type-specimen"><div class="type-headline" style="font-family:\'' +
+            tp.headline.family +
+            "',sans-serif;font-weight:" +
+            tp.headline.weight +
+            ';font-size:24px;">' +
+            tp.preview +
+            '</div><div class="type-body" style="font-family:\'' +
+            tp.body.family +
+            "',monospace;font-weight:" +
+            tp.body.weight +
+            ';">' +
+            tp.body_preview +
+            '</div></div><div class="type-meta"><div class="type-families">' +
+            tp.headline.family +
+            " " +
+            tp.headline.weight +
+            " · " +
+            tp.body.family +
+            " " +
+            tp.body.weight +
+            '</div><div class="type-letters" style="font-family:\'' +
+            tp.headline.family +
+            "',sans-serif;font-weight:" +
+            tp.headline.weight +
+            ';">' +
+            letters +
+            "</div></div>";
+          el.onclick = function () {
+            sel("type", i, typeOpts);
+          };
+          typeOpts.appendChild(el);
+        });
+      }
+      buildTypeOpts();
 
-      // Theme chips
-      var themeOpts = document.getElementById("theme-options");
-      THEMES.forEach(function (th, i) {
-        var el = document.createElement("div");
-        el.className = "chip theme-chip";
-        el.innerHTML =
-          '<div class="theme-swatch" style="background:' +
-          th.bg +
-          ';"></div><div class="chip-label">' +
-          th.name +
-          '</div><div class="chip-sub">' +
-          th.desc +
-          "</div>";
-        el.onclick = function () {
-          chipSel("theme", i, themeOpts);
-        };
-        themeOpts.appendChild(el);
-      });
+      function updateDefaultTypeFromIframe(ifr) {
+        if (PALETTES[0]._native) return; // Skip if NATIVE_FONTS already set
+        if (!ifr || !ifr.contentDocument) return;
+        var doc = ifr.contentDocument;
+        // Extract fonts from Google Fonts link in the template
+        var fonts = [];
+        doc.querySelectorAll('link[href*="fonts.googleapis.com"]').forEach(function (link) {
+          var matches = link.href.match(/family=([^&]+)/g);
+          if (matches)
+            matches.forEach(function (m) {
+              var parts = m.replace("family=", "").split(":");
+              var family = decodeURIComponent(parts[0]).replace(/\+/g, " ");
+              var weight = 400;
+              if (parts[1]) {
+                var wMatch = parts[1].match(/(\d{3,4})/);
+                if (wMatch) weight = parseInt(wMatch[1]);
+              }
+              fonts.push({ family: family, weight: weight });
+            });
+        });
+        // Also check inline @font-face or font-family in stylesheets
+        if (fonts.length === 0) {
+          doc.querySelectorAll("style").forEach(function (st) {
+            var ff = st.textContent.match(/font-family:\s*['"]([^'"]+)['"]/g);
+            if (ff)
+              ff.forEach(function (m) {
+                var name = m.match(/font-family:\s*['"]([^'"]+)['"]/)[1];
+                if (
+                  name &&
+                  fonts.findIndex(function (f) {
+                    return f.family === name;
+                  }) === -1
+                ) {
+                  fonts.push({ family: name, weight: 400 });
+                }
+              });
+          });
+        }
+        if (fonts.length >= 1) {
+          var hFont = fonts[0];
+          var bFont =
+            fonts.length >= 2
+              ? fonts[1]
+              : { family: hFont.family, weight: Math.min(hFont.weight, 400) };
+          TYPEPAIRS[0] = {
+            name: "Template Default",
+            headline: { family: hFont.family, weight: hFont.weight },
+            body: { family: bFont.family, weight: bFont.weight },
+            preview: (PROMPT && PROMPT.headline) || "TITLE",
+            body_preview: "Template typography.",
+            desc: "Original fonts",
+          };
+          var link = document.createElement("link");
+          link.rel = "stylesheet";
+          link.href =
+            "https://fonts.googleapis.com/css2?family=" +
+            hFont.family.replace(/ /g, "+") +
+            ":wght@" +
+            hFont.weight +
+            "&family=" +
+            bFont.family.replace(/ /g, "+") +
+            ":wght@" +
+            bFont.weight +
+            "&display=swap";
+          document.head.appendChild(link);
+          buildTypeOpts();
+        }
+      }
 
       // Corner chips
       var cornerOpts = document.getElementById("corner-options");
@@ -1109,6 +2500,7 @@
           "</div></div>";
         el.onclick = function () {
           chipSel("corners", i, cornerOpts);
+          tpScrollToSurface();
         };
         cornerOpts.appendChild(el);
       });
@@ -1129,6 +2521,7 @@
           "</div></div>";
         el.onclick = function () {
           chipSel("density", i, densityOpts);
+          tpScrollToSurface();
         };
         densityOpts.appendChild(el);
       });
@@ -1153,6 +2546,7 @@
           "</div></div>";
         el.onclick = function () {
           chipSel("depth", i, depthOpts);
+          tpScrollToSurface();
         };
         depthOpts.appendChild(el);
       });
@@ -1173,12 +2567,29 @@
           e.value +
           "</div></div>";
         el.onclick = function () {
-          easeOpts.querySelectorAll(".ease-opt").forEach(function (c) {
+          easeOpts.querySelectorAll(".ease-opt, .bezier-editor").forEach(function (c) {
             c.classList.remove("selected");
           });
           el.classList.add("selected");
           picks.easing = i;
           checkReady();
+          // Force hero re-animation on next render
+          window._lastEaseKey = null;
+          window._lastHeroEasing = null;
+          renderPreview();
+          // Snap preview iframe to top so the hero entrance animation is visible
+          setTimeout(function () {
+            var dif = document.getElementById("design-iframe");
+            if (dif && dif.contentWindow) {
+              try { dif.contentWindow.scrollTo(0, 0); } catch (_) {}
+            }
+          }, 60);
+          setTimeout(function () {
+            var dif = document.getElementById("design-iframe");
+            if (dif && dif.contentWindow) {
+              try { dif.contentWindow.scrollTo(0, 0); } catch (_) {}
+            }
+          }, 320);
         };
         easeOpts.appendChild(el);
         // Animate the dot with GSAP
@@ -1192,8 +2603,892 @@
         });
       });
 
-      function chipSel(key, idx, container) {
-        container.querySelectorAll(".chip").forEach(function (c) {
+      // ── Custom Ease Editor (GSAP CustomEase, multi-waypoint) ──
+      (function () {
+        var customIdx = EASINGS.length;
+        var initPath = "M0,0 C0.228,-0.019 0.172,0.504 0.312,0.711 C0.46,0.928 0.614,0.996 1,1";
+        EASINGS.push({
+          name: "Custom",
+          value: initPath,
+          desc: "Click curve to add points, drag to shape",
+        });
+        if (typeof CustomEase !== "undefined") {
+          gsap.registerPlugin(CustomEase);
+          CustomEase.create("_pickerCustom", initPath);
+        }
+
+        // Anchors: [{x,y,ox,oy,ix,iy}] — ox/oy = outgoing handle, ix/iy = incoming handle (absolute coords, 0-1 normalized, y=0 is bottom)
+        var anchors = [
+          { x: 0, y: 0, ox: 0.228, oy: -0.019, ix: 0, iy: 0 },
+          { x: 0.312, y: 0.711, ox: 0.46, oy: 0.928, ix: 0.172, iy: 0.504 },
+          { x: 1, y: 1, ox: 1, oy: 1, ix: 0.614, iy: 0.996 },
+        ];
+        var selectedAnchor = -1;
+
+        var wrap = document.createElement("div");
+        wrap.className = "bezier-editor";
+        wrap.innerHTML =
+          '<div class="bezier-header"><div class="ease-name">Custom</div><div class="ease-value" id="bezier-value" style="font-size:8px;word-break:break-all;max-height:28px;overflow:hidden;margin-left:8px;">' +
+          initPath +
+          "</div></div>" +
+          '<div class="bezier-canvas-wrap" id="bezier-wrap"><canvas id="bezier-canvas"></canvas></div>' +
+          '<div class="bezier-hint">Click curve to add point · Select + Delete to remove · Drag handles to shape</div>' +
+          '<div class="bezier-track"><div class="bezier-dot" id="bezier-dot"></div></div>';
+
+        wrap.addEventListener("click", function (e) {
+          if (
+            e.target.closest(".bezier-canvas-wrap") ||
+            e.target.closest(".bezier-anchor") ||
+            e.target.closest(".bezier-handle")
+          )
+            return;
+          selectCustom();
+        });
+        easeOpts.appendChild(wrap);
+
+        var canvas = document.getElementById("bezier-canvas");
+        var bwrap = document.getElementById("bezier-wrap");
+        var valEl = document.getElementById("bezier-value");
+        var dotEl = document.getElementById("bezier-dot");
+        var handles = []; // DOM elements for handles/anchors
+
+        function selectCustom() {
+          easeOpts.querySelectorAll(".ease-opt").forEach(function (c) {
+            c.classList.remove("selected");
+          });
+          wrap.classList.add("selected");
+          picks.easing = customIdx;
+          checkReady();
+          renderPreview();
+          // Redraw after the canvas becomes visible (display:none → block)
+          if (typeof window._redrawBezier === "function") window._redrawBezier();
+        }
+
+        // Convert anchors to SVG path (CustomEase: y=0 is start, y=1 is end — same as our internal coords)
+        function toPath() {
+          var d = "M0,0";
+          for (var i = 0; i < anchors.length - 1; i++) {
+            var a = anchors[i],
+              b = anchors[i + 1];
+            d +=
+              " C" +
+              n(a.ox) +
+              "," +
+              n(a.oy) +
+              " " +
+              n(b.ix) +
+              "," +
+              n(b.iy) +
+              " " +
+              n(b.x) +
+              "," +
+              n(b.y);
+          }
+          return d;
+        }
+        function n(v) {
+          return parseFloat(v.toFixed(3));
+        }
+
+        // De Casteljau split
+        function splitBezier(p0, cp1, cp2, p1, t) {
+          var u = 1 - t;
+          var q0 = lerp(p0, cp1, t),
+            q1 = lerp(cp1, cp2, t),
+            q2 = lerp(cp2, p1, t);
+          var r0 = lerp(q0, q1, t),
+            r1 = lerp(q1, q2, t);
+          var s = lerp(r0, r1, t);
+          return { left: { cp1: q0, cp2: r0, end: s }, right: { cp1: r1, cp2: q2, end: p1 } };
+        }
+        function lerp(a, b, t) {
+          return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+        }
+
+        // Find closest point on curve to click
+        function closestOnCurve(mx, my) {
+          var best = { dist: Infinity, seg: 0, t: 0.5 };
+          for (var i = 0; i < anchors.length - 1; i++) {
+            var a = anchors[i],
+              b = anchors[i + 1];
+            var p0 = { x: a.x, y: a.y },
+              cp1 = { x: a.ox, y: a.oy },
+              cp2 = { x: b.ix, y: b.iy },
+              p1 = { x: b.x, y: b.y };
+            for (var t = 0; t <= 1; t += 0.01) {
+              var u = 1 - t;
+              var px =
+                u * u * u * p0.x + 3 * u * u * t * cp1.x + 3 * u * t * t * cp2.x + t * t * t * p1.x;
+              var py =
+                u * u * u * p0.y + 3 * u * u * t * cp1.y + 3 * u * t * t * cp2.y + t * t * t * p1.y;
+              var dx = px - mx,
+                dy = py - my;
+              var d = dx * dx + dy * dy;
+              if (d < best.dist) {
+                best.dist = d;
+                best.seg = i;
+                best.t = t;
+              }
+            }
+          }
+          return best;
+        }
+
+        // Add waypoint
+        function addWaypoint(seg, t) {
+          var a = anchors[seg],
+            b = anchors[seg + 1];
+          var p0 = { x: a.x, y: a.y },
+            cp1 = { x: a.ox, y: a.oy },
+            cp2 = { x: b.ix, y: b.iy },
+            p1 = { x: b.x, y: b.y };
+          var sp = splitBezier(p0, cp1, cp2, p1, t);
+          a.ox = sp.left.cp1.x;
+          a.oy = sp.left.cp1.y;
+          var newAnchor = {
+            x: sp.left.end.x,
+            y: sp.left.end.y,
+            ix: sp.left.cp2.x,
+            iy: sp.left.cp2.y,
+            ox: sp.right.cp1.x,
+            oy: sp.right.cp1.y,
+          };
+          b.ix = sp.right.cp2.x;
+          b.iy = sp.right.cp2.y;
+          anchors.splice(seg + 1, 0, newAnchor);
+          selectedAnchor = seg + 1;
+          rebuild();
+          updateValue();
+        }
+
+        // Remove waypoint
+        function removeWaypoint(idx) {
+          if (idx <= 0 || idx >= anchors.length - 1) return;
+          anchors.splice(idx, 1);
+          selectedAnchor = -1;
+          rebuild();
+          updateValue();
+        }
+
+        // Rebuild handle DOM elements
+        function rebuild() {
+          handles.forEach(function (h) {
+            if (h.el.parentNode) h.el.parentNode.removeChild(h.el);
+          });
+          handles = [];
+          for (var i = 0; i < anchors.length; i++) {
+            var a = anchors[i];
+            // Anchor point (not for first/last x position, but y is draggable)
+            if (i > 0 && i < anchors.length - 1) {
+              makeHandle(i, "anchor", "x", "y", true, true);
+            }
+            // Outgoing handle (not for last anchor)
+            if (i < anchors.length - 1) {
+              makeHandle(i, "out", "ox", "oy", true, true);
+            }
+            // Incoming handle (not for first anchor)
+            if (i > 0) {
+              makeHandle(i, "in", "ix", "iy", true, true);
+            }
+          }
+          draw();
+        }
+
+        function makeHandle(idx, type, xk, yk, dragX, dragY) {
+          var el = document.createElement("div");
+          el.className = type === "anchor" ? "bezier-anchor" : "bezier-handle";
+          el.dataset.idx = idx;
+          el.dataset.type = type;
+          bwrap.appendChild(el);
+          var info = { el: el, idx: idx, type: type, xk: xk, yk: yk };
+          handles.push(info);
+
+          var dragging = false;
+          el.addEventListener("mousedown", function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            dragging = true;
+            el.classList.add("dragging");
+            selectCustom();
+            if (type === "anchor") {
+              selectedAnchor = idx;
+              handles.forEach(function (h) {
+                if (h.type === "anchor") h.el.classList.toggle("selected", h.idx === idx);
+              });
+            }
+          });
+          window.addEventListener("mousemove", function (e) {
+            if (!dragging) return;
+            var r = bwrap.getBoundingClientRect();
+            var nx = (e.clientX - r.left) / r.width;
+            var ny = 1 - (e.clientY - r.top) / r.height;
+            if (type === "anchor") {
+              var prev = anchors[idx - 1],
+                next = anchors[idx + 1];
+              nx = Math.max(prev.x + 0.01, Math.min(next.x - 0.01, nx));
+              var dx = nx - anchors[idx].x,
+                dy = ny - anchors[idx].y;
+              anchors[idx].x = nx;
+              anchors[idx].y = ny;
+              anchors[idx].ox += dx;
+              anchors[idx].oy += dy;
+              anchors[idx].ix += dx;
+              anchors[idx].iy += dy;
+            } else {
+              anchors[idx][xk] = nx;
+              anchors[idx][yk] = ny;
+            }
+            draw();
+            updateValue();
+          });
+          window.addEventListener("mouseup", function () {
+            if (dragging) {
+              dragging = false;
+              el.classList.remove("dragging");
+            }
+          });
+        }
+
+        // Canvas click to add waypoint
+        bwrap.addEventListener("click", function (e) {
+          if (
+            e.target.classList.contains("bezier-handle") ||
+            e.target.classList.contains("bezier-anchor")
+          )
+            return;
+          var r = bwrap.getBoundingClientRect();
+          var mx = (e.clientX - r.left) / r.width;
+          var my = 1 - (e.clientY - r.top) / r.height;
+          var hit = closestOnCurve(mx, my);
+          if (hit.dist < 0.005) {
+            addWaypoint(hit.seg, hit.t);
+          } else {
+            selectedAnchor = -1;
+            handles.forEach(function (h) {
+              if (h.type === "anchor") h.el.classList.remove("selected");
+            });
+          }
+        });
+
+        // Delete key removes selected waypoint
+        document.addEventListener("keydown", function (e) {
+          if (
+            (e.key === "Delete" || e.key === "Backspace") &&
+            selectedAnchor > 0 &&
+            selectedAnchor < anchors.length - 1
+          ) {
+            if (
+              document.activeElement &&
+              (document.activeElement.tagName === "INPUT" ||
+                document.activeElement.tagName === "TEXTAREA")
+            )
+              return;
+            e.preventDefault();
+            removeWaypoint(selectedAnchor);
+          }
+        });
+
+        function draw() {
+          var r = bwrap.getBoundingClientRect();
+          canvas.width = r.width * 2;
+          canvas.height = r.height * 2;
+          var ctx = canvas.getContext("2d");
+          var w = canvas.width,
+            ht = canvas.height;
+          ctx.clearRect(0, 0, w, ht);
+
+          // Grid
+          ctx.strokeStyle = "rgba(255,255,255,0.04)";
+          ctx.lineWidth = 1;
+          for (var g = 0.25; g < 1; g += 0.25) {
+            ctx.beginPath();
+            ctx.moveTo(g * w, 0);
+            ctx.lineTo(g * w, ht);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.moveTo(0, g * ht);
+            ctx.lineTo(w, g * ht);
+            ctx.stroke();
+          }
+          // Diagonal
+          ctx.strokeStyle = "rgba(255,255,255,0.06)";
+          ctx.setLineDash([6, 6]);
+          ctx.beginPath();
+          ctx.moveTo(0, ht);
+          ctx.lineTo(w, 0);
+          ctx.stroke();
+          ctx.setLineDash([]);
+
+          // Handle lines
+          ctx.strokeStyle = "rgba(78,127,255,0.3)";
+          ctx.lineWidth = 1.5;
+          for (var i = 0; i < anchors.length; i++) {
+            var a = anchors[i];
+            if (i < anchors.length - 1) {
+              ctx.beginPath();
+              ctx.moveTo(a.x * w, (1 - a.y) * ht);
+              ctx.lineTo(a.ox * w, (1 - a.oy) * ht);
+              ctx.stroke();
+            }
+            if (i > 0) {
+              ctx.beginPath();
+              ctx.moveTo(a.x * w, (1 - a.y) * ht);
+              ctx.lineTo(a.ix * w, (1 - a.iy) * ht);
+              ctx.stroke();
+            }
+          }
+
+          // Curve
+          ctx.strokeStyle = "#0ae448";
+          ctx.lineWidth = 3;
+          ctx.beginPath();
+          ctx.moveTo(0, ht);
+          for (var i = 0; i < anchors.length - 1; i++) {
+            var a = anchors[i],
+              b = anchors[i + 1];
+            ctx.bezierCurveTo(
+              a.ox * w,
+              (1 - a.oy) * ht,
+              b.ix * w,
+              (1 - b.iy) * ht,
+              b.x * w,
+              (1 - b.y) * ht,
+            );
+          }
+          ctx.stroke();
+
+          // Position handle DOM elements
+          handles.forEach(function (h) {
+            var a = anchors[h.idx];
+            var px = a[h.xk] * r.width,
+              py = (1 - a[h.yk]) * r.height;
+            h.el.style.left = px + "px";
+            h.el.style.top = py + "px";
+          });
+        }
+
+        function updateValue() {
+          var path = toPath();
+          EASINGS[customIdx].value = path;
+          valEl.textContent = path;
+          if (typeof CustomEase !== "undefined") {
+            CustomEase.create("_pickerCustom", path);
+          }
+          if (picks.easing === customIdx) {
+            animateBezierDot();
+            renderPreview();
+          }
+        }
+
+        var bzTween = null;
+        function animateBezierDot() {
+          if (bzTween) {
+            bzTween.kill();
+            bzTween = null;
+          }
+          if (typeof CustomEase === "undefined") return;
+          bzTween = gsap.fromTo(
+            dotEl,
+            { left: 0 },
+            {
+              left: "calc(100% - 12px)",
+              duration: 1.2,
+              ease: "_pickerCustom",
+              repeat: -1,
+              repeatDelay: 0.5,
+              yoyo: true,
+            },
+          );
+        }
+
+        rebuild();
+        setTimeout(function () {
+          draw();
+          animateBezierDot();
+        }, 100);
+        window.addEventListener("resize", function () {
+          draw();
+        });
+        // Redraw when Phase 2 becomes visible
+        window._redrawBezier = function () {
+          setTimeout(function () {
+            draw();
+          }, 50);
+        };
+      })();
+
+      // ── Background / Three.js Gradient Presets ──
+      var bgOpts = document.getElementById("bg-options");
+      var shaderEditor = document.getElementById("shader-editor");
+      var seC1 = document.getElementById("se-c1");
+      var seC2 = document.getElementById("se-c2");
+      var seC3 = document.getElementById("se-c3");
+      var seUsePal = document.getElementById("se-use-palette");
+
+      var BG_PRESETS = [
+        { name: "None", desc: "No shader" },
+        {
+          name: "Aurora",
+          desc: "Flowing warmth",
+          type: "plane",
+          shader: "defaults",
+          density: 1.3,
+          speed: 0.4,
+          strength: 4,
+          rotX: 0,
+          rotY: 10,
+          rotZ: 50,
+          camDist: 3.6,
+          camAz: 180,
+          camPol: 90,
+          zoom: 1,
+          posX: -1.4,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.05, max: 1.0, step: 0.05 },
+            { label: "Density", key: "density", min: 0.5, max: 3.0, step: 0.1 },
+            { label: "Rotation", key: "rotZ", min: -180, max: 180, step: 5 },
+          ],
+        },
+        {
+          name: "Tide",
+          desc: "Undulating surface",
+          type: "water",
+          shader: "defaults",
+          density: 1.2,
+          speed: 0.2,
+          strength: 3.4,
+          rotX: 45,
+          rotY: 0,
+          rotZ: 0,
+          camDist: 4.4,
+          camAz: 170,
+          camPol: 70,
+          zoom: 1,
+          posY: 0.9,
+          posZ: -0.3,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.05, max: 0.8, step: 0.05 },
+            { label: "Wave height", key: "strength", min: 0.5, max: 6.0, step: 0.2 },
+            { label: "Wave density", key: "density", min: 0.5, max: 3.0, step: 0.1 },
+          ],
+        },
+        {
+          name: "Nebula",
+          desc: "Iridescent depth",
+          type: "sphere",
+          shader: "cosmic",
+          density: 0.8,
+          speed: 0.3,
+          strength: 0.3,
+          rotX: 0,
+          rotY: 130,
+          rotZ: 70,
+          camDist: 0.5,
+          camAz: 270,
+          camPol: 180,
+          zoom: 15.1,
+          posX: -0.1,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.05, max: 0.8, step: 0.05 },
+            { label: "Shimmer", key: "strength", min: 0.05, max: 0.8, step: 0.05 },
+            { label: "Pattern scale", key: "density", min: 0.3, max: 2.0, step: 0.1 },
+          ],
+        },
+        {
+          name: "Drift",
+          desc: "Slow dark current",
+          type: "water",
+          shader: "defaults",
+          density: 1.5,
+          speed: 0.3,
+          strength: 0.4,
+          rotX: 50,
+          rotY: 0,
+          rotZ: -60,
+          camDist: 2.8,
+          camAz: 180,
+          camPol: 80,
+          zoom: 9.1,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.05, max: 0.8, step: 0.05 },
+            { label: "Wave height", key: "strength", min: 0.1, max: 2.0, step: 0.1 },
+            { label: "Darkness", key: "density", min: 0.5, max: 3.0, step: 0.1 },
+          ],
+        },
+        {
+          name: "Ember",
+          desc: "Radiant orb",
+          type: "sphere",
+          shader: "defaults",
+          density: 1.1,
+          speed: 0.1,
+          strength: 0.4,
+          rotX: 0,
+          rotY: 0,
+          rotZ: 0,
+          camDist: 7.1,
+          camAz: 60,
+          camPol: 90,
+          zoom: 15.3,
+          posY: -0.15,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.02, max: 0.4, step: 0.02 },
+            { label: "Glow", key: "strength", min: 0.1, max: 1.0, step: 0.05 },
+          ],
+        },
+        {
+          name: "Silk",
+          desc: "Gentle pastel motion",
+          type: "water",
+          shader: "defaults",
+          density: 1,
+          speed: 0.3,
+          strength: 3,
+          rotX: 0,
+          rotY: 0,
+          rotZ: -90,
+          camDist: 2.9,
+          camAz: 180,
+          camPol: 120,
+          zoom: 1,
+          posY: 1.8,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.05, max: 0.8, step: 0.05 },
+            { label: "Wave height", key: "strength", min: 0.5, max: 5.0, step: 0.2 },
+            { label: "Softness", key: "density", min: 0.5, max: 2.5, step: 0.1 },
+          ],
+        },
+        {
+          name: "Prism",
+          desc: "Light refraction",
+          type: "water",
+          shader: "glass",
+          density: 1.2,
+          speed: 0.2,
+          strength: 3.4,
+          rotX: 45,
+          rotY: 0,
+          rotZ: 0,
+          camDist: 4.4,
+          camAz: 170,
+          camPol: 70,
+          zoom: 1,
+          posY: 0.9,
+          posZ: -0.3,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.05, max: 0.6, step: 0.05 },
+            { label: "Refraction", key: "strength", min: 0.5, max: 6.0, step: 0.2 },
+            { label: "Clarity", key: "density", min: 0.5, max: 3.0, step: 0.1 },
+          ],
+        },
+        {
+          name: "Fog",
+          desc: "Layered color mist",
+          type: "sphere",
+          shader: "fog",
+          density: 1.0,
+          speed: 0.4,
+          strength: 1.0,
+          rotX: 0,
+          rotY: 0,
+          rotZ: 0,
+          camDist: 0.5,
+          camAz: 180,
+          camPol: 90,
+          zoom: 25,
+          posX: 0,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.05, max: 0.8, step: 0.05 },
+            { label: "Scale", key: "density", min: 0.3, max: 2.5, step: 0.1 },
+            { label: "Intensity", key: "strength", min: 0.3, max: 2.0, step: 0.1 },
+            { label: "Zoom", key: "zoom", min: 20, max: 40, step: 1 },
+          ],
+        },
+        {
+          name: "Blob",
+          desc: "Organic wobble",
+          type: "sphere",
+          shader: "defaults",
+          density: 1.3,
+          speed: 0.4,
+          strength: 1.5,
+          rotX: 0,
+          rotY: 10,
+          rotZ: 0,
+          camDist: 3.6,
+          camAz: 180,
+          camPol: 90,
+          zoom: 1,
+          controls: [
+            { label: "Speed", key: "speed", min: 0.1, max: 1.0, step: 0.05 },
+            { label: "Wobble", key: "strength", min: 0.3, max: 4.0, step: 0.1 },
+            { label: "Wobble density", key: "density", min: 0.5, max: 3.0, step: 0.1 },
+            { label: "Zoom", key: "zoom", min: 1, max: 8, step: 0.5 },
+          ],
+        },
+      ];
+
+      var seControls = document.getElementById("se-controls");
+
+      var _iframeDebounce = null;
+      function debouncedIframeUpdate() {
+        clearTimeout(_iframeDebounce);
+        _iframeDebounce = setTimeout(function () {
+          if (window._currentTemplateSlug) renderDesignIframe();
+        }, 500);
+      }
+
+      function makeSlider(parent, label, key, min, max, step, preset) {
+        var wrap = document.createElement("label");
+        wrap.style.cssText = "font-size:10px;color:#666;display:block;margin-bottom:6px;";
+        var input = document.createElement("input");
+        input.type = "range";
+        input.min = min;
+        input.max = max;
+        input.step = step;
+        input.value = preset[key];
+        input.style.cssText =
+          "width:100%;accent-color:#0ae448;height:4px;-webkit-appearance:none;background:#222;border-radius:2px;outline:none;margin-top:4px;";
+        input.dataset.key = key;
+        var valSpan = document.createElement("span");
+        valSpan.style.cssText = "float:right;color:#888;font-family:monospace;";
+        valSpan.textContent = preset[key];
+        input.addEventListener("input", function () {
+          var val = parseFloat(this.value);
+          preset[this.dataset.key] = val;
+          valSpan.textContent = val;
+          if (typeof window._sgUpdateBg === "function") window._sgUpdateBg();
+          debouncedIframeUpdate();
+        });
+        wrap.textContent = label + " ";
+        wrap.appendChild(valSpan);
+        wrap.appendChild(input);
+        parent.appendChild(wrap);
+      }
+
+      function renderBgControls(preset) {
+        seControls.innerHTML = "";
+        if (!preset) return;
+        // Preset-specific controls
+        if (preset.controls) {
+          var shapeLabel = document.createElement("div");
+          shapeLabel.style.cssText =
+            "font-size:9px;color:#444;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;";
+          shapeLabel.textContent = "Animation";
+          seControls.appendChild(shapeLabel);
+          preset.controls.forEach(function (c) {
+            makeSlider(seControls, c.label, c.key, c.min, c.max, c.step, preset);
+          });
+        }
+        // Camera controls (always shown)
+        var camLabel = document.createElement("div");
+        camLabel.style.cssText =
+          "font-size:9px;color:#444;text-transform:uppercase;letter-spacing:0.1em;margin:10px 0 6px;border-top:1px solid #222;padding-top:8px;";
+        camLabel.textContent = "Camera";
+        seControls.appendChild(camLabel);
+        var isSphere = preset.type === "sphere";
+        var hasCustomZoom =
+          preset.controls &&
+          preset.controls.some(function (c) {
+            return c.key === "zoom";
+          });
+        if (isSphere && !hasCustomZoom) {
+          makeSlider(seControls, "Zoom", "zoom", 1, 20, 0.5, preset);
+        }
+        if (!isSphere) {
+          makeSlider(seControls, "Distance", "camDist", 1, 10, 0.2, preset);
+        }
+        makeSlider(seControls, "Angle", "camAz", 0, 360, 5, preset);
+        makeSlider(seControls, "Tilt", "camPol", 30, 170, 5, preset);
+
+        // Rendering controls
+        var renderLabel = document.createElement("div");
+        renderLabel.style.cssText =
+          "font-size:9px;color:#444;text-transform:uppercase;letter-spacing:0.1em;margin:10px 0 6px;border-top:1px solid #222;padding-top:8px;";
+        renderLabel.textContent = "Rendering";
+        seControls.appendChild(renderLabel);
+
+        // Render + grain config persists across shader changes (single global object,
+        // not per-preset). Switching shaders keeps user-tuned brightness/grain values.
+        if (!window._sgRender)
+          window._sgRender = {
+            brightness: 1.0,
+            contrast: 1.0,
+            saturation: 1.0,
+            grainRadius: 2,
+            grainScatter: 1,
+            grainBlending: 1,
+          };
+        preset._render = window._sgRender;
+        makeSlider(seControls, "Brightness", "brightness", 0.2, 2.0, 0.05, preset._render);
+        makeSlider(seControls, "Contrast", "contrast", 0.5, 2.0, 0.05, preset._render);
+        makeSlider(seControls, "Saturation", "saturation", 0.0, 2.0, 0.05, preset._render);
+
+        // Grain controls rendered separately
+        var grainBox = document.getElementById("se-grain-controls");
+        grainBox.innerHTML = "";
+        if (document.getElementById("se-grain").checked) {
+          makeSlider(grainBox, "Size", "grainRadius", 1, 6, 0.5, preset._render);
+          makeSlider(grainBox, "Scatter", "grainScatter", 0, 2, 0.1, preset._render);
+          makeSlider(grainBox, "Blend", "grainBlending", 0, 1, 0.05, preset._render);
+        }
+      }
+
+      BG_PRESETS.forEach(function (p, i) {
+        var el = document.createElement("div");
+        el.className = "opt";
+        el.innerHTML =
+          '<div class="opt-inner"><div class="opt-name">' +
+          p.name +
+          '</div><div class="opt-desc">' +
+          p.desc +
+          "</div></div>";
+        el.onclick = function () {
+          // Render controls FIRST so preset._render points to window._sgRender
+          // before sel triggers renderPreview (which reads preset._render).
+          shaderEditor.style.display = i > 0 ? "block" : "none";
+          renderBgControls(i > 0 ? p : null);
+          window._lastBgModeKey = null;
+          sel("bg_mode", i, bgOpts);
+          if (typeof window._sgUpdateBg === "function") window._sgUpdateBg();
+        };
+        bgOpts.appendChild(el);
+      });
+
+      function getBgColors() {
+        // Template Default (picks.palette === null) falls back to PALETTES[0]
+        // which holds the active template's native colors. Otherwise use the picked palette.
+        if (seUsePal.checked) {
+          var pi = picks.palette !== null ? picks.palette : 0;
+          var p = PALETTES[pi];
+          if (p) return [p.secondary, p.accent, p.tertiary];
+        }
+        return [seC1.value, seC2.value, seC3.value];
+      }
+
+      seUsePal.addEventListener("change", function () {
+        if (this.checked && picks.palette !== null) {
+          var p = PALETTES[picks.palette];
+          seC1.value = p.secondary;
+          seC2.value = p.accent;
+          seC3.value = p.tertiary;
+        }
+        if (typeof window._sgUpdateBg === "function") window._sgUpdateBg();
+        debouncedIframeUpdate();
+      });
+      document.getElementById("se-grain").addEventListener("change", function () {
+        if (typeof window._sgToggleGrain === "function") window._sgToggleGrain(!this.checked);
+        var grainBox = document.getElementById("se-grain-controls");
+        grainBox.innerHTML = "";
+        if (this.checked && picks.bg_mode > 0) {
+          var preset = BG_PRESETS[picks.bg_mode];
+          if (preset && preset._render) {
+            makeSlider(grainBox, "Size", "grainRadius", 1, 6, 0.5, preset._render);
+            makeSlider(grainBox, "Scatter", "grainScatter", 0, 2, 0.1, preset._render);
+            makeSlider(grainBox, "Blend", "grainBlending", 0, 1, 0.05, preset._render);
+          }
+        }
+        debouncedIframeUpdate();
+      });
+      [seC1, seC2, seC3].forEach(function (el) {
+        el.addEventListener("input", function () {
+          if (typeof window._sgUpdateBg === "function") window._sgUpdateBg();
+          debouncedIframeUpdate();
+        });
+      });
+
+      // Store original CSS var values per template slug to avoid remapping drift
+      var _origVarCache = {};
+
+      function captureOriginalVars(ifr, slug) {
+        var key = slug || ifr.src || "default";
+        if (_origVarCache[key]) return _origVarCache[key];
+        var doc = ifr.contentDocument;
+        if (!doc) return {};
+
+        // Temporarily remove override to read originals
+        var overrideEl = doc.getElementById("finetune-override");
+        var savedOverride = "";
+        if (overrideEl) {
+          savedOverride = overrideEl.textContent;
+          overrideEl.textContent = "";
+        }
+
+        var vars = {};
+        doc.querySelectorAll("style").forEach(function (st) {
+          if (st.id === "finetune-override") return;
+          var m = st.textContent.match(/--[\w-]+\s*:/g);
+          if (m)
+            m.forEach(function (v) {
+              var name = v.replace(/\s*:$/, "");
+              if (!vars[name]) {
+                vars[name] = ifr.contentWindow
+                  .getComputedStyle(doc.documentElement)
+                  .getPropertyValue(name)
+                  .trim();
+              }
+            });
+        });
+
+        // Restore override
+        if (overrideEl) overrideEl.textContent = savedOverride;
+
+        if (Object.keys(vars).length > 0) _origVarCache[key] = vars;
+        return vars;
+      }
+
+      function buildTemplateOverrideCss(bg, fg, ac, mt, t, cr) {
+        return {
+          bg: bg,
+          fg: fg,
+          ac: ac,
+          mt: mt,
+          hFont: t.headline.family,
+          bFont: t.body.family,
+          radius: cr.value,
+        };
+      }
+
+      function applyOverrideToIframe(ifr, opts, slug) {
+        if (!ifr || !ifr.contentDocument) return;
+        var doc = ifr.contentDocument;
+        var style = doc.getElementById("finetune-override");
+        if (!style) {
+          style = doc.createElement("style");
+          style.id = "finetune-override";
+          doc.head.appendChild(style);
+        }
+        style.textContent =
+          ":root {\n" +
+          "  --tp-bg: " +
+          opts.bg +
+          " !important;\n" +
+          "  --tp-fg: " +
+          opts.fg +
+          " !important;\n" +
+          "  --tp-ac: " +
+          opts.ac +
+          " !important;\n" +
+          "  --tp-mt: " +
+          opts.mt +
+          " !important;\n" +
+          "  --tp-surface: " +
+          opts.bg +
+          " !important;\n" +
+          "  --tp-border: " +
+          opts.mt +
+          " !important;\n" +
+          '  --tp-hf: "' +
+          opts.hFont +
+          '" !important;\n' +
+          '  --tp-bf: "' +
+          opts.bFont +
+          '" !important;\n' +
+          "}\n";
+      }
+
+      function sel(key, idx, container, cls) {
+        container.querySelectorAll(cls || ".opt").forEach(function (c) {
           c.classList.remove("selected");
         });
         container.children[idx].classList.add("selected");
@@ -1201,85 +3496,1009 @@
         checkReady();
         renderPreview();
       }
-      function sel(key, idx, container) {
-        container.querySelectorAll(".opt").forEach(function (c) {
-          c.classList.remove("selected");
-        });
-        container.children[idx].classList.add("selected");
-        picks[key] = idx;
-        checkReady();
-        renderPreview();
+      function chipSel(key, idx, container) {
+        sel(key, idx, container, ".chip");
+      }
+
+      function tpScrollToSurface() {
+        setTimeout(function () {
+          var ifr = document.getElementById("design-iframe");
+          if (!ifr || !ifr.contentDocument) return;
+          var s = ifr.contentDocument.getElementById("surface");
+          if (s && s.scrollIntoView) s.scrollIntoView({ behavior: "smooth", block: "start" });
+        }, 80);
       }
 
       function checkReady() {
-        var ready =
-          picks.theme !== null &&
-          picks.arch !== null &&
-          picks.palette !== null &&
-          picks.type !== null &&
-          picks.corners !== null &&
-          picks.density !== null &&
-          picks.depth !== null &&
-          picks.easing !== null;
-        document
-          .getElementById("fab")
-          .classList.toggle("visible", ready && currentPhase === "tune");
+        // Button always visible in tune phase — Template Default values fill in any unselected configs.
+        document.getElementById("fab").classList.toggle("visible", currentPhase === "tune");
         document.getElementById("md-overlay").classList.remove("visible");
+      }
+
+      // Template's actual --tp-* values, indexed by slug. Used for slide injection so slides render natively.
+      var NATIVE_TEMPLATE_PALETTES = {
+        "8-bit-orbit": ["#0A0E27","#0F1B3D","#E2D5F2","#F0A6CA"],
+        "biennale-yellow": ["#1B2566","#E9E5DB","#F0DA7C","#F1EE2E"],
+        "block-frame": ["#FFDC8B","#000000","#FFFFFF","#FE90E8"],
+        "blue-professional": ["#111111","#fdfae7","#6b6b6b","#1e2bfa"],
+        "bold-poster": ["#1C1410","#FFFFFF","#F5F2EF","#D8000F"],
+        "broadside": ["#f0ece5","#111111","#282826","#e85d26"],
+        "capsule": ["#1A1A1A","#F5F5F0","#1E1E1E","#E85D4E"],
+        "cartesian": ["#1a1a1a","#ede8e0","#b8b0a4","#e2dbd1"],
+        "cobalt-grid": ["#1F2BE0","#F0EBDE","#E6E0CE","#1F2BE0"],
+        "coral": ["#1A1A1A","#F5F0E8","#6B6B6B","#E85D5D"],
+        "creative-mode": ["#0F0F0F","#EFE9D9","#2A2A2A","#1F8A4C"],
+        "daisy-days": ["#2D2D2D","#F5F0E6","#F7C8D4","#F8635F"],
+        "editorial-forest": ["#1a1a17","#efe7d4","#3a5a36","#2e4a2a"],
+        "editorial-tri-tone": ["#7A1F35","#F2D86A","#7A1F35","#F2B6C6"],
+        "emerald-editorial": ["#0F1A5C","#3CD896","#3A4593","#25B377"],
+        "grove": ["#d4cfbf","#192b1b","#dedad0","#c8524a"],
+        "long-table": ["#B53D2A","#FAF1E2","#E8D7B6","#8E2D1F"],
+        "mat": ["#f0e8d2","#232e26","#2e3d30","#c07030"],
+        "monochrome": ["#1a1a16","#fafadf","#1a1a16","#fafadf"],
+        "neo-grid-bold": ["#0A0A0A","#ECECE8","#0A0A0A","#E6FF3D"],
+        "peoples-platform": ["#0E0E14","#F4E9D6","#F5F2EA","#2C2CDC"],
+        "pink-script": ["#060507","#F5EDF1","#0F0D11","#ED3D8C"],
+        "playful": ["#1A1A1A","#F0C8A0","#F7DEC6","#E8B88E"],
+        "raw-grid": ["#0a0a0a","#ffffff","#f5f5f5","#f2d4cf"],
+        "retro-windows": ["#000000","#c0c0c0","#808080","#000080"],
+        "retro-zine": ["#1A1A1A","#C8B99A","#1A1A1A","#008F4D"],
+        "sakura-chroma": ["#3A2516","#F1E6CB","#3A2516","#E5392A"],
+        "scatterbrain": ["#2d2a26","#faf8f3","#5c5750","#ffe066"],
+        "signal": ["#e2dcd0","#1c2644","#2e3d5c","#c8a870"],
+        "soft-editorial": ["#2A241B","#F2EEDF","#5C5345","#E1A4C2"],
+        "stencil-tablet": ["#000000","#F4EFE0","#0A0A0A","#3F73B7"],
+        "studio": ["#f5d200","#1c1c1c","#2e2e2c","#f5d200"],
+        "vellum": ["#E8D85C","#2a3870","#343f80","#3a7878"],
+      };
+
+      function updateSlideIframes() {
+        var iframes = document.querySelectorAll("#sc-scene-grid iframe, #sc-specimen-grid iframe");
+        if (!iframes.length) return;
+        var slug = window._currentTemplateSlug;
+        // For Template Default: inject template's own --tp-* values so slides render exactly like the original template.
+        var p;
+        if ((picks.palette === null || picks.palette === 0) && NATIVE_TEMPLATE_PALETTES[slug]) {
+          var ntp = NATIVE_TEMPLATE_PALETTES[slug];
+          p = { primary: ntp[0], secondary: ntp[1], tertiary: ntp[2], accent: ntp[3] };
+        } else {
+          p = picks.palette !== null ? PALETTES[picks.palette] : PALETTES[0];
+        }
+        var cr = picks.corners !== null ? CORNERS[picks.corners] : CORNERS[1];
+        var dnIdx = picks.density !== null ? picks.density : 1;
+        var dp = picks.depth !== null ? DEPTHS[picks.depth] : DEPTHS[0];
+        var t = picks.type !== null ? TYPEPAIRS[picks.type] : TYPEPAIRS[0];
+        var padV = DENSITIES[dnIdx].padding || "20px";
+        var gapV = DENSITIES[dnIdx].gap || "16px";
+        var shadowV = dp.css || "none";
+
+        // Build :root override (will be injected as separate style tag so other vars in original :root are preserved)
+        var I = " !important";
+        var newRoot =
+          ":root{" +
+          "--bg:" + p.secondary + I +
+          ";--fg:" + p.primary + I +
+          ";--mt:" + (p.tertiary || "#888") + I +
+          ";--ac:" + p.accent + I + ";" +
+          "--tp-primary:" + p.primary + I +
+          ";--tp-secondary:" + p.secondary + I +
+          ";--tp-tertiary:" + (p.tertiary || "#888") + I +
+          ";--tp-accent:" + p.accent + I + ";" +
+          "--hair:color-mix(in srgb," + p.primary + " 12%,transparent)" + I +
+          ";--surf:color-mix(in srgb," + p.secondary + " 94%," + p.primary + ")" + I +
+          ";--dim:color-mix(in srgb," + p.primary + " 55%," + p.secondary + ")" + I + ";" +
+          "--cr:" + cr.value + I +
+          ";--pad:" + padV + I +
+          ";--gap:" + gapV + I +
+          ";--shadow:" + shadowV + I + ";" +
+          "}";
+
+        iframes.forEach(function (ifr) {
+          if (!ifr.contentDocument || !ifr.contentDocument.head) return;
+          var doc = ifr.contentDocument;
+          // Set CSS vars directly on documentElement — wins over style sheets due to specificity
+          var root = doc.documentElement;
+          var props = [
+            ["--bg", p.secondary],
+            ["--fg", p.primary],
+            ["--mt", p.tertiary || "#888"],
+            ["--ac", p.accent],
+            ["--tp-primary", p.primary],
+            ["--tp-secondary", p.secondary],
+            ["--tp-tertiary", p.tertiary || "#888"],
+            ["--tp-accent", p.accent],
+            ["--cr", cr.value],
+            ["--pad", padV],
+            ["--gap", gapV],
+            ["--shadow", shadowV],
+          ];
+          for (var pi = 0; pi < props.length; pi++) {
+            root.style.setProperty(props[pi][0], props[pi][1], "important");
+          }
+          // Force body colors directly
+          if (doc.body) {
+            doc.body.style.background = p.secondary;
+            doc.body.style.color = p.primary;
+          }
+          doc.querySelectorAll(".dark,.s6").forEach(function (el) {
+            el.style.background = p.primary;
+            el.style.color = p.secondary;
+          });
+          // Font override
+          if (picks.type !== null && picks.type > 0) {
+            var fl = doc.getElementById("tp-font-link");
+            if (!fl) {
+              fl = doc.createElement("link");
+              fl.id = "tp-font-link";
+              fl.rel = "stylesheet";
+              doc.head.appendChild(fl);
+            }
+            fl.href =
+              "https://fonts.googleapis.com/css2?family=" +
+              t.headline.family.replace(/ /g, "+") +
+              ":wght@" +
+              t.headline.weight +
+              "&family=" +
+              t.body.family.replace(/ /g, "+") +
+              ":wght@" +
+              t.body.weight +
+              "&display=swap";
+          }
+        });
+      }
+
+      function renderDesignIframe() {
+        var slug = window._currentTemplateSlug;
+        if (!slug) return;
+        var iframe = document.getElementById("design-iframe");
+        if (!iframe) return;
+
+        var p = picks.palette !== null ? PALETTES[picks.palette] : PALETTES[0];
+        var t = picks.type !== null ? TYPEPAIRS[picks.type] : TYPEPAIRS[0];
+        var e = picks.easing !== null ? EASINGS[picks.easing] : EASINGS[0];
+        var cr = picks.corners !== null ? CORNERS[picks.corners] : CORNERS[1];
+        var dn = picks.density !== null ? DENSITIES[picks.density] : DENSITIES[1];
+        var dp = picks.depth !== null ? DEPTHS[picks.depth] : DEPTHS[1];
+        var bg = picks.bg_mode !== null ? BG_PRESETS[picks.bg_mode] : BG_PRESETS[0];
+        var name = (PROMPT && PROMPT.title) || "Untitled";
+
+        // Set Template Default from the design page's authored native palette
+        // (NATIVE_PALETTES is shared with tpBuildGrid for cover-rendering)
+        var NATIVE_PALETTES = window.NATIVE_PALETTES || (window.NATIVE_PALETTES = {
+          "8-bit-orbit": ["#F3F2EA", "#0A1429", "#4ADDE5", "#FF52A2"],
+          "biennale-yellow": ["#F3ECDA", "#1B2960", "#C9572A", "#F4E36A"],
+          "block-frame": ["#FFDC8B", "#000000", "#FFFFFF", "#FE90E8"],
+          "blue-professional": ["#F1ECDF", "#11151B", "#444C5A", "#2C5BFF"],
+          "bold-poster": ["#F4ECDB", "#161210", "#6E5B45", "#E53935"],
+          broadside: ["#f0ece5", "#111111", "#282826", "#e85d26"],
+          capsule: ["#F0E9D9", "#1A1A1A", "#C7E1D4", "#F2B5B5"],
+          cartesian: ["#F1EBDC", "#2A241D", "#B89F7F", "#806D52"],
+          "cobalt-grid": ["#F5F4F0", "#0E1116", "#5C6A82", "#1E40FF"],
+          coral: ["#F3E9D2", "#14110E", "#5C4C39", "#F2674E"],
+          "creative-mode": ["#F2EBDD", "#131313", "#7D6F58", "#E26A47"],
+          "daisy-days": ["#FCF1D8", "#2A2624", "#BBD0A4", "#F4B5C9"],
+          "editorial-forest": ["#EDE6D2", "#1B2D24", "#7A8F7E", "#C97E48"],
+          "editorial-tri-tone": ["#F3E1D6", "#5B1A1F", "#D9B86F", "#2B1112"],
+          "emerald-editorial": ["#F8F2E3", "#0D2B23", "#3C7864", "#D4B26A"],
+          grove: ["#F2E9D3", "#1C342B", "#5F8772", "#BD6034"],
+          "long-table": ["#F4ECDA", "#2A2018", "#9C8266", "#B04E2A"],
+          mat: ["#EAE0CC", "#2A3530", "#66796E", "#CB6730"],
+          monochrome: ["#F8F4EA", "#111111", "#5A5752", "#111111"],
+          "neo-grid-bold": ["#F4F1EA", "#1A1A1A", "#6E6E6E", "#E5FF3F"],
+          "peoples-platform": ["#F1ECDF", "#111111", "#112D54", "#E15A2E"],
+          "pin-and-paper": ["#F2DD8A", "#14213B", "#B0903A", "#2E4D8C"],
+          "pink-script": ["#F4ECE0", "#0A0A0A", "#4A4744", "#FF3F8D"],
+          playful: ["#FCE2C2", "#2A1E15", "#B89070", "#F08660"],
+          "raw-grid": ["#EFE5D9", "#1F1B17", "#B8C9A8", "#ECC2D2"],
+          "retro-windows": ["#FFFFFF", "#000000", "#C0C0C0", "#000080"],
+          "retro-zine": ["#ECE3CB", "#1A1815", "#C2A85B", "#3B6E48"],
+          "sakura-chroma": ["#EFE6D3", "#1C1612", "#2880A3", "#E25C58"],
+          scatterbrain: ["#F4EFE2", "#1F1B16", "#B0A693", "#FF8A4C"],
+          signal: ["#EBE2C9", "#14202F", "#6E7780", "#BD9E54"],
+          "soft-editorial": ["#F3EFE3", "#2A2A28", "#9BAA8F", "#D9A6A6"],
+          "stencil-tablet": ["#EAE3D2", "#2B2723", "#8E6E48", "#B85D3A"],
+          studio: ["#FAFAF7", "#050505", "#ABABAB", "#f5d200"],
+          vellum: ["#FCFAF1", "#0F1A2E", "#6D9CA1", "#F4E2A4"],
+        });
+        var NATIVE_FONTS = {
+          "8-bit-orbit": ["Press Start 2P", 400, "VT323", 400],
+          "biennale-yellow": ["Newsreader", 700, "Inter", 400],
+          "block-frame": ["Anton", 400, "Inter", 500],
+          "blue-professional": ["Geist", 700, "Geist", 400],
+          "bold-poster": ["Shrikhand", 400, "IBM Plex Sans", 500],
+          broadside: ["Barlow", 900, "IBM Plex Mono", 300],
+          capsule: ["Outfit", 900, "DM Sans", 500],
+          cartesian: ["EB Garamond", 700, "EB Garamond", 400],
+          "cobalt-grid": ["Space Grotesk", 700, "Manrope", 500],
+          coral: ["Bebas Neue", 400, "Manrope", 400],
+          "creative-mode": ["Archivo Black", 400, "Manrope", 500],
+          "daisy-days": ["DM Serif Display", 700, "Quicksand", 500],
+          "editorial-forest": ["Cormorant Garamond", 700, "Inter", 400],
+          "editorial-tri-tone": ["Instrument Serif", 700, "Bricolage Grotesque", 500],
+          "emerald-editorial": ["Playfair Display", 700, "Inter", 400],
+          grove: ["Playfair Display", 700, "Source Sans 3", 400],
+          "long-table": ["Lora", 700, "Inter", 400],
+          mat: ["Source Serif 4", 500, "Source Sans 3", 400],
+          monochrome: ["Lora", 700, "Jost", 400],
+          "neo-grid-bold": ["Bricolage Grotesque", 800, "Inter", 500],
+          "peoples-platform": ["Alfa Slab One", 400, "Source Sans 3", 500],
+          "pin-and-paper": ["Crimson Pro", 700, "Crimson Pro", 400],
+          "pink-script": ["Instrument Serif", 700, "Inter", 300],
+          playful: ["Syne", 800, "Sora", 500],
+          "raw-grid": ["Space Grotesk", 700, "Manrope", 500],
+          "retro-windows": ["VT323", 400, "VT323", 400],
+          "retro-zine": ["Bebas Neue", 400, "PT Sans", 400],
+          "sakura-chroma": ["Oswald", 700, "Noto Sans", 500],
+          scatterbrain: ["Shrikhand", 400, "Zilla Slab", 500],
+          signal: ["Spectral", 600, "Inter", 400],
+          "soft-editorial": ["Cormorant Garamond", 700, "Cormorant Garamond", 400],
+          "stencil-tablet": ["Big Shoulders Stencil Display", 900, "Inter", 500],
+          studio: ["Anton", 400, "Inter", 400],
+          vellum: ["Cormorant Garamond", 500, "Cormorant Garamond", 400],
+        };
+        if (typeof DESIGN_MD !== "undefined" && DESIGN_MD) {
+          NATIVE_PALETTES["user-design"] = [
+            DESIGN_MD.primary,
+            DESIGN_MD.secondary,
+            DESIGN_MD.tertiary,
+            DESIGN_MD.accent,
+          ];
+          NATIVE_FONTS["user-design"] = [DESIGN_MD.font, 500, DESIGN_MD.font, 400];
+        }
+        if (PALETTES[0]._native !== slug && NATIVE_PALETTES[slug]) {
+          var np = NATIVE_PALETTES[slug];
+          var ntpe = NATIVE_TEMPLATE_PALETTES[slug];
+          PALETTES[0].primary = np[0];
+          PALETTES[0].secondary = np[1];
+          // Tertiary stays from curated design palette (avoids tone-on-tone unreadability).
+          // Accent: prefer template's native --tp-* (so chip matches slide accent).
+          PALETTES[0].tertiary = np[2];
+          PALETTES[0].accent = (ntpe && ntpe[3]) || np[3];
+          PALETTES[0].name = "Template Default";
+          PALETTES[0]._native = slug;
+          buildPalOpts();
+          // Also set native fonts as Template Default
+          if (NATIVE_FONTS[slug]) {
+            var nf = NATIVE_FONTS[slug];
+            TYPEPAIRS[0] = {
+              name: "Template Default",
+              headline: { family: nf[0], weight: nf[1] },
+              body: { family: nf[2], weight: nf[3] },
+              preview: (PROMPT && PROMPT.headline) || "TITLE",
+              body_preview: "Template typography.",
+            };
+            buildTypeOpts();
+            // Load the native fonts
+            var fl = document.createElement("link");
+            fl.rel = "stylesheet";
+            fl.href =
+              "https://fonts.googleapis.com/css2?family=" +
+              nf[0].replace(/ /g, "+") +
+              ":wght@" +
+              nf[1] +
+              "&family=" +
+              nf[2].replace(/ /g, "+") +
+              ":wght@" +
+              nf[3] +
+              "&display=swap";
+            document.head.appendChild(fl);
+          }
+        }
+
+        // Fetch design template
+        // For user-design, prefer DESIGN.html at project root over the generic template
+        var designUrl = "templates/" + slug + "/design.html?t=" + Date.now();
+        if (slug === "user-design") {
+          var chk = new XMLHttpRequest();
+          chk.open("HEAD", "DESIGN.html", false);
+          chk.send();
+          if (chk.status === 200) designUrl = "DESIGN.html?t=" + Date.now();
+        }
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", designUrl, false);
+        xhr.send();
+        if (xhr.status !== 200) return;
+        var h = xhr.responseText;
+
+        // Fetch summary
+        var sxhr = new XMLHttpRequest();
+        sxhr.open("GET", "templates/" + slug + "/summary.html?t=" + Date.now(), false);
+        sxhr.send();
+        var summary = sxhr.status === 200 ? sxhr.responseText : "";
+
+        // Token replacement
+        h = h.replace(/__PRIMARY__/g, p.primary);
+        h = h.replace(/__SECONDARY__/g, p.secondary);
+        h = h.replace(/__TERTIARY__/g, p.tertiary || "#888");
+        h = h.replace(/__ACCENT__/g, p.accent);
+        h = h.replace(/__PRIMARY_NAME__/g, "primary");
+        h = h.replace(/__SECONDARY_NAME__/g, "secondary");
+        h = h.replace(/__TERTIARY_NAME__/g, "tertiary");
+        h = h.replace(/__ACCENT_NAME__/g, "accent");
+        h = h.replace(/__ACCENT_LABEL__/g, "Accent " + p.accent);
+        h = h.replace(/__PALETTE_LEDE__/g, "Four tokens. Primary, secondary, tertiary, accent.");
+        var nameParts = name.match(/[A-Z][a-z]*/g) || [name];
+        h = h.replace(/__NAME__/g, name);
+        h = h.replace(/__NAME_LINE1__/g, nameParts[0] || name);
+        h = h.replace(/__NAME_LINE2__/g, nameParts.slice(1).join("") || "");
+        h = h.replace(/__CORNER_RADIUS__/g, cr.value);
+        h = h.replace(/__PADDING__/g, dn.padding || "16px");
+        h = h.replace(/__GAP__/g, dn.gap || "16px");
+        h = h.replace(/__ELEVATION__/g, dp.name);
+        h = h.replace(/__DENSITY__/g, dn.name + " — " + dn.desc);
+        h = h.replace(/__BORDER__/g, "4px solid");
+        h = h.replace(/__SHADOW__/g, dp.css || "none");
+        h = h.replace(/__EASING_NAME__/g, e.name.toLowerCase());
+        h = h.replace(/__EASING_VALUE__/g, e.value);
+        h = h.replace(/__EASING_DESC__/g, e.desc);
+        h = h.replace(/__EASING_HEADLINE__/g, e.name.toLowerCase() + ".<br/>fast in.");
+        h = h.replace(/__EASING_LEDE__/g, e.desc + ". Vary entrances by intent.");
+        h = h.replace(/__DURATION_DEFAULT__/g, "0.8s default");
+        h = h.replace(/__DURATION_DESC__/g, "Slides: 0.8s. Entrances: 0.5s.");
+        h = h.replace(/__DURATION_VALUES__/g, "--dur-slide: 0.8s\n--dur-enter: 0.5s");
+        if (bg && bg.type) {
+          h = h.replace(/__BG_HEADLINE__/g, bg.name.toLowerCase() + ".<br/>" + bg.type + ".");
+          h = h.replace(/__BG_LEDE__/g, bg.name + " shader.");
+          h = h.replace(/__BG_BADGE__/g, bg.name + " \xb7 " + bg.type);
+          h = h.replace(/__BG_TYPE__/g, bg.type.charAt(0).toUpperCase() + bg.type.slice(1));
+          h = h.replace(/__BG_DENSITY__/g, String(bg.density));
+          h = h.replace(/__BG_SPEED__/g, String(bg.speed));
+          h = h.replace(/__BG_STRENGTH__/g, String(bg.strength));
+          var _grainCheck = document.getElementById("se-grain").checked;
+          var _grV = bg._render || { grainRadius: 2, grainScatter: 1 };
+          h = h.replace(
+            /__BG_GRAIN__/g,
+            _grainCheck ? _grV.grainRadius + " \xb7 scatter " + _grV.grainScatter : "off",
+          );
+          h = h.replace(
+            /__SHADER_CONFIG__/g,
+            JSON.stringify({
+              type: bg.type,
+              density: bg.density,
+              speed: bg.speed,
+              strength: bg.strength,
+              colors: [p.secondary, p.accent, p.tertiary || "#888"],
+            }),
+          );
+        } else {
+          h = h.replace(/__BG_HEADLINE__/g, "none.");
+          h = h.replace(/__BG_LEDE__/g, "No shader.");
+          h = h.replace(/__BG_BADGE__/g, "none");
+          h = h.replace(/__BG_TYPE__/g, "—");
+          h = h.replace(/__BG_DENSITY__/g, "—");
+          h = h.replace(/__BG_SPEED__/g, "—");
+          h = h.replace(/__BG_STRENGTH__/g, "—");
+          h = h.replace(/__BG_GRAIN__/g, "—");
+          h = h.replace(/__SHADER_CONFIG__/g, "{}");
+        }
+        // Fill shader GLSL + renderer script
+        var _sg = window._sgShaders || {};
+        if (bg && bg.type) {
+          if (!bg._render)
+            bg._render = {
+              brightness: 1,
+              contrast: 1,
+              saturation: 1,
+              grainRadius: 2,
+              grainScatter: 1,
+              grainBlending: 1,
+            };
+        }
+        if (bg && bg.type && _sg.vertex) {
+          var vtxSrc = _sg.vertex || "";
+          var fragSrc = bg.fragmentShader || _sg[bg.shader] || _sg.defaults || "";
+          h = h.replace(/__SHADER_VERTEX__/g, vtxSrc.replace(/&/g, "&amp;").replace(/</g, "&lt;"));
+          h = h.replace(
+            /__SHADER_FRAGMENT__/g,
+            fragSrc.replace(/&/g, "&amp;").replace(/</g, "&lt;"),
+          );
+
+          var bgColors = getBgColors();
+          var _r = bg._render || { brightness: 1, contrast: 1, saturation: 1 };
+          var isSphere = bg.type === "sphere";
+          var dist = isSphere ? 14 : bg.camDist;
+          var camX = (
+            dist *
+            Math.sin((bg.camPol * Math.PI) / 180) *
+            Math.sin((bg.camAz * Math.PI) / 180)
+          ).toFixed(3);
+          var camY = (dist * Math.cos((bg.camPol * Math.PI) / 180)).toFixed(3);
+          var camZ = (
+            dist *
+            Math.sin((bg.camPol * Math.PI) / 180) *
+            Math.cos((bg.camAz * Math.PI) / 180)
+          ).toFixed(3);
+          var ss = '<script type="module">\n';
+          ss += 'import*as THREE from"three";\n';
+          ss += 'import{EffectComposer}from"three/addons/postprocessing/EffectComposer.js";\n';
+          ss += 'import{RenderPass}from"three/addons/postprocessing/RenderPass.js";\n';
+          ss += 'import{HalftonePass}from"three/addons/postprocessing/HalftonePass.js";\n';
+          ss +=
+            'const c=document.getElementById("design-bg"),r=new THREE.WebGLRenderer({canvas:c,antialias:!0,alpha:!0,preserveDrawingBuffer:!0});\n';
+          ss += "r.setPixelRatio(Math.min(devicePixelRatio,2));\n";
+          ss +=
+            "const s=new THREE.Scene,cam=new THREE.PerspectiveCamera(45,innerWidth/innerHeight,.1,100);\n";
+          ss += "cam.position.set(" + camX + "," + camY + "," + camZ + ");cam.lookAt(0,0,0);";
+          ss += "cam.zoom=" + (isSphere ? bg.zoom || 1 : 1) + ";cam.updateProjectionMatrix();\n";
+          ss +=
+            "s.add(new THREE.AmbientLight(0xffffff,.6));const dl=new THREE.DirectionalLight(0xffffff,.8);dl.position.set(5,5,5);s.add(dl);\n";
+          ss +=
+            'const cs=n=>{const v=getComputedStyle(document.documentElement).getPropertyValue(n).trim();return new THREE.Color(v||"#111")};\n';
+          ss +=
+            "const u={uTime:{value:0},uSpeed:{value:" +
+            bg.speed +
+            "},uDensity:{value:" +
+            bg.density +
+            "},uStrength:{value:" +
+            bg.strength +
+            "},";
+          ss +=
+            'uColor1:{value:new THREE.Color("' +
+            bgColors[0] +
+            '")},uColor2:{value:new THREE.Color("' +
+            bgColors[1] +
+            '")},uColor3:{value:new THREE.Color("' +
+            (bgColors[2] || "#888") +
+            '")},';
+          ss +=
+            "uBrightness:{value:" +
+            _r.brightness +
+            "},uContrast:{value:" +
+            _r.contrast +
+            "},uSaturation:{value:" +
+            _r.saturation +
+            "}};\n";
+          ss +=
+            'const vtx=document.getElementById("vtx-src").textContent,frg=document.getElementById("frg-src").textContent;\n';
+          ss +=
+            "const mat=new THREE.ShaderMaterial({vertexShader:vtx,fragmentShader:frg,uniforms:u,side:THREE.DoubleSide});\n";
+          ss +=
+            "const m=new THREE.Mesh(new THREE." +
+            (isSphere ? "SphereGeometry(1,128,128)" : "PlaneGeometry(10,10,128,128)") +
+            ",mat);\n";
+          ss +=
+            "m.rotation.set(" +
+            (((bg.rotX || 0) * Math.PI) / 180).toFixed(3) +
+            "," +
+            (((bg.rotY || 0) * Math.PI) / 180).toFixed(3) +
+            "," +
+            (((bg.rotZ || 0) * Math.PI) / 180).toFixed(3) +
+            ");";
+          ss +=
+            "m.position.set(" +
+            (bg.posX || 0) +
+            "," +
+            (bg.posY || 0) +
+            "," +
+            (bg.posZ || 0) +
+            ");s.add(m);\n";
+          var _grainOn = document.getElementById("se-grain").checked;
+          var _gr = bg._render || { grainRadius: 2, grainScatter: 1, grainBlending: 1 };
+          ss += "const comp=new EffectComposer(r);comp.addPass(new RenderPass(s,cam));\n";
+          if (_grainOn) {
+            ss +=
+              "comp.addPass(new HalftonePass(innerWidth,innerHeight,{shape:1,radius:" +
+              _gr.grainRadius +
+              ",rotateR:Math.PI/12,rotateG:Math.PI/6,rotateB:Math.PI/4,scatter:" +
+              _gr.grainScatter +
+              ",blending:" +
+              _gr.grainBlending +
+              ",blendingMode:1,greyscale:!1}));\n";
+          }
+          ss +=
+            "function rs(){r.setSize(innerWidth,innerHeight,!1);comp.setSize(innerWidth,innerHeight);cam.aspect=innerWidth/innerHeight;cam.updateProjectionMatrix()}\n";
+          ss += 'addEventListener("resize",rs);rs();\n';
+          ss += "const t0=performance.now();\n";
+          ss += 'const pc=document.getElementById("bg-preview-canvas");let pctx=null;\n';
+          ss +=
+            'if(pc){pc.width=pc.clientWidth*2;pc.height=pc.clientHeight*2;pctx=pc.getContext("2d");}\n';
+          ss +=
+            "(function tick(t){u.uTime.value=(t-t0)*.001;comp.render();if(pctx)pctx.drawImage(c,0,0,pc.width,pc.height);requestAnimationFrame(tick)})(performance.now());\n";
+          ss += "<\/script>";
+          h = h.replace(/__SHADER_SCRIPT__/g, ss);
+        } else {
+          h = h.replace(/__SHADER_VERTEX__/g, "");
+          h = h.replace(/__SHADER_FRAGMENT__/g, "");
+          h = h.replace(/__SHADER_SCRIPT__/g, "");
+        }
+        var dos = [
+          "Use accent (" + p.accent + ") for the element to remember",
+          "Maintain corners (" + cr.value + ")",
+          "Keep headline weight consistent",
+          "Use body font for readable text",
+          "Tint neutrals toward accent",
+        ];
+        var donts = [
+          "Don't introduce a second accent",
+          "Don't use accent for bg fills",
+          "Don't use body text under 24px",
+          "Don't repeat same entrance animation",
+          "Don't use pure #000 for canvas",
+        ];
+        h = h.replace(
+          /__DOS__/g,
+          dos
+            .map(function (d) {
+              return "<li>" + d + "</li>";
+            })
+            .join("\n"),
+        );
+        h = h.replace(
+          /__DONTS__/g,
+          donts
+            .map(function (d) {
+              return "<li>" + d + "</li>";
+            })
+            .join("\n"),
+        );
+
+        // Template CSS + slide cards from summary
+        if (summary) {
+          var styleMatch = summary.match(/<style[\s\S]*?<\/style>/);
+          // Extract font links before stripping
+          var fontLinks = summary.match(/<link[^>]*fonts\.googleapis[^>]*>/g) || [];
+          var skeletonHtml = summary
+            .replace(/<style[\s\S]*?<\/style>/, "")
+            .replace(/<link[^>]*>/g, "")
+            .trim();
+          // Inject template font links + picker's selected fonts into design page head
+          var pickerFontLink = "";
+          if (picks.type !== null) {
+            var ft = TYPEPAIRS[picks.type];
+            pickerFontLink =
+              '<link href="https://fonts.googleapis.com/css2?family=' +
+              ft.headline.family.replace(/ /g, "+") +
+              ":wght@" +
+              ft.headline.weight +
+              "&family=" +
+              ft.body.family.replace(/ /g, "+") +
+              ":wght@" +
+              ft.body.weight +
+              '&display=swap" rel="stylesheet">';
+          }
+          h = h.replace("</head>", fontLinks.join("\n") + "\n" + pickerFontLink + "\n</head>");
+          if (styleMatch) {
+            var tmplCss = styleMatch[0].replace(/<\/?style[^>]*>/g, "");
+            // Detect template convention: if template's --tp-primary is DARK (ink-role), swap mapping
+            // so design.html's --primary (canvas in DESIGN conv) doesn't get assigned to template's ink slot.
+            var _ntpc = NATIVE_TEMPLATE_PALETTES[slug];
+            function _lc(h) {
+              if (!h || h[0] !== "#") return 0.5;
+              var x = h.slice(1);
+              if (x.length === 3) x = x.split("").map(function(c){return c+c;}).join("");
+              if (x.length < 6) return 0.5;
+              return 0.299*parseInt(x.slice(0,2),16)/255 + 0.587*parseInt(x.slice(2,4),16)/255 + 0.114*parseInt(x.slice(4,6),16)/255;
+            }
+            // Swap only for STANDARD light-theme templates: tp-primary dark (ink) AND tp-secondary light (paper).
+            // FLIPPED (both light) and DARK-theme (both dark) templates: no swap.
+            var _tpSwap = _ntpc && _lc(_ntpc[0]) < 0.5 && _lc(_ntpc[1]) > 0.5;
+            var _tpPriRef = _tpSwap ? "var(--secondary)" : "var(--primary)";
+            var _tpSecRef = _tpSwap ? "var(--primary)" : "var(--secondary)";
+            tmplCss = tmplCss.replace(/--tp-primary:\s*[^;]+;/g, "--tp-primary: " + _tpPriRef + ";");
+            tmplCss = tmplCss.replace(
+              /--tp-secondary:\s*[^;]+;/g,
+              "--tp-secondary: " + _tpSecRef + ";",
+            );
+            // Strip --tp-accent from scoped template CSS so .ds-slide-frame inherits from html root
+            // (where setProperty in updateSlideIframes controls the value). Avoids circular refs with
+            // templates that also alias --accent: var(--tp-accent). Initial value seeded by setProperty.
+            tmplCss = tmplCss.replace(/--tp-accent:\s*[^;]+;/g, "");
+            // --tp-tertiary stays conditional — PALETTES[0].tertiary uses curated value that may differ from template native.
+            if (picks.palette !== null && picks.palette > 0) {
+              tmplCss = tmplCss.replace(/--tp-tertiary:\s*[^;]+;/g, "--tp-tertiary: var(--tertiary);");
+            }
+            var scoped = tmplCss
+              .replace(/:root\s*\{/g, ".ds-slide-frame {")
+              .replace(/^\s*\*\s*,/gm, ".ds-slide-frame *,")
+              .replace(/^\s*\*\s*\{/gm, ".ds-slide-frame * {")
+              .replace(/\*::before/g, ".ds-slide-frame *::before")
+              .replace(/\*::after/g, ".ds-slide-frame *::after")
+              .replace(/^(\s*)(\.[a-zA-Z_][\w-]*)/gm, "$1.ds-slide-frame $2")
+              .replace(
+                /^(\s*)(section|h1|h2|h3|p|ul|li|a|span|svg|div)(\s*[{,.])/gm,
+                "$1.ds-slide-frame $2$3",
+              )
+              .replace(/\.ds-slide-frame \.ds-slide-frame/g, ".ds-slide-frame");
+            scoped +=
+              "\n.ds-slide-frame{--cr:" +
+              cr.value +
+              ";--pad:" +
+              (dn.padding || "20px") +
+              ";--gap:" +
+              (dn.gap || "16px") +
+              ";--shadow:" +
+              (dp.css || "none") +
+              "}";
+            scoped +=
+              "\n.ds-slide-frame .slide,.ds-slide-frame section{opacity:1!important;visibility:visible!important;position:relative!important;width:1920px!important;height:1080px!important}";
+            // .slide.dark/.light/.orange overrides removed — template's native semantics preserved
+            // Force picker's font choices onto slide content
+            if (picks.type !== null) {
+              var ft = TYPEPAIRS[picks.type];
+              scoped +=
+                "\n.ds-slide-frame{--f-display:'" +
+                ft.headline.family +
+                "',sans-serif!important;--f-heading:'" +
+                ft.headline.family +
+                "',sans-serif!important;--f-body:'" +
+                ft.body.family +
+                "',sans-serif!important}";
+              scoped +=
+                "\n.ds-slide-frame [class*='heading'],.ds-slide-frame .display,.ds-slide-frame .h1,.ds-slide-frame .h2,.ds-slide-frame .h3,.ds-slide-frame .hero-title,.ds-slide-frame .nb-heading-xl,.ds-slide-frame .nb-heading-lg,.ds-slide-frame .nb-heading-md{font-family:'" +
+                ft.headline.family +
+                "',sans-serif!important;font-weight:" +
+                ft.headline.weight +
+                "!important}";
+              scoped +=
+                "\n.ds-slide-frame .lead,.ds-slide-frame .body,.ds-slide-frame p,.ds-slide-frame .nb-body{font-family:'" +
+                ft.body.family +
+                "',sans-serif!important;font-weight:" +
+                ft.body.weight +
+                "!important}";
+            }
+            h = h.replace(/__TEMPLATE_CSS__/g, scoped);
+          } else {
+            h = h.replace(/__TEMPLATE_CSS__/g, "");
+          }
+          var blocks = skeletonHtml.split(/(?=<!-- )/);
+          var cards = "",
+            idx = 0,
+            total = blocks.filter(function (b) {
+              return b.trim() && /<!-- [\w-]+ -->/.test(b);
+            }).length;
+          blocks.forEach(function (block) {
+            block = block.trim();
+            if (!block) return;
+            var nm = block.match(/<!-- ([\w-]+) -->/);
+            if (!nm) return;
+            var skel = block.replace(/<!-- [\w-]+ -->\s*/, "");
+            if (!skel.trim()) return;
+            // Replace placeholders with sample content for visual display
+            skel = skel
+              .replace(/\{\{headline\}\}/g, "Headline")
+              .replace(/\{\{body\}\}/g, "Body text goes here with supporting detail.")
+              .replace(/\{\{text\}\}/g, "Text")
+              .replace(/\{\{label\}\}/g, "Label")
+              .replace(/\{\{number\}\}/g, "42");
+            idx++;
+            cards +=
+              '<div class="tmpl" data-idx="' +
+              String(idx).padStart(2, "0") +
+              '"><div class="tmpl-thumb"><div class="scale-wrap"><div class="ds-slide-frame">\n' +
+              skel +
+              '\n</div></div></div><div class="tmpl-foot"><span class="name">' +
+              nm[1] +
+              '</span><span class="idx">' +
+              String(idx).padStart(2, "0") +
+              " / " +
+              total +
+              "</span></div></div>\n";
+          });
+          h = h.replace(/__SLIDE_CARDS__/g, cards);
+          h = h.replace(/__SLIDE_COUNT__/g, String(idx));
+          var words = [
+            "zero",
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen",
+            "seventeen",
+            "eighteen",
+            "nineteen",
+            "twenty",
+          ];
+          h = h.replace(/__SLIDE_COUNT_WORD__/g, words[idx] || String(idx));
+        } else {
+          h = h.replace(/__TEMPLATE_CSS__/g, "");
+          h = h.replace(/__SLIDE_CARDS__/g, "");
+          h = h.replace(/__SLIDE_COUNT__/g, "0");
+          h = h.replace(/__SLIDE_COUNT_WORD__/g, "zero");
+        }
+        h = h.replace(/__FONT_LINK_EXTRA__/g, "");
+        h = h.replace(
+          /__DATE__/g,
+          new Date().toLocaleDateString("en-US", { month: "long", year: "numeric" }),
+        );
+
+        // Inject core token override + force swatch backgrounds to core tokens
+        var _ft = picks.type !== null ? TYPEPAIRS[picks.type] : TYPEPAIRS[0];
+        // Pick contrasting text per swatch by luminance
+        function _swText(hex) {
+          var h = String(hex || "").replace("#", "");
+          if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+          if (h.length !== 6) return "#000";
+          var r = parseInt(h.substr(0, 2), 16) / 255,
+            g = parseInt(h.substr(2, 2), 16) / 255,
+            b = parseInt(h.substr(4, 2), 16) / 255;
+          var L = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+          return L < 0.55 ? "#fff" : "#111";
+        }
+        var _swTxt1 = _swText(p.primary),
+          _swTxt2 = _swText(p.secondary),
+          _swTxt3 = _swText(p.tertiary || "#888"),
+          _swTxt4 = _swText(p.accent);
+        var overrideCSS =
+          '<style id="picker-override">' +
+          ":root{" +
+          "--primary:" +
+          p.primary +
+          "!important;--secondary:" +
+          p.secondary +
+          "!important;--tertiary:" +
+          (p.tertiary || "#888") +
+          "!important;--accent:" +
+          p.accent +
+          "!important;--tp-accent:" +
+          p.accent +
+          "!important;" +
+          '--f-disp:"' +
+          _ft.headline.family +
+          '",sans-serif!important;--f-head:"' +
+          _ft.headline.family +
+          '",sans-serif!important;--f-body:"' +
+          _ft.body.family +
+          '",sans-serif!important;--f-sans:"' +
+          _ft.body.family +
+          '",sans-serif!important' +
+          "}" +
+          ".palette .swatch:nth-child(1),.palette .swatch:nth-child(1) *{color:" +
+          _swTxt1 +
+          "!important}" +
+          ".palette .swatch:nth-child(1){background:" +
+          p.primary +
+          "!important}" +
+          ".palette .swatch:nth-child(2),.palette .swatch:nth-child(2) *{color:" +
+          _swTxt2 +
+          "!important}" +
+          ".palette .swatch:nth-child(2){background:" +
+          p.secondary +
+          "!important}" +
+          ".palette .swatch:nth-child(3),.palette .swatch:nth-child(3) *{color:" +
+          _swTxt3 +
+          "!important}" +
+          ".palette .swatch:nth-child(3){background:" +
+          (p.tertiary || "#888") +
+          "!important}" +
+          ".palette .swatch:nth-child(4),.palette .swatch:nth-child(4) *{color:" +
+          _swTxt4 +
+          "!important}" +
+          ".palette .swatch:nth-child(4){background:" +
+          p.accent +
+          "!important}" +
+          "html,body{overflow-y:auto!important}" +
+          // Surface example card only — corners/density/depth must not leak to other surfaces
+          (picks.corners !== null
+            ? ".demo-card{border-radius:" + cr.value + "!important}"
+            : "") +
+          (picks.density !== null
+            ? ".demo-card{padding:" + (dn.padding || "20px") + "!important;gap:" + (dn.gap || "16px") + "!important}"
+            : "") +
+          (picks.depth !== null
+            ? ".demo-card{box-shadow:" + (dp.css || "none") + "!important}"
+            : "") +
+          (bg && bg.type
+            ? "html,body{background:transparent!important}.cover{background:transparent!important}#bg-veil{display:none!important}#design-bg{opacity:1!important}section{background:transparent!important}"
+            : "") +
+          "</style>";
+        h = h.replace("</head>", overrideCSS + "</head>");
+
+        // Save scroll position before rewrite
+        var scrollY = 0;
+        try {
+          scrollY =
+            iframe.contentWindow.scrollY || iframe.contentDocument.documentElement.scrollTop || 0;
+        } catch (e) {}
+
+        // Inject hero entrance animation only on init or when easing changes
+        var _easingKey = e.name + "|" + (picks.easing || 0);
+        var _easingChanged = window._lastHeroEasing && window._lastHeroEasing !== _easingKey;
+        var _shouldAnimate = !window._lastHeroEasing || window._lastHeroEasing !== _easingKey;
+        window._lastHeroEasing = _easingKey;
+
+        // If only easing changed and iframe already has content, animate in-place without reload
+        if (_easingChanged && iframe.contentDocument && iframe.contentDocument.body) {
+          try {
+            var _iw = iframe.contentWindow;
+            var _id = iframe.contentDocument;
+            var _easeVal = e.value;
+            var _isC = _easeVal && _easeVal.indexOf('M') === 0;
+            try { iframe.contentWindow.scrollTo(0, 0); } catch(e2) {}
+            function _runHeroAnim() {
+              if (typeof _iw.gsap === 'undefined') return;
+              if (_isC && typeof _iw.CustomEase !== 'undefined') {
+                _iw.gsap.registerPlugin(_iw.CustomEase);
+                _iw.CustomEase.create('_heroCustom', _easeVal);
+              }
+              var _ease = _isC ? '_heroCustom' : _easeVal;
+              var _cover = _id.querySelector('[data-screen-label="00 Cover"]') || _id.querySelector('.cover') || _id.querySelector('header');
+              if (!_cover) return;
+              var _els = [];
+              _cover.querySelectorAll('*').forEach(function(el) {
+                if (el.tagName === 'STYLE' || el.tagName === 'SCRIPT' || el.tagName === 'CANVAS' || el.tagName === 'TEMPLATE') return;
+                var r = el.getBoundingClientRect();
+                if (r.width < 1 || r.height < 1) return;
+                // skip if an ancestor is already being animated
+                var anc = el.parentElement;
+                while (anc && anc !== _cover) {
+                  if (_els.indexOf(anc) > -1) return;
+                  anc = anc.parentElement;
+                }
+                _els.push(el);
+              });
+              var _vw = _iw.innerWidth;
+              _els.forEach(function(el, i) {
+                _iw.gsap.set(el, { x: _vw, force3D: true });
+                _iw.gsap.to(el, { x: 0, duration: 0.9, ease: _ease, delay: 0.05 + i * 0.08 });
+              });
+            }
+            function _loadAndRun() {
+              if (_isC && typeof _iw.CustomEase === 'undefined') {
+                var _sc = _id.createElement('script');
+                _sc.src = 'https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/CustomEase.min.js';
+                _sc.onload = function() { setTimeout(_runHeroAnim, 50); };
+                _id.head.appendChild(_sc);
+              } else {
+                _runHeroAnim();
+              }
+            }
+            if (typeof _iw.gsap !== 'undefined') {
+              _loadAndRun();
+            } else {
+              var _s = _id.createElement('script');
+              _s.src = 'https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js';
+              _s.onload = function() { setTimeout(_loadAndRun, 50); };
+              _id.head.appendChild(_s);
+            }
+            return; // skip blob rebuild
+          } catch(ex) { /* fall through to full rebuild */ }
+        }
+
+        var heroAnim = '';
+        if (_shouldAnimate) {
+        var isCustomEase = e.value && e.value.indexOf('M') === 0;
+        heroAnim = '<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"><\/script>\n' +
+          (isCustomEase ? '<script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/CustomEase.min.js"><\/script>\n' : '') +
+          '<script>\n' +
+          'window.addEventListener("load",function(){\n' +
+          '  window.scrollTo(0,0);\n' +
+          '  setTimeout(function(){\n' +
+          (isCustomEase ? '  if(typeof CustomEase!=="undefined"){gsap.registerPlugin(CustomEase);CustomEase.create("_heroCustom","' + e.value.replace(/"/g, '\\"') + '");}\n' : '') +
+          '  var ease=' + (isCustomEase ? '"_heroCustom"' : '"' + e.value + '"') + ';\n' +
+          '  var els=[];\n' +
+          '  var cover=document.querySelector("[data-screen-label=\\"00 Cover\\"]")||document.querySelector(".cover")||document.querySelector("header");\n' +
+          '  if(cover){\n' +
+          '    cover.querySelectorAll("*").forEach(function(el){\n' +
+          '      if(el.tagName==="STYLE"||el.tagName==="SCRIPT"||el.tagName==="CANVAS"||el.tagName==="TEMPLATE")return;\n' +
+          '      var r=el.getBoundingClientRect();\n' +
+          '      if(r.width<1||r.height<1)return;\n' +
+          '      var anc=el.parentElement;\n' +
+          '      while(anc&&anc!==cover){if(els.indexOf(anc)>-1)return;anc=anc.parentElement}\n' +
+          '      els.push(el);\n' +
+          '    });\n' +
+          '  }\n' +
+          '  var vw=window.innerWidth;\n' +
+          '  els.forEach(function(el,i){\n' +
+          '    gsap.set(el,{x:vw,force3D:true});\n' +
+          '    gsap.to(el,{x:0,duration:0.9,ease:ease,delay:0.05+i*0.08});\n' +
+          '  });\n' +
+          '  },300);\n' +
+          '});\n' +
+          '<\/script>';
+        }
+        if (heroAnim) h = h.replace('</body>', heroAnim + '\n</body>');
+
+        // Use blob URL for smooth transition. Reset _lastBgModeKey so the next
+        // renderPreview cycle treats the freshly-reloaded iframe as a new shader
+        // mount — forces uColor uniforms to re-bake from the current palette.
+        window._lastBgModeKey = null;
+        if (iframe._blobUrl) URL.revokeObjectURL(iframe._blobUrl);
+        var blob = new Blob([h], { type: "text/html" });
+        iframe._blobUrl = URL.createObjectURL(blob);
+        iframe._restoreScroll = scrollY;
+        iframe.onload = function () {
+          if (iframe._restoreScroll) {
+            iframe.contentWindow.scrollTo(0, iframe._restoreScroll);
+          }
+        };
+        iframe.src = iframe._blobUrl;
+        iframe.style.display = "";
       }
 
       function renderPreview() {
         var pv = document.getElementById("preview");
-        if (picks.arch === null) {
-          pv.innerHTML = '<div class="preview-empty">Pick a structure to preview</div>';
+        var sc = document.getElementById("showcase");
+        var designIframe = document.getElementById("design-iframe");
+        var empty = pv.querySelector(".preview-empty");
+
+        // If a template is selected, render the design.html iframe instead of the old showcase
+        if (window._currentTemplateSlug) {
+          if (empty) empty.style.display = "none";
+          sc.style.display = "none";
+          renderDesignIframe();
+          updateSlideIframes();
           return;
         }
+
+        if (picks.arch === null) {
+          if (empty) empty.style.display = "";
+          sc.style.display = "none";
+          if (designIframe) designIframe.style.display = "none";
+          return;
+        }
+        if (empty) empty.style.display = "none";
+        sc.style.display = "";
+
         var a = ARCHITECTURES[picks.arch];
         var th = picks.theme !== null ? THEMES[picks.theme] : THEMES[0];
         var p =
-          picks.palette !== null ? PALETTES[picks.palette] : { accent: "#888", muted: "#555" };
+          picks.palette !== null
+            ? PALETTES[picks.palette]
+            : {
+                primary: "#eee",
+                secondary: "#0e0e0e",
+                tertiary: "#555",
+                accent: "#888",
+                name: "Default",
+              };
         var t =
           picks.type !== null
             ? TYPEPAIRS[picks.type]
             : {
-                headline: { family: "system-ui", weight: 600 },
-                body: { family: "system-ui", weight: 400 },
+                headline: { family: "system-ui", weight: "600" },
+                body: { family: "system-ui", weight: "400" },
+                name: "Default",
               };
-        var cr = picks.corners !== null ? CORNERS[picks.corners].value : "0px";
+        var cr = picks.corners !== null ? CORNERS[picks.corners] : { name: "Slight", value: "4px" };
         var dn = picks.density !== null ? picks.density : 1;
-        var dp = picks.depth !== null ? picks.depth : 0;
+        var dp = picks.depth !== null ? DEPTHS[picks.depth] : DEPTHS[0];
+        var easeObj = picks.easing !== null ? EASINGS[picks.easing] : null;
         var bg, fg;
-        if (th.id === "palette" && p.background) {
-          bg = p.background;
-          fg = p.foreground;
+        if (th.id === "palette" && p.secondary) {
+          bg = p.secondary;
+          fg = p.primary;
         } else {
           bg = th.bg;
           fg = th.fg;
         }
         var ac = p.accent,
-          mt = p.muted || al(fg, 0.4);
+          mt = p.tertiary || al(fg, 0.4);
+        var isDark = bg && bg[0] === "#" ? parseInt(bg.slice(1, 3), 16) < 80 : true;
         var pad = [12, 20, 36][dn] + "px",
           gap = [8, 16, 28][dn] + "px";
-        var isDark = bg && bg[0] === "#" ? parseInt(bg.slice(1, 3), 16) < 80 : true;
         var shCol = isDark ? ac : fg;
         var shadow = [
           "none",
           "0 2px 16px " + al(shCol, isDark ? 0.15 : 0.1),
           "0 4px 32px " + al(shCol, isDark ? 0.3 : 0.18),
-        ][dp];
+        ][picks.depth || 0];
+
+        // Token map for frame rendering
         var tokens = {
           "{{bg}}": bg,
           "{{fg}}": fg,
           "{{ac}}": ac,
           "{{mt}}": mt,
-          "{{sf}}": al(fg, 0.06),
           "{{hf}}": t.headline.family,
           "{{hw}}": t.headline.weight,
           "{{bf}}": t.body.family,
           "{{bw}}": t.body.weight,
-          "{{cr}}": cr,
+          "{{cr}}": cr.value,
           "{{pad}}": pad,
           "{{gap}}": gap,
           "{{shadow}}": shadow,
+          "{{sf}}": al(fg, 0.06),
           "{{g}}": al(fg, 0.06),
           "{{fg3}}": al(fg, 0.03),
           "{{fg6}}": al(fg, 0.06),
@@ -1291,131 +4510,1550 @@
           "{{prompt_headline}}": (PROMPT && PROMPT.headline) || "Your Headline",
           "{{prompt_sub}}": (PROMPT && PROMPT.subline) || "Subline.",
         };
-        var h =
-          a.preview_html ||
+
+        // Set CSS variables for the showcase
+        sc.style.setProperty("--sc-bg", bg);
+        sc.style.setProperty("--sc-fg", fg);
+        sc.style.setProperty("--sc-ac", ac);
+        sc.style.setProperty("--sc-mt", mt);
+
+        // ── Overview ──
+        document.getElementById("sc-overview-title").textContent =
+          (PROMPT && PROMPT.title) || "Untitled";
+        document.getElementById("sc-overview-lead").textContent =
+          (a.mood || "") +
+          " " +
+          (a.description || "") +
+          ". " +
+          (isDark ? "Dark" : "Light") +
+          " canvas, " +
+          t.headline.family +
+          " headlines, " +
+          t.body.family +
+          " body.";
+        // Overview inherits from CSS variables set on .showcase
+
+        // ── Palette ──
+        var swatchData = [
+          { name: "Primary", hex: p.primary, role: "Text, headings" },
+          { name: "Secondary", hex: p.secondary, role: "Background, canvas" },
+          { name: "Tertiary", hex: p.tertiary, role: "Borders, captions, muted" },
+          { name: "Accent", hex: p.accent, role: "Focal elements, CTAs" },
+        ];
+        document.getElementById("sc-palette-lead").textContent =
+          p.name + " palette. Accent (" + ac + ") carries every focal element. Use it scarcely.";
+        var swatchHtml = swatchData
+          .map(function (s) {
+            return (
+              '<div class="swatch-card"><span class="swatch-chip" style="background:' +
+              s.hex +
+              ';"></span><div><div class="swatch-name">' +
+              s.name +
+              '</div><div class="swatch-hex">' +
+              s.hex +
+              '</div><div class="swatch-role">' +
+              s.role +
+              "</div></div></div>"
+            );
+          })
+          .join("");
+        document.getElementById("sc-swatches").innerHTML = swatchHtml;
+
+        // ── Typography ──
+        document.getElementById("sc-type-lead").textContent =
+          t.headline.family +
+          " (weight " +
+          t.headline.weight +
+          ") for headlines. " +
+          t.body.family +
+          " (weight " +
+          t.body.weight +
+          ") for body. Cross-category pairing.";
+        var typeRows = [
+          {
+            token: "hero-slam",
+            size: "96px",
+            weight: t.headline.weight,
+            family: t.headline.family,
+            sample: (PROMPT && PROMPT.headline) || "Hero Headline",
+            lh: "0.95",
+            ls: "-0.03em",
+          },
+          {
+            token: "section",
+            size: "48px",
+            weight: t.headline.weight,
+            family: t.headline.family,
+            sample: "Section Headline",
+            lh: "1.1",
+            ls: "-0.02em",
+          },
+          {
+            token: "body",
+            size: "28px",
+            weight: t.body.weight,
+            family: t.body.family,
+            sample: "Body text at video scale — readable at 3 seconds on screen.",
+            lh: "1.5",
+            ls: "0",
+          },
+          {
+            token: "label",
+            size: "14px",
+            weight: t.body.weight,
+            family: t.body.family,
+            sample: "OVERLINE LABEL · UPPERCASE · WIDE TRACKING",
+            lh: "1.4",
+            ls: "0.1em",
+          },
+          {
+            token: "data",
+            size: "64px",
+            weight: t.headline.weight,
+            family: t.body.family,
+            sample: "2,481,000",
+            lh: "1.0",
+            ls: "-0.02em",
+          },
+        ];
+        var typeHtml = typeRows
+          .map(function (r) {
+            return (
+              '<div class="type-specimen-row"><div class="type-meta"><strong>' +
+              r.token +
+              "</strong>" +
+              '<div style="margin-top:4px;font-size:10px;color:' +
+              mt +
+              ';font-family:ui-monospace,monospace;">' +
+              r.family +
+              " " +
+              r.weight +
+              "</div>" +
+              '<div style="font-size:9px;color:' +
+              mt +
+              ';opacity:0.6;font-family:ui-monospace,monospace;">' +
+              r.size +
+              " / " +
+              r.lh +
+              " / " +
+              r.ls +
+              "</div>" +
+              '</div><div class="type-sample" style="font-family:\'' +
+              r.family +
+              "',sans-serif;font-weight:" +
+              r.weight +
+              ";font-size:" +
+              r.size +
+              ";line-height:" +
+              r.lh +
+              ";letter-spacing:" +
+              r.ls +
+              ";color:" +
+              fg +
+              ';">' +
+              r.sample +
+              "</div></div>"
+            );
+          })
+          .join("");
+        document.getElementById("sc-type-specimens").innerHTML = typeHtml;
+
+        // ── Apply fine-tune overrides to template iframes ──
+        if (window._templatePreviewInline) {
+          var overrideCss = ":root {\n";
+
+          if (picks.palette !== null && picks.palette > 0) {
+            overrideCss +=
+              "  --tp-primary: " +
+              p.primary +
+              " !important;\n" +
+              "  --tp-secondary: " +
+              p.secondary +
+              " !important;\n" +
+              "  --tp-tertiary: " +
+              p.tertiary +
+              " !important;\n" +
+              "  --tp-accent: " +
+              p.accent +
+              " !important;\n" +
+              "  --bg: " +
+              p.secondary +
+              " !important;\n" +
+              "  --fg: " +
+              p.primary +
+              " !important;\n" +
+              "  --mt: " +
+              (p.tertiary || "#888") +
+              " !important;\n" +
+              "  --ac: " +
+              p.accent +
+              " !important;\n" +
+              "  --hair: color-mix(in srgb," +
+              p.primary +
+              " 12%,transparent) !important;\n" +
+              "  --surf: color-mix(in srgb," +
+              p.secondary +
+              " 94%," +
+              p.primary +
+              ") !important;\n" +
+              "  --dim: color-mix(in srgb," +
+              p.primary +
+              " 55%," +
+              p.secondary +
+              ") !important;\n";
+            overrideCss +=
+              "html,body { background: " +
+              p.secondary +
+              " !important; color: " +
+              p.primary +
+              " !important; }\n";
+          }
+
+          // Surface tokens — use both --tp-* (for themed templates) and --cr/--pad/--gap/--shadow (for user-design)
+          overrideCss +=
+            "  --tp-radius: " +
+            cr.value +
+            " !important;\n" +
+            "  --tp-padding: " +
+            pad +
+            " !important;\n" +
+            "  --tp-gap: " +
+            gap +
+            " !important;\n" +
+            "  --tp-shadow: " +
+            shadow +
+            " !important;\n" +
+            "  --cr: " +
+            cr.value +
+            " !important;\n" +
+            "  --pad: " +
+            pad +
+            " !important;\n" +
+            "  --gap: " +
+            gap +
+            " !important;\n" +
+            "  --shadow: " +
+            shadow +
+            " !important;\n" +
+            "}\n";
+
+          // Typography: override fonts via JS (CSS can't catch all custom classes)
+          window._fontOverride =
+            picks.type !== null && picks.type > 0
+              ? {
+                  hf: t.headline.family,
+                  hw: t.headline.weight,
+                  bf: t.body.family,
+                  bw: t.body.weight,
+                }
+              : null;
+
+          // Corners, density, depth applied via JS below (after iframe injection)
+
+          document
+            .querySelectorAll("#sc-scene-grid iframe, #sc-specimen-grid iframe")
+            .forEach(function (ifr) {
+              if (!ifr.contentDocument) return;
+              var doc = ifr.contentDocument;
+              var win = ifr.contentWindow;
+              var style = doc.getElementById("tp-finetune-override");
+              if (!style) {
+                style = doc.createElement("style");
+                style.id = "tp-finetune-override";
+                doc.head.appendChild(style);
+              }
+              style.textContent = overrideCss;
+              // Font override via JS — force every element
+              var fo = window._fontOverride;
+              if (fo && win) {
+                // Load fonts in iframe
+                var fontLink = doc.getElementById("tp-font-link");
+                if (!fontLink) {
+                  fontLink = doc.createElement("link");
+                  fontLink.id = "tp-font-link";
+                  fontLink.rel = "stylesheet";
+                  doc.head.appendChild(fontLink);
+                }
+                fontLink.href =
+                  "https://fonts.googleapis.com/css2?family=" +
+                  fo.hf.replace(/ /g, "+") +
+                  ":wght@" +
+                  fo.hw +
+                  "&family=" +
+                  fo.bf.replace(/ /g, "+") +
+                  ":wght@" +
+                  fo.bw +
+                  "&display=swap";
+                // Apply after short delay for font load
+                setTimeout(function () {
+                  doc.querySelectorAll("*").forEach(function (el) {
+                    try {
+                      var fs = parseFloat(win.getComputedStyle(el).fontSize);
+                      if (fs >= 32) {
+                        el.style.setProperty("font-family", '"' + fo.hf + '", serif', "important");
+                        el.style.setProperty("font-weight", String(fo.hw), "important");
+                      } else {
+                        el.style.setProperty(
+                          "font-family",
+                          '"' + fo.bf + '", sans-serif',
+                          "important",
+                        );
+                        el.style.setProperty("font-weight", String(fo.bw), "important");
+                      }
+                    } catch (e) {}
+                  });
+                }, 100);
+              } else {
+                // Remove font overrides — restore template defaults
+                doc.querySelectorAll("*").forEach(function (el) {
+                  el.style.removeProperty("font-family");
+                  el.style.removeProperty("font-weight");
+                });
+                var fontLink = doc.getElementById("tp-font-link");
+                if (fontLink) fontLink.remove();
+              }
+            });
+        }
+
+        // ── Density + Corners + Depth via JS on iframe elements ──
+        var _surfaceKey =
+          (picks.density || 0) + "-" + (picks.corners || 0) + "-" + (picks.depth || 0);
+        var isDefaultDensity = picks.density === 1;
+        var isDefaultCorners = picks.corners === 1;
+        var isDefaultDepth = picks.depth === 1;
+        if (window._templatePreviewInline && window._lastSurfaceKey !== _surfaceKey) {
+          window._lastSurfaceKey = _surfaceKey;
+          document
+            .querySelectorAll("#sc-scene-grid iframe, #sc-specimen-grid iframe")
+            .forEach(function (ifr) {
+              if (!ifr.contentDocument || !ifr.contentWindow) return;
+              var iDoc = ifr.contentDocument;
+              var iWin = ifr.contentWindow;
+              iDoc.querySelectorAll("*").forEach(function (el) {
+                try {
+                  // Store originals on first pass
+                  if (!el.dataset.tpOrigGap) {
+                    el.style.removeProperty("gap");
+                    el.style.removeProperty("padding");
+                    el.style.removeProperty("border-radius");
+                    el.style.removeProperty("box-shadow");
+                    var cs = iWin.getComputedStyle(el);
+                    var g = cs.gap,
+                      p = cs.padding,
+                      r = cs.borderRadius,
+                      s = cs.boxShadow;
+                    el.dataset.tpOrigGap = g || "";
+                    el.dataset.tpOrigPad = p || "";
+                    el.dataset.tpOrigRadius = r || "";
+                    el.dataset.tpOrigShadow = s || "";
+                  }
+                  var origGap = parseFloat(el.dataset.tpOrigGap);
+                  var origPad = parseFloat(el.dataset.tpOrigPad);
+                  // Density
+                  if (!isDefaultDensity) {
+                    if (origGap > 0)
+                      el.style.setProperty(
+                        "gap",
+                        Math.round(origGap * (parseInt(gap) / 16)) + "px",
+                        "important",
+                      );
+                    if (origPad > 4)
+                      el.style.setProperty(
+                        "padding",
+                        Math.round(origPad * (parseInt(pad) / 20)) + "px",
+                        "important",
+                      );
+                  } else {
+                    el.style.removeProperty("gap");
+                    el.style.removeProperty("padding");
+                  }
+                  // Corners
+                  if (!isDefaultCorners && el.dataset.tpOrigRadius !== "0px") {
+                    el.style.setProperty("border-radius", cr.value, "important");
+                  } else {
+                    el.style.removeProperty("border-radius");
+                  }
+                  // Depth
+                  if (
+                    !isDefaultDepth &&
+                    el.dataset.tpOrigShadow &&
+                    el.dataset.tpOrigShadow !== "none"
+                  ) {
+                    el.style.setProperty("box-shadow", shadow, "important");
+                  } else {
+                    el.style.removeProperty("box-shadow");
+                  }
+                } catch (e) {}
+              });
+            });
+        }
+
+        // ── Animate template only on easing change or first load ──
+        var _easeKey = picks.easing;
+        if (window._templatePreviewInline && easeObj && window._lastEaseKey !== _easeKey) {
+          window._lastEaseKey = _easeKey;
+          tpAnimateHero(easeObj);
+        }
+
+        // ── Shader background ──
+        var _bgModeKey = picks.bg_mode || 0;
+        if (window._lastBgModeKey !== _bgModeKey) {
+          window._lastBgModeKey = _bgModeKey;
+          if (typeof window._sgUpdateBg === "function") window._sgUpdateBg();
+        } else if (_bgModeKey > 0 && typeof window._sgUpdateColors === "function") {
+          window._sgUpdateColors();
+        }
+
+        // ── Motion ──
+        var motionLead = easeObj
+          ? easeObj.name + " energy. Entry easing: " + easeObj.value + " — " + easeObj.desc + "."
+          : "Select an easing to preview.";
+        document.getElementById("sc-motion-lead").textContent = motionLead;
+        var easePreview = document.getElementById("sc-ease-preview");
+        // Kill any existing ease animation
+        if (window._easeDotTween) {
+          window._easeDotTween.kill();
+          window._easeDotTween = null;
+        }
+        if (window._easeDotReturn) {
+          window._easeDotReturn.kill();
+          window._easeDotReturn = null;
+        }
+        easePreview.innerHTML =
+          '<div class="ease-preview-track"><div class="ease-preview-dot" id="sc-ease-dot" style="background:' +
+          ac +
+          ';"></div></div>';
+        if (easeObj && typeof gsap !== "undefined") {
+          var dot = document.getElementById("sc-ease-dot");
+          var isCustom = easeObj.value.indexOf("M") === 0;
+          var currentEase = isCustom ? "_pickerCustom" : easeObj.value;
+          function animateDot() {
+            window._easeDotTween = gsap.fromTo(
+              dot,
+              { left: 10 },
+              {
+                left: "calc(100% - 34px)",
+                duration: 1.2,
+                ease: currentEase,
+                delay: 0.5,
+                onComplete: function () {
+                  window._easeDotReturn = gsap.to(dot, {
+                    left: 10,
+                    duration: 1.2,
+                    ease: currentEase,
+                    delay: 0.5,
+                    onComplete: animateDot,
+                  });
+                },
+              },
+            );
+          }
+          animateDot();
+        }
+
+        // ── Elevation ──
+        document.getElementById("sc-elevation-lead").textContent = dp.name + " — " + dp.desc + ".";
+        var surfBg = isDark ? al(fg, 0.06) : al(fg, 0.03);
+        var elvGrid = document.getElementById("sc-elevation-grid");
+        elvGrid.innerHTML =
+          [64, 48, 36]
+            .map(function (size) {
+              return (
+                '<div style="width:' +
+                size +
+                "px;height:" +
+                size +
+                "px;background:" +
+                surfBg +
+                ";border-radius:" +
+                cr.value +
+                ";box-shadow:" +
+                shadow +
+                ';"></div>'
+              );
+            })
+            .join("") +
+          '<div style="width:80px;height:48px;background:' +
+          surfBg +
+          ";border-radius:" +
+          cr.value +
+          ";box-shadow:" +
+          shadow +
+          ';"></div>' +
+          '<div style="width:48px;height:64px;background:' +
+          surfBg +
+          ";border-radius:" +
+          cr.value +
+          ";box-shadow:" +
+          shadow +
+          ';"></div>';
+
+        // ── Radius ──
+        var radGrid = document.getElementById("sc-radius-grid");
+        var cards = [
+          { title: "$1,299", sub: "7 nights · all inclusive" },
+          { title: "28°C", sub: "Average summer" },
+          { title: "Oia", sub: "Famous sunset point" },
+        ];
+        radGrid.innerHTML =
+          cards
+            .map(function (c) {
+              return (
+                '<div style="background:' +
+                surfBg +
+                ";border-radius:" +
+                cr.value +
+                ";padding:20px 24px;min-width:160px;box-shadow:" +
+                shadow +
+                ';">' +
+                "<div style=\"font-family:'" +
+                t.headline.family +
+                "',sans-serif;font-weight:" +
+                t.headline.weight +
+                ";font-size:28px;color:" +
+                ac +
+                ';">' +
+                c.title +
+                "</div>" +
+                '<div style="font-size:13px;color:' +
+                mt +
+                ";margin-top:6px;font-family:'" +
+                t.body.family +
+                "',serif;\">" +
+                c.sub +
+                "</div></div>"
+              );
+            })
+            .join("") +
           '<div style="background:' +
-            bg +
-            ";padding:40px;min-height:100%;display:flex;align-items:center;justify-content:center;color:" +
-            mt +
-            ';font-size:14px;">No preview</div>';
-        Object.keys(tokens).forEach(function (k) {
-          h = h.split(k).join(tokens[k]);
-        });
-        pv.innerHTML = h;
+          ac +
+          ";color:" +
+          bg +
+          ";border-radius:" +
+          cr.value +
+          ";padding:14px 32px;display:flex;align-items:center;font-family:'" +
+          t.headline.family +
+          "',sans-serif;font-weight:" +
+          t.headline.weight +
+          ';font-size:16px;">Book Now</div>' +
+          '<div style="background:transparent;border:1px solid ' +
+          al(fg, 0.12) +
+          ";border-radius:" +
+          cr.value +
+          ";padding:14px 32px;display:flex;align-items:center;font-size:16px;color:" +
+          fg +
+          ";font-family:'" +
+          t.headline.family +
+          "',sans-serif;font-weight:" +
+          t.headline.weight +
+          ';">Learn More</div>';
       }
 
       // ── Output ──
+      // GLSL accessed via window._sgShaders (set by the module script)
+
       function showOutput() {
-        if (
-          picks.theme === null ||
-          picks.arch === null ||
-          picks.palette === null ||
-          picks.type === null ||
-          picks.corners === null ||
-          picks.density === null ||
-          picks.depth === null
-        )
-          return;
-        var a = ARCHITECTURES[picks.arch],
-          p = PALETTES[picks.palette],
-          t = TYPEPAIRS[picks.type];
-        var th = THEMES[picks.theme],
-          cr = CORNERS[picks.corners],
-          dn = DENSITIES[picks.density],
-          dp = DEPTHS[picks.depth];
-        var bg = th.id === "palette" && p.background ? p.background : th.bg;
-        var fg = th.id === "palette" && p.foreground ? p.foreground : th.fg;
+        // Template Default fills in any unselected picks so the button can fire
+        // anytime the user is in the tune phase.
+        var a = ARCHITECTURES[picks.arch !== null ? picks.arch : 0],
+          p = PALETTES[picks.palette !== null ? picks.palette : 0],
+          t = TYPEPAIRS[picks.type !== null ? picks.type : 0];
+        var th = THEMES[picks.theme !== null ? picks.theme : 0],
+          cr = CORNERS[picks.corners !== null ? picks.corners : 1],
+          dn = DENSITIES[picks.density !== null ? picks.density : 1],
+          dp = DEPTHS[picks.depth !== null ? picks.depth : 0];
+        var bg = th.id === "palette" && p.secondary ? p.secondary : th.bg;
+        var fg = th.id === "palette" && p.primary ? p.primary : th.fg;
         var ac = p.accent,
-          mt = p.muted || p.mid || "#888";
+          mt = p.tertiary || "#888";
         var padVal = { Tight: "8px", Normal: "16px", Generous: "32px" }[dn.name] || "16px";
         var gapVal = { Tight: "8px", Normal: "16px", Generous: "28px" }[dn.name] || "16px";
-
-        var md = "---\n";
-        md += "name: " + ((PROMPT && PROMPT.title) || "Untitled") + "\n";
-        md +=
-          'colors:\n  primary: "' +
-          bg +
-          '"\n  on-primary: "' +
-          fg +
-          '"\n  accent: "' +
-          ac +
-          '"\n  muted: "' +
-          mt +
-          '"\n';
-        md +=
-          "typography:\n  headline:\n    fontFamily: " +
-          t.headline.family +
-          "\n    fontSize: 3.5rem\n    fontWeight: " +
-          t.headline.weight +
-          "\n    letterSpacing: -0.03em\n";
-        md +=
-          "  body:\n    fontFamily: " +
-          t.body.family +
-          "\n    fontSize: 1rem\n    fontWeight: " +
-          t.body.weight +
-          "\n    lineHeight: 1.5\n";
-        md += "rounded:\n  md: " + cr.value + "\n";
-        md += "spacing:\n  md: " + padVal + "\n  lg: " + gapVal + "\n";
-        md += "---\n\n";
-        md += "## Overview\n\n" + a.mood + ". " + a.description + ". " + p.description + ".\n\n";
-        md +=
-          "## Colors\n\n- **Primary** (`" +
-          bg +
-          "`) — Canvas background\n- **On-Primary** (`" +
-          fg +
-          "`) — Text and content\n- **Accent** (`" +
-          ac +
-          "`) — CTAs, highlights\n- **Muted** (`" +
-          mt +
-          "`) — Secondary text\n\n";
-        md +=
-          "## Typography\n\n- **Headline** — " +
-          t.headline.family +
-          " at weight " +
-          t.headline.weight +
-          "\n- **Body** — " +
-          t.body.family +
-          " at weight " +
-          t.body.weight +
-          "\n\n";
-        md +=
-          "## Layout\n\n- Structure: " +
-          a.name +
-          " — " +
-          a.tag +
-          "\n- Density: " +
-          dn.name +
-          " (" +
-          dn.desc +
-          ")\n- Corners: " +
-          cr.name +
-          " (" +
-          cr.value +
-          ")\n\n";
-        md += "## Elevation\n\n" + dp.name + " — " + dp.desc + ".\n\n";
         var easeObj = picks.easing !== null ? EASINGS[picks.easing] : null;
-        if (easeObj) {
-          md +=
-            "## Motion\n\n- **Entry easing:** `" +
-            easeObj.value +
-            "` — " +
-            easeObj.desc +
-            "\n- **Energy:** " +
-            easeObj.name +
-            "\n\n";
-        }
-        if (a.components) md += "## Components\n\n" + a.components + "\n\n";
-        md += "## Do's and Don'ts\n\n";
-        if (a.dos) {
-          md += a.dos + "\n";
-        } else {
-          md +=
-            "### Do's\n- Use accent color sparingly for maximum impact\n- Maintain consistent " +
-            cr.name.toLowerCase() +
-            " corners\n\n### Don'ts\n- Do not mix multiple accent colors\n- Do not use weights outside the headline/body pair\n";
+        var isDark = bg && bg[0] === "#" ? parseInt(bg.slice(1, 3), 16) < 80 : true;
+
+        // ── Build design.html ──
+        var wDiff = parseInt(t.headline.weight) - parseInt(t.body.weight);
+        var bgpObj =
+          picks.bg_mode > 0 && BG_PRESETS[picks.bg_mode] ? BG_PRESETS[picks.bg_mode] : null;
+        var bgColors = bgpObj ? getBgColors() : [];
+
+        var templateSlug = window._currentTemplateSlug || "";
+
+        var spec = {
+          name: (PROMPT && PROMPT.title) || "Untitled",
+          template: templateSlug,
+          palette: {
+            primary: p.primary,
+            secondary: p.secondary,
+            tertiary: p.tertiary,
+            accent: p.accent,
+          },
+          typography: {
+            headline: { family: t.headline.family, weight: t.headline.weight },
+            body: { family: t.body.family, weight: t.body.weight },
+          },
+          surface: {
+            corners: cr.value,
+            elevation: dp.name,
+            padding: padVal,
+            gap: gapVal,
+            shadow: dp.css || "none",
+          },
+          motion: easeObj
+            ? { easing: easeObj.value, energy: easeObj.name.toLowerCase(), desc: easeObj.desc }
+            : null,
+          background: bgpObj
+            ? {
+                preset: bgpObj.name,
+                type: bgpObj.type,
+                shader: bgpObj.shader,
+                fragmentShader: bgpObj.fragmentShader || null,
+                colors: bgColors,
+                density: bgpObj.density,
+                speed: bgpObj.speed,
+                strength: bgpObj.strength,
+                rotation: [bgpObj.rotX, bgpObj.rotY, bgpObj.rotZ],
+                camera: {
+                  distance: bgpObj.camDist,
+                  azimuth: bgpObj.camAz,
+                  polar: bgpObj.camPol,
+                  zoom: bgpObj.zoom || 1,
+                },
+                position: [bgpObj.posX || 0, bgpObj.posY || 0, bgpObj.posZ || 0],
+                rendering: bgpObj._render
+                  ? {
+                      brightness: bgpObj._render.brightness,
+                      contrast: bgpObj._render.contrast,
+                      saturation: bgpObj._render.saturation,
+                    }
+                  : null,
+                grain: document.getElementById("se-grain").checked
+                  ? {
+                      enabled: true,
+                      radius: bgpObj._render ? bgpObj._render.grainRadius : 2,
+                      scatter: bgpObj._render ? bgpObj._render.grainScatter : 1,
+                      blending: bgpObj._render ? bgpObj._render.grainBlending : 1,
+                    }
+                  : { enabled: false },
+              }
+            : null,
+          density: { level: dn.name, desc: dn.desc },
+          dos: [
+            "Use accent (" + p.accent + ") for exactly the element the viewer should remember",
+            "Maintain " + cr.name.toLowerCase() + " corners (" + cr.value + ") on every container",
+            "Keep headline weight at " + t.headline.weight,
+            "Use " + t.body.family + " for all readable body text",
+            "Tint neutrals toward the accent hue",
+          ],
+          donts: [
+            "Don't introduce a second accent color",
+            "Don't use accent for background fills or large surfaces",
+            "Don't use body text under 24px in video compositions",
+            "Don't use the same entrance animation on every element",
+            isDark
+              ? "Don't use pure #000 for canvas or pure #fff for text"
+              : "Don't leave light backgrounds untextured",
+          ],
+        };
+
+        // ── Shader sources ──
+        var _sg = window._sgShaders || {};
+        var vtxSrc = _sg.vertex || "";
+        var fragSrc = bgpObj
+          ? bgpObj.fragmentShader || _sg[bgpObj.shader] || _sg.defaults || ""
+          : "";
+        var _grainEnabled = bgpObj ? document.getElementById("se-grain").checked : false;
+        var _gr = bgpObj
+          ? bgpObj._render || { grainRadius: 2, grainScatter: 1, grainBlending: 1 }
+          : {};
+        var _r = bgpObj ? bgpObj._render || { brightness: 1, contrast: 1, saturation: 1 } : {};
+
+        // ── Try per-template design.html ──
+        var designTmpl = null;
+        if (templateSlug) {
+          var dxhr = new XMLHttpRequest();
+          dxhr.open("GET", "templates/" + templateSlug + "/design.html?t=" + Date.now(), false);
+          dxhr.send();
+          if (dxhr.status === 200) designTmpl = dxhr.responseText;
         }
 
-        document.getElementById("md-output").value = md;
+        if (designTmpl) {
+          // ── Token replacement on design template ──
+          var h = designTmpl;
+
+          // Palette
+          h = h.replace(/__PRIMARY__/g, p.primary);
+          h = h.replace(/__SECONDARY__/g, p.secondary);
+          h = h.replace(/__TERTIARY__/g, p.tertiary);
+          h = h.replace(/__ACCENT__/g, p.accent);
+          h = h.replace(/__PRIMARY_NAME__/g, "primary");
+          h = h.replace(/__SECONDARY_NAME__/g, "secondary");
+          h = h.replace(/__TERTIARY_NAME__/g, "tertiary");
+          h = h.replace(/__ACCENT_NAME__/g, "accent");
+          h = h.replace(/__ACCENT_LABEL__/g, "Accent " + p.accent);
+          h = h.replace(
+            /__PALETTE_LEDE__/g,
+            "Four tokens. Primary for text on dark, secondary for canvas, tertiary for muted, accent for signal. Decorative colours may supplement but never replace.",
+          );
+
+          // Name
+          var nameParts = spec.name.split(/(?=[A-Z])/);
+          h = h.replace(/__NAME__/g, spec.name);
+          h = h.replace(/__NAME_LINE1__/g, nameParts[0] || spec.name);
+          h = h.replace(/__NAME_LINE2__/g, nameParts.slice(1).join("") || "");
+
+          // Surface
+          h = h.replace(/__CORNER_RADIUS__/g, cr.value);
+          h = h.replace(/__PADDING__/g, padVal);
+          h = h.replace(/__GAP__/g, gapVal);
+          h = h.replace(/__ELEVATION__/g, dp.name);
+          h = h.replace(/__DENSITY__/g, dn.name + " — " + dn.desc);
+          h = h.replace(/__BORDER__/g, "4px solid");
+          h = h.replace(/__SHADOW__/g, dp.css || "none");
+
+          // Motion
+          if (easeObj) {
+            h = h.replace(/__EASING_NAME__/g, easeObj.name.toLowerCase());
+            h = h.replace(/__EASING_VALUE__/g, easeObj.value);
+            h = h.replace(/__EASING_DESC__/g, easeObj.desc);
+            h = h.replace(/__EASING_HEADLINE__/g, easeObj.name.toLowerCase() + ".<br/>fast in.");
+            h = h.replace(/__EASING_LEDE__/g, easeObj.desc + ". Vary entrances by intent.");
+          } else {
+            h = h.replace(/__EASING_NAME__/g, "default");
+            h = h.replace(/__EASING_VALUE__/g, "ease");
+            h = h.replace(/__EASING_DESC__/g, "Standard easing.");
+            h = h.replace(/__EASING_HEADLINE__/g, "motion.");
+            h = h.replace(/__EASING_LEDE__/g, "Default motion.");
+          }
+          h = h.replace(/__DURATION_DEFAULT__/g, "0.8s default");
+          h = h.replace(
+            /__DURATION_DESC__/g,
+            "Slides: 0.8s. Element entrances: 0.5s. Variation across a deck creates rhythm.",
+          );
+          h = h.replace(/__DURATION_VALUES__/g, "--dur-slide: 0.8s\n--dur-enter: 0.5s");
+
+          // Background
+          if (bgpObj) {
+            h = h.replace(
+              /__BG_HEADLINE__/g,
+              bgpObj.name.toLowerCase() + ".<br/>" + bgpObj.type + ".",
+            );
+            h = h.replace(
+              /__BG_LEDE__/g,
+              bgpObj.name + " shader — " + bgpObj.type + " geometry with noise distortion.",
+            );
+            h = h.replace(
+              /__BG_BADGE__/g,
+              bgpObj.name + " \xb7 " + bgpObj.type + (_grainEnabled ? " \xb7 grain" : ""),
+            );
+            h = h.replace(
+              /__BG_TYPE__/g,
+              bgpObj.type.charAt(0).toUpperCase() + bgpObj.type.slice(1),
+            );
+            h = h.replace(/__BG_DENSITY__/g, String(bgpObj.density));
+            h = h.replace(/__BG_SPEED__/g, String(bgpObj.speed));
+            h = h.replace(/__BG_STRENGTH__/g, String(bgpObj.strength));
+            h = h.replace(
+              /__BG_GRAIN__/g,
+              _grainEnabled ? _gr.grainRadius + " \xb7 scatter " + _gr.grainScatter : "off",
+            );
+
+            var shaderConfig = JSON.stringify({
+              type: bgpObj.type,
+              density: bgpObj.density,
+              speed: bgpObj.speed,
+              strength: bgpObj.strength,
+              colors: bgColors,
+              rotation: [bgpObj.rotX, bgpObj.rotY, bgpObj.rotZ],
+              camera: {
+                distance: bgpObj.camDist,
+                azimuth: bgpObj.camAz,
+                polar: bgpObj.camPol,
+                zoom: bgpObj.zoom || 1,
+              },
+              position: [bgpObj.posX || 0, bgpObj.posY || 0, bgpObj.posZ || 0],
+              rendering: {
+                brightness: _r.brightness,
+                contrast: _r.contrast,
+                saturation: _r.saturation,
+              },
+              grain: _grainEnabled
+                ? {
+                    radius: _gr.grainRadius,
+                    scatter: _gr.grainScatter,
+                    blending: _gr.grainBlending,
+                  }
+                : false,
+            });
+            h = h.replace(/__SHADER_CONFIG__/g, shaderConfig);
+            var vtxEsc = vtxSrc.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+            var fragEsc = fragSrc.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+            h = h.replace(/__SHADER_VERTEX__/g, vtxEsc);
+            h = h.replace(/__SHADER_FRAGMENT__/g, fragEsc);
+
+            // Build shader script
+            var isSphere = bgpObj.type === "sphere";
+            var dist = isSphere ? 14 : bgpObj.camDist;
+            var camX = (
+              dist *
+              Math.sin((bgpObj.camPol * Math.PI) / 180) *
+              Math.sin((bgpObj.camAz * Math.PI) / 180)
+            ).toFixed(3);
+            var camY = (dist * Math.cos((bgpObj.camPol * Math.PI) / 180)).toFixed(3);
+            var camZ = (
+              dist *
+              Math.sin((bgpObj.camPol * Math.PI) / 180) *
+              Math.cos((bgpObj.camAz * Math.PI) / 180)
+            ).toFixed(3);
+            var ss = '<script type="module">\n';
+            ss += 'import*as THREE from"three";\n';
+            ss += 'import{EffectComposer}from"three/addons/postprocessing/EffectComposer.js";\n';
+            ss += 'import{RenderPass}from"three/addons/postprocessing/RenderPass.js";\n';
+            ss += 'import{HalftonePass}from"three/addons/postprocessing/HalftonePass.js";\n';
+            ss +=
+              'const c=document.getElementById("design-bg"),r=new THREE.WebGLRenderer({canvas:c,antialias:!0,alpha:!0,preserveDrawingBuffer:!0});\n';
+            ss += "r.setPixelRatio(Math.min(devicePixelRatio,2));\n";
+            ss +=
+              "const s=new THREE.Scene,cam=new THREE.PerspectiveCamera(45,innerWidth/innerHeight,.1,100);\n";
+            ss += "cam.position.set(" + camX + "," + camY + "," + camZ + ");cam.lookAt(0,0,0);";
+            ss +=
+              "cam.zoom=" + (isSphere ? bgpObj.zoom || 1 : 1) + ";cam.updateProjectionMatrix();\n";
+            ss +=
+              "s.add(new THREE.AmbientLight(0xffffff,.6));const dl=new THREE.DirectionalLight(0xffffff,.8);dl.position.set(5,5,5);s.add(dl);\n";
+            ss +=
+              'const cs=n=>{const v=getComputedStyle(document.documentElement).getPropertyValue(n).trim();return new THREE.Color(v||"#111")};\n';
+            ss +=
+              "const u={uTime:{value:0},uSpeed:{value:" +
+              bgpObj.speed +
+              "},uDensity:{value:" +
+              bgpObj.density +
+              "},uStrength:{value:" +
+              bgpObj.strength +
+              "},";
+            ss +=
+              'uColor1:{value:new THREE.Color("' +
+              bgColors[0] +
+              '")},uColor2:{value:new THREE.Color("' +
+              bgColors[1] +
+              '")},uColor3:{value:new THREE.Color("' +
+              (bgColors[2] || "#888") +
+              '")},';
+            ss +=
+              "uBrightness:{value:" +
+              _r.brightness +
+              "},uContrast:{value:" +
+              _r.contrast +
+              "},uSaturation:{value:" +
+              _r.saturation +
+              "}};\n";
+            ss +=
+              'const vtx=document.getElementById("vtx-src").textContent,frg=document.getElementById("frg-src").textContent;\n';
+            ss +=
+              "const mat=new THREE.ShaderMaterial({vertexShader:vtx,fragmentShader:frg,uniforms:u,side:THREE.DoubleSide});\n";
+            ss +=
+              "const m=new THREE.Mesh(new THREE." +
+              (isSphere ? "SphereGeometry(1,128,128)" : "PlaneGeometry(10,10,128,128)") +
+              ",mat);\n";
+            ss +=
+              "m.rotation.set(" +
+              ((bgpObj.rotX * Math.PI) / 180).toFixed(3) +
+              "," +
+              ((bgpObj.rotY * Math.PI) / 180).toFixed(3) +
+              "," +
+              ((bgpObj.rotZ * Math.PI) / 180).toFixed(3) +
+              ");";
+            ss +=
+              "m.position.set(" +
+              (bgpObj.posX || 0) +
+              "," +
+              (bgpObj.posY || 0) +
+              "," +
+              (bgpObj.posZ || 0) +
+              ");s.add(m);\n";
+            ss += "const comp=new EffectComposer(r);comp.addPass(new RenderPass(s,cam));\n";
+            if (_grainEnabled) {
+              ss +=
+                "comp.addPass(new HalftonePass(innerWidth,innerHeight,{shape:1,radius:" +
+                _gr.grainRadius +
+                ",rotateR:Math.PI/12,rotateG:Math.PI/6,rotateB:Math.PI/4,scatter:" +
+                _gr.grainScatter +
+                ",blending:" +
+                _gr.grainBlending +
+                ",blendingMode:1,greyscale:!1}));\n";
+            }
+            ss +=
+              "function rs(){r.setSize(innerWidth,innerHeight,!1);comp.setSize(innerWidth,innerHeight);cam.aspect=innerWidth/innerHeight;cam.updateProjectionMatrix()}\n";
+            ss += 'addEventListener("resize",rs);rs();\n';
+            ss += "const t0=performance.now();\n";
+            ss += 'const pc=document.getElementById("bg-preview-canvas");\n';
+            ss += "let pctx=null;\n";
+            ss +=
+              'if(pc){pc.width=pc.clientWidth*devicePixelRatio;pc.height=pc.clientHeight*devicePixelRatio;pctx=pc.getContext("2d");}\n';
+            ss +=
+              "(function tick(t){u.uTime.value=(t-t0)*.001;comp.render();if(pctx){pctx.drawImage(c,0,0,pc.width,pc.height);}requestAnimationFrame(tick)})(performance.now());\n";
+            ss += "<\/script>";
+            h = h.replace(/__SHADER_SCRIPT__/g, ss);
+          } else {
+            h = h.replace(/__BG_HEADLINE__/g, "none.");
+            h = h.replace(/__BG_LEDE__/g, "No animated background selected.");
+            h = h.replace(/__BG_BADGE__/g, "none");
+            h = h.replace(/__BG_TYPE__/g, "—");
+            h = h.replace(/__BG_DENSITY__/g, "—");
+            h = h.replace(/__BG_SPEED__/g, "—");
+            h = h.replace(/__BG_STRENGTH__/g, "—");
+            h = h.replace(/__BG_GRAIN__/g, "—");
+            h = h.replace(/__SHADER_CONFIG__/g, "{}");
+            h = h.replace(/__SHADER_VERTEX__/g, "");
+            h = h.replace(/__SHADER_FRAGMENT__/g, "");
+            h = h.replace(/__SHADER_SCRIPT__/g, "");
+          }
+
+          // Guidelines
+          var dosHtml = "",
+            dontsHtml = "";
+          for (var di = 0; di < spec.dos.length; di++)
+            dosHtml += "      <li>" + spec.dos[di] + "</li>\n";
+          for (var di = 0; di < spec.donts.length; di++)
+            dontsHtml += "      <li>" + spec.donts[di] + "</li>\n";
+          h = h.replace(/__DOS__/g, dosHtml);
+          h = h.replace(/__DONTS__/g, dontsHtml);
+
+          // Template CSS + slide cards
+          var templateSummary = "";
+          var summaryXhr = new XMLHttpRequest();
+          summaryXhr.open(
+            "GET",
+            "templates/" + templateSlug + "/summary.html?t=" + Date.now(),
+            false,
+          );
+          summaryXhr.send();
+          if (summaryXhr.status === 200) templateSummary = summaryXhr.responseText;
+
+          if (templateSummary) {
+            var tmplStyleMatch = templateSummary.match(/<style[\s\S]*?<\/style>/);
+            var tmplSkeletonHtml = templateSummary
+              .replace(/<style[\s\S]*?<\/style>/, "")
+              .replace(/<link[^>]*>/g, "")
+              .trim();
+
+            // Scope template CSS
+            if (tmplStyleMatch) {
+              var tmplCssRaw = tmplStyleMatch[0].replace(/<\/?style[^>]*>/g, "");
+              tmplCssRaw = tmplCssRaw.replace(
+                /--tp-primary:\s*[^;]+;/g,
+                "--tp-primary: var(--primary);",
+              );
+              tmplCssRaw = tmplCssRaw.replace(
+                /--tp-secondary:\s*[^;]+;/g,
+                "--tp-secondary: var(--secondary);",
+              );
+              tmplCssRaw = tmplCssRaw.replace(
+                /--tp-tertiary:\s*[^;]+;/g,
+                "--tp-tertiary: var(--tertiary);",
+              );
+              tmplCssRaw = tmplCssRaw.replace(
+                /--tp-accent:\s*[^;]+;/g,
+                "--tp-accent: var(--accent);",
+              );
+              var scopedCss = tmplCssRaw
+                .replace(/:root\s*\{/g, ".ds-slide-frame {")
+                .replace(/^\s*\*\s*,/gm, ".ds-slide-frame *,")
+                .replace(/^\s*\*\s*\{/gm, ".ds-slide-frame * {")
+                .replace(/\*::before/g, ".ds-slide-frame *::before")
+                .replace(/\*::after/g, ".ds-slide-frame *::after")
+                .replace(/^(\s*)(\.[a-zA-Z_][\w-]*)/gm, "$1.ds-slide-frame $2")
+                .replace(
+                  /^(\s*)(section|h1|h2|h3|p|ul|li|a|span|svg|div)(\s*[{,.])/gm,
+                  "$1.ds-slide-frame $2$3",
+                )
+                .replace(/\.ds-slide-frame \.ds-slide-frame/g, ".ds-slide-frame");
+              scopedCss +=
+                "\n.ds-slide-frame .slide, .ds-slide-frame section { display:flex !important; opacity:1 !important; position:relative !important; width:1920px !important; height:1080px !important; }";
+              scopedCss +=
+                "\n.ds-slide-frame .slide.dark { background:" +
+                p.secondary +
+                " !important; color:" +
+                p.primary +
+                " !important; }";
+              scopedCss +=
+                "\n.ds-slide-frame .slide.orange { background:" + p.accent + " !important; }";
+              scopedCss +=
+                "\n.ds-slide-frame .slide.light { background:" +
+                p.primary +
+                " !important; color:" +
+                p.secondary +
+                " !important; }";
+              h = h.replace(/__TEMPLATE_CSS__/g, scopedCss);
+            } else {
+              h = h.replace(/__TEMPLATE_CSS__/g, "");
+            }
+
+            // Build slide cards
+            var slideBlocks = tmplSkeletonHtml.split(/(?=<!-- )/);
+            var cardsHtml = "";
+            var slideIdx = 0;
+            for (var si = 0; si < slideBlocks.length; si++) {
+              var block = slideBlocks[si].trim();
+              if (!block) continue;
+              var nameMatch = block.match(/<!-- ([\w-]+) -->/);
+              if (!nameMatch) continue;
+              var slideName = nameMatch[1];
+              var skeletonHtml = block.replace(/<!-- [\w-]+ -->\s*/, "");
+              if (!skeletonHtml.trim()) continue;
+              slideIdx++;
+              var totalSlides = slideBlocks.filter(function (b) {
+                return b.trim() && /<!-- [\w-]+ -->/.test(b);
+              }).length;
+              cardsHtml +=
+                '<div class="tmpl" data-idx="' +
+                String(slideIdx).padStart(2, "0") +
+                '"><div class="tmpl-thumb"><div class="scale-wrap"><div class="ds-slide-frame">\n';
+              cardsHtml += skeletonHtml + "\n";
+              cardsHtml +=
+                '</div></div></div><div class="tmpl-foot"><span class="name">' +
+                slideName +
+                '</span><span class="idx">' +
+                String(slideIdx).padStart(2, "0") +
+                " / " +
+                totalSlides +
+                "</span></div></div>\n\n";
+            }
+            h = h.replace(/__SLIDE_CARDS__/g, cardsHtml);
+            h = h.replace(/__SLIDE_COUNT__/g, String(slideIdx));
+            var countWords = [
+              "zero",
+              "one",
+              "two",
+              "three",
+              "four",
+              "five",
+              "six",
+              "seven",
+              "eight",
+              "nine",
+              "ten",
+              "eleven",
+              "twelve",
+              "thirteen",
+              "fourteen",
+              "fifteen",
+              "sixteen",
+              "seventeen",
+              "eighteen",
+              "nineteen",
+              "twenty",
+            ];
+            h = h.replace(/__SLIDE_COUNT_WORD__/g, countWords[slideIdx] || String(slideIdx));
+          } else {
+            h = h.replace(/__TEMPLATE_CSS__/g, "");
+            h = h.replace(/__SLIDE_CARDS__/g, "");
+            h = h.replace(/__SLIDE_COUNT__/g, "0");
+            h = h.replace(/__SLIDE_COUNT_WORD__/g, "zero");
+          }
+
+          // Font link extras
+          h = h.replace(/__FONT_LINK_EXTRA__/g, "");
+
+          // Date
+          h = h.replace(
+            /__DATE__/g,
+            new Date().toLocaleDateString("en-US", { month: "long", year: "numeric" }),
+          );
+
+          document.getElementById("md-output").value = h;
+          document.getElementById("md-overlay").classList.add("visible");
+          return;
+        }
+
+        // ── Fallback: fetch template summary for generated output ──
+        var templateSummary = "";
+        if (templateSlug) {
+          var xhr = new XMLHttpRequest();
+          xhr.open("GET", "templates/" + templateSlug + "/summary.html?t=" + Date.now(), false);
+          xhr.send();
+          if (xhr.status === 200) templateSummary = xhr.responseText;
+        }
+
+        // ── Fallback: Build generated DESIGN.html ──
+        var h = '<!doctype html>\n<html lang="en">\n<head>\n';
+        h += '<meta charset="UTF-8">\n';
+        h += "<title>Design System — " + spec.name + "</title>\n";
+        h += '<link rel="preconnect" href="https://fonts.googleapis.com">\n';
+        h +=
+          '<link href="https://fonts.googleapis.com/css2?family=' +
+          t.headline.family.replace(/ /g, "+") +
+          ":wght@" +
+          t.headline.weight +
+          "&family=" +
+          t.body.family.replace(/ /g, "+") +
+          ":wght@" +
+          t.body.weight +
+          '&display=swap" rel="stylesheet">\n';
+        h += "<style>\n";
+        h += ":root {\n";
+        h += "  --bg:" + bg + "; --fg:" + fg + "; --accent:" + ac + "; --muted:" + mt + ";\n";
+        h +=
+          '  --font-hl:"' +
+          t.headline.family +
+          '",sans-serif; --font-hl-w:' +
+          t.headline.weight +
+          ";\n";
+        h += '  --font-bd:"' + t.body.family + '",sans-serif; --font-bd-w:' + t.body.weight + ";\n";
+        h += "  --radius:" + cr.value + "; --pad:" + padVal + "; --gap:" + gapVal + ";\n";
+        h += "}\n";
+        h +=
+          "body{margin:0;background:transparent;color:var(--fg);font:var(--font-bd-w) 15px/1.6 var(--font-bd);}\n";
+        h += ".ds{position:relative;z-index:1;max-width:960px;margin:0 auto;padding:48px 24px;}\n";
+        h +=
+          ".ds h1{font:var(--font-hl-w) clamp(36px,6vw,64px)/1 var(--font-hl);margin:0 0 4px;}\n";
+        h +=
+          ".ds h2{font:600 11px/1 var(--font-bd);letter-spacing:.14em;text-transform:uppercase;color:var(--accent);margin:40px 0 16px;}\n";
+        h +=
+          ".ds-sub{font-size:13px;color:var(--muted);letter-spacing:.08em;text-transform:uppercase;margin-bottom:48px;}\n";
+        h += ".ds-row{display:flex;gap:var(--gap);flex-wrap:wrap;}\n";
+        h +=
+          ".ds-sw{width:110px;height:72px;border-radius:var(--radius);display:flex;align-items:flex-end;padding:6px;}\n";
+        h +=
+          ".ds-sw span{background:rgba(0,0,0,.45);color:#fff;padding:2px 6px;border-radius:2px;font:500 10px/1.4 monospace;}\n";
+        h +=
+          ".ds-hl{font:var(--font-hl-w) clamp(24px,4vw,44px)/1.1 var(--font-hl);margin:0 0 10px;}\n";
+        h += ".ds-bd{opacity:.65;max-width:55ch;}\n";
+        h += ".ds-meta{font:11px/1.4 monospace;color:var(--muted);margin-top:6px;}\n";
+        h +=
+          ".ds-card{background:var(--fg);color:var(--bg);border-radius:var(--radius);padding:var(--pad);box-shadow:" +
+          spec.surface.shadow +
+          ";display:inline-flex;flex-direction:column;gap:6px;min-width:180px;}\n";
+        h += ".ds-card strong{font-size:14px;}\n";
+        h += ".ds-card small{font-size:12px;opacity:.6;}\n";
+        h += ".ds-props{display:flex;flex-direction:column;gap:6px;font-size:12px;opacity:.6;}\n";
+        h += ".ds-props strong{opacity:1;}\n";
+        h += ".ds-rules{display:grid;grid-template-columns:1fr 1fr;gap:24px;}\n";
+        h +=
+          ".ds-rules ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:8px;}\n";
+        h +=
+          ".ds-rules li{font-size:13px;opacity:.7;line-height:1.5;padding-left:16px;position:relative;}\n";
+        h += '.ds-do li::before{content:"\\2713";position:absolute;left:0;color:var(--accent);}\n';
+        h += '.ds-dont li::before{content:"\\2717";position:absolute;left:0;opacity:.4;}\n';
+        h +=
+          ".ds-do h3,.ds-dont h3{font:600 12px/1 var(--font-bd);letter-spacing:.1em;text-transform:uppercase;margin:0 0 10px;}\n";
+        h += ".ds-do h3{color:var(--accent);}\n";
+        h += ".ds-dont h3{opacity:.4;}\n";
+        h += ".ds-hr{height:1px;background:var(--fg);opacity:.08;margin:32px 0;}\n";
+        h +=
+          "pre{background:rgba(128,128,128,.08);border:1px solid rgba(128,128,128,.12);border-radius:var(--radius);padding:16px;overflow-x:auto;font:13px/1.5 monospace;color:var(--fg);white-space:pre-wrap;}\n";
+        h += ".ds-gallery{display:flex;flex-wrap:wrap;gap:16px;}\n";
+        h +=
+          ".ds-slide-wrap{border:1px solid rgba(128,128,128,.15);border-radius:var(--radius);overflow:hidden;position:relative;}\n";
+        h += ".ds-slide-frame{width:1920px;height:1080px;overflow:hidden;}\n";
+        h +=
+          ".ds-slide-name{padding:4px 10px;font:500 10px/1.4 monospace;letter-spacing:.1em;text-transform:uppercase;color:var(--fg);opacity:.45;border-top:1px solid rgba(128,128,128,.1);}\n";
+        h +=
+          "@media(max-width:640px){.ds-rules{grid-template-columns:1fr;}.ds-row{flex-direction:column;}.ds-gallery{grid-template-columns:1fr;}}\n";
+        h += "</style>\n";
+
+        // Shader dependencies
+        if (bgpObj) {
+          h +=
+            '<script type="importmap">{"imports":{"three":"https://cdn.jsdelivr.net/npm/three@0.167.0/build/three.module.js","three/addons/":"https://cdn.jsdelivr.net/npm/three@0.167.0/examples/jsm/"}}<\/script>\n';
+        }
+        h += "</head>\n<body>\n\n";
+
+        // ── Live shader canvas (visible background) ──
+        if (bgpObj) {
+          h +=
+            '<canvas id="design-bg" style="position:fixed;inset:0;width:100%;height:100%;z-index:-1;"><\/canvas>\n\n';
+        }
+
+        // ── Visible content ──
+        h += '<div class="ds">\n\n';
+
+        // Parsing guide
+        h += "<!-- DESIGN.html — HyperFrames Design System\n";
+        h += "     This file is both human-viewable and agent-parseable.\n";
+        h +=
+          "     Structure: Palette > Typography > Surface > Motion > Background > Guidelines > Template\n";
+        h +=
+          "     Template section contains CSS design tokens and HTML slide skeletons with {{placeholders}}.\n";
+        h +=
+          "     Shader GLSL is in the Background section. The live canvas renders it behind this content. -->\n\n";
+
+        // Title
+        h += "<h1>" + spec.name + "</h1>\n";
+        h +=
+          '<div class="ds-sub">Design System' +
+          (templateSlug ? " &middot; " + templateSlug : "") +
+          "</div>\n\n";
+
+        // ── Palette ──
+        h += "<h2>Palette</h2>\n";
+        h += '<div class="ds-row">\n';
+        var roles = [
+          ["Primary", p.primary],
+          ["Secondary", p.secondary],
+          ["Tertiary", p.tertiary],
+          ["Accent", p.accent],
+        ];
+        for (var ri = 0; ri < roles.length; ri++) {
+          h +=
+            '  <div class="ds-sw" style="background:' +
+            roles[ri][1] +
+            '"><span>' +
+            roles[ri][0] +
+            " " +
+            roles[ri][1] +
+            "</span></div>\n";
+        }
+        h += "</div>\n\n";
+
+        // ── Typography ──
+        h += "<h2>Typography</h2>\n";
+        h += '<div class="ds-hl">The quick brown fox jumps</div>\n';
+        h +=
+          '<div class="ds-bd">Pack my box with five dozen liquor jugs. How vexingly quick daft zebras jump.</div>\n';
+        h +=
+          '<div class="ds-meta">Headline: ' +
+          t.headline.family +
+          " " +
+          t.headline.weight +
+          " &middot; Body: " +
+          t.body.family +
+          " " +
+          t.body.weight +
+          "</div>\n\n";
+
+        // ── Surface ──
+        h += "<h2>Surface</h2>\n";
+        h += '<div class="ds-row" style="align-items:flex-start">\n';
+        h +=
+          '  <div class="ds-card"><strong>Example Card</strong><small>Configured corners, padding, and shadow.</small></div>\n';
+        h += '  <div class="ds-props">\n';
+        h += "    <div>Corners <strong>" + cr.value + "</strong></div>\n";
+        h += "    <div>Padding <strong>" + padVal + "</strong></div>\n";
+        h += "    <div>Gap <strong>" + gapVal + "</strong></div>\n";
+        h += "    <div>Elevation <strong>" + dp.name + "</strong></div>\n";
+        h += "    <div>Density <strong>" + dn.name + " — " + dn.desc + "</strong></div>\n";
+        h += "  </div>\n";
+        h += "</div>\n\n";
+
+        // ── Motion ──
+        if (easeObj) {
+          h += "<h2>Motion</h2>\n";
+          h +=
+            '<div class="ds-meta"><strong>' +
+            easeObj.name +
+            "</strong> — " +
+            easeObj.desc +
+            "</div>\n";
+          h += "<pre>" + easeObj.value + "</pre>\n\n";
+        }
+
+        // ── Background ──
+        if (bgpObj) {
+          var _r = bgpObj._render || { brightness: 1, contrast: 1, saturation: 1 };
+          var _gr = bgpObj._render || { grainRadius: 2, grainScatter: 1, grainBlending: 1 };
+          h += "<h2>Background</h2>\n";
+          h +=
+            '<div class="ds-meta"><strong>' +
+            bgpObj.name +
+            "</strong> &middot; " +
+            bgpObj.type +
+            " geometry";
+          if (_grainEnabled) h += " &middot; grain enabled";
+          h += "</div>\n";
+          h += '<div class="ds-row" style="margin:12px 0">\n';
+          for (var ci = 0; ci < bgColors.length; ci++) {
+            h +=
+              '  <div class="ds-sw" style="background:' +
+              bgColors[ci] +
+              ';width:80px;height:48px"><span>' +
+              bgColors[ci] +
+              "</span></div>\n";
+          }
+          h += "</div>\n";
+
+          // Shader config
+          h +=
+            '<details><summary style="cursor:pointer;font-size:13px;color:var(--accent);margin:8px 0">Shader Config</summary>\n';
+          h += "<pre>{\n";
+          h += '  "type": "' + bgpObj.type + '",\n';
+          h +=
+            '  "density": ' +
+            bgpObj.density +
+            ', "speed": ' +
+            bgpObj.speed +
+            ', "strength": ' +
+            bgpObj.strength +
+            ",\n";
+          h += '  "colors": ' + JSON.stringify(bgColors) + ",\n";
+          h += '  "rotation": [' + bgpObj.rotX + ", " + bgpObj.rotY + ", " + bgpObj.rotZ + "],\n";
+          h +=
+            '  "camera": { "distance": ' +
+            bgpObj.camDist +
+            ', "azimuth": ' +
+            bgpObj.camAz +
+            ', "polar": ' +
+            bgpObj.camPol +
+            ', "zoom": ' +
+            (bgpObj.zoom || 1) +
+            " },\n";
+          h +=
+            '  "position": [' +
+            (bgpObj.posX || 0) +
+            ", " +
+            (bgpObj.posY || 0) +
+            ", " +
+            (bgpObj.posZ || 0) +
+            "],\n";
+          h +=
+            '  "rendering": { "brightness": ' +
+            _r.brightness +
+            ', "contrast": ' +
+            _r.contrast +
+            ', "saturation": ' +
+            _r.saturation +
+            " },\n";
+          h +=
+            '  "grain": ' +
+            (_grainEnabled
+              ? '{ "radius": ' +
+                _gr.grainRadius +
+                ', "scatter": ' +
+                _gr.grainScatter +
+                ', "blending": ' +
+                _gr.grainBlending +
+                " }"
+              : "false") +
+            "\n";
+          h += "}</pre>\n";
+          h += "</details>\n";
+
+          // GLSL
+          h +=
+            '<details><summary style="cursor:pointer;font-size:13px;color:var(--accent);margin:8px 0">Vertex Shader (GLSL)</summary>\n';
+          h += "<pre>" + vtxSrc.replace(/&/g, "&amp;").replace(/</g, "&lt;") + "</pre>\n";
+          h += "</details>\n";
+          h +=
+            '<details><summary style="cursor:pointer;font-size:13px;color:var(--accent);margin:8px 0">Fragment Shader (GLSL)</summary>\n';
+          h += "<pre>" + fragSrc.replace(/&/g, "&amp;").replace(/</g, "&lt;") + "</pre>\n";
+          h += "</details>\n\n";
+        }
+
+        // ── Guidelines ──
+        h += '<div class="ds-hr"></div>\n';
+        h += "<h2>Guidelines</h2>\n";
+        h += '<div class="ds-rules">\n';
+        h += '  <div class="ds-do"><h3>Do</h3><ul>\n';
+        for (var di = 0; di < spec.dos.length; di++) h += "    <li>" + spec.dos[di] + "</li>\n";
+        h += "  </ul></div>\n";
+        h += '  <div class="ds-dont"><h3>Don\'t</h3><ul>\n';
+        for (var di = 0; di < spec.donts.length; di++) h += "    <li>" + spec.donts[di] + "</li>\n";
+        h += "  </ul></div>\n";
+        h += "</div>\n\n";
+
+        // ── Template — rendered, not code ──
+        if (templateSummary) {
+          h += '<div class="ds-hr"></div>\n';
+          h += "<h2>Template — " + templateSlug + "</h2>\n";
+
+          // Extract parts
+          var tmplStyleMatch = templateSummary.match(/<style[\s\S]*?<\/style>/);
+          var tmplFonts = templateSummary.match(/<link[^>]*fonts\.googleapis[^>]*>/g);
+          var tmplSkeletonHtml = templateSummary
+            .replace(/<style[\s\S]*?<\/style>/, "")
+            .replace(/<link[^>]*>/g, "")
+            .trim();
+
+          // Inject template fonts
+          if (tmplFonts) {
+            for (var fi = 0; fi < tmplFonts.length; fi++) h += tmplFonts[fi] + "\n";
+          }
+
+          // Inject template CSS scoped under .ds-slide-frame
+          if (tmplStyleMatch) {
+            var tmplCssRaw = tmplStyleMatch[0].replace(/<\/?style[^>]*>/g, "");
+            // Override --tp-* with user's chosen palette
+            tmplCssRaw = tmplCssRaw.replace(
+              /--tp-primary:\s*[^;]+;/g,
+              "--tp-primary: " + p.primary + ";",
+            );
+            tmplCssRaw = tmplCssRaw.replace(
+              /--tp-secondary:\s*[^;]+;/g,
+              "--tp-secondary: " + p.secondary + ";",
+            );
+            tmplCssRaw = tmplCssRaw.replace(
+              /--tp-tertiary:\s*[^;]+;/g,
+              "--tp-tertiary: " + p.tertiary + ";",
+            );
+            tmplCssRaw = tmplCssRaw.replace(
+              /--tp-accent:\s*[^;]+;/g,
+              "--tp-accent: " + p.accent + ";",
+            );
+            // Scope: :root → .ds-slide-frame, * → .ds-slide-frame *, selectors → .ds-slide-frame selector
+            var scopedCss = tmplCssRaw
+              .replace(/:root\s*\{/g, ".ds-slide-frame {")
+              .replace(/^\s*\*\s*,/gm, ".ds-slide-frame *,")
+              .replace(/^\s*\*\s*\{/gm, ".ds-slide-frame * {")
+              .replace(/\*::before/g, ".ds-slide-frame *::before")
+              .replace(/\*::after/g, ".ds-slide-frame *::after")
+              .replace(/^(\s*)(\.[a-zA-Z_][\w-]*)/gm, "$1.ds-slide-frame $2")
+              .replace(
+                /^(\s*)(section|h1|h2|h3|p|ul|li|a|span|svg|div)(\s*[{,.])/gm,
+                "$1.ds-slide-frame $2$3",
+              )
+              .replace(/\.ds-slide-frame \.ds-slide-frame/g, ".ds-slide-frame");
+            scopedCss +=
+              "\n.ds-slide-frame .slide, .ds-slide-frame section { display:flex !important; opacity:1 !important; position:relative !important; width:1920px !important; height:1080px !important; }";
+            scopedCss +=
+              "\n.ds-slide-frame .slide.dark { background:" +
+              p.secondary +
+              " !important; color:" +
+              p.primary +
+              " !important; }";
+            scopedCss +=
+              "\n.ds-slide-frame .slide.orange { background:" + p.accent + " !important; }";
+            scopedCss +=
+              "\n.ds-slide-frame .slide.light { background:" +
+              p.primary +
+              " !important; color:" +
+              p.secondary +
+              " !important; }";
+            h += '<style id="template-css">\n' + scopedCss + "\n</style>\n\n";
+          }
+
+          // Render skeletons in scaled gallery
+          var slideBlocks = tmplSkeletonHtml.split(/(?=<!-- )/);
+          h += '<div class="ds-gallery">\n';
+          for (var si = 0; si < slideBlocks.length; si++) {
+            var block = slideBlocks[si].trim();
+            if (!block) continue;
+            var nameMatch = block.match(/<!-- ([\w-]+) -->/);
+            if (!nameMatch) continue;
+            var slideName = nameMatch[1];
+            var skeletonHtml = block.replace(/<!-- [\w-]+ -->\s*/, "");
+            if (!skeletonHtml.trim()) continue;
+            // Compute scale to fit 1920px into container
+            h += '  <div class="ds-slide-wrap">\n';
+            h += '    <div class="ds-slide-frame" style="zoom:' + (320 / 1920).toFixed(4) + '">\n';
+            h += "      " + skeletonHtml + "\n";
+            h += "    </div>\n";
+            h += '    <div class="ds-slide-name">' + slideName + "</div>\n";
+            h += "  </div>\n";
+          }
+          h += "</div>\n\n";
+        }
+
+        h += "</div>\n\n";
+
+        // ── Shader renderer (the only script — powers the visible canvas) ──
+        if (bgpObj) {
+          h += '<script type="module">\n';
+          h += 'import*as THREE from"three";\n';
+          h += 'import{EffectComposer}from"three/addons/postprocessing/EffectComposer.js";\n';
+          h += 'import{RenderPass}from"three/addons/postprocessing/RenderPass.js";\n';
+          h += 'import{HalftonePass}from"three/addons/postprocessing/HalftonePass.js";\n';
+          h +=
+            'const c=document.getElementById("design-bg"),r=new THREE.WebGLRenderer({canvas:c,antialias:!0,alpha:!0});\n';
+          h += "r.setPixelRatio(Math.min(devicePixelRatio,2));\n";
+          h +=
+            "const s=new THREE.Scene,cam=new THREE.PerspectiveCamera(45,innerWidth/innerHeight,.1,100);\n";
+          var isSphere = bgpObj.type === "sphere";
+          var dist = isSphere ? 14 : bgpObj.camDist;
+          h +=
+            "cam.position.set(" +
+            (
+              dist *
+              Math.sin((bgpObj.camPol * Math.PI) / 180) *
+              Math.sin((bgpObj.camAz * Math.PI) / 180)
+            ).toFixed(3) +
+            "," +
+            (dist * Math.cos((bgpObj.camPol * Math.PI) / 180)).toFixed(3) +
+            "," +
+            (
+              dist *
+              Math.sin((bgpObj.camPol * Math.PI) / 180) *
+              Math.cos((bgpObj.camAz * Math.PI) / 180)
+            ).toFixed(3) +
+            ");\n";
+          h +=
+            "cam.lookAt(0,0,0);cam.zoom=" +
+            (isSphere ? bgpObj.zoom || 1 : 1) +
+            ";cam.updateProjectionMatrix();\n";
+          h +=
+            "s.add(new THREE.AmbientLight(0xffffff,.6));const dl=new THREE.DirectionalLight(0xffffff,.8);dl.position.set(5,5,5);s.add(dl);\n";
+          h +=
+            "const u={uTime:{value:0},uSpeed:{value:" +
+            bgpObj.speed +
+            "},uDensity:{value:" +
+            bgpObj.density +
+            "},uStrength:{value:" +
+            bgpObj.strength +
+            "},";
+          h +=
+            'uColor1:{value:new THREE.Color("' +
+            bgColors[0] +
+            '")},uColor2:{value:new THREE.Color("' +
+            bgColors[1] +
+            '")},uColor3:{value:new THREE.Color("' +
+            bgColors[2] +
+            '")},';
+          var _r = bgpObj._render || { brightness: 1, contrast: 1, saturation: 1 };
+          h +=
+            "uBrightness:{value:" +
+            _r.brightness +
+            "},uContrast:{value:" +
+            _r.contrast +
+            "},uSaturation:{value:" +
+            _r.saturation +
+            "}};\n";
+          h +=
+            'const vtx=document.querySelectorAll("details summary")[1]?.parentElement.querySelector("pre")?.textContent||"";\n';
+          h +=
+            'const frg=document.querySelectorAll("details summary")[2]?.parentElement.querySelector("pre")?.textContent||"";\n';
+          h +=
+            "const mat=new THREE.ShaderMaterial({vertexShader:vtx,fragmentShader:frg,uniforms:u,side:THREE.DoubleSide});\n";
+          h +=
+            "const geo=" +
+            (isSphere
+              ? "new THREE.SphereGeometry(1,256,256)"
+              : "new THREE.PlaneGeometry(10,10,128,128)") +
+            ";\n";
+          h +=
+            "const m=new THREE.Mesh(geo,mat);m.rotation.set(" +
+            ((bgpObj.rotX * Math.PI) / 180).toFixed(3) +
+            "," +
+            ((bgpObj.rotY * Math.PI) / 180).toFixed(3) +
+            "," +
+            ((bgpObj.rotZ * Math.PI) / 180).toFixed(3) +
+            ");";
+          h +=
+            "m.position.set(" +
+            (bgpObj.posX || 0) +
+            "," +
+            (bgpObj.posY || 0) +
+            "," +
+            (bgpObj.posZ || 0) +
+            ");s.add(m);\n";
+          h += "const comp=new EffectComposer(r);comp.addPass(new RenderPass(s,cam));\n";
+          if (_grainEnabled) {
+            var _gr = bgpObj._render || { grainRadius: 2, grainScatter: 1, grainBlending: 1 };
+            h +=
+              "comp.addPass(new HalftonePass(innerWidth,innerHeight,{shape:1,radius:" +
+              _gr.grainRadius +
+              ",rotateR:Math.PI/12,rotateG:Math.PI/6,rotateB:Math.PI/4,scatter:" +
+              _gr.grainScatter +
+              ",blending:" +
+              _gr.grainBlending +
+              ",blendingMode:1,greyscale:!1}));\n";
+          }
+          h +=
+            "function renderAt(t){r.setSize(innerWidth,innerHeight,!1);comp.setSize(innerWidth,innerHeight);cam.aspect=innerWidth/innerHeight;cam.updateProjectionMatrix();u.uTime.value=t;comp.render()}\n";
+          h += 'addEventListener("hf-seek",e=>renderAt(e.detail.time));renderAt(0);\n';
+          h += "<\/script>\n";
+        }
+
+        h += "</body>\n</html>";
+
+        document.getElementById("md-output").value = h;
         document.getElementById("md-overlay").classList.add("visible");
       }
 
@@ -1427,6 +6065,1158 @@
           }, 2000);
         });
       });
+
+      // ── Template picker (Phase 1) ──
+      var tpActivePal = 0;
+
+      function tpBuildPalChips() {
+        var c = document.getElementById("tp-pchips");
+        c.innerHTML = "";
+        var roman = ["i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x", "xi", "xii"];
+        PALETTES.forEach(function (p, i) {
+          var row = document.createElement("li");
+          row.className =
+            "idx-row" +
+            (i === tpActivePal ? " on" : "") +
+            (i === 0 ? " idx-row-default" : "");
+          var rn = roman[i] || String(i + 1);
+          if (i === 0) {
+            row.innerHTML =
+              '<div class="idx-row-num">' + rn + ".</div>" +
+              '<div class="idx-row-name">Template default</div>' +
+              '<div class="idx-row-strip" aria-hidden="true"></div>' +
+              '<div class="idx-row-note"><em>Each specimen keeps the colors it was designed with.</em></div>';
+          } else {
+            var note = p.desc ? p.desc : (p.name + " palette");
+            row.innerHTML =
+              '<div class="idx-row-num">' + rn + ".</div>" +
+              '<div class="idx-row-name">' + p.name + "</div>" +
+              '<div class="idx-row-strip">' +
+              '<span style="background:' + p.primary + '" title="Primary"></span>' +
+              '<span style="background:' + p.secondary + '" title="Secondary"></span>' +
+              '<span style="background:' + p.tertiary + '" title="Tertiary"></span>' +
+              '<span style="background:' + p.accent + '" title="Accent"></span>' +
+              "</div>" +
+              '<div class="idx-row-note"><em>' + note + "</em></div>";
+          }
+          row.onclick = function () {
+            tpActivePal = i;
+            tpBuildPalChips();
+            tpApplyAllPalettes();
+          };
+          c.appendChild(row);
+        });
+      }
+
+      function tpApplyAllPalettes() {
+        ALL_TEMPLATES.forEach(function (t) {
+          var ifr = document.getElementById("tp-ifr-" + t.slug);
+          if (!ifr || !ifr.contentDocument) return;
+          var doc = ifr.contentDocument;
+          if (!doc.head) return;
+          var style = doc.getElementById("tp-pal-override");
+          if (!style) {
+            style = doc.createElement("style");
+            style.id = "tp-pal-override";
+            doc.head.appendChild(style);
+          }
+          if (tpActivePal === 0) {
+            style.textContent = "";
+          } else {
+            var p = PALETTES[tpActivePal];
+            // design.html cover uses --primary/--secondary/--tertiary/--accent at :root —
+            // override those (alongside --tp-* for templates that read tp- tokens directly)
+            style.textContent =
+              ":root {\n" +
+              "  --primary: " + p.primary + " !important;\n" +
+              "  --secondary: " + p.secondary + " !important;\n" +
+              "  --tertiary: " + p.tertiary + " !important;\n" +
+              "  --accent: " + p.accent + " !important;\n" +
+              "  --tp-primary: " +
+              p.primary +
+              " !important;\n" +
+              "  --tp-secondary: " +
+              p.secondary +
+              " !important;\n" +
+              "  --tp-tertiary: " +
+              p.tertiary +
+              " !important;\n" +
+              "  --tp-accent: " +
+              p.accent +
+              " !important;\n" +
+              "  --tp-bg: " +
+              p.secondary +
+              " !important;\n" +
+              "  --tp-fg: " +
+              p.primary +
+              " !important;\n" +
+              "  --tp-ac: " +
+              p.accent +
+              " !important;\n" +
+              "  --tp-mt: " +
+              p.tertiary +
+              " !important;\n" +
+              "  --tp-surface: " +
+              p.secondary +
+              " !important;\n" +
+              "  --tp-border: " +
+              p.tertiary +
+              " !important;\n" +
+              "}\n";
+          }
+        });
+      }
+
+      function tpOnIframeLoad(slug, ifr) {
+        if (!ifr.contentDocument) return;
+        var doc = ifr.contentDocument;
+        var win = ifr.contentWindow;
+        doc.querySelectorAll("script").forEach(function (s) {
+          s.remove();
+        });
+
+        var ds = doc.querySelector("deck-stage");
+        if (ds) {
+          var dsStyle = doc.createElement("style");
+          dsStyle.textContent =
+            "deck-stage{display:block;width:1920px;height:1080px;position:relative;overflow:hidden;}deck-stage>section{position:absolute;top:0;left:0;width:100%;height:100%;visibility:hidden;opacity:0;}deck-stage>section:first-child{visibility:visible;opacity:1;}";
+          doc.head.appendChild(dsStyle);
+        }
+
+        // Universal slide override: force absolute positioning so all templates behave the same
+        var overrideStyle = doc.createElement("style");
+        overrideStyle.id = "tp-slide-override";
+        overrideStyle.textContent =
+          ".deck, .slide-deck, .slides-container, .presentation, deck-stage { display: block !important; width: 1920px !important; height: 1080px !important; transform: none !important; position: relative !important; overflow: hidden !important; }" +
+          ".slide, section.slide, div.slide, deck-stage > section { position: absolute !important; inset: 0 !important; width: 100% !important; height: 100% !important; min-height: 0 !important; opacity: 0 !important; visibility: hidden !important; pointer-events: none !important; }" +
+          ".slide.active, section.slide.active, div.slide.active, deck-stage > section.active { opacity: 1 !important; visibility: visible !important; pointer-events: auto !important; }";
+        doc.head.appendChild(overrideStyle);
+        doc.body.style.overflow = "hidden";
+        doc.documentElement.style.overflow = "hidden";
+
+        var slides = doc.querySelectorAll("section.slide, div.slide, .slide, deck-stage > section");
+        if (slides.length > 0) {
+          slides.forEach(function (s, i) {
+            if (i === 0) s.classList.add("active");
+            else s.classList.remove("active");
+          });
+          slides[0].querySelectorAll("*").forEach(function (el) {
+            try {
+              var cs = win.getComputedStyle(el);
+              if (cs.opacity === "0" && cs.display !== "none") el.style.opacity = "1";
+            } catch (e) {}
+          });
+        }
+
+        tpScaleIframe(ifr);
+        if (tpActivePal > 0) tpApplyAllPalettes();
+      }
+
+      function tpScaleIframe(ifr) {
+        var cprev = ifr.closest(".idx-spec-preview, .cprev");
+        if (!cprev) return;
+        var w = cprev.offsetWidth;
+        if (w > 0) ifr.style.transform = "scale(" + w / 1920 + ")";
+      }
+
+      function tpScaleAllIframes() {
+        document.querySelectorAll("#tp-grid iframe").forEach(tpScaleIframe);
+        // Also scale Phase 2 hero + specimen iframes
+        document.querySelectorAll("#sc-scene-grid iframe").forEach(function (ifr) {
+          var container = ifr.parentElement;
+          if (container) {
+            var w = container.offsetWidth;
+            if (w > 0) ifr.style.transform = "scale(" + w / 1920 + ")";
+          }
+        });
+        document.querySelectorAll(".specimen-cell iframe").forEach(function (ifr) {
+          var cell = ifr.closest(".specimen-cell");
+          if (cell) {
+            var w = cell.offsetWidth;
+            if (w > 0) ifr.style.transform = "scale(" + w / 1920 + ")";
+          }
+        });
+      }
+      window.addEventListener("resize", tpScaleAllIframes);
+
+      var _heroAnimTimeline = null;
+      function tpPreloadGsap(ifr) {
+        // GSAP runs in parent — no iframe injection needed
+      }
+
+      function tpAnimateHero(easeObj) {
+        if (_heroAnimTimeline) {
+          _heroAnimTimeline.kill();
+          _heroAnimTimeline = null;
+        }
+        var heroIfr = document.querySelector("#sc-scene-grid iframe");
+        if (!heroIfr || !heroIfr.contentDocument) return;
+        if (typeof gsap === "undefined") return;
+        _runHeroAnim(heroIfr.contentDocument, easeObj);
+      }
+
+      var _heroAnimEls = [];
+      function _runHeroAnim(doc, easeObj) {
+        var isCustom = easeObj.value.indexOf("M") === 0;
+        var ease;
+        if (isCustom && typeof CustomEase !== "undefined") {
+          CustomEase.create("_heroCustom", easeObj.value);
+          ease = "_heroCustom";
+        } else {
+          ease = isCustom ? "power2.out" : easeObj.value;
+        }
+
+        _heroAnimEls.forEach(function (el) {
+          el.style.transform = "";
+          el.style.opacity = "1";
+        });
+        _heroAnimEls = [];
+
+        var activeSlide =
+          doc.querySelector(".slide.active, deck-stage > section.active") ||
+          doc.querySelector(".slide:first-child, deck-stage > section:first-child");
+        if (!activeSlide) return;
+
+        var ifrWin = doc.defaultView;
+        var els = [];
+        activeSlide.querySelectorAll("*").forEach(function (el) {
+          try {
+            var cs = ifrWin.getComputedStyle(el);
+            if (cs.display === "none" || cs.visibility === "hidden") return;
+          } catch (e) {
+            return;
+          }
+          var rect = el.getBoundingClientRect();
+          if (rect.width < 10 || rect.height < 10) return;
+          var tag = el.tagName.toLowerCase();
+          var isLeaf =
+            el.children.length === 0 || tag === "img" || tag === "svg" || tag === "picture";
+          var hasDirectText = false;
+          for (var c = el.firstChild; c; c = c.nextSibling) {
+            if (c.nodeType === 3 && c.textContent.trim().length > 0) {
+              hasDirectText = true;
+              break;
+            }
+          }
+          if (isLeaf || hasDirectText) els.push(el);
+        });
+
+        if (els.length === 0) return;
+        _heroAnimEls = els;
+
+        var tl = gsap.timeline();
+        _heroAnimTimeline = tl;
+
+        els.forEach(function (el) {
+          var rect = el.getBoundingClientRect();
+          gsap.set(el, { opacity: 0, x: 1920 - rect.left + 20 });
+        });
+        tl.to(els, {
+          opacity: 1,
+          x: 0,
+          duration: 0.8,
+          ease: ease,
+          stagger: 0.08,
+          delay: 0,
+          onComplete: function () {
+            els.forEach(function (el) {
+              el.style.removeProperty("transform");
+              el.style.opacity = "1";
+            });
+          },
+        });
+      }
+
+      // Split a template name into two lines for cover headlines.
+      // Prefers " (" boundary, then space, then CamelCase. Falls back to [name, ""].
+      function _tpNameSplit(n) {
+        if (!n) return ["", ""];
+        var pi = n.indexOf(" (");
+        if (pi > 0) return [n.slice(0, pi), n.slice(pi + 1)];
+        var sp = n.indexOf(" ");
+        if (sp > 0) return [n.slice(0, sp), n.slice(sp + 1)];
+        var m = n.match(/^([A-Z][a-z0-9]+?)([A-Z].*)$/);
+        if (m) return [m[1], m[2]];
+        return [n, ""];
+      }
+
+      // Substitute design.html template tokens so the cover renders standalone in a card preview
+      function tpPrepDesignCover(html, slug, name) {
+        var np = (window.NATIVE_PALETTES && window.NATIVE_PALETTES[slug]) || ["#111", "#eee", "#888", "#ff5500"];
+        var dateStr = new Date().toLocaleDateString("en-US", { month: "long", year: "numeric" });
+        return html
+          .replace(/__PRIMARY__/g, np[0])
+          .replace(/__SECONDARY__/g, np[1])
+          .replace(/__TERTIARY__/g, np[2] || "#888")
+          .replace(/__ACCENT__/g, np[3])
+          .replace(/__PRIMARY_NAME__/g, "primary")
+          .replace(/__SECONDARY_NAME__/g, "secondary")
+          .replace(/__TERTIARY_NAME__/g, "tertiary")
+          .replace(/__ACCENT_NAME__/g, "accent")
+          .replace(/__NAME__/g, name || slug)
+          .replace(/__NAME_LINE1__/g, _tpNameSplit(name || slug)[0])
+          .replace(/__NAME_LINE2__/g, _tpNameSplit(name || slug)[1])
+          .replace(/__DATE__/g, dateStr)
+          .replace(/__FONT_LINK_EXTRA__/g, "")
+          .replace(/__SHADER_VERTEX__/g, "")
+          .replace(/__SHADER_FRAGMENT__/g, "")
+          .replace(/__SHADER_SCRIPT__/g, "")
+          .replace(/__SHADER_CONFIG__/g, "{}")
+          .replace(/__BG_HEADLINE__/g, "none.")
+          .replace(/__BG_LEDE__/g, "No shader.")
+          .replace(/__BG_BADGE__/g, "none")
+          .replace(/__BG_TYPE__/g, "—")
+          .replace(/__BG_DENSITY__/g, "—")
+          .replace(/__BG_SPEED__/g, "—")
+          .replace(/__BG_STRENGTH__/g, "—")
+          .replace(/__BG_GRAIN__/g, "—")
+          .replace(/__TEMPLATE_CSS__/g, "")
+          .replace(/__SLIDE_CARDS__/g, "")
+          .replace(/__SLIDE_COUNT__/g, "0")
+          .replace(/__SLIDE_COUNT_WORD__/g, "zero")
+          .replace(/__CORNER_RADIUS__/g, "4px")
+          .replace(/__PADDING__/g, "20px")
+          .replace(/__GAP__/g, "16px")
+          .replace(/__ELEVATION__/g, "Flat")
+          .replace(/__DENSITY__/g, "Normal — Balanced")
+          .replace(/__SHADOW__/g, "none")
+          .replace(/__BORDER__/g, "1px solid")
+          .replace(/__EASING_NAME__/g, "confident")
+          .replace(/__EASING_VALUE__/g, "power3.out")
+          .replace(/__EASING_DESC__/g, "Fast start, smooth deceleration")
+          .replace(/__EASING_HEADLINE__/g, "confident.<br/>fast in.")
+          .replace(/__EASING_LEDE__/g, "Fast start, smooth deceleration. Vary entrances by intent.")
+          .replace(/__DURATION_DEFAULT__/g, "0.8s default")
+          .replace(/__DURATION_DESC__/g, "Slides: 0.8s. Entrances: 0.5s.")
+          .replace(/__DURATION_VALUES__/g, "--dur-slide: 0.8s\n--dur-enter: 0.5s")
+          .replace(/__DOS__/g, "<li>—</li>")
+          .replace(/__DONTS__/g, "<li>—</li>");
+      }
+
+      function tpLoadDesignCover(ifr, slug, name) {
+        fetch("templates/" + slug + "/design.html")
+          .then(function (r) { return r.text(); })
+          .then(function (h) {
+            var prepared = tpPrepDesignCover(h, slug, name);
+            if (ifr._blobUrl) URL.revokeObjectURL(ifr._blobUrl);
+            var blob = new Blob([prepared], { type: "text/html" });
+            ifr._blobUrl = URL.createObjectURL(blob);
+            ifr.src = ifr._blobUrl;
+          })
+          .catch(function () {
+            // Fall back to direct template if design.html unavailable
+            ifr.src = "templates/" + slug + "/template.html";
+          });
+      }
+
+      function tpBuildGrid() {
+        var grid = document.getElementById("tp-grid");
+        grid.innerHTML = "";
+        var roman = [
+          "i","ii","iii","iv","v","vi","vii","viii","ix","x",
+          "xi","xii","xiii","xiv","xv","xvi","xvii","xviii","xix","xx",
+          "xxi","xxii","xxiii","xxiv","xxv","xxvi","xxvii","xxviii","xxix","xxx",
+          "xxxi","xxxii","xxxiii","xxxiv","xxxv","xxxvi","xxxvii","xxxviii","xxxix","xl",
+        ];
+        ALL_TEMPLATES.forEach(function (t, idx) {
+          var card = document.createElement("li");
+          card.className = "idx-spec" + (t._provided ? " provided" : "");
+          card.id = "tp-card-" + t.slug;
+          var rn = roman[idx] || String(idx + 1);
+          var folio = String(idx + 1).padStart(2, "0") + " / " + String(ALL_TEMPLATES.length).padStart(2, "0");
+          var schemeLabel = t.scheme ? t.scheme : "";
+          var densityLabel = t.density ? t.density : "";
+          var metaParts = [];
+          if (schemeLabel) metaParts.push(schemeLabel);
+          if (densityLabel) metaParts.push(densityLabel);
+          var metaStr = metaParts.join(" · ");
+          card.innerHTML =
+            '<div class="idx-spec-num"><span>' + rn + ".</span><span class=\"idx-spec-folio\">" + folio + "</span></div>" +
+            '<div class="idx-spec-preview"><iframe id="tp-ifr-' +
+            t.slug +
+            '" sandbox="allow-same-origin" loading="lazy"></iframe></div>' +
+            '<div class="idx-spec-caption">' +
+            '<h3 class="idx-spec-name">' + t.name + "</h3>" +
+            (metaStr ? '<span class="idx-spec-meta">' + metaStr + "</span>" : "") +
+            (t.tagline ? '<p class="idx-spec-tagline"><em>' + t.tagline + "</em></p>" : "") +
+            "</div>";
+          card.addEventListener(
+            "click",
+            (function (slug) {
+              return function () {
+                tpSelectTemplate(slug);
+              };
+            })(t.slug),
+          );
+          grid.appendChild(card);
+          var ifr = card.querySelector("iframe");
+          tpLoadDesignCover(ifr, t.slug, t.name);
+          ifr.addEventListener(
+            "load",
+            (function (s, f) {
+              return function () {
+                tpOnIframeLoad(s, f);
+              };
+            })(t.slug, ifr),
+          );
+        });
+      }
+
+      function tpSelectTemplate(slug) {
+        var t = null;
+        for (var i = 0; i < ALL_TEMPLATES.length; i++) {
+          if (ALL_TEMPLATES[i].slug === slug) {
+            t = ALL_TEMPLATES[i];
+            break;
+          }
+        }
+        if (!t) return;
+        var pal = tpActivePal > 0 ? PALETTES[tpActivePal] : null;
+        var pick = {
+          slug: slug,
+          name: t.name,
+          tagline: t.tagline,
+          scheme: t.scheme,
+          palette: pal
+            ? { bg: pal.secondary, fg: pal.primary, accent: pal.accent, muted: pal.tertiary }
+            : null,
+        };
+        var card = document.getElementById("tp-card-" + slug);
+        var overlay = document.getElementById("tp-trans-overlay");
+        overlay.classList.add("active");
+        if (card) card.classList.add("selected-exit");
+        setTimeout(function () {
+          handleTemplatePick(pick);
+        }, 900);
+      }
+
+      function tpUpdateNav() {
+        var nav = document.getElementById("tp-nav");
+        var slug = window._currentTemplateSlug;
+        if (!nav || !slug || !ALL_TEMPLATES.length) return;
+        var idx = -1;
+        for (var i = 0; i < ALL_TEMPLATES.length; i++) {
+          if (ALL_TEMPLATES[i].slug === slug) { idx = i; break; }
+        }
+        if (idx < 0) { nav.style.display = "none"; return; }
+        var n = ALL_TEMPLATES.length;
+        var prev = ALL_TEMPLATES[(idx - 1 + n) % n];
+        var next = ALL_TEMPLATES[(idx + 1) % n];
+        var cur = ALL_TEMPLATES[idx];
+        nav.style.display = "flex";
+        document.getElementById("tp-nav-title").textContent = cur.name;
+        document.getElementById("tp-nav-prev").title = prev.name;
+        document.getElementById("tp-nav-next").title = next.name;
+      }
+
+      function tpNavTo(dir) {
+        var slug = window._currentTemplateSlug;
+        if (!slug || !ALL_TEMPLATES.length) return;
+        var idx = -1;
+        for (var i = 0; i < ALL_TEMPLATES.length; i++) {
+          if (ALL_TEMPLATES[i].slug === slug) { idx = i; break; }
+        }
+        if (idx < 0) return;
+        var n = ALL_TEMPLATES.length;
+        var nxt = ALL_TEMPLATES[(idx + dir + n) % n];
+        var pal = tpActivePal > 0 ? PALETTES[tpActivePal] : null;
+        handleTemplatePick({
+          slug: nxt.slug,
+          name: nxt.name,
+          tagline: nxt.tagline,
+          scheme: nxt.scheme,
+          palette: pal ? { bg: pal.secondary, fg: pal.primary, accent: pal.accent, muted: pal.tertiary } : null,
+        });
+      }
+
+      function handleTemplatePick(pick) {
+        if (!pick || !pick.slug) return;
+        window._currentTemplateSlug = pick.slug;
+        PALETTES[0]._native = null; // Reset so native palette is re-read for new template
+        tpUpdateNav();
+        var tn = document.getElementById("current-tmpl-name");
+        if (tn) tn.textContent = pick.name;
+        _origVarCache = {};
+        PROMPT.title = pick.name;
+        PROMPT.headline = pick.name.toUpperCase();
+        PROMPT.subline = pick.tagline;
+        if (ARCHITECTURES[0]) {
+          ARCHITECTURES[0].name = pick.name;
+          ARCHITECTURES[0].description = pick.tagline;
+          ARCHITECTURES[0].tag = pick.slug;
+          ARCHITECTURES[0].mood =
+            (pick.scheme === "dark" ? "Dark" : "Light") + " template — " + pick.tagline;
+        }
+        if (pick.palette) {
+          var bestIdx = 0,
+            bestDist = Infinity;
+          PALETTES.forEach(function (p, i) {
+            if (i === 0 || !p.secondary || !p.primary || !p.accent) return;
+            var d =
+              Math.abs(
+                parseInt(p.secondary.slice(1, 3), 16) - parseInt(pick.palette.bg.slice(1, 3), 16),
+              ) +
+              Math.abs(
+                parseInt(p.primary.slice(1, 3), 16) - parseInt(pick.palette.fg.slice(1, 3), 16),
+              ) +
+              Math.abs(
+                parseInt(p.accent.slice(1, 3), 16) - parseInt(pick.palette.accent.slice(1, 3), 16),
+              );
+            if (d < bestDist) {
+              bestDist = d;
+              bestIdx = i;
+            }
+          });
+          overridePalette = bestIdx;
+        }
+        var tabMood = document.getElementById("tab-mood");
+        if (tabMood) {
+          tabMood.textContent = "← Template";
+          tabMood.onclick = function () {
+            showPhase("mood");
+            tabMood.textContent = "1. Template";
+            var overlay = document.getElementById("tp-trans-overlay");
+            if (overlay) overlay.classList.remove("active");
+            document.querySelectorAll(".selected-exit").forEach(function (c) {
+              c.classList.remove("selected-exit");
+            });
+          };
+        }
+        // Reset config picks to defaults when a new template is selected.
+        // Carry the Phase 1 palette pick forward (Template Default = 0 → null).
+        picks.palette = tpActivePal > 0 ? tpActivePal : null;
+        picks.type = null;
+        picks.corners = null;
+        picks.density = null;
+        picks.depth = null;
+        picks.easing = null;
+        picks.bg_mode = null;
+        overridePalette = null;
+        window._lastHeroEasing = null; // force animation on next render
+        selectedMood = 0;
+        goToTune();
+        // Mark default option (first) as active for palette + type — those fall back
+        // to PALETTES[0]/TYPEPAIRS[0] when picks is null. Corners/density/depth/ease/bg
+        // use the template's native values when null (no picker option in effect), so
+        // no marker shown for those.
+        setTimeout(function () {
+          [
+            ["pal-options", ".opt"],
+            ["type-options", ".opt"],
+          ].forEach(function (pair) {
+            var c = document.getElementById(pair[0]);
+            if (!c) return;
+            c.querySelectorAll(pair[1]).forEach(function (el) {
+              el.classList.remove("selected");
+            });
+            // For palette: highlight the index carried forward from Phase 1
+            var idx = 0;
+            if (pair[0] === "pal-options" && tpActivePal > 0) idx = tpActivePal;
+            var children = c.querySelectorAll(pair[1]);
+            if (children[idx]) children[idx].classList.add("selected");
+          });
+          ["corner-options", "density-options", "depth-options", "ease-options", "bg-options"].forEach(function (id) {
+            var c = document.getElementById(id);
+            if (!c) return;
+            c.querySelectorAll(".chip,.opt,.ease-opt").forEach(function (el) {
+              el.classList.remove("selected");
+            });
+          });
+        }, 0);
+        // Scroll sidebar + preview iframe to top after goToTune rebuilds content
+        setTimeout(function() {
+          var panelLeft = document.querySelector(".panel-left");
+          if (panelLeft) panelLeft.scrollTop = 0;
+          var dif = document.getElementById("design-iframe");
+          if (dif && dif.contentWindow) {
+            try { dif.contentWindow.scrollTo(0, 0); } catch (e) {}
+          }
+          // Also retry once iframe finishes rendering new template
+          setTimeout(function () {
+            if (dif && dif.contentWindow) {
+              try { dif.contentWindow.scrollTo(0, 0); } catch (e) {}
+            }
+          }, 300);
+        }, 0);
+        if (pick.slug) {
+          var grid = document.getElementById("sc-scene-grid");
+          if (grid) {
+            grid.innerHTML = "";
+            var wrap = document.createElement("div");
+            wrap.style.cssText =
+              "grid-column:1/-1;position:relative;width:100%;aspect-ratio:16/9;overflow:hidden;background:#000;border-radius:4px;";
+            var ifr = document.createElement("iframe");
+            var tmplSrc =
+              pick.slug === "user-design" &&
+              document.querySelector('link[href$="DESIGN.html"],script[src$="DESIGN.html"]') ===
+                null
+                ? (function () {
+                    var x = new XMLHttpRequest();
+                    x.open("HEAD", "DESIGN.html", false);
+                    x.send();
+                    return x.status === 200
+                      ? "DESIGN.html"
+                      : "templates/" + pick.slug + "/template.html";
+                  })()
+                : "templates/" + pick.slug + "/template.html";
+            ifr.src = tmplSrc;
+            ifr.sandbox = "allow-same-origin allow-scripts";
+            ifr.style.cssText =
+              "width:1920px;height:1080px;border:none;transform-origin:top left;pointer-events:none;";
+            wrap.appendChild(ifr);
+            grid.appendChild(wrap);
+            ifr.addEventListener("load", function () {
+              tpOnIframeLoad(pick.slug, ifr);
+              tpPreloadGsap(ifr);
+              updateDefaultPaletteFromIframe(ifr);
+              updateDefaultTypeFromIframe(ifr);
+              function scaleHero() {
+                var w = wrap.offsetWidth;
+                if (w > 0) {
+                  ifr.style.transform = "scale(" + w / 1920 + ")";
+                } else {
+                  setTimeout(scaleHero, 50);
+                }
+              }
+              scaleHero();
+              renderPreview();
+              // Build specimen grid with ALL slides (including first)
+              var doc = ifr.contentDocument;
+              if (!doc) return;
+              var slides = doc.querySelectorAll(
+                "section.slide, div.slide, .slide, deck-stage > section",
+              );
+              var specGrid = document.getElementById("sc-specimen-grid");
+              window._heroSlideIdx = 0;
+              if (specGrid && slides.length > 0) {
+                specGrid.innerHTML = "";
+                for (var si = 0; si < slides.length; si++) {
+                  (function (slideIdx) {
+                    var cell = document.createElement("div");
+                    cell.className = "specimen-cell" + (slideIdx === 0 ? " active" : "");
+                    cell.dataset.slideIdx = slideIdx;
+                    cell.setAttribute("data-slide-idx", slideIdx);
+                    var specIfr = document.createElement("iframe");
+                    specIfr.src =
+                      pick.slug === "user-design" && tmplSrc === "DESIGN.html"
+                        ? "DESIGN.html"
+                        : "templates/" + pick.slug + "/template.html";
+                    specIfr.sandbox = "allow-same-origin allow-scripts";
+                    specIfr.loading = "lazy";
+                    specIfr.style.cssText =
+                      "width:1920px;height:1080px;border:none;transform-origin:top left;pointer-events:none;";
+                    cell.appendChild(specIfr);
+                    var label = document.createElement("div");
+                    label.className = "specimen-label";
+                    label.textContent = "Slide " + (slideIdx + 1);
+                    cell.appendChild(label);
+                    specGrid.appendChild(cell);
+                    // Click to swap hero
+                    cell.addEventListener("click", function () {
+                      specGrid.querySelectorAll(".specimen-cell").forEach(function (c) {
+                        c.classList.remove("active");
+                      });
+                      cell.classList.add("active");
+                      window._heroSlideIdx = slideIdx;
+                      var heroIfr = document.querySelector("#sc-scene-grid iframe");
+                      if (heroIfr && heroIfr.contentDocument) {
+                        var hSlides = heroIfr.contentDocument.querySelectorAll(
+                          "section.slide, div.slide, .slide, deck-stage > section",
+                        );
+                        hSlides.forEach(function (s, i) {
+                          s.classList.toggle("active", i === slideIdx);
+                        });
+                        // Reset opacity on newly active slide children
+                        if (hSlides[slideIdx]) {
+                          hSlides[slideIdx].querySelectorAll("*").forEach(function (el) {
+                            try {
+                              if (heroIfr.contentWindow.getComputedStyle(el).opacity === "0")
+                                el.style.opacity = "1";
+                            } catch (e) {}
+                          });
+                        }
+                        var easeObj = picks.easing !== null ? EASINGS[picks.easing] : null;
+                        if (easeObj) tpAnimateHero(easeObj);
+                        // Shader transparency is handled by CSS override on --tp-secondary
+                        // No re-application needed on slide switch
+                      }
+                    });
+                    specIfr.addEventListener("load", function () {
+                      var sDoc = specIfr.contentDocument;
+                      var sWin = specIfr.contentWindow;
+                      if (!sDoc) return;
+                      sDoc.querySelectorAll("script").forEach(function (s) {
+                        s.remove();
+                      });
+                      var ds = sDoc.querySelector("deck-stage");
+                      if (ds) {
+                        var dsStyle = sDoc.createElement("style");
+                        dsStyle.textContent =
+                          "deck-stage{display:block;width:1920px;height:1080px;position:relative;overflow:hidden;}";
+                        sDoc.head.appendChild(dsStyle);
+                      }
+                      var ovr = sDoc.createElement("style");
+                      ovr.textContent =
+                        ".deck, .slide-deck, .slides-container, .presentation, deck-stage { display: block !important; width: 1920px !important; height: 1080px !important; transform: none !important; position: relative !important; overflow: hidden !important; }" +
+                        ".slide, section.slide, div.slide, deck-stage > section { position: absolute !important; inset: 0 !important; width: 100% !important; height: 100% !important; min-height: 0 !important; opacity: 0 !important; visibility: hidden !important; pointer-events: none !important; }" +
+                        ".slide.active, section.slide.active, div.slide.active, deck-stage > section.active { opacity: 1 !important; visibility: visible !important; pointer-events: auto !important; }";
+                      sDoc.head.appendChild(ovr);
+                      sDoc.body.style.overflow = "hidden";
+                      sDoc.documentElement.style.overflow = "hidden";
+                      var sSlides = sDoc.querySelectorAll(
+                        "section.slide, div.slide, .slide, deck-stage > section",
+                      );
+                      sSlides.forEach(function (s, i) {
+                        if (i === slideIdx) s.classList.add("active");
+                        else s.classList.remove("active");
+                      });
+                      if (sSlides[slideIdx]) {
+                        sSlides[slideIdx].querySelectorAll("*").forEach(function (el) {
+                          try {
+                            if (sWin.getComputedStyle(el).opacity === "0") el.style.opacity = "1";
+                          } catch (e) {}
+                        });
+                      }
+                      (function scaleSpec() {
+                        var w = cell.offsetWidth;
+                        if (w > 0) specIfr.style.transform = "scale(" + w / 1920 + ")";
+                        else setTimeout(scaleSpec, 50);
+                      })();
+                      // Re-run slide injection to cover this newly-loaded specimen iframe
+                      if (typeof updateSlideIframes === "function") updateSlideIframes();
+                    });
+                  })(si);
+                }
+              }
+            });
+            window._templatePreviewInline = true;
+          }
+        }
+      }
+
+      // Initialize template picker
+      if (typeof ALL_TEMPLATES !== "undefined" && ALL_TEMPLATES.length) {
+        tpBuildPalChips();
+        tpBuildGrid();
+        // Auto-advance to Phase 2 when design.md provides a user-design template
+        if (typeof DESIGN_MD !== "undefined" && DESIGN_MD) {
+          // Find matching palette or use first non-default
+          var dmPalIdx = 1;
+          for (var di = 1; di < PALETTES.length; di++) {
+            if (PALETTES[di].accent === DESIGN_MD.accent) {
+              dmPalIdx = di;
+              break;
+            }
+          }
+          tpActivePal = dmPalIdx;
+          tpBuildPalChips();
+          tpApplyAllPalettes();
+          setTimeout(function () {
+            tpSelectTemplate("user-design");
+          }, 600);
+        }
+      }
+    </script>
+
+    <!-- Three.js shader gradient backgrounds (ES module) -->
+    <script type="module">
+      import * as THREE from "three";
+      import { EffectComposer } from "three/addons/postprocessing/EffectComposer.js";
+      import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
+      import { HalftonePass } from "three/addons/postprocessing/HalftonePass.js";
+      window.THREE = THREE;
+      window._HalftonePass = HalftonePass;
+      window._EffectComposer = EffectComposer;
+      window._RenderPass = RenderPass;
+
+      const vertexShader = `
+vec3 mod289(vec3 x){return x-floor(x*(1.0/289.0))*289.0;}
+vec4 mod289(vec4 x){return x-floor(x*(1.0/289.0))*289.0;}
+vec4 permute(vec4 x){return mod289(((x*34.0)+1.0)*x);}
+vec4 taylorInvSqrt(vec4 r){return 1.79284291400159-0.85373472095314*r;}
+vec3 fade(vec3 t){return t*t*t*(t*(t*6.0-15.0)+10.0);}
+float cnoise(vec3 P){vec3 Pi0=floor(P);vec3 Pi1=Pi0+vec3(1.0);Pi0=mod289(Pi0);Pi1=mod289(Pi1);vec3 Pf0=fract(P);vec3 Pf1=Pf0-vec3(1.0);vec4 ix=vec4(Pi0.x,Pi1.x,Pi0.x,Pi1.x);vec4 iy=vec4(Pi0.yy,Pi1.yy);vec4 iz0=Pi0.zzzz;vec4 iz1=Pi1.zzzz;vec4 ixy=permute(permute(ix)+iy);vec4 ixy0=permute(ixy+iz0);vec4 ixy1=permute(ixy+iz1);vec4 gx0=ixy0*(1.0/7.0);vec4 gy0=fract(floor(gx0)*(1.0/7.0))-0.5;gx0=fract(gx0);vec4 gz0=vec4(0.5)-abs(gx0)-abs(gy0);vec4 sz0=step(gz0,vec4(0.0));gx0-=sz0*(step(0.0,gx0)-0.5);gy0-=sz0*(step(0.0,gy0)-0.5);vec4 gx1=ixy1*(1.0/7.0);vec4 gy1=fract(floor(gx1)*(1.0/7.0))-0.5;gx1=fract(gx1);vec4 gz1=vec4(0.5)-abs(gx1)-abs(gy1);vec4 sz1=step(gz1,vec4(0.0));gx1-=sz1*(step(0.0,gx1)-0.5);gy1-=sz1*(step(0.0,gy1)-0.5);vec3 g000=vec3(gx0.x,gy0.x,gz0.x);vec3 g100=vec3(gx0.y,gy0.y,gz0.y);vec3 g010=vec3(gx0.z,gy0.z,gz0.z);vec3 g110=vec3(gx0.w,gy0.w,gz0.w);vec3 g001=vec3(gx1.x,gy1.x,gz1.x);vec3 g101=vec3(gx1.y,gy1.y,gz1.y);vec3 g011=vec3(gx1.z,gy1.z,gz1.z);vec3 g111=vec3(gx1.w,gy1.w,gz1.w);vec4 norm0=taylorInvSqrt(vec4(dot(g000,g000),dot(g010,g010),dot(g100,g100),dot(g110,g110)));g000*=norm0.x;g010*=norm0.y;g100*=norm0.z;g110*=norm0.w;vec4 norm1=taylorInvSqrt(vec4(dot(g001,g001),dot(g011,g011),dot(g101,g101),dot(g111,g111)));g001*=norm1.x;g011*=norm1.y;g101*=norm1.z;g111*=norm1.w;float n000=dot(g000,Pf0);float n100=dot(g100,vec3(Pf1.x,Pf0.yz));float n010=dot(g010,vec3(Pf0.x,Pf1.y,Pf0.z));float n110=dot(g110,vec3(Pf1.xy,Pf0.z));float n001=dot(g001,vec3(Pf0.xy,Pf1.z));float n101=dot(g101,vec3(Pf1.x,Pf0.y,Pf1.z));float n011=dot(g011,vec3(Pf0.x,Pf1.yz));float n111=dot(g111,Pf1);vec3 fade_xyz=fade(Pf0);vec4 n_z=mix(vec4(n000,n100,n010,n110),vec4(n001,n101,n011,n111),fade_xyz.z);vec2 n_yz=mix(n_z.xy,n_z.zw,fade_xyz.y);return 2.2*mix(n_yz.x,n_yz.y,fade_xyz.x);}
+varying vec3 vPos;varying vec3 vNormal;varying vec3 vViewPos;
+uniform float uTime;uniform float uSpeed;uniform float uDensity;uniform float uStrength;
+void main(){
+  vNormal=normalize(normalMatrix*normal);
+  float t=uTime*uSpeed;
+  vec3 noisePos=0.43*position*uDensity;
+  float distortion=0.75*cnoise(noisePos+t);
+  vec3 pos=position+normal*distortion*uStrength;
+  vPos=pos;
+  vec4 mvPos=modelViewMatrix*vec4(pos,1.0);
+  vViewPos=mvPos.xyz;
+  gl_Position=projectionMatrix*mvPos;
+}`;
+
+      const COLOR_ADJUST_GLSL = `
+uniform float uBrightness;
+uniform float uContrast;
+uniform float uSaturation;
+vec3 adjustColor(vec3 col) {
+  col *= uBrightness;
+  col = mix(vec3(0.5), col, uContrast);
+  float lum = dot(col, vec3(0.299, 0.587, 0.114));
+  col = mix(vec3(lum), col, uSaturation);
+  return clamp(col, 0.0, 1.0);
+}`;
+
+      const FRAG_DEFAULTS = `varying vec3 vPos;varying vec3 vNormal;varying vec3 vViewPos;uniform vec3 uColor1;uniform vec3 uColor2;uniform vec3 uColor3;uniform float uTime;
+${COLOR_ADJUST_GLSL}
+void main(){
+  vec3 base=mix(mix(uColor1,uColor2,smoothstep(-3.0,3.0,vPos.x)),uColor3,smoothstep(-2.0,2.0,vPos.z));
+  vec3 n=normalize(vNormal);vec3 v=normalize(-vViewPos);
+  vec3 l1=normalize(vec3(1,1,0.5));vec3 l2=normalize(vec3(-0.5,0.3,1));vec3 l3=normalize(vec3(0,-1,0.3));
+  float diff=max(dot(n,l1),0.0)*0.25+max(dot(n,l2),0.0)*0.15+max(dot(n,l3),0.0)*0.1;
+  float spec=pow(max(dot(n,normalize(l1+v)),0.0),64.0)*0.25+pow(max(dot(n,normalize(l2+v)),0.0),48.0)*0.15;
+  float fresnel=pow(1.0-max(dot(n,v),0.0),4.0);
+  vec3 col=base*(0.65+diff)+vec3(spec)+mix(base,vec3(1),0.3)*fresnel*0.2;
+  col=adjustColor(col);
+  gl_FragColor=vec4(col,1.0);
+}`;
+
+      const FRAG_COSMIC = `varying vec3 vPos;varying vec3 vNormal;varying vec3 vViewPos;uniform vec3 uColor1;uniform vec3 uColor2;uniform vec3 uColor3;uniform float uTime;uniform float uSpeed;
+${COLOR_ADJUST_GLSL}
+float hash(vec2 p){return fract(sin(dot(p,vec2(127.1,311.7)))*43758.5453123);}
+float noise2D(vec2 p){vec2 i=floor(p);vec2 f=fract(p);vec2 u=f*f*(3.0-2.0*f);return mix(mix(hash(i),hash(i+vec2(1,0)),u.x),mix(hash(i+vec2(0,1)),hash(i+vec2(1,1)),u.x),u.y);}
+void main(){
+  float t=uTime*uSpeed;vec3 n=normalize(vNormal);vec3 v=normalize(-vViewPos);
+  float i1=sin(vPos.x*20.0+t*3.0)*cos(vPos.y*15.0+t*2.0);
+  float i2=sin(vPos.x*35.0+t*4.0)*sin(vPos.y*30.0+t*3.5);
+  float i3=cos(vPos.x*50.0+t*5.0)*cos(vPos.y*45.0+t*4.5);
+  float holo=(i1+i2*0.5+i3*0.25)/1.75;
+  float shimmer=noise2D(vPos.xy*40.0+t*2.0)*0.3;float glow=noise2D(vPos.xy*8.0+t*0.5)*0.5;
+  vec3 shift=vec3(sin(vPos.x*10.0+t*2.0)*0.1,sin(vPos.x*10.0+t*2.0+2.094)*0.1,sin(vPos.x*10.0+t*2.0+4.188)*0.1);
+  float gx=smoothstep(-4.0,4.0,vPos.x+holo*2.0);
+  vec3 col=mix(mix(uColor1,uColor2,gx),uColor3,smoothstep(-2.0,2.0,vPos.z)*0.7);
+  col+=shift+vec3(glow*0.15,shimmer*0.1,(glow+shimmer)*0.08);
+  float irid=sin(vPos.x*25.0+t*3.0)*cos(vPos.y*20.0+t*2.5)*0.08;
+  col+=vec3(irid*0.2,irid*0.3,irid*0.4);
+  vec3 l1=normalize(vec3(1,1,0.5));vec3 l2=normalize(vec3(-0.5,0.3,1));
+  float diff=max(dot(n,l1),0.0)*0.2+max(dot(n,l2),0.0)*0.12;
+  float spec=pow(max(dot(n,normalize(l1+v)),0.0),64.0)*0.3+pow(max(dot(n,normalize(l2+v)),0.0),48.0)*0.15;
+  float fresnel=pow(1.0-max(dot(n,v),0.0),4.0);
+  col=col*(0.7+diff)+vec3(spec)+mix(col,vec3(1),0.3)*fresnel*0.25;
+  col=adjustColor(col);
+  gl_FragColor=vec4(col,1.0);
+}`;
+
+      const FRAG_GLASS = `varying vec3 vPos;varying vec3 vNormal;varying vec3 vViewPos;uniform vec3 uColor1;uniform vec3 uColor2;uniform vec3 uColor3;uniform float uTime;
+${COLOR_ADJUST_GLSL}
+void main(){
+  vec3 base=mix(mix(uColor1,uColor2,smoothstep(-3.0,3.0,vPos.x)),uColor3,smoothstep(-2.0,2.0,vPos.z));
+  vec3 n=normalize(vNormal);vec3 v=normalize(-vViewPos);
+  float fresnel=pow(1.0-max(dot(n,v),0.0),3.0);
+  vec3 l1=normalize(vec3(1,1,0.5));vec3 l2=normalize(vec3(-0.5,0.3,1));
+  float diff=max(dot(n,l1),0.0)*0.15+max(dot(n,l2),0.0)*0.1;
+  float spec=pow(max(dot(n,normalize(l1+v)),0.0),128.0)*0.5+pow(max(dot(n,normalize(l2+v)),0.0),96.0)*0.25;
+  vec3 col=mix(base,base*0.85+vec3(0.08),fresnel*0.6);
+  col=col*(0.75+diff)+vec3(spec)+mix(base,vec3(1),0.4)*fresnel*0.25;
+  col=adjustColor(col);
+  gl_FragColor=vec4(col,1.0);
+}`;
+
+      const FRAG_FOG = `varying vec3 vPos;varying vec3 vNormal;varying vec3 vViewPos;uniform vec3 uColor1;uniform vec3 uColor2;uniform vec3 uColor3;uniform float uTime;uniform float uSpeed;uniform float uDensity;uniform float uStrength;
+${COLOR_ADJUST_GLSL}
+vec3 mod289v3(vec3 x){return x-floor(x*(1.0/289.0))*289.0;}
+vec4 mod289v4(vec4 x){return x-floor(x*(1.0/289.0))*289.0;}
+vec4 perm(vec4 x){return mod289v4(((x*34.0)+1.0)*x);}
+float snoise3(vec3 p){
+  vec3 a=floor(p);vec3 d=p-a;d=d*d*(3.0-2.0*d);
+  vec4 b=a.xxyy+vec4(0,1,0,1);
+  vec4 k1=perm(b.xyxy);vec4 k2=perm(k1.xyxy+b.zzww);
+  vec4 c=k2+a.zzzz;vec4 k3=perm(c);vec4 k4=perm(c+1.0);
+  vec4 o1=fract(k3*(1.0/41.0));vec4 o2=fract(k4*(1.0/41.0));
+  vec4 o3=o2*d.z+o1*(1.0-d.z);
+  vec2 o4=o3.yw*d.x+o3.xz*(1.0-d.x);
+  return o4.y*d.y+o4.x*(1.0-d.y);
+}
+float fbm(vec3 p){float v=0.0;float a=0.5;float f=1.0;for(int i=0;i<6;i++){v+=a*snoise3(p*f);f*=2.0;a*=0.5;}return v;}
+void main(){
+  float t=uTime*uSpeed*0.15;
+  vec3 p=vPos*uDensity*0.8;
+  float n1=fbm(p+vec3(t*0.4,t*0.2,-t*0.1));
+  float n2=fbm(p*1.3+vec3(-t*0.3,t*0.5,t*0.15)+5.0);
+  float n3=fbm(p*0.6+vec3(t*0.1,-t*0.4,t*0.25)+11.0);
+  float layer1=smoothstep(0.3,0.65,n1);
+  float layer2=smoothstep(0.35,0.6,n2);
+  float layer3=smoothstep(0.4,0.7,n3);
+  vec3 col=uColor1;
+  col=mix(col,uColor2,layer1*uStrength);
+  col=mix(col,uColor3,layer2*uStrength*0.7);
+  col=mix(col,mix(uColor1,uColor2,0.5),layer3*uStrength*0.4);
+  float wisp=fbm(p*3.0+vec3(t*0.8,0,0))*0.12*uStrength;
+  col+=wisp;
+  vec3 n=normalize(vNormal);vec3 v=normalize(-vViewPos);
+  float rim=pow(1.0-max(dot(n,v),0.0),4.0);
+  col=mix(col,mix(uColor2,uColor3,0.5),rim*0.2);
+  float diff=max(dot(n,normalize(vec3(1,1,0.5))),0.0)*0.08;
+  col+=diff;
+  col=adjustColor(col);
+  gl_FragColor=vec4(col,1.0);
+}`;
+
+      const FRAGS = {
+        defaults: FRAG_DEFAULTS,
+        cosmic: FRAG_COSMIC,
+        glass: FRAG_GLASS,
+        fog: FRAG_FOG,
+      };
+      window._sgShaders = {
+        vertex: vertexShader,
+        defaults: FRAG_DEFAULTS,
+        cosmic: FRAG_COSMIC,
+        glass: FRAG_GLASS,
+        fog: FRAG_FOG,
+      };
+
+      function degToRad(d) {
+        return (d * Math.PI) / 180;
+      }
+
+      let activeRenderers = [];
+
+      function destroyRenderers() {
+        activeRenderers.forEach((r) => {
+          try {
+            r.renderer.dispose();
+            r.renderer.forceContextLoss();
+          } catch (e) {}
+          if (r.composer)
+            try {
+              r.composer.renderTarget1?.dispose();
+              r.composer.renderTarget2?.dispose();
+            } catch (e) {}
+        });
+        activeRenderers = [];
+      }
+
+      window._sgUpdateColors = function () {
+        const colors = window.getBgColors
+          ? window.getBgColors()
+          : ["#ffffff", "#888888", "#444444"];
+        activeRenderers.forEach((s) => {
+          s.uniforms.uColor1.value.set(colors[0]);
+          s.uniforms.uColor2.value.set(colors[1]);
+          s.uniforms.uColor3.value.set(colors[2]);
+        });
+      };
+
+      window._sgToggleGrain = function (disable) {
+        activeRenderers.forEach((s) => {
+          if (s.htPass && s.htPass.uniforms && s.htPass.uniforms.disable) {
+            s.htPass.uniforms.disable.value = disable;
+          }
+        });
+      };
+
+      let _sgDebounce = null;
+      window._sgUpdateBg = function () {
+        clearTimeout(_sgDebounce);
+        _sgDebounce = setTimeout(_sgUpdateBgNow, 80);
+      };
+      function _sgUpdateBgNow() {
+        destroyRenderers();
+        const bgMode = window.picks ? window.picks.bg_mode : 0;
+        const hasShader = bgMode && bgMode > 0;
+        const preset = hasShader && window.BG_PRESETS ? window.BG_PRESETS[bgMode] : null;
+
+        // Set iframe elements transparent/opaque via JS (not CSS vars, to avoid affecting text color)
+        document
+          .querySelectorAll("#sc-scene-grid iframe, #sc-specimen-grid iframe")
+          .forEach((ifr) => {
+            ifr.style.background = hasShader ? "transparent" : "";
+            if (!ifr.contentDocument || !ifr.contentWindow) return;
+            var iDoc = ifr.contentDocument;
+            var iWin = ifr.contentWindow;
+            // Resolve --tp-secondary to rgb via temp element
+            var tpSec = iWin
+              .getComputedStyle(iDoc.documentElement)
+              .getPropertyValue("--tp-secondary")
+              .trim();
+            var tmp = iDoc.createElement("div");
+            tmp.style.backgroundColor = tpSec;
+            iDoc.body.appendChild(tmp);
+            var secRgb = iWin.getComputedStyle(tmp).backgroundColor;
+            tmp.remove();
+            var shaderStyle = iDoc.getElementById("tp-shader-bg");
+            if (!shaderStyle) {
+              shaderStyle = iDoc.createElement("style");
+              shaderStyle.id = "tp-shader-bg";
+              iDoc.head.appendChild(shaderStyle);
+            }
+            if (hasShader) {
+              shaderStyle.textContent = "html, body { background: transparent !important; }";
+              iDoc.documentElement.style.setProperty("background", "transparent", "important");
+              iDoc.body.style.setProperty("background", "transparent", "important");
+              // Clear background on slide containers and stage elements
+              var bgEls = iDoc.querySelectorAll(
+                ".slide, section, .slides-container, .stage, .deck, deck-stage, .presentation",
+              );
+              bgEls.forEach(function (el) {
+                var cs = iWin.getComputedStyle(el);
+                var bg = cs.backgroundColor;
+                if (bg && bg !== "rgba(0, 0, 0, 0)" && bg !== "transparent") {
+                  // Parse RGB to check luminance — only clear dark backgrounds
+                  var m = bg.match(/(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+                  if (m) {
+                    var lum =
+                      (parseInt(m[1]) * 299 + parseInt(m[2]) * 587 + parseInt(m[3]) * 114) / 1000;
+                    if (lum < 80) {
+                      el.style.setProperty("background", "transparent", "important");
+                      el.style.setProperty("background-color", "transparent", "important");
+                    }
+                  }
+                }
+              });
+            } else {
+              shaderStyle.textContent = "";
+              iDoc.documentElement.style.removeProperty("background");
+              iDoc.body.style.removeProperty("background");
+              var bgEls = iDoc.querySelectorAll(
+                ".slide, section, .slides-container, .stage, .deck, deck-stage, .presentation",
+              );
+              bgEls.forEach(function (el) {
+                el.style.removeProperty("background");
+                el.style.removeProperty("background-color");
+              });
+            }
+          });
+
+        if (!hasShader || !preset || !preset.type) return;
+
+        const colors = window.getBgColors
+          ? window.getBgColors()
+          : ["#ffffff", "#888888", "#444444"];
+        // Target: hero wrapper + specimen cells
+        const containers = document.querySelectorAll("#sc-scene-grid > div");
+        if (containers.length === 0) return;
+
+        containers.forEach((container) => {
+          container.style.position = "relative";
+          container.querySelectorAll("canvas.sg-bg").forEach((c) => c.remove());
+
+          const canvas = document.createElement("canvas");
+          canvas.className = "sg-bg";
+          canvas.style.cssText =
+            "position:absolute;inset:0;width:100%;height:100%;z-index:0;pointer-events:none;";
+          container.insertBefore(canvas, container.firstChild);
+
+          const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+          renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
+
+          const scene = new THREE.Scene();
+          const camera = new THREE.PerspectiveCamera(45, 16 / 9, 0.1, 100);
+
+          const isSphere = preset.type === "sphere";
+          const dist = isSphere ? 14 : preset.camDist;
+          const az = degToRad(preset.camAz);
+          const pol = degToRad(preset.camPol);
+          camera.position.set(
+            dist * Math.sin(pol) * Math.sin(az),
+            dist * Math.cos(pol),
+            dist * Math.sin(pol) * Math.cos(az),
+          );
+          camera.lookAt(0, 0, 0);
+          camera.zoom = isSphere ? preset.zoom || 1 : 1;
+          camera.updateProjectionMatrix();
+
+          scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+          const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+          dir.position.set(5, 5, 5);
+          scene.add(dir);
+
+          const frag = preset.fragmentShader || FRAGS[preset.shader] || FRAG_DEFAULTS;
+          const uniforms = {
+            uTime: { value: 0 },
+            uSpeed: { value: preset.speed },
+            uDensity: { value: preset.density },
+            uStrength: { value: preset.strength },
+            uColor1: { value: new THREE.Color(colors[0]) },
+            uColor2: { value: new THREE.Color(colors[1]) },
+            uColor3: { value: new THREE.Color(colors[2]) },
+            uBrightness: { value: preset._render ? preset._render.brightness : 1.0 },
+            uContrast: { value: preset._render ? preset._render.contrast : 1.0 },
+            uSaturation: { value: preset._render ? preset._render.saturation : 1.0 },
+          };
+
+          const material = new THREE.ShaderMaterial({
+            vertexShader,
+            fragmentShader: frag,
+            uniforms,
+            side: THREE.DoubleSide,
+          });
+
+          let geometry;
+          if (isSphere) geometry = new THREE.SphereGeometry(1, 256, 256);
+          else geometry = new THREE.PlaneGeometry(10, 10, 128, 128);
+
+          const mesh = new THREE.Mesh(geometry, material);
+          mesh.rotation.set(degToRad(preset.rotX), degToRad(preset.rotY), degToRad(preset.rotZ));
+          mesh.position.set(preset.posX || 0, preset.posY || 0, preset.posZ || 0);
+          scene.add(mesh);
+
+          const composer = new EffectComposer(renderer);
+          composer.addPass(new RenderPass(scene, camera));
+          var grainOn = document.getElementById("se-grain");
+          var htPass = new HalftonePass(canvas.offsetWidth || 640, canvas.offsetHeight || 360, {
+            shape: 1,
+            radius: 2,
+            rotateR: Math.PI / 12,
+            rotateG: (Math.PI / 12) * 2,
+            rotateB: (Math.PI / 12) * 3,
+            scatter: 1,
+            blending: 1,
+            blendingMode: 1,
+            greyscale: false,
+            disable: grainOn && !grainOn.checked,
+          });
+          composer.addPass(htPass);
+
+          activeRenderers.push({
+            renderer,
+            scene,
+            camera,
+            uniforms,
+            canvas,
+            composer,
+            htPass,
+            preset,
+          });
+        });
+
+        if (!window._sgAnimating) {
+          window._sgAnimating = true;
+          function animate() {
+            const t = performance.now() * 0.001;
+            activeRenderers.forEach((s) => {
+              if (s.renderer.getContext().isContextLost()) return;
+              const w = s.canvas.offsetWidth,
+                h = s.canvas.offsetHeight;
+              if (w <= 0) return;
+              s.renderer.setSize(w, h, false);
+              s.composer.setSize(w, h);
+              s.camera.aspect = w / h;
+              s.camera.updateProjectionMatrix();
+              s.uniforms.uTime.value = t;
+              if (s.preset && s.preset._render) {
+                s.uniforms.uBrightness.value = s.preset._render.brightness;
+                s.uniforms.uContrast.value = s.preset._render.contrast;
+                s.uniforms.uSaturation.value = s.preset._render.saturation;
+                if (s.htPass && s.htPass.uniforms) {
+                  s.htPass.uniforms.radius.value = s.preset._render.grainRadius;
+                  s.htPass.uniforms.scatter.value = s.preset._render.grainScatter;
+                  s.htPass.uniforms.blending.value = s.preset._render.grainBlending;
+                }
+              }
+              s.composer.render();
+            });
+            requestAnimationFrame(animate);
+          }
+          animate();
+        }
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

The picker UI itself — a single ~6k-line HTML file with two phases. Built by `build-design-picker.py` (PR #973), opened by `hyperframes pick` (PR #975).

## Scope

- 1 file: `skills/hyperframes/templates/design-picker.html`
- ~12k lines (HTML + scoped CSS + vanilla JS, no framework)
- Reviewable as one cohesive surface

## Phases

### Phase 1 — Templates index

Editorial-catalog layout. Source Serif 4 italic + Hanken Grotesk on warm-tinted OKLCH neutrals. Roman-numeral folio markers, hairline rules, generous space.

- **Sticky palette bar** at the top — each palette is a row of `i. Name · 4-cell swatch strip`, horizontally scrollable, ~60px tall (much shorter than a chip card).
- **3-up specimen grid** — each card renders the template's `design.html` cover (from PR #972) via client-side token substitution + blob URL. No card borders, no shadows, hairline rule under the preview, italic tagline below.
- **Per-card iframe scaling** — each card is 16:9; the iframe inside is 1920×1080, scaled down via `transform: scale(containerWidth/1920)`.
- Roman-numeral folios (`i. — xxxiv.`) and `01 / 34` counters in the gutter.

### Phase 2 — Fine-tune

Sidebar with the picker controls + a right pane showing the chosen template's `design.html` in an iframe. Picker controls inject `--primary` / `--secondary` / `--tertiary` / `--accent` / `--tp-*` tokens directly on the iframe's `documentElement` on every change.

Sections:
- **Palette** — 5-6 curated palettes per prompt + Template Default + custom palette editor
- **Typography** — 5-6 type pairings, font discovery via the picker's JSON manifest
- **Corners** / **Density** / **Depth** — chips. These are scoped to `.demo-card` only (no leakage to other surfaces).
- **Motion** — easing curves with live preview, custom-bezier editor included
- **Background** — three.js shader presets (vertex + fragment GLSL), brightness/contrast/saturation/grain config persists across preset changes via `window._sgRender`
- **Use-palette toggle** — shader can either use the picked palette colors or three custom color pickers

### Per-swatch text color

Each palette swatch's text color is computed from the bg luminance so previews stay legible regardless of palette. Inserted at picker-render time by `build-design-picker.py` (PR #973).

### Phase 1 → Phase 2

Palette pick from Phase 1 is carried forward into Phase 2 (`picks.palette = tpActivePal`). Sidebar scrolls to top + iframe preview scrolls to top on every template change.

## Hot spots for review

- **Token injection paths.** `tpApplyAllPalettes` injects both `--tp-*` and the `--primary`/`--secondary`/`--tertiary`/`--accent` design.html tokens on the iframe document. `--tp-accent` is intentionally *stripped* from the scoped template CSS so cascade inheritance flows from `html` style attribute → `.ds-slide-frame` without circular `var()` references.
- **Shader uniform rebake.** `_lastBgModeKey` is reset after every `renderDesignIframe` call so palette changes force the shader uniforms to re-bake from the current palette via `getBgColors()`.
- **`tpScaleIframe` selector.** Matches both `.idx-spec-preview` (new editorial layout) and legacy `.cprev` so existing callers still work.
- **`_tpNameSplit`** — splits template names on `" ("`, then space, then CamelCase. Handles `BlockFrame` → `Block / Frame`, `People's Platform (Block & Bold)` → `People's Platform / (Block & Bold)`.

## What's *not* in scope

- The CLI command that runs the picker — that's PR #975
- The build script that produces the picker HTML from this template — that's PR #973
- The 34 vendored `design.html` files the picker renders — those are PR #972

## Test plan

- [ ] `hyperframes pick` (from PR #975) opens the picker
- [ ] Phase 1 renders 34 specimens with their authored colors
- [ ] Picking a palette in Phase 1 re-themes every card
- [ ] Picking a template advances to Phase 2 with the palette carried forward
- [ ] In Phase 2: changing palette updates the iframe + shader bg
- [ ] In Phase 2: changing corners / density / depth updates *only* the `.demo-card` in the Surface section
- [ ] In Phase 2: changing motion re-runs hero entrance animation + scrolls iframe to top
- [ ] In Phase 2: changing shader preset preserves brightness / contrast / saturation / grain config

## Stack

Depends on #971, #972, #973. Followed by #975 (CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)