### PR TITLE
fix(studio): align editor overlays with GSAP-transformed elements during playback

### DIFF
--- a/packages/studio/src/components/editor/domEditOverlayGeometry.ts
+++ b/packages/studio/src/components/editor/domEditOverlayGeometry.ts
@@ -92,9 +92,16 @@ export function toOverlayRect(
   const root =
     doc?.querySelector<HTMLElement>("[data-composition-id]") ?? doc?.documentElement ?? null;
   const rootRect = root?.getBoundingClientRect();
-  const rootWidth = rootRect?.width;
-  const rootHeight = rootRect?.height;
-  if (!rootWidth || !rootHeight) return null;
+  // Use the composition's declared dimensions (data-width/data-height) for scale
+  // calculation instead of rootRect.width/height. When GSAP applies transforms
+  // (scale, translate) to the root element, rootRect dimensions change but the
+  // composition's canonical size stays the same. Using rootRect causes overlay
+  // misalignment during animated playback.
+  const declaredWidth = readPositiveDimension(root?.getAttribute("data-width") ?? null);
+  const declaredHeight = readPositiveDimension(root?.getAttribute("data-height") ?? null);
+  const rootWidth = declaredWidth ?? rootRect?.width;
+  const rootHeight = declaredHeight ?? rootRect?.height;
+  if (!rootWidth || !rootHeight || !rootRect) return null;
 
   const elementRect = element.getBoundingClientRect();
   const rootScaleX = iframeRect.width / rootWidth;

--- a/packages/studio/src/components/editor/domEditOverlayGeometry.ts
+++ b/packages/studio/src/components/editor/domEditOverlayGeometry.ts
@@ -118,8 +118,8 @@ export function toOverlayRect(
   });
 
   return {
-    left: iframeRect.left - overlayRect.left + (elementRect.left - rootRect.left) * rootScaleX,
-    top: iframeRect.top - overlayRect.top + (elementRect.top - rootRect.top) * rootScaleY,
+    left: iframeRect.left - overlayRect.left + elementRect.left * rootScaleX,
+    top: iframeRect.top - overlayRect.top + elementRect.top * rootScaleY,
     width: elementRect.width * rootScaleX,
     height: elementRect.height * rootScaleY,
     editScaleX: editScale.scaleX,


### PR DESCRIPTION
## Summary

Fix studio editor overlays (selection borders, element highlights) appearing at wrong positions when GSAP transforms are active on the composition root — e.g., during scroll animations (`y: -500`) or entrance animations (`scale: 0.95`).

## Root Cause

`toOverlayRect()` in `domEditOverlayGeometry.ts` calculated overlay position as:

```typescript
left: iframeRect.left - overlayRect.left + (elementRect.left - rootRect.left) * rootScaleX
top:  iframeRect.top  - overlayRect.top  + (elementRect.top  - rootRect.top)  * rootScaleY
```

The `elementRect - rootRect` subtraction **cancels out** the root's GSAP transform. Both `elementRect` and `rootRect` shift by the same amount when the root is transformed, so their difference always reflects the un-transformed position. The overlay stays at the element's original layout position, ignoring any GSAP animation.

Additionally, `rootScaleX/Y` was computed from `rootRect.width/height` (the transformed bounding rect), which changes when GSAP applies scale transforms — producing wrong scale factors.

## Fix

Two changes:

1. **Remove `rootRect` subtraction** — use `elementRect.left/top` directly. `getBoundingClientRect()` returns viewport-relative coordinates that already reflect GSAP transforms, which is exactly what the overlay needs.

```diff
- left: iframeRect.left - overlayRect.left + (elementRect.left - rootRect.left) * rootScaleX,
- top:  iframeRect.top  - overlayRect.top  + (elementRect.top  - rootRect.top)  * rootScaleY,
+ left: iframeRect.left - overlayRect.left + elementRect.left * rootScaleX,
+ top:  iframeRect.top  - overlayRect.top  + elementRect.top  * rootScaleY,
```

2. **Use `data-width`/`data-height` for scale** — the composition's declared dimensions don't change with GSAP transforms, unlike `rootRect.width/height`.

```diff
+ const declaredWidth = readPositiveDimension(root?.getAttribute("data-width") ?? null);
+ const declaredHeight = readPositiveDimension(root?.getAttribute("data-height") ?? null);
+ const rootWidth = declaredWidth ?? rootRect?.width;
+ const rootHeight = declaredHeight ?? rootRect?.height;
```

## Test plan

- [x] Select an element during GSAP scroll animation (`y: -500`) — overlay follows the element
- [ ] Select an element during GSAP entrance (`scale: 0.95 → 1.0`) — overlay matches element size
- [ ] Verify overlays work on compositions without GSAP transforms (normal case)
- [ ] Verify drag/resize gestures still work correctly
- [ ] Verify overlay positioning in nested sub-compositions