### PR TITLE
feat(studio): enable blocks panel by default

### DIFF
--- a/packages/studio/src/components/editor/manualEditingAvailability.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.ts
@@ -62,7 +62,7 @@ export const STUDIO_MOTION_PANEL_ENABLED = resolveStudioBooleanEnvFlag(
 export const STUDIO_BLOCKS_PANEL_ENABLED = resolveStudioBooleanEnvFlag(
   env,
   ["VITE_STUDIO_ENABLE_BLOCKS_PANEL", "VITE_STUDIO_BLOCKS_PANEL_ENABLED"],
-  false,
+  true,
 );
 
 export const STUDIO_PREVIEW_SELECTION_ENABLED = STUDIO_INSPECTOR_PANELS_ENABLED;


### PR DESCRIPTION
## Summary
- Flip `STUDIO_BLOCKS_PANEL_ENABLED` fallback from `false` to `true` so the blocks panel is visible by default for all users — both inside the monorepo and when using the published package.
- Users can still opt out via `VITE_STUDIO_ENABLE_BLOCKS_PANEL=false`.

## Test plan
- [x] Open studio without any env overrides → blocks tab visible in sidebar
- [x] Set `VITE_STUDIO_ENABLE_BLOCKS_PANEL=false` → blocks tab hidden