### PR TITLE
fix(studio): timeline seekbar focus blocks NLE keyboard shortcuts

### DIFF
--- a/packages/studio/src/components/editor/propertyPanelColor.tsx
+++ b/packages/studio/src/components/editor/propertyPanelColor.tsx
@@ -80,6 +80,9 @@ function ColorSlider({
           event.currentTarget.setPointerCapture(event.pointerId);
           commitFromClientX(event.clientX);
         }}
+        onPointerUp={(event) => {
+          event.currentTarget.blur();
+        }}
         onPointerMove={(event) => {
           if (disabled || event.buttons !== 1) return;
           commitFromClientX(event.clientX);

--- a/packages/studio/src/player/components/PlayerControls.tsx
+++ b/packages/studio/src/player/components/PlayerControls.tsx
@@ -282,7 +282,7 @@ const SeekBar = memo(function SeekBar({
       aria-valuemin={0}
       aria-valuemax={Math.round(duration)}
       aria-valuenow={0}
-      className={`min-w-[96px] flex-1 h-6 flex items-center group ${
+      className={`min-w-[96px] flex-1 h-6 flex items-center group outline-none focus-visible:ring-1 focus-visible:ring-white/30 focus-visible:rounded ${
         disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"
       }`}
       style={{ touchAction: "none" }}

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -428,7 +428,8 @@ export const Timeline = memo(function Timeline({
     >
       <div
         ref={scrollRef}
-        className={`${zoomMode === "fit" ? "overflow-x-hidden" : "overflow-x-auto"} overflow-y-auto h-full`}
+        tabIndex={-1}
+        className={`${zoomMode === "fit" ? "overflow-x-hidden" : "overflow-x-auto"} overflow-y-auto h-full outline-none`}
         onDragOver={handleAssetDragOver}
         onDragLeave={() => setIsDragOver(false)}
         onDrop={handleAssetDrop}

--- a/packages/studio/src/player/components/useSeekBarDrag.ts
+++ b/packages/studio/src/player/components/useSeekBarDrag.ts
@@ -110,6 +110,7 @@ export function useSeekBarDrag(
         window.removeEventListener("pointercancel", onUp);
         document.removeEventListener("visibilitychange", onVisibilityChange);
         window.removeEventListener("blur", cleanup);
+        target.blur();
       };
       const onUp = (ev: PointerEvent) => {
         if (ev.pointerId !== pointerId) return;


### PR DESCRIPTION
## Root cause

Clicking the player controls seekbar called `e.currentTarget.focus()` (line 62 of `useSeekBarDrag.ts`), leaving the `role="slider"` element focused. `shouldIgnorePlaybackShortcutTarget` in `playbackShortcuts.ts` filters out `[role='slider']` targets to avoid conflicting with slider arrow-key handling — so with the seekbar focused, every playback shortcut (Space, J/K/L, ArrowLeft/Right) was silently swallowed until the user clicked elsewhere.

Separately, Chrome auto-focuses `overflow:auto` scrollable elements when clicked. The NLE timeline scroll div was getting focus this way, showing the browser's default white focus ring.

## Changes

| File | Change |
|------|--------|
| `useSeekBarDrag.ts` | `target.blur()` at end of `cleanup()` — yields focus back after pointer release |
| `PlayerControls.tsx` | Replace default white outline with `outline-none focus-visible:ring-1 focus-visible:ring-white/30` — subtle ring for keyboard nav, no ring from mouse click |
| `Timeline.tsx` | `tabIndex={-1}` + `outline-none` on the scroll div — prevents Chrome from auto-focusing it |

## Test plan

- Click the seek bar to seek → white ring no longer appears; releasing the mouse immediately restores Space/J/K/L/Delete
- Tab to the seek bar → subtle white/30 ring appears (accessibility preserved)
- While dragging the seek bar, arrow keys still step frames (focus stays during drag, blur fires on pointer release)
- Click anywhere on the NLE timeline tracks → no white outline appears

Fixes #1136