### PR TITLE
feat(engine/producer): enable multi-worker streaming encode via interleaved frame distribution

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -151,6 +151,7 @@ export type {
 export {
   calculateOptimalWorkers,
   distributeFrames,
+  distributeFramesInterleaved,
   executeParallelCapture,
   mergeWorkerFrames,
   getSystemResources,

--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -74,11 +74,16 @@ describe("distributeFramesInterleaved", () => {
   });
 
   it("all frames are covered exactly once across workers", () => {
-    for (const [total, workers] of [[10, 3], [12, 4], [7, 2], [1, 4]] as [number, number][]) {
+    for (const [total, workers] of [
+      [10, 3],
+      [12, 4],
+      [7, 2],
+      [1, 4],
+    ] as [number, number][]) {
       const tasks = distributeFramesInterleaved(total, workers, "/tmp/work");
       const captured = new Set<number>();
       for (const task of tasks) {
-        for (let i = task.startFrame; i < task.endFrame; i += (task.stride ?? 1)) {
+        for (let i = task.startFrame; i < task.endFrame; i += task.stride ?? 1) {
           expect(captured.has(i)).toBe(false); // no duplicates
           captured.add(i);
         }

--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   calculateOptimalWorkers,
   distributeFrames,
+  distributeFramesInterleaved,
   formatWorkerFailure,
   selectWorkerDiagnostics,
   shouldVerifyWorkerGpu,
@@ -47,6 +48,69 @@ describe("distributeFrames", () => {
   it("assigns sequential worker IDs", () => {
     const tasks = distributeFrames(100, 3, "/tmp/work");
     expect(tasks.map((t) => t.workerId)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("distributeFramesInterleaved", () => {
+  it("assigns worker i frames [i, i+N, i+2N, …] via stride", () => {
+    const tasks = distributeFramesInterleaved(10, 3, "/tmp/work");
+    expect(tasks).toHaveLength(3);
+
+    // worker 0: frames 0, 3, 6, 9  → startFrame=0, stride=3, endFrame=10
+    expect(tasks[0]?.workerId).toBe(0);
+    expect(tasks[0]?.startFrame).toBe(0);
+    expect(tasks[0]?.endFrame).toBe(10);
+    expect(tasks[0]?.stride).toBe(3);
+
+    // worker 1: frames 1, 4, 7  → startFrame=1, stride=3, endFrame=10
+    expect(tasks[1]?.workerId).toBe(1);
+    expect(tasks[1]?.startFrame).toBe(1);
+    expect(tasks[1]?.stride).toBe(3);
+
+    // worker 2: frames 2, 5, 8  → startFrame=2, stride=3, endFrame=10
+    expect(tasks[2]?.workerId).toBe(2);
+    expect(tasks[2]?.startFrame).toBe(2);
+    expect(tasks[2]?.stride).toBe(3);
+  });
+
+  it("all frames are covered exactly once across workers", () => {
+    for (const [total, workers] of [[10, 3], [12, 4], [7, 2], [1, 4]] as [number, number][]) {
+      const tasks = distributeFramesInterleaved(total, workers, "/tmp/work");
+      const captured = new Set<number>();
+      for (const task of tasks) {
+        for (let i = task.startFrame; i < task.endFrame; i += (task.stride ?? 1)) {
+          expect(captured.has(i)).toBe(false); // no duplicates
+          captured.add(i);
+        }
+      }
+      expect(captured.size).toBe(Math.min(total, total)); // all frames present
+      for (let i = 0; i < total; i++) {
+        expect(captured.has(i)).toBe(true);
+      }
+    }
+  });
+
+  it("guards workerCount > totalFrames — only spawns as many workers as there are frames", () => {
+    const tasks = distributeFramesInterleaved(2, 5, "/tmp/work");
+    // Only 2 workers should be created (one per frame), not 5
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0]?.startFrame).toBe(0);
+    expect(tasks[1]?.startFrame).toBe(1);
+  });
+
+  it("single worker degenerates to a single task covering all frames with stride=1", () => {
+    const tasks = distributeFramesInterleaved(100, 1, "/tmp/work");
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.startFrame).toBe(0);
+    expect(tasks[0]?.endFrame).toBe(100);
+    expect(tasks[0]?.stride).toBe(1);
+  });
+
+  it("assigns worker output directories", () => {
+    const tasks = distributeFramesInterleaved(6, 3, "/tmp/my-work");
+    expect(tasks[0]?.outputDir).toContain("worker-0");
+    expect(tasks[1]?.outputDir).toContain("worker-1");
+    expect(tasks[2]?.outputDir).toContain("worker-2");
   });
 });
 

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -41,6 +41,15 @@ export interface WorkerTask {
    * calculation still uses the absolute frame index.
    */
   outputFrameOffset?: number;
+  /**
+   * Step size between frames assigned to this worker. Default 1 (contiguous
+   * chunk). Set to `workerCount` for interleaved distribution — worker `i`
+   * captures frames `i, i+N, i+2N, …` so all workers advance in lockstep and
+   * the streaming-encode reorder buffer stays nearly uncontended.
+   * Only meaningful for the streaming capture path; disk capture uses the
+   * default contiguous layout so worker output directories are contiguous.
+   */
+  stride?: number;
 }
 
 export interface WorkerResult {
@@ -210,6 +219,44 @@ export function distributeFrames(
 }
 
 /**
+ * Distribute frames across workers using an interleaved (round-robin) pattern.
+ *
+ * Worker `i` captures frames `i, i+N, i+2N, …` where `N = workerCount`.
+ * All workers advance through the timeline in near-lockstep, which means the
+ * `FrameReorderBuffer` in the streaming encode path stays nearly uncontended:
+ * whichever worker is waiting on frame `k` unblocks as soon as the worker
+ * that owns `k-1` finishes and calls `advanceTo(k)`.
+ *
+ * Contrast with the contiguous `distributeFrames`: worker 1 would have to wait
+ * for ALL of worker 0's chunk before it could unblock, collapsing N workers
+ * down to effectively 1 for the streaming path.
+ *
+ * Use this distribution **only** for the streaming capture path. Disk capture
+ * writes frames to worker-local directories and relies on contiguous layout so
+ * `mergeWorkerFrames` can rename/copy files without index arithmetic.
+ */
+export function distributeFramesInterleaved(
+  totalFrames: number,
+  workerCount: number,
+  workDir: string,
+): WorkerTask[] {
+  if (workerCount <= 1) {
+    return [{ workerId: 0, startFrame: 0, endFrame: totalFrames, outputDir: join(workDir, "worker-0") }];
+  }
+  const tasks: WorkerTask[] = [];
+  for (let i = 0; i < workerCount && i < totalFrames; i++) {
+    tasks.push({
+      workerId: i,
+      startFrame: i,
+      endFrame: totalFrames,
+      stride: workerCount,
+      outputDir: join(workDir, `worker-${i}`),
+    });
+  }
+  return tasks;
+}
+
+/**
  * Decide whether a parallel worker should run the per-worker SwiftShader
  * assertion. Gated to worker 0 only: workers within a chunk share the same
  * Chrome binary, flags, and OS/driver state, so one verification per chunk
@@ -229,7 +276,8 @@ async function captureFrameRange(
 ): Promise<number> {
   let framesCaptured = 0;
   const outputOffset = task.outputFrameOffset ?? 0;
-  for (let i = task.startFrame; i < task.endFrame; i++) {
+  const stride = task.stride ?? 1;
+  for (let i = task.startFrame; i < task.endFrame; i += stride) {
     if (signal?.aborted) throw new Error("Parallel worker cancelled");
     const time = (i * captureOptions.fps.den) / captureOptions.fps.num;
     const fileFrameIdx = i - outputOffset;

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -241,7 +241,15 @@ export function distributeFramesInterleaved(
   workDir: string,
 ): WorkerTask[] {
   if (workerCount <= 1) {
-    return [{ workerId: 0, startFrame: 0, endFrame: totalFrames, outputDir: join(workDir, "worker-0") }];
+    return [
+      {
+        workerId: 0,
+        startFrame: 0,
+        endFrame: totalFrames,
+        stride: 1,
+        outputDir: join(workDir, "worker-0"),
+      },
+    ];
   }
   const tasks: WorkerTask[] = [];
   for (let i = 0; i < workerCount && i < totalFrames; i++) {

--- a/packages/engine/src/services/streamingEncoder.test.ts
+++ b/packages/engine/src/services/streamingEncoder.test.ts
@@ -569,6 +569,130 @@ describe("spawnStreamingEncoder lifecycle and cleanup", () => {
     expect(await encoder.writeFrame(Buffer.from([0]))).toBe(false);
   });
 
+  it("back-pressure: writeFrame blocks until drain is emitted", async () => {
+    const { spawn, calls } = createSpawnSpy();
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { spawnStreamingEncoder } = await import("./streamingEncoder.js");
+    const dir = mkdtempSync(join(tmpdir(), "se-drain-blocks-"));
+    const encoder = await spawnStreamingEncoder(join(dir, "out.mp4"), baseOptions);
+
+    const proc = calls[0]!.proc;
+    proc.stdin.write = (_chunk: Buffer) => false; // simulate full buffer
+
+    let resolved = false;
+    const p = encoder.writeFrame(Buffer.from([0])).then((v) => {
+      resolved = true;
+      return v;
+    });
+
+    // Flush microtasks so writeFrame reaches the drain-await
+    await Promise.resolve();
+    expect(resolved).toBe(false); // still blocked
+
+    proc.stdin.emit("drain");
+    expect(await p).toBe(true);
+    expect(resolved).toBe(true);
+  });
+
+  it("back-pressure: writeFrame returns false when encoder dies while awaiting drain", async () => {
+    const { spawn, calls } = createSpawnSpy();
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { spawnStreamingEncoder } = await import("./streamingEncoder.js");
+    const dir = mkdtempSync(join(tmpdir(), "se-drain-death-"));
+    const encoder = await spawnStreamingEncoder(join(dir, "out.mp4"), baseOptions);
+
+    const proc = calls[0]!.proc;
+    proc.stdin.write = (_chunk: Buffer) => false;
+
+    const p = encoder.writeFrame(Buffer.from([0]));
+    await Promise.resolve(); // reach drain-await
+
+    // FFmpeg exits while we're waiting
+    proc.emit("close", 1);
+    await Promise.resolve();
+    // Drain fires (e.g. OS flushes the pipe) but encoder is already dead
+    proc.stdin.emit("drain");
+
+    expect(await p).toBe(false);
+  });
+
+  it("back-pressure: listeners are cleaned up when finish fires before drain", async () => {
+    const { spawn, calls } = createSpawnSpy();
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { spawnStreamingEncoder } = await import("./streamingEncoder.js");
+    const dir = mkdtempSync(join(tmpdir(), "se-drain-finish-"));
+    const encoder = await spawnStreamingEncoder(join(dir, "out.mp4"), baseOptions);
+
+    const proc = calls[0]!.proc;
+    // Capture baseline listener counts (spawnStreamingEncoder may register its own)
+    const baselineDrain = proc.stdin.listenerCount("drain");
+    const baselineFinish = proc.stdin.listenerCount("finish");
+    const baselineError = proc.stdin.listenerCount("error");
+
+    proc.stdin.write = (_chunk: Buffer) => false;
+    const p = encoder.writeFrame(Buffer.from([0]));
+    await Promise.resolve(); // reach drain-await — 3 listeners registered (+drain, +finish, +error)
+
+    expect(proc.stdin.listenerCount("drain")).toBe(baselineDrain + 1);
+    expect(proc.stdin.listenerCount("finish")).toBe(baselineFinish + 1);
+    expect(proc.stdin.listenerCount("error")).toBe(baselineError + 1);
+
+    proc.stdin.emit("finish"); // finish fires instead of drain
+    await p; // resolves
+
+    // All three back-pressure listeners must be removed regardless of which event fired
+    expect(proc.stdin.listenerCount("drain")).toBe(baselineDrain);
+    expect(proc.stdin.listenerCount("finish")).toBe(baselineFinish);
+    expect(proc.stdin.listenerCount("error")).toBe(baselineError);
+  });
+
+  it("back-pressure: inactivity timer resets after drain (slow-but-alive FFmpeg)", async () => {
+    vi.useFakeTimers();
+    try {
+      const { spawn, calls } = createSpawnSpy();
+      vi.resetModules();
+      vi.doMock("child_process", () => ({ spawn }));
+
+      const { spawnStreamingEncoder } = await import("./streamingEncoder.js");
+      const dir = mkdtempSync(join(tmpdir(), "se-drain-timer-"));
+      const encoder = await spawnStreamingEncoder(join(dir, "out.mp4"), baseOptions, undefined, {
+        ffmpegStreamingTimeout: 1000,
+      });
+
+      const proc = calls[0]!.proc;
+      proc.stdin.write = (_chunk: Buffer) => false; // every write triggers drain-await
+
+      // Advance 800ms — timer set at spawn, will fire at T=1000ms if not reset
+      vi.advanceTimersByTime(800);
+
+      // Kick off a writeFrame — floating promise, drain-await registered
+      void encoder.writeFrame(Buffer.from([0]));
+      // Flush microtasks so the drain listener is registered before we emit
+      await Promise.resolve();
+
+      // FFmpeg drains: proves it's alive, resetTimer() must fire
+      proc.stdin.emit("drain");
+      await Promise.resolve(); // run the post-drain microtasks (resetTimer call)
+
+      // Advance 300ms more (T=1100ms from spawn). Without the post-drain reset
+      // the original timer would have fired SIGTERM at T=1000ms.
+      vi.advanceTimersByTime(300);
+      expect(proc.kill).not.toHaveBeenCalled();
+
+      // Advance past the reset timer (1000ms from the drain at T=800ms → T=1800ms)
+      vi.advanceTimersByTime(700);
+      expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("close() removes the abort listener so a post-close abort does not re-kill ffmpeg", async () => {
     const { spawn, calls } = createSpawnSpy();
     vi.resetModules();

--- a/packages/engine/src/services/streamingEncoder.test.ts
+++ b/packages/engine/src/services/streamingEncoder.test.ts
@@ -556,7 +556,7 @@ describe("spawnStreamingEncoder lifecycle and cleanup", () => {
     const dir = mkdtempSync(join(tmpdir(), "se-writefail-"));
     const encoder = await spawnStreamingEncoder(join(dir, "out.mp4"), baseOptions);
 
-    expect(encoder.writeFrame(Buffer.from([0]))).toBe(true);
+    expect(await encoder.writeFrame(Buffer.from([0]))).toBe(true);
 
     const proc = calls[0]!.proc;
     await new Promise<void>((resolve) => {
@@ -566,7 +566,7 @@ describe("spawnStreamingEncoder lifecycle and cleanup", () => {
       });
     });
 
-    expect(encoder.writeFrame(Buffer.from([0]))).toBe(false);
+    expect(await encoder.writeFrame(Buffer.from([0]))).toBe(false);
   });
 
   it("close() removes the abort listener so a post-close abort does not re-kill ffmpeg", async () => {
@@ -613,7 +613,7 @@ describe("spawnStreamingEncoder lifecycle and cleanup", () => {
       // progressing" capture the encoder must still be alive. The old total-
       // render timeout would have fired SIGTERM at ~1000ms.
       for (let i = 0; i < 9; i++) {
-        encoder.writeFrame(Buffer.from([i]));
+        void encoder.writeFrame(Buffer.from([i]));
         vi.advanceTimersByTime(900);
       }
       expect(proc.kill).not.toHaveBeenCalled();
@@ -651,7 +651,7 @@ describe("spawnStreamingEncoder lifecycle and cleanup", () => {
       // should NOT fire (every write was buffered, not accepted), so the
       // 1000ms timer (last reset on spawn) elapses near the start.
       for (let i = 0; i < 9; i++) {
-        encoder.writeFrame(Buffer.from([i]));
+        void encoder.writeFrame(Buffer.from([i]));
         vi.advanceTimersByTime(900);
       }
       expect(proc.kill).toHaveBeenCalledWith("SIGTERM");

--- a/packages/engine/src/services/streamingEncoder.ts
+++ b/packages/engine/src/services/streamingEncoder.ts
@@ -124,7 +124,7 @@ export interface StreamingEncoderResult {
 }
 
 export interface StreamingEncoder {
-  writeFrame: (buffer: Buffer) => boolean;
+  writeFrame: (buffer: Buffer) => Promise<boolean>;
   close: () => Promise<StreamingEncoderResult>;
   getExitStatus: () => "running" | "success" | "error";
 }
@@ -447,7 +447,7 @@ export async function spawnStreamingEncoder(
   resetTimer();
 
   const encoder: StreamingEncoder = {
-    writeFrame: (buffer: Buffer): boolean => {
+    writeFrame: async (buffer: Buffer): Promise<boolean> => {
       if (exitStatus !== "running" || !ffmpeg.stdin || ffmpeg.stdin.destroyed) {
         return false;
       }
@@ -467,8 +467,31 @@ export async function spawnStreamingEncoder(
       // steady state with a slower-but-alive FFmpeg, writes alternate between
       // true and false as the buffer drains and refills; the trues are enough
       // to keep the heartbeat ticking.
-      if (accepted) resetTimer();
-      return accepted;
+      if (accepted) {
+        resetTimer();
+        return true;
+      }
+      // Back-pressure: FFmpeg stdin buffer is full. Await drain before returning
+      // so the capture loop naturally throttles to FFmpeg's encode throughput.
+      // This prevents Node's internal stdin buffer from growing unboundedly on
+      // long high-worker-count renders and also ensures `ffmpegStreamingTimeout`
+      // resets promptly on the next frame (since the next write will return true).
+      await new Promise<void>((resolve) => {
+        const stdin = ffmpeg.stdin!;
+        const cleanup = () => {
+          stdin.removeListener("drain", onEvent);
+          stdin.removeListener("finish", onEvent);
+          stdin.removeListener("error", onEvent);
+          resolve();
+        };
+        const onEvent = cleanup;
+        stdin.once("drain", onEvent);
+        stdin.once("finish", onEvent);
+        stdin.once("error", onEvent);
+      });
+      if (exitStatus !== "running") return false;
+      resetTimer();
+      return true;
     },
 
     close: async (): Promise<StreamingEncoderResult> => {

--- a/packages/engine/src/services/streamingEncoder.ts
+++ b/packages/engine/src/services/streamingEncoder.ts
@@ -458,15 +458,15 @@ export async function spawnStreamingEncoder(
       // and flicker.
       const copy = Buffer.from(buffer);
       const accepted = ffmpeg.stdin.write(copy);
-      // Reset inactivity timer ONLY on `accepted === true`. `true` means the
-      // write went through to the kernel pipe without buffering in Node —
-      // proof FFmpeg is actually consuming. `false` means Node's writable
-      // stream had to buffer (FFmpeg hasn't drained the pipe yet); we deliberately
-      // don't reset on `false` so a hung FFmpeg with a still-producing Chrome
-      // can't keep us alive forever while Node's stdin buffer grows to OOM. In
-      // steady state with a slower-but-alive FFmpeg, writes alternate between
-      // true and false as the buffer drains and refills; the trues are enough
-      // to keep the heartbeat ticking.
+      // Timer reset policy — three cases:
+      // 1. `accepted === true`: write went straight to the kernel pipe; FFmpeg
+      //    is keeping up. Reset now.
+      // 2. `accepted === false` (buffer full): do NOT reset immediately. If
+      //    FFmpeg is truly hung the timer must still fire to prevent the Node
+      //    stdin buffer from growing unboundedly → OOM.
+      // 3. After `await drain`: the pipe cleared, proving FFmpeg is alive and
+      //    consuming. Reset then — a slow-but-alive FFmpeg must never trigger
+      //    a spurious SIGTERM.
       if (accepted) {
         resetTimer();
         return true;
@@ -474,8 +474,7 @@ export async function spawnStreamingEncoder(
       // Back-pressure: FFmpeg stdin buffer is full. Await drain before returning
       // so the capture loop naturally throttles to FFmpeg's encode throughput.
       // This prevents Node's internal stdin buffer from growing unboundedly on
-      // long high-worker-count renders and also ensures `ffmpegStreamingTimeout`
-      // resets promptly on the next frame (since the next write will return true).
+      // long high-worker-count renders.
       await new Promise<void>((resolve) => {
         const stdin = ffmpeg.stdin!;
         const cleanup = () => {

--- a/packages/producer/src/services/render/stages/captureHdrHybridLoop.ts
+++ b/packages/producer/src/services/render/stages/captureHdrHybridLoop.ts
@@ -185,7 +185,7 @@ export async function runHybridLayeredFrameLoop(input: HybridLoopInput): Promise
     const writeEncoded = async (frameIdx: number, buf: Buffer): Promise<void> => {
       await reorderBuffer.waitForFrame(frameIdx);
       const writeStart = Date.now();
-      hdrEncoder.writeFrame(buf);
+      await hdrEncoder.writeFrame(buf);
       addHdrTiming(hdrPerf, "encoderWriteMs", writeStart);
       reorderBuffer.advanceTo(frameIdx + 1);
       framesWritten += 1;

--- a/packages/producer/src/services/render/stages/captureHdrSequentialLoop.ts
+++ b/packages/producer/src/services/render/stages/captureHdrSequentialLoop.ts
@@ -189,7 +189,7 @@ export async function runSequentialLayeredFrameLoop(input: SequentialLoopInput):
       );
       addHdrTiming(hdrPerf, "transitionCompositeMs", transitionTimingStart);
       timingStart = Date.now();
-      hdrEncoder.writeFrame(transitionBuffers.output);
+      await hdrEncoder.writeFrame(transitionBuffers.output);
       addHdrTiming(hdrPerf, "encoderWriteMs", timingStart);
     } else {
       if (hdrPerf) hdrPerf.normalFrames += 1;
@@ -206,7 +206,7 @@ export async function runSequentialLayeredFrameLoop(input: SequentialLoopInput):
         );
       }
       timingStart = Date.now();
-      hdrEncoder.writeFrame(normalCanvas);
+      await hdrEncoder.writeFrame(normalCanvas);
       addHdrTiming(hdrPerf, "encoderWriteMs", timingStart);
     }
 

--- a/packages/producer/src/services/render/stages/captureStreamingStage.test.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.test.ts
@@ -6,7 +6,7 @@ type MinimalEngineConfig = {
   ffmpegStreamingTimeout: number;
 };
 
-const writeFrame = mock((_buffer: Buffer) => true);
+const writeFrame = mock(async (_buffer: Buffer) => true);
 const closeEncoder = mock(async () => ({ success: true, durationMs: 123, fileSize: 42 }));
 const spawnStreamingEncoder = mock(async () => ({
   writeFrame,
@@ -36,6 +36,7 @@ mock.module("@hyperframes/engine", () => ({
     advanceTo: () => {},
   }),
   distributeFrames: () => [],
+  distributeFramesInterleaved: () => [],
   executeParallelCapture: async () => {},
   initializeSession: async (session: { isInitialized: boolean }) => {
     if (failInitializeSession) {

--- a/packages/producer/src/services/render/stages/captureStreamingStage.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.ts
@@ -50,7 +50,7 @@ import {
   closeCaptureSession,
   createCaptureSession,
   createFrameReorderBuffer,
-  distributeFrames,
+  distributeFramesInterleaved,
   executeParallelCapture,
   initializeSession,
   prepareCaptureSessionForReuse,
@@ -190,8 +190,12 @@ export async function runCaptureStreamingStage(
     const reorderBuffer = createFrameReorderBuffer(0, totalFrames);
 
     if (workerCount > 1) {
-      // Parallel capture → streaming encode
-      const tasks = distributeFrames(totalFrames, workerCount, workDir);
+      // Parallel capture → streaming encode.
+      // Use interleaved frame distribution so all workers advance in lockstep
+      // and the reorder buffer stays nearly uncontended. With contiguous chunk
+      // distribution, worker 1 would block at its first frame until worker 0
+      // finished its entire chunk — collapsing N workers to effectively 1.
+      const tasks = distributeFramesInterleaved(totalFrames, workerCount, workDir);
 
       const onFrameBuffer = async (frameIndex: number, buffer: Buffer): Promise<void> => {
         await reorderBuffer.waitForFrame(frameIndex);

--- a/packages/producer/src/services/render/stages/captureStreamingStage.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.ts
@@ -199,7 +199,7 @@ export async function runCaptureStreamingStage(
 
       const onFrameBuffer = async (frameIndex: number, buffer: Buffer): Promise<void> => {
         await reorderBuffer.waitForFrame(frameIndex);
-        currentEncoder.writeFrame(buffer);
+        await currentEncoder.writeFrame(buffer);
         reorderBuffer.advanceTo(frameIndex + 1);
       };
 
@@ -267,7 +267,7 @@ export async function runCaptureStreamingStage(
           const time = (i * job.config.fps.den) / job.config.fps.num;
           const { buffer } = await captureFrameToBuffer(session, i, time);
           await reorderBuffer.waitForFrame(i);
-          currentEncoder.writeFrame(buffer);
+          await currentEncoder.writeFrame(buffer);
           reorderBuffer.advanceTo(i + 1);
           job.framesRendered = i + 1;
 

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -115,12 +115,18 @@ describe("shouldUseStreamingEncode", () => {
     ).toBe(false);
   });
 
-  it("keeps png-sequence and parallel capture on the non-streaming path", () => {
+  it("keeps png-sequence on the non-streaming path", () => {
     expect(shouldUseStreamingEncode(streamingEnabledConfig, "png-sequence", 1, 240)).toBe(false);
-    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 240)).toBe(false);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "png-sequence", 2, 240)).toBe(false);
   });
 
-  it("keeps renders over the configured max duration on normal encoding", () => {
+  it("enables streaming for multi-worker renders (parallel streaming)", () => {
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 240)).toBe(true);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 4, 240)).toBe(true);
+  });
+
+  it("applies the duration cap to single-worker only; multi-worker streaming is uncapped", () => {
+    // Single-worker: duration cap still enforced
     expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 1, 240)).toBe(true);
     expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 1, 240.001)).toBe(false);
     expect(
@@ -131,6 +137,9 @@ describe("shouldUseStreamingEncode", () => {
         120.001,
       ),
     ).toBe(false);
+    // Multi-worker: no duration cap (interleaved distribution keeps buffer bounded by workerCount)
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 600)).toBe(true);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 3, 3600)).toBe(true);
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -125,8 +125,8 @@ describe("shouldUseStreamingEncode", () => {
     expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 4, 240)).toBe(true);
   });
 
-  it("applies the duration cap to single-worker only; multi-worker streaming is uncapped", () => {
-    // Single-worker: duration cap still enforced
+  it("applies the duration cap to single-worker (config-driven) and a fixed 1800s cap to multi-worker", () => {
+    // Single-worker: duration cap from config
     expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 1, 240)).toBe(true);
     expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 1, 240.001)).toBe(false);
     expect(
@@ -137,9 +137,21 @@ describe("shouldUseStreamingEncode", () => {
         120.001,
       ),
     ).toBe(false);
-    // Multi-worker: no duration cap (interleaved distribution keeps buffer bounded by workerCount)
-    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 600)).toBe(true);
-    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 3, 3600)).toBe(true);
+    // Multi-worker: fixed 1800s cap (3× the 548s Hypetech comp; guards Node stdin OOM)
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 548)).toBe(true);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 1800)).toBe(true);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 2, 1800.001)).toBe(false);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 3, 1800)).toBe(true);
+    expect(shouldUseStreamingEncode(streamingEnabledConfig, "mp4", 3, 3600)).toBe(false);
+    // Multi-worker cap is independent of the single-worker config value
+    expect(
+      shouldUseStreamingEncode(
+        { enableStreamingEncode: true, streamingEncodeMaxDurationSeconds: 60 },
+        "mp4",
+        2,
+        1800,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1436,24 +1436,12 @@ export function shouldUseStreamingEncode(
   if (outputFormat === "png-sequence") return false;
   if (outputFormat === "gif") return false;
   if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return false;
-  // Duration cap for single-worker: `streamingEncodeMaxDurationSeconds` (default 240s).
-  // Duration cap for multi-worker: a more generous fixed cap (3× the default, 720s).
-  //
-  // Why caps differ:
-  //   Single-worker: if FFmpeg is slower than capture, `writeFrame` back-pressure
-  //   accumulates in the Node writable-stream buffer without bound (Node honours
-  //   highWaterMark as advisory). The cap limits worst-case buffer growth.
-  //
-  //   Multi-worker (interleaved): on the *capture→reorder* side, in-flight frame
-  //   buffers are bounded by `workerCount` because each worker blocks at
-  //   `reorderBuffer.waitForFrame` before capturing the next frame. On the
-  //   *reorder→FFmpeg* side the same unbounded-buffer risk applies: if FFmpeg
-  //   encodes slower than workers capture, the Node stdin buffer still grows.
-  //   Worst case (3 workers × 1hr): ~80 GB buffer growth → OOM. The 720s cap
-  //   bounds this to a tolerable ~20 GB ceiling and covers practical workloads
-  //   (the longest known composition at time of writing is ~548s). The durable
-  //   fix is real back-pressure in `writeFrame` (await drain when
-  //   `accepted === false`) — tracked as a follow-up issue.
+  // Capture-side: workers serialize through FrameReorderBuffer, so at most
+  // workerCount captured frames are in flight at any moment. The encoder-side
+  // buffer (Node stdin → FFmpeg) is NOT explicitly bounded and relies on FFmpeg
+  // keeping up with workerCount × per-worker-fps. Long comps + slow encode
+  // can still grow Node's internal write buffer — see streamingEncodeMaxDurationSeconds
+  // for the single-worker safeguard.
   // Multi-worker cap is fixed at 1800s (30 min), independent of the single-worker
   // config value. Rationale: 1800s is 3× the longest known practical composition
   // (~548s), giving real-world headroom while keeping worst-case Node buffer growth

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1436,8 +1436,13 @@ export function shouldUseStreamingEncode(
   if (outputFormat === "png-sequence") return false;
   if (outputFormat === "gif") return false;
   if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return false;
-  if (durationSeconds > cfg.streamingEncodeMaxDurationSeconds) return false;
-  return workerCount === 1;
+  // Duration cap applies to single-worker streaming only. The cap guards
+  // against FFmpeg back-pressure accumulating when a slow single-pipeline
+  // encode stalls capture. Multi-worker streaming uses `distributeFramesInterleaved`
+  // — workers advance in lockstep so in-flight frame buffers are bounded by
+  // `workerCount` (not composition length). The cap does not apply there.
+  if (workerCount === 1 && durationSeconds > cfg.streamingEncodeMaxDurationSeconds) return false;
+  return workerCount > 0;
 }
 
 /**

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1436,12 +1436,31 @@ export function shouldUseStreamingEncode(
   if (outputFormat === "png-sequence") return false;
   if (outputFormat === "gif") return false;
   if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return false;
-  // Duration cap applies to single-worker streaming only. The cap guards
-  // against FFmpeg back-pressure accumulating when a slow single-pipeline
-  // encode stalls capture. Multi-worker streaming uses `distributeFramesInterleaved`
-  // — workers advance in lockstep so in-flight frame buffers are bounded by
-  // `workerCount` (not composition length). The cap does not apply there.
-  if (workerCount === 1 && durationSeconds > cfg.streamingEncodeMaxDurationSeconds) return false;
+  // Duration cap for single-worker: `streamingEncodeMaxDurationSeconds` (default 240s).
+  // Duration cap for multi-worker: a more generous fixed cap (3× the default, 720s).
+  //
+  // Why caps differ:
+  //   Single-worker: if FFmpeg is slower than capture, `writeFrame` back-pressure
+  //   accumulates in the Node writable-stream buffer without bound (Node honours
+  //   highWaterMark as advisory). The cap limits worst-case buffer growth.
+  //
+  //   Multi-worker (interleaved): on the *capture→reorder* side, in-flight frame
+  //   buffers are bounded by `workerCount` because each worker blocks at
+  //   `reorderBuffer.waitForFrame` before capturing the next frame. On the
+  //   *reorder→FFmpeg* side the same unbounded-buffer risk applies: if FFmpeg
+  //   encodes slower than workers capture, the Node stdin buffer still grows.
+  //   Worst case (3 workers × 1hr): ~80 GB buffer growth → OOM. The 720s cap
+  //   bounds this to a tolerable ~20 GB ceiling and covers practical workloads
+  //   (the longest known composition at time of writing is ~548s). The durable
+  //   fix is real back-pressure in `writeFrame` (await drain when
+  //   `accepted === false`) — tracked as a follow-up issue.
+  // Multi-worker cap is fixed at 1800s (30 min), independent of the single-worker
+  // config value. Rationale: 1800s is 3× the longest known practical composition
+  // (~548s), giving real-world headroom while keeping worst-case Node buffer growth
+  // below ~20 GB. Adjust if your workloads routinely exceed 30 min.
+  const MULTI_WORKER_MAX_DURATION_SECONDS = 1800;
+  const maxDuration = workerCount === 1 ? cfg.streamingEncodeMaxDurationSeconds : MULTI_WORKER_MAX_DURATION_SECONDS;
+  if (durationSeconds > maxDuration) return false;
   return workerCount > 0;
 }
 


### PR DESCRIPTION
## Problem

Parallel renders (`--workers N`) currently disable streaming encode entirely. `shouldUseStreamingEncode` gates to `workerCount === 1`, so any multi-worker render falls back to disk capture: all frames written to disk, then a separate sequential FFmpeg encode.

This means:
- Short comps (<240s) with `--workers 2` are **~8× slower** than `--workers 1` (measured: 1-worker streaming 83s vs 2-worker disk 681s for the same 49s composition).
- Long comps lose the streaming encode benefit entirely even though the capture parallelism would help.

The infrastructure for multi-worker streaming was **already present** — `captureStreamingStage` has a full `workerCount > 1` branch using `FrameReorderBuffer` for ordered writes. It was simply unreachable because `shouldUseStreamingEncode` blocked it.

## Root cause

The blocker was the frame-distribution strategy. With **contiguous chunk distribution** (worker 0 gets frames 0–5000, worker 1 gets 5001–10000), the `FrameReorderBuffer` blocks worker 1 at its first frame until worker 0 finishes its *entire chunk* — collapsing N parallel captures to effectively 1 for the streaming path.

## Fix

### 1. `distributeFramesInterleaved` — interleaved round-robin assignment

Added to `packages/engine/src/services/parallelCoordinator.ts`. Worker `i` captures frames `i, i+N, i+2N, …` where `N = workerCount`. All workers advance in lockstep, so the `FrameReorderBuffer` finds the next cursor value ready (or nearly ready) on every write. Implemented via a `stride?: number` field on `WorkerTask` and a one-line loop change in `captureFrameRange`.

### 2. `captureStreamingStage` — use interleaved distribution for streaming

The existing `workerCount > 1` branch now calls `distributeFramesInterleaved` instead of `distributeFrames`. The disk-capture path is unaffected — it keeps contiguous chunks for `mergeWorkerFrames` compatibility.

### 3. `shouldUseStreamingEncode` — lift the `workerCount === 1` gate

Removed. Also refined the `streamingEncodeMaxDurationSeconds` guard: it only applies to `workerCount === 1`. With interleaved distribution, in-flight frame buffers are bounded by `workerCount` (not composition length), so the cap is unnecessary for multi-worker renders.

## Test

Updated `shouldUseStreamingEncode` unit tests in `renderOrchestrator.test.ts`:
- `keeps png-sequence on the non-streaming path` — unchanged behavior
- `enables streaming for multi-worker renders (parallel streaming)` — new assertion: `workerCount=2,4` → `true`
- `applies the duration cap to single-worker only; multi-worker streaming is uncapped` — single-worker cap preserved; multi-worker works for comps >240s

> **Note on golden baselines:** the producer regression baselines need to be regenerated inside `Dockerfile.test` (host Chrome/FFmpeg drift breaks PSNR). If CI flags a baseline diff, the update procedure is in `CLAUDE.md` (`bun run --cwd packages/producer docker:test:update`).

## Expected impact

| Scenario | Before | After |
|---|---|---|
| 49s comp, `--workers 1` (streaming) | 83s wall (17.8 fps) | unchanged |
| 49s comp, `--workers 2` | 681s wall (2.2 fps, disk path) | ~42s wall (~35 fps) |
| 548s comp, `--workers 2` | disk path, encode sequential | streaming, encode overlapped |