### PR TITLE
fix(producer): drop empty trailing chunk slice in distributed render plan

### DIFF
--- a/packages/producer/src/services/distributed/plan.test.ts
+++ b/packages/producer/src/services/distributed/plan.test.ts
@@ -125,6 +125,43 @@ describe("resolveChunkPlan", () => {
     expect(result.chunkCount).toBe(5);
     expect(result.effectiveChunkSize).toBe(MIN_CHUNK_SIZE);
   });
+
+  it("tightens chunkCount so an explicit small chunkSize leaves no empty trailing slice", () => {
+    // 121 frames, chunkSize=10, maxParallelChunks=12: ceil(121/10)=13 naive →
+    // capped at 12, but effectiveChunkSize rounds up to ceil(121/12)=11. Eleven
+    // 11-frame chunks already cover [0,121), so a 12th would be the empty slice
+    // [121,121) that renderChunk rejects (framesInChunk <= 0). chunkCount must
+    // tighten to 11.
+    const result = resolveChunkPlan(121, 10, 12);
+    expect(result.effectiveChunkSize).toBe(11);
+    expect(result.chunkCount).toBe(11);
+    const slices = buildChunkSlices(121, result.chunkCount, result.effectiveChunkSize);
+    expect(slices).toHaveLength(11);
+    expect(slices[slices.length - 1]).toEqual({ index: 10, startFrame: 110, endFrame: 121 });
+  });
+
+  it("never emits an empty or inverted slice across a grid of explicit chunk sizes", () => {
+    for (const totalFrames of [37, 50, 121, 333, 1000, 4001]) {
+      for (const maxParallel of [2, 4, 12, 16, 40]) {
+        for (const chunkSize of [10, 11, 15, 24, 100]) {
+          const { chunkCount, effectiveChunkSize } = resolveChunkPlan(
+            totalFrames,
+            chunkSize,
+            maxParallel,
+          );
+          expect(chunkCount).toBeLessThanOrEqual(maxParallel);
+          const slices = buildChunkSlices(totalFrames, chunkCount, effectiveChunkSize);
+          let cursor = 0;
+          for (const s of slices) {
+            expect(s.startFrame).toBe(cursor); // contiguous from 0
+            expect(s.endFrame).toBeGreaterThan(s.startFrame); // non-empty
+            cursor = s.endFrame;
+          }
+          expect(cursor).toBe(totalFrames); // union is exactly [0, totalFrames)
+        }
+      }
+    }
+  });
 });
 
 describe("buildChunkSlices", () => {

--- a/packages/producer/src/services/distributed/plan.ts
+++ b/packages/producer/src/services/distributed/plan.ts
@@ -400,6 +400,7 @@ export function measurePlanDirBytes(planDir: string): number {
  *     resolvedChunkSize   = configChunkSize ?? max(MIN_CHUNK_SIZE, ceil(totalFrames / maxParallelChunks))
  *     chunkCount          = min(maxParallelChunks, ceil(totalFrames / resolvedChunkSize))
  *     effectiveChunkSize  = max(resolvedChunkSize, ceil(totalFrames / chunkCount))
+ *     chunkCount          = min(chunkCount, ceil(totalFrames / effectiveChunkSize))  // drop empty trailing slice
  *
  * Long renders auto-rescale to fewer-but-longer chunks rather than
  * fragmenting infinitely. Returned `chunkCount >= 1` (`totalFrames === 0`
@@ -434,7 +435,17 @@ export function resolveChunkPlan(
   const naiveCount = Math.ceil(totalFrames / resolvedChunkSize);
   const chunkCount = Math.min(maxParallelChunks, Math.max(1, naiveCount));
   const effectiveChunkSize = Math.max(resolvedChunkSize, Math.ceil(totalFrames / chunkCount));
-  return { chunkCount, effectiveChunkSize };
+  // Rounding effectiveChunkSize up can let the first (chunkCount - 1) chunks
+  // already cover every frame, leaving an empty/inverted trailing slice that
+  // buildChunkSlices would still emit and renderChunk would then reject
+  // (framesInChunk <= 0), failing the whole distributed render. Tighten
+  // chunkCount to the number of chunks effectiveChunkSize actually needs so the
+  // union stays exactly [0, totalFrames) with no empty tail. This only ever
+  // lowers chunkCount in the explicit-small-chunkSize case; the auto-sized and
+  // large-chunkSize paths already satisfy ceil(totalFrames / effectiveChunkSize)
+  // >= chunkCount, so it's a no-op there.
+  const tightChunkCount = Math.min(chunkCount, Math.ceil(totalFrames / effectiveChunkSize));
+  return { chunkCount: tightChunkCount, effectiveChunkSize };
 }
 
 function assertPositiveInteger(name: string, value: number): void {


### PR DESCRIPTION
### The bug

`resolveChunkPlan` derives `chunkCount` from the naive count (`min(maxParallelChunks, ceil(totalFrames / resolvedChunkSize))`), then rounds `effectiveChunkSize` **up** to `ceil(totalFrames / chunkCount)`. When that ceil rounds up, the first `chunkCount - 1` chunks can already cover every frame, so `buildChunkSlices` emits a final slice with `startFrame >= totalFrames` — an empty `[n, n)` or inverted range.

`renderChunk` then rejects that slice (`framesInChunk = endFrame - startFrame <= 0` → `RenderChunkValidationError`), and under Step Functions retries it exhausts retries and **fails the whole distributed render**, even though `[0, totalFrames)` was already fully covered. It also violates `buildChunkSlices`'s own documented contract ("the union is exactly `[0, totalFrames)`").

### Reachability

This is reachable straight from the user-facing CLI. `--chunk-size` and `--max-parallel-chunks` are first-class flags on `hyperframes lambda render` that flow into `DistributedRenderConfig` → `resolveChunkPlan`:

```
hyperframes lambda render --chunk-size 10 --max-parallel-chunks 12
```

on a ~4s / 30fps (121-frame) composition gives `resolvedChunkSize=10`, `chunkCount=min(12, 13)=12`, `effectiveChunkSize=max(10, ceil(121/12)=11)=11`. Slices 0–10 cover `[0, 121)`; slice 11 is `[121, 121)`.

### The fix

Tighten `chunkCount` to `ceil(totalFrames / effectiveChunkSize)` after the size is finalized, so the trailing empty slice is dropped and the union stays exactly `[0, totalFrames)`. This only ever lowers `chunkCount` in the explicit-small-`chunkSize` case; the auto-sized and large-`chunkSize` paths already satisfy `ceil(totalFrames / effectiveChunkSize) >= chunkCount`, so it's a no-op there (every existing test's asserted `chunkCount` is unchanged). `maxParallelChunks` is still respected.

### Tests

`plan.test.ts` gains the `121 / 10 / 12` regression case (asserts `chunkCount === 11` and the last slice is `[110, 121)`) plus a grid property test over a range of `totalFrames × maxParallelChunks × explicit chunkSize` asserting every slice is non-empty, contiguous from 0, and ends exactly at `totalFrames`.