### PR TITLE
feat(cli): warn when lambda --width/--height conflicts with composition

### DIFF
--- a/packages/aws-lambda/src/sdk/getRenderProgress.test.ts
+++ b/packages/aws-lambda/src/sdk/getRenderProgress.test.ts
@@ -67,6 +67,54 @@ function stateExited(name: string, output?: unknown): HistoryEvent {
   } as HistoryEvent;
 }
 
+// Optimized `lambda:invoke` integration's wire shape: Task* events with
+// the handler payload at `.Payload`. Helpers below fabricate these so
+// tests cover the same events a real CDK-deployed render produces.
+function taskScheduled(): HistoryEvent {
+  return {
+    type: "TaskScheduled",
+    id: 1,
+    timestamp: new Date(),
+    taskScheduledEventDetails: {
+      resource: "invoke",
+      resourceType: "lambda",
+      region: "us-east-1",
+      parameters: "{}",
+    },
+  } as HistoryEvent;
+}
+
+function taskSucceeded(payload: unknown): HistoryEvent {
+  return {
+    type: "TaskSucceeded",
+    id: 1,
+    timestamp: new Date(),
+    taskSucceededEventDetails: {
+      resource: "invoke",
+      resourceType: "lambda",
+      output: JSON.stringify({
+        ExecutedVersion: "$LATEST",
+        Payload: payload,
+        StatusCode: 200,
+      }),
+    },
+  } as HistoryEvent;
+}
+
+function taskFailed(error: string, cause: string): HistoryEvent {
+  return {
+    type: "TaskFailed",
+    id: 1,
+    timestamp: new Date(),
+    taskFailedEventDetails: {
+      resource: "invoke",
+      resourceType: "lambda",
+      error,
+      cause,
+    },
+  } as HistoryEvent;
+}
+
 describe("getRenderProgress", () => {
   it("reports 0 progress before Plan completes", async () => {
     const sfn = new FakeSFN();
@@ -221,6 +269,116 @@ describe("getRenderProgress", () => {
 
   it("requires executionArn", async () => {
     await expect(getRenderProgress({ executionArn: "" })).rejects.toThrow(/executionArn/);
+  });
+
+  describe("optimized lambda:invoke integration", () => {
+    it("counts a single TaskSucceeded as one Lambda invocation", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 240, DurationMs: 1_000 }),
+        ],
+      ];
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        defaultMemorySizeMb: 10_240,
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.lambdasInvoked).toBe(1);
+      expect(progress.totalFrames).toBe(240);
+      // computeRenderCost rounds to 4 decimals; precision=4 not 6.
+      expect(progress.costs.breakdown.lambdaUsd).toBeCloseTo(0.0002, 4);
+      expect(progress.costs.breakdown.lambdaUsd).toBeGreaterThan(0);
+    });
+
+    it("attributes RenderChunk FramesEncoded but ignores Plan/Assemble FramesEncoded", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 100, DurationMs: 1_000 }),
+          stateEntered("RenderChunk"),
+          taskScheduled(),
+          taskSucceeded({ Action: "renderChunk", FramesEncoded: 50, DurationMs: 2_000 }),
+          stateEntered("Assemble"),
+          taskScheduled(),
+          taskSucceeded({
+            Action: "assemble",
+            FramesEncoded: 100, // would double-count if Assemble's count bled in
+            FileSize: 9_000_000,
+            OutputS3Uri: "s3://b/k.mp4",
+            DurationMs: 1_500,
+          }),
+        ],
+      ];
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.framesRendered).toBe(50);
+      expect(progress.lambdasInvoked).toBe(3);
+    });
+
+    it("captures TaskFailed errors with the enclosing state name", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("RenderChunk"),
+          taskScheduled(),
+          taskFailed("Sandbox.Timedout", "Task timed out after 900.00 seconds"),
+        ],
+      ];
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.errors).toEqual([
+        {
+          state: "RenderChunk",
+          error: "Sandbox.Timedout",
+          cause: "Task timed out after 900.00 seconds",
+        },
+      ]);
+    });
+
+    it("sums billed seconds across plan + chunks + assemble", async () => {
+      const sfn = new FakeSFN();
+      const renderChunkSucceeded = (frames: number, ms: number) => [
+        stateEntered("RenderChunk"),
+        taskScheduled(),
+        taskSucceeded({ Action: "renderChunk", FramesEncoded: frames, DurationMs: ms }),
+      ];
+      // 1 plan + 16 chunks @ 217s + 1 assemble = 3492.7s billed.
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 1349, DurationMs: 13_000 }),
+          ...Array.from({ length: 16 }, () => renderChunkSucceeded(84, 217_000)).flat(),
+          stateEntered("Assemble"),
+          taskScheduled(),
+          taskSucceeded({
+            Action: "assemble",
+            FileSize: 81_000_000,
+            OutputS3Uri: "s3://b/k.mp4",
+            DurationMs: 7_700,
+          }),
+        ],
+      ];
+      sfn.describe.status = "SUCCEEDED";
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        defaultMemorySizeMb: 10_240,
+        sfn: sfn as unknown as SFNClient,
+      });
+      // 3492.7s × 10GB × $0.0000166667/GB-s ≈ $0.582.
+      expect(progress.costs.breakdown.lambdaUsd).toBeCloseTo(0.582, 2);
+      expect(progress.framesRendered).toBe(84 * 16);
+      expect(progress.lambdasInvoked).toBe(18);
+    });
   });
 });
 

