### PR TITLE
fix(cli): suppress EPIPE crashes in piped agent environments

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,9 +5,19 @@
 // Cursor, etc.), the reader may close the pipe before we finish writing.
 // Node treats EPIPE on stdout/stderr as an uncaughtException, which crashes
 // the process. This is a normal lifecycle event — suppress it.
+//
+// commandFailed must be declared here (before the handlers) so the EPIPE
+// stream-error path can set it before process.exit(0). The telemetry exit
+// handler reads this flag to determine success/failure — an EPIPE exit
+// should NOT score as success:true in telemetry.
+let commandFailed = false;
+
 for (const stream of [process.stdout, process.stderr]) {
   stream.on("error", (err) => {
-    if ((err as NodeJS.ErrnoException).code === "EPIPE") process.exit(0);
+    if ((err as NodeJS.ErrnoException).code === "EPIPE") {
+      commandFailed = true;
+      process.exit(0);
+    }
   });
 }
 
@@ -205,7 +215,6 @@ if (!isHelp && !hasJsonFlag && command !== "upgrade") {
 }
 
 const commandStart = Date.now();
-let commandFailed = false;
 
 // Async flush for normal exit. `beforeExit` re-fires every time the
 // event loop drains, and the async `_flush()` itself schedules new
@@ -231,7 +240,10 @@ process.on("exit", (code) => {
 });
 
 process.on("uncaughtException", (error) => {
-  if ((error as NodeJS.ErrnoException).code === "EPIPE") process.exit(0);
+  if ((error as NodeJS.ErrnoException).code === "EPIPE") {
+    commandFailed = true;
+    process.exit(0);
+  }
   commandFailed = true;
   _trackCliError?.({
     error_name: error.name,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 
+// ── EPIPE suppression (must run before ANY stdout/stderr write) ────────────
+// When the CLI runs inside a piped agent environment (Claude Code, Codex,
+// Cursor, etc.), the reader may close the pipe before we finish writing.
+// Node treats EPIPE on stdout/stderr as an uncaughtException, which crashes
+// the process. This is a normal lifecycle event — suppress it.
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on("error", (err) => {
+    if ((err as NodeJS.ErrnoException).code === "EPIPE") process.exit(0);
+  });
+}
+
 // ── Worker entry path bootstrap (must run before any producer/engine load) ──
 // The hf#677 worker_threads pools (`pngDecodeBlitWorkerPool`,
 // `shaderTransitionWorkerPool`) live in the producer package and try to
@@ -220,6 +231,7 @@ process.on("exit", (code) => {
 });
 
 process.on("uncaughtException", (error) => {
+  if ((error as NodeJS.ErrnoException).code === "EPIPE") process.exit(0);
   commandFailed = true;
   _trackCliError?.({
     error_name: error.name,


### PR DESCRIPTION
## Summary

- Add stream-level EPIPE handlers on `process.stdout` and `process.stderr` at the top of the CLI entry point, before any output can occur
- Make the `uncaughtException` handler EPIPE-aware so it exits with code 0 instead of crash-reporting

## Problem

When the CLI runs inside piped agent environments (Claude Code, Codex, Cursor), the agent may close the pipe before the CLI finishes writing. Node treats EPIPE on stdout/stderr as an `uncaughtException`, crashing the process with exit code 1.

The `preview` command is particularly affected — it writes to stdout via a clack spinner every 80ms, so any pipe closure during a long-running session triggers the crash.

## Reproduction

```bash
# WITHOUT fix — EPIPE reaches uncaughtException, process reports crash:
node -e "
process.on('uncaughtException', (error) => {
  process.stderr.write('CRASHED: ' + error.code + '\n');
  process.exit(1);
});
function writeLoop(i) {
  if (i <= 0) { process.exit(0); return; }
  const ok = process.stdout.write('x'.repeat(8192) + '\n');
  if (!ok) { process.stdout.once('drain', () => writeLoop(i - 1)); }
  else { setImmediate(() => writeLoop(i - 1)); }
}
writeLoop(5000);
" 2>/tmp/epipe_test | head -c 1 > /dev/null
cat /tmp/epipe_test
# Output: CRASHED: EPIPE

# WITH fix — stream handler catches EPIPE, clean exit:
node -e "
for (const stream of [process.stdout, process.stderr]) {
  stream.on('error', (err) => { if (err.code === 'EPIPE') process.exit(0); });
}
process.on('uncaughtException', (error) => {
  if (error.code === 'EPIPE') process.exit(0);
  process.stderr.write('CRASHED: ' + error.code + '\n');
  process.exit(1);
});
function writeLoop(i) {
  if (i <= 0) { process.exit(0); return; }
  const ok = process.stdout.write('x'.repeat(8192) + '\n');
  if (!ok) { process.stdout.once('drain', () => writeLoop(i - 1)); }
  else { setImmediate(() => writeLoop(i - 1)); }
}
writeLoop(5000);
" 2>/tmp/epipe_test | head -c 1 > /dev/null
cat /tmp/epipe_test
# Output: (empty — no crash)
```

## Fix

- `process.stdout.on('error')` / `process.stderr.on('error')` — catches EPIPE at the stream level before it becomes an uncaught exception
- `uncaughtException` handler — defense-in-depth check for EPIPE (exits 0 instead of crash-tracking + exit 1)

Both guards exit with code 0 since pipe closure is a normal lifecycle event, not a bug.

## Test plan

- [x] Build passes (`bun run build`)
- [x] All pre-commit hooks pass (lint, format, typecheck, fallow)
- [x] Continuous-write EPIPE reproduction: crashes without fix, exits cleanly with fix
- [x] `node dist/cli.js --version | head -c 1 >/dev/null` exits code 0
- [ ] Verify EPIPE errors drop after deploy