### PR TITLE
docs(registry): fix typos in north-korea-locked-down source prompt

### DIFF
--- a/docs/catalog/blocks/north-korea-locked-down.mdx
+++ b/docs/catalog/blocks/north-korea-locked-down.mdx
@@ -14,7 +14,7 @@ Created by [Stronkter](https://x.com/Stronkter).
 ## Source Prompt
 
 ```text
-use 📷HyperFrames by HeyGen and Image Gen  if you need it for assets or like png images of assets without backround to make a youtube style camera moving in out and other things that are in youtube videos, to make a video of a map zooms in on north korea and a scribble style circle circles the country and a text pops up above it saying locked down when the text apears the video turns a bit redish make the video 7 seconds long id like the map to look realistic and accurate to real lfe
+use 📷HyperFrames by HeyGen and Image Gen if you need it for assets or like png images of assets without background to make a youtube style camera moving in out and other things that are in youtube videos, to make a video of a map zooms in on north korea and a scribble style circle circles the country and a text pops up above it saying locked down when the text appears the video turns a bit reddish make the video 7 seconds long id like the map to look realistic and accurate to real life
 ```
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/north-korea-locked-down.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/north-korea-locked-down.png" autoPlay muted loop playsInline />

--- a/registry/blocks/north-korea-locked-down/registry-item.json
+++ b/registry/blocks/north-korea-locked-down/registry-item.json
@@ -7,7 +7,7 @@
   "tags": ["showcase", "map", "annotation", "youtube", "kinetic"],
   "author": "Stronkter",
   "authorUrl": "https://x.com/Stronkter",
-  "sourcePrompt": "use 📷HyperFrames by HeyGen and Image Gen  if you need it for assets or like png images of assets without backround to make a youtube style camera moving in out and other things that are in youtube videos, to make a video of a map zooms in on north korea and a scribble style circle circles the country and a text pops up above it saying locked down when the text apears the video turns a bit redish make the video 7 seconds long id like the map to look realistic and accurate to real lfe",
+  "sourcePrompt": "use 📷HyperFrames by HeyGen and Image Gen if you need it for assets or like png images of assets without background to make a youtube style camera moving in out and other things that are in youtube videos, to make a video of a map zooms in on north korea and a scribble style circle circles the country and a text pops up above it saying locked down when the text appears the video turns a bit reddish make the video 7 seconds long id like the map to look realistic and accurate to real life",
   "dimensions": {
     "width": 1920,
     "height": 1080


### PR DESCRIPTION
## What

Corrects clear spelling errors in the verbatim `sourcePrompt` of the `north-korea-locked-down` registry block, and keeps the generated catalog page in sync.

| Wrong | Right |
| --- | --- |
| `backround` | `background` |
| `apears` | `appears` |
| `redish` | `reddish` |
| `lfe` | `life` |
| `Image Gen␠␠if` (double space) | `Image Gen if` |

Casual phrasing (`north korea`, `youtube`, `id like`) is intentionally left as-is to keep the prompt authentic to what the author originally wrote.

## Files

- `registry/blocks/north-korea-locked-down/registry-item.json` — source manifest (`sourcePrompt`)
- `docs/catalog/blocks/north-korea-locked-down.mdx` — auto-generated catalog page, kept in sync (single line)

## Notes

A full `codespell` sweep across all prose docs (including `docs/guides`) and registry manifests found no other genuine typos.