### PR TITLE
style: oxfmt pre-existing format violations in studio hooks

### DIFF
--- a/packages/studio/src/hooks/gsapDragCommit.ts
+++ b/packages/studio/src/hooks/gsapDragCommit.ts
@@ -292,4 +292,3 @@ export async function commitGsapPositionFromDrag(
     );
   }
 }
-

--- a/packages/studio/src/hooks/useBlockHandlers.ts
+++ b/packages/studio/src/hooks/useBlockHandlers.ts
@@ -45,14 +45,8 @@ export interface UseBlockHandlersResult {
     React.SetStateAction<UseBlockHandlersResult["activeBlockParams"]>
   >;
   handleAddBlock: (blockName: string) => void;
-  handleTimelineBlockDrop: (
-    blockName: string,
-    placement: { start: number; track: number },
-  ) => void;
-  handlePreviewBlockDrop: (
-    blockName: string,
-    position: { left: number; top: number },
-  ) => void;
+  handleTimelineBlockDrop: (blockName: string, placement: { start: number; track: number }) => void;
+  handlePreviewBlockDrop: (blockName: string, position: { left: number; top: number }) => void;
 }
 
 export function useBlockHandlers({
@@ -62,9 +56,8 @@ export function useBlockHandlers({
   setRightCollapsed,
   setRightPanelTab,
 }: UseBlockHandlersParams): UseBlockHandlersResult {
-  const [activeBlockParams, setActiveBlockParams] = useState<
-    UseBlockHandlersResult["activeBlockParams"]
-  >(null);
+  const [activeBlockParams, setActiveBlockParams] =
+    useState<UseBlockHandlersResult["activeBlockParams"]>(null);
 
   const blockCtx = useMemo(
     () => ({

--- a/packages/studio/src/hooks/useDomEditPreviewSync.ts
+++ b/packages/studio/src/hooks/useDomEditPreviewSync.ts
@@ -4,9 +4,7 @@
  * Extracted from useDomEditSession to keep file sizes under the 600-line limit.
  */
 import { useEffect, useRef } from "react";
-import {
-  STUDIO_INSPECTOR_PANELS_ENABLED,
-} from "../components/editor/manualEditingAvailability";
+import { STUDIO_INSPECTOR_PANELS_ENABLED } from "../components/editor/manualEditingAvailability";
 import { findElementForSelection, type DomEditSelection } from "../components/editor/domEditing";
 import { reapplyPositionEditsAfterSeek } from "../components/editor/manualEdits";
 import type { SidebarTab } from "../components/sidebar/LeftSidebar";

--- a/packages/studio/src/hooks/useDomEditSession.ts
+++ b/packages/studio/src/hooks/useDomEditSession.ts
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { TimelineElement } from "../player";
 import { usePlayerStore } from "../player";
-import {
-  STUDIO_GSAP_PANEL_ENABLED,
-} from "../components/editor/manualEditingAvailability";
+import { STUDIO_GSAP_PANEL_ENABLED } from "../components/editor/manualEditingAvailability";
 import { type DomEditSelection } from "../components/editor/domEditing";
 import { useDomEditPreviewSync } from "./useDomEditPreviewSync";
 import type { ImportedFontAsset } from "../components/editor/fontAssets";

--- a/packages/studio/src/hooks/useGestureCommit.ts
+++ b/packages/studio/src/hooks/useGestureCommit.ts
@@ -147,7 +147,14 @@ export function useGestureCommit({
         void stopAndCommitRecording();
       }
     }, 100);
-  }, [gestureRecording, showToast, stopAndCommitRecording, previewIframeRef, domEditSessionRef, isGestureRecordingRef]);
+  }, [
+    gestureRecording,
+    showToast,
+    stopAndCommitRecording,
+    previewIframeRef,
+    domEditSessionRef,
+    isGestureRecordingRef,
+  ]);
 
   return { gestureState, gestureRecording, handleToggleRecording };
 }


### PR DESCRIPTION
## Summary

`bun run format:check` (CI's Format job) has been failing on `main` for 5 files under `packages/studio/src/hooks/` that landed without a `bun run format` pass. This PR re-runs the formatter to unblock unrelated PRs (the README hero swap in #1315 trips on the same check).

**Files touched** (whitespace-only, zero logic):
- `packages/studio/src/hooks/gsapDragCommit.ts`
- `packages/studio/src/hooks/useBlockHandlers.ts`
- `packages/studio/src/hooks/useDomEditPreviewSync.ts`
- `packages/studio/src/hooks/useDomEditSession.ts`
- `packages/studio/src/hooks/useGestureCommit.ts`

Diff stat: 5 files changed, 14 insertions(+), 19 deletions(-). Pure oxfmt output — no behavioral changes.

## Test plan

- [ ] CI Format check goes green on this PR
- [ ] After merge, #1315 (README hero swap) gets a CI re-run and passes the Format check on the same files

## Surfaced by

#1315 — the README hero-media swap PR; its only change is a single `<img>` src URL but Format runs repo-wide and tripped on these unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)