### PR TITLE
docs: add HyperFrames showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 
 <p align="center">
   <a href="https://hyperframes.heygen.com/quickstart">Quickstart</a> |
+  <a href="https://hyperframes.heygen.com/showcase">Showcase</a> |
+  <a href="https://www.hyperframes.dev/">Playground</a> |
   <a href="https://hyperframes.heygen.com/catalog/blocks/data-chart">Catalog</a> |
-  <a href="https://hyperframes.heygen.com/examples">Examples</a> |
   <a href="https://hyperframes.heygen.com/introduction">Docs</a> |
   <a href="https://discord.gg/EbK98HBPdk">Discord</a>
 </p>
@@ -60,6 +61,8 @@ npx hyperframes render       # render to MP4
 **Requirements:** Node.js 22+, FFmpeg
 
 ## What You Can Build
+
+Need ideas? Browse the [Showcase](https://hyperframes.heygen.com/showcase) for finished videos you can watch, read, run, and remix.
 
 - Product launch videos and feature announcements
 - PR walkthroughs with animated code diffs, narration, and captions
@@ -162,6 +165,7 @@ Read the full comparison in the [HyperFrames vs Remotion guide](https://hyperfra
 Full documentation: [hyperframes.heygen.com/introduction](https://hyperframes.heygen.com/introduction)
 
 - [Quickstart](https://hyperframes.heygen.com/quickstart)
+- [Showcase](https://hyperframes.heygen.com/showcase)
 - [Guides](https://hyperframes.heygen.com/guides/gsap-animation)
 - [API Reference](https://hyperframes.heygen.com/packages/core)
 - [Catalog](https://hyperframes.heygen.com/catalog/blocks/data-chart)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,6 +54,7 @@
             "pages": [
               "introduction",
               "quickstart",
+              "showcase",
               "examples",
               "launch-videos"
             ]

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -5,6 +5,10 @@ description: "Built-in examples for common video patterns. Hover to preview anim
 
 Hyperframes includes starter examples to help you scaffold compositions quickly. Each example gives you a working project with the correct [composition structure](/concepts/compositions), [data attributes](/concepts/data-attributes), and a [GSAP timeline](/guides/gsap-animation) already wired up.
 
+<Note>
+  Looking for finished videos and production projects? Start with the [Showcase](/showcase).
+</Note>
+
 ```bash Terminal
 npx hyperframes init my-video --example <name>
 ```

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -30,6 +30,9 @@ Here is a video defined entirely as HTML:
 Run `npx hyperframes render --output demo.mp4` and this produces an MP4 with deterministic, frame-by-frame capture. Same input, identical output, every time. No timeline editor. No proprietary format. Just HTML.
 
 <CardGroup cols={2}>
+  <Card title="Watch the Showcase" icon="play" href="/showcase">
+    Finished HyperFrames videos you can watch, read, run, and remix — product launches, website-to-video demos, UI reveals, and VFX experiments.
+  </Card>
   <Card title="Browse the Catalog" icon="grid-2" href="/catalog/blocks/data-chart">
     50+ ready-to-use blocks and components — social overlays, shader transitions, data visualizations, and cinematic effects. Install any of them with one command.
   </Card>
@@ -93,6 +96,9 @@ Run `npx hyperframes render --output demo.mp4` and this produces an MP4 with det
 ## Next Steps
 
 <CardGroup cols={2}>
+  <Card title="Showcase" icon="play" href="/showcase">
+    Get inspired by finished videos and production launch projects.
+  </Card>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Build and render your first video in 60 seconds
   </Card>

--- a/docs/launch-videos.mdx
+++ b/docs/launch-videos.mdx
@@ -9,6 +9,9 @@ The HeyGen team builds its launch videos in HyperFrames. Every composition — i
   Open-source HyperFrames compositions behind HeyGen's product launch videos.
 </Card>
 
+Want to browse the finished videos first? Start with the [Showcase](/showcase).
+This page is the deeper production writeup for the same launch projects.
+
 ## What's in there
 
 Each subdirectory is a standalone HyperFrames project — `index.html`, `compositions/`, `assets/`, and a rendered output you can compare against:

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -1,0 +1,262 @@
+---
+title: Showcase
+description: "Finished HyperFrames videos you can watch, read, run, and remix."
+---
+
+The README explains what HyperFrames is. This page shows what you can build with it.
+
+Every project below is a real HyperFrames composition with source you can inspect,
+preview, render, and remix.
+
+Want the production notes, repo structure, and clone options behind these videos?
+Read [Launch Videos](/launch-videos). This page is the visual gallery; Launch
+Videos is the deeper teardown.
+
+## Production Launches
+
+<div className="not-prose grid grid-cols-1 md:grid-cols-2 gap-5 my-8">
+  <div
+    className="group block overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+  >
+    <video
+      className="aspect-video w-full object-cover bg-zinc-100 dark:bg-zinc-900"
+      src="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/hyperframes-launch-preview.mp4"
+      poster="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/hyperframes-launch-poster.jpg"
+      controls
+      muted
+      loop
+      playsInline
+      preload="metadata"
+    />
+    <div className="p-4">
+      <div className="text-xs uppercase tracking-wide text-zinc-500">Product launch</div>
+      <h3 className="mt-1 text-lg font-semibold text-zinc-950 dark:text-zinc-50">HyperFrames launch video</h3>
+      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+        A full announcement video with CSS, GSAP, Lottie, shader transitions, Three.js,
+        footage compositing, captions, voiceover, and SFX.
+      </p>
+      <a
+        className="mt-3 block text-sm font-medium text-zinc-950 dark:text-zinc-50"
+        href="https://github.com/heygen-com/hyperframes-launches/tree/main/hyperframes-launch"
+      >
+        View source ->
+      </a>
+    </div>
+  </div>
+
+  <div
+    className="group block overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+  >
+    <video
+      className="aspect-video w-full object-cover bg-zinc-100 dark:bg-zinc-900"
+      src="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/website-to-hyperframes-preview.mp4"
+      poster="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/website-to-hyperframes-poster.jpg"
+      controls
+      muted
+      loop
+      playsInline
+      preload="metadata"
+    />
+    <div className="p-4">
+      <div className="text-xs uppercase tracking-wide text-zinc-500">Website to video</div>
+      <h3 className="mt-1 text-lg font-semibold text-zinc-950 dark:text-zinc-50">Website to HyperFrames demo</h3>
+      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+        A 41.8-second launch video showing AI agents turning websites into product
+        promos, social ads, feature showcases, and brand reels.
+      </p>
+      <a
+        className="mt-3 block text-sm font-medium text-zinc-950 dark:text-zinc-50"
+        href="https://github.com/heygen-com/hyperframes-launches/tree/main/website-to-hyperframes"
+      >
+        View source ->
+      </a>
+    </div>
+  </div>
+
+  <div
+    className="group block overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+  >
+    <video
+      className="aspect-video w-full object-cover bg-zinc-100 dark:bg-zinc-900"
+      src="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/timeline-editor-preview.mp4"
+      poster="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/timeline-editor-poster.jpg"
+      controls
+      muted
+      loop
+      playsInline
+      preload="metadata"
+    />
+    <div className="p-4">
+      <div className="text-xs uppercase tracking-wide text-zinc-500">Product reveal</div>
+      <h3 className="mt-1 text-lg font-semibold text-zinc-950 dark:text-zinc-50">Timeline editor launch</h3>
+      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+        A launch reveal with UI mockups, voiceover, SFX, prompt-driven iteration,
+        and a narrative arc around fine-tuning rendered video.
+      </p>
+      <a
+        className="mt-3 block text-sm font-medium text-zinc-950 dark:text-zinc-50"
+        href="https://github.com/heygen-com/hyperframes-launches/tree/main/timeline-launch"
+      >
+        View source ->
+      </a>
+    </div>
+  </div>
+
+  <div
+    className="group block overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+  >
+    <video
+      className="aspect-video w-full object-cover bg-zinc-100 dark:bg-zinc-900"
+      src="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/texture-launch-preview.mp4"
+      poster="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/texture-launch-poster.jpg"
+      controls
+      muted
+      loop
+      playsInline
+      preload="metadata"
+    />
+    <div className="p-4">
+      <div className="text-xs uppercase tracking-wide text-zinc-500">Title system</div>
+      <h3 className="mt-1 text-lg font-semibold text-zinc-950 dark:text-zinc-50">Texture launch</h3>
+      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+        Texture-mask typography, shader backgrounds, and transition-heavy title
+        design built as a full HyperFrames composition.
+      </p>
+      <a
+        className="mt-3 block text-sm font-medium text-zinc-950 dark:text-zinc-50"
+        href="https://github.com/heygen-com/hyperframes-launches/tree/main/texture-launch-video"
+      >
+        View source ->
+      </a>
+    </div>
+  </div>
+
+  <div
+    className="group block overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+  >
+    <video
+      className="aspect-video w-full object-cover bg-zinc-100 dark:bg-zinc-900"
+      src="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/vfx-heygen-preview.mp4"
+      poster="https://static.heygen.ai/hyperframes-oss/docs/images/showcase/vfx-heygen-poster.jpg"
+      controls
+      muted
+      loop
+      playsInline
+      preload="metadata"
+    />
+    <div className="p-4">
+      <div className="text-xs uppercase tracking-wide text-zinc-500">VFX system</div>
+      <h3 className="mt-1 text-lg font-semibold text-zinc-950 dark:text-zinc-50">VFX x HeyGen combined</h3>
+      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+        A rendered effects reel combining Three.js, HTML-in-canvas, generated
+        media, text animation, and product UI beats.
+      </p>
+      <a
+        className="mt-3 block text-sm font-medium text-zinc-950 dark:text-zinc-50"
+        href="https://github.com/heygen-com/hyperframes-launches/tree/main/vfx-heygen-combined"
+      >
+        View source ->
+      </a>
+    </div>
+  </div>
+
+  <a
+    className="group block overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+    href="https://www.hyperframes.dev/"
+  >
+    <div className="aspect-video w-full bg-zinc-950 p-6 text-white">
+      <div className="flex h-full flex-col justify-between">
+        <div className="text-sm text-zinc-400">Community playground</div>
+        <div>
+          <div className="text-3xl font-semibold">Open. Remix. Publish.</div>
+          <p className="mt-3 max-w-md text-sm text-zinc-300">
+            Use hyperframes.dev to preview community projects, share your own,
+            and keep iterating in the browser.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div className="p-4">
+      <div className="text-xs uppercase tracking-wide text-zinc-500">Playground</div>
+      <h3 className="mt-1 text-lg font-semibold text-zinc-950 dark:text-zinc-50">hyperframes.dev</h3>
+      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+        A hosted community surface for previewing, iterating, sharing, and
+        rendering HTML-native video projects.
+      </p>
+      <div className="mt-3 text-sm font-medium text-zinc-950 dark:text-zinc-50">Open playground -></div>
+    </div>
+  </a>
+</div>
+
+## Go Deeper
+
+<CardGroup cols={2}>
+  <Card title="Launch Videos" icon="rocket" href="/launch-videos">
+    Read the production notes, project structure, and Git LFS clone options behind
+    these launches.
+  </Card>
+  <Card title="Source Repository" icon="github" href="https://github.com/heygen-com/hyperframes-launches">
+    Open the full collection of HeyGen launch compositions.
+  </Card>
+</CardGroup>
+
+## Start from a Use Case
+
+| If you want to build... | Start here | Why |
+| --- | --- | --- |
+| A product announcement | [HyperFrames launch](https://github.com/heygen-com/hyperframes-launches/tree/main/hyperframes-launch) | Shows a complete launch narrative with multiple animation runtimes. |
+| A website-to-video product tour | [Website to HyperFrames](https://github.com/heygen-com/hyperframes-launches/tree/main/website-to-hyperframes) | Shows captured website footage, agent prompts, captions, VO, and SFX. |
+| A product UI reveal | [Timeline editor launch](https://github.com/heygen-com/hyperframes-launches/tree/main/timeline-launch) | Shows mockups, interface closeups, and feature storytelling. |
+| A texture or title-card system | [Texture launch](https://github.com/heygen-com/hyperframes-launches/tree/main/texture-launch-video) | Shows expressive text treatment and shader-backed motion. |
+| An effects-heavy launch reel | [VFX x HeyGen combined](https://github.com/heygen-com/hyperframes-launches/tree/main/vfx-heygen-combined) | Shows Three.js, generated media, and HTML-in-canvas in one render. |
+| A starter project | [Examples](/examples) | Scaffold working templates with `npx hyperframes init --example <name>`. |
+| A reusable motion part | [Catalog](/catalog/blocks/data-chart) | Add blocks and components to an existing composition. |
+
+## Run One Locally
+
+These launch projects use Git LFS for video, audio, image, and font assets.
+Install Git LFS before cloning; otherwise the preview opens with pointer files
+instead of the real media.
+
+```bash Terminal
+brew install git-lfs   # macOS, or your platform's git-lfs install
+git lfs install
+git clone https://github.com/heygen-com/hyperframes-launches.git
+cd hyperframes-launches/website-to-hyperframes
+
+npx hyperframes preview
+npx hyperframes render
+```
+
+To skip pulling every launch asset up front, clone first and pull only the
+project you want to run:
+
+```bash Terminal
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/heygen-com/hyperframes-launches.git
+cd hyperframes-launches
+git lfs pull --include="website-to-hyperframes/**"
+cd website-to-hyperframes
+
+npx hyperframes preview
+```
+
+The launch projects include source HTML, sub-compositions, assets, rendered
+outputs, and production notes such as `STORYBOARD.md`, `DESIGN.md`, and
+`HANDOFF.md` where available.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Starter Examples" icon="layer-group" href="/examples">
+    Scaffold remixable templates with `npx hyperframes init --example`.
+  </Card>
+  <Card title="Community Playground" icon="play" href="https://www.hyperframes.dev/">
+    Open shared projects, preview videos, and publish your own.
+  </Card>
+  <Card title="Website to Video" icon="globe" href="/guides/website-to-video">
+    Turn websites into rendered videos with an agent-friendly workflow.
+  </Card>
+  <Card title="Pipeline Guide" icon="diagram-project" href="/guides/pipeline">
+    Learn the storyboard, script, design, and render loop behind larger videos.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What

Adds a first-class Showcase page for the docs and wires it into the README/docs entry points.

- New `docs/showcase.mdx` inspiration page with production launch cards, CDN preview media, source links, use-case routing, and local run commands
- Uses docs-CDN MP4 previews and posters for HyperFrames launch, Website to HyperFrames, Timeline editor, Texture launch, and VFX x HeyGen combined
- Adds Git LFS-aware clone instructions plus a targeted `git lfs pull` option for running one launch locally
- Cross-links Showcase and Launch Videos so the pages have distinct jobs: quick visual gallery vs. deeper production teardown
- Adds `showcase` to the Getting Started docs nav before Examples
- Updates README top links and What You Can Build copy to point visitors to Showcase and the playground
- Adds Showcase CTAs to the docs introduction and a note from Examples to Showcase

## Why

Developer-relations feedback was that the repo explains what HyperFrames is, but does not quickly answer: “what can I build with this?” This gives visitors an inspiration layer: finished videos they can watch, read, run, and remix, powered by the existing `heygen-com/hyperframes-launches` repo.

## How

The Showcase leans on real launch work we already have:

- Rendered or reused videos from `heygen-com/hyperframes-launches`
- Cut lightweight, muted MP4 preview clips plus JPG posters for docs cards
- Uploaded those assets to `https://static.heygen.ai/hyperframes-oss/docs/images/showcase/`
- Made videos user-playable with native controls instead of five concurrent autoplay loops
- Kept the source repo links prominent so visitors can jump from inspiration to code
- Kept hyperframes.dev as the community playground CTA

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Validation:

- `bun run format:check`
- `bun run lint` (passed outside sandbox; sandbox run failed because `tsx` could not create its IPC pipe under `/var/folders`)
- `git diff --check`
- `docs/docs.json` parse check
- CDN `HEAD` checks for every uploaded Showcase MP4 and poster
