### PR TITLE
fix(cli): cloud delete --no-confirm and cloud render --no-wait

### DIFF
--- a/packages/cli/src/commands/cloud/delete.ts
+++ b/packages/cli/src/commands/cloud/delete.ts
@@ -25,15 +25,23 @@ export default defineCommand({
       description: "Emit machine-readable JSON",
       default: false,
     },
-    "no-confirm": {
+    // Citty intercepts the `--no-` prefix as a negation of the base
+    // flag, so a flag literally named "no-confirm" gets parsed as
+    // `--confirm=false` and the `args["no-confirm"]` lookup never
+    // sees `true`. Naming the flag `confirm` with `default: true` lets
+    // citty's negation handle `--no-confirm` correctly — same
+    // user-facing flag (`--no-confirm` to skip the prompt), correct
+    // runtime semantics.
+    confirm: {
       type: "boolean",
-      description: "Skip the interactive confirmation prompt (required for scripts and --json)",
-      default: false,
+      description:
+        "Prompt before deleting (default: true). Pass `--no-confirm` to skip — required for scripts and --json.",
+      default: true,
     },
   },
   // fallow-ignore-next-line complexity
   async run({ args }) {
-    if (!args["no-confirm"]) {
+    if (args.confirm) {
       // Don't auto-bypass the prompt just because stdin isn't a TTY
       // or `--json` was passed — both used to silently skip the
       // safety check. Force the caller to opt in via `--no-confirm`

--- a/packages/cli/src/commands/cloud/render.ts
+++ b/packages/cli/src/commands/cloud/render.ts
@@ -141,10 +141,17 @@ export default defineCommand({
       description:
         "Public HTTPS URL of a composition zip. Mutually exclusive with --asset-id and the project dir.",
     },
-    "no-wait": {
+    // Citty parses `--no-FOO` as `--FOO=false`. A flag literally named
+    // "no-wait" gets routed as `args.wait=false`, leaving
+    // `args["no-wait"]` undefined and the early-return for
+    // fire-and-forget mode unreachable. Named the arg `wait` so the
+    // user-facing `--no-wait` flag works via citty's negation; the
+    // run() body checks `if (!args.wait)`.
+    wait: {
       type: "boolean",
-      description: "Submit and exit; print the render_id to stdout",
-      default: false,
+      description:
+        "Poll until completion and download the video (default: true). Pass `--no-wait` for fire-and-forget — submits and exits with the render_id.",
+      default: true,
     },
     output: {
       type: "string",
@@ -216,7 +223,7 @@ export default defineCommand({
     });
 
     const renderId = submitted.render_id;
-    if (args["no-wait"]) {
+    if (!args.wait) {
       if (asJson) {
         console.log(
           JSON.stringify(


### PR DESCRIPTION
## What

Two related bugs in the just-merged `cloud` commands, caught during the live end-to-end smoke test:

- `hyperframes cloud delete <id> --no-confirm` was hitting "Confirmation required" and exiting 1 without ever calling the API.
- `hyperframes cloud render --no-wait` was running the full poll + download flow instead of submitting and exiting with the render_id.

## Why

Same root cause: citty parses `--no-FOO` as a negation of the base flag `FOO`. A flag literally named `no-confirm` gets routed as `args.confirm=false` (not `args["no-confirm"]=true`), and same for `no-wait`.

```ts
// Before
"no-confirm": { type: "boolean", default: false }
// `--no-confirm` parses as args.confirm=false; args["no-confirm"] is undefined.
// if (!args["no-confirm"]) is always true → prompt path runs even with the flag.
```

## How

Rename the arg keys to `confirm` (default `true`) and `wait` (default `true`) so citty's built-in `--no-FOO` negation handles the user-facing flags correctly. The flag names stay the same; only the runtime arg keys change.

```ts
// After
confirm: { type: "boolean", default: true }
wait:    { type: "boolean", default: true }
// `--no-confirm` parses as args.confirm=false. Code reads `if (args.confirm)`.
// `--no-wait`    parses as args.wait=false.    Code reads `if (!args.wait)`.
```

## Test plan

- [x] `bun run --cwd packages/cli typecheck` — clean
- [x] `bunx oxlint` + `oxfmt --check` — clean
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — clean
- [x] `bun run --cwd packages/cli test` — 589 / 589 pass
- [x] Live smoke against the API:
  - `cloud render` of `packages/producer/tests/webm-transparency/src` → completed, downloaded 18KB MP4 ✓
  - `cloud render --no-wait --json` → returns `{render: {render_id, status: "queued"}, _meta}` and exits ✓
  - `cloud delete <id> --no-confirm` → `✓ Deleted`, subsequent `cloud get` returns 404 ✓
  - `echo "" | cloud delete <id>` (no `--no-confirm`) → still gates with "Confirmation required" errorBox ✓

## Pre-existing latent issue (out of scope)

`commands/add.ts:187` uses the same broken pattern with `--no-clipboard`. Not fixed here — would inflate the PR scope and is unrelated to the cloud-render rollout. Should be cleaned up alongside any wider audit of the CLI's interactive-vs-noninteractive flag conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)