### PR TITLE
feat(cli): split cloud render --resolution into --aspect-ratio + --resolution

### DIFF
--- a/packages/cli/src/cloud/_gen/types.ts
+++ b/packages/cli/src/cloud/_gen/types.ts
@@ -79,17 +79,15 @@ export interface CreateHyperframesRenderRequest {
    */
   format?: "mp4" | "webm" | "mov";
   /**
-   * Optional resolution preset. If omitted, the composition's own declared
-   * dimensions are used.
+   * Output resolution tier. Defaults to '1080p'. Pass '4k' for 4K renders
+   * (billed at 1.5x).
    */
-  resolution?:
-    | "landscape"
-    | "portrait"
-    | "landscape-4k"
-    | "portrait-4k"
-    | "square"
-    | "square-4k"
-    | null;
+  resolution?: HyperframesResolution;
+  /**
+   * Output aspect ratio. Defaults to '16:9' (landscape). Pass '9:16' for
+   * portrait or '1:1' for square.
+   */
+  aspect_ratio?: HyperframesAspectRatio;
   /**
    * Entry HTML file relative to the project root (e.g. compositions/intro.html).
    * Defaults to index.html when omitted.
@@ -134,6 +132,15 @@ export interface DeleteHyperframesRenderResponse {
    */
   render_id: string;
 }
+
+/**
+ * Output aspect ratio. Only the three ratios already supported end-to-end by
+ * the render pipeline are exposed today: ``16:9`` (landscape), ``9:16``
+ * (portrait), ``1:1`` (square). ``auto`` and other social-media ratios (4:5,
+ * 5:4) are reserved for a follow-up PR that wires composition-dim inference at
+ * the controller boundary.
+ */
+export type HyperframesAspectRatio = "16:9" | "9:16" | "1:1";
 
 /**
  * Detailed HyperFrames render resource.
@@ -181,16 +188,13 @@ export interface HyperframesRenderDetail {
    */
   format: "mp4" | "webm" | "mov";
   /**
-   * Resolution preset, if one was set.
+   * Resolution tier, if one was set.
    */
-  resolution?:
-    | "landscape"
-    | "portrait"
-    | "landscape-4k"
-    | "portrait-4k"
-    | "square"
-    | "square-4k"
-    | null;
+  resolution?: HyperframesResolution | null;
+  /**
+   * Aspect ratio, if one was set.
+   */
+  aspect_ratio?: HyperframesAspectRatio | null;
   /**
    * Composition entry file path.
    */
