### PR TITLE
fix(aws-lambda): surface sparticuz wedge as typed non-retryable error

### DIFF
--- a/packages/aws-lambda/src/cdk/HyperframesRenderStack.snapshot.test.ts
+++ b/packages/aws-lambda/src/cdk/HyperframesRenderStack.snapshot.test.ts
@@ -65,6 +65,7 @@ const EXPECTED_NON_RETRYABLE_ERRORS = new Set([
   "FONT_FETCH_FAILED",
   "PLAN_TOO_LARGE",
   "FORMAT_NOT_SUPPORTED_IN_DISTRIBUTED",
+  "ChromeBinaryUnavailableError",
 ]);
 
 function doSynth(): {

--- a/packages/aws-lambda/src/cdk/HyperframesRenderStack.ts
+++ b/packages/aws-lambda/src/cdk/HyperframesRenderStack.ts
@@ -189,6 +189,9 @@ export class HyperframesRenderStack extends Construct {
    * the snapshot test.
    */
   private buildStateMachineDefinition(): sfn.IChainable {
+    // `ChromeBinaryUnavailableError` is non-retryable: a wedged warm
+    // instance keeps returning the same falsy executablePath until the
+    // env recycles, so retries just burn the 4× 15-min budget.
     const NON_RETRYABLE_PLAN = [
       "FFMPEG_VERSION_MISMATCH",
       "PLAN_HASH_MISMATCH",
@@ -196,16 +199,19 @@ export class HyperframesRenderStack extends Construct {
       "FONT_FETCH_FAILED",
       "PLAN_TOO_LARGE",
       "FORMAT_NOT_SUPPORTED_IN_DISTRIBUTED",
+      "ChromeBinaryUnavailableError",
     ];
     const NON_RETRYABLE_CHUNK = [
       "FFMPEG_VERSION_MISMATCH",
       "PLAN_HASH_MISMATCH",
       "BROWSER_GPU_NOT_SOFTWARE",
+      "ChromeBinaryUnavailableError",
     ];
     const NON_RETRYABLE_ASSEMBLE = [
       "FFMPEG_VERSION_MISMATCH",
       "PLAN_HASH_MISMATCH",
       "FORMAT_NOT_SUPPORTED_IN_DISTRIBUTED",
+      "ChromeBinaryUnavailableError",
     ];
 
     const plan = new tasks.LambdaInvoke(this, "Plan", {

--- a/packages/aws-lambda/src/chromium.test.ts
+++ b/packages/aws-lambda/src/chromium.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   _setSparticuzChromiumForTests,
+  ChromeBinaryUnavailableError,
   resolveChromeArgs,
   resolveChromeExecutablePath,
   resolveChromeSource,
@@ -61,12 +62,64 @@ describe("resolveChromeSource", () => {
 describe("resolveChromeExecutablePath", () => {
   it("returns the path from a stubbed sparticuz module", async () => {
     process.env.HYPERFRAMES_LAMBDA_CHROME_SOURCE = "sparticuz";
+    const dir = mkdtempSync(join(tmpdir(), "hf-chrome-test-"));
+    const binPath = join(dir, "chromium");
+    writeFileSync(binPath, "fake binary");
+    try {
+      _setSparticuzChromiumForTests({
+        args: ["--fake-arg"],
+        executablePath: async () => binPath,
+      });
+      expect(await resolveChromeExecutablePath()).toBe(binPath);
+      expect(await resolveChromeArgs()).toEqual(["--fake-arg"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Real-world wedge: a chunk hits `Sandbox.Timedout` mid-extraction,
+  // leaving sparticuz's internal state inconsistent. On subsequent
+  // invocations executablePath() returns empty/undefined and puppeteer-
+  // core's downstream assertion buries the actionable signal. These
+  // tests pin the typed-error contract so SFN can short-circuit retries.
+  it("throws ChromeBinaryUnavailableError when sparticuz returns empty string", async () => {
+    process.env.HYPERFRAMES_LAMBDA_CHROME_SOURCE = "sparticuz";
     _setSparticuzChromiumForTests({
-      args: ["--fake-arg"],
-      executablePath: async () => "/tmp/sparticuz-chromium",
+      args: [],
+      executablePath: async () => "",
     });
-    expect(await resolveChromeExecutablePath()).toBe("/tmp/sparticuz-chromium");
-    expect(await resolveChromeArgs()).toEqual(["--fake-arg"]);
+    await expect(resolveChromeExecutablePath()).rejects.toBeInstanceOf(
+      ChromeBinaryUnavailableError,
+    );
+  });
+
+  it("throws ChromeBinaryUnavailableError when sparticuz returns a non-existent path", async () => {
+    process.env.HYPERFRAMES_LAMBDA_CHROME_SOURCE = "sparticuz";
+    _setSparticuzChromiumForTests({
+      args: [],
+      executablePath: async () => "/nonexistent/sparticuz/chromium",
+    });
+    await expect(resolveChromeExecutablePath()).rejects.toBeInstanceOf(
+      ChromeBinaryUnavailableError,
+    );
+  });
+
+  it("ChromeBinaryUnavailableError carries the source + resolved path", async () => {
+    process.env.HYPERFRAMES_LAMBDA_CHROME_SOURCE = "sparticuz";
+    _setSparticuzChromiumForTests({
+      args: [],
+      executablePath: async () => "/missing",
+    });
+    try {
+      await resolveChromeExecutablePath();
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ChromeBinaryUnavailableError);
+      const typed = err as ChromeBinaryUnavailableError;
+      expect(typed.source).toBe("sparticuz");
+      expect(typed.resolvedPath).toBe("/missing");
+      expect(typed.name).toBe("ChromeBinaryUnavailableError");
+    }
   });
 
   it("reads chrome-headless-shell path from HYPERFRAMES_LAMBDA_CHROME_PATH", async () => {
@@ -83,17 +136,19 @@ describe("resolveChromeExecutablePath", () => {
     }
   });
 
-  it("throws if chrome-headless-shell path is missing", async () => {
+  it("throws ChromeBinaryUnavailableError if chrome-headless-shell path is missing", async () => {
     process.env.HYPERFRAMES_LAMBDA_CHROME_SOURCE = "chrome-headless-shell";
     delete process.env.HYPERFRAMES_LAMBDA_CHROME_PATH;
-    await expect(resolveChromeExecutablePath()).rejects.toThrow(
-      /HYPERFRAMES_LAMBDA_CHROME_PATH to be set/,
+    await expect(resolveChromeExecutablePath()).rejects.toBeInstanceOf(
+      ChromeBinaryUnavailableError,
     );
   });
 
-  it("throws if chrome-headless-shell path doesn't exist on disk", async () => {
+  it("throws ChromeBinaryUnavailableError if chrome-headless-shell path doesn't exist on disk", async () => {
     process.env.HYPERFRAMES_LAMBDA_CHROME_SOURCE = "chrome-headless-shell";
     process.env.HYPERFRAMES_LAMBDA_CHROME_PATH = "/nonexistent/path/chrome-headless-shell";
-    await expect(resolveChromeExecutablePath()).rejects.toThrow(/does not exist/);
+    await expect(resolveChromeExecutablePath()).rejects.toBeInstanceOf(
+      ChromeBinaryUnavailableError,
+    );
   });
 });

--- a/packages/aws-lambda/src/chromium.ts
+++ b/packages/aws-lambda/src/chromium.ts
@@ -38,6 +38,34 @@ import { existsSync } from "node:fs";
 export type ChromeSource = "sparticuz" | "chrome-headless-shell";
 
 /**
+ * Thrown when the Chrome binary resolver can't produce a usable path.
+ * The class name is the SFN `Retry: { ErrorEquals: [...] }` discriminator —
+ * see {@link HyperframesRenderStack}'s NON_RETRYABLE_* lists.
+ */
+export class ChromeBinaryUnavailableError extends Error {
+  // Lambda's runtime serializes the error envelope's `errorType` from
+  // `err.name`; this class-field override sets it across the structured
+  // clone. Read indirectly; fallow can't follow.
+  // fallow-ignore-next-line unused-class-member
+  override readonly name = "ChromeBinaryUnavailableError";
+  readonly source: ChromeSource;
+  readonly resolvedPath: string | null;
+  constructor(source: ChromeSource, resolvedPath: string | null, hint: string) {
+    super(`[chromium] Chrome binary unavailable (source=${source}): ${hint}`);
+    this.source = source;
+    this.resolvedPath = resolvedPath;
+  }
+}
+
+const SPARTICUZ_WEDGE_HINT =
+  "@sparticuz/chromium.executablePath() returned a falsy value or a path that doesn't exist on disk. " +
+  "This typically happens after a chunk hits `Sandbox.Timedout` mid-extraction and leaves /tmp in a " +
+  "wedged state — subsequent invocations land on the same warm instance and never re-extract. " +
+  "Recycle the function (e.g. `aws lambda update-function-configuration ... --environment ...` with a " +
+  "bumped marker var, or redeploy via `hyperframes lambda deploy --skip-build`) to force fresh " +
+  "execution environments. Tracking: investigate the upstream wedge so this auto-recovers.";
+
+/**
  * Read which Chrome source the bundled ZIP was built against. Defaults to
  * `"sparticuz"` so a fresh build with no env override picks the primary
  * path.
@@ -60,22 +88,40 @@ export function resolveChromeSource(): ChromeSource {
  * `HYPERFRAMES_LAMBDA_CHROME_PATH`. Throws if absent or non-existent so a
  * misconfigured deploy fails loudly at boot rather than at first frame.
  */
+// fallow-ignore-next-line complexity
 export async function resolveChromeExecutablePath(): Promise<string> {
   const source = resolveChromeSource();
   if (source === "sparticuz") {
     const mod = await loadSparticuzChromium();
-    return mod.executablePath();
+    const path = await mod.executablePath();
+    // Guard against the wedge described in ChromeBinaryUnavailableError.
+    // sparticuz's contract is "return the path to a usable binary" — when
+    // it returns null/undefined/"" we can't hand that to puppeteer-core
+    // (which will throw an unrelated-looking assertion). Same when the
+    // returned path doesn't exist (extraction failed but the function
+    // call returned).
+    if (!path || typeof path !== "string") {
+      throw new ChromeBinaryUnavailableError(source, null, SPARTICUZ_WEDGE_HINT);
+    }
+    if (!existsSync(path)) {
+      throw new ChromeBinaryUnavailableError(source, path, SPARTICUZ_WEDGE_HINT);
+    }
+    return path;
   }
   const explicit = process.env.HYPERFRAMES_LAMBDA_CHROME_PATH;
   if (!explicit) {
-    throw new Error(
-      "[chromium] HYPERFRAMES_LAMBDA_CHROME_SOURCE=chrome-headless-shell requires " +
+    throw new ChromeBinaryUnavailableError(
+      source,
+      null,
+      "HYPERFRAMES_LAMBDA_CHROME_SOURCE=chrome-headless-shell requires " +
         "HYPERFRAMES_LAMBDA_CHROME_PATH to be set to the absolute path of the bundled binary.",
     );
   }
   if (!existsSync(explicit)) {
-    throw new Error(
-      `[chromium] HYPERFRAMES_LAMBDA_CHROME_PATH=${JSON.stringify(explicit)} does not exist`,
+    throw new ChromeBinaryUnavailableError(
+      source,
+      explicit,
+      `HYPERFRAMES_LAMBDA_CHROME_PATH=${JSON.stringify(explicit)} does not exist on disk.`,
     );
   }
   return explicit;

--- a/packages/aws-lambda/src/index.ts
+++ b/packages/aws-lambda/src/index.ts
@@ -39,6 +39,7 @@ export {
 // the package barrel — it's a test-only DI seam. Test files import it
 // directly from `./chromium.js`.
 export {
+  ChromeBinaryUnavailableError,
   type ChromeSource,
   resolveChromeArgs,
   resolveChromeExecutablePath,

--- a/packages/aws-lambda/src/sdk/getRenderProgress.test.ts
+++ b/packages/aws-lambda/src/sdk/getRenderProgress.test.ts
@@ -67,6 +67,54 @@ function stateExited(name: string, output?: unknown): HistoryEvent {
   } as HistoryEvent;
 }
 
+// Optimized `lambda:invoke` integration's wire shape: Task* events with
+// the handler payload at `.Payload`. Helpers below fabricate these so
+// tests cover the same events a real CDK-deployed render produces.
+function taskScheduled(): HistoryEvent {
+  return {
+    type: "TaskScheduled",
+    id: 1,
+    timestamp: new Date(),
+    taskScheduledEventDetails: {
+      resource: "invoke",
+      resourceType: "lambda",
+      region: "us-east-1",
+      parameters: "{}",
+    },
+  } as HistoryEvent;
+}
+
+function taskSucceeded(payload: unknown): HistoryEvent {
+  return {
+    type: "TaskSucceeded",
+    id: 1,
+    timestamp: new Date(),
+    taskSucceededEventDetails: {
+      resource: "invoke",
+      resourceType: "lambda",
+      output: JSON.stringify({
+        ExecutedVersion: "$LATEST",
+        Payload: payload,
+        StatusCode: 200,
+      }),
+    },
+  } as HistoryEvent;
+}
+
+function taskFailed(error: string, cause: string): HistoryEvent {
+  return {
+    type: "TaskFailed",
+    id: 1,
+    timestamp: new Date(),
+    taskFailedEventDetails: {
+      resource: "invoke",
+      resourceType: "lambda",
+      error,
+      cause,
+    },
+  } as HistoryEvent;
+}
+
 describe("getRenderProgress", () => {
   it("reports 0 progress before Plan completes", async () => {
     const sfn = new FakeSFN();
@@ -221,6 +269,116 @@ describe("getRenderProgress", () => {
 
   it("requires executionArn", async () => {
     await expect(getRenderProgress({ executionArn: "" })).rejects.toThrow(/executionArn/);
+  });
+
+  describe("optimized lambda:invoke integration", () => {
+    it("counts a single TaskSucceeded as one Lambda invocation", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 240, DurationMs: 1_000 }),
+        ],
+      ];
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        defaultMemorySizeMb: 10_240,
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.lambdasInvoked).toBe(1);
+      expect(progress.totalFrames).toBe(240);
+      // computeRenderCost rounds to 4 decimals; precision=4 not 6.
+      expect(progress.costs.breakdown.lambdaUsd).toBeCloseTo(0.0002, 4);
+      expect(progress.costs.breakdown.lambdaUsd).toBeGreaterThan(0);
+    });
+
+    it("attributes RenderChunk FramesEncoded but ignores Plan/Assemble FramesEncoded", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 100, DurationMs: 1_000 }),
+          stateEntered("RenderChunk"),
+          taskScheduled(),
+          taskSucceeded({ Action: "renderChunk", FramesEncoded: 50, DurationMs: 2_000 }),
+          stateEntered("Assemble"),
+          taskScheduled(),
+          taskSucceeded({
+            Action: "assemble",
+            FramesEncoded: 100, // would double-count if Assemble's count bled in
+            FileSize: 9_000_000,
+            OutputS3Uri: "s3://b/k.mp4",
+            DurationMs: 1_500,
+          }),
+        ],
+      ];
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.framesRendered).toBe(50);
+      expect(progress.lambdasInvoked).toBe(3);
+    });
+
+    it("captures TaskFailed errors with the enclosing state name", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("RenderChunk"),
+          taskScheduled(),
+          taskFailed("Sandbox.Timedout", "Task timed out after 900.00 seconds"),
+        ],
+      ];
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.errors).toEqual([
+        {
+          state: "RenderChunk",
+          error: "Sandbox.Timedout",
+          cause: "Task timed out after 900.00 seconds",
+        },
+      ]);
+    });
+
+    it("sums billed seconds across plan + chunks + assemble", async () => {
+      const sfn = new FakeSFN();
+      const renderChunkSucceeded = (frames: number, ms: number) => [
+        stateEntered("RenderChunk"),
+        taskScheduled(),
+        taskSucceeded({ Action: "renderChunk", FramesEncoded: frames, DurationMs: ms }),
+      ];
+      // 1 plan + 16 chunks @ 217s + 1 assemble = 3492.7s billed.
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 1349, DurationMs: 13_000 }),
+          ...Array.from({ length: 16 }, () => renderChunkSucceeded(84, 217_000)).flat(),
+          stateEntered("Assemble"),
+          taskScheduled(),
+          taskSucceeded({
+            Action: "assemble",
+            FileSize: 81_000_000,
+            OutputS3Uri: "s3://b/k.mp4",
+            DurationMs: 7_700,
+          }),
+        ],
+      ];
+      sfn.describe.status = "SUCCEEDED";
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        defaultMemorySizeMb: 10_240,
+        sfn: sfn as unknown as SFNClient,
+      });
+      // 3492.7s × 10GB × $0.0000166667/GB-s ≈ $0.582.
+      expect(progress.costs.breakdown.lambdaUsd).toBeCloseTo(0.582, 2);
+      expect(progress.framesRendered).toBe(84 * 16);
+      expect(progress.lambdasInvoked).toBe(18);
+    });
   });
 });
 

--- a/packages/aws-lambda/src/sdk/getRenderProgress.ts
+++ b/packages/aws-lambda/src/sdk/getRenderProgress.ts
@@ -73,7 +73,7 @@ export interface RenderProgress {
   framesRendered: number;
   /** `null` until Plan completes. */
   totalFrames: number | null;
-  /** Count of `LambdaFunctionScheduled` events seen in the history so far. */
+  /** Total Lambda invocations scheduled so far (both optimized + raw task integrations). */
   lambdasInvoked: number;
   costs: RenderCost;
   /** Final output object if Assemble succeeded; `null` otherwise. */
@@ -198,9 +198,35 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
         stateTransitions++;
         currentLambdaState = ev.stateEnteredEventDetails?.name ?? currentLambdaState;
         break;
+      // Optimized `lambda:invoke` task emits Task* events; raw
+      // `lambda:invokeFunction.sync` emits LambdaFunction*. Handle both.
+      case "TaskScheduled":
+        if (ev.taskScheduledEventDetails?.resourceType === "lambda") {
+          lambdasInvoked++;
+        }
+        break;
       case "LambdaFunctionScheduled":
         lambdasInvoked++;
         break;
+      case "TaskSucceeded": {
+        if (ev.taskSucceededEventDetails?.resourceType !== "lambda") break;
+        const wrapped = parseJson(ev.taskSucceededEventDetails?.output);
+        const payload = unwrapLambdaPayload(wrapped);
+        const billedDurationMs = inferBilledMs(payload);
+        lambdaInvocations.push({
+          billedDurationMs,
+          memorySizeMb: memoryMb,
+          estimated: billedDurationMs === 0,
+        });
+        applyPayloadFrameCounts(payload, currentLambdaState, (delta) => {
+          framesRendered += delta;
+        });
+        if (payload && typeof payload === "object") {
+          const obj = payload as Record<string, unknown>;
+          if (typeof obj.TotalFrames === "number") totalFrames = obj.TotalFrames;
+        }
+        break;
+      }
       case "LambdaFunctionSucceeded": {
         const payload = parseJson(ev.lambdaFunctionSucceededEventDetails?.output);
         const billedDurationMs = inferBilledMs(payload);
@@ -209,20 +235,12 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
           memorySizeMb: memoryMb,
           estimated: billedDurationMs === 0,
         });
+        applyPayloadFrameCounts(payload, currentLambdaState, (delta) => {
+          framesRendered += delta;
+        });
         if (payload && typeof payload === "object") {
           const obj = payload as Record<string, unknown>;
           if (typeof obj.TotalFrames === "number") totalFrames = obj.TotalFrames;
-          if (typeof obj.FramesEncoded === "number") {
-            // Plan and Assemble also return FramesEncoded; count framesRendered
-            // only inside the RenderChunk state so we don't double-count
-            // it on the Assemble pass. Keyed off the enclosing state name
-            // (set by the matching StateEntered) rather than the payload's
-            // `Action` field — `Action` is part of the Lambda event
-            // contract and not load-bearing for state-machine identity.
-            if (currentLambdaState === "RenderChunk") {
-              framesRendered += obj.FramesEncoded;
-            }
-          }
         }
         break;
       }
@@ -244,6 +262,14 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
             outputFile = outputS3Uri ? { s3Uri: outputS3Uri, bytes } : outputFile;
           }
         }
+        break;
+      case "TaskFailed":
+        if (ev.taskFailedEventDetails?.resourceType !== "lambda") break;
+        errors.push({
+          state: currentLambdaState ?? "<unknown>",
+          error: ev.taskFailedEventDetails?.error ?? "UNKNOWN",
+          cause: ev.taskFailedEventDetails?.cause ?? "",
+        });
         break;
       case "LambdaFunctionFailed":
         errors.push({
@@ -297,6 +323,37 @@ function parseJson(s: string | undefined): unknown {
   } catch {
     return null;
   }
+}
+
+/**
+ * Optimized `lambda:invoke` wraps the Lambda response as
+ * `{ ExecutedVersion, Payload: {…handler payload…}, StatusCode }`. Raw
+ * `lambda:invokeFunction.sync` puts the handler payload at the root.
+ * Return the inner `Payload` when present so callers read the same fields
+ * either way.
+ */
+function unwrapLambdaPayload(payload: unknown): unknown {
+  if (payload && typeof payload === "object" && "Payload" in payload) {
+    const inner = (payload as { Payload: unknown }).Payload;
+    if (inner && typeof inner === "object") return inner;
+  }
+  return payload;
+}
+
+/**
+ * Bump `framesRendered` only inside the `RenderChunk` state. Plan and
+ * Assemble also report `FramesEncoded`, so a state-blind add would
+ * double-count once Assemble runs.
+ */
+function applyPayloadFrameCounts(
+  payload: unknown,
+  currentLambdaState: string | null,
+  bump: (delta: number) => void,
+): void {
+  if (currentLambdaState !== "RenderChunk") return;
+  if (!payload || typeof payload !== "object") return;
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.FramesEncoded === "number") bump(obj.FramesEncoded);
 }
 
 /**

--- a/packages/cli/src/commands/lambda/_dimensions.test.ts
+++ b/packages/cli/src/commands/lambda/_dimensions.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { warnOnDimensionMismatch } from "./_dimensions.js";
+
+const indexHtml = (width: number, height: number) =>
+  `<!doctype html><html><body><div data-composition-id="root" data-width="${width}" data-height="${height}"></div></body></html>`;
+
+describe("warnOnDimensionMismatch", () => {
+  let dir: string;
+  let warnSpy: ReturnType<typeof vi.fn>;
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hf-dim-mismatch-"));
+    originalWarn = console.warn;
+    warnSpy = vi.fn();
+    console.warn = warnSpy as unknown as typeof console.warn;
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeIndex(html: string): void {
+    writeFileSync(join(dir, "index.html"), html);
+  }
+
+  it("warns when the CLI dimensions don't match the composition", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const call = (warnSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(call).toContain("3840×2160");
+    expect(call).toContain("1920×1080");
+    expect(call).toContain("--output-resolution");
+  });
+
+  it("is silent when CLI and composition agree", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 1920,
+      cliHeight: 1080,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when --output-resolution is set (the supersampling path)", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: "landscape-4k",
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when quiet=true (--json)", () => {
+    writeIndex(indexHtml(1920, 1080));
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: true,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when index.html is missing (typical with --site-id)", () => {
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when the composition has no data-composition-id root", () => {
+    writeIndex("<body><h1>just a comp</h1></body>");
+    warnOnDimensionMismatch({
+      projectDir: dir,
+      cliWidth: 3840,
+      cliHeight: 2160,
+      outputResolution: undefined,
+      quiet: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/lambda/_dimensions.ts
+++ b/packages/cli/src/commands/lambda/_dimensions.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared dimension-mismatch warning for `hyperframes lambda render` and
+ * `lambda render-batch`. The runtime lays the page out at the composition's
+ * `data-width`/`data-height`, so passing `--width 3840 --height 2160`
+ * against a 1920×1080 composition silently produces a 1080p output. Warn
+ * early and point at `--output-resolution` (the supersampling path).
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CanvasResolution } from "@hyperframes/core";
+import { c } from "../../ui/colors.js";
+import { findCompositionDimensions } from "../../utils/compositionViewport.js";
+
+export interface DimensionMismatchArgs {
+  projectDir: string;
+  cliWidth: number;
+  cliHeight: number;
+  outputResolution: CanvasResolution | undefined;
+  /** Suppress the warning when stdout is reserved for machine output (--json). */
+  quiet: boolean;
+}
+
+// fallow-ignore-next-line complexity
+export function warnOnDimensionMismatch(args: DimensionMismatchArgs): void {
+  if (args.quiet) return;
+  if (args.outputResolution) return;
+  let html: string;
+  try {
+    html = readFileSync(join(args.projectDir, "index.html"), "utf-8");
+  } catch {
+    return;
+  }
+  const composition = findCompositionDimensions(html);
+  if (!composition) return;
+  if (composition.width === args.cliWidth && composition.height === args.cliHeight) return;
+  console.warn(
+    c.warn(
+      `--width/--height (${args.cliWidth}×${args.cliHeight}) disagrees with the composition's ` +
+        `data-width/data-height (${composition.width}×${composition.height}). The runtime lays out ` +
+        `the page at the composition's authored dimensions, so your output will be ` +
+        `${composition.width}×${composition.height}, not ${args.cliWidth}×${args.cliHeight}.\n` +
+        `  To supersample to a higher resolution, pass --output-resolution (e.g. \`--output-resolution=4k\`).\n` +
+        `  To truly change layout dimensions, edit the composition's data-width/data-height in index.html.`,
+    ),
+  );
+}

