### PR TITLE
feat(cli): detect Windsurf, Cline, Gemini CLI, and Crush agents

### DIFF
--- a/packages/cli/src/telemetry/agent_runtime.test.ts
+++ b/packages/cli/src/telemetry/agent_runtime.test.ts
@@ -20,6 +20,9 @@ const VENDOR_ENV_KEYS = [
   "OPENCLAW_STATE_DIR",
   "OPENCLAW_CONFIG_PATH",
   "PI_CODING_AGENT",
+  "CLINE_ACTIVE",
+  "GEMINI_CLI",
+  "CRUSH",
 ] as const;
 
 function stripVendorEnv(): void {
@@ -117,6 +120,12 @@ describe("detectAgentRuntime — Cursor / Copilot / cohort", () => {
     expect(detectAgentRuntime()).toBe("cursor");
   });
 
+  it("detects Cursor case-insensitively (TERM_PROGRAM=Cursor)", async () => {
+    process.env["TERM_PROGRAM"] = "Cursor";
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("cursor");
+  });
+
   it("detects Copilot Coding Agent via GITHUB_ACTIONS + COPILOT_AGENT_ID", async () => {
     process.env["GITHUB_ACTIONS"] = "true";
     process.env["COPILOT_AGENT_ID"] = "abc123";
@@ -175,6 +184,11 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
   });
 
   afterEach(() => {
+    // Clear the node:os / node:fs doMock registrations so they don't leak into
+    // the env-var-only suites that follow (restoreAllMocks does not undo
+    // doMock, and those suites don't resetModules in beforeEach).
+    vi.doUnmock("node:os");
+    vi.doUnmock("node:fs");
     vi.resetModules();
     vi.restoreAllMocks();
   });
@@ -275,6 +289,50 @@ describe("detectAgentRuntime — Gemini managed agent", () => {
     mockAgentsDir();
     const { detectAgentRuntime } = await import("./agent_runtime.js");
     expect(detectAgentRuntime()).toBe("gemini_managed_agent");
+  });
+});
+
+describe("detectAgentRuntime — Windsurf / Cline / Gemini CLI / Crush", () => {
+  const savedEnv = { ...process.env };
+  beforeEach(stripVendorEnv);
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it("detects Windsurf via TERM_PROGRAM=windsurf", async () => {
+    process.env["TERM_PROGRAM"] = "windsurf";
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("windsurf");
+  });
+
+  it("detects Windsurf case-insensitively (TERM_PROGRAM=Windsurf)", async () => {
+    process.env["TERM_PROGRAM"] = "Windsurf";
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("windsurf");
+  });
+
+  it("detects Cline via CLINE_ACTIVE (default vscode-terminal path)", async () => {
+    process.env["CLINE_ACTIVE"] = "true";
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("cline");
+  });
+
+  it("detects Gemini CLI via GEMINI_CLI", async () => {
+    process.env["GEMINI_CLI"] = "1";
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("gemini_cli");
+  });
+
+  it("detects Crush via CRUSH (set unconditionally on every spawned shell)", async () => {
+    process.env["CRUSH"] = "1";
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("crush");
+  });
+
+  it("does NOT misread the user-set value (existence only) — GEMINI_CLI key shape ignored", async () => {
+    process.env["GEMINI_CLI"] = "anything";
+    const { detectAgentRuntime } = await import("./agent_runtime.js");
+    expect(detectAgentRuntime()).toBe("gemini_cli");
   });
 });
 

--- a/packages/cli/src/telemetry/agent_runtime.ts
+++ b/packages/cli/src/telemetry/agent_runtime.ts
@@ -31,6 +31,10 @@ export type AgentRuntime =
   | "openclaw"
   | "pi"
   | "gemini_managed_agent"
