### PR TITLE
fix(registry): add Apple Terminal blocks to registry manifest

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -368,6 +368,54 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "code-snippet-apple-terminal-basic",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-clear-dark",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-clear-light",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-grass",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-homebrew",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-man-page",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-novel",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-ocean",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-pro",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-red-sands",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-silver-aerogel",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-apple-terminal-solid-colors",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },


### PR DESCRIPTION
## Summary

- Missed step from #1161: the 12 `code-snippet-apple-terminal-*` blocks were added to `registry/blocks/` but not to `registry/registry.json`, which is what the CLI reads to resolve item names
- Without this, `npx hyperframes add code-snippet-apple-terminal-basic` returns "Item not found in registry"
- Adds all 12 entries to the manifest

## Test

After merge, `npx hyperframes add code-snippet-apple-terminal-basic` should resolve and install correctly (CLI reads from `raw.githubusercontent.com/heygen-com/hyperframes/main/registry/registry.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)