### PR TITLE
test(producer): regenerate stale style-7-prod baseline in Docker

### DIFF
--- a/packages/producer/tests/style-7-prod/output/compiled.html
+++ b/packages/producer/tests/style-7-prod/output/compiled.html
@@ -1001,7 +1001,7 @@
       <!-- Main A-roll and Stats (3s - End) -->
       <div data-hf-authored-id="main" data-composition-file="compositions/main.html" id="main-layer" data-composition-id="main" data-start="0" data-duration="16.7" data-width="1920" data-height="1080" data-track-index="5" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 5">
     <!-- A-roll Video -->
-    <video id="aroll" src="https://gen-os-static.s3.us-east-2.amazonaws.com/astral_assets/uploaded_assets/70648f53_abe84fb9991841ae8ba82ee21ba6d37e.mp4" data-start="0" data-duration="16.043" data-track-index="1" muted data-end="16.043" data-has-audio="false"></video>
+    <video id="aroll" src="_remote_media/download_054a544691a0.mp4" data-start="0" data-duration="16.043" data-track-index="1" muted data-end="16.043" data-has-audio="false"></video>
 
     <!-- Statistics Overlay -->
     <div class="stats-container">
@@ -1048,7 +1048,7 @@
   </div>
 
       <!-- Background Audio (A-roll Audio) -->
-      <audio id="aroll-audio" src="https://gen-os-static.s3.us-east-2.amazonaws.com/astral_assets/uploaded_assets/70648f53_abe84fb9991841ae8ba82ee21ba6d37e.mp4" data-start="0" data-duration="16.043" data-track-index="1" data-end="16.043"></audio>
+      <audio id="aroll-audio" src="_remote_media/download_054a544691a0.mp4" data-start="0" data-duration="16.043" data-track-index="1" data-end="16.043"></audio>
     </div>
 
     

--- a/packages/producer/tests/style-7-prod/output/output.mp4
+++ b/packages/producer/tests/style-7-prod/output/output.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09431551eb685c9c9de061930c719825f8584c8740e8fd51a09bebeff434b1b1
-size 12262740
+oid sha256:bc63320024888aadc78256bdd6485362a8f27523a6a1cdc196db2dd0ba73ecae
+size 12264858


### PR DESCRIPTION
Stale baseline — output diverged from the stored reference (pre-existing drift, same pattern as #1135). Regenerated inside `Dockerfile.test` with the current Chrome + FFmpeg build.

Full suite after regen: **51/51 passed** (0 visual, 0 audio failures). The `<=` boundary fix from #1166 had no impact on rendered output, as expected (render captures frames at discrete timestamps, not at exactly `t=duration`).