### PR TITLE
fix(publish): purge jsDelivr cache after stable release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,3 +184,18 @@ jobs:
             fi
             gh release create "v${VERSION}" "${FLAGS[@]}"
           fi
+
+      - name: Purge jsDelivr cache for latest-tagged packages
+        if: steps.version.outputs.prerelease == 'false'
+        run: |
+          # jsDelivr caches unversioned URLs against the npm `latest` tag.
+          # After publishing a new stable release, purge so the unversioned
+          # CDN URLs immediately serve the new version instead of stale content.
+          urls=(
+            "https://purge.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js"
+            "https://purge.jsdelivr.net/npm/@hyperframes/core/dist/hyperframe.runtime.mjs"
+          )
+          for url in "${urls[@]}"; do
+            resp=$(curl -sf "$url" 2>/dev/null || echo '{"status":"error"}')
+            echo "Purged $url: $resp"
+          done


### PR DESCRIPTION
## Summary

After publishing a new stable release to npm, jsDelivr's CDN caches the unversioned URL (`/npm/@hyperframes/core/dist/hyperframe.runtime.iife.js`) and doesn't always pick up the new version immediately. This caused demo-next users to get the pre-fix runtime even after v0.6.73 was published — the `el.ended` guard wasn't active until the cache expired or was manually purged.

This PR adds an automatic jsDelivr cache purge step at the end of every stable release publish workflow so the unversioned CDN URLs always serve the latest version immediately.

The purge is skipped for pre-release (alpha/beta) tags since those don't update the `latest` dist-tag.

## Root cause

jsDelivr's unversioned URL cache has a TTL (~10 min for tag resolution) but CDN edge nodes can serve stale content for longer. The `runtime.iife.js` for 0.6.73 was published but the unversioned URL on Cloudflare/Fastly edges still served the pre-fix build, causing the audio `el.ended` guard to be missing in the live preview player.

## Test plan

- [ ] Workflow runs on next stable release tag push
- [ ] Purge step executes and logs success responses from jsDelivr
- [ ] Unversioned URL serves the new version immediately after publish