### PR TITLE
fix(cli): preflight FFmpeg + Chrome check before studio renders

### DIFF
--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -205,6 +205,32 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
 
     resolveProject: (id: string) => (id === projectId ? project : null),
 
+    async preflightCheck() {
+      const { findFFmpeg, getFFmpegInstallHint } = await import("../browser/ffmpeg.js");
+      const { findBrowser } = await import("../browser/manager.js");
+
+      if (!findFFmpeg()) {
+        const hint = getFFmpegInstallHint();
+        return {
+          error: "FFmpeg not found",
+          detail: `FFmpeg is required to render video but was not found in your PATH.\n\nInstall it:\n  ${hint}`,
+        };
+      }
+
+      const browser = await findBrowser();
+      if (!browser) {
+        return {
+          error: "Chrome not found",
+          detail:
+            "A Chrome-based browser is required to render but none was found.\n\n" +
+            "Install the headless shell:\n  npx @puppeteer/browsers install chrome-headless-shell\n\n" +
+            "Or run:\n  hyperframes browser install",
+        };
+      }
+
+      return null;
+    },
+
     async bundle(dir: string): Promise<string | null> {
       try {
         const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");

--- a/packages/core/src/studio-api/routes/render.test.ts
+++ b/packages/core/src/studio-api/routes/render.test.ts
@@ -38,6 +38,68 @@ function buildApp(spy: ReturnType<typeof vi.fn>): { app: Hono; cleanup: () => vo
   return { app, cleanup: () => rmSync(rendersDir, { recursive: true, force: true }) };
 }
 
+describe("POST /projects/:id/render — preflight check", () => {
+  it("returns 422 with error details when preflightCheck fails", async () => {
+    const spy = vi.fn();
+    const { adapter, rendersDir } = createAdapter(spy);
+    adapter.preflightCheck = async () => ({
+      error: "FFmpeg not found",
+      detail: "FFmpeg is required but was not found in your PATH.",
+    });
+    const app = new Hono();
+    registerRenderRoutes(app, adapter);
+    try {
+      const res = await app.request("http://localhost/projects/demo/render", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ fps: 30, quality: "standard", format: "mp4" }),
+      });
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.error).toBe("FFmpeg not found");
+      expect(body.detail).toContain("FFmpeg is required");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(rendersDir, { recursive: true, force: true });
+    }
+  });
+
+  it("proceeds normally when preflightCheck passes", async () => {
+    const spy = vi.fn();
+    const { adapter, rendersDir } = createAdapter(spy);
+    adapter.preflightCheck = async () => null;
+    const app = new Hono();
+    registerRenderRoutes(app, adapter);
+    try {
+      const res = await app.request("http://localhost/projects/demo/render", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ fps: 30, quality: "standard", format: "mp4" }),
+      });
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledOnce();
+    } finally {
+      rmSync(rendersDir, { recursive: true, force: true });
+    }
+  });
+
+  it("proceeds normally when preflightCheck is not provided", async () => {
+    const spy = vi.fn();
+    const { app, cleanup } = buildApp(spy);
+    try {
+      const res = await app.request("http://localhost/projects/demo/render", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ fps: 30, quality: "standard", format: "mp4" }),
+      });
+      expect(res.status).toBe(200);
+      expect(spy).toHaveBeenCalledOnce();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("POST /projects/:id/render — outputResolution forwarding", () => {
   it("forwards a valid resolution preset to the adapter", async () => {
     const spy = vi.fn();

--- a/packages/core/src/studio-api/routes/render.ts
+++ b/packages/core/src/studio-api/routes/render.ts
@@ -86,6 +86,16 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
       composition = body.composition;
     }
 
+    // Preflight: verify external dependencies (FFmpeg, Chrome) are available
+    // before starting the render. Without this, the render fails deep in the
+    // pipeline with an opaque ENOENT or "browser not found" error.
+    if (adapter.preflightCheck) {
+      const preflight = await adapter.preflightCheck();
+      if (preflight) {
+        return c.json({ error: preflight.error, detail: preflight.detail }, 422);
+      }
+    }
+
     const now = new Date();
     const datePart = now.toISOString().slice(0, 10);
     const timePart = now.toTimeString().slice(0, 8).replace(/:/g, "-");

--- a/packages/core/src/studio-api/types.ts
+++ b/packages/core/src/studio-api/types.ts
@@ -117,4 +117,12 @@ export interface StudioApiAdapter {
     project: ResolvedProject;
     blockName: string;
   }): Promise<{ written: string[]; block: RegistryItem }>;
+
+  /**
+   * Optional: run a preflight check before starting a render.
+   * Returns `null` when everything is ready, or an object with
+   * `error` (short label) and `detail` (actionable fix instructions)
+   * when a required dependency is missing.
+   */
+  preflightCheck?(): Promise<{ error: string; detail: string } | null>;
 }

--- a/packages/studio/src/components/renders/useRenderQueue.ts
+++ b/packages/studio/src/components/renders/useRenderQueue.ts
@@ -136,11 +136,22 @@ export function useRenderQueue(projectId: string | null) {
         return;
       }
       if (!res.ok) {
+        let errorMessage = `Server error (${res.status}). Check the terminal for details.`;
+        try {
+          const body = await res.json();
+          if (body.detail) {
+            errorMessage = body.detail;
+          } else if (body.error) {
+            errorMessage = body.error;
+          }
+        } catch {
+          // Response wasn't JSON — keep the generic message
+        }
         const failedJob: RenderJob = {
           id: crypto.randomUUID(),
           status: "failed",
           progress: 0,
-          error: `Server error (${res.status}). Check the terminal for details.`,
+          error: errorMessage,
           filename: "Export failed",
           createdAt: startTime,
         };


### PR DESCRIPTION
## Summary

- Adds a `preflightCheck()` method to the `StudioApiAdapter` interface that the render route calls before starting any render job
- The CLI adapter implementation checks for FFmpeg (`findFFmpeg`) and Chrome headless shell (`findBrowser`) availability, returning a 422 with actionable install instructions when either is missing
- The Studio frontend now reads the structured error from the response body and displays the full detail message inline in the render queue, replacing the generic "Server error (status)" message

Fixes PRINFRA-177 — the top three render errors (`spawn ffmpeg ENOENT`, `Browser was not found`, `window.__hf not ready`) account for 23 events/month. The first two are now caught before the pipeline starts with clear remediation steps.

## Test plan

- [ ] New unit tests in `render.test.ts` verify: preflight failure returns 422 with error/detail, preflight pass proceeds normally, missing preflight (backward compat) proceeds normally
- [ ] Run `bun run --cwd packages/core test` — all 15 render route tests pass
- [ ] Manual: uninstall ffmpeg, hit Export in Studio — should show "FFmpeg not found" with install hint instead of crashing mid-render
- [ ] Manual: remove Chrome headless shell cache, hit Export — should show "Chrome not found" with `npx @puppeteer/browsers install` instruction
- [ ] Verify existing render flow works unchanged when both dependencies are present