### PR TITLE
fix(release): drop stale version field from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,6 @@
       "name": "hyperframes",
       "source": "./",
       "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-      "version": "0.1.0",
       "homepage": "https://hyperframes.heygen.com",
       "license": "Apache-2.0"
     }


### PR DESCRIPTION
## Summary

The `plugins[].version` in `.claude-plugin/marketplace.json` was a second source of truth that `scripts/set-version.ts` never touches, so it stayed frozen at `0.1.0` while each `plugin.json` advanced every release. Per [Claude's plugin marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels), `plugin.json`'s `version` is always read regardless, making the marketplace registration's version redundant.

This removes it so `plugin.json` is the single authoritative source and nothing can drift.

Follows up on review feedback in #1051 (per [this comment](https://github.com/heygen-com/hyperframes/pull/1051#issuecomment-4554571759)).

## Changes

- **`.claude-plugin/marketplace.json`**: remove the `"version": "0.1.0"` line from the single plugin registration. No other fields change.

## Verification

- `jq` confirms the file is still valid JSON and `.plugins[0]` no longer has a `version` key.
- `bunx oxfmt --check .claude-plugin/marketplace.json` passes.

## Out-of-scope note

While here I noticed the `v0.6.49` release commit (`7ea4d1c1`) bumped only the eight `package.json` files — the three `plugin.json` manifests are still at `0.6.48`. PR #1051's `set-version.ts` loop should have bumped them, so the `0.6.49` release may not have been cut with `set-version.ts`. Flagging separately; not addressed here.