### PR TITLE
fix(producer): pass streaming encoder config

### DIFF
--- a/packages/producer/src/services/render/stages/captureStreamingStage.test.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, mock } from "bun:test";
+
+type MinimalEngineConfig = {
+  forceScreenshot: boolean;
+  ffmpegStreamingTimeout: number;
+};
+
+const writeFrame = mock((_buffer: Buffer) => true);
+const closeEncoder = mock(async () => ({ success: true, durationMs: 123, fileSize: 42 }));
+const spawnStreamingEncoder = mock(async () => ({
+  writeFrame,
+  close: closeEncoder,
+  getExitStatus: () => "success",
+}));
+
+mock.module("@hyperframes/engine", () => ({
+  captureFrameToBuffer: async () => ({ buffer: Buffer.from("frame"), captureTimeMs: 1 }),
+  closeCaptureSession: async () => {},
+  createCaptureSession: async () => ({ isInitialized: false, browserConsoleBuffer: [] }),
+  createFrameReorderBuffer: () => ({
+    waitForFrame: async () => {},
+    advanceTo: () => {},
+  }),
+  distributeFrames: () => [],
+  executeParallelCapture: async () => {},
+  initializeSession: async (session: { isInitialized: boolean }) => {
+    session.isInitialized = true;
+  },
+  prepareCaptureSessionForReuse: () => {},
+  spawnStreamingEncoder,
+}));
+
+mock.module("@hyperframes/core", () => ({
+  CANVAS_DIMENSIONS: {},
+}));
+
+function createInput(cfg: MinimalEngineConfig) {
+  return {
+    fileServer: {
+      url: "http://127.0.0.1:4173",
+      port: 4173,
+      close: () => {},
+      addPreHeadScript: () => {},
+    },
+    workDir: "/tmp/hf-test-work",
+    framesDir: "/tmp/hf-test-frames",
+    videoOnlyPath: "/tmp/hf-test-video-only.mp4",
+    job: {
+      id: "streaming-config-test",
+      config: { fps: { num: 30, den: 1 }, quality: "draft" },
+      status: "queued",
+      progress: 0,
+      currentStage: "Streaming",
+      createdAt: new Date(0),
+      duration: 0,
+    },
+    totalFrames: 0,
+    cfg,
+    forceScreenshot: false,
+    log: {
+      error: () => {},
+      warn: () => {},
+      info: () => {},
+      debug: () => {},
+    },
+    workerCount: 1,
+    probeSession: null,
+    outputFormat: "mp4",
+    streamingEncoderOptions: { fps: { num: 30, den: 1 }, width: 1920, height: 1080 },
+    buildCaptureOptions: () => ({}),
+    createRenderVideoFrameInjector: () => null,
+    abortSignal: undefined,
+    assertNotAborted: () => {},
+  };
+}
+
+describe("runCaptureStreamingStage", () => {
+  it("passes the resolved engine config to spawnStreamingEncoder", async () => {
+    const { runCaptureStreamingStage } = await import("./captureStreamingStage.js");
+    const cfg = { forceScreenshot: false, ffmpegStreamingTimeout: 3_600_000 };
+    const input = createInput(cfg);
+
+    const result = await runCaptureStreamingStage(input);
+
+    expect(result.success).toBe(true);
+    expect(spawnStreamingEncoder.mock.calls[0]?.[3]).toBe(cfg);
+  });
+});

--- a/packages/producer/src/services/render/stages/captureStreamingStage.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.ts
@@ -160,6 +160,7 @@ export async function runCaptureStreamingStage(
       videoOnlyPath,
       streamingEncoderOptions,
       abortSignal,
+      cfg,
     );
     assertNotAborted();
   } catch (err) {


### PR DESCRIPTION
## What

Pass the resolved producer `EngineConfig` through to `spawnStreamingEncoder` in the regular capture-streaming stage.

## Why

`resolveConfig()` already reads `FFMPEG_STREAMING_TIMEOUT_MS`, but the regular producer streaming path did not pass `cfg` into the engine streaming encoder. That meant this path always used the encoder default instead of the resolved timeout override.

This is a small follow-up to #901: the timeout now behaves as an inactivity timer, but downstream callers still need the resolved config to reach the encoder.

## How

- Add the existing `cfg` object as the fourth `spawnStreamingEncoder(...)` argument in `captureStreamingStage`
- Add a Bun unit test that mocks `@hyperframes/engine` and verifies the resolved config is forwarded unchanged

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)

Commands run:

```bash
bun test packages/producer/src/services/render/stages/captureStreamingStage.test.ts
bunx oxlint packages/producer/src/services/render/stages/captureStreamingStage.ts packages/producer/src/services/render/stages/captureStreamingStage.test.ts
bunx oxfmt --check packages/producer/src/services/render/stages/captureStreamingStage.ts packages/producer/src/services/render/stages/captureStreamingStage.test.ts
bunx fallow audit --base origin/main --fail-on-issues
bun run --filter @hyperframes/producer typecheck
bun run --filter @hyperframes/producer build
```
