### PR TITLE
fix(cli): stop dropping CI/agent telemetry, suppress HeyGen CI at workflow level

### DIFF
--- a/.github/workflows/catalog-previews.yml
+++ b/.github/workflows/catalog-previews.yml
@@ -3,6 +3,11 @@ name: Catalog Previews
 permissions:
   contents: read
 
+# Suppress hyperframes CLI telemetry from HeyGen's own CI runs.
+# External users' CI continues to emit telemetry unless they set this themselves.
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ permissions:
   contents: read
   pull-requests: read
 
+# Suppress hyperframes CLI telemetry from HeyGen's own CI runs.
+# External users' CI continues to emit telemetry unless they set this themselves.
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
 on:
   pull_request:
     # `edited` is required so the workflow re-fires when a PR's base ref is

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Docs
 permissions:
   contents: read
 
+# Suppress hyperframes CLI telemetry from HeyGen's own CI runs.
+# External users' CI continues to emit telemetry unless they set this themselves.
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/player-perf.yml
+++ b/.github/workflows/player-perf.yml
@@ -3,6 +3,11 @@ name: Player perf
 permissions:
   contents: read
 
+# Suppress hyperframes CLI telemetry from HeyGen's own CI runs.
+# External users' CI continues to emit telemetry unless they set this themselves.
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
 on:
   pull_request:
   push:

--- a/.github/workflows/preview-regression.yml
+++ b/.github/workflows/preview-regression.yml
@@ -3,6 +3,11 @@ name: preview-regression
 permissions:
   contents: read
 
+# Suppress hyperframes CLI telemetry from HeyGen's own CI runs.
+# External users' CI continues to emit telemetry unless they set this themselves.
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
 on:
   pull_request:
   push:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -3,6 +3,11 @@ name: regression
 permissions:
   contents: read
 
+# Suppress hyperframes CLI telemetry from HeyGen's own CI runs.
+# External users' CI continues to emit telemetry unless they set this themselves.
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
 on:
   pull_request:
   push:

--- a/.github/workflows/windows-render.yml
+++ b/.github/workflows/windows-render.yml
@@ -3,6 +3,11 @@ name: Windows render verification
 permissions:
   contents: read
 
+# Suppress hyperframes CLI telemetry from HeyGen's own CI runs.
+# External users' CI continues to emit telemetry unless they set this themselves.
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
 # Manually triggered smoke test that renders a HyperFrames composition on a
 # real Windows runner. Proves the PR #336 `where ffmpeg` fix actually works
 # end-to-end: FFmpeg is discovered natively on Windows, Chrome is installed

--- a/packages/cli/src/telemetry/client.ts
+++ b/packages/cli/src/telemetry/client.ts
@@ -40,11 +40,6 @@ export function shouldTrack(): boolean {
     return false;
   }
 
-  if (process.env["CI"] === "true" || process.env["CI"] === "1") {
-    telemetryEnabled = false;
-    return false;
-  }
-
   if (isDevMode()) {
     telemetryEnabled = false;
     return false;


### PR DESCRIPTION
## What

Two changes:

1. **Remove the `CI=true` early-exit in `shouldTrack()`** in `packages/cli/src/telemetry/client.ts`. The previous block silently dropped every event from any environment that set `CI=true` or `CI=1` — which is most of where modern usage now lives: coding agents in Codespaces, GitHub Actions, hosted dev sandboxes.
2. **Add `HYPERFRAMES_NO_TELEMETRY=1`** to every HeyGen workflow that exercises the CLI (`ci`, `regression`, `preview-regression`, `catalog-previews`, `player-perf`, `windows-render`, `docs`). HeyGen-internal CI stays out of telemetry; external users' CI now flows in.

## Why

Investigating two recent traffic spikes on PostHog (Apr 23-30 and May 19) it became clear that most of the headless/agentic traffic we *can* see is from environments that don't set `CI=true` (Codespaces, agent sandboxes). The traffic we *can't* see is from environments that do — i.e. proper CI pipelines. That's the wrong split: we want both populations measured, with the ability to slice between them.

Every event still carries `is_ci` (plus `ci_name`, `is_docker`, `is_tty`) from `system.ts`, so CI vs interactive can be separated in PostHog post-hoc instead of being filtered at ingest.

## How

- Deleted the `CI=true` / `CI=1` branch in `shouldTrack()`. The remaining gates are unchanged: `HYPERFRAMES_NO_TELEMETRY=1`, `DO_NOT_TRACK=1`, dev mode, missing PostHog key, user opt-out via the config file.
- Added `env: HYPERFRAMES_NO_TELEMETRY: "1"` at the top of each HeyGen workflow that runs the CLI directly or through producer tests. Skipped `publish.yml` and `codeql.yml` (don't exercise the CLI).
- `detectCI()` and `getCIName()` in `system.ts` continue to read `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, etc. to label events with `is_ci` and `ci_name`. Unchanged.
- `autoUpdate.ts` and `updateCheck.ts` still skip on `CI=true` — that's about update prompts, unrelated to telemetry. Left alone.

## Test plan

- [x] `bunx oxlint` / `bunx oxfmt --check` clean on changed files
- [x] `bunx tsc --noEmit` passes in `packages/core` and `packages/studio`
- [x] `bunx fallow audit` clean
- [ ] CI green on this PR
- [ ] After merge, monitor PostHog: `cli_command` events with `is_ci=true` should start appearing (previously near-zero). Events from `*.github/workflows/*` runs of this repo should NOT appear.

## Notes

- Behavior change for any downstream user whose CI was relying on silent telemetry suppression. They can keep the previous behavior by setting `HYPERFRAMES_NO_TELEMETRY=1` (or `DO_NOT_TRACK=1`) themselves.
- The first-run telemetry notice (`showTelemetryNotice` in `client.ts`) still gates on `shouldTrack()`, so CI environments will technically "show" the notice (to nobody) once per ephemeral machine. Standard OSS telemetry pattern.