### PR TITLE
fix(release): include sdk in fixed-version bump

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.6.86",
+  "version": "0.6.91",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/scripts/set-version.test.ts
+++ b/scripts/set-version.test.ts
@@ -116,7 +116,12 @@ describe("changed-path guard", () => {
     const allowed = releaseAllowedPaths("1.2.3");
     assert.deepEqual(
       findUnexpectedChanges(
-        ["packages/core/package.json", ".claude-plugin/plugin.json", "releases/v1.2.3.md"],
+        [
+          "packages/core/package.json",
+          "packages/sdk/package.json",
+          ".claude-plugin/plugin.json",
+          "releases/v1.2.3.md",
+        ],
         allowed,
       ),
       [],

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -30,6 +30,7 @@ const PACKAGES = [
   "packages/cli",
   "packages/aws-lambda",
   "packages/gcp-cloud-run",
+  "packages/sdk",
 ];
 
 const PLUGINS = [".claude-plugin", ".codex-plugin", ".cursor-plugin"];


### PR DESCRIPTION
## Summary

- include `packages/sdk` in the fixed-version release package list
- cover the SDK manifest in the release allowed-paths test
- align the SDK package metadata with the current workspace version

## Notes

I noticed `@hyperframes/sdk` is already part of the workspace build/test path, but the release helper did not include `packages/sdk` in the fixed-version package list. With the current helper, running a release bump leaves the SDK package version behind while the rest of the workspace advances.

This intentionally does not add `@hyperframes/sdk` to the publish workflow. Publishing the SDK seems like a separate maintainer decision; this PR only keeps its package metadata aligned with the repo's fixed-version release tooling.

## Testing

- `bun run test:scripts`
- `bunx oxfmt --check scripts/set-version.ts scripts/set-version.test.ts packages/sdk/package.json`
- `bunx oxlint scripts/set-version.ts scripts/set-version.test.ts`
- `bun install --frozen-lockfile`
- temp worktree check: `bun run set-version 0.6.92 --no-tag --skip-changelog-check --skip-monotonicity-check` bumps `@hyperframes/sdk` with the rest of the workspace
