### PR TITLE
fix(core): stop binding class values in composition scoped window

### DIFF
--- a/packages/core/src/compiler/compositionScoping.test.ts
+++ b/packages/core/src/compiler/compositionScoping.test.ts
@@ -146,6 +146,28 @@ body { margin: 0; }
     expect(variablesByComp["card-1"]).toEqual({ title: "Pro" });
   });
 
+  it("preserves static methods on classes exposed through window", () => {
+    const { document } = parseHTML(`<div data-composition-id="scene"></div>`);
+    class FakeTexts {
+      static mountChars() {
+        return "ok";
+      }
+    }
+    const fakeWindow: Record<string, unknown> = {
+      document,
+      __timelines: {},
+      Texts: FakeTexts,
+    };
+    const wrapped = wrapScopedCompositionScript(
+      `window.__capturedMountCharsType = typeof window.Texts?.mountChars;`,
+      "scene",
+    );
+
+    new Function("window", wrapped)(fakeWindow);
+
+    expect(fakeWindow.__capturedMountCharsType).toBe("function");
+  });
+
   it("executes document and GSAP selectors inside the composition root", () => {
     const { document } = parseHTML(`
       <div data-composition-id="scene" data-start="intro"><h1 class="title">Scene</h1></div>

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -383,8 +383,7 @@ export function wrapScopedCompositionScript(
     ? new Proxy(window, {
         get: function(target, prop, receiver) {
           if (prop === "__timelines") return __hfGetTimelineRegistry();
-          var value = Reflect.get(target, prop, target);
-          return typeof value === "function" ? value.bind(target) : value;
+          return Reflect.get(target, prop, target);
         },
         set: function(target, prop, value, receiver) {
           if (prop === "__timelines") {


### PR DESCRIPTION
## What

Preserve static methods on classes exposed through the scoped window inside composition scripts.

## Why

Scoped compositions currently bind every callable read from window. That breaks class objects exposed on window, because classes are also callable values in JavaScript. After binding, static members are no longer available on the returned value.

## How

Update the scoped window proxy in composition scoping so it returns properties directly instead of auto-binding every callable.

## Test plan

How was this tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
