### PR TITLE
fix(producer): strip embedded runtime before render-mode detection

### DIFF
--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -21,7 +21,7 @@ import {
   type ResolvedDuration,
   type UnresolvedElement,
 } from "@hyperframes/core";
-import { inlineSubCompositions as inlineSubCompositionsShared } from "@hyperframes/core/compiler";
+import { inlineSubCompositions as inlineSubCompositionsShared, stripEmbeddedRuntimeScripts } from "@hyperframes/core/compiler";
 import { extractMediaMetadata, extractAudioMetadata } from "../utils/ffprobe.js";
 import { isPathInside, toExternalAssetKey } from "../utils/paths.js";
 import {
@@ -933,8 +933,9 @@ export async function compileForRender(
     /(<(?:video|audio)\b[^>]*?)\s+preload\s*=\s*["']none["']/gi,
     "$1",
   );
-  const renderModeHints = detectRenderModeHints(sanitizedHtml);
-  const hasShaderTransitions = detectShaderTransitionUsage(sanitizedHtml);
+  const htmlForAnalysis = stripEmbeddedRuntimeScripts(sanitizedHtml);
+  const renderModeHints = detectRenderModeHints(htmlForAnalysis);
+  const hasShaderTransitions = detectShaderTransitionUsage(htmlForAnalysis);
 
   const coalescedHtml = await injectDeterministicFontFaces(
     injectTextRenderingRule(


### PR DESCRIPTION
Fixes cloud renders producing frozen/missing video when the HTML was bundled by demo-next with an inlined runtime.

**Root cause:** `detectRenderModeHints` scanned the raw HTML including the 184KB embedded HyperFrames runtime script, which contains `requestAnimationFrame`. This false positive forced screenshot capture mode for compositions that have no rAF in their own code, breaking the video frame injection pipeline.

**Fix:** Strip embedded runtime scripts before analyzing render mode hints so only user-authored code is inspected.

Before: `renderModeHints: {"recommendScreenshot":true,"reasons":["requestAnimationFrame"]}`
After: `renderModeHints: {"recommendScreenshot":false,"reasons":[]}`