### PR TITLE
fix(core): preserve replace-pattern characters in bundled runtime IIFE

### DIFF
--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { parseHTML } from "linkedom";
 import { describe, it, expect } from "vitest";
 import { bundleToSingleHtml } from "./htmlBundler";
+import { getHyperframeRuntimeScript } from "../generated/runtime-inline";
 
 function makeTempProject(files: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), "hf-bundler-test-"));
@@ -80,6 +81,55 @@ describe("bundleToSingleHtml", () => {
     // Must have a non-trivial inlined body (the runtime IIFE is ~150KB).
     const innerLength = (runtimeBlock!.match(/>([\s\S]*?)<\/script>/)?.[1] ?? "").length;
     expect(innerLength).toBeGreaterThan(1000);
+  });
+
+  it("preserves `$&` replace-pattern characters in the inlined runtime body", async () => {
+    // Regression guard: `injectInterceptor` used to insert the runtime via
+    // `sanitized.replace("</head>", `${tag}\n</head>`)`. `String.prototype.replace`'s
+    // second argument is a substitution template — `$&` expands to the matched
+    // substring (here, `</head>`). The minified runtime IIFE contains legitimate
+    // `$&` sequences (e.g. `if(te&&$&!y.hasAttribute(...))`), so the bundler
+    // silently injected stray `</head>` tags inside the runtime, producing a JS
+    // SyntaxError that broke every timeline in the bundle. Switching to the
+    // function-replacer form passes the runtime body through verbatim.
+    // Use a document with an explicit `<head>` so the bundler takes the
+    // `sanitized.replace("</head>", …)` injection path — the only branch that
+    // exercises the substitution-template behavior. Authoring without a
+    // `<head>` falls back to slice+concat (safe but doesn't catch this bug).
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><head></head><body>
+  <div data-composition-id="root" data-width="320" data-height="180"></div>
+</body></html>`,
+    });
+
+    const previousUrl = process.env.HYPERFRAME_RUNTIME_URL;
+    delete process.env.HYPERFRAME_RUNTIME_URL;
+    let bundled: string;
+    try {
+      bundled = await bundleToSingleHtml(dir);
+    } finally {
+      if (previousUrl !== undefined) process.env.HYPERFRAME_RUNTIME_URL = previousUrl;
+    }
+
+    const original = getHyperframeRuntimeScript();
+    // Sanity: the built runtime exercises this regression (no `$&` means the
+    // test would tautologically pass even with the broken implementation).
+    expect(original).toContain("$&");
+
+    const runtimeBlock = bundled.match(
+      /<script\b[^>]*data-hyperframes-preview-runtime[^>]*>([\s\S]*?)<\/script>/i,
+    );
+    expect(runtimeBlock).not.toBeNull();
+    const runtimeBody = runtimeBlock?.[1] ?? "";
+    expect(runtimeBody).toBe(original);
+
+    // Defense in depth: the entire bundled document should contain exactly one
+    // `</head>` — the real closing tag. Before the fix, every `$&` in the
+    // runtime expanded to an extra `</head>` inside the inlined IIFE,
+    // producing a `Unexpected token '<'` SyntaxError at parse time.
+    const headCloses = bundled.match(/<\/head>/g) ?? [];
+    expect(headCloses.length).toBe(1);
   });
 
   it("preserves chunk integrity when a chunk ends with a line comment (ASI hazard guard)", async () => {

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -52,7 +52,14 @@ function injectInterceptor(html: string, runtimeMode: "inline" | "placeholder" =
     tag = `<script ${RUNTIME_BOOTSTRAP_ATTR}="1">${inlinedRuntime}</script>`;
   }
   if (sanitized.includes("</head>")) {
-    return sanitized.replace("</head>", `${tag}\n</head>`);
+    // Use a function replacer so `String.prototype.replace`'s substitution
+    // patterns (`$&`, `$$`, `$'`, `` $` ``, `$1`–`$99`) inside the inlined
+    // runtime IIFE are passed through verbatim. The minified runtime
+    // contains the literal sequence `$&` as part of legitimate JS, and
+    // the older `(pattern, string)` form would expand it to the matched
+    // `</head>`, silently corrupting the runtime and breaking every
+    // timeline in the bundle with a parse-time SyntaxError.
+    return sanitized.replace("</head>", () => `${tag}\n</head>`);
   }
   const htmlOpenMatch = sanitized.match(/<html\b[^>]*>/i);
   if (htmlOpenMatch?.index != null) {


### PR DESCRIPTION
## What

In `packages/core/src/compiler/htmlBundler.ts:55`, switch the runtime injection from `sanitized.replace("</head>", \`${tag}\n</head>\`)` to the function-replacer form `sanitized.replace("</head>", () => \`${tag}\n</head>\`)`, and add a regression test in `htmlBundler.test.ts`.

## Why

`String.prototype.replace`'s second argument is a substitution template — `$&` expands to the matched substring, and `$$`, `$'`, `` $` ``, `$1`–`$99` have similar meanings. The minified runtime IIFE returned by `getHyperframeRuntimeScript()` contains legitimate `$&` sequences in operator-adjacent positions (e.g. `if(te&&$&!y.hasAttribute(...))`) and `$2` capture-group references in regex contexts. With the old two-argument form, every `$&` inside the inlined runtime body was silently rewritten to the matched substring `</head>`, turning real JS like `te&&$&!y.hasAttribute(…)` into `te&&</head>&!y.hasAttribute(…)` and producing a parse-time `SyntaxError: Unexpected token '<'`. That single error tears down the runtime IIFE, so `__renderReady` never flips, no `__player.seek` ever wires up, and every `window.__timelines[*]` stays paused at frame 0 — the entire bundled HTML renders empty.

The same code path is hit by `hyperframes snapshot`, `hyperframes preview` (studio), `hyperframes validate`, and `hyperframes layout`, because all four consume `bundleToSingleHtml`. Render is unaffected: `producer/services/fileServer.ts` already inserts the runtime via `injectScriptsIntoHtml` (`htmlDocument.ts:186`), which has been on the function-replacer form. The two paths were silently diverging, and only the bundler was buggy.

## How

One-line code change: pass a callback to `String.prototype.replace` instead of a substitution template, so the runtime body is forwarded verbatim and no `$`-pattern expansion runs. A comment at the call site spells out the failure mode and why both paths in `injectInterceptor` are not equally affected (the no-`<head>` fallback uses `slice` + concat, which never invokes substitution at all).

I considered escaping `$` in the replacement string instead (`tag.replace(/\$/g, "$$$$")`), but that pushes the burden onto every future change to `tag` and is easy to forget when adding more dynamic content. The function-replacer form is the canonical fix recommended by MDN for exactly this hazard.

## Test plan

Added `htmlBundler.test.ts > preserves \`$&\` replace-pattern characters in the inlined runtime body`:

1. Bundle a project whose `index.html` includes an explicit `<head>` (the only path that exercises the substitution-template branch — the no-`<head>` fallback is already safe).
2. Sanity-assert that the built runtime contains `$&`, so the test isn't tautological on future runtime builds without those sequences.
3. Extract the runtime `<script>` body from the bundled output and assert it is byte-equal to `getHyperframeRuntimeScript()`.
4. Assert the entire bundled document contains exactly one `</head>` — defense in depth, because every `$&` in the runtime would expand to an extra `</head>` before the fix.

I verified the regression test catches the bug by temporarily reverting `htmlBundler.ts` to the two-argument form: the new test fails, the existing 31 tests still pass. With the fix re-applied, all 32 tests pass.

- [x] Unit tests added/updated
- [x] Manual testing performed (reproduced the original SyntaxError on a real composition, confirmed it disappears after the fix; verified `bun run --filter
@hyperframes/core test htmlBundler` and `bunx oxlint` / `bunx oxfmt --check` all pass)
- [x] Documentation updated (not applicable — pure bug fix, no API or behavior surface change beyond what authors already expect)
