### PR TITLE
fix(runtime): don't restart non-loop media that has naturally ended

### DIFF
--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -320,6 +320,25 @@ describe("syncRuntimeMedia", () => {
     expect(clip.el.pause).toHaveBeenCalled();
   });
 
+  it("does not restart a non-loop clip that has naturally ended before the clip's end time", () => {
+    // Reproduces: bg-music WAV is 60s but data-duration="68.6" (composition duration).
+    // At t=62 the file has ended; without this guard the runtime calls el.play() every
+    // rAF tick, resetting currentTime to 0 and causing audible stutter for 8.6s.
+    const clip = createMockClip({ start: 0, end: 68.6, loop: false });
+    Object.defineProperty(clip.el, "paused", { value: true, writable: true });
+    Object.defineProperty(clip.el, "ended", { value: true, writable: true, configurable: true });
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 62, playing: true, playbackRate: 1 });
+    expect(clip.el.play).not.toHaveBeenCalled();
+  });
+
+  it("does restart a loop clip that has naturally ended while still within its active window", () => {
+    const clip = createMockClip({ start: 0, end: 68.6, loop: true, sourceDuration: 60 });
+    Object.defineProperty(clip.el, "paused", { value: true, writable: true });
+    Object.defineProperty(clip.el, "ended", { value: true, writable: true, configurable: true });
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 62, playing: true, playbackRate: 1 });
+    expect(clip.el.play).toHaveBeenCalled();
+  });
+
   it("sets volume when clip has volume", () => {
     const clip = createMockClip({ start: 0, end: 10, volume: 0.7 });
     syncRuntimeMedia({ clips: [clip], timeSeconds: 5, playing: false, playbackRate: 1 });

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -339,6 +339,20 @@ describe("syncRuntimeMedia", () => {
     expect(clip.el.play).toHaveBeenCalled();
   });
 
+  it("resumes a previously-ended non-loop clip after a backward seek resets el.ended", () => {
+    // el.ended resets to false when the browser processes a seek (per WHATWG spec).
+    // This test pins the contract: silent at t=62 (ended), playable again at t=30 (seeked back).
+    const clip = createMockClip({ start: 0, end: 68.6, loop: false });
+    Object.defineProperty(clip.el, "paused", { value: true, writable: true });
+    Object.defineProperty(clip.el, "ended", { value: true, writable: true, configurable: true });
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 62, playing: true, playbackRate: 1 });
+    expect(clip.el.play).not.toHaveBeenCalled();
+    // Simulate backward seek: browser resets ended to false before committing new currentTime
+    Object.defineProperty(clip.el, "ended", { value: false, writable: true, configurable: true });
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 30, playing: true, playbackRate: 1 });
+    expect(clip.el.play).toHaveBeenCalledTimes(1);
+  });
+
   it("sets volume when clip has volume", () => {
     const clip = createMockClip({ start: 0, end: 10, volume: 0.7 });
     syncRuntimeMedia({ clips: [clip], timeSeconds: 5, playing: false, playbackRate: 1 });

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -159,8 +159,15 @@ export function syncRuntimeMedia(params: {
     const { el } = clip;
     if (!el.isConnected) continue;
     let relTime = (params.timeSeconds - clip.start) * clip.playbackRate + clip.mediaStart;
+    // An ended non-loop element has played its file to natural completion.
+    // Don't restart it — if the authored duration extends past the file's
+    // actual length, the element sits silently until the composition ends.
+    // (el.ended resets to false when the user scrubs back, so seeks work.)
     const isActive =
-      params.timeSeconds >= clip.start && params.timeSeconds < clip.end && relTime >= 0;
+      params.timeSeconds >= clip.start &&
+      params.timeSeconds < clip.end &&
+      relTime >= 0 &&
+      (!el.ended || clip.loop);
     if (isActive) {
       // Loop wrapping: when media reaches end, restart from mediaStart
       if (clip.loop && clip.sourceDuration != null && clip.sourceDuration > 0) {


### PR DESCRIPTION
## Problem

When a media element's authored `data-duration` exceeds the actual file length, `el.ended` becomes `true` at the file's natural end while the clip is still within its active window (`timeSeconds < clip.end`). The runtime was calling `el.play()` on the ended element every rAF tick (~60fps), which:

1. Resets `currentTime` to 0 and starts playing from the beginning
2. Next tick: drift ≈ file_duration → `hardSync` fires → `el.currentTime = relTime` → browser clamps to file max → element ends again immediately
3. Rapid restart→clamp→end→restart cycle for the overshoot duration → audible clicks/stutter

**Reproducer:** bg-music WAV is 60s but `data-duration="68.6"` (the composition duration). Last 8.6s of playback: perceptible stutter + brief music restart around t=63s.

## Fix

Add `!el.ended || clip.loop` to the `isActive` check. A naturally-ended non-loop element stays inactive for the rest of the composition window. `el.ended` resets to `false` on any seek, so scrubbing backward correctly resumes playback.

```diff
-    const isActive =
-      params.timeSeconds >= clip.start && params.timeSeconds < clip.end && relTime >= 0;
+    const isActive =
+      params.timeSeconds >= clip.start &&
+      params.timeSeconds < clip.end &&
+      relTime >= 0 &&
+      (!el.ended || clip.loop);
```

## Tests

Two new cases in `media.test.ts`:
- Non-loop clip with `el.ended=true` at t=62 within a 68.6s window → `play()` not called
- Loop clip with `el.ended=true` in same scenario → `play()` is called (loops continue normally)

All 55 existing tests pass.