### PR TITLE
fix(studio): filter media decode errors from crash telemetry

### DIFF
--- a/packages/studio/src/main.tsx
+++ b/packages/studio/src/main.tsx
@@ -23,10 +23,10 @@ function errorProps(value: unknown): {
 }
 
 // fallow-ignore-next-line complexity
-function isCompositionAssetError(msg: string): boolean {
+function isCompositionAssetError(msg: string, name: string | null): boolean {
   if (msg.includes("Error fetching") && (msg.includes("404") || msg.includes("Not Found")))
     return true;
-  if (msg.includes("unsupported or unrecognizable format")) return true;
+  if (name === "EncodingError" || msg.includes("unsupported or unrecognizable format")) return true;
   if (msg.includes("MEDIA_ERR_SRC_NOT_SUPPORTED")) return true;
   return false;
 }
@@ -62,9 +62,22 @@ window.addEventListener("error", (event) => {
   });
 });
 
+let filteredAssetErrorCount = 0;
+
+// fallow-ignore-next-line complexity
 window.addEventListener("unhandledrejection", (event) => {
   const props = errorProps(event.reason);
-  if (isCompositionAssetError(props.error_message)) return;
+  if (isCompositionAssetError(props.error_message, props.error_name)) {
+    filteredAssetErrorCount++;
+    if (filteredAssetErrorCount === 1 || filteredAssetErrorCount % 100 === 0) {
+      trackStudioEvent("composition_asset_error_filtered", {
+        error_message: props.error_message.slice(0, 200),
+        error_name: props.error_name,
+        total_filtered: filteredAssetErrorCount,
+      });
+    }
+    return;
+  }
 
   rejectionCount++;
   if (rejectionCount > ERROR_CAP) {


### PR DESCRIPTION
## Summary

- Broadens `isCompositionAssetError()` in `main.tsx` to filter media decode failures from crash telemetry
- "Input has an unsupported or unrecognizable format" (`decodeAudioData` DOMException) and `MEDIA_ERR_SRC_NOT_SUPPORTED` are user-content failures (unsupported codec), not application bugs
- Uses `error_name === "EncodingError"` for tighter cross-browser filtering (canonical DOMException name)
- Adds sampled `composition_asset_error_filtered` tracking event (1st + every 100th) so regressions remain visible
- **567K events from 1,017 users** in the last 7 days — all noise, drowning out real crashes

Dashboard: https://us.posthog.com/project/356858/dashboard/1613945

## Changes

- `packages/studio/src/main.tsx`: `isCompositionAssetError` now accepts `error_name` and matches on `EncodingError` + message strings. Sampled counter fires on 1st occurrence and every 100th.

## Test plan

- [ ] Load a composition with an unsupported audio format — verify no `unhandled_promise_rejection` telemetry fires, but `composition_asset_error_filtered` does fire once
- [ ] Load a composition with a 404 asset — verify existing filter still works
- [ ] Load a normal composition — verify real errors are still tracked