### PR TITLE
fix(producer): don't mix audio from muted videos into the render

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -1,5 +1,94 @@
 import { describe, expect, it } from "vitest";
-import { extractStandaloneEntryFromIndex } from "./renderOrchestrator.js";
+import {
+  appendAutoDetectedVideoAudio,
+  extractStandaloneEntryFromIndex,
+} from "./renderOrchestrator.js";
+import type { AudioElement, ExtractedFrames, VideoElement } from "@hyperframes/engine";
+
+function makeVideo(overrides: Partial<VideoElement> = {}): VideoElement {
+  return {
+    id: "v1",
+    src: "clip.mp4",
+    start: 0,
+    end: 5,
+    mediaStart: 0,
+    hasAudio: true,
+    ...overrides,
+  };
+}
+
+function makeExtracted(videoId: string, fileHasAudio: boolean): ExtractedFrames {
+  return {
+    videoId,
+    srcPath: "/tmp/clip.mp4",
+    outputDir: "/tmp/frames",
+    framePattern: "frame_%04d.jpg",
+    fps: 30,
+    totalFrames: 150,
+    framePaths: new Map(),
+    metadata: {
+      durationSeconds: 5,
+      width: 1080,
+      height: 1920,
+      fps: 30,
+      videoCodec: "h264",
+      hasAudio: fileHasAudio,
+      isVFR: false,
+    },
+  };
+}
+
+describe("appendAutoDetectedVideoAudio", () => {
+  it("adds the audio of a video that declares data-has-audio", () => {
+    const composition = { videos: [makeVideo()], audios: [] as AudioElement[] };
+
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", true)]);
+
+    expect(composition.audios).toHaveLength(1);
+    expect(composition.audios[0]).toMatchObject({ id: "v1-audio", src: "clip.mp4" });
+  });
+
+  it("skips a muted video even when the source file ships an audio track", () => {
+    const composition = {
+      videos: [makeVideo({ hasAudio: false })],
+      audios: [] as AudioElement[],
+    };
+
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", true)]);
+
+    expect(composition.audios).toHaveLength(0);
+  });
+
+  it("skips files without an audio track", () => {
+    const composition = { videos: [makeVideo()], audios: [] as AudioElement[] };
+
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", false)]);
+
+    expect(composition.audios).toHaveLength(0);
+  });
+
+  it("does not duplicate audio for a src already in the mix", () => {
+    const composition = {
+      videos: [makeVideo()],
+      audios: [
+        {
+          id: "music",
+          src: "clip.mp4",
+          start: 0,
+          end: 5,
+          mediaStart: 0,
+          layer: 0,
+          volume: 1,
+          type: "audio",
+        },
+      ] as AudioElement[],
+    };
+
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", true)]);
+
+    expect(composition.audios).toHaveLength(1);
+  });
+});
 
 describe("extractStandaloneEntryFromIndex", () => {
   it("reuses the index wrapper and keeps only the requested composition host", () => {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -29,6 +29,7 @@ import {
   extractAllVideoFrames,
   createFrameLookupTable,
   type VideoElement,
+  type ExtractedFrames,
   FrameLookupTable,
   createCaptureSession,
   initializeSession,
@@ -189,6 +190,39 @@ export interface CompositionMetadata {
   audios: AudioElement[];
   width: number;
   height: number;
+}
+
+/**
+ * Auto-detect audio from extracted video files (via ffprobe metadata) and
+ * append it to `composition.audios` so the mixer includes it in the final mix.
+ *
+ * The element's declared intent wins over the file's contents: videos whose
+ * `hasAudio` flag is false (compiled from `muted` / data-has-audio="false")
+ * are skipped even when the source file ships an audio track. Without this
+ * check, a muted <video> whose file contains audio leaks that audio into the
+ * render at full volume.
+ */
+export function appendAutoDetectedVideoAudio(
+  composition: Pick<CompositionMetadata, "videos" | "audios">,
+  extracted: ExtractedFrames[],
+): void {
+  const existingAudioSrcs = new Set(composition.audios.map((a) => a.src));
+  for (const ext of extracted) {
+    if (!ext.metadata.hasAudio) continue;
+    const video = composition.videos.find((v) => v.id === ext.videoId);
+    if (!video || !video.hasAudio || existingAudioSrcs.has(video.src)) continue;
+    composition.audios.push({
+      id: `${video.id}-audio`,
+      src: video.src,
+      start: video.start,
+      end: video.end,
+      mediaStart: video.mediaStart,
+      layer: 0,
+      volume: 1.0,
+      type: "video",
+    });
+    existingAudioSrcs.add(video.src);
+  }
 }
 
 function updateJobStatus(
@@ -724,26 +758,7 @@ export async function executeRenderJob(
 
       perfStages.videoExtractMs = Date.now() - stage2Start;
 
-      // Auto-detect audio from video files via ffprobe metadata
-      const existingAudioSrcs = new Set(composition.audios.map((a) => a.src));
-      for (const ext of extractionResult.extracted) {
-        if (ext.metadata.hasAudio) {
-          const video = composition.videos.find((v) => v.id === ext.videoId);
-          if (video && !existingAudioSrcs.has(video.src)) {
-            composition.audios.push({
-              id: `${video.id}-audio`,
-              src: video.src,
-              start: video.start,
-              end: video.end,
-              mediaStart: video.mediaStart,
-              layer: 0,
-              volume: 1.0,
-              type: "video",
-            });
-            existingAudioSrcs.add(video.src);
-          }
-        }
-      }
+      appendAutoDetectedVideoAudio(composition, extractionResult.extracted);
     } else {
       perfStages.videoExtractMs = Date.now() - stage2Start;
     }


### PR DESCRIPTION
## Problem

A muted `<video>` ends up with its source file's audio track in the final render, at full volume.

The compiler marks muted videos with `data-has-audio="false"` and the audio mixer respects that, but the orchestrator has a second path: after frame extraction it re-adds audio for any video whose *file* contains an audio track (ffprobe `metadata.hasAudio`), ignoring what the element declared.

Repro: a composition with `<video src="clip-with-sound.mp4" muted playsinline data-start="0" data-duration="5">` — the rendered mp4 contains the clip's audio. Reproduced on npm 0.6.40 and 0.6.88 (the same block ships in `dist/cli.js`).

## Fix

Only auto-add extracted audio when the element is audible (`video.hasAudio`). Non-muted videos are unaffected — the compiler already injects `data-has-audio="true"` for them. Pulled the block into `appendAutoDetectedVideoAudio()` and added unit tests for the four cases (audible, muted, file without audio, src already in the mix).