### PR TITLE
fix(studio): remove unused onSelectElementById after indicator removal

### DIFF
--- a/packages/studio/src/components/StudioPreviewArea.tsx
+++ b/packages/studio/src/components/StudioPreviewArea.tsx
@@ -108,7 +108,6 @@ export function StudioPreviewArea({
     handlePreviewCanvasPointerMove,
     handlePreviewCanvasPointerLeave,
     applyDomSelection,
-    buildDomSelectionFromTarget,
     handleBlockedDomMove,
     handleDomManualDragStart,
     handleDomPathOffsetCommit,
@@ -291,14 +290,6 @@ export function StudioPreviewArea({
                   onRotationCommit={handleDomRotationCommit}
                   gridVisible={snapPrefs.gridVisible}
                   gridSpacing={snapPrefs.gridSpacing}
-                  onSelectElementById={async (id) => {
-                    const iframe = previewIframeRef.current;
-                    const el = iframe?.contentDocument?.getElementById(id);
-                    if (!el) return null;
-                    const sel = await buildDomSelectionFromTarget(el);
-                    if (sel) applyDomSelection(sel, { revealPanel: true });
-                    return sel;
-                  }}
                 />
                 <SnapToolbar onSnapChange={setSnapPrefs} />
                 {gestureOverlay}

--- a/packages/studio/src/components/editor/DomEditOverlay.tsx
+++ b/packages/studio/src/components/editor/DomEditOverlay.tsx
@@ -54,7 +54,6 @@ interface DomEditOverlayProps {
   ) => void;
   onBlockedMove: (selection: DomEditSelection) => void;
   onManualDragStart?: () => void;
-  onSelectElementById?: (id: string) => Promise<DomEditSelection | null>;
   onPathOffsetCommit: (
     selection: DomEditSelection,
     next: { x: number; y: number },
@@ -84,7 +83,6 @@ export const DomEditOverlay = memo(function DomEditOverlay({
   gridVisible = false,
   gridSpacing = 50,
   onManualDragStart,
-  onSelectElementById,
   onPathOffsetCommit,
   onGroupPathOffsetCommit,
   onBoxSizeCommit,
@@ -213,7 +211,6 @@ export const DomEditOverlay = memo(function DomEditOverlay({
     frame = requestAnimationFrame(update);
     return () => cancelAnimationFrame(frame);
   });
-
 
   const gestures = createDomEditOverlayGestureHandlers({
     overlayRef,


### PR DESCRIPTION
## Summary

Cleanup after #1376 — removes the `onSelectElementById` prop from DomEditOverlay and its caller in StudioPreviewArea. The prop was only used by the off-screen indicators which were removed in #1376. Also removes the now-unused `buildDomSelectionFromTarget` destructure.

Fixes CI lint failure: `Parameter 'onSelectElementById' is declared but never used`.