### PR TITLE
fix(runtime,player): replay bridge state on iframe ready to repair race

### DIFF
--- a/packages/core/src/runtime/README.md
+++ b/packages/core/src/runtime/README.md
@@ -32,6 +32,11 @@ postMessage:
 - runtime -> parent events:
   - `source: "hf-preview"`
   - `type: "state"` and `type: "timeline"`
+  - `type: "ready"` — emitted once when `installRuntimeControlBridge` registers
+    the control-message listener. The parent uses it to replay current playback
+    state (`set-muted`, `set-volume`, `set-playback-rate`) so any control
+    message sent before the listener was installed isn't lost. Emitted again on
+    every iframe reload because the new runtime instance starts with no state.
 
 Determinism baseline:
 

--- a/packages/core/src/runtime/bridge.test.ts
+++ b/packages/core/src/runtime/bridge.test.ts
@@ -168,4 +168,14 @@ describe("installRuntimeControlBridge", () => {
       handler(makeControlMessage("flash-elements", { selectors: [".test"], duration: 500 })),
     ).not.toThrow();
   });
+
+  it("posts a ready message to window.parent on install", () => {
+    // The bridge announces itself so the parent can replay any control
+    // messages it posted before the iframe runtime's listener was installed.
+    const postSpy = vi.spyOn(window.parent, "postMessage");
+    const deps = createMockDeps();
+    installRuntimeControlBridge(deps);
+    expect(postSpy).toHaveBeenCalledWith({ source: "hf-preview", type: "ready" }, "*");
+    postSpy.mockRestore();
+  });
 });

--- a/packages/core/src/runtime/bridge.ts
+++ b/packages/core/src/runtime/bridge.ts
@@ -79,6 +79,12 @@ export function installRuntimeControlBridge(deps: BridgeDeps): (event: MessageEv
     }
   };
   window.addEventListener("message", handler);
