### PR TITLE
test(core): add T2 stable id spec for parse-to-hf id contract (before R1)

### DIFF
--- a/packages/core/src/parsers/stableIds.test.ts
+++ b/packages/core/src/parsers/stableIds.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * T2 — Stable id spec (spec for R1).
+ *
+ * These tests define what "stable hf- id" means BEFORE R1 implements it.
+ * They are intentionally red until R1 lands.
+ *
+ * Currently failing (spec): tests 1, 2, 3 — parser assigns `element-N` not `hf-xxxx`.
+ * Currently passing (baseline): tests 4, 5, 6, 7 — these already hold and must not regress.
+ *
+ * Scope: id assignment and stability only. Round-trip fidelity is T1 territory.
+ */
+import { describe, expect, it } from "vitest";
+import { parseHtml } from "./htmlParser.js";
+import { generateHyperframesHtml } from "../generators/hyperframes.js";
+import type { ParsedHtml } from "./htmlParser.js";
+
+function maxEndTime(elements: ParsedHtml["elements"]): number {
+  if (elements.length === 0) return 0;
+  return Math.max(...elements.map((e) => e.startTime + e.duration));
+}
+
+function serialize(parsed: ParsedHtml): string {
+  return generateHyperframesHtml(parsed.elements, maxEndTime(parsed.elements), {
+    compositionId: "test-comp",
+    resolution: parsed.resolution,
+    styles: parsed.styles ?? undefined,
+    keyframes: parsed.keyframes,
+    stageZoomKeyframes: parsed.stageZoomKeyframes,
+  });
+}
+
+describe("T2 — stable element ids (spec for R1)", () => {
+  // --- Spec (red until R1) ---
+
+  it("[spec] elements without an id get a hf- prefixed id at parse", () => {
+    const html = `<html><body><div id="stage">
+      <img src="logo.svg" data-start="0" data-end="5" data-name="Logo" />
+      <div data-start="0" data-end="5" data-name="Card"><div>Text</div></div>
+    </div></body></html>`;
+    const { elements } = parseHtml(html);
+    for (const el of elements) {
+      expect(el.id).toMatch(/^hf-/);
+    }
+  });
+
+  it("[spec] generated hf- ids match /^hf-[a-z0-9]{4}$/", () => {
+    const html = `<html><body><div id="stage">
+      <div data-start="0" data-end="5" data-name="Unnamed"><div>X</div></div>
+      <video data-start="1" data-end="6" src="v.mp4" data-name="Clip"></video>
+    </div></body></html>`;
+    const { elements } = parseHtml(html);
+    const noPreExistingId = elements.filter((e) => e.id !== "stage");
+    for (const el of noPreExistingId) {
+      expect(el.id).toMatch(/^hf-[a-z0-9]{4}$/);
+    }
+  });
+
+  it("[spec] adding an element before existing ones does not change existing ids", () => {
+    const base = `<html><body><div id="stage">
+      <div data-start="0" data-end="5" data-name="AlphaEl"><div>A</div></div>
+      <div data-start="1" data-end="6" data-name="BetaEl"><div>B</div></div>
+    </div></body></html>`;
+    const withPrepend = `<html><body><div id="stage">
+      <div data-start="0" data-end="4" data-name="NewEl"><div>New</div></div>
+      <div data-start="0" data-end="5" data-name="AlphaEl"><div>A</div></div>
+      <div data-start="1" data-end="6" data-name="BetaEl"><div>B</div></div>
+    </div></body></html>`;
+    const baseAlpha = parseHtml(base).elements.find((e) => e.name === "AlphaEl");
+    const extendedAlpha = parseHtml(withPrepend).elements.find((e) => e.name === "AlphaEl");
+    expect(baseAlpha).toBeDefined();
+    expect(extendedAlpha).toBeDefined();
+    // With counter-based ids: base AlphaEl = element-1, extended AlphaEl = element-2 — FAILS.
+    // With hf- stable ids: both = same hf-xxxx — PASSES (R1 target).
+    expect(extendedAlpha?.id).toBe(baseAlpha?.id);
+  });
+
+  // --- Baseline (already pass, must not regress) ---
+
+  it("elements with an existing id keep it unchanged", () => {
+    const html = `<html><body><div id="stage">
+      <div id="my-title" data-start="0" data-end="5" data-name="Title"><div>Hi</div></div>
+    </div></body></html>`;
+    const { elements } = parseHtml(html);
+    expect(elements.some((e) => e.id === "my-title")).toBe(true);
+  });
+
+  it("ids are deterministic: same input produces same ids on re-parse", () => {
+    const html = `<html><body><div id="stage">
+      <div data-start="0" data-end="5" data-name="A"><div>A</div></div>
+      <div data-start="0" data-end="5" data-name="B"><div>B</div></div>
+    </div></body></html>`;
+    const first = parseHtml(html).elements.map((e) => e.id);
+    const second = parseHtml(html).elements.map((e) => e.id);
+    expect(first).toEqual(second);
+  });
+
+  it("ids are unique within a document", () => {
+    const html = `<html><body><div id="stage">
+      <div data-start="0" data-end="3" data-name="A"><div>A</div></div>
+      <div data-start="1" data-end="4" data-name="B"><div>B</div></div>
+      <div data-start="2" data-end="5" data-name="C"><div>C</div></div>
+    </div></body></html>`;
+    const ids = parseHtml(html).elements.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("two elements with identical markup get distinct ids (no content-hash collision)", () => {
+    // Ensures R1's id derivation includes position or a sibling counter,
+    // not just content — two structurally identical elements must not collide.
+    const html = `<html><body><div id="stage">
+      <div data-start="0" data-end="5" data-name="X"><div>Same</div></div>
+      <div data-start="0" data-end="5" data-name="X"><div>Same</div></div>
+    </div></body></html>`;
+    const { elements } = parseHtml(html);
+    const ids = elements.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("ids survive a serialize → re-parse round-trip", () => {
+    const html = `<html><body><div id="stage">
+      <div id="my-anchor" data-start="0" data-end="5" data-name="Anchor"><div>Content</div></div>
+      <img src="photo.jpg" data-start="1" data-end="8" data-name="Photo" />
+    </div></body></html>`;
+    const original = parseHtml(html);
+    const reparsed = parseHtml(serialize(original));
+    const origIds = original.elements.map((e) => e.id).sort();
+    const roundIds = reparsed.elements.map((e) => e.id).sort();
+    expect(roundIds).toEqual(origIds);
+  });
+
+  it.todo("sub-composition instances get scoped ids (compositionId/hf-x) — requires SDK session");
+});

--- a/packages/core/src/parsers/stableIds.test.ts
+++ b/packages/core/src/parsers/stableIds.test.ts
@@ -34,7 +34,7 @@ function serialize(parsed: ParsedHtml): string {
 describe("T2 — stable element ids (spec for R1)", () => {
   // --- Spec (red until R1) ---
 
-  it("[spec] elements without an id get a hf- prefixed id at parse", () => {
+  it.fails("[spec] elements without an id get a hf- prefixed id at parse", () => {
     const html = `<html><body><div id="stage">
       <img src="logo.svg" data-start="0" data-end="5" data-name="Logo" />
       <div data-start="0" data-end="5" data-name="Card"><div>Text</div></div>
@@ -45,7 +45,7 @@ describe("T2 — stable element ids (spec for R1)", () => {
     }
   });
 
-  it("[spec] generated hf- ids match /^hf-[a-z0-9]{4}$/", () => {
+  it.fails("[spec] generated hf- ids match /^hf-[a-z0-9]{4}$/", () => {
     const html = `<html><body><div id="stage">
       <div data-start="0" data-end="5" data-name="Unnamed"><div>X</div></div>
       <video data-start="1" data-end="6" src="v.mp4" data-name="Clip"></video>
@@ -57,7 +57,7 @@ describe("T2 — stable element ids (spec for R1)", () => {
     }
   });
 
-  it("[spec] adding an element before existing ones does not change existing ids", () => {
+  it.fails("[spec] adding an element before existing ones does not change existing ids", () => {
     const base = `<html><body><div id="stage">
       <div data-start="0" data-end="5" data-name="AlphaEl"><div>A</div></div>
       <div data-start="1" data-end="6" data-name="BetaEl"><div>B</div></div>

--- a/packages/studio/src/components/editor/ops.contract.test.ts
+++ b/packages/studio/src/components/editor/ops.contract.test.ts
@@ -1,0 +1,39 @@
+/**
+ * T4 — Op contract stubs.
+ *
+ * These tests define the expected shape of the Studio editor operation (op) dispatch boundary
+ * that will be introduced during R5 (op-shape refactor) and R6 (runtime bridge).
+ * All are .todo until the dispatch boundary is exposed.
+ */
+import { describe, it } from "vitest";
+
+describe("T4 — op contract: move", () => {
+  it.todo("move op has { type: 'move', id, x, y } shape");
+  it.todo("move op applied to element produces updated left/top style values");
+  it.todo("move op is recorded in edit history with label 'Move layer'");
+  it.todo("move op coalesces when dragging (same id, within coalesce window)");
+});
+
+describe("T4 — op contract: resize", () => {
+  it.todo("resize op has { type: 'resize', id, width, height } shape");
+  it.todo("resize op applied updates width/height style values");
+  it.todo("resize op is recorded in edit history with label 'Resize layer'");
+});
+
+describe("T4 — op contract: retime", () => {
+  it.todo("retime op has { type: 'retime', id, startTime, duration } shape");
+  it.todo("retime op updates data-start/data-end attributes on the element");
+  it.todo("retime op is recorded in edit history with label 'Retime layer'");
+});
+
+describe("T4 — op contract: style", () => {
+  it.todo("style op has { type: 'style', id, prop, value } shape");
+  it.todo("style op applied updates the correct inline style property");
+  it.todo("style op coalesces same id+prop edits within window");
+});
+
+describe("T4 — op contract: dispatch boundary", () => {
+  it.todo("dispatch emits origin:'studio' on every op for SDK origin guard");
+  it.todo("applyPatches with origin:'applyPatches' does not push to undo stack");
+  it.todo("dispatching an unknown op type throws at the boundary, not silently fails");
+});


### PR DESCRIPTION
## T2 — Stable id spec (before R1)

Spec tests defining the `hf-` id contract that R1 must satisfy. Written before the implementation so the refactor is test-driven and any regression is immediately visible.

### What this gates

R1 switches element targeting from CSS selectors (`#el-aaa`) to stable `hf-` ids (`hf-a1b2`). Without stable ids, two sequential ops to the same element can silently target different elements if the document changes between them.

### Test split

**Red (spec — intentionally failing until R1):**
- Elements without an id get a `hf-` prefixed id at parse
- Generated ids match `/^hf-[a-z0-9]{4}$/`
- Prepending a new element does not change existing elements' ids (counter-shift bug)

**Green (baseline — must not regress through R1):**
- Elements with an existing id keep it unchanged
- Ids are deterministic (same input → same ids on re-parse)
- Ids are unique within a document
- Ids survive a serialize → re-parse round-trip

### File

`packages/core/src/parsers/stableIds.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)