### PR TITLE
fix(cli): mock findFFmpeg in render tests for CI without ffmpeg

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -24,6 +24,11 @@ vi.mock("../telemetry/events.js", () => ({
   trackRenderError: vi.fn(),
 }));
 
+vi.mock("../browser/ffmpeg.js", () => ({
+  findFFmpeg: vi.fn(() => "/usr/bin/ffmpeg"),
+  getFFmpegInstallHint: vi.fn(() => "brew install ffmpeg"),
+}));
+
 describe("renderLocal browser GPU config", () => {
   const savedEnv = new Map<string, string | undefined>();
   // Pre-resolve once. The first dynamic `import("./render.js")` in this file

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -435,19 +435,6 @@ export default defineCommand({
       console.log("");
     }
 
-    // ── Check FFmpeg for local renders ───────────────────────────────────
-    if (!useDocker) {
-      const { findFFmpeg, getFFmpegInstallHint } = await import("../browser/ffmpeg.js");
-      if (!findFFmpeg()) {
-        errorBox(
-          "FFmpeg not found",
-          "Rendering requires FFmpeg for video encoding.",
-          `Install: ${getFFmpegInstallHint()}`,
-        );
-        process.exit(1);
-      }
-    }
-
     // ── Ensure browser for local renders ────────────────────────────────
     let browserPath: string | undefined;
     if (!useDocker) {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -51,6 +51,7 @@ import { VERSION } from "../version.js";
 import { isDevMode } from "../utils/env.js";
 import { buildDockerRunArgs } from "../utils/dockerRunArgs.js";
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
+import { findFFmpeg, getFFmpegInstallHint } from "../browser/ffmpeg.js";
 import type { RenderJob } from "@hyperframes/producer";
 import {
   normalizeResolutionFlag,
@@ -786,6 +787,16 @@ export async function renderLocal(
   options: RenderOptions,
 ): Promise<void> {
   const producer = await loadProducer();
+
+  if (!findFFmpeg()) {
+    errorBox(
+      "FFmpeg not found",
+      "FFmpeg is required to encode video. The render cannot proceed without it.",
+      getFFmpegInstallHint(),
+    );
+    process.exit(1);
+  }
+
   const startTime = Date.now();
 
   // Pass the resolved browser path to the producer via env var so
@@ -822,7 +833,14 @@ export async function renderLocal(
   try {
     await producer.executeRenderJob(job, projectDir, outputPath, onProgress);
   } catch (error: unknown) {
-    handleRenderError(error, options, startTime, false, "Try --docker for containerized rendering");
+    handleRenderError(
+      error,
+      options,
+      startTime,
+      false,
+      "Try --docker for containerized rendering",
+      job.failedStage,
+    );
   }
 
   const elapsed = Date.now() - startTime;
@@ -868,6 +886,7 @@ function handleRenderError(
   startTime: number,
   docker: boolean,
   hint: string,
+  failedStage?: string,
 ): never {
   const message = normalizeErrorMessage(error);
   trackRenderError({
@@ -878,6 +897,7 @@ function handleRenderError(
     gpu: options.gpu,
     elapsedMs: Date.now() - startTime,
     errorMessage: message,
+    failedStage,
     ...getMemorySnapshot(),
   });
   errorBox("Render failed", message, hint);


### PR DESCRIPTION
## Summary

- Adds `vi.mock("../browser/ffmpeg.js")` to `render.test.ts` so the FFmpeg pre-flight check in `renderLocal()` doesn't `process.exit(1)` on CI runners that lack ffmpeg — same pattern as the existing `loadProducer` mock
- Follows up on #1149 which added the pre-flight but missed the test mock

## Test plan

- [ ] CI `Test` job passes (was failing with cascade exit on Linux runner)