+  // Announce that the bridge listener is installed so the parent can replay
+  // any control messages it posted before the iframe runtime was ready
+  // (avoids losing the initial `set-muted` / `set-volume` / `set-playback-rate`
+  // when the parent finishes loading before the iframe does — a deterministic
+  // race on warm-cache reloads and inside the Claude desktop Electron client).
+  postRuntimeMessage({ source: "hf-preview", type: "ready" });
   return handler;
 }
 

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -154,6 +154,20 @@ export type RuntimeMediaAutoplayBlockedMessage = {
 };
 
 /**
+ * Posted by the runtime when `installRuntimeControlBridge` finishes registering
+ * its message listener — signals that subsequent control messages
+ * (`set-muted`, `set-volume`, `set-playback-rate`, etc.) will now be received
+ * and processed. The parent (web component / host app) listens for this and
+ * replays current playback state to repair any race where bridge messages
+ * were posted before the listener was installed. Emitted again on every iframe
+ * reload because the new runtime instance starts with no state.
+ */
+export type RuntimeReadyMessage = {
+  source: "hf-preview";
+  type: "ready";
+};
+
+/**
  * Analytics events emitted by the runtime.
  *
  * The host app receives these via postMessage and forwards to its analytics
@@ -199,6 +213,7 @@ export type RuntimeOutboundMessage =
   | RuntimePickerCancelledMessage
   | RuntimeStageSizeMessage
   | RuntimeMediaAutoplayBlockedMessage
+  | RuntimeReadyMessage
   | RuntimeAnalyticsMessage
   | RuntimePerformanceMessage;
 

--- a/packages/player/src/hyperframes-player.test.ts
+++ b/packages/player/src/hyperframes-player.test.ts
@@ -1591,6 +1591,130 @@ describe("HyperframesPlayer audio lock", () => {
   });
 });
 
+describe("HyperframesPlayer runtime ready handshake", () => {
+  // When the iframe runtime announces `{type: "ready"}` the player replays
+  // current bridge state (muted, volume, playback rate) so any control message
+  // that arrived before the iframe runtime registered its listener isn't lost.
+  // This fixes a deterministic race on warm-cache reloads of claude.ai and
+  // inside the Claude desktop Electron client where the iframe finishes
+  // loading after the player has already set audio-locked.
+  interface PlayerInternal extends HTMLElement {
+    muted: boolean;
+    volume: number;
+    audioLocked: boolean;
+    playbackRate: number;
+    iframe: HTMLIFrameElement;
+    _onMessage: (event: MessageEvent) => void;
+  }
+
+  let player: PlayerInternal;
+  let frameWindow: Window;
+  let postSpy: ReturnType<typeof vi.spyOn>;
+
+  function readyMessage() {
+    return new MessageEvent("message", {
+      source: frameWindow,
+      data: { source: "hf-preview", type: "ready" },
+    });
+  }
+
+  function findControlCalls(action: string) {
+    return postSpy.mock.calls.filter((call) => {
+      const data = call[0] as { type?: string; action?: string };
+      return data?.type === "control" && data?.action === action;
+    });
+  }
+
+  beforeEach(async () => {
+    await import("./hyperframes-player.js");
+    player = document.createElement("hyperframes-player") as PlayerInternal;
+    frameWindow = window;
+    postSpy = vi.spyOn(frameWindow, "postMessage").mockImplementation(() => undefined);
+    Object.defineProperty(player.iframe, "contentWindow", {
+      configurable: true,
+      get: () => frameWindow,
+    });
+    document.body.appendChild(player);
+  });
+
+  afterEach(() => {
+    player.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("replays current muted state when runtime emits ready", () => {
+    player.muted = true;
+    postSpy.mockClear();
+
+    player._onMessage(readyMessage());
+
+    const muteCalls = findControlCalls("set-muted");
+    expect(muteCalls).toHaveLength(1);
+    expect(muteCalls[0]?.[0]).toMatchObject({
+      source: "hf-parent",
+      type: "control",
+      action: "set-muted",
+      muted: true,
+    });
+  });
+
+  it("replays volume and playback-rate alongside muted", () => {
+    player.volume = 0.5;
+    player.playbackRate = 1.25;
+    postSpy.mockClear();
+
+    player._onMessage(readyMessage());
+
+    expect(findControlCalls("set-muted")).toHaveLength(1);
+    expect(findControlCalls("set-volume")[0]?.[0]).toMatchObject({
+      action: "set-volume",
+      volume: 0.5,
+    });
+    expect(findControlCalls("set-playback-rate")[0]?.[0]).toMatchObject({
+      action: "set-playback-rate",
+      playbackRate: 1.25,
+    });
+  });
+
+  it("replays the muted state forced by audio-locked", () => {
+    // The audio-locked attribute is the original motivating case for this
+    // handshake — its `muted = true` side effect must survive an iframe race.
+    player.setAttribute("audio-locked", "");
+    expect(player.muted).toBe(true);
+    postSpy.mockClear();
+
+    player._onMessage(readyMessage());
+
+    const muteCalls = findControlCalls("set-muted");
+    expect(muteCalls).toHaveLength(1);
+    expect(muteCalls[0]?.[0]).toMatchObject({ action: "set-muted", muted: true });
+  });
+
+  it("replays again on a second ready (idempotent — iframe reloads emit again)", () => {
+    player.muted = true;
+    postSpy.mockClear();
+
+    player._onMessage(readyMessage());
+    player._onMessage(readyMessage());
+
+    expect(findControlCalls("set-muted")).toHaveLength(2);
+  });
+
+  it("ignores ready events from a different window", () => {
+    postSpy.mockClear();
+    const otherSource = {} as Window;
+
+    player._onMessage(
+      new MessageEvent("message", {
+        source: otherSource,
+        data: { source: "hf-preview", type: "ready" },
+      }),
+    );
+
+    expect(findControlCalls("set-muted")).toHaveLength(0);
+  });
+});
+
 describe("HyperframesPlayer audio lock — Claude desktop UA fallback", () => {
   // Some host renderers (observed on the Claude desktop Electron client) strip
   // unknown custom-element attributes before they reach the DOM, so the

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -428,6 +428,21 @@ class HyperframesPlayer extends HTMLElement {
     }
   }
 
+  /**
+   * Replay current bridge state to the iframe runtime. Triggered when the
+   * runtime announces `{type: "ready"}` — repairs the race where the parent
+   * posts control messages before the iframe's bridge listener is installed
+   * (warm-cache reloads, the Claude desktop Electron client, anywhere the
+   * iframe finishes loading after we've already called `set-muted` etc).
+   * Re-sending current state is idempotent — even at default values it just
+   * confirms what the runtime would have done anyway.
+   */
+  private _replayBridgeState(): void {
+    this._sendControl("set-muted", { muted: this.muted });
+    this._sendControl("set-volume", { volume: this._volume });
+    this._sendControl("set-playback-rate", { playbackRate: this.playbackRate });
+  }
+
   private _reloadShaderOptions(): void {
     if (getShaderModeFromElement(this) !== "player") this.shaderLoader.reset();
     if (this.hasAttribute("srcdoc")) {
@@ -529,6 +544,7 @@ class HyperframesPlayer extends HTMLElement {
       },
       sendControl: (action, extra) => this._sendControl(action, extra),
       getIframeDoc: () => this.iframe.contentDocument,
+      onRuntimeReady: () => this._replayBridgeState(),
       updateControlsTime: (t, d) => this.controlsApi?.updateTime(t, d),
       updateControlsPlaying: (p) => this.controlsApi?.updatePlaying(p),
       dispatchEvent: (ev) => this.dispatchEvent(ev),

--- a/packages/player/src/runtime-message-handler.ts
+++ b/packages/player/src/runtime-message-handler.ts
@@ -23,6 +23,10 @@ export interface MessageHandlerCallbacks extends PlaybackStateCallbacks {
   setCompositionSize: (width: number, height: number) => void;
   sendControl: (action: string, extra?: Record<string, unknown>) => void;
   getIframeDoc: () => Document | null;
+  /** Invoked when the iframe runtime posts `{type: "ready"}` — the player
+   *  uses it to replay current bridge state (mute, volume, playback rate) so
+   *  control messages sent before the iframe's listener registered aren't lost. */
+  onRuntimeReady: () => void;
 }
 
 export function handleRuntimeMessage(
@@ -45,6 +49,11 @@ export function handleRuntimeMessage(
         detail: { compositionId: data["compositionId"], state },
       }),
     );
+    return;
+  }
+
+  if (data["type"] === "ready") {
+    callbacks.onRuntimeReady();
     return;
   }
 


