### PR TITLE
feat(studio): snap engine, grid overlay, and snap UI components

### DIFF
--- a/packages/studio/src/components/editor/GridOverlay.tsx
+++ b/packages/studio/src/components/editor/GridOverlay.tsx
@@ -1,0 +1,50 @@
+// fallow-ignore-file unused-files
+import { memo } from "react";
+
+interface GridOverlayProps {
+  visible: boolean;
+  spacing: number;
+  scaleX: number;
+  scaleY: number;
+  compositionLeft: number;
+  compositionTop: number;
+  compositionWidth: number;
+  compositionHeight: number;
+}
+
+// fallow-ignore-next-line complexity
+export const GridOverlay = memo(function GridOverlay({
+  visible,
+  spacing,
+  scaleX,
+  scaleY,
+  compositionLeft,
+  compositionTop,
+  compositionWidth,
+  compositionHeight,
+}: GridOverlayProps) {
+  if (!visible || spacing <= 0) return null;
+
+  const overlaySpacingX = spacing * scaleX;
+  const overlaySpacingY = spacing * scaleY;
+
+  if (overlaySpacingX < 4 || overlaySpacingY < 4) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute"
+      style={{
+        left: compositionLeft,
+        top: compositionTop,
+        width: compositionWidth,
+        height: compositionHeight,
+        backgroundImage: [
+          `repeating-linear-gradient(90deg, rgba(255,255,255,0.12) 0px, rgba(255,255,255,0.12) 1px, transparent 1px, transparent ${overlaySpacingX}px)`,
+          `repeating-linear-gradient(0deg, rgba(255,255,255,0.12) 0px, rgba(255,255,255,0.12) 1px, transparent 1px, transparent ${overlaySpacingY}px)`,
+        ].join(", "),
+        backgroundSize: `${overlaySpacingX}px ${overlaySpacingY}px`,
+      }}
+    />
+  );
+});

