### PR TITLE
fix(lint): exclude gsap.fromTo() from gsap_from_opacity_noop rule

### DIFF
--- a/packages/core/src/lint/rules/gsap.test.ts
+++ b/packages/core/src/lint/rules/gsap.test.ts
@@ -806,6 +806,24 @@ describe("GSAP rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does NOT error when gsap.fromTo({opacity:0}, {opacity:1}) — destination overrides CSS", () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="title" style="opacity: 0; font-size: 120px;">Hello</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#title", { opacity: 0, y: 30 }, { opacity: 1, y: 0, duration: 0.5 }, 0.2);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_from_opacity_noop");
+    expect(finding).toBeUndefined();
+  });
+
   it("does NOT error when gsap.to() uses opacity:0 (exit animation)", () => {
     const html = `
 <html><body>

--- a/packages/core/src/lint/rules/gsap.ts
+++ b/packages/core/src/lint/rules/gsap.ts
@@ -875,7 +875,7 @@ export const gsapRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
       const windows = extractGsapWindows(script.content);
 
       for (const win of windows) {
-        if (win.method !== "from" && win.method !== "fromTo") continue;
+        if (win.method !== "from") continue;
         if (!win.properties.includes("opacity")) continue;
         const sel = win.targetSelector;
         const cssKey = sel.startsWith("#") || sel.startsWith(".") ? sel : `#${sel}`;


### PR DESCRIPTION
## Summary

- **Fix false positive**: `gsap_from_opacity_noop` was triggering on `gsap.fromTo()` calls, but `fromTo(target, fromVars, toVars)` animates to `toVars` — not to the current CSS value. So `fromTo({opacity:0}, {opacity:1})` with CSS `opacity:0` is a legitimate 0→1 fade-in, not a noop. The rule was blocking these with error severity, which would halt the render pipeline.
- **One-line fix**: drop the `fromTo` branch from the method guard — only `gsap.from()` has the CSS-destination semantics that cause the actual noop.
- **New test case**: `fromTo({opacity:0}, {opacity:1})` with CSS `opacity:0` — proves no false positive.

Addresses review feedback from hf#1001.

## Test plan

- [x] New test: `does NOT error when gsap.fromTo({opacity:0}, {opacity:1})` passes
- [x] All 41 gsap lint tests pass
- [x] `core` package builds clean
- [x] Pre-commit hooks (lint, format, typecheck, fallow) all green