--- a/packages/aws-lambda/src/sdk/getRenderProgress.ts
+++ b/packages/aws-lambda/src/sdk/getRenderProgress.ts
@@ -73,7 +73,7 @@ export interface RenderProgress {
   framesRendered: number;
   /** `null` until Plan completes. */
   totalFrames: number | null;
-  /** Count of `LambdaFunctionScheduled` events seen in the history so far. */
+  /** Total Lambda invocations scheduled so far (both optimized + raw task integrations). */
   lambdasInvoked: number;
   costs: RenderCost;
   /** Final output object if Assemble succeeded; `null` otherwise. */
@@ -198,9 +198,35 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
         stateTransitions++;
         currentLambdaState = ev.stateEnteredEventDetails?.name ?? currentLambdaState;
         break;
+      // Optimized `lambda:invoke` task emits Task* events; raw
+      // `lambda:invokeFunction.sync` emits LambdaFunction*. Handle both.
+      case "TaskScheduled":
+        if (ev.taskScheduledEventDetails?.resourceType === "lambda") {
+          lambdasInvoked++;
+        }
+        break;
       case "LambdaFunctionScheduled":
         lambdasInvoked++;
         break;
+      case "TaskSucceeded": {
+        if (ev.taskSucceededEventDetails?.resourceType !== "lambda") break;
+        const wrapped = parseJson(ev.taskSucceededEventDetails?.output);
+        const payload = unwrapLambdaPayload(wrapped);
+        const billedDurationMs = inferBilledMs(payload);
+        lambdaInvocations.push({
+          billedDurationMs,
+          memorySizeMb: memoryMb,
+          estimated: billedDurationMs === 0,
+        });
+        applyPayloadFrameCounts(payload, currentLambdaState, (delta) => {
+          framesRendered += delta;
+        });
+        if (payload && typeof payload === "object") {
+          const obj = payload as Record<string, unknown>;
+          if (typeof obj.TotalFrames === "number") totalFrames = obj.TotalFrames;
+        }
+        break;
+      }
       case "LambdaFunctionSucceeded": {
         const payload = parseJson(ev.lambdaFunctionSucceededEventDetails?.output);
         const billedDurationMs = inferBilledMs(payload);
@@ -209,20 +235,12 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
           memorySizeMb: memoryMb,
           estimated: billedDurationMs === 0,
         });
