### PR TITLE
fix(cli): pre-flight FFmpeg check and propagate render failure stage

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -435,19 +435,6 @@ export default defineCommand({
       console.log("");
     }
 
-    // ── Check FFmpeg for local renders ───────────────────────────────────
-    if (!useDocker) {
-      const { findFFmpeg, getFFmpegInstallHint } = await import("../browser/ffmpeg.js");
-      if (!findFFmpeg()) {
-        errorBox(
-          "FFmpeg not found",
-          "Rendering requires FFmpeg for video encoding.",
-          `Install: ${getFFmpegInstallHint()}`,
-        );
-        process.exit(1);
-      }
-    }
-
     // ── Ensure browser for local renders ────────────────────────────────
     let browserPath: string | undefined;
     if (!useDocker) {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -51,6 +51,7 @@ import { VERSION } from "../version.js";
 import { isDevMode } from "../utils/env.js";
 import { buildDockerRunArgs } from "../utils/dockerRunArgs.js";
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
+import { findFFmpeg, getFFmpegInstallHint } from "../browser/ffmpeg.js";
 import type { RenderJob } from "@hyperframes/producer";
 import {
   normalizeResolutionFlag,
@@ -786,6 +787,16 @@ export async function renderLocal(
   options: RenderOptions,
 ): Promise<void> {
   const producer = await loadProducer();
+
+  if (!findFFmpeg()) {
+    errorBox(
+      "FFmpeg not found",
+      "FFmpeg is required to encode video. The render cannot proceed without it.",
+      getFFmpegInstallHint(),
+    );
+    process.exit(1);
+  }
+
   const startTime = Date.now();
 
   // Pass the resolved browser path to the producer via env var so
@@ -822,7 +833,14 @@ export async function renderLocal(
   try {
     await producer.executeRenderJob(job, projectDir, outputPath, onProgress);
   } catch (error: unknown) {
-    handleRenderError(error, options, startTime, false, "Try --docker for containerized rendering");
+    handleRenderError(
+      error,
+      options,
+      startTime,
+      false,
+      "Try --docker for containerized rendering",
+      job.failedStage,
+    );
   }
 
   const elapsed = Date.now() - startTime;
@@ -868,6 +886,7 @@ function handleRenderError(
   startTime: number,
   docker: boolean,
   hint: string,
+  failedStage?: string,
 ): never {
   const message = normalizeErrorMessage(error);
   trackRenderError({
@@ -878,6 +897,7 @@ function handleRenderError(
     gpu: options.gpu,
     elapsedMs: Date.now() - startTime,
     errorMessage: message,
+    failedStage,
     ...getMemorySnapshot(),
   });
   errorBox("Render failed", message, hint);


### PR DESCRIPTION
## Summary

- Adds an FFmpeg availability check at the start of `renderLocal()` — the render now fails immediately with a platform-specific install hint instead of crashing mid-pipeline with a cryptic ENOENT
- Threads `job.failedStage` through to `trackRenderError()` so render failure telemetry includes which pipeline stage actually failed (capture, encode, assemble, etc.) — previously this was always `undefined` for CLI renders
- Does not add the FFmpeg check to `renderDocker()` since Docker containers bundle their own FFmpeg

## Test plan

- [ ] Run `hyperframes render` on a machine without FFmpeg installed — should see a clear error box with install instructions instead of a stack trace
- [ ] Run `hyperframes render` with FFmpeg installed — should work as before
- [ ] Trigger a render failure (e.g., invalid composition) and verify `failed_stage` appears in the `render_error` telemetry event