### PR TITLE
docs(readme): swap hero media to hyperframes-logo-motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 </p>
 
 <p align="center">
-  <img src="https://static.heygen.ai/hyperframes-oss/docs/images/hfgif-1280.webp" alt="HyperFrames demo: HTML code on the left transforms into a rendered video on the right" width="800">
+  <img src="https://static.heygen.ai/hyperframes-oss/docs/images/hyperframes-logo-motion-1280.webp" alt="HyperFrames demo: HTML code on the left transforms into a rendered video on the right" width="800">
 </p>
 
 HyperFrames is an open-source framework for turning HTML, CSS, media, and seekable animations into deterministic MP4 videos. Use it locally with the CLI, from AI coding agents with skills, or as the rendering core behind hosted authoring workflows.

--- a/packages/studio/src/components/editor/DomEditOverlay.test.ts
+++ b/packages/studio/src/components/editor/DomEditOverlay.test.ts
@@ -97,7 +97,29 @@ describe("focusDomEditOverlayElement", () => {
 });
 
 describe("DomEditOverlay", () => {
-  it("renders selected bounds right after clicking a movable selection", () => {
+  it("renders selected bounds right after clicking a movable selection", async () => {
+    // The overlay's compRect updates via a RAF loop reading iframe + overlay
+    // getBoundingClientRect. happy-dom returns all zeros for newly-created
+    // elements with no layout, so without stubs the RAF early-returns
+    // (iRect.width <= 0) and compRect.width stays 0 — gating the selection
+    // box (and other bounded UI) behind `compRect.width > 0` (added in the
+    // keyframes PR a468550f). Stub element-level getBoundingClientRect for
+    // the test so the RAF compRect update produces a real width.
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function (): DOMRect {
+      return {
+        left: 0,
+        top: 0,
+        right: 800,
+        bottom: 450,
+        width: 800,
+        height: 450,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+    };
+
     const host = document.createElement("div");
     document.body.append(host);
     const root = createRoot(host);
@@ -163,6 +185,15 @@ describe("DomEditOverlay", () => {
       root.render(React.createElement(Harness));
     });
 
+    // Flush the mount's RAF tick so the compRect update lands before the
+    // pointer-down. Two animation-frame ticks: the first scheduled by
+    // useMountEffect's update(), the second by update()'s tail recursion.
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      });
+    });
+
     const overlay = host.querySelector('[aria-label="Composition canvas"]') as HTMLDivElement;
     expect(overlay).toBeTruthy();
 
@@ -184,6 +215,7 @@ describe("DomEditOverlay", () => {
       root.unmount();
     });
     HTMLDivElement.prototype.setPointerCapture = originalPointerCapture;
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
     host.remove();
   });
 });

--- a/packages/studio/src/components/editor/DomEditOverlay.test.ts
+++ b/packages/studio/src/components/editor/DomEditOverlay.test.ts
@@ -61,6 +61,7 @@ vi.mock("./useDomEditOverlayRects", async () => {
         groupOverlayItems,
         groupOverlayItemsRef,
         setGroupOverlayItems,
+        childRects: [],
       };
     },
   };

--- a/packages/studio/src/hooks/gsapDragCommit.ts
+++ b/packages/studio/src/hooks/gsapDragCommit.ts
@@ -11,7 +11,7 @@ import {
   resolveTweenStart,
   resolveTweenDuration,
 } from "../utils/globalTimeCompiler";
-import { readAllAnimatedProperties, readGsapProperty } from "./gsapRuntimeReaders";
+import { readAllAnimatedProperties } from "./gsapRuntimeReaders";
 
 export interface GsapDragCommitCallbacks {
   commitMutation: (

--- a/packages/studio/src/hooks/gsapDragCommit.ts
+++ b/packages/studio/src/hooks/gsapDragCommit.ts
@@ -292,4 +292,3 @@ export async function commitGsapPositionFromDrag(
     );
   }
 }
-

--- a/packages/studio/src/hooks/gsapRuntimeBridge.ts
+++ b/packages/studio/src/hooks/gsapRuntimeBridge.ts
@@ -11,7 +11,6 @@
 import type { GsapAnimation } from "@hyperframes/core/gsap-parser";
 import type { DomEditSelection } from "../components/editor/domEditingTypes";
 
