### PR TITLE
fix(studio): add FFmpeg pre-flight check before render

### DIFF
--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -508,6 +508,18 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     });
   });
 
+  // ── Pre-flight checks for render ────────────────────────────────────────
+  // Intercept render requests before they reach the shared API so we can
+  // fail fast with an actionable hint instead of burning through the entire
+  // capture pipeline before hitting "spawn ffmpeg ENOENT" at encode.
+  app.post("/api/projects/:id/render", async (c, next) => {
+    const { findFFmpeg, getFFmpegInstallHint } = await import("../browser/ffmpeg.js");
+    if (!findFFmpeg()) {
+      return c.json({ error: "FFmpeg not found", hint: getFFmpegInstallHint() }, 422);
+    }
+    return next();
+  });
+
   // Mount the shared studio API at /api.
   // Use fetch() forwarding (not .route()) so the sub-app sees paths without
   // the /api prefix — the shared module's path extraction uses c.req.path.

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -512,10 +512,14 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
   // Intercept render requests before they reach the shared API so we can
   // fail fast with an actionable hint instead of burning through the entire
   // capture pipeline before hitting "spawn ffmpeg ENOENT" at encode.
+  let cachedFFmpegPath: string | undefined;
   app.post("/api/projects/:id/render", async (c, next) => {
     const { findFFmpeg, getFFmpegInstallHint } = await import("../browser/ffmpeg.js");
-    if (!findFFmpeg()) {
-      return c.json({ error: "FFmpeg not found", hint: getFFmpegInstallHint() }, 422);
+    if (!cachedFFmpegPath) {
+      cachedFFmpegPath = findFFmpeg();
+    }
+    if (!cachedFFmpegPath) {
+      return c.json({ error: "FFmpeg not found", hint: getFFmpegInstallHint() }, 503);
     }
     return next();
   });


### PR DESCRIPTION
## Summary

- Adds a pre-flight FFmpeg check to the Studio render route that returns a 422 with a platform-specific install hint when FFmpeg is missing
- Prevents the render pipeline from burning through the entire capture phase before failing at encode with "spawn ffmpeg ENOENT"
- Mirrors the existing check in `hyperframes render` CLI command

## Context

48% of Studio errors today (38/79) are `spawn ffmpeg ENOENT` — the Studio server path skipped the FFmpeg availability check that the CLI render command already performs. Users would wait through the full capture phase only to get an unhelpful error at the encode step.

The fix intercepts `POST /api/projects/:id/render` with a Hono middleware before the request reaches the shared studio API. If `findFFmpeg()` returns undefined, it short-circuits with `{ error: "FFmpeg not found", hint: "<platform-specific install command>" }` and a 422 status. No telemetry event is emitted since this is a pre-flight check, not a render failure.

## Test plan

- [ ] Start Studio preview, trigger a render — should succeed if FFmpeg is installed
- [ ] Temporarily rename/hide FFmpeg binary, trigger a render — should get 422 with install hint immediately (no capture phase)
- [ ] Verify the hint is platform-appropriate (macOS: `brew install ffmpeg`, Linux: `sudo apt install ffmpeg`)