### PR TITLE
feat(gsap): expose innerText counter animations in GSAP inspector panel

### DIFF
--- a/packages/core/src/parsers/gsapConstants.ts
+++ b/packages/core/src/parsers/gsapConstants.ts
@@ -41,6 +41,8 @@ export const SUPPORTED_PROPS = [
   // Filter & Clipping
   "filter",
   "clipPath",
+  // DOM content (number counters, text roll-ups)
+  "innerText",
 ];
 
 export const SUPPORTED_EASES = [

--- a/packages/studio/src/components/editor/gsapAnimationConstants.ts
+++ b/packages/studio/src/components/editor/gsapAnimationConstants.ts
@@ -37,6 +37,7 @@ export const PROP_LABELS: Record<string, string> = {
   letterSpacing: "Tracking",
   skewX: "Skew X",
   skewY: "Skew Y",
+  innerText: "Counter Value",
 };
 
 export const PROP_UNITS: Record<string, string> = {
@@ -65,6 +66,7 @@ export const PROP_TOOLTIPS: Record<string, string> = {
   height: "Element height",
   autoAlpha: "Like opacity but hides element completely at 0",
   visibility: "Show or hide the element",
+  innerText: "End value for a number roll-up (the number it counts up/down to)",
 };
 
 export const EASE_LABELS: Record<string, string> = {
@@ -154,6 +156,7 @@ export const PROP_CONSTRAINTS: Record<string, { min?: number; max?: number; step
   y: { step: 1 },
   fontSize: { min: 1, step: 1 },
   letterSpacing: { step: 0.1 },
+  innerText: { step: 1 },
 };
 
 export function clampPropertyValue(prop: string, value: number): number {


### PR DESCRIPTION
## Summary

Resolves #1179

Users can now edit number roll-up (count-up) animations via the GSAP inspector panel. Previously, `innerText` tweens were silently invisible to the inspector — the animation ran but you couldn't change the end value or speed from the UI.

## What changed

- **`packages/core/src/parsers/gsapConstants.ts`**: Added `"innerText"` to `SUPPORTED_PROPS`
- **`packages/studio/src/components/editor/gsapAnimationConstants.ts`**:
  - Label: `Counter Value`
  - Tooltip: *End value for a number roll-up (the number it counts up/down to)*
  - Constraint: `step: 1` (integers only)

## How it works

```js
gsap.to(el, { innerText: 80_000_000_000, snap: { innerText: 1 }, duration: 2 })
```

- `innerText: 80e9` → editable as **Counter Value** in the inspector
- `snap: { innerText: 1 }` → preserved verbatim via `EXTRAS_KEYS`, no UI change needed
- Speed → already editable via **Duration**

No GSAP plugin required — plain DOM property tweening.