### PR TITLE
fix(engine): scale V8 heap and GPU budget proportionally on low-memory systems

### DIFF
--- a/packages/engine/src/services/browserManager.test.ts
+++ b/packages/engine/src/services/browserManager.test.ts
@@ -14,6 +14,15 @@ import {
   resolveBrowserGpuMode,
 } from "./browserManager.js";
 
+vi.mock("./systemMemory.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./systemMemory.js")>();
+  return { ...actual, getSystemTotalMb: vi.fn(() => 32768) };
+});
+
+import { getSystemTotalMb } from "./systemMemory.js";
+
+const mockGetSystemTotalMb = vi.mocked(getSystemTotalMb);
+
 describe("buildChromeArgs browser GPU mode", () => {
   const base = { width: 1920, height: 1080 };
 
@@ -306,5 +315,59 @@ describe("browser pool", () => {
 
     // The acquire should still resolve (the launch completed before drain closed it)
     await acquirePromise.catch(() => {});
+  });
+});
+
+describe("memory-adaptive Chrome flags", () => {
+  const base = { width: 1920, height: 1080 };
+
+  afterEach(() => {
+    mockGetSystemTotalMb.mockReturnValue(32768);
+  });
+
+  function heapFlag(args: string[]): number | null {
+    const flag = args.find((a) => a.includes("--max-old-space-size="));
+    if (!flag) return null;
+    return parseInt(flag.match(/--max-old-space-size=(\d+)/)?.[1] ?? "", 10);
+  }
+
+  function gpuBudget(args: string[]): number {
+    const flag = args.find((a) => a.startsWith("--force-gpu-mem-available-mb="))!;
+    return parseInt(flag.split("=")[1]!, 10);
+  }
+
+  it("does not set heap limit above 8 GB", () => {
+    mockGetSystemTotalMb.mockReturnValue(16384);
+    expect(heapFlag(buildChromeArgs(base))).toBeNull();
+  });
+
+  it("scales heap to total/8 on 8 GB systems", () => {
+    mockGetSystemTotalMb.mockReturnValue(8192);
+    expect(heapFlag(buildChromeArgs(base))).toBe(1024);
+  });
+
+  it("scales heap to total/8 on 6 GB systems", () => {
+    mockGetSystemTotalMb.mockReturnValue(6144);
+    expect(heapFlag(buildChromeArgs(base))).toBe(768);
+  });
+
+  it("uses 256 MB heap floor below 4 GB", () => {
+    mockGetSystemTotalMb.mockReturnValue(3072);
+    expect(heapFlag(buildChromeArgs(base))).toBe(256);
+  });
+
+  it("scales GPU budget to total/4 on 8 GB systems", () => {
+    mockGetSystemTotalMb.mockReturnValue(8192);
+    expect(gpuBudget(buildChromeArgs(base))).toBe(2048);
+  });
+
+  it("scales GPU budget to total/2 above threshold", () => {
+    mockGetSystemTotalMb.mockReturnValue(16384);
+    expect(gpuBudget(buildChromeArgs(base))).toBe(8192);
+  });
+
+  it("uses 512 MB GPU budget below 4 GB", () => {
+    mockGetSystemTotalMb.mockReturnValue(3072);
+    expect(gpuBudget(buildChromeArgs(base))).toBe(512);
   });
 });

--- a/packages/engine/src/services/browserManager.test.ts
+++ b/packages/engine/src/services/browserManager.test.ts
@@ -19,7 +19,7 @@ vi.mock("./systemMemory.js", async (importOriginal) => {
   return { ...actual, getSystemTotalMb: vi.fn(() => 32768) };
 });
 
-import { getSystemTotalMb } from "./systemMemory.js";
+import { getSystemTotalMb, LOW_MEMORY_TOTAL_MB_THRESHOLD } from "./systemMemory.js";
 
 const mockGetSystemTotalMb = vi.mocked(getSystemTotalMb);
 
