### PR TITLE
test(studio): add T4 op-contract stubs for editor dispatch boundary

### DIFF
--- a/packages/studio/src/components/editor/ops.contract.test.ts
+++ b/packages/studio/src/components/editor/ops.contract.test.ts
@@ -1,0 +1,39 @@
+/**
+ * T4 — Op contract stubs.
+ *
+ * These tests define the expected shape of the Studio editor operation (op) dispatch boundary
+ * that will be introduced during R5 (op-shape refactor) and R6 (runtime bridge).
+ * All are .todo until the dispatch boundary is exposed.
+ */
+import { describe, it } from "vitest";
+
+describe("T4 — op contract: move", () => {
+  it.todo("move op has { type: 'move', id, x, y } shape");
+  it.todo("move op applied to element produces updated left/top style values");
+  it.todo("move op is recorded in edit history with label 'Move layer'");
+  it.todo("move op coalesces when dragging (same id, within coalesce window)");
+});
+
+describe("T4 — op contract: resize", () => {
+  it.todo("resize op has { type: 'resize', id, width, height } shape");
+  it.todo("resize op applied updates width/height style values");
+  it.todo("resize op is recorded in edit history with label 'Resize layer'");
+});
+
+describe("T4 — op contract: retime", () => {
+  it.todo("retime op has { type: 'retime', id, startTime, duration } shape");
+  it.todo("retime op updates data-start/data-end attributes on the element");
+  it.todo("retime op is recorded in edit history with label 'Retime layer'");
+});
+
+describe("T4 — op contract: style", () => {
+  it.todo("style op has { type: 'style', id, prop, value } shape");
+  it.todo("style op applied updates the correct inline style property");
+  it.todo("style op coalesces same id+prop edits within window");
+});
+
+describe("T4 — op contract: dispatch boundary", () => {
+  it.todo("dispatch emits origin:'studio' on every op for SDK origin guard");
+  it.todo("applyPatches with origin:'applyPatches' does not push to undo stack");
+  it.todo("dispatching an unknown op type throws at the boundary, not silently fails");
+});


### PR DESCRIPTION
## What

Adds `ops.contract.test.ts` — T4 from the SDK migration test plan. All tests are `.todo` stubs defining the expected op-dispatch contract for the Studio editor.

## Purpose

Specifies the shape and behaviour of the editor operation boundary before R5 (op-shape) and R6 (runtime bridge) implement it. Having the contract written as failing tests first:
- gives R5/R6 a clear acceptance criterion
- prevents the boundary from being designed ad-hoc

## Op types covered

| Op | Shape | Covered behaviours |
|----|-------|--------------------|
| `move` | `{ type, id, x, y }` | shape, style output, history label, coalescing |
| `resize` | `{ type, id, width, height }` | shape, style output, history label |
| `retime` | `{ type, id, startTime, duration }` | shape, attribute output, history label |
| `style` | `{ type, id, prop, value }` | shape, style output, coalescing |
| dispatch boundary | — | `origin:'studio'` on every op, `applyPatches` excluded from undo, unknown op throws |

## Stack

Stacked on T11 (#1242). Top of the stack.