### PR TITLE
fix(cli): print the update-available notice once, not on every event-loop drain

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -193,8 +193,12 @@ if (!isHelp && !hasJsonFlag && command !== "upgrade") {
 const commandStart = Date.now();
 let commandFailed = false;
 
-// Async flush for normal exit (beforeExit fires when the event loop drains)
-process.on("beforeExit", () => {
+// Async flush for normal exit. `beforeExit` re-fires every time the
+// event loop drains, and the async `_flush()` itself schedules new
+// work — so a plain `on` listener would print the update notice (and
+// re-flush) once per drain (the user-reported double-print). `once`
+// detaches after first invocation, which is what we want for both.
+process.once("beforeExit", () => {
   _flush?.().catch(() => {});
   if (!hasJsonFlag) _printUpdateNotice?.();
 });


### PR DESCRIPTION
## What

`process.on("beforeExit", …)` re-fires every time the event loop drains. The listener kicks off a fire-and-forget async telemetry flush, which schedules new work — so on a successful command the user sees the "Update available: …" notice twice (once after the initial drain, again after the flush settles, and so on).

Switched to `process.once` so the listener detaches after first invocation. Side benefit: prevents the double-flush of telemetry on the same path.

```diff
- // Async flush for normal exit (beforeExit fires when the event loop drains)
- process.on("beforeExit", () => {
+ // … `once` detaches after first invocation …
+ process.once("beforeExit", () => {
    _flush?.().catch(() => {});
    if (!hasJsonFlag) _printUpdateNotice?.();
  });
```

## Why

Reported during local testing of the auth stack (#1081 / #1084), but the bug affects every command — any code path where `_flush()` schedules work (which is, by design, every non-`--json` invocation when telemetry is enabled).

User-visible symptom:
```
✓ API key saved. Authenticated as james.russo@heygen.com.

  Update available: 0.6.46 → 0.6.52
  Run: npx hyperframes@latest


  Update available: 0.6.46 → 0.6.52
  Run: npx hyperframes@latest
```

## Test plan

- Ran the full CLI suite (`bun run --cwd packages/cli test`): 446/446 green.
- `bunx oxlint`, `bunx oxfmt --check`, `bunx tsc --noEmit -p packages/cli/tsconfig.json`, `bunx fallow audit --base origin/main` all clean.
- Manual repro: built the bundle and ran a command that exercises the post-exit notice — only one banner now.

Not adding a unit test for the listener wiring itself — `beforeExit` re-fire behavior is a Node-level contract that's awkward to mock cleanly and the `once` semantic is structural; future regressions would just bring the double-print back, which is visually obvious.

## Out of scope

Other commands in the auth stack (#1081 / #1084) — unrelated; this is a separate, narrowly-scoped fix off `main` so it can ship/merge independently.