### PR TITLE
fix(core): ceil timeline payload duration to match render frames

### DIFF
--- a/packages/core/src/runtime/timeline.test.ts
+++ b/packages/core/src/runtime/timeline.test.ts
@@ -183,6 +183,21 @@ describe("collectRuntimeTimelinePayload", () => {
     expect(result.durationInFrames).toBe(300); // 10s * 30fps
   });
 
+  it("ceil durationInFrames to match render frame count", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-duration", "1.01");
+    document.body.appendChild(root);
+
+    const clip = document.createElement("div");
+    clip.setAttribute("data-start", "0");
+    clip.setAttribute("data-duration", "1.01");
+    root.appendChild(clip);
+
+    const result = collectRuntimeTimelinePayload(defaultParams);
+    expect(result.durationInFrames).toBe(31); // ceil(1.01s * 30fps), same as render.
+  });
+
   it("preserves the authored root duration when clips end earlier", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");

--- a/packages/core/src/runtime/timeline.ts
+++ b/packages/core/src/runtime/timeline.ts
@@ -674,7 +674,7 @@ export function collectRuntimeTimelinePayload(params: {
   const shouldEmitNonDeterministicInf = timelineLooksLoopInflated && attrDurationCandidate == null;
   const durationInFrames = shouldEmitNonDeterministicInf
     ? Number.POSITIVE_INFINITY
-    : Math.max(1, Math.round(safeDuration * Math.max(1, params.canonicalFps)));
+    : Math.max(1, Math.ceil(safeDuration * Math.max(1, params.canonicalFps)));
   return {
     source: "hf-preview",
     type: "timeline",


### PR DESCRIPTION
## What

Change runtime timeline payload duration frame calculation from rounding to ceiling.

## Why

Render probe computes total frames with `ceil(duration * fps)`. The timeline payload used `round(duration * fps)`, so fractional durations like `1.01s @ 30fps` could report 30 frames while render captures 31 frames.

## How

Use ceiling when converting the playable timeline duration to `durationInFrames`, matching render frame count semantics.

## Test plan

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)