### PR TITLE
fix: delay ObjectURL revocation and silence TS5 baseUrl deprecations

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,7 +14,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "./dist",
-    "declaration": true
+    "declaration": true,
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/studio/src/hooks/useFrameCapture.ts
+++ b/packages/studio/src/hooks/useFrameCapture.ts
@@ -69,7 +69,7 @@ export function useFrameCapture({
           document.body.appendChild(link);
           link.click();
           link.remove();
-          setTimeout(() => URL.revokeObjectURL(blobUrl), 0);
+          setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
         } catch (fetchErr) {
           clearTimeout(timeout);
           if (fetchErr instanceof DOMException && fetchErr.name === "AbortError") {

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -23,7 +23,8 @@
     "noEmit": true,
     "incremental": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src"],
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"]


### PR DESCRIPTION
Clean cherry-pick of the valid changes from #795 (originally by @Jefsky), rebased on current main. The spurious `LayersPanel.tsx` and already-merged caption fix have been dropped.

## Changes

**`useFrameCapture.ts` — ObjectURL revocation timing**

`setTimeout(..., 0)` fires before the browser initiates the download, causing the blob URL to be revoked while the download machinery is still reading it. 1000ms is conservative-safe.

```diff
- setTimeout(() => URL.revokeObjectURL(blobUrl), 0);
+ setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
```

**`cli/tsconfig.json` + `studio/tsconfig.json` — TS5 deprecation warnings**

`baseUrl`/`paths` are deprecated in TypeScript 5.0+. `ignoreDeprecations: "5.0"` is the canonical way to silence the warnings without changing behavior.

## What was dropped vs #795

- `LayersPanel.tsx` — stale addition that would have conflicted with existing file; layer seek fix already merged via #792
- `generator.ts` — caption escaping fix already merged via #625

Closes #795.

Co-authored-by: Jefsky Wong <jefsky@qq.com>