### PR TITLE
feat(core): expose hf-ids as subpath export for @hyperframes/sdk

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,10 @@
       "import": "./src/runtime/mediaVolumeEnvelope.ts",
       "types": "./src/runtime/mediaVolumeEnvelope.ts"
     },
+    "./hf-ids": {
+      "import": "./src/parsers/hfIds.ts",
+      "types": "./src/parsers/hfIds.ts"
+    },
     "./gsap-parser": {
       "import": "./src/parsers/gsapParser.ts",
       "types": "./src/parsers/gsapParser.ts"
@@ -140,6 +144,10 @@
       "./media-volume-envelope": {
         "import": "./dist/runtime/mediaVolumeEnvelope.js",
         "types": "./dist/runtime/mediaVolumeEnvelope.d.ts"
+      },
+      "./hf-ids": {
+        "import": "./dist/parsers/hfIds.js",
+        "types": "./dist/parsers/hfIds.d.ts"
       },
       "./gsap-parser": {
         "import": "./dist/parsers/gsapParser.js",


### PR DESCRIPTION
## Summary

Exposes `hf-ids` as a dedicated subpath export from `@hyperframes/core` so `@hyperframes/sdk` can import ID-stamping logic without pulling in the full core bundle.

- Adds `"exports"` entry for `./hf-ids` in `packages/core/package.json`
- No change to the existing top-level export — no breaking change for existing consumers

## Why

`@hyperframes/sdk` needs `parseMutable`/`stampHfIds` from core. A subpath export isolates that boundary and keeps the SDK bundle lean.

## Test plan
- [ ] `bun run build` — both packages build without errors
- [ ] `bun test packages/sdk` — import resolves correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)