### PR TITLE
fix(core): recognize dot-property timeline registration

### DIFF
--- a/packages/core/src/lint/rules/core.test.ts
+++ b/packages/core/src/lint/rules/core.test.ts
@@ -71,6 +71,24 @@ describe("core rules", () => {
     expect(finding?.message).toContain("without initializing");
   });
 
+  it("reports error when dot timeline registry is assigned without initializing", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="stage"></div>
+  </div>
+  <script>
+    const tl = gsap.timeline({ paused: true });
+    tl.to("#stage", { opacity: 1, duration: 1 }, 0);
+    window.__timelines.c1 = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "timeline_registry_missing_init");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+  });
+
   it("does not flag timeline assignment when init guard is present", async () => {
     const validComposition = `
 <html>
@@ -90,6 +108,54 @@ describe("core rules", () => {
     const result = await lintHyperframeHtml(validComposition);
     const finding = result.findings.find((f) => f.code === "timeline_registry_missing_init");
     expect(finding).toBeUndefined();
+  });
+
+  describe("timeline_id_mismatch", () => {
+    it("accepts dot timeline registration", async () => {
+      const html = `
+<html><body>
+  <div data-composition-id="launch" data-width="1920" data-height="1080"></div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    window.__timelines.launch = tl;
+  </script>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "timeline_id_mismatch");
+      expect(finding).toBeUndefined();
+    });
+
+    it("reports mismatched dot timeline registration", async () => {
+      const html = `
+<html><body>
+  <div data-composition-id="launch" data-width="1920" data-height="1080"></div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    window.__timelines.intro = tl;
+  </script>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "timeline_id_mismatch");
+      expect(finding).toBeDefined();
+      expect(finding?.message).toContain('Timeline registered as "intro"');
+    });
+
+    it("accepts bracket timeline registration for hyphenated ids", async () => {
+      const html = `
+<html><body>
+  <div data-composition-id="product-launch" data-width="1920" data-height="1080"></div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    window.__timelines["product-launch"] = tl;
+  </script>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "timeline_id_mismatch");
+      expect(finding).toBeUndefined();
+    });
   });
 
   it("warns when a timeline-visible element has no stable id for Studio editing", async () => {

--- a/packages/core/src/lint/rules/core.ts
+++ b/packages/core/src/lint/rules/core.ts
@@ -4,6 +4,7 @@ import {
   readAttr,
   truncateSnippet,
   extractCompositionIdsFromCss,
+  extractTimelineRegistryKeys,
   getInlineScriptSyntaxError,
   TIMELINE_REGISTRY_INIT_PATTERN,
   TIMELINE_REGISTRY_ASSIGN_PATTERN,
@@ -118,13 +119,12 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
     const htmlCompIds = new Set<string>();
     const timelineRegKeys = new Set<string>();
     const compIdRe = /data-composition-id\s*=\s*["']([^"']+)["']/gi;
-    const tlKeyRe = /window\.__timelines\[\s*["']([^"']+)["']\s*\]/g;
     let m: RegExpExecArray | null;
     while ((m = compIdRe.exec(source)) !== null) {
       if (m[1]) htmlCompIds.add(m[1]);
     }
-    while ((m = tlKeyRe.exec(source)) !== null) {
-      if (m[1]) timelineRegKeys.add(m[1]);
+    for (const key of extractTimelineRegistryKeys(source)) {
+      timelineRegKeys.add(key);
     }
     for (const key of timelineRegKeys) {
       if (!htmlCompIds.has(key)) {

--- a/packages/core/src/lint/rules/gsap.test.ts
+++ b/packages/core/src/lint/rules/gsap.test.ts
@@ -903,6 +903,25 @@ describe("GSAP rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does NOT warn when timeline is registered with dot property syntax", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="root" data-width="1920" data-height="1080">
+    <div id="box">Hello</div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.to("#box", { opacity: 0.5, duration: 2 });
+    window.__timelines.root = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_timeline_not_registered");
+    expect(finding).toBeUndefined();
+  });
+
   it("does NOT warn for sub-compositions (template-based)", async () => {
     const html = `
 <template>

--- a/packages/core/src/lint/rules/gsap.ts
+++ b/packages/core/src/lint/rules/gsap.ts
@@ -125,7 +125,7 @@ function countClassUsage(tags: OpenTag[]): Map<string, number> {
 
 function readRegisteredTimelineCompositionId(script: string): string | null {
   const match = script.match(WINDOW_TIMELINE_ASSIGN_PATTERN);
-  return match?.[1] || null;
+  return match?.[1] || match?.[2] || null;
 }
 
 /** Strip a `__raw:` prefix the parser adds to unresolvable values. */

--- a/packages/core/src/lint/utils.ts
+++ b/packages/core/src/lint/utils.ts
@@ -21,10 +21,14 @@ export const SCRIPT_BLOCK_PATTERN = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
 const COMPOSITION_ID_IN_CSS_PATTERN = /\[data-composition-id=["']([^"']+)["']\]/g;
 export const TIMELINE_REGISTRY_INIT_PATTERN =
   /window\.__timelines\s*=\s*window\.__timelines\s*\|\|\s*\{\}|window\.__timelines\s*=\s*\{\}|window\.__timelines\s*\?\?=\s*\{\}/i;
-export const TIMELINE_REGISTRY_ASSIGN_PATTERN = /window\.__timelines\[[^\]]+\]\s*=/i;
+export const TIMELINE_REGISTRY_ASSIGN_PATTERN =
+  /window\.__timelines(?:\[[^\]]+\]|\.[A-Za-z_$][\w$]*)\s*=/i;
 export const WINDOW_TIMELINE_ASSIGN_PATTERN =
-  /window\.__timelines\[\s*["']([^"']+)["']\s*\]\s*=\s*([A-Za-z_$][\w$]*)/i;
+  /window\.__timelines(?:\[\s*["']([^"']+)["']\s*\]|\.\s*([A-Za-z_$][\w$]*))\s*=\s*([A-Za-z_$][\w$]*)/i;
 export const INVALID_SCRIPT_CLOSE_PATTERN = /<script[^>]*>[\s\S]*?<\s*\/\s*script(?!>)/i;
+
+const TIMELINE_REGISTRY_KEY_PATTERN =
+  /window\.__timelines(?:\[\s*["']([^"']+)["']\s*\]|\.\s*([A-Za-z_$][\w$]*))\s*=/g;
 
 export function extractOpenTags(source: string): OpenTag[] {
   const tags: OpenTag[] = [];
@@ -139,6 +143,20 @@ export function extractCompositionIdsFromCss(css: string): string[] {
     if (match[1]) ids.add(match[1]);
   }
   return [...ids];
+}
+
+export function extractTimelineRegistryKeys(source: string): string[] {
+  const keys = new Set<string>();
+  let match: RegExpExecArray | null;
+  const pattern = new RegExp(
+    TIMELINE_REGISTRY_KEY_PATTERN.source,
+    TIMELINE_REGISTRY_KEY_PATTERN.flags,
+  );
+  while ((match = pattern.exec(source)) !== null) {
+    const key = match[1] ?? match[2];
+    if (key) keys.add(key);
+  }
+  return [...keys];
 }
 
 export function getInlineScriptSyntaxError(source: string): string | null {


### PR DESCRIPTION
## What
Fixes Hyperframe lint rules so timeline registration can be done through dot-property:
```js
window.timelines.root = tl;
```

Previously, lint checks only recognized bracket syntax:

```js
window.timelines["root"] = tl;
```

This caused valid dot-property registrations to be incorrectly reported as missing or mismatched.

## Why
The linter was stricter than the runtime behavior, this created false positives when using valid identifiers like `root`, `launch`, or `intro`.

## How
Updated shared timeline regex utilities to recognize both (dot and bracket) forms.

Notable implementation details:

- `TIMELINE_REGISTRY_ASSIGN_PATTERN` detects either bracket or dot assignment.
- `WINDOW_TIMELINE_ASSIGN_PATTERN` captures the timeline key from either syntax.
- Added `extractTimelineRegistryKeys(...)` so timeline-id mismatch logic uses one shared extraction path instead of duplicating bracket-only regex logic.
- Updated GSAP timeline registration handling to read the key from either capture group.
- Kept bracket syntax coverage for (-) composition IDs, since those cannot be represented with dot-property syntax:
```js
window.__timelines["product-launch"] = tl;
```
## Test plan
Tested with:
```txt
bun run --filter @hyperframes/core test src/lint/rules/core.test.ts src/lint/rules/gsap.test.ts
bun run --filter @hyperframes/core typecheck
bun run format:check ...
bun run lint
```

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