+  | "windsurf"
+  | "cline"
+  | "gemini_cli"
+  | "crush"
   | null;
 
 interface VendorRule {
@@ -70,12 +74,25 @@ const VENDOR_RULES: VendorRule[] = [
       typeof env["CODEX_CI"] === "string" ||
       typeof env["CODEX_SANDBOX_NETWORK_DISABLED"] === "string",
   },
-  // Cursor IDE integrated terminal — exports TERM_PROGRAM=cursor.
-  // Cursor Background Agent env vars are not publicly documented; if a
-  // canonical marker is identified later, add it here.
+  // Cursor IDE integrated terminal — exports TERM_PROGRAM=cursor. Compared
+  // case-insensitively for parity with the Windsurf rule below: Cursor sets
+  // lowercase today, but matching loosely costs nothing and won't miss a
+  // capitalized variant. Cursor Background Agent env vars are not publicly
+  // documented; if a canonical marker is identified later, add it here.
   {
     name: "cursor",
-    check: (env) => env["TERM_PROGRAM"] === "cursor",
+    check: (env) => env["TERM_PROGRAM"]?.toLowerCase() === "cursor",
+  },
+  // Windsurf (Codeium) integrated terminal — exports TERM_PROGRAM=windsurf, the
+  // direct analog of the Cursor rule above. Attested across many independent
+  // detectors (nx packages/nx/src/native/ide/detection.rs, adonisjs/application,
+  // ag-grid git-hooks). Compared case-insensitively because sources disagree on
+  // casing ("windsurf" vs "Windsurf"). Like Cursor this marks the editor's
+  // integrated terminal, not specifically that the Cascade agent is driving;
+  // under WSL/remote it can also fall back to TERM_PROGRAM=vscode.
+  {
+    name: "windsurf",
+    check: (env) => env["TERM_PROGRAM"]?.toLowerCase() === "windsurf",
   },
   // GitHub Copilot Coding Agent — runs inside GitHub Actions and the
   // workflow injects an additional marker to distinguish from generic CI.
@@ -125,7 +142,73 @@ const VENDOR_RULES: VendorRule[] = [
     name: "pi",
     check: (env) => typeof env["PI_CODING_AGENT"] === "string",
   },
+  // Cline (cline/cline) VS Code extension — injects CLINE_ACTIVE=true into the
+  // integrated terminal via vscode.TerminalOptions.env, which the terminal
+  // exports to every shell command run in it
+  // (apps/vscode/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts:29).
+  // Caveat: present only on the default "vscodeTerminal" exec path — the opt-in
+  // backgroundExec/YOLO path spawns via child_process without the marker. Same
+  // integrated-terminal-only scope as the Cursor/Windsurf rules above.
+  // Source: https://github.com/cline/cline (VscodeTerminalRegistry.ts:29)
+  {
+    name: "cline",
+    check: (env) => typeof env["CLINE_ACTIVE"] === "string",
+  },
+  // Google Gemini CLI (open-source @google/gemini-cli) — DISTINCT from the
+  // Gemini managed-agent sandbox. (If a /.agents/ filesystem detector is
+  // present in detectAgentRuntime() it runs ahead of this loop and wins for a
+  // managed-agent sandbox, leaving this rule to match only the local CLI.)
+  // The shell-execution service
+  // sets GEMINI_CLI=1 on the child env of every shell command it spawns, so
+  // downstream executables can tell they were launched by Gemini CLI
+  // (packages/core/src/services/shellExecutionService.ts:56,486-487 — spread
+  // onto baseEnv after sanitizeEnvironment, passed as env: to both the
+  // child_process and node-pty spawn paths).
+  // Caveat: under STRICT sanitization (when GITHUB_SHA is set / the GitHub
+  // Action surface) GEMINI_CLI is not allow-listed and gets stripped — reliable
+  // for the local CLI, not inside Gemini's GitHub Action runner.
+  // Source: https://github.com/google-gemini/gemini-cli (shellExecutionService.ts:56,486-487)
+  {
+    name: "gemini_cli",
+    check: (env) => typeof env["GEMINI_CLI"] === "string",
+  },
+  // Crush (charmbracelet/crush) — internal/shell/shell.go:43-48,98
+  // unconditionally appends CRUSH=1 (plus generic AGENT=crush / AI_AGENT=crush)
+  // to the env of every shell it spawns: both the interactive bash tool and the
+  // hook runner. We key on CRUSH since AGENT/AI_AGENT are generic and collide.
+  // Source: https://github.com/charmbracelet/crush (internal/shell/shell.go:43-48,98)
+  {
+    name: "crush",
+    check: (env) => typeof env["CRUSH"] === "string",
+  },
 ];
