### PR TITLE
fix(engine): skip video frame injection when a sub-composition host is hidden

### DIFF
--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -232,10 +232,16 @@ async function captureSnapshots(
 
       // Chrome-headless ignores programmatic <video>.currentTime writes, so
       // we extract frames via FFmpeg and overlay them as <img> elements.
+      //
+      // The engine's injectVideoFramesBatch returns the subset of videoIds it
+      // actually painted (skipped ancestor-hidden videos are excluded).
+      // Snapshot doesn't use the return value, but the local type must match
+      // the real export — a `Promise<void>` shape rejects the `as` cast on
+      // the dynamic import.
       type InjectFn = (
         page: unknown,
         updates: Array<{ videoId: string; dataUri: string }>,
-      ) => Promise<void>;
+      ) => Promise<string[]>;
       type SyncVisibilityFn = (page: unknown, activeVideoIds: string[]) => Promise<void>;
       type ExtractMediaMetadataFn = (
         filePath: string,

--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -6,6 +6,7 @@ import {
   pageScreenshotCapture,
   cdpSessionCache,
   injectVideoFramesBatch,
+  syncVideoFrameVisibility,
 } from "./screenshotService.js";
 
 // Stub a Page + CDPSession just enough that pageScreenshotCapture can call
@@ -189,5 +190,197 @@ describe("injectVideoFramesBatch replacement layout", () => {
     expect(img?.style.right).toBe("auto");
     expect(img?.style.bottom).toBe("auto");
     expect(img?.style.inset).toBe("auto");
+  });
+});
+
+describe("video-frame injection respects ancestor visibility", () => {
+  // Regression guard: the runtime's `[data-start]` lifecycle hides
+  // out-of-window sub-composition hosts with `visibility:hidden`, but the
+  // injector used to ignore that and paint a replacement <img> for every
+  // active `<video data-start>` element. Inner-PIP videos inside *other*
+  // moments still appear active in the raw time-window check (their auto-
+  // injected `data-start="0"` + probed full-source duration cover the
+  // whole timeline), so the bug produced one full-bleed speaker overlay
+  // per inactive sub-comp — covering whichever moment was actually visible.
+  // See: https://github.com/lirian-su-opus/hyperframes branch issue thread.
+
+  type StyleLike = {
+    display?: string;
+    visibility?: string;
+    opacity?: string;
+    objectFit?: string;
+    objectPosition?: string;
+    zIndex?: string;
+  };
+
+  function setupHostHiddenScenario(hostStyle: StyleLike) {
+    const { window, document } = parseHTML(
+      '<html><body><div id="host"><div id="pip-frame"><video id="pip" data-start="0" data-duration="10"></video></div></div></body></html>',
+    );
+
+    Object.defineProperty(window.HTMLImageElement.prototype, "decode", {
+      configurable: true,
+      value: () => Promise.resolve(),
+    });
+
+    const host = document.getElementById("host") as HTMLElement;
+    const pipFrame = document.getElementById("pip-frame") as HTMLElement;
+    const video = document.getElementById("pip") as HTMLVideoElement;
+
+    Object.defineProperties(video, {
+      offsetLeft: { configurable: true, get: () => 0 },
+      offsetTop: { configurable: true, get: () => 0 },
+      offsetWidth: { configurable: true, get: () => 1080 },
+      offsetHeight: { configurable: true, get: () => 1920 },
+    });
+    video.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: 1080,
+        bottom: 1920,
+        width: 1080,
+        height: 1920,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const styles = new Map<Element, StyleLike>();
+    styles.set(host, hostStyle);
+    styles.set(pipFrame, {});
+    styles.set(video, { opacity: "1", objectFit: "cover", objectPosition: "center", zIndex: "1" });
+
+    Object.defineProperty(window, "getComputedStyle", {
+      configurable: true,
+      value: (el: Element) => {
+        const declared = styles.get(el) ?? {};
+        return {
+          display: declared.display ?? "block",
+          visibility: declared.visibility ?? "visible",
+          opacity: declared.opacity ?? "1",
+          objectFit: declared.objectFit ?? "fill",
+          objectPosition: declared.objectPosition ?? "50% 50%",
+          zIndex: declared.zIndex ?? "auto",
+          getPropertyValue: (prop: string) => {
+            const camel = prop.replace(/-([a-z])/g, (_, c: string) =>
+              c.toUpperCase(),
+            ) as keyof StyleLike;
+            return declared[camel] ?? "";
+          },
+        };
+      },
+    });
+
+    return { window, document, video, host, pipFrame };
+  }
+
+  function withGlobals<T extends { window: Window; document: Document; video: HTMLVideoElement }>(
+    setup: T,
+  ): { teardown: () => void; setup: T } {
+    const globals = globalThis as unknown as { window?: Window; document?: Document };
+    const previousWindow = globals.window;
+    const previousDocument = globals.document;
+    globals.window = setup.window;
+    globals.document = setup.document;
+    return {
+      setup,
+      teardown: () => {
+        globals.window = previousWindow;
+        globals.document = previousDocument;
+      },
+    };
+  }
+
+  function passthroughPage(): Page {
+    return {
+      evaluate: async (fn: (...args: unknown[]) => unknown, ...args: unknown[]) =>
+        // The implementation is built to run inside the page sandbox via
+        // `page.evaluate`, but linkedom gives us a DOM compatible enough to
+        // execute the function body directly in Node.
+        Promise.resolve((fn as (...a: unknown[]) => unknown)(...args)),
+    } as unknown as Page;
+  }
+
+  it("skips replacement-frame creation when the video's host has visibility:hidden", async () => {
+    const { teardown, setup } = withGlobals(setupHostHiddenScenario({ visibility: "hidden" }));
+    try {
+      await injectVideoFramesBatch(passthroughPage(), [
+        {
+          videoId: "pip",
+          dataUri:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=",
+        },
+      ]);
+    } finally {
+      teardown();
+    }
+
+    // No replacement <img> should be injected next to the video — the host is
+    // currently hidden, so painting a frame over it would bleed onto whichever
+    // sibling host is actually visible on this seek.
+    const sibling = setup.video.nextElementSibling as HTMLElement | null;
+    expect(sibling).toBeNull();
+  });
+
+  it("skips replacement-frame creation when the video's host has display:none", async () => {
+    const { teardown, setup } = withGlobals(setupHostHiddenScenario({ display: "none" }));
+    try {
+      await injectVideoFramesBatch(passthroughPage(), [
+        {
+          videoId: "pip",
+          dataUri:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=",
+        },
+      ]);
+    } finally {
+      teardown();
+    }
+
+    const sibling = setup.video.nextElementSibling as HTMLElement | null;
+    expect(sibling).toBeNull();
+  });
+
+  it("hides an existing replacement <img> when the host becomes visibility:hidden", async () => {
+    // First seed an existing __render_frame__ <img> next to the video (the
+    // state the page is in after a previous seek when the host was visible).
+    const { teardown, setup } = withGlobals(setupHostHiddenScenario({ visibility: "hidden" }));
+    const seededImg = setup.document.createElement("img");
+    seededImg.classList.add("__render_frame__");
+    seededImg.style.visibility = "visible";
+    setup.video.parentNode?.insertBefore(seededImg, setup.video.nextSibling);
+
+    try {
+      await injectVideoFramesBatch(passthroughPage(), [
+        {
+          videoId: "pip",
+          dataUri:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=",
+        },
+      ]);
+    } finally {
+      teardown();
+    }
+
+    expect(seededImg.style.visibility).toBe("hidden");
+  });
+
+  it("syncVideoFrameVisibility hides the replacement <img> for ancestor-hidden actives", async () => {
+    const { teardown, setup } = withGlobals(setupHostHiddenScenario({ visibility: "hidden" }));
+    const seededImg = setup.document.createElement("img");
+    seededImg.classList.add("__render_frame__");
+    seededImg.style.visibility = "visible";
+    setup.video.parentNode?.insertBefore(seededImg, setup.video.nextSibling);
+
+    try {
+      // "pip" IS in the active set (per the raw time-window check) but the
+      // host is hidden. sync must keep the <img> hidden, not flip it to
+      // `visibility: visible`.
+      await syncVideoFrameVisibility(passthroughPage(), ["pip"]);
+    } finally {
+      teardown();
+    }
+
+    expect(seededImg.style.visibility).toBe("hidden");
   });
 });

