### PR TITLE
docs: document feedback collection — cadence, data, opt-out

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -90,7 +90,8 @@
               "guides/timeline-editing",
               "guides/video-editor-cheatsheet",
               "guides/common-mistakes",
-              "guides/troubleshooting"
+              "guides/troubleshooting",
+              "guides/feedback"
             ]
           },
           {

--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -205,7 +205,7 @@ If you need to suppress it in a custom Studio build (e.g. embedded or kiosk use)
 - `hyperframes-studio:feedbackSessionCount` — incremented each session
 - `hyperframes-studio:feedbackLastPromptedAt` — the count value when the bar last appeared
 
-Setting both to the same large number (`"99999"`) will defer the next prompt indefinitely. This is a workaround, not a supported API — a proper opt-out flag is tracked as a follow-up to hf#1101.
+Setting only `feedbackLastPromptedAt` to a large number (e.g. `"9999999"`) will defer the next prompt indefinitely — the gate is `sessionCount - lastPromptedAt >= interval`, so a large `lastPromptedAt` keeps the difference deeply negative regardless of how many sessions accumulate. This is a workaround, not a supported API — a proper opt-out flag is tracked as a follow-up to hf#1101.
 
 ## Related
 

--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -198,14 +198,19 @@ The CLI feedback prompt is automatically suppressed when the `CI` environment va
 
 ### Studio
 
-The Studio feedback bar is not affected by the CLI telemetry setting, and there is no build-time flag to disable it — the bar is mounted unconditionally and appears based on the session cadence in `localStorage`.
+The Studio feedback bar is not affected by the CLI telemetry setting. To disable it at build time, set:
 
-If you need to suppress it in a custom Studio build (e.g. embedded or kiosk use), the cadence state lives in two `localStorage` keys:
+```
+VITE_HYPERFRAMES_NO_FEEDBACK=1
+```
 
-- `hyperframes-studio:feedbackSessionCount` — incremented each session
-- `hyperframes-studio:feedbackLastPromptedAt` — the count value when the bar last appeared
+When set to `"1"`, the bar never shows — `shouldShowFeedback()` returns `false` unconditionally regardless of session count or `localStorage` state.
 
-Setting only `feedbackLastPromptedAt` to a large number (e.g. `"9999999"`) will defer the next prompt indefinitely — the gate is `sessionCount - lastPromptedAt >= interval`, so a large `lastPromptedAt` keeps the difference deeply negative regardless of how many sessions accumulate. This is a workaround, not a supported API — a proper opt-out flag is tracked as a follow-up to hf#1101.
+The session interval is still configurable independently:
+
+```
+VITE_HYPERFRAMES_FEEDBACK_INTERVAL=20
+```
 
 ## Related
 

--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -3,13 +3,19 @@ title: Feedback Collection
 description: "How HyperFrames collects feedback, what data is collected, and how to opt out."
 ---
 
-HyperFrames prompts for anonymous satisfaction feedback periodically — after CLI renders and in Studio sessions. This page explains when prompts appear, what data is collected, and how to disable them entirely.
+HyperFrames occasionally asks how a render went or how a Studio session felt. This page explains why we do it, when prompts appear, what data is collected, and how to disable them.
+
+## Why We Ask
+
+We use anonymous satisfaction scores to understand whether the tool is actually working well — not just whether it runs without errors. A render that takes 10 minutes and produces a broken file counts as a success in logs but a failure in practice. The feedback prompt is the only signal we have for that gap.
+
+No account, email, or identity is tied to responses. Each installation generates a random UUID at setup; that is the only identifier.
 
 ## How It Works
 
 ### CLI — post-render prompt
 
-After a successful `hyperframes render`, a short satisfaction prompt may appear:
+After a successful `hyperframes render`, a short prompt may appear:
 
 ```
   How was this render? [1=poor 5=great, enter to skip]
@@ -19,9 +25,9 @@ After a successful `hyperframes render`, a short satisfaction prompt may appear:
 **When it shows:**
 
 - First ever successful render
-- Then every 15th successful render (15th, 30th, 45th...)
+- Then every 15 renders after that (16th, 31st, 46th...)
 - At most once per process — re-renders in the same session don't trigger a second prompt
-- Skipped in quiet mode (`--quiet`), non-TTY shells, CI environments, and Docker renders
+- Automatically suppressed in quiet mode (`--quiet`), non-TTY shells, and CI environments
 
 The prompt has a **10-second auto-timeout** — if you don't respond, it silently disappears and the CLI continues normally.
 
@@ -34,13 +40,13 @@ HYPERFRAMES_FEEDBACK_INTERVAL=5 hyperframes render --output out.mp4
 
 ### Studio — session feedback bar
 
-A thin 32px bar slides in at the bottom of the preview area every 10 Studio sessions:
+A thin 32px bar slides in at the bottom of the preview area periodically:
 
 - Never on the first session — only starting from the 10th
 - Then every 10 sessions (10th, 20th, 30th...)
 - Slides in 3 seconds after page load to avoid flash
 - Auto-dismisses after 20 seconds if ignored
-- After any interaction (dismiss, skip, or submit), the counter resets — next prompt after 10 more sessions
+- After any interaction (dismiss or submit), the session counter resets — next prompt after 10 more sessions
 
 The session interval is configurable at build time:
 
@@ -49,6 +55,8 @@ VITE_HYPERFRAMES_FEEDBACK_INTERVAL=3
 ```
 
 Invalid values (non-integer, zero, negative) fall back to the default.
+
+**Note:** Disabling CLI telemetry (`hyperframes telemetry disable`) does not suppress the Studio bar — Studio feedback is gated separately. The submitted data is still sent through the same anonymous PostHog pipeline, so the same privacy guarantees apply.
 
 ### `hyperframes feedback` command
 
@@ -71,15 +79,30 @@ This command collects a doctor summary automatically, flushes telemetry, and exi
 
 ## Agent Runtimes
 
-When an AI agent is detected (Claude Code, Codex, Cursor, Copilot, Replit, and others), HyperFrames **skips the interactive readline prompt** and prints a structured hint instead:
+When an AI agent is detected, HyperFrames **skips the interactive readline prompt** and prints a structured hint instead:
 
 ```
   [hyperframes] Agent feedback: hyperframes feedback --rating <1-5> --comment "..."
 ```
 
-Agents can then submit feedback using the `hyperframes feedback` command above. Detection is based on well-known environment variables (`CLAUDE_CODE`, `CODEX`, `CURSOR_TRACE`, etc.) — their values are never read, only their presence.
+Agents can then submit feedback using the `hyperframes feedback` command above.
 
-The same cadence gate applies to agents: the hint only appears on the first render, then every 15th.
+The same cadence gate applies: the hint only appears on the first render, then every 15th.
+
+**Detected agents and their markers:**
+
+| Agent | Environment markers |
+|-------|---------------------|
+| Claude Code | `CLAUDECODE` present, or `CLAUDE_CODE_ENTRYPOINT` present |
+| Codex | `CODEX_THREAD_ID`, `CODEX_CI`, or `CODEX_SANDBOX_NETWORK_DISABLED` present |
+| Cursor | `TERM_PROGRAM` equals `cursor` |
+| GitHub Copilot Agent | `GITHUB_ACTIONS` equals `true` and (`COPILOT_AGENT_ID` present or `RUNNER_NAME` equals `Copilot`) |
+| Replit | `REPL_ID` or `REPLIT_USER` present |
+| Hermes | `HERMES_QUIET` present |
+| openclaw | `OPENCLAW_STATE_DIR` or `OPENCLAW_CONFIG_PATH` present |
+| Pi | `PI_CODING_AGENT` present |
+
+Only the existence (or in some cases the value) of these variables is checked — API keys and secrets that happen to share a prefix are never read.
 
 ## What Is Collected
 
@@ -89,7 +112,7 @@ The same cadence gate applies to agents: the hint only appears on the first rend
 |-------|-------|
 | `$survey_id` | `render_satisfaction` |
 | `$survey_response` | Rating (1–5) |
-| `$survey_response_2` | Free-text comment (if provided) |
+| `$survey_response_2` | Free-text comment (only when provided) |
 | `render_duration_ms` | Time the render took in milliseconds |
 | `doctor_summary` | System context (see below) |
 
@@ -99,7 +122,7 @@ The `doctor_summary` is a compact string with environment context — included a
 os=darwin/arm64 node=v22.11.0 cpu=10cores mem=32GB ffmpeg=yes
 ```
 
-It may also include `docker` or `wsl` flags when those environments are detected.
+It may also include `wsl` or sandbox runtime flags when those environments are detected.
 
 ### Studio feedback
 
@@ -107,7 +130,7 @@ It may also include `docker` or `wsl` flags when those environments are detected
 |-------|-------|
 | `$survey_id` | `studio_experience` |
 | `$survey_response` | Rating (1–5) |
-| `$survey_response_2` | Free-text comment (if provided) |
+| `$survey_response_2` | Free-text comment (only when provided) |
 | `source` | `studio` |
 | `doctor_summary` | Browser context (platform, screen, CPU cores, device memory, network type) |
 
@@ -118,7 +141,6 @@ It may also include `docker` or `wsl` flags when those environments are detected
 - Environment variable values
 - Personally identifiable information
 - IP addresses or precise location
-- Anything when telemetry is disabled
 
 Feedback is anonymous. Each installation has a random UUID (`anonymousId`) — there is no account, login, or email association.
 
@@ -140,18 +162,18 @@ The CLI persists feedback state in `~/.hyperframes/config.json`:
 | Field | Description |
 |-------|-------------|
 | `renderSuccessCount` | Total successful renders across all sessions |
-| `lastFeedbackPromptAt` | The `renderSuccessCount` value when the prompt last appeared |
+| `lastFeedbackPromptAt` | The `renderSuccessCount` value when the prompt last appeared — used to compute whether 15 renders have passed |
 
 Studio stores the equivalent state in `localStorage` under the `hyperframes-studio:` prefix.
 
 ## Opting Out
 
-### Disable telemetry entirely
+### CLI — disable telemetry entirely
 
-Disabling telemetry suppresses all feedback prompts (and all other usage tracking):
+Disabling telemetry suppresses the CLI feedback prompt and all other CLI usage tracking:
 
 ```bash
-# Via CLI command
+# Via CLI command (persisted to ~/.hyperframes/config.json)
 hyperframes telemetry disable
 
 # Or via environment variable (per-session)
@@ -163,7 +185,7 @@ DO_NOT_TRACK=1 hyperframes render --output out.mp4
 
 Once disabled, the `hyperframes feedback` command will print `Telemetry is disabled. Feedback not sent.` and exit without sending anything.
 
-### Suppress output without disabling telemetry
+### CLI — suppress output without disabling telemetry
 
 ```bash
 # Quiet mode: renders without any post-render output (including the feedback prompt)
@@ -172,7 +194,11 @@ hyperframes render --quiet --output out.mp4
 
 ### CI environments
 
-The feedback prompt is automatically suppressed when the `CI` environment variable is set (GitHub Actions, CircleCI, etc. set this by default).
+The CLI feedback prompt is automatically suppressed when the `CI` environment variable is set (GitHub Actions, CircleCI, etc. set this by default).
+
+### Studio
+
+The Studio feedback bar is not affected by the CLI telemetry setting. To suppress it, set `VITE_HYPERFRAMES_FEEDBACK_INTERVAL=0` at build time or remove the `VITE_HYPERFRAMES_FEEDBACK` feature flag from your Studio build.
 
 ## Related
 

--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -1,0 +1,181 @@
+---
+title: Feedback Collection
+description: "How HyperFrames collects feedback, what data is collected, and how to opt out."
+---
+
+HyperFrames prompts for anonymous satisfaction feedback periodically — after CLI renders and in Studio sessions. This page explains when prompts appear, what data is collected, and how to disable them entirely.
+
+## How It Works
+
+### CLI — post-render prompt
+
+After a successful `hyperframes render`, a short satisfaction prompt may appear:
+
+```
+  How was this render? [1=poor 5=great, enter to skip]
+  Any details? (enter to skip)
+```
+
+**When it shows:**
+
+- First ever successful render
+- Then every 15th successful render (15th, 30th, 45th...)
+- At most once per process — re-renders in the same session don't trigger a second prompt
+- Skipped in quiet mode (`--quiet`), non-TTY shells, CI environments, and Docker renders
+
+The prompt has a **10-second auto-timeout** — if you don't respond, it silently disappears and the CLI continues normally.
+
+The render interval is configurable:
+
+```bash
+# Show prompt every 5 renders instead of 15 (useful for testing)
+HYPERFRAMES_FEEDBACK_INTERVAL=5 hyperframes render --output out.mp4
+```
+
+### Studio — session feedback bar
+
+A thin 32px bar slides in at the bottom of the preview area every 10 Studio sessions:
+
+- Never on the first session — only starting from the 10th
+- Then every 10 sessions (10th, 20th, 30th...)
+- Slides in 3 seconds after page load to avoid flash
+- Auto-dismisses after 20 seconds if ignored
+- After any interaction (dismiss, skip, or submit), the counter resets — next prompt after 10 more sessions
+
+The session interval is configurable at build time:
+
+```
+VITE_HYPERFRAMES_FEEDBACK_INTERVAL=3
+```
+
+Invalid values (non-integer, zero, negative) fall back to the default.
+
+### `hyperframes feedback` command
+
+You can submit feedback manually at any time:
+
+```bash
+# Quick rating
+hyperframes feedback --rating 5
+
+# Rating with details
+hyperframes feedback --rating 3 --comment "render succeeded but GSAP timeline didn't animate text overlay"
+```
+
+| Flag | Description |
+|------|-------------|
+| `--rating` | Satisfaction score, 1–5 (required) |
+| `--comment` | Optional free-text details |
+
+This command collects a doctor summary automatically, flushes telemetry, and exits. It appears under the **Settings** group in `hyperframes --help`.
+
+## Agent Runtimes
+
+When an AI agent is detected (Claude Code, Codex, Cursor, Copilot, Replit, and others), HyperFrames **skips the interactive readline prompt** and prints a structured hint instead:
+
+```
+  [hyperframes] Agent feedback: hyperframes feedback --rating <1-5> --comment "..."
+```
+
+Agents can then submit feedback using the `hyperframes feedback` command above. Detection is based on well-known environment variables (`CLAUDE_CODE`, `CODEX`, `CURSOR_TRACE`, etc.) — their values are never read, only their presence.
+
+The same cadence gate applies to agents: the hint only appears on the first render, then every 15th.
+
+## What Is Collected
+
+### CLI feedback
+
+| Field | Value |
+|-------|-------|
+| `$survey_id` | `render_satisfaction` |
+| `$survey_response` | Rating (1–5) |
+| `$survey_response_2` | Free-text comment (if provided) |
+| `render_duration_ms` | Time the render took in milliseconds |
+| `doctor_summary` | System context (see below) |
+
+The `doctor_summary` is a compact string with environment context — included automatically so you don't need to run `hyperframes doctor` when reporting a problem:
+
+```
+os=darwin/arm64 node=v22.11.0 cpu=10cores mem=32GB ffmpeg=yes
+```
+
+It may also include `docker` or `wsl` flags when those environments are detected.
+
+### Studio feedback
+
+| Field | Value |
+|-------|-------|
+| `$survey_id` | `studio_experience` |
+| `$survey_response` | Rating (1–5) |
+| `$survey_response_2` | Free-text comment (if provided) |
+| `source` | `studio` |
+| `doctor_summary` | Browser context (platform, screen, CPU cores, device memory, network type) |
+
+## What Is NOT Collected
+
+- File paths or project names
+- Composition content, HTML, or video files
+- Environment variable values
+- Personally identifiable information
+- IP addresses or precise location
+- Anything when telemetry is disabled
+
+Feedback is anonymous. Each installation has a random UUID (`anonymousId`) — there is no account, login, or email association.
+
+## Config File
+
+The CLI persists feedback state in `~/.hyperframes/config.json`:
+
+```json
+{
+  "telemetryEnabled": true,
+  "anonymousId": "a1b2c3d4-...",
+  "telemetryNoticeShown": true,
+  "commandCount": 47,
+  "renderSuccessCount": 14,
+  "lastFeedbackPromptAt": 1
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `renderSuccessCount` | Total successful renders across all sessions |
+| `lastFeedbackPromptAt` | The `renderSuccessCount` value when the prompt last appeared |
+
+Studio stores the equivalent state in `localStorage` under the `hyperframes-studio:` prefix.
+
+## Opting Out
+
+### Disable telemetry entirely
+
+Disabling telemetry suppresses all feedback prompts (and all other usage tracking):
+
+```bash
+# Via CLI command
+hyperframes telemetry disable
+
+# Or via environment variable (per-session)
+HYPERFRAMES_NO_TELEMETRY=1 hyperframes render --output out.mp4
+
+# Or via DO_NOT_TRACK (respects the global standard)
+DO_NOT_TRACK=1 hyperframes render --output out.mp4
+```
+
+Once disabled, the `hyperframes feedback` command will print `Telemetry is disabled. Feedback not sent.` and exit without sending anything.
+
+### Suppress output without disabling telemetry
+
+```bash
+# Quiet mode: renders without any post-render output (including the feedback prompt)
+hyperframes render --quiet --output out.mp4
+```
+
+### CI environments
+
+The feedback prompt is automatically suppressed when the `CI` environment variable is set (GitHub Actions, CircleCI, etc. set this by default).
+
+## Related
+
+- [Telemetry](/packages/cli#telemetry) — full telemetry settings and what usage data is collected
+- [`hyperframes feedback`](/packages/cli#feedback) — CLI command reference
+- [Troubleshooting](/guides/troubleshooting) — if a prompt is blocking your pipeline unexpectedly

--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -198,7 +198,14 @@ The CLI feedback prompt is automatically suppressed when the `CI` environment va
 
 ### Studio
 
-The Studio feedback bar is not affected by the CLI telemetry setting. To suppress it, set `VITE_HYPERFRAMES_FEEDBACK_INTERVAL=0` at build time or remove the `VITE_HYPERFRAMES_FEEDBACK` feature flag from your Studio build.
+The Studio feedback bar is not affected by the CLI telemetry setting, and there is no build-time flag to disable it — the bar is mounted unconditionally and appears based on the session cadence in `localStorage`.
+
+If you need to suppress it in a custom Studio build (e.g. embedded or kiosk use), the cadence state lives in two `localStorage` keys:
+
+- `hyperframes-studio:feedbackSessionCount` — incremented each session
+- `hyperframes-studio:feedbackLastPromptedAt` — the count value when the bar last appeared
+
+Setting both to the same large number (`"99999"`) will defer the next prompt indefinitely. This is a workaround, not a supported API — a proper opt-out flag is tracked as a follow-up to hf#1101.
 
 ## Related
 

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -803,6 +803,27 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
 
     Available topics: `data-attributes`, `examples`, `rendering`, `gsap`, `troubleshooting`, `compositions`. Run without a topic to see the full list.
 
+    ### `feedback`
+
+    Submit anonymous satisfaction feedback about your experience:
+
+    ```bash
+    # Quick rating (1 = poor, 5 = great)
+    npx hyperframes feedback --rating 5
+
+    # Rating with optional details
+    npx hyperframes feedback --rating 3 --comment "render succeeded but GSAP timeline didn't animate"
+    ```
+
+    | Flag | Description |
+    |------|-------------|
+    | `--rating` | Satisfaction score, 1–5 (required) |
+    | `--comment` | Optional free-text details |
+
+    This command is also available to AI agents after a render — see [Feedback Collection](/guides/feedback#agent-runtimes) for how agent detection and the automatic post-render hint work.
+
+    No-op when telemetry is disabled — prints `Telemetry is disabled. Feedback not sent.` and exits cleanly.
+
     ### `telemetry`
 
     Manage anonymous usage telemetry:
@@ -814,6 +835,8 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
     ```
 
     Telemetry collects command names, render performance, example choices, and system info — including a coarse environment fingerprint (OS, kernel string, CPU/memory shape, sandbox runtime such as gVisor or Docker, and the *name* of a coding agent driving the CLI when one is detected, e.g. `claude_code` / `codex` / `cursor`). The agent name is derived from the existence of well-known environment variables; their values are never read. Telemetry does **not** collect file paths, project names, video content, environment variable values, or personally identifiable information. Disable with `HYPERFRAMES_NO_TELEMETRY=1` or the command above.
+
+    See [Feedback Collection](/guides/feedback) for how the periodic post-render prompt and Studio feedback bar work, what data they collect, and how to opt out.
 
     ### `skills`
 

--- a/packages/studio/src/components/StudioFeedbackBar.tsx
+++ b/packages/studio/src/components/StudioFeedbackBar.tsx
@@ -4,6 +4,14 @@ import { trackStudioFeedback } from "../telemetry/events";
 const DEFAULT_FEEDBACK_INTERVAL = 10;
 const AUTO_DISMISS_MS = 20_000;
 
+function isFeedbackDisabled(): boolean {
+  try {
+    return import.meta.env.VITE_HYPERFRAMES_NO_FEEDBACK === "1";
+  } catch {
+    return false;
+  }
+}
+
 // fallow-ignore-next-line complexity
 function getFeedbackInterval(): number {
   try {
@@ -25,6 +33,7 @@ const STORAGE_KEYS = {
 
 // fallow-ignore-next-line complexity
 function shouldShowFeedback(): boolean {
+  if (isFeedbackDisabled()) return false;
   try {
     const count = parseInt(localStorage.getItem(STORAGE_KEYS.sessionCount) || "0", 10) || 0;
     const lastAt = parseInt(localStorage.getItem(STORAGE_KEYS.lastPromptedAt) || "0", 10) || 0;


### PR DESCRIPTION
## Summary

- Adds `docs/guides/feedback.mdx` — new guide covering the post-render CLI prompt, Studio feedback bar, and `hyperframes feedback` command
- Adds `feedback` command entry to `docs/packages/cli.mdx` (Utilities tab, alongside `telemetry`)
- Registers `guides/feedback` in `docs/docs.json` nav

## What's documented

**Cadence** — CLI: first render, then every 15th. Studio: every 10th session (never the first). Both configurable via env vars.

**Data collected** — PostHog `survey sent` event fields (`$survey_id`, `$survey_response`, `doctor_summary`), what each surface collects, and config file field meanings.

**What's NOT collected** — file paths, project names, video content, env var values, PII.

**Opt-out paths** — `hyperframes telemetry disable`, `HYPERFRAMES_NO_TELEMETRY=1`, `DO_NOT_TRACK=1`, `--quiet` flag, CI auto-suppression.

**Agent runtimes** — structured hint instead of readline prompt; same cadence gate; `hyperframes feedback --rating <1-5>` for agent submission.

**Config file** — `~/.hyperframes/config.json` fields (`renderSuccessCount`, `lastFeedbackPromptAt`) and Studio localStorage keys.

## Test plan

- [ ] Review `docs/guides/feedback.mdx` for accuracy against PR #1101 implementation
- [ ] Verify `guides/feedback` renders correctly in Mintlify preview
- [ ] Check cross-links (`/guides/feedback`, `/packages/cli#feedback`) resolve

— Magi