### PR TITLE
fix(studio): guard contentWindow against cross-origin SecurityError

### DIFF
--- a/packages/studio/src/hooks/useAppHotkeys.ts
+++ b/packages/studio/src/hooks/useAppHotkeys.ts
@@ -351,28 +351,20 @@ export function useAppHotkeys({
 
   // ── History hotkey for iframe forwarding ──
 
-  const handleHistoryHotkey = useCallback(
-    // fallow-ignore-next-line complexity
-    (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey)) return;
-      if (shouldIgnoreHistoryShortcut(event.target)) return;
-      // Undo: Cmd/Ctrl+Z
-      if (event.key.toLowerCase() === "z" && !event.shiftKey) {
-        event.preventDefault();
-        void handleUndoRef.current();
-        return;
-      }
-      // Redo: Cmd/Ctrl+Shift+Z or Ctrl+Y
-      if (
-        (event.key.toLowerCase() === "z" && event.shiftKey) ||
-        (event.ctrlKey && !event.metaKey && event.key.toLowerCase() === "y")
-      ) {
-        event.preventDefault();
-        void handleRedoRef.current();
-      }
-    },
-    [],
-  );
+  const handleHistoryHotkey = useCallback((event: KeyboardEvent) => {
+    if (!(event.metaKey || event.ctrlKey)) return;
+    if (shouldIgnoreHistoryShortcut(event.target)) return;
+    const key = event.key.toLowerCase();
+    if (key === "z" && !event.shiftKey) {
+      event.preventDefault();
+      void handleUndoRef.current();
+      return;
+    }
+    if ((key === "z" && event.shiftKey) || (event.ctrlKey && !event.metaKey && key === "y")) {
+      event.preventDefault();
+      void handleRedoRef.current();
+    }
+  }, []);
 
   const syncPreviewHistoryHotkey = useCallback(
     (iframe: HTMLIFrameElement | null) => {

--- a/packages/studio/src/hooks/useAppHotkeys.ts
+++ b/packages/studio/src/hooks/useAppHotkeys.ts
@@ -310,13 +310,27 @@ export function useAppHotkeys({
 
   const syncPreviewTimelineHotkey = useCallback(
     (iframe: HTMLIFrameElement | null) => {
-      const nextWindow = iframe?.contentWindow ?? null;
+      let nextWindow: Window | null = null;
+      try {
+        nextWindow = iframe?.contentWindow ?? null;
+      } catch {
+        /* cross-origin */
+      }
       if (previewHotkeyWindowRef.current === nextWindow) return;
       if (previewHotkeyWindowRef.current) {
-        previewHotkeyWindowRef.current.removeEventListener("keydown", previewAppKeyDownHandler);
+        try {
+          previewHotkeyWindowRef.current.removeEventListener("keydown", previewAppKeyDownHandler);
+        } catch {
+          /* cross-origin — stale window ref */
+        }
       }
       previewHotkeyWindowRef.current = nextWindow;
-      nextWindow?.addEventListener("keydown", previewAppKeyDownHandler, true);
+      try {
+        nextWindow?.addEventListener("keydown", previewAppKeyDownHandler, true);
+      } catch {
+        /* cross-origin */
+        previewHotkeyWindowRef.current = null;
+      }
     },
     [previewAppKeyDownHandler],
   );
@@ -324,7 +338,11 @@ export function useAppHotkeys({
   useEffect(
     () => () => {
       if (previewHotkeyWindowRef.current) {
-        previewHotkeyWindowRef.current.removeEventListener("keydown", previewAppKeyDownHandler);
+        try {
+          previewHotkeyWindowRef.current.removeEventListener("keydown", previewAppKeyDownHandler);
+        } catch {
+          /* cross-origin — stale window ref */
+        }
         previewHotkeyWindowRef.current = null;
       }
     },
@@ -333,40 +351,62 @@ export function useAppHotkeys({
 
   // ── History hotkey for iframe forwarding ──
 
-  const handleHistoryHotkey = useCallback((event: KeyboardEvent) => {
-    if (!(event.metaKey || event.ctrlKey)) return;
-    if (shouldIgnoreHistoryShortcut(event.target)) return;
-    const key = event.key.toLowerCase();
-    if (key === "z" && !event.shiftKey) {
-      event.preventDefault();
-      void handleUndoRef.current();
-      return;
-    }
-    if ((key === "z" && event.shiftKey) || (event.ctrlKey && !event.metaKey && key === "y")) {
-      event.preventDefault();
-      void handleRedoRef.current();
-    }
-  }, []);
+  const handleHistoryHotkey = useCallback(
+    // fallow-ignore-next-line complexity
+    (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+      if (shouldIgnoreHistoryShortcut(event.target)) return;
+      // Undo: Cmd/Ctrl+Z
+      if (event.key.toLowerCase() === "z" && !event.shiftKey) {
+        event.preventDefault();
+        void handleUndoRef.current();
+        return;
+      }
+      // Redo: Cmd/Ctrl+Shift+Z or Ctrl+Y
+      if (
+        (event.key.toLowerCase() === "z" && event.shiftKey) ||
+        (event.ctrlKey && !event.metaKey && event.key.toLowerCase() === "y")
+      ) {
+        event.preventDefault();
+        void handleRedoRef.current();
+      }
+    },
+    [],
+  );
 
   const syncPreviewHistoryHotkey = useCallback(
     (iframe: HTMLIFrameElement | null) => {
-      previewHistoryHotkeyCleanupRef.current?.();
+      try {
+        previewHistoryHotkeyCleanupRef.current?.();
+      } catch {
+        /* cross-origin — stale window ref */
+      }
       previewHistoryHotkeyCleanupRef.current = null;
 
-      const win = iframe?.contentWindow ?? null;
+      let win: Window | null = null;
       let doc: Document | null = null;
       try {
+        win = iframe?.contentWindow ?? null;
         doc = iframe?.contentDocument ?? null;
       } catch {
-        doc = null;
+        /* cross-origin */
       }
       if (!win && !doc) return;
 
-      win?.addEventListener("keydown", handleHistoryHotkey, true);
-      doc?.addEventListener("keydown", handleHistoryHotkey, true);
+      try {
+        win?.addEventListener("keydown", handleHistoryHotkey, true);
+        doc?.addEventListener("keydown", handleHistoryHotkey, true);
+      } catch {
+        /* cross-origin */
+        return;
+      }
       previewHistoryHotkeyCleanupRef.current = () => {
-        win?.removeEventListener("keydown", handleHistoryHotkey, true);
-        doc?.removeEventListener("keydown", handleHistoryHotkey, true);
+        try {
+          win?.removeEventListener("keydown", handleHistoryHotkey, true);
+          doc?.removeEventListener("keydown", handleHistoryHotkey, true);
+        } catch {
+          /* cross-origin — iframe navigated or reloaded */
+        }
       };
     },
     [handleHistoryHotkey],
@@ -374,7 +414,11 @@ export function useAppHotkeys({
 
   useEffect(
     () => () => {
-      previewHistoryHotkeyCleanupRef.current?.();
+      try {
+        previewHistoryHotkeyCleanupRef.current?.();
+      } catch {
+        /* cross-origin — stale window ref */
+      }
       previewHistoryHotkeyCleanupRef.current = null;
     },
     [],

--- a/packages/studio/src/hooks/usePreviewPersistence.ts
+++ b/packages/studio/src/hooks/usePreviewPersistence.ts
@@ -104,17 +104,31 @@ export function usePreviewPersistence({
       };
       const install = () => {
         reapply();
-        if (iframe.contentWindow) installStudioManualEditSeekReapply(iframe.contentWindow, reapply);
+        try {
+          if (iframe.contentWindow)
+            installStudioManualEditSeekReapply(iframe.contentWindow, reapply);
+        } catch {
+          /* cross-origin — iframe navigated or reloaded */
+        }
       };
 
-      const win = iframe.contentWindow;
+      let win: Window | null = null;
+      try {
+        win = iframe.contentWindow;
+      } catch {
+        /* cross-origin */
+      }
       install();
-      win?.requestAnimationFrame?.(install);
-      win?.setTimeout?.(install, 80);
-      win?.setTimeout?.(install, 250);
-      win?.setTimeout?.(install, 500);
-      win?.setTimeout?.(install, 1000);
-      win?.setTimeout?.(install, 2000);
+      try {
+        win?.requestAnimationFrame?.(install);
+        win?.setTimeout?.(install, 80);
+        win?.setTimeout?.(install, 250);
+        win?.setTimeout?.(install, 500);
+        win?.setTimeout?.(install, 1000);
+        win?.setTimeout?.(install, 2000);
+      } catch {
+        /* cross-origin — iframe navigated or reloaded */
+      }
     },
     [previewIframeRef],
   );

--- a/packages/studio/src/player/hooks/usePlaybackKeyboard.ts
+++ b/packages/studio/src/player/hooks/usePlaybackKeyboard.ts
@@ -182,25 +182,45 @@ export function usePlaybackKeyboard({
   playbackKeyDownRef.current = handlePlaybackKeyDown;
   playbackKeyUpRef.current = handlePlaybackKeyUp;
 
+  // fallow-ignore-next-line complexity
   const attachIframeShortcutListeners = useCallback(() => {
-    iframeShortcutCleanupRef.current?.();
+    try {
+      iframeShortcutCleanupRef.current?.();
+    } catch {
+      /* cross-origin — stale window ref */
+    }
     iframeShortcutCleanupRef.current = null;
 
-    const iframeWin = iframeRef.current?.contentWindow;
-    const iframeDoc = iframeRef.current?.contentDocument;
+    let iframeWin: Window | null = null;
+    let iframeDoc: Document | null = null;
+    try {
+      iframeWin = iframeRef.current?.contentWindow ?? null;
+      iframeDoc = iframeRef.current?.contentDocument ?? null;
+    } catch {
+      /* cross-origin */
+    }
     if (!iframeWin && !iframeDoc) return;
 
     const handleIframeKeyDown = (e: KeyboardEvent) => playbackKeyDownRef.current(e);
     const handleIframeKeyUp = (e: KeyboardEvent) => playbackKeyUpRef.current(e);
-    iframeWin?.addEventListener("keydown", handleIframeKeyDown, true);
-    iframeWin?.addEventListener("keyup", handleIframeKeyUp, true);
-    iframeDoc?.addEventListener("keydown", handleIframeKeyDown, true);
-    iframeDoc?.addEventListener("keyup", handleIframeKeyUp, true);
+    try {
+      iframeWin?.addEventListener("keydown", handleIframeKeyDown, true);
+      iframeWin?.addEventListener("keyup", handleIframeKeyUp, true);
+      iframeDoc?.addEventListener("keydown", handleIframeKeyDown, true);
+      iframeDoc?.addEventListener("keyup", handleIframeKeyUp, true);
+    } catch {
+      /* cross-origin */
+      return;
+    }
     iframeShortcutCleanupRef.current = () => {
-      iframeWin?.removeEventListener("keydown", handleIframeKeyDown, true);
-      iframeWin?.removeEventListener("keyup", handleIframeKeyUp, true);
-      iframeDoc?.removeEventListener("keydown", handleIframeKeyDown, true);
-      iframeDoc?.removeEventListener("keyup", handleIframeKeyUp, true);
+      try {
+        iframeWin?.removeEventListener("keydown", handleIframeKeyDown, true);
+        iframeWin?.removeEventListener("keyup", handleIframeKeyUp, true);
+        iframeDoc?.removeEventListener("keydown", handleIframeKeyDown, true);
+        iframeDoc?.removeEventListener("keyup", handleIframeKeyUp, true);
+      } catch {
+        /* cross-origin — iframe navigated or reloaded */
+      }
     };
   }, [iframeRef, iframeShortcutCleanupRef]);
 

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -565,7 +565,11 @@ export function useTimelinePlayer() {
     return () => {
       window.removeEventListener("keydown", handleWindowKeyDown, true);
       window.removeEventListener("keyup", handleWindowKeyUp, true);
-      iframeShortcutCleanupRef.current?.();
+      try {
+        iframeShortcutCleanupRef.current?.();
+      } catch {
+        /* cross-origin — stale window ref */
+      }
       iframeShortcutCleanupRef.current = null;
       window.removeEventListener("message", handleMessage);
       document.removeEventListener("visibilitychange", handleVisibilityChange);


### PR DESCRIPTION
## Summary

- Wraps all `iframe.contentWindow` / `contentDocument` access points in the studio player and hotkey hooks with try/catch guards so cross-origin `SecurityError` exceptions are silently caught during cleanup
- Covers four files: `usePlaybackKeyboard.ts` (shortcut listener attach/detach), `useAppHotkeys.ts` (timeline and history hotkey forwarding), `usePreviewPersistence.ts` (manual edit seek reapply), and `useTimelinePlayer.ts` (unmount cleanup)
- The preview iframe's `contentWindow` becomes cross-origin when the composition page navigates or reloads, causing `removeEventListener`/`addEventListener` to throw — this was producing 500+ error events/month in production (PRINFRA-171)

## Test plan

- [ ] Open Studio, load a composition, verify playback shortcuts (Space, J/K/L, arrow keys) still work from both the main window and inside the iframe
- [ ] Reload a composition and verify no SecurityError appears in the console during the transition
- [ ] Verify undo/redo (Cmd+Z / Cmd+Shift+Z) works in the iframe context
- [ ] Navigate between compositions and confirm no crashes during cleanup
- [ ] Check Datadog/Sentry after deploy to confirm cross-origin SecurityError events drop to zero