### PR TITLE
fix(studio): make static-seek adapter honor keepPlaying option

### DIFF
--- a/packages/studio/src/player/lib/playbackAdapter.test.ts
+++ b/packages/studio/src/player/lib/playbackAdapter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { wrapTimeline } from "./playbackAdapter";
-import type { TimelineLike } from "./playbackTypes";
+import { createStaticSeekPlaybackAdapter, wrapTimeline } from "./playbackAdapter";
+import type {
+  RuntimePlaybackAdapter,
+  StaticSeekPlaybackClock,
+  TimelineLike,
+} from "./playbackTypes";
 
 describe("wrapTimeline seek keepPlaying option (#834)", () => {
   function mockTimeline(): TimelineLike & {
@@ -46,5 +50,164 @@ describe("wrapTimeline seek keepPlaying option (#834)", () => {
 
     expect(tl.pause).toHaveBeenCalledTimes(2);
     expect(tl.seek).toHaveBeenCalledWith(5);
+  });
+});
+
+describe("createStaticSeekPlaybackAdapter seek keepPlaying option", () => {
+  type StaticSeekPlayer = Pick<RuntimePlaybackAdapter, "getTime"> &
+    Partial<Pick<RuntimePlaybackAdapter, "renderSeek" | "seek">>;
+
+  function makeFakeClock(): StaticSeekPlaybackClock & {
+    runNextFrame: () => boolean;
+    cancelled: number[];
+    scheduled: number;
+    setNow: (ms: number) => void;
+  } {
+    let now = 0;
+    let nextHandle = 0;
+    const pending = new Map<number, FrameRequestCallback>();
+    const cancelled: number[] = [];
+    let scheduled = 0;
+    return {
+      now: () => now,
+      requestAnimationFrame: (cb) => {
+        nextHandle += 1;
+        pending.set(nextHandle, cb);
+        scheduled += 1;
+        return nextHandle;
+      },
+      cancelAnimationFrame: (handle) => {
+        if (pending.delete(handle)) cancelled.push(handle);
+      },
+      runNextFrame: () => {
+        const next = pending.entries().next();
+        if (next.done) return false;
+        const [handle, cb] = next.value;
+        pending.delete(handle);
+        cb(now);
+        return true;
+      },
+      cancelled,
+      get scheduled() {
+        return scheduled;
+      },
+      setNow: (ms) => {
+        now = ms;
+      },
+    };
+  }
+
+  function makePlayer(): StaticSeekPlayer & {
+    renderSeek: ReturnType<typeof vi.fn>;
+  } {
+    return {
+      getTime: () => 0,
+      renderSeek: vi.fn(),
+    };
+  }
+
+  it("default seek stops the RAF ticker so the adapter reports paused", () => {
+    const clock = makeFakeClock();
+    const player = makePlayer();
+    const adapter = createStaticSeekPlaybackAdapter(player, 10, clock);
+
+    adapter.play();
+    expect(adapter.isPlaying()).toBe(true);
+
+    adapter.seek(5);
+
+    expect(adapter.isPlaying()).toBe(false);
+    expect(adapter.getTime()).toBe(5);
+    expect(player.renderSeek).toHaveBeenLastCalledWith(5);
+    expect(clock.cancelled.length).toBeGreaterThan(0);
+  });
+
+  it("default seek prevents the ticker from advancing further", () => {
+    const clock = makeFakeClock();
+    const player = makePlayer();
+    const adapter = createStaticSeekPlaybackAdapter(player, 10, clock);
+
+    adapter.play();
+    player.renderSeek.mockClear();
+
+    adapter.seek(5);
+
+    // Any frame the RAF callback already had queued before cancel should be a no-op.
+    clock.setNow(1000);
+    clock.runNextFrame();
+    expect(player.renderSeek).toHaveBeenCalledTimes(1); // only the seek itself
+    expect(player.renderSeek).toHaveBeenLastCalledWith(5);
+    expect(adapter.getTime()).toBe(5);
+  });
+
+  it("seek with { keepPlaying: true } preserves playback and rebases the ticker", () => {
+    const clock = makeFakeClock();
+    const player = makePlayer();
+    const adapter = createStaticSeekPlaybackAdapter(player, 10, clock);
+
+    adapter.play();
+    clock.setNow(500);
+    expect(adapter.isPlaying()).toBe(true);
+
+    adapter.seek(3, { keepPlaying: true });
+
+    expect(adapter.isPlaying()).toBe(true);
+    expect(adapter.getTime()).toBe(3);
+
+    // Advance 1s of wall-clock time. With playStartTime rebased to 3 and
+    // playStartNow rebased to 500, the next tick should render around t=4.
+    clock.setNow(1500);
+    clock.runNextFrame();
+    expect(player.renderSeek).toHaveBeenLastCalledWith(4);
+  });
+
+  it("seek with { keepPlaying: false } pauses (matches default)", () => {
+    const clock = makeFakeClock();
+    const player = makePlayer();
+    const adapter = createStaticSeekPlaybackAdapter(player, 10, clock);
+
+    adapter.play();
+    adapter.seek(5, { keepPlaying: false });
+
+    expect(adapter.isPlaying()).toBe(false);
+    expect(player.renderSeek).toHaveBeenLastCalledWith(5);
+  });
+
+  it("seek with { keepPlaying: true } does not force playback when adapter is paused", () => {
+    const clock = makeFakeClock();
+    const player = makePlayer();
+    const adapter = createStaticSeekPlaybackAdapter(player, 10, clock);
+
+    adapter.seek(2, { keepPlaying: true });
+
+    expect(adapter.isPlaying()).toBe(false);
+    expect(adapter.getTime()).toBe(2);
+    expect(player.renderSeek).toHaveBeenLastCalledWith(2);
+  });
+
+  it("seek without options stays back-compatible with the previous signature", () => {
+    const clock = makeFakeClock();
+    const player = makePlayer();
+    const adapter = createStaticSeekPlaybackAdapter(player, 10, clock);
+
+    // Caller written before the options parameter existed.
+    adapter.seek(4);
+
+    expect(player.renderSeek).toHaveBeenLastCalledWith(4);
+    expect(adapter.getTime()).toBe(4);
+    expect(adapter.isPlaying()).toBe(false);
+  });
+
+  it("default seek clamps to duration and still pauses", () => {
+    const clock = makeFakeClock();
+    const player = makePlayer();
+    const adapter = createStaticSeekPlaybackAdapter(player, 10, clock);
+
+    adapter.play();
+    adapter.seek(99);
+
+    expect(adapter.getTime()).toBe(10);
+    expect(player.renderSeek).toHaveBeenLastCalledWith(10);
+    expect(adapter.isPlaying()).toBe(false);
   });
 });

--- a/packages/studio/src/player/lib/playbackAdapter.ts
+++ b/packages/studio/src/player/lib/playbackAdapter.ts
@@ -113,12 +113,20 @@ export function createStaticSeekPlaybackAdapter(
       playing = false;
       stopTicker();
     },
-    seek: (time) => {
+    seek: (time, options) => {
       renderSeek(time);
-      if (playing) {
-        playStartTime = currentTime;
-        playStartNow = clock.now();
+      if (options?.keepPlaying) {
+        if (playing) {
+          playStartTime = currentTime;
+          playStartNow = clock.now();
+        }
+        return;
       }
+      // Default seek aligns with wrapTimeline: stop the RAF ticker so the
+      // adapter's `playing` flag matches the public seek contract instead of
+      // silently driving renderSeek in the background.
+      playing = false;
+      stopTicker();
     },
     getTime: () => currentTime,
     getDuration: () => safeDuration,


### PR DESCRIPTION
## Summary

`createStaticSeekPlaybackAdapter.seek` now accepts the `{ keepPlaying }` option declared by the `PlaybackAdapter` contract (`playbackTypes.ts:10`) and aligns its default-pause semantics with `wrapTimeline.seek` (recently hardened in `3e7b464b`, "ensure GSAP timeline stays paused after seek"). Same call sites, same wrapTimeline default — now the static-seek path matches.

## Background

This is the follow-up I called out as "Out of scope" in #863 and that @jrusso1020 invited in review:

> *"createStaticSeekPlaybackAdapter type drift (out of scope, called out in PR). Worth tightening the type now — it's a one-line change and the body already preserves playback by accident. Leaving the type signature mismatched is a footgun for the next person who reads the adapter and thinks keepPlaying is unhandled. Happy to follow up in a separate PR if you'd rather keep this one tight."* — #863 review

## What was wrong

The adapter's `seek` signature was `(time) => void`, narrower than the `PlaybackAdapter.seek` contract. The body also had an asymmetric default vs `wrapTimeline.seek`:

- `wrapTimeline.seek` (line 137, post-`3e7b464b`): default seek `tl.pause()` → `tl.seek()` → `tl.pause()`. `keepPlaying: true` skips both pauses.
- `createStaticSeekPlaybackAdapter.seek` (before this PR): default seek kept `playing = true`, so the RAF ticker continued calling `renderSeek` in the iframe even when the public `useTimelinePlayer.seek` wrapper had already called `stopRAFLoop()` + `setIsPlaying(false)`.

User-observable on non-GSAP compositions (the path where this adapter is used — `useTimelinePlayer.ts:160` fallback when `win.__timelines` is absent): scrubbing the timeline during playback would leave the iframe content silently advancing while the UI reported "paused".

## Fix

`packages/studio/src/player/lib/playbackAdapter.ts` — 7 lines:

```ts
seek: (time, options) => {
  renderSeek(time);
  if (options?.keepPlaying) {
    if (playing) {
      playStartTime = currentTime;
      playStartNow = clock.now();
    }
    return;
  }
  // Default seek aligns with wrapTimeline: stop the RAF ticker so the
  // adapter's `playing` flag matches the public seek contract instead of
  // silently driving renderSeek in the background.
  playing = false;
  stopTicker();
},
```

`keepPlaying: true` keeps the existing "rebase playStartTime/playStartNow" behavior so the next tick renders from the new position. Default and explicit `keepPlaying: false` now clear `playing` + cancel the RAF.

## Internal callers checked

All `adapter.seek()` call sites in `packages/studio/src/player/hooks/useTimelinePlayer.ts` are safe under the new default:

- `useTimelinePlayer.ts:199` (forward loop wrap-around): immediately calls `adapter.play()` after the seek, so a pause-on-default seek is replayed in the same tick.
- `useTimelinePlayer.ts:259` (replay from end inside `play()`): same — followed by `adapter.play()`.
- `useTimelinePlayer.ts:286` (`playBackward` init): preceded by an explicit `adapter.pause()`, so default-pause is a no-op.
- `useTimelinePlayer.ts:307` (backward loop end, no-loop terminal): immediately followed by `setIsPlaying(false)`; default-pause is the desired terminal state.
- `useTimelinePlayer.ts:316` (backward tick mid-traversal): the reverse path drives playback through its own RAF (`reverseRafRef`), not the static-seek internal tick, so cancelling the static-seek tick on every reverse step is harmless.
- `useTimelinePlayer.ts:362` (public `seek(time, options)`): forwards `options` straight through. `keepPlaying: true` from A/E shortcuts now reaches the static-seek adapter end-to-end.
- `useTimelineSyncCallbacks.ts:161` (initial adapter setup): adapter is paused at construction; default-pause is consistent.

## Tests

`packages/studio/src/player/lib/playbackAdapter.test.ts` only covered `wrapTimeline` (no coverage for `createStaticSeekPlaybackAdapter`). Adds 7 tests under a new `describe("createStaticSeekPlaybackAdapter seek keepPlaying option")` block, driving the adapter with a deterministic fake `StaticSeekPlaybackClock`:

- default seek stops the RAF ticker (`isPlaying() === false`, `cancelAnimationFrame` observed)
- default seek prevents queued frames from advancing renderSeek beyond the seek target
- `keepPlaying: true` preserves playback and rebases the ticker so the next frame renders from the new position
- explicit `keepPlaying: false` matches the default
- `keepPlaying: true` does not force playback when the adapter is already paused (intent is *preserve*, not *force play*)
- back-compat: calling `seek(t)` without options matches the contract (still pauses)
- default seek clamps overshoot to duration and still pauses

## Validation

| Check | Result |
| --- | --- |
| `bun run --cwd packages/studio test` | 612/612 ✅ (+7) |
| `bun run --cwd packages/studio typecheck` | clean |
| `bunx oxlint` (touched files) | 0/0 |
| `bunx oxfmt --check` (touched files) | clean |
| Lefthook (filesize + lint + format + typecheck + fallow + commitlint) | ✅ |
| Fallow audit | ✓ No issues in 2 changed files |

## Cross-PR check

Branched from `upstream/main` at `3cd6cd6a`. Of the 30 open PRs, only #1085 (@miguel-heygen) touches the seek path — it refactors `useTimelinePlayer.ts` to extract `shouldResumeForwardPlaybackAfterSeek` / `shouldStopAfterSeek` helpers but does not touch `playbackAdapter.ts`. Zero file overlap. #1085's new public-seek logic still forwards `options` to `adapter.seek(nextTime, options)`, so the contract this PR establishes is what that refactor relies on.

## Out of scope (intentionally)

The remaining nits from @jrusso1020's #863 review (sibling play→pause→play churn in `seekMasterAndSiblingTimelinesDeterministically`, missing `onDeterministicPause` emit on `seek()`, `setIsPlaying(true)` asymmetry in the `keepPlaying` branch of `runtime/player.ts`) are independent of this adapter and not addressed here.