### PR TITLE
fix(studio): soft-reload GSAP property edits, preserve shader cache

### DIFF
--- a/packages/core/src/studio-api/routes/files.ts
+++ b/packages/core/src/studio-api/routes/files.ts
@@ -713,6 +713,12 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
 
     // Re-parse the mutated script so the UI gets fresh state
     const freshParsed = parseGsapScript(newScript);
-    return c.json({ ok: true, parsed: freshParsed, before: html, after: newHtml });
+    return c.json({
+      ok: true,
+      parsed: freshParsed,
+      before: html,
+      after: newHtml,
+      scriptText: newScript,
+    });
   });
 }

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -247,11 +247,14 @@ function getDocumentStyleSignature(doc: Document): string {
 
 // fallow-ignore-next-line complexity
 function isGsapAnimationOnlyScript(text: string): boolean {
+  const hasGsap =
+    text.includes("gsap.timeline") ||
+    text.includes("__timelines") ||
+    text.includes(".to(") ||
+    text.includes(".set(");
+  if (!hasGsap) return false;
   return (
-    (text.includes("gsap.timeline") || text.includes("__timelines")) &&
-    !text.includes("HyperShader") &&
-    !text.includes("hyper-shader") &&
-    !text.includes("hyperShader")
+    !text.includes("HyperShader") && !text.includes("hyper-shader") && !text.includes("hyperShader")
   );
 }
 

--- a/packages/shader-transitions/src/hyper-shader.ts
+++ b/packages/shader-transitions/src/hyper-shader.ts
@@ -245,6 +245,16 @@ function getDocumentStyleSignature(doc: Document): string {
   return stableHash(`${styleText}\n${linkedStyles}`);
 }
 
+// fallow-ignore-next-line complexity
+function isGsapAnimationOnlyScript(text: string): boolean {
+  return (
+    (text.includes("gsap.timeline") || text.includes("__timelines")) &&
+    !text.includes("HyperShader") &&
+    !text.includes("hyper-shader") &&
+    !text.includes("hyperShader")
+  );
+}
+
 function getDocumentScriptSignature(doc: Document): string {
   const projectSignature = Array.from(
     doc.querySelectorAll<HTMLMetaElement>('meta[name="hyperframes-project-signature"]'),
@@ -252,6 +262,12 @@ function getDocumentScriptSignature(doc: Document): string {
     .map((meta) => meta.getAttribute("content") || "")
     .join("\n");
   const scriptText = Array.from(doc.querySelectorAll<HTMLScriptElement>("script"))
+    .filter((script) => {
+      if (script.src) return true;
+      const text = script.textContent || "";
+      if (!text.trim()) return false;
+      return !isGsapAnimationOnlyScript(text);
+    })
     .map((script) => {
       const attrs = [
         script.type,
@@ -2191,6 +2207,10 @@ export function init(config: HyperShaderConfig): GsapTimeline {
   const hfWin = window as unknown as { __hf?: { shaderTransitionsReady?: Promise<void> } };
   hfWin.__hf = hfWin.__hf || {};
   hfWin.__hf.shaderTransitionsReady = prewarmPromise;
+
+  (
+    window as Window & { __hfSuppressSceneMutations?: <T>(fn: () => T) => T }
+  ).__hfSuppressSceneMutations = <T>(fn: () => T): T => suppressSceneMutationTracking(fn);
 
   registerTimeline(compId, tl, config.timeline);
   return tl;

--- a/packages/studio/src/hooks/useDomEditSession.ts
+++ b/packages/studio/src/hooks/useDomEditSession.ts
@@ -224,6 +224,7 @@ export function useDomEditSession({
   } = useGsapScriptCommits({
     projectIdRef,
     activeCompPath,
+    previewIframeRef,
     editHistory,
     domEditSaveTimestampRef,
     reloadPreview,

--- a/packages/studio/src/hooks/useGsapScriptCommits.ts
+++ b/packages/studio/src/hooks/useGsapScriptCommits.ts
@@ -46,6 +46,7 @@ interface MutationResult {
   parsed?: ParsedGsap;
   before?: string;
   after?: string;
+  scriptText?: string;
 }
 
 async function mutateGsapScript(
@@ -134,8 +135,8 @@ export function useGsapScriptCommits({
 
       onCacheInvalidate();
 
-      if (options.softReload && result.after) {
-        if (!applySoftReload(previewIframeRef.current, result.after)) {
+      if (options.softReload && result.scriptText) {
+        if (!applySoftReload(previewIframeRef.current, result.scriptText)) {
           reloadPreview();
         }
       } else {

--- a/packages/studio/src/hooks/useGsapScriptCommits.ts
+++ b/packages/studio/src/hooks/useGsapScriptCommits.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import type { ParsedGsap } from "@hyperframes/core/gsap-parser";
 import type { DomEditSelection } from "../components/editor/domEditingTypes";
 import type { EditHistoryKind } from "../utils/editHistory";
+import { applySoftReload } from "../utils/gsapSoftReload";
 
 const PROPERTY_DEFAULTS: Record<string, number> = {
   opacity: 1,
@@ -71,6 +72,7 @@ async function mutateGsapScript(
 interface GsapScriptCommitsParams {
   projectIdRef: React.MutableRefObject<string | null>;
   activeCompPath: string | null;
+  previewIframeRef: React.RefObject<HTMLIFrameElement | null>;
   editHistory: {
     recordEdit: (entry: {
       label: string;
@@ -90,6 +92,7 @@ const DEBOUNCE_MS = 150;
 export function useGsapScriptCommits({
   projectIdRef,
   activeCompPath,
+  previewIframeRef,
   editHistory,
   domEditSaveTimestampRef,
   reloadPreview,
@@ -131,13 +134,18 @@ export function useGsapScriptCommits({
 
       onCacheInvalidate();
 
-      if (!options.softReload) {
+      if (options.softReload && result.after) {
+        if (!applySoftReload(previewIframeRef.current, result.after)) {
+          reloadPreview();
+        }
+      } else {
         reloadPreview();
       }
     },
     [
       projectIdRef,
       activeCompPath,
+      previewIframeRef,
       editHistory,
       domEditSaveTimestampRef,
       reloadPreview,
@@ -156,6 +164,7 @@ export function useGsapScriptCommits({
       {
         label: `Edit GSAP ${property}`,
         coalesceKey: `gsap:${animationId}:${property}`,
+        softReload: true,
       },
     );
   }, [commitMutation]);

--- a/packages/studio/src/utils/gsapSoftReload.test.ts
+++ b/packages/studio/src/utils/gsapSoftReload.test.ts
@@ -83,4 +83,22 @@ describe("applySoftReload", () => {
     expect(result).toBe(true);
     expect(suppressionCalled).toBe(true);
   });
+
+  it("returns false when multiple GSAP scripts exist (ambiguous)", () => {
+    const script1 = document.createElement("script");
+    script1.textContent = "const tl = gsap.timeline({ paused: true });";
+    const script2 = document.createElement("script");
+    script2.textContent = 'tl.to("#other", { x: 10 });';
+    const container = document.createElement("div");
+    container.appendChild(script1);
+    container.appendChild(script2);
+
+    const { iframe } = buildMockIframe();
+    (iframe as unknown as { contentDocument: unknown }).contentDocument = {
+      querySelectorAll: (sel: string) => (sel === "script:not([src])" ? [script1, script2] : []),
+      createElement: (tag: string) => document.createElement(tag),
+      body: container,
+    };
+    expect(applySoftReload(iframe, SCRIPT_TEXT)).toBe(false);
+  });
 });

--- a/packages/studio/src/utils/gsapSoftReload.test.ts
+++ b/packages/studio/src/utils/gsapSoftReload.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi } from "vitest";
+import { applySoftReload } from "./gsapSoftReload";
+
+const AFTER_HTML = `<html><body>
+<div data-composition-id="root"></div>
+<script>
+const tl = gsap.timeline({ paused: true });
+tl.to("#box", { opacity: 0.8 });
+window.__timelines["root"] = tl;
+</script>
+</body></html>`;
+
+function buildMockIframe(overrides: Record<string, unknown> = {}) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent =
+    'const tl = gsap.timeline({ paused: true }); tl.to("#box", { opacity: 0.5 });';
+  const container = document.createElement("div");
+  container.appendChild(scriptEl);
+
+  const mockTimeline = { kill: vi.fn(), pause: vi.fn() };
+  const contentWindow = {
+    gsap: { timeline: vi.fn() },
+    __hfForceTimelineRebind: vi.fn(),
+    __timelines: { root: mockTimeline } as Record<string, typeof mockTimeline>,
+    __player: { getTime: () => 2.0, seek: vi.fn() },
+    __hfStudioManualEditsApply: vi.fn(),
+    __hfSuppressSceneMutations: undefined as undefined | (<T>(fn: () => T) => T),
+    ...overrides,
+  };
+
+  const contentDocument = {
+    querySelectorAll: (sel: string) => (sel === "script:not([src])" ? [scriptEl] : []),
+    createElement: (tag: string) => document.createElement(tag),
+  };
+
+  return {
+    iframe: { contentWindow, contentDocument } as unknown as HTMLIFrameElement,
+    contentWindow,
+    mockTimeline,
+  };
+}
+
+describe("applySoftReload", () => {
+  it("returns false when iframe is null", () => {
+    expect(applySoftReload(null, AFTER_HTML)).toBe(false);
+  });
+
+  it("returns false when gsap is not on iframe window", () => {
+    const { iframe } = buildMockIframe({ gsap: undefined });
+    expect(applySoftReload(iframe, AFTER_HTML)).toBe(false);
+  });
+
+  it("returns false when __hfForceTimelineRebind is missing", () => {
+    const { iframe } = buildMockIframe({ __hfForceTimelineRebind: undefined });
+    expect(applySoftReload(iframe, AFTER_HTML)).toBe(false);
+  });
+
+  it("returns false when afterHtml has no GSAP script", () => {
+    const { iframe } = buildMockIframe();
+    expect(applySoftReload(iframe, "<html><body><p>no script</p></body></html>")).toBe(false);
+  });
+
+  it("kills existing timelines, rebinds, and re-seeks on success", () => {
+    const { iframe, contentWindow, mockTimeline } = buildMockIframe();
+    const result = applySoftReload(iframe, AFTER_HTML);
+    expect(result).toBe(true);
+    expect(mockTimeline.kill).toHaveBeenCalled();
+    expect(contentWindow.__hfForceTimelineRebind).toHaveBeenCalled();
+    expect(contentWindow.__player.seek).toHaveBeenCalledWith(2.0);
+    expect(contentWindow.__hfStudioManualEditsApply).toHaveBeenCalled();
+  });
+
+  it("wraps execution in __hfSuppressSceneMutations when available", () => {
+    let suppressionCalled = false;
+    const { iframe } = buildMockIframe({
+      __hfSuppressSceneMutations: <T>(fn: () => T): T => {
+        suppressionCalled = true;
+        return fn();
+      },
+    });
+    const result = applySoftReload(iframe, AFTER_HTML);
+    expect(result).toBe(true);
+    expect(suppressionCalled).toBe(true);
+  });
+});

--- a/packages/studio/src/utils/gsapSoftReload.test.ts
+++ b/packages/studio/src/utils/gsapSoftReload.test.ts
@@ -3,14 +3,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { applySoftReload } from "./gsapSoftReload";
 
-const AFTER_HTML = `<html><body>
-<div data-composition-id="root"></div>
-<script>
+const SCRIPT_TEXT = `
+window.__timelines = window.__timelines || {};
 const tl = gsap.timeline({ paused: true });
 tl.to("#box", { opacity: 0.8 });
 window.__timelines["root"] = tl;
-</script>
-</body></html>`;
+`;
 
 function buildMockIframe(overrides: Record<string, unknown> = {}) {
   const scriptEl = document.createElement("script");
@@ -33,6 +31,7 @@ function buildMockIframe(overrides: Record<string, unknown> = {}) {
   const contentDocument = {
     querySelectorAll: (sel: string) => (sel === "script:not([src])" ? [scriptEl] : []),
     createElement: (tag: string) => document.createElement(tag),
+    body: container,
   };
 
   return {
@@ -44,27 +43,27 @@ function buildMockIframe(overrides: Record<string, unknown> = {}) {
 
 describe("applySoftReload", () => {
   it("returns false when iframe is null", () => {
-    expect(applySoftReload(null, AFTER_HTML)).toBe(false);
+    expect(applySoftReload(null, SCRIPT_TEXT)).toBe(false);
+  });
+
+  it("returns false when scriptText is empty", () => {
+    const { iframe } = buildMockIframe();
+    expect(applySoftReload(iframe, "")).toBe(false);
   });
 
   it("returns false when gsap is not on iframe window", () => {
     const { iframe } = buildMockIframe({ gsap: undefined });
-    expect(applySoftReload(iframe, AFTER_HTML)).toBe(false);
+    expect(applySoftReload(iframe, SCRIPT_TEXT)).toBe(false);
   });
 
   it("returns false when __hfForceTimelineRebind is missing", () => {
     const { iframe } = buildMockIframe({ __hfForceTimelineRebind: undefined });
-    expect(applySoftReload(iframe, AFTER_HTML)).toBe(false);
-  });
-
-  it("returns false when afterHtml has no GSAP script", () => {
-    const { iframe } = buildMockIframe();
-    expect(applySoftReload(iframe, "<html><body><p>no script</p></body></html>")).toBe(false);
+    expect(applySoftReload(iframe, SCRIPT_TEXT)).toBe(false);
   });
 
   it("kills existing timelines, rebinds, and re-seeks on success", () => {
     const { iframe, contentWindow, mockTimeline } = buildMockIframe();
-    const result = applySoftReload(iframe, AFTER_HTML);
+    const result = applySoftReload(iframe, SCRIPT_TEXT);
     expect(result).toBe(true);
     expect(mockTimeline.kill).toHaveBeenCalled();
     expect(contentWindow.__hfForceTimelineRebind).toHaveBeenCalled();
@@ -80,7 +79,7 @@ describe("applySoftReload", () => {
         return fn();
       },
     });
-    const result = applySoftReload(iframe, AFTER_HTML);
+    const result = applySoftReload(iframe, SCRIPT_TEXT);
     expect(result).toBe(true);
     expect(suppressionCalled).toBe(true);
   });

--- a/packages/studio/src/utils/gsapSoftReload.ts
+++ b/packages/studio/src/utils/gsapSoftReload.ts
@@ -16,23 +16,13 @@ function findGsapScriptElement(doc: Document): HTMLScriptElement | null {
   return null;
 }
 
-function extractGsapScriptFromHtml(html: string): string | null {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, "text/html");
-  const script = findGsapScriptElement(doc);
-  return script?.textContent || null;
-}
-
-export function applySoftReload(iframe: HTMLIFrameElement | null, afterHtml: string): boolean {
-  if (!iframe) return false;
+export function applySoftReload(iframe: HTMLIFrameElement | null, scriptText: string): boolean {
+  if (!iframe || !scriptText) return false;
 
   const win = iframe.contentWindow as IframeWindow | null;
   const doc = iframe.contentDocument;
   if (!win || !doc) return false;
   if (!win.gsap || !win.__hfForceTimelineRebind) return false;
-
-  const newScriptText = extractGsapScriptFromHtml(afterHtml);
-  if (!newScriptText) return false;
 
   const oldScriptEl = findGsapScriptElement(doc);
   if (!oldScriptEl) return false;
@@ -52,7 +42,7 @@ export function applySoftReload(iframe: HTMLIFrameElement | null, afterHtml: str
 
     oldScriptEl.remove();
     const newScript = doc.createElement("script");
-    newScript.textContent = `(function(){${newScriptText}\n})();`;
+    newScript.textContent = `(function(){${scriptText}\n})();`;
     doc.body.appendChild(newScript);
 
     win.__hfForceTimelineRebind?.();

--- a/packages/studio/src/utils/gsapSoftReload.ts
+++ b/packages/studio/src/utils/gsapSoftReload.ts
@@ -11,7 +11,13 @@ function findGsapScriptElement(doc: Document): HTMLScriptElement | null {
   const scripts = doc.querySelectorAll<HTMLScriptElement>("script:not([src])");
   for (const script of scripts) {
     const text = script.textContent || "";
-    if (text.includes("gsap.timeline") || text.includes("__timelines")) return script;
+    if (
+      text.includes("gsap.timeline") ||
+      text.includes("__timelines") ||
+      text.includes(".to(") ||
+      text.includes(".set(")
+    )
+      return script;
   }
   return null;
 }

--- a/packages/studio/src/utils/gsapSoftReload.ts
+++ b/packages/studio/src/utils/gsapSoftReload.ts
@@ -1,0 +1,73 @@
+type IframeWindow = Window & {
+  __timelines?: Record<string, { kill?: () => void; pause?: () => void }>;
+  __player?: { getTime?: () => number; seek?: (t: number) => void };
+  __hfForceTimelineRebind?: () => void;
+  __hfSuppressSceneMutations?: <T>(fn: () => T) => T;
+  __hfStudioManualEditsApply?: () => void;
+  gsap?: { timeline?: (...args: unknown[]) => unknown };
+};
+
+function findGsapScriptElement(doc: Document): HTMLScriptElement | null {
+  const scripts = doc.querySelectorAll<HTMLScriptElement>("script:not([src])");
+  for (const script of scripts) {
+    const text = script.textContent || "";
+    if (text.includes("gsap.timeline") || text.includes("__timelines")) return script;
+  }
+  return null;
+}
+
+function extractGsapScriptFromHtml(html: string): string | null {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+  const script = findGsapScriptElement(doc);
+  return script?.textContent || null;
+}
+
+export function applySoftReload(iframe: HTMLIFrameElement | null, afterHtml: string): boolean {
+  if (!iframe) return false;
+
+  const win = iframe.contentWindow as IframeWindow | null;
+  const doc = iframe.contentDocument;
+  if (!win || !doc) return false;
+  if (!win.gsap || !win.__hfForceTimelineRebind) return false;
+
+  const newScriptText = extractGsapScriptFromHtml(afterHtml);
+  if (!newScriptText) return false;
+
+  const oldScriptEl = findGsapScriptElement(doc);
+  if (!oldScriptEl) return false;
+
+  const currentTime = win.__player?.getTime?.() ?? 0;
+
+  const doReload = () => {
+    const timelines = win.__timelines;
+    if (timelines) {
+      for (const key of Object.keys(timelines)) {
+        try {
+          timelines[key]?.kill?.();
+        } catch {}
+        delete timelines[key];
+      }
+    }
+
+    const newScript = doc.createElement("script");
+    newScript.textContent = newScriptText;
+    oldScriptEl.parentNode?.insertBefore(newScript, oldScriptEl);
+    oldScriptEl.remove();
+
+    win.__hfForceTimelineRebind?.();
+    win.__player?.seek?.(currentTime);
+    win.__hfStudioManualEditsApply?.();
+  };
+
+  try {
+    if (win.__hfSuppressSceneMutations) {
+      win.__hfSuppressSceneMutations(doReload);
+    } else {
+      doReload();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/studio/src/utils/gsapSoftReload.ts
+++ b/packages/studio/src/utils/gsapSoftReload.ts
@@ -50,10 +50,10 @@ export function applySoftReload(iframe: HTMLIFrameElement | null, afterHtml: str
       }
     }
 
-    const newScript = doc.createElement("script");
-    newScript.textContent = newScriptText;
-    oldScriptEl.parentNode?.insertBefore(newScript, oldScriptEl);
     oldScriptEl.remove();
+    const newScript = doc.createElement("script");
+    newScript.textContent = `(function(){${newScriptText}\n})();`;
+    doc.body.appendChild(newScript);
 
     win.__hfForceTimelineRebind?.();
     win.__player?.seek?.(currentTime);

--- a/packages/studio/src/utils/gsapSoftReload.ts
+++ b/packages/studio/src/utils/gsapSoftReload.ts
@@ -7,21 +7,37 @@ type IframeWindow = Window & {
   gsap?: { timeline?: (...args: unknown[]) => unknown };
 };
 
-function findGsapScriptElement(doc: Document): HTMLScriptElement | null {
-  const scripts = doc.querySelectorAll<HTMLScriptElement>("script:not([src])");
-  for (const script of scripts) {
-    const text = script.textContent || "";
-    if (
-      text.includes("gsap.timeline") ||
-      text.includes("__timelines") ||
-      text.includes(".to(") ||
-      text.includes(".set(")
-    )
-      return script;
-  }
-  return null;
+function isGsapScript(text: string): boolean {
+  return (
+    text.includes("gsap.timeline") ||
+    text.includes("__timelines") ||
+    text.includes(".to(") ||
+    text.includes(".set(")
+  );
 }
 
+function findGsapScriptElements(doc: Document): HTMLScriptElement[] {
+  const results: HTMLScriptElement[] = [];
+  const scripts = doc.querySelectorAll<HTMLScriptElement>("script:not([src])");
+  for (const script of scripts) {
+    if (isGsapScript(script.textContent || "")) results.push(script);
+  }
+  return results;
+}
+
+/**
+ * Replace the GSAP script in the live iframe without reloading. This preserves
+ * the WebGL context and shader transition cache.
+ *
+ * Scoped to root-document GSAP scripts only — scripts inside `<template>`
+ * elements (sub-compositions) are not visible to `querySelectorAll` and will
+ * fall back to a full iframe reload.
+ *
+ * Returns false (triggering a full reload fallback) when:
+ * - The iframe or GSAP runtime isn't available
+ * - Multiple GSAP scripts are found (ambiguous which to replace)
+ * - No matching GSAP script element exists in the live DOM
+ */
 export function applySoftReload(iframe: HTMLIFrameElement | null, scriptText: string): boolean {
   if (!iframe || !scriptText) return false;
 
@@ -30,8 +46,9 @@ export function applySoftReload(iframe: HTMLIFrameElement | null, scriptText: st
   if (!win || !doc) return false;
   if (!win.gsap || !win.__hfForceTimelineRebind) return false;
 
-  const oldScriptEl = findGsapScriptElement(doc);
-  if (!oldScriptEl) return false;
+  const gsapScripts = findGsapScriptElements(doc);
+  if (gsapScripts.length !== 1) return false;
+  const oldScriptEl = gsapScripts[0]!;
 
   const currentTime = win.__player?.getTime?.() ?? 0;
 
@@ -48,6 +65,9 @@ export function applySoftReload(iframe: HTMLIFrameElement | null, scriptText: st
 
     oldScriptEl.remove();
     const newScript = doc.createElement("script");
+    // IIFE prevents const/let redeclaration errors across consecutive edits.
+    // Top-level declarations are scoped to the IIFE; window.* assignments
+    // (e.g. window.__timelines["root"] = tl) still reach the global scope.
     newScript.textContent = `(function(){${scriptText}\n})();`;
     doc.body.appendChild(newScript);
 


### PR DESCRIPTION
## Summary

GSAP property value edits in the design panel now update the live timeline without reloading the preview iframe. This preserves the WebGL context and shader transition cache, eliminating the multi-second loading overlay that appeared on every property edit.

### What changed

- **Soft-reload for property edits** — after the GSAP mutation API writes the file, the studio kills the old timeline, re-executes the updated script inside the iframe, calls `__hfForceTimelineRebind()`, and re-seeks to the current time. Falls back to full reload on failure.

- **MutationObserver suppression** — exposes `__hfSuppressSceneMutations` from hyper-shader.ts so the soft-reload can wrap the kill/re-execute/re-seek sequence without the observer marking transitions dirty.

- **Smarter shader cache keys** — `getDocumentScriptSignature` now excludes pure GSAP animation scripts (those containing `gsap.timeline`/`__timelines` but NOT `HyperShader.init`). Full reloads (undo, external changes) no longer bust the transition cache when only animation values changed.

### What stays the same

- Add/delete animation, undo/redo, external file changes still trigger full iframe reloads
- The `softReload` flag on `commitMutation` was already in the type signature — this PR is the first caller

## Test plan

- [ ] Edit opacity in design panel on a composition with shader transitions — no loading overlay should appear
- [ ] Verify the preview updates instantly with the new value
- [ ] Seek to a transition time after editing — shader transition should still render
- [ ] Undo the edit — full reload fires (correct)
- [ ] Edit property on a composition without shader transitions — works normally
- [ ] Add a new animation — full reload fires (correct, not soft-reloaded yet)