### PR TITLE
fix(studio): use tsx/esm loader for vite build to resolve .ts imports

### DIFF
--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node --import tsx/esm node_modules/.bin/vite build",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## What changed

`packages/studio/package.json` build script changed from:
```
vite build
```
to:
```
node --import tsx/esm node_modules/.bin/vite build
```

## Why

When Vite loads `vite.config.ts`, it imports workspace packages via their `exports` map. In development mode, `@hyperframes/core` maps subpath exports (e.g. `./fonts/aliases`) directly to `.ts` source files. Node's native ESM loader rejects `.ts` extensions, throwing:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
for /packages/core/src/fonts/aliases.ts
```

Prefixing the build command with `node --import tsx/esm` registers the tsx loader before Vite starts, so Node can resolve and transpile TypeScript source exports during config load. This unblocks the studio build and, downstream, the CLI build which bundles the studio `dist/`.

## Testing

```bash
bun run --filter @hyperframes/studio build  # now exits 0
bun run --filter @hyperframes/cli build     # now exits 0
```