### PR TITLE
fix(studio): inject version from package.json and include in all telemetry events

### DIFF
--- a/packages/studio/src/telemetry/system.ts
+++ b/packages/studio/src/telemetry/system.ts
@@ -12,6 +12,7 @@ export interface BrowserSystemMeta {
   device_pixel_ratio: number;
   timezone_offset_minutes: number;
   is_mobile: boolean;
+  studio_version: string;
 }
 
 const EMPTY_META: BrowserSystemMeta = {
@@ -22,6 +23,7 @@ const EMPTY_META: BrowserSystemMeta = {
   device_pixel_ratio: 0,
   timezone_offset_minutes: 0,
   is_mobile: false,
+  studio_version: "dev",
 };
 
 let cached: BrowserSystemMeta | null = null;
@@ -43,6 +45,9 @@ export function getBrowserSystemMeta(): BrowserSystemMeta {
     device_pixel_ratio: window.devicePixelRatio,
     timezone_offset_minutes: new Date().getTimezoneOffset(),
     is_mobile: /Android|iPhone|iPad/i.test(ua),
+    studio_version: typeof __STUDIO_VERSION__ !== "undefined" ? __STUDIO_VERSION__ : "dev",
   };
   return cached;
 }
+
+declare const __STUDIO_VERSION__: string;

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -21,6 +21,8 @@ async function loadRuntimeSourceForDev(
   return null;
 }
 
+const studioPkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
+
 // ── Bridge Hono fetch → Node http response ───────────────────────────────────
 
 async function bridgeHonoResponse(
@@ -167,7 +169,7 @@ function devProjectApi(): Plugin {
 export default defineConfig({
   plugins: [react(), devProjectApi()],
   define: {
-    __STUDIO_VERSION__: JSON.stringify(process.env.npm_package_version ?? "dev"),
+    __STUDIO_VERSION__: JSON.stringify(studioPkg.version),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- The Vite build config now reads the Studio version directly from `package.json` instead of relying on `process.env.npm_package_version` — this was falling back to `"dev"` in any build context that didn't go through `npm run` or `bun run` (e.g., bare `vite build` in CI)
- Adds `studio_version` to `BrowserSystemMeta` so all events emitted through the new telemetry system (including `studio_session_start` and `studio_render_start`) include the deployed version — previously only the legacy `trackStudioEvent()` system attached it

## Test plan

- [ ] Run `bun run build` in `packages/studio` — verify `__STUDIO_VERSION__` is injected as the package.json version (not "dev")
- [ ] Run bare `npx vite build` in `packages/studio` — verify same result
- [ ] Open Studio, check that `studio_session_start` events in PostHog include `studio_version` with the actual version number