### PR TITLE
feat(registry): add parallax-unzoom component

### DIFF
--- a/docs/catalog/components/parallax-unzoom.mdx
+++ b/docs/catalog/components/parallax-unzoom.mdx
@@ -1,0 +1,38 @@
+---
+title: "Parallax Unzoom"
+description: "Reveal transition — focus card scales down from full frame as siblings parallax in to form a grid (reverse of parallax-zoom)"
+---
+
+# Parallax Unzoom
+
+Reveal transition — focus card scales down from full frame as siblings parallax in to form a grid (reverse of parallax-zoom)
+
+`transition` `reveal` `unzoom` `parallax` `grid` `hero`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-unzoom.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-unzoom.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add parallax-unzoom
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `parallax-unzoom.html` | `compositions/components/parallax-unzoom.html` | hyperframes:snippet |
+
+## Usage
+
+Open `compositions/components/parallax-unzoom.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.

--- a/registry/components/parallax-unzoom/demo.html
+++ b/registry/components/parallax-unzoom/demo.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>Parallax Unzoom — Demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #f6f6f4;
+        font-family: "Inter", system-ui, sans-serif;
+      }
+
+      .demo-canvas {
+        width: 1920px;
+        height: 1080px;
+        position: relative;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .parallax-unzoom-grid {
+        display: grid;
+        grid-template-columns: repeat(5, 240px);
+        grid-template-rows: repeat(3, 320px);
+        gap: 40px;
+      }
+
+      .parallax-unzoom-card {
+        border-radius: 22px;
+        overflow: hidden;
+        position: relative;
+        box-shadow: 0 12px 36px rgba(20, 20, 30, 0.08);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .card-glyph {
+        font-size: 92px;
+        font-weight: 800;
+        color: rgba(255, 255, 255, 0.92);
+        text-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+        letter-spacing: -0.04em;
+        line-height: 1;
+      }
+
+      /* Distinct gradient per card */
+      .pu-c0 {
+        background: linear-gradient(135deg, #3a8b6f, #1d4d3d);
+      }
+      .pu-c1 {
+        background: linear-gradient(135deg, #8b4a3a, #4a2418);
+      }
+      .pu-c2 {
+        background: linear-gradient(135deg, #c89868, #8a6038);
+      }
+      .pu-c3 {
+        background: linear-gradient(135deg, #3a6088, #1a2f4a);
+      }
+      .pu-c4 {
+        background: linear-gradient(135deg, #b03838, #6a1818);
+      }
+      .pu-c5 {
+        background: linear-gradient(135deg, #bcbcbc, #6e6e6e);
+      }
+      .pu-c6 {
+        background: linear-gradient(135deg, #8a5fa0, #4a2860);
+      }
+      .pu-c7-focus {
+        background: linear-gradient(135deg, #f5c93f, #d99a18);
+      }
+      .pu-c8 {
+        background: linear-gradient(135deg, #d8d8d8, #9a9a9a);
+      }
+      .pu-c9 {
+        background: linear-gradient(135deg, #5fa37e, #2a6a4a);
+      }
+      .pu-c10 {
+        background: linear-gradient(135deg, #d1b66a, #8a7028);
+      }
+      .pu-c11 {
+        background: linear-gradient(135deg, #4f7fc0, #1f3f80);
+      }
+      .pu-c12 {
+        background: linear-gradient(135deg, #5a3a8f, #2a1858);
+      }
+      .pu-c13 {
+        background: linear-gradient(135deg, #b85a3a, #6a2818);
+      }
+      .pu-c14 {
+        background: linear-gradient(135deg, #f0f0e8, #c8c8be);
+      }
+
+      .parallax-unzoom-card[data-pu-focus="true"] {
+        grid-column: 3;
+        grid-row: 2;
+      }
+
+      .focus-label {
+        font-weight: 900;
+        font-size: 56px;
+        letter-spacing: -0.04em;
+        color: #1a1208;
+        text-align: center;
+        line-height: 1;
+        opacity: 0;
+      }
+
+      .focus-label small {
+        display: block;
+        font-size: 18px;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+        margin-bottom: 14px;
+        color: rgba(26, 18, 8, 0.7);
+      }
+
+      .hero-headline {
+        position: absolute;
+        top: 80px;
+        left: 0;
+        width: 100%;
+        text-align: center;
+        font-size: 68px;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        color: #1a1a1a;
+        opacity: 1;
+      }
+
+      /* ---- parallax-unzoom snippet (inlined) ---- */
+      .parallax-unzoom-grid {
+        --pu-progress: 0;
+        --pu-focus-scale: 8;
+        --pu-sibling-push: 900px;
+        --pu-sibling-fade: 1;
+        position: relative;
+        transform-style: preserve-3d;
+      }
+
+      .parallax-unzoom-card {
+        transform-origin: center center;
+        will-change: transform, opacity;
+        transform: translate3d(
+            calc(var(--pu-dx, 0px) * (1 - var(--pu-progress))),
+            calc(var(--pu-dy, 0px) * (1 - var(--pu-progress))),
+            0
+          )
+          scale(calc(0.7 + 0.3 * var(--pu-progress)));
+        opacity: calc(var(--pu-progress) * var(--pu-sibling-fade));
+      }
+
+      .parallax-unzoom-card[data-pu-focus="true"] {
+        z-index: 10;
+        transform: translate3d(0, 0, 0)
+          scale(calc(var(--pu-focus-scale) - (var(--pu-focus-scale) - 1) * var(--pu-progress)));
+        opacity: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="demo"
+      data-composition-id="parallax-unzoom-demo"
+      data-width="1920"
+      data-height="1080"
+      data-duration="6"
+      data-start="0"
+    >
+      <div class="demo-canvas">
+        <div class="hero-headline">Inspired by how people discover.</div>
+
+        <div class="parallax-unzoom-grid">
+          <!-- Row 0 -->
+          <div class="parallax-unzoom-card pu-c0" data-pu-row="0" data-pu-col="0">
+            <span class="card-glyph">◇</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c1" data-pu-row="0" data-pu-col="1">
+            <span class="card-glyph">◐</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c2" data-pu-row="0" data-pu-col="2">
+            <span class="card-glyph">◯</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c3" data-pu-row="0" data-pu-col="3">
+            <span class="card-glyph">◑</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c4" data-pu-row="0" data-pu-col="4">
+            <span class="card-glyph">▲</span>
+          </div>
+
+          <!-- Row 1 -->
+          <div class="parallax-unzoom-card pu-c5" data-pu-row="1" data-pu-col="0">
+            <span class="card-glyph">✦</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c6" data-pu-row="1" data-pu-col="1">
+            <span class="card-glyph">❖</span>
+          </div>
+          <div
+            class="parallax-unzoom-card pu-c7-focus"
+            data-pu-row="1"
+            data-pu-col="2"
+            data-pu-focus="true"
+          >
+            <div class="focus-label">
+              <small>EBAY PLAYBOOK</small>
+              DISCOVER
+            </div>
+          </div>
+          <div class="parallax-unzoom-card pu-c8" data-pu-row="1" data-pu-col="3">
+            <span class="card-glyph">✧</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c9" data-pu-row="1" data-pu-col="4">
+            <span class="card-glyph">◈</span>
+          </div>
+
+          <!-- Row 2 -->
+          <div class="parallax-unzoom-card pu-c10" data-pu-row="2" data-pu-col="0">
+            <span class="card-glyph">▼</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c11" data-pu-row="2" data-pu-col="1">
+            <span class="card-glyph">◆</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c12" data-pu-row="2" data-pu-col="2">
+            <span class="card-glyph">●</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c13" data-pu-row="2" data-pu-col="3">
+            <span class="card-glyph">◭</span>
+          </div>
+          <div class="parallax-unzoom-card pu-c14" data-pu-row="2" data-pu-col="4">
+            <span class="card-glyph" style="color: rgba(40, 40, 40, 0.7)">◇</span>
+          </div>
+        </div>
+      </div>
+
+      <script>
+        (function () {
+          // ---- parallax-unzoom snippet (inlined) ----
+          const grids = document.querySelectorAll(".parallax-unzoom-grid");
+          grids.forEach((grid) => {
+            const cards = Array.from(grid.querySelectorAll(".parallax-unzoom-card"));
+            if (cards.length === 0) return;
+            let focal = cards.find((c) => c.dataset.puFocus === "true");
+            if (!focal) {
+              focal = cards[Math.floor(cards.length / 2)];
+              focal.dataset.puFocus = "true";
+            }
+            const focusRow = Number(focal.dataset.puRow ?? 0);
+            const focusCol = Number(focal.dataset.puCol ?? 0);
+            const push =
+              parseFloat(getComputedStyle(grid).getPropertyValue("--pu-sibling-push")) || 900;
+            cards.forEach((card) => {
+              if (card === focal) return;
+              const row = Number(card.dataset.puRow ?? 0);
+              const col = Number(card.dataset.puCol ?? 0);
+              const dCol = col - focusCol;
+              const dRow = row - focusRow;
+              const mag = Math.hypot(dCol, dRow) || 1;
+              const nx = (dCol / mag) * push * mag;
+              const ny = (dRow / mag) * push * mag;
+              card.style.setProperty("--pu-dx", `${nx}px`);
+              card.style.setProperty("--pu-dy", `${ny}px`);
+            });
+          });
+
+          // ---- demo timeline ----
+          const tl = gsap.timeline({ paused: true });
+
+          // 0.0-0.3s: hold the "from" state — focus card filling viewport, headline visible
+          // (no animation; initial CSS state covers this)
+
+          // 0.3-0.8s: fade the hero headline out as the unzoom begins
+          tl.to(
+            ".hero-headline",
+            {
+              opacity: 0,
+              duration: 0.5,
+              ease: "power2.in",
+            },
+            0.3,
+          );
+
+          // 0.5-3.5s: drive the unzoom reveal
+          tl.fromTo(
+            ".parallax-unzoom-grid",
+            { "--pu-progress": 0 },
+            {
+              "--pu-progress": 1,
+              duration: 3.0,
+              ease: "power2.inOut",
+            },
+            0.5,
+          );
+
+          // 2.5-3.5s: fade the focus card label IN as it settles into the grid
+          tl.to(
+            ".focus-label",
+            {
+              opacity: 1,
+              duration: 1.0,
+              ease: "power2.out",
+            },
+            2.5,
+          );
+
+          // 3.5-6.0s: grid sits at rest (no animation, just hold)
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines["parallax-unzoom-demo"] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/components/parallax-unzoom/parallax-unzoom.html
+++ b/registry/components/parallax-unzoom/parallax-unzoom.html
@@ -1,0 +1,106 @@
+<!--
+  Parallax Unzoom — focus card scales down from full frame while siblings
+  parallax IN to form a grid. The reverse of parallax-zoom.
+
+  Pairs naturally with parallax-zoom: zoom INTO a card in scene 1, then
+  unzoom OUT of it in scene 2 to reveal a fresh grid underneath.
+
+  Usage:
+  1. Wrap your card grid with class="parallax-unzoom-grid".
+  2. Mark each card with class="parallax-unzoom-card".
+  3. Add data-pu-row="0|1|2|..." and data-pu-col="0|1|2|..." per card.
+  4. Mark the card that starts at full size with data-pu-focus="true".
+  5. Drive --pu-progress 0 → 1 on the .parallax-unzoom-grid from your
+     composition's paused GSAP timeline (see example at bottom).
+
+  Tunable CSS variables on .parallax-unzoom-grid:
+  - --pu-focus-scale  (default 6)      starting scale of the focus card
+  - --pu-sibling-push (default 900px)  outward distance siblings start at
+  - --pu-sibling-fade (default 1)      sibling opacity falloff (0–1)
+-->
+
+<style>
+  .parallax-unzoom-grid {
+    --pu-progress: 0;
+    --pu-focus-scale: 6;
+    --pu-sibling-push: 900px;
+    --pu-sibling-fade: 1;
+    position: relative;
+    transform-style: preserve-3d;
+  }
+
+  .parallax-unzoom-card {
+    transform-origin: center center;
+    will-change: transform, opacity;
+    transform: translate3d(
+        calc(var(--pu-dx, 0px) * (1 - var(--pu-progress))),
+        calc(var(--pu-dy, 0px) * (1 - var(--pu-progress))),
+        0
+      )
+      scale(calc(0.7 + 0.3 * var(--pu-progress)));
+    opacity: calc(var(--pu-progress) * var(--pu-sibling-fade));
+  }
+
+  .parallax-unzoom-card[data-pu-focus="true"] {
+    z-index: 10;
+    transform: translate3d(0, 0, 0)
+      scale(calc(var(--pu-focus-scale) - (var(--pu-focus-scale) - 1) * var(--pu-progress)));
+    opacity: 1;
+  }
+</style>
+
+<script>
+  (function () {
+    const grids = document.querySelectorAll(".parallax-unzoom-grid");
+
+    grids.forEach((grid) => {
+      const cards = Array.from(grid.querySelectorAll(".parallax-unzoom-card"));
+      if (cards.length === 0) return;
+
+      let focal = cards.find((c) => c.dataset.puFocus === "true");
+      if (!focal) {
+        focal = cards[Math.floor(cards.length / 2)];
+        focal.dataset.puFocus = "true";
+      }
+
+      const focusRow = Number(focal.dataset.puRow ?? 0);
+      const focusCol = Number(focal.dataset.puCol ?? 0);
+      const push = parseFloat(getComputedStyle(grid).getPropertyValue("--pu-sibling-push")) || 900;
+
+      cards.forEach((card) => {
+        if (card === focal) return;
+        const row = Number(card.dataset.puRow ?? 0);
+        const col = Number(card.dataset.puCol ?? 0);
+        const dCol = col - focusCol;
+        const dRow = row - focusRow;
+        const mag = Math.hypot(dCol, dRow) || 1;
+        // Normalize, scale by push and ring distance so outer cards start
+        // farther out (and travel farther in).
+        const nx = (dCol / mag) * push * mag;
+        const ny = (dRow / mag) * push * mag;
+        card.style.setProperty("--pu-dx", `${nx}px`);
+        card.style.setProperty("--pu-dy", `${ny}px`);
+      });
+    });
+  })();
+</script>
+
+<!--
+  Timeline integration example (paste into your composition's GSAP timeline):
+
+  tl.fromTo(
+    ".parallax-unzoom-grid",
+    { "--pu-progress": 0 },
+    {
+      "--pu-progress": 1,
+      duration: 2.4,
+      ease: "power2.inOut",
+    },
+    startTime, // start time in seconds
+  );
+
+  Chaining with parallax-zoom example:
+  // Scene 1 (0-3s): zoom IN to the focal card via parallax-zoom
+  // Scene 2 (3-6s): unzoom OUT of a NEW grid via parallax-unzoom,
+  //                 with the focal card pre-positioned to match scene 1
+-->

--- a/registry/components/parallax-unzoom/registry-item.json
+++ b/registry/components/parallax-unzoom/registry-item.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "parallax-unzoom",
+  "type": "hyperframes:component",
+  "title": "Parallax Unzoom",
+  "description": "Reveal transition — focus card scales down from full frame as siblings parallax in to form a grid (reverse of parallax-zoom)",
+  "tags": ["transition", "reveal", "unzoom", "parallax", "grid", "hero"],
+  "files": [
+    {
+      "path": "parallax-unzoom.html",
+      "target": "compositions/components/parallax-unzoom.html",
+      "type": "hyperframes:snippet"
+    }
+  ],
+  "preview": {
+    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-unzoom.png"
+  }
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -342,6 +342,10 @@
     {
       "name": "vfx-shatter",
       "type": "hyperframes:block"
+    },
+    {
+      "name": "parallax-unzoom",
+      "type": "hyperframes:component"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a new registry **component** — `parallax-unzoom` — the reverse of [`parallax-zoom`](https://github.com/heygen-com/hyperframes/pull/1007). A focus card starts at full-frame scale and shrinks back into its natural grid position while sibling cards parallax IN from off-screen and fade up.

## Why both directions

`parallax-zoom` and `parallax-unzoom` are designed to chain. The common use case is a multi-scene composition:

- **Scene 1 (0-3s):** `parallax-zoom` — viewer zooms INTO a card from a grid, revealing a hero moment
- **Scene 2 (3-6s):** `parallax-unzoom` — viewer unzooms OUT of that same hero, revealing a NEW grid of cards underneath

This mirrors the eBay Playbook page navigation pattern: cards open into hero moments, hero moments reveal more cards.

## How it works

Single CSS-variable-driven snippet (`--pu-progress` 0 → 1), fully seekable and deterministic. The user wraps a grid with `.parallax-unzoom-grid`, marks each child as `.parallax-unzoom-card` with `data-pu-row` / `data-pu-col`, and tags the focal card with `data-pu-focus="true"`. Same init-script approach as `parallax-zoom` — no `getBoundingClientRect` calls, stable across render seeks.

**Tunable knobs** (CSS custom properties on `.parallax-unzoom-grid`):
- `--pu-focus-scale` — starting scale of the focus card (default 6, demo uses 8)
- `--pu-sibling-push` — distance siblings start out from (default 900px)
- `--pu-sibling-fade` — sibling opacity falloff (default 1)

The `pu` prefix (vs `pz` on parallax-zoom) is intentional — it lets both components live in the same composition without CSS variable collisions.

## Files

- `registry/components/parallax-unzoom/registry-item.json` — manifest
- `registry/components/parallax-unzoom/parallax-unzoom.html` — the snippet
- `registry/components/parallax-unzoom/demo.html` — 6s 1920×1080 demo composition
- `registry/registry.json` — appended one entry
- `docs/catalog/components/parallax-unzoom.mdx` — auto-generated by `scripts/generate-catalog-pages.ts`

## Quality gate

- `bunx oxfmt --check` → clean
- `npx hyperframes lint` → 0 errors, 0 warnings
- `npx hyperframes validate --no-contrast` → no console errors
- `npx hyperframes render` → 1.1MB / 6s preview MP4 renders cleanly

## Preview

I'll attach the rendered preview MP4 to this PR description in a follow-up edit so a maintainer can generate the catalog `.png` per the external-contributor flow.

## Test plan

- [ ] Maintainer verifies `npx hyperframes add parallax-unzoom` installs into a HyperFrames project cleanly
- [ ] Maintainer renders preview locally and confirms motion matches the attached MP4
- [ ] Maintainer generates catalog `.png` + `.mp4` via `scripts/generate-catalog-previews.ts --only parallax-unzoom` and uploads to CDN

## Related

Companion to #1007 (`parallax-zoom`). Either can be reviewed/merged independently, but they're designed to ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)