--- a/packages/studio/src/components/editor/SnapGuideOverlay.tsx
+++ b/packages/studio/src/components/editor/SnapGuideOverlay.tsx
@@ -1,0 +1,166 @@
+// fallow-ignore-file unused-files
+import { memo, useRef, type RefObject } from "react";
+import { useMountEffect } from "../../hooks/useMountEffect";
+import type { SnapGuide, SpacingGuide } from "./snapEngine";
+
+export interface SnapGuidesState {
+  guides: SnapGuide[];
+  spacingGuides: SpacingGuide[];
+}
+
+const MAX_GUIDES = 6;
+const MAX_SPACING_GUIDES = 4;
+
+const GUIDE_COLOR = "rgba(255, 68, 204, 0.85)";
+const SPACING_COLOR = "rgba(255, 68, 204, 0.6)";
+const SPACING_BG = "rgba(255, 68, 204, 0.15)";
+
+interface SnapGuideOverlayProps {
+  snapGuidesRef: RefObject<SnapGuidesState | null>;
+  overlayWidth: number;
+  overlayHeight: number;
+}
+
+export const SnapGuideOverlay = memo(function SnapGuideOverlay({
+  snapGuidesRef,
+  overlayWidth,
+  overlayHeight,
+}: SnapGuideOverlayProps) {
+  const guideElsRef = useRef<(HTMLDivElement | null)[]>([]);
+  const spacingElsRef = useRef<(HTMLDivElement | null)[]>([]);
+  const spacingLabelElsRef = useRef<(HTMLSpanElement | null)[]>([]);
+  const overlayWidthRef = useRef(overlayWidth);
+  overlayWidthRef.current = overlayWidth;
+  const overlayHeightRef = useRef(overlayHeight);
+  overlayHeightRef.current = overlayHeight;
+
+  useMountEffect(() => {
+    let frame = 0;
+
+    // fallow-ignore-next-line complexity
+    const update = () => {
+      frame = requestAnimationFrame(update);
+
+      const state = snapGuidesRef.current;
+      const guides = state?.guides ?? [];
+      const spacingGuides = state?.spacingGuides ?? [];
+      const w = overlayWidthRef.current;
+      const h = overlayHeightRef.current;
+
+      for (let i = 0; i < MAX_GUIDES; i++) {
+        const el = guideElsRef.current[i];
+        if (!el) continue;
+
+        const guide = guides[i];
+        if (!guide) {
+          el.style.display = "none";
+          continue;
+        }
+
+        el.style.display = "";
+        if (guide.axis === "x") {
+          el.style.left = `${guide.position}px`;
+          el.style.top = "0";
+          el.style.width = "1px";
+          el.style.height = `${h}px`;
+        } else {
+          el.style.left = "0";
+          el.style.top = `${guide.position}px`;
+          el.style.width = `${w}px`;
+          el.style.height = "1px";
+        }
+      }
+
+      for (let i = 0; i < MAX_SPACING_GUIDES; i++) {
+        const el = spacingElsRef.current[i];
+        const label = spacingLabelElsRef.current[i];
+        if (!el) continue;
+
+        const sg = spacingGuides[i];
+        if (!sg) {
+          el.style.display = "none";
+          continue;
+        }
+
+        el.style.display = "flex";
+        el.style.alignItems = "center";
+        el.style.justifyContent = "center";
+        if (sg.axis === "x") {
+          el.style.left = `${sg.position}px`;
+          el.style.top = `${sg.from}px`;
+          el.style.width = `${sg.size}px`;
+          el.style.height = `${sg.to - sg.from}px`;
+          el.style.borderLeft = `1px dashed ${SPACING_COLOR}`;
+          el.style.borderRight = `1px dashed ${SPACING_COLOR}`;
+          el.style.borderTop = "none";
+          el.style.borderBottom = "none";
+        } else {
+          el.style.left = `${sg.from}px`;
+          el.style.top = `${sg.position}px`;
+          el.style.width = `${sg.to - sg.from}px`;
+          el.style.height = `${sg.size}px`;
+          el.style.borderTop = `1px dashed ${SPACING_COLOR}`;
+          el.style.borderBottom = `1px dashed ${SPACING_COLOR}`;
+          el.style.borderLeft = "none";
+          el.style.borderRight = "none";
+        }
+
+        if (label) {
+          label.textContent = `${Math.round(sg.size)}`;
+        }
+      }
+    };
+
+    frame = requestAnimationFrame(update);
+    return () => cancelAnimationFrame(frame);
+  });
+
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+      {Array.from({ length: MAX_GUIDES }, (_, i) => (
+        <div
+          key={`guide-${i}`}
+          ref={(el) => {
+            guideElsRef.current[i] = el;
+          }}
+          style={{
+            display: "none",
+            position: "absolute",
+            backgroundColor: GUIDE_COLOR,
+            zIndex: 50,
+          }}
+        />
+      ))}
+
+      {Array.from({ length: MAX_SPACING_GUIDES }, (_, i) => (
+        <div
+          key={`spacing-${i}`}
+          ref={(el) => {
+            spacingElsRef.current[i] = el;
+          }}
+          style={{
+            display: "none",
+            position: "absolute",
+            zIndex: 50,
+          }}
+        >
+          <span
+            ref={(el) => {
+              spacingLabelElsRef.current[i] = el;
+            }}
+            style={{
+              fontSize: "10px",
+              fontFamily: "monospace",
+              color: GUIDE_COLOR,
+              backgroundColor: SPACING_BG,
+              padding: "0 3px",
+              borderRadius: "2px",
+              lineHeight: "14px",
+              whiteSpace: "nowrap",
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+});

--- a/packages/studio/src/components/editor/SnapToolbar.tsx
+++ b/packages/studio/src/components/editor/SnapToolbar.tsx
@@ -1,0 +1,160 @@
+// fallow-ignore-file unused-files
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { MagnetStraight, GridFour } from "@phosphor-icons/react";
+import { readStudioUiPreferences, writeStudioUiPreferences } from "../../utils/studioUiPreferences";
+
+const SNAP_DEFAULTS = {
+  snapEnabled: true,
+  gridVisible: false,
+  gridSpacing: 50,
+  snapToGrid: false,
+};
+
+// fallow-ignore-next-line complexity
+function readSnapPrefs() {
+  const prefs = readStudioUiPreferences();
+  return {
+    snapEnabled: prefs.snapEnabled ?? SNAP_DEFAULTS.snapEnabled,
+    gridVisible: prefs.gridVisible ?? SNAP_DEFAULTS.gridVisible,
+    gridSpacing: prefs.gridSpacing ?? SNAP_DEFAULTS.gridSpacing,
+    snapToGrid: prefs.snapToGrid ?? SNAP_DEFAULTS.snapToGrid,
+  };
+}
+
+interface SnapToolbarProps {
+  onSnapChange?: (prefs: {
+    snapEnabled: boolean;
+    gridVisible: boolean;
+    gridSpacing: number;
+    snapToGrid: boolean;
+  }) => void;
+}
+
+// fallow-ignore-next-line complexity
+export const SnapToolbar = memo(function SnapToolbar({ onSnapChange }: SnapToolbarProps) {
+  const [prefs, setPrefs] = useState(readSnapPrefs);
+  const [gridPopoverOpen, setGridPopoverOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const gridButtonRef = useRef<HTMLButtonElement>(null);
+
+  const updatePrefs = useCallback(
+    (patch: Partial<typeof prefs>) => {
+      setPrefs((prev) => {
+        const next = { ...prev, ...patch };
+        writeStudioUiPreferences(patch);
+        onSnapChange?.(next);
+        return next;
+      });
+    },
+    [onSnapChange],
+  );
+
+  const toggleSnap = useCallback(() => {
+    updatePrefs({ snapEnabled: !prefs.snapEnabled });
+  }, [prefs.snapEnabled, updatePrefs]);
+
+  const toggleGrid = useCallback(() => {
+    updatePrefs({ gridVisible: !prefs.gridVisible });
+  }, [prefs.gridVisible, updatePrefs]);
+
+  useEffect(() => {
+    // fallow-ignore-next-line complexity
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === "s" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        updatePrefs({ snapEnabled: !readSnapPrefs().snapEnabled });
+      }
+      if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        updatePrefs({ gridVisible: !readSnapPrefs().gridVisible });
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [updatePrefs]);
+
+  useEffect(() => {
+    if (!gridPopoverOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (popoverRef.current?.contains(target) || gridButtonRef.current?.contains(target)) return;
+      setGridPopoverOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [gridPopoverOpen]);
+
+  return (
+    <div className="absolute top-2 right-2 z-50 flex items-center gap-1">
+      <button
+        type="button"
+        className={`rounded-md p-1.5 transition-colors ${
+          prefs.snapEnabled
+            ? "bg-studio-accent/20 text-studio-accent"
+            : "bg-black/40 text-white/60 hover:bg-black/60 hover:text-white/80"
+        }`}
+        onClick={toggleSnap}
+        title={prefs.snapEnabled ? "Snap enabled (S)" : "Snap disabled (S)"}
+        aria-label="Toggle snap"
+      >
+        <MagnetStraight size={16} weight={prefs.snapEnabled ? "fill" : "regular"} />
+      </button>
+
+      <div className="relative">
+        <button
+          ref={gridButtonRef}
+          type="button"
+          className={`rounded-md p-1.5 transition-colors ${
+            prefs.gridVisible
+              ? "bg-studio-accent/20 text-studio-accent"
+              : "bg-black/40 text-white/60 hover:bg-black/60 hover:text-white/80"
+          }`}
+          onClick={toggleGrid}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setGridPopoverOpen((v) => !v);
+          }}
+          title={prefs.gridVisible ? "Grid visible (G)" : "Grid hidden (G)"}
+          aria-label="Toggle grid"
+        >
+          <GridFour size={16} weight={prefs.gridVisible ? "fill" : "regular"} />
+        </button>
+
+        {gridPopoverOpen && (
+          <div
+            ref={popoverRef}
+            className="absolute right-0 top-full mt-1 rounded-lg bg-neutral-800 border border-neutral-700 p-3 shadow-xl min-w-[180px]"
+          >
+            <label className="flex items-center justify-between text-xs text-white/80 mb-2">
+              <span>Grid spacing</span>
+              <input
+                type="number"
+                min={10}
+                max={500}
+                step={10}
+                value={prefs.gridSpacing}
+                onChange={(e) => {
+                  const val = Number.parseInt(e.target.value, 10);
+                  if (Number.isFinite(val) && val >= 10 && val <= 500) {
+                    updatePrefs({ gridSpacing: val });
+                  }
+                }}
+                className="w-16 rounded bg-neutral-900 border border-neutral-600 px-1.5 py-0.5 text-xs text-white text-right tabular-nums outline-none focus:border-studio-accent"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-xs text-white/80 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={prefs.snapToGrid}
+                onChange={() => updatePrefs({ snapToGrid: !prefs.snapToGrid })}
+                className="accent-studio-accent"
+              />
+              <span>Snap to grid</span>
+            </label>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/packages/studio/src/components/editor/snapEngine.test.ts
+++ b/packages/studio/src/components/editor/snapEngine.test.ts
@@ -1,0 +1,624 @@
+// fallow-ignore-file code-duplication
+import { describe, test, expect } from "vitest";
+import {
+  extractSnapTargets,
+  buildCompositionSnapTarget,
+  buildGridSnapEdges,
+  resolveSnapAdjustment,
+  resolveResizeSnapAdjustment,
+  resolveEquidistanceGuides,
+  SNAP_THRESHOLD_PX,
+  type SnapTarget,
+} from "./snapEngine";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rect(left: number, top: number, width: number, height: number) {
+  return { left, top, width, height };
+}
+
+function target(id: string, left: number, top: number, width: number, height: number): SnapTarget {
+  return {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    centerX: left + width / 2,
+    centerY: top + height / 2,
+    id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// extractSnapTargets
+// ---------------------------------------------------------------------------
+
+describe("extractSnapTargets", () => {
+  test("computes right, bottom, centerX, centerY", () => {
+    const rects = [rect(10, 20, 100, 50)];
+    const [t] = extractSnapTargets(rects, ["a"]);
+    expect(t.left).toBe(10);
+    expect(t.top).toBe(20);
+    expect(t.right).toBe(110);
+    expect(t.bottom).toBe(70);
+    expect(t.centerX).toBe(60);
+    expect(t.centerY).toBe(45);
+    expect(t.id).toBe("a");
+  });
+
+  test("handles multiple rects", () => {
+    const targets = extractSnapTargets([rect(0, 0, 10, 10), rect(50, 50, 20, 30)], ["x", "y"]);
+    expect(targets).toHaveLength(2);
+    expect(targets[1].right).toBe(70);
+    expect(targets[1].bottom).toBe(80);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCompositionSnapTarget
+// ---------------------------------------------------------------------------
+
+describe("buildCompositionSnapTarget", () => {
+  test("has id 'composition' and correct edges", () => {
+    const t = buildCompositionSnapTarget(rect(0, 0, 1920, 1080));
+    expect(t.id).toBe("composition");
+    expect(t.left).toBe(0);
+    expect(t.right).toBe(1920);
+    expect(t.centerX).toBe(960);
+    expect(t.centerY).toBe(540);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGridSnapEdges
+// ---------------------------------------------------------------------------
+
+describe("buildGridSnapEdges", () => {
+  test("generates correct grid lines", () => {
+    const { x, y } = buildGridSnapEdges(rect(0, 0, 300, 200), 100, 1);
+    // At scale=1, step=100: x lines at 100, 200 (not 0 or 300)
+    expect(x.map((e) => e.position)).toEqual([100, 200]);
+    expect(y.map((e) => e.position)).toEqual([100]);
+    expect(x[0].source).toBe("grid");
+  });
+
+  test("applies scale to grid spacing", () => {
+    const { x } = buildGridSnapEdges(rect(0, 0, 600, 100), 100, 2);
+    // step = 200, lines at 200, 400
+    expect(x.map((e) => e.position)).toEqual([200, 400]);
+  });
+
+  test("handles offset composition rect", () => {
+    const { x } = buildGridSnapEdges(rect(50, 0, 300, 100), 100, 1);
+    // Lines at 150, 250 (offset + step, offset + 2*step)
+    expect(x.map((e) => e.position)).toEqual([150, 250]);
+  });
+
+  test("returns empty for zero gridSpacing", () => {
+    const { x, y } = buildGridSnapEdges(rect(0, 0, 300, 200), 0, 1);
+    expect(x).toHaveLength(0);
+    expect(y).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSnapAdjustment — edge alignment
+// ---------------------------------------------------------------------------
+
+describe("resolveSnapAdjustment", () => {
+  const compositionTarget = target("composition", 0, 0, 1000, 800);
+
+  test("left-to-right alignment: moving left snaps to target right", () => {
+    // Target at x=200, width=100 => right edge at 300
+    // Moving rect at x=0, width=50. Propose dx=297 => proposed left=297
+    // Should snap left=300 (delta +3)
+    const t = target("a", 200, 100, 100, 100);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 100, 50, 50),
+      proposedDx: 297,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(300);
+    expect(result.guides.length).toBeGreaterThanOrEqual(1);
+    expect(result.guides[0].axis).toBe("x");
+    expect(result.guides[0].position).toBe(300);
+  });
+
+  test("right-to-left alignment: moving right snaps to target left", () => {
+    // Target at x=200. Moving rect width=50, at x=0.
+    // Proposed dx=146 => proposed right = 196. Target left=200. diff=4 within threshold.
+    const t = target("a", 200, 100, 100, 100);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 100, 50, 50),
+      proposedDx: 146,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    // Proposed right = 196, target left = 200, adjustment = +4
+    expect(result.dx).toBe(150);
+  });
+
+  test("center-to-center alignment on X axis", () => {
+    // Target center at x=250. Moving rect width=100 at x=0 => center at 50.
+    // Propose dx=198 => proposed center=248, target center=250, diff=2
+    const t = target("a", 200, 100, 100, 100);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 100, 100, 50),
+      proposedDx: 198,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(200);
+  });
+
+  test("top-to-bottom alignment", () => {
+    // Target bottom at 200. Moving top proposed at 197. Should snap to 200.
+    const t = target("a", 100, 100, 100, 100);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(100, 0, 50, 50),
+      proposedDx: 0,
+      proposedDy: 197,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dy).toBe(200);
+  });
+
+  test("center-to-center alignment on Y axis", () => {
+    // Target centerY = 150. Moving height=100 at y=0 => center=50.
+    // Propose dy=98 => proposed center=148, target center=150, diff=2
+    const t = target("a", 100, 100, 100, 100);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(100, 0, 100, 100),
+      proposedDx: 0,
+      proposedDy: 98,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dy).toBe(100);
+  });
+
+  test("composition center snap", () => {
+    // Composition center at 500, 400. Moving rect 100x100 at 0,0 => center 50,50.
+    // Propose dx=447, dy=347 => proposed center 497,397. Should snap to 500,400.
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 100, 100),
+      proposedDx: 447,
+      proposedDy: 347,
+      targets: [compositionTarget],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(450);
+    expect(result.dy).toBe(350);
+  });
+
+  test("no snap when outside threshold", () => {
+    const t = target("a", 200, 200, 100, 100);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 50, 50),
+      proposedDx: 10,
+      proposedDy: 10,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    // Moving rect edges: left=10, center=35, right=60
+    // Target edges: left=200, center=250, right=300
+    // All distances > 6
+    expect(result.dx).toBe(10);
+    expect(result.dy).toBe(10);
+    expect(result.guides).toHaveLength(0);
+  });
+
+  test("multiple matching guides at same distance", () => {
+    // Two targets with left edges at 100 — both should produce guides
+    const t1 = target("a", 100, 0, 50, 50);
+    const t2 = target("b", 100, 200, 50, 50);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 100, 50, 50),
+      proposedDx: 97,
+      proposedDy: 0,
+      targets: [t1, t2],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(100);
+    // Should have a guide at x=100
+    const xGuides = result.guides.filter((g) => g.axis === "x");
+    expect(xGuides.length).toBeGreaterThanOrEqual(1);
+    expect(xGuides[0].position).toBe(100);
+    // The guide extent should cover both targets and the moving rect
+    expect(xGuides[0].from).toBe(0); // t1 top
+    expect(xGuides[0].to).toBe(250); // t2 bottom
+  });
+
+  test("disabled=true returns passthrough", () => {
+    const t = target("a", 100, 100, 50, 50);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 50, 50),
+      proposedDx: 98,
+      proposedDy: 98,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: true,
+    });
+    expect(result.dx).toBe(98);
+    expect(result.dy).toBe(98);
+    expect(result.guides).toHaveLength(0);
+  });
+
+  test("threshold=0 means no snap", () => {
+    const t = target("a", 100, 100, 50, 50);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 50, 50),
+      proposedDx: 99,
+      proposedDy: 99,
+      targets: [t],
+      threshold: 0,
+      disabled: false,
+    });
+    expect(result.dx).toBe(99);
+    expect(result.dy).toBe(99);
+    expect(result.guides).toHaveLength(0);
+  });
+
+  test("element snap takes priority over grid snap", () => {
+    // Element left edge at 100. Grid line at 97.
+    // Moving rect proposed left at 98 => dist to element=2, dist to grid=1.
+    // Grid is closer but element should win (priority).
+    // Actually the spec says element takes priority when both match within threshold.
+    // Let's set up: element at 103, grid at 97. Moving proposed left=100.
+    // Dist to element=3, dist to grid=3. Element should win.
+    const t = target("a", 103, 100, 50, 50);
+    const gridEdges = {
+      x: [{ position: 97, source: "grid" as const, id: "grid-x-0" }],
+      y: [],
+    };
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 100, 50, 50),
+      proposedDx: 100,
+      proposedDy: 0,
+      targets: [t],
+      gridEdges,
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    // Element at 103 wins over grid at 97 (both within threshold, same distance)
+    expect(result.dx).toBe(103);
+  });
+
+  test("grid snap used when no element matches", () => {
+    const gridEdges = {
+      x: [{ position: 100, source: "grid" as const, id: "grid-x-0" }],
+      y: [],
+    };
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 50, 50),
+      proposedDx: 97,
+      proposedDy: 10,
+      targets: [],
+      gridEdges,
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(100);
+  });
+
+  test("snaps X and Y independently", () => {
+    const t = target("a", 200, 300, 100, 100);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 100, 100),
+      proposedDx: 198,
+      proposedDy: 500,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    // X should snap (left-to-left, diff=2), Y should not snap (too far)
+    expect(result.dx).toBe(200);
+    expect(result.dy).toBe(500);
+  });
+
+  test("works correctly with many targets (80)", () => {
+    const targets: SnapTarget[] = [];
+    for (let i = 0; i < 80; i++) {
+      targets.push(target(`el-${i}`, i * 50, i * 30, 40, 20));
+    }
+    // Moving rect near target el-40: left=2000, top=1200
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 40, 20),
+      proposedDx: 1998,
+      proposedDy: 1198,
+      targets,
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(2000);
+    expect(result.dy).toBe(1200);
+    expect(result.guides.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveResizeSnapAdjustment
+// ---------------------------------------------------------------------------
+
+describe("resolveResizeSnapAdjustment", () => {
+  test("only right edge snaps on X", () => {
+    // Moving rect at (100, 100) size 50x50, right=150.
+    // Target left at 200. Propose dx=47 => proposed right=197. Dist to 200=3.
+    const t = target("a", 200, 100, 100, 100);
+    const result = resolveResizeSnapAdjustment({
+      movingRect: rect(100, 100, 50, 50),
+      proposedDx: 47,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(50); // right edge snaps to 200
+  });
+
+  test("only bottom edge snaps on Y", () => {
+    // Moving rect at (100, 100) size 50x50, bottom=150.
+    // Target top at 200. Propose dy=47 => proposed bottom=197. Dist to 200=3.
+    const t = target("a", 100, 200, 100, 100);
+    const result = resolveResizeSnapAdjustment({
+      movingRect: rect(100, 100, 50, 50),
+      proposedDx: 0,
+      proposedDy: 47,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dy).toBe(50); // bottom edge snaps to 200
+  });
+
+  test("left edge does NOT snap during resize", () => {
+    // Target right at 150. Moving rect left=100. If drag were active,
+    // left would snap. But during resize, only right edge snaps.
+    // Moving rect at (100, 100) size 200x200, right=300.
+    // Target right=150. Proposed dx=-153 => proposed right=147. Dist to 150=3.
+    // This SHOULD snap right to 150 (dx = -150). But left stays at 100.
+    const t = target("a", 50, 100, 100, 100); // right=150
+    const result = resolveResizeSnapAdjustment({
+      movingRect: rect(100, 100, 200, 200),
+      proposedDx: -153,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    // Right edge: 300 + (-153) = 147 => snaps to 150, adjustment = +3, dx = -150
+    expect(result.dx).toBe(-150);
+  });
+
+  test("disabled=true returns passthrough for resize", () => {
+    const t = target("a", 200, 200, 100, 100);
+    const result = resolveResizeSnapAdjustment({
+      movingRect: rect(100, 100, 50, 50),
+      proposedDx: 47,
+      proposedDy: 47,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: true,
+    });
+    expect(result.dx).toBe(47);
+    expect(result.dy).toBe(47);
+    expect(result.guides).toHaveLength(0);
+  });
+
+  test("resize produces guide lines", () => {
+    const t = target("a", 200, 100, 100, 100);
+    const result = resolveResizeSnapAdjustment({
+      movingRect: rect(100, 100, 50, 50),
+      proposedDx: 47,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.guides.length).toBeGreaterThanOrEqual(1);
+    const xGuide = result.guides.find((g) => g.axis === "x");
+    expect(xGuide).toBeDefined();
+    expect(xGuide!.position).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEquidistanceGuides
+// ---------------------------------------------------------------------------
+
+describe("resolveEquidistanceGuides", () => {
+  test("detects equal horizontal spacing", () => {
+    // Three elements in a row: A(0..40), moving(70..110), B(140..180)
+    // Gap A-moving = 70 - 40 = 30, gap moving-B = 140 - 110 = 30 => equal
+    const targets = [target("a", 0, 0, 40, 40), target("b", 140, 0, 40, 40)];
+    const guides = resolveEquidistanceGuides({
+      movingRect: rect(70, 0, 40, 40),
+      targets,
+      threshold: SNAP_THRESHOLD_PX,
+    });
+    const xGuides = guides.filter((g) => g.axis === "x");
+    expect(xGuides.length).toBe(2);
+    expect(xGuides[0].size).toBe(30);
+    expect(xGuides[1].size).toBe(30);
+  });
+
+  test("detects equal vertical spacing", () => {
+    // A(y=0..40), moving(y=60..100), B(y=120..160)
+    // Gap = 20 each
+    const targets = [target("a", 0, 0, 40, 40), target("b", 0, 120, 40, 40)];
+    const guides = resolveEquidistanceGuides({
+      movingRect: rect(0, 60, 40, 40),
+      targets,
+      threshold: SNAP_THRESHOLD_PX,
+    });
+    const yGuides = guides.filter((g) => g.axis === "y");
+    expect(yGuides.length).toBe(2);
+    expect(yGuides[0].size).toBe(20);
+  });
+
+  test("no equidistance when gaps differ", () => {
+    // A(0..40), moving(80..120), B(200..240)
+    // Gap A-moving = 40, gap moving-B = 80 => not equal
+    const targets = [target("a", 0, 0, 40, 40), target("b", 200, 0, 40, 40)];
+    const guides = resolveEquidistanceGuides({
+      movingRect: rect(80, 0, 40, 40),
+      targets,
+      threshold: SNAP_THRESHOLD_PX,
+    });
+    const xGuides = guides.filter((g) => g.axis === "x");
+    expect(xGuides.length).toBe(0);
+  });
+
+  test("handles tolerance of 1px", () => {
+    // A(0..40), moving(70..110), B(139..179)
+    // Gap A-moving = 30, gap moving-B = 29 => difference = 1 => within tolerance
+    const targets = [target("a", 0, 0, 40, 40), target("b", 139, 0, 40, 40)];
+    const guides = resolveEquidistanceGuides({
+      movingRect: rect(70, 0, 40, 40),
+      targets,
+      threshold: SNAP_THRESHOLD_PX,
+    });
+    const xGuides = guides.filter((g) => g.axis === "x");
+    expect(xGuides.length).toBe(2);
+  });
+
+  test("ignores overlapping elements", () => {
+    // A(0..100), moving(50..150), B(200..300) — A and moving overlap
+    const targets = [target("a", 0, 0, 100, 40), target("b", 200, 0, 100, 40)];
+    const guides = resolveEquidistanceGuides({
+      movingRect: rect(50, 0, 100, 40),
+      targets,
+      threshold: SNAP_THRESHOLD_PX,
+    });
+    const xGuides = guides.filter((g) => g.axis === "x");
+    // Gap A-moving = 50 - 100 = -50 (overlap), should be skipped
+    expect(xGuides.length).toBe(0);
+  });
+
+  test("only reports triplets involving the moving rect", () => {
+    // A(0..40), B(60..100), C(120..160) — all gaps = 20 but none involves moving
+    // Moving rect is far away at (500..540)
+    const targets = [
+      target("a", 0, 0, 40, 40),
+      target("b", 60, 0, 40, 40),
+      target("c", 120, 0, 40, 40),
+    ];
+    const guides = resolveEquidistanceGuides({
+      movingRect: rect(500, 0, 40, 40),
+      targets,
+      threshold: SNAP_THRESHOLD_PX,
+    });
+    // The A-B-C triplet doesn't involve moving, so no guides from it
+    // Any triplet involving moving would have huge gaps that don't match
+    const xGuides = guides.filter((g) => g.axis === "x");
+    expect(xGuides.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("edge cases", () => {
+  test("empty targets returns passthrough", () => {
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 50, 50),
+      proposedDx: 10,
+      proposedDy: 20,
+      targets: [],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(10);
+    expect(result.dy).toBe(20);
+    expect(result.guides).toHaveLength(0);
+  });
+
+  test("exact match (zero distance) produces snap", () => {
+    const t = target("a", 100, 100, 50, 50);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 50, 50),
+      proposedDx: 100,
+      proposedDy: 100,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(100);
+    expect(result.dy).toBe(100);
+    expect(result.guides.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("negative proposed delta works", () => {
+    const t = target("a", 50, 50, 100, 100);
+    // Moving rect at (200, 200), propose dx=-148 => proposed left=52, target left=50, diff=2
+    const result = resolveSnapAdjustment({
+      movingRect: rect(200, 200, 50, 50),
+      proposedDx: -148,
+      proposedDy: -148,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(-150);
+    expect(result.dy).toBe(-150);
+  });
+
+  test("left-to-left alignment", () => {
+    const t = target("a", 100, 0, 200, 200);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 300, 80, 80),
+      proposedDx: 97,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(100);
+  });
+
+  test("right-to-right alignment", () => {
+    // Target right = 300. Moving rect width=80 at x=0, right=80.
+    // Propose dx=217 => proposed right=297, target right=300, diff=3.
+    const t = target("a", 100, 0, 200, 200);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 300, 80, 80),
+      proposedDx: 217,
+      proposedDy: 0,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dx).toBe(220); // proposed left=220, proposed right=300
+  });
+
+  test("bottom-to-bottom alignment", () => {
+    // Target bottom = 200. Moving rect height=50 at y=0, bottom=50.
+    // Propose dy=147 => proposed bottom=197, target bottom=200, diff=3.
+    const t = target("a", 0, 0, 200, 200);
+    const result = resolveSnapAdjustment({
+      movingRect: rect(0, 0, 50, 50),
+      proposedDx: 0,
+      proposedDy: 147,
+      targets: [t],
+      threshold: SNAP_THRESHOLD_PX,
+      disabled: false,
+    });
+    expect(result.dy).toBe(150);
+  });
+});

--- a/packages/studio/src/components/editor/snapEngine.ts
+++ b/packages/studio/src/components/editor/snapEngine.ts
@@ -1,0 +1,580 @@
+// fallow-ignore-file code-duplication
+// Snap computation engine — pure functions, zero React/DOM dependencies.
+// All position values are in overlay-space (screen) pixels.
+
+export const SNAP_THRESHOLD_PX = 6;
+const EQUIDISTANCE_TOLERANCE_PX = 1;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SnapEdge {
+  position: number;
+  source: "element" | "composition" | "grid";
+  id: string;
+}
+
+export interface SnapTarget {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  centerX: number;
+  centerY: number;
+  id: string;
+}
+
+export interface SnapGuide {
+  axis: "x" | "y";
+  position: number;
+  /** Extent of the guide line (min of involved elements). */
+  from: number;
+  /** Extent of the guide line (max of involved elements). */
+  to: number;
+}
+
+export interface SpacingGuide {
+  axis: "x" | "y";
+  /** Position of the gap (start of gap). */
+  position: number;
+  /** Size of the gap in pixels. */
+  size: number;
+  /** Extent for rendering the indicator. */
+  from: number;
+  /** Extent for rendering the indicator. */
+  to: number;
+}
+
+export interface SnapResult {
+  dx: number;
+  dy: number;
+  guides: SnapGuide[];
+  spacingGuides: SpacingGuide[];
+}
+
+// ---------------------------------------------------------------------------
+// Rect shorthand used across the public API
+// ---------------------------------------------------------------------------
+
+interface Rect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rectRight(r: Rect): number {
+  return r.left + r.width;
+}
+
+function rectBottom(r: Rect): number {
+  return r.top + r.height;
+}
+
+function rectCenterX(r: Rect): number {
+  return r.left + r.width / 2;
+}
+
+function rectCenterY(r: Rect): number {
+  return r.top + r.height / 2;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert overlay rects to snap targets with precomputed edges & centers.
+ */
+export function extractSnapTargets(rects: Rect[], ids: string[]): SnapTarget[] {
+  const targets: SnapTarget[] = [];
+  for (let i = 0; i < rects.length; i++) {
+    const r = rects[i];
+    targets.push({
+      left: r.left,
+      top: r.top,
+      right: rectRight(r),
+      bottom: rectBottom(r),
+      centerX: rectCenterX(r),
+      centerY: rectCenterY(r),
+      id: ids[i],
+    });
+  }
+  return targets;
+}
+
+/**
+ * Create a snap target from the composition/overlay boundary.
+ */
+export function buildCompositionSnapTarget(rect: Rect): SnapTarget {
+  return {
+    left: rect.left,
+    top: rect.top,
+    right: rectRight(rect),
+    bottom: rectBottom(rect),
+    centerX: rectCenterX(rect),
+    centerY: rectCenterY(rect),
+    id: "composition",
+  };
+}
+
+/**
+ * Generate grid-line snap edges.
+ * `gridSpacing` is in composition pixels; `scale` converts to overlay pixels.
+ * X edges are vertical grid lines; Y edges are horizontal grid lines.
+ */
+export function buildGridSnapEdges(
+  compositionRect: Rect,
+  gridSpacing: number,
+  scale: number,
+): { x: SnapEdge[]; y: SnapEdge[] } {
+  const xEdges: SnapEdge[] = [];
+  const yEdges: SnapEdge[] = [];
+
+  if (gridSpacing <= 0 || scale <= 0) return { x: xEdges, y: yEdges };
+
+  const step = gridSpacing * scale;
+
+  // Vertical grid lines (x-axis edges)
+  let x = compositionRect.left + step;
+  const xMax = compositionRect.left + compositionRect.width;
+  let idx = 0;
+  while (x < xMax) {
+    xEdges.push({ position: x, source: "grid", id: `grid-x-${idx}` });
+    x += step;
+    idx++;
+  }
+
+  // Horizontal grid lines (y-axis edges)
+  let y = compositionRect.top + step;
+  const yMax = compositionRect.top + compositionRect.height;
+  idx = 0;
+  while (y < yMax) {
+    yEdges.push({ position: y, source: "grid", id: `grid-y-${idx}` });
+    y += step;
+    idx++;
+  }
+
+  return { x: xEdges, y: yEdges };
+}
+
+// ---------------------------------------------------------------------------
+// Internal snap resolution helpers
+// ---------------------------------------------------------------------------
+
+interface EdgeCandidate {
+  /** Distance the moving rect must adjust to align with this edge. */
+  adjustment: number;
+  /** Absolute distance (for comparison). */
+  distance: number;
+  /** Position of the guide line. */
+  guidePosition: number;
+  /** Source of the match. */
+  source: "element" | "composition" | "grid";
+  /** Id of the target or grid line. */
+  targetId: string;
+}
+
+/**
+ * Collect edge candidates on a single axis for a moving rect.
+ * `movingEdges` are the edges of the moving rect (e.g. left, centerX, right).
+ * `targetEdges` are the corresponding edges on each target.
+ */
+// fallow-ignore-next-line complexity
+function collectCandidates(
+  movingEdges: number[],
+  targets: SnapTarget[],
+  targetEdgeExtractor: (t: SnapTarget) => number[],
+  gridEdges: SnapEdge[] | undefined,
+  threshold: number,
+): EdgeCandidate[] {
+  const candidates: EdgeCandidate[] = [];
+
+  for (const target of targets) {
+    const tEdges = targetEdgeExtractor(target);
+    for (const mEdge of movingEdges) {
+      for (const tEdge of tEdges) {
+        const adjustment = tEdge - mEdge;
+        const distance = Math.abs(adjustment);
+        if (distance <= threshold) {
+          candidates.push({
+            adjustment,
+            distance,
+            guidePosition: tEdge,
+            source: target.id === "composition" ? "composition" : "element",
+            targetId: target.id,
+          });
+        }
+      }
+    }
+  }
+
+  if (gridEdges) {
+    for (const edge of gridEdges) {
+      for (const mEdge of movingEdges) {
+        const adjustment = edge.position - mEdge;
+        const distance = Math.abs(adjustment);
+        if (distance <= threshold) {
+          candidates.push({
+            adjustment,
+            distance,
+            guidePosition: edge.position,
+            source: "grid",
+            targetId: edge.id,
+          });
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * From a list of candidates, pick the best adjustment:
+ * - Element/composition matches take priority over grid matches.
+ * - Among equal-priority matches, pick the smallest distance.
+ * - Return all guides that share the winning adjustment.
+ */
+function pickBest(candidates: EdgeCandidate[]): {
+  adjustment: number;
+  matches: EdgeCandidate[];
+} | null {
+  if (candidates.length === 0) return null;
+
+  // Partition into element/composition vs grid
+  const elementCandidates = candidates.filter(
+    (c) => c.source === "element" || c.source === "composition",
+  );
+  const gridCandidates = candidates.filter((c) => c.source === "grid");
+
+  // Pick the pool with the best (smallest distance) match, preferring element
+  let pool: EdgeCandidate[];
+  const bestElem = elementCandidates.length
+    ? Math.min(...elementCandidates.map((c) => c.distance))
+    : Infinity;
+  const bestGrid = gridCandidates.length
+    ? Math.min(...gridCandidates.map((c) => c.distance))
+    : Infinity;
+
+  if (bestElem <= bestGrid) {
+    pool = elementCandidates;
+  } else {
+    pool = gridCandidates;
+  }
+
+  const minDist = Math.min(...pool.map((c) => c.distance));
+  const winners = pool.filter((c) => c.distance === minDist);
+
+  // All winners share the same adjustment magnitude but could differ in sign
+  // if two edges snap at the same distance in opposite directions. Pick the
+  // adjustment from the first winner (they're all at minDist).
+  const adjustment = winners[0].adjustment;
+
+  // Return all matches at this exact adjustment (same direction)
+  const matches = pool.filter((c) => c.adjustment === adjustment);
+  return { adjustment, matches };
+}
+
+// ---------------------------------------------------------------------------
+// Guide extent computation
+// ---------------------------------------------------------------------------
+
+function computeGuideExtent(
+  axis: "x" | "y",
+  guidePosition: number,
+  movingRect: Rect,
+  matchedTargetIds: string[],
+  allTargets: SnapTarget[],
+): { from: number; to: number } {
+  // Collect cross-axis extents from the moving rect and matched targets
+  const extents: number[] = [];
+
+  if (axis === "x") {
+    // Guide is vertical — extent runs along Y
+    extents.push(movingRect.top, rectBottom(movingRect));
+    for (const tid of matchedTargetIds) {
+      const t = allTargets.find((tgt) => tgt.id === tid);
+      if (t) {
+        extents.push(t.top, t.bottom);
+      }
+    }
+  } else {
+    // Guide is horizontal — extent runs along X
+    extents.push(movingRect.left, rectRight(movingRect));
+    for (const tid of matchedTargetIds) {
+      const t = allTargets.find((tgt) => tgt.id === tid);
+      if (t) {
+        extents.push(t.left, t.right);
+      }
+    }
+  }
+
+  return { from: Math.min(...extents), to: Math.max(...extents) };
+}
+
+// ---------------------------------------------------------------------------
+// Shared guide-building logic
+// ---------------------------------------------------------------------------
+
+function buildGuidesFromMatches(
+  bestX: { adjustment: number; matches: EdgeCandidate[] } | null,
+  bestY: { adjustment: number; matches: EdgeCandidate[] } | null,
+  adjustedRect: Rect,
+  allTargets: SnapTarget[],
+): SnapGuide[] {
+  const guides: SnapGuide[] = [];
+
+  for (const [axis, best] of [
+    ["x", bestX],
+    ["y", bestY],
+  ] as const) {
+    if (!best) continue;
+    const seenPositions = new Set<number>();
+    for (const m of best.matches) {
+      if (seenPositions.has(m.guidePosition)) continue;
+      seenPositions.add(m.guidePosition);
+      const targetIds = best.matches
+        .filter((mm) => mm.guidePosition === m.guidePosition)
+        .map((mm) => mm.targetId);
+      const extent = computeGuideExtent(axis, m.guidePosition, adjustedRect, targetIds, allTargets);
+      guides.push({ axis, position: m.guidePosition, from: extent.from, to: extent.to });
+    }
+  }
+
+  return guides;
+}
+
+const DISABLED_RESULT = (dx: number, dy: number): SnapResult => ({
+  dx,
+  dy,
+  guides: [],
+  spacingGuides: [],
+});
+
+// ---------------------------------------------------------------------------
+// resolveSnapAdjustment — main drag snap entry point
+// ---------------------------------------------------------------------------
+
+// fallow-ignore-next-line complexity
+export function resolveSnapAdjustment(input: {
+  movingRect: Rect;
+  proposedDx: number;
+  proposedDy: number;
+  targets: SnapTarget[];
+  gridEdges?: { x: SnapEdge[]; y: SnapEdge[] };
+  threshold: number;
+  disabled: boolean;
+}): SnapResult {
+  if (input.disabled || input.threshold <= 0) {
+    return DISABLED_RESULT(input.proposedDx, input.proposedDy);
+  }
+
+  const mr = input.movingRect;
+  const proposed: Rect = {
+    left: mr.left + input.proposedDx,
+    top: mr.top + input.proposedDy,
+    width: mr.width,
+    height: mr.height,
+  };
+
+  const xCandidates = collectCandidates(
+    [proposed.left, rectCenterX(proposed), rectRight(proposed)],
+    input.targets,
+    (t) => [t.left, t.centerX, t.right],
+    input.gridEdges?.x,
+    input.threshold,
+  );
+  const yCandidates = collectCandidates(
+    [proposed.top, rectCenterY(proposed), rectBottom(proposed)],
+    input.targets,
+    (t) => [t.top, t.centerY, t.bottom],
+    input.gridEdges?.y,
+    input.threshold,
+  );
+
+  const bestX = pickBest(xCandidates);
+  const bestY = pickBest(yCandidates);
+  const adjustedDx = input.proposedDx + (bestX?.adjustment ?? 0);
+  const adjustedDy = input.proposedDy + (bestY?.adjustment ?? 0);
+
+  const adjustedRect: Rect = {
+    left: mr.left + adjustedDx,
+    top: mr.top + adjustedDy,
+    width: mr.width,
+    height: mr.height,
+  };
+
+  return {
+    dx: adjustedDx,
+    dy: adjustedDy,
+    guides: buildGuidesFromMatches(bestX, bestY, adjustedRect, input.targets),
+    spacingGuides: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveResizeSnapAdjustment — resize variant (only right/bottom snap)
+// ---------------------------------------------------------------------------
+
+// fallow-ignore-next-line complexity
+export function resolveResizeSnapAdjustment(input: {
+  movingRect: Rect;
+  proposedDx: number;
+  proposedDy: number;
+  targets: SnapTarget[];
+  gridEdges?: { x: SnapEdge[]; y: SnapEdge[] };
+  threshold: number;
+  disabled: boolean;
+}): SnapResult {
+  if (input.disabled || input.threshold <= 0) {
+    return DISABLED_RESULT(input.proposedDx, input.proposedDy);
+  }
+
+  const mr = input.movingRect;
+  const proposedRight = rectRight(mr) + input.proposedDx;
+  const proposedBottom = rectBottom(mr) + input.proposedDy;
+
+  const xCandidates = collectCandidates(
+    [proposedRight],
+    input.targets,
+    (t) => [t.left, t.centerX, t.right],
+    input.gridEdges?.x,
+    input.threshold,
+  );
+  const yCandidates = collectCandidates(
+    [proposedBottom],
+    input.targets,
+    (t) => [t.top, t.centerY, t.bottom],
+    input.gridEdges?.y,
+    input.threshold,
+  );
+
+  const bestX = pickBest(xCandidates);
+  const bestY = pickBest(yCandidates);
+  const adjustedDx = input.proposedDx + (bestX?.adjustment ?? 0);
+  const adjustedDy = input.proposedDy + (bestY?.adjustment ?? 0);
+
+  const adjustedRect: Rect = {
+    left: mr.left,
+    top: mr.top,
+    width: mr.width + adjustedDx,
+    height: mr.height + adjustedDy,
+  };
+
+  return {
+    dx: adjustedDx,
+    dy: adjustedDy,
+    guides: buildGuidesFromMatches(bestX, bestY, adjustedRect, input.targets),
+    spacingGuides: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveEquidistanceGuides
+// ---------------------------------------------------------------------------
+
+// fallow-ignore-next-line complexity
+export function resolveEquidistanceGuides(input: {
+  movingRect: Rect;
+  targets: SnapTarget[];
+  threshold: number;
+}): SpacingGuide[] {
+  const guides: SpacingGuide[] = [];
+  const mr = input.movingRect;
+
+  const movingTarget: SnapTarget = {
+    left: mr.left,
+    top: mr.top,
+    right: rectRight(mr),
+    bottom: rectBottom(mr),
+    centerX: rectCenterX(mr),
+    centerY: rectCenterY(mr),
+    id: "__moving__",
+  };
+
+  const allTargets = [...input.targets, movingTarget];
+
+  // X axis: sort by centerX, scan for equal gaps between adjacent triplets
+  const sortedX = [...allTargets].sort((a, b) => a.centerX - b.centerX);
+  for (let i = 0; i < sortedX.length - 2; i++) {
+    const a = sortedX[i];
+    const b = sortedX[i + 1];
+    const c = sortedX[i + 2];
+
+    // Gap between A and B = B.left - A.right
+    const gapAB = b.left - a.right;
+    const gapBC = c.left - b.right;
+
+    if (gapAB < 0 || gapBC < 0) continue; // overlapping elements
+
+    // Check if the moving rect is one of A, B, or C
+    const involvesMoving = a.id === "__moving__" || b.id === "__moving__" || c.id === "__moving__";
+    if (!involvesMoving) continue;
+
+    if (Math.abs(gapAB - gapBC) <= EQUIDISTANCE_TOLERANCE_PX) {
+      const crossMin = Math.min(a.top, b.top, c.top);
+      const crossMax = Math.max(a.bottom, b.bottom, c.bottom);
+
+      // Gap A-B
+      guides.push({
+        axis: "x",
+        position: a.right,
+        size: gapAB,
+        from: crossMin,
+        to: crossMax,
+      });
+      // Gap B-C
+      guides.push({
+        axis: "x",
+        position: b.right,
+        size: gapBC,
+        from: crossMin,
+        to: crossMax,
+      });
+    }
+  }
+
+  // Y axis: sort by centerY, scan for equal gaps between adjacent triplets
+  const sortedY = [...allTargets].sort((a, b) => a.centerY - b.centerY);
+  for (let i = 0; i < sortedY.length - 2; i++) {
+    const a = sortedY[i];
+    const b = sortedY[i + 1];
+    const c = sortedY[i + 2];
+
+    const gapAB = b.top - a.bottom;
+    const gapBC = c.top - b.bottom;
+
+    if (gapAB < 0 || gapBC < 0) continue;
+
+    const involvesMoving = a.id === "__moving__" || b.id === "__moving__" || c.id === "__moving__";
+    if (!involvesMoving) continue;
+
+    if (Math.abs(gapAB - gapBC) <= EQUIDISTANCE_TOLERANCE_PX) {
+      const crossMin = Math.min(a.left, b.left, c.left);
+      const crossMax = Math.max(a.right, b.right, c.right);
+
+      guides.push({
+        axis: "y",
+        position: a.bottom,
+        size: gapAB,
+        from: crossMin,
+        to: crossMax,
+      });
+      guides.push({
+        axis: "y",
+        position: b.bottom,
+        size: gapBC,
+        from: crossMin,
+        to: crossMax,
+      });
+    }
+  }
+
+  return guides;
+}

--- a/packages/studio/src/components/editor/snapTargetCollection.ts
+++ b/packages/studio/src/components/editor/snapTargetCollection.ts
@@ -1,0 +1,141 @@
+// fallow-ignore-file unused-files
+// fallow-ignore-file code-duplication
+import type { DomEditSelection } from "./domEditing";
+import {
+  isElementVisibleForOverlay,
+  toOverlayRect,
+  type OverlayRect,
+} from "./domEditOverlayGeometry";
+import {
+  extractSnapTargets,
+  buildCompositionSnapTarget,
+  buildGridSnapEdges,
+  type SnapTarget,
+  type SnapEdge,
+} from "./snapEngine";
+import { readStudioUiPreferences } from "../../utils/studioUiPreferences";
+
+export interface SnapContext {
+  targets: SnapTarget[];
+  compositionTarget: SnapTarget | null;
+  gridEdges: { x: SnapEdge[]; y: SnapEdge[] } | null;
+  snapEnabled: boolean;
+}
+
+function readPositiveDimension(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+const IGNORED_TAGS = new Set(["script", "style", "link", "meta", "base", "template", "br", "wbr"]);
+
+function isHtmlElement(node: Node): node is HTMLElement {
+  return node.nodeType === 1;
+}
+
+function collectVisibleElements(
+  root: HTMLElement,
+  excludeElements: Set<HTMLElement>,
+  maxItems: number,
+): HTMLElement[] {
+  const result: HTMLElement[] = [];
+  const visit = (el: HTMLElement) => {
+    if (result.length >= maxItems) return;
+    for (const child of Array.from(el.children)) {
+      if (!isHtmlElement(child)) continue;
+      if (IGNORED_TAGS.has(child.tagName.toLowerCase())) continue;
+      if (child.hasAttribute("data-composition-id")) continue;
+      if (excludeElements.has(child)) continue;
+      if (!isElementVisibleForOverlay(child)) continue;
+      result.push(child);
+      visit(child);
+    }
+  };
+  visit(root);
+  return result;
+}
+
+// fallow-ignore-next-line complexity
+export function collectSnapContext(input: {
+  overlayEl: HTMLDivElement;
+  iframe: HTMLIFrameElement;
+  excludeElements: Set<HTMLElement>;
+}): SnapContext {
+  const prefs = readStudioUiPreferences();
+  const snapEnabled = prefs.snapEnabled ?? true;
+
+  const doc = input.iframe.contentDocument;
+  if (!doc) {
+    return { targets: [], compositionTarget: null, gridEdges: null, snapEnabled };
+  }
+
+  const root =
+    doc.querySelector<HTMLElement>("[data-composition-id]") ?? (doc.documentElement as HTMLElement);
+  const rootRect = root?.getBoundingClientRect();
+  const declaredWidth = readPositiveDimension(root?.getAttribute("data-width") ?? null);
+  const declaredHeight = readPositiveDimension(root?.getAttribute("data-height") ?? null);
+  const rootWidth = declaredWidth ?? rootRect?.width;
+  const rootHeight = declaredHeight ?? rootRect?.height;
+
+  if (!rootWidth || !rootHeight || !rootRect) {
+    return { targets: [], compositionTarget: null, gridEdges: null, snapEnabled };
+  }
+
+  const iframeRect = input.iframe.getBoundingClientRect();
+  const overlayRect = input.overlayEl.getBoundingClientRect();
+  const rootScaleX = iframeRect.width / rootWidth;
+  const rootScaleY = iframeRect.height / rootHeight;
+
+  const compositionOverlayRect: OverlayRect = {
+    left: iframeRect.left - overlayRect.left,
+    top: iframeRect.top - overlayRect.top,
+    width: iframeRect.width,
+    height: iframeRect.height,
+    editScaleX: rootScaleX,
+    editScaleY: rootScaleY,
+  };
+  const compositionTarget = buildCompositionSnapTarget(compositionOverlayRect);
+
+  const elements = collectVisibleElements(root, input.excludeElements, 80);
+
+  const rects: Array<{ left: number; top: number; width: number; height: number }> = [];
+  const ids: string[] = [];
+
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i];
+    const rect = toOverlayRect(input.overlayEl, input.iframe, el);
+    if (!rect) continue;
+    rects.push(rect);
+    ids.push(`snap-target-${i}`);
+  }
+
+  const targets = extractSnapTargets(rects, ids);
+
+  let gridEdges: { x: SnapEdge[]; y: SnapEdge[] } | null = null;
+  const gridSpacing = prefs.gridSpacing ?? 50;
+  const snapToGrid = prefs.snapToGrid ?? false;
+  if (snapToGrid && gridSpacing > 0) {
+    gridEdges = buildGridSnapEdges(compositionOverlayRect, gridSpacing, rootScaleX);
+  }
+
+  return { targets, compositionTarget, gridEdges, snapEnabled };
+}
+
+export function buildExcludeElements(input: {
+  iframe: HTMLIFrameElement;
+  selection?: DomEditSelection | null;
+  groupSelections?: DomEditSelection[];
+}): Set<HTMLElement> {
+  const elements = new Set<HTMLElement>();
+  const sel = input.selection;
+  if (sel?.element) {
+    elements.add(sel.element);
+  }
+  if (input.groupSelections) {
+    for (const gs of input.groupSelections) {
+      if (gs.element) elements.add(gs.element);
+    }
+  }
+  return elements;
+}

--- a/packages/studio/src/utils/studioUiPreferences.ts
+++ b/packages/studio/src/utils/studioUiPreferences.ts
@@ -11,6 +11,10 @@ export interface StudioUiPreferences {
   audioMuted?: boolean;
   previewZoom?: StoredPreviewZoomState;
   recentBlocks?: string[];
+  snapEnabled?: boolean;
+  gridVisible?: boolean;
+  gridSpacing?: number;
+  snapToGrid?: boolean;
 }
 
 const STUDIO_UI_PREFERENCES_KEY = "hf-studio-ui-preferences";
@@ -28,6 +32,7 @@ function getBrowserStorage(): Storage | null {
   }
 }
 
+// fallow-ignore-next-line complexity
 function readStorage(storage: Storage | null): StudioUiPreferences {
   if (!storage) return {};
   try {
@@ -66,6 +71,18 @@ function readStorage(storage: Storage | null): StudioUiPreferences {
       preferences.recentBlocks = parsed.recentBlocks.filter(
         (v: unknown): v is string => typeof v === "string",
       );
+    }
+    if (typeof parsed.snapEnabled === "boolean") {
+      preferences.snapEnabled = parsed.snapEnabled;
+    }
+    if (typeof parsed.gridVisible === "boolean") {
+      preferences.gridVisible = parsed.gridVisible;
+    }
+    if (typeof parsed.gridSpacing === "number" && Number.isFinite(parsed.gridSpacing)) {
+      preferences.gridSpacing = parsed.gridSpacing;
+    }
+    if (typeof parsed.snapToGrid === "boolean") {
+      preferences.snapToGrid = parsed.snapToGrid;
     }
     return preferences;
   } catch {


### PR DESCRIPTION
## Summary

Pure modules for the snap/grid system — no wiring into gesture handlers.

- `snapEngine.ts`: stateless snap computation (resolveSnapAdjustment, resolveResizeSnapAdjustment, resolveEquidistanceGuides)
- `snapTargetCollection.ts`: walks iframe DOM to build snap targets
- `SnapGuideOverlay.tsx`: pre-allocated div pool for guide line rendering
- `SnapToolbar.tsx`: magnet/grid toggle with keyboard shortcuts (S/G)
- `GridOverlay.tsx`: CSS repeating-linear-gradient grid overlay
- `studioUiPreferences.ts`: snap/grid persistence in localStorage
- 38 unit tests for the snap engine

**Stack:** 1/3 — next: wire into preview gestures

## Test plan

- [ ] `bun test packages/studio/src/components/editor/snapEngine.test.ts` passes (38 tests)
- [ ] TypeScript compiles clean