### PR TITLE
feat(studio): catalog panel with Ask agent, block preview, and composition context

### DIFF
--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -398,8 +398,38 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     async installRegistryBlock(opts) {
       const { resolveItem } = await import("../registry/resolver.js");
       const { installItem } = await import("../registry/installer.js");
+      const { readFileSync, writeFileSync, existsSync } = await import("node:fs");
+      const { join } = await import("node:path");
       const item = await resolveItem(opts.blockName);
       const { written } = await installItem(item, { destDir: opts.project.dir });
+
+      const indexPath = join(opts.project.dir, "index.html");
+      if (existsSync(indexPath)) {
+        const indexHtml = readFileSync(indexPath, "utf-8");
+        const hostW = indexHtml.match(/data-width="(\d+)"/)?.[1];
+        const hostH = indexHtml.match(/data-height="(\d+)"/)?.[1];
+        if (hostW && hostH) {
+          for (const absPath of written) {
+            if (!absPath.endsWith(".html")) continue;
+            let content = readFileSync(absPath, "utf-8");
+            content = content.replace(
+              /(<meta\s+name="viewport"\s+content="width=)\d+(,\s*height=)\d+/i,
+              `$1${hostW}$2${hostH}`,
+            );
+            content = content.replace(
+              /(\bwidth:\s*)\d+(px;\s*\n?\s*height:\s*)\d+(px;)/g,
+              (match, pre, mid, post) => {
+                if (match.includes("1920") || match.includes("1080")) {
+                  return `${pre}${hostW}${mid}${hostH}${post}`;
+                }
+                return match;
+              },
+            );
+            writeFileSync(absPath, content, "utf-8");
+          }
+        }
+      }
+
       const relativePaths = written.map((abs) => {
         const rel = abs.startsWith(opts.project.dir) ? abs.slice(opts.project.dir.length + 1) : abs;
         return rel;

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -109,6 +109,7 @@ export function StudioRightPanel({
                   <button
                     type="button"
                     onClick={() => setRightPanelTab("design")}
+                    title="Design"
                     className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
                       rightPanelTab === "design"
                         ? "bg-neutral-800 text-white"
@@ -120,6 +121,7 @@ export function StudioRightPanel({
                   <button
                     type="button"
                     onClick={() => setRightPanelTab("layers")}
+                    title="Layers"
                     className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
                       rightPanelTab === "layers"
                         ? "bg-neutral-800 text-white"
@@ -132,6 +134,7 @@ export function StudioRightPanel({
                     <button
                       type="button"
                       onClick={() => setRightPanelTab("motion")}
+                      title="Motion"
                       className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
                         rightPanelTab === "motion"
                           ? "bg-neutral-800 text-white"
@@ -146,6 +149,7 @@ export function StudioRightPanel({
               <button
                 type="button"
                 onClick={() => setRightPanelTab("renders")}
+                title="Renders"
                 className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
                   rightPanelTab === "renders"
                     ? "bg-neutral-800 text-white"

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "./ui";
 import { PropertyPanel } from "./editor/PropertyPanel";
 import { MotionPanel } from "./editor/MotionPanel";
 import { LayersPanel } from "./editor/LayersPanel";
@@ -106,58 +107,62 @@ export function StudioRightPanel({
             <div className="flex items-center gap-1 border-b border-neutral-800 px-3 py-2">
               {STUDIO_INSPECTOR_PANELS_ENABLED && (
                 <>
-                  <button
-                    type="button"
-                    onClick={() => setRightPanelTab("design")}
-                    title="Design"
-                    className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
-                      rightPanelTab === "design"
-                        ? "bg-neutral-800 text-white"
-                        : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
-                    }`}
-                  >
-                    Design
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setRightPanelTab("layers")}
-                    title="Layers"
-                    className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
-                      rightPanelTab === "layers"
-                        ? "bg-neutral-800 text-white"
-                        : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
-                    }`}
-                  >
-                    Layers
-                  </button>
-                  {STUDIO_MOTION_PANEL_ENABLED && (
+                  <Tooltip label="Element styles and properties" side="bottom">
                     <button
                       type="button"
-                      onClick={() => setRightPanelTab("motion")}
-                      title="Motion"
+                      onClick={() => setRightPanelTab("design")}
                       className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
-                        rightPanelTab === "motion"
+                        rightPanelTab === "design"
                           ? "bg-neutral-800 text-white"
                           : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
                       }`}
                     >
-                      Motion
+                      Design
                     </button>
+                  </Tooltip>
+                  <Tooltip label="Composition layer stack" side="bottom">
+                    <button
+                      type="button"
+                      onClick={() => setRightPanelTab("layers")}
+                      className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
+                        rightPanelTab === "layers"
+                          ? "bg-neutral-800 text-white"
+                          : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
+                      }`}
+                    >
+                      Layers
+                    </button>
+                  </Tooltip>
+                  {STUDIO_MOTION_PANEL_ENABLED && (
+                    <Tooltip label="Animation and motion" side="bottom">
+                      <button
+                        type="button"
+                        onClick={() => setRightPanelTab("motion")}
+                        className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
+                          rightPanelTab === "motion"
+                            ? "bg-neutral-800 text-white"
+                            : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
+                        }`}
+                      >
+                        Motion
+                      </button>
+                    </Tooltip>
                   )}
                 </>
               )}
-              <button
-                type="button"
-                onClick={() => setRightPanelTab("renders")}
-                title="Renders"
-                className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
-                  rightPanelTab === "renders"
-                    ? "bg-neutral-800 text-white"
-                    : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
-                }`}
-              >
-                {renderJobs.length > 0 ? `Renders (${renderJobs.length})` : "Renders"}
-              </button>
+              <Tooltip label="Render queue and exports" side="bottom">
+                <button
+                  type="button"
+                  onClick={() => setRightPanelTab("renders")}
+                  className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
+                    rightPanelTab === "renders"
+                      ? "bg-neutral-800 text-white"
+                      : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
+                  }`}
+                >
+                  {renderJobs.length > 0 ? `Renders (${renderJobs.length})` : "Renders"}
+                </button>
+              </Tooltip>
             </div>
             <div className="min-h-0 flex-1">
               {rightPanelTab === "block-params" && activeBlockParams ? (

--- a/packages/studio/src/components/TimelineToolbar.tsx
+++ b/packages/studio/src/components/TimelineToolbar.tsx
@@ -4,6 +4,7 @@ import {
 } from "../player/components/timelineZoom";
 import { getTimelineToggleTitle } from "../utils/timelineDiscovery";
 import { usePlayerStore } from "../player";
+import { Tooltip } from "./ui";
 
 interface TimelineToolbarProps {
   toggleTimelineVisibility: () => void;
@@ -23,65 +24,71 @@ export function TimelineToolbar({ toggleTimelineVisibility }: TimelineToolbarPro
           Timeline
         </div>
         <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => setZoomMode("fit")}
-            className={`h-7 px-2.5 rounded-md border text-[11px] font-medium transition-colors ${
-              zoomMode === "fit"
-                ? "border-studio-accent/30 bg-studio-accent/10 text-studio-accent"
-                : "border-neutral-800 text-neutral-400 hover:border-neutral-700 hover:text-neutral-200"
-            }`}
-            title="Fit timeline to width"
-          >
-            Fit
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setZoomMode("manual");
-              setManualZoomPercent(getNextTimelineZoomPercent("out", zoomMode, manualZoomPercent));
-            }}
-            className="h-7 w-7 rounded-md border border-neutral-800 text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-200"
-            title="Zoom out"
-          >
-            -
-          </button>
+          <Tooltip label="Fit timeline to width">
+            <button
+              type="button"
+              onClick={() => setZoomMode("fit")}
+              className={`h-7 px-2.5 rounded-md border text-[11px] font-medium transition-colors ${
+                zoomMode === "fit"
+                  ? "border-studio-accent/30 bg-studio-accent/10 text-studio-accent"
+                  : "border-neutral-800 text-neutral-400 hover:border-neutral-700 hover:text-neutral-200"
+              }`}
+            >
+              Fit
+            </button>
+          </Tooltip>
+          <Tooltip label="Zoom out">
+            <button
+              type="button"
+              onClick={() => {
+                setZoomMode("manual");
+                setManualZoomPercent(
+                  getNextTimelineZoomPercent("out", zoomMode, manualZoomPercent),
+                );
+              }}
+              className="h-7 w-7 rounded-md border border-neutral-800 text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-200"
+            >
+              -
+            </button>
+          </Tooltip>
           <div className="min-w-[58px] text-center text-[10px] font-medium tabular-nums text-neutral-500">
             {`${displayedTimelineZoomPercent}%`}
           </div>
-          <button
-            type="button"
-            onClick={() => {
-              setZoomMode("manual");
-              setManualZoomPercent(getNextTimelineZoomPercent("in", zoomMode, manualZoomPercent));
-            }}
-            className="h-7 w-7 rounded-md border border-neutral-800 text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-200"
-            title="Zoom in"
-          >
-            +
-          </button>
-          <button
-            type="button"
-            onClick={toggleTimelineVisibility}
-            className="ml-1 flex h-7 w-7 items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-neutral-900 hover:text-neutral-200"
-            title={getTimelineToggleTitle(true)}
-            aria-label="Hide timeline editor"
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
+          <Tooltip label="Zoom in">
+            <button
+              type="button"
+              onClick={() => {
+                setZoomMode("manual");
+                setManualZoomPercent(getNextTimelineZoomPercent("in", zoomMode, manualZoomPercent));
+              }}
+              className="h-7 w-7 rounded-md border border-neutral-800 text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-200"
             >
-              <path d="M5 7h14" />
-              <path d="m8 11 4 4 4-4" />
-            </svg>
-          </button>
+              +
+            </button>
+          </Tooltip>
+          <Tooltip label={getTimelineToggleTitle(true)}>
+            <button
+              type="button"
+              onClick={toggleTimelineVisibility}
+              className="ml-1 flex h-7 w-7 items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-neutral-900 hover:text-neutral-200"
+              aria-label="Hide timeline editor"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 7h14" />
+                <path d="m8 11 4 4 4-4" />
+              </svg>
+            </button>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -391,6 +391,16 @@ export const NLEPreview = memo(function NLEPreview({
             }}
             data-testid="preview-zoom-stage"
           >
+            {directUrl?.includes("/components/") && (
+              <Player
+                key={`backdrop-${projectId}`}
+                projectId={projectId}
+                onLoad={() => {}}
+                portrait={portrait}
+                suppressLoadingOverlay
+                style={{ position: "absolute", inset: 0, zIndex: 0 }}
+              />
+            )}
             <Player
               key={activeKey}
               ref={iframeRef}
@@ -403,6 +413,11 @@ export const NLEPreview = memo(function NLEPreview({
               onCompositionLoadingChange={onCompositionLoadingChange}
               portrait={portrait}
               suppressLoadingOverlay={suppressLoadingOverlay}
+              style={
+                directUrl?.includes("/components/")
+                  ? { position: "absolute", inset: 0, zIndex: 1 }
+                  : undefined
+              }
             />
           </div>
         </div>

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -15,11 +15,12 @@ export interface BlockPreviewInfo {
 }
 
 interface BlocksTabProps {
+  onAddBlock?: (blockName: string) => void;
   onPreviewBlock?: (preview: BlockPreviewInfo | null) => void;
 }
 
 // fallow-ignore-next-line complexity
-export const BlocksTab = memo(function BlocksTab({ onPreviewBlock }: BlocksTabProps) {
+export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }: BlocksTabProps) {
   const { loading, error, search, setSearch, category, setCategory, filteredBlocks } =
     useBlockCatalog();
 
@@ -117,6 +118,11 @@ export const BlocksTab = memo(function BlocksTab({ onPreviewBlock }: BlocksTabPr
                   posterUrl={block.preview?.poster}
                   videoUrl={block.preview?.video}
                   onPreview={onPreviewBlock}
+                  onAdd={
+                    block.type === "hyperframes:component"
+                      ? () => onAddBlock?.(block.name)
+                      : undefined
+                  }
                 />
               );
             })}
@@ -280,9 +286,11 @@ function BlockCard({
   tags?: string[];
   posterUrl?: string;
   videoUrl?: string;
+  onAdd?: () => void;
   onPreview?: (preview: BlockPreviewInfo | null) => void;
 }) {
   const [hovered, setHovered] = useState(false);
+  const [adding, setAdding] = useState(false);
   const [copied, setCopied] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const colors = getCategoryColors(category);
@@ -309,6 +317,17 @@ function BlockCard({
       if (hoverTimer.current) clearTimeout(hoverTimer.current);
     };
   }, []);
+
+  const handleAdd = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (adding || !onAdd) return;
+      setAdding(true);
+      onAdd();
+      setTimeout(() => setAdding(false), 1000);
+    },
+    [adding],
+  );
 
   const { activeCompPath, compositionDimensions } = useStudioContext();
 
@@ -372,28 +391,46 @@ function BlockCard({
           </div>
         )}
 
-        {/* Ask agent overlay */}
-        <button
-          type="button"
-          onClick={handleCopyPrompt}
-          className="absolute inset-0 flex items-center justify-center gap-1.5 bg-black/60 opacity-0 group-hover/card:opacity-100 transition-opacity"
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            className="text-white"
+        {/* Action overlay */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-black/60 opacity-0 group-hover/card:opacity-100 transition-opacity">
+          {onAdd && (
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="flex items-center gap-1 px-3 py-1.5 rounded-md bg-white text-black text-[10px] font-semibold hover:bg-neutral-200 transition-colors"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+              >
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+              {adding ? "Added" : "Add"}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleCopyPrompt}
+            className={`flex items-center gap-1 px-3 ${onAdd ? "py-1" : "py-1.5"} rounded-md ${onAdd ? "bg-white/15 text-white/90 text-[9px]" : "bg-white text-black text-[10px] font-semibold"} hover:bg-white/25 transition-colors`}
           >
-            <rect x="9" y="9" width="13" height="13" rx="2" />
-            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-          </svg>
-          <span className="text-[10px] font-semibold text-white">
+            <svg
+              width={onAdd ? 9 : 12}
+              height={onAdd ? 9 : 12}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
             {copied ? "Copied!" : "Ask agent"}
-          </span>
-        </button>
+          </button>
+        </div>
 
         {/* Badges */}
         <div className="absolute top-1 right-1 flex items-center gap-0.5 pointer-events-none">

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -290,6 +290,7 @@ function BlockCard({
   posterUrl,
   videoUrl,
   onAdd,
+  onShowPrompt,
   onPreview,
 }: {
   name: string;
@@ -366,7 +367,7 @@ function BlockCard({
       const prompt = buildAgentPrompt(title, name, description, category, blockType, context);
       onShowPrompt?.({ title, prompt });
     },
-    [title, name, description, category, blockType, activeCompPath, compositionDimensions],
+    [title, name, description, category, blockType, activeCompPath, compositionDimensions, onShowPrompt],
   );
 
   return (

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -367,7 +367,16 @@ function BlockCard({
       const prompt = buildAgentPrompt(title, name, description, category, blockType, context);
       onShowPrompt?.({ title, prompt });
     },
-    [title, name, description, category, blockType, activeCompPath, compositionDimensions, onShowPrompt],
+    [
+      title,
+      name,
+      description,
+      category,
+      blockType,
+      activeCompPath,
+      compositionDimensions,
+      onShowPrompt,
+    ],
   );
 
   return (
@@ -524,7 +533,15 @@ function PromptPreviewModal({
             className="p-1 rounded-md text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800/50"
             onClick={onClose}
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />
             </svg>

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -119,7 +119,9 @@ export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }:
                   videoUrl={block.preview?.video}
                   onPreview={onPreviewBlock}
                   onAdd={
-                    block.type === "hyperframes:component"
+                    block.category === "vfx" ||
+                    block.category === "social" ||
+                    block.category === "scenes"
                       ? () => onAddBlock?.(block.name)
                       : undefined
                   }

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -63,7 +63,7 @@ export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }:
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search blocks…"
+            placeholder="Search by name, category, or tag…"
             className="w-full bg-neutral-900 border border-neutral-800 rounded-md pl-7 pr-2 py-1.5 text-[11px] text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-neutral-700 transition-colors"
           />
         </div>
@@ -400,6 +400,7 @@ function BlockCard({
             <button
               type="button"
               onClick={handleAdd}
+              title="Add to composition at current time"
               className="flex items-center gap-1 px-3 py-1.5 rounded-md bg-white text-black text-[10px] font-semibold hover:bg-neutral-200 transition-colors"
             >
               <svg
@@ -412,26 +413,51 @@ function BlockCard({
               >
                 <path d="M12 5v14M5 12h14" />
               </svg>
-              {adding ? "Added" : "Add"}
+              {adding ? "Added!" : "Add"}
             </button>
           )}
           <button
             type="button"
             onClick={handleCopyPrompt}
-            className={`flex items-center gap-1 px-3 ${onAdd ? "py-1" : "py-1.5"} rounded-md ${onAdd ? "bg-white/15 text-white/90 text-[9px]" : "bg-white text-black text-[10px] font-semibold"} hover:bg-white/25 transition-colors`}
+            title="Copy a prompt to paste into your AI agent"
+            className={`flex items-center gap-1.5 px-3 ${onAdd ? "py-1" : "py-1.5"} rounded-md transition-colors ${
+              copied
+                ? "bg-emerald-500 text-white"
+                : onAdd
+                  ? "bg-white/15 text-white/90 hover:bg-white/25"
+                  : "bg-white text-black hover:bg-neutral-200"
+            } ${onAdd ? "text-[9px]" : "text-[10px] font-semibold"}`}
           >
-            <svg
-              width={onAdd ? 9 : 12}
-              height={onAdd ? 9 : 12}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <rect x="9" y="9" width="13" height="13" rx="2" />
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-            </svg>
-            {copied ? "Copied!" : "Ask agent"}
+            {copied ? (
+              <>
+                <svg
+                  width={onAdd ? 9 : 11}
+                  height={onAdd ? 9 : 11}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                >
+                  <path d="M20 6 9 17l-5-5" />
+                </svg>
+                Copied!
+              </>
+            ) : (
+              <>
+                <svg
+                  width={onAdd ? 9 : 11}
+                  height={onAdd ? 9 : 11}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <rect x="9" y="9" width="13" height="13" rx="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+                Ask agent
+              </>
+            )}
           </button>
         </div>
 

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -1,4 +1,5 @@
 import { memo, useState, useCallback, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { useBlockCatalog } from "../../hooks/useBlockCatalog";
 import {
   BLOCK_CATEGORIES,
@@ -23,6 +24,7 @@ interface BlocksTabProps {
 export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }: BlocksTabProps) {
   const { loading, error, search, setSearch, category, setCategory, filteredBlocks } =
     useBlockCatalog();
+  const [promptModal, setPromptModal] = useState<{ title: string; prompt: string } | null>(null);
 
   if (loading) {
     return (
@@ -118,6 +120,7 @@ export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }:
                   posterUrl={block.preview?.poster}
                   videoUrl={block.preview?.video}
                   onPreview={onPreviewBlock}
+                  onShowPrompt={setPromptModal}
                   onAdd={
                     block.category === "vfx" ||
                     block.category === "social" ||
@@ -131,6 +134,15 @@ export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }:
           </div>
         )}
       </div>
+      {promptModal &&
+        createPortal(
+          <PromptPreviewModal
+            title={promptModal.title}
+            prompt={promptModal.prompt}
+            onClose={() => setPromptModal(null)}
+          />,
+          document.body,
+        )}
     </div>
   );
 });
@@ -290,11 +302,11 @@ function BlockCard({
   posterUrl?: string;
   videoUrl?: string;
   onAdd?: () => void;
+  onShowPrompt?: (info: { title: string; prompt: string }) => void;
   onPreview?: (preview: BlockPreviewInfo | null) => void;
 }) {
   const [hovered, setHovered] = useState(false);
   const [adding, setAdding] = useState(false);
-  const [copied, setCopied] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const colors = getCategoryColors(category);
   const needsWebGL = tags?.includes("html-in-canvas") || tags?.includes("webgl");
@@ -334,7 +346,7 @@ function BlockCard({
 
   const { activeCompPath, compositionDimensions } = useStudioContext();
 
-  const handleCopyPrompt = useCallback(
+  const handleShowPrompt = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
       const state = usePlayerStore.getState();
@@ -352,9 +364,7 @@ function BlockCard({
         compositionDimensions: compositionDimensions ?? undefined,
       };
       const prompt = buildAgentPrompt(title, name, description, category, blockType, context);
-      navigator.clipboard.writeText(prompt);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      onShowPrompt?.({ title, prompt });
     },
     [title, name, description, category, blockType, activeCompPath, compositionDimensions],
   );
@@ -418,46 +428,26 @@ function BlockCard({
           )}
           <button
             type="button"
-            onClick={handleCopyPrompt}
-            title="Copy a prompt to paste into your AI agent"
+            onClick={handleShowPrompt}
+            title="Generate a prompt to paste into your AI agent"
             className={`flex items-center gap-1.5 px-3 ${onAdd ? "py-1" : "py-1.5"} rounded-md transition-colors ${
-              copied
-                ? "bg-emerald-500 text-white"
-                : onAdd
-                  ? "bg-white/15 text-white/90 hover:bg-white/25"
-                  : "bg-white text-black hover:bg-neutral-200"
-            } ${onAdd ? "text-[9px]" : "text-[10px] font-semibold"}`}
+              onAdd
+                ? "bg-white/15 text-white/90 hover:bg-white/25 text-[9px]"
+                : "bg-white text-black hover:bg-neutral-200 text-[10px] font-semibold"
+            }`}
           >
-            {copied ? (
-              <>
-                <svg
-                  width={onAdd ? 9 : 11}
-                  height={onAdd ? 9 : 11}
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                >
-                  <path d="M20 6 9 17l-5-5" />
-                </svg>
-                Copied!
-              </>
-            ) : (
-              <>
-                <svg
-                  width={onAdd ? 9 : 11}
-                  height={onAdd ? 9 : 11}
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                >
-                  <rect x="9" y="9" width="13" height="13" rx="2" />
-                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                </svg>
-                Ask agent
-              </>
-            )}
+            <svg
+              width={onAdd ? 9 : 11}
+              height={onAdd ? 9 : 11}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            Ask agent
           </button>
         </div>
 
@@ -486,6 +476,81 @@ function BlockCard({
           <span className={`text-[8px] ${colors.text}`}>
             {BLOCK_CATEGORIES.find((c) => c.id === category)?.label}
           </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PromptPreviewModal({
+  title,
+  prompt,
+  onClose,
+}: {
+  title: string;
+  prompt: string;
+  onClose: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [prompt]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-[520px] max-h-[80vh] flex flex-col rounded-2xl border border-neutral-800 bg-neutral-950 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-800/60">
+          <div>
+            <h3 className="text-sm font-medium text-neutral-200">Ask agent</h3>
+            <p className="text-xs text-neutral-500 mt-0.5">{title}</p>
+          </div>
+          <button
+            className="p-1 rounded-md text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800/50"
+            onClick={onClose}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <p className="text-[11px] text-neutral-500 mb-2">
+            Copy this prompt and paste it into your AI agent (Claude Code, Cursor, etc.)
+          </p>
+          <pre className="text-[11px] text-neutral-300 leading-relaxed whitespace-pre-wrap font-mono bg-neutral-900/60 rounded-lg p-3 border border-neutral-800 select-all">
+            {prompt}
+          </pre>
+        </div>
+        <div className="flex items-center justify-between px-5 py-3 border-t border-neutral-800/60">
+          <span className="text-[11px] text-neutral-600">Paste into your agent after copying</span>
+          <button
+            className={`px-4 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              copied
+                ? "bg-emerald-500 text-white"
+                : "bg-studio-accent/90 text-neutral-950 hover:bg-studio-accent"
+            }`}
+            onClick={handleCopy}
+          >
+            {copied ? "Copied!" : "Copy prompt"}
+          </button>
         </div>
       </div>
     </div>

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -113,6 +113,8 @@ export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }:
                   key={block.name}
                   name={block.name}
                   title={block.title}
+                  description={block.description}
+                  blockType={block.type}
                   duration={dur}
                   category={block.category}
                   tags={block.tags}
@@ -160,9 +162,47 @@ function CategoryPill({
   );
 }
 
+function buildAgentPrompt(
+  title: string,
+  name: string,
+  description: string,
+  category: BlockCategory,
+  blockType: string,
+): string {
+  const isComponent = blockType === "hyperframes:component";
+  const kind = isComponent ? "component" : "block";
+
+  const categoryHints: Record<string, string> = {
+    captions:
+      "This is a caption style. Add it to the composition, then customize the transcript text, fonts, colors, and timing to match the voiceover or audio.",
+    vfx: "This is a VFX effect. Add it as an overlay and adjust shader parameters, colors, and intensity to match the scene.",
+    transitions:
+      "This is a transition. Place it between two scenes on the timeline and adjust the duration and direction.",
+    effects:
+      "This is a visual effect overlay. Layer it on top of existing content and tweak colors, opacity, and animation timing.",
+    social:
+      "This is a social media template. Customize the text, handle, avatar, and metrics to match the content.",
+    data: "This is a data visualization. Update the data values, labels, colors, and animation stagger to tell the right story.",
+    scenes:
+      "This is a full scene. Customize the text, images, layout, and animation timing to fit the narrative.",
+  };
+
+  const hint = categoryHints[category] ?? `Customize this ${kind} to fit the composition.`;
+
+  return [
+    `Add the "${title}" ${kind} (registry: ${name}) to my composition using /hyperframes.`,
+    "",
+    `${description}`,
+    "",
+    hint,
+  ].join("\n");
+}
+
 function BlockCard({
   name,
   title,
+  description,
+  blockType,
   duration,
   category,
   tags,
@@ -174,6 +214,8 @@ function BlockCard({
 }: {
   name: string;
   title: string;
+  description: string;
+  blockType: string;
   duration?: number;
   category: BlockCategory;
   tags?: string[];
@@ -185,6 +227,7 @@ function BlockCard({
 }) {
   const [hovered, setHovered] = useState(false);
   const [adding, setAdding] = useState(false);
+  const [copied, setCopied] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const colors = getCategoryColors(category);
   const needsWebGL = tags?.includes("html-in-canvas") || tags?.includes("webgl");
@@ -220,6 +263,17 @@ function BlockCard({
       setTimeout(() => setAdding(false), 1000);
     },
     [onAdd, adding],
+  );
+
+  const handleCopyPrompt = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const prompt = buildAgentPrompt(title, name, description, category, blockType);
+      navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    },
+    [title, name, description, category, blockType],
   );
 
   const handleDragStart = useCallback(
@@ -267,14 +321,44 @@ function BlockCard({
           </div>
         )}
 
-        {/* Add button overlay */}
-        <button
-          type="button"
-          onClick={handleAdd}
-          className="absolute inset-0 flex items-center justify-center bg-black/60 opacity-0 group-hover/card:opacity-100 transition-opacity"
-        >
-          <span className="text-[10px] font-semibold text-white">{adding ? "Added" : "Add"}</span>
-        </button>
+        {/* Action buttons overlay */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-black/60 opacity-0 group-hover/card:opacity-100 transition-opacity">
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="flex items-center gap-1 px-3 py-1.5 rounded-md bg-white text-black text-[10px] font-semibold hover:bg-neutral-200 transition-colors"
+          >
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            {adding ? "Added" : "Add"}
+          </button>
+          <button
+            type="button"
+            onClick={handleCopyPrompt}
+            className="flex items-center gap-1 px-3 py-1 rounded-md bg-white/15 text-white/90 text-[9px] font-medium hover:bg-white/25 transition-colors"
+          >
+            <svg
+              width="9"
+              height="9"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            {copied ? "Copied!" : "Agent prompt"}
+          </button>
+        </div>
 
         {/* Badges */}
         <div className="absolute top-1 right-1 flex items-center gap-0.5 pointer-events-none">

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -492,13 +492,19 @@ function PromptPreviewModal({
   prompt: string;
   onClose: () => void;
 }) {
+  const [value, setValue] = useState(prompt);
   const [copied, setCopied] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, []);
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(prompt);
+    navigator.clipboard.writeText(value);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
-  }, [prompt]);
+  }, [value]);
 
   return (
     <div
@@ -506,7 +512,7 @@ function PromptPreviewModal({
       onClick={onClose}
     >
       <div
-        className="w-[520px] max-h-[80vh] flex flex-col rounded-2xl border border-neutral-800 bg-neutral-950 shadow-2xl"
+        className="w-[560px] max-h-[80vh] flex flex-col rounded-2xl border border-neutral-800 bg-neutral-950 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-800/60">
@@ -518,15 +524,7 @@ function PromptPreviewModal({
             className="p-1 rounded-md text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800/50"
             onClick={onClose}
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-            >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />
             </svg>
@@ -534,14 +532,23 @@ function PromptPreviewModal({
         </div>
         <div className="flex-1 overflow-y-auto px-5 py-4">
           <p className="text-[11px] text-neutral-500 mb-2">
-            Copy this prompt and paste it into your AI agent (Claude Code, Cursor, etc.)
+            Edit the prompt below, then copy and paste into your AI agent
           </p>
-          <pre className="text-[11px] text-neutral-300 leading-relaxed whitespace-pre-wrap font-mono bg-neutral-900/60 rounded-lg p-3 border border-neutral-800 select-all">
-            {prompt}
-          </pre>
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleCopy();
+              if (e.key === "Escape") onClose();
+            }}
+            className="w-full min-h-[240px] text-[11px] text-neutral-200 leading-relaxed font-mono bg-neutral-900/60 rounded-lg p-3 border border-neutral-800 resize-y focus:outline-none focus:border-studio-accent/60 focus:ring-1 focus:ring-studio-accent/30"
+          />
         </div>
         <div className="flex items-center justify-between px-5 py-3 border-t border-neutral-800/60">
-          <span className="text-[11px] text-neutral-600">Paste into your agent after copying</span>
+          <span className="text-[11px] text-neutral-600">
+            {navigator.platform.includes("Mac") ? "⌘" : "Ctrl"}+Enter to copy
+          </span>
           <button
             className={`px-4 py-1.5 rounded-lg text-xs font-medium transition-colors ${
               copied

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -275,6 +275,7 @@ function BlockCard({
   tags,
   posterUrl,
   videoUrl,
+  onAdd,
   onPreview,
 }: {
   name: string;
@@ -326,7 +327,7 @@ function BlockCard({
       onAdd();
       setTimeout(() => setAdding(false), 1000);
     },
-    [adding],
+    [onAdd, adding],
   );
 
   const { activeCompPath, compositionDimensions } = useStudioContext();

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -5,6 +5,9 @@ import {
   getCategoryColors,
   type BlockCategory,
 } from "../../utils/blockCategories";
+import { usePlayerStore } from "../../player";
+import { formatTime } from "../../player/lib/time";
+import { useStudioContext } from "../../contexts/StudioContext";
 export interface BlockPreviewInfo {
   videoUrl?: string;
   posterUrl?: string;
@@ -153,15 +156,59 @@ function CategoryPill({
   );
 }
 
+interface CompositionContext {
+  currentTime: number;
+  activeCompPath: string | null;
+  elements: Array<{
+    id: string;
+    start: number;
+    duration: number;
+    track: number;
+    label?: string;
+    compositionSrc?: string;
+  }>;
+  compositionDimensions?: { width: number; height: number };
+}
+
+function formatCompositionContext(ctx: CompositionContext): string {
+  const lines: string[] = [
+    `Playback time: ${formatTime(ctx.currentTime)}`,
+    `Active composition: ${ctx.activeCompPath || "index.html"}`,
+  ];
+  if (ctx.compositionDimensions) {
+    lines.push(
+      `Dimensions: ${ctx.compositionDimensions.width}x${ctx.compositionDimensions.height}`,
+    );
+  }
+  const visibleNow = ctx.elements.filter(
+    (el) => ctx.currentTime >= el.start && ctx.currentTime < el.start + el.duration,
+  );
+  if (visibleNow.length > 0) {
+    lines.push(
+      "",
+      `Elements visible at ${formatTime(ctx.currentTime)}:`,
+      ...visibleNow.map(
+        (el) =>
+          `- ${el.label || el.id} (track ${el.track}, ${formatTime(el.start)}–${formatTime(el.start + el.duration)}${el.compositionSrc ? `, src: ${el.compositionSrc}` : ""})`,
+      ),
+    );
+  }
+  const maxZ = ctx.elements.length > 0 ? Math.max(...ctx.elements.map((_, i) => i + 1)) : 0;
+  lines.push("", `Highest track index: ${maxZ}`);
+  return lines.join("\n");
+}
+
 function buildAgentPrompt(
   title: string,
   name: string,
   description: string,
   category: BlockCategory,
   blockType: string,
+  context: CompositionContext,
 ): string {
   const isComponent = blockType === "hyperframes:component";
   const kind = isComponent ? "component" : "block";
+  const compositionInfo = formatCompositionContext(context);
 
   const categoryPrompts: Record<string, string> = {
     captions: [
@@ -201,14 +248,15 @@ function buildAgentPrompt(
     ].join("\n\n"),
   };
 
-  return (
+  const instruction =
     categoryPrompts[category] ??
     [
       `Using /hyperframes, add the "${title}" ${kind} (registry: ${name}) to my composition.`,
       `${description}`,
       `Customize it to match my composition's design and timeline.`,
-    ].join("\n\n")
-  );
+    ].join("\n\n");
+
+  return [instruction, "", "## Current composition state", "", compositionInfo].join("\n");
 }
 
 function BlockCard({
@@ -262,15 +310,31 @@ function BlockCard({
     };
   }, []);
 
+  const { activeCompPath, compositionDimensions } = useStudioContext();
+
   const handleCopyPrompt = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      const prompt = buildAgentPrompt(title, name, description, category, blockType);
+      const state = usePlayerStore.getState();
+      const context: CompositionContext = {
+        currentTime: state.currentTime,
+        activeCompPath,
+        elements: state.elements.map((el) => ({
+          id: el.id,
+          start: el.start,
+          duration: el.duration,
+          track: el.track,
+          label: el.label,
+          compositionSrc: el.compositionSrc,
+        })),
+        compositionDimensions: compositionDimensions ?? undefined,
+      };
+      const prompt = buildAgentPrompt(title, name, description, category, blockType, context);
       navigator.clipboard.writeText(prompt);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     },
-    [title, name, description, category, blockType],
+    [title, name, description, category, blockType, activeCompPath, compositionDimensions],
   );
 
   return (

--- a/packages/studio/src/components/sidebar/BlocksTab.tsx
+++ b/packages/studio/src/components/sidebar/BlocksTab.tsx
@@ -5,8 +5,6 @@ import {
   getCategoryColors,
   type BlockCategory,
 } from "../../utils/blockCategories";
-import { TIMELINE_BLOCK_MIME } from "../../utils/timelineAssetDrop";
-
 export interface BlockPreviewInfo {
   videoUrl?: string;
   posterUrl?: string;
@@ -14,12 +12,11 @@ export interface BlockPreviewInfo {
 }
 
 interface BlocksTabProps {
-  onAddBlock: (blockName: string) => void;
   onPreviewBlock?: (preview: BlockPreviewInfo | null) => void;
 }
 
 // fallow-ignore-next-line complexity
-export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }: BlocksTabProps) {
+export const BlocksTab = memo(function BlocksTab({ onPreviewBlock }: BlocksTabProps) {
   const { loading, error, search, setSearch, category, setCategory, filteredBlocks } =
     useBlockCatalog();
 
@@ -104,10 +101,6 @@ export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }:
           >
             {filteredBlocks.map((block) => {
               const dur = "duration" in block ? (block.duration as number) : undefined;
-              const dims =
-                "dimensions" in block
-                  ? (block.dimensions as { width: number; height: number })
-                  : undefined;
               return (
                 <BlockCard
                   key={block.name}
@@ -120,8 +113,6 @@ export const BlocksTab = memo(function BlocksTab({ onAddBlock, onPreviewBlock }:
                   tags={block.tags}
                   posterUrl={block.preview?.poster}
                   videoUrl={block.preview?.video}
-                  dimensions={dims}
-                  onAdd={() => onAddBlock(block.name)}
                   onPreview={onPreviewBlock}
                 />
               );
@@ -172,30 +163,52 @@ function buildAgentPrompt(
   const isComponent = blockType === "hyperframes:component";
   const kind = isComponent ? "component" : "block";
 
-  const categoryHints: Record<string, string> = {
-    captions:
-      "This is a caption style. Add it to the composition, then customize the transcript text, fonts, colors, and timing to match the voiceover or audio.",
-    vfx: "This is a VFX effect. Add it as an overlay and adjust shader parameters, colors, and intensity to match the scene.",
-    transitions:
-      "This is a transition. Place it between two scenes on the timeline and adjust the duration and direction.",
-    effects:
-      "This is a visual effect overlay. Layer it on top of existing content and tweak colors, opacity, and animation timing.",
-    social:
-      "This is a social media template. Customize the text, handle, avatar, and metrics to match the content.",
-    data: "This is a data visualization. Update the data values, labels, colors, and animation stagger to tell the right story.",
-    scenes:
-      "This is a full scene. Customize the text, images, layout, and animation timing to fit the narrative.",
+  const categoryPrompts: Record<string, string> = {
+    captions: [
+      `Using /hyperframes, add the "${title}" caption style (registry: ${name}) to my composition.`,
+      `${description}`,
+      `Transcribe the audio with /hyperframes-media, then wire the transcript into this caption component. Match the font colors and animation timing to my composition's design tokens. Place it as an overlay above the main content with the highest z-index.`,
+    ].join("\n\n"),
+    vfx: [
+      `Using /hyperframes, add the "${title}" VFX (registry: ${name}) as a full-screen overlay on my composition.`,
+      `${description}`,
+      `This is a WebGL effect that requires chrome://flags/#html-in-canvas. Layer it on top of all content, adjust the shader uniforms and color palette to complement my scene, and set the duration to match the composition length.`,
+    ].join("\n\n"),
+    transitions: [
+      `Using /hyperframes, add the "${title}" transition (registry: ${name}) between my scenes.`,
+      `${description}`,
+      `Place this transition at the cut point between the current scene and the next. Set the duration to 0.5–1s, position it at the scene boundary on the timeline, and make sure the z-index is above both scenes. Adjust colors to match my palette.`,
+    ].join("\n\n"),
+    effects: [
+      `Using /hyperframes, add the "${title}" effect (registry: ${name}) as an overlay on my composition.`,
+      `${description}`,
+      `Layer this on top of the current content. Adjust the opacity, colors, and animation timing to enhance the scene without overwhelming the main content.`,
+    ].join("\n\n"),
+    social: [
+      `Using /hyperframes, add the "${title}" template (registry: ${name}) to my composition.`,
+      `${description}`,
+      `Replace the placeholder text, handle, and avatar with my actual content. Match the typography and colors to my brand. Adjust timing so the elements animate in sync with the voiceover.`,
+    ].join("\n\n"),
+    data: [
+      `Using /hyperframes, add the "${title}" visualization (registry: ${name}) to my composition.`,
+      `${description}`,
+      `Replace the placeholder data with my actual values and labels. Adjust the color scale, animation stagger timing, and typography to match my composition's design system. Size it to fit the current viewport.`,
+    ].join("\n\n"),
+    scenes: [
+      `Using /hyperframes, add the "${title}" scene (registry: ${name}) to my composition.`,
+      `${description}`,
+      `Replace all placeholder text, images, and content with my actual material. Match fonts, colors, and layout to my existing design tokens. Set the timeline position and duration to fit the narrative flow.`,
+    ].join("\n\n"),
   };
 
-  const hint = categoryHints[category] ?? `Customize this ${kind} to fit the composition.`;
-
-  return [
-    `Add the "${title}" ${kind} (registry: ${name}) to my composition using /hyperframes.`,
-    "",
-    `${description}`,
-    "",
-    hint,
-  ].join("\n");
+  return (
+    categoryPrompts[category] ??
+    [
+      `Using /hyperframes, add the "${title}" ${kind} (registry: ${name}) to my composition.`,
+      `${description}`,
+      `Customize it to match my composition's design and timeline.`,
+    ].join("\n\n")
+  );
 }
 
 function BlockCard({
@@ -208,8 +221,6 @@ function BlockCard({
   tags,
   posterUrl,
   videoUrl,
-  dimensions,
-  onAdd,
   onPreview,
 }: {
   name: string;
@@ -221,12 +232,9 @@ function BlockCard({
   tags?: string[];
   posterUrl?: string;
   videoUrl?: string;
-  dimensions?: { width: number; height: number };
-  onAdd: () => void;
   onPreview?: (preview: BlockPreviewInfo | null) => void;
 }) {
   const [hovered, setHovered] = useState(false);
-  const [adding, setAdding] = useState(false);
   const [copied, setCopied] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const colors = getCategoryColors(category);
@@ -254,17 +262,6 @@ function BlockCard({
     };
   }, []);
 
-  const handleAdd = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (adding) return;
-      setAdding(true);
-      onAdd();
-      setTimeout(() => setAdding(false), 1000);
-    },
-    [onAdd, adding],
-  );
-
   const handleCopyPrompt = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -276,21 +273,11 @@ function BlockCard({
     [title, name, description, category, blockType],
   );
 
-  const handleDragStart = useCallback(
-    (e: React.DragEvent) => {
-      e.dataTransfer.effectAllowed = "copy";
-      e.dataTransfer.setData(TIMELINE_BLOCK_MIME, JSON.stringify({ name, duration, dimensions }));
-    },
-    [name, duration, dimensions],
-  );
-
   return (
     <div
       className="group/card rounded-md overflow-hidden cursor-pointer transition-colors bg-neutral-900 hover:bg-neutral-800"
       onPointerEnter={handleEnter}
       onPointerLeave={handleLeave}
-      draggable
-      onDragStart={handleDragStart}
     >
       {/* Thumbnail */}
       <div className="aspect-video w-full overflow-hidden relative">
@@ -321,44 +308,28 @@ function BlockCard({
           </div>
         )}
 
-        {/* Action buttons overlay */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-black/60 opacity-0 group-hover/card:opacity-100 transition-opacity">
-          <button
-            type="button"
-            onClick={handleAdd}
-            className="flex items-center gap-1 px-3 py-1.5 rounded-md bg-white text-black text-[10px] font-semibold hover:bg-neutral-200 transition-colors"
+        {/* Ask agent overlay */}
+        <button
+          type="button"
+          onClick={handleCopyPrompt}
+          className="absolute inset-0 flex items-center justify-center gap-1.5 bg-black/60 opacity-0 group-hover/card:opacity-100 transition-opacity"
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="text-white"
           >
-            <svg
-              width="10"
-              height="10"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-            >
-              <path d="M12 5v14M5 12h14" />
-            </svg>
-            {adding ? "Added" : "Add"}
-          </button>
-          <button
-            type="button"
-            onClick={handleCopyPrompt}
-            className="flex items-center gap-1 px-3 py-1 rounded-md bg-white/15 text-white/90 text-[9px] font-medium hover:bg-white/25 transition-colors"
-          >
-            <svg
-              width="9"
-              height="9"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <rect x="9" y="9" width="13" height="13" rx="2" />
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-            </svg>
-            {copied ? "Copied!" : "Agent prompt"}
-          </button>
-        </div>
+            <rect x="9" y="9" width="13" height="13" rx="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+          <span className="text-[10px] font-semibold text-white">
+            {copied ? "Copied!" : "Ask agent"}
+          </span>
+        </button>
 
         {/* Badges */}
         <div className="absolute top-1 right-1 flex items-center gap-0.5 pointer-events-none">

--- a/packages/studio/src/components/sidebar/LeftSidebar.tsx
+++ b/packages/studio/src/components/sidebar/LeftSidebar.tsx
@@ -13,6 +13,7 @@ import { trackStudioEvent } from "../../utils/studioTelemetry";
 import { BlocksTab, type BlockPreviewInfo } from "./BlocksTab";
 import { FileTree } from "../editor/FileTree";
 import { STUDIO_BLOCKS_PANEL_ENABLED } from "../editor/manualEditingAvailability";
+import { Tooltip } from "../ui";
 
 export type SidebarTab = "compositions" | "assets" | "code" | "blocks";
 
@@ -124,55 +125,59 @@ export const LeftSidebar = memo(
                       : "1fr 1fr 1fr",
                   }}
                 >
-                  <button
-                    type="button"
-                    onClick={() => selectTab("code")}
-                    title="Source code editor"
-                    className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
-                      tab === "code"
-                        ? "bg-neutral-800 text-white"
-                        : "text-neutral-500 hover:text-neutral-200"
-                    }`}
-                  >
-                    Code
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => selectTab("compositions")}
-                    title="Composition layers and sub-compositions"
-                    className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
-                      tab === "compositions"
-                        ? "bg-neutral-800 text-white"
-                        : "text-neutral-500 hover:text-neutral-200"
-                    }`}
-                  >
-                    Comps
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => selectTab("assets")}
-                    title="Media assets — videos, images, audio, fonts"
-                    className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
-                      tab === "assets"
-                        ? "bg-neutral-800 text-white"
-                        : "text-neutral-500 hover:text-neutral-200"
-                    }`}
-                  >
-                    Assets
-                  </button>
-                  {STUDIO_BLOCKS_PANEL_ENABLED && (
+                  <Tooltip label="Source code editor" side="bottom">
                     <button
                       type="button"
-                      onClick={() => selectTab("blocks")}
-                      title="Browse blocks, components, and templates from the registry"
+                      onClick={() => selectTab("code")}
                       className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
-                        tab === "blocks"
+                        tab === "code"
                           ? "bg-neutral-800 text-white"
                           : "text-neutral-500 hover:text-neutral-200"
                       }`}
                     >
-                      Catalog
+                      Code
                     </button>
+                  </Tooltip>
+                  <Tooltip label="Compositions and sub-compositions" side="bottom">
+                    <button
+                      type="button"
+                      onClick={() => selectTab("compositions")}
+                      className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
+                        tab === "compositions"
+                          ? "bg-neutral-800 text-white"
+                          : "text-neutral-500 hover:text-neutral-200"
+                      }`}
+                    >
+                      Comps
+                    </button>
+                  </Tooltip>
+                  <Tooltip label="Videos, images, audio, fonts" side="bottom">
+                    <button
+                      type="button"
+                      onClick={() => selectTab("assets")}
+                      className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
+                        tab === "assets"
+                          ? "bg-neutral-800 text-white"
+                          : "text-neutral-500 hover:text-neutral-200"
+                      }`}
+                    >
+                      Assets
+                    </button>
+                  </Tooltip>
+                  {STUDIO_BLOCKS_PANEL_ENABLED && (
+                    <Tooltip label="Browse blocks and components" side="bottom">
+                      <button
+                        type="button"
+                        onClick={() => selectTab("blocks")}
+                        className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
+                          tab === "blocks"
+                            ? "bg-neutral-800 text-white"
+                            : "text-neutral-500 hover:text-neutral-200"
+                        }`}
+                      >
+                        Catalog
+                      </button>
+                    </Tooltip>
                   )}
                 </div>
                 {onToggleCollapse && (

--- a/packages/studio/src/components/sidebar/LeftSidebar.tsx
+++ b/packages/studio/src/components/sidebar/LeftSidebar.tsx
@@ -84,6 +84,7 @@ export const LeftSidebar = memo(
       onLint,
       linting,
       onToggleCollapse,
+      onAddBlock,
       onPreviewBlock,
       takeoverContent,
     },
@@ -246,7 +247,7 @@ export const LeftSidebar = memo(
             )}
 
             {STUDIO_BLOCKS_PANEL_ENABLED && tab === "blocks" && (
-              <BlocksTab onPreviewBlock={onPreviewBlock} />
+              <BlocksTab onAddBlock={onAddBlock} onPreviewBlock={onPreviewBlock} />
             )}
 
             {/* Lint button pinned at the bottom */}

--- a/packages/studio/src/components/sidebar/LeftSidebar.tsx
+++ b/packages/studio/src/components/sidebar/LeftSidebar.tsx
@@ -127,6 +127,7 @@ export const LeftSidebar = memo(
                   <button
                     type="button"
                     onClick={() => selectTab("code")}
+                    title="Source code editor"
                     className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
                       tab === "code"
                         ? "bg-neutral-800 text-white"
@@ -138,6 +139,7 @@ export const LeftSidebar = memo(
                   <button
                     type="button"
                     onClick={() => selectTab("compositions")}
+                    title="Composition layers and sub-compositions"
                     className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
                       tab === "compositions"
                         ? "bg-neutral-800 text-white"
@@ -149,6 +151,7 @@ export const LeftSidebar = memo(
                   <button
                     type="button"
                     onClick={() => selectTab("assets")}
+                    title="Media assets — videos, images, audio, fonts"
                     className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
                       tab === "assets"
                         ? "bg-neutral-800 text-white"
@@ -161,6 +164,7 @@ export const LeftSidebar = memo(
                     <button
                       type="button"
                       onClick={() => selectTab("blocks")}
+                      title="Browse blocks, components, and templates from the registry"
                       className={`rounded-[14px] px-1.5 py-2 text-[10px] font-semibold truncate transition-all ${
                         tab === "blocks"
                           ? "bg-neutral-800 text-white"

--- a/packages/studio/src/components/sidebar/LeftSidebar.tsx
+++ b/packages/studio/src/components/sidebar/LeftSidebar.tsx
@@ -84,7 +84,6 @@ export const LeftSidebar = memo(
       onLint,
       linting,
       onToggleCollapse,
-      onAddBlock,
       onPreviewBlock,
       takeoverContent,
     },
@@ -246,8 +245,8 @@ export const LeftSidebar = memo(
               </div>
             )}
 
-            {STUDIO_BLOCKS_PANEL_ENABLED && tab === "blocks" && onAddBlock && (
-              <BlocksTab onAddBlock={onAddBlock} onPreviewBlock={onPreviewBlock} />
+            {STUDIO_BLOCKS_PANEL_ENABLED && tab === "blocks" && (
+              <BlocksTab onPreviewBlock={onPreviewBlock} />
             )}
 
             {/* Lint button pinned at the bottom */}

--- a/packages/studio/src/components/ui/Tooltip.tsx
+++ b/packages/studio/src/components/ui/Tooltip.tsx
@@ -1,0 +1,61 @@
+import { useState, useRef, useCallback, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface TooltipProps {
+  label: string;
+  children: ReactNode;
+  delay?: number;
+  side?: "top" | "bottom";
+}
+
+export function Tooltip({ label, children, delay = 400, side = "top" }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+
+  const show = useCallback(() => {
+    timerRef.current = setTimeout(() => {
+      const el = triggerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      setPos({
+        x: rect.left + rect.width / 2,
+        y: side === "top" ? rect.top - 6 : rect.bottom + 6,
+      });
+      setVisible(true);
+    }, delay);
+  }, [delay, side]);
+
+  const hide = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setVisible(false);
+  }, []);
+
+  return (
+    <>
+      <span ref={triggerRef} onPointerEnter={show} onPointerLeave={hide} className="contents">
+        {children}
+      </span>
+      {visible &&
+        createPortal(
+          <div
+            className="fixed z-[200] pointer-events-none"
+            style={{
+              left: pos.x,
+              top: pos.y,
+              transform: side === "top" ? "translate(-50%, -100%)" : "translate(-50%, 0)",
+            }}
+          >
+            <div className="px-2 py-1 rounded-md bg-neutral-800 border border-neutral-700/50 text-[10px] font-medium text-neutral-200 whitespace-nowrap shadow-lg">
+              {label}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/packages/studio/src/components/ui/Tooltip.tsx
+++ b/packages/studio/src/components/ui/Tooltip.tsx
@@ -18,7 +18,9 @@ export function Tooltip({ label, children, delay = 400, side = "top" }: TooltipP
     timerRef.current = setTimeout(() => {
       const el = triggerRef.current;
       if (!el) return;
-      const rect = el.getBoundingClientRect();
+      const child = el.firstElementChild as HTMLElement | null;
+      const rect = (child ?? el).getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) return;
       setPos({
         x: rect.left + rect.width / 2,
         y: side === "top" ? rect.top - 6 : rect.bottom + 6,

--- a/packages/studio/src/components/ui/index.ts
+++ b/packages/studio/src/components/ui/index.ts
@@ -2,3 +2,4 @@
 export { Button, IconButton } from "./Button";
 export { HyperframesLoader, StatusFrame } from "./HyperframesLoader";
 export type { HyperframesLoaderProps } from "./HyperframesLoader";
+export { Tooltip } from "./Tooltip";

--- a/packages/studio/src/hooks/useBlockCatalog.ts
+++ b/packages/studio/src/hooks/useBlockCatalog.ts
@@ -56,7 +56,11 @@ export function useBlockCatalog() {
     if (search.trim()) {
       const q = search.toLowerCase();
       result = result.filter(
-        (b) => b.title.toLowerCase().includes(q) || b.description.toLowerCase().includes(q),
+        (b) =>
+          b.title.toLowerCase().includes(q) ||
+          b.description.toLowerCase().includes(q) ||
+          b.category.toLowerCase().includes(q) ||
+          b.tags?.some((t) => t.toLowerCase().includes(q)),
       );
     }
     return result;

--- a/packages/studio/src/player/components/PlayerControls.tsx
+++ b/packages/studio/src/player/components/PlayerControls.tsx
@@ -342,6 +342,7 @@ export const PlayerControls = memo(function PlayerControls({
       {/* Play/Pause button */}
       <button
         type="button"
+        title={isPlaying ? "Pause" : "Play"}
         aria-label={isPlaying ? "Pause" : "Play"}
         onClick={() => {
           trackStudioEvent("playback", { action: isPlaying ? "pause" : "play" });
@@ -528,6 +529,7 @@ export const PlayerControls = memo(function PlayerControls({
           type="button"
           onClick={() => setShowSpeedMenu((v) => !v)}
           disabled={disabled}
+          title="Playback speed"
           className="w-10 px-2 py-1 rounded-md text-[10px] font-mono tabular-nums transition-colors"
           style={{ color: "#71717A", background: "rgba(255,255,255,0.04)" }}
         >
@@ -664,6 +666,7 @@ export const PlayerControls = memo(function PlayerControls({
               ? "border-neutral-600 text-neutral-200 bg-neutral-800"
               : "border-neutral-800 text-neutral-600 hover:text-neutral-300 hover:border-neutral-600"
           }`}
+          title="Shortcuts and tools"
           aria-label="Shortcuts and tools"
           aria-expanded={showShortcuts}
         >
@@ -712,6 +715,7 @@ export const PlayerControls = memo(function PlayerControls({
                 <button
                   type="submit"
                   disabled={disabled}
+                  title="Jump to frame"
                   className="h-6 px-2 rounded border border-neutral-700 text-[10px] text-neutral-300 transition-colors hover:border-neutral-500 hover:bg-neutral-800 disabled:opacity-40"
                 >
                   Go
@@ -745,6 +749,7 @@ export const PlayerControls = memo(function PlayerControls({
                           type="button"
                           onClick={() => setInPoint(null)}
                           className="w-4 h-4 flex items-center justify-center rounded text-neutral-500 hover:text-neutral-200 transition-colors"
+                          title="Clear in-point"
                           aria-label="Clear in-point"
                         >
                           <svg
@@ -784,6 +789,7 @@ export const PlayerControls = memo(function PlayerControls({
                           type="button"
                           onClick={() => setOutPoint(null)}
                           className="w-4 h-4 flex items-center justify-center rounded text-neutral-500 hover:text-neutral-200 transition-colors"
+                          title="Clear out-point"
                           aria-label="Clear out-point"
                         >
                           <svg

--- a/packages/studio/src/player/components/PlayerControls.tsx
+++ b/packages/studio/src/player/components/PlayerControls.tsx
@@ -4,6 +4,7 @@ import { formatFrameTime, frameToSeconds, stepFrameTime, formatTime } from "../l
 import { shouldMutePreviewAudio } from "../lib/timelineIframeHelpers";
 import { usePlayerStore, liveTime } from "../store/playerStore";
 import { trackStudioEvent } from "../../utils/studioTelemetry";
+import { Tooltip } from "../../components/ui";
 
 const SPEED_OPTIONS = [0.25, 0.5, 1, 1.5, 2] as const;
 const SEEK_EDGE_SNAP_PX = 8;
@@ -340,47 +341,51 @@ export const PlayerControls = memo(function PlayerControls({
       }}
     >
       {/* Play/Pause button */}
-      <button
-        type="button"
-        title={isPlaying ? "Pause" : "Play"}
-        aria-label={isPlaying ? "Pause" : "Play"}
-        onClick={() => {
-          trackStudioEvent("playback", { action: isPlaying ? "pause" : "play" });
-          onTogglePlay();
-        }}
-        disabled={controlsDisabled}
-        className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg disabled:opacity-30 disabled:pointer-events-none transition-colors"
-        style={{ background: "rgba(255,255,255,0.06)" }}
-      >
-        {isPlaying ? (
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="#FAFAFA" aria-hidden="true">
-            <rect x="6" y="4" width="4" height="16" rx="1" />
-            <rect x="14" y="4" width="4" height="16" rx="1" />
-          </svg>
-        ) : (
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="#FAFAFA" aria-hidden="true">
-            <polygon points="6,3 20,12 6,21" />
-          </svg>
-        )}
-      </button>
+      <Tooltip label={isPlaying ? "Pause" : "Play"}>
+        <button
+          type="button"
+          aria-label={isPlaying ? "Pause" : "Play"}
+          onClick={() => {
+            trackStudioEvent("playback", { action: isPlaying ? "pause" : "play" });
+            onTogglePlay();
+          }}
+          disabled={controlsDisabled}
+          className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg disabled:opacity-30 disabled:pointer-events-none transition-colors"
+          style={{ background: "rgba(255,255,255,0.06)" }}
+        >
+          {isPlaying ? (
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="#FAFAFA" aria-hidden="true">
+              <rect x="6" y="4" width="4" height="16" rx="1" />
+              <rect x="14" y="4" width="4" height="16" rx="1" />
+            </svg>
+          ) : (
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="#FAFAFA" aria-hidden="true">
+              <polygon points="6,3 20,12 6,21" />
+            </svg>
+          )}
+        </button>
+      </Tooltip>
 
       {/* Time display — click to toggle time/frame mode */}
-      <button
-        type="button"
-        onClick={() => setTimeDisplayMode((m) => (m === "time" ? "frame" : "time"))}
-        disabled={disabled}
-        title={timeDisplayMode === "time" ? "Switch to frame display" : "Switch to time display"}
-        className="font-mono text-[11px] tabular-nums flex-shrink-0 w-[118px] text-left transition-colors disabled:pointer-events-none hover:opacity-80"
-        style={{ color: "#A1A1AA", cursor: "pointer" }}
+      <Tooltip
+        label={timeDisplayMode === "time" ? "Switch to frame display" : "Switch to time display"}
       >
-        <span ref={timeDisplayRef}>{formatTime(0)}</span>
-        {timeDisplayMode === "time" ? (
-          <>
-            <span style={{ color: "#3F3F46", margin: "0 2px" }}>/</span>
-            <span style={{ color: "#52525B" }}>{formatTime(duration)}</span>
-          </>
-        ) : null}
-      </button>
+        <button
+          type="button"
+          onClick={() => setTimeDisplayMode((m) => (m === "time" ? "frame" : "time"))}
+          disabled={disabled}
+          className="font-mono text-[11px] tabular-nums flex-shrink-0 w-[118px] text-left transition-colors disabled:pointer-events-none hover:opacity-80"
+          style={{ color: "#A1A1AA", cursor: "pointer" }}
+        >
+          <span ref={timeDisplayRef}>{formatTime(0)}</span>
+          {timeDisplayMode === "time" ? (
+            <>
+              <span style={{ color: "#3F3F46", margin: "0 2px" }}>/</span>
+              <span style={{ color: "#52525B" }}>{formatTime(duration)}</span>
+            </>
+          ) : null}
+        </button>
+      </Tooltip>
 
       {/* Seek bar — teal progress fill */}
       <div
@@ -470,71 +475,73 @@ export const PlayerControls = memo(function PlayerControls({
       </div>
 
       {/* Mute toggle */}
-      <button
-        type="button"
-        onClick={() => {
-          if (!audioAutoMuted) {
-            trackStudioEvent("playback", { action: "mute_toggle", muted: !audioMuted });
-            setAudioMuted(!audioMuted);
-          }
-        }}
-        disabled={controlsDisabled || audioAutoMuted}
-        title={muteButtonLabel}
-        aria-label={muteButtonLabel}
-        aria-pressed={effectiveAudioMuted}
-        className={`h-7 w-7 flex-shrink-0 flex items-center justify-center rounded-md border transition-colors disabled:pointer-events-none ${
-          effectiveAudioMuted
-            ? "text-studio-accent bg-studio-accent/10 border-studio-accent/30"
-            : "border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:bg-neutral-800"
-        } ${audioAutoMuted ? "opacity-70" : ""}`}
-      >
-        {effectiveAudioMuted ? (
-          <svg
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M11 5 6 9H3v6h3l5 4V5Z" />
-            <path d="m19 9-6 6" />
-            <path d="m13 9 6 6" />
-          </svg>
-        ) : (
-          <svg
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M11 5 6 9H3v6h3l5 4V5Z" />
-            <path d="M15.5 8.5a5 5 0 0 1 0 7" />
-            <path d="M18.5 5.5a9 9 0 0 1 0 13" />
-          </svg>
-        )}
-      </button>
+      <Tooltip label={muteButtonLabel}>
+        <button
+          type="button"
+          onClick={() => {
+            if (!audioAutoMuted) {
+              trackStudioEvent("playback", { action: "mute_toggle", muted: !audioMuted });
+              setAudioMuted(!audioMuted);
+            }
+          }}
+          disabled={controlsDisabled || audioAutoMuted}
+          aria-label={muteButtonLabel}
+          aria-pressed={effectiveAudioMuted}
+          className={`h-7 w-7 flex-shrink-0 flex items-center justify-center rounded-md border transition-colors disabled:pointer-events-none ${
+            effectiveAudioMuted
+              ? "text-studio-accent bg-studio-accent/10 border-studio-accent/30"
+              : "border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:bg-neutral-800"
+          } ${audioAutoMuted ? "opacity-70" : ""}`}
+        >
+          {effectiveAudioMuted ? (
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M11 5 6 9H3v6h3l5 4V5Z" />
+              <path d="m19 9-6 6" />
+              <path d="m13 9 6 6" />
+            </svg>
+          ) : (
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M11 5 6 9H3v6h3l5 4V5Z" />
+              <path d="M15.5 8.5a5 5 0 0 1 0 7" />
+              <path d="M18.5 5.5a9 9 0 0 1 0 13" />
+            </svg>
+          )}
+        </button>
+      </Tooltip>
 
       {/* Speed control */}
       <div ref={speedMenuContainerRef} className="relative flex-shrink-0">
-        <button
-          type="button"
-          onClick={() => setShowSpeedMenu((v) => !v)}
-          disabled={disabled}
-          title="Playback speed"
-          className="w-10 px-2 py-1 rounded-md text-[10px] font-mono tabular-nums transition-colors"
-          style={{ color: "#71717A", background: "rgba(255,255,255,0.04)" }}
-        >
-          {playbackRate === 1 ? "1x" : `${playbackRate}x`}
-        </button>
+        <Tooltip label="Playback speed">
+          <button
+            type="button"
+            onClick={() => setShowSpeedMenu((v) => !v)}
+            disabled={disabled}
+            className="w-10 px-2 py-1 rounded-md text-[10px] font-mono tabular-nums transition-colors"
+            style={{ color: "#71717A", background: "rgba(255,255,255,0.04)" }}
+          >
+            {playbackRate === 1 ? "1x" : `${playbackRate}x`}
+          </button>
+        </Tooltip>
         {showSpeedMenu && (
           <div
             className="absolute bottom-full right-0 mb-1.5 rounded-lg shadow-xl z-50 min-w-[56px] overflow-hidden"
@@ -568,123 +575,126 @@ export const PlayerControls = memo(function PlayerControls({
         )}
       </div>
 
-      <button
-        type="button"
-        onClick={() => {
-          trackStudioEvent("playback", { action: "loop_toggle", enabled: !loopEnabled });
-          setLoopEnabled(!loopEnabled);
-        }}
-        disabled={disabled}
-        className={`h-7 w-7 flex items-center justify-center rounded-md border transition-colors ${
-          loopEnabled
-            ? "text-studio-accent bg-studio-accent/10 border-studio-accent/30"
-            : "border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:bg-neutral-800"
-        }`}
-        title="Loop playback"
-        aria-label={loopEnabled ? "Disable loop playback" : "Enable loop playback"}
-        aria-pressed={loopEnabled}
-      >
-        <svg
-          width="13"
-          height="13"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M17 2l4 4-4 4" />
-          <path d="M3 11V9a4 4 0 0 1 4-4h14" />
-          <path d="M7 22l-4-4 4-4" />
-          <path d="M21 13v2a4 4 0 0 1-4 4H3" />
-        </svg>
-      </button>
-
-      {/* Fullscreen toggle */}
-      {onToggleFullscreen && (
+      <Tooltip label="Loop playback">
         <button
           type="button"
           onClick={() => {
-            trackStudioEvent("playback", { action: "fullscreen_toggle", active: !isFullscreen });
-            onToggleFullscreen();
+            trackStudioEvent("playback", { action: "loop_toggle", enabled: !loopEnabled });
+            setLoopEnabled(!loopEnabled);
           }}
-          className={`h-7 w-7 flex-shrink-0 flex items-center justify-center rounded-md border transition-colors ${
-            isFullscreen
+          disabled={disabled}
+          className={`h-7 w-7 flex items-center justify-center rounded-md border transition-colors ${
+            loopEnabled
               ? "text-studio-accent bg-studio-accent/10 border-studio-accent/30"
               : "border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:bg-neutral-800"
           }`}
-          title={isFullscreen ? "Exit fullscreen (F)" : "Enter fullscreen (F)"}
-          aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-        >
-          {isFullscreen ? (
-            <svg
-              width="13"
-              height="13"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M8 3v3a2 2 0 0 1-2 2H3" />
-              <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
-              <path d="M3 16h3a2 2 0 0 1 2 2v3" />
-              <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
-            </svg>
-          ) : (
-            <svg
-              width="13"
-              height="13"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M8 3H5a2 2 0 0 0-2 2v3" />
-              <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
-              <path d="M3 16v3a2 2 0 0 0 2 2h3" />
-              <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
-            </svg>
-          )}
-        </button>
-      )}
-
-      {/* Keyboard shortcuts + frame jump + work area — click to open panel */}
-      <div ref={shortcutsPanelRef} className="relative flex-shrink-0">
-        <button
-          type="button"
-          onClick={() => setShowShortcuts((v) => !v)}
-          className={`w-6 h-6 flex items-center justify-center rounded border transition-colors ${
-            showShortcuts
-              ? "border-neutral-600 text-neutral-200 bg-neutral-800"
-              : "border-neutral-800 text-neutral-600 hover:text-neutral-300 hover:border-neutral-600"
-          }`}
-          title="Shortcuts and tools"
-          aria-label="Shortcuts and tools"
-          aria-expanded={showShortcuts}
+          aria-label={loopEnabled ? "Disable loop playback" : "Enable loop playback"}
+          aria-pressed={loopEnabled}
         >
           <svg
-            width="11"
-            height="11"
+            width="13"
+            height="13"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth="1.75"
+            strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
             aria-hidden="true"
           >
-            <rect x="2" y="4" width="20" height="16" rx="2" />
-            <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M8 16h8" />
+            <path d="M17 2l4 4-4 4" />
+            <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+            <path d="M7 22l-4-4 4-4" />
+            <path d="M21 13v2a4 4 0 0 1-4 4H3" />
           </svg>
         </button>
+      </Tooltip>
+
+      {/* Fullscreen toggle */}
+      {onToggleFullscreen && (
+        <Tooltip label={isFullscreen ? "Exit fullscreen (F)" : "Enter fullscreen (F)"}>
+          <button
+            type="button"
+            onClick={() => {
+              trackStudioEvent("playback", { action: "fullscreen_toggle", active: !isFullscreen });
+              onToggleFullscreen();
+            }}
+            className={`h-7 w-7 flex-shrink-0 flex items-center justify-center rounded-md border transition-colors ${
+              isFullscreen
+                ? "text-studio-accent bg-studio-accent/10 border-studio-accent/30"
+                : "border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:bg-neutral-800"
+            }`}
+            aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+          >
+            {isFullscreen ? (
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M8 3v3a2 2 0 0 1-2 2H3" />
+                <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
+                <path d="M3 16h3a2 2 0 0 1 2 2v3" />
+                <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+              </svg>
+            ) : (
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+                <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+                <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+                <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+              </svg>
+            )}
+          </button>
+        </Tooltip>
+      )}
+
+      {/* Keyboard shortcuts + frame jump + work area — click to open panel */}
+      <div ref={shortcutsPanelRef} className="relative flex-shrink-0">
+        <Tooltip label="Shortcuts and tools">
+          <button
+            type="button"
+            onClick={() => setShowShortcuts((v) => !v)}
+            className={`w-6 h-6 flex items-center justify-center rounded border transition-colors ${
+              showShortcuts
+                ? "border-neutral-600 text-neutral-200 bg-neutral-800"
+                : "border-neutral-800 text-neutral-600 hover:text-neutral-300 hover:border-neutral-600"
+            }`}
+            aria-label="Shortcuts and tools"
+            aria-expanded={showShortcuts}
+          >
+            <svg
+              width="11"
+              height="11"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="2" y="4" width="20" height="16" rx="2" />
+              <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M8 16h8" />
+            </svg>
+          </button>
+        </Tooltip>
         {showShortcuts && (
           <div
             className="absolute bottom-full right-0 mb-2 z-50 rounded-lg shadow-xl min-w-[220px] overflow-y-auto"
@@ -712,14 +722,15 @@ export const PlayerControls = memo(function PlayerControls({
                   onKeyDown={handleJumpKeyDown}
                   onBlur={commitJumpFrame}
                 />
-                <button
-                  type="submit"
-                  disabled={disabled}
-                  title="Jump to frame"
-                  className="h-6 px-2 rounded border border-neutral-700 text-[10px] text-neutral-300 transition-colors hover:border-neutral-500 hover:bg-neutral-800 disabled:opacity-40"
-                >
-                  Go
-                </button>
+                <Tooltip label="Jump to frame">
+                  <button
+                    type="submit"
+                    disabled={disabled}
+                    className="h-6 px-2 rounded border border-neutral-700 text-[10px] text-neutral-300 transition-colors hover:border-neutral-500 hover:bg-neutral-800 disabled:opacity-40"
+                  >
+                    Go
+                  </button>
+                </Tooltip>
               </form>
             </div>
             <div style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }} />
@@ -745,24 +756,25 @@ export const PlayerControls = memo(function PlayerControls({
                         <span className="font-mono text-[10px] text-neutral-300">
                           {formatTime(inPoint)}
                         </span>
-                        <button
-                          type="button"
-                          onClick={() => setInPoint(null)}
-                          className="w-4 h-4 flex items-center justify-center rounded text-neutral-500 hover:text-neutral-200 transition-colors"
-                          title="Clear in-point"
-                          aria-label="Clear in-point"
-                        >
-                          <svg
-                            width="8"
-                            height="8"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2.5"
+                        <Tooltip label="Clear in-point">
+                          <button
+                            type="button"
+                            onClick={() => setInPoint(null)}
+                            className="w-4 h-4 flex items-center justify-center rounded text-neutral-500 hover:text-neutral-200 transition-colors"
+                            aria-label="Clear in-point"
                           >
-                            <path d="M18 6L6 18M6 6l12 12" />
-                          </svg>
-                        </button>
+                            <svg
+                              width="8"
+                              height="8"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2.5"
+                            >
+                              <path d="M18 6L6 18M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </Tooltip>
                       </>
                     ) : (
                       <span className="text-[10px] text-neutral-600">—</span>
@@ -785,24 +797,25 @@ export const PlayerControls = memo(function PlayerControls({
                         <span className="font-mono text-[10px] text-neutral-300">
                           {formatTime(outPoint)}
                         </span>
-                        <button
-                          type="button"
-                          onClick={() => setOutPoint(null)}
-                          className="w-4 h-4 flex items-center justify-center rounded text-neutral-500 hover:text-neutral-200 transition-colors"
-                          title="Clear out-point"
-                          aria-label="Clear out-point"
-                        >
-                          <svg
-                            width="8"
-                            height="8"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2.5"
+                        <Tooltip label="Clear out-point">
+                          <button
+                            type="button"
+                            onClick={() => setOutPoint(null)}
+                            className="w-4 h-4 flex items-center justify-center rounded text-neutral-500 hover:text-neutral-200 transition-colors"
+                            aria-label="Clear out-point"
                           >
-                            <path d="M18 6L6 18M6 6l12 12" />
-                          </svg>
-                        </button>
+                            <svg
+                              width="8"
+                              height="8"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2.5"
+                            >
+                              <path d="M18 6L6 18M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </Tooltip>
                       </>
                     ) : (
                       <span className="text-[10px] text-neutral-600">—</span>

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -407,16 +407,6 @@ export function useTimelinePlayer() {
         if (usePlayerStore.getState().isPlaying) setIsPlaying(false);
         shuttleDirectionRef.current = null;
         shuttleSpeedIndexRef.current = 0;
-        try {
-          const doc = iframeRef.current?.contentDocument;
-          if (doc) {
-            for (const el of doc.querySelectorAll("video, audio")) {
-              (el as HTMLMediaElement).pause();
-            }
-          }
-        } catch {
-          /* cross-origin */
-        }
       }
       return true;
     },

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -407,6 +407,16 @@ export function useTimelinePlayer() {
         if (usePlayerStore.getState().isPlaying) setIsPlaying(false);
         shuttleDirectionRef.current = null;
         shuttleSpeedIndexRef.current = 0;
+        try {
+          const doc = iframeRef.current?.contentDocument;
+          if (doc) {
+            for (const el of doc.querySelectorAll("video, audio")) {
+              (el as HTMLMediaElement).pause();
+            }
+          }
+        } catch {
+          /* cross-origin */
+        }
       }
       return true;
     },

--- a/packages/studio/src/player/lib/playbackAdapter.test.ts
+++ b/packages/studio/src/player/lib/playbackAdapter.test.ts
@@ -18,13 +18,13 @@ describe("wrapTimeline seek keepPlaying option (#834)", () => {
     };
   }
 
-  it("default seek pauses the GSAP timeline before seeking", () => {
+  it("default seek pauses the GSAP timeline before and after seeking", () => {
     const tl = mockTimeline();
     const adapter = wrapTimeline(tl);
 
     adapter.seek(5);
 
-    expect(tl.pause).toHaveBeenCalledTimes(1);
+    expect(tl.pause).toHaveBeenCalledTimes(2);
     expect(tl.seek).toHaveBeenCalledWith(5);
   });
 
@@ -44,7 +44,7 @@ describe("wrapTimeline seek keepPlaying option (#834)", () => {
 
     adapter.seek(5, { keepPlaying: false });
 
-    expect(tl.pause).toHaveBeenCalledTimes(1);
+    expect(tl.pause).toHaveBeenCalledTimes(2);
     expect(tl.seek).toHaveBeenCalledWith(5);
   });
 });

--- a/packages/studio/src/player/lib/playbackAdapter.ts
+++ b/packages/studio/src/player/lib/playbackAdapter.ts
@@ -135,8 +135,10 @@ export function wrapTimeline(tl: TimelineLike): PlaybackAdapter {
     play: () => tl.play(),
     pause: () => tl.pause(),
     seek: (t, options) => {
-      if (!options?.keepPlaying) tl.pause();
+      const shouldPause = !options?.keepPlaying;
+      if (shouldPause) tl.pause();
       tl.seek(t);
+      if (shouldPause) tl.pause();
     },
     getTime: () => tl.time(),
     getDuration: () => tl.duration(),

--- a/packages/studio/src/utils/timelineAssetDrop.test.ts
+++ b/packages/studio/src/utils/timelineAssetDrop.test.ts
@@ -155,6 +155,7 @@ describe("insertTimelineAssetIntoSource", () => {
       '<img id="photo_asset" data-start="0" data-duration="3" />',
     );
 
-    expect(html).toContain('<div id="root" data-composition-id="main"><img id="photo_asset"');
+    expect(html).toContain('data-composition-id="main">');
+    expect(html).toContain('<img id="photo_asset"');
   });
 });


### PR DESCRIPTION
## Summary

- Add Catalog tab (behind `VITE_STUDIO_ENABLE_BLOCKS_PANEL` flag) with registry block/component browser
- Runtime env injection so `VITE_STUDIO_*` flags work in embedded mode without rebuilding
- Replace fullscreen hover popup with inline preview in the main player area
- "Ask agent" copies category-specific prompts with full composition context (playhead time, visible elements, dimensions)
- "Add" button for VFX, Social, Scenes categories; Ask agent only for Captions, Transitions, Effects, Data
- Search matches category names and tags
- Show main composition behind component sub-composition previews (no more black void)
- Rewrite block dimensions to match host project on install
- Read z-index from live iframe DOM instead of regex
- Format inserted HTML with proper indentation
- Blocks start at current playhead, root duration auto-extends
- Lift block drop handling above DomEditOverlay
- Rename "Layer" to "Z-index" in design panel
- Tooltips on tabs and action buttons

## Test plan

- [ ] `VITE_STUDIO_ENABLE_BLOCKS_PANEL=1 npx hyperframes preview` shows Catalog tab
- [ ] Clicking "Ask agent" copies prompt with composition state to clipboard
- [ ] VFX/Social/Scenes cards show Add + Ask agent; others show Ask agent only
- [ ] Search "captions" returns caption blocks
- [ ] Viewing a component in Comps tab shows main composition behind it