### PR TITLE
fix(core): clamp audio volume to [0,1] range

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1586,7 +1586,7 @@ export function initSandboxRuntimeModular(): void {
         if (!(el instanceof HTMLMediaElement)) continue;
         const parsed = parseFloat(el.dataset.volume ?? "");
         const clipVolume = Number.isFinite(parsed) ? parsed : 1;
-        el.volume = clipVolume * volume;
+        el.volume = Math.max(0, Math.min(1, clipVolume * volume));
       }
     },
     onSetMediaOutputMuted: (muted) => {

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -152,7 +152,7 @@ export function syncRuntimeMedia(params: {
         }
       }
       const userVol = params.userVolume ?? 1;
-      el.volume = (clip.volume ?? 1) * userVol;
+      el.volume = Math.max(0, Math.min(1, (clip.volume ?? 1) * userVol));
       if (shouldMute) el.muted = true;
       // Ensure full preload for every active media element. Streaming
       // formats (MP3) may arrive with preload="metadata", which only

--- a/packages/player/src/parent-media.ts
+++ b/packages/player/src/parent-media.ts
@@ -109,7 +109,7 @@ export class ParentMediaManager {
   }
 
   updateVolume(volume: number): void {
-    for (const m of this._entries) m.el.volume = volume;
+    for (const m of this._entries) m.el.volume = Math.max(0, Math.min(1, volume));
   }
 
   updatePlaybackRate(rate: number): void {
@@ -249,7 +249,7 @@ export class ParentMediaManager {
     el.src = src;
     el.load();
     el.muted = this._getMuted();
-    el.volume = this._getVolume();
+    el.volume = Math.max(0, Math.min(1, this._getVolume()));
     const rate = this._getPlaybackRate();
     if (rate !== 1) el.playbackRate = rate;
 


### PR DESCRIPTION
## Summary

- Clamp the computed volume to `[0, 1]` before assigning to `HTMLMediaElement.volume` at all four assignment sites across `core/runtime` and `player/parent-media`
- The product of per-clip `data-volume` (e.g. 1.2) and the user volume slider can exceed 1.0, which throws an `IndexSizeError` — ~2,800 events/month in production (PRINFRA-173)
- The bridge and player setter already clamp their own inputs, but the downstream multiplication sites did not guard the final value

## Test plan

- [ ] Existing core tests pass (983 tests, verified locally)
- [ ] Existing player tests pass (110 tests, verified locally)
- [ ] All three affected packages build cleanly (`core`, `player`, `studio`)
- [ ] Set `data-volume="1.5"` on an `<audio>` element in a composition and verify playback works without console errors
- [ ] Verify volume slider at max with a clip that has `data-volume > 1` does not throw