--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -202,6 +202,17 @@ describe("video-frame injection respects ancestor visibility", () => {
   // injected `data-start="0"` + probed full-source duration cover the
   // whole timeline), so the bug produced one full-bleed speaker overlay
   // per inactive sub-comp — covering whichever moment was actually visible.
+  //
+  // The skip is intentionally narrow: `visibility:hidden` on a regular
+  // `[data-start]` container must NOT skip injection, because the
+  // replacement <img>'s explicit `visibility:visible` overrides the
+  // ancestor (CSS spec) and consumers rely on that to hold the final
+  // GSAP-driven frame when an authored `data-duration` outlives the
+  // composition's GSAP timeline. We therefore only treat
+  // `visibility:hidden` as a skip signal on sub-composition hosts
+  // (`[data-composition-src]` / `[data-composition-file]`). `display:none`,
+  // by contrast, takes the whole subtree out of layout regardless of any
+  // child override, so it always triggers the skip.
 
   type StyleLike = {
     display?: string;
@@ -212,9 +223,19 @@ describe("video-frame injection respects ancestor visibility", () => {
     zIndex?: string;
   };
 
-  function setupHostHiddenScenario(hostStyle: StyleLike) {
+  type HostAttribute = "data-composition-src" | "data-composition-file" | "data-start";
+
+  function setupHostHiddenScenario(
+    hostStyle: StyleLike,
+    options: { hostAttribute?: HostAttribute } = {},
+  ) {
+    const hostAttribute = options.hostAttribute ?? "data-composition-src";
+    const hostAttrMarkup =
+      hostAttribute === "data-start"
+        ? 'data-start="0" data-duration="10"'
+        : `${hostAttribute}="sub.html"`;
     const { window, document } = parseHTML(
-      '<html><body><div id="host"><div id="pip-frame"><video id="pip" data-start="0" data-duration="10"></video></div></div></body></html>',
+      `<html><body><div id="host" ${hostAttrMarkup}><div id="pip-frame"><video id="pip" data-start="0" data-duration="10"></video></div></div></body></html>`,
     );
 
     Object.defineProperty(window.HTMLImageElement.prototype, "decode", {
@@ -381,5 +402,55 @@ describe("video-frame injection respects ancestor visibility", () => {
     }
 
     expect(seededImg.style.visibility).toBe("hidden");
+  });
+
+  it("still injects when a plain [data-start] host is visibility:hidden (CSS-escapable)", async () => {
+    // Regression guard for the style-9-prod symptom: a regular
+    // `[data-start]` container whose GSAP timeline is shorter than its
+    // authored `data-duration` ends up `visibility: hidden` past the
+    // timeline end. The replacement <img>'s explicit `visibility: visible`
+    // correctly overrides that per CSS spec, so the injector must NOT
+    // short-circuit — it would otherwise drop the final-state frame and
+    // produce blank tail frames.
+    const { teardown, setup } = withGlobals(
+      setupHostHiddenScenario({ visibility: "hidden" }, { hostAttribute: "data-start" }),
+    );
+
+    try {
+      await injectVideoFramesBatch(passthroughPage(), [
+        {
+          videoId: "pip",
+          dataUri:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=",
+        },
+      ]);
+    } finally {
+      teardown();
+    }
+
+    const sibling = setup.video.nextElementSibling as HTMLElement | null;
+    expect(sibling).not.toBeNull();
+    expect(sibling?.classList.contains("__render_frame__")).toBe(true);
+    expect(sibling?.style.visibility).toBe("visible");
+  });
+
+  it("syncVideoFrameVisibility shows the replacement <img> when a plain [data-start] host is visibility:hidden", async () => {
+    const { teardown, setup } = withGlobals(
+      setupHostHiddenScenario({ visibility: "hidden" }, { hostAttribute: "data-start" }),
+    );
+    const seededImg = setup.document.createElement("img");
+    seededImg.classList.add("__render_frame__");
+    seededImg.style.visibility = "hidden";
+    setup.video.parentNode?.insertBefore(seededImg, setup.video.nextSibling);
+
+    try {
+      await syncVideoFrameVisibility(passthroughPage(), ["pip"]);
+    } finally {
+      teardown();
+    }
+
+    // The host's `visibility: hidden` is escapable; sync must flip the
+    // <img> to `visibility: visible` so it overrides the ancestor.
+    expect(seededImg.style.visibility).toBe("visible");
   });
 });

--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -202,7 +202,6 @@ describe("video-frame injection respects ancestor visibility", () => {
   // injected `data-start="0"` + probed full-source duration cover the
   // whole timeline), so the bug produced one full-bleed speaker overlay
   // per inactive sub-comp — covering whichever moment was actually visible.
-  // See: https://github.com/lirian-su-opus/hyperframes branch issue thread.
 
   type StyleLike = {
     display?: string;

--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -453,4 +453,58 @@ describe("video-frame injection respects ancestor visibility", () => {
     // <img> to `visibility: visible` so it overrides the ancestor.
     expect(seededImg.style.visibility).toBe("visible");
   });
+
+  // Regression for the layered/HDR mask path: `applyDomLayerMask` writes an
+  // `!important` stylesheet rule `#${showId} *{visibility:visible !important}`
+  // which, if a sub-comp host id appears in the show set, would revive a
+  // plain (non-important) inline `visibility: hidden` on a descendant
+  // `__render_frame__` — the cascade rule is "important stylesheet author
+  // beats non-important inline author". To stay safe regardless of which
+  // layer ends up in `show`, the ancestor-hidden hide must be written with
+  // `!important` so inline `!important` beats stylesheet `!important`.
+  //
+  // linkedom strips `!important` from `cssText`/`getPropertyPriority`, so we
+  // pin the contract on the API call site instead: a `setProperty(name,
+  // value, "important")` invocation on the live `<img>`'s style.
+  it("injectVideoFramesBatch hides a stale <img> with !important so the layer mask cannot revive it", async () => {
+    const { teardown, setup } = withGlobals(setupHostHiddenScenario({ visibility: "hidden" }));
+    const seededImg = setup.document.createElement("img");
+    seededImg.classList.add("__render_frame__");
+    seededImg.style.visibility = "visible";
+    setup.video.parentNode?.insertBefore(seededImg, setup.video.nextSibling);
+    const setPropertySpy = vi.spyOn(seededImg.style, "setProperty");
+
+    try {
+      await injectVideoFramesBatch(passthroughPage(), [
+        {
+          videoId: "pip",
+          dataUri:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=",
+        },
+      ]);
+    } finally {
+      teardown();
+    }
+
+    expect(seededImg.style.visibility).toBe("hidden");
+    expect(setPropertySpy).toHaveBeenCalledWith("visibility", "hidden", "important");
+  });
+
+  it("syncVideoFrameVisibility hides an existing <img> with !important so the layer mask cannot revive it", async () => {
+    const { teardown, setup } = withGlobals(setupHostHiddenScenario({ visibility: "hidden" }));
+    const seededImg = setup.document.createElement("img");
+    seededImg.classList.add("__render_frame__");
+    seededImg.style.visibility = "visible";
+    setup.video.parentNode?.insertBefore(seededImg, setup.video.nextSibling);
+    const setPropertySpy = vi.spyOn(seededImg.style, "setProperty");
+
+    try {
+      await syncVideoFrameVisibility(passthroughPage(), ["pip"]);
+    } finally {
+      teardown();
+    }
+
+    expect(seededImg.style.visibility).toBe("hidden");
+    expect(setPropertySpy).toHaveBeenCalledWith("visibility", "hidden", "important");
+  });
 });

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -386,19 +386,40 @@ export async function injectVideoFramesBatch(
         "bottom",
         "inset",
       ]);
-      // Walk ancestors looking for a host that the page has hidden via
-      // `display:none` or `visibility:hidden`. The runtime hides
-      // `[data-composition-src]` and `[data-start]` hosts that fall outside
-      // their time window using exactly these properties; a nested
-      // `<video data-start>` inside such a host still appears "active" in the
-      // raw time-window check (its own `data-start`/`data-end` cover the
-      // whole clip), so without this guard we would paint a full-bleed
-      // replacement frame over a sibling host that *is* visible.
+      // Walk ancestors looking for a host that the page has hidden. The
+      // runtime hides `[data-composition-src]` and `[data-start]` hosts that
+      // fall outside their time window; a nested `<video data-start>` inside
+      // such a host still appears "active" in the raw time-window check (its
+      // own `data-start`/`data-end` cover the whole clip), so without this
+      // guard we would paint a full-bleed replacement frame over a sibling
+      // host that *is* visible.
+      //
+      // `display: none` is always a skip signal — a `display: none` ancestor
+      // takes its whole subtree out of layout, and a child `<img>` cannot
+      // escape that. `visibility: hidden`, by contrast, is escapable: a
+      // descendant with `visibility: visible` overrides an ancestor's
+      // `visibility: hidden` per the CSS spec, and the replacement `<img>`
+      // intentionally sets `visibility: visible`. We therefore only treat
+      // `visibility: hidden` as a skip signal on sub-composition hosts
+      // (`[data-composition-src]` / `[data-composition-file]`), which is the
+      // scenario this guard exists for. Plain `[data-start]` containers may
+      // be hidden with `visibility: hidden` while still wanting their inner
+      // video's final-state frame to paint through (e.g. a GSAP timeline
+      // shorter than the host's authored data-duration, where the runtime
+      // truncates visibility but the replacement <img> must hold its last
+      // frame) — those must NOT be skipped here.
       const isVisualAncestorHidden = (el: HTMLElement): boolean => {
         let parent = el.parentElement;
         while (parent !== null && parent !== document.documentElement) {
           const computed = window.getComputedStyle(parent);
-          if (computed.display === "none" || computed.visibility === "hidden") return true;
+          if (computed.display === "none") return true;
+          if (
+            computed.visibility === "hidden" &&
+            (parent.hasAttribute("data-composition-src") ||
+              parent.hasAttribute("data-composition-file"))
+          ) {
+            return true;
+          }
           parent = parent.parentElement;
         }
         return false;
@@ -516,17 +537,22 @@ export async function syncVideoFrameVisibility(
   activeVideoIds: string[],
 ): Promise<void> {
   await page.evaluate((ids: string[]) => {
-    // Mirror the ancestor-visibility guard from `injectVideoFramesBatch`: a
-    // video whose host is `display:none` / `visibility:hidden` (e.g., a
-    // sub-composition that the runtime has marked out-of-window) must not
-    // have its replacement <img> reach `visibility:visible` here, otherwise
-    // it would paint through the hidden host onto whichever sibling host is
-    // currently visible.
+    // Mirror the ancestor-visibility guard from `injectVideoFramesBatch`.
+    // See that copy for the full rationale on why `visibility: hidden` is
+    // narrowed to sub-composition hosts only — keep these two functions in
+    // sync so the inactive-arm decision matches the inject-time decision.
     const isVisualAncestorHidden = (el: HTMLElement): boolean => {
       let parent = el.parentElement;
       while (parent !== null && parent !== document.documentElement) {
         const computed = window.getComputedStyle(parent);
-        if (computed.display === "none" || computed.visibility === "hidden") return true;
+        if (computed.display === "none") return true;
+        if (
+          computed.visibility === "hidden" &&
+          (parent.hasAttribute("data-composition-src") ||
+            parent.hasAttribute("data-composition-file"))
+        ) {
+          return true;
+        }
         parent = parent.parentElement;
       }
       return false;

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -386,12 +386,39 @@ export async function injectVideoFramesBatch(
         "bottom",
         "inset",
       ]);
+      // Walk ancestors looking for a host that the page has hidden via
+      // `display:none` or `visibility:hidden`. The runtime hides
+      // `[data-composition-src]` and `[data-start]` hosts that fall outside
+      // their time window using exactly these properties; a nested
+      // `<video data-start>` inside such a host still appears "active" in the
+      // raw time-window check (its own `data-start`/`data-end` cover the
+      // whole clip), so without this guard we would paint a full-bleed
+      // replacement frame over a sibling host that *is* visible.
+      const isVisualAncestorHidden = (el: HTMLElement): boolean => {
+        let parent = el.parentElement;
+        while (parent !== null && parent !== document.documentElement) {
+          const computed = window.getComputedStyle(parent);
+          if (computed.display === "none" || computed.visibility === "hidden") return true;
+          parent = parent.parentElement;
+        }
+        return false;
+      };
       for (const item of items) {
         const video = document.getElementById(item.videoId) as HTMLVideoElement | null;
         if (!video) continue;
 
         let img = video.nextElementSibling as HTMLImageElement | null;
-        const isNewImage = !img || !img.classList.contains("__render_frame__");
+        const hasImg = img !== null && img.classList.contains("__render_frame__");
+
+        if (isVisualAncestorHidden(video)) {
+          // Don't paint a frame over a hidden host — if an existing replacement
+          // <img> is still around from when the host was visible, hide it so it
+          // doesn't bleed through a sibling host that *is* visible on this seek.
+          if (hasImg && img) img.style.visibility = "hidden";
+          continue;
+        }
+
+        const isNewImage = !hasImg;
         const computedStyle = window.getComputedStyle(video);
         // Read the GSAP-controlled opacity directly from the native <video>.
         // We hide the <video> below with `visibility: hidden` only (never
@@ -489,12 +516,28 @@ export async function syncVideoFrameVisibility(
   activeVideoIds: string[],
 ): Promise<void> {
   await page.evaluate((ids: string[]) => {
+    // Mirror the ancestor-visibility guard from `injectVideoFramesBatch`: a
+    // video whose host is `display:none` / `visibility:hidden` (e.g., a
+    // sub-composition that the runtime has marked out-of-window) must not
+    // have its replacement <img> reach `visibility:visible` here, otherwise
+    // it would paint through the hidden host onto whichever sibling host is
+    // currently visible.
+    const isVisualAncestorHidden = (el: HTMLElement): boolean => {
+      let parent = el.parentElement;
+      while (parent !== null && parent !== document.documentElement) {
+        const computed = window.getComputedStyle(parent);
+        if (computed.display === "none" || computed.visibility === "hidden") return true;
+        parent = parent.parentElement;
+      }
+      return false;
+    };
     const active = new Set(ids);
     const videos = Array.from(document.querySelectorAll("video[data-start]")) as HTMLVideoElement[];
     for (const video of videos) {
       const img = video.nextElementSibling as HTMLElement | null;
       const hasImg = img && img.classList.contains("__render_frame__");
-      if (active.has(video.id)) {
+      const ancestorHidden = isVisualAncestorHidden(video);
+      if (active.has(video.id) && !ancestorHidden) {
         // Active video: show injected <img>, hide native <video>.
         // Do NOT clobber inline opacity here — GSAP-controlled opacity must
         // survive until injectVideoFramesBatch reads it via getComputedStyle.
@@ -506,8 +549,8 @@ export async function syncVideoFrameVisibility(
           img.style.visibility = "visible";
         }
       } else {
-        // Inactive video: hide both. Use visibility only (never opacity) so we
-        // never clobber GSAP-controlled inline opacity.
+        // Inactive (or ancestor-hidden) video: hide both. Use visibility only
+        // (never opacity) so we never clobber GSAP-controlled inline opacity.
         video.style.removeProperty("display");
         video.style.setProperty("visibility", "hidden", "important");
         video.style.setProperty("pointer-events", "none", "important");

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -369,13 +369,22 @@ export async function removeDomLayerMask(page: Page, extraHideIds: string[]): Pr
   );
 }
 
+/**
+ * Returns the subset of `updates.videoId`s that were actually painted in
+ * this call. Videos skipped because of a hidden visual ancestor are NOT
+ * included — the caller relies on this to avoid recording a `lastInjected`
+ * cache entry for a frame that never reached the page, which would otherwise
+ * short-circuit the next inject at the same frameIndex and leave the host's
+ * first visible frame blank.
+ */
 export async function injectVideoFramesBatch(
   page: Page,
   updates: Array<{ videoId: string; dataUri: string }>,
-): Promise<void> {
-  if (updates.length === 0) return;
-  await page.evaluate(
+): Promise<string[]> {
+  if (updates.length === 0) return [];
+  return await page.evaluate(
     async (items: Array<{ videoId: string; dataUri: string }>, visualProperties: string[]) => {
+      const injectedIds: string[] = [];
       const pendingDecodes: Array<Promise<void>> = [];
       const replacementLayoutProperties = new Set([
         "width",
@@ -435,7 +444,13 @@ export async function injectVideoFramesBatch(
           // Don't paint a frame over a hidden host — if an existing replacement
           // <img> is still around from when the host was visible, hide it so it
           // doesn't bleed through a sibling host that *is* visible on this seek.
-          if (hasImg && img) img.style.visibility = "hidden";
+          //
+          // Use `!important` so the inline hide survives `applyDomLayerMask`'s
+          // stylesheet `#${showId} *{visibility:visible !important}` when the
+          // sub-comp host happens to land in the active layer's `show` set —
+          // important stylesheet beats non-important inline, but important
+          // inline beats important stylesheet.
+          if (hasImg && img) img.style.setProperty("visibility", "hidden", "important");
           continue;
         }
 
@@ -522,10 +537,12 @@ export async function injectVideoFramesBatch(
         // GSAP-controlled value.
         video.style.setProperty("visibility", "hidden", "important");
         video.style.setProperty("pointer-events", "none", "important");
+        injectedIds.push(item.videoId);
       }
       if (pendingDecodes.length > 0) {
         await Promise.all(pendingDecodes);
       }
+      return injectedIds;
     },
     updates,
     [...MEDIA_VISUAL_STYLE_PROPERTIES],
@@ -577,11 +594,16 @@ export async function syncVideoFrameVisibility(
       } else {
         // Inactive (or ancestor-hidden) video: hide both. Use visibility only
         // (never opacity) so we never clobber GSAP-controlled inline opacity.
+        // Use `!important` on the <img> hide so `applyDomLayerMask`'s
+        // important stylesheet rule (`#${showId} *{visibility:visible !important}`)
+        // cannot revive a stale frame when the sub-comp host lands in the
+        // active layer's `show` set — same mask-defense reasoning as the
+        // `isVisualAncestorHidden` branch in `injectVideoFramesBatch`.
         video.style.removeProperty("display");
         video.style.setProperty("visibility", "hidden", "important");
         video.style.setProperty("pointer-events", "none", "important");
         if (hasImg) {
-          img.style.visibility = "hidden";
+          img.style.setProperty("visibility", "hidden", "important");
         }
       }
     }

--- a/packages/engine/src/services/videoFrameInjector.test.ts
+++ b/packages/engine/src/services/videoFrameInjector.test.ts
@@ -1,9 +1,30 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { __testing } from "./videoFrameInjector.js";
+import { type Page } from "puppeteer-core";
+
+// Hoist mocks before importing the module under test so the mock factory wins.
+// The cache-hygiene block exercises createVideoFrameInjector against stubbed
+// page-side primitives so we can assert on Node-side state (cache poisoning)
+// without standing up a real browser.
+const { injectVideoFramesBatchMock, syncVideoFrameVisibilityMock } = vi.hoisted(() => ({
+  injectVideoFramesBatchMock: vi.fn<
+    (page: Page, updates: Array<{ videoId: string; dataUri: string }>) => Promise<string[]>
+  >(async (_page, updates) => updates.map((u) => u.videoId)),
+  syncVideoFrameVisibilityMock: vi.fn<(page: Page, ids: string[]) => Promise<void>>(
+    async () => undefined,
+  ),
+}));
+
+vi.mock("./screenshotService.js", () => ({
+  injectVideoFramesBatch: injectVideoFramesBatchMock,
+  syncVideoFrameVisibility: syncVideoFrameVisibilityMock,
+}));
+
+import { __testing, createVideoFrameInjector } from "./videoFrameInjector.js";
+import { type FrameLookupTable } from "./videoFrameExtractor.js";
 import { DEFAULT_CONFIG } from "../config.js";
 
 const { createFrameSourceCache } = __testing;
@@ -141,5 +162,93 @@ describe("frame source cache eviction", () => {
   it("stats() exposes counters used by telemetry", async () => {
     const cache = createFrameSourceCache(1, Number.MAX_SAFE_INTEGER);
     expect(cache.stats()).toMatchObject({ ...SHARED_STATS, entries: 0, bytes: 0 });
+  });
+});
+
+describe("createVideoFrameInjector cache hygiene against page-side skips", () => {
+  // Build a minimal FrameLookupTable stand-in that returns one fixed payload
+  // for every time so we can drive the hook deterministically. The real
+  // table is exercised exhaustively in videoFrameExtractor.test.ts.
+  function fakeTable(payload: { videoId: string; framePath: string; frameIndex: number }) {
+    return {
+      getActiveFramePayloads: () =>
+        new Map([
+          [payload.videoId, { framePath: payload.framePath, frameIndex: payload.frameIndex }],
+        ]),
+    } as unknown as FrameLookupTable;
+  }
+
+  // Bypass the on-disk frame cache by handing back a synthetic data URI.
+  function inlineResolver(framePath: string): string {
+    return `data:image/png;base64,fake-${framePath}`;
+  }
+
+  beforeEach(() => {
+    injectVideoFramesBatchMock.mockReset();
+    syncVideoFrameVisibilityMock.mockReset();
+    syncVideoFrameVisibilityMock.mockResolvedValue(undefined);
+  });
+
+  it("does not poison the lastInjected cache when the page reports zero ids injected", async () => {
+    // Regression for the agentic-finecut scenario after PR #1028's ancestor
+    // skip: when injectVideoFramesBatch silently drops a video (its sub-comp
+    // host is hidden), the caller used to record `lastInjectedFrame[v] = N`
+    // anyway. On the next frame, if the source frameIndex is unchanged
+    // (low-fps source, multiple output frames per source frame, or
+    // non-frame-aligned host start), the cache short-circuits the second
+    // call and the host's first visible frame paints blank because the
+    // replacement <img> was never created.
+    //
+    // Pin the contract: when the page returns `[]` (no ids actually
+    // injected), the cache must not record those frameIndexes, so a follow-
+    // up call at the same frameIndex still issues an inject.
+    const fakePage = {} as Page;
+    const hook = createVideoFrameInjector(
+      fakeTable({ videoId: "pip", framePath: "/p", frameIndex: 5 }),
+      {
+        frameSrcResolver: inlineResolver,
+      },
+    );
+    expect(hook).not.toBeNull();
+
+    // First call: simulate the ancestor-hidden skip — page-side reports it
+    // injected nothing.
+    injectVideoFramesBatchMock.mockResolvedValueOnce([]);
+    await hook!(fakePage, 0);
+    expect(injectVideoFramesBatchMock).toHaveBeenCalledTimes(1);
+    expect(injectVideoFramesBatchMock).toHaveBeenLastCalledWith(fakePage, [
+      { videoId: "pip", dataUri: "data:image/png;base64,fake-/p" },
+    ]);
+
+    // Second call: same frameIndex, but the previous call did not really
+    // paint. The cache must NOT short-circuit; the inject must run again.
+    injectVideoFramesBatchMock.mockResolvedValueOnce(["pip"]);
+    await hook!(fakePage, 0);
+    expect(injectVideoFramesBatchMock).toHaveBeenCalledTimes(2);
+    expect(injectVideoFramesBatchMock).toHaveBeenLastCalledWith(fakePage, [
+      { videoId: "pip", dataUri: "data:image/png;base64,fake-/p" },
+    ]);
+  });
+
+  it("does cache normally when the page reports the id as injected", async () => {
+    // Counter-test: when injection succeeds for a videoId, the cache must
+    // record it and a second call at the same frameIndex must short-circuit.
+    // This pins the happy path so a future refactor can't trade the skip
+    // bug for a never-cache regression.
+    const fakePage = {} as Page;
+    const hook = createVideoFrameInjector(
+      fakeTable({ videoId: "pip", framePath: "/p", frameIndex: 5 }),
+      {
+        frameSrcResolver: inlineResolver,
+      },
+    );
+
+    injectVideoFramesBatchMock.mockResolvedValueOnce(["pip"]);
+    await hook!(fakePage, 0);
+    expect(injectVideoFramesBatchMock).toHaveBeenCalledTimes(1);
+
+    await hook!(fakePage, 0);
+    // Cache hit — no second inject for the same frameIndex.
+    expect(injectVideoFramesBatchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/engine/src/services/videoFrameInjector.ts
+++ b/packages/engine/src/services/videoFrameInjector.ts
@@ -197,12 +197,22 @@ export function createVideoFrameInjector(
 
     await syncVideoFrameVisibility(page, Array.from(activeIds));
     if (updates.length > 0) {
-      await injectVideoFramesBatch(
-        page,
-        updates.map((u) => ({ videoId: u.videoId, dataUri: u.dataUri })),
+      // Only record cache entries for videos the page actually painted.
+      // injectVideoFramesBatch skips any video whose visual ancestor is
+      // hidden (sub-comp host out-of-window) and returns the subset of ids
+      // it really wrote — recording the rest would short-circuit the next
+      // call at the same frameIndex and leave the host's first visible
+      // frame blank.
+      const injectedIds = new Set(
+        await injectVideoFramesBatch(
+          page,
+          updates.map((u) => ({ videoId: u.videoId, dataUri: u.dataUri })),
+        ),
       );
       for (const update of updates) {
-        lastInjectedFrameByVideo.set(update.videoId, update.frameIndex);
+        if (injectedIds.has(update.videoId)) {
+          lastInjectedFrameByVideo.set(update.videoId, update.frameIndex);
+        }
       }
     }
   };


### PR DESCRIPTION
## What

In `packages/engine/src/services/screenshotService.ts` + `videoFrameInjector.ts`, stop painting the page-side replacement `<img class="__render_frame__">` when a `<video data-start>`'s visual ancestor is hidden, and make the skip robust against the two ways it could still cause stale or blank frames:

1. **Walk ancestors** in both `injectVideoFramesBatch` and `syncVideoFrameVisibility`. `display: none` on any ancestor is always a skip signal; `visibility: hidden` is a skip signal only on sub-composition hosts (`[data-composition-src]` / `[data-composition-file]`).
2. **Hide stale frames with `!important`** so `applyDomLayerMask`'s `#${showId} *{visibility:visible !important}` rule cannot revive them when a sub-comp host lands in an active layer's `show` set.
3. **Return injected ids** from `injectVideoFramesBatch` (`Promise<string[]>`) so `createVideoFrameInjector` only caches videos the page actually painted — skipped ones must re-attempt next call, not be remembered as up-to-date.

Add regression suite covering all three guarantees, plus the carve-out for plain `[data-start]` hosts whose `visibility: hidden` is escapable by the descendant `<img>`'s explicit `visibility: visible`.

## Why

### The original symptom — inner-PIP overpaint

The injector iterates every `video[data-start]` whose raw `[data-start, data-start + data-duration)` window covers the current seek and overlays the extracted source-video frame on each one. That contract is wrong for `<video>` elements nested inside `data-composition-src` sub-compositions:

1. `compileTimingAttrs` auto-injects `data-start="0"` + a `data-hf-auto-start` marker on any `<video>` without timing attrs. The duration prober then resolves `data-end` to the full source duration. So an inner PIP `<video>` covers the entire timeline in the active check, regardless of which moment its host actually belongs to.
2. The runtime's `[data-start]` lifecycle hides out-of-window hosts with `visibility: hidden`. The cascade hides the nested `<video>`'s rendered output — *but* the injector still creates an `<img>` next to it and explicitly sets `img.style.visibility = "visible"`, which under CSS rules defeats the parent `visibility: hidden`.
3. GSAP has not yet morphed the host (it advances only when the host enters its time window), so the `<video>`'s used box is the CSS default — typically full-bleed.

Net effect: every inactive sub-comp with a nested `<video>` painted one full-bleed replacement frame on top of whichever moment was currently visible.

### Why the narrowing — `style-9-prod`

CSS-spec-wise, a descendant `visibility: visible` overrides an ancestor `visibility: hidden`. Regular `[data-start]` containers rely on that override: in `style-9-prod`, `#aroll-comp` has `data-duration="16.04"` but its GSAP timeline only tweens to t=9.88s; the runtime truncates the host to `visibility: hidden` after t=9.88s, and the replacement `<img>` *must* paint through to hold the final-state frame. An unconditional skip dropped 38 tail frames there and crashed PSNR from ~50 to ~11. `display: none` does not have this carve-out — it removes the subtree from layout entirely and no child override can escape.

### Why mask defence

`applyDomLayerMask` writes `body *{visibility:hidden !important}` plus `#${showId} *{visibility:visible !important}` for each show id. If a sub-comp host's id lands in the show set, the show rule cascades to descendant `__render_frame__` siblings. A plain inline `visibility: hidden` we wrote in the ancestor-hidden branch loses to important stylesheet author per CSS cascade — the stale frame would re-paint on the layer composite. Inline `!important` beats stylesheet `!important` (author-origin precedence), which is what `applyDomLayerMask`'s own `hide` arm already does for `extraHideIds`.

### Why cache hygiene

`createVideoFrameInjector` recorded `lastInjectedFrameByVideo.set(id, frameIndex)` after every call to `injectVideoFramesBatch`, including videos the page silently skipped. On the next call at the same source `frameIndex` — common when source fps < output fps, source is paused, or host start isn't frame-aligned — the cache short-circuited the second inject and the host's first visible frame painted blank because the `<img>` was never created. Returning the actually-painted ids and caching only those keeps the skipped videos re-eligible for injection on the next tick.

## How

### Ancestor check (both functions)

```ts
const isVisualAncestorHidden = (el: HTMLElement): boolean => {
  let parent = el.parentElement;
  while (parent !== null && parent !== document.documentElement) {
    const computed = window.getComputedStyle(parent);
    if (computed.display === "none") return true;
    if (
      computed.visibility === "hidden" &&
      (parent.hasAttribute("data-composition-src") ||
        parent.hasAttribute("data-composition-file"))
    ) {
      return true;
    }
    parent = parent.parentElement;
  }
  return false;
};
```

Walk starts at `parentElement` because both functions write `visibility: hidden !important` to the `<video>` itself, so reading the video's own computed visibility is unreliable.

- `injectVideoFramesBatch` — short-circuit per video: hide a stale `__render_frame__` sibling via `setProperty("visibility", "hidden", "important")`, then `continue`. Do not push the videoId into `injectedIds`. Return `injectedIds` to the caller at the end.
- `syncVideoFrameVisibility` — fall through into the inactive arm so the `<img>` lands on inline `!important` hidden, matching what CSS already implies for the rest of the subtree.

The helper is inlined in both functions instead of hoisted to a shared module because the bodies run inside `page.evaluate` and a cross-file string-serialized helper would be more brittle than two identical copies. The regression tests exercise both paths so drift would surface.

### Caller cache

```ts
const injectedIds = new Set(
  await injectVideoFramesBatch(
    page,
    updates.map((u) => ({ videoId: u.videoId, dataUri: u.dataUri })),
  ),
);
for (const update of updates) {
  if (injectedIds.has(update.videoId)) {
    lastInjectedFrameByVideo.set(update.videoId, update.frameIndex);
  }
}
```

### Alternatives considered and rejected

- **Filter the active list at the call site** (`snapshot.ts`, `producer/services/videoFrameInjector.ts`). Two equivalent implementations would have to stay in sync, and any future caller would have to remember to filter.
- **Read the host's `data-start`/`data-end` and recompute active per-video.** Couples the injector to the timing convention; doesn't generalize to hosts hidden for other authoring reasons.
- **Have the runtime tear down inner `<video>` elements when the host is out of window.** Same outcome but a much bigger blast radius — the injector is the layer that knows it's about to override the cascade, so it's the natural enforcement point.
- **Page-side roundtrip just to filter ancestor-hidden videos before the inject call.** One extra `page.evaluate` per tick when `injectVideoFramesBatch` already has the DOM in scope and can return the same information for free.

## Test plan

### `screenshotService.test.ts` — `video-frame injection respects ancestor visibility` (8 cases)

1. `visibility: hidden` **sub-comp** host → `injectVideoFramesBatch` creates no `<img>` next to the video.
2. `display: none` sub-comp host → same.
3. Stale `__render_frame__` `<img>` + sub-comp host now `visibility: hidden` → `injectVideoFramesBatch` flips it to `visibility: hidden`.
4. `syncVideoFrameVisibility` called with the video in `active` but a sub-comp ancestor hidden → the existing `<img>` stays hidden, not "visible".
5. **`style-9-prod` regression guard**: plain `[data-start]` host at `visibility: hidden` → `injectVideoFramesBatch` *still* injects the `<img>` with `visibility: visible`.
6. **`style-9-prod` regression guard (sync arm)**: plain `[data-start]` host at `visibility: hidden`, video active → `syncVideoFrameVisibility` flips an existing `<img>` to `visibility: visible`.
7. **Mask defence (inject arm)**: ancestor-hidden + pre-existing visible `<img>` → `injectVideoFramesBatch` calls `style.setProperty("visibility", "hidden", "important")` so `applyDomLayerMask`'s important stylesheet rule cannot revive it. Asserted via spy on the live `<img>`'s `setProperty` (linkedom strips `!important` from cssText/getPropertyPriority).
8. **Mask defence (sync arm)**: same setup, `syncVideoFrameVisibility` → same spy assertion.

`setupHostHiddenScenario` takes an optional `hostAttribute` so cases 5/6 swap the host's `data-composition-src` for `data-start`.

### `videoFrameInjector.test.ts` — `createVideoFrameInjector cache hygiene against page-side skips` (2 cases)

1. **Cache not poisoned** by silent page-side skip: first call returns `[]` (ancestor-hidden), second call at the same `frameIndex` must still issue an inject.
2. **Happy-path cache hit** still works: first call returns `["pip"]`, second call at the same `frameIndex` short-circuits (no second inject). Pin so a future refactor can't trade the skip bug for a never-cache regression.

Stubs are wired via `vi.mock("./screenshotService.js", ...)` with hoisted spies on `injectVideoFramesBatch` and `syncVideoFrameVisibility`; the `FrameLookupTable` is faked with a one-payload `getActiveFramePayloads`, and `frameSrcResolver` short-circuits the on-disk cache.

### Suite totals

`bun run --filter @hyperframes/engine test`: `619/622 passed`. The three failures are in `ffprobe.test.ts` (HDR PNG cICP metadata parsing + ffprobe-missing fallback) and reproduce identically on `main` — unrelated to this change.

- [x] Unit tests added/updated
- [x] Manual testing performed (reproduced the symptom in a real `hyperframes render` run, confirmed the visible host's content shows through after the fix; verified `bunx oxlint` / `bunx oxfmt --check` and the engine test suite minus the pre-existing failures)
- [x] Documentation updated (n/a — fix is internal to the page-side injector + caller and does not change any external contract)
