### PR TITLE
docs: update rendering comparison and license wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Hyperframes is inspired by [Remotion](https://www.remotion.dev) — we used Remo
 | Build step                                            | None; `index.html` plays as-is | Required (bundler)                |
 | Library-clock animations (GSAP, Anime.js, Motion One) | Seekable, frame-accurate       | Plays at wall-clock during render |
 | Arbitrary HTML / CSS passthrough                      | Paste and animate              | Rewrite as JSX                    |
-| Distributed rendering                                 | Single-machine today           | Lambda, production-ready          |
+| Distributed rendering                                 | AWS Lambda support             | Lambda, production-ready          |
 
 ### Licensing: fully open source vs source-available
 

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -159,4 +159,4 @@ All of the following must pass before your PR can be merged:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](https://github.com/heygen-com/hyperframes/blob/main/LICENSE).
+By contributing, you agree that your contributions will be licensed under the [Apache 2.0 License](https://github.com/heygen-com/hyperframes/blob/main/LICENSE).

--- a/docs/guides/hyperframes-vs-remotion.mdx
+++ b/docs/guides/hyperframes-vs-remotion.mdx
@@ -37,7 +37,7 @@ We architected Hyperframes to be the most native to agents while making it easy 
 | Build step | None; `index.html` plays as-is | Required (webpack, bundler) |
 | Library-clock animations (GSAP, Anime.js, Motion One) | Seekable; frame-accurate | Plays at wall-clock during render |
 | Arbitrary HTML / CSS passthrough | Paste and animate | Rewrite as JSX |
-| Distributed rendering | Single-machine today | [Remotion Lambda](https://www.remotion.dev/lambda), production-ready |
+| Distributed rendering | [AWS Lambda](/deploy/aws-lambda) support | [Remotion Lambda](https://www.remotion.dev/lambda), mature and production-tested |
 | [HDR output](/guides/hdr) | Supported | Documented as unsupported |
 | Visual editor over render source | Native; same DOM is editable | Source is code plus a build step |
 | License | [Apache 2.0](https://github.com/heygen-com/hyperframes/blob/main/LICENSE) | [Commercial](https://www.remotion.pro/license) |
@@ -109,11 +109,11 @@ In practice: GSAP timelines, CSS `@keyframes` (via the Web Animations API adapte
 
 If your team already has a design system in React components, Remotion lets you compose videos from the same primitives you ship in your app. Type safety, IDE completion, cross-file refactoring — everything React brings to developer ergonomics. For teams with existing React investment, this is a real advantage Hyperframes doesn't try to match.
 
-### Distributed rendering (Remotion's clean lead)
+### Distributed rendering
 
-[Remotion Lambda](https://www.remotion.dev/lambda) splits long videos across hundreds of AWS Lambda functions. It's mature, production-tested, and well-documented — a thing you can pick up today and use at hyperscale.
+[Remotion Lambda](https://www.remotion.dev/lambda) splits long videos across hundreds of AWS Lambda functions. It's mature, production-tested, and well-documented — a thing teams have used in production for years.
 
-Hyperframes' renderer runs on a single machine today. The architecture doesn't block distributed rendering — compositions are stateless HTML, the renderer is stateless — we just haven't gotten there yet. Closing this gap is on our roadmap.
+Hyperframes now ships an [AWS Lambda deployment path](/deploy/aws-lambda): one Lambda function behind a Step Functions workflow that fans renders out across chunk workers, stores intermediates in S3, and exposes `lambda render`, `lambda render-batch`, progress polling, and SDK usage. The surface is newer than Remotion Lambda, so the practical tradeoff is maturity versus Hyperframes' HTML-native composition model.
 
 ### Visual editing over the render source (Hyperframes' natural bet)
 


### PR DESCRIPTION
## What

This updates a few documentation references after the recent AWS Lambda rendering work:

- Updates the README Remotion comparison row to reflect that HyperFrames now has documented AWS Lambda distributed rendering support.
- Updates the HyperFrames vs Remotion guide so it no longer describes HyperFrames as single-machine-only.
- Keeps the comparison conservative: Remotion Lambda is still described as mature and production-tested, while HyperFrames points readers to the current AWS Lambda docs.
- Corrects the contributing docs license wording from MIT to Apache 2.0, matching the repository LICENSE and README.

## Why

Recent releases added the AWS Lambda rendering flow, including `lambda deploy`, `lambda render`, `lambda render-batch`, progress/cost polling, and SDK usage. Some comparison docs still reflected the earlier single-machine-only state, which could confuse adopters evaluating HyperFrames for production rendering.

The contributing docs also had license wording that did not match the repository license.

## Notes

Docs-only change. No runtime or API behavior changes.

## Validation

- `bunx oxfmt --check README.md docs/guides/hyperframes-vs-remotion.mdx docs/contributing.mdx`
- `git diff --check`
