### PR TITLE
fix(core): revert Function constructor regression in sub-composition scripts

### DIFF
--- a/packages/core/src/compiler/compositionScoping.test.ts
+++ b/packages/core/src/compiler/compositionScoping.test.ts
@@ -572,14 +572,15 @@ window.__afterTimeline = window.__timelines.scene;
     expect(scoped).toContain('[data-composition-id="chrome-overlay"] .child-element');
   });
 
-  it("wraps scoped composition script source as a string literal", () => {
+  it("escapes </script> in scoped composition script source to prevent injection", () => {
     const wrapped = wrapScopedCompositionScript(
       'window.payload = "</script><script>window.pwned = true;</script>";',
       "scene",
     );
 
-    expect(wrapped).toContain('Function("document", "gsap", "window", "__hyperframes", ');
-    expect(wrapped).toContain('\\"</script><script>window.pwned = true;</script>\\"');
+    expect(wrapped).toContain("(function(document, gsap, window, __hyperframes)");
+    expect(wrapped).not.toContain("</script><script>");
+    expect(wrapped).toContain("<\\/script>");
   });
 
   it("wraps unscoped composition script source as a string literal", () => {

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -486,7 +486,7 @@ export function wrapScopedCompositionScript(
   var __hfRun = function() {
     try {
       (function(document, gsap, window, __hyperframes) {
-${source}
+${source.replace(/<\/(script)/gi, "<\\/$1")}
       }).call(window, __hfScopedDocument, __hfScopedGsap, __hfScopedWindow, __hfScopedHyperframes);
     } catch (_err) {
       console.error(__hfErrorLabel, __hfCompId, _err);

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -216,7 +216,6 @@ export function wrapScopedCompositionScript(
   const authoredRootIdFormsLiteral = JSON.stringify(
     getAuthoredRootIdSelectorForms(authoredRootId?.trim() || ""),
   );
-  const sourceLiteral = JSON.stringify(source);
   return `(function(){
   var __hfCompId = ${compositionIdLiteral};
   var __hfTimelineCompId = ${timelineCompositionIdLiteral};
@@ -486,8 +485,9 @@ export function wrapScopedCompositionScript(
       });
   var __hfRun = function() {
     try {
-      var __hfScript = Function("document", "gsap", "window", "__hyperframes", ${sourceLiteral});
-      __hfScript.call(window, __hfScopedDocument, __hfScopedGsap, __hfScopedWindow, __hfScopedHyperframes);
+      (function(document, gsap, window, __hyperframes) {
+${source}
+      }).call(window, __hfScopedDocument, __hfScopedGsap, __hfScopedWindow, __hfScopedHyperframes);
     } catch (_err) {
       console.error(__hfErrorLabel, __hfCompId, _err);
     }

--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -758,8 +758,8 @@ describe("bundleToSingleHtml", () => {
     expect(bundled).toContain('[data-composition-id="scene"] .title { color: red; }');
     expect(bundled).toContain("new Proxy(window.document");
     expect(bundled).toContain("new Proxy(__hfBaseGsap");
-    expect(bundled).toContain('Function("document", "gsap", "window", "__hyperframes",');
-    expect(bundled).toContain("tl.to('.title'");
+    expect(bundled).toContain("(function(document, gsap, window, __hyperframes)");
+    expect(bundled).toContain('tl.to(".title"');
   });
 
   it("isolates sibling instances of the same external sub-composition", async () => {


### PR DESCRIPTION
## Summary

Reverts the `Function` constructor change from commit `3bb0d1ef` that broke all sub-composition scripts using `document.getElementById()`. The `Function` constructor creates functions with global scope (`[[Scope]] = global`), losing access to the composition-scoped DOM proxy — native method calls on proxy-returned elements throw `"Illegal invocation"`.

Closes #1074

## Root cause

`3bb0d1ef` changed `wrapScopedCompositionScript` from an inline IIFE to a `Function`-constructor invocation:

```diff
-  (function(document, gsap, window, __hyperframes) {
-    ${source}
-  }).call(window, __hfScopedDocument, ...);
+  var __hfScript = Function("document", "gsap", "window", "__hyperframes", sourceLiteral);
+  __hfScript.call(window, __hfScopedDocument, ...);
```

The `Function` constructor's scope chain is always global — the composition-scoped `__hf*` helpers are only available as named parameters, not via closure. This breaks the DOM proxy's `value.bind(target)` chain for native methods like `canvas.getContext("2d")`.

## Affected surface

All registry shader-transition blocks (`swirl-vortex`, `sdf-iris`, `glitch`, etc.) and any user composition where a sub-comp script calls `document.getElementById()` followed by a native DOM method.

## Verification

Reproduced with the reporter's minimal repro (sub-comp with `<canvas id="gl-canvas">` + `document.getElementById("gl-canvas").getContext("2d")`):
- **Before fix**: `TypeError: Illegal invocation` / `null` from getElementById
- **After fix**: Render completes successfully (3.4KB, 1.5s)

## Test plan

- [ ] Render a composition with sub-comp scripts calling `document.getElementById` — no errors
- [ ] Render a shader-transition composition (WebGL sub-comp) — canvas initializes correctly
- [ ] Render a GSAP-only sub-comp — unchanged behavior (was already working)
- [ ] `bun run --cwd packages/core test` passes