### PR TITLE
fix(engine): flush compositor before screenshot to fix WebGL capture

### DIFF
--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -20,11 +20,51 @@ function makeFakePageWithCdp(send: (method: string, params: object) => Promise<{
   return fakePage;
 }
 
-describe("pageScreenshotCapture supersample plumbing", () => {
+describe("pageScreenshotCapture", () => {
   // Minimal 1×1 transparent PNG, base64. The function returns Buffer.from(data, "base64")
   // and we never inspect the bytes — only the params we pass to client.send.
   const ONE_PIXEL_PNG_B64 =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+  // The flush call is always the first CDP send; the real screenshot is the second.
+  const flushCallIndex = 0;
+  const realCallIndex = 1;
+
+  it("issues a 1×1 compositor flush before the real screenshot", async () => {
+    const send = vi.fn().mockResolvedValue({ data: ONE_PIXEL_PNG_B64 });
+    const page = makeFakePageWithCdp(send);
+
+    await pageScreenshotCapture(page, {
+      width: 1920,
+      height: 1080,
+      fps: { num: 30, den: 1 },
+      format: "jpeg",
+    });
+
+    expect(send).toHaveBeenCalledTimes(2);
+
+    const flushParams = send.mock.calls[flushCallIndex]?.[1] as Record<string, unknown>;
+    expect(flushParams).toEqual({
+      format: "jpeg",
+      quality: 1,
+      clip: { x: 0, y: 0, width: 1, height: 1, scale: 1 },
+    });
+  });
+
+  it("flush does not use captureBeyondViewport so standard compositor path runs", async () => {
+    const send = vi.fn().mockResolvedValue({ data: ONE_PIXEL_PNG_B64 });
+    const page = makeFakePageWithCdp(send);
+
+    await pageScreenshotCapture(page, {
+      width: 1920,
+      height: 1080,
+      fps: { num: 30, den: 1 },
+      format: "jpeg",
+    });
+
+    const flushParams = send.mock.calls[flushCallIndex]?.[1] as Record<string, unknown>;
+    expect(flushParams).not.toHaveProperty("captureBeyondViewport");
+  });
 
   it("passes `clip` with scale 1 when deviceScaleFactor is undefined (default 1)", async () => {
     const send = vi.fn().mockResolvedValue({ data: ONE_PIXEL_PNG_B64 });
@@ -58,7 +98,7 @@ describe("pageScreenshotCapture supersample plumbing", () => {
       deviceScaleFactor: 1,
     });
 
-    const params = send.mock.calls[0]?.[1] as { clip?: { scale: number } };
+    const params = send.mock.calls[realCallIndex]?.[1] as { clip?: { scale: number } };
     expect(params.clip).toEqual({ x: 0, y: 0, width: 1920, height: 1080, scale: 1 });
   });
 
@@ -94,8 +134,24 @@ describe("pageScreenshotCapture supersample plumbing", () => {
       deviceScaleFactor: 3,
     });
 
-    const params = send.mock.calls[0]?.[1] as { clip?: { scale: number } };
+    const params = send.mock.calls[realCallIndex]?.[1] as { clip?: { scale: number } };
     expect(params.clip?.scale).toBe(3);
+  });
+
+  it("real screenshot uses captureBeyondViewport: true and fromSurface: true", async () => {
+    const send = vi.fn().mockResolvedValue({ data: ONE_PIXEL_PNG_B64 });
+    const page = makeFakePageWithCdp(send);
+
+    await pageScreenshotCapture(page, {
+      width: 1920,
+      height: 1080,
+      fps: { num: 30, den: 1 },
+      format: "jpeg",
+    });
+
+    const realParams = send.mock.calls[realCallIndex]?.[1] as Record<string, unknown>;
+    expect(realParams.captureBeyondViewport).toBe(true);
+    expect(realParams.fromSurface).toBe(true);
   });
 });
 

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -131,14 +131,24 @@ export async function pageScreenshotCapture(page: Page, options: CaptureOptions)
   const isPng = options.format === "png";
   const dpr = options.deviceScaleFactor ?? 1;
   const clip = { x: 0, y: 0, width: options.width, height: options.height, scale: dpr };
+
+  // Force a standard compositor cycle before the real capture. The 1×1
+  // micro-screenshot runs with captureBeyondViewport:false (the default),
+  // which triggers Chrome's viewport-bounded composite path — this path
+  // reliably composites WebGL/ANGLE canvas layers into the surface texture.
+  // Without this flush, captureBeyondViewport:true can skip WebGL layer
+  // compositing under certain GPU configs (SwiftShader, some ANGLE backends),
+  // producing a black canvas in the final screenshot.
+  await client.send("Page.captureScreenshot", {
+    format: "jpeg",
+    quality: 1,
+    clip: { x: 0, y: 0, width: 1, height: 1, scale: 1 },
+  });
+
   const result = await client.send("Page.captureScreenshot", {
     format: isPng ? "png" : "jpeg",
     quality: isPng ? undefined : (options.quality ?? 80),
     fromSurface: true,
-    // The explicit clip rect constrains output to exact composition
-    // dimensions. The viewport-boundary pre-clip from captureBeyondViewport:
-    // false is redundant, and Chrome's compositor rounds it inward under
-    // multi-tab load — clipping the bottom/right edge of tall viewports.
     captureBeyondViewport: true,
     optimizeForSpeed: !isPng,
     clip,


### PR DESCRIPTION
## Problem

Three.js/WebGL canvas content renders correctly in `hyperframes preview` but appears as black/transparent in `hyperframes render` output. Works in v0.5.5, broken in v0.6.x.

Reported in #1260.

## Root Cause

The `captureBeyondViewport: true` change (#1094, commit 3bbfea38) altered Chrome's compositor code path for CDP screenshots. The expanded-viewport path does not reliably composite WebGL/ANGLE canvas layers into the surface texture under certain GPU configurations (SwiftShader, some ANGLE backends), producing a black region where the WebGL content should be.

In v0.5.5, `captureBeyondViewport: false` used Chrome's standard viewport-bounded composite, which correctly included WebGL layers.

## Fix

Add a 1×1 micro-screenshot (without `captureBeyondViewport`) before each real `Page.captureScreenshot` call in `pageScreenshotCapture()`. This forces Chrome's standard compositor path to run, ensuring WebGL layers are composited into the surface texture before the real screenshot reads it.

This pattern already exists in the codebase — the shader transitions pipeline uses an identical micro-screenshot for GPU flushing in `prepareFrameForCapture()` (frameCapture.ts).

**Performance impact:** ~0.5-1ms per frame (1×1 JPEG at quality 1). Negligible compared to the real screenshot (~5-15ms).

## Test Plan

- [x] Existing `pageScreenshotCapture` tests updated for the additional CDP call
- [x] New tests verify: flush fires first, flush omits `captureBeyondViewport`, real screenshot preserves all existing params
- [x] All 16 screenshot service tests pass
- [x] 685/687 engine tests pass (2 pre-existing ffmpeg failures unrelated to this change)
- [x] Pre-commit hooks pass (lint, format, fallow, typecheck)

Closes #1260