@@ -336,14 +336,14 @@ describe("memory-adaptive Chrome flags", () => {
     return parseInt(flag.split("=")[1]!, 10);
   }
 
-  it("does not set heap limit above 8 GB", () => {
-    mockGetSystemTotalMb.mockReturnValue(16384);
+  it("does not set heap limit above threshold", () => {
+    mockGetSystemTotalMb.mockReturnValue(LOW_MEMORY_TOTAL_MB_THRESHOLD + 1);
     expect(heapFlag(buildChromeArgs(base))).toBeNull();
   });
 
-  it("scales heap to total/8 on 8 GB systems", () => {
-    mockGetSystemTotalMb.mockReturnValue(8192);
-    expect(heapFlag(buildChromeArgs(base))).toBe(1024);
+  it("scales heap to total/8 at threshold", () => {
+    mockGetSystemTotalMb.mockReturnValue(LOW_MEMORY_TOTAL_MB_THRESHOLD);
+    expect(heapFlag(buildChromeArgs(base))).toBe(Math.floor(LOW_MEMORY_TOTAL_MB_THRESHOLD / 8));
   });
 
   it("scales heap to total/8 on 6 GB systems", () => {
@@ -351,19 +351,29 @@ describe("memory-adaptive Chrome flags", () => {
     expect(heapFlag(buildChromeArgs(base))).toBe(768);
   });
 
+  it("uses proportional heap at 4 GB boundary", () => {
+    mockGetSystemTotalMb.mockReturnValue(4096);
+    expect(heapFlag(buildChromeArgs(base))).toBe(512);
+  });
+
   it("uses 256 MB heap floor below 4 GB", () => {
     mockGetSystemTotalMb.mockReturnValue(3072);
     expect(heapFlag(buildChromeArgs(base))).toBe(256);
   });
 
-  it("scales GPU budget to total/4 on 8 GB systems", () => {
-    mockGetSystemTotalMb.mockReturnValue(8192);
-    expect(gpuBudget(buildChromeArgs(base))).toBe(2048);
+  it("scales GPU budget to total/4 at threshold", () => {
+    mockGetSystemTotalMb.mockReturnValue(LOW_MEMORY_TOTAL_MB_THRESHOLD);
+    expect(gpuBudget(buildChromeArgs(base))).toBe(Math.floor(LOW_MEMORY_TOTAL_MB_THRESHOLD / 4));
+  });
+
+  it("uses proportional GPU budget at 4 GB boundary", () => {
+    mockGetSystemTotalMb.mockReturnValue(4096);
+    expect(gpuBudget(buildChromeArgs(base))).toBe(1024);
   });
 
   it("scales GPU budget to total/2 above threshold", () => {
-    mockGetSystemTotalMb.mockReturnValue(16384);
-    expect(gpuBudget(buildChromeArgs(base))).toBe(8192);
+    mockGetSystemTotalMb.mockReturnValue(LOW_MEMORY_TOTAL_MB_THRESHOLD * 2);
+    expect(gpuBudget(buildChromeArgs(base))).toBe(LOW_MEMORY_TOTAL_MB_THRESHOLD);
   });
 
   it("uses 512 MB GPU budget below 4 GB", () => {

--- a/packages/engine/src/services/browserManager.test.ts
+++ b/packages/engine/src/services/browserManager.test.ts
@@ -321,6 +321,10 @@ describe("browser pool", () => {
 describe("memory-adaptive Chrome flags", () => {
   const base = { width: 1920, height: 1080 };
 
+  beforeEach(() => {
+    mockGetSystemTotalMb.mockReturnValue(32768);
+  });
+
   afterEach(() => {
     mockGetSystemTotalMb.mockReturnValue(32768);
   });

--- a/packages/engine/src/services/browserManager.test.ts
+++ b/packages/engine/src/services/browserManager.test.ts
@@ -371,7 +371,14 @@ describe("memory-adaptive Chrome flags", () => {
     expect(gpuBudget(buildChromeArgs(base))).toBe(1024);
   });
 
-  it("scales GPU budget to total/2 above threshold", () => {
+  it("switches to total/2 GPU and no heap limit just above threshold", () => {
+    const above = LOW_MEMORY_TOTAL_MB_THRESHOLD + 1;
+    mockGetSystemTotalMb.mockReturnValue(above);
+    expect(gpuBudget(buildChromeArgs(base))).toBe(Math.floor(above / 2));
+    expect(heapFlag(buildChromeArgs(base))).toBeNull();
+  });
+
+  it("scales GPU budget to total/2 well above threshold", () => {
     mockGetSystemTotalMb.mockReturnValue(LOW_MEMORY_TOTAL_MB_THRESHOLD * 2);
     expect(gpuBudget(buildChromeArgs(base))).toBe(LOW_MEMORY_TOTAL_MB_THRESHOLD);
   });

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -512,14 +512,14 @@ function getGpuMemBudgetMb(): number {
 
   const total = getSystemTotalMb();
   if (total < 4096) return 512;
-  if (total <= LOW_MEMORY_TOTAL_MB_THRESHOLD) return 1024;
+  if (total <= LOW_MEMORY_TOTAL_MB_THRESHOLD) return Math.floor(total / 4);
   return Math.min(Math.floor(total / 2), 16384);
 }
 
 function getLowMemoryFlags(): string[] {
   const total = getSystemTotalMb();
   if (total > LOW_MEMORY_TOTAL_MB_THRESHOLD) return [];
-  const heapMb = total < 4096 ? 256 : 512;
+  const heapMb = total < 4096 ? 256 : Math.floor(total / 8);
   return [`--js-flags=--max-old-space-size=${heapMb}`];
 }
 


### PR DESCRIPTION
## Problem

On systems with 4–8 GB RAM, `getLowMemoryFlags()` applies a fixed `--max-old-space-size=512` V8 heap limit regardless of actual available memory. For 8 GB systems this is overly aggressive — a composition with multiple video elements and the GSAP runtime can exhaust the 512 MB heap budget, increasing GC pressure during page load.

Similarly, `getGpuMemBudgetMb()` returns a hard-coded 1024 MB for the entire 4–8 GB range, under-provisioning the GPU process on systems closer to the upper end.

## Root cause

The fixed-tier approach introduced in v0.6.74 (#1221) created a cliff edge at the threshold boundary — systems went from full resources to aggressive constraints with no gradation.

## Fix

Replace fixed tiers with proportional scaling for systems in the 4–8 GB range:

| System RAM | V8 heap (before) | V8 heap (after) | GPU budget (before) | GPU budget (after) |
|---|---|---|---|---|
| 3 GB | 256 MB | 256 MB | 512 MB | 512 MB |
| 4 GB | 512 MB | 512 MB | 1024 MB | 1024 MB |
| 6 GB | 512 MB | 768 MB | 1024 MB | 1536 MB |
| 8 GB | 512 MB | 1024 MB | 1024 MB | 2048 MB |
| 16 GB+ | none | none | total/2 | total/2 |

The formulas are `total/8` for V8 heap and `total/4` for GPU budget. A residual step remains at the threshold boundary (constrained → unconstrained), tested at the 8193 MiB edge.

**Note:** This does NOT address #1231 (navigation timeout on 24 GB Mac M4) — that system is above the low-memory threshold so these code paths don't execute. #1231 is a separate regression being investigated independently.

## Test plan

- 10 tests covering memory-adaptive Chrome flags at each tier boundary (4 GB, 6 GB, 8 GB, threshold+1, 16 GB, 3 GB)
- All 30 browserManager tests pass
- Tests import `LOW_MEMORY_TOTAL_MB_THRESHOLD` from source to stay honest if the constant changes