### PR TITLE
fix(core): guard getTimeline() against missing time/duration

### DIFF
--- a/packages/core/src/runtime/player.test.ts
+++ b/packages/core/src/runtime/player.test.ts
@@ -535,5 +535,65 @@ describe("createRuntimePlayer", () => {
       const player = createRuntimePlayer(deps);
       expect(player.getPlaybackRate()).toBe(2);
     });
+
+    it("getTime returns 0 when timeline object lacks .time method", () => {
+      const broken = {
+        play: vi.fn(),
+        pause: vi.fn(),
+        seek: vi.fn(),
+        add: vi.fn(),
+        paused: vi.fn(),
+        set: vi.fn(),
+        duration: vi.fn(() => 10),
+      } as unknown as RuntimeTimelineLike;
+      const deps = createMockDeps(broken);
+      const player = createRuntimePlayer(deps);
+      expect(player.getTime()).toBe(0);
+    });
+
+    it("getDuration returns 0 when timeline object lacks .duration method", () => {
+      const broken = {
+        play: vi.fn(),
+        pause: vi.fn(),
+        seek: vi.fn(),
+        add: vi.fn(),
+        paused: vi.fn(),
+        set: vi.fn(),
+        time: vi.fn(() => 5),
+      } as unknown as RuntimeTimelineLike;
+      const deps = createMockDeps(broken);
+      const player = createRuntimePlayer(deps);
+      expect(player.getDuration()).toBe(0);
+    });
+
+    it("play does not crash when timeline lacks .time and .duration methods", () => {
+      const broken = {
+        play: vi.fn(),
+        pause: vi.fn(),
+        seek: vi.fn(),
+        add: vi.fn(),
+        paused: vi.fn(),
+        set: vi.fn(),
+      } as unknown as RuntimeTimelineLike;
+      const deps = createMockDeps(broken);
+      deps.getSafeDuration.mockReturnValue(0);
+      const player = createRuntimePlayer(deps);
+      expect(() => player.play()).not.toThrow();
+    });
+
+    it("pause does not crash when timeline lacks .time method", () => {
+      const broken = {
+        play: vi.fn(),
+        pause: vi.fn(),
+        seek: vi.fn(),
+        add: vi.fn(),
+        paused: vi.fn(),
+        set: vi.fn(),
+      } as unknown as RuntimeTimelineLike;
+      const deps = createMockDeps(broken);
+      const player = createRuntimePlayer(deps);
+      expect(() => player.pause()).not.toThrow();
+      expect(deps.onDeterministicSeek).toHaveBeenCalledWith(0);
+    });
   });
 });

--- a/packages/core/src/runtime/player.ts
+++ b/packages/core/src/runtime/player.ts
@@ -2,6 +2,18 @@ import type { RuntimePlayer, RuntimeTimelineLike } from "./types";
 import { quantizeTimeToFrame } from "../inline-scripts/parityContract";
 import { swallow } from "./diagnostics";
 
