### PR TITLE
fix(aws-lambda): resolve Chromium for handlePlan before invoking probe

### DIFF
--- a/packages/aws-lambda/src/handler.test.ts
+++ b/packages/aws-lambda/src/handler.test.ts
@@ -209,6 +209,75 @@ describe("handler dispatch", () => {
     ).toBe(true);
   });
 
+  it("plan honors a pre-set PRODUCER_HEADLESS_SHELL_PATH instead of re-resolving Chrome", async () => {
+    // Mirrors the renderChunk env-var guard — when a caller (e.g. SAM-local
+    // RIE smoke) seeds the path, handlePlan must not overwrite it.
+    const tmpRoot = makeTmpRoot();
+    const s3 = new FakeS3Client();
+    s3.objects.set("s3://bucket/project.tar.gz", await makeMinimalProjectTar());
+
+    const planMock = mock(
+      async (_projectDir: string, _config: unknown, planDir: string): Promise<PlanResult> => {
+        mkdirSync(planDir, { recursive: true });
+        writeFileSync(join(planDir, "plan.json"), JSON.stringify({ planHash: "fakehash" }));
+        mkdirSync(join(planDir, "meta"), { recursive: true });
+        writeFileSync(join(planDir, "meta", "chunks.json"), "[]");
+        return {
+          planDir,
+          planHash: "fakehash",
+          chunkCount: 1,
+          totalFrames: 30,
+          fps: 30 as const,
+          width: 1920,
+          height: 1080,
+          format: "mp4" as const,
+          ffmpegVersion: "6.0",
+          producerVersion: "0.0.0-test",
+        };
+      },
+    );
+    const renderChunkMock = mock(async () => {
+      throw new Error("should not be called");
+    });
+    const assembleMock = mock(async () => {
+      throw new Error("should not be called");
+    });
+
+    const event: PlanEvent = {
+      Action: "plan",
+      ProjectS3Uri: "s3://bucket/project.tar.gz",
+      PlanOutputS3Prefix: "s3://bucket/renders/abc/",
+      Config: { fps: 30, width: 1920, height: 1080, format: "mp4" },
+    };
+
+    const sentinel = "/tmp/test-chrome-sentinel";
+    const prev = process.env.PRODUCER_HEADLESS_SHELL_PATH;
+    process.env.PRODUCER_HEADLESS_SHELL_PATH = sentinel;
+    try {
+      // Note: no skipChromeResolution flag — the guard must short-circuit
+      // because PRODUCER_HEADLESS_SHELL_PATH is already set.
+      await handler(event, {
+        s3: s3 as unknown as import("@aws-sdk/client-s3").S3Client,
+        primitives: {
+          plan: planMock as unknown as typeof import("@hyperframes/producer/distributed").plan,
+          renderChunk:
+            renderChunkMock as unknown as typeof import("@hyperframes/producer/distributed").renderChunk,
+          assemble:
+            assembleMock as unknown as typeof import("@hyperframes/producer/distributed").assemble,
+        },
+        tmpRoot,
+      });
+      expect(process.env.PRODUCER_HEADLESS_SHELL_PATH).toBe(sentinel);
+      expect(planMock).toHaveBeenCalledTimes(1);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.PRODUCER_HEADLESS_SHELL_PATH;
+      } else {
+        process.env.PRODUCER_HEADLESS_SHELL_PATH = prev;
+      }
+    }
+  });
+
   it("routes Action='renderChunk' to the renderChunk primitive", async () => {
     const tmpRoot = makeTmpRoot();
     const s3 = new FakeS3Client();

--- a/packages/aws-lambda/src/handler.ts
+++ b/packages/aws-lambda/src/handler.ts
@@ -229,6 +229,16 @@ async function handlePlan(event: PlanEvent, deps?: HandlerDeps): Promise<PlanLam
   const s3 = deps?.s3 ?? getS3Client();
   const primitive = deps?.primitives?.plan ?? plan;
 
+  // The producer's probe stage launches Chromium whenever the composition
+  // needs a runtime duration probe or has unresolved sub-compositions, so
+  // plan has to resolve Chrome the same way renderChunk does. Without this
+  // the probe throws "An `executablePath` or `channel` must be specified
+  // for `puppeteer-core`" the moment runProbeStage calls puppeteer.launch.
+  if (!deps?.skipChromeResolution && !process.env.PRODUCER_HEADLESS_SHELL_PATH) {
+    const chromePath = await resolveChromeExecutablePath();
+    process.env.PRODUCER_HEADLESS_SHELL_PATH = chromePath;
+  }
+
   const work = mkdtempSync(join(deps?.tmpRoot ?? tmpdir(), "hf-lambda-plan-"));
   // We use `.tar.gz` (not `.zip`) as the project archive's on-the-wire
   // format because Lambda's Amazon Linux base image ships GNU `tar` but


### PR DESCRIPTION
## What

Mirror the `PRODUCER_HEADLESS_SHELL_PATH` guard from `handleRenderChunk` inside `handlePlan` so the producer's probe stage can launch Chromium on a cold container.

Fixes #1055.

## Why

Plan invocations crash the moment `runProbeStage` calls `puppeteer.launch` on a cold Lambda container. The producer relies on `PRODUCER_HEADLESS_SHELL_PATH` to find the bundled Sparticuz binary, but only `handleRenderChunk` was setting it. When the Plan stage needs a browser probe (root duration unknown, unresolved nested compositions, or `data-hf-auto-start` media), plan never resolves Chrome, and puppeteer-core throws `An executablePath or channel must be specified for puppeteer-core`.

Inline `requestAnimationFrame(...)` is related but separate: it routes capture through screenshot mode later in the pipeline, but it does not by itself force the Plan-stage browser probe unless one of the probe conditions above is also present.

A warm Lambda execution environment that previously served a render-chunk can happen to work because the env var is sticky. Within a single Step Functions execution, Plan still runs before RenderChunks, so cold Plan invocations need the same guard.

`handleAssemble` doesn't launch Chromium so it doesn't need the guard.

## How

- `handlePlan` gains the same four-line block `handleRenderChunk` already has — `skipChromeResolution` short-circuit, then `resolveChromeExecutablePath()` followed by `process.env.PRODUCER_HEADLESS_SHELL_PATH = chromePath`.
- New dispatch test pre-seeds `PRODUCER_HEADLESS_SHELL_PATH` with a sentinel, runs plan *without* `skipChromeResolution`, and asserts the env var is preserved (i.e. the guard short-circuited instead of overwriting).

## Test plan

- [x] `bun --filter @hyperframes/aws-lambda test` — 110 pass / 0 fail (109 prior + 1 new).
- [x] `bun --filter @hyperframes/aws-lambda typecheck` clean.
- [x] `bun run lint` clean.
- [x] `bun run format:check` clean.
- [x] Manual: ran a project against a `hyperframes lambda deploy`'d stack — plan now writes `plan.tar.gz` and chunks proceed instead of failing at the puppeteer assertion.

## Notes

I considered hoisting the guard into the `handler` dispatcher so any future action gets it for free, but that would also pre-warm Chromium for `assemble`, which doesn't need it. The surgical copy keeps the cost where the work actually happens. Happy to switch direction if you'd prefer the dispatcher version.
