### PR TITLE
fix: support animated media volume

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1241,6 +1241,10 @@ export function initSandboxRuntimeModular(): void {
     for (const mediaEl of mediaEls) {
       if (metadataBoundMedia.has(mediaEl)) continue;
       metadataBoundMedia.add(mediaEl);
+      const parsedVolume = Number.parseFloat(mediaEl.dataset.volume ?? "");
+      if (Number.isFinite(parsedVolume)) {
+        mediaEl.volume = Math.max(0, Math.min(1, parsedVolume));
+      }
       mediaEl.addEventListener("loadedmetadata", scheduleMetadataDurationHydration);
       mediaEl.addEventListener("durationchange", scheduleMetadataDurationHydration);
 
@@ -1312,6 +1316,7 @@ export function initSandboxRuntimeModular(): void {
       userMuted: state.bridgeMuted,
       userVolume: state.bridgeVolume,
       forceSync,
+      onElementVolume: (el, volume) => webAudio.setElementVolume(el, volume),
       onAutoplayBlocked: () => {
         if (state.mediaAutoplayBlockedPosted) return;
         state.mediaAutoplayBlockedPosted = true;
@@ -1461,8 +1466,8 @@ export function initSandboxRuntimeModular(): void {
         externalCompositionsReady = true;
         bindRootTimelineIfAvailable();
         window.__renderReady = true;
-        runAdapters("discover", state.currentTime);
         bindMediaMetadataListeners();
+        runAdapters("discover", state.currentTime);
         installAssetFailureDiagnostics();
         applyCaptionOverrides();
         postTimeline();
@@ -1667,8 +1672,8 @@ export function initSandboxRuntimeModular(): void {
   ] as RuntimeDeterministicAdapter[];
   patchVideoTextureCompat();
   installRuntimeErrorDiagnostics();
-  runAdapters("discover");
   bindMediaMetadataListeners();
+  runAdapters("discover");
   // ── Single-clock transport ──
   //
   // TransportClock is the sole time authority. GSAP is always paused —

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -343,6 +343,41 @@ describe("syncRuntimeMedia", () => {
     expect(clip.el.volume).toBeCloseTo(0.3);
   });
 
+  it("preserves authored volume changes made between sync ticks", () => {
+    const clip = createMockClip({ start: 0, end: 10, volume: 0 });
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 0, playing: false, playbackRate: 1 });
+    expect(clip.el.volume).toBe(0);
+
+    clip.el.volume = 0.5;
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 0.5, playing: false, playbackRate: 1 });
+
+    expect(clip.el.volume).toBe(0.5);
+  });
+
+  it("reports the effective element volume to external audio transports", () => {
+    const clip = createMockClip({ start: 0, end: 10, volume: 0 });
+    const onElementVolume = vi.fn();
+    syncRuntimeMedia({
+      clips: [clip],
+      timeSeconds: 0,
+      playing: false,
+      playbackRate: 1,
+      onElementVolume,
+    });
+    clip.el.volume = 0.75;
+    syncRuntimeMedia({
+      clips: [clip],
+      timeSeconds: 1,
+      playing: false,
+      playbackRate: 1,
+      userVolume: 0.5,
+      onElementVolume,
+    });
+
+    expect(clip.el.volume).toBeCloseTo(0.375);
+    expect(onElementVolume).toHaveBeenLastCalledWith(clip.el, 0.375);
+  });
+
   it("hard-syncs on the first active tick (sub-composition activation, mediaStart offsets)", () => {
     const clip = createMockClip({ start: 0, end: 10, mediaStart: 0 });
     Object.defineProperty(clip.el, "currentTime", { value: 0, writable: true });

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -103,6 +103,13 @@ function markPlayRequested(el: HTMLMediaElement): void {
   el.addEventListener("error", clear, { once: true });
 }
 
+const lastRuntimeAppliedVolume = new WeakMap<HTMLMediaElement, number>();
+
+function clampVolume(volume: number): number {
+  if (!Number.isFinite(volume)) return 1;
+  return Math.max(0, Math.min(1, volume));
+}
+
 export function syncRuntimeMedia(params: {
   clips: RuntimeMediaClip[];
   timeSeconds: number;
@@ -132,6 +139,7 @@ export function syncRuntimeMedia(params: {
    * outbound message; further invocations are suppressed by the caller.
    */
   onAutoplayBlocked?: () => void;
+  onElementVolume?: (el: HTMLMediaElement, volume: number) => void;
   forceSync?: boolean;
 }): void {
   // Either flag silences output. Combined up front so the per-clip loop is
@@ -151,8 +159,19 @@ export function syncRuntimeMedia(params: {
           relTime = clip.mediaStart + ((relTime - clip.mediaStart) % loopLength);
         }
       }
-      const userVol = params.userVolume ?? 1;
-      el.volume = (clip.volume ?? 1) * userVol;
+      const userVol = clampVolume(params.userVolume ?? 1);
+      const fallbackAuthorVolume = clampVolume(clip.volume ?? 1);
+      const previousRuntimeVolume = lastRuntimeAppliedVolume.get(el);
+      const currentElementVolume = clampVolume(el.volume);
+      const authorVolume =
+        previousRuntimeVolume !== undefined &&
+        Math.abs(currentElementVolume - previousRuntimeVolume) > 0.0001
+          ? currentElementVolume
+          : fallbackAuthorVolume;
+      const effectiveVolume = clampVolume(authorVolume * userVol);
+      el.volume = effectiveVolume;
+      lastRuntimeAppliedVolume.set(el, effectiveVolume);
+      params.onElementVolume?.(el, effectiveVolume);
       if (shouldMute) el.muted = true;
       // Ensure full preload for every active media element. Streaming
       // formats (MP3) may arrive with preload="metadata", which only
@@ -283,6 +302,7 @@ export function syncRuntimeMedia(params: {
     lastOffset.delete(el);
     strictDriftSamples.delete(el);
     seekLoadRetried.delete(el);
+    lastRuntimeAppliedVolume.delete(el);
     if (!el.paused) el.pause();
   }
 }

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -191,6 +191,18 @@ export class WebAudioTransport {
     }
   }
 
+  setElementVolume(el: HTMLMediaElement, volume: number): void {
+    const safeVolume = Math.max(0, Math.min(1, volume));
+    for (const source of this._activeSources) {
+      if (source.el !== el) continue;
+      try {
+        source.gainNode.gain.value = safeVolume;
+      } catch (err) {
+        swallow("webAudioTransport.setElementVolume", err);
+      }
+    }
+  }
+
   setMuted(muted: boolean): void {
     if (this._masterGain) {
       this._masterGain.gain.value = muted ? 0 : 1;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -135,7 +135,12 @@ export {
 export { createVideoFrameInjector } from "./services/videoFrameInjector.js";
 
 export { parseAudioElements, processCompositionAudio } from "./services/audioMixer.js";
-export type { AudioElement, AudioTrack, MixResult } from "./services/audioMixer.types.js";
+export type {
+  AudioElement,
+  AudioTrack,
+  AudioVolumeKeyframe,
+  MixResult,
+} from "./services/audioMixer.types.js";
 
 // ── Parallel rendering ─────────────────────────────────────────────────────────
 export {

--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -64,4 +64,47 @@ describe("processCompositionAudio", () => {
     expect(filter).toContain("volume=0");
     expect(filter).toContain("[mixed]volume=1[out]");
   });
+
+  it("uses frame-evaluated volume automation when keyframes are present", async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), "hf-audio-base-"));
+    const workDir = mkdtempSync(join(tmpdir(), "hf-audio-work-"));
+    tempDirs.push(baseDir, workDir);
+
+    writeFileSync(join(baseDir, "voice.wav"), "stub");
+
+    const result = await processCompositionAudio(
+      [
+        {
+          id: "voice",
+          src: "voice.wav",
+          start: 2,
+          end: 5,
+          mediaStart: 0,
+          layer: 0,
+          volume: 0,
+          volumeKeyframes: [
+            { time: 2, volume: 0 },
+            { time: 3, volume: 1 },
+            { time: 5, volume: 0.5 },
+          ],
+          type: "audio",
+        },
+      ],
+      baseDir,
+      workDir,
+      join(baseDir, "out.m4a"),
+      5,
+    );
+
+    expect(result.success).toBe(true);
+
+    const mixArgs = runFfmpegMock.mock.calls[1]?.[0];
+    const filterIndex = mixArgs.indexOf("-filter_complex");
+    const filter = mixArgs[filterIndex + 1];
+
+    expect(filter).toContain("volume=");
+    expect(filter).toContain(":eval=frame");
+    expect(filter).toContain("lt(t\\,1)");
+    expect(filter).toContain("adelay=2000|2000");
+  });
 });

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -27,7 +27,7 @@ function formatFilterNumber(value: number): string {
 }
 
 function escapeExpressionCommas(expression: string): string {
-  return expression.replace(/,/g, "\\,");
+  return expression.replace(/\\/g, "\\\\").replace(/,/g, "\\,");
 }
 
 function buildVolumeExpression(track: AudioTrack): string {

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -15,7 +15,67 @@ import { unwrapTemplate } from "../utils/htmlTemplate.js";
 import { resolveProjectRelativeSrc } from "./videoFrameExtractor.js";
 import type { AudioElement, AudioTrack, MixResult } from "./audioMixer.types.js";
 
-export type { AudioElement, AudioTrack, MixResult } from "./audioMixer.types.js";
+export type { AudioElement, MixResult } from "./audioMixer.types.js";
+
+function clampVolume(volume: number): number {
+  if (!Number.isFinite(volume)) return 1;
+  return Math.max(0, Math.min(1, volume));
+}
+
+function formatFilterNumber(value: number): string {
+  return Number(value.toFixed(6)).toString();
+}
+
+function escapeExpressionCommas(expression: string): string {
+  return expression.replace(/,/g, "\\,");
+}
+
+function buildVolumeExpression(track: AudioTrack): string {
+  const trimDuration = track.end - track.start;
+  const staticVolume = clampVolume(track.volume);
+  const keyframes = (track.volumeKeyframes ?? [])
+    .filter((keyframe) => Number.isFinite(keyframe.time) && Number.isFinite(keyframe.volume))
+    .map((keyframe) => ({
+      time: Math.max(0, Math.min(trimDuration, keyframe.time - track.start)),
+      volume: clampVolume(keyframe.volume),
+    }))
+    .sort((a, b) => a.time - b.time);
+
+  if (keyframes.length === 0) return `volume=${formatFilterNumber(staticVolume)}`;
+
+  if (keyframes[0]!.time > 0) {
+    keyframes.unshift({ time: 0, volume: staticVolume });
+  }
+
+  const deduped: typeof keyframes = [];
+  for (const keyframe of keyframes) {
+    const previous = deduped.at(-1);
+    if (previous && Math.abs(previous.time - keyframe.time) < 0.000001) {
+      previous.volume = keyframe.volume;
+    } else {
+      deduped.push(keyframe);
+    }
+  }
+
+  if (deduped.length === 1) {
+    return `volume=${formatFilterNumber(deduped[0]!.volume)}`;
+  }
+
+  let expression = formatFilterNumber(deduped.at(-1)!.volume);
+  for (let i = deduped.length - 2; i >= 0; i -= 1) {
+    const current = deduped[i]!;
+    const next = deduped[i + 1]!;
+    const currentTime = formatFilterNumber(current.time);
+    const nextTime = formatFilterNumber(next.time);
+    const currentVolume = formatFilterNumber(current.volume);
+    const span = Math.max(0.000001, next.time - current.time);
+    const slope = formatFilterNumber((next.volume - current.volume) / span);
+    const segment = `${currentVolume}+(${slope})*(t-${currentTime})`;
+    expression = `if(lt(t,${nextTime}),${segment},${expression})`;
+  }
+
+  return `volume=${escapeExpressionCommas(expression)}:eval=frame`;
+}
 
 interface ExtractResult {
   success: boolean;
@@ -246,8 +306,9 @@ async function mixAudioTracks(
     inputs.push("-i", track.srcPath);
     const delayMs = Math.round(track.start * 1000);
     const trimDuration = track.end - track.start;
+    const volumeFilter = buildVolumeExpression(track);
     filterParts.push(
-      `[${i}:a]atrim=0:${trimDuration},volume=${track.volume},adelay=${delayMs}|${delayMs},apad=whole_dur=${totalDuration}[a${i}]`,
+      `[${i}:a]atrim=0:${trimDuration},${volumeFilter},adelay=${delayMs}|${delayMs},apad=whole_dur=${totalDuration}[a${i}]`,
     );
   });
 
@@ -399,6 +460,7 @@ export async function processCompositionAudio(
           mediaStart: element.mediaStart,
           duration: element.end - element.start,
           volume: element.volume ?? 1.0,
+          volumeKeyframes: element.volumeKeyframes,
         });
       } catch (err: unknown) {
         errors.push(`Error: ${element.id} — ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/engine/src/services/audioMixer.types.ts
+++ b/packages/engine/src/services/audioMixer.types.ts
@@ -1,3 +1,8 @@
+export interface AudioVolumeKeyframe {
+  time: number;
+  volume: number;
+}
+
 export interface AudioElement {
   id: string;
   src: string;
@@ -6,6 +11,7 @@ export interface AudioElement {
   mediaStart: number;
   layer: number;
   volume?: number;
+  volumeKeyframes?: AudioVolumeKeyframe[];
   type: "audio" | "video";
 }
 
@@ -17,6 +23,7 @@ export interface AudioTrack {
   mediaStart: number;
   duration: number;
   volume: number;
+  volumeKeyframes?: AudioVolumeKeyframe[];
 }
 
 export interface MixResult {

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -8,6 +8,7 @@ import {
   compileForRender,
   detectRenderModeHints,
   detectShaderTransitionUsage,
+  discoverAudioVolumeAutomationFromTimeline,
   inlineExternalScripts,
   recompileWithResolutions,
 } from "./htmlCompiler.js";
@@ -793,5 +794,74 @@ describe("text-rendering rule injection", () => {
     const compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
 
     expect(compiled.html.replace(/\s+/g, "")).toContain("text-rendering:geometricPrecision");
+  });
+});
+
+describe("discoverAudioVolumeAutomationFromTimeline", () => {
+  it("samples video-derived audio volume without firing GSAP callbacks", async () => {
+    class TestAudioElement {}
+    class TestVideoElement {
+      id = "bg-video";
+      dataset = { start: "0", duration: "1", volume: "0" };
+      volume = 0;
+    }
+
+    const video = new TestVideoElement();
+    const seekCalls: { time: number; suppressEvents: boolean | undefined }[] = [];
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+    const previousAudioElement = globalThis.HTMLAudioElement;
+    const previousVideoElement = globalThis.HTMLVideoElement;
+
+    globalThis.window = {
+      __timelines: {
+        root: {
+          totalTime: (time: number, suppressEvents?: boolean) => {
+            seekCalls.push({ time, suppressEvents });
+            video.volume = Math.min(1, Math.max(0, time));
+          },
+        },
+      },
+    } as any;
+    globalThis.document = {
+      querySelector: (selector: string) =>
+        selector === "[data-composition-id]"
+          ? { getAttribute: (name: string) => (name === "data-composition-id" ? "root" : null) }
+          : null,
+      getElementById: (id: string) => (id === "bg-video" ? video : null),
+    } as any;
+    globalThis.HTMLAudioElement = TestAudioElement as any;
+    globalThis.HTMLVideoElement = TestVideoElement as any;
+
+    try {
+      const page = {
+        evaluate: async (fn: (arg: unknown) => unknown, arg: unknown) => fn(arg),
+      } as any;
+
+      const result = await discoverAudioVolumeAutomationFromTimeline(
+        page,
+        ["bg-video-audio"],
+        1,
+        2,
+      );
+
+      expect(result).toEqual([
+        {
+          id: "bg-video-audio",
+          keyframes: [
+            { time: 0, volume: 0 },
+            { time: 0.5, volume: 0.5 },
+            { time: 1, volume: 1 },
+          ],
+        },
+      ]);
+      expect(seekCalls.length).toBeGreaterThan(0);
+      expect(seekCalls.every((call) => call.suppressEvents === true)).toBe(true);
+    } finally {
+      globalThis.window = previousWindow;
+      globalThis.document = previousDocument;
+      globalThis.HTMLAudioElement = previousAudioElement;
+      globalThis.HTMLVideoElement = previousVideoElement;
+    }
   });
 });

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -1155,9 +1155,9 @@ export async function discoverAudioVolumeAutomationFromTimeline(
 
       const seekTl = (t: number) => {
         if (typeof tl.totalTime === "function") {
-          tl.totalTime(t, false);
+          tl.totalTime(t, true);
         } else if (typeof tl.seek === "function") {
-          tl.seek(t, false);
+          tl.seek(t, true);
         }
       };
 

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -31,6 +31,7 @@ import {
   type ImageElement,
   parseAudioElements,
   type AudioElement,
+  type AudioVolumeKeyframe,
   analyzeKeyframeIntervals,
 } from "@hyperframes/engine";
 import { downloadToTemp, isHttpUrl } from "../utils/urlDownloader.js";
@@ -1069,6 +1070,11 @@ export interface BrowserMediaElement {
   volume: number;
 }
 
+export interface BrowserAudioVolumeAutomation {
+  id: string;
+  keyframes: AudioVolumeKeyframe[];
+}
+
 export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMediaElement[]> {
   const elements = await page.evaluate(() => {
     const results: {
@@ -1117,6 +1123,97 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
   });
 
   return elements as BrowserMediaElement[];
+}
+
+export async function discoverAudioVolumeAutomationFromTimeline(
+  page: Page,
+  audioIds: string[],
+  compositionDuration: number,
+  sampleFps: number,
+): Promise<BrowserAudioVolumeAutomation[]> {
+  if (audioIds.length === 0 || compositionDuration <= 0) return [];
+
+  const sampleStep = 1 / Math.min(60, Math.max(1, sampleFps));
+  return page.evaluate(
+    ({ ids, duration, step }) => {
+      const results: { id: string; keyframes: { time: number; volume: number }[] }[] = [];
+      const timelines = (window as unknown as { __timelines?: Record<string, unknown> })
+        .__timelines;
+      if (!timelines) return results;
+
+      const rootEl = document.querySelector("[data-composition-id]");
+      const compId = rootEl?.getAttribute("data-composition-id");
+      if (!compId) return results;
+
+      const tl = timelines[compId] as
+        | {
+            totalTime?: (t: number, suppressEvents?: boolean) => unknown;
+            seek?: (t: number, suppressEvents?: boolean) => unknown;
+          }
+        | undefined;
+      if (!tl) return results;
+
+      const seekTl = (t: number) => {
+        if (typeof tl.totalTime === "function") {
+          tl.totalTime(t, false);
+        } else if (typeof tl.seek === "function") {
+          tl.seek(t, false);
+        }
+      };
+
+      for (const id of ids) {
+        const el =
+          document.getElementById(id) ?? document.getElementById(id.replace(/-audio$/, ""));
+        if (!(el instanceof HTMLAudioElement) && !(el instanceof HTMLVideoElement)) continue;
+
+        const start = Number.parseFloat(el.dataset.start ?? "0") || 0;
+        const endAttr = Number.parseFloat(el.dataset.end ?? "");
+        const durationAttr = Number.parseFloat(el.dataset.duration ?? "");
+        const end =
+          Number.isFinite(endAttr) && endAttr > start
+            ? endAttr
+            : Number.isFinite(durationAttr) && durationAttr > 0
+              ? start + durationAttr
+              : duration;
+        const sampleStart = Math.max(0, start);
+        const sampleEnd = Math.min(duration, end);
+        const initialVolumeAttr = Number.parseFloat(el.dataset.volume ?? "");
+        if (Number.isFinite(initialVolumeAttr)) {
+          el.volume = Math.max(0, Math.min(1, initialVolumeAttr));
+        }
+
+        const keyframes: { time: number; volume: number }[] = [];
+        for (let t = sampleStart; t <= sampleEnd + 0.000001; t += step) {
+          const boundedTime = Math.min(sampleEnd, t);
+          seekTl(boundedTime);
+          const rawVolume = Number(el.volume);
+          if (!Number.isFinite(rawVolume)) continue;
+          const volume = Math.max(0, Math.min(1, rawVolume));
+          const last = keyframes.at(-1);
+          if (!last || Math.abs(last.volume - volume) > 0.0001 || boundedTime === sampleEnd) {
+            keyframes.push({
+              time: Number(boundedTime.toFixed(6)),
+              volume: Number(volume.toFixed(6)),
+            });
+          }
+          if (boundedTime === sampleEnd) break;
+        }
+
+        const staticAttr = Number.parseFloat(el.dataset.volume ?? "");
+        const staticVolume = Number.isFinite(staticAttr) ? Math.max(0, Math.min(1, staticAttr)) : 1;
+        const hasAutomation = keyframes.some(
+          (keyframe) => Math.abs(keyframe.volume - staticVolume) > 0.0001,
+        );
+        if (hasAutomation) {
+          results.push({ id, keyframes });
+        }
+      }
+
+      seekTl(0);
+      return results;
+    },
+    { ids: audioIds, duration: compositionDuration, step: sampleStep },
+  );
 }
 
 export interface VideoVisibilityWindow {

--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { hasScriptedAudioVolumeAutomation } from "./probeStage.js";
+
+describe("hasScriptedAudioVolumeAutomation", () => {
+  it("ignores non-script volume text", () => {
+    expect(
+      hasScriptedAudioVolumeAutomation(
+        `<style>.volume-control { opacity: 1; }</style><script>const level = 1;</script>`,
+        1,
+      ),
+    ).toBe(false);
+  });
+
+  it("detects direct media volume writes", () => {
+    expect(hasScriptedAudioVolumeAutomation(`<script>audio.volume = 0.5;</script>`, 1)).toBe(true);
+  });
+
+  it("detects GSAP volume tweens", () => {
+    expect(
+      hasScriptedAudioVolumeAutomation(`<script>gsap.to(audio, { volume: 1 });</script>`, 1),
+    ).toBe(true);
+  });
+
+  it("requires audio metadata", () => {
+    expect(
+      hasScriptedAudioVolumeAutomation(`<script>gsap.to(audio, { volume: 1 });</script>`, 0),
+    ).toBe(false);
+  });
+});

--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -21,6 +21,10 @@ describe("hasScriptedAudioVolumeAutomation", () => {
     ).toBe(true);
   });
 
+  it("parses script tags with whitespace before the closing bracket", () => {
+    expect(hasScriptedAudioVolumeAutomation(`<script>audio.volume = 0.5;</script >`, 1)).toBe(true);
+  });
+
   it("requires audio metadata", () => {
     expect(
       hasScriptedAudioVolumeAutomation(`<script>gsap.to(audio, { volume: 1 });</script>`, 0),

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -88,6 +88,22 @@ export interface ProbeStageResult {
   browserProbeMs: number;
 }
 
+export function hasScriptedAudioVolumeAutomation(html: string, audioCount: number): boolean {
+  if (audioCount <= 0) return false;
+
+  const scriptBodies = [...html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)]
+    .map((match) => match[1] ?? "")
+    .join("\n");
+  if (!scriptBodies) return false;
+
+  return (
+    /\.\s*volume\s*=/i.test(scriptBodies) ||
+    /\b(?:gsap|tl|timeline|tween)\s*\.\s*(?:to|fromTo|set)\s*\([\s\S]{0,2000}\bvolume\s*:/i.test(
+      scriptBodies,
+    )
+  );
+}
+
 export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageResult> {
   const {
     projectDir,
@@ -109,10 +125,10 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
 
   const probeStart = Date.now();
   const hasAutoStartVideos = compiled.html.includes("data-hf-auto-start");
-  const hasScriptedAudio =
-    composition.audios.length > 0 &&
-    /<script\b/i.test(compiled.html) &&
-    /\b(?:volume|data-volume)\b/i.test(compiled.html);
+  const hasScriptedAudio = hasScriptedAudioVolumeAutomation(
+    compiled.html,
+    composition.audios.length,
+  );
   const needsBrowser =
     composition.duration <= 0 ||
     compiled.unresolvedCompositions.length > 0 ||

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -40,6 +40,7 @@ import { fpsToNumber } from "@hyperframes/core";
 import type { CompiledComposition } from "../../htmlCompiler.js";
 import {
   discoverMediaFromBrowser,
+  discoverAudioVolumeAutomationFromTimeline,
   discoverVideoVisibilityFromTimeline,
   recompileWithResolutions,
   resolveCompositionDurations,
@@ -108,14 +109,22 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
 
   const probeStart = Date.now();
   const hasAutoStartVideos = compiled.html.includes("data-hf-auto-start");
+  const hasScriptedAudio =
+    composition.audios.length > 0 &&
+    /<script\b/i.test(compiled.html) &&
+    /\b(?:volume|data-volume)\b/i.test(compiled.html);
   const needsBrowser =
-    composition.duration <= 0 || compiled.unresolvedCompositions.length > 0 || hasAutoStartVideos;
+    composition.duration <= 0 ||
+    compiled.unresolvedCompositions.length > 0 ||
+    hasAutoStartVideos ||
+    hasScriptedAudio;
 
   if (needsBrowser) {
     const reasons = [];
     if (composition.duration <= 0) reasons.push("root duration unknown");
     if (compiled.unresolvedCompositions.length > 0)
       reasons.push(`${compiled.unresolvedCompositions.length} unresolved composition(s)`);
+    if (hasScriptedAudio) reasons.push("scripted audio volume");
 
     fileServer = await createFileServer({
       projectDir,
@@ -289,6 +298,27 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
             });
             existingAudioIds.add(el.id);
           }
+        }
+      }
+    }
+
+    if (composition.audios.length > 0) {
+      const automation = await discoverAudioVolumeAutomationFromTimeline(
+        probeSession.page,
+        composition.audios.map((audio) => audio.id),
+        composition.duration,
+        fpsToNumber(job.config.fps),
+      );
+      assertNotAborted();
+      if (automation.length > 0) {
+        const byId = new Map(automation.map((entry) => [entry.id, entry.keyframes]));
+        for (const audio of composition.audios) {
+          const keyframes = byId.get(audio.id);
+          if (!keyframes || keyframes.length === 0) continue;
+          audio.volumeKeyframes = keyframes;
+          log.info(`[Probe] Runtime audio volume automation: ${audio.id}`, {
+            keyframeCount: keyframes.length,
+          });
         }
       }
     }

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -28,6 +28,7 @@
  */
 
 import { join } from "node:path";
+import { parseHTML } from "linkedom";
 import {
   type CaptureOptions,
   type CaptureSession,
@@ -91,8 +92,9 @@ export interface ProbeStageResult {
 export function hasScriptedAudioVolumeAutomation(html: string, audioCount: number): boolean {
   if (audioCount <= 0) return false;
 
-  const scriptBodies = [...html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)]
-    .map((match) => match[1] ?? "")
+  const { document } = parseHTML(html);
+  const scriptBodies = [...document.querySelectorAll("script")]
+    .map((script) => script.textContent ?? "")
     .join("\n");
   if (!scriptBodies) return false;
 


### PR DESCRIPTION
## Problem

Audio-capable media could only use a static `data-volume` value during preview/render. Issue #1064 reports this for `<audio>`: GSAP/JS attempts to fade an element from `volume: 0` to a non-zero value still rendered as silent because HyperFrames only respected the initial `data-volume` value.

The same root cause applies to `<video data-has-audio="true">`: preview/runtime can animate the media element, but the offline audio mix previously only had one static volume number for the extracted audio track.

Closes #1064.

## What this fixes

- Preserves authored `HTMLMediaElement.volume` changes made by GSAP/JS between runtime media sync ticks instead of clobbering them back to `data-volume`.
- Updates the WebAudio transport gain for active media sources when the element volume changes.
- Probes scripted media timelines in the producer browser pass and records sampled volume keyframes for both `<audio>` elements and video-derived audio tracks.
- Maps extracted video audio IDs such as `bg-video-audio` back to their source `<video id="bg-video">` so video volume automation is sampled from the actual element.
- Converts sampled keyframes into a frame-evaluated FFmpeg `volume` expression during audio mixing, so rendered output includes fades and other timeline-driven media volume changes.

## Root cause

There were two static-volume paths:

1. Runtime media sync treated `clip.volume` parsed from `data-volume` as authoritative on every tick and rewrote `el.volume = clip.volume * userVolume`, undoing GSAP/JS updates after timeline seeks.
2. The producer audio stage mixed audio from compile/probe metadata, where `volume` was a single number. The FFmpeg filter used `volume=<initial value>`, so a clip starting at `data-volume="0"` stayed silent in the muxed output even if the browser timeline had changed `audio.volume` or `video.volume`.

The fix makes the browser/runtime media volume the source of truth when authors animate it, then carries that time-varying signal into the offline mix.

## Verification

### Local checks

- `bun install` in the clean worktree
- `bun run build:hyperframes-runtime`
- `bun run --filter @hyperframes/core test -- src/runtime/media.test.ts`
- `bun run --filter @hyperframes/engine test -- src/services/audioMixer.test.ts`
- `bun run --filter @hyperframes/core typecheck && bun run --filter @hyperframes/engine typecheck && bun run --filter @hyperframes/producer typecheck`
- `bunx oxfmt --check <10 touched files>`
- `bunx oxlint <10 touched files>`
- `bun run --filter @hyperframes/producer build`

### Audio repro and render proof

Created `/tmp/hf-1064` with `<audio id="bg-audio" ... data-volume="0">` and `gsap.to(audio, { volume: 1 })`.

Before fix:
- `RMS level dB: -inf`

After fix:
- `[Probe] Runtime audio volume automation: bg-audio {"keyframeCount":12}`
- `RMS level dB: -24.133461`

### Video repro and render proof

Created `/tmp/hf-1064-video` with `<video id="bg-video" data-has-audio="true" data-volume="0">` and `gsap.to(video, { volume: 1 })`.

After widening the probe mapping:
- `[Probe] Runtime audio volume automation: bg-video-audio {"keyframeCount":12}`
- `RMS level dB: -24.203664`

### Preview verification

Used `hyperframes preview` from the PR branch and `agent-browser` against Studio:

- Audio preview direct seek through `window.__player.seek(...)` showed `#bg-audio.volume`: `0 -> 0.5 -> 1`.
- Audio preview playback advanced to ~0.92s with `#bg-audio.volume` ~0.917 and the audio element unpaused.
- Video preview direct seek showed `#bg-video.volume`: `0 -> 0.5 -> 1`.
- Video preview playback sampled during the fade at ~0.68s showed `#bg-video.volume` around `0.664`.

### Browser verification

Used `agent-browser` against the rendered MP4 from the PR branch:

- Opened `file:///tmp/hf-1064/out-pr.mp4`
- Verified the browser loaded a playable `<video>`: `{"hasVideo":true,"duration":3.020996,"readyState":4,"paused":false}`
- Screenshot artifact: `/Users/miguel07code/dev/hyperframes-oss/qa-artifacts/issue-1064/pr-rendered-video.png`
- Recording artifact: `/Users/miguel07code/dev/hyperframes-oss/qa-artifacts/issue-1064/pr-rendered-video.webm`

## Notes

- The commit was prepared in a clean worktree based on `origin/main` to avoid mixing in the existing `fix/nonlatin-media-src-resolution` checkout changes.
- Pre-commit lint, format, and typecheck passed. The hook's Fallow audit still exits non-zero on inherited duplication/complexity in the touched large runtime/probe files; the dead-code issue from the new type export was fixed before committing.
- Volume automation is sampled from the browser timeline and approximated as piecewise-linear FFmpeg volume expressions. This is intended for timeline-driven GSAP/JS fades, not audio-rate DSP.
