### PR TITLE
fix(runtime): show elements at exact end of their duration

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1413,7 +1413,7 @@ export function initSandboxRuntimeModular(): void {
         duration != null && duration > 0 ? start + duration : Number.POSITIVE_INFINITY;
       const isVisibleNow =
         state.currentTime >= start &&
-        (Number.isFinite(computedEnd) ? state.currentTime < computedEnd : true);
+        (Number.isFinite(computedEnd) ? state.currentTime <= computedEnd : true);
       rawNode.style.visibility = isVisibleNow ? "visible" : "hidden";
     }
   };


### PR DESCRIPTION
## Summary

- Visibility check used strict less-than (`currentTime < end`), hiding elements at exactly `t=duration`. Changed to `<=` so the last frame renders the final animation state.

## Test plan

- [x] Seek to exactly t=5 on a 5s composition — elements visible at their 100% keyframe state
- [x] Play through the composition — elements don't persist one frame past their `data-duration`
- [x] Overlapping clips still hide/show correctly at boundaries