### PR TITLE
feat: Add video frame format render option

### DIFF
--- a/docs/guides/rendering.mdx
+++ b/docs/guides/rendering.mdx
@@ -121,6 +121,7 @@ Render your Hyperframes [compositions](/concepts/compositions) to MP4, MOV, or W
 | `--quality` | draft, standard, high | standard | Encoding quality preset |
 | `--crf` | 0–51 | — | Override CRF (lower = higher quality). Cannot combine with `--video-bitrate` |
 | `--video-bitrate` | e.g. `10M`, `5000k` | — | Target bitrate encoding. Cannot combine with `--crf` |
+| `--video-frame-format` | auto, jpg, png | auto | Source video frame extraction format. Use `png` for UI recordings, screen captures, and color-sensitive source videos |
 | `--workers` | 1-8 or `auto` | auto | Parallel render workers (see [Workers](#workers) below) |
 | `--max-concurrent-renders` | 1-10 | 2 | Max simultaneous renders via the producer server (see [Concurrent Renders](#concurrent-renders) below) |
 | `--gpu` | — | off | GPU encoding (NVENC, VideoToolbox, AMF, VAAPI, QSV) |
@@ -151,6 +152,8 @@ npx hyperframes render --video-bitrate 10M --output controlled.mp4
 ```
 
 **Tip**: The default `standard` preset (CRF 18) is visually lossless at 1080p — most people cannot distinguish it from the source. Use `--quality draft` for faster iteration, or `--quality high` / `--crf 10` when file size is no concern.
+
+For UI recordings, screen captures, or other source videos where saturated interface colors matter, pass `--video-frame-format png` to extract source video layers as PNG before browser capture. The default `auto` mode preserves the historical behavior: alpha-capable sources use PNG, opaque sources use JPG.
 
 ## GPU Acceleration
 

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -612,6 +612,7 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
     | `--quality` | draft, standard, high | standard | Encoding quality preset (drives CRF/bitrate) |
     | `--crf` | 0-51 | — | Override encoder CRF (lower = higher quality). Mutually exclusive with `--video-bitrate` |
     | `--video-bitrate` | e.g. `10M`, `5000k` | — | Target video bitrate. Mutually exclusive with `--crf` |
+    | `--video-frame-format` | auto, jpg, png | auto | Source video frame extraction format. Use `png` for UI recordings, screen captures, and color-sensitive source videos |
     | `--resolution` | landscape, portrait, landscape-4k, portrait-4k, square, square-4k (aliases: `1080p`, `4k`, `uhd`, `1080p-square`, `square-1080p`, `4k-square`) | — | Output resolution preset. Supersamples a smaller composition via Chrome `deviceScaleFactor` so the screenshot lands at the requested dimensions. Aspect ratio must match the composition; the scale must be an integer multiple. Not supported with `--hdr`. See [4K Rendering](/guides/4k-rendering) |
     | `--hdr` | — | off | Force HDR output even if no HDR sources are detected. MP4 only. See [HDR Rendering](/guides/hdr) |
     | `--sdr` | — | off | Force SDR output even if HDR sources are detected |
@@ -624,7 +625,7 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
     | `--variables-file` | path | — | Path to a JSON file with variable overrides (alternative to `--variables`) |
     | `--strict-variables` | — | off | Fail render if any `--variables` key is undeclared or has a wrong type vs the composition's `data-composition-variables`. Without this flag, mismatches print as warnings and the render continues. |
 
-    CRF and target bitrate default to the `--quality` preset. Use `--crf` or `--video-bitrate` for fine-grained overrides; `RenderConfig.crf` and `RenderConfig.videoBitrate` accept the same overrides programmatically.
+    CRF and target bitrate default to the `--quality` preset. Use `--crf` or `--video-bitrate` for fine-grained overrides; `RenderConfig.crf` and `RenderConfig.videoBitrate` accept the same overrides programmatically. Use `--video-frame-format png` when source videos are UI recordings, screen captures, or other color-sensitive clips that should avoid JPEG frame extraction.
 
     #### Parametrized renders
 

--- a/packages/aws-lambda/src/sdk/validateConfig.test.ts
+++ b/packages/aws-lambda/src/sdk/validateConfig.test.ts
@@ -30,6 +30,7 @@ describe("validateDistributedRenderConfig", () => {
       maxParallelChunks: 16,
       runtimeCap: "lambda",
       hdrMode: "force-sdr",
+      videoFrameFormat: "png",
     };
     expect(validateDistributedRenderConfig(cfg)).toBe(cfg);
   });
@@ -91,6 +92,14 @@ describe("validateDistributedRenderConfig", () => {
       "malformed bitrate",
       { ...VALID, bitrate: "fast" } satisfies SerializableDistributedRenderConfig,
       "config.bitrate",
+    ],
+    [
+      "unsupported videoFrameFormat",
+      {
+        ...VALID,
+        videoFrameFormat: "webp",
+      } as unknown as SerializableDistributedRenderConfig,
+      "config.videoFrameFormat",
     ],
     [
       "non-positive chunkSize",

--- a/packages/aws-lambda/src/sdk/validateConfig.ts
+++ b/packages/aws-lambda/src/sdk/validateConfig.ts
@@ -43,6 +43,7 @@ const ALLOWED_FORMATS = [
 ] as const satisfies readonly DistributedFormat[];
 const ALLOWED_CODECS = ["h264", "h265"] as const;
 const ALLOWED_QUALITIES = ["draft", "standard", "high"] as const;
+const ALLOWED_VIDEO_FRAME_FORMATS = ["auto", "jpg", "png"] as const;
 const ALLOWED_RUNTIME_CAPS = ["lambda", "temporal", "cloud-run-job", "k8s-job", "none"] as const;
 const ALLOWED_HDR_MODES = ["auto", "force-sdr"] as const;
 
@@ -117,6 +118,16 @@ export function validateDistributedRenderConfig(
     throw new InvalidConfigError(
       "config.bitrate",
       `must look like "10M" or "5000k"; got ${JSON.stringify(config.bitrate)}`,
+    );
+  }
+
+  if (
+    config.videoFrameFormat !== undefined &&
+    !ALLOWED_VIDEO_FRAME_FORMATS.includes(config.videoFrameFormat)
+  ) {
+    throw new InvalidConfigError(
+      "config.videoFrameFormat",
+      `must be one of ${ALLOWED_VIDEO_FRAME_FORMATS.join(", ")}; got ${String(config.videoFrameFormat)}`,
     );
   }
 

--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -164,6 +164,21 @@ describe("renderLocal browser GPU config", () => {
     expect(producerState.createdJobs[0]?.format).toBe("png-sequence");
   });
 
+  it("forwards videoFrameFormat to createRenderJob", async () => {
+    await renderLocal("/tmp/project", "/tmp/out.mp4", {
+      fps: { num: 30, den: 1 },
+      quality: "standard",
+      format: "mp4",
+      gpu: false,
+      browserGpuMode: "software",
+      hdrMode: "auto",
+      quiet: true,
+      videoFrameFormat: "png",
+    });
+
+    expect(producerState.createdJobs[0]?.videoFrameFormat).toBe("png");
+  });
+
   it("omits variables from createRenderJob when not provided", async () => {
     await renderLocal("/tmp/project", "/tmp/out.mp4", {
       fps: { num: 30, den: 1 },

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -63,6 +63,13 @@ import {
 } from "@hyperframes/core";
 
 const VALID_QUALITY = new Set(["draft", "standard", "high"]);
+const VIDEO_FRAME_FORMATS = ["auto", "jpg", "png"] as const;
+type VideoFrameFormat = (typeof VIDEO_FRAME_FORMATS)[number];
+const VALID_VIDEO_FRAME_FORMAT = new Set<string>(VIDEO_FRAME_FORMATS);
+
+function isVideoFrameFormat(value: string): value is VideoFrameFormat {
+  return VALID_VIDEO_FRAME_FORMAT.has(value);
+}
 
 /**
  * Map a {@link FpsParseResult} failure reason to a human-friendly
@@ -147,6 +154,14 @@ export default defineCommand({
         "(MOV/WebM render with transparency; png-sequence writes RGBA frames " +
         "to a directory for AE/Nuke/Fusion ingest)",
       default: "mp4",
+    },
+    "video-frame-format": {
+      type: "string",
+      description:
+        "Source video frame extraction format: auto, jpg, png (default: auto). " +
+        "Use png for UI recordings, screen captures, and color-sensitive source videos; " +
+        "alpha-capable sources always extract as PNG.",
+      default: "auto",
     },
     workers: {
       type: "string",
@@ -266,6 +281,16 @@ export default defineCommand({
       process.exit(1);
     }
     const format = formatRaw as "mp4" | "webm" | "mov" | "png-sequence";
+
+    const videoFrameFormatRaw = args["video-frame-format"] ?? "auto";
+    if (!isVideoFrameFormat(videoFrameFormatRaw)) {
+      errorBox(
+        "Invalid video-frame-format",
+        `Got "${videoFrameFormatRaw}". Must be auto, jpg, or png.`,
+      );
+      process.exit(1);
+    }
+    const videoFrameFormat = videoFrameFormatRaw;
 
     // ── Validate resolution ────────────────────────────────────────────────
     let outputResolution: CanvasResolution | undefined;
@@ -530,6 +555,7 @@ export default defineCommand({
         hdrMode: args.sdr ? "force-sdr" : args.hdr ? "force-hdr" : "auto",
         crf,
         videoBitrate,
+        videoFrameFormat,
         quiet,
         variables,
         entryFile,
@@ -548,6 +574,7 @@ export default defineCommand({
         hdrMode: args.sdr ? "force-sdr" : args.hdr ? "force-hdr" : "auto",
         crf,
         videoBitrate,
+        videoFrameFormat,
         quiet,
         browserPath,
         variables,
@@ -574,6 +601,7 @@ interface RenderOptions {
   hdrMode: "auto" | "force-hdr" | "force-sdr";
   crf?: number;
   videoBitrate?: string;
+  videoFrameFormat?: VideoFrameFormat;
   quiet: boolean;
   browserPath?: string;
   variables?: Record<string, unknown>;
@@ -734,6 +762,7 @@ async function renderDocker(
       hdrMode: options.hdrMode,
       crf: options.crf,
       videoBitrate: options.videoBitrate,
+      videoFrameFormat: options.videoFrameFormat,
       quiet: options.quiet,
       variables: options.variables,
       entryFile: options.entryFile,
@@ -808,6 +837,7 @@ export async function renderLocal(
     hdrMode: options.hdrMode,
     crf: options.crf,
     videoBitrate: options.videoBitrate,
+    videoFrameFormat: options.videoFrameFormat,
     variables: options.variables,
     entryFile: options.entryFile,
     outputResolution: options.outputResolution,

--- a/packages/cli/src/docs/rendering.md
+++ b/packages/cli/src/docs/rendering.md
@@ -19,6 +19,7 @@ Requires: Docker installed and running.
 - `-w, --workers` — Parallel workers 1-8 (default: auto)
 - `--crf` — Override encoder CRF (mutually exclusive with `--video-bitrate`)
 - `--video-bitrate` — Target video bitrate such as `10M` (mutually exclusive with `--crf`)
+- `--video-frame-format` — Source video frame extraction format: `auto`, `jpg`, or `png` (default: `auto`). Use `png` for UI recordings, screen captures, and color-sensitive source videos.
 - `--gpu` — Use GPU encoding (NVENC, VideoToolbox, AMF, VAAPI, QSV)
 - `--browser-gpu` / `--no-browser-gpu` — Force host GPU or software (SwiftShader) for Chrome/WebGL capture. Default for local renders is `auto` — probe WebGL availability on first launch and fall back to software if no GPU is reachable. Docker mode always uses software.
 - `-o, --output` — Custom output path
@@ -28,5 +29,6 @@ Requires: Docker installed and running.
 - Use `draft` quality for fast previews during development
 - Local renders auto-detect GPU on first launch; use `--browser-gpu` to force hardware (errors if no GPU) or `--no-browser-gpu` to force SwiftShader
 - Use `--gpu` when a local render also benefits from hardware FFmpeg encoding
+- Use `--video-frame-format png` when source videos contain saturated UI colors that should avoid JPEG extraction
 - Use `npx hyperframes benchmark` to find optimal settings
 - 4 workers is usually the sweet spot for most compositions

--- a/packages/cli/src/utils/dockerRunArgs.test.ts
+++ b/packages/cli/src/utils/dockerRunArgs.test.ts
@@ -160,6 +160,7 @@ describe("buildDockerRunArgs", () => {
         hdrMode: "force-hdr",
         crf: 16,
         videoBitrate: undefined,
+        videoFrameFormat: "png",
         quiet: true,
         entryFile: "compositions/intro.html",
       },
@@ -173,6 +174,8 @@ describe("buildDockerRunArgs", () => {
     expect(args).toContain("8");
     expect(args).toContain("--crf");
     expect(args).toContain("16");
+    expect(args).toContain("--video-frame-format");
+    expect(args).toContain("png");
     expect(args).toContain("--quiet");
     expect(args).toContain("--gpu");
     expect(args).toContain("--no-browser-gpu");
@@ -200,6 +203,27 @@ describe("buildDockerRunArgs", () => {
     expect(args).toContain("--video-bitrate");
     expect(args).toContain("10M");
     expect(args).not.toContain("--crf");
+  });
+
+  it("forwards --video-frame-format to the container when set to png", () => {
+    const args = buildDockerRunArgs({
+      ...FIXED_INPUT,
+      options: { ...BASE, videoFrameFormat: "png" },
+    });
+    expect(args).toContain("--video-frame-format");
+    expect(args).toContain("png");
+  });
+
+  it("omits --video-frame-format when it is auto or unset", () => {
+    expect(buildDockerRunArgs({ ...FIXED_INPUT, options: BASE })).not.toContain(
+      "--video-frame-format",
+    );
+    expect(
+      buildDockerRunArgs({
+        ...FIXED_INPUT,
+        options: { ...BASE, videoFrameFormat: "auto" },
+      }),
+    ).not.toContain("--video-frame-format");
   });
 
   it("forwards --variables JSON to the container when set", () => {

--- a/packages/cli/src/utils/dockerRunArgs.ts
+++ b/packages/cli/src/utils/dockerRunArgs.ts
@@ -36,6 +36,7 @@ export interface DockerRenderOptions {
   hdrMode: "auto" | "force-hdr" | "force-sdr";
   crf?: number;
   videoBitrate?: string;
+  videoFrameFormat?: "auto" | "jpg" | "png";
   quiet: boolean;
   variables?: Record<string, unknown>;
   entryFile?: string;
@@ -71,6 +72,9 @@ export function buildDockerRunArgs(input: DockerRunArgsInput): string[] {
     ...(options.workers != null ? ["--workers", String(options.workers)] : []),
     ...(options.crf != null ? ["--crf", String(options.crf)] : []),
     ...(options.videoBitrate ? ["--video-bitrate", options.videoBitrate] : []),
+    ...(options.videoFrameFormat && options.videoFrameFormat !== "auto"
+      ? ["--video-frame-format", options.videoFrameFormat]
+      : []),
     ...(options.quiet ? ["--quiet"] : []),
     ...(options.gpu ? ["--gpu"] : []),
     ...(options.browserGpu ? [] : ["--no-browser-gpu"]),

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -130,6 +130,7 @@ export {
   type ExtractionOptions,
   type ExtractionResult,
   type ExtractionPhaseBreakdown,
+  type VideoFrameFormat,
 } from "./services/videoFrameExtractor.js";
 
 export { createVideoFrameInjector } from "./services/videoFrameInjector.js";

--- a/packages/engine/src/services/videoFrameExtractor.test.ts
+++ b/packages/engine/src/services/videoFrameExtractor.test.ts
@@ -18,12 +18,13 @@ import {
   extractAllVideoFrames,
   createFrameLookupTable,
   resolveProjectRelativeSrc,
+  resolveFrameFormat,
   codecMayHaveAlpha,
   decoderForCodec,
   type VideoElement,
   type ExtractedFrames,
 } from "./videoFrameExtractor.js";
-import { extractVideoMetadata } from "../utils/ffprobe.js";
+import { extractVideoMetadata, type VideoMetadata } from "../utils/ffprobe.js";
 import { runFfmpeg } from "../utils/runFfmpeg.js";
 
 // ffmpeg is not preinstalled on GitHub's ubuntu-24.04 runners. The producer
@@ -67,6 +68,45 @@ describe("codec alpha capability", () => {
     expect(decoderForCodec("vp9")).toBe("libvpx-vp9");
     expect(decoderForCodec("VP9")).toBe("libvpx-vp9");
     expect(decoderForCodec("vp8")).toBe("libvpx");
+  });
+});
+
+describe("resolveFrameFormat", () => {
+  function metadata(overrides: Partial<VideoMetadata> = {}): VideoMetadata {
+    return {
+      durationSeconds: 1,
+      width: 320,
+      height: 180,
+      fps: 30,
+      hasAudio: false,
+      videoCodec: "h264",
+      colorSpace: {
+        colorTransfer: "bt709",
+        colorPrimaries: "bt709",
+        colorSpace: "bt709",
+      },
+      isVFR: false,
+      hasAlpha: false,
+      ...overrides,
+    };
+  }
+
+  it("keeps opaque non-alpha sources on jpg by default", () => {
+    expect(resolveFrameFormat(metadata(), undefined)).toBe("jpg");
+    expect(resolveFrameFormat(metadata(), "auto")).toBe("jpg");
+  });
+
+  it("honors explicit png for opaque videos", () => {
+    expect(resolveFrameFormat(metadata(), "png")).toBe("png");
+  });
+
+  it("honors explicit jpg for opaque videos", () => {
+    expect(resolveFrameFormat(metadata(), "jpg")).toBe("jpg");
+  });
+
+  it("forces png when alpha is present or the codec can carry alpha", () => {
+    expect(resolveFrameFormat(metadata({ hasAlpha: true }), "jpg")).toBe("png");
+    expect(resolveFrameFormat(metadata({ videoCodec: "vp9" }), "jpg")).toBe("png");
   });
 });
 
@@ -336,6 +376,198 @@ describe("parseImageElements", () => {
     );
     expect(images[0]!.end).toBe(5);
   });
+});
+
+type Rgb = [number, number, number];
+
+const UI_FIXTURE_WIDTH = 240;
+const UI_FIXTURE_HEIGHT = 160;
+const RED_SAMPLE_PIXELS = [
+  [70, 72],
+  [118, 82],
+  [178, 92],
+] as const;
+
+function readFirstFramePixel(mediaPath: string, x: number, y: number): Rgb {
+  const result = spawnSync(
+    "ffmpeg",
+    [
+      "-v",
+      "error",
+      "-i",
+      mediaPath,
+      "-frames:v",
+      "1",
+      "-f",
+      "rawvideo",
+      "-pix_fmt",
+      "rgb24",
+      "pipe:1",
+    ],
+    { maxBuffer: UI_FIXTURE_WIDTH * UI_FIXTURE_HEIGHT * 3 + 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(`ffmpeg pixel decode failed: ${result.stderr.toString().slice(-400)}`);
+  }
+
+  const offset = (y * UI_FIXTURE_WIDTH + x) * 3;
+  return [
+    result.stdout[offset] ?? 0,
+    result.stdout[offset + 1] ?? 0,
+    result.stdout[offset + 2] ?? 0,
+  ];
+}
+
+function maxChannelDelta(a: Rgb, b: Rgb): number {
+  return Math.max(Math.abs(a[0] - b[0]), Math.abs(a[1] - b[1]), Math.abs(a[2] - b[2]));
+}
+
+// Regression for saturated UI recordings: default JPEG extraction can shift
+// high-chroma reds before browser capture. Forcing PNG should keep extracted
+// source-video frames effectively identical to the decoded source pixels.
+describe.skipIf(!HAS_FFMPEG)("video frame extraction format", () => {
+  const FIXTURE_DIR = mkdtempSync(join(tmpdir(), "hf-video-frame-format-"));
+  const UI_FIXTURE = join(FIXTURE_DIR, "ui-red.mp4");
+
+  beforeAll(async () => {
+    const result = await runFfmpeg([
+      "-y",
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-f",
+      "lavfi",
+      "-i",
+      `color=c=0xffe7ee:s=${UI_FIXTURE_WIDTH}x${UI_FIXTURE_HEIGHT}:d=1:r=1`,
+      "-vf",
+      "drawbox=x=44:y=58:w=152:h=44:color=0xdd382e@1:t=fill,drawbox=x=64:y=75:w=112:h=10:color=0xfff0f0@1:t=fill",
+      "-c:v",
+      "libx264",
+      "-preset",
+      "ultrafast",
+      "-crf",
+      "0",
+      "-pix_fmt",
+      "yuv420p",
+      "-color_primaries",
+      "bt709",
+      "-color_trc",
+      "bt709",
+      "-colorspace",
+      "bt709",
+      UI_FIXTURE,
+    ]);
+    if (!result.success) {
+      throw new Error(`UI color fixture synthesis failed: ${result.stderr.slice(-400)}`);
+    }
+  }, 30_000);
+
+  afterAll(() => {
+    if (existsSync(FIXTURE_DIR)) rmSync(FIXTURE_DIR, { recursive: true, force: true });
+  });
+
+  function fixtureVideo(): VideoElement {
+    return {
+      id: "ui",
+      src: UI_FIXTURE,
+      start: 0,
+      end: 1,
+      mediaStart: 0,
+      loop: false,
+      hasAudio: false,
+    };
+  }
+
+  it("keeps color-sensitive UI reds closer to source when extraction is forced to png", async () => {
+    const defaultOut = join(FIXTURE_DIR, "out-default");
+    const pngOut = join(FIXTURE_DIR, "out-png");
+    mkdirSync(defaultOut, { recursive: true });
+    mkdirSync(pngOut, { recursive: true });
+
+    const defaultResult = await extractAllVideoFrames([fixtureVideo()], FIXTURE_DIR, {
+      fps: 1,
+      outputDir: defaultOut,
+    });
+    const pngResult = await extractAllVideoFrames([fixtureVideo()], FIXTURE_DIR, {
+      fps: 1,
+      outputDir: pngOut,
+      format: "png",
+    });
+
+    expect(defaultResult.errors).toEqual([]);
+    expect(pngResult.errors).toEqual([]);
+    const defaultFrame = defaultResult.extracted[0]!.framePaths.get(0)!;
+    const pngFrame = pngResult.extracted[0]!.framePaths.get(0)!;
+    expect(defaultFrame.endsWith(".jpg")).toBe(true);
+    expect(pngFrame.endsWith(".png")).toBe(true);
+
+    let worstDefaultDelta = 0;
+    let worstPngDelta = 0;
+    for (const [x, y] of RED_SAMPLE_PIXELS) {
+      const sourcePixel = readFirstFramePixel(UI_FIXTURE, x, y);
+      worstDefaultDelta = Math.max(
+        worstDefaultDelta,
+        maxChannelDelta(sourcePixel, readFirstFramePixel(defaultFrame, x, y)),
+      );
+      worstPngDelta = Math.max(
+        worstPngDelta,
+        maxChannelDelta(sourcePixel, readFirstFramePixel(pngFrame, x, y)),
+      );
+    }
+
+    expect(worstPngDelta).toBeLessThanOrEqual(5);
+    expect(worstPngDelta).toBeLessThanOrEqual(worstDefaultDelta);
+  }, 60_000);
+
+  it("keeps jpg and png extraction caches separate", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "hf-extract-format-cache-"));
+    try {
+      const defaultOut = join(FIXTURE_DIR, "cache-default");
+      const pngOut = join(FIXTURE_DIR, "cache-png");
+      const pngHitOut = join(FIXTURE_DIR, "cache-png-hit");
+      mkdirSync(defaultOut, { recursive: true });
+      mkdirSync(pngOut, { recursive: true });
+      mkdirSync(pngHitOut, { recursive: true });
+
+      const defaultResult = await extractAllVideoFrames(
+        [fixtureVideo()],
+        FIXTURE_DIR,
+        { fps: 1, outputDir: defaultOut },
+        undefined,
+        { extractCacheDir: cacheDir },
+      );
+      expect(defaultResult.errors).toEqual([]);
+      expect(defaultResult.phaseBreakdown.cacheHits).toBe(0);
+      expect(defaultResult.phaseBreakdown.cacheMisses).toBe(1);
+      expect(defaultResult.extracted[0]!.framePaths.get(0)!.endsWith(".jpg")).toBe(true);
+
+      const pngMiss = await extractAllVideoFrames(
+        [fixtureVideo()],
+        FIXTURE_DIR,
+        { fps: 1, outputDir: pngOut, format: "png" },
+        undefined,
+        { extractCacheDir: cacheDir },
+      );
+      expect(pngMiss.errors).toEqual([]);
+      expect(pngMiss.phaseBreakdown.cacheHits).toBe(0);
+      expect(pngMiss.phaseBreakdown.cacheMisses).toBe(1);
+      expect(pngMiss.extracted[0]!.framePaths.get(0)!.endsWith(".png")).toBe(true);
+
+      const pngHit = await extractAllVideoFrames(
+        [fixtureVideo()],
+        FIXTURE_DIR,
+        { fps: 1, outputDir: pngHitOut, format: "png" },
+        undefined,
+        { extractCacheDir: cacheDir },
+      );
+      expect(pngHit.errors).toEqual([]);
+      expect(pngHit.phaseBreakdown.cacheHits).toBe(1);
+      expect(pngHit.phaseBreakdown.cacheMisses).toBe(0);
+      expect(pngHit.extracted[0]!.framePaths.get(0)!.endsWith(".png")).toBe(true);
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 60_000);
 });
 
 // Regression test for the VFR (variable frame rate) freeze bug.

--- a/packages/engine/src/services/videoFrameExtractor.ts
+++ b/packages/engine/src/services/videoFrameExtractor.ts
@@ -59,11 +59,13 @@ export interface ExtractedFrames {
   ownedByLookup?: boolean;
 }
 
+export type VideoFrameFormat = "auto" | "jpg" | "png";
+
 export interface ExtractionOptions {
   fps: number;
   outputDir: string;
   quality?: number;
-  format?: "jpg" | "png";
+  format?: VideoFrameFormat;
 }
 
 /**
@@ -431,9 +433,12 @@ export function decoderForCodec(codec: string | undefined): string {
   return c;
 }
 
-function resolveFrameFormat(metadata: VideoMetadata, requested?: "jpg" | "png"): CacheFrameFormat {
-  if (requested) return requested;
+export function resolveFrameFormat(
+  metadata: VideoMetadata,
+  requested?: VideoFrameFormat,
+): CacheFrameFormat {
   if (metadata.hasAlpha || codecMayHaveAlpha(metadata.videoCodec)) return "png";
+  if (requested === "png" || requested === "jpg") return requested;
   return "jpg";
 }
 

--- a/packages/producer/README.md
+++ b/packages/producer/README.md
@@ -47,15 +47,16 @@ await startServer({ port: 8080 });
 
 `RenderConfig` controls the render pipeline:
 
-| Option       | Default      | Description                                                                                                                          |
-| ------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `inputPath`  | —            | Path to the HTML composition                                                                                                         |
-| `outputPath` | —            | Output video file path (or directory, for `format: "png-sequence"`)                                                                  |
-| `width`      | 1920         | Frame width in pixels                                                                                                                |
-| `height`     | 1080         | Frame height in pixels                                                                                                               |
-| `fps`        | 30           | Frames per second (24, 30, or 60)                                                                                                    |
-| `quality`    | `"standard"` | Encoder preset (`"draft"`, `"standard"`, `"high"`)                                                                                   |
-| `format`     | `"mp4"`      | Output container — `"mp4"`, `"webm"`, `"mov"`, or `"png-sequence"`. See [Transparent Video Output](#transparent-video-output) below. |
+| Option             | Default      | Description                                                                                                                                              |
+| ------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inputPath`        | —            | Path to the HTML composition                                                                                                                             |
+| `outputPath`       | —            | Output video file path (or directory, for `format: "png-sequence"`)                                                                                      |
+| `width`            | 1920         | Frame width in pixels                                                                                                                                    |
+| `height`           | 1080         | Frame height in pixels                                                                                                                                   |
+| `fps`              | 30           | Frames per second (24, 30, or 60)                                                                                                                        |
+| `quality`          | `"standard"` | Encoder preset (`"draft"`, `"standard"`, `"high"`)                                                                                                       |
+| `format`           | `"mp4"`      | Output container — `"mp4"`, `"webm"`, `"mov"`, or `"png-sequence"`. See [Transparent Video Output](#transparent-video-output) below.                     |
+| `videoFrameFormat` | `"auto"`     | Source video frame extraction format — `"auto"`, `"jpg"`, or `"png"`. Use `"png"` for UI recordings, screen captures, and color-sensitive source videos. |
 
 ## Transparent Video Output
 

--- a/packages/producer/src/server.ts
+++ b/packages/producer/src/server.ts
@@ -33,6 +33,7 @@ import {
   RenderCancelledError,
   createRenderJob,
   executeRenderJob,
+  type RenderConfig,
 } from "./services/renderOrchestrator.js";
 import { prepareHyperframeLintBody, runHyperframeLint } from "./services/hyperframeLint.js";
 import { resolveRenderPaths } from "./utils/paths.js";
@@ -72,6 +73,7 @@ interface RenderInput {
   fps: import("@hyperframes/core").Fps;
   quality: "draft" | "standard" | "high";
   format?: "mp4" | "webm" | "mov";
+  videoFrameFormat?: RenderConfig["videoFrameFormat"];
   workers?: number;
   useGpu: boolean;
   debug: boolean;
@@ -112,9 +114,24 @@ function parseRenderOptions(body: Record<string, unknown>): Omit<RenderInput, "p
 
   const format = (
     ["mp4", "webm", "mov"].includes(body.format as string) ? body.format : undefined
-  ) as "mp4" | "webm" | "mov" | undefined;
+  ) as RenderInput["format"];
+  const videoFrameFormat = (
+    ["auto", "jpg", "png"].includes(body.videoFrameFormat as string)
+      ? body.videoFrameFormat
+      : undefined
+  ) as RenderConfig["videoFrameFormat"];
 
-  return { outputPath, fps, quality, workers, useGpu, debug, entryFile, format };
+  return {
+    outputPath,
+    fps,
+    quality,
+    workers,
+    useGpu,
+    debug,
+    entryFile,
+    format,
+    videoFrameFormat,
+  };
 }
 
 async function prepareRenderBody(
@@ -349,6 +366,7 @@ export function createRenderHandlers(options: HandlerOptions = {}): RenderHandle
       useGpu: input.useGpu,
       debug: input.debug,
       entryFile: input.entryFile,
+      videoFrameFormat: input.videoFrameFormat,
       logger: log,
     });
 
@@ -463,6 +481,7 @@ export function createRenderHandlers(options: HandlerOptions = {}): RenderHandle
         useGpu: input.useGpu,
         debug: input.debug,
         entryFile: input.entryFile,
+        videoFrameFormat: input.videoFrameFormat,
         logger: log,
       });
       const abortController = new AbortController();

--- a/packages/producer/src/services/distributed/plan.ts
+++ b/packages/producer/src/services/distributed/plan.ts
@@ -36,7 +36,12 @@ import {
 } from "node:fs";
 import { join, relative, sep } from "node:path";
 import { type CanvasResolution } from "@hyperframes/core";
-import { type EngineConfig, getEncoderPreset, resolveConfig } from "@hyperframes/engine";
+import {
+  type EngineConfig,
+  type VideoFrameFormat,
+  getEncoderPreset,
+  resolveConfig,
+} from "@hyperframes/engine";
 import { defaultLogger, type ProducerLogger } from "../../logger.js";
 import { runAudioStage } from "../render/stages/audioStage.js";
 import { runCompileStage } from "../render/stages/compileStage.js";
@@ -104,6 +109,12 @@ export interface DistributedRenderConfig {
   crf?: number;
   /** Target video bitrate (e.g. `"10M"`); mutually exclusive with `crf`. */
   bitrate?: string;
+  /**
+   * Source-video frame extraction format. Defaults to `"auto"`, matching the
+   * in-process renderer: alpha/alpha-capable sources extract as PNG, other
+   * sources extract as JPG unless the caller explicitly requests `"png"`.
+   */
+  videoFrameFormat?: VideoFrameFormat;
   /** Output resolution preset; engages Chrome `deviceScaleFactor` supersampling. */
   outputResolution?: CanvasResolution;
 
@@ -672,6 +683,7 @@ export async function plan(
     format: config.format,
     crf: config.crf,
     bitrate: config.bitrate,
+    videoFrameFormat: config.videoFrameFormat,
     outputResolution: config.outputResolution,
     // HDR is banned in distributed mode. force-sdr keeps the
     // extract / encoder paths off the HDR branches entirely.

--- a/packages/producer/src/services/distributed/shared.ts
+++ b/packages/producer/src/services/distributed/shared.ts
@@ -10,7 +10,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { type Fps } from "@hyperframes/core";
-import { type VideoElement, type VideoMetadata } from "@hyperframes/engine";
+import { type VideoElement, type VideoFrameFormat, type VideoMetadata } from "@hyperframes/engine";
 import { type RenderConfig, type RenderJob, createRenderJob } from "../renderOrchestrator.js";
 import { defaultLogger, type ProducerLogger } from "../../logger.js";
 
@@ -97,6 +97,7 @@ export interface SyntheticRenderJobInput {
   quality: RenderConfig["quality"];
   crf?: number;
   bitrate?: string;
+  videoFrameFormat?: VideoFrameFormat;
   outputResolution?: RenderConfig["outputResolution"];
   hdrMode: RenderConfig["hdrMode"];
   entryFile: string;
@@ -116,6 +117,7 @@ export function buildSyntheticRenderJob(input: SyntheticRenderJobInput): RenderJ
     format: input.format,
     crf: input.crf,
     videoBitrate: input.bitrate,
+    videoFrameFormat: input.videoFrameFormat,
     outputResolution: input.outputResolution,
     // Distributed mode hard-pins to software GPU. The plan-time validator
     // refuses to fan out otherwise.

--- a/packages/producer/src/services/render/stages/extractVideosStage.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.ts
@@ -185,6 +185,7 @@ export async function runExtractVideosStage(
       {
         fps: fpsToNumber(job.config.fps),
         outputDir: join(compiledDir, "__hyperframes_video_frames"),
+        format: job.config.videoFrameFormat ?? "auto",
       },
       abortSignal,
       { extractCacheDir: cfg.extractCacheDir },

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -49,6 +49,7 @@ import {
   type EngineConfig,
   resolveConfig,
   type ExtractionPhaseBreakdown,
+  type VideoFrameFormat,
   type HdrTransfer,
   closeCaptureSession,
   type CaptureOptions,
@@ -254,6 +255,14 @@ export interface RenderConfig {
   crf?: number;
   /** Target video bitrate (e.g. "10M"). Mutually exclusive with `crf`. */
   videoBitrate?: string;
+  /**
+   * Source-video frame extraction format. Defaults to `"auto"`, which preserves
+   * the historical behavior: alpha/alpha-capable sources extract as PNG, all
+   * other videos extract as JPG. Set to `"png"` for lossless source-frame
+   * extraction on UI recordings, screen captures, or other color-sensitive
+   * videos.
+   */
+  videoFrameFormat?: VideoFrameFormat;
   /** HDR rendering mode.
    * - `auto` (default): probe sources; enable HDR if any HDR content is found.
    * - `force-hdr`: enable HDR even on SDR-only compositions (falls back to HLG transfer).

--- a/packages/producer/src/services/videoFrameExtractor.ts
+++ b/packages/producer/src/services/videoFrameExtractor.ts
@@ -11,6 +11,7 @@ export {
   FrameLookupTable,
   type VideoElement,
   type ExtractedFrames,
+  type VideoFrameFormat,
   type ExtractionOptions,
   type ExtractionResult,
   type ExtractionPhaseBreakdown,


### PR DESCRIPTION
## Summary

Adds a first-class render option for source-video frame extraction:

```bash
hyperframes render --video-frame-format <auto|jpg|png>
```

and the matching programmatic config field:

```ts
videoFrameFormat?: "auto" | "jpg" | "png";
```

The default remains `auto`, preserving the existing behavior: alpha or alpha-capable video sources extract as PNG, and opaque sources extract as JPG.

## Rationale

When compositing screen recordings, for example an iPhone UI recording, the timeline/browser preview can look close to the source while the rendered MP4 shifts saturated UI colors. Changing final H.264 color tags or range does not address this when the color shift has already happened earlier in the pipeline.

Pixel checks showed the shifted color was already present in HyperFrames' captured browser PNG frames. The root cause is that non-alpha source videos were extracted as JPEG frames before browser capture, which can visibly change saturated UI reds before final encoding ever runs. In one representative sample, the original phone recording frame sampled `RGB(221,56,46)` on a saturated red UI indicator, while HyperFrames' browser PNG frame sampled `RGB(186,51,58)`. A direct ffmpeg source-video composite preserved the same pixel closely at `RGB(220,56,50)`, showing the final H.264 encoder can preserve the color when the source video does not pass through JPEG extraction.

This PR adds an explicit, opt-in PNG extraction path for UI recordings, screen captures, and other color-sensitive source videos. It avoids an RGB lift or color-correction workaround and leaves final encoder defaults unchanged.

## What Changed

- Adds `--video-frame-format auto|jpg|png` to `hyperframes render`.
- Adds `RenderConfig.videoFrameFormat`.
- Threads the option through local render, Docker render, producer server render, and distributed planning.
- Updates `resolveFrameFormat` so:
  - explicit `png` extracts opaque videos as PNG
  - explicit `jpg` extracts opaque videos as JPG
  - `auto`/undefined preserves existing behavior
  - alpha and alpha-capable codecs still force PNG
- Ensures extraction cache entries use the effective frame format, so JPG and PNG frame caches cannot collide.
- Documents the option in CLI and rendering docs.

## Validation

- `bun run --filter @hyperframes/engine test -- src/services/videoFrameExtractor.test.ts`
- `bun run --filter @hyperframes/cli test -- src/commands/render.test.ts src/utils/dockerRunArgs.test.ts`
- `bun run --filter @hyperframes/aws-lambda test -- src/sdk/validateConfig.test.ts`
- `bun run --filter @hyperframes/engine typecheck`
- `bun run --filter @hyperframes/producer typecheck`
- `bun run --filter @hyperframes/cli typecheck`
- `bun run --filter @hyperframes/aws-lambda typecheck`
- `bunx oxfmt --check`
- `bunx oxlint`

The new regression test synthesizes a tiny saturated-red UI fixture on a pale pink background and verifies PNG extraction keeps sampled red pixels within a max channel delta of 5 from the decoded source, while also proving JPG and PNG extraction caches remain separate.
