### PR TITLE
fix(studio): compensate GSAP translate when starting manual drag

### DIFF
--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -1,8 +1,12 @@
 import { memo } from "react";
 import { Clock, Eye, Layers, MessageSquare, Move, X } from "../../icons/SystemIcons";
 import { type DomEditSelection } from "./domEditing";
-import { readStudioBoxSize, readStudioPathOffset, readStudioRotation } from "./manualEdits";
-import { readGsapTranslateFromTransform } from "./manualOffsetDrag";
+import {
+  readStudioBoxSize,
+  readStudioPathOffset,
+  readStudioRotation,
+  readGsapTranslateFromTransform,
+} from "./manualEdits";
 import type { ImportedFontAsset } from "./fontAssets";
 import {
   EMPTY_STYLES,

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Clock, Eye, Layers, MessageSquare, Move, X } from "../../icons/SystemIcons";
 import { type DomEditSelection } from "./domEditing";
 import { readStudioBoxSize, readStudioPathOffset, readStudioRotation } from "./manualEdits";
+import { readGsapTranslateFromTransform } from "./manualOffsetDrag";
 import type { ImportedFontAsset } from "./fontAssets";
 import {
   EMPTY_STYLES,
@@ -181,6 +182,11 @@ export const PropertyPanel = memo(function PropertyPanel({
   const sourceLabel = element.id ? `#${element.id}` : element.selector;
   const showEditableSections = element.capabilities.canEditStyles;
   const manualOffset = readStudioPathOffset(element.element);
+  const gsapTranslate = readGsapTranslateFromTransform(element.element);
+  const visualOffset = {
+    x: manualOffset.x + gsapTranslate.x,
+    y: manualOffset.y + gsapTranslate.y,
+  };
   const manualSize = readStudioBoxSize(element.element);
   const resolvedWidth =
     manualSize.width > 0
@@ -194,10 +200,11 @@ export const PropertyPanel = memo(function PropertyPanel({
   const commitManualOffset = (axis: "x" | "y", nextValue: string) => {
     const parsed = parsePxMetricValue(nextValue);
     if (parsed == null) return;
-    const current = readStudioPathOffset(element.element);
+    const currentRaw = readStudioPathOffset(element.element);
+    const currentGsap = readGsapTranslateFromTransform(element.element);
     onSetManualOffset(element, {
-      x: axis === "x" ? parsed : current.x,
-      y: axis === "y" ? parsed : current.y,
+      x: axis === "x" ? parsed - currentGsap.x : currentRaw.x,
+      y: axis === "y" ? parsed - currentGsap.y : currentRaw.y,
     });
   };
 
@@ -289,14 +296,14 @@ export const PropertyPanel = memo(function PropertyPanel({
           <div className={RESPONSIVE_GRID}>
             <MetricField
               label="X"
-              value={formatPxMetricValue(manualOffset.x)}
+              value={formatPxMetricValue(visualOffset.x)}
               disabled={manualOffsetEditingDisabled}
               scrub
               onCommit={(next) => commitManualOffset("x", next)}
             />
             <MetricField
               label="Y"
-              value={formatPxMetricValue(manualOffset.y)}
+              value={formatPxMetricValue(visualOffset.y)}
               disabled={manualOffsetEditingDisabled}
               scrub
               onCommit={(next) => commitManualOffset("y", next)}

--- a/packages/studio/src/components/editor/manualEdits.ts
+++ b/packages/studio/src/components/editor/manualEdits.ts
@@ -20,6 +20,7 @@ export {
   readStudioPathOffset,
   readStudioBoxSize,
   readStudioRotation,
+  readGsapTranslateFromTransform,
   applyStudioPathOffset,
   applyStudioPathOffsetDraft,
   applyStudioBoxSize,

--- a/packages/studio/src/components/editor/manualEditsDom.ts
+++ b/packages/studio/src/components/editor/manualEditsDom.ts
@@ -219,6 +219,20 @@ function isIdentityAfterTranslateStrip(m: DOMMatrix): boolean {
   return m.is2D && m.a === 1 && m.b === 0 && m.c === 0 && m.d === 1;
 }
 
+export function readGsapTranslateFromTransform(element: HTMLElement): { x: number; y: number } {
+  const transform = element.style.getPropertyValue("transform");
+  if (!transform || transform === "none") return { x: 0, y: 0 };
+  const DOMMatrixCtor = (element.ownerDocument.defaultView as (Window & typeof globalThis) | null)
+    ?.DOMMatrix;
+  if (!DOMMatrixCtor) return { x: 0, y: 0 };
+  try {
+    const m = new DOMMatrixCtor(transform);
+    return { x: m.m41, y: m.m42 };
+  } catch {
+    return { x: 0, y: 0 };
+  }
+}
+
 function stripGsapTranslateFromTransform(element: HTMLElement): void {
   const transform = element.style.getPropertyValue("transform");
   if (!transform || transform === "none") return;

--- a/packages/studio/src/components/editor/manualOffsetDrag.test.ts
+++ b/packages/studio/src/components/editor/manualOffsetDrag.test.ts
@@ -2,6 +2,7 @@ import { Window } from "happy-dom";
 import { describe, expect, it } from "vitest";
 import {
   applyManualOffsetDragMatrix,
+  createManualOffsetDragMember,
   invertManualOffsetDragMatrix,
   measureManualOffsetDragScreenToOffsetMatrix,
   resolveManualOffsetForPointerDelta,
@@ -136,5 +137,85 @@ describe("measureManualOffsetDragScreenToOffsetMatrix", () => {
     const measured = measureManualOffsetDragScreenToOffsetMatrix(element, { x: 0, y: 0 });
 
     expect(measured.ok).toBe(false);
+  });
+});
+
+describe("createManualOffsetDragMember GSAP translate compensation", () => {
+  it("folds GSAP translate from element.style.transform into initialOffset", () => {
+    const window = new Window();
+    const element = window.document.createElement("div");
+    window.document.body.append(element);
+
+    element.style.setProperty("transform", "translate(0px, -20px)");
+
+    element.getBoundingClientRect = () => {
+      const offsetX = Number.parseFloat(element.style.getPropertyValue(STUDIO_OFFSET_X_PROP)) || 0;
+      const offsetY = Number.parseFloat(element.style.getPropertyValue(STUDIO_OFFSET_Y_PROP)) || 0;
+      return new window.DOMRect(10 + offsetX, 20 + offsetY, 100, 50);
+    };
+
+    const result = createManualOffsetDragMember({
+      key: "test",
+      selection: { element } as never,
+      element,
+      rect: { left: 10, top: 20, width: 100, height: 50, editScaleX: 1, editScaleY: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.member.initialOffset.x).toBe(0);
+    expect(result.member.initialOffset.y).toBe(-20);
+  });
+
+  it("leaves initialOffset unchanged when no GSAP transform is present", () => {
+    const window = new Window();
+    const element = window.document.createElement("div");
+    window.document.body.append(element);
+
+    element.getBoundingClientRect = () => {
+      const offsetX = Number.parseFloat(element.style.getPropertyValue(STUDIO_OFFSET_X_PROP)) || 0;
+      const offsetY = Number.parseFloat(element.style.getPropertyValue(STUDIO_OFFSET_Y_PROP)) || 0;
+      return new window.DOMRect(10 + offsetX, 20 + offsetY, 100, 50);
+    };
+
+    const result = createManualOffsetDragMember({
+      key: "test",
+      selection: { element } as never,
+      element,
+      rect: { left: 10, top: 20, width: 100, height: 50, editScaleX: 1, editScaleY: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.member.initialOffset.x).toBe(0);
+    expect(result.member.initialOffset.y).toBe(0);
+  });
+
+  it("combines existing manual offset with GSAP translate", () => {
+    const window = new Window();
+    const element = window.document.createElement("div");
+    window.document.body.append(element);
+
+    element.style.setProperty(STUDIO_OFFSET_X_PROP, "30px");
+    element.style.setProperty(STUDIO_OFFSET_Y_PROP, "10px");
+    element.style.setProperty("transform", "translate(50px, -15px)");
+
+    element.getBoundingClientRect = () => {
+      const offsetX = Number.parseFloat(element.style.getPropertyValue(STUDIO_OFFSET_X_PROP)) || 0;
+      const offsetY = Number.parseFloat(element.style.getPropertyValue(STUDIO_OFFSET_Y_PROP)) || 0;
+      return new window.DOMRect(10 + offsetX, 20 + offsetY, 100, 50);
+    };
+
+    const result = createManualOffsetDragMember({
+      key: "test",
+      selection: { element } as never,
+      element,
+      rect: { left: 10, top: 20, width: 100, height: 50, editScaleX: 1, editScaleY: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.member.initialOffset.x).toBe(80);
+    expect(result.member.initialOffset.y).toBe(-5);
   });
 });

--- a/packages/studio/src/components/editor/manualOffsetDrag.ts
+++ b/packages/studio/src/components/editor/manualOffsetDrag.ts
@@ -5,6 +5,7 @@ import {
   beginStudioManualEditGesture,
   captureStudioPathOffset,
   endStudioManualEditGesture,
+  readGsapTranslateFromTransform,
   readStudioPathOffset,
   restoreStudioPathOffset,
   type StudioPathOffsetSnapshot,
@@ -13,20 +14,6 @@ import {
 const DEFAULT_OFFSET_PROBE_PX = 100;
 const MIN_PROBE_VECTOR_LENGTH_PX = 0.01;
 const MIN_MATRIX_DETERMINANT = 0.000001;
-
-export function readGsapTranslateFromTransform(element: HTMLElement): { x: number; y: number } {
-  const transform = element.style.getPropertyValue("transform");
-  if (!transform || transform === "none") return { x: 0, y: 0 };
-  const DOMMatrixCtor = (element.ownerDocument.defaultView as (Window & typeof globalThis) | null)
-    ?.DOMMatrix;
-  if (!DOMMatrixCtor) return { x: 0, y: 0 };
-  try {
-    const m = new DOMMatrixCtor(transform);
-    return { x: m.m41, y: m.m42 };
-  } catch {
-    return { x: 0, y: 0 };
-  }
-}
 
 export interface ManualOffsetDragMatrix {
   a: number;

--- a/packages/studio/src/components/editor/manualOffsetDrag.ts
+++ b/packages/studio/src/components/editor/manualOffsetDrag.ts
@@ -14,7 +14,7 @@ const DEFAULT_OFFSET_PROBE_PX = 100;
 const MIN_PROBE_VECTOR_LENGTH_PX = 0.01;
 const MIN_MATRIX_DETERMINANT = 0.000001;
 
-function readGsapTranslateFromTransform(element: HTMLElement): { x: number; y: number } {
+export function readGsapTranslateFromTransform(element: HTMLElement): { x: number; y: number } {
   const transform = element.style.getPropertyValue("transform");
   if (!transform || transform === "none") return { x: 0, y: 0 };
   const DOMMatrixCtor = (element.ownerDocument.defaultView as (Window & typeof globalThis) | null)

--- a/packages/studio/src/components/editor/manualOffsetDrag.ts
+++ b/packages/studio/src/components/editor/manualOffsetDrag.ts
@@ -14,6 +14,20 @@ const DEFAULT_OFFSET_PROBE_PX = 100;
 const MIN_PROBE_VECTOR_LENGTH_PX = 0.01;
 const MIN_MATRIX_DETERMINANT = 0.000001;
 
+function readGsapTranslateFromTransform(element: HTMLElement): { x: number; y: number } {
+  const transform = element.style.getPropertyValue("transform");
+  if (!transform || transform === "none") return { x: 0, y: 0 };
+  const DOMMatrixCtor = (element.ownerDocument.defaultView as (Window & typeof globalThis) | null)
+    ?.DOMMatrix;
+  if (!DOMMatrixCtor) return { x: 0, y: 0 };
+  try {
+    const m = new DOMMatrixCtor(transform);
+    return { x: m.m41, y: m.m42 };
+  } catch {
+    return { x: 0, y: 0 };
+  }
+}
+
 export interface ManualOffsetDragMatrix {
   a: number;
   b: number;
@@ -231,7 +245,12 @@ export function createManualOffsetDragMember(input: {
   element: HTMLElement;
   rect: ManualOffsetDragRect;
 }): ManualOffsetDragMemberResult {
-  const initialOffset = readStudioPathOffset(input.element);
+  const rawOffset = readStudioPathOffset(input.element);
+  const gsapTranslate = readGsapTranslateFromTransform(input.element);
+  const initialOffset = {
+    x: rawOffset.x + gsapTranslate.x,
+    y: rawOffset.y + gsapTranslate.y,
+  };
   const initialPathOffset = captureStudioPathOffset(input.element);
   const gestureToken = beginStudioManualEditGesture(input.element);
   const measured = measureManualOffsetDragScreenToOffsetMatrix(input.element, initialOffset);

--- a/packages/studio/src/hooks/useDomEditCommits.ts
+++ b/packages/studio/src/hooks/useDomEditCommits.ts
@@ -430,6 +430,7 @@ export function useDomEditCommits({
           throw new Error("Selected element has no patchable target");
         }
 
+        domEditSaveTimestampRef.current = Date.now();
         const removeResponse = await fetch(
           `/api/projects/${pid}/file-mutations/remove-element/${encodeURIComponent(targetPath)}`,
           {
@@ -443,8 +444,6 @@ export function useDomEditCommits({
         const removeData = (await removeResponse.json()) as { changed?: boolean; content?: string };
         const patchedContent =
           typeof removeData.content === "string" ? removeData.content : originalContent;
-
-        domEditSaveTimestampRef.current = Date.now();
         await saveProjectFilesWithHistory({
           projectId: pid,
           label: "Delete element",

--- a/packages/studio/src/hooks/useDomEditCommits.ts
+++ b/packages/studio/src/hooks/useDomEditCommits.ts
@@ -155,6 +155,11 @@ export function useDomEditCommits({
         selectorIndex: selection.selectorIndex,
       };
 
+      // Mark the save timestamp before the file write so the SSE file-change
+      // handler suppresses the reload even if the event arrives before the
+      // response (the server writes the file and emits SSE during the fetch).
+      domEditSaveTimestampRef.current = Date.now();
+
       const patchResponse = await fetch(
         `/api/projects/${pid}/file-mutations/patch-element/${encodeURIComponent(targetPath)}`,
         {
@@ -193,9 +198,7 @@ export function useDomEditCommits({
         files: { [targetPath]: { before: originalContent, after: finalContent } },
       });
 
-      if (options?.skipRefresh) {
-        domEditSaveTimestampRef.current = Date.now();
-      } else {
+      if (!options?.skipRefresh) {
         reloadPreview();
       }
     },


### PR DESCRIPTION
## Summary

Three related fixes for GSAP transform interaction with Studio's manual editing system:

**1. Drag offset compensation** (`manualOffsetDrag.ts`)
- When dragging an element at a timeline position where GSAP has applied a translate (x/y), the probe phase strips GSAP's translate from `element.style.transform` without accounting for it in the initial offset — causing a position shift after page reload.
- Reads GSAP's translate (m41/m42 from the transform matrix) and folds it into `initialOffset` before the probe, so the offset compensates for the stripped translate.

**2. Layout panel visual position** (`PropertyPanel.tsx`)
- X/Y fields now display the visual position (manual offset + GSAP translate) instead of the raw CSS var offset, matching what the user sees in the preview.
- Editing a value reverses the compensation so the correct raw offset is persisted.

**3. Save-reload race condition** (`useDomEditCommits.ts`)
- `domEditSaveTimestampRef` was set **after** the patch API call completed. The server writes the file and emits an SSE `hf:file-change` event during the `fetch` — if the event arrived before the response, the file watcher would trigger a spurious `reloadPreview()`, resetting playback to t=0.
- Moved the timestamp update **before** the fetch so the debounce guard is active when the SSE event arrives.

## Test plan

- [x] Open a composition with GSAP tweens animating x/y (e.g., `tl.to("#el", { y: -20, ... })`)
- [x] Seek to a time where the GSAP tween is active (element is visually displaced)
- [x] Verify the Layout panel X/Y fields show the visual position, not just the raw offset
- [x] Drag the element — no jump on mouse-down, position stable after reload
- [x] Edit a style property (color, font-size) in the Design panel — verify the preview doesn't reload/restart playback
- [x] Verify elements without GSAP tweens still drag and edit normally
- [x] `bun test packages/studio/src/components/editor/manualOffsetDrag.test.ts` — 10 tests pass