### PR TITLE
fix(engine): prevent CDP screenshot viewport edge bleed

### DIFF
--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -135,7 +135,13 @@ export async function pageScreenshotCapture(page: Page, options: CaptureOptions)
     format: isPng ? "png" : "jpeg",
     quality: isPng ? undefined : (options.quality ?? 80),
     fromSurface: true,
-    captureBeyondViewport: false,
+    // The explicit clip rect already constrains output to exact viewport
+    // dimensions. The additional viewport-boundary clipping from
+    // captureBeyondViewport:false is redundant and introduces intermittent
+    // 1-2px edge bleed: Chrome's compositor occasionally rounds the
+    // viewport boundary inward under load, exposing the body background
+    // at the bottom/right edge of the captured frame.
+    captureBeyondViewport: true,
     optimizeForSpeed: !isPng,
     clip,
   });

--- a/packages/producer/tests/viewport-edge-bleed/meta.json
+++ b/packages/producer/tests/viewport-edge-bleed/meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "viewport-edge-bleed",
+  "description": "Regression test for CDP screenshot viewport edge clipping. A red grid fills the viewport edge-to-edge; any body background bleed at the edges drops PSNR sharply against the golden baseline.",
+  "tags": ["regression", "capture"],
+  "minPsnr": 38,
+  "maxFrameFailures": 0,
+  "minAudioCorrelation": 0,
+  "maxAudioLagWindows": 1,
+  "renderConfig": {
+    "fps": 30,
+    "workers": 1
+  }
+}

--- a/packages/producer/tests/viewport-edge-bleed/src/index.html
+++ b/packages/producer/tests/viewport-edge-bleed/src/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { width: 1920px; height: 1080px; overflow: hidden; background: #ff00ff; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(4, 480px);
+    grid-template-rows: repeat(3, 360px);
+    width: 1920px;
+    height: 1080px;
+  }
+  .cell {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font: bold 48px system-ui;
+    color: rgba(255,255,255,0.9);
+  }
+  .cell:nth-child(odd)  { background: #1a1a2e; }
+  .cell:nth-child(even) { background: #16213e; }
+</style>
+</head>
+<body>
+  <div id="root" data-composition-id="viewport-edge-bleed" data-width="1920" data-height="1080" data-start="0" data-duration="2">
+    <div class="grid">
+      <div class="cell">1</div><div class="cell">2</div><div class="cell">3</div><div class="cell">4</div>
+      <div class="cell">5</div><div class="cell">6</div><div class="cell">7</div><div class="cell">8</div>
+      <div class="cell">9</div><div class="cell">10</div><div class="cell">11</div><div class="cell">12</div>
+    </div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Fixes an intermittent rendering artifact where 1-2px of body background bleeds through at the bottom/right edge of captured frames.

**Root cause**: `pageScreenshotCapture()` in `screenshotService.ts` passes `captureBeyondViewport: false` to Chrome's CDP `Page.captureScreenshot`. This adds a viewport-boundary pre-clip *before* the explicit clip rect is applied. Under compositor load (especially multi-worker parallelism), Chrome occasionally rounds that viewport boundary inward by 1-2px, exposing the body background at the edges.

**Fix**: Change `captureBeyondViewport` to `true`. The explicit clip rect `{x:0, y:0, width, height, scale:dpr}` already constrains output to exact viewport dimensions — the redundant viewport boundary clip was only causing problems.

## Changes

- `packages/engine/src/services/screenshotService.ts`: `captureBeyondViewport: false` → `true` in `pageScreenshotCapture()`
- New regression test `viewport-edge-bleed`: magenta body background with dark grid cells edge-to-edge. Any background bleed drops PSNR sharply.

## Test plan

- [x] Build passes
- [x] Rendered parallax-zoom and parallax-unzoom demos with 4 workers — no edge bleed
- [ ] Docker regression test: `bun run --cwd packages/producer docker:test viewport-edge-bleed`
- [ ] Verify existing regression tests still pass