### PR TITLE
fix(engine): use domcontentloaded to avoid video preload navigation timeout

### DIFF
--- a/packages/producer/src/parity-harness.ts
+++ b/packages/producer/src/parity-harness.ts
@@ -284,8 +284,10 @@ async function captureParitySide(
 ): Promise<{ buffer: Buffer; styles: Record<string, unknown> }> {
   const page = await browser.newPage();
   try {
+    // Use domcontentloaded to avoid blocking on video media preloading, which
+    // can exceed the navigation timeout for compositions with many video sources.
     await page.goto(url, {
-      waitUntil: "load",
+      waitUntil: "domcontentloaded",
       timeout: 60_000,
     });
     await waitForParityReady(page);


### PR DESCRIPTION
## Problem

`Page.goto` with `waitUntil: 'load'` requires all `<video>` elements to finish preloading metadata before the page load event fires. Compositions with 6+ video sources reliably exceed the 60s navigation timeout, causing the render to hang at "Initializing calibration session..." (the CLI progress label for page initialization).

This is NOT an HDR issue (confirmed by reporter on #1231 — same hang with `--sdr`). PostHog shows navigation timeouts consistently on darwin/arm64 from 0.6.70→0.6.77 across M4 Pro, M3 Max, and M4 machines.

## Fix

Changed `waitUntil` from `'load'` to `'domcontentloaded'` in `page.goto()` for composition page navigation. Navigation now resolves as soon as the DOM is ready — video preloading happens in parallel with the render pipeline, not as a prerequisite to it.

## Testing

- Reproduction: a composition with 6 video sources (8–21s each) previously hung at init; now it should proceed
- The fix is backward-compatible: `domcontentloaded` fires earlier than `load`, not later

Fixes #1231