### PR TITLE
fix(core): remove 1800s hard cap on timeline duration

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -538,8 +538,7 @@ export function initSandboxRuntimeModular(): void {
     } else {
       safeDuration = fallbackDuration;
     }
-    const hardDurationCap = Math.max(1, Number(state.maxTimelineDurationSeconds) || 1800);
-    return safeDuration > 0 ? Math.max(0, Math.min(safeDuration, hardDurationCap)) : 0;
+    return safeDuration > 0 ? Math.max(0, safeDuration) : 0;
   };
 
   const resolveRootTimelineFromDocument = (): TimelineResolution => {
@@ -1423,7 +1422,6 @@ export function initSandboxRuntimeModular(): void {
     bindRootTimelineIfAvailable();
     const payload = collectRuntimeTimelinePayload({
       canonicalFps: state.canonicalFps,
-      maxTimelineDurationSeconds: state.maxTimelineDurationSeconds,
     });
     window.__clipManifest = payload;
     postRuntimeMessage(payload);

--- a/packages/core/src/runtime/state.test.ts
+++ b/packages/core/src/runtime/state.test.ts
@@ -12,7 +12,6 @@ describe("createRuntimeState", () => {
     expect(state.capturedTimeline).toBeNull();
     expect(state.rafId).toBeNull();
     expect(state.tornDown).toBe(false);
-    expect(state.maxTimelineDurationSeconds).toBe(1800);
     expect(state.parityModeEnabled).toBe(true);
   });
 

--- a/packages/core/src/runtime/state.ts
+++ b/packages/core/src/runtime/state.ts
@@ -72,7 +72,6 @@ export type RuntimeState = {
   cachedVideoClips: RuntimeMediaClip[];
   cachedMediaTimelineDurationSeconds: number;
   tornDown: boolean;
-  maxTimelineDurationSeconds: number;
   nativeVisualWatchdogTick: number;
   /**
    * Single-clock transport. The sole time authority — GSAP is always
@@ -115,7 +114,6 @@ export function createRuntimeState(): RuntimeState {
     cachedVideoClips: [],
     cachedMediaTimelineDurationSeconds: 0,
     tornDown: false,
-    maxTimelineDurationSeconds: 1800,
     nativeVisualWatchdogTick: 0,
     transportClock: null,
     transportRafId: null,

--- a/packages/core/src/runtime/timeline.test.ts
+++ b/packages/core/src/runtime/timeline.test.ts
@@ -7,7 +7,7 @@ describe("collectRuntimeTimelinePayload", () => {
     delete (window as any).__timelines;
   });
 
-  const defaultParams = { canonicalFps: 30, maxTimelineDurationSeconds: 1800 };
+  const defaultParams = { canonicalFps: 30 };
 
   it("returns minimal payload for empty document", () => {
     const result = collectRuntimeTimelinePayload(defaultParams);
@@ -214,7 +214,7 @@ describe("collectRuntimeTimelinePayload", () => {
     expect(result.durationInFrames).toBe(210); // 7s * 30fps
   });
 
-  it("clamps duration to maxTimelineDurationSeconds", () => {
+  it("respects long composition durations without capping", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");
     root.setAttribute("data-duration", "5000");
@@ -225,11 +225,8 @@ describe("collectRuntimeTimelinePayload", () => {
     clip.setAttribute("data-duration", "5000");
     root.appendChild(clip);
 
-    const result = collectRuntimeTimelinePayload({
-      canonicalFps: 30,
-      maxTimelineDurationSeconds: 60,
-    });
-    expect(result.durationInFrames).toBeLessThanOrEqual(60 * 30);
+    const result = collectRuntimeTimelinePayload({ canonicalFps: 30 });
+    expect(result.durationInFrames).toBe(5000 * 30);
   });
 
   it("skips script/style/meta nodes", () => {

--- a/packages/core/src/runtime/timeline.ts
+++ b/packages/core/src/runtime/timeline.ts
@@ -176,7 +176,6 @@ function buildTimelineClipLabel(node: Element, kind: RuntimeTimelineClip["kind"]
 
 export function collectRuntimeTimelinePayload(params: {
   canonicalFps: number;
-  maxTimelineDurationSeconds: number;
 }): RuntimeTimelineMessage {
   const runtimeWindow = window as Window & {
     __timelines?: Record<string, RuntimeTimelineLike | undefined>;
@@ -347,10 +346,7 @@ export function collectRuntimeTimelinePayload(params: {
           mediaWindowDurationCandidate,
           compositionWindowDurationCandidate,
         ));
-  const rootCompositionDuration =
-    preferredRootDuration != null
-      ? Math.min(preferredRootDuration, params.maxTimelineDurationSeconds)
-      : null;
+  const rootCompositionDuration = preferredRootDuration ?? null;
   const rootCompositionEnd =
     rootCompositionDuration != null ? rootCompositionStart + rootCompositionDuration : null;
   const timelineWindowEnd =
@@ -666,13 +662,7 @@ export function collectRuntimeTimelinePayload(params: {
   // hide structural/background tracks from the timeline UI; if we collapse the
   // payload duration down to the last visible clip end, the controls jump even
   // though playback still runs for the full authored root duration.
-  const safeDuration = Math.max(
-    1,
-    Math.min(
-      Math.max(maxEnd || 1, rootCompositionDuration ?? 0),
-      params.maxTimelineDurationSeconds,
-    ),
-  );
+  const safeDuration = Math.max(1, maxEnd || 1, rootCompositionDuration ?? 0);
   const shouldEmitNonDeterministicInf = timelineLooksLoopInflated && attrDurationCandidate == null;
   const durationInFrames = shouldEmitNonDeterministicInf
     ? Number.POSITIVE_INFINITY


### PR DESCRIPTION
## Summary

- **Root cause**: `maxTimelineDurationSeconds` defaulted to 1800 (30 min) and silently clamped the `TransportClock` duration. Any `clock.seek(t)` beyond 1800s was clamped to 1800, so `seekTimelineAndAdapters()` never reached GSAP tweens starting past that threshold — they stayed at their pre-tween CSS state (e.g. `opacity:0`).
- **Fix**: Remove the `maxTimelineDurationSeconds` field and all three clamping sites. The `data-duration` attribute is the authored source of truth; the existing `timelineLooksLoopInflated` guard already handles infinite `repeat:-1` timelines.
- All 1011 core tests pass, including a new test confirming 5000s compositions are respected without truncation.

## Test plan

- [x] `bun run build` — passes
- [x] `bun run --cwd packages/core test` — 1011 tests pass
- [x] Lint + format clean
- [x] Manual: render the minimal repro from #1107 (2400s composition with a tween at t=2000s) — frame at t=2010 should now show the LATE card

Closes #1107