+
+// Agents evaluated and deliberately NOT added. Each fails the bar the rules
+// above meet — a marker reliably present in the environment of the
+// shell/subprocess the agent spawns. Recorded here (not only in the PR) so the
+// next person doesn't re-derive it:
+//   - OpenHands — OPENHANDS_BUILD_GIT_SHA/_REF exists in the agent-server
+//     Dockerfile (base-image-minimal stage, added 2025-11-09 in PR #1100) but
+//     is empirically ABSENT from the runtime env of every published
+//     ghcr.io/openhands/agent-server image inspected (12+ tags, 2025-10 →
+//     2026-01, incl. the introducing PR's merge commit). The declared ENV
+//     never reaches the published image. Re-add only if a real published image
+//     carries it in `docker inspect .Config.Env`.
+//   - Aider — sets no self-identifying env var; both shell-spawn sites
+//     (run_cmd.py Popen / pexpect.spawn) pass no env=, so children inherit
+//     os.environ verbatim.
+//   - Goose — AGENT=goose/GOOSE_TERMINAL=1 are set on the recipe-retry path
+//     and the computercontroller MCP extension, but NOT on the default
+//     developer `shell` tool (sets only PATH+cwd), so the primary path is
+//     undetected.
+//   - opencode — OPENCODE_TERMINAL=1 is set only on the interactive PTY panel,
+//     not on the model's bash/shell tool.
+//   - Roo Code — ROO_ACTIVE is set only on the `vscode` terminal provider; the
+//     shipped default is the execa provider (terminalShellIntegrationDisabled
+//     defaults true), which sets no marker.
+//   - Amp / Devin / Jules / Factory Droid — no verifiable unconditional runtime
+//     marker (Amp is closed/minified; Devin/Jules are closed sandboxes;
+//     Factory's FACTORY_PROJECT_DIR / DROID_PLUGIN_ROOT are hook-scoped only).
 
 /**
  * Identify the managed sandbox runtime hosting this CLI invocation.


### PR DESCRIPTION
## What

Extends `detectAgentRuntime()` (`packages/cli/src/telemetry/agent_runtime.ts`) with four more coding-agent vendors: **windsurf**, **cline**, **gemini_cli**, **crush**. Adds them to the `AgentRuntime` union and `VENDOR_RULES`, with vitest coverage.

(OpenHands was evaluated and **dropped after runtime testing** — see below.)

## Why

The existing telemetry classifies Claude Code, Codex, Cursor, Copilot Coding Agent, Replit, Hermes, openclaw, and Pi. This closes obvious gaps with markers verified to the same bar as the existing rules: present in the environment of the shell/subprocess the agent spawns, keyed on existence only.

## Verification (two tiers)

**Runtime-confirmed** — I installed/executed the agent's real code and observed the marker land in a spawned child whose parent did not have it:

| Vendor | Marker | Runtime proof |
|---|---|---|
| `gemini_cli` | `GEMINI_CLI=1` | Ran published `@google/gemini-cli-core@0.46.0` `ShellExecutionService.execute()` on a child: control (`child_process`) = `UNSET`, via the service = `1`. |
| `crush` | `CRUSH=1` | Test inside `charmbracelet/crush internal/shell` driving the real `Shell.Exec()`: parent `UNSET`, child = `1`. |

**Source + independent third-party detectors** (VS Code / editor surfaces; not headless-runnable here, but corroborated by other projects' shipping detectors):

| Vendor | Marker | Source + corroboration |
|---|---|---|
| `cline` | `CLINE_ACTIVE=true` | cline/cline `VscodeTerminalRegistry.ts:29` (`TerminalOptions.env`); also detected by `firebase/firebase-tools` and `aliyun/aliyun-cli`. Default `vscodeTerminal` path only (backgroundExec omits it). |
| `windsurf` | `TERM_PROGRAM=windsurf` (case-insensitive) | nrwl/nx `detection.rs:47`; also adonisjs, ag-grid. Editor-terminal scope (same as the existing Cursor rule); can fall back to `vscode` under WSL. |

## Deliberately NOT added (re-verified against current source / runtime)

- **OpenHands** — **dropped after runtime testing.** `OPENHANDS_BUILD_GIT_SHA`/`_REF` exists in the agent-server Dockerfile (base-image-minimal stage, added 2025-11-09 in PR #1100), but inspecting the config `Env` of 12+ published `ghcr.io/openhands/agent-server` images (2025-10-21 → 2026-01-13, including the merge commit of the introducing PR) shows the marker **absent from every one**. The declared `ENV` never reaches the published runtime image, so a rule would never fire. Source ≠ runtime. Re-add only if a real published image is confirmed to carry it.
- **Aider** — sets no self-identifying env var; both spawn sites (`run_cmd.py:62/116`) pass no `env=`, children inherit `os.environ` verbatim.
- **Goose** — `AGENT=goose`/`GOOSE_TERMINAL=1` are set on the recipe-retry path (`retry.rs:239`) and the `computercontroller` MCP extension (`mod.rs:855`), but **not** on the default `developer` shell tool (`developer/shell.rs:600-660`, only `PATH`+`cwd`). Primary path undetected → would undercount.
- **opencode** — `OPENCODE_TERMINAL=1` is set only on the interactive PTY panel (`pty-preparation.ts:22`), not the model's `bash`/`shell` tools.
- **Roo Code** — `ROO_ACTIVE` only on the `vscode` provider; `terminalShellIntegrationDisabled` defaults `true`, so the default `execa` provider sets no marker.
- **Amp / Devin / Jules / Factory Droid** — no verifiable unconditional runtime marker. Amp is closed/minified; Devin/Jules are closed sandboxes; Factory's `FACTORY_PROJECT_DIR`/`DROID_PLUGIN_ROOT` are hook-scoped only (docs.factory.ai).

## Test plan

- [x] 6 new vitest cases (windsurf incl. case-insensitive, cline, gemini_cli, crush, existence-only) — 26 passed under `vitest run`
- [x] `bunx oxlint` + `bunx oxfmt --check` clean; pre-commit hook (lint/format/typecheck) green
- [x] Commits signed (GitHub verified)
- [x] gemini_cli + crush confirmed by executing their real shell layers; OpenHands removed after its marker was found absent from all real published images

Note: after this and #1294 both merge, the `gemini_managed_agent` filesystem check runs ahead of `VENDOR_RULES`, so a managed agent that also exports `GEMINI_CLI` is classified as the managed agent, not `gemini_cli`.