### PR TITLE
fix(aws-lambda): set PRODUCER_HEADLESS_SHELL_PATH in handlePlan

### DIFF
--- a/packages/aws-lambda/src/handler.ts
+++ b/packages/aws-lambda/src/handler.ts
@@ -229,6 +229,16 @@ async function handlePlan(event: PlanEvent, deps?: HandlerDeps): Promise<PlanLam
   const s3 = deps?.s3 ?? getS3Client();
   const primitive = deps?.primitives?.plan ?? plan;
 
+  // LOCAL PATCH (typecut): handlePlan calls plan() → runProbeStage() which
+  // launches Chrome. The published handler only set up the Chrome executable
+  // path in handleRenderChunk, so plan invocations errored with
+  // "An `executablePath` or `channel` must be specified for `puppeteer-core`".
+  // Mirror the renderChunk setup here. File upstream PR.
+  if (!deps?.skipChromeResolution && !process.env.PRODUCER_HEADLESS_SHELL_PATH) {
+    const chromePath = await resolveChromeExecutablePath();
+    process.env.PRODUCER_HEADLESS_SHELL_PATH = chromePath;
+  }
+
   const work = mkdtempSync(join(deps?.tmpRoot ?? tmpdir(), "hf-lambda-plan-"));
   // We use `.tar.gz` (not `.zip`) as the project archive's on-the-wire
   // format because Lambda's Amazon Linux base image ships GNU `tar` but


### PR DESCRIPTION
## Summary

`handlePlan` calls `plan()` → `runProbeStage()` → `createCaptureSession()` which launches Chromium. Without `PRODUCER_HEADLESS_SHELL_PATH` set in env, puppeteer-core throws at launch:

```
Error: An `executablePath` or `channel` must be specified for `puppeteer-core`
    at assert (puppeteer-core/src/util/assert.ts:19:11)
    at ChromeLauncher.computeLaunchArguments (puppeteer-core/src/node/ChromeLauncher.ts:125:7)
    at async launchBrowser (handler.mjs:376:17)
    at async acquireBrowser (handler.mjs:349:22)
    at async createCaptureSession (handler.mjs:12223:36)
    at async runProbeStage (handler.mjs:36451:20)
    at async plan (handler.mjs:37803:23)
    at async handlePlan (handler.mjs:41909:20)
```

`handleRenderChunk` already does this setup (current main, ~lines 301-308):

```ts
if (!deps?.skipChromeResolution && !process.env.PRODUCER_HEADLESS_SHELL_PATH) {
  const chromePath = await resolveChromeExecutablePath();
  process.env.PRODUCER_HEADLESS_SHELL_PATH = chromePath;
}
```

This PR mirrors that block into `handlePlan` so the Plan stage can also resolve Chrome via `@sparticuz/chromium`.

## Reproduction

Deploy the SAM stack via `hyperframes lambda deploy`. Invoke via `renderToLambda` with any composition that doesn't pre-supply duration on the root composition element — Plan needs to browse the page to compute `totalFrames`, hits the launch step, fails.

With the fix, Plan resolves Chrome the same way RenderChunk does and the distributed render proceeds normally.

## Test plan

- [ ] Deploy stack with patched handler
- [ ] Render an HTML composition that requires duration probing (no static `data-duration` on the root)
- [ ] Verify Plan succeeds and the rest of Plan → Map → Assemble runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)