### PR TITLE
fix(studio): suppress ResizeObserver loop noise from error telemetry

### DIFF
--- a/packages/studio/src/main.tsx
+++ b/packages/studio/src/main.tsx
@@ -23,6 +23,12 @@ function errorProps(value: unknown): {
 }
 
 window.addEventListener("error", (event) => {
+  if (event.message?.includes("ResizeObserver loop")) {
+    event.stopImmediatePropagation();
+    event.preventDefault();
+    return;
+  }
+
   trackStudioEvent("unhandled_error", {
     ...errorProps(event.error),
     error_message: event.message,


### PR DESCRIPTION
## Summary

- Suppress `ResizeObserver loop completed with undelivered notifications.` errors in the Studio global error handler — this is a benign browser-internal message (not a real bug) that was flooding telemetry with ~18,000 events/month, drowning out actionable errors.
- The guard checks `event.message` for "ResizeObserver loop" at the top of the `window.addEventListener("error", ...)` handler and short-circuits with `stopImmediatePropagation()` + `preventDefault()` before reaching `trackStudioEvent`.

## Test plan

- [ ] Open Studio in Chrome/Firefox, resize panels and timeline to trigger ResizeObserver recalculations — verify no `unhandled_error` telemetry events are emitted for ResizeObserver loop messages.
- [ ] Trigger a real JS error (e.g., via console `throw new Error("test")`) — verify it still appears in telemetry as `unhandled_error`.
- [ ] Confirm the browser console no longer shows the ResizeObserver warning (prevented by `preventDefault()`).