### PR TITLE
docs(nav): consolidate deploy pages into one sidebar group

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -82,7 +82,6 @@
               "guides/hyperframes-vs-remotion",
               "guides/gsap-animation",
               "guides/rendering",
-              "guides/deploy",
               "guides/remove-background",
               "guides/hdr",
               "guides/4k-rendering",
@@ -91,6 +90,15 @@
               "guides/video-editor-cheatsheet",
               "guides/common-mistakes",
               "guides/troubleshooting"
+            ]
+          },
+          {
+            "group": "Deploy",
+            "pages": [
+              "guides/deploy",
+              "deploy/aws-lambda",
+              "deploy/templates-on-lambda",
+              "deploy/migrating-to-hyperframes-lambda"
             ]
           }
         ]
@@ -239,14 +247,6 @@
               "packages/producer",
               "packages/studio",
               "packages/cli"
-            ]
-          },
-          {
-            "group": "Deploy",
-            "pages": [
-              "deploy/aws-lambda",
-              "deploy/templates-on-lambda",
-              "deploy/migrating-to-hyperframes-lambda"
             ]
           }
         ]


### PR DESCRIPTION
## What

Move the three AWS Lambda deploy pages out of the **Packages** tab and pull `guides/deploy` out of the Guides group, into a single new **Deploy** group in the Documentation tab sidebar:

```
Documentation tab
├── Getting Started
├── Concepts
├── Guides            ← guides/deploy removed
└── Deploy            ← new group
    ├── guides/deploy
    ├── deploy/aws-lambda
    ├── deploy/templates-on-lambda
    └── deploy/migrating-to-hyperframes-lambda
```

The `Deploy` group is also removed from the Packages tab. File paths are unchanged — only the `docs.json` sidebar entries move, so all existing URLs (`/deploy/aws-lambda`, `/guides/deploy`, etc.) keep working and no redirects are needed.

## Why

The three Lambda deploy pages (`deploy/aws-lambda`, `deploy/templates-on-lambda`, `deploy/migrating-to-hyperframes-lambda`) were sitting under the **Packages** tab in a "Deploy" subgroup. That tab is for package-level reference docs (core, engine, player, producer, studio, cli) — Lambda deployment isn't a package, it's deployment guidance, so readers looking for "how do I deploy?" had to know to click Packages to find it.

`guides/deploy` covers the same surface from a different angle (one-click Vercel + Cloudflare render-API templates) but lived in the Guides flow next to authoring topics. Putting all four under a single Deploy group surfaces them together at the level readers actually look.

## How

Single change in `docs/docs.json`:

- Remove `"guides/deploy"` from the **Guides** group (line 85).
- Add a new **Deploy** group after Guides in the Documentation tab containing all four pages.
- Remove the **Deploy** group from the Packages tab (was lines 244–251).

Order inside the new group: one-click templates first (broadest audience), then AWS Lambda distributed rendering, then the personalised-batch guide, then the Remotion migration page.

## Test plan

- [ ] Unit tests added/updated — N/A (nav-config only)
- [x] Manual testing performed — `npx mint broken-links` from `docs/` returns "no broken links found"; JSON validates with `python3 -c "import json; json.load(open('docs/docs.json'))"`. Diff is 9 insertions / 9 deletions in a single file.
- [x] Documentation updated (if applicable) — this PR is the documentation nav update.

🤖 Generated with Claude Code