### PR TITLE
fix(studio): accept razor splits at the canvas clamp boundary

### DIFF
--- a/packages/studio/src/hooks/useRazorSplit.ts
+++ b/packages/studio/src/hooks/useRazorSplit.ts
@@ -7,7 +7,7 @@ import {
   canSplitElement,
   buildPatchTarget,
   readFileContent,
-  SPLIT_BOUNDARY_EPSILON_S,
+  isSplitTimeWithinBounds,
 } from "../utils/timelineElementSplit";
 import type { RecordEditInput } from "./useTimelineEditing";
 
@@ -171,12 +171,7 @@ export function useRazorSplit({
       const pid = projectIdRef.current;
       if (!pid || !canSplitElement(element)) return;
 
-      const clipStart = element.start;
-      const clipEnd = element.start + element.duration;
-      if (
-        splitTime <= clipStart + SPLIT_BOUNDARY_EPSILON_S ||
-        splitTime >= clipEnd - SPLIT_BOUNDARY_EPSILON_S
-      ) {
+      if (!isSplitTimeWithinBounds(splitTime, element.start, element.duration)) {
         return;
       }
 

--- a/packages/studio/src/utils/timelineElementSplit.test.ts
+++ b/packages/studio/src/utils/timelineElementSplit.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { SPLIT_BOUNDARY_EPSILON_S, isSplitTimeWithinBounds } from "./timelineElementSplit";
+
+describe("isSplitTimeWithinBounds", () => {
+  const start = 1;
+  const duration = 4;
+  const end = start + duration;
+
+  it("accepts the exact lower clamp boundary", () => {
+    // The timeline canvas clamps an edge click to exactly
+    // start + SPLIT_BOUNDARY_EPSILON_S, so that value must be splittable.
+    expect(isSplitTimeWithinBounds(start + SPLIT_BOUNDARY_EPSILON_S, start, duration)).toBe(true);
+  });
+
+  it("accepts the exact upper clamp boundary", () => {
+    expect(
+      isSplitTimeWithinBounds(start + duration - SPLIT_BOUNDARY_EPSILON_S, start, duration),
+    ).toBe(true);
+  });
+
+  it("accepts an interior split time", () => {
+    expect(isSplitTimeWithinBounds(3, start, duration)).toBe(true);
+  });
+
+  it("rejects times at or outside the clip edges", () => {
+    expect(isSplitTimeWithinBounds(start, start, duration)).toBe(false);
+    expect(isSplitTimeWithinBounds(end, start, duration)).toBe(false);
+    expect(isSplitTimeWithinBounds(start - 1, start, duration)).toBe(false);
+    expect(isSplitTimeWithinBounds(end + 1, start, duration)).toBe(false);
+  });
+
+  it("rejects times inside the epsilon margins", () => {
+    expect(isSplitTimeWithinBounds(start + SPLIT_BOUNDARY_EPSILON_S / 2, start, duration)).toBe(
+      false,
+    );
+    expect(isSplitTimeWithinBounds(end - SPLIT_BOUNDARY_EPSILON_S / 2, start, duration)).toBe(
+      false,
+    );
+  });
+
+  it("rejects every time on a clip shorter than two epsilons", () => {
+    // Math.max(min, Math.min(max, t)) collapses to min when the clip is too
+    // short for the clamp range; that collapsed value must still be rejected.
+    const shortDuration = SPLIT_BOUNDARY_EPSILON_S;
+    expect(isSplitTimeWithinBounds(start + SPLIT_BOUNDARY_EPSILON_S, start, shortDuration)).toBe(
+      false,
+    );
+    expect(isSplitTimeWithinBounds(start + shortDuration / 2, start, shortDuration)).toBe(false);
+  });
+});

--- a/packages/studio/src/utils/timelineElementSplit.ts
+++ b/packages/studio/src/utils/timelineElementSplit.ts
@@ -5,6 +5,22 @@ export { buildPatchTarget, readFileContent } from "../hooks/timelineEditingHelpe
 /** Minimum distance (seconds) from clip boundaries to allow a split. */
 export const SPLIT_BOUNDARY_EPSILON_S = 0.03;
 
+/**
+ * True when splitTime leaves at least SPLIT_BOUNDARY_EPSILON_S on both sides
+ * of the cut. Inclusive at the epsilon offsets: the timeline canvas clamps
+ * edge clicks to exactly start/end ± epsilon, so the clamped value must pass.
+ */
+export function isSplitTimeWithinBounds(
+  splitTime: number,
+  clipStart: number,
+  clipDuration: number,
+): boolean {
+  return (
+    splitTime >= clipStart + SPLIT_BOUNDARY_EPSILON_S &&
+    splitTime <= clipStart + clipDuration - SPLIT_BOUNDARY_EPSILON_S
+  );
+}
+
 export function canSplitElement(el: TimelineElement): boolean {
   return (
     !el.timelineLocked &&


### PR DESCRIPTION
Razor clicks near a clip edge silently do nothing. The two halves of the feature disagree about the boundary:

- `TimelineCanvas` deliberately clamps the click time into the inclusive range `[start + SPLIT_BOUNDARY_EPSILON_S, end - SPLIT_BOUNDARY_EPSILON_S]`, so an edge click produces exactly the boundary value.
- `handleRazorSplit` then rejects that value with exclusive comparisons (`<=` / `>=`) and returns silently (no toast, unlike the other failure paths in the hook).

So a click in the edge zone of a clip is clamped on purpose and then dropped on purpose. Repro: enable the razor tool (B), click within ~30ms-worth of pixels of a clip's left or right edge. Nothing happens. The same clamped value splits fine via shift-click, because `handleRazorSplitAll` filters with plain `> start && < end`, which makes the single-click rejection inconsistent on top of silent.

The server-side guard (`splitElementInHtml` in sourceMutation.ts) only rejects `splitTime <= start || >= start + duration`, so accepting the epsilon boundary is consistent end to end and preserves the intended minimum segment of `SPLIT_BOUNDARY_EPSILON_S`.

## Change

- Extract the guard into `isSplitTimeWithinBounds` next to `canSplitElement` and the epsilon constant, inclusive at the epsilon offsets to mirror the canvas clamp.
- `handleRazorSplit` uses it; behavior for interior and out-of-range times is unchanged.
- Clips shorter than two epsilons (where `Math.max(min, Math.min(max, t))` collapses to `min`) are still rejected, covered by a test.

## Tests

6 cases in `timelineElementSplit.test.ts`. The two clamp-boundary cases fail against the previous exclusive comparisons (verified by flipping the operators back). Full studio suite green (71 files, 793 passed), `tsc` and `vite build` clean.