### PR TITLE
fix(studio): stop 3M/day rejection flood from composition 404s

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -34,6 +34,7 @@
     "skills/**/scripts/**",
     "registry/**",
     "examples/**",
+    "playground/**",
     ".github/workflows/fixtures/**",
   ],
   "ignoreExports": [

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -34,7 +34,6 @@
     "skills/**/scripts/**",
     "registry/**",
     "examples/**",
-    "playground/**",
     ".github/workflows/fixtures/**",
   ],
   "ignoreExports": [

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -18,6 +18,7 @@ export type ScheduledSource = {
 export class WebAudioTransport {
   private _ctx: AudioContext | null = null;
   private _bufferCache = new Map<string, AudioBuffer>();
+  private _failedSrcs = new Set<string>();
   private _activeSources: ScheduledSource[] = [];
   private _masterGain: GainNode | null = null;
   // Composition-time reference frame: at AudioContext time `_rateAnchorCtx`,
@@ -53,14 +54,21 @@ export class WebAudioTransport {
     const src = el.currentSrc || el.getAttribute("src");
     if (!src) return null;
     if (this._bufferCache.has(src)) return this._bufferCache.get(src)!;
+    if (this._failedSrcs.has(src)) return null;
     if (!this._ctx) return null;
     try {
       const response = await fetch(src);
+      if (!response.ok) {
+        this._failedSrcs.add(src);
+        swallow("webAudioTransport.fetch", new Error(`${response.status} ${src}`));
+        return null;
+      }
       const arrayBuffer = await response.arrayBuffer();
       const audioBuffer = await this._ctx.decodeAudioData(arrayBuffer);
       this._bufferCache.set(src, audioBuffer);
       return audioBuffer;
     } catch (err) {
+      this._failedSrcs.add(src);
       swallow("webAudioTransport.decode", err);
       return null;
     }

--- a/packages/studio/src/main.tsx
+++ b/packages/studio/src/main.tsx
@@ -22,10 +22,29 @@ function errorProps(value: unknown): {
   return { error_message: String(value), error_name: null, stack_trace: null };
 }
 
+function isCompositionAssetError(msg: string): boolean {
+  return msg.includes("Error fetching") && (msg.includes("404") || msg.includes("Not Found"));
+}
+
+const ERROR_CAP = 50;
+let errorCount = 0;
+let rejectionCount = 0;
+let errorCapSent = false;
+let rejectionCapSent = false;
+
 window.addEventListener("error", (event) => {
   if (event.message?.includes("ResizeObserver loop")) {
     event.stopImmediatePropagation();
     event.preventDefault();
+    return;
+  }
+
+  errorCount++;
+  if (errorCount > ERROR_CAP) {
+    if (!errorCapSent) {
+      errorCapSent = true;
+      trackStudioEvent("error_cap_reached", { count: errorCount });
+    }
     return;
   }
 
@@ -39,7 +58,19 @@ window.addEventListener("error", (event) => {
 });
 
 window.addEventListener("unhandledrejection", (event) => {
-  trackStudioEvent("unhandled_promise_rejection", errorProps(event.reason));
+  const props = errorProps(event.reason);
+  if (isCompositionAssetError(props.error_message)) return;
+
+  rejectionCount++;
+  if (rejectionCount > ERROR_CAP) {
+    if (!rejectionCapSent) {
+      rejectionCapSent = true;
+      trackStudioEvent("rejection_cap_reached", { count: rejectionCount });
+    }
+    return;
+  }
+
+  trackStudioEvent("unhandled_promise_rejection", props);
 });
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary

- Filter composition asset-fetch 404s from rejection telemetry — these are content errors, not Studio bugs
- Rate-limit error and rejection telemetry at 50 events per session to prevent any single session from flooding PostHog
- Cache failed audio URLs in `webAudioTransport` so playback ticks don't re-fetch the same 404 every frame

## Test plan

- [x] `bun run --cwd packages/core build` — clean
- [x] `bun run --cwd packages/studio build` — clean
- [x] `bun run --cwd packages/core test` — 984 tests pass
- [x] Lint + format + typecheck + fallow — all green
- [x] Deploy to preview, verify rejection events stop flooding PostHog
- [x] Verify real Studio errors still get tracked up to the 50-event cap