+        applyPayloadFrameCounts(payload, currentLambdaState, (delta) => {
+          framesRendered += delta;
+        });
         if (payload && typeof payload === "object") {
           const obj = payload as Record<string, unknown>;
           if (typeof obj.TotalFrames === "number") totalFrames = obj.TotalFrames;
-          if (typeof obj.FramesEncoded === "number") {
-            // Plan and Assemble also return FramesEncoded; count framesRendered
-            // only inside the RenderChunk state so we don't double-count
-            // it on the Assemble pass. Keyed off the enclosing state name
-            // (set by the matching StateEntered) rather than the payload's
-            // `Action` field — `Action` is part of the Lambda event
-            // contract and not load-bearing for state-machine identity.
-            if (currentLambdaState === "RenderChunk") {
-              framesRendered += obj.FramesEncoded;
-            }
-          }
         }
         break;
       }
@@ -244,6 +262,14 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
             outputFile = outputS3Uri ? { s3Uri: outputS3Uri, bytes } : outputFile;
           }
         }
+        break;
+      case "TaskFailed":
+        if (ev.taskFailedEventDetails?.resourceType !== "lambda") break;
+        errors.push({
+          state: currentLambdaState ?? "<unknown>",
+          error: ev.taskFailedEventDetails?.error ?? "UNKNOWN",
+          cause: ev.taskFailedEventDetails?.cause ?? "",
+        });
         break;
       case "LambdaFunctionFailed":
         errors.push({
@@ -297,6 +323,37 @@ function parseJson(s: string | undefined): unknown {
   } catch {
     return null;
   }
+}
+
+/**
+ * Optimized `lambda:invoke` wraps the Lambda response as
+ * `{ ExecutedVersion, Payload: {…handler payload…}, StatusCode }`. Raw
+ * `lambda:invokeFunction.sync` puts the handler payload at the root.
+ * Return the inner `Payload` when present so callers read the same fields
+ * either way.
+ */
+function unwrapLambdaPayload(payload: unknown): unknown {
+  if (payload && typeof payload === "object" && "Payload" in payload) {
+    const inner = (payload as { Payload: unknown }).Payload;
+    if (inner && typeof inner === "object") return inner;
+  }
+  return payload;
+}
+
+/**
+ * Bump `framesRendered` only inside the `RenderChunk` state. Plan and
+ * Assemble also report `FramesEncoded`, so a state-blind add would
+ * double-count once Assemble runs.
+ */
+function applyPayloadFrameCounts(
+  payload: unknown,
+  currentLambdaState: string | null,
+  bump: (delta: number) => void,
+): void {
+  if (currentLambdaState !== "RenderChunk") return;
+  if (!payload || typeof payload !== "object") return;
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.FramesEncoded === "number") bump(obj.FramesEncoded);
 }
 
 /**

--- a/packages/cli/src/commands/lambda/_dimensions.test.ts
+++ b/packages/cli/src/commands/lambda/_dimensions.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { warnOnDimensionMismatch } from "./_dimensions.js";
+
+const indexHtml = (width: number, height: number) =>
+  `<!doctype html><html><body><div data-composition-id="root" data-width="${width}" data-height="${height}"></div></body></html>`;
+
+describe("warnOnDimensionMismatch", () => {
+  let dir: string;
+  let warnSpy: ReturnType<typeof vi.fn>;
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hf-dim-mismatch-"));
+    originalWarn = console.warn;
+    warnSpy = vi.fn();
+    console.warn = warnSpy as unknown as typeof console.warn;
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeIndex(html: string): void {
+    writeFileSync(join(dir, "index.html"), html);
+  }
+
+  it("warns when the CLI dimensions don't match the composition", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const call = (warnSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(call).toContain("3840×2160");
+    expect(call).toContain("1920×1080");
+    expect(call).toContain("--output-resolution");
+  });
+
+  it("is silent when CLI and composition agree", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 1920,
+      cliHeight: 1080,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when --output-resolution is set (the supersampling path)", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: "landscape-4k",
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when quiet=true (--json)", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: true,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when index.html is missing (typical with --site-id)", () => {
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when the composition has no data-composition-id root", () => {
+    writeIndex("<body><h1>just a comp</h1></body>");
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/lambda/_dimensions.ts
+++ b/packages/cli/src/commands/lambda/_dimensions.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared dimension-mismatch warning for `hyperframes lambda render` and
+ * `lambda render-batch`. The runtime lays the page out at the composition's
+ * `data-width`/`data-height`, so passing `--width 3840 --height 2160`
+ * against a 1920×1080 composition silently produces a 1080p output. Warn
+ * early and point at `--output-resolution` (the supersampling path).
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CanvasResolution } from "@hyperframes/core";
+import { c } from "../../ui/colors.js";
+import { findCompositionDimensions } from "../../utils/compositionViewport.js";
+
+export interface DimensionMismatchArgs {
+  projectDir: string;
+  cliWidth: number;
+  cliHeight: number;
+  outputResolution: CanvasResolution | undefined;
+  /** Suppress the warning when stdout is reserved for machine output (--json). */
+  quiet: boolean;
+}
+
+// fallow-ignore-next-line complexity
+export function warnOnDimensionMismatch(args: DimensionMismatchArgs): void {
+  if (args.quiet) return;
+  if (args.outputResolution) return;
+  let html: string;
+  try {
+    html = readFileSync(join(args.projectDir, "index.html"), "utf-8");
+  } catch {
+    return;
+  }
+  const composition = findCompositionDimensions(html);
+  if (!composition) return;
+  if (composition.width === args.cliWidth && composition.height === args.cliHeight) return;
+  console.warn(
+    c.warn(
+      `--width/--height (${args.cliWidth}×${args.cliHeight}) disagrees with the composition's ` +
+        `data-width/data-height (${composition.width}×${composition.height}). The runtime lays out ` +
+        `the page at the composition's authored dimensions, so your output will be ` +
+        `${composition.width}×${composition.height}, not ${args.cliWidth}×${args.cliHeight}.\n` +
+        `  To supersample to a higher resolution, pass --output-resolution (e.g. \`--output-resolution=4k\`).\n` +
+        `  To truly change layout dimensions, edit the composition's data-width/data-height in index.html.`,
+    ),
+  );
+}

