### PR TITLE
fix(core): emit mediaVolumeEnvelope in tsc lib output

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,6 +13,7 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
+  "files": ["src/runtime/mediaVolumeEnvelope.ts"],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/tests", "src/runtime", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- `@hyperframes/core` declares a `./media-volume-envelope` subpath export pointing to `dist/runtime/mediaVolumeEnvelope.{js,d.ts}`, but `src/runtime` is excluded from tsc compilation (it's the browser IIFE bundle). The file was never emitted to dist.
- In-monorepo this is invisible (dev export resolves via `src/`), but external consumers like `producer-internal` hit TS2307 when typechecking engine's source import of `@hyperframes/core/media-volume-envelope`.
- Fix: add `src/runtime/mediaVolumeEnvelope.ts` to tsconfig's `files` array, which overrides `exclude` per the TypeScript spec. One line change, no package.json or import changes needed. The IIFE bundler (esbuild) is unaffected — it resolves from its own entry point.

Unblocks hyperframes-internal#376 (core+producer bump to 0.6.67+).

## Test plan

- [x] `bun run --cwd packages/core build` — `dist/runtime/mediaVolumeEnvelope.{js,d.ts}` now emitted
- [x] `bun run --cwd packages/engine typecheck` — engine's `@hyperframes/core/media-volume-envelope` import resolves
- [x] `bun run --cwd packages/core test` — 1163 tests pass
- [x] Full monorepo `bun run build` — green