### PR DESCRIPTION
## What

Adds a `{source: \"hf-preview\", type: \"ready\"}` event the runtime emits once `installRuntimeControlBridge` has registered its message listener, and a corresponding listener in the player web component that replays current bridge state (`set-muted`, `set-volume`, `set-playback-rate`) on receipt.

## Why

The previously-shipped audio-locked attribute (#1234) was correctly setting `muted = true` and posting `set-muted` to the iframe runtime — but on warm-cache reloads of claude.ai and inside the Claude desktop Electron client, the iframe finishes loading *after* the parent has already sent control messages. The iframe runtime's postMessage listener isn't installed yet, so the messages are silently dropped. Audio plays unmuted with no UI path to recover.

Confirmed empirically by the user:

- **First open on claude.ai** (cold cache, iframe slow to load): listener up before `set-muted` lands → audio muted ✅
- **Hard refresh on claude.ai** (warm cache, iframe loads instantly): listener up *after* the message arrives → message lost → audio plays ❌
- **Claude desktop** (Electron renderer is consistently fast): race always loses → audio plays ❌

Same code, same widget, same player, same pacific bundle on both — the only difference is iframe load timing relative to player setAttribute timing. That's a textbook race condition.

The earlier UA-based fallback in #1300 was based on an incorrect \"Electron strips attributes\" hypothesis; it's unreachable on desktop because the attribute path always wins on `_isAudioLocked()`. This PR addresses the *actual* root cause.

## How

The protocol additions are small:

1. **Runtime** (`packages/core/src/runtime/bridge.ts`): after `installRuntimeControlBridge` calls `window.addEventListener(\"message\", handler)`, it calls `postRuntimeMessage({source: \"hf-preview\", type: \"ready\"})`. Single line, idempotent if called multiple times.
2. **Player** (`packages/player/src/hyperframes-player.ts`): the existing `_onMessage` → `handleRuntimeMessage` chain gets a new `onRuntimeReady` callback. The player implements it as `_replayBridgeState`, which re-sends `set-muted`, `set-volume`, and `set-playback-rate` based on the player's current state (`this.muted`, `this._volume`, `this.playbackRate`).
3. **Type** (`packages/core/src/runtime/types.ts`): adds `RuntimeReadyMessage` to the outbound message union for type safety.

The replay is idempotent — re-asserting defaults is a no-op — so it's also safe across iframe reloads (a new runtime instance just emits ready again, the player replays again, no state mismatch).

## Why this beats alternatives

- Adding a retry/timeout to `_sendControl` would mask the race but add UI jank (re-send delays) and require tuning per environment.
- Buffering messages in the iframe before the runtime initializes would require a separate pre-bridge in the composition HTML — much more invasive.
- The ready-handshake places the source of truth where it belongs: the side that knows when it's ready announces it; the side with state replays.

## Changes

- `packages/core/src/runtime/types.ts`: new `RuntimeReadyMessage` + add to `RuntimeOutboundMessage` union
- `packages/core/src/runtime/bridge.ts`: emit `ready` once listener is installed
- `packages/core/src/runtime/bridge.test.ts`: assert `ready` posted on install (+1 test)
- `packages/core/src/runtime/README.md`: document the new event
- `packages/player/src/runtime-message-handler.ts`: route `type: \"ready\"` to new `onRuntimeReady` callback
- `packages/player/src/hyperframes-player.ts`: implement `_replayBridgeState` + wire it into `_onMessage` callbacks
- `packages/player/src/hyperframes-player.test.ts`: 5 new tests covering replay of muted/volume/playback-rate, audio-locked-forced-mute case, idempotency on repeated ready, and ignoring events from wrong source

## Tests

```
$ bun run --cwd packages/core test
Test Files  72 passed (72)
     Tests  1387 passed | 3 todo (1390)

$ bun run --cwd packages/player test
Test Files  5 passed (5)
     Tests  137 passed (137)
```

(132 → 137 in player.) `oxlint`, `oxfmt --check`, and `tsc --noEmit` all clean for both packages.

## Follow-up

After this lands and ships in the next player release, pacific should pick it up via the existing `@hyperframes/player` pin bump pattern — no API changes required at the consumer level.

The earlier 0.6.85 UA fallback (#1300) is now defensible only as belt-and-suspenders for *truly* attribute-stripping hosts. Worth considering removing it in a separate cleanup PR if we want to keep the player lean.

## Refs

- Original audio-locked feature: #1234
- Ineffective UA-fallback attempt: #1300
- Pacific consumer: heygen-com/pacific#28773, heygen-com/pacific#28908
- MCP widget data emission: heygen-com/experiment-framework#38809

🤖 Generated with [Claude Code](https://claude.com/claude-code)