### PR TITLE
feat(studio): add M (mute) and Shift+L (loop) keyboard shortcuts

### DIFF
--- a/packages/studio/src/player/components/PlayerControls.tsx
+++ b/packages/studio/src/player/components/PlayerControls.tsx
@@ -15,6 +15,8 @@ const SHORTCUT_SECTIONS = [
       { key: "J", label: "Play backward" },
       { key: "K", label: "Stop" },
       { key: "L", label: "Play forward" },
+      { key: "M", label: "Toggle mute" },
+      { key: "⇧L", label: "Toggle loop" },
       { key: "←/→", label: "Step 1 frame" },
       { key: "⇧←/⇧→", label: "Step 10 frames" },
     ],

--- a/packages/studio/src/player/hooks/usePlaybackKeyboard.test.ts
+++ b/packages/studio/src/player/hooks/usePlaybackKeyboard.test.ts
@@ -172,3 +172,58 @@ describe("usePlaybackKeyboard — keyboard layout independence (#834)", () => {
     expect(spies.play).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("usePlaybackKeyboard — mute & loop shortcuts (#905)", () => {
+  it("M toggles audioMuted", () => {
+    const { dispatch } = setupHook();
+    expect(usePlayerStore.getState().audioMuted).toBe(false);
+
+    act(() => {
+      dispatch(keydown({ code: "KeyM", key: "m" }));
+    });
+    expect(usePlayerStore.getState().audioMuted).toBe(true);
+
+    act(() => {
+      dispatch(keydown({ code: "KeyM", key: "m" }));
+    });
+    expect(usePlayerStore.getState().audioMuted).toBe(false);
+  });
+
+  it("M does NOT toggle audioMuted above 1x playback (matches button gating)", () => {
+    const { dispatch } = setupHook();
+    usePlayerStore.setState({ playbackRate: 2, audioMuted: false });
+
+    act(() => {
+      dispatch(keydown({ code: "KeyM", key: "m" }));
+    });
+
+    expect(usePlayerStore.getState().audioMuted).toBe(false);
+  });
+
+  it("Shift+L toggles loopEnabled without starting forward shuttle", () => {
+    const { dispatch, spies } = setupHook();
+    expect(usePlayerStore.getState().loopEnabled).toBe(false);
+
+    act(() => {
+      dispatch(keydown({ code: "KeyL", key: "L", shiftKey: true }));
+    });
+    expect(usePlayerStore.getState().loopEnabled).toBe(true);
+    expect(spies.play).not.toHaveBeenCalled();
+
+    act(() => {
+      dispatch(keydown({ code: "KeyL", key: "L", shiftKey: true }));
+    });
+    expect(usePlayerStore.getState().loopEnabled).toBe(false);
+  });
+
+  it("Plain L still starts forward shuttle (regression guard)", () => {
+    const { dispatch, spies } = setupHook();
+
+    act(() => {
+      dispatch(keydown({ code: "KeyL", key: "l" }));
+    });
+
+    expect(spies.play).toHaveBeenCalledTimes(1);
+    expect(usePlayerStore.getState().loopEnabled).toBe(false);
+  });
+});

--- a/packages/studio/src/player/hooks/usePlaybackKeyboard.ts
+++ b/packages/studio/src/player/hooks/usePlaybackKeyboard.ts
@@ -108,6 +108,21 @@ export function usePlaybackKeyboard({
         return;
       }
       if (e.repeat) return;
+      if (key === "m") {
+        e.preventDefault();
+        const state = usePlayerStore.getState();
+        // Audio is force-muted above 1x playback — match the mute button's gating.
+        if (state.playbackRate <= 1) {
+          state.setAudioMuted(!state.audioMuted);
+        }
+        return;
+      }
+      if (key === "l" && e.shiftKey) {
+        e.preventDefault();
+        const state = usePlayerStore.getState();
+        state.setLoopEnabled(!state.loopEnabled);
+        return;
+      }
       if (key === "k") {
         e.preventDefault();
         pause();


### PR DESCRIPTION
## Summary

Adds NLE-style keyboard shortcuts for muting audio and toggling loop playback in the Studio player, matching the conventions in DaVinci Resolve, Premiere, and Final Cut.

- **`M`** — toggle audio mute
- **`⇧L`** — toggle loop playback

Fixes #905.

## Implementation notes

- Both handlers live in [`usePlaybackKeyboard.ts`](packages/studio/src/player/hooks/usePlaybackKeyboard.ts) alongside the existing J / K / L / I / O / A / E shortcuts. The Shift+L case runs **before** the existing plain-`L` shuttle case so Shift+L doesn't also kick off forward playback.
- `M` mirrors the mute button's gating: above 1x playback, audio is force-muted by `shouldMutePreviewAudio`, so the shortcut becomes a no-op there (just like the button is `disabled`).
- The issue mentioned `Ctrl+L` as an alternative. It's intentionally **not** wired up because [`shouldIgnorePlaybackShortcutEvent`](packages/studio/src/player/lib/playbackShortcuts.ts) already filters out events with `ctrlKey`/`metaKey`/`altKey`, and Ctrl/Cmd+L conflicts with the browser address-bar shortcut. `Shift+L` is also consistent with the existing `Shift+I` / `Shift+O` modifier pattern in this hook.
- The in-app shortcuts help panel ([`PlayerControls.tsx`](packages/studio/src/player/components/PlayerControls.tsx)) lists the two new shortcuts in the "Playback" section.

## Test plan

- [x] `bun run --filter @hyperframes/studio test` — all 601 studio tests pass, including 4 new tests covering: M toggles mute, M is a no-op above 1x, Shift+L toggles loop without starting shuttle, plain L still starts shuttle (regression guard).
- [x] `bunx oxlint` + `bunx oxfmt --check` on changed files — clean.
- [x] `bun run --filter @hyperframes/studio typecheck` — clean.
- [ ] Manual verification: open Studio, focus the player, press `M` (mute icon toggles), press `Shift+L` (loop icon toggles), confirm plain `L` still starts forward shuttle.