@@ -214,6 +218,13 @@ export interface HyperframesRenderDetail {
  * Lifecycle status of a HyperFrames render.
  */
 export type HyperframesRenderStatus = "queued" | "rendering" | "completed" | "failed";
+
+/**
+ * Output resolution tier. Pricing diverges only at 4K (1.5x multiplier). The
+ * render-pipeline value set is intentionally narrow at launch; 720p and other
+ * tiers will follow once the producer/CLI surface catches up.
+ */
+export type HyperframesResolution = "1080p" | "4k";
 
 export interface StandardAPIError {
   /**

--- a/packages/cli/src/commands/cloud/render.ts
+++ b/packages/cli/src/commands/cloud/render.ts
@@ -58,14 +58,8 @@ import { isAbsolute, resolve as resolvePath } from "node:path";
 
 const VALID_QUALITY = ["draft", "standard", "high"] as const;
 const VALID_FORMAT = ["mp4", "webm", "mov"] as const;
-const VALID_RESOLUTION = [
-  "landscape",
-  "portrait",
-  "landscape-4k",
-  "portrait-4k",
-  "square",
-  "square-4k",
-] as const;
+const VALID_RESOLUTION = ["1080p", "4k"] as const;
+const VALID_ASPECT_RATIO = ["16:9", "9:16", "1:1"] as const;
 
 const FORMAT_EXT: Record<string, string> = { mp4: ".mp4", webm: ".webm", mov: ".mov" };
 
@@ -96,8 +90,11 @@ export default defineCommand({
     format: { type: "string", description: "mp4 | webm | mov (default: mp4)" },
     resolution: {
       type: "string",
-      description:
-        "Resolution preset: landscape | portrait | landscape-4k | portrait-4k | square | square-4k",
+      description: "Resolution tier: 1080p | 4k (default: 1080p; 4k is billed at 1.5x)",
+    },
+    "aspect-ratio": {
+      type: "string",
+      description: "Aspect ratio: 16:9 | 9:16 | 1:1 (default: 16:9)",
     },
     composition: {
       type: "string",
@@ -185,6 +182,9 @@ export default defineCommand({
     const resolution = parseEnumFlag(args.resolution, VALID_RESOLUTION, {
       flag: "--resolution",
     });
+    const aspectRatio = parseEnumFlag(args["aspect-ratio"], VALID_ASPECT_RATIO, {
+      flag: "--aspect-ratio",
+    });
     const pollIntervalMs = parsePollIntervalMs(args["poll-interval"]);
     const maxWaitMs = parseMaxWaitMs(args["max-wait"]);
     validateIdempotencyKey(args["idempotency-key"]);
@@ -214,6 +214,7 @@ export default defineCommand({
       quality,
       format,
       resolution,
+      aspectRatio,
       composition: args.composition,
       variables,
       title: args.title,
@@ -443,6 +444,7 @@ interface SubmitOptions {
   quality: "draft" | "standard" | "high" | undefined;
   format: "mp4" | "webm" | "mov" | undefined;
   resolution: CreateHyperframesRenderRequest["resolution"] | undefined;
+  aspectRatio: CreateHyperframesRenderRequest["aspect_ratio"] | undefined;
   composition: string | undefined;
   variables: Record<string, unknown> | undefined;
   title: string | undefined;
@@ -470,6 +472,7 @@ function buildRenderBody(opts: SubmitOptions): CreateHyperframesRenderRequest {
   if (opts.quality !== undefined) body.quality = opts.quality;
   if (opts.format !== undefined) body.format = opts.format;
   if (opts.resolution !== undefined) body.resolution = opts.resolution;
+  if (opts.aspectRatio !== undefined) body.aspect_ratio = opts.aspectRatio;
   if (opts.composition !== undefined) body.composition = opts.composition;
   if (opts.variables !== undefined) body.variables = opts.variables;
   if (opts.title !== undefined) body.title = opts.title;


### PR DESCRIPTION
## What

Aligns the `hyperframes cloud render` CLI with the v3 API's decomposed resolution shape (companion to https://github.com/heygen-com/experiment-framework/pull/38182). Replaces the flat 6-value `--resolution` flag with two independent flags:

- `--resolution`: tier ∈ `{1080p, 4k}`; default `1080p`; 4K is billed at 1.5x by the API.
- `--aspect-ratio`: ratio ∈ `{16:9, 9:16, 1:1}`; default `16:9`.

Old CLI values (`landscape`, `portrait-4k`, etc.) now reject at the flag-parsing layer (`parseEnumFlag` → `Invalid --resolution`) so callers see a clean local error instead of a server 422.

## Why

Today the CLI exposes the same 6-string flat preset (`landscape`, `landscape-4k`, `portrait`, `portrait-4k`, `square`, `square-4k`) that the v3 API used until ef#38182. That shape conflates "aspect ratio" and "resolution tier" into a single value, which is awkward to author and reason about — devs naturally think `--resolution 1080p` and `--aspect-ratio 16:9` independently. The flat preset has also caused 400s for `npx hyperframes cloud render` users trying the obvious shape.

This PR moves the CLI to match the v3 API's new decomposed shape so the two stay in sync. Combined with ef#38182, a user can now say `hyperframes cloud render --resolution 4k --aspect-ratio 1:1` and have it render at 4K square instead of needing to remember `--resolution square-4k`.

## How

Three files touched:

1. `packages/cli/src/commands/cloud/render.ts` — `VALID_RESOLUTION` changes to `["1080p", "4k"]`, new `VALID_ASPECT_RATIO = ["16:9", "9:16", "1:1"]`, new `--aspect-ratio` arg in the command schema, parsed via `parseEnumFlag`, threaded through `SubmitOptions` and `buildRenderBody` into the request body as `aspect_ratio`.
2. `packages/cli/src/cloud/_gen/types.ts` — auto-regenerated from ef#38182's updated `openapi/external-api.json`. New `HyperframesResolution = "1080p" | "4k"` and `HyperframesAspectRatio = "16:9" | "9:16" | "1:1"` types; `CreateHyperframesRenderRequest` gains `aspect_ratio?: HyperframesAspectRatio`; `HyperframesRenderDetail` gains `aspect_ratio?: HyperframesAspectRatio | null`.
3. (Optional) `packages/cli/src/cloud/_gen/client.ts` — also regenerated but no semantic delta (the request body is passed through verbatim via the typed interface); skipped to keep the PR minimal.

The six legacy `--resolution` combinations map to the same effective output in the new shape — see the migration table in ef#38182's PR body. The new shape is strictly a smaller surface (3×2 = 6 cells exactly).

## Pre-existing red CI

`Test` job fails on `packages/engine/src/services/audioMixer.test.ts:122` (`compensates amix normalization so multi-track master gain equals track count`) — the test reads `mixArgs[mixArgs.indexOf("-filter_complex") + 1]` and expects `"amix=inputs=3"` but gets `"-ss"`. Wrong arg-index assumption.

*This is pre-existing on main*, NOT introduced by this work. hf#1140 (Miguel's audio mixer fix, merged earlier) ALSO had `Test fail` in its CI checks — the test added by Magi in commit `e7355703` passes locally per Magi's report but fails in CI because the actual ffmpeg arg layout differs from what the test assumes. This PR's diff is CLI-only (`packages/cli/src/commands/cloud/render.ts` + `_gen/types.ts`); it cannot affect `packages/engine` tests. Verified by inspection.

Cleanup PR needed against main from Magi or whoever owns the engine surface. Don't block this PR's review on it.

## Test plan

- `bunx oxlint`, `bunx oxfmt --check`, `bunx fallow audit --base origin/main`, and `cd packages/core && bunx tsc --noEmit && cd ../studio && bunx tsc --noEmit` all green locally via lefthook pre-commit.
- Manual flag parsing: `--resolution 1080p`, `--resolution 4k`, `--aspect-ratio 16:9` accepted; `--resolution landscape` (and other old presets), `--aspect-ratio auto` rejected with `parseEnumFlag` error.
- Existing cloud-render unit tests in `packages/cli/src/cloud/*.test.ts` (ansi, download, errors, parsing, poll) are unaffected by this change — none reference `resolution` directly.

- [x] Unit tests added/updated — N/A; no `cloud/render.test.ts` exists today and the change is mechanical (flag plumbing). Will add coverage in the same PR that adds `auto` + `720p` support (those need new paths worth pinning).
- [x] Manual testing performed — flag-parse smoke per above.
- [ ] Documentation updated — `packages/cli/src/docs/rendering.md` doesn't reference the old presets, no doc update needed in this PR.

## Deferred

`720p`, `4:5`, `5:4`, and `auto` are intentionally NOT in the new enum surface. They need render-pipeline capability additions (producer-side preset support for `720p`/`4:5`/`5:4`, controller-side composition-dim inference for `auto`) — those will follow in a separate PR. The CLI will gain the same values when the API does.

— Created by Rames Jusso (hyperframes specialist, Rames team)