### PR TITLE
fix(producer): don't mix audio from muted videos into the render

### DIFF
--- a/packages/producer/src/services/render/stages/extractVideosStage.test.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.test.ts
@@ -15,10 +15,7 @@ function makeVideo(overrides: Partial<VideoElement> = {}): VideoElement {
   };
 }
 
-function makeExtracted(
-  videoId: string,
-  fileHasAudio: boolean,
-): ExtractedFrames {
+function makeExtracted(videoId: string, fileHasAudio: boolean): ExtractedFrames {
   return {
     videoId,
     srcPath: "/tmp/clip.mp4",

--- a/packages/producer/src/services/render/stages/extractVideosStage.test.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { appendAutoDetectedVideoAudio } from "./extractVideosStage.js";
+import type { ExtractedFrames, VideoElement } from "@hyperframes/engine";
+
+function makeVideo(overrides: Partial<VideoElement> = {}): VideoElement {
+  return {
+    id: "v1",
+    src: "clip.mp4",
+    start: 0,
+    end: 5,
+    mediaStart: 0,
+    loop: false,
+    hasAudio: true,
+    ...overrides,
+  };
+}
+
+function makeExtracted(
+  videoId: string,
+  fileHasAudio: boolean,
+): ExtractedFrames {
+  return {
+    videoId,
+    srcPath: "/tmp/clip.mp4",
+    outputDir: "/tmp/frames",
+    framePattern: "frame_%05d.jpg",
+    fps: 30,
+    totalFrames: 150,
+    framePaths: new Map(),
+    metadata: {
+      durationSeconds: 5,
+      width: 1920,
+      height: 1080,
+      fps: 30,
+      codec: "h264",
+      hasAudio: fileHasAudio,
+    },
+  } as ExtractedFrames;
+}
+
+describe("appendAutoDetectedVideoAudio", () => {
+  it("adds audio for an audible video whose file has an audio track", () => {
+    const composition = { videos: [makeVideo()], audios: [] as never[] };
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", true)]);
+    expect(composition.audios).toHaveLength(1);
+    expect(composition.audios[0]).toMatchObject({
+      id: "v1-audio",
+      src: "clip.mp4",
+    });
+  });
+
+  it("skips a muted video even when the source file has audio", () => {
+    const composition = {
+      videos: [makeVideo({ hasAudio: false })],
+      audios: [] as never[],
+    };
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", true)]);
+    expect(composition.audios).toHaveLength(0);
+  });
+
+  it("skips when the source file has no audio track", () => {
+    const composition = { videos: [makeVideo()], audios: [] as never[] };
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", false)]);
+    expect(composition.audios).toHaveLength(0);
+  });
+
+  it("does not duplicate audio for a src already in the mix", () => {
+    const composition = {
+      videos: [makeVideo()],
+      audios: [
+        {
+          id: "existing",
+          src: "clip.mp4",
+          start: 0,
+          end: 5,
+          mediaStart: 0,
+          layer: 0,
+          volume: 1,
+          type: "video" as const,
+        },
+      ],
+    };
+    appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", true)]);
+    expect(composition.audios).toHaveLength(1);
+  });
+});

--- a/packages/producer/src/services/render/stages/extractVideosStage.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.ts
@@ -214,12 +214,15 @@ export async function runExtractVideosStage(
     );
     videoMetadataHints = collectVideoMetadataHints(extractionResult.extracted);
 
-    // Auto-detect audio from video files via ffprobe metadata
+    // Auto-detect audio from video files via ffprobe metadata.
+    // Both the file (ext.metadata.hasAudio) AND the element (video.hasAudio)
+    // must declare audio — a muted <video> whose source contains audio should
+    // not leak that audio into the render.
     const existingAudioSrcs = new Set(composition.audios.map((a) => a.src));
     for (const ext of extractionResult.extracted) {
       if (ext.metadata.hasAudio) {
         const video = composition.videos.find((v) => v.id === ext.videoId);
-        if (video && !existingAudioSrcs.has(video.src)) {
+        if (video && video.hasAudio && !existingAudioSrcs.has(video.src)) {
           composition.audios.push({
             id: `${video.id}-audio`,
             src: video.src,

--- a/packages/producer/src/services/render/stages/extractVideosStage.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.ts
@@ -33,6 +33,7 @@ import { isAbsolute, join } from "node:path";
 import {
   type CaptureVideoMetadataHint,
   type EngineConfig,
+  type ExtractedFrames,
   type FrameLookupTable,
   type HdrTransfer,
   type VideoColorSpace,
@@ -214,29 +215,7 @@ export async function runExtractVideosStage(
     );
     videoMetadataHints = collectVideoMetadataHints(extractionResult.extracted);
 
-    // Auto-detect audio from video files via ffprobe metadata.
-    // Both the file (ext.metadata.hasAudio) AND the element (video.hasAudio)
-    // must declare audio — a muted <video> whose source contains audio should
-    // not leak that audio into the render.
-    const existingAudioSrcs = new Set(composition.audios.map((a) => a.src));
-    for (const ext of extractionResult.extracted) {
-      if (ext.metadata.hasAudio) {
-        const video = composition.videos.find((v) => v.id === ext.videoId);
-        if (video && video.hasAudio && !existingAudioSrcs.has(video.src)) {
-          composition.audios.push({
-            id: `${video.id}-audio`,
-            src: video.src,
-            start: video.start,
-            end: video.end,
-            mediaStart: video.mediaStart,
-            layer: 0,
-            volume: 1.0,
-            type: "video",
-          });
-          existingAudioSrcs.add(video.src);
-        }
-      }
-    }
+    appendAutoDetectedVideoAudio(composition, extractionResult.extracted);
   }
   const videoExtractMs = Date.now() - stage2Start;
 
@@ -253,4 +232,32 @@ export async function runExtractVideosStage(
     imageColorSpaces,
     videoExtractMs,
   };
+}
+
+/**
+ * Auto-detect audio from extracted video files (ffprobe metadata) and append
+ * to composition.audios. Both the file AND the element must declare audio —
+ * a muted <video> whose source contains audio should not leak into the render.
+ */
+export function appendAutoDetectedVideoAudio(
+  composition: Pick<CompositionMetadata, "videos" | "audios">,
+  extracted: ExtractedFrames[],
+): void {
+  const existingAudioSrcs = new Set(composition.audios.map((a) => a.src));
+  for (const ext of extracted) {
+    if (!ext.metadata.hasAudio) continue;
+    const video = composition.videos.find((v) => v.id === ext.videoId);
+    if (!video || !video.hasAudio || existingAudioSrcs.has(video.src)) continue;
+    composition.audios.push({
+      id: `${video.id}-audio`,
+      src: video.src,
+      start: video.start,
+      end: video.end,
+      mediaStart: video.mediaStart,
+      layer: 0,
+      volume: 1.0,
+      type: "video",
+    });
+    existingAudioSrcs.add(video.src);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes muted `<video>` elements leaking audio into rendered output at full volume.

### Root cause

`extractVideosStage.ts:220` auto-detects audio from extracted video files via ffprobe metadata (`ext.metadata.hasAudio`) but never checks the element's declared intent (`video.hasAudio`). The compiler marks muted videos with `data-has-audio="false"` and the audio mixer respects that, but this auto-detect block bypasses the element flag entirely.

### Fix

Add `video.hasAudio` guard: `if (video && video.hasAudio && !existingAudioSrcs.has(video.src))`. Both the file AND the element must declare audio for it to be mixed in. Non-muted videos are unaffected — the compiler injects `data-has-audio="true"` for them.

### Supersedes #1321

PR #1321 identified the same bug but targets `renderOrchestrator.ts` — the code was moved to `extractVideosStage.ts` in a recent refactor. This PR fixes it at the correct location on current main.

## Test plan

- [x] Typecheck clean
- Muted `<video>` with audio track in source file → no audio in render
- Non-muted `<video>` with audio track → audio included (unchanged behavior)
- `<video>` without audio track → no audio (unchanged behavior)