### PR TITLE
feat(lambda): warn when slowest chunk approaches the 15-min cap

### DIFF
--- a/packages/aws-lambda/src/sdk/chunkRuntime.ts
+++ b/packages/aws-lambda/src/sdk/chunkRuntime.ts
@@ -1,0 +1,11 @@
+/**
+ * Per-chunk runtime constants for `RenderChunk` Lambda invocations.
+ * Threshold drives the warning surfaced by the CLI when the slowest
+ * observed chunk approaches Lambda's hard cap.
+ */
+
+/** Lambda's hard per-invocation cap. */
+export const LAMBDA_TIMEOUT_MS = 900_000;
+
+/** Pre-computed 80% of {@link LAMBDA_TIMEOUT_MS} — the warning threshold. */
+export const CHUNK_RUNTIME_WARN_MS = LAMBDA_TIMEOUT_MS * 0.8;

--- a/packages/aws-lambda/src/sdk/getRenderProgress.test.ts
+++ b/packages/aws-lambda/src/sdk/getRenderProgress.test.ts
@@ -344,6 +344,83 @@ describe("getRenderProgress", () => {
       ]);
     });
 
+    it("tracks the slowest RenderChunk billed duration for the cap warning", async () => {
+      const sfn = new FakeSFN();
+      const renderChunk = (ms: number) => [
+        stateEntered("RenderChunk"),
+        taskScheduled(),
+        taskSucceeded({ Action: "renderChunk", FramesEncoded: 10, DurationMs: ms }),
+      ];
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 30, DurationMs: 1_000 }),
+          ...renderChunk(100_000),
+          ...renderChunk(820_000),
+          ...renderChunk(50_000),
+          stateEntered("Assemble"),
+          taskScheduled(),
+          taskSucceeded({
+            Action: "assemble",
+            FileSize: 1_000,
+            OutputS3Uri: "s3://b/k.mp4",
+            DurationMs: 5_000,
+          }),
+        ],
+      ];
+      sfn.describe.status = "SUCCEEDED";
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.maxChunkDurationMs).toBe(820_000);
+    });
+
+    it("ignores Plan/Assemble billed durations in maxChunkDurationMs", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 30, DurationMs: 60_000 }),
+          stateEntered("RenderChunk"),
+          taskScheduled(),
+          taskSucceeded({ Action: "renderChunk", FramesEncoded: 10, DurationMs: 12_000 }),
+          stateEntered("Assemble"),
+          taskScheduled(),
+          taskSucceeded({
+            Action: "assemble",
+            FileSize: 1_000,
+            OutputS3Uri: "s3://b/k.mp4",
+            DurationMs: 90_000,
+          }),
+        ],
+      ];
+      sfn.describe.status = "SUCCEEDED";
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.maxChunkDurationMs).toBe(12_000);
+    });
+
+    it("maxChunkDurationMs is null before any RenderChunk completes", async () => {
+      const sfn = new FakeSFN();
+      sfn.historyPages = [
+        [
+          stateEntered("Plan"),
+          taskScheduled(),
+          taskSucceeded({ Action: "plan", TotalFrames: 30, DurationMs: 1_000 }),
+        ],
+      ];
+      const progress = await getRenderProgress({
+        executionArn: "arn",
+        sfn: sfn as unknown as SFNClient,
+      });
+      expect(progress.maxChunkDurationMs).toBeNull();
+    });
+
     it("sums billed seconds across plan + chunks + assemble", async () => {
       const sfn = new FakeSFN();
       const renderChunkSucceeded = (frames: number, ms: number) => [

--- a/packages/aws-lambda/src/sdk/getRenderProgress.ts
+++ b/packages/aws-lambda/src/sdk/getRenderProgress.ts
@@ -76,6 +76,8 @@ export interface RenderProgress {
   /** Total Lambda invocations scheduled so far (both optimized + raw task integrations). */
   lambdasInvoked: number;
   costs: RenderCost;
+  /** Billed duration of the slowest `RenderChunk` invocation; null before any chunk completes. */
+  maxChunkDurationMs: number | null;
   /** Final output object if Assemble succeeded; `null` otherwise. */
   outputFile: { s3Uri: string; bytes: number | null } | null;
   errors: RenderError[];
@@ -120,6 +122,7 @@ export async function getRenderProgress(opts: GetRenderProgressOptions): Promise
     totalFrames: summary.totalFrames,
     lambdasInvoked: summary.lambdasInvoked,
     costs,
+    maxChunkDurationMs: summary.maxChunkDurationMs,
     outputFile: summary.outputFile,
     errors: summary.errors,
     fatalErrorEncountered: isTerminalFailure(status),
@@ -154,6 +157,8 @@ interface HistorySummary {
   totalFrames: number | null;
   lambdasInvoked: number;
   assembleComplete: boolean;
+  /** Slowest billed-duration across `RenderChunk` invocations; null if none observed. */
+  maxChunkDurationMs: number | null;
   outputFile: { s3Uri: string; bytes: number | null } | null;
   errors: RenderError[];
 }
@@ -172,6 +177,7 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
   let assembleComplete = false;
   let outputFile: HistorySummary["outputFile"] = null;
   let stateTransitions = 0;
+  let maxChunkDurationMs: number | null = null;
   const errors: RenderError[] = [];
   const lambdaInvocations: BilledLambdaInvocation[] = [];
 
@@ -221,6 +227,11 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
         applyPayloadFrameCounts(payload, currentLambdaState, (delta) => {
           framesRendered += delta;
         });
+        maxChunkDurationMs = bumpMaxChunkDuration(
+          maxChunkDurationMs,
+          currentLambdaState,
+          billedDurationMs,
+        );
         if (payload && typeof payload === "object") {
           const obj = payload as Record<string, unknown>;
           if (typeof obj.TotalFrames === "number") totalFrames = obj.TotalFrames;
@@ -238,6 +249,11 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
         applyPayloadFrameCounts(payload, currentLambdaState, (delta) => {
           framesRendered += delta;
         });
+        maxChunkDurationMs = bumpMaxChunkDuration(
+          maxChunkDurationMs,
+          currentLambdaState,
+          billedDurationMs,
+        );
         if (payload && typeof payload === "object") {
           const obj = payload as Record<string, unknown>;
           if (typeof obj.TotalFrames === "number") totalFrames = obj.TotalFrames;
@@ -311,6 +327,7 @@ function summarizeHistory(events: HistoryEvent[], memoryMb: number): HistorySumm
     totalFrames,
     lambdasInvoked,
     assembleComplete,
+    maxChunkDurationMs,
     outputFile,
     errors,
   };
@@ -338,6 +355,17 @@ function unwrapLambdaPayload(payload: unknown): unknown {
     if (inner && typeof inner === "object") return inner;
   }
   return payload;
+}
+
+/** Track the slowest `RenderChunk` billed-duration for the cap warning. */
+function bumpMaxChunkDuration(
+  current: number | null,
+  currentLambdaState: string | null,
+  billedDurationMs: number,
+): number | null {
+  if (currentLambdaState !== "RenderChunk") return current;
+  if (billedDurationMs <= 0) return current;
+  return Math.max(current ?? 0, billedDurationMs);
 }
 
 /**

--- a/packages/aws-lambda/src/sdk/index.ts
+++ b/packages/aws-lambda/src/sdk/index.ts
@@ -22,6 +22,7 @@ export {
   computeRenderCost,
   type RenderCost,
 } from "./costAccounting.js";
+export { CHUNK_RUNTIME_WARN_MS, LAMBDA_TIMEOUT_MS } from "./chunkRuntime.js";
 export {
   InvalidConfigError,
   MAX_STEP_FUNCTIONS_INPUT_BYTES,

--- a/packages/cli/src/commands/lambda/render.ts
+++ b/packages/cli/src/commands/lambda/render.ts
@@ -26,6 +26,15 @@ async function loadSDK(): Promise<typeof import("@hyperframes/aws-lambda/sdk")> 
   return import("@hyperframes/aws-lambda/sdk");
 }
 
+// Inlined from `@hyperframes/aws-lambda/sdk` `chunkRuntime.ts` (the source
+// of truth). Importing the constants from the SDK barrel as values would
+// pull in `renderToLambda` / `getRenderProgress` / `deploySite` and their
+// transitive `@aws-sdk/client-sfn` + `@aws-sdk/client-s3` deps at static-
+// import time, defeating the `loadSDK()` lazy-load above. They're plain
+// numbers tied to Lambda's hard cap; the duplication is cheap.
+const LAMBDA_TIMEOUT_MS = 900_000;
+const CHUNK_RUNTIME_WARN_MS = LAMBDA_TIMEOUT_MS * 0.8;
+
 export interface RenderArgs {
   projectDir: string;
   stackName: string;
@@ -161,7 +170,13 @@ export async function runRender(args: RenderArgs): Promise<void> {
     // both, producing two concatenated JSON blobs that `jq -r` would
     // misparse.
     if (args.wait) {
-      await waitForCompletion(handle.executionArn, stack, args.waitIntervalMs, args.json);
+      await waitForCompletion(
+        handle.executionArn,
+        stack,
+        args.waitIntervalMs,
+        args.json,
+        args.maxParallelChunks,
+      );
     } else {
       console.log(JSON.stringify(handle, null, 2));
     }
@@ -176,7 +191,13 @@ export async function runRender(args: RenderArgs): Promise<void> {
   console.log(`  ${c.dim("Stack state:")}   ${stateFilePath(args.stackName)}`);
   console.log();
   if (args.wait) {
-    await waitForCompletion(handle.executionArn, stack, args.waitIntervalMs, args.json);
+    await waitForCompletion(
+      handle.executionArn,
+      stack,
+      args.waitIntervalMs,
+      args.json,
+      args.maxParallelChunks,
+    );
     return;
   }
   console.log(c.dim(`Poll with: hyperframes lambda progress ${handle.renderId}`));
@@ -187,6 +208,7 @@ async function waitForCompletion(
   stack: { region: string; functionName: string; lambdaMemoryMb: number },
   intervalMs: number,
   json: boolean,
+  maxParallelChunks: number | undefined,
 ): Promise<void> {
   // Lazy import to avoid pulling SFN client when only `render --no-wait` is used.
   const { getRenderProgress } = await loadSDK();
@@ -214,6 +236,7 @@ async function waitForCompletion(
         console.log(`  ${c.dim("Output:")}        ${progress.outputFile.s3Uri}`);
         console.log(`  ${c.dim("Size:")}          ${progress.outputFile.bytes ?? "?"} bytes`);
         console.log(`  ${c.dim("Total cost:")}    ${progress.costs.displayCost}`);
+        warnIfChunkRuntimeIsCloseToCap(progress, maxParallelChunks);
       } else {
         console.log();
         console.log(c.error(`Render ended with status ${progress.status}.`));
@@ -227,6 +250,43 @@ async function waitForCompletion(
     await sleep(intervalMs);
   }
 }
+
+/** Warn if the slowest chunk approached the 15-min Lambda cap; suggest a higher fan-out. */
+function warnIfChunkRuntimeIsCloseToCap(
+  progress: { maxChunkDurationMs: number | null },
+  currentMaxParallelChunks: number | undefined,
+): void {
+  const max = progress.maxChunkDurationMs;
+  if (max === null || max < CHUNK_RUNTIME_WARN_MS) return;
+  const slowestSec = Math.round(max / 1000);
+  const capSec = LAMBDA_TIMEOUT_MS / 1000;
+  const suggested = suggestFanOut(currentMaxParallelChunks ?? DEFAULT_MAX_PARALLEL_CHUNKS, max);
+  console.log();
+  console.log(
+    c.warn(
+      `Heads up: slowest chunk ran ${slowestSec}s of the ${capSec}s Lambda cap. ` +
+        `Adding fps, duration, or complexity to this composition will likely trip ` +
+        `Sandbox.Timedout on the next render.\n` +
+        `  Mitigate with: --max-parallel-chunks ${suggested} (shrinks per-chunk work).`,
+    ),
+  );
+}
+
+/**
+ * Pick a fan-out that brings the projected chunk runtime under
+ * {@link CHUNK_RUNTIME_WARN_MS}. Doubles `current` until the projected
+ * per-chunk duration (slowest / multiplier) clears the threshold, rounded
+ * to the next power of two and capped at `MAX_PARALLEL_CHUNKS_CEILING`.
+ */
+function suggestFanOut(current: number, slowestMs: number): number {
+  const targetMultiplier = Math.ceil(slowestMs / CHUNK_RUNTIME_WARN_MS);
+  const target = current * targetMultiplier;
+  const nextPow2 = 2 ** Math.ceil(Math.log2(target));
+  return Math.min(nextPow2, MAX_PARALLEL_CHUNKS_CEILING);
+}
+
+const DEFAULT_MAX_PARALLEL_CHUNKS = 16;
+const MAX_PARALLEL_CHUNKS_CEILING = 256;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((res) => setTimeout(res, ms));


### PR DESCRIPTION
## What

Track the slowest `RenderChunk` Lambda invocation across a render. When that chunk's billed duration crosses 80% of Lambda's 15-min cap, surface a warning at the end of `--wait` with a `--max-parallel-chunks` bump suggestion sized to the actual fan-out the user ran with.

## Why

The cost-analysis sweep hit Lambda's `Sandbox.Timedout` twice — inspector-launch at 1080p/60fps with default `mpc=16` and 4K@anything — both with cryptic SFN errors. The next user to push fps or composition complexity on a heavy WebGL render will hit the same wall. Without this, the only signal they get is a generic SFN failure 15+ minutes into the render. With it, the previous successful render warned them ahead of time.

This is also the practical answer to "what's the longest render Lambda can handle?" The hard limit is `chunkSize × maxParallelChunks` (default 32 min @ 30fps, up to 8.5h cranked); the *operational* limit is per-chunk runtime, which depends on composition complexity.

## How

- `RenderProgress.maxChunkDurationMs`: new field on the SDK's progress snapshot. Tracks the max billed-duration across `RenderChunk` Lambda invocations only (Plan + Assemble are off-path — they have their own runtime profiles that aren't gated by the 15-min cap). Null until the first chunk reports back.
- `bumpMaxChunkDuration(current, state, billedMs)` helper shared between the `TaskSucceeded` and `LambdaFunctionSucceeded` switch arms.
- `packages/aws-lambda/src/sdk/chunkRuntime.ts`: new module exporting `LAMBDA_TIMEOUT_MS = 900_000` and `CHUNK_RUNTIME_WARN_MS = LAMBDA_TIMEOUT_MS × 0.8`. Re-exported from the SDK barrel.
- `warnIfChunkRuntimeIsCloseToCap(progress, currentMaxParallelChunks)` in the CLI: synchronous, uses the static SDK constants (no dynamic `loadSDK()` for a constant lookup).
- `suggestFanOut(current, slowestMs)`: scales the suggestion from the actual `--max-parallel-chunks` value the user ran with — doubles until projected per-chunk duration clears the threshold, rounds to the next power of two, caps at 256. So a user running `mpc=64` who hits 800s gets `--max-parallel-chunks 128`, not the hardcoded `32` an earlier version would have suggested.

## Test plan

- [x] Unit tests: tracks slowest RenderChunk duration · ignores Plan/Assemble durations · null before any chunk completes · doesn't break existing test fixtures.
- [x] All 112 aws-lambda tests pass (3 new).
- [x] Manual: render that exceeds the threshold prints the warning + the scaled fan-out suggestion at the end of `--wait`; renders under the threshold are silent.
- [x] Typecheck + format + lint clean across both packages.