### PR TITLE
refactor(cli): restore exact-match Cursor rule (revert unsourced loosening)

### DIFF
--- a/packages/cli/src/telemetry/agent_runtime.test.ts
+++ b/packages/cli/src/telemetry/agent_runtime.test.ts
@@ -120,12 +120,6 @@ describe("detectAgentRuntime — Cursor / Copilot / cohort", () => {
     expect(detectAgentRuntime()).toBe("cursor");
   });
 
-  it("detects Cursor case-insensitively (TERM_PROGRAM=Cursor)", async () => {
-    process.env["TERM_PROGRAM"] = "Cursor";
-    const { detectAgentRuntime } = await import("./agent_runtime.js");
-    expect(detectAgentRuntime()).toBe("cursor");
-  });
-
   it("detects Copilot Coding Agent via GITHUB_ACTIONS + COPILOT_AGENT_ID", async () => {
     process.env["GITHUB_ACTIONS"] = "true";
     process.env["COPILOT_AGENT_ID"] = "abc123";

--- a/packages/cli/src/telemetry/agent_runtime.ts
+++ b/packages/cli/src/telemetry/agent_runtime.ts
@@ -74,22 +74,21 @@ const VENDOR_RULES: VendorRule[] = [
       typeof env["CODEX_CI"] === "string" ||
       typeof env["CODEX_SANDBOX_NETWORK_DISABLED"] === "string",
   },
-  // Cursor IDE integrated terminal — exports TERM_PROGRAM=cursor. Compared
-  // case-insensitively for parity with the Windsurf rule below: Cursor sets
-  // lowercase today, but matching loosely costs nothing and won't miss a
-  // capitalized variant. Cursor Background Agent env vars are not publicly
-  // documented; if a canonical marker is identified later, add it here.
+  // Cursor IDE integrated terminal — exports TERM_PROGRAM=cursor (exact,
+  // lowercase). Cursor Background Agent env vars are not publicly documented;
+  // if a canonical marker is identified later, add it here.
   {
     name: "cursor",
-    check: (env) => env["TERM_PROGRAM"]?.toLowerCase() === "cursor",
+    check: (env) => env["TERM_PROGRAM"] === "cursor",
   },
-  // Windsurf (Codeium) integrated terminal — exports TERM_PROGRAM=windsurf, the
-  // direct analog of the Cursor rule above. Attested across many independent
-  // detectors (nx packages/nx/src/native/ide/detection.rs, adonisjs/application,
-  // ag-grid git-hooks). Compared case-insensitively because sources disagree on
-  // casing ("windsurf" vs "Windsurf"). Like Cursor this marks the editor's
-  // integrated terminal, not specifically that the Cascade agent is driving;
-  // under WSL/remote it can also fall back to TERM_PROGRAM=vscode.
+  // Windsurf (Codeium) integrated terminal — exports TERM_PROGRAM=windsurf.
+  // Attested across many independent detectors (nx
+  // packages/nx/src/native/ide/detection.rs, adonisjs/application, ag-grid
+  // git-hooks). Compared case-INsensitively (unlike the exact Cursor rule
+  // above) because Windsurf sources disagree on casing ("windsurf" vs
+  // "Windsurf"); Cursor's do not, so it stays exact. Like Cursor this marks the
+  // editor's integrated terminal, not specifically that the Cascade agent is
+  // driving; under WSL/remote it can also fall back to TERM_PROGRAM=vscode.
   {
     name: "windsurf",
     check: (env) => env["TERM_PROGRAM"]?.toLowerCase() === "windsurf",


### PR DESCRIPTION
## What

Reverts the Cursor `TERM_PROGRAM` check from case-insensitive back to exact match:

```ts
- check: (env) => env["TERM_PROGRAM"]?.toLowerCase() === "cursor",
+ check: (env) => env["TERM_PROGRAM"] === "cursor",
```

Drops the now-irrelevant `TERM_PROGRAM=Cursor` test and updates the comments so the casing asymmetry between the Cursor and Windsurf rules is documented as intentional.

## Why

Follow-up to #1328. That PR loosened the Cursor rule "for parity with the Windsurf rule," but [Magi/Hermes flagged on the #1328 review](https://github.com/heygen-com/hyperframes/pull/1328) that the parity is false:

- **Windsurf** is matched case-insensitively because its sources genuinely disagree on casing (`nx` lowercases `TERM_PROGRAM`; other detectors check `"Windsurf"` capitalized). That loosening is *sourced*.
- **Cursor** consistently emits lowercase `"cursor"`. There is no source justifying loosening an existing, working, exact-match rule.

Making Cursor case-insensitive was an unsourced change to a pre-existing rule — it widened the false-positive surface (a non-Cursor tool exporting `TERM_PROGRAM=CURSOR` would misclassify as `cursor`) for no evidenced benefit. This restores the original behavior and keeps the file consistent with the "no unsourced detection changes" discipline the rest of this work followed.

## Impact

**None functionally.** Cursor always emitted lowercase `"cursor"`, so detection is unchanged. This only removes an unjustified false-positive surface and the asymmetry is now explained in-comment. Windsurf stays case-insensitive (sourced, unchanged).

## Test plan

- [x] `agent_runtime.test.ts` — 31 pass under `vitest run` (removed the `TERM_PROGRAM=Cursor` case; the `TERM_PROGRAM=cursor` case still passes)
- [x] `bunx oxlint` + `bunx oxfmt --check` clean; pre-commit hook (lint/format/typecheck) green
- [x] Commit signed (GitHub verified)