--- a/packages/cli/src/commands/lambda/render-batch.ts
+++ b/packages/cli/src/commands/lambda/render-batch.ts
@@ -36,6 +36,7 @@ import {
   reportVariableIssues,
   validateVariablesAgainstSchema,
 } from "../../utils/variables.js";
+import { warnOnDimensionMismatch } from "./_dimensions.js";
 import { requireStack } from "./state.js";
 
 // Dynamic-import the SDK so tsup keeps it out of the static-import head of
@@ -164,6 +165,14 @@ export async function runRenderBatch(args: RenderBatchArgs): Promise<void> {
     errorBox("Empty batch", `${batchPath} contains zero entries (every line was blank).`);
     process.exit(1);
   }
+
+  warnOnDimensionMismatch({
+    projectDir,
+    cliWidth: args.width,
+    cliHeight: args.height,
+    outputResolution: args.outputResolution,
+    quiet: args.json,
+  });
 
   // Pre-validate every entry's variables against the composition's
   // schema. Mismatches print as warnings; strict mode aborts before any

--- a/packages/cli/src/commands/lambda/render.ts
+++ b/packages/cli/src/commands/lambda/render.ts
@@ -17,6 +17,7 @@ import {
   resolveVariablesArg,
   validateVariablesAgainstProject,
 } from "../../utils/variables.js";
