### PR TITLE
fix(engine): add --autoplay-policy=no-user-gesture-required to headless Chrome args

### DIFF
--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -580,6 +580,12 @@ export function buildChromeArgs(
     ...getLowMemoryFlags(),
     // Disable features that add overhead
     "--disable-features=AudioServiceOutOfProcess,IsolateOrigins,site-per-process,Translate,BackForwardCache,IntensiveWakeUpThrottling",
+    // Allow AudioContext to start without a user gesture in headless Chrome.
+    // Without this flag, any code path that constructs an AudioContext
+    // (including GSAP tweening an <audio> element's volume) triggers the
+    // autoplay policy and causes the AudioContext to stay suspended. The
+    // frame-capture loop then blocks waiting for it, deadlocking the render.
+    "--autoplay-policy=no-user-gesture-required",
   ];
 
   if (browserGpuMode !== "software") {

--- a/packages/engine/src/services/hdrCapture.ts
+++ b/packages/engine/src/services/hdrCapture.ts
@@ -310,5 +310,6 @@ export function buildHdrChromeArgs(width: number, height: number): string[] {
     "--disable-sync",
     "--no-zygote",
     "--force-gpu-mem-available-mb=4096",
+    "--autoplay-policy=no-user-gesture-required",
   ];
 }


### PR DESCRIPTION
## Fixes

Closes #1176

## Root cause

GSAP's `tl.to("#audio", { volume: 0, ... })` causes Chrome to construct a `WebAudioTransport` / `AudioContext`. In headless Chrome, the autoplay policy blocks `AudioContext` startup with _"The AudioContext was not allowed to start"_ — the frame-capture loop then waits for it indefinitely and deadlocks **before** the `BeginFrame` fallback can recover. The render hangs at "Starting frame capture" with 0 output frames and times out at 600s.

## Fix

Add `--autoplay-policy=no-user-gesture-required` to both Chrome launch sites:
- `browserManager.ts` — main render path
- `hdrCapture.ts` — HDR capture path

This flag lets `AudioContext` start without a user gesture, which is correct for headless rendering where no real user interaction is possible anyway. It's the standard fix used by Remotion, Playwright, and other headless capture tools for the same class of issue.

## Test plan

- [ ] Apply Abhai's minimal repro (GSAP volume tween + audio element) — should render clean
- [ ] Existing compositions without audio tweens — no regression
- [ ] HDR render path — verify clean startup