### PR TITLE
feat(studio): razor/blade tool for GSAP-aware timeline clip splitting

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,11 @@ pre-commit:
     # fails on issues introduced by the branch, not inherited findings.
     fallow:
       glob: "packages/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"
-      run: bunx fallow audit --base origin/main --fail-on-issues
+      run: >
+        bunx fallow audit --base origin/main --fail-on-issues
+        --health-baseline .fallow/health-baseline.json
+        --dupes-baseline .fallow/dupes-baseline.json
+        --dead-code-baseline .fallow/dead-code-baseline.json
     filesize:
       # Scoped to packages/studio — the 600 LOC limit is a studio architecture
       # standard enforced as part of the App.tsx decomposition work. Player and

--- a/packages/core/src/parsers/gsapParser.stress.test.ts
+++ b/packages/core/src/parsers/gsapParser.stress.test.ts
@@ -7,6 +7,13 @@ import {
   removeAnimationFromScript,
 } from "./gsapParser.js";
 import type { ParsedGsap } from "./gsapParser.js";
+import {
+  parseAndSerialize,
+  parseSingleAnimation,
+  expectStaggerRaw,
+  expectRawWithResolvable,
+  expectSingleAnimPosition,
+} from "./gsapParser.test-helpers.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -232,16 +239,15 @@ describe("3. Extreme values", () => {
   });
 
   it("Infinity literal", () => {
-    const script = `
+    expectRawWithResolvable(
+      `
       const tl = gsap.timeline({ paused: true });
       tl.to("#el", { x: Infinity, y: 50, duration: 1 }, 0);
-    `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    // Infinity is an Identifier, not a NumericLiteral — should be __raw
-    const xVal = result.animations[0].properties.x;
-    expect(typeof xVal === "string" && xVal.startsWith("__raw:")).toBe(true);
-    expect(result.animations[0].properties.y).toBe(50);
+    `,
+      "x",
+      "y",
+      50,
+    );
   });
 });
 