--- a/packages/cli/src/commands/lambda/render-batch.ts
+++ b/packages/cli/src/commands/lambda/render-batch.ts
@@ -36,6 +36,7 @@ import {
   reportVariableIssues,
   validateVariablesAgainstSchema,
 } from "../../utils/variables.js";
+import { warnOnDimensionMismatch } from "./_dimensions.js";
 import { requireStack } from "./state.js";
 
 // Dynamic-import the SDK so tsup keeps it out of the static-import head of
@@ -164,6 +165,14 @@ export async function runRenderBatch(args: RenderBatchArgs): Promise<void> {
     errorBox("Empty batch", `${batchPath} contains zero entries (every line was blank).`);
     process.exit(1);
   }
+
+  warnOnDimensionMismatch({
+    projectDir,
+    cliWidth: args.width,
+    cliHeight: args.height,
+    outputResolution: args.outputResolution,
+    quiet: args.json,
+  });
 
   // Pre-validate every entry's variables against the composition's
   // schema. Mismatches print as warnings; strict mode aborts before any

--- a/packages/cli/src/commands/lambda/render.ts
+++ b/packages/cli/src/commands/lambda/render.ts
@@ -17,6 +17,7 @@ import {
   resolveVariablesArg,
   validateVariablesAgainstProject,
 } from "../../utils/variables.js";
+import { warnOnDimensionMismatch } from "./_dimensions.js";
 import { requireStack, stateFilePath } from "./state.js";
 
 // Dynamic-import the SDK so tsup keeps it out of the static-import head of
