### PR TITLE
fix(core): apply playbackRate to all media duration sites

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -9,7 +9,7 @@ import { createThreeAdapter } from "./adapters/three";
 import { createTypegpuAdapter } from "./adapters/typegpu";
 import { patchVideoTextureCompat } from "./adapters/video-texture-compat";
 import { createWaapiAdapter } from "./adapters/waapi";
-import { refreshRuntimeMediaCache, syncRuntimeMedia } from "./media";
+import { readElementPlaybackRate, refreshRuntimeMediaCache, syncRuntimeMedia } from "./media";
 import { probeAndCacheElementVolume, type VolumeKeyframe } from "./mediaVolumeEnvelope.js";
 import { createPickerModule } from "./picker";
 import { createRuntimePlayer } from "./player";
@@ -1356,9 +1356,7 @@ export function initSandboxRuntimeModular(): void {
         const mediaStart =
           Number.parseFloat(element.dataset.playbackStart ?? element.dataset.mediaStart ?? "0") ||
           0;
-        const rawRate = element.defaultPlaybackRate;
-        const playbackRate =
-          Number.isFinite(rawRate) && rawRate > 0 ? Math.max(0.1, Math.min(5, rawRate)) : 1;
+        const playbackRate = readElementPlaybackRate(element);
         const hostRemaining =
           context.inheritedStart != null &&
           context.inheritedDuration != null &&

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { refreshRuntimeMediaCache, syncRuntimeMedia } from "./media";
+import { readElementPlaybackRate, refreshRuntimeMediaCache, syncRuntimeMedia } from "./media";
 import type { RuntimeMediaClip } from "./media";
 
 function createVideo(attrs: Record<string, string>): HTMLVideoElement {
@@ -22,6 +22,37 @@ function createAudio(attrs: Record<string, string>): HTMLAudioElement {
   document.body.appendChild(el);
   return el;
 }
+
+describe("readElementPlaybackRate", () => {
+  it("reads defaultPlaybackRate from element", () => {
+    const el = document.createElement("video");
+    Object.defineProperty(el, "defaultPlaybackRate", { value: 0.5, writable: true });
+    expect(readElementPlaybackRate(el)).toBe(0.5);
+  });
+
+  it("defaults to 1 when not set", () => {
+    const el = document.createElement("video");
+    expect(readElementPlaybackRate(el)).toBe(1);
+  });
+
+  it("clamps to [0.1, 5]", () => {
+    const el = document.createElement("video");
+    Object.defineProperty(el, "defaultPlaybackRate", { value: 0.01, writable: true });
+    expect(readElementPlaybackRate(el)).toBe(0.1);
+    Object.defineProperty(el, "defaultPlaybackRate", { value: 10, writable: true });
+    expect(readElementPlaybackRate(el)).toBe(5);
+  });
+
+  it("defaults to 1 for NaN/negative/zero", () => {
+    const el = document.createElement("video");
+    Object.defineProperty(el, "defaultPlaybackRate", { value: NaN, writable: true });
+    expect(readElementPlaybackRate(el)).toBe(1);
+    Object.defineProperty(el, "defaultPlaybackRate", { value: -1, writable: true });
+    expect(readElementPlaybackRate(el)).toBe(1);
+    Object.defineProperty(el, "defaultPlaybackRate", { value: 0, writable: true });
+    expect(readElementPlaybackRate(el)).toBe(1);
+  });
+});
 
 describe("refreshRuntimeMediaCache", () => {
   afterEach(() => {
@@ -140,9 +171,7 @@ describe("refreshRuntimeMediaCache", () => {
         const mediaStart =
           Number.parseFloat(element.dataset.playbackStart ?? element.dataset.mediaStart ?? "0") ||
           0;
-        const rawRate = element.defaultPlaybackRate;
-        const playbackRate =
-          Number.isFinite(rawRate) && rawRate > 0 ? Math.max(0.1, Math.min(5, rawRate)) : 1;
+        const playbackRate = readElementPlaybackRate(element);
         return Number.isFinite(element.duration) && element.duration > mediaStart
           ? Math.max(0, (element.duration - mediaStart) / playbackRate)
           : null;

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -1,6 +1,11 @@
 import { swallow } from "./diagnostics";
 import { interpolateVolumeGain, type VolumeKeyframe } from "./mediaVolumeEnvelope.js";
 
+export function readElementPlaybackRate(el: HTMLMediaElement): number {
+  const raw = el.defaultPlaybackRate;
+  return Number.isFinite(raw) && raw > 0 ? Math.max(0.1, Math.min(5, raw)) : 1;
+}
+
 export type RuntimeMediaClip = {
   el: HTMLVideoElement | HTMLAudioElement;
   start: number;
@@ -47,11 +52,7 @@ export function refreshRuntimeMediaCache(params?: {
     if (!Number.isFinite(start)) continue;
     const mediaStart =
       Number.parseFloat(el.dataset.playbackStart ?? el.dataset.mediaStart ?? "0") || 0;
-    // Read per-element rate from the native defaultPlaybackRate property.
-    // LLMs set this via el.defaultPlaybackRate = 0.5 in a <script> tag.
-    const rawRate = el.defaultPlaybackRate;
-    const playbackRate =
-      Number.isFinite(rawRate) && rawRate > 0 ? Math.max(0.1, Math.min(5, rawRate)) : 1;
+    const playbackRate = readElementPlaybackRate(el);
     const loop = el.loop;
     const sourceDuration = Number.isFinite(el.duration) && el.duration > 0 ? el.duration : null;
     let duration =

--- a/packages/core/src/runtime/startResolver.ts
+++ b/packages/core/src/runtime/startResolver.ts
@@ -1,5 +1,6 @@
 import type { RuntimeTimelineLike } from "./types";
 import { swallow } from "./diagnostics";
+import { readElementPlaybackRate } from "./media";
 
 const AUTHORED_DURATION_ATTR = "data-hf-authored-duration";
 const AUTHORED_END_ATTR = "data-hf-authored-end";
@@ -106,7 +107,7 @@ export function createRuntimeStartTimeResolver(params: {
         parseNumeric(element.getAttribute("data-media-start")) ??
         0;
       if (Number.isFinite(element.duration) && element.duration > playbackStart) {
-        resolved = element.duration - playbackStart;
+        resolved = (element.duration - playbackStart) / readElementPlaybackRate(element);
       }
     }
     if (resolved == null || resolved <= 0) {

--- a/packages/core/src/runtime/timeline.ts
+++ b/packages/core/src/runtime/timeline.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeTimelineLike,
 } from "./types";
 import { swallow } from "./diagnostics";
+import { readElementPlaybackRate } from "./media";
 import { createRuntimeStartTimeResolver } from "./startResolver";
 
 const AUTHORED_DURATION_ATTR = "data-hf-authored-duration";
@@ -208,7 +209,7 @@ export function collectRuntimeTimelinePayload(params: {
       parseNum(mediaEl.getAttribute("data-media-start")) ??
       0;
     if (Number.isFinite(mediaEl.duration) && mediaEl.duration > playbackStart) {
-      return Math.max(0, mediaEl.duration - playbackStart);
+      return Math.max(0, (mediaEl.duration - playbackStart) / readElementPlaybackRate(mediaEl));
     }
     return null;
   };


### PR DESCRIPTION
## Summary

Follow-up to #1287 addressing the remaining `playbackRate` gaps flagged by Vai's review.

## Changes

1. **Extract** **`readElementPlaybackRate()`** — consolidates the inline `defaultPlaybackRate` clamping that was duplicated in `media.ts`, `init.ts`, `startResolver.ts`, and `timeline.ts` into a single shared function.
2. **Fix** **`startResolver.ts:109`** — visibility resolver used raw `element.duration - playbackStart` without rate division. A slowed-down video without `data-duration` would get hidden mid-playback because the visibility window was too short.
3. **Fix** **`timeline.ts:211`** — `resolveMediaElementDurationSeconds` had the same issue, underreporting the end window sent to the renderer and affecting preview parity.
4. **Add tests** — 4 new tests for `readElementPlaybackRate()` covering default, read, clamp, and NaN/negative/zero edge cases.

## Test plan

- [x] 61 media.test.ts tests pass (57 existing + 4 new)
- [x] CI green