### PR TITLE
fix(core): account for playbackRate in media duration resolution

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1356,6 +1356,9 @@ export function initSandboxRuntimeModular(): void {
         const mediaStart =
           Number.parseFloat(element.dataset.playbackStart ?? element.dataset.mediaStart ?? "0") ||
           0;
+        const rawRate = element.defaultPlaybackRate;
+        const playbackRate =
+          Number.isFinite(rawRate) && rawRate > 0 ? Math.max(0.1, Math.min(5, rawRate)) : 1;
         const hostRemaining =
           context.inheritedStart != null &&
           context.inheritedDuration != null &&
@@ -1364,7 +1367,7 @@ export function initSandboxRuntimeModular(): void {
             : null;
         const sourceDuration =
           Number.isFinite(element.duration) && element.duration > mediaStart
-            ? Math.max(0, element.duration - mediaStart)
+            ? Math.max(0, (element.duration - mediaStart) / playbackRate)
             : null;
         if (sourceDuration != null && hostRemaining != null) {
           return Math.min(sourceDuration, hostRemaining);

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -131,6 +131,28 @@ describe("refreshRuntimeMediaCache", () => {
     expect(result.mediaClips[0].duration).toBe(20);
   });
 
+  it("resolveDurationSeconds must account for playbackRate (regression: clip clipped early)", () => {
+    const el = createVideo({ "data-start": "0", "data-duration": "10" });
+    Object.defineProperty(el, "defaultPlaybackRate", { value: 0.5, writable: true });
+    Object.defineProperty(el, "duration", { value: 5, writable: true });
+    const result = refreshRuntimeMediaCache({
+      resolveDurationSeconds: (element) => {
+        const mediaStart =
+          Number.parseFloat(element.dataset.playbackStart ?? element.dataset.mediaStart ?? "0") ||
+          0;
+        const rawRate = element.defaultPlaybackRate;
+        const playbackRate =
+          Number.isFinite(rawRate) && rawRate > 0 ? Math.max(0.1, Math.min(5, rawRate)) : 1;
+        return Number.isFinite(element.duration) && element.duration > mediaStart
+          ? Math.max(0, (element.duration - mediaStart) / playbackRate)
+          : null;
+      },
+    });
+    // 5s source at 0.5x = 10s effective; should NOT be capped to 5s
+    expect(result.mediaClips[0].duration).toBe(10);
+    expect(result.mediaClips[0].end).toBe(10);
+  });
+
   it("reads native loop attribute", () => {
     createVideo({ "data-start": "0", "data-duration": "15", loop: "" });
     const result = refreshRuntimeMediaCache();


### PR DESCRIPTION
## Summary

Fixes media elements with `defaultPlaybackRate` set to values other than 1.0 being clipped to the raw source duration instead of the effective timeline duration.

A 5s video at `defaultPlaybackRate = 0.5` should span 10s on the timeline. Instead, `resolveDurationSeconds` in `syncMediaForCurrentState` computed `sourceDuration = element.duration - mediaStart` without dividing by `playbackRate`, returning 5s. This capped the clip early, causing the video to go black once the raw source was exhausted.

## Root cause

`resolveDurationSeconds` (init.ts) did not read `element.defaultPlaybackRate`. The separate `refreshRuntimeMediaCache` (media.ts:59-62) does account for playback rate in its fallback auto-calc, but that path only fires when `resolveDurationSeconds` returns null — which it doesn't when the element has a known duration.

## Fix

Read `defaultPlaybackRate` from the element (same clamping as `refreshRuntimeMediaCache`) and divide `sourceDuration` by it: `(element.duration - mediaStart) / playbackRate`.

## Repro

```html
<video id="v" src="5sec.mp4" muted data-start="0" data-duration="10"></video>
<script>document.getElementById('v').defaultPlaybackRate = 0.5;</script>
```

Before fix: video goes black at timeline 5s. After fix: video plays through full 10s at half speed.

## Test plan

- [x] 56 existing media.test.ts tests pass
- [x] Lint, format, typecheck, fallow all pass
- [x] CI green