### PR TITLE
feat(cli): detect Gemini managed-agent sandbox in detectAgentRuntime

### DIFF
--- a/packages/cli/src/telemetry/agent_runtime.test.ts
+++ b/packages/cli/src/telemetry/agent_runtime.test.ts
@@ -164,9 +164,11 @@ describe("detectAgentRuntime — Replit / Hermes / openclaw / Pi", () => {
 });
 
 describe("detectAgentRuntime — Gemini managed agent", () => {
-  // Gemini managed agent is detected via filesystem markers (`/.agents/AGENTS.md`)
-  // and the gVisor kernel string, NOT env vars — so these tests mock node:fs
-  // and node:os rather than mutating process.env.
+  // Gemini managed agent is detected via the `/.agents/` platform mount and
+  // the gVisor kernel string, NOT env vars — so these tests mock node:fs and
+  // node:os rather than mutating process.env. We key on the `/.agents/`
+  // DIRECTORY (not the optional AGENTS.md file) so skills-only and
+  // inline-instruction agents are still detected.
   beforeEach(() => {
     vi.resetModules();
     stripVendorEnv();
@@ -177,7 +179,7 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
     vi.restoreAllMocks();
   });
 
-  it("reports gemini_managed_agent when /.agents/AGENTS.md exists AND the kernel is gVisor", async () => {
+  it("reports gemini_managed_agent when /.agents/ exists AND the kernel is gVisor", async () => {
     vi.doMock("node:os", async () => {
       const actual = await vi.importActual<typeof import("node:os")>("node:os");
       return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
@@ -186,14 +188,37 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
       const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
       return {
         ...actual,
-        existsSync: (path: string) => path === "/.agents/AGENTS.md" || actual.existsSync(path),
+        existsSync: (path: string) => path === "/.agents" || actual.existsSync(path),
       };
     });
     const { detectAgentRuntime } = await import("./agent_runtime.js");
     expect(detectAgentRuntime()).toBe("gemini_managed_agent");
   });
 
-  it("does NOT report gemini_managed_agent when /.agents/AGENTS.md is absent (even on gVisor)", async () => {
+  it("detects a skills-only managed agent (no AGENTS.md) — the generalizability case", async () => {
+    // AGENTS.md is OPTIONAL: an agent may use inline `system_instruction` or a
+    // skills-only definition and ship no AGENTS.md. Keying on the `/.agents/`
+    // directory (not the file) must still detect it. Here `/.agents/AGENTS.md`
+    // is explicitly absent while the mount + skills/ are present.
+    vi.doMock("node:os", async () => {
+      const actual = await vi.importActual<typeof import("node:os")>("node:os");
+      return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
+    });
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: string) =>
+          path === "/.agents" || path === "/.agents/skills" || actual.existsSync(path),
+        // /.agents/AGENTS.md intentionally NOT matched -> the old file-based
+        // rule would have returned null here.
+      };
+    });
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("gemini_managed_agent");
+  });
+
+  it("does NOT report gemini_managed_agent when /.agents/ is absent (even on gVisor)", async () => {
     // A generic gVisor surface (GKE Sandbox / Cloud Run gen2) that doesn't
     // mount the managed-agent layout must fall through to env-var rules.
     vi.doMock("node:os", async () => {
@@ -211,9 +236,9 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
     expect(detectAgentRuntime()).toBeNull();
   });
 
-  it("does NOT report gemini_managed_agent when /.agents/AGENTS.md exists but the kernel is not gVisor", async () => {
-    // A dev box that happens to have a stray /.agents/AGENTS.md must not
-    // false-positive — the gVisor conjunction is what makes the signal safe.
+  it("does NOT report gemini_managed_agent when /.agents/ exists but the kernel is not gVisor", async () => {
+    // A dev box that happens to have a stray /.agents/ must not false-positive
+    // — the gVisor conjunction is what makes the signal safe.
     vi.doMock("node:os", async () => {
       const actual = await vi.importActual<typeof import("node:os")>("node:os");
       return { ...actual, release: () => "6.8.0-100-generic", platform: () => "linux" };
@@ -222,7 +247,7 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
       const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
       return {
         ...actual,
-        existsSync: (path: string) => path === "/.agents/AGENTS.md" || actual.existsSync(path),
+        existsSync: (path: string) => path === "/.agents" || actual.existsSync(path),
         readFileSync: (path: string) =>
           path === "/proc/version"
             ? "Linux version 6.8.0-100-generic (buildd@lcy01)"
@@ -246,7 +271,7 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
       const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
       return {
         ...actual,
-        existsSync: (path: string) => path === "/.agents/AGENTS.md" || actual.existsSync(path),
+        existsSync: (path: string) => path === "/.agents" || actual.existsSync(path),
       };
     });
     const { detectAgentRuntime } = await import("./agent_runtime.js");

--- a/packages/cli/src/telemetry/agent_runtime.test.ts
+++ b/packages/cli/src/telemetry/agent_runtime.test.ts
@@ -163,6 +163,97 @@ describe("detectAgentRuntime — Replit / Hermes / openclaw / Pi", () => {
   });
 });
 
+describe("detectAgentRuntime — Gemini managed agent", () => {
+  // Gemini managed agent is detected via filesystem markers (`/.agents/AGENTS.md`)
+  // and the gVisor kernel string, NOT env vars — so these tests mock node:fs
+  // and node:os rather than mutating process.env.
+  beforeEach(() => {
+    vi.resetModules();
+    stripVendorEnv();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("reports gemini_managed_agent when /.agents/AGENTS.md exists AND the kernel is gVisor", async () => {
+    vi.doMock("node:os", async () => {
+      const actual = await vi.importActual<typeof import("node:os")>("node:os");
+      return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
+    });
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: string) => path === "/.agents/AGENTS.md" || actual.existsSync(path),
+      };
+    });
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("gemini_managed_agent");
+  });
+
+  it("does NOT report gemini_managed_agent when /.agents/AGENTS.md is absent (even on gVisor)", async () => {
+    // A generic gVisor surface (GKE Sandbox / Cloud Run gen2) that doesn't
+    // mount the managed-agent layout must fall through to env-var rules.
+    vi.doMock("node:os", async () => {
+      const actual = await vi.importActual<typeof import("node:os")>("node:os");
+      return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
+    });
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: () => false,
+      };
+    });
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBeNull();
+  });
+
+  it("does NOT report gemini_managed_agent when /.agents/AGENTS.md exists but the kernel is not gVisor", async () => {
+    // A dev box that happens to have a stray /.agents/AGENTS.md must not
+    // false-positive — the gVisor conjunction is what makes the signal safe.
+    vi.doMock("node:os", async () => {
+      const actual = await vi.importActual<typeof import("node:os")>("node:os");
+      return { ...actual, release: () => "6.8.0-100-generic", platform: () => "linux" };
+    });
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: string) => path === "/.agents/AGENTS.md" || actual.existsSync(path),
+        readFileSync: (path: string) =>
+          path === "/proc/version"
+            ? "Linux version 6.8.0-100-generic (buildd@lcy01)"
+            : actual.readFileSync(path),
+      };
+    });
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBeNull();
+  });
+
+  it("returns gemini_managed_agent over an env-var rule when both signals match", async () => {
+    // If a user happens to set CLAUDECODE=1 inside a Gemini sandbox (or any
+    // odd config), the filesystem+kernel signal wins — Gemini is more
+    // specific than a generic env-var marker.
+    process.env["CLAUDECODE"] = "1";
+    vi.doMock("node:os", async () => {
+      const actual = await vi.importActual<typeof import("node:os")>("node:os");
+      return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
+    });
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: string) => path === "/.agents/AGENTS.md" || actual.existsSync(path),
+      };
+    });
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("gemini_managed_agent");
+  });
+});
+
 describe("detectSandboxRuntime — file-system path", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/packages/cli/src/telemetry/agent_runtime.test.ts
+++ b/packages/cli/src/telemetry/agent_runtime.test.ts
@@ -164,11 +164,11 @@ describe("detectAgentRuntime — Replit / Hermes / openclaw / Pi", () => {
 });
 
 describe("detectAgentRuntime — Gemini managed agent", () => {
-  // Gemini managed agent is detected via the `/.agents/` platform mount and
-  // the gVisor kernel string, NOT env vars — so these tests mock node:fs and
-  // node:os rather than mutating process.env. We key on the `/.agents/`
-  // DIRECTORY (not the optional AGENTS.md file) so skills-only and
-  // inline-instruction agents are still detected.
+  // Gemini managed agent is detected via the `/.agents/` platform mount (a
+  // DIRECTORY) and the gVisor kernel string, NOT env vars — so these tests
+  // mock node:fs statSync and node:os rather than mutating process.env. We key
+  // on the `/.agents/` directory (not the optional AGENTS.md file) so
+  // skills-only and inline-instruction agents are still detected.
   beforeEach(() => {
     vi.resetModules();
     stripVendorEnv();
@@ -179,18 +179,26 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
     vi.restoreAllMocks();
   });
 
-  it("reports gemini_managed_agent when /.agents/ exists AND the kernel is gVisor", async () => {
-    vi.doMock("node:os", async () => {
-      const actual = await vi.importActual<typeof import("node:os")>("node:os");
-      return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
-    });
+  // Mock node:fs so statSync("/.agents") reports a directory; everything else
+  // delegates to the real fs.
+  const mockAgentsDir = () =>
     vi.doMock("node:fs", async () => {
       const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
       return {
         ...actual,
-        existsSync: (path: string) => path === "/.agents" || actual.existsSync(path),
+        statSync: (path: string) =>
+          path === "/.agents"
+            ? ({ isDirectory: () => true } as unknown as import("node:fs").Stats)
+            : actual.statSync(path),
       };
     });
+
+  it("reports gemini_managed_agent when /.agents/ is a directory AND the kernel is gVisor", async () => {
+    vi.doMock("node:os", async () => {
+      const actual = await vi.importActual<typeof import("node:os")>("node:os");
+      return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
+    });
+    mockAgentsDir();
     const { detectAgentRuntime } = await import("./agent_runtime.js");
     expect(detectAgentRuntime()).toBe("gemini_managed_agent");
   });
@@ -198,22 +206,13 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
   it("detects a skills-only managed agent (no AGENTS.md) — the generalizability case", async () => {
     // AGENTS.md is OPTIONAL: an agent may use inline `system_instruction` or a
     // skills-only definition and ship no AGENTS.md. Keying on the `/.agents/`
-    // directory (not the file) must still detect it. Here `/.agents/AGENTS.md`
-    // is explicitly absent while the mount + skills/ are present.
+    // directory mount (not the file) must still detect it — the mock makes
+    // `/.agents` a directory with no AGENTS.md present.
     vi.doMock("node:os", async () => {
       const actual = await vi.importActual<typeof import("node:os")>("node:os");
       return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
     });
-    vi.doMock("node:fs", async () => {
-      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-      return {
-        ...actual,
-        existsSync: (path: string) =>
-          path === "/.agents" || path === "/.agents/skills" || actual.existsSync(path),
-        // /.agents/AGENTS.md intentionally NOT matched -> the old file-based
-        // rule would have returned null here.
-      };
-    });
+    mockAgentsDir();
     const { detectAgentRuntime } = await import("./agent_runtime.js");
     expect(detectAgentRuntime()).toBe("gemini_managed_agent");
   });
@@ -229,14 +228,17 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
       const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
       return {
         ...actual,
-        existsSync: () => false,
+        statSync: (path: string) => {
+          if (path === "/.agents") throw new Error("ENOENT: no such file or directory");
+          return actual.statSync(path);
+        },
       };
     });
     const { detectAgentRuntime } = await import("./agent_runtime.js");
     expect(detectAgentRuntime()).toBeNull();
   });
 
-  it("does NOT report gemini_managed_agent when /.agents/ exists but the kernel is not gVisor", async () => {
+  it("does NOT report gemini_managed_agent when /.agents/ is a directory but the kernel is not gVisor", async () => {
     // A dev box that happens to have a stray /.agents/ must not false-positive
     // — the gVisor conjunction is what makes the signal safe.
     vi.doMock("node:os", async () => {
@@ -247,7 +249,10 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
       const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
       return {
         ...actual,
-        existsSync: (path: string) => path === "/.agents" || actual.existsSync(path),
+        statSync: (path: string) =>
+          path === "/.agents"
+            ? ({ isDirectory: () => true } as unknown as import("node:fs").Stats)
+            : actual.statSync(path),
         readFileSync: (path: string) =>
           path === "/proc/version"
             ? "Linux version 6.8.0-100-generic (buildd@lcy01)"
@@ -267,13 +272,7 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
       const actual = await vi.importActual<typeof import("node:os")>("node:os");
       return { ...actual, release: () => "4.19.0-gvisor", platform: () => "linux" };
     });
-    vi.doMock("node:fs", async () => {
-      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-      return {
-        ...actual,
-        existsSync: (path: string) => path === "/.agents" || actual.existsSync(path),
-      };
-    });
+    mockAgentsDir();
     const { detectAgentRuntime } = await import("./agent_runtime.js");
     expect(detectAgentRuntime()).toBe("gemini_managed_agent");
   });

--- a/packages/cli/src/telemetry/agent_runtime.ts
+++ b/packages/cli/src/telemetry/agent_runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { platform, release } from "node:os";
 import { detectWSL } from "./platform.js";
 
@@ -277,8 +277,13 @@ function isGeminiManagedAgent(): boolean {
   // The uniqueness anchor: the managed-agent definition mount root. We key on
   // the `/.agents/` directory (not the optional AGENTS.md file) so skills-only
   // and inline-instruction agents are still detected. Nothing else on gVisor
-  // (Cloud Run, GKE Sandbox, Fly.io) creates this path.
-  if (!existsSync("/.agents")) return false;
+  // (Cloud Run, GKE Sandbox, Fly.io) creates this path. Require an actual
+  // directory — a stray file or symlink named `/.agents` must not match.
+  try {
+    if (!statSync("/.agents").isDirectory()) return false;
+  } catch {
+    return false; // ENOENT / EACCES — no mount, not a managed agent.
+  }
   // The guard: rule out a stray user-created `/.agents/` on a non-sandbox
   // host. Not a second uniqueness signal — gVisor isn't unique on its own.
   return isGVisor();

--- a/packages/cli/src/telemetry/agent_runtime.ts
+++ b/packages/cli/src/telemetry/agent_runtime.ts
@@ -151,10 +151,10 @@ export function detectSandboxRuntime(): SandboxRuntime {
  * detector functions ahead of the env-var rule loop.
  */
 export function detectAgentRuntime(): AgentRuntime {
-  // Gemini managed agent — empirical signal is a filesystem layout
-  // (`/.agents/AGENTS.md`) inside the gVisor kernel that hosts it. Env vars
-  // alone are insufficient (`GEMINI_API_KEY` is user-settable on any host),
-  // so this gets a dedicated check ahead of the env-var-only VENDOR_RULES.
+  // Gemini managed agent — keyed on a filesystem mount (`/.agents/AGENTS.md`)
+  // with a gVisor guard against false positives. See `isGeminiManagedAgent`
+  // for the load-bearing-vs-guard split. Env vars alone are insufficient
+  // (`GEMINI_API_KEY` is user-settable), so this runs ahead of VENDOR_RULES.
   if (isGeminiManagedAgent()) return "gemini_managed_agent";
   for (const rule of VENDOR_RULES) {
     if (rule.check(process.env)) return rule.name;
@@ -228,19 +228,41 @@ function isKVM(): boolean {
 /**
  * Gemini managed-agent sandbox — Google's managed runtime that mounts the
  * agent's repo under `/.agents/` (AGENTS.md + skills/ + workspace/) and runs
- * inside a gVisor kernel. The conjunction is what makes this unambiguous:
- *   - `/.agents/AGENTS.md` excludes generic gVisor surfaces (GKE Sandbox,
- *     Cloud Run gen2) that don't mount the managed-agent layout.
- *   - The gVisor kernel check excludes a dev box that happens to have a
- *     stray `/.agents/` directory.
+ * inside a gVisor kernel.
  *
- * Source: empirical introspection of a live Gemini managed-agent sandbox
- * (env_id `b9db4e56`, 2026-06-09) by gemini-agent. `GEMINI_API_KEY` is NOT
- * keyed on because it's user-settable on any host; the filesystem +
- * kernel-string pair is the actually-distinctive signal.
+ * Signal hierarchy (the two checks are NOT co-equal):
+ *   - `/.agents/AGENTS.md` is the *uniqueness anchor*: definitionally a
+ *     managed-agent artifact (the platform injects it per-run; its mtime
+ *     tracks the interaction, not the base image). Nothing in the generic
+ *     Google-Cloud-on-gVisor universe (Cloud Run gen2, GKE Sandbox) mounts
+ *     `/.agents/`. This single check carries essentially all uniqueness.
+ *   - `isGVisor()` is a *guard*, not a co-uniqueness signal. gVisor itself
+ *     is shared with GKE Sandbox + Cloud Run gen2 — it does not discriminate
+ *     Antigravity from those. Its job here is to rule out the unlikely case
+ *     of a human creating `/.agents/AGENTS.md` on a non-sandbox host.
+ *
+ * Things deliberately NOT keyed on (each fails the uniqueness test —
+ * shared across the broader Google-Cloud-on-gVisor universe or trivially
+ * user-settable on any host):
+ *   - gVisor alone
+ *   - `Google Compute Engine` DMI (entire GCP reports this)
+ *   - `job` cgroup (Google-internal but broadly present)
+ *   - egress-proxy env / CA-cert env cluster (any MITM container sets these)
+ *   - `/.google/` base-image overlay
+ *   - `GEMINI_API_KEY` (user-settable on any host)
+ *
+ * Source: empirical introspection of live Gemini managed-agent sandboxes by
+ * gemini-agent (2026-06-09) — stability verified across 3 independent fresh
+ * sandbox spins (spike + `b9db4e56` + `d59d6361`); uniqueness analysis ruled
+ * out the corroborating signals above by FS-root + cgroup + netns + DMI +
+ * PID-1 introspection.
  */
 function isGeminiManagedAgent(): boolean {
   if (platform() !== "linux") return false;
+  // The uniqueness anchor: managed-agent platform mount. Nothing else on
+  // gVisor (Cloud Run, GKE Sandbox, Fly.io) creates this path.
   if (!existsSync("/.agents/AGENTS.md")) return false;
+  // The guard: rule out a stray user-created `/.agents/AGENTS.md` on a
+  // non-sandbox host. Not a second uniqueness signal — gVisor isn't unique.
   return isGVisor();
 }

--- a/packages/cli/src/telemetry/agent_runtime.ts
+++ b/packages/cli/src/telemetry/agent_runtime.ts
@@ -30,6 +30,7 @@ export type AgentRuntime =
   | "hermes"
   | "openclaw"
   | "pi"
+  | "gemini_managed_agent"
   | null;
 
 interface VendorRule {
@@ -144,10 +145,17 @@ export function detectSandboxRuntime(): SandboxRuntime {
 
 /**
  * Identify the coding-agent vendor that spawned this process, if any.
- * Returns null on a regular interactive shell. Only checks for the
- * EXISTENCE of well-known env vars — never reads their values.
+ * Returns null on a regular interactive shell. Most rules only check the
+ * EXISTENCE of well-known env vars (never their values), but a few agents
+ * are best identified by filesystem markers — those run via dedicated
+ * detector functions ahead of the env-var rule loop.
  */
 export function detectAgentRuntime(): AgentRuntime {
+  // Gemini managed agent — empirical signal is a filesystem layout
+  // (`/.agents/AGENTS.md`) inside the gVisor kernel that hosts it. Env vars
+  // alone are insufficient (`GEMINI_API_KEY` is user-settable on any host),
+  // so this gets a dedicated check ahead of the env-var-only VENDOR_RULES.
+  if (isGeminiManagedAgent()) return "gemini_managed_agent";
   for (const rule of VENDOR_RULES) {
     if (rule.check(process.env)) return rule.name;
   }
@@ -215,4 +223,24 @@ function isKVM(): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Gemini managed-agent sandbox — Google's managed runtime that mounts the
+ * agent's repo under `/.agents/` (AGENTS.md + skills/ + workspace/) and runs
+ * inside a gVisor kernel. The conjunction is what makes this unambiguous:
+ *   - `/.agents/AGENTS.md` excludes generic gVisor surfaces (GKE Sandbox,
+ *     Cloud Run gen2) that don't mount the managed-agent layout.
+ *   - The gVisor kernel check excludes a dev box that happens to have a
+ *     stray `/.agents/` directory.
+ *
+ * Source: empirical introspection of a live Gemini managed-agent sandbox
+ * (env_id `b9db4e56`, 2026-06-09) by gemini-agent. `GEMINI_API_KEY` is NOT
+ * keyed on because it's user-settable on any host; the filesystem +
+ * kernel-string pair is the actually-distinctive signal.
+ */
+function isGeminiManagedAgent(): boolean {
+  if (platform() !== "linux") return false;
+  if (!existsSync("/.agents/AGENTS.md")) return false;
+  return isGVisor();
 }

--- a/packages/cli/src/telemetry/agent_runtime.ts
+++ b/packages/cli/src/telemetry/agent_runtime.ts
@@ -151,9 +151,9 @@ export function detectSandboxRuntime(): SandboxRuntime {
  * detector functions ahead of the env-var rule loop.
  */
 export function detectAgentRuntime(): AgentRuntime {
-  // Gemini managed agent — keyed on a filesystem mount (`/.agents/AGENTS.md`)
-  // with a gVisor guard against false positives. See `isGeminiManagedAgent`
-  // for the load-bearing-vs-guard split. Env vars alone are insufficient
+  // Gemini managed agent — keyed on the `/.agents/` platform mount with a
+  // gVisor guard against false positives. See `isGeminiManagedAgent` for the
+  // uniqueness-anchor-vs-guard split. Env vars alone are insufficient
   // (`GEMINI_API_KEY` is user-settable), so this runs ahead of VENDOR_RULES.
   if (isGeminiManagedAgent()) return "gemini_managed_agent";
   for (const rule of VENDOR_RULES) {
@@ -226,20 +226,35 @@ function isKVM(): boolean {
 }
 
 /**
- * Gemini managed-agent sandbox — Google's managed runtime that mounts the
- * agent's repo under `/.agents/` (AGENTS.md + skills/ + workspace/) and runs
- * inside a gVisor kernel.
+ * Gemini managed-agent sandbox — Google's Managed Agents runtime (the
+ * Antigravity base agent). The platform auto-discovers the agent definition
+ * under `/.agents/` and runs it inside a gVisor kernel.
  *
  * Signal hierarchy (the two checks are NOT co-equal):
- *   - `/.agents/AGENTS.md` is the *uniqueness anchor*: definitionally a
- *     managed-agent artifact (the platform injects it per-run; its mtime
- *     tracks the interaction, not the base image). Nothing in the generic
- *     Google-Cloud-on-gVisor universe (Cloud Run gen2, GKE Sandbox) mounts
- *     `/.agents/`. This single check carries essentially all uniqueness.
+ *   - `/.agents/` is the *uniqueness anchor*: the platform's agent-definition
+ *     mount root. Per Google's Managed Agents docs the runtime scans `/.agents/`
+ *     for the agent's instructions (`/.agents/AGENTS.md`) and skills
+ *     (`/.agents/skills/<name>/SKILL.md`). Nothing in the generic
+ *     Google-Cloud-on-gVisor universe (Cloud Run gen2, GKE Sandbox, Fly.io)
+ *     mounts `/.agents/` at the filesystem root.
+ *
+ *     We key on the `/.agents/` DIRECTORY, not `/.agents/AGENTS.md`: AGENTS.md
+ *     is OPTIONAL. Google's docs state "AGENTS.md is optional ... the
+ *     system_instruction and AGENTS.md are additive; both apply when present",
+ *     so an agent may declare its instructions inline via `system_instruction`
+ *     in agent.yaml and ship no AGENTS.md file. Keying on the file would
+ *     silently miss every managed agent that uses inline instructions or a
+ *     skills-only definition; the directory mount generalizes across all
+ *     managed agents that ship any definition.
  *   - `isGVisor()` is a *guard*, not a co-uniqueness signal. gVisor itself
  *     is shared with GKE Sandbox + Cloud Run gen2 — it does not discriminate
- *     Antigravity from those. Its job here is to rule out the unlikely case
- *     of a human creating `/.agents/AGENTS.md` on a non-sandbox host.
+ *     the managed-agent surface from those. Its job here is to rule out the
+ *     unlikely case of a human creating `/.agents/` on a non-sandbox host.
+ *
+ * Known coverage gap: an agent defined with ONLY inline `system_instruction`
+ * (no skills, no AGENTS.md) may not materialize a `/.agents/` mount — that
+ * tail can't be closed from the docs and needs an empirical spin to confirm.
+ * The common case (skills and/or AGENTS.md present) is covered.
  *
  * Things deliberately NOT keyed on (each fails the uniqueness test —
  * shared across the broader Google-Cloud-on-gVisor universe or trivially
@@ -248,21 +263,23 @@ function isKVM(): boolean {
  *   - `Google Compute Engine` DMI (entire GCP reports this)
  *   - `job` cgroup (Google-internal but broadly present)
  *   - egress-proxy env / CA-cert env cluster (any MITM container sets these)
- *   - `/.google/` base-image overlay
+ *   - `/workspace/` (the agent's data mount — generic, not unique)
  *   - `GEMINI_API_KEY` (user-settable on any host)
  *
- * Source: empirical introspection of live Gemini managed-agent sandboxes by
- * gemini-agent (2026-06-09) — stability verified across 3 independent fresh
- * sandbox spins (spike + `b9db4e56` + `d59d6361`); uniqueness analysis ruled
- * out the corroborating signals above by FS-root + cgroup + netns + DMI +
- * PID-1 introspection.
+ * Source: Google Managed Agents docs (ai.google.dev/gemini-api/docs/custom-agents
+ * + managed-agents-quickstart) for the `/.agents/` mount contract and AGENTS.md
+ * optionality; empirical introspection of live managed-agent sandboxes by
+ * gemini-agent (2026-06-09) for the gVisor pairing — present across 3
+ * independent fresh sandbox spins (spike + `b9db4e56` + `d59d6361`).
  */
 function isGeminiManagedAgent(): boolean {
   if (platform() !== "linux") return false;
-  // The uniqueness anchor: managed-agent platform mount. Nothing else on
-  // gVisor (Cloud Run, GKE Sandbox, Fly.io) creates this path.
-  if (!existsSync("/.agents/AGENTS.md")) return false;
-  // The guard: rule out a stray user-created `/.agents/AGENTS.md` on a
-  // non-sandbox host. Not a second uniqueness signal — gVisor isn't unique.
+  // The uniqueness anchor: the managed-agent definition mount root. We key on
+  // the `/.agents/` directory (not the optional AGENTS.md file) so skills-only
+  // and inline-instruction agents are still detected. Nothing else on gVisor
+  // (Cloud Run, GKE Sandbox, Fly.io) creates this path.
+  if (!existsSync("/.agents")) return false;
+  // The guard: rule out a stray user-created `/.agents/` on a non-sandbox
+  // host. Not a second uniqueness signal — gVisor isn't unique on its own.
   return isGVisor();
 }

--- a/packages/cli/src/telemetry/system.ts
+++ b/packages/cli/src/telemetry/system.ts
@@ -39,10 +39,11 @@ export interface SystemMeta {
    */
   sandbox_runtime: SandboxRuntime;
   /**
-   * Coding-agent vendor that spawned this process, if any (claude_code,
-   * codex, cursor, copilot_agent, replit, hermes, openclaw, pi).
-   * Detected by env-var existence only — values are never read. Every rule
-   * keys on a marker that has a public-source citation in agent_runtime.ts;
+   * Coding-agent vendor that spawned this process, if any (see the
+   * `AgentRuntime` union in agent_runtime.ts for the full, current set).
+   * Most rules check env-var existence only — values are never read; a few
+   * use filesystem/kernel markers (e.g. the Gemini managed-agent mount).
+   * Every rule keys on a marker with a source citation in agent_runtime.ts;
    * unverified guesses are deliberately omitted (false-negative > guess).
    * null when no agent is detected.
    */


### PR DESCRIPTION
## What

Adds Gemini managed-agent sandbox detection to the CLI's existing agent-runtime telemetry. Returns `"gemini_managed_agent"` from `detectAgentRuntime()` when the CLI is invoked inside a Google Gemini managed-agent sandbox; null elsewhere.

## Why

The CLI already classifies invocations from Claude Code, Cursor, Codex, Replit, Hermes, openclaw, Pi, GitHub Copilot Agent (the existing `VENDOR_RULES` array in `agent_runtime.ts`). A Gemini managed-agent template is now using the `hyperframes` CLI internally for local renders (the dual-mode work in `heygen-com/hyperframes-gemini-agent#1`), and the team wants the same adoption signal for that surface.

## How

Two changes in `packages/cli/src/telemetry/agent_runtime.ts`:

1. Add `"gemini_managed_agent"` to the `AgentRuntime` type union.
2. Add `isGeminiManagedAgent()` — a filesystem-based detector that returns true when *both* signals are present:
   - `existsSync('/.agents/AGENTS.md')` — *the uniqueness anchor*. Definitionally a managed-agent artifact (the platform injects it per-run; its mtime tracks the interaction). Nothing in the generic Google-Cloud-on-gVisor universe (Cloud Run gen2, GKE Sandbox, Fly.io) mounts `/.agents/`. This single check carries essentially all uniqueness.
   - `isGVisor()` — *a guard*, not a second uniqueness signal. gVisor itself is shared with GKE Sandbox + Cloud Run gen2 — it does not discriminate Antigravity. Its job here is to rule out a stray user-created `/.agents/AGENTS.md` on a non-sandbox host.
3. `detectAgentRuntime()` checks `isGeminiManagedAgent()` ahead of the env-var-only `VENDOR_RULES` loop, since the Gemini signal is filesystem + kernel, not env.

`GEMINI_API_KEY` is deliberately NOT keyed on — it's user-settable on any host. Other signals explicitly excluded with documented reasons: gVisor alone, `Google Compute Engine` DMI (entire GCP reports this), `job` cgroup (Google-internal but broadly present), the egress-proxy env cluster (any MITM container sets these), `/.google/` base-image overlay.

## Empirical verification

Two independent verification passes by gemini-agent (introspection-based — `env`, `/proc/version`, `/proc/1/cgroup`, `/proc/net/tcp`, `ip route`, `ip link`, `ls -la /`, DMI, PID-1):

**Stability** — 3 independent fresh sandbox spins (the original spike, `b9db4e56`, `d59d6361`) all show both signals present. Full 3-spin matrix posted as a comment on this PR.

**Uniqueness** — FS-root + cgroup + netns + DMI + PID-1 introspection of `d59d6361` to discriminate Antigravity-unique markers from the broader Google-Cloud-on-gVisor universe. Verdict:
- `/.agents/AGENTS.md` carries essentially all uniqueness (definitional managed-agent mount).
- gVisor is shared with GKE Sandbox + Cloud Run gen2 — guard only, not a discriminator.
- Several hoped-for stronger markers don't exist in the empirical environment: no `antigravity`/`managed-agent` in any cgroup path; no `ANTIGRAVITY_*` / `MANAGED_AGENT_*` env var; no `:8081` listener in `/proc/net/tcp` (proxy is the veth /30 gateway, not a local socket); no `/credentials` or service-account path.

Stability ≠ uniqueness; both are required for a correct detection rule. The 3-spin work confirms the signals are reliably present; the uniqueness analysis confirms they discriminate Antigravity from neighboring gVisor surfaces.

## Test plan

4 new vitest cases in `agent_runtime.test.ts`:
- [x] Positive: `/.agents/AGENTS.md` exists + kernel is `4.19.0-gvisor` → `gemini_managed_agent`
- [x] Negative: gVisor alone (no `/.agents/`) → `null` (generic gVisor surface fallthrough)
- [x] Negative: `/.agents/AGENTS.md` exists on a non-gVisor kernel → `null` (dev-box false-positive guard)
- [x] Precedence: Gemini signal wins over a coincident `CLAUDECODE` env var
- [x] All 24 tests in `agent_runtime.test.ts` pass under `vitest run` (the CI runner)
- [x] `bun run lint` + `bun run format:check` repo-wide clean
- [x] Commit signed (GitHub verified)
- [x] Cross-spin empirical verification (stability)
- [x] Uniqueness empirical verification
- [ ] Documentation updated — `detectAgentRuntime()`'s docstring updated inline; no separate docs surface

🤖 Signed off by Jerrai (hyperframes specialist)