### PR TITLE
fix(engine): correct mock call index in multi-track audioMixer test

### DIFF
--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -116,7 +116,10 @@ describe("processCompositionAudio", () => {
     );
 
     expect(result.success).toBe(true);
-    const mixArgs = runFfmpegMock.mock.calls[1]?.[0];
+    // 3 prepare calls (one per track via Promise.all) precede the mix call,
+    // so the mix is at index 3, not index 1.
+    expect(runFfmpegMock).toHaveBeenCalledTimes(4);
+    const mixArgs = runFfmpegMock.mock.calls[3]?.[0];
     const filter = mixArgs[mixArgs.indexOf("-filter_complex") + 1];
 
     expect(filter).toContain("amix=inputs=3");


### PR DESCRIPTION
## Root cause

`processCompositionAudio` prepares all tracks in parallel via `Promise.all`, so for N tracks the mix call lands at mock call index N, not index 1. The 3-track test added in hf#1140 was reading `calls[1]` (the second prepare call) instead of `calls[3]` (the actual mix call), causing `indexOf("-filter_complex")` to return -1 and all subsequent assertions to read the wrong args.

## Fix

Change `mock.calls[1]?.[0]` → `mock.calls[3]?.[0]` in the multi-track test and add `expect(runFfmpegMock).toHaveBeenCalledTimes(4)` to pin the call structure explicitly (3 prepare + 1 mix).

## Verification

`vitest run packages/engine/src/services/audioMixer.test.ts` — 6/6 pass.