### PR TITLE
fix(aws-lambda): fail build-zip when ffmpeg-static binary isn't Linux x86-64

### DIFF
--- a/packages/aws-lambda/scripts/build-zip.ts
+++ b/packages/aws-lambda/scripts/build-zip.ts
@@ -32,11 +32,14 @@
 import { spawnSync } from "node:child_process";
 import {
   chmodSync,
+  closeSync,
   cpSync,
   existsSync,
   mkdirSync,
+  openSync,
   readdirSync,
   readFileSync,
+  readSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -349,6 +352,55 @@ function stageHyperframeRuntime(stagingDir: string): void {
   console.log(`[build-zip] staged hyperframe.manifest.json + hyperframe.runtime.iife.js`);
 }
 
+// ELF header constants used by `assertLinuxX86_64Elf`. Header layout:
+// bytes 0..3 magic `0x7F 'E' 'L' 'F'`, byte 4 EI_CLASS (`2` = ELFCLASS64),
+// bytes 18..19 e_machine little-endian (`0x3E` = EM_X86_64).
+const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+const ELF_CLASS_64 = 2;
+const ELF_MACHINE_X86_64 = 0x3e;
+const ELF_HEADER_BYTES = 20;
+
+/**
+ * Verify the binary at `path` is a Linux x86-64 ELF executable, the only
+ * shape the Lambda runtime can exec. Throws with the canonical workaround
+ * (Docker `--platform=linux/amd64` or `npm_config_platform` /
+ * `npm_config_arch` overrides) so the build doesn't ship a silently
+ * broken zip when a non-Linux host's postinstall fetched the wrong arch.
+ */
+function assertLinuxX86_64Elf(path: string, label: string): void {
+  const head = readFileHead(path, ELF_HEADER_BYTES, label);
+  const isElf = head.subarray(0, 4).equals(ELF_MAGIC);
+  const isElf64 = head[4] === ELF_CLASS_64;
+  const machine = head.readUInt16LE(18);
+  if (isElf && isElf64 && machine === ELF_MACHINE_X86_64) return;
+
+  const magicHex = head.subarray(0, 4).toString("hex");
+  throw new Error(
+    `[build-zip] ${label} at ${path} is not a Linux x86-64 ELF executable ` +
+      `(magic=0x${magicHex}, ei_class=${head[4]}, e_machine=0x${machine.toString(16)}). ` +
+      `This usually means the deploy host's postinstall fetched a host-platform binary ` +
+      `(e.g. macOS arm64 ffmpeg) instead of the linux/x64 binary Lambda needs. ` +
+      `Re-run the build inside a linux/amd64 container, or pre-install with ` +
+      `\`npm_config_platform=linux npm_config_arch=x64\` so the package fetches the right binary.`,
+  );
+}
+
+function readFileHead(path: string, byteCount: number, label: string): Buffer {
+  const fd = openSync(path, "r");
+  try {
+    const buf = Buffer.alloc(byteCount);
+    const bytesRead = readSync(fd, buf, 0, byteCount, 0);
+    if (bytesRead < byteCount) {
+      throw new Error(
+        `[build-zip] ${label} at ${path} is too short — read ${bytesRead} of ${byteCount} bytes.`,
+      );
+    }
+    return buf;
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function stageFfmpeg(stagingDir: string): void {
   const binDir = join(stagingDir, "bin");
   mkdirSync(binDir, { recursive: true });
@@ -356,12 +408,19 @@ function stageFfmpeg(stagingDir: string): void {
   // ffmpeg from `ffmpeg-static`. The package only ships the encoder
   // binary; the audio pad/trim path also needs ffprobe, which comes
   // from `ffprobe-static`.
+  //
+  // `ffmpeg-static`'s postinstall fetches a binary for the host platform
+  // (e.g. arm64 Mach-O on Apple Silicon macOS). Lambda runs Linux x86-64,
+  // so a build from a non-Linux host silently produces a zip that boots
+  // but fails at first ffmpeg invocation with `cannot execute binary file`.
+  // Verify the ELF header up front and bail with a clear message instead.
   const ffmpegBinary = join(resolveModuleDir("ffmpeg-static"), "ffmpeg");
   if (!existsSync(ffmpegBinary)) {
     throw new Error(
       `[build-zip] ffmpeg-static binary missing at ${ffmpegBinary}. Did postinstall run?`,
     );
   }
+  assertLinuxX86_64Elf(ffmpegBinary, "ffmpeg-static binary");
   const ffmpegDest = join(binDir, "ffmpeg");
   cpSync(ffmpegBinary, ffmpegDest);
   chmodSync(ffmpegDest, 0o755);


### PR DESCRIPTION
## What

`stageFfmpeg` in `packages/aws-lambda/scripts/build-zip.ts` now reads the ELF header of `ffmpeg-static/ffmpeg` before copying it into the deploy zip, and throws if the binary isn't a Linux x86-64 ELF64 executable. This catches the case where the install step materialized the wrong ffmpeg for Lambda's x86-64 runtime (for example, a default macOS arm64 install), which otherwise produces a zip Lambda accepts but can't actually run.

Closes #1057.

## Why

`ffmpeg-static` materializes a single platform-selected binary at install time. By default that is the install host's platform/arch. Anyone running `bun run build:zip` from macOS or a Linux/arm64 box without target-platform overrides can get a zip that uploads to Lambda cleanly and then dies the first time Lambda invokes ffmpeg:

```
/var/task/bin/ffmpeg: cannot execute binary file
```

In the current distributed path, `plan()` calls `ffmpeg -version` after the browser probe and before returning the plan result, so the observed failure can happen in the Plan state before any chunks are scheduled. Any later encode/assemble spawn would fail for the same binary-mismatch reason.

`ffprobe-static` doesn't have this problem — it ships every platform under `bin/<os>/<arch>/`, and `stageFfmpeg` already picks the linux/x64 path explicitly. The bug is specific to the ffmpeg side.

A defensive check is the smallest blast-radius fix: it doesn't change dependencies or the install flow, it just refuses to ship a broken zip. The error message points at the canonical workarounds (`docker run --platform=linux/amd64`, or `npm_config_platform=linux npm_config_arch=x64`) so the operator can recover without digging into CloudWatch logs.

Heavier alternatives (swapping `ffmpeg-static` for `@ffmpeg-installer/ffmpeg`, downloading the binary on demand) are spelled out in #1057 — happy to follow up with one of those if it's a better fit for the codebase, but they felt out of scope for an upstream patch.

## How

`assertLinuxX86_64Elf(path, label)` reads the first 20 bytes of the binary and checks:

- bytes 0..3: ELF magic `0x7F 'E' 'L' 'F'`
- byte 4: EI_CLASS = `2` (ELFCLASS64)
- bytes 18..19 (little-endian): e_machine = `0x3E` (EM_X86_64)

On mismatch it throws with the parsed header values so the failure mode is obvious from the build log, plus the workaround commands. `stageFfmpeg` calls it right after the `existsSync` guard so the check runs before `cpSync` touches the staging dir.

A small `readFileHead` helper keeps `assertLinuxX86_64Elf` shaped like the rest of the file (one job per function, no nested fs handles).

## Test plan

- [x] `bun run --cwd packages/aws-lambda typecheck`
- [x] `bun run --cwd packages/aws-lambda test` — 109 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — no new findings (5 inherited findings excluded by the default `--gate new-only`)
- [x] Manual: re-ran `build:zip` against a `ffmpeg-static` install with the macOS arm64 binary in place and confirmed the build now fails with a descriptive error instead of producing a broken zip.
- [x] Manual: re-ran `build:zip` against a `ffmpeg-static` install hydrated via `npm_config_platform=linux npm_config_arch=x64 bun install` and confirmed it produces the expected linux/x64 zip without complaint.

## Notes

- Only the ffmpeg path needs this check — ffprobe goes through `ffprobe-static/bin/linux/x64/ffprobe` explicitly.
- The check is read-only, so it's safe even when the binary turns out to be correct: cost is one `openSync` + 20-byte `readSync` per build.
