### PR TITLE
fix(registry): add 14 missing blocks to registry manifest

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -416,6 +416,62 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "code-snippet-dark-2026",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-dark-modern",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-dark-plus",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-high-contrast",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-high-contrast-light",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-light-2026",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-light-modern",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-light-plus",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-monokai",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-solarized-light",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-visual-studio-dark",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "code-snippet-visual-studio-light",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "flowchart-vertical",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "vfx-liquid-glass",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },


### PR DESCRIPTION
## Summary

Audit of `registry/blocks/` vs `registry/registry.json` found 14 blocks that existed on disk but weren't registered — meaning `npx hyperframes add <name>` would fail for all of them.

**Missing blocks:**
- 12 VS Code `code-snippet-*` blocks (from #1113, same missed step as the Apple Terminal blocks in #1162)
- `flowchart-vertical`
- `vfx-liquid-glass`

Single-file change adding all 14 entries.