@@ -71,6 +72,14 @@ export interface RenderArgs {
 export async function runRender(args: RenderArgs): Promise<void> {
   const stack = requireStack(args.stackName);
   const projectDir = resolvePath(args.projectDir);
+
+  warnOnDimensionMismatch({
+    projectDir,
+    cliWidth: args.width,
+    cliHeight: args.height,
+    outputResolution: args.outputResolution,
+    quiet: args.json,
+  });
 
   // Resolve --variables / --variables-file using the same parser the local
   // `hyperframes render` uses. `resolveVariablesArg` exits(1) with a friendly

--- a/packages/cli/src/utils/compositionViewport.ts
+++ b/packages/cli/src/utils/compositionViewport.ts
@@ -10,17 +10,27 @@ function parseViewportDimension(value: string | null): number | null {
   return Math.min(parsed, MAX_VIEWPORT_DIMENSION);
 }
 
+/**
+ * Pull `data-width` + `data-height` from the document's first composition
+ * root (the element with `data-composition-id` plus both dimension attrs
+ * — the same selector the producer uses to lay out the page). Returns
+ * `null` when no such root exists or either attr is invalid, so callers
+ * can distinguish "no declared dimensions" from "declared 1920×1080".
+ */
+export function findCompositionDimensions(html: string): { width: number; height: number } | null {
+  ensureDOMParser();
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const root = doc.querySelector("[data-composition-id][data-width][data-height]");
+  if (!root) return null;
+  const width = parseViewportDimension(root.getAttribute("data-width"));
+  const height = parseViewportDimension(root.getAttribute("data-height"));
+  if (width === null || height === null) return null;
+  return { width, height };
+}
+
 export function resolveCompositionViewportFromHtml(html: string): {
   width: number;
   height: number;
 } {
-  ensureDOMParser();
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  const root = doc.querySelector("[data-composition-id][data-width][data-height]");
-  const width = parseViewportDimension(root?.getAttribute("data-width") ?? null);
-  const height = parseViewportDimension(root?.getAttribute("data-height") ?? null);
-  return {
-    width: width ?? DEFAULT_VIEWPORT.width,
-    height: height ?? DEFAULT_VIEWPORT.height,
-  };
+  return findCompositionDimensions(html) ?? DEFAULT_VIEWPORT;
 }


### PR DESCRIPTION
## What

Warn early when `hyperframes lambda render` / `render-batch` is passed `--width`/`--height` values that disagree with the composition's authored `data-width`/`data-height`. Points the user at `--output-resolution` (PR #1020) — the supported supersampling escape hatch.

## Why

This is a real footgun I hit during the cost-analysis sweep. I passed `--width 3840 --height 2160` to render a 1080p composition at 4K, the command succeeded after 8 minutes, and the output was still 1080p. The runtime lays out the page at the composition's authored `data-width` / `data-height` — Config.width is ignored on disagreement, silently. A 30-minute render later you learn what `data-*` does.

The warning catches this at CLI dispatch time (~5ms before any AWS call) and tells the user how to actually get the higher resolution.

## How

- New `warnOnDimensionMismatch` helper in `packages/cli/src/commands/lambda/_dimensions.ts`, called from both `runRender` and `runRenderBatch` (in `render-batch` it fires once before the per-entry loop — a 1000-row batch with wrong dimensions burns the bug across every entry).
- **Reuse:** delegates HTML parsing to the existing `findCompositionDimensions` helper added to `packages/cli/src/utils/compositionViewport.ts` (a thin null-returning variant of `resolveCompositionViewportFromHtml`, which already powers `validate` + `snapshot` and uses the same `[data-composition-id][data-width][data-height]` selector the producer uses to lay out the page). No regex parallel-parser.
- Suppressed when `--output-resolution` is set (user has opted in to supersampling), when `--json` is set (machine consumers parse the manifest), or when `index.html` isn't on disk (typical with `--site-id` pointing at a pre-uploaded site).
- Single `try { readFileSync }` — no `existsSync` TOCTOU.

## Test plan

- [x] Unit tests: warning fires on mismatch · silent on match · silent under `--output-resolution` · silent under `--json` · silent when `index.html` missing · silent when composition has no `data-composition-id` root.
- [x] Typecheck + format + lint clean.
- [x] Manual: passing `--width 3840 --height 2160` against a 1080p composition prints the warning + suggestion before the render starts.