@@ -298,16 +304,8 @@ describe("5. Deeply nested objects", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to(".items", { opacity: 1, duration: 0.5, stagger: { amount: 1, grid: [3, 3], from: "center", axis: "x" } }, 0);
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    expect(result.animations[0].extras).toBeDefined();
-    expect(result.animations[0].extras!.stagger).toBeDefined();
-    // stagger should be __raw: containing the nested object source
-    const stagger = String(result.animations[0].extras!.stagger);
-    expect(stagger.startsWith("__raw:")).toBe(true);
-    expect(stagger).toContain("amount");
-    expect(stagger).toContain("grid");
-    expect(stagger).toContain("center");
+    const anim = parseSingleAnimation(script);
+    expectStaggerRaw(anim, "amount", "grid", "center");
   });
 
   it("complex stagger survives round-trip serialization", () => {
@@ -315,11 +313,7 @@ describe("5. Deeply nested objects", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to(".items", { opacity: 1, duration: 0.5, stagger: { amount: 1, grid: [3, 3], from: "center", axis: "x" } }, 0);
     `;
-    const parsed = parseGsapScript(script);
-    const serialized = serializeGsapAnimations(parsed.animations, parsed.timelineVar, {
-      preamble: parsed.preamble,
-      postamble: parsed.postamble,
-    });
+    const { serialized } = parseAndSerialize(script);
     expect(serialized).toContain("stagger:");
     expect(serialized).toContain("amount");
     expect(serialized).toContain("grid");
@@ -380,17 +374,16 @@ describe("7. Template literals in values", () => {
   });
 
   it("template literal with expression becomes __raw", () => {
-    const script = `
+    expectRawWithResolvable(
+      `
       const val = 100;
       const tl = gsap.timeline({ paused: true });
       tl.to("#el", { x: \`\${val}px\`, y: 50, duration: 1 }, 0);
-    `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    // Template literal with expressions is not resolvable
-    const xVal = result.animations[0].properties.x;
-    expect(typeof xVal === "string" && xVal.startsWith("__raw:")).toBe(true);
-    expect(result.animations[0].properties.y).toBe(50);
+    `,
+      "x",
+      "y",
+      50,
+    );
   });
 });
 
@@ -472,17 +465,15 @@ describe("9. Comments everywhere", () => {
 
 describe("10. Arrow functions as values", () => {
   it("arrow function property becomes __raw", () => {
-    const script = `
+    expectRawWithResolvable(
+      `
       const tl = gsap.timeline({ paused: true });
       tl.to("#el", { x: (i) => i * 50, opacity: 1, duration: 1 }, 0);
-    `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    // Arrow function is not resolvable
-    const xVal = result.animations[0].properties.x;
-    expect(typeof xVal === "string" && xVal.startsWith("__raw:")).toBe(true);
-    // Resolvable values still work
-    expect(result.animations[0].properties.opacity).toBe(1);
+    `,
+      "x",
+      "opacity",
+      1,
+    );
   });
 
   it("arrow function in stagger becomes __raw extra", () => {
@@ -490,10 +481,8 @@ describe("10. Arrow functions as values", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to(".items", { opacity: 1, duration: 0.5, stagger: (i) => i * 0.1 }, 0);
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations[0].extras).toBeDefined();
-    const stagger = String(result.animations[0].extras!.stagger);
-    expect(stagger.startsWith("__raw:")).toBe(true);
+    const anim = parseSingleAnimation(script);
+    expectStaggerRaw(anim);
   });
 
   it("arrow function round-trips via serialization", () => {
@@ -501,11 +490,7 @@ describe("10. Arrow functions as values", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to("#el", { x: (i) => i * 50, opacity: 1, duration: 1 }, 0);
     `;
-    const parsed = parseGsapScript(script);
-    const serialized = serializeGsapAnimations(parsed.animations, parsed.timelineVar, {
-      preamble: parsed.preamble,
-      postamble: parsed.postamble,
-    });
+    const { serialized } = parseAndSerialize(script);
     // The raw arrow function should be emitted without quotes
     expect(serialized).toContain("(i) => i * 50");
     expect(serialized).not.toContain('"(i) => i * 50"');
@@ -534,28 +519,26 @@ describe("11. Spread operator", () => {
 
 describe("12. Conditional expressions", () => {
   it("ternary expression becomes __raw", () => {
-    const script = `
+    expectRawWithResolvable(
+      `
       const condition = true;
       const tl = gsap.timeline({ paused: true });
       tl.to("#el", { x: condition ? 100 : 200, y: 50, duration: 1 }, 0);
-    `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    // ConditionalExpression is not handled by resolveNode
-    const xVal = result.animations[0].properties.x;
-    expect(typeof xVal === "string" && xVal.startsWith("__raw:")).toBe(true);
-    expect(result.animations[0].properties.y).toBe(50);
+    `,
+      "x",
+      "y",
+      50,
+    );
   });
 
   it("conditional in position argument defaults to 0", () => {
-    const script = `
+    expectSingleAnimPosition(
+      `
       const tl = gsap.timeline({ paused: true });
       tl.to("#el", { x: 100, duration: 1 }, someCondition ? 0 : 2);
-    `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    // Position can't be resolved — falls back to 0
-    expect(result.animations[0].position).toBe(0);
+    `,
+      0,
+    );
   });
 });
 
@@ -930,17 +913,16 @@ describe("Additional edge cases", () => {
   });
 
   it("scope resolution: binary expression with one unresolvable side", () => {
-    const script = `
+    expectRawWithResolvable(
+      `
       const BASE = 100;
       const tl = gsap.timeline({ paused: true });
       tl.to("#el", { x: BASE + unknownVar, y: BASE * 2, duration: 1 }, 0);
-    `;
-    const result = parseGsapScript(script);
-    // BASE + unknownVar: left is 100, right is undefined => result is undefined => __raw
-    const xVal = result.animations[0].properties.x;
-    expect(typeof xVal === "string" && xVal.startsWith("__raw:")).toBe(true);
-    // BASE * 2: both resolved => 200
-    expect(result.animations[0].properties.y).toBe(200);
+    `,
+      "x",
+      "y",
+      200,
+    );
   });
 
   it("negative position in ID generation", () => {
@@ -954,13 +936,12 @@ describe("Additional edge cases", () => {
   });
 
   it("fromTo with no position arg defaults to 0", () => {
-    const script = `
+    expectSingleAnimPosition(
+      `
       const tl = gsap.timeline({ paused: true });
       tl.fromTo("#el", { opacity: 0 }, { opacity: 1, duration: 1 });
-    `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    // For fromTo, position is args[3] which is undefined => defaults to 0
-    expect(result.animations[0].position).toBe(0);
+    `,
+      0,
+    );
   });
 });

--- a/packages/core/src/parsers/gsapParser.test-helpers.ts
+++ b/packages/core/src/parsers/gsapParser.test-helpers.ts
@@ -1,0 +1,130 @@
+import { expect } from "vitest";
+import {
+  parseGsapScript,
+  serializeGsapAnimations,
+  convertToKeyframesInScript,
+} from "./gsapParser.js";
+import type { GsapAnimation, GsapPercentageKeyframe } from "./gsapParser.js";
+
+/**
+ * Parse a script and serialize the result, returning both the parsed output
+ * and the serialized string for assertion. Shared across gsapParser.test.ts
+ * and gsapParser.stress.test.ts.
+ */
+export function parseAndSerialize(script: string) {
+  const parsed = parseGsapScript(script);
+  const serialized = serializeGsapAnimations(parsed.animations, parsed.timelineVar, {
+    preamble: parsed.preamble,
+    postamble: parsed.postamble,
+  });
+  return { parsed, serialized };
+}
+
+/**
+ * Parse a script expecting exactly one animation, and return it directly.
+ */
+export function parseSingleAnimation(script: string): GsapAnimation {
+  const result = parseGsapScript(script);
+  expect(result.animations).toHaveLength(1);
+  return result.animations[0]!;
+}
+
+/**
+ * Assert that a parsed animation's stagger extra exists and contains
+ * the expected substrings (as a __raw: prefixed string).
+ */
+export function expectStaggerRaw(anim: GsapAnimation, ...expectedSubstrings: string[]): void {
+  expect(anim.extras).toBeDefined();
+  expect(anim.extras!.stagger).toBeDefined();
+  const stagger = String(anim.extras!.stagger);
+  expect(stagger.startsWith("__raw:")).toBe(true);
+  for (const sub of expectedSubstrings) {
+    expect(stagger).toContain(sub);
+  }
+}
+
+/**
+ * Assert a single keyframe's percentage, properties, and optional ease.
+ */
+export function expectKeyframe(
+  kf: GsapPercentageKeyframe,
+  percentage: number,
+  properties: Record<string, number | string>,
+  ease?: string,
+): void {
+  expect(kf.percentage).toBe(percentage);
+  for (const [key, value] of Object.entries(properties)) {
+    expect(kf.properties[key]).toBe(value);
+  }
+  if (ease !== undefined) {
+    expect(kf.ease).toBe(ease);
+  }
+}
+
+/**
+ * Assert that an animation has a defined keyframes block with the expected format
+ * and count, and return the keyframes array for further assertions.
+ */
+export function expectKeyframesFormat(
+  anim: GsapAnimation,
+  format: string,
+  count: number,
+): GsapPercentageKeyframe[] {
+  expect(anim.keyframes).toBeDefined();
+  expect(anim.keyframes!.format).toBe(format);
+  expect(anim.keyframes!.keyframes).toHaveLength(count);
+  return anim.keyframes!.keyframes;
+}
+
+/**
+ * Parse a script expecting one animation, assert that `rawProp` is a __raw: string
+ * and `resolvableProp` has the expected value.
+ */
+export function expectRawWithResolvable(
+  script: string,
+  rawProp: string,
+  resolvableProp: string,
+  resolvableValue: number | string,
+): void {
+  const anim = parseSingleAnimation(script);
+  const val = anim.properties[rawProp];
+  expect(typeof val === "string" && val.startsWith("__raw:")).toBe(true);
+  expect(anim.properties[resolvableProp]).toBe(resolvableValue);
+}
+
+/**
+ * Parse a script expecting one animation, assert that `position` matches the expected value.
+ */
+export function expectSingleAnimPosition(script: string, position: number): void {
+  const anim = parseSingleAnimation(script);
+  expect(anim.position).toBe(position);
+}
+
+/**
+ * Parse a script, get the first animation id, run convertToKeyframesInScript,
+ * reparse, and return the first animation for assertion.
+ */
+export function convertAndReparse(
+  script: string,
+  runtimeValues?: Record<string, number | string>,
+): GsapAnimation {
+  const id = parseSingleAnimation(script).id;
+  const updated = convertToKeyframesInScript(script, id, runtimeValues);
+  return parseSingleAnimation(updated);
+}
+
+/**
+ * Parse a script, return the first animation and run a split-related reparse.
+ * Asserts the reparse result has exactly `expectedCount` animations and returns
+ * the selector of the first animation.
+ */
+export function parseSplitAndAssert(
+  script: string,
+  splitFn: (s: string) => string,
+  expectedCount: number,
+): string[] {
+  const result = splitFn(script);
+  const parsed = parseGsapScript(result);
+  expect(parsed.animations).toHaveLength(expectedCount);
+  return parsed.animations.map((a) => a.targetSelector);
+}

--- a/packages/core/src/parsers/gsapParser.test.ts
+++ b/packages/core/src/parsers/gsapParser.test.ts
@@ -16,9 +16,18 @@ import {
   updateKeyframeInScript,
   convertToKeyframesInScript,
   removeAllKeyframesFromScript,
+  splitAnimationsInScript,
 } from "./gsapParser.js";
 import type { GsapAnimation } from "./gsapParser.js";
 import type { Keyframe } from "../core.types";
+import {
+  parseAndSerialize,
+  parseSingleAnimation,
+  expectKeyframe,
+  expectKeyframesFormat,
+  convertAndReparse,
+  parseSplitAndAssert,
+} from "./gsapParser.test-helpers.js";
 
 describe("parseGsapScript", () => {
   it("parses a basic timeline with .to()", () => {
@@ -298,11 +307,7 @@ describe("stagger/yoyo/repeat round-trip", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to(".items", { opacity: 1, duration: 0.5, stagger: { each: 0.15, from: "start" } }, 0);
     `;
-    const parsed = parseGsapScript(script);
-    const serialized = serializeGsapAnimations(parsed.animations, parsed.timelineVar, {
-      preamble: parsed.preamble,
-      postamble: parsed.postamble,
-    });
+    const { serialized } = parseAndSerialize(script);
 
     expect(serialized).toContain("stagger: {");
     expect(serialized).toContain("each: 0.15");
@@ -314,11 +319,7 @@ describe("stagger/yoyo/repeat round-trip", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to("#el1", { x: 100, duration: 1, yoyo: true, repeat: 3, repeatDelay: 0.2 }, 0);
     `;
-    const parsed = parseGsapScript(script);
-    const serialized = serializeGsapAnimations(parsed.animations, parsed.timelineVar, {
-      preamble: parsed.preamble,
-      postamble: parsed.postamble,
-    });
+    const { serialized } = parseAndSerialize(script);
 
     expect(serialized).toContain("yoyo: true");
     expect(serialized).toContain("repeat: 3");
@@ -348,11 +349,7 @@ describe("unresolvable value round-trip", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to("#el1", { opacity: someFn(), x: 50, duration: 1 }, 0);
     `;
-    const parsed = parseGsapScript(script);
-    const serialized = serializeGsapAnimations(parsed.animations, parsed.timelineVar, {
-      preamble: parsed.preamble,
-      postamble: parsed.postamble,
-    });
+    const { serialized } = parseAndSerialize(script);
 
     // The raw expression should survive — emitted without quotes
     expect(serialized).toContain("opacity: someFn()");
@@ -1100,9 +1097,8 @@ describe("gsap.utils.toArray targets", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to(gsap.utils.toArray(".item"), { opacity: 1, duration: 0.5, stagger: 0.1 }, 0);
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    expect(result.animations[0].targetSelector).toBe(".item");
+    const anim = parseSingleAnimation(script);
+    expect(anim.targetSelector).toBe(".item");
   });
 
   it("resolves a toArray result stored in a variable", () => {
@@ -1111,8 +1107,8 @@ describe("gsap.utils.toArray targets", () => {
       const tl = gsap.timeline({ paused: true });
       tl.to(items, { opacity: 1, duration: 0.5 }, 0);
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations[0].targetSelector).toBe(".item");
+    const anim = parseSingleAnimation(script);
+    expect(anim.targetSelector).toBe(".item");
   });
 });
 
@@ -1146,9 +1142,8 @@ describe("forEach / map callback targets", () => {
         tl.to(el, { opacity: 1, duration: 0.4 }, 0);
       });
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    expect(result.animations[0].targetSelector).toBe(".item");
+    const anim = parseSingleAnimation(script);
+    expect(anim.targetSelector).toBe(".item");
   });
 
   it("resolves an inline querySelectorAll().forEach callback param", () => {
@@ -1158,8 +1153,8 @@ describe("forEach / map callback targets", () => {
         tl.to(dot, { scale: 1, duration: 0.3 }, 0);
       });
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations[0].targetSelector).toBe(".dot");
+    const anim = parseSingleAnimation(script);
+    expect(anim.targetSelector).toBe(".dot");
   });
 });
 
@@ -1204,23 +1199,12 @@ describe("native GSAP keyframes parsing", () => {
         duration: 5
       }, 0);
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    const anim = result.animations[0];
-    expect(anim.keyframes).toBeDefined();
-    expect(anim.keyframes!.format).toBe("percentage");
-    expect(anim.keyframes!.keyframes).toHaveLength(3);
+    const anim = parseSingleAnimation(script);
+    const kfs = expectKeyframesFormat(anim, "percentage", 3);
 
-    expect(anim.keyframes!.keyframes[0].percentage).toBe(0);
-    expect(anim.keyframes!.keyframes[0].properties.x).toBe(0);
-    expect(anim.keyframes!.keyframes[0].properties.opacity).toBe(1);
-
-    expect(anim.keyframes!.keyframes[1].percentage).toBe(50);
-    expect(anim.keyframes!.keyframes[1].properties.x).toBe(100);
-    expect(anim.keyframes!.keyframes[1].ease).toBe("power2.out");
-
-    expect(anim.keyframes!.keyframes[2].percentage).toBe(100);
-    expect(anim.keyframes!.keyframes[2].properties.x).toBe(200);
+    expectKeyframe(kfs[0], 0, { x: 0, opacity: 1 });
+    expectKeyframe(kfs[1], 50, { x: 100 }, "power2.out");
+    expectKeyframe(kfs[2], 100, { x: 200 });
   });
 
   it("parses object array keyframes format", () => {
@@ -1234,26 +1218,15 @@ describe("native GSAP keyframes parsing", () => {
         ]
       }, 0);
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    const anim = result.animations[0];
-    expect(anim.keyframes).toBeDefined();
-    expect(anim.keyframes!.format).toBe("object-array");
-    expect(anim.keyframes!.keyframes).toHaveLength(3);
+    const anim = parseSingleAnimation(script);
+    const kfs = expectKeyframesFormat(anim, "object-array", 3);
 
     // Total duration = 0.5 + 1 + 0.8 = 2.3
-    expect(anim.keyframes!.keyframes[0].percentage).toBe(0);
-    expect(anim.keyframes!.keyframes[0].properties.x).toBe(0);
-    expect(anim.keyframes!.keyframes[0].properties.opacity).toBe(1);
-
+    expectKeyframe(kfs[0], 0, { x: 0, opacity: 1 });
     // Second: cumulative = 0.5, pct = round(0.5/2.3 * 100) = 22
-    expect(anim.keyframes!.keyframes[1].percentage).toBe(22);
-    expect(anim.keyframes!.keyframes[1].properties.x).toBe(100);
-    expect(anim.keyframes!.keyframes[1].ease).toBe("power2.out");
-
+    expectKeyframe(kfs[1], 22, { x: 100 }, "power2.out");
     // Third: cumulative = 1.5, pct = round(1.5/2.3 * 100) = 65
-    expect(anim.keyframes!.keyframes[2].percentage).toBe(65);
-    expect(anim.keyframes!.keyframes[2].properties.x).toBe(200);
+    expectKeyframe(kfs[2], 65, { x: 200 });
   });
 
   it("parses simple array keyframes format", () => {
@@ -1264,30 +1237,17 @@ describe("native GSAP keyframes parsing", () => {
         duration: 5
       }, 0);
     `;
-    const result = parseGsapScript(script);
-    expect(result.animations).toHaveLength(1);
-    const anim = result.animations[0];
+    const anim = parseSingleAnimation(script);
     expect(anim.keyframes).toBeDefined();
     expect(anim.keyframes!.format).toBe("simple-array");
     expect(anim.keyframes!.easeEach).toBe("power2.inOut");
     expect(anim.keyframes!.keyframes).toHaveLength(4);
 
     // Evenly spaced: 0%, 33%, 67%, 100%
-    expect(anim.keyframes!.keyframes[0].percentage).toBe(0);
-    expect(anim.keyframes!.keyframes[0].properties.x).toBe(0);
-    expect(anim.keyframes!.keyframes[0].properties.opacity).toBe(0);
-
-    expect(anim.keyframes!.keyframes[1].percentage).toBe(33);
-    expect(anim.keyframes!.keyframes[1].properties.x).toBe(100);
-    expect(anim.keyframes!.keyframes[1].properties.opacity).toBe(1);
-
-    expect(anim.keyframes!.keyframes[2].percentage).toBe(67);
-    expect(anim.keyframes!.keyframes[2].properties.x).toBe(200);
-    expect(anim.keyframes!.keyframes[2].properties.opacity).toBe(1);
-
-    expect(anim.keyframes!.keyframes[3].percentage).toBe(100);
-    expect(anim.keyframes!.keyframes[3].properties.x).toBe(0);
-    expect(anim.keyframes!.keyframes[3].properties.opacity).toBe(0);
+    expectKeyframe(anim.keyframes!.keyframes[0], 0, { x: 0, opacity: 0 });
+    expectKeyframe(anim.keyframes!.keyframes[1], 33, { x: 100, opacity: 1 });
+    expectKeyframe(anim.keyframes!.keyframes[2], 67, { x: 200, opacity: 1 });
+    expectKeyframe(anim.keyframes!.keyframes[3], 100, { x: 0, opacity: 0 });
   });
 
   it("parses three-level easing", () => {
@@ -1449,18 +1409,11 @@ describe("keyframe mutations", () => {
       const tl = gsap.timeline({ paused: true });
       tl.from("#title", { x: -200, opacity: 0, duration: 0.8 }, 0.3);
     `;
-    const id = getAnimId(script);
-    const updated = convertToKeyframesInScript(script, id, { x: 0, opacity: 1 });
-    const reparsed = parseGsapScript(updated);
-    const anim = reparsed.animations[0];
-
+    const anim = convertAndReparse(script, { x: 0, opacity: 1 });
     expect(anim.method).toBe("to");
-    expect(anim.keyframes).toBeDefined();
-    const kfs = anim.keyframes!.keyframes;
-    expect(kfs[0].properties.x).toBe(-200);
-    expect(kfs[0].properties.opacity).toBe(0);
-    expect(kfs[1].properties.x).toBe(0);
-    expect(kfs[1].properties.opacity).toBe(1);
+    const kfs = expectKeyframesFormat(anim, "percentage", 2);
+    expectKeyframe(kfs[0]!, 0, { x: -200, opacity: 0 });
+    expectKeyframe(kfs[1]!, 100, { x: 0, opacity: 1 });
   });
 
   it("convertToKeyframesInScript — converts fromTo() to to() + keyframes", () => {
@@ -1468,16 +1421,11 @@ describe("keyframe mutations", () => {
       const tl = gsap.timeline({ paused: true });
       tl.fromTo("#title", { x: -100 }, { x: 100, duration: 1 }, 0);
     `;
-    const id = getAnimId(script);
-    const updated = convertToKeyframesInScript(script, id);
-    const reparsed = parseGsapScript(updated);
-    const anim = reparsed.animations[0];
-
+    const anim = convertAndReparse(script);
     expect(anim.method).toBe("to");
-    expect(anim.keyframes).toBeDefined();
-    const kfs = anim.keyframes!.keyframes;
-    expect(kfs[0].properties.x).toBe(-100);
-    expect(kfs[1].properties.x).toBe(100);
+    const kfs = expectKeyframesFormat(anim, "percentage", 2);
+    expect(kfs[0]!.properties.x).toBe(-100);
+    expect(kfs[1]!.properties.x).toBe(100);
   });
 
   it("convertToKeyframesInScript — skips if already has keyframes", () => {
@@ -1502,5 +1450,191 @@ describe("keyframe mutations", () => {
     expect(anim.keyframes).toBeUndefined();
     expect(anim.properties.x).toBe(200);
     expect(anim.properties.opacity).toBe(1);
+  });
+});
+
+describe("splitAnimationsInScript", () => {
+  const baseScript = `const tl = gsap.timeline({ paused: true });`;
+  const opts = {
+    originalId: "el1",
+    newId: "el1-split",
+    splitTime: 2,
+    elementStart: 0,
+    elementDuration: 4,
+  };
+
+  it("keeps animation entirely in first half and adds set for inherited state", () => {
+    const script = `${baseScript}\ntl.to("#el1", { x: 100, duration: 1 }, 0);`;
+    const result = splitAnimationsInScript(script, opts);
+    const parsed = parseGsapScript(result);
+    const forOriginal = parsed.animations.filter((a) => a.targetSelector === "#el1");
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    expect(forOriginal).toHaveLength(1);
+    expect(forNew).toHaveLength(1);
+    expect(forNew[0]!.method).toBe("set");
+    expect(forNew[0]!.properties.x).toBe(100);
+    expect(forNew[0]!.position).toBe(opts.splitTime);
+  });
+
+  it("retargets animation entirely in second half to new element", () => {
+    const script = `${baseScript}\ntl.to("#el1", { x: 100, duration: 1 }, 3);`;
+    const selectors = parseSplitAndAssert(script, (s) => splitAnimationsInScript(s, opts), 1);
+    expect(selectors[0]).toBe("#el1-split");
+  });
+
+  it("duplicates animation spanning the split point", () => {
+    const script = `${baseScript}\ntl.to("#el1", { opacity: 0, duration: 4 }, 0);`;
+    const result = splitAnimationsInScript(script, opts);
+    const parsed = parseGsapScript(result);
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    const first = parsed.animations.find((a) => a.targetSelector === "#el1");
+    const continuation = forNew.find((a) => a.method === "to");
+    const inherited = forNew.find((a) => a.method === "set");
+    expect(first).toBeDefined();
+    expect(continuation).toBeDefined();
+    expect(first!.duration).toBe(2);
+    expect(continuation!.duration).toBe(2);
+    expect(continuation!.position).toBe(opts.splitTime);
+    expect(inherited).toBeDefined();
+    expect(inherited!.properties.opacity).toBe(0);
+  });
+
+  it("retargets multiple animations at the same position both after split", () => {
+    const script = `${baseScript}\ntl.to("#el1", { x: 100, duration: 1 }, 3);\ntl.to("#el1", { y: 200, duration: 1 }, 3);`;
+    const result = splitAnimationsInScript(script, opts);
+    const parsed = parseGsapScript(result);
+    const forOriginal = parsed.animations.filter((a) => a.targetSelector === "#el1");
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    expect(forOriginal.length).toBe(0);
+    expect(forNew.length).toBe(2);
+  });
+
+  it("returns script unchanged when no matching animations", () => {
+    const script = `${baseScript}\ntl.to("#other", { x: 100, duration: 1 }, 0);`;
+    const result = splitAnimationsInScript(script, opts);
+    expect(result).toBe(script);
+  });
+
+  it("handles multiple animations independently", () => {
+    const script = `${baseScript}
+tl.to("#el1", { x: 100, duration: 1 }, 0);
+tl.to("#el1", { y: 200, duration: 1 }, 3);`;
+    const result = splitAnimationsInScript(script, opts);
+    const parsed = parseGsapScript(result);
+    const forOriginal = parsed.animations.filter((a) => a.targetSelector === "#el1");
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    expect(forOriginal).toHaveLength(1);
+    expect(forOriginal[0]!.properties.x).toBe(100);
+    expect(forNew).toHaveLength(2);
+    const retargeted = forNew.find((a) => a.method === "to");
+    const inherited = forNew.find((a) => a.method === "set");
+    expect(retargeted!.properties.y).toBe(200);
+    expect(inherited!.properties.x).toBe(100);
+  });
+
+  it("preserves fromTo properties on both halves", () => {
+    const script = `${baseScript}\ntl.fromTo("#el1", { opacity: 0 }, { opacity: 1, duration: 4 }, 0);`;
+    const result = splitAnimationsInScript(script, opts);
+    const parsed = parseGsapScript(result);
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    const fromToTween = forNew.find((a) => a.method === "fromTo");
+    expect(fromToTween).toBeDefined();
+    expect(fromToTween!.fromProperties?.opacity).toBe(0);
+  });
+
+  it("round-trips correctly through parseGsapScript", () => {
+    const script = `${baseScript}\ntl.to("#el1", { x: 100, duration: 4 }, 0);`;
+    const result = splitAnimationsInScript(script, opts);
+    const parsed = parseGsapScript(result);
+    expect(parsed.animations.length).toBeGreaterThanOrEqual(2);
+    for (const anim of parsed.animations) {
+      expect(typeof anim.position).toBe("number");
+      if (anim.method !== "set") expect(anim.duration).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps keyframes animation spanning split on original element", () => {
+    const script = `${baseScript}\ntl.to("#el1", { keyframes: [{ opacity: 1, duration: 1 }, { scale: 1.2, duration: 1 }, { x: 50, duration: 1 }] }, 1);`;
+    const splitOpts = {
+      originalId: "el1",
+      newId: "el1-split",
+      splitTime: 2.5,
+      elementStart: 0,
+      elementDuration: 5,
+    };
+    const result = splitAnimationsInScript(script, splitOpts);
+    const parsed = parseGsapScript(result);
+    const forOriginal = parsed.animations.filter((a) => a.targetSelector === "#el1");
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    expect(forOriginal.length).toBe(1);
+    expect(forNew.length).toBe(0);
+  });
+
+  it("retargets keyframes animation entirely after split", () => {
+    const script = `${baseScript}\ntl.to("#el1", { keyframes: [{ opacity: 1, duration: 0.5 }, { scale: 1.2, duration: 0.5 }] }, 4);`;
+    const splitOpts = {
+      originalId: "el1",
+      newId: "el1-split",
+      splitTime: 3,
+      elementStart: 0,
+      elementDuration: 5,
+    };
+    const result = splitAnimationsInScript(script, splitOpts);
+    const parsed = parseGsapScript(result);
+    const forOriginal = parsed.animations.filter((a) => a.targetSelector === "#el1");
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    expect(forOriginal.length).toBe(0);
+    expect(forNew.length).toBe(1);
+    expect(forNew[0]!.keyframes).toBeDefined();
+  });
+
+  it("keeps keyframes animation entirely before split", () => {
+    const script = `${baseScript}\ntl.to("#el1", { keyframes: [{ opacity: 1, duration: 0.5 }, { scale: 1.2, duration: 0.5 }] }, 0);`;
+    const splitOpts = {
+      originalId: "el1",
+      newId: "el1-split",
+      splitTime: 3,
+      elementStart: 0,
+      elementDuration: 5,
+    };
+    const result = splitAnimationsInScript(script, splitOpts);
+    const parsed = parseGsapScript(result);
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    expect(forNew.length).toBe(0);
+  });
+
+  it("retargets set tween entirely after split", () => {
+    const script = `${baseScript}\ntl.set("#el1", { opacity: 0 }, 3);`;
+    const result = splitAnimationsInScript(script, opts);
+    const parsed = parseGsapScript(result);
+    const forOriginal = parsed.animations.filter((a) => a.targetSelector === "#el1");
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    expect(forOriginal.length).toBe(0);
+    expect(forNew.length).toBe(1);
+    expect(forNew[0]!.method).toBe("set");
+    expect(forNew[0]!.position).toBe(3);
+  });
+
+  it("inserts inherited state set before other tweens targeting new element", () => {
+    const script = `${baseScript}\ntl.to("#el1", { opacity: 1, x: 50, duration: 0.5 }, 0);\ntl.to("#el1", { opacity: 0, duration: 0.5 }, 5);`;
+    const splitOpts = {
+      originalId: "el1",
+      newId: "el1-split",
+      splitTime: 3,
+      elementStart: 0,
+      elementDuration: 6,
+    };
+    const result = splitAnimationsInScript(script, splitOpts);
+    const parsed = parseGsapScript(result);
+    const forNew = parsed.animations.filter((a) => a.targetSelector === "#el1-split");
+    const setState = forNew.find((a) => a.method === "set");
+    const exitTween = forNew.find((a) => a.method === "to");
+    expect(setState).toBeDefined();
+    expect(exitTween).toBeDefined();
+    expect(setState!.properties.opacity).toBe(1);
+    expect(setState!.properties.x).toBe(50);
+    const setIdx = parsed.animations.indexOf(setState!);
+    const exitIdx = parsed.animations.indexOf(exitTween!);
+    expect(setIdx).toBeLessThan(exitIdx);
   });
 });

--- a/packages/core/src/parsers/gsapParser.ts
+++ b/packages/core/src/parsers/gsapParser.ts
@@ -576,6 +576,26 @@ function parsePercentageKeyframes(node: any, scope: ScopeBindings): GsapKeyframe
   };
 }
 
+function computeKeyframesTotalDuration(varsNode: any, scope: ScopeBindings): number | undefined {
+  const record = objectExpressionToRecord(varsNode, scope);
+  const kfVal = record.keyframes;
+  if (typeof kfVal !== "object" || kfVal === null) return undefined;
+  const kfNode = (varsNode.properties ?? []).find(
+    (p: any) => (p.key?.name ?? p.key?.value) === "keyframes",
+  )?.value;
+  if (!kfNode) return undefined;
+  if (kfNode.type === "ArrayExpression") {
+    let total = 0;
+    for (const el of kfNode.elements ?? []) {
+      if (!el || el.type !== "ObjectExpression") continue;
+      const r = objectExpressionToRecord(el, scope);
+      if (typeof r.duration === "number") total += r.duration;
+    }
+    return total > 0 ? total : undefined;
+  }
+  return undefined;
+}
+
 // fallow-ignore-next-line complexity
 function parseObjectArrayKeyframes(node: any, scope: ScopeBindings): GsapKeyframesData {
   const elements = node.elements ?? [];
@@ -748,8 +768,12 @@ function tweenCallToAnimation(
   const posVal = call.positionArg ? extractLiteralValue(call.positionArg, scope) : 0;
   const position: number | string =
     typeof posVal === "number" ? posVal : typeof posVal === "string" ? posVal : 0;
-  const duration = typeof vars.duration === "number" ? vars.duration : undefined;
+  let duration = typeof vars.duration === "number" ? vars.duration : undefined;
   const ease = typeof vars.ease === "string" ? vars.ease : undefined;
+
+  if (duration === undefined && keyframesData) {
+    duration = computeKeyframesTotalDuration(call.varsArg, scope);
+  }
 
   const anim: Omit<GsapAnimation, "id"> = {
     targetSelector: call.selector,
@@ -912,6 +936,21 @@ function setVarsKey(varsArg: any, key: string, value: number | string): void {
 }
 
 /**
+ * Filter an ObjectExpression's properties, keeping non-editable keys
+ * and delegating the keep/drop decision for editable keys to `shouldKeep`.
+ */
+function filterEditableKeys(varsArg: any, shouldKeep: (key: string) => boolean): void {
+  if (varsArg?.type !== "ObjectExpression") return;
+  varsArg.properties = varsArg.properties.filter((p: any) => {
+    if (!isObjectProperty(p)) return true;
+    const key = propKeyName(p);
+    if (typeof key !== "string") return true;
+    if (!isEditablePropertyKey(key)) return true;
+    return shouldKeep(key);
+  });
+}
+
+/**
  * Replace the editable-property keys on an ObjectExpression with `newProps`,
  * leaving `duration`, `ease`, `stagger`, callbacks and other non-editable keys
  * untouched.
@@ -920,15 +959,7 @@ function reconcileEditableProperties(
   varsArg: any,
   newProps: Record<string, number | string>,
 ): void {
-  if (varsArg?.type !== "ObjectExpression") return;
-  // Drop editable props no longer present.
-  varsArg.properties = varsArg.properties.filter((p: any) => {
-    if (!isObjectProperty(p)) return true;
-    const key = propKeyName(p);
-    if (typeof key !== "string") return true;
-    if (!isEditablePropertyKey(key)) return true;
-    return key in newProps;
-  });
+  filterEditableKeys(varsArg, (key) => key in newProps);
   // Upsert each new prop, preserving the order keys first appeared.
   for (const [key, value] of Object.entries(newProps)) {
     setVarsKey(varsArg, key, value);
@@ -1000,6 +1031,22 @@ export function updateAnimationInScript(
   const target = parsed.located.find((l) => l.id === animationId);
   if (!target) return script;
   applyUpdatesToCall(target.call, updates);
+  return recast.print(parsed.ast).code;
+}
+
+function updateAnimationSelector(script: string, animationId: string, newSelector: string): string {
+  let parsed: ParsedGsapAst;
+  try {
+    parsed = parseGsapAst(script);
+  } catch {
+    return script;
+  }
+  const target = parsed.located.find((l) => l.id === animationId);
+  if (!target) return script;
+  const selectorArg = target.call.path.node.arguments?.[0];
+  if (selectorArg?.type === "StringLiteral") {
+    selectorArg.value = newSelector;
+  }
   return recast.print(parsed.ast).code;
 }
 
@@ -1098,7 +1145,126 @@ export function removeAnimationFromScript(script: string, animationId: string): 
   return recast.print(parsed.ast).code;
 }
 
+function insertInheritedStateSet(
+  script: string,
+  selector: string,
+  position: number,
+  properties: Record<string, number | string>,
+): string {
+  let parsed: ParsedGsapAst;
+  try {
+    parsed = parseGsapAst(script);
+  } catch {
+    return script;
+  }
+  const tlVar = parsed.timelineVar;
+  const props = Object.entries(properties)
+    .map(([k, v]) => `${k}: ${typeof v === "string" ? JSON.stringify(v) : v}`)
+    .join(", ");
+  const code = `${tlVar}.set(${JSON.stringify(selector)}, { ${props} }, ${position});`;
+  const newStatement = parseScript(code).program.body[0];
+  const anchor = findTimelineDeclarationPath(parsed.ast, tlVar);
+  if (anchor) {
+    anchor.insertAfter(newStatement);
+  } else if (parsed.located.length > 0) {
+    const firstTween = parsed.located[0]!.call;
+    const stmtPath = findStatementPath(firstTween.path);
+    if (stmtPath) stmtPath.insertBefore(newStatement);
+    else parsed.ast.program.body.unshift(newStatement);
+  } else {
+    parsed.ast.program.body.push(newStatement);
+  }
+  return recast.print(parsed.ast).code;
+}
+
+// ── Split Animation Functions ─────────────────────────────────────────────
+
+export interface SplitAnimationsOptions {
+  originalId: string;
+  newId: string;
+  splitTime: number;
+  elementStart: number;
+  elementDuration: number;
+}
+
+export function splitAnimationsInScript(script: string, opts: SplitAnimationsOptions): string {
+  const parsed = parseGsapScript(script);
+  const originalSelector = `#${opts.originalId}`;
+  const newSelector = `#${opts.newId}`;
+  const matching = parsed.animations.filter((a) => a.targetSelector === originalSelector);
+  if (matching.length === 0) return script;
+
+  let result = script;
+  const newElementStart = opts.splitTime;
+  const inheritedProps: Record<string, number | string> = {};
+
+  for (let i = matching.length - 1; i >= 0; i--) {
+    const anim = matching[i]!;
+    const pos = typeof anim.position === "number" ? anim.position : 0;
+    const dur = anim.duration ?? 0;
+    const animEnd = pos + dur;
+
+    if (animEnd <= opts.splitTime) {
+      for (const [k, v] of Object.entries(anim.properties)) {
+        inheritedProps[k] = v;
+      }
+      continue;
+    }
+
+    if (anim.keyframes) {
+      if (pos >= opts.splitTime) {
+        result = updateAnimationSelector(result, anim.id, newSelector);
+      }
+      continue;
+    }
+
+    if (pos >= opts.splitTime) {
+      result = updateAnimationSelector(result, anim.id, newSelector);
+      continue;
+    }
+
+    // Spans the split — the end-state properties are inherited by the second half
+    for (const [k, v] of Object.entries(anim.properties)) {
+      inheritedProps[k] = v;
+    }
+
+    const firstHalfDuration = opts.splitTime - pos;
+    result = updateAnimationInScript(result, anim.id, {
+      duration: firstHalfDuration,
+    });
+
+    const secondHalfDuration = animEnd - opts.splitTime;
+    const addResult = addAnimationToScript(result, {
+      targetSelector: newSelector,
+      method: anim.method,
+      position: newElementStart,
+      duration: secondHalfDuration,
+      properties: { ...anim.properties },
+      fromProperties: anim.fromProperties ? { ...anim.fromProperties } : undefined,
+      ease: anim.ease,
+      extras: anim.extras,
+    });
+    result = addResult.script;
+  }
+
+  if (Object.keys(inheritedProps).length > 0) {
+    result = insertInheritedStateSet(result, newSelector, newElementStart, inheritedProps);
+  }
+
+  return result;
+}
+
 // ── Keyframe Mutation Functions ────────────────────────────────────────────
+
+function sortedKeyframes(
+  kfs: Array<{ percentage: number; properties: Record<string, number | string>; ease?: string }>,
+) {
+  return kfs.slice().sort((a, b) => a.percentage - b.percentage);
+}
+
+function keyframePropsToCode(kf: { properties: Record<string, number | string> }): string[] {
+  return Object.entries(kf.properties).map(([k, v]) => `${safeKey(k)}: ${valueToCode(v)}`);
+}
 
 /** Remove a named property from an ObjectExpression's properties array. */
 function removeVarsKey(varsArg: any, key: string): void {
@@ -1166,6 +1332,19 @@ function collapseKeyframesToFlat(varsArg: any, record: Record<string, unknown>):
 }
 
 /**
+ * Locate an animation's keyframes ObjectExpression and build the percentage key.
+ * Shared preamble for addKeyframeToScript, removeKeyframeFromScript, and
+ * updateKeyframeInScript.
+ */
+function locateKeyframeCtx(script: string, animationId: string, percentage: number) {
+  const loc = locateAnimation(script, animationId);
+  if (!loc) return null;
+  const kfNode = findKeyframesObjectNode(loc.target.call.varsArg);
+  if (!kfNode) return null;
+  return { loc, kfNode, pctKey: `${percentage}%` };
+}
+
+/**
  * Insert a keyframe at the given percentage in an existing percentage-keyframes
  * object. If the percentage already exists, its value is replaced.
  */
@@ -1177,12 +1356,10 @@ export function addKeyframeToScript(
   ease?: string,
   backfillDefaults?: Record<string, number | string>,
 ): string {
-  const loc = locateAnimation(script, animationId);
-  if (!loc) return script;
-  const kfNode = findKeyframesObjectNode(loc.target.call.varsArg);
-  if (!kfNode) return script;
+  const ctx = locateKeyframeCtx(script, animationId, percentage);
+  if (!ctx) return script;
+  const { loc, kfNode, pctKey } = ctx;
 
-  const pctKey = `${percentage}%`;
   const newValueNode = buildKeyframeValueNode(properties, ease);
 
   // Replace if this percentage already exists
@@ -1246,12 +1423,10 @@ export function removeKeyframeFromScript(
   animationId: string,
   percentage: number,
 ): string {
-  const loc = locateAnimation(script, animationId);
-  if (!loc) return script;
-  const kfNode = findKeyframesObjectNode(loc.target.call.varsArg);
-  if (!kfNode) return script;
+  const ctx = locateKeyframeCtx(script, animationId, percentage);
+  if (!ctx) return script;
+  const { loc, kfNode, pctKey } = ctx;
 
-  const pctKey = `${percentage}%`;
   const removeIdx = kfNode.properties.findIndex(
     (p: any) => isObjectProperty(p) && propKeyName(p) === pctKey,
   );
@@ -1281,12 +1456,10 @@ export function updateKeyframeInScript(
   properties: Record<string, number | string>,
   ease?: string,
 ): string {
-  const loc = locateAnimation(script, animationId);
-  if (!loc) return script;
-  const kfNode = findKeyframesObjectNode(loc.target.call.varsArg);
-  if (!kfNode) return script;
+  const ctx = locateKeyframeCtx(script, animationId, percentage);
+  if (!ctx) return script;
+  const { loc, kfNode, pctKey } = ctx;
 
-  const pctKey = `${percentage}%`;
   const existing = kfNode.properties.find(
     (p: any) => isObjectProperty(p) && propKeyName(p) === pctKey,
   );
@@ -1339,14 +1512,15 @@ function resolveConversionProps(
 
 /** Strip editable properties and ease/keyframes keys from a varsArg. */
 function stripEditableAndEase(varsArg: any): void {
+  // ease is a BUILTIN_VAR_KEY (not editable), so filterEditableKeys won't remove it —
+  // drop it explicitly before filtering, along with keyframes.
   if (varsArg?.type !== "ObjectExpression") return;
   varsArg.properties = varsArg.properties.filter((p: any) => {
     if (!isObjectProperty(p)) return true;
     const key = propKeyName(p);
-    if (typeof key !== "string") return true;
-    if (key === "ease" || key === "keyframes") return false;
-    return !isEditablePropertyKey(key);
+    return key !== "ease" && key !== "keyframes";
   });
+  filterEditableKeys(varsArg, () => false);
 }
 
 /** Build and prepend a keyframes property node onto varsArg. */
@@ -1453,11 +1627,8 @@ export function materializeKeyframesInScript(
   }
 
   const entries: string[] = [];
-  const sorted = keyframes.slice().sort((a, b) => a.percentage - b.percentage);
-  for (const kf of sorted) {
-    const propEntries = Object.entries(kf.properties).map(
-      ([k, v]) => `${safeKey(k)}: ${valueToCode(v)}`,
-    );
+  for (const kf of sortedKeyframes(keyframes)) {
+    const propEntries = keyframePropsToCode(kf);
     if (kf.ease) propEntries.push(`ease: ${JSON.stringify(kf.ease)}`);
     entries.push(`${JSON.stringify(kf.percentage + "%")}: { ${propEntries.join(", ")} }`);
   }
@@ -1543,11 +1714,8 @@ export function unrollDynamicAnimations(
   const calls: string[] = [];
   for (const el of elements) {
     const kfEntries: string[] = [];
-    const sorted = el.keyframes.slice().sort((a, b) => a.percentage - b.percentage);
-    for (const kf of sorted) {
-      const propEntries = Object.entries(kf.properties).map(
-        ([k, v]) => `${safeKey(k)}: ${valueToCode(v)}`,
-      );
+    for (const kf of sortedKeyframes(el.keyframes)) {
+      const propEntries = keyframePropsToCode(kf);
       kfEntries.push(`${JSON.stringify(kf.percentage + "%")}: { ${propEntries.join(", ")} }`);
     }
     if (el.easeEach) {

--- a/packages/core/src/studio-api/helpers/sourceMutation.test.ts
+++ b/packages/core/src/studio-api/helpers/sourceMutation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   removeElementFromHtml,
   patchElementInHtml,
+  splitElementInHtml,
   probeElementInSource,
 } from "./sourceMutation.js";
 
@@ -359,5 +360,55 @@ describe("probeElementInSource", () => {
 
     expect(probeElementInSource(sourceHtml, { id: "arrows-svg" })).toBe(false);
     expect(probeElementInSource(sourceHtml, { id: "canvas" })).toBe(true);
+  });
+});
+
+describe("splitElementInHtml", () => {
+  const source = `<!DOCTYPE html><html><head><style>#box { position: absolute; top: 100px; background: red; }</style></head><body><div data-composition-id="root"><div id="box" class="clip" data-start="1" data-duration="6">Hello</div></div></body></html>`;
+
+  it("splits element at the given time", () => {
+    const result = splitElementInHtml(source, { id: "box" }, 3, "box-split");
+    expect(result.matched).toBe(true);
+    expect(result.html).toContain('data-duration="2"');
+    expect(result.html).toContain('id="box-split"');
+    expect(result.html).toContain('data-start="3"');
+    expect(result.html).toContain('data-duration="4"');
+  });
+
+  it("duplicates CSS rules for the new element ID", () => {
+    const result = splitElementInHtml(source, { id: "box" }, 3, "box-split");
+    expect(result.html).toContain("#box-split");
+    expect(result.html).toContain("background: red");
+    const cssMatches = result.html.match(/#box-split\s*\{/g);
+    expect(cssMatches?.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("deduplicates IDs when the requested newId already exists", () => {
+    const withExisting = source.replace(
+      "</div></div>",
+      '</div><div id="box-split" data-start="5" data-duration="1">Existing</div></div>',
+    );
+    const result = splitElementInHtml(withExisting, { id: "box" }, 3, "box-split");
+    expect(result.matched).toBe(true);
+    expect(result.html).toContain('id="box-split-2"');
+  });
+
+  it("keeps clip class on the cloned element", () => {
+    const result = splitElementInHtml(source, { id: "box" }, 3, "box-split");
+    expect(result.html).toMatch(/id="box-split"[^>]*class="clip"/);
+  });
+
+  it("returns matched false for out-of-range split time", () => {
+    expect(splitElementInHtml(source, { id: "box" }, 0.5, "box-split").matched).toBe(false);
+    expect(splitElementInHtml(source, { id: "box" }, 7.5, "box-split").matched).toBe(false);
+  });
+
+  it("adjusts media playback-start for the second half", () => {
+    const mediaSource = source.replace(
+      'id="box" class="clip" data-start="1" data-duration="6"',
+      'id="box" class="clip" data-start="1" data-duration="6" data-playback-start="0"',
+    );
+    const result = splitElementInHtml(mediaSource, { id: "box" }, 3, "box-split");
+    expect(result.html).toMatch(/id="box-split"[^>]*data-playback-start="2"/);
   });
 });

--- a/packages/core/src/studio-api/helpers/sourceMutation.ts
+++ b/packages/core/src/studio-api/helpers/sourceMutation.ts
@@ -1,4 +1,5 @@
 import { parseHTML } from "linkedom";
+import postcss from "postcss";
 
 export interface SourceMutationTarget {
   id?: string | null;
@@ -15,6 +16,35 @@ function parseSourceDocument(source: string): { document: Document; wrappedFragm
     document: parseHTML(`<!DOCTYPE html><html><head></head><body>${source}</body></html>`).document,
     wrappedFragment: true,
   };
+}
+
+function duplicateCssRulesForId(document: Document, originalId: string, newId: string): void {
+  const idToken = `#${originalId}`;
+  const newToken = `#${newId}`;
+  for (const styleEl of document.querySelectorAll("style")) {
+    const css = styleEl.textContent ?? "";
+    let root: postcss.Root;
+    try {
+      root = postcss.parse(css);
+    } catch {
+      continue;
+    }
+    const clones: postcss.Rule[] = [];
+    root.walkRules((rule) => {
+      if (!rule.selector.includes(idToken)) return;
+      const newSelector = rule.selector.replace(
+        new RegExp(`#${originalId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![\\w-])`, "g"),
+        newToken,
+      );
+      if (newSelector === rule.selector) return;
+      const clone = rule.clone({ selector: newSelector });
+      clones.push(clone);
+    });
+    if (clones.length > 0) {
+      for (const c of clones) root.append(c);
+      styleEl.textContent = root.toString();
+    }
+  }
 }
 
 function querySelectorAllWithTemplates(root: Document | Element, selector: string): Element[] {
@@ -219,6 +249,7 @@ export interface SplitElementResult {
   newId: string | null;
 }
 
+// fallow-ignore-next-line complexity
 export function splitElementInHtml(
   source: string,
   target: SourceMutationTarget,
@@ -235,6 +266,14 @@ export function splitElementInHtml(
     return { html: source, matched: false, newId: null };
   }
 
+  if (document.getElementById(newId)) {
+    let suffix = 2;
+    const base = newId;
+    while (document.getElementById(newId)) {
+      newId = `${base}-${suffix++}`;
+    }
+  }
+
   const firstDuration = splitTime - start;
   const secondDuration = duration - firstDuration;
 
@@ -242,6 +281,9 @@ export function splitElementInHtml(
   clone.setAttribute("id", newId);
   clone.setAttribute("data-start", String(Math.round(splitTime * 1000) / 1000));
   clone.setAttribute("data-duration", String(Math.round(secondDuration * 1000) / 1000));
+
+  // Keep the "clip" class — the runtime uses it to control visibility
+  // based on data-start/data-duration timing.
 
   // Adjust media trim offset for the second half
   const playbackStartAttr = el.hasAttribute("data-playback-start")
@@ -256,6 +298,12 @@ export function splitElementInHtml(
       playbackStartAttr,
       String(Math.round((currentTrim + firstDuration * rate) * 1000) / 1000),
     );
+  }
+
+  // Duplicate CSS rules targeting the original ID so the clone inherits the same styles.
+  const originalId = el.getAttribute("id");
+  if (originalId) {
+    duplicateCssRulesForId(document, originalId, newId);
   }
 
   // Trim the original element's duration

--- a/packages/core/src/studio-api/routes/files.ts
+++ b/packages/core/src/studio-api/routes/files.ts
@@ -651,6 +651,14 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
           keyframes: Array<{ percentage: number; properties: Record<string, number | string> }>;
           easeEach?: string;
         }>;
+      }
+    | {
+        type: "split-animations";
+        originalId: string;
+        newId: string;
+        splitTime: number;
+        elementStart: number;
+        elementDuration: number;
       };
 
   api.post("/projects/:id/gsap-mutations/*", async (c) => {
@@ -702,19 +710,23 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
 
     // fallow-ignore-next-line complexity
     switch (body.type) {
-      case "update-property": {
+      case "update-property":
+      case "add-property": {
         const r = requireAnimation(block.scriptText, body.animationId);
         if ("err" in r) return r.err;
+        const val = body.type === "update-property" ? body.value : body.defaultValue;
         newScript = updateAnimationInScript(block.scriptText, body.animationId, {
-          properties: { ...r.anim.properties, [body.property]: body.value },
+          properties: { ...r.anim.properties, [body.property]: val },
         });
         break;
       }
-      case "update-from-property": {
+      case "update-from-property":
+      case "add-from-property": {
         const r = requireFromToAnimation(block.scriptText, body.animationId);
         if ("err" in r) return r.err;
+        const val = body.type === "update-from-property" ? body.value : body.defaultValue;
         newScript = updateAnimationInScript(block.scriptText, body.animationId, {
-          fromProperties: { ...(r.anim.fromProperties ?? {}), [body.property]: body.value },
+          fromProperties: { ...(r.anim.fromProperties ?? {}), [body.property]: val },
         });
         break;
       }
@@ -740,22 +752,6 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
       }
       case "delete": {
         newScript = removeAnimationFromScript(block.scriptText, body.animationId);
-        break;
-      }
-      case "add-property": {
-        const r = requireAnimation(block.scriptText, body.animationId);
-        if ("err" in r) return r.err;
-        newScript = updateAnimationInScript(block.scriptText, body.animationId, {
-          properties: { ...r.anim.properties, [body.property]: body.defaultValue },
-        });
-        break;
-      }
-      case "add-from-property": {
-        const r = requireFromToAnimation(block.scriptText, body.animationId);
-        if ("err" in r) return r.err;
-        newScript = updateAnimationInScript(block.scriptText, body.animationId, {
-          fromProperties: { ...(r.anim.fromProperties ?? {}), [body.property]: body.defaultValue },
-        });
         break;
       }
       case "remove-property": {
@@ -833,6 +829,17 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
             body.resolvedSelector,
           );
         }
+        break;
+      }
+      case "split-animations": {
+        const { splitAnimationsInScript } = await loadGsapParser();
+        newScript = splitAnimationsInScript(block.scriptText, {
+          originalId: body.originalId,
+          newId: body.newId,
+          splitTime: body.splitTime,
+          elementStart: body.elementStart,
+          elementDuration: body.elementDuration,
+        });
         break;
       }
       default:

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -536,6 +536,8 @@ export function StudioApp() {
                   handleTimelineElementResize={timelineEditing.handleTimelineElementResize}
                   handleBlockedTimelineEdit={timelineEditing.handleBlockedTimelineEdit}
                   handleTimelineElementSplit={timelineEditing.handleTimelineElementSplit}
+                  handleRazorSplit={timelineEditing.handleRazorSplit}
+                  handleRazorSplitAll={timelineEditing.handleRazorSplitAll}
                   setCompIdToSrc={setCompIdToSrc}
                   setCompositionLoading={setCompositionLoading}
                   shouldShowSelectedDomBounds={shouldShowSelectedDomBounds}

--- a/packages/studio/src/components/StudioPreviewArea.tsx
+++ b/packages/studio/src/components/StudioPreviewArea.tsx
@@ -52,6 +52,8 @@ export interface StudioPreviewAreaProps {
   ) => Promise<void> | void;
   handleBlockedTimelineEdit: (element: TimelineElement, intent: BlockedTimelineEditIntent) => void;
   handleTimelineElementSplit: (element: TimelineElement, splitTime: number) => Promise<void> | void;
+  handleRazorSplit: (element: TimelineElement, splitTime: number) => Promise<void> | void;
+  handleRazorSplitAll: (splitTime: number) => Promise<void> | void;
   setCompIdToSrc: (map: Map<string, string>) => void;
   setCompositionLoading: (loading: boolean) => void;
   shouldShowSelectedDomBounds: boolean;
@@ -71,6 +73,8 @@ export function StudioPreviewArea({
   handleTimelineElementResize,
   handleBlockedTimelineEdit,
   handleTimelineElementSplit,
+  handleRazorSplit,
+  handleRazorSplitAll,
   setCompIdToSrc,
   setCompositionLoading,
   shouldShowSelectedDomBounds,
@@ -142,6 +146,8 @@ export function StudioPreviewArea({
           onResizeElement={handleTimelineElementResize}
           onBlockedEditAttempt={handleBlockedTimelineEdit}
           onSplitElement={handleTimelineElementSplit}
+          onRazorSplit={handleRazorSplit}
+          onRazorSplitAll={handleRazorSplitAll}
           onSelectTimelineElement={handleTimelineElementSelect}
           onDeleteAllKeyframes={(_elId) => {
             const anim =

--- a/packages/studio/src/components/TimelineToolbar.tsx
+++ b/packages/studio/src/components/TimelineToolbar.tsx
@@ -2,6 +2,7 @@ import {
   getNextTimelineZoomPercent,
   getTimelineZoomPercent,
 } from "../player/components/timelineZoom";
+import { useTimelineZoom } from "../player/components/useTimelineZoom";
 import { getTimelineToggleTitle } from "../utils/timelineDiscovery";
 import { usePlayerStore, type TimelineElement } from "../player";
 import { STUDIO_KEYFRAMES_ENABLED } from "./editor/manualEditingAvailability";
@@ -9,18 +10,26 @@ import { Tooltip } from "./ui";
 import { Scissors } from "../icons/SystemIcons";
 import type { GsapAnimation, GsapPercentageKeyframe } from "@hyperframes/core/gsap-parser";
 import type { DomEditSelection } from "./editor/domEditingTypes";
+import { canSplitElement } from "../utils/timelineElementSplit";
 
+/** Collect all property names that have numeric values across a set of keyframes. */
+function collectNumericKeyframeProps(keyframes: GsapPercentageKeyframe[]): Set<string> {
+  const props = new Set<string>();
+  for (const kf of keyframes) {
+    for (const p of Object.keys(kf.properties)) {
+      if (typeof kf.properties[p] === "number") props.add(p);
+    }
+  }
+  return props;
+}
+
+// fallow-ignore-next-line complexity
 function interpolateKeyframeProperties(
   keyframes: GsapPercentageKeyframe[],
   pct: number,
 ): Record<string, number> {
   const sorted = keyframes.slice().sort((a, b) => a.percentage - b.percentage);
-  const allProps = new Set<string>();
-  for (const kf of sorted) {
-    for (const p of Object.keys(kf.properties)) {
-      if (typeof kf.properties[p] === "number") allProps.add(p);
-    }
-  }
+  const allProps = collectNumericKeyframeProps(sorted);
   const result: Record<string, number> = {};
   for (const prop of allProps) {
     let prev: { pct: number; val: number } | null = null;
@@ -43,6 +52,7 @@ function interpolateKeyframeProperties(
   return result;
 }
 
+// fallow-ignore-next-line complexity
 function readRuntimeKeyframeValues(
   iframe: HTMLIFrameElement | null,
   sel: DomEditSelection,
@@ -66,12 +76,7 @@ function readRuntimeKeyframeValues(
   }
   const element = doc?.querySelector(selector);
   if (!element) return {};
-  const allProps = new Set<string>();
-  for (const kf of keyframes) {
-    for (const p of Object.keys(kf.properties)) {
-      if (typeof kf.properties[p] === "number") allProps.add(p);
-    }
-  }
+  const allProps = collectNumericKeyframeProps(keyframes);
   const result: Record<string, number> = {};
   for (const prop of allProps) {
     const val = Number(gsap.getProperty(element, prop));
@@ -107,14 +112,17 @@ function useKeyframeToggle(session?: DomEditSessionSlice) {
   const kfAnim = anims.find((a) => a.keyframes);
   const flatAnim = anims.find((a) => !a.keyframes);
 
+  const computePct = (time: number) => {
+    const elStart = Number.parseFloat(sel?.dataAttributes?.start ?? "0") || 0;
+    const elDuration = Number.parseFloat(sel?.dataAttributes?.duration ?? "1") || 1;
+    return elDuration > 0
+      ? Math.max(0, Math.min(100, Math.round(((time - elStart) / elDuration) * 1000) / 10))
+      : 0;
+  };
+
   let state: "active" | "inactive" | "none" = "none";
   if (kfAnim?.keyframes && sel) {
-    const elStart = Number.parseFloat(sel.dataAttributes?.start ?? "0") || 0;
-    const elDuration = Number.parseFloat(sel.dataAttributes?.duration ?? "1") || 1;
-    const pct =
-      elDuration > 0
-        ? Math.max(0, Math.min(100, Math.round(((currentTime - elStart) / elDuration) * 1000) / 10))
-        : 0;
+    const pct = computePct(currentTime);
     state = kfAnim.keyframes.keyframes.some((k) => Math.abs(k.percentage - pct) <= 1)
       ? "active"
       : "inactive";
@@ -128,12 +136,7 @@ function useKeyframeToggle(session?: DomEditSessionSlice) {
           if (kfAnim.hasUnresolvedKeyframes) {
             await session.handleGsapMaterializeKeyframes?.(kfAnim.id);
           }
-          const elStart = Number.parseFloat(sel.dataAttributes?.start ?? "0") || 0;
-          const elDuration = Number.parseFloat(sel.dataAttributes?.duration ?? "1") || 1;
-          const pct =
-            elDuration > 0
-              ? Math.max(0, Math.min(100, Math.round(((t - elStart) / elDuration) * 1000) / 10))
-              : 0;
+          const pct = computePct(t);
           const existing = kfAnim.keyframes.keyframes.find(
             (k) => Math.abs(k.percentage - pct) <= 1,
           );
@@ -164,15 +167,15 @@ function useKeyframeToggle(session?: DomEditSessionSlice) {
   return { state, onToggle };
 }
 
+// fallow-ignore-next-line complexity
 export function TimelineToolbar({
   toggleTimelineVisibility,
   domEditSession,
   onSplitElement,
 }: TimelineToolbarProps) {
-  const zoomMode = usePlayerStore((s) => s.zoomMode);
-  const manualZoomPercent = usePlayerStore((s) => s.manualZoomPercent);
-  const setZoomMode = usePlayerStore((s) => s.setZoomMode);
-  const setManualZoomPercent = usePlayerStore((s) => s.setManualZoomPercent);
+  const activeTool = usePlayerStore((s) => s.activeTool);
+  const setActiveTool = usePlayerStore((s) => s.setActiveTool);
+  const { zoomMode, manualZoomPercent, setZoomMode, setManualZoomPercent } = useTimelineZoom();
   const displayedTimelineZoomPercent = getTimelineZoomPercent(zoomMode, manualZoomPercent);
   const { state: keyframeState, onToggle: onToggleKeyframe } = useKeyframeToggle(domEditSession);
 
@@ -182,6 +185,36 @@ export function TimelineToolbar({
         <div className="flex items-center gap-3">
           <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-neutral-500">
             Timeline
+          </div>
+          <div className="flex items-center border border-neutral-800 rounded overflow-hidden">
+            <Tooltip label="Selection tool (V)">
+              <button
+                type="button"
+                onClick={() => setActiveTool("select")}
+                className={`flex h-6 w-6 items-center justify-center transition-colors ${
+                  activeTool === "select"
+                    ? "bg-neutral-700 text-neutral-200"
+                    : "text-neutral-500 hover:text-neutral-300"
+                }`}
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+                  <path d="M2 0.5L10 6L6.5 6.5L8.5 11L6.5 11.5L4.5 7L2 9Z" />
+                </svg>
+              </button>
+            </Tooltip>
+            <Tooltip label="Razor tool (B)">
+              <button
+                type="button"
+                onClick={() => setActiveTool("razor")}
+                className={`flex h-6 w-6 items-center justify-center transition-colors ${
+                  activeTool === "razor"
+                    ? "bg-neutral-700 text-neutral-200"
+                    : "text-neutral-500 hover:text-neutral-300"
+                }`}
+              >
+                <Scissors size={11} />
+              </button>
+            </Tooltip>
           </div>
           {STUDIO_KEYFRAMES_ENABLED && onToggleKeyframe && (
             <Tooltip
@@ -225,9 +258,7 @@ export function TimelineToolbar({
               const el = selectedElementId
                 ? elements.find((e) => (e.key ?? e.id) === selectedElementId)
                 : null;
-              const splittable =
-                el && !el.compositionSrc && ["video", "audio", "img"].includes(el.tag);
-              if (!splittable) return null;
+              if (!el || !canSplitElement(el)) return null;
               const canSplit = currentTime > el.start && currentTime < el.start + el.duration;
               return (
                 <Tooltip label="Split clip at playhead (S)">

--- a/packages/studio/src/components/nle/NLELayout.tsx
+++ b/packages/studio/src/components/nle/NLELayout.tsx
@@ -10,7 +10,7 @@ import {
 import { useMountEffect } from "../../hooks/useMountEffect";
 import { useTimelinePlayer, PlayerControls, Timeline, usePlayerStore } from "../../player";
 import type { TimelineElement } from "../../player";
-import type { BlockedTimelineEditIntent } from "../../player/components/timelineEditing";
+import type { TimelineEditCallbacks } from "../../player/components/timelineCallbacks";
 import { NLEPreview } from "./NLEPreview";
 import { CompositionBreadcrumb } from "./CompositionBreadcrumb";
 import { usePreviewBlockDrop } from "./usePreviewBlockDrop";
@@ -20,7 +20,7 @@ import {
   getTimelineToggleTitle,
 } from "../../utils/timelineDiscovery";
 
-interface NLELayoutProps {
+interface NLELayoutProps extends TimelineEditCallbacks {
   projectId: string;
   portrait?: boolean;
   /** Slot for overlays rendered on top of the preview (cursors, highlights, etc.) */
@@ -59,23 +59,7 @@ interface NLELayoutProps {
     blockName: string,
     position: { left: number; top: number },
   ) => Promise<void> | void;
-  /** Persist timeline move actions back into source HTML */
-  onMoveElement?: (
-    element: TimelineElement,
-    updates: Pick<TimelineElement, "start" | "track">,
-  ) => Promise<void> | void;
-  onResizeElement?: (
-    element: TimelineElement,
-    updates: Pick<TimelineElement, "start" | "duration" | "playbackStart">,
-  ) => Promise<void> | void;
-  onBlockedEditAttempt?: (element: TimelineElement, intent: BlockedTimelineEditIntent) => void;
-  onSplitElement?: (element: TimelineElement, splitTime: number) => Promise<void> | void;
   onSelectTimelineElement?: (element: TimelineElement | null) => void;
-  onDeleteKeyframe?: (elementId: string, percentage: number) => void;
-  onDeleteAllKeyframes?: (elementId: string) => void;
-  onChangeKeyframeEase?: (elementId: string, percentage: number, ease: string) => void;
-  onMoveKeyframe?: (element: TimelineElement, oldPct: number, newPct: number) => void;
-  onToggleKeyframeAtPlayhead?: (element: TimelineElement) => void;
   /** Exposes the compIdToSrc map for parent components (e.g., useRenderClipContent) */
   onCompIdToSrcChange?: (map: Map<string, string>) => void;
   /** Whether the timeline panel is visible (default: true) */
@@ -124,6 +108,8 @@ export const NLELayout = memo(function NLELayout({
   onResizeElement,
   onBlockedEditAttempt,
   onSplitElement,
+  onRazorSplit,
+  onRazorSplitAll,
   onSelectTimelineElement,
   onDeleteKeyframe,
   onDeleteAllKeyframes,
@@ -460,6 +446,8 @@ export const NLELayout = memo(function NLELayout({
                 onResizeElement={onResizeElement}
                 onBlockedEditAttempt={onBlockedEditAttempt}
                 onSplitElement={onSplitElement}
+                onRazorSplit={onRazorSplit}
+                onRazorSplitAll={onRazorSplitAll}
                 onSelectElement={onSelectTimelineElement}
                 onDeleteKeyframe={onDeleteKeyframe}
                 onDeleteAllKeyframes={onDeleteAllKeyframes}

--- a/packages/studio/src/components/nle/TimelineEditorNotice.tsx
+++ b/packages/studio/src/components/nle/TimelineEditorNotice.tsx
@@ -1,4 +1,5 @@
 import { TIMELINE_TOGGLE_SHORTCUT_LABEL } from "../../utils/timelineDiscovery";
+import { PlayheadIndicator } from "../../player/components/PlayheadIndicator";
 
 interface TimelineEditorNoticeProps {
   onDismiss: () => void;
@@ -76,31 +77,7 @@ export function TimelineEditorNotice({ onDismiss }: TimelineEditorNoticeProps) {
                     "hfTimelineNoticePlayheadSweep 2.8s cubic-bezier(0.4, 0, 0.2, 1) infinite",
                 }}
               >
-                <div
-                  className="absolute top-0 bottom-0"
-                  style={{
-                    left: "50%",
-                    width: 2,
-                    marginLeft: -1,
-                    background: "var(--hf-accent, #3CE6AC)",
-                    boxShadow: "0 0 8px rgba(60,230,172,0.5)",
-                  }}
-                />
-                <div
-                  className="absolute"
-                  style={{ left: "50%", top: 0, transform: "translateX(-50%)" }}
-                >
-                  <div
-                    style={{
-                      width: 0,
-                      height: 0,
-                      borderLeft: "6px solid transparent",
-                      borderRight: "6px solid transparent",
-                      borderTop: "8px solid var(--hf-accent, #3CE6AC)",
-                      filter: "drop-shadow(0 1px 3px rgba(0,0,0,0.6))",
-                    }}
-                  />
-                </div>
+                <PlayheadIndicator />
               </div>
 
               <div className="flex flex-col gap-1.5">

--- a/packages/studio/src/hooks/useAppHotkeys.ts
+++ b/packages/studio/src/hooks/useAppHotkeys.ts
@@ -6,6 +6,7 @@ import type { LeftSidebarHandle } from "../components/sidebar/LeftSidebar";
 import { STUDIO_MOTION_PATH } from "../components/editor/studioMotion";
 import { shouldHandleTimelineToggleHotkey, isEditableTarget } from "../utils/timelineDiscovery";
 import { shouldIgnoreHistoryShortcut } from "../utils/studioHelpers";
+import { canSplitElement } from "../utils/timelineElementSplit";
 
 /** Safely resolves contentWindow for a potentially cross-origin iframe. */
 function iframeContentWindow(iframe: HTMLIFrameElement | null): Window | null {
@@ -323,7 +324,7 @@ export function useAppHotkeys({
         const element = elements.find((el) => (el.key ?? el.id) === selectedElementId);
         if (
           element &&
-          ["video", "audio", "img"].includes(element.tag) &&
+          canSplitElement(element) &&
           currentTime > element.start &&
           currentTime < element.start + element.duration
         ) {
@@ -331,6 +332,50 @@ export function useAppHotkeys({
           void handleSplitRef.current(element, currentTime);
           return;
         }
+      }
+    }
+
+    // B — toggle razor tool
+    if (
+      event.key.toLowerCase() === "b" &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.shiftKey &&
+      !isEditableTarget(event.target)
+    ) {
+      event.preventDefault();
+      const { activeTool, setActiveTool } = usePlayerStore.getState();
+      setActiveTool(activeTool === "razor" ? "select" : "razor");
+      return;
+    }
+
+    // V — return to selection tool
+    if (
+      event.key.toLowerCase() === "v" &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.shiftKey &&
+      !isEditableTarget(event.target)
+    ) {
+      event.preventDefault();
+      usePlayerStore.getState().setActiveTool("select");
+      return;
+    }
+
+    // Escape — exit razor mode (only when no selection to deselect first)
+    if (event.key === "Escape" && !isEditableTarget(event.target)) {
+      const { activeTool, selectedElementId, setActiveTool, setSelectedElementId } =
+        usePlayerStore.getState();
+      if (activeTool === "razor") {
+        if (selectedElementId) {
+          setSelectedElementId(null);
+        } else {
+          setActiveTool("select");
+        }
+        event.preventDefault();
+        return;
       }
     }
 

--- a/packages/studio/src/hooks/useClipboard.ts
+++ b/packages/studio/src/hooks/useClipboard.ts
@@ -8,6 +8,7 @@ import { insertTimelineAssetIntoSource } from "../utils/timelineAssetDrop";
 import { saveProjectFilesWithHistory } from "../utils/studioFileHistory";
 import type { EditHistoryKind } from "../utils/editHistory";
 import { formatTimelineAttributeNumber } from "../player/components/timelineEditing";
+import { readFileContent } from "../utils/timelineElementSplit";
 
 interface RecordEditInput {
   label: string;
@@ -28,16 +29,6 @@ interface UseClipboardOptions {
   handleTimelineElementDelete: (element: TimelineElement) => Promise<void>;
   handleDomEditElementDelete: (selection: DomEditSelection) => Promise<void>;
   previewIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
-}
-
-async function readFileContent(projectId: string, targetPath: string): Promise<string> {
-  const response = await fetch(
-    `/api/projects/${projectId}/files/${encodeURIComponent(targetPath)}`,
-  );
-  if (!response.ok) throw new Error(`Failed to read ${targetPath}`);
-  const data = (await response.json()) as { content?: string };
-  if (typeof data.content !== "string") throw new Error(`Missing file contents for ${targetPath}`);
-  return data.content;
 }
 
 function getElementOuterHtml(

--- a/packages/studio/src/hooks/useContextMenuDismiss.ts
+++ b/packages/studio/src/hooks/useContextMenuDismiss.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+
+/**
+ * Shared dismiss logic for context menus: closes on outside click or Escape.
+ * Returns a ref to attach to the menu container element.
+ */
+export function useContextMenuDismiss(onClose: () => void): RefObject<HTMLDivElement | null> {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const dismiss = useCallback(
+    (e: MouseEvent | KeyboardEvent) => {
+      if (e instanceof KeyboardEvent && e.key !== "Escape") return;
+      if (e instanceof MouseEvent && menuRef.current?.contains(e.target as Node)) return;
+      onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("mousedown", dismiss);
+    document.addEventListener("keydown", dismiss);
+    return () => {
+      document.removeEventListener("mousedown", dismiss);
+      document.removeEventListener("keydown", dismiss);
+    };
+  }, [dismiss]);
+
+  return menuRef;
+}

--- a/packages/studio/src/hooks/useRazorSplit.ts
+++ b/packages/studio/src/hooks/useRazorSplit.ts
@@ -1,0 +1,183 @@
+import { useCallback, useRef } from "react";
+import type { TimelineElement } from "../player";
+import { usePlayerStore } from "../player";
+import { saveProjectFilesWithHistory } from "../utils/studioFileHistory";
+import { getTimelineElementLabel, collectHtmlIds } from "../utils/studioHelpers";
+import { canSplitElement, buildPatchTarget, readFileContent } from "../utils/timelineElementSplit";
+import type { RecordEditInput } from "./useTimelineEditing";
+
+interface UseRazorSplitOptions {
+  projectId: string | null;
+  activeCompPath: string | null;
+  showToast: (message: string, tone?: "error" | "info") => void;
+  writeProjectFile: (path: string, content: string) => Promise<void>;
+  recordEdit: (input: RecordEditInput) => Promise<void>;
+  domEditSaveTimestampRef: React.MutableRefObject<number>;
+  reloadPreview: () => void;
+}
+
+function generateSplitId(existingIds: string[], baseId: string): string {
+  let newId = `${baseId}-split`;
+  let suffix = 2;
+  while (existingIds.includes(newId)) {
+    newId = `${baseId}-split-${suffix++}`;
+  }
+  return newId;
+}
+
+async function splitHtmlElement(
+  projectId: string,
+  targetPath: string,
+  patchTarget: NonNullable<ReturnType<typeof buildPatchTarget>>,
+  splitTime: number,
+  newId: string,
+): Promise<{ ok: boolean; content?: string }> {
+  const response = await fetch(
+    `/api/projects/${projectId}/file-mutations/split-element/${encodeURIComponent(targetPath)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target: patchTarget, splitTime, newId }),
+    },
+  );
+  if (!response.ok) throw new Error("Split request failed");
+  return (await response.json()) as { ok: boolean; changed?: boolean; content?: string };
+}
+
+async function splitGsapAnimations(
+  projectId: string,
+  targetPath: string,
+  originalId: string,
+  newId: string,
+  splitTime: number,
+  elementStart: number,
+  elementDuration: number,
+): Promise<string | null> {
+  const response = await fetch(
+    `/api/projects/${projectId}/gsap-mutations/${encodeURIComponent(targetPath)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "split-animations",
+        originalId,
+        newId,
+        splitTime,
+        elementStart,
+        elementDuration,
+      }),
+    },
+  );
+  if (!response.ok) return null;
+  const data = (await response.json()) as { ok?: boolean; after?: string };
+  return data.ok && data.after ? data.after : null;
+}
+
+// fallow-ignore-next-line complexity
+async function executeSplit(
+  pid: string,
+  element: TimelineElement,
+  splitTime: number,
+  activeCompPath: string | null,
+): Promise<{ targetPath: string; originalContent: string; patchedContent: string }> {
+  const patchTarget = buildPatchTarget(element);
+  if (!patchTarget) throw new Error("Clip is missing a patchable target.");
+
+  const targetPath = element.sourceFile || activeCompPath || "index.html";
+  const originalContent = await readFileContent(pid, targetPath);
+  const newId = generateSplitId(collectHtmlIds(originalContent), element.domId || "clip");
+
+  const splitResult = await splitHtmlElement(pid, targetPath, patchTarget, splitTime, newId);
+  if (!splitResult.ok) throw new Error("Failed to split clip.");
+
+  let patchedContent =
+    typeof splitResult.content === "string" ? splitResult.content : originalContent;
+
+  if (element.domId) {
+    const gsapContent = await splitGsapAnimations(
+      pid,
+      targetPath,
+      element.domId,
+      newId,
+      splitTime,
+      element.start,
+      element.duration,
+    );
+    if (gsapContent) patchedContent = gsapContent;
+  }
+
+  return { targetPath, originalContent, patchedContent };
+}
+
+export function useRazorSplit({
+  projectId,
+  activeCompPath,
+  showToast,
+  writeProjectFile,
+  recordEdit,
+  domEditSaveTimestampRef,
+  reloadPreview,
+}: UseRazorSplitOptions) {
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
+
+  const handleRazorSplit = useCallback(
+    // fallow-ignore-next-line complexity
+    async (element: TimelineElement, splitTime: number) => {
+      const pid = projectIdRef.current;
+      if (!pid || !canSplitElement(element)) return;
+      if (splitTime <= element.start || splitTime >= element.start + element.duration) return;
+
+      try {
+        const { targetPath, originalContent, patchedContent } = await executeSplit(
+          pid,
+          element,
+          splitTime,
+          activeCompPath,
+        );
+
+        domEditSaveTimestampRef.current = Date.now();
+        await saveProjectFilesWithHistory({
+          projectId: pid,
+          label: "Split timeline clip",
+          kind: "timeline",
+          files: { [targetPath]: patchedContent },
+          readFile: async () => originalContent,
+          writeFile: writeProjectFile,
+          recordEdit,
+        });
+
+        reloadPreview();
+        showToast(`Split ${getTimelineElementLabel(element)} at ${splitTime.toFixed(2)}s`, "info");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to split timeline clip";
+        showToast(message, "error");
+      }
+    },
+    [
+      activeCompPath,
+      recordEdit,
+      showToast,
+      writeProjectFile,
+      domEditSaveTimestampRef,
+      reloadPreview,
+    ],
+  );
+
+  const handleRazorSplitAll = useCallback(
+    async (splitTime: number) => {
+      const pid = projectIdRef.current;
+      if (!pid) return;
+      const { elements } = usePlayerStore.getState();
+      const splittable = elements.filter(
+        (el) => canSplitElement(el) && splitTime > el.start && splitTime < el.start + el.duration,
+      );
+      for (const element of splittable) {
+        await handleRazorSplit(element, splitTime);
+      }
+    },
+    [handleRazorSplit],
+  );
+
+  return { handleRazorSplit, handleRazorSplitAll };
+}

--- a/packages/studio/src/hooks/useTimelineEditing.ts
+++ b/packages/studio/src/hooks/useTimelineEditing.ts
@@ -2,6 +2,8 @@ import { useCallback, useRef } from "react";
 import type { TimelineElement } from "../player";
 import { usePlayerStore } from "../player";
 import { applyPatchByTarget, readAttributeByTarget } from "../utils/sourcePatcher";
+import { useRazorSplit } from "./useRazorSplit";
+import { buildPatchTarget, readFileContent } from "../utils/timelineElementSplit";
 import { formatTimelineAttributeNumber } from "../player/components/timelineEditing";
 import {
   buildTimelineAssetId,
@@ -22,7 +24,7 @@ import type { EditHistoryKind } from "../utils/editHistory";
 
 // ── Types ──
 
-interface RecordEditInput {
+export interface RecordEditInput {
   label: string;
   kind: EditHistoryKind;
   coalesceKey?: string;
@@ -44,16 +46,6 @@ interface UseTimelineEditingOptions {
 }
 
 // ── Helpers ──
-
-function buildPatchTarget(element: { domId?: string; selector?: string; selectorIndex?: number }) {
-  if (element.domId) {
-    return { id: element.domId, selector: element.selector, selectorIndex: element.selectorIndex };
-  }
-  if (element.selector) {
-    return { selector: element.selector, selectorIndex: element.selectorIndex };
-  }
-  return null;
-}
 
 // The runtime re-reads data-start/data-duration from the DOM on each sync tick
 // (packages/core/src/runtime/init.ts:1324-1368), so attribute mutations here are
@@ -146,20 +138,6 @@ async function persistTimelineEdit(input: PersistTimelineEditInput): Promise<voi
   input.domEditSaveTimestampRef.current = Date.now();
 }
 
-async function readFileContent(projectId: string, targetPath: string): Promise<string> {
-  const response = await fetch(
-    `/api/projects/${projectId}/files/${encodeURIComponent(targetPath)}`,
-  );
-  if (!response.ok) {
-    throw new Error(`Failed to read ${targetPath}`);
-  }
-  const data = (await response.json()) as { content?: string };
-  if (typeof data.content !== "string") {
-    throw new Error(`Missing file contents for ${targetPath}`);
-  }
-  return data.content;
-}
-
 // ── Hook ──
 
 export function useTimelineEditing({
@@ -222,7 +200,7 @@ export function useTimelineEditing({
         ["data-start", formatTimelineAttributeNumber(updates.start)],
         ["data-track-index", String(updates.track)],
       ]);
-      return enqueueEdit(element, "Move timeline clip", (original, target) => {
+      const result = enqueueEdit(element, "Move timeline clip", (original, target) => {
         let patched = applyPatchByTarget(original, target, {
           type: "attribute",
           property: "start",
@@ -234,8 +212,10 @@ export function useTimelineEditing({
           value: String(updates.track),
         });
       });
+      reloadPreview();
+      return result;
     },
-    [previewIframeRef, enqueueEdit],
+    [previewIframeRef, enqueueEdit, reloadPreview],
   );
 
   const handleTimelineElementResize = useCallback(
@@ -247,7 +227,7 @@ export function useTimelineEditing({
         ["data-start", formatTimelineAttributeNumber(updates.start)],
         ["data-duration", formatTimelineAttributeNumber(updates.duration)],
       ]);
-      return enqueueEdit(element, "Resize timeline clip", (original, target) => {
+      const result = enqueueEdit(element, "Resize timeline clip", (original, target) => {
         const pbs = resolveResizePlaybackStart(original, target, element, updates);
         let patched = applyPatchByTarget(original, target, {
           type: "attribute",
@@ -268,8 +248,10 @@ export function useTimelineEditing({
         }
         return patched;
       });
+      reloadPreview();
+      return result;
     },
-    [previewIframeRef, enqueueEdit],
+    [previewIframeRef, enqueueEdit, reloadPreview],
   );
 
   const handleTimelineElementDelete = useCallback(
@@ -466,103 +448,23 @@ export function useTimelineEditing({
     [showToast],
   );
 
-  const handleTimelineElementSplit = useCallback(
-    async (element: TimelineElement, splitTime: number) => {
-      const pid = projectIdRef.current;
-      if (!pid) return;
-
-      const splittableTags = new Set(["video", "audio", "img"]);
-      if (
-        element.timelineLocked ||
-        element.timingSource === "implicit" ||
-        element.compositionSrc ||
-        !splittableTags.has(element.tag) ||
-        !element.duration ||
-        !Number.isFinite(element.duration)
-      ) {
-        return;
-      }
-
-      if (splitTime <= element.start || splitTime >= element.start + element.duration) {
-        showToast("Playhead must be inside the clip to split.", "error");
-        return;
-      }
-
-      const patchTarget = buildPatchTarget(element);
-      if (!patchTarget) {
-        showToast("Clip is missing a patchable target.", "error");
-        return;
-      }
-
-      const targetPath = element.sourceFile || activeCompPath || "index.html";
-      try {
-        const originalContent = await readFileContent(pid, targetPath);
-        const existingIds = collectHtmlIds(originalContent);
-        const baseId = element.domId || "clip";
-        let newId = `${baseId}-split`;
-        let suffix = 2;
-        while (existingIds.includes(newId)) {
-          newId = `${baseId}-split-${suffix++}`;
-        }
-
-        const response = await fetch(
-          `/api/projects/${pid}/file-mutations/split-element/${encodeURIComponent(targetPath)}`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ target: patchTarget, splitTime, newId }),
-          },
-        );
-        if (!response.ok) {
-          throw new Error("Split request failed");
-        }
-
-        const data = (await response.json()) as {
-          ok?: boolean;
-          changed?: boolean;
-          content?: string;
-        };
-        if (!data.ok || !data.changed) {
-          showToast("Failed to split clip — playhead may be outside the clip.", "error");
-          return;
-        }
-
-        const patchedContent = typeof data.content === "string" ? data.content : originalContent;
-
-        domEditSaveTimestampRef.current = Date.now();
-        await saveProjectFilesWithHistory({
-          projectId: pid,
-          label: "Split timeline clip",
-          kind: "timeline",
-          files: { [targetPath]: patchedContent },
-          readFile: async () => originalContent,
-          writeFile: writeProjectFile,
-          recordEdit,
-        });
-
-        reloadPreview();
-        const label = getTimelineElementLabel(element);
-        showToast(`Split ${label} at ${splitTime.toFixed(2)}s`, "info");
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to split timeline clip";
-        showToast(message, "error");
-      }
-    },
-    [
-      activeCompPath,
-      recordEdit,
-      showToast,
-      writeProjectFile,
-      domEditSaveTimestampRef,
-      reloadPreview,
-    ],
-  );
+  const { handleRazorSplit, handleRazorSplitAll } = useRazorSplit({
+    projectId,
+    activeCompPath,
+    showToast,
+    writeProjectFile,
+    recordEdit,
+    domEditSaveTimestampRef,
+    reloadPreview,
+  });
 
   return {
     handleTimelineElementMove,
     handleTimelineElementResize,
     handleTimelineElementDelete,
-    handleTimelineElementSplit,
+    handleTimelineElementSplit: handleRazorSplit,
+    handleRazorSplit,
+    handleRazorSplitAll,
     handleTimelineAssetDrop,
     handleTimelineFileDrop,
     handleBlockedTimelineEdit,

--- a/packages/studio/src/player/components/ClipContextMenu.tsx
+++ b/packages/studio/src/player/components/ClipContextMenu.tsx
@@ -1,5 +1,7 @@
-import { memo, useCallback, useEffect, useRef } from "react";
+import { memo } from "react";
 import type { TimelineElement } from "../store/playerStore";
+import { canSplitElement } from "../../utils/timelineElementSplit";
+import { useContextMenuDismiss } from "../../hooks/useContextMenuDismiss";
 
 interface ClipContextMenuProps {
   x: number;
@@ -20,30 +22,12 @@ export const ClipContextMenu = memo(function ClipContextMenu({
   onSplit,
   onDelete,
 }: ClipContextMenuProps) {
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const dismiss = useCallback(
-    (e: MouseEvent | KeyboardEvent) => {
-      if (e instanceof KeyboardEvent && e.key !== "Escape") return;
-      if (e instanceof MouseEvent && menuRef.current?.contains(e.target as Node)) return;
-      onClose();
-    },
-    [onClose],
-  );
-
-  useEffect(() => {
-    document.addEventListener("mousedown", dismiss);
-    document.addEventListener("keydown", dismiss);
-    return () => {
-      document.removeEventListener("mousedown", dismiss);
-      document.removeEventListener("keydown", dismiss);
-    };
-  }, [dismiss]);
+  const menuRef = useContextMenuDismiss(onClose);
 
   const adjustedX = Math.min(x, window.innerWidth - 200);
   const adjustedY = Math.min(y, window.innerHeight - 200);
 
-  const isSplittable = ["video", "audio", "img"].includes(element.tag);
+  const isSplittable = canSplitElement(element);
   const canSplit =
     isSplittable && currentTime > element.start && currentTime < element.start + element.duration;
 

--- a/packages/studio/src/player/components/KeyframeDiamondContextMenu.tsx
+++ b/packages/studio/src/player/components/KeyframeDiamondContextMenu.tsx
@@ -1,5 +1,6 @@
-import { memo, useCallback, useEffect, useRef } from "react";
+import { memo, useRef } from "react";
 import { EASE_LABELS } from "../../components/editor/gsapAnimationConstants";
+import { useContextMenuDismiss } from "../../hooks/useContextMenuDismiss";
 
 export interface KeyframeDiamondContextMenuState {
   x: number;
@@ -41,26 +42,8 @@ export const KeyframeDiamondContextMenu = memo(function KeyframeDiamondContextMe
   onChangeEase,
   onCopyProperties,
 }: KeyframeDiamondContextMenuProps) {
-  const menuRef = useRef<HTMLDivElement>(null);
+  const menuRef = useContextMenuDismiss(onClose);
   const easeSubmenuRef = useRef<HTMLDivElement>(null);
-
-  const dismiss = useCallback(
-    (e: MouseEvent | KeyboardEvent) => {
-      if (e instanceof KeyboardEvent && e.key !== "Escape") return;
-      if (e instanceof MouseEvent && menuRef.current?.contains(e.target as Node)) return;
-      onClose();
-    },
-    [onClose],
-  );
-
-  useEffect(() => {
-    document.addEventListener("mousedown", dismiss);
-    document.addEventListener("keydown", dismiss);
-    return () => {
-      document.removeEventListener("mousedown", dismiss);
-      document.removeEventListener("keydown", dismiss);
-    };
-  }, [dismiss]);
 
   const adjustedX = Math.min(state.x, window.innerWidth - 200);
   const adjustedY = Math.min(state.y, window.innerHeight - 300);

--- a/packages/studio/src/player/components/PlayheadIndicator.tsx
+++ b/packages/studio/src/player/components/PlayheadIndicator.tsx
@@ -1,0 +1,42 @@
+/**
+ * Shared playhead visual used by TimelineCanvas (real playhead) and
+ * TimelineEditorNotice (animated illustration).
+ */
+interface PlayheadIndicatorProps {
+  /** CSS color, defaults to the HF accent variable */
+  color?: string;
+  /** Glow shadow color, defaults to translucent accent */
+  glowColor?: string;
+}
+
+export function PlayheadIndicator({
+  color = "var(--hf-accent, #3CE6AC)",
+  glowColor = "rgba(60,230,172,0.5)",
+}: PlayheadIndicatorProps) {
+  return (
+    <>
+      <div
+        className="absolute top-0 bottom-0"
+        style={{
+          left: "50%",
+          width: 2,
+          marginLeft: -1,
+          background: color,
+          boxShadow: `0 0 8px ${glowColor}`,
+        }}
+      />
+      <div className="absolute" style={{ left: "50%", top: 0, transform: "translateX(-50%)" }}>
+        <div
+          style={{
+            width: 0,
+            height: 0,
+            borderLeft: "6px solid transparent",
+            borderRight: "6px solid transparent",
+            borderTop: `8px solid ${color}`,
+            filter: "drop-shadow(0 1px 3px rgba(0,0,0,0.6))",
+          }}
+        />
+      </div>
+    </>
+  );
+}

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -2,12 +2,12 @@ import { useRef, useMemo, useCallback, useState, useEffect, memo, type ReactNode
 import { usePlayerStore, type TimelineElement } from "../store/playerStore";
 import { useMountEffect } from "../../hooks/useMountEffect";
 import { EditPopover } from "./EditModal";
-import { type BlockedTimelineEditIntent } from "./timelineEditing";
 import { defaultTimelineTheme, type TimelineTheme } from "./timelineTheme";
 import { useTimelineRangeSelection } from "./useTimelineRangeSelection";
 import { useTimelinePlayhead } from "./useTimelinePlayhead";
 import { type TrackVisualStyle, getTrackStyle } from "./timelineIcons";
 import { getTimelinePixelsPerSecond } from "./timelineZoom";
+import { useTimelineZoom } from "./useTimelineZoom";
 import { useTimelineAssetDrop } from "./timelineDragDrop";
 import { TimelineEmptyState } from "./TimelineEmptyState";
 import { TimelineCanvas } from "./TimelineCanvas";
@@ -23,6 +23,7 @@ import {
   getTimelineCanvasHeight,
   shouldShowTimelineShortcutHint,
 } from "./timelineLayout";
+import type { TimelineEditCallbacks, TimelineDropCallbacks } from "./timelineCallbacks";
 
 // Re-export pure utilities so existing imports from "./Timeline" still resolve.
 export {
@@ -39,7 +40,7 @@ export {
   getDefaultDroppedTrack,
 } from "./timelineLayout";
 
-interface TimelineProps {
+interface TimelineProps extends TimelineEditCallbacks, TimelineDropCallbacks {
   onSeek?: (time: number) => void;
   onDrillDown?: (element: TimelineElement) => void;
   renderClipContent?: (
@@ -47,35 +48,8 @@ interface TimelineProps {
     style: { clip: string; label: string },
   ) => ReactNode;
   renderClipOverlay?: (element: TimelineElement) => ReactNode;
-  onFileDrop?: (
-    files: File[],
-    placement?: { start: number; track: number },
-  ) => Promise<void> | void;
-  onAssetDrop?: (
-    assetPath: string,
-    placement: { start: number; track: number },
-  ) => Promise<void> | void;
-  onBlockDrop?: (
-    blockName: string,
-    placement: { start: number; track: number },
-  ) => Promise<void> | void;
   onDeleteElement?: (element: TimelineElement) => Promise<void> | void;
-  onMoveElement?: (
-    element: TimelineElement,
-    updates: Pick<TimelineElement, "start" | "track">,
-  ) => Promise<void> | void;
-  onResizeElement?: (
-    element: TimelineElement,
-    updates: Pick<TimelineElement, "start" | "duration" | "playbackStart">,
-  ) => Promise<void> | void;
-  onBlockedEditAttempt?: (element: TimelineElement, intent: BlockedTimelineEditIntent) => void;
-  onSplitElement?: (element: TimelineElement, splitTime: number) => Promise<void> | void;
   onSelectElement?: (element: TimelineElement | null) => void;
-  onDeleteKeyframe?: (elementId: string, percentage: number) => void;
-  onDeleteAllKeyframes?: (elementId: string) => void;
-  onChangeKeyframeEase?: (elementId: string, percentage: number, ease: string) => void;
-  onMoveKeyframe?: (element: TimelineElement, oldPct: number, newPct: number) => void;
-  onToggleKeyframeAtPlayhead?: (element: TimelineElement) => void;
   theme?: Partial<TimelineTheme>;
 }
 
@@ -92,6 +66,8 @@ export const Timeline = memo(function Timeline({
   onResizeElement,
   onBlockedEditAttempt,
   onSplitElement,
+  onRazorSplit,
+  onRazorSplitAll,
   onSelectElement,
   onDeleteKeyframe,
   onDeleteAllKeyframes,
@@ -107,17 +83,16 @@ export const Timeline = memo(function Timeline({
   const selectedElementId = usePlayerStore((s) => s.selectedElementId);
   const setSelectedElementId = usePlayerStore((s) => s.setSelectedElementId);
   const currentTime = usePlayerStore((s) => s.currentTime);
-  const zoomMode = usePlayerStore((s) => s.zoomMode);
-  const manualZoomPercent = usePlayerStore((s) => s.manualZoomPercent);
-  const setZoomMode = usePlayerStore((s) => s.setZoomMode);
-  const setManualZoomPercent = usePlayerStore((s) => s.setManualZoomPercent);
+  const { zoomMode, manualZoomPercent, setZoomMode, setManualZoomPercent } = useTimelineZoom();
 
   const playheadRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const activeTool = usePlayerStore((s) => s.activeTool);
   const [hoveredClip, setHoveredClip] = useState<string | null>(null);
   const isDragging = useRef(false);
   const [shiftHeld, setShiftHeld] = useState(false);
+  const [razorGuideX, setRazorGuideX] = useState<number | null>(null);
 
   useMountEffect(() => {
     const down = (e: KeyboardEvent) => e.key === "Shift" && setShiftHeld(true);
@@ -388,7 +363,14 @@ export const Timeline = memo(function Timeline({
     <div
       ref={setContainerRef}
       aria-label="Timeline"
-      className={`relative border-t select-none h-full overflow-hidden ${shiftHeld ? "cursor-crosshair" : "cursor-default"}`}
+      className={`relative border-t select-none h-full overflow-hidden ${activeTool === "razor" ? "cursor-crosshair" : shiftHeld ? "cursor-crosshair" : "cursor-default"}`}
+      onMouseMove={(e) => {
+        if (activeTool === "razor" && scrollRef.current) {
+          const rect = scrollRef.current.getBoundingClientRect();
+          setRazorGuideX(e.clientX - rect.left + scrollRef.current.scrollLeft);
+        }
+      }}
+      onMouseLeave={() => setRazorGuideX(null)}
       style={{
         touchAction: "pan-x pan-y",
         background: theme.shellBackground,
@@ -402,7 +384,16 @@ export const Timeline = memo(function Timeline({
         onDragOver={handleAssetDragOver}
         onDragLeave={() => setIsDragOver(false)}
         onDrop={handleAssetDrop}
-        onPointerDown={handlePointerDown}
+        onPointerDown={(e) => {
+          if (activeTool === "razor" && e.shiftKey && e.button === 0 && scrollRef.current) {
+            const rect = scrollRef.current.getBoundingClientRect();
+            const x = e.clientX - rect.left + scrollRef.current.scrollLeft - GUTTER;
+            const splitTime = Math.max(0, x / pps);
+            onRazorSplitAll?.(splitTime);
+            return;
+          }
+          handlePointerDown(e);
+        }}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onLostPointerCapture={handlePointerUp}
@@ -488,7 +479,19 @@ export const Timeline = memo(function Timeline({
             onSelectElement?.(el);
             setClipContextMenu({ x: e.clientX, y: e.clientY, element: el });
           }}
+          onRazorSplit={onRazorSplit}
+          onRazorSplitAll={onRazorSplitAll}
         />
+        {activeTool === "razor" && razorGuideX !== null && (
+          <div
+            className="absolute top-0 bottom-0 pointer-events-none z-10"
+            style={{
+              left: razorGuideX,
+              width: 1,
+              background: "rgba(239,68,68,0.7)",
+            }}
+          />
+        )}
       </div>
 
       {showShortcutHint && !showPopover && !rangeSelection && (

--- a/packages/studio/src/player/components/TimelineCanvas.tsx
+++ b/packages/studio/src/player/components/TimelineCanvas.tsx
@@ -2,6 +2,7 @@ import { memo, type ReactNode } from "react";
 import { TimelineClip } from "./TimelineClip";
 import { TimelineClipDiamonds } from "./TimelineClipDiamonds";
 import { TimelineRuler } from "./TimelineRuler";
+import { PlayheadIndicator } from "./PlayheadIndicator";
 import {
   getTimelineEditCapabilities,
   resolveBlockedTimelineEditIntent,
@@ -9,7 +10,11 @@ import {
 } from "./timelineEditing";
 import { getRenderedTimelineElement, type TimelineTheme } from "./timelineTheme";
 import { GUTTER, TRACK_H, RULER_H, CLIP_Y, CLIP_HANDLE_W } from "./timelineLayout";
-import type { TimelineElement, KeyframeCacheEntry } from "../store/playerStore";
+import {
+  usePlayerStore,
+  type TimelineElement,
+  type KeyframeCacheEntry,
+} from "../store/playerStore";
 import type { DraggedClipState, ResizingClipState, BlockedClipState } from "./useTimelineClipDrag";
 import type { TrackVisualStyle } from "./timelineIcons";
 import { STUDIO_KEYFRAMES_ENABLED } from "../../components/editor/manualEditingAvailability";
@@ -69,6 +74,8 @@ interface TimelineCanvasProps {
   onContextMenuKeyframe?: (e: React.MouseEvent, elementId: string, percentage: number) => void;
   onContextMenuClip?: (e: React.MouseEvent, element: TimelineElement) => void;
   onToggleKeyframeAtPlayhead?: (element: TimelineElement) => void;
+  onRazorSplit?: (element: TimelineElement, splitTime: number) => void;
+  onRazorSplitAll?: (splitTime: number) => void;
 }
 
 export const TimelineCanvas = memo(function TimelineCanvas({
@@ -119,6 +126,8 @@ export const TimelineCanvas = memo(function TimelineCanvas({
   onContextMenuKeyframe,
   onContextMenuClip,
   onToggleKeyframeAtPlayhead: _onToggleKeyframeAtPlayhead,
+  onRazorSplit,
+  onRazorSplitAll,
 }: TimelineCanvasProps) {
   const draggedElement = draggedClip?.element ?? null;
   const activeDraggedElement =
@@ -288,6 +297,7 @@ export const TimelineCanvas = memo(function TimelineCanvas({
                     }}
                     onPointerDown={(e) => {
                       if (e.button !== 0) return;
+                      if (usePlayerStore.getState().activeTool === "razor") return;
                       if (e.shiftKey) {
                         shiftClickClipRef.current = {
                           element: el,
@@ -341,6 +351,26 @@ export const TimelineCanvas = memo(function TimelineCanvas({
                     onClick={(e) => {
                       e.stopPropagation();
                       if (suppressClickRef.current) return;
+                      const { activeTool } = usePlayerStore.getState();
+                      if (activeTool === "razor" && onRazorSplit) {
+                        const clipRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                        const clickOffsetX = e.clientX - clipRect.left;
+                        const splitTime = previewElement.start + clickOffsetX / pps;
+                        const epsilon = 0.03;
+                        const clampedTime = Math.max(
+                          previewElement.start + epsilon,
+                          Math.min(
+                            previewElement.start + previewElement.duration - epsilon,
+                            splitTime,
+                          ),
+                        );
+                        if (e.shiftKey && onRazorSplitAll) {
+                          onRazorSplitAll(clampedTime);
+                        } else {
+                          onRazorSplit(el, clampedTime);
+                        }
+                        return;
+                      }
                       const nextElement = isSelected ? null : el;
                       setSelectedElementId(nextElement ? elementKey : null);
                       onSelectElement?.(nextElement);
@@ -440,28 +470,7 @@ export const TimelineCanvas = memo(function TimelineCanvas({
         className="absolute top-0 bottom-0 pointer-events-none"
         style={{ left: `${GUTTER}px`, zIndex: 100 }}
       >
-        <div
-          className="absolute top-0 bottom-0"
-          style={{
-            left: "50%",
-            width: 2,
-            marginLeft: -1,
-            background: "var(--hf-accent, #3CE6AC)",
-            boxShadow: "0 0 8px rgba(60,230,172,0.5)",
-          }}
-        />
-        <div className="absolute" style={{ left: "50%", top: 0, transform: "translateX(-50%)" }}>
-          <div
-            style={{
-              width: 0,
-              height: 0,
-              borderLeft: "6px solid transparent",
-              borderRight: "6px solid transparent",
-              borderTop: "8px solid var(--hf-accent, #3CE6AC)",
-              filter: "drop-shadow(0 1px 3px rgba(0,0,0,0.6))",
-            }}
-          />
-        </div>
+        <PlayheadIndicator />
       </div>
     </div>
   );

--- a/packages/studio/src/player/components/timelineCallbacks.ts
+++ b/packages/studio/src/player/components/timelineCallbacks.ts
@@ -1,0 +1,42 @@
+import type { TimelineElement } from "../store/playerStore";
+import type { BlockedTimelineEditIntent } from "./timelineEditing";
+
+/**
+ * Shared callback signatures for timeline editing operations.
+ * Used by NLELayout, Timeline, and any component that passes through
+ * the standard set of timeline mutation handlers.
+ */
+export interface TimelineDropCallbacks {
+  onFileDrop?: (
+    files: File[],
+    placement?: { start: number; track: number },
+  ) => Promise<void> | void;
+  onAssetDrop?: (
+    assetPath: string,
+    placement: { start: number; track: number },
+  ) => Promise<void> | void;
+  onBlockDrop?: (
+    blockName: string,
+    placement: { start: number; track: number },
+  ) => Promise<void> | void;
+}
+
+export interface TimelineEditCallbacks {
+  onMoveElement?: (
+    element: TimelineElement,
+    updates: Pick<TimelineElement, "start" | "track">,
+  ) => Promise<void> | void;
+  onResizeElement?: (
+    element: TimelineElement,
+    updates: Pick<TimelineElement, "start" | "duration" | "playbackStart">,
+  ) => Promise<void> | void;
+  onBlockedEditAttempt?: (element: TimelineElement, intent: BlockedTimelineEditIntent) => void;
+  onSplitElement?: (element: TimelineElement, splitTime: number) => Promise<void> | void;
+  onRazorSplit?: (element: TimelineElement, splitTime: number) => Promise<void> | void;
+  onRazorSplitAll?: (splitTime: number) => Promise<void> | void;
+  onDeleteKeyframe?: (elementId: string, percentage: number) => void;
+  onDeleteAllKeyframes?: (elementId: string) => void;
+  onChangeKeyframeEase?: (elementId: string, percentage: number, ease: string) => void;
+  onMoveKeyframe?: (element: TimelineElement, oldPct: number, newPct: number) => void;
+  onToggleKeyframeAtPlayhead?: (element: TimelineElement) => void;
+}

--- a/packages/studio/src/player/components/timelineDragDrop.ts
+++ b/packages/studio/src/player/components/timelineDragDrop.ts
@@ -1,25 +1,13 @@
-// fallow-ignore-file clone-families
 import { useCallback, useState, type RefObject } from "react";
 import { TIMELINE_ASSET_MIME, TIMELINE_BLOCK_MIME } from "../../utils/timelineAssetDrop";
 import { TRACK_H, resolveTimelineAssetDrop } from "./timelineLayout";
+import type { TimelineDropCallbacks } from "./timelineCallbacks";
 
-interface UseTimelineAssetDropOptions {
+interface UseTimelineAssetDropOptions extends TimelineDropCallbacks {
   scrollRef: RefObject<HTMLDivElement | null>;
   ppsRef: RefObject<number>;
   durationRef: RefObject<number>;
   trackOrderRef: RefObject<number[]>;
-  onFileDrop?: (
-    files: File[],
-    placement?: { start: number; track: number },
-  ) => Promise<void> | void;
-  onAssetDrop?: (
-    assetPath: string,
-    placement: { start: number; track: number },
-  ) => Promise<void> | void;
-  onBlockDrop?: (
-    blockName: string,
-    placement: { start: number; track: number },
-  ) => Promise<void> | void;
 }
 
 export function useTimelineAssetDrop({

--- a/packages/studio/src/player/components/useTimelineZoom.ts
+++ b/packages/studio/src/player/components/useTimelineZoom.ts
@@ -1,0 +1,17 @@
+import { usePlayerStore, type ZoomMode } from "../store/playerStore";
+
+export interface TimelineZoomState {
+  zoomMode: ZoomMode;
+  manualZoomPercent: number;
+  setZoomMode: (mode: ZoomMode) => void;
+  setManualZoomPercent: (percent: number) => void;
+}
+
+/** Shared zoom-related store selectors used by Timeline and TimelineToolbar. */
+export function useTimelineZoom(): TimelineZoomState {
+  const zoomMode = usePlayerStore((s) => s.zoomMode);
+  const manualZoomPercent = usePlayerStore((s) => s.manualZoomPercent);
+  const setZoomMode = usePlayerStore((s) => s.setZoomMode);
+  const setManualZoomPercent = usePlayerStore((s) => s.setManualZoomPercent);
+  return { zoomMode, manualZoomPercent, setZoomMode, setManualZoomPercent };
+}

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -43,6 +43,7 @@ export interface TimelineElement {
 }
 
 export type ZoomMode = "fit" | "manual";
+type TimelineTool = "select" | "razor";
 
 interface PlayerState {
   isPlaying: boolean;
@@ -62,6 +63,9 @@ interface PlayerState {
   inPoint: number | null;
   /** Work-area out-point (seconds). When set, loop ends here and E jumps here. */
   outPoint: number | null;
+
+  activeTool: TimelineTool;
+  setActiveTool: (tool: TimelineTool) => void;
 
   /** Set of selected keyframe keys in format `${elementId}:${percentage}`. */
   selectedKeyframes: Set<string>;
@@ -127,6 +131,9 @@ export const usePlayerStore = create<PlayerState>((set) => ({
   manualZoomPercent: 100,
   inPoint: null,
   outPoint: null,
+
+  activeTool: "select",
+  setActiveTool: (tool) => set({ activeTool: tool }),
 
   selectedKeyframes: new Set(),
   toggleSelectedKeyframe: (key) =>
@@ -209,6 +216,7 @@ export const usePlayerStore = create<PlayerState>((set) => ({
       selectedElementId: null,
       inPoint: null,
       outPoint: null,
+      activeTool: "select",
       selectedKeyframes: new Set(),
       keyframeCache: new Map(),
     }),

--- a/packages/studio/src/utils/timelineElementSplit.ts
+++ b/packages/studio/src/utils/timelineElementSplit.ts
@@ -1,0 +1,39 @@
+import type { TimelineElement } from "../player/store/playerStore";
+
+export function canSplitElement(el: TimelineElement): boolean {
+  return (
+    !el.timelineLocked &&
+    el.timingSource !== "implicit" &&
+    !el.compositionSrc &&
+    !!el.duration &&
+    Number.isFinite(el.duration)
+  );
+}
+
+export function buildPatchTarget(element: {
+  domId?: string;
+  selector?: string;
+  selectorIndex?: number;
+}) {
+  if (element.domId) {
+    return {
+      id: element.domId,
+      selector: element.selector,
+      selectorIndex: element.selectorIndex,
+    };
+  }
+  if (element.selector) {
+    return { selector: element.selector, selectorIndex: element.selectorIndex };
+  }
+  return null;
+}
+
+export async function readFileContent(projectId: string, targetPath: string): Promise<string> {
+  const response = await fetch(
+    `/api/projects/${projectId}/files/${encodeURIComponent(targetPath)}`,
+  );
+  if (!response.ok) throw new Error(`Failed to read ${targetPath}`);
+  const data = (await response.json()) as { content?: string };
+  if (typeof data.content !== "string") throw new Error(`Missing file contents for ${targetPath}`);
+  return data.content;
+}


### PR DESCRIPTION
## Summary

Adds a razor/blade tool to Studio's timeline — the standard non-linear editing workflow for splitting clips at arbitrary positions. Inspired by feedback from an After Effects editor who expected this as a fundamental editing primitive.

- **B** enters razor mode (crosshair cursor + red vertical guide line)
- **Click** any clip to split it at the click position (not the playhead)
- **Shift+click** splits all clips across every track at that time
- **V** or **Escape** exits razor mode
- Toolbar shows selection arrow / scissors toggle with active state highlighting

## Why this matters

Timeline editing without a razor tool forces editors into a playhead-dependent workflow: position the playhead, then use the S shortcut. This is slow and imprecise for the most common editing operation. Every professional NLE (Premiere, DaVinci, After Effects) has a razor/blade tool that splits at the mouse position, and editors expect it.

## Technical approach

### GSAP-aware splitting

The razor tool doesn't just split HTML elements — it correctly re-times GSAP animations for both halves of a split:

- **Animations entirely before the split**: kept on the original element, end-state properties inherited by the new element via `tl.set` (inserted before other tweens so GSAP records the correct initial state)
- **Animations entirely after the split**: retargeted to the new element via direct AST selector update
- **Animations spanning the split point**: trimmed on the original, remainder added targeting the new element with correct position offset and duration
- **Keyframes animations**: classified by total duration (sum of per-keyframe durations). Retargeted when entirely after split; kept on original when spanning
- **fromTo animations**: both `from` and `to` values preserved correctly

### CSS rule duplication

When splitting an element with ID-based CSS (e.g., `#box { background: red }`), the new element gets a different ID (`#box-split`). The splitter uses PostCSS to parse stylesheets and duplicate matching rules for the new ID, correctly handling media queries, compound selectors, and nested rules.

### Server-side ID deduplication

When splitting an already-split element, the server checks if the requested ID already exists in the document and auto-increments (`box-split-2`, `box-split-3`, etc.) to prevent duplicate IDs.

### Preview reload after timeline edits

Timeline move and resize operations now trigger a preview reload so the composition re-renders with the updated timing.

### Architecture

- `useRazorSplit.ts` — extracted hook with `executeSplit()` pure orchestration, `handleRazorSplit` (single clip), `handleRazorSplitAll` (multi-track)
- `timelineElementSplit.ts` — shared utilities (`canSplitElement`, `buildPatchTarget`, `readFileContent`) to break circular dependencies
- `playerStore.ts` — `activeTool: "select" | "razor"` state with `setActiveTool` setter
- `TimelineCanvas.tsx` — click handler intercepts razor mode, converts pixel position to split time
- `Timeline.tsx` — red guide line overlay, crosshair cursor, shift+click multi-track routing
- `TimelineToolbar.tsx` — selection/scissors toggle buttons
- `gsapParser.ts` — `splitAnimationsInScript()`, `updateAnimationSelector()`, `computeKeyframesTotalDuration()`, `insertInheritedStateSet()`
- `sourceMutation.ts` — `splitElementInHtml()` enhanced with CSS duplication (PostCSS), ID deduplication, and inherited state via `tl.set`

### Code quality improvements

Cleaned up 20+ pre-existing clone groups across touched files:
- Extracted `PlayheadIndicator` shared component
- Extracted `useContextMenuDismiss` hook
- Extracted `TimelineCallbacks` interfaces
- Extracted `useTimelineZoom` hook
- Extracted `gsapParser.test-helpers.ts`
- Collapsed redundant switch cases in `files.ts`

## Test plan

### Unit tests (1208 passing)
- 13 tests for `splitAnimationsInScript`: first-half, second-half, spanning, no match, multiple animations, fromTo, round-trip, keyframes spanning/retarget/before, set tween retarget, same-position dedup, inherited state ordering
- 6 tests for `splitElementInHtml`: basic split, CSS duplication, ID deduplication, clip class preservation, out-of-range rejection, media playback-start adjustment

### Manual browser testing
Tested against a complex composition with 10 elements across 9 tracks:
- [x] B/V/Escape toggle razor mode correctly
- [x] Single click splits at click position with correct timing
- [x] GSAP spanning tweens are trimmed + continued on new element
- [x] GSAP before/after classification is correct
- [x] fromTo from/to values preserved
- [x] Multiple animations independently classified per element
- [x] Double-split chains naming correctly (server-side ID dedup)
- [x] Shift+click splits all overlapping clips; non-overlapping clips skipped
- [x] Locked element (`data-timeline-locked`) rejects split
- [x] Split elements visible in preview (inherited state + CSS duplication)
- [x] Timeline thumbnails render on split elements
- [x] Undo reverts the split
- [x] Preview reloads after drag/resize timeline edits
