### PR TITLE
feat(studio): add stack traces to error telemetry

### DIFF
--- a/packages/studio/src/components/StudioErrorBoundary.tsx
+++ b/packages/studio/src/components/StudioErrorBoundary.tsx
@@ -21,7 +21,8 @@ export class StudioErrorBoundary extends Component<Props, State> {
     trackStudioEvent("crash", {
       error_message: error.message,
       error_name: error.name,
-      component_stack: info.componentStack?.slice(0, 500) ?? null,
+      stack_trace: error.stack?.slice(0, 4000) ?? null,
+      component_stack: info.componentStack?.slice(0, 2000) ?? null,
     });
   }
 

--- a/packages/studio/src/main.tsx
+++ b/packages/studio/src/main.tsx
@@ -7,19 +7,33 @@ import "./styles/studio.css";
 
 trackStudioEvent("session_start");
 
+function errorProps(value: unknown): {
+  error_message: string;
+  error_name: string | null;
+  stack_trace: string | null;
+} {
+  if (value instanceof Error) {
+    return {
+      error_message: value.message,
+      error_name: value.name,
+      stack_trace: value.stack?.slice(0, 4000) ?? null,
+    };
+  }
+  return { error_message: String(value), error_name: null, stack_trace: null };
+}
+
 window.addEventListener("error", (event) => {
   trackStudioEvent("unhandled_error", {
+    ...errorProps(event.error),
     error_message: event.message,
-    filename: event.filename ?? null,
-    lineno: event.lineno ?? null,
-    colno: event.colno ?? null,
+    filename: event.filename,
+    lineno: event.lineno,
+    colno: event.colno,
   });
 });
 
 window.addEventListener("unhandledrejection", (event) => {
-  trackStudioEvent("unhandled_promise_rejection", {
-    error_message: event.reason instanceof Error ? event.reason.message : String(event.reason),
-  });
+  trackStudioEvent("unhandled_promise_rejection", errorProps(event.reason));
 });
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary

- Sends `stack_trace` (JS call stack, up to 4KB) on all three error telemetry events: `studio:crash`, `studio:unhandled_error`, and `studio:unhandled_promise_rejection`
- Bumps `component_stack` capture from 500 → 2000 chars on crash events (React component tree)
- Adds `error_name` to promise rejection events for better classification in PostHog

## Context

Studio error events were shipping `error_message` only — no stack traces, no source locations for rejections. This made it nearly impossible to triage crashes from the PostHog dashboard. Now every error event includes enough context to pinpoint the failing code path without needing to reproduce locally.

## Changes

| File | What changed |
|---|---|
| `packages/studio/src/main.tsx` | Extract `errorProps()` helper that safely pulls message, name, and stack from any thrown value. Wire it into both `error` and `unhandledrejection` listeners. |
| `packages/studio/src/components/StudioErrorBoundary.tsx` | Add `stack_trace: error.stack` to crash events; bump `component_stack` slice limit 500→2000 |

## Test plan

- [x] `bun run --cwd packages/studio build` — clean
- [x] Lint + format + typecheck + fallow — all green
- [x] Deploy to preview, open Studio, trigger a crash (e.g. bad composition), verify `stack_trace` appears on the event in PostHog