### PR TITLE
fix(core,cli): defer __renderReady until root timeline is bound

### DIFF
--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -276,6 +276,7 @@ async function captureSnapshots(
       for (let i = 0; i < positions.length; i++) {
         const time = positions[i]!;
 
+        // 30 = runtime's default canonicalFps (not exposed on PlayerAPI)
         await page.evaluate((t: number) => {
           const player = (window as any).__player;
           if (!player) return;

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -276,17 +276,14 @@ async function captureSnapshots(
       for (let i = 0; i < positions.length; i++) {
         const time = positions[i]!;
 
-        // 30 = runtime's default canonicalFps (not exposed on PlayerAPI)
         await page.evaluate((t: number) => {
           const player = (window as any).__player;
           if (!player) return;
           const safe = Math.max(0, Number(t) || 0);
-          const frame = Math.floor(safe * 30 + 1e-9);
-          const quantized = frame / 30;
           if (typeof player.renderSeek === "function") {
-            player.renderSeek(quantized);
+            player.renderSeek(safe);
           } else if (typeof player.seek === "function") {
-            player.seek(quantized);
+            player.seek(safe);
           }
           if ((window as any).gsap?.ticker?.tick) {
             (window as any).gsap.ticker.tick();

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -97,16 +97,12 @@ async function captureSnapshots(
 
   const numFrames = opts.frames ?? 5;
 
-  // 1. Bundle. `bundleToSingleHtml` now inlines the runtime IIFE by default,
-  // so the previous post-bundle runtime substitution is no longer needed.
   const html = await bundleToSingleHtml(projectDir);
-
   const server = await serveStaticProjectHtml(projectDir, html);
 
   const savedPaths: string[] = [];
 
   try {
-    // 3. Launch headless Chrome
     const browser = await ensureBrowser();
     const puppeteer = await import("puppeteer-core");
     const chromeBrowser = await puppeteer.default.launch({
@@ -131,63 +127,33 @@ async function captureSnapshots(
         timeout: 10000,
       });
 
-      // Wait for the runtime to be fully render-ready: player constructed
-      // AND root timeline bound. __renderReady is only set after the timeline
-      // binding completes (synchronous or deferred), so this guarantees
-      // renderSeek will operate on the real timeline.
+      // __renderReady is set after the player is constructed AND the root
+      // timeline is bound — waiting for it guarantees renderSeek will work.
       const timeoutMs = opts.timeout ?? 5000;
-      await page
-        .waitForFunction(() => !!(window as any).__renderReady, {
-          timeout: timeoutMs,
-        })
-        .catch(() => {});
+      const runtimeReady = await page
+        .waitForFunction(() => !!(window as any).__renderReady, { timeout: timeoutMs })
+        .then(() => true)
+        .catch(() => false);
 
-      // Wait for ALL sub-compositions to be mounted by the runtime.
-      // The old check resolved when the first sub-timeline registered, causing
-      // "last beat black" bugs: beat-5's sub-comp hadn't loaded yet when the
-      // snapshot seeked into its time range. Now we count data-composition-src
-      // host elements and wait until we have a matching number of sub-timelines.
-      await page
-        .waitForFunction(
-          () => {
-            const tls = (window as any).__timelines;
-            if (!tls) return false;
-            const hosts = document.querySelectorAll("[data-composition-src]").length;
-            if (hosts === 0) return Object.keys(tls).length >= 1;
-            const subKeys = Object.keys(tls).filter((k) => k !== "main");
-            return subKeys.length >= hosts;
-          },
-          { timeout: timeoutMs },
-        )
-        .catch(() => {});
+      if (!runtimeReady) {
+        console.warn(
+          `\n   ${c.warn("⚠")} Runtime did not become render-ready within ${timeoutMs}ms — snapshots may be inaccurate`,
+        );
+      }
 
-      // Wait for shader transition pre-rendering to complete (if active).
-      //
-      // Two failure modes existed with the previous overlay-only check:
-      //   1. Cold cache: HyperShader creates [data-hyper-shader-loading] but never
-      //      removes it from the DOM — it only sets display:none. Checking for
-      //      element *absence* never resolved, so the wait always timed out at 60s.
-      //   2. Warm cache: HyperShader loads frames from IndexedDB without showing
-      //      the overlay at all. Checking for element absence resolved instantly
-      //      (no element) while hydration was still running in the background.
-      //
-      // Fix: use window.__hf.shaderTransitions[].ready as the primary signal
-      // (set after both warm and cold cache paths complete), with the overlay
-      // display:none as a fallback for older builds that lack the ready state.
+      // Wait for shader transition pre-rendering (HyperShader IndexedDB hydration).
+      // Uses the ready state flag as primary signal, with the loading overlay
+      // display:none as a fallback for older builds.
       await page
         .waitForFunction(
           () => {
             const win = window as unknown as {
               __hf?: { shaderTransitions?: Record<string, { ready?: boolean }> };
             };
-            // Primary: HyperShader ready state — authoritative for both cache paths
             const shaderTransitions = win.__hf?.shaderTransitions;
             if (shaderTransitions !== undefined) {
               return Object.values(shaderTransitions).every((s) => s.ready === true);
             }
-            // Fallback: overlay visibility (older builds without ready state).
-            // Check display:none rather than element absence — element stays in
-            // the DOM when hidden.
             const overlay = document.querySelector(
               "[data-hyper-shader-loading]",
             ) as HTMLElement | null;
@@ -196,7 +162,9 @@ async function captureSnapshots(
           },
           { timeout: 90_000 },
         )
-        .catch(() => {});
+        .catch(() => {
+          console.warn(`   ${c.warn("⚠")} Shader transitions did not finish pre-rendering`);
+        });
 
       // Wait for fonts to finish loading before capturing
       await page.evaluate(() => document.fonts.ready).catch(() => {});
@@ -227,20 +195,14 @@ async function captureSnapshots(
         }
       }
 
-      // Get composition duration
       const duration = await page.evaluate(() => {
         const win = window as any;
-        const pd = win.__player?.duration;
-        if (pd != null) return typeof pd === "function" ? pd() : pd;
+        if (typeof win.__player?.getDuration === "function") {
+          const d = win.__player.getDuration();
+          if (Number.isFinite(d) && d > 0) return d;
+        }
         const root = document.querySelector("[data-composition-id][data-duration]");
         if (root) return parseFloat(root.getAttribute("data-duration") ?? "0");
-        const tls = win.__timelines;
-        if (tls) {
-          for (const key in tls) {
-            const d = tls[key]?.duration;
-            if (d != null) return typeof d === "function" ? d() : d;
-          }
-        }
         return 0;
       });
 
@@ -255,27 +217,21 @@ async function captureSnapshots(
           ? [duration / 2]
           : Array.from({ length: numFrames }, (_, i) => (i / (numFrames - 1)) * duration);
 
-      // Create output directory and clear previous frames so old captures
-      // don't mix with the current run in contact sheets.
       const snapshotDir = join(projectDir, "snapshots");
       mkdirSync(snapshotDir, { recursive: true });
       try {
-        const { readdirSync, rmSync } = await import("node:fs");
+        const { readdirSync } = await import("node:fs");
         for (const file of readdirSync(snapshotDir)) {
           if (/\.(png|jpg|jpeg)$/i.test(file)) {
             rmSync(join(snapshotDir, file), { force: true });
           }
         }
       } catch {
-        /* best-effort clear — proceed even if cleanup fails */
+        /* best-effort — proceed even if cleanup fails */
       }
 
-      // Lazily load the engine's <img>-overlay injector. Chrome-headless cannot
-      // reliably advance <video>.currentTime mid-seek (the setter is accepted but
-      // the decoder ignores it without user activation), so the render pipeline
-      // already extracts each frame via FFmpeg and injects it as an <img> sibling
-      // over the <video>. We reuse that same primitive here so `snapshot` and
-      // `render` behave identically for timed <video data-start> elements.
+      // Chrome-headless ignores programmatic <video>.currentTime writes, so
+      // we extract frames via FFmpeg and overlay them as <img> elements.
       type InjectFn = (
         page: unknown,
         updates: Array<{ videoId: string; dataUri: string }>,
@@ -312,30 +268,30 @@ async function captureSnapshots(
         return pending;
       };
 
-      // Seek and capture each frame
+      const hasPlayer = await page.evaluate(() => !!(window as any).__player);
+      if (!hasPlayer) {
+        console.warn(`   ${c.warn("⚠")} No player API — seeks will be skipped`);
+      }
+
       for (let i = 0; i < positions.length; i++) {
         const time = positions[i]!;
 
         await page.evaluate((t: number) => {
-          const win = window as any;
-          const player = win.__player;
-          if (player) {
-            const fps = 30;
-            const safe = Math.max(0, Number(t) || 0);
-            const frame = Math.floor(safe * fps + 1e-9);
-            const quantized = frame / fps;
-            if (typeof player.renderSeek === "function") {
-              player.renderSeek(quantized);
-            } else if (typeof player.seek === "function") {
-              player.seek(quantized);
-            }
+          const player = (window as any).__player;
+          if (!player) return;
+          const safe = Math.max(0, Number(t) || 0);
+          const frame = Math.floor(safe * 30 + 1e-9);
+          const quantized = frame / 30;
+          if (typeof player.renderSeek === "function") {
+            player.renderSeek(quantized);
+          } else if (typeof player.seek === "function") {
+            player.seek(quantized);
           }
-          if (win.gsap?.ticker?.tick) {
-            win.gsap.ticker.tick();
+          if ((window as any).gsap?.ticker?.tick) {
+            (window as any).gsap.ticker.tick();
           }
         }, time);
 
-        // Wait for rendering to settle — match the parity harness pattern
         await page.evaluate(`new Promise(function(r) {
           var settled = false;
           function finish() { if (settled) return; settled = true; r(); }
@@ -343,18 +299,7 @@ async function captureSnapshots(
           requestAnimationFrame(function() { requestAnimationFrame(finish); });
         })`);
 
-        // ─── Inject real video frames over any active <video data-start> ───
-        // Without this, Chrome-headless renders them blank/first-frame because
-        // it silently drops programmatic `currentTime` writes during capture.
-        // No-op when the composition has no timed videos (basecamp, linear, etc.)
         if (injectVideoFramesBatch && syncVideoFrameVisibility) {
-          // Mirror the runtime's media math in packages/core/src/runtime/media.ts
-          // so clips with non-1 `defaultPlaybackRate` get the right active
-          // window and the right `relTime`:
-          //   playbackRate = clamp(defaultPlaybackRate, 0.1, 5) — default 1
-          //   duration fallback = (sourceDuration - mediaStart) / playbackRate
-          //   relTime = (t - start) * playbackRate + mediaStart
-          //   active  = t >= start && t < start+duration && relTime >= 0
           const active = await page.evaluate((t: number) => {
             return Array.from(document.querySelectorAll("video[data-start]"))
               .map((el) => {
@@ -390,11 +335,6 @@ async function captureSnapshots(
 
           const updates: Array<{ videoId: string; dataUri: string }> = [];
           for (const v of active) {
-            // The page-served URL (http://127.0.0.1:PORT/relative/path.mp4)
-            // maps 1:1 to <projectDir>/relative/path.mp4. decodeURIComponent
-            // the pathname — the file server decodes inbound requests, so a
-            // file with spaces in its path lives at the decoded name on disk
-            // while `new URL().pathname` preserves the %-encoding.
             let filePath: string | null = null;
             try {
               const url = new URL(v.src);
@@ -420,12 +360,7 @@ async function captureSnapshots(
             });
           }
 
-          // Always run the visibility sync — even when `active` is empty and
-          // no new updates were injected. Without this, stale __render_frame__
-          // <img> overlays left by a previous seek (where different clips were
-          // active) remain visible in later snapshots, because the runtime's
-          // visibility toggles act on the <video> element but not its injected
-          // <img> sibling.
+          // Sync visibility even when empty — clears stale overlays from prior seeks
           try {
             if (updates.length > 0) {
               await injectVideoFramesBatch(page, updates);
@@ -435,8 +370,7 @@ async function captureSnapshots(
               active.map((a) => a.id),
             );
           } catch {
-            // If either step fails, fall through to the plain screenshot —
-            // no worse than the pre-fix behaviour.
+            /* fall through to plain screenshot */
           }
         }
 

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -131,10 +131,13 @@ async function captureSnapshots(
         timeout: 10000,
       });
 
-      // Wait for runtime to initialize and sub-compositions to load
+      // Wait for the runtime to be fully render-ready: player constructed
+      // AND root timeline bound. __renderReady is only set after the timeline
+      // binding completes (synchronous or deferred), so this guarantees
+      // renderSeek will operate on the real timeline.
       const timeoutMs = opts.timeout ?? 5000;
       await page
-        .waitForFunction(() => !!(window as any).__timelines || !!(window as any).__playerReady, {
+        .waitForFunction(() => !!(window as any).__renderReady, {
           timeout: timeoutMs,
         })
         .catch(() => {});
@@ -195,7 +198,10 @@ async function captureSnapshots(
         )
         .catch(() => {});
 
-      // Extra settle time for media, fonts, and animations to initialize
+      // Wait for fonts to finish loading before capturing
+      await page.evaluate(() => document.fonts.ready).catch(() => {});
+
+      // Extra settle time for media and animations to initialize
       await new Promise((r) => setTimeout(r, 1500));
 
       // Font verification — report which fonts loaded vs fell back
@@ -312,38 +318,30 @@ async function captureSnapshots(
 
         await page.evaluate((t: number) => {
           const win = window as any;
-          if (win.__player?.seek) {
-            win.__player.seek(t);
-          } else {
-            const tls = win.__timelines;
-            if (tls) {
-              for (const key in tls) {
-                if (tls[key]?.seek) {
-                  // Sub-composition timelines run in local time relative to
-                  // their data-start. Seeking them to global time causes beats
-                  // with exit animations to appear black (global t clamps past
-                  // the exit). Compute local time: global_t - data_start.
-                  const host = document.querySelector<HTMLElement>(
-                    `[data-composition-id="${key}"]`,
-                  );
-                  const dataStart = host
-                    ? parseFloat(host.getAttribute("data-start") ?? "0") || 0
-                    : 0;
-                  const localTime = Math.max(0, t - dataStart);
-                  tls[key].pause();
-                  tls[key].seek(localTime);
-                }
-              }
+          const player = win.__player;
+          if (player) {
+            const fps = 30;
+            const safe = Math.max(0, Number(t) || 0);
+            const frame = Math.floor(safe * fps + 1e-9);
+            const quantized = frame / fps;
+            if (typeof player.renderSeek === "function") {
+              player.renderSeek(quantized);
+            } else if (typeof player.seek === "function") {
+              player.seek(quantized);
             }
+          }
+          if (win.gsap?.ticker?.tick) {
+            win.gsap.ticker.tick();
           }
         }, time);
 
-        // Wait for rendering to settle after seek
-        await page.evaluate(
-          () =>
-            new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))),
-        );
-        await new Promise((r) => setTimeout(r, 200));
+        // Wait for rendering to settle — match the parity harness pattern
+        await page.evaluate(`new Promise(function(r) {
+          var settled = false;
+          function finish() { if (settled) return; settled = true; r(); }
+          window.setTimeout(finish, 100);
+          requestAnimationFrame(function() { requestAnimationFrame(finish); });
+        })`);
 
         // ─── Inject real video frames over any active <video data-start> ───
         // Without this, Chrome-headless renders them blank/first-frame because

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -576,4 +576,52 @@ describe("initSandboxRuntimeModular", () => {
     expect(player?.getTime()).toBeCloseTo(1, 1);
     expect(childTimeline.time()).toBeCloseTo(1, 1);
   });
+
+  it("sets __renderReady only after timeline is bound, not at __playerReady time", async () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+      main: createMockTimeline(10),
+    };
+
+    initSandboxRuntimeModular();
+
+    const win = window as Window & {
+      __playerReady?: boolean;
+      __renderReady?: boolean;
+      __player?: { _timeline: RuntimeTimelineLike | null };
+    };
+
+    expect(win.__playerReady).toBe(true);
+    expect(win.__renderReady).toBe(true);
+    expect(win.__player?._timeline).not.toBeNull();
+  });
+
+  it("does not set __renderReady when no timeline is available", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {};
+
+    initSandboxRuntimeModular();
+
+    const win = window as Window & {
+      __playerReady?: boolean;
+      __renderReady?: boolean;
+    };
+
+    expect(win.__playerReady).toBe(true);
+    expect(win.__renderReady).toBeUndefined();
+  });
 });

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -86,12 +86,12 @@ describe("initSandboxRuntimeModular", () => {
   });
 
   afterEach(() => {
-    (window as Window & { __hfRuntimeTeardown?: (() => void) | null }).__hfRuntimeTeardown?.();
+    window.__hfRuntimeTeardown?.();
     document.body.innerHTML = "";
-    delete (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines;
-    delete (window as Window & { __player?: unknown }).__player;
-    delete (window as Window & { __playerReady?: boolean }).__playerReady;
-    delete (window as Window & { __renderReady?: boolean }).__renderReady;
+    window.__timelines = {} as Record<string, RuntimeTimelineLike>;
+    delete window.__player;
+    delete window.__playerReady;
+    delete window.__renderReady;
     vi.restoreAllMocks();
     window.requestAnimationFrame = originalRequestAnimationFrame;
     window.cancelAnimationFrame = originalCancelAnimationFrame;
@@ -112,18 +112,14 @@ describe("initSandboxRuntimeModular", () => {
     child.setAttribute("data-hf-authored-duration", "14");
     root.appendChild(child);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(20),
       "slide-1": createMockTimeline(8),
     };
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { renderSeek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     player?.renderSeek(9);
@@ -146,18 +142,14 @@ describe("initSandboxRuntimeModular", () => {
     child.setAttribute("data-hf-authored-duration", "2");
     root.appendChild(child);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(20),
       "slide-1": createMockTimeline(8),
     };
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { renderSeek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     player?.renderSeek(3);
@@ -190,7 +182,7 @@ describe("initSandboxRuntimeModular", () => {
     `;
     document.body.appendChild(template);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(3),
       sub: createMockTimeline(1),
     };
@@ -198,11 +190,7 @@ describe("initSandboxRuntimeModular", () => {
     initSandboxRuntimeModular();
     await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
 
-    const player = (
-      window as Window & {
-        __player?: { renderSeek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
     expect(child.querySelector("#hold-marker")?.textContent).toBe("HOLD ME");
 
@@ -228,7 +216,7 @@ describe("initSandboxRuntimeModular", () => {
     child.innerHTML = '<div id="hold-marker">HOLD ME</div>';
     root.appendChild(child);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(3),
       sub: createMockTimeline(1),
     };
@@ -236,11 +224,7 @@ describe("initSandboxRuntimeModular", () => {
     initSandboxRuntimeModular();
     await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
 
-    const player = (
-      window as Window & {
-        __player?: { renderSeek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     player?.renderSeek(2);
@@ -278,17 +262,13 @@ describe("initSandboxRuntimeModular", () => {
     slide3.setAttribute("data-hf-authored-duration", "16");
     root.appendChild(slide3);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createPaddableMockTimeline(14),
     };
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { getDuration: () => number; seek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
     expect(player?.getDuration()).toBe(42);
 
@@ -326,18 +306,14 @@ describe("initSandboxRuntimeModular", () => {
     video.load = () => {};
     video.pause = pause;
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(40),
       "slide-translation": createMockTimeline(16),
     };
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { seek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     player?.seek(29);
@@ -373,18 +349,14 @@ describe("initSandboxRuntimeModular", () => {
     sceneB.setAttribute("data-duration", "4");
     child.appendChild(sceneB);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(20),
       nested: createMockTimeline(8),
     };
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { seek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     player?.seek(11);
@@ -424,18 +396,14 @@ describe("initSandboxRuntimeModular", () => {
     video.load = () => {};
     video.pause = pause;
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(40),
       "slide-translation": createMockTimeline(16),
     };
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { seek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     player?.seek(37);
@@ -479,7 +447,7 @@ describe("initSandboxRuntimeModular", () => {
     const tweetTimeline = createMockTimeline(4.5);
     const rootTimeline = createMockTimeline(24);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: rootTimeline,
       hook: hookTimeline,
       tweet: tweetTimeline,
@@ -487,11 +455,7 @@ describe("initSandboxRuntimeModular", () => {
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { renderSeek: (timeSeconds: number) => void };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     // Simulate that the hook timeline was paused (as happens when
@@ -556,17 +520,13 @@ describe("initSandboxRuntimeModular", () => {
     root.appendChild(audio);
 
     const childTimeline = createMockTimeline(4);
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       scene: childTimeline,
     };
 
     initSandboxRuntimeModular();
 
-    const player = (
-      window as Window & {
-        __player?: { play: () => void; getTime: () => number; isPlaying: () => boolean };
-      }
-    ).__player;
+    const player = window.__player;
     expect(player).toBeDefined();
 
     player?.play();
@@ -586,21 +546,15 @@ describe("initSandboxRuntimeModular", () => {
     root.setAttribute("data-height", "1080");
     document.body.appendChild(root);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+    window.__timelines = {
       main: createMockTimeline(10),
     };
 
     initSandboxRuntimeModular();
 
-    const win = window as Window & {
-      __playerReady?: boolean;
-      __renderReady?: boolean;
-      __player?: { _timeline: RuntimeTimelineLike | null };
-    };
-
-    expect(win.__playerReady).toBe(true);
-    expect(win.__renderReady).toBe(true);
-    expect(win.__player?._timeline).not.toBeNull();
+    expect(window.__playerReady).toBe(true);
+    expect(window.__renderReady).toBe(true);
+    expect(window.__player).toBeDefined();
   });
 
   it("does not set __renderReady when no timeline is available", () => {
@@ -612,16 +566,11 @@ describe("initSandboxRuntimeModular", () => {
     root.setAttribute("data-height", "1080");
     document.body.appendChild(root);
 
-    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {};
+    window.__timelines = {};
 
     initSandboxRuntimeModular();
 
-    const win = window as Window & {
-      __playerReady?: boolean;
-      __renderReady?: boolean;
-    };
-
-    expect(win.__playerReady).toBe(true);
-    expect(win.__renderReady).toBeUndefined();
+    expect(window.__playerReady).toBe(true);
+    expect(window.__renderReady).toBeUndefined();
   });
 });

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -557,7 +557,7 @@ describe("initSandboxRuntimeModular", () => {
     expect(window.__player).toBeDefined();
   });
 
-  it("does not set __renderReady when no timeline is available", () => {
+  it("sets __renderReady even without a GSAP timeline (CSS/WAAPI compositions)", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");
     root.setAttribute("data-root", "true");
@@ -571,6 +571,6 @@ describe("initSandboxRuntimeModular", () => {
     initSandboxRuntimeModular();
 
     expect(window.__playerReady).toBe(true);
-    expect(window.__renderReady).toBeUndefined();
+    expect(window.__renderReady).toBe(true);
   });
 });

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1634,6 +1634,8 @@ export function initSandboxRuntimeModular(): void {
     player._timeline = state.capturedTimeline;
   }
 
+  // __renderReady = timeline is bound, safe for deterministic seeking.
+  // fileServer.ts sets this immediately (no timeline to bind in its runtime).
   if (state.capturedTimeline) {
     (window as Window & { __renderReady?: boolean }).__renderReady = true;
   }

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1463,7 +1463,9 @@ export function initSandboxRuntimeModular(): void {
       .finally(() => {
         externalCompositionsReady = true;
         bindRootTimelineIfAvailable();
-        (window as Window & { __renderReady?: boolean }).__renderReady = true;
+        if (state.capturedTimeline) {
+          (window as Window & { __renderReady?: boolean }).__renderReady = true;
+        }
         runAdapters("discover", state.currentTime);
         bindMediaMetadataListeners();
         installAssetFailureDiagnostics();
@@ -1650,9 +1652,10 @@ export function initSandboxRuntimeModular(): void {
       if (bindRootTimelineIfAvailable() && state.capturedTimeline !== prevTimeline) {
         player._timeline = state.capturedTimeline;
       }
-      // Re-run adapters to discover new elements
       runAdapters("discover", state.currentTime);
-      (window as Window & { __renderReady?: boolean }).__renderReady = true;
+      if (state.capturedTimeline) {
+        (window as Window & { __renderReady?: boolean }).__renderReady = true;
+      }
       postTimeline();
       postState(true);
     }, 0);

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -28,17 +28,14 @@ const AUTHORED_END_ATTR = "data-hf-authored-end";
 
 export function initSandboxRuntimeModular(): void {
   const state = createRuntimeState();
-  const runtimeWindow = window as Window & {
-    __hfRuntimeTeardown?: (() => void) | null;
-  };
   let runtimeErrorListener: ((event: ErrorEvent) => void) | null = null;
   let runtimeUnhandledRejectionListener: ((event: PromiseRejectionEvent) => void) | null = null;
   const runtimeCleanupCallbacks: Array<() => void> = [];
   const postedDiagnosticKeys = new Set<string>();
   let rootStageDiagnosticRafId: number | null = null;
-  if (typeof runtimeWindow.__hfRuntimeTeardown === "function") {
+  if (typeof window.__hfRuntimeTeardown === "function") {
     try {
-      runtimeWindow.__hfRuntimeTeardown();
+      window.__hfRuntimeTeardown();
     } catch (err) {
       // keep runtime resilient across reinits
       swallow("runtime.init.site1", err);
@@ -1464,7 +1461,7 @@ export function initSandboxRuntimeModular(): void {
         externalCompositionsReady = true;
         bindRootTimelineIfAvailable();
         if (state.capturedTimeline) {
-          (window as Window & { __renderReady?: boolean }).__renderReady = true;
+          window.__renderReady = true;
         }
         runAdapters("discover", state.currentTime);
         bindMediaMetadataListeners();
@@ -1546,7 +1543,7 @@ export function initSandboxRuntimeModular(): void {
   });
 
   window.__player = createPlayerApiCompat(player);
-  (window as Window & { __playerReady?: boolean }).__playerReady = true;
+  window.__playerReady = true;
 
   // Wire analytics event emission through the bridge
   initRuntimeAnalytics(postRuntimeMessage as (payload: unknown) => void);
@@ -1639,7 +1636,7 @@ export function initSandboxRuntimeModular(): void {
   // __renderReady = timeline is bound, safe for deterministic seeking.
   // fileServer.ts sets this immediately (no timeline to bind in its runtime).
   if (state.capturedTimeline) {
-    (window as Window & { __renderReady?: boolean }).__renderReady = true;
+    window.__renderReady = true;
   }
 
   // When the bundler inlines compositions, data-composition-src is removed so
@@ -1654,7 +1651,7 @@ export function initSandboxRuntimeModular(): void {
       }
       runAdapters("discover", state.currentTime);
       if (state.capturedTimeline) {
-        (window as Window & { __renderReady?: boolean }).__renderReady = true;
+        window.__renderReady = true;
       }
       postTimeline();
       postState(true);
@@ -2169,11 +2166,11 @@ export function initSandboxRuntimeModular(): void {
     }
     state.injectedCompScripts = [];
     state.capturedTimeline = null;
-    if (runtimeWindow.__hfRuntimeTeardown === teardown) {
-      runtimeWindow.__hfRuntimeTeardown = null;
+    if (window.__hfRuntimeTeardown === teardown) {
+      window.__hfRuntimeTeardown = null;
     }
   };
-  runtimeWindow.__hfRuntimeTeardown = teardown;
+  window.__hfRuntimeTeardown = teardown;
   state.beforeUnloadHandler = teardown;
   window.addEventListener("beforeunload", state.beforeUnloadHandler);
 }

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1460,9 +1460,7 @@ export function initSandboxRuntimeModular(): void {
       .finally(() => {
         externalCompositionsReady = true;
         bindRootTimelineIfAvailable();
-        if (state.capturedTimeline) {
-          window.__renderReady = true;
-        }
+        window.__renderReady = true;
         runAdapters("discover", state.currentTime);
         bindMediaMetadataListeners();
         installAssetFailureDiagnostics();
@@ -1633,11 +1631,11 @@ export function initSandboxRuntimeModular(): void {
     player._timeline = state.capturedTimeline;
   }
 
-  // __renderReady = timeline is bound, safe for deterministic seeking.
+  // __renderReady = timeline binding attempted, safe for deterministic seeking.
+  // Set unconditionally: renderSeek works with or without a GSAP timeline
+  // (CSS/WAAPI/Lottie compositions use adapter-only seeking).
   // fileServer.ts sets this immediately (no timeline to bind in its runtime).
-  if (state.capturedTimeline) {
-    window.__renderReady = true;
-  }
+  window.__renderReady = true;
 
   // When the bundler inlines compositions, data-composition-src is removed so
   // loadExternalCompositions() is skipped. But inline scripts registering child
@@ -1650,9 +1648,7 @@ export function initSandboxRuntimeModular(): void {
         player._timeline = state.capturedTimeline;
       }
       runAdapters("discover", state.currentTime);
-      if (state.capturedTimeline) {
-        window.__renderReady = true;
-      }
+      window.__renderReady = true;
       postTimeline();
       postState(true);
     }, 0);

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1463,6 +1463,7 @@ export function initSandboxRuntimeModular(): void {
       .finally(() => {
         externalCompositionsReady = true;
         bindRootTimelineIfAvailable();
+        (window as Window & { __renderReady?: boolean }).__renderReady = true;
         runAdapters("discover", state.currentTime);
         bindMediaMetadataListeners();
         installAssetFailureDiagnostics();
@@ -1544,7 +1545,6 @@ export function initSandboxRuntimeModular(): void {
 
   window.__player = createPlayerApiCompat(player);
   (window as Window & { __playerReady?: boolean }).__playerReady = true;
-  (window as Window & { __renderReady?: boolean }).__renderReady = true;
 
   // Wire analytics event emission through the bridge
   initRuntimeAnalytics(postRuntimeMessage as (payload: unknown) => void);
@@ -1634,6 +1634,10 @@ export function initSandboxRuntimeModular(): void {
     player._timeline = state.capturedTimeline;
   }
 
+  if (state.capturedTimeline) {
+    (window as Window & { __renderReady?: boolean }).__renderReady = true;
+  }
+
   // When the bundler inlines compositions, data-composition-src is removed so
   // loadExternalCompositions() is skipped. But inline scripts registering child
   // timelines in __timelines haven't executed yet (they run in the browser's next
@@ -1646,6 +1650,7 @@ export function initSandboxRuntimeModular(): void {
       }
       // Re-run adapters to discover new elements
       runAdapters("discover", state.currentTime);
+      (window as Window & { __renderReady?: boolean }).__renderReady = true;
       postTimeline();
       postState(true);
     }, 0);

--- a/packages/core/src/runtime/window.d.ts
+++ b/packages/core/src/runtime/window.d.ts
@@ -31,6 +31,7 @@ declare global {
     __clipManifest?: RuntimeTimelineMessage;
     __playerReady?: boolean;
     __renderReady?: boolean;
+    __hfRuntimeTeardown?: (() => void) | null;
     __HF_PARITY_MODE?: boolean;
     __HF_FPS?: number;
     __HF_MAX_DURATION_SEC?: number;

--- a/packages/producer/src/services/fileServer.ts
+++ b/packages/producer/src/services/fileServer.ts
@@ -390,6 +390,8 @@ const RENDER_MODE_SCRIPT = `(function() {
       },
     };
     window.__playerReady = true;
+    // Media-fallback player has no timeline to bind, so render-ready is immediate.
+    // init.ts defers __renderReady until the timeline is bound — different runtime.
     window.__renderReady = true;
     return true;
   }


### PR DESCRIPTION
## Summary

- **Root cause in init.ts**: `__renderReady` was set at the same time as `__playerReady`, before the root timeline was bound. Moved it to fire only after `bindRootTimelineIfAvailable()` succeeds — either immediately, via the deferred `setTimeout(0)` rebinding for bundled compositions, or via the async `.finally()` for externally loaded compositions.
- **Snapshot consumer fix**: waits for `__renderReady` (the now-truthful signal) instead of `__timelines || __playerReady`. Uses `renderSeek()` with frame quantization and GSAP ticker tick, matching the parity harness. Awaits `document.fonts.ready` before capturing.

## Root cause

`init.ts` set `__renderReady = true` on line 1547, at the same time as `__playerReady`. But timeline binding happens later:
- Synchronously at `bindRootTimelineIfAvailable()` (line 1632)
- Via `setTimeout(0)` for bundled compositions (line 1642)
- Asynchronously via `loadExternalCompositions` (line 1461)

This meant `__renderReady` lied — it said "safe for deterministic frame capture" while the player had no timeline. The snapshot command (and any consumer using `__renderReady`) could call `renderSeek()` on a player with no captured timeline.

## Duration fallback removal

The old snapshot code walked `__timelines` looking for `.duration` as a fallback. This was dead code — it used the nonexistent `.duration` property (not a method call) which always returned `undefined`, falling through to the DOM attribute anyway. The new code uses `getDuration()` (the actual PlayerAPI method) with the DOM `data-duration` attribute as fallback. Since `__renderReady` guarantees the player is fully initialized, `getDuration()` should always be available at seek time.

## Verification

Instrumented the runtime to confirm:
- `__timelines` is set 15-56ms before `__playerReady` (same synchronous block, but the readiness check pattern matters for future consumers)
- After fix: `__renderReady` fires 1.4-3.4ms after `__playerReady`, confirming the timeline is bound before the signal
- `renderSeek(5)` works correctly at the moment `__renderReady` is set (verified across warm-grain, play-mode, product-promo)
- The old `__timelines` manual seek fallback produces **visually different frames** from `renderSeek` at 4/5 timestamps on warm-grain — the animation states diverge due to missing time quantization and sibling timeline activation

## Fallow audit

Fallow exits non-zero due to pre-existing duplication in `init.ts` (clone groups at lines 757-805 and 1612-1905, untouched by this PR) and inherited complexity findings across both files. The `captureSnapshots` function was already over the CRAP threshold pre-PR; the net -66 line reduction improves it slightly but doesn't cross it below. No new complexity or duplication introduced.

## Test plan

- [x] 985 core tests pass
- [x] 419 CLI tests pass
- [x] `bun run build` passes
- [x] Pre-commit lint, format, typecheck pass
- [x] `hyperframes snapshot` works on product-promo and warm-grain (built CLI)
- [x] `__renderReady` timing verified via instrumented probes (3 examples, 3 runs each)

Closes #1047