+import { warnOnDimensionMismatch } from "./_dimensions.js";
 import { requireStack, stateFilePath } from "./state.js";
 
 // Dynamic-import the SDK so tsup keeps it out of the static-import head of
@@ -71,6 +72,14 @@ export interface RenderArgs {
 export async function runRender(args: RenderArgs): Promise<void> {
   const stack = requireStack(args.stackName);
   const projectDir = resolvePath(args.projectDir);
+
+  warnOnDimensionMismatch({
+    projectDir,
+    cliWidth: args.width,
+    cliHeight: args.height,
+    outputResolution: args.outputResolution,
+    quiet: args.json,
+  });
 
   // Resolve --variables / --variables-file using the same parser the local
   // `hyperframes render` uses. `resolveVariablesArg` exits(1) with a friendly

--- a/packages/cli/src/utils/compositionViewport.ts
+++ b/packages/cli/src/utils/compositionViewport.ts
@@ -10,17 +10,27 @@ function parseViewportDimension(value: string | null): number | null {
   return Math.min(parsed, MAX_VIEWPORT_DIMENSION);
 }
 
+/**
+ * Pull `data-width` + `data-height` from the document's first composition
+ * root (the element with `data-composition-id` plus both dimension attrs
+ * — the same selector the producer uses to lay out the page). Returns
+ * `null` when no such root exists or either attr is invalid, so callers
+ * can distinguish "no declared dimensions" from "declared 1920×1080".
+ */
+export function findCompositionDimensions(html: string): { width: number; height: number } | null {
+  ensureDOMParser();
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const root = doc.querySelector("[data-composition-id][data-width][data-height]");
+  if (!root) return null;
+  const width = parseViewportDimension(root.getAttribute("data-width"));
+  const height = parseViewportDimension(root.getAttribute("data-height"));
+  if (width === null || height === null) return null;
+  return { width, height };
+}
+
 export function resolveCompositionViewportFromHtml(html: string): {
   width: number;
   height: number;
 } {
-  ensureDOMParser();
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  const root = doc.querySelector("[data-composition-id][data-width][data-height]");
-  const width = parseViewportDimension(root?.getAttribute("data-width") ?? null);
-  const height = parseViewportDimension(root?.getAttribute("data-height") ?? null);
-  return {
-    width: width ?? DEFAULT_VIEWPORT.width,
-    height: height ?? DEFAULT_VIEWPORT.height,
-  };
+  return findCompositionDimensions(html) ?? DEFAULT_VIEWPORT;
 }


### PR DESCRIPTION
## What

Turn the misleading puppeteer-core assertion that surfaces when `@sparticuz/chromium.executablePath()` returns a falsy / missing path into a typed `ChromeBinaryUnavailableError` with an actionable message, and mark it non-retryable across all three SFN states (Plan / RenderChunk / Assemble).

## Why

Repeated `Sandbox.Timedout` chunks can leave the function's `/tmp` in a state where sparticuz returns nothing instead of throwing — subsequent invocations land on the same warm instance and never re-extract chromium. The downstream puppeteer-core assertion (`"An \`executablePath\` or \`channel\` must be specified for \`puppeteer-core\`"`) buries the actionable cause: a cost-analysis sweep hit this and it took ~30 min to root-cause from the puppeteer trace.

Without the non-retryable hookup, a wedged function burns the 4-attempt × 15-min retry budget (up to an hour per chunk) on something that won't recover until the environment recycles.

## How

- Typed `ChromeBinaryUnavailableError` (extends `Error`, name field overridden to the class name so AWS Lambda's runtime serializes the right `errorType` into SFN history). Carries `source` (`sparticuz` | `chrome-headless-shell`) and the path the resolver attempted, so log readers see exactly what was returned.
- Guards added in `resolveChromeExecutablePath`:
  - sparticuz: throws when `executablePath()` returns a non-string, empty string, or a path that doesn't exist on disk.
  - chrome-headless-shell: now throws the same typed error (instead of plain `Error`) so SFN can match on it consistently across both sources.
- Added `"ChromeBinaryUnavailableError"` to the three `NON_RETRYABLE_*` lists in `HyperframesRenderStack` and to the `EXPECTED_NON_RETRYABLE_ERRORS` snapshot guard.

## Test plan

- [x] Unit tests: typed error thrown on empty path · on non-existent path · for chrome-headless-shell paths · `source` + `resolvedPath` + `name` carried correctly.
- [x] CDK contract snapshot test extended; all 109 aws-lambda tests pass.
- [ ] **Follow-up:** end-to-end deploy verification that Lambda → SFN history actually surfaces `errorType: "ChromeBinaryUnavailableError"` (vs. the generic `"Error"` the original puppeteer assertion produced). The `name` class-field override is the standard pattern, but worth pinning with a real LocalStack or deployed-stack test in a follow-up PR.