### PR TITLE
fix(runtime): make audio/media sync boundary inclusive to match visibility fix

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1933,7 +1933,7 @@ export function initSandboxRuntimeModular(): void {
             const mediaStart =
               Number.parseFloat(rawEl.dataset.playbackStart ?? rawEl.dataset.mediaStart ?? "0") ||
               0;
-            if (Number.isFinite(start) && state.currentTime >= start && state.currentTime < end) {
+            if (Number.isFinite(start) && state.currentTime >= start && state.currentTime <= end) {
               if (!rawEl.paused) {
                 clock.attachAudioSource({ el: rawEl, compositionStart: start, mediaStart });
                 foundActive = true;

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -165,7 +165,7 @@ export function syncRuntimeMedia(params: {
     // (el.ended resets to false when the user scrubs back, so seeks work.)
     const isActive =
       params.timeSeconds >= clip.start &&
-      params.timeSeconds < clip.end &&
+      params.timeSeconds <= clip.end &&
       relTime >= 0 &&
       (!el.ended || clip.loop);
     if (isActive) {


### PR DESCRIPTION
## Summary

Follows up on #1166 which changed element visibility to \`<= computedEnd\`. The audio clock and \`syncRuntimeMedia\` still used \`< end\`, creating a 1-frame asymmetry: the host was visible at exactly \`t = duration\` but audio was silent.

**Changed:**
- \`init.ts:1908\` audio clock: \`state.currentTime < end\` → \`state.currentTime <= end\`
- \`media.ts:163\` \`syncRuntimeMedia\`: \`params.timeSeconds < clip.end\` → \`params.timeSeconds <= clip.end\`

**Why \`<=\` is safe for audio at clip boundaries:**

For \`init.ts\` (audio clock): the loop does \`break\` on the first active clip (line 1918), so at \`t = boundary\` only the outgoing clip is attached — incoming is never reached.

For \`media.ts\` (\`syncRuntimeMedia\`): the loop has no \`break\` — it iterates all clips. At \`t = boundary\` both clips satisfy \`<= end / >= start\`, so both are \`isActive = true\`. However, the outgoing clip's \`el.paused\` is \`false\` (mid-play), so the \`el.paused\` gate skips its \`play()\` call. Only the incoming clip's \`play()\` fires. The result is a ~1-frame audio overlap (~33ms at 30fps) — imperceptible for typical content. The \`el.paused\` gate, not a loop break, is what prevents dual-activation here.

**Effect:**
- Seeking to \`t = duration\` on a composition: audio and visuals both hold their final state (symmetric)
- Adjacent clip boundaries: unchanged in practice — outgoing audio plays through \`t = boundary\`, incoming starts at next tick

## Test plan

- [x] \`bun run --cwd packages/core test\` — 1163/1163 pass (after build)
- [ ] Manual: seek to exact \`t = duration\` on a composition with audio — verify audio audible at that frame
- [ ] Manual: play through a slide transition — verify audio doesn't gap at boundary