### PR TITLE
fix(cli): drop misleading hint on hyperframes_project_invalid

### DIFF
--- a/packages/cli/src/cloud/errors.ts
+++ b/packages/cli/src/cloud/errors.ts
@@ -18,8 +18,6 @@ import { HyperframesApiError } from "./_gen/client.js";
  * say, leave the code out and let the message stand on its own.
  */
 const ERROR_CODE_HINTS: Record<string, string> = {
-  hyperframes_project_invalid:
-    "The uploaded zip didn't validate. Confirm it contains index.html at the root (or matches --composition), and that all referenced assets are present.",
   hyperframes_project_too_large:
     "The zip exceeded the 32 MB limit. Trim large media (or pre-host them and reference by URL), then try again.",
   hyperframes_render_not_found:


### PR DESCRIPTION
## Summary

The CLI maps `hyperframes_project_invalid` to a single hint ("uploaded zip didn't validate"), but the server returns this code for multiple failure modes — invalid zip, missing resolution, other validation errors. The hint is correct for the zip-invalid case but actively misleading for the others (concretely: a missing-resolution failure reads the explicit server message AND the wrong hint, and a user takes the hint as authoritative).

Drop the hint entry. Server messages are already explicit; surfacing them alone is more honest.

Once the sibling EF PR (defaulting render resolution to 1080p server-side) lands, this code will only fire for legitimate zip/composition failures — at which point a targeted hint could be added back if useful. For now, no hint beats a misleading one.

## Test plan

- [ ] Trigger a `hyperframes_project_invalid` failure (e.g. malformed zip, missing resolution while billing-enabled) and confirm the CLI surfaces only the server's explicit message — no contradicting hint.
- [ ] `bun run lint` / `bun run format --check` / `bun run typecheck` clean.