+/** Safely read `.time()` from a timeline that may not fully conform to the interface. */
+function safeTimelineTime(tl: RuntimeTimelineLike | null | undefined): number {
+  if (!tl || typeof tl.time !== "function") return 0;
+  return Math.max(0, Number(tl.time()) || 0);
+}
+
+/** Safely read `.duration()` from a timeline that may not fully conform to the interface. */
+function safeTimelineDuration(tl: RuntimeTimelineLike | null | undefined): number {
+  if (!tl || typeof tl.duration !== "function") return 0;
+  return Math.max(0, Number(tl.duration()) || 0);
+}
+
 type PlayerDeps = {
   getTimeline: () => RuntimeTimelineLike | null;
   setTimeline: (timeline: RuntimeTimelineLike | null) => void;
@@ -103,10 +115,10 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
       if (!timeline || deps.getIsPlaying()) return;
       const safeDuration = Math.max(
         0,
-        Number(deps.getSafeDuration?.() ?? timeline.duration() ?? 0) || 0,
+        Number(deps.getSafeDuration?.() ?? safeTimelineDuration(timeline)) || 0,
       );
       if (safeDuration > 0) {
-        const currentTime = Math.max(0, Number(timeline.time()) || 0);
+        const currentTime = safeTimelineTime(timeline);
         if (currentTime >= safeDuration) {
           timeline.pause();
           timeline.seek(0, false);
@@ -136,7 +148,7 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
       forEachSiblingTimeline(deps.getTimelineRegistry?.(), timeline, (tl) => {
         tl.pause();
       });
-      const time = Math.max(0, Number(timeline.time()) || 0);
+      const time = safeTimelineTime(timeline);
       deps.onDeterministicSeek(time);
       deps.onDeterministicPause();
       deps.setIsPlaying(false);
@@ -199,8 +211,8 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
       deps.onRenderFrameSeek(quantized);
       deps.onStatePost(true);
     },
-    getTime: () => Number(deps.getTimeline()?.time() ?? 0),
-    getDuration: () => Number(deps.getTimeline()?.duration() ?? 0),
+    getTime: () => safeTimelineTime(deps.getTimeline()),
+    getDuration: () => safeTimelineDuration(deps.getTimeline()),
     isPlaying: () => deps.getIsPlaying(),
     setPlaybackRate: (rate: number) => deps.setPlaybackRate(rate),
     getPlaybackRate: () => deps.getPlaybackRate(),

--- a/packages/core/src/runtime/player.ts
+++ b/packages/core/src/runtime/player.ts
@@ -2,15 +2,29 @@ import type { RuntimePlayer, RuntimeTimelineLike } from "./types";
 import { quantizeTimeToFrame } from "../inline-scripts/parityContract";
 import { swallow } from "./diagnostics";
 
+const guardSwallowed = new Set<string>();
+
 /** Safely read `.time()` from a timeline that may not fully conform to the interface. */
 function safeTimelineTime(tl: RuntimeTimelineLike | null | undefined): number {
-  if (!tl || typeof tl.time !== "function") return 0;
+  if (!tl || typeof tl.time !== "function") {
+    if (tl && !guardSwallowed.has("time")) {
+      guardSwallowed.add("time");
+      swallow("player.safeTimelineTime", new Error("timeline missing .time()"));
+    }
+    return 0;
+  }
   return Math.max(0, Number(tl.time()) || 0);
 }
 
 /** Safely read `.duration()` from a timeline that may not fully conform to the interface. */
 function safeTimelineDuration(tl: RuntimeTimelineLike | null | undefined): number {
-  if (!tl || typeof tl.duration !== "function") return 0;
+  if (!tl || typeof tl.duration !== "function") {
+    if (tl && !guardSwallowed.has("duration")) {
+      guardSwallowed.add("duration");
+      swallow("player.safeTimelineDuration", new Error("timeline missing .duration()"));
+    }
+    return 0;
+  }
   return Math.max(0, Number(tl.duration()) || 0);
 }
 


### PR DESCRIPTION
## Summary

- Adds `safeTimelineTime` / `safeTimelineDuration` helpers to `player.ts` that check `typeof tl.time === "function"` before calling, matching the existing defensive pattern in `init.ts`'s `getTimelineDurationSeconds`
- Applies guards to all five bare `.time()` / `.duration()` call sites in the runtime player: `getTime`, `getDuration`, `play` (duration + time reads), and `pause` (time read)
- Adds 4 regression tests covering timelines that lack `.time`, `.duration`, or both

Fixes PRINFRA-175 — `getTimeline()?.time is not a function` (10/mo) and `getTimeline()?.duration is not a function` (19/mo). The root cause is that `capturedTimeline` can hold a truthy object whose methods haven't been attached yet (partially initialized GSAP timeline or non-conforming adapter). Optional chaining only guards `null`/`undefined`, not missing methods on a truthy object.

## Test plan

- [x] `bun test packages/core/src/runtime/player.test.ts` — 39 tests pass (4 new)
- [x] `bun run --cwd packages/core build` — typecheck + bundle clean
- [x] `bunx oxlint` + `bunx oxfmt --check` — no warnings
- [x] Pre-commit hooks (lint, format, typecheck, fallow, commitlint) all pass