### PR TITLE
fix(cli): validate init flags before creating the project directory

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -147,6 +147,51 @@ describe("hyperframes init flag rename", () => {
       ]);
       expect(res.status).toBe(1);
       expect(res.stderr).toContain("Video file not found: missing.mp4");
+      expect(existsSync(target)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--audio with a missing file fails without creating the project directory", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-init-test-"));
+    const target = join(dir, "proj");
+    try {
+      const res = runInit([
+        target,
+        "--example",
+        "blank",
+        "--non-interactive",
+        "--skip-skills",
+        "--audio",
+        "missing.mp3",
+      ]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("Audio file not found: missing.mp3");
+      expect(existsSync(target)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--video and --audio together fail without creating the project directory", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-init-test-"));
+    const target = join(dir, "proj");
+    try {
+      const res = runInit([
+        target,
+        "--example",
+        "blank",
+        "--non-interactive",
+        "--skip-skills",
+        "--video",
+        "clip.mp4",
+        "--audio",
+        "track.mp3",
+      ]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("Cannot use --video and --audio together");
+      expect(existsSync(target)).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -693,24 +693,33 @@ export default defineCommand({
         process.exit(1);
       }
 
+      if (videoFlag && audioFlag) {
+        console.error(c.error("Cannot use --video and --audio together"));
+        process.exit(1);
+      }
+
+      // Validate source files before creating destDir so a failed run does
+      // not leave an empty orphan directory behind. The interactive path
+      // already validates in this order.
+      const videoPath = videoFlag ? resolve(videoFlag) : undefined;
+      if (videoPath && !existsSync(videoPath)) {
+        console.error(c.error(`Video file not found: ${videoFlag}`));
+        process.exit(1);
+      }
+      const audioPath = audioFlag ? resolve(audioFlag) : undefined;
+      if (audioPath && !existsSync(audioPath)) {
+        console.error(c.error(`Audio file not found: ${audioFlag}`));
+        process.exit(1);
+      }
+
       mkdirSync(destDir, { recursive: true });
 
       let localVideoName: string | undefined;
       let videoDuration: number | undefined;
       let sourceFilePath: string | undefined;
 
-      if (videoFlag && audioFlag) {
-        console.error(c.error("Cannot use --video and --audio together"));
-        process.exit(1);
-      }
-
       // Handle video
-      if (videoFlag) {
-        const videoPath = resolve(videoFlag);
-        if (!existsSync(videoPath)) {
-          console.error(c.error(`Video file not found: ${videoFlag}`));
-          process.exit(1);
-        }
+      if (videoPath) {
         sourceFilePath = videoPath;
         const result = await handleVideoFile(videoPath, destDir, false);
         localVideoName = result.localVideoName;
@@ -721,12 +730,7 @@ export default defineCommand({
       }
 
       // Handle audio
-      if (audioFlag) {
-        const audioPath = resolve(audioFlag);
-        if (!existsSync(audioPath)) {
-          console.error(c.error(`Audio file not found: ${audioFlag}`));
-          process.exit(1);
-        }
+      if (audioPath) {
         sourceFilePath = audioPath;
         copyFileSync(audioPath, resolve(destDir, basename(audioPath)));
         console.log(`Audio: ${basename(audioPath)}`);


### PR DESCRIPTION
## Problem

In non-interactive mode, `hyperframes init` creates the project directory before validating the source-file flags. Three failure paths exit after the `mkdirSync`:

- `--video` and `--audio` passed together
- `--video <path>` where the file does not exist
- `--audio <path>` where the file does not exist

Each one leaves an empty orphan directory behind in the caller's CWD. For CI and agent loops (the audience of `--non-interactive`) a failed scaffold that still mutates the filesystem is surprising: a retry with a corrected flag passes the "directory already exists and is not empty" check only because the orphan happens to be empty, and an aborted run pollutes the workspace.

The other early validations already get this right: `--template`, `-V`, and `--resolution` all reject before any filesystem write, and their tests assert `existsSync(target) === false`. The interactive path also validates the source file before its `mkdirSync`. The non-interactive video/audio path was the only one ordered the other way.

## Fix

Reorder the non-interactive block: flag-conflict check and source-file existence checks first, `mkdirSync(destDir)` after. The existence checks reuse the already-resolved paths, so the video/audio handling below switches from re-resolving `videoFlag`/`audioFlag` to using `videoPath`/`audioPath` directly. No messages or exit codes changed.

Not touched: the interactive path resolves `--video`/`--audio` with else-if precedence (video wins) rather than rejecting the combination. That asymmetry predates this change and is a UX question rather than a bug, so it stays as is.

## Tests

- Strengthened the existing `-v missing.mp4` case with the `existsSync(target) === false` assertion the sibling tests already use (it would have failed before this fix).
- New: `--audio missing.mp3` exits 1 with no directory created.
- New: `--video` + `--audio` together exits 1 with no directory created.

All three fail on main and pass with the reorder. Full cli suite: 690/690.