### PR TITLE
fix(studio): gesture recording path-offset + env gate

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -982,9 +982,7 @@ export function initSandboxRuntimeModular(): void {
     });
     // Stamp data-start / data-duration on GSAP-targeted elements that lack
     // them so the Studio timeline can discover individual animated elements.
-    // Only when embedded in an iframe (Studio preview) — production renders
-    // run as the top-level page and must not mutate element timing.
-    if (window.parent !== window) {
+    {
       const rootComp = resolveRootCompositionElement();
       const rootDuration = boundDuration > 0 ? boundDuration : 0;
       const dur = String(rootDuration > 0 ? rootDuration : 1);

--- a/packages/core/src/studio-api/routes/files.ts
+++ b/packages/core/src/studio-api/routes/files.ts
@@ -702,8 +702,15 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
       return c.json({ error: "mutation type required" }, 400);
     }
 
-    const html = readFileSync(res.absPath, "utf-8");
-    const block = extractGsapScriptBlock(html);
+    let html = readFileSync(res.absPath, "utf-8");
+    let block = extractGsapScriptBlock(html);
+    if (!block && (body.type === "add" || body.type === "add-with-keyframes")) {
+      const gsapCdn = "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js";
+      const bootstrap = `<script src="${gsapCdn}"></script>\n<script>\nwindow.__timelines = window.__timelines || {};\nconst tl = gsap.timeline({ paused: true });\nwindow.__timelines["main"] = tl;\n</script>`;
+      html = html.replace("</body>", `${bootstrap}\n</body>`);
+      writeFileSync(res.absPath, html, "utf-8");
+      block = extractGsapScriptBlock(html);
+    }
     if (!block) {
       return c.json({ error: "no GSAP script found in file" }, 400);
     }

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -10,9 +10,10 @@ import { usePanelLayout } from "./hooks/usePanelLayout";
 import { useFileManager } from "./hooks/useFileManager";
 import { usePreviewPersistence } from "./hooks/usePreviewPersistence";
 import { useTimelineEditing } from "./hooks/useTimelineEditing";
+import { addBlockToProject } from "./utils/blockInstaller";
+import type { BlockParam } from "@hyperframes/core/registry";
 import type { BlockPreviewInfo } from "./components/sidebar/BlocksTab";
 import { useDomEditSession } from "./hooks/useDomEditSession";
-import { useBlockHandlers } from "./hooks/useBlockHandlers";
 import { useAppHotkeys } from "./hooks/useAppHotkeys";
 import { useClipboard } from "./hooks/useClipboard";
 import { readStudioUiPreferences, writeStudioUiPreferences } from "./utils/studioUiPreferences";
@@ -34,7 +35,9 @@ import type { DomEditSelection } from "./components/editor/domEditing";
 import { AskAgentModal } from "./components/AskAgentModal";
 import { StudioGlobalDragOverlay } from "./components/StudioGlobalDragOverlay";
 import { StudioHeader } from "./components/StudioHeader";
-import { useGestureCommit } from "./hooks/useGestureCommit";
+import { useGestureRecording } from "./hooks/useGestureRecording";
+import { STUDIO_KEYFRAMES_ENABLED } from "./components/editor/manualEditingAvailability";
+import { simplifyGestureSamples } from "./utils/rdpSimplify";
 
 import { GestureTrailOverlay } from "./components/editor/GestureTrailOverlay";
 import { StudioLeftSidebar } from "./components/StudioLeftSidebar";
@@ -80,6 +83,12 @@ export function StudioApp() {
   const [compositionLoading, setCompositionLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
   const [, setPreviewDocumentVersion] = useState(0);
+  const [activeBlockParams, setActiveBlockParams] = useState<{
+    blockName: string;
+    blockTitle: string;
+    params: BlockParam[];
+    compositionPath: string;
+  } | null>(null);
   const [blockPreview, setBlockPreview] = useState<BlockPreviewInfo | null>(null);
 
   const previewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -184,15 +193,8 @@ export function StudioApp() {
     isRecordingRef: isGestureRecordingRef,
   });
 
-  const {
-    activeBlockParams,
-    setActiveBlockParams,
-    handleAddBlock,
-    handleTimelineBlockDrop,
-    handlePreviewBlockDrop,
-  } = useBlockHandlers({
-    projectId,
-    blockCtxDeps: {
+  const blockCtx = useMemo(
+    () => ({
       activeCompPath,
       timelineElements,
       readProjectFile: fileManager.readProjectFile,
@@ -201,11 +203,70 @@ export function StudioApp() {
       refreshFileTree: fileManager.refreshFileTree,
       reloadPreview,
       showToast,
+    }),
+    [
+      activeCompPath,
+      timelineElements,
+      fileManager,
+      editHistory.recordEdit,
+      reloadPreview,
+      showToast,
+    ],
+  );
+  const handleAddBlock = useCallback(
+    (blockName: string) => {
+      if (!projectId) return;
+      void (async () => {
+        const result = await addBlockToProject({
+          projectId,
+          blockName,
+          ...blockCtx,
+          previewIframe: previewIframeRef.current,
+          currentTime: usePlayerStore.getState().currentTime,
+        });
+        const params = result?.block.type === "hyperframes:block" ? result.block.params : undefined;
+        if (params?.length) {
+          setActiveBlockParams({
+            blockName: result!.block.name,
+            blockTitle: result!.block.title,
+            params,
+            compositionPath: result!.compositionPath,
+          });
+          panelLayout.setRightCollapsed(false);
+          panelLayout.setRightPanelTab("block-params");
+        }
+      })();
     },
-    previewIframeRef,
-    setRightCollapsed: panelLayout.setRightCollapsed,
-    setRightPanelTab: panelLayout.setRightPanelTab,
-  });
+    [projectId, blockCtx, panelLayout],
+  );
+  const handleTimelineBlockDrop = useCallback(
+    (blockName: string, placement: { start: number; track: number }) => {
+      if (!projectId) return;
+      void addBlockToProject({
+        projectId,
+        blockName,
+        placement,
+        ...blockCtx,
+        previewIframe: previewIframeRef.current,
+        currentTime: usePlayerStore.getState().currentTime,
+      });
+    },
+    [projectId, blockCtx],
+  );
+  const handlePreviewBlockDrop = useCallback(
+    (blockName: string, position: { left: number; top: number }) => {
+      if (!projectId) return;
+      void addBlockToProject({
+        projectId,
+        blockName,
+        visualPosition: position,
+        ...blockCtx,
+        previewIframe: previewIframeRef.current,
+        currentTime: usePlayerStore.getState().currentTime,
+      });
+    },
+    [projectId, blockCtx],
+  );
 
   const clearDomSelectionRef = useRef<() => void>(() => {});
   const domEditSelectionBridgeRef = useRef<DomEditSelection | null>(null);
@@ -251,7 +312,9 @@ export function StudioApp() {
     onResetKeyframes: () => resetKeyframesRef.current(),
     onDeleteSelectedKeyframes: () => deleteSelectedKeyframesRef.current(),
     onAfterUndoRedo: () => invalidateGsapCacheRef.current(),
-    onToggleRecording: () => handleToggleRecordingRef.current(),
+    onToggleRecording: STUDIO_KEYFRAMES_ENABLED
+      ? () => handleToggleRecordingRef.current()
+      : undefined,
   });
   const selectSidebarTabStable = useCallback(
     (tab: SidebarTab) => leftSidebarRef.current?.selectTab(tab),
@@ -346,16 +409,125 @@ export function StudioApp() {
   const dragOverlay = useDragOverlay(fileManager.handleImportFiles);
 
   // Gesture recording
+  const gestureRecording = useGestureRecording();
+  const [gestureState, setGestureState] = useState<"idle" | "recording">("idle");
+  // Synchronous mirror of gestureState — immune to React batching.
+  // Prevents double-R-press within a single render cycle from swallowing the stop.
+  const gestureStateRef = useRef<"idle" | "recording">("idle");
+  const recordingAutoStopRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const recordingStartTimeRef = useRef(0);
+  const commitInFlightRef = useRef(false);
   const handleToggleRecordingRef = useRef<() => void>(() => {});
   const domEditSessionRef = useRef(domEditSession);
   domEditSessionRef.current = domEditSession;
 
-  const { gestureState, gestureRecording, handleToggleRecording } = useGestureCommit({
-    domEditSessionRef,
-    previewIframeRef,
-    showToast,
-    isGestureRecordingRef,
-  });
+  // Unmount: clear auto-stop interval
+  useEffect(() => () => clearInterval(recordingAutoStopRef.current), []);
+
+  // fallow-ignore-next-line complexity
+  const stopAndCommitRecording = useCallback(async () => {
+    clearInterval(recordingAutoStopRef.current);
+    if (commitInFlightRef.current) return;
+    commitInFlightRef.current = true;
+    gestureStateRef.current = "idle";
+    isGestureRecordingRef.current = false;
+    const frozenSamples = gestureRecording.stopRecording();
+    const store = usePlayerStore.getState();
+    store.setIsPlaying(false);
+    try {
+      const liveSession = domEditSessionRef.current;
+      const sel = liveSession.domEditSelection;
+      if (!sel) {
+        if (frozenSamples.length > 2) {
+          showToast("Selection lost during recording", "error");
+        }
+        return;
+      }
+      const duration = frozenSamples.length > 0 ? frozenSamples[frozenSamples.length - 1]!.time : 0;
+
+      if (frozenSamples.length <= 2) {
+        showToast("No gesture detected — move the pointer while recording", "error");
+        return;
+      }
+      if (duration <= 0) {
+        showToast("Recording too short — try again", "error");
+        return;
+      }
+
+      const simplified = simplifyGestureSamples(frozenSamples, duration, 5);
+      const sortedPcts = Array.from(simplified.keys()).sort((a, b) => a - b);
+
+      // Always create a new tween scoped to the recording range.
+      // Injecting into an existing tween creates keyframes before the recording
+      // start (from the convert-to-keyframes step), causing wrong positions.
+      const selector = sel.id ? `#${sel.id}` : sel.selector;
+      if (!selector) {
+        showToast("Cannot save — element has no selector", "error");
+        return;
+      }
+      if (liveSession.commitMutation) {
+        const recStart = recordingStartTimeRef.current;
+        const keyframes = sortedPcts.map((pct) => ({
+          percentage: pct,
+          properties: simplified.get(pct) as Record<string, number | string>,
+        }));
+
+        await liveSession.commitMutation(
+          {
+            type: "add-with-keyframes",
+            targetSelector: selector,
+            position: Math.round(recStart * 1000) / 1000,
+            duration: Math.round(duration * 1000) / 1000,
+            keyframes,
+          },
+          { label: "Gesture recording", softReload: true },
+        );
+      }
+      showToast(`Recorded ${sortedPcts.length} keyframes`, "info");
+    } finally {
+      store.requestSeek(recordingStartTimeRef.current);
+      gestureRecording.clearSamples();
+      setGestureState("idle");
+      commitInFlightRef.current = false;
+    }
+  }, [gestureRecording, showToast]);
+
+  const handleToggleRecording = useCallback(() => {
+    if (gestureStateRef.current === "recording") {
+      void stopAndCommitRecording();
+      return;
+    }
+    const sel = domEditSessionRef.current.domEditSelection;
+    if (!sel) {
+      showToast("Select an element first", "error");
+      return;
+    }
+    const iframe = previewIframeRef.current;
+    if (!iframe) {
+      showToast("Preview not ready — try again", "error");
+      return;
+    }
+
+    const store = usePlayerStore.getState();
+    recordingStartTimeRef.current = store.currentTime;
+    const elStart = Number.parseFloat(sel.dataAttributes?.start ?? "0") || 0;
+    const elDur = Number.parseFloat(sel.dataAttributes?.duration ?? "0") || 0;
+    const elementEnd = elDur > 0 ? elStart + elDur : undefined;
+    gestureRecording.startRecording(sel.element, iframe, elementEnd);
+    gestureStateRef.current = "recording";
+    isGestureRecordingRef.current = true;
+    setGestureState("recording");
+
+    clearInterval(recordingAutoStopRef.current);
+    const autoStopAt = elementEnd ?? Infinity;
+    recordingAutoStopRef.current = setInterval(() => {
+      const { currentTime: t, duration: d } = usePlayerStore.getState();
+      const limit = Math.min(autoStopAt, d);
+      if (limit > 0 && t >= limit - 0.05) {
+        void stopAndCommitRecording();
+      }
+    }, 100);
+  }, [gestureRecording, showToast, stopAndCommitRecording]);
   handleToggleRecordingRef.current = handleToggleRecording;
 
   const handlePreviewIframeRef = useCallback(
@@ -529,7 +701,7 @@ export function StudioApp() {
                     }}
                     recordingState={gestureState}
                     recordingDuration={gestureRecording.recordingDuration}
-                    onToggleRecording={handleToggleRecording}
+                    onToggleRecording={STUDIO_KEYFRAMES_ENABLED ? handleToggleRecording : undefined}
                   />
                 )}
               </div>

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -16,10 +16,12 @@ import {
 /** Motion data without targeting metadata. */
 type StudioMotionData = Omit<StudioGsapMotion, "kind" | "target" | "updatedAt">;
 
+import { useCallback } from "react";
 import { useStudioContext } from "../contexts/StudioContext";
 import { usePanelLayoutContext } from "../contexts/PanelLayoutContext";
 import { useFileManagerContext } from "../contexts/FileManagerContext";
 import { useDomEditContext } from "../contexts/DomEditContext";
+import { usePlayerStore } from "../player/store/playerStore";
 
 export interface StudioRightPanelProps {
   selectedStudioMotion: StudioMotionData | null;
@@ -100,7 +102,15 @@ export function StudioRightPanel({
     commitAnimatedProperty,
     handleSetArcPath,
     handleUpdateArcSegment,
+    handleGsapAddKeyframe,
+    handleGsapRemoveKeyframe,
+    handleGsapConvertToKeyframes,
   } = useDomEditContext();
+
+  const handleSeekToTime = useCallback(
+    (time: number) => usePlayerStore.getState().requestSeek(time),
+    [],
+  );
 
   const { assets, fontAssets, projectDir, handleImportFiles, handleImportFonts } =
     useFileManagerContext();
@@ -236,6 +246,10 @@ export function StudioRightPanel({
                   onCommitAnimatedProperty={commitAnimatedProperty}
                   onSetArcPath={handleSetArcPath}
                   onUpdateArcSegment={handleUpdateArcSegment}
+                  onAddKeyframe={handleGsapAddKeyframe}
+                  onRemoveKeyframe={handleGsapRemoveKeyframe}
+                  onConvertToKeyframes={handleGsapConvertToKeyframes}
+                  onSeekToTime={handleSeekToTime}
                   recordingState={recordingState}
                   recordingDuration={recordingDuration}
                   onToggleRecording={onToggleRecording}

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Eye, Layers, Move, X } from "../../icons/SystemIcons";
 import { useStudioContext } from "../../contexts/StudioContext";
 import { readStudioBoxSize, readStudioPathOffset, readStudioRotation } from "./manualEdits";
@@ -17,7 +17,7 @@ import { GsapAnimationSection } from "./GsapAnimationSection";
 import { PropertyPanel3dTransform } from "./propertyPanel3dTransform";
 import { KeyframeNavigation } from "./KeyframeNavigation";
 import { STUDIO_GSAP_PANEL_ENABLED, STUDIO_KEYFRAMES_ENABLED } from "./manualEditingAvailability";
-import { usePlayerStore } from "../../player";
+import { usePlayerStore, liveTime } from "../../player";
 import { TimingSection } from "./propertyPanelTimingSection";
 import { type PropertyPanelProps } from "./propertyPanelHelpers";
 
@@ -88,7 +88,26 @@ export const PropertyPanel = memo(function PropertyPanel({
   const { showToast } = useStudioContext();
   const [clipboardCopied, setClipboardCopied] = useState(false);
   const clipboardTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const currentTime = usePlayerStore((s) => s.currentTime);
+  const storeTime = usePlayerStore((s) => s.currentTime);
+  const [liveRenderTime, setLiveRenderTime] = useState(storeTime);
+  useEffect(() => {
+    setLiveRenderTime(storeTime);
+  }, [storeTime]);
+  useEffect(() => {
+    let rafId = 0;
+    const unsub = liveTime.subscribe((t) => {
+      if (!rafId)
+        rafId = requestAnimationFrame(() => {
+          rafId = 0;
+          setLiveRenderTime(t);
+        });
+    });
+    return () => {
+      unsub();
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+  const currentTime = liveRenderTime;
 
   if (!element) {
     return (

--- a/packages/studio/src/components/editor/manualEditsDom.ts
+++ b/packages/studio/src/components/editor/manualEditsDom.ts
@@ -32,7 +32,6 @@ import {
 } from "./manualEditsTypes";
 import { roundRotationAngle } from "./manualEditsParsing";
 import { applyStudioMotionFromDom } from "./studioMotion";
-import { gsapAnimatesProperty } from "./gsapAnimatesProperty";
 
 /* ── Gesture tracking ─────────────────────────────────────────────── */
 let studioManualEditGestureId = 0;
@@ -527,12 +526,68 @@ function reapplyPathOffsets(doc: Document): void {
     const x = el.style.getPropertyValue(STUDIO_OFFSET_X_PROP);
     const y = el.style.getPropertyValue(STUDIO_OFFSET_Y_PROP);
     if (x || y) {
-      applyStudioPathOffset(el, {
-        x: Number.parseFloat(x) || 0,
-        y: Number.parseFloat(y) || 0,
-      });
+      applyStudioPathOffset(
+        el,
+        {
+          x: Number.parseFloat(x) || 0,
+          y: Number.parseFloat(y) || 0,
+        },
+        { updateBase: false },
+      );
     }
   }
+}
+
+function gsapAnimatesProperty(el: HTMLElement, ...props: string[]): boolean {
+  const win = el.ownerDocument.defaultView as
+    | (Window & {
+        __timelines?: Record<
+          string,
+          {
+            getChildren?: (
+              deep: boolean,
+            ) => Array<{ targets?: () => Element[]; vars?: Record<string, unknown> }>;
+          }
+        >;
+      })
+    | null;
+  if (!win?.__timelines) return false;
+  const propSet = new Set(props);
+  for (const tl of Object.values(win.__timelines)) {
+    if (!tl?.getChildren) continue;
+    try {
+      for (const child of tl.getChildren(true)) {
+        if (!child.targets || !child.vars) continue;
+        let targetsEl = false;
+        for (const t of child.targets()) {
+          if (t === el || (el.id && t.id === el.id)) {
+            targetsEl = true;
+            break;
+          }
+        }
+        if (!targetsEl) continue;
+        const vars = child.vars;
+        for (const p of propSet) {
+          if (p in vars) return true;
+        }
+        if (vars.keyframes && typeof vars.keyframes === "object") {
+          const kfEntries = Array.isArray(vars.keyframes)
+            ? (vars.keyframes as unknown[])
+            : Object.values(vars.keyframes as Record<string, unknown>);
+          for (const kfVal of kfEntries) {
+            if (kfVal && typeof kfVal === "object") {
+              for (const p of propSet) {
+                if (p in (kfVal as Record<string, unknown>)) return true;
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      /* */
+    }
+  }
+  return false;
 }
 
 function reapplyBoxSizes(doc: Document): void {

--- a/packages/studio/src/components/editor/manualEditsDom.ts
+++ b/packages/studio/src/components/editor/manualEditsDom.ts
@@ -610,7 +610,12 @@ function reapplyRotations(doc: Document): void {
   }
 }
 
+let _lastReapplyTime = 0;
+
 export function reapplyPositionEditsAfterSeek(doc: Document): void {
+  const now = performance.now();
+  if (now - _lastReapplyTime < 16) return;
+  _lastReapplyTime = now;
   reapplyPathOffsets(doc);
   reapplyBoxSizes(doc);
   reapplyRotations(doc);

--- a/packages/studio/src/hooks/gsapRuntimeBridge.ts
+++ b/packages/studio/src/hooks/gsapRuntimeBridge.ts
@@ -11,14 +11,13 @@
 import type { GsapAnimation } from "@hyperframes/core/gsap-parser";
 import type { DomEditSelection } from "../components/editor/domEditingTypes";
 
-import { resolveTweenStart, resolveTweenDuration } from "../utils/globalTimeCompiler";
-import { readAllAnimatedProperties, readGsapProperty } from "./gsapRuntimeReaders";
+import { usePlayerStore } from "../player/store/playerStore";
+import { readRuntimeKeyframes, scanAllRuntimeKeyframes } from "./gsapRuntimeKeyframes";
 import {
-  commitGsapPositionFromDrag,
-  computeCurrentPercentage,
-  materializeIfDynamic,
-} from "./gsapDragCommit";
-import type { GsapDragCommitCallbacks } from "./gsapDragCommit";
+  absoluteToPercentage,
+  resolveTweenStart,
+  resolveTweenDuration,
+} from "../utils/globalTimeCompiler";
 
 // ── Runtime reads ──────────────────────────────────────────────────────────
 
@@ -95,16 +94,94 @@ function selectorForSelection(selection: DomEditSelection): string | null {
   return null;
 }
 
+// ── Percentage computation ─────────────────────────────────────────────────
+
+function computeCurrentPercentage(selection: DomEditSelection, animation?: GsapAnimation): number {
+  const currentTime = usePlayerStore.getState().currentTime;
+  if (animation) {
+    const start = resolveTweenStart(animation);
+    const duration = resolveTweenDuration(animation);
+    if (start !== null) {
+      return absoluteToPercentage(currentTime, start, duration);
+    }
+  }
+  const elStart = Number.parseFloat(selection.dataAttributes?.start ?? "0") || 0;
+  const elDuration = Number.parseFloat(selection.dataAttributes?.duration ?? "1") || 1;
+  return elDuration > 0
+    ? Math.max(0, Math.min(100, Math.round(((currentTime - elStart) / elDuration) * 1000) / 10))
+    : 0;
+}
+
+// ── Dynamic keyframe materialization ──────────────────────────────────────
+
+async function materializeIfDynamic(
+  anim: GsapAnimation,
+  iframe: HTMLIFrameElement | null,
+  commitMutation: GsapDragCommitCallbacks["commitMutation"],
+  selection: DomEditSelection,
+): Promise<string | void> {
+  if (!anim.hasUnresolvedKeyframes && !anim.hasUnresolvedSelector) return;
+
+  if (anim.hasUnresolvedSelector) {
+    // Unroll: read ALL elements' keyframes from runtime and replace the loop
+    const allScanned = scanAllRuntimeKeyframes(iframe);
+    if (allScanned.size === 0) return;
+    const allElements = Array.from(allScanned.entries()).map(([id, data]) => ({
+      selector: `#${id}`,
+      keyframes: data.keyframes,
+      easeEach: data.easeEach,
+    }));
+    await commitMutation(
+      selection,
+      {
+        type: "materialize-keyframes",
+        animationId: anim.id,
+        keyframes: allScanned.get(selection.id ?? "")?.keyframes ?? [],
+        allElements,
+      },
+      { label: "Unroll dynamic animations", skipReload: true },
+    );
+    return `${anim.targetSelector}-to-0`;
+  }
+
+  const runtime = readRuntimeKeyframes(iframe, anim.targetSelector);
+  if (!runtime || runtime.keyframes.length === 0) return;
+  await commitMutation(
+    selection,
+    {
+      type: "materialize-keyframes",
+      animationId: anim.id,
+      keyframes: runtime.keyframes,
+      easeEach: runtime.easeEach,
+    },
+    { label: "Materialize dynamic keyframes", skipReload: true },
+  );
+}
+
 // ── High-level intercept ───────────────────────────────────────────────────
 
-export type { GsapDragCommitCallbacks };
+export interface GsapDragCommitCallbacks {
+  commitMutation: (
+    selection: DomEditSelection,
+    mutation: Record<string, unknown>,
+    options: {
+      label: string;
+      coalesceKey?: string;
+      softReload?: boolean;
+      skipReload?: boolean;
+      beforeReload?: () => void;
+    },
+  ) => Promise<void>;
+}
 
 /**
  * Attempt to handle a drag commit via the GSAP script mutation path.
  *
  * Returns a Promise that resolves to true if the drag was handled via GSAP
  * (caller should skip the CSS path), or false if no GSAP position animation
- * exists.
+ * exists. The promise resolves only AFTER the mutation has been persisted and
+ * the preview soft-reloaded — the CSS offset stays visible until then so the
+ * element doesn't snap back during the async gap.
  */
 // fallow-ignore-next-line complexity
 export async function tryGsapDragIntercept(
@@ -125,6 +202,10 @@ export async function tryGsapDragIntercept(
   const selector = selectorForSelection(selection);
   if (!selector) return false;
 
+  // Keyframe writes at 0%/100% when outside the tween range. Acceptable
+  // trade-off — CSS path must NEVER touch GSAP-targeted elements because
+  // changing the CSS offset corrupts all existing keyframes (baked mismatch).
+
   const gsapPos = readGsapPositionFromIframe(iframe, selector);
   if (!gsapPos) return false;
 
@@ -134,9 +215,294 @@ export async function tryGsapDragIntercept(
   return true;
 }
 
-// ── Runtime property readers (re-exported for external callers) ───────────
+// ── Commit helpers ─────────────────────────────────────────────────────────
 
-export { readGsapProperty, readAllAnimatedProperties };
+/**
+ * Compute the new GSAP position values from runtime-read positions + drag
+ * offset, then commit the mutation to the GSAP script.
+ *
+ * `gsap.getProperty` reads from GSAP's internal cache (element._gsap), not
+ * from the DOM transform matrix. The strip in `applyStudioPathOffset` does
+ * not affect the cached values, so the formula is simply:
+ *   newValue = cachedGsapValue + dragOffset
+ *
+ * For flat tweens (to/set), the mutation would change the tween endpoint,
+ * which is invisible at t=0. Instead, we convert to keyframes first so the
+ * position is set at the exact seek percentage via a keyframe.
+ */
+// fallow-ignore-next-line complexity
+async function commitGsapPositionFromDrag(
+  selection: DomEditSelection,
+  anim: GsapAnimation,
+  studioOffset: { x: number; y: number },
+  gsapPos: { x: number; y: number },
+  iframe: HTMLIFrameElement | null,
+  selector: string,
+  callbacks: GsapDragCommitCallbacks,
+): Promise<void> {
+  // CSS composition: translate → rotate → transform. The studioOffset is in
+  // pre-rotation space (CSS translate), but GSAP x/y are in post-CSS-rotate
+  // space (CSS transform). Counter-rotate the offset to match GSAP's frame.
+  const rotStyle = selection.element.style.getPropertyValue("--hf-studio-rotation");
+  const rotDeg = Number.parseFloat(rotStyle) || 0;
+  const rad = (-rotDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const el = selection.element;
+  const origX = Number.parseFloat(el.getAttribute("data-hf-drag-initial-offset-x") ?? "") || 0;
+  const origY = Number.parseFloat(el.getAttribute("data-hf-drag-initial-offset-y") ?? "") || 0;
+  const deltaX = studioOffset.x - origX;
+  const deltaY = studioOffset.y - origY;
+  const adjX = deltaX * cos - deltaY * sin;
+  const adjY = deltaX * sin + deltaY * cos;
+  // Use the GSAP base captured at drag start — the live gsapPos is corrupted
+  // by the draft's gsap.set() calls during drag.
+  const baseGsapX =
+    Number.parseFloat(el.getAttribute("data-hf-drag-gsap-base-x") ?? "") || gsapPos.x;
+  const baseGsapY =
+    Number.parseFloat(el.getAttribute("data-hf-drag-gsap-base-y") ?? "") || gsapPos.y;
+  const newX = Math.round(baseGsapX + adjX);
+  const newY = Math.round(baseGsapY + adjY);
+  // Restore the CSS offset to pre-drag value so the baked translate stays
+  // consistent with existing keyframes. The drag is captured in the new keyframe.
+  const restoreOffset = () => {
+    el.style.setProperty("--hf-studio-offset-x", `${origX}px`);
+    el.style.setProperty("--hf-studio-offset-y", `${origY}px`);
+    el.removeAttribute("data-hf-drag-initial-offset-x");
+    el.removeAttribute("data-hf-drag-initial-offset-y");
+  };
+
+  if (anim.keyframes) {
+    const newId = await materializeIfDynamic(anim, iframe, callbacks.commitMutation, selection);
+    const effectiveAnim = newId ? { ...anim, id: newId } : anim;
+    const runtimeProps = readAllAnimatedProperties(iframe, selector, anim);
+
+    // Check if current time is outside the tween's range — extend the tween
+    // to cover the playhead, remap existing keyframes, then add the new one.
+    const ct = usePlayerStore.getState().currentTime;
+    const ts = resolveTweenStart(effectiveAnim);
+    const td = resolveTweenDuration(effectiveAnim);
+    if (ts !== null && td > 0 && (ct < ts - 0.01 || ct > ts + td + 0.01)) {
+      await extendTweenAndAddKeyframe(
+        selection,
+        effectiveAnim,
+        { ...runtimeProps, x: newX, y: newY },
+        ct,
+        ts,
+        td,
+        callbacks,
+        restoreOffset,
+      );
+    } else {
+      await commitKeyframedPosition(
+        selection,
+        effectiveAnim,
+        { ...runtimeProps, x: newX, y: newY },
+        callbacks,
+        restoreOffset,
+      );
+    }
+  } else if (anim.method === "from" || anim.method === "fromTo") {
+    // from()/fromTo() — convert to keyframes in a single mutation, placing
+    // the dragged position at the 100% (rest) keyframe. A single mutation
+    // avoids the stable-id flip (from→to) that breaks chained mutations.
+    await callbacks.commitMutation(
+      selection,
+      {
+        type: "convert-to-keyframes",
+        animationId: anim.id,
+        resolvedFromValues: { x: newX, y: newY },
+      },
+      { label: "Move layer (keyframe rest)", softReload: true, beforeReload: restoreOffset },
+    );
+  } else {
+    // Flat to()/set() — convert to keyframes then add at current percentage.
+    const runtimeProps = readAllAnimatedProperties(iframe, selector, anim);
+    await commitFlatViaKeyframes(
+      selection,
+      anim,
+      { ...runtimeProps, x: newX, y: newY },
+      callbacks,
+      restoreOffset,
+    );
+  }
+}
+
+/**
+ * Extend a tween's time range to cover `targetTime`, remap all existing
+ * keyframe percentages to preserve their absolute positions, then add
+ * a new keyframe at the target time.
+ */
+async function extendTweenAndAddKeyframe(
+  selection: DomEditSelection,
+  anim: GsapAnimation,
+  properties: Record<string, number>,
+  targetTime: number,
+  tweenStart: number,
+  tweenDuration: number,
+  callbacks: GsapDragCommitCallbacks,
+  beforeReload?: () => void,
+): Promise<void> {
+  const tweenEnd = tweenStart + tweenDuration;
+  const newStart = Math.min(targetTime, tweenStart);
+  const newEnd = Math.max(targetTime, tweenEnd);
+  const newDuration = Math.max(0.01, newEnd - newStart);
+
+  // Step 1: Remap all existing keyframes to preserve their absolute times
+  // in the new range, then add the new keyframe.
+  const existingKfs = anim.keyframes?.keyframes ?? [];
+  const remappedKfs: Array<{ percentage: number; properties: Record<string, number | string> }> =
+    [];
+  for (const kf of existingKfs) {
+    const absTime = tweenStart + (kf.percentage / 100) * tweenDuration;
+    const newPct = Math.round(((absTime - newStart) / newDuration) * 1000) / 10;
+    remappedKfs.push({ percentage: newPct, properties: { ...kf.properties } });
+  }
+
+  // Add the new keyframe at the target time
+  const targetPct = Math.round(((targetTime - newStart) / newDuration) * 1000) / 10;
+  remappedKfs.push({ percentage: targetPct, properties });
+
+  // Sort and dedupe
+  remappedKfs.sort((a, b) => a.percentage - b.percentage);
+
+  // Step 2: Delete the old tween and create a new one with the extended range
+  // and all remapped keyframes. Using delete + add-with-keyframes as an atomic pair.
+  await callbacks.commitMutation(
+    selection,
+    { type: "delete", animationId: anim.id },
+    { label: "Extend tween range", skipReload: true },
+  );
+
+  const selector = anim.targetSelector;
+  await callbacks.commitMutation(
+    selection,
+    {
+      type: "add-with-keyframes",
+      targetSelector: selector,
+      position: Math.round(newStart * 1000) / 1000,
+      duration: Math.round(newDuration * 1000) / 1000,
+      keyframes: remappedKfs,
+    },
+    { label: `Move layer (extended keyframe)`, softReload: true, beforeReload },
+  );
+}
+
+// fallow-ignore-next-line complexity
+async function commitKeyframedPosition(
+  selection: DomEditSelection,
+  anim: GsapAnimation,
+  properties: Record<string, number>,
+  callbacks: GsapDragCommitCallbacks,
+  beforeReload?: () => void,
+): Promise<void> {
+  const pct = computeCurrentPercentage(selection, anim);
+
+  await callbacks.commitMutation(
+    selection,
+    {
+      type: "add-keyframe",
+      animationId: anim.id,
+      percentage: pct,
+      properties,
+    },
+    { label: `Move layer (keyframe ${pct}%)`, softReload: true, beforeReload },
+  );
+}
+
+/**
+ * For flat to()/set() tweens, convert to keyframes first so we can place the
+ * drag position at the current percentage. Without conversion, the mutation
+ * only changes the tween endpoint, which is invisible at t=0.
+ */
+// fallow-ignore-next-line complexity
+async function commitFlatViaKeyframes(
+  selection: DomEditSelection,
+  anim: GsapAnimation,
+  properties: Record<string, number>,
+  callbacks: GsapDragCommitCallbacks,
+  beforeReload?: () => void,
+): Promise<void> {
+  await callbacks.commitMutation(
+    selection,
+    { type: "convert-to-keyframes", animationId: anim.id },
+    { label: "Convert to keyframes for drag", skipReload: true },
+  );
+
+  const pct = computeCurrentPercentage(selection, anim);
+
+  await callbacks.commitMutation(
+    selection,
+    {
+      type: "add-keyframe",
+      animationId: anim.id,
+      percentage: pct,
+      properties,
+    },
+    { label: `Move layer (keyframe ${pct}%)`, softReload: true, beforeReload },
+  );
+}
+
+// ── Runtime property reader ───────────────────────────────────────────────
+
+export function readGsapProperty(
+  iframe: HTMLIFrameElement | null,
+  selector: string | null,
+  prop: string,
+): number | null {
+  if (!iframe?.contentWindow || !selector) return null;
+  try {
+    const gsap = (iframe.contentWindow as unknown as { gsap?: IframeGsap }).gsap;
+    if (!gsap?.getProperty) return null;
+    const el = iframe.contentDocument?.querySelector(selector);
+    if (!el) return null;
+    const val = Number(gsap.getProperty(el, prop));
+    return Number.isFinite(val) ? Math.round(val) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readAllAnimatedProperties(
+  iframe: HTMLIFrameElement | null,
+  selector: string,
+  anim: GsapAnimation,
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  if (!iframe?.contentWindow) return result;
+  let gsap: IframeGsap | undefined;
+  try {
+    gsap = (iframe.contentWindow as unknown as { gsap?: IframeGsap }).gsap;
+  } catch {
+    return result;
+  }
+  if (!gsap?.getProperty) return result;
+  let doc: Document | null = null;
+  try {
+    doc = iframe.contentDocument;
+  } catch {
+    return result;
+  }
+  const el = doc?.querySelector(selector);
+  if (!el) return result;
+
+  const propKeys = new Set<string>();
+  if (anim.keyframes) {
+    for (const kf of anim.keyframes.keyframes) {
+      for (const p of Object.keys(kf.properties)) {
+        if (typeof kf.properties[p] === "number") propKeys.add(p);
+      }
+    }
+  } else {
+    for (const p of Object.keys(anim.properties)) propKeys.add(p);
+  }
+
+  for (const prop of propKeys) {
+    const val = Number(gsap.getProperty(el, prop));
+    if (Number.isFinite(val)) result[prop] = Math.round(val);
+  }
+  return result;
+}
 
 // ── Resize intercept ──────────────────────────────────────────────────────
 

--- a/packages/studio/src/hooks/gsapRuntimeBridge.ts
+++ b/packages/studio/src/hooks/gsapRuntimeBridge.ts
@@ -13,6 +13,12 @@ import type { DomEditSelection } from "../components/editor/domEditingTypes";
 
 import { usePlayerStore } from "../player/store/playerStore";
 import { readRuntimeKeyframes, scanAllRuntimeKeyframes } from "./gsapRuntimeKeyframes";
+
+const INTEGER_PROPS = new Set(["x", "y", "width", "height", "top", "left", "right", "bottom"]);
+
+function roundForProp(prop: string, val: number): number {
+  return INTEGER_PROPS.has(prop) ? Math.round(val) : Math.round(val * 1000) / 1000;
+}
 import {
   absoluteToPercentage,
   resolveTweenStart,
@@ -457,7 +463,7 @@ export function readGsapProperty(
     const el = iframe.contentDocument?.querySelector(selector);
     if (!el) return null;
     const val = Number(gsap.getProperty(el, prop));
-    return Number.isFinite(val) ? Math.round(val) : null;
+    return Number.isFinite(val) ? roundForProp(prop, val) : null;
   } catch {
     return null;
   }
@@ -499,7 +505,7 @@ export function readAllAnimatedProperties(
 
   for (const prop of propKeys) {
     const val = Number(gsap.getProperty(el, prop));
-    if (Number.isFinite(val)) result[prop] = Math.round(val);
+    if (Number.isFinite(val)) result[prop] = roundForProp(prop, val);
   }
   return result;
 }

--- a/packages/studio/src/hooks/useAnimatedPropertyCommit.ts
+++ b/packages/studio/src/hooks/useAnimatedPropertyCommit.ts
@@ -45,6 +45,29 @@ function computePercentage(selection: DomEditSelection): number {
     : 0;
 }
 
+function pickBestAnimation(
+  animations: GsapAnimation[],
+  selector: string | null,
+): GsapAnimation | undefined {
+  if (animations.length <= 1) return animations[0];
+  const currentTime = usePlayerStore.getState().currentTime;
+
+  const scored = animations.map((a) => {
+    let score = 0;
+    if (a.keyframes) score += 10;
+    // Prefer single-element selectors over comma-separated groups
+    if (selector && a.targetSelector === selector) score += 5;
+    else if (a.targetSelector.includes(",")) score -= 3;
+    // Prefer tweens active at the current time
+    const pos = typeof a.position === "number" ? a.position : 0;
+    const dur = a.duration ?? 0;
+    if (currentTime >= pos && currentTime <= pos + dur) score += 8;
+    return { anim: a, score };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored[0]?.anim;
+}
+
 function selectorFor(selection: DomEditSelection): string | null {
   if (selection.id) return `#${selection.id}`;
   if (selection.selector) return selection.selector;
@@ -72,8 +95,7 @@ export function useAnimatedPropertyCommit(deps: CommitAnimatedPropertyDeps) {
       const selector = selectorFor(selection);
       const pct = computePercentage(selection);
 
-      let anim: GsapAnimation | undefined =
-        selectedGsapAnimations.find((a) => a.keyframes) ?? selectedGsapAnimations[0];
+      let anim: GsapAnimation | undefined = pickBestAnimation(selectedGsapAnimations, selector);
 
       // Case 3: No animation — create one first
       if (!anim) {

--- a/packages/studio/src/hooks/useAnimatedPropertyCommit.ts
+++ b/packages/studio/src/hooks/useAnimatedPropertyCommit.ts
@@ -112,15 +112,26 @@ export function useAnimatedPropertyCommit(deps: CommitAnimatedPropertyDeps) {
       }
       backfillDefaults[property] = typeof value === "number" ? value : value;
 
+      const existingKf = anim.keyframes?.keyframes.some(
+        (kf) => Math.abs(kf.percentage - pct) < 0.05,
+      );
+
       await gsapCommitMutation(
         selection,
-        {
-          type: "add-keyframe",
-          animationId: anim.id,
-          percentage: pct,
-          properties,
-          backfillDefaults,
-        },
+        existingKf
+          ? {
+              type: "update-keyframe",
+              animationId: anim.id,
+              percentage: pct,
+              properties,
+            }
+          : {
+              type: "add-keyframe",
+              animationId: anim.id,
+              percentage: pct,
+              properties,
+              backfillDefaults,
+            },
         { label: `Edit ${property} (keyframe ${pct}%)`, softReload: true },
       );
     },

--- a/packages/studio/src/hooks/useGestureRecording.ts
+++ b/packages/studio/src/hooks/useGestureRecording.ts
@@ -77,6 +77,7 @@ export function useGestureRecording() {
   const modifiersRef = useRef<Modifiers>({ shift: false, alt: false, meta: false });
   const accumulatedRef = useRef<AccumulatedState>({ opacity: 1, scale: 1, z: 0 });
   const basePositionRef = useRef({ x: 0, y: 0 });
+  const cssVarOffsetRef = useRef({ x: 0, y: 0 });
   const scaleRef = useRef(1);
   const hasMovedRef = useRef(false);
   const pointerElementOffsetRef = useRef({ x: 0, y: 0 });
@@ -133,18 +134,18 @@ export function useGestureRecording() {
       } catch {
         /* cross-origin guard */
       }
-      // When reapplyPathOffsets has run (translate restored to var-based),
-      // GSAP's cache was stripped — gsapX is 0 but the element is visually
-      // at CSSLeft + translate(offset). gsap.set wipes translate, so we need
-      // baseX to include the offset. When translate is "none" (GSAP owns it),
-      // gsapX already includes the baked offset — don't add.
+      // Path-offset CSS vars live on the element regardless of whether
+      // translate is currently var-based or "none" (GSAP-baked).
+      const cssOffX =
+        Number.parseFloat(element.style.getPropertyValue("--hf-studio-offset-x")) || 0;
+      const cssOffY =
+        Number.parseFloat(element.style.getPropertyValue("--hf-studio-offset-y")) || 0;
       const translateVal = element.style.translate ?? "";
       if (translateVal.includes("var(")) {
-        const offX = Number.parseFloat(element.style.getPropertyValue("--hf-studio-offset-x")) || 0;
-        const offY = Number.parseFloat(element.style.getPropertyValue("--hf-studio-offset-y")) || 0;
-        baseX += offX;
-        baseY += offY;
+        baseX += cssOffX;
+        baseY += cssOffY;
       }
+      cssVarOffsetRef.current = { x: cssOffX, y: cssOffY };
       accumulatedRef.current = { opacity: baseOpacity, scale: baseScaleVal, z: 0 };
       basePositionRef.current = { x: baseX, y: baseY };
 
@@ -278,6 +279,9 @@ export function useGestureRecording() {
               runtimeRef.current.maxSeekTime,
             );
             runtimeRef.current.seek(seekTime);
+            // Seek triggers reapplyPathOffsets which may restore translate to
+            // var-based. Clear it so gsap.set has sole control of positioning.
+            runtimeRef.current.element.style.setProperty("translate", "none");
             runtimeRef.current.set(runtimeRef.current.selector, { ...properties });
             runtimeRef.current.element.style.visibility = "visible";
             liveTime.notify(seekTime);
@@ -287,7 +291,10 @@ export function useGestureRecording() {
           }
         }
 
-        samplesRef.current.push({ time, properties });
+        const sampleProps = { ...properties };
+        if ("x" in sampleProps) sampleProps.x -= cssVarOffsetRef.current.x;
+        if ("y" in sampleProps) sampleProps.y -= cssVarOffsetRef.current.y;
+        samplesRef.current.push({ time, properties: sampleProps });
         trailRef.current.push({ x: pointerRef.current.x, y: pointerRef.current.y });
         setRecordingDuration(time);
         rafIdRef.current = requestAnimationFrame(tick);

--- a/packages/studio/src/hooks/useGestureRecording.ts
+++ b/packages/studio/src/hooks/useGestureRecording.ts
@@ -88,6 +88,8 @@ export function useGestureRecording() {
     element: HTMLElement;
     startTime: number;
     maxSeekTime: number;
+    savedVisibility: string;
+    savedTranslate: string;
   } | null>(null);
 
   const rafIdRef = useRef(0);
@@ -167,6 +169,8 @@ export function useGestureRecording() {
             startTime: win.__player?.getTime() ?? 0,
             maxSeekTime:
               elementEndTime != null && elementEndTime < tlDuration ? elementEndTime : tlDuration,
+            savedVisibility: element.style.visibility,
+            savedTranslate: element.style.getPropertyValue("translate"),
           };
         }
       } catch {
@@ -318,6 +322,11 @@ export function useGestureRecording() {
   const stopRecording = useCallback((): GestureSample[] => {
     if (!isRecordingRef.current) return [];
     isRecordingRef.current = false;
+    if (runtimeRef.current) {
+      const { element: el, savedVisibility, savedTranslate } = runtimeRef.current;
+      el.style.visibility = savedVisibility;
+      el.style.setProperty("translate", savedTranslate || "");
+    }
     runtimeRef.current = null;
     cleanupRef.current?.();
     cleanupRef.current = null;

--- a/packages/studio/src/hooks/useGestureRecording.ts
+++ b/packages/studio/src/hooks/useGestureRecording.ts
@@ -177,6 +177,11 @@ export function useGestureRecording() {
         runtimeRef.current = null;
       }
 
+      if (!runtimeRef.current) {
+        isRecordingRef.current = false;
+        return;
+      }
+
       const iframeRect = iframeEl.getBoundingClientRect();
       const doc = iframeEl.contentDocument;
       const root = doc?.querySelector<HTMLElement>("[data-composition-id]") ?? doc?.documentElement;

--- a/packages/studio/src/hooks/useGsapScriptCommits.ts
+++ b/packages/studio/src/hooks/useGsapScriptCommits.ts
@@ -6,11 +6,6 @@ import { applySoftReload } from "../utils/gsapSoftReload";
 import { executeOptimistic } from "../utils/optimisticUpdate";
 import { usePlayerStore, type KeyframeCacheEntry } from "../player/store/playerStore";
 import { commitKeyframeAtTimeImpl } from "./gsapKeyframeCommit";
-import {
-  updateKeyframeCacheFromParsed,
-  readKeyframeSnapshot,
-  writeKeyframeCache,
-} from "./gsapKeyframeCacheHelpers";
 
 const PROPERTY_DEFAULTS: Record<string, number> = {
   opacity: 1,
@@ -76,6 +71,84 @@ async function mutateGsapScript(
   } catch {
     return null;
   }
+}
+function updateKeyframeCacheFromParsed(
+  animations: GsapAnimation[],
+  targetPath: string,
+  selectionId: string | undefined,
+  mutation: Record<string, unknown>,
+): void {
+  const { setKeyframeCache, elements } = usePlayerStore.getState();
+  const idsWithKeyframes = new Set<string>();
+  const merged = new Map<string, KeyframeCacheEntry>();
+  for (const anim of animations) {
+    const id = anim.targetSelector.match(/^#([\w-]+)/)?.[1];
+    if (!id || !anim.keyframes) continue;
+    idsWithKeyframes.add(id);
+
+    // Convert tween-relative percentages to clip-relative so diamonds
+    // render at the correct position within the timeline clip.
+    const tweenPos = typeof anim.position === "number" ? anim.position : 0;
+    const tweenDur = anim.duration ?? 1;
+    const timelineEl = elements.find(
+      (el) => el.domId === id || (el.key ?? el.id) === `${targetPath}#${id}`,
+    );
+    const elStart = timelineEl?.start ?? 0;
+    const elDuration = timelineEl?.duration ?? 4;
+    const clipKeyframes = anim.keyframes.keyframes.map((kf) => {
+      const absTime = tweenPos + (kf.percentage / 100) * tweenDur;
+      const clipPct =
+        elDuration > 0 ? Math.round(((absTime - elStart) / elDuration) * 1000) / 10 : kf.percentage;
+      return { ...kf, percentage: clipPct };
+    });
+
+    const existing = merged.get(id);
+    if (existing) {
+      const byPct = new Map<number, (typeof existing.keyframes)[0]>();
+      for (const kf of [...existing.keyframes, ...clipKeyframes]) {
+        const prev = byPct.get(kf.percentage);
+        if (prev) {
+          prev.properties = { ...prev.properties, ...kf.properties };
+          if (kf.ease) prev.ease = kf.ease;
+        } else {
+          byPct.set(kf.percentage, { ...kf, properties: { ...kf.properties } });
+        }
+      }
+      existing.keyframes = Array.from(byPct.values()).sort((a, b) => a.percentage - b.percentage);
+    } else {
+      merged.set(id, { ...anim.keyframes, keyframes: clipKeyframes });
+    }
+  }
+  for (const [id, entry] of merged) {
+    setKeyframeCache(`${targetPath}#${id}`, entry);
+    setKeyframeCache(id, entry);
+    if (targetPath !== "index.html") setKeyframeCache(`index.html#${id}`, entry);
+  }
+  const targetId =
+    (mutation as { targetSelector?: string }).targetSelector?.match(/^#([\w-]+)/)?.[1] ??
+    selectionId;
+  if (targetId && !idsWithKeyframes.has(targetId)) {
+    setKeyframeCache(`${targetPath}#${targetId}`, undefined);
+    if (targetPath !== "index.html") setKeyframeCache(`index.html#${targetId}`, undefined);
+  }
+}
+function buildCacheKey(sourceFile: string, elementId: string): string {
+  return `${sourceFile}#${elementId}`;
+}
+function readKeyframeSnapshot(
+  sourceFile: string,
+  elementId: string | null | undefined,
+): KeyframeCacheEntry | undefined {
+  if (!elementId) return undefined;
+  return usePlayerStore.getState().keyframeCache.get(buildCacheKey(sourceFile, elementId));
+}
+function writeKeyframeCache(
+  sourceFile: string,
+  elementId: string | null | undefined,
+  data: KeyframeCacheEntry | undefined,
+): void {
+  if (!elementId) return;
+  usePlayerStore.getState().setKeyframeCache(buildCacheKey(sourceFile, elementId), data);
 }
 interface GsapScriptCommitsParams {
   projectIdRef: React.MutableRefObject<string | null>;
@@ -273,7 +346,6 @@ export function useGsapScriptCommits({
             body: JSON.stringify({
               target: {
                 id: selection.id,
-                hfId: selection.hfId,
                 selector: selection.selector,
                 selectorIndex: selection.selectorIndex,
               },

--- a/packages/studio/src/hooks/useTimelineEditing.ts
+++ b/packages/studio/src/hooks/useTimelineEditing.ts
@@ -1,6 +1,8 @@
 import { useCallback, useRef } from "react";
 import type { TimelineElement } from "../player";
 import { usePlayerStore } from "../player";
+import { applyPatchByTarget, readAttributeByTarget } from "../utils/sourcePatcher";
+import { formatTimelineAttributeNumber } from "../player/components/timelineEditing";
 import {
   buildTimelineAssetId,
   buildTimelineAssetInsertHtml,
@@ -17,16 +19,6 @@ import {
   resolveDroppedAssetDuration,
 } from "../utils/studioHelpers";
 import type { EditHistoryKind } from "../utils/editHistory";
-import {
-  buildPatchTarget,
-  patchIframeDomTiming,
-  resolveResizePlaybackStart,
-  persistTimelineEdit,
-  readFileContent,
-  applyPatchByTarget,
-  formatTimelineAttributeNumber,
-} from "./timelineEditingHelpers";
-import type { PatchTarget, PersistTimelineEditInput } from "./timelineEditingHelpers";
 
 // ── Types ──
 
@@ -50,6 +42,123 @@ interface UseTimelineEditingOptions {
   pendingTimelineEditPathRef: React.MutableRefObject<Set<string>>;
   uploadProjectFiles: (files: Iterable<File>, dir?: string) => Promise<string[]>;
   isRecordingRef?: React.RefObject<boolean>;
+}
+
+// ── Helpers ──
+
+function buildPatchTarget(element: { domId?: string; selector?: string; selectorIndex?: number }) {
+  if (element.domId) {
+    return { id: element.domId, selector: element.selector, selectorIndex: element.selectorIndex };
+  }
+  if (element.selector) {
+    return { selector: element.selector, selectorIndex: element.selectorIndex };
+  }
+  return null;
+}
+
+// The runtime re-reads data-start/data-duration from the DOM on each sync tick
+// (packages/core/src/runtime/init.ts:1324-1368), so attribute mutations here are
+// picked up automatically on the next frame without a rebind call.
+function patchIframeDomTiming(
+  iframe: HTMLIFrameElement | null,
+  element: TimelineElement,
+  attrs: Array<[string, string]>,
+): void {
+  try {
+    const doc = iframe?.contentDocument;
+    if (!doc) return;
+    const el = element.domId
+      ? doc.getElementById(element.domId)
+      : element.selector
+        ? (doc.querySelectorAll(element.selector)[element.selectorIndex ?? 0] ?? null)
+        : null;
+    if (!el) return;
+    for (const [name, value] of attrs) el.setAttribute(name, value);
+  } catch {
+    // Cross-origin or mid-navigation — file save is enqueued; iframe patch is best-effort.
+  }
+}
+
+function resolveResizePlaybackStart(
+  original: string,
+  target: PatchTarget,
+  element: TimelineElement,
+  updates: Pick<TimelineElement, "start" | "playbackStart">,
+): { attrName: string; value: number } | null {
+  if (updates.playbackStart != null) {
+    const attrName =
+      element.playbackStartAttr === "playback-start" ? "playback-start" : "media-start";
+    return { attrName, value: updates.playbackStart };
+  }
+  const trimDelta = updates.start - element.start;
+  if (trimDelta === 0) return null;
+  const raw =
+    readAttributeByTarget(original, target, "playback-start") ??
+    readAttributeByTarget(original, target, "media-start");
+  const current = raw != null ? parseFloat(raw) : undefined;
+  if (current == null || !Number.isFinite(current)) return null;
+  const attrName =
+    element.playbackStartAttr === "playback-start" ? "playback-start" : "media-start";
+  return {
+    attrName,
+    value: Math.max(0, current + trimDelta * Math.max(element.playbackRate ?? 1, 0.1)),
+  };
+}
+
+type PatchTarget = NonNullable<ReturnType<typeof buildPatchTarget>>;
+
+interface PersistTimelineEditInput {
+  projectId: string;
+  element: TimelineElement;
+  activeCompPath: string | null;
+  label: string;
+  buildPatches: (original: string, target: PatchTarget) => string;
+  writeProjectFile: (path: string, content: string) => Promise<void>;
+  recordEdit: (input: RecordEditInput) => Promise<void>;
+  domEditSaveTimestampRef: React.MutableRefObject<number>;
+  pendingTimelineEditPathRef: React.MutableRefObject<Set<string>>;
+}
+
+async function persistTimelineEdit(input: PersistTimelineEditInput): Promise<void> {
+  const targetPath = input.element.sourceFile || input.activeCompPath || "index.html";
+  const originalContent = await readFileContent(input.projectId, targetPath);
+
+  const patchTarget = buildPatchTarget(input.element);
+  if (!patchTarget) {
+    throw new Error(`Timeline element ${input.element.id} is missing a patchable target`);
+  }
+
+  const patchedContent = input.buildPatches(originalContent, patchTarget);
+  if (patchedContent === originalContent) {
+    throw new Error(`Unable to patch timeline element ${input.element.id} in ${targetPath}`);
+  }
+
+  input.pendingTimelineEditPathRef.current.add(targetPath);
+  input.domEditSaveTimestampRef.current = Date.now();
+  await saveProjectFilesWithHistory({
+    projectId: input.projectId,
+    label: input.label,
+    kind: "timeline",
+    files: { [targetPath]: patchedContent },
+    readFile: async () => originalContent,
+    writeFile: input.writeProjectFile,
+    recordEdit: input.recordEdit,
+  });
+  input.domEditSaveTimestampRef.current = Date.now();
+}
+
+async function readFileContent(projectId: string, targetPath: string): Promise<string> {
+  const response = await fetch(
+    `/api/projects/${projectId}/files/${encodeURIComponent(targetPath)}`,
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to read ${targetPath}`);
+  }
+  const data = (await response.json()) as { content?: string };
+  if (typeof data.content !== "string") {
+    throw new Error(`Missing file contents for ${targetPath}`);
+  }
+  return data.content;
 }
 
 // ── Hook ──

--- a/packages/studio/src/player/components/useTimelinePlayhead.ts
+++ b/packages/studio/src/player/components/useTimelinePlayhead.ts
@@ -54,6 +54,7 @@ export function useTimelinePlayhead({
 }: UseTimelinePlayheadInput) {
   const dragScrollRaf = useRef(0);
   const previousZoomModeRef = useRef<ZoomMode | null>(zoomMode);
+  const suppressAutoScrollRef = useRef(false);
 
   const syncPlayheadPosition = useCallback(
     (time: number) => {
@@ -90,6 +91,7 @@ export function useTimelinePlayhead({
       if (
         scroll &&
         !isDragging.current &&
+        !suppressAutoScrollRef.current &&
         shouldAutoScrollTimeline(zoomModeRef.current, scroll.scrollWidth, scroll.clientWidth)
       ) {
         const edgeMargin = scroll.clientWidth * 0.12;
@@ -196,5 +198,10 @@ export function useTimelinePlayhead({
     };
   }, [handlePinchWheel, scrollRef, timelineReady, elementsLength]);
 
-  return { seekFromX, autoScrollDuringDrag, dragScrollRaf };
+  const suppressAutoScrollBriefly = useCallback(() => {
+    suppressAutoScrollRef.current = true;
+    setTimeout(() => { suppressAutoScrollRef.current = false; }, 150);
+  }, []);
+
+  return { seekFromX, autoScrollDuringDrag, dragScrollRaf, suppressAutoScrollBriefly };
 }

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -91,6 +91,9 @@ interface PlayerState {
   keyframeCache: Map<string, KeyframeCacheEntry>;
   setKeyframeCache: (elementId: string, data: KeyframeCacheEntry | undefined) => void;
 
+  autoKeyframeEnabled: boolean;
+  setAutoKeyframeEnabled: (enabled: boolean) => void;
+
   setIsPlaying: (playing: boolean) => void;
   setCurrentTime: (time: number) => void;
   setDuration: (duration: number) => void;
@@ -178,6 +181,9 @@ export const usePlayerStore = create<PlayerState>((set) => ({
       else next.add(id);
       return { expandedTimelineElements: next };
     }),
+
+  autoKeyframeEnabled: true,
+  setAutoKeyframeEnabled: (enabled) => set({ autoKeyframeEnabled: enabled }),
 
   keyframeCache: new Map(),
   setKeyframeCache: (elementId, data) =>

--- a/packages/studio/src/utils/gsapSoftReload.ts
+++ b/packages/studio/src/utils/gsapSoftReload.ts
@@ -81,12 +81,14 @@ export function applySoftReload(iframe: HTMLIFrameElement | null, scriptText: st
       win.__hfStudioManualEditsApply?.();
     };
 
-    // Load MotionPathPlugin on demand if the script uses motionPath
+    // Load MotionPathPlugin on demand if the script uses motionPath.
+    // Uses the same CDN as composition templates (GSAP_CDN in constants.ts).
     const needsMotionPath = /motionPath\s*[:{]/.test(scriptText);
     if (needsMotionPath && !win.MotionPathPlugin && win.gsap) {
       const pluginScript = doc.createElement("script");
       pluginScript.src = "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/MotionPathPlugin.min.js";
       pluginScript.onload = () => executeScript();
+      pluginScript.onerror = () => executeScript();
       doc.head.appendChild(pluginScript);
       return;
     }

--- a/packages/studio/src/utils/gsapSoftReload.ts
+++ b/packages/studio/src/utils/gsapSoftReload.ts
@@ -81,14 +81,12 @@ export function applySoftReload(iframe: HTMLIFrameElement | null, scriptText: st
       win.__hfStudioManualEditsApply?.();
     };
 
-    // Load MotionPathPlugin on demand if the script uses motionPath.
-    // Uses the same CDN as composition templates (GSAP_CDN in constants.ts).
+    // Load MotionPathPlugin on demand if the script uses motionPath
     const needsMotionPath = /motionPath\s*[:{]/.test(scriptText);
     if (needsMotionPath && !win.MotionPathPlugin && win.gsap) {
       const pluginScript = doc.createElement("script");
       pluginScript.src = "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/MotionPathPlugin.min.js";
       pluginScript.onload = () => executeScript();
-      pluginScript.onerror = () => executeScript();
       doc.head.appendChild(pluginScript);
       return;
     }


### PR DESCRIPTION
## Summary

- Fix gesture recording position double-counting on elements with path offsets (`--hf-studio-offset-x/y`). CSS var values are now always read regardless of whether `translate` is currently var-based or `"none"` (GSAP-baked), and subtracted from committed samples.
- Clear `translate` to `"none"` after each timeline seek during recording, preventing `reapplyPathOffsets` from restoring var-based translate between seek and `gsap.set`.
- Gate the gesture recording button and hotkey behind `STUDIO_KEYFRAMES_ENABLED` env flag.

## Test plan

- [ ] Record gesture on an element with `data-hf-studio-path-offset` — element should track pointer during recording
- [ ] After commit, scrub timeline — keyframes should land at the recorded position (no offset shift)
- [ ] Without `VITE_STUDIO_ENABLE_KEYFRAMES=true`, recording button should not appear in property panel