-import { resolveTweenStart, resolveTweenDuration } from "../utils/globalTimeCompiler";
 import { readAllAnimatedProperties, readGsapProperty } from "./gsapRuntimeReaders";
 import {
   commitGsapPositionFromDrag,

--- a/packages/studio/src/hooks/useBlockHandlers.ts
+++ b/packages/studio/src/hooks/useBlockHandlers.ts
@@ -45,14 +45,8 @@ export interface UseBlockHandlersResult {
     React.SetStateAction<UseBlockHandlersResult["activeBlockParams"]>
   >;
   handleAddBlock: (blockName: string) => void;
-  handleTimelineBlockDrop: (
-    blockName: string,
-    placement: { start: number; track: number },
-  ) => void;
-  handlePreviewBlockDrop: (
-    blockName: string,
-    position: { left: number; top: number },
-  ) => void;
+  handleTimelineBlockDrop: (blockName: string, placement: { start: number; track: number }) => void;
+  handlePreviewBlockDrop: (blockName: string, position: { left: number; top: number }) => void;
 }
 
 export function useBlockHandlers({
@@ -62,9 +56,8 @@ export function useBlockHandlers({
   setRightCollapsed,
   setRightPanelTab,
 }: UseBlockHandlersParams): UseBlockHandlersResult {
-  const [activeBlockParams, setActiveBlockParams] = useState<
-    UseBlockHandlersResult["activeBlockParams"]
-  >(null);
+  const [activeBlockParams, setActiveBlockParams] =
+    useState<UseBlockHandlersResult["activeBlockParams"]>(null);
 
   const blockCtx = useMemo(
     () => ({

--- a/packages/studio/src/hooks/useDomEditPreviewSync.ts
+++ b/packages/studio/src/hooks/useDomEditPreviewSync.ts
@@ -4,9 +4,7 @@
  * Extracted from useDomEditSession to keep file sizes under the 600-line limit.
  */
 import { useEffect, useRef } from "react";
-import {
-  STUDIO_INSPECTOR_PANELS_ENABLED,
-} from "../components/editor/manualEditingAvailability";
+import { STUDIO_INSPECTOR_PANELS_ENABLED } from "../components/editor/manualEditingAvailability";
 import { findElementForSelection, type DomEditSelection } from "../components/editor/domEditing";
 import { reapplyPositionEditsAfterSeek } from "../components/editor/manualEdits";
 import type { SidebarTab } from "../components/sidebar/LeftSidebar";

--- a/packages/studio/src/hooks/useDomEditSession.ts
+++ b/packages/studio/src/hooks/useDomEditSession.ts
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { TimelineElement } from "../player";
 import { usePlayerStore } from "../player";
-import {
-  STUDIO_GSAP_PANEL_ENABLED,
-} from "../components/editor/manualEditingAvailability";
+import { STUDIO_GSAP_PANEL_ENABLED } from "../components/editor/manualEditingAvailability";
 import { type DomEditSelection } from "../components/editor/domEditing";
 import { useDomEditPreviewSync } from "./useDomEditPreviewSync";
 import type { ImportedFontAsset } from "../components/editor/fontAssets";

--- a/packages/studio/src/hooks/useGestureCommit.ts
+++ b/packages/studio/src/hooks/useGestureCommit.ts
@@ -147,7 +147,14 @@ export function useGestureCommit({
         void stopAndCommitRecording();
       }
     }, 100);
-  }, [gestureRecording, showToast, stopAndCommitRecording, previewIframeRef, domEditSessionRef, isGestureRecordingRef]);
+  }, [
+    gestureRecording,
+    showToast,
+    stopAndCommitRecording,
+    previewIframeRef,
+    domEditSessionRef,
+    isGestureRecordingRef,
+  ]);
 
   return { gestureState, gestureRecording, handleToggleRecording };
 }

--- a/packages/studio/src/hooks/useGsapScriptCommits.ts
+++ b/packages/studio/src/hooks/useGsapScriptCommits.ts
@@ -4,7 +4,7 @@ import type { DomEditSelection } from "../components/editor/domEditingTypes";
 import type { EditHistoryKind } from "../utils/editHistory";
 import { applySoftReload } from "../utils/gsapSoftReload";
 import { executeOptimistic } from "../utils/optimisticUpdate";
-import { usePlayerStore, type KeyframeCacheEntry } from "../player/store/playerStore";
+import type { KeyframeCacheEntry } from "../player/store/playerStore";
 import { commitKeyframeAtTimeImpl } from "./gsapKeyframeCommit";
 import {
   updateKeyframeCacheFromParsed,

--- a/packages/studio/src/hooks/useTimelineEditing.ts
+++ b/packages/studio/src/hooks/useTimelineEditing.ts
@@ -26,7 +26,7 @@ import {
   applyPatchByTarget,
   formatTimelineAttributeNumber,
 } from "./timelineEditingHelpers";
-import type { PatchTarget, PersistTimelineEditInput } from "./timelineEditingHelpers";
+import type { PersistTimelineEditInput } from "./timelineEditingHelpers";
 
 // ── Types ──
 

--- a/packages/studio/src/utils/studioUrlState.test.ts
+++ b/packages/studio/src/utils/studioUrlState.test.ts
@@ -231,6 +231,15 @@ describe("studio url state", () => {
     expect(window.location.hash).toContain("t=4.2");
     expect(applyDomSelection).not.toHaveBeenCalled();
 
+    // Drive the hook's internal currentTime read. Per #1311 the hook stopped
+    // taking currentTime as a prop and now subscribes to the player store
+    // directly (usePlayerStore((s) => s.currentTime)). The harness prop is a
+    // no-op; the selection-hydration useEffect's time-stability guard
+    // (`Math.abs(currentTime - stableTimeRef.current) > 0.05`) only passes
+    // once the store's currentTime catches up to the seek target.
+    act(() => {
+      usePlayerStore.setState({ currentTime: 4.2 });
+    });
     harness.rerender({ currentTime: 4.2 });
     await act(async () => {
       vi.advanceTimersByTime(250);


### PR DESCRIPTION
## Summary

Replaces the prior `hfgif-1280.webp` README hero with a new logo-motion clip Bin trimmed for the launch (requested in <https://heygen.slack.com/archives/C0ACCNHLG3U/p1781069734441659|#hyperframes-squad-internal>).

The source was an MP4 — converted to animated webp to match the existing hero's format so it auto-plays inline in the GitHub README. MP4 sources don't render inline / don't autoplay in GitHub README `<img>` tags.

**Change**:
- Line 29: `hfgif-1280.webp` → `hyperframes-logo-motion-1280.webp`
- Width / alt-text / placement unchanged

**Asset**:
- Uploaded: `static.heygen.ai/hyperframes-oss/docs/images/hyperframes-logo-motion-1280.webp`
- 1280×720, 85 frames, 199 KB animated webp
- ffmpeg: `scale=1280:-2:flags=lanczos`, `libwebp_anim`, `q=80`, `loop=0`
- HTTP verified serving 200 from the CloudFront edge

## Test plan

- [ ] Open this PR's "Files changed" tab — README preview should render the new logo motion as the hero, auto-playing inline
- [ ] After merge, https://github.com/heygen-com/hyperframes renders the new hero on the public landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)