### PR TITLE
fix(cli): resolve and install transitive registry dependencies

### DIFF
--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -15,6 +15,8 @@ const MANIFEST: RegistryManifest = {
     { name: "my-block", type: "hyperframes:block" },
     { name: "deprecated-block", type: "hyperframes:block" },
     { name: "future-block", type: "hyperframes:block" },
+    { name: "dep-block", type: "hyperframes:block" },
+    { name: "base-component", type: "hyperframes:component" },
     { name: "my-component", type: "hyperframes:component" },
     { name: "my-example", type: "hyperframes:example" },
   ],
@@ -90,6 +92,36 @@ const FUTURE_BLOCK_ITEM: RegistryItem = {
   ],
 };
 
+const BASE_COMPONENT_ITEM: RegistryItem = {
+  $schema: "https://hyperframes.heygen.com/schema/registry-item.json",
+  name: "base-component",
+  type: "hyperframes:component",
+  title: "Base Component",
+  description: "Base component dependency for tests",
+  files: [
+    {
+      path: "base-component.css",
+      target: "compositions/components/base-component/base-component.css",
+      type: "hyperframes:style",
+    },
+  ],
+};
+
+// A block that declares a transitive registryDependency on base-component.
+const DEP_BLOCK_ITEM: RegistryItem = {
+  ...BLOCK_ITEM,
+  name: "dep-block",
+  title: "Dependent Block",
+  registryDependencies: ["base-component"],
+  files: [
+    {
+      path: "dep-block.html",
+      target: "compositions/dep-block.html",
+      type: "hyperframes:composition",
+    },
+  ],
+};
+
 const EXAMPLE_ITEM: RegistryItem = {
   $schema: "https://hyperframes.heygen.com/schema/registry-item.json",
   name: "my-example",
@@ -105,6 +137,8 @@ const ITEM_BY_NAME: Record<string, RegistryItem> = {
   "my-block": BLOCK_ITEM,
   "deprecated-block": DEPRECATED_BLOCK_ITEM,
   "future-block": FUTURE_BLOCK_ITEM,
+  "dep-block": DEP_BLOCK_ITEM,
+  "base-component": BASE_COMPONENT_ITEM,
   "my-component": COMPONENT_ITEM,
   "my-example": EXAMPLE_ITEM,
 };
@@ -232,6 +266,7 @@ describe("runAdd (integration, mocked registry)", () => {
       expect(result.name).toBe("my-block");
       expect(result.type).toBe("hyperframes:block");
       expect(result.written).toHaveLength(1);
+      expect(result.installed).toEqual(["my-block"]);
       expect(result.warnings).toEqual([]);
       expect(existsSync(join(dir, "compositions/my-block.html"))).toBe(true);
       const installed = readFileSync(join(dir, "compositions/my-block.html"), "utf-8");
@@ -298,6 +333,27 @@ describe("runAdd (integration, mocked registry)", () => {
       expect(existsSync(join(dir, "src/fx/my-component/my-component.css"))).toBe(true);
       expect(existsSync(join(dir, "assets/my-component/mask.png"))).toBe(true);
       expect(result.snippet).toContain("src/fx/my-component/my-component.html");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("installs transitive registryDependencies before the requested item", async () => {
+    const dir = tmp();
+    try {
+      writeRegistryConfig(dir);
+
+      const result = await runAdd({ name: "dep-block", projectDir: dir, skipClipboard: true });
+      expect(result.name).toBe("dep-block");
+      // Dependency first, requested item last.
+      expect(result.installed).toEqual(["base-component", "dep-block"]);
+      expect(result.written).toHaveLength(2);
+      expect(
+        existsSync(join(dir, "compositions/components/base-component/base-component.css")),
+      ).toBe(true);
+      expect(existsSync(join(dir, "compositions/dep-block.html"))).toBe(true);
+      // Snippet points at the requested block, not the dependency.
+      expect(result.snippet).toContain("compositions/dep-block.html");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,7 +14,8 @@ import { existsSync } from "node:fs";
 import { resolve, relative } from "node:path";
 import { ITEM_TYPE_DIRS, type RegistryItem } from "@hyperframes/core";
 import { c } from "../ui/colors.js";
-import { installItem, resolveItem, resolveItemsByTag } from "../registry/index.js";
+import { installItem, resolveItemsByTag } from "../registry/index.js";
+import { resolveItemWithDependencies } from "../registry/resolver.js";
 import { checkRegistryItemCompatibility } from "../registry/compatibility.js";
 import {
   DEFAULT_PROJECT_CONFIG,
@@ -86,6 +87,8 @@ export interface RunAddResult {
   type: RegistryItem["type"];
   typeDir: string;
   written: string[];
+  /** Names of every item installed, in order — dependencies first, then `name`. */
+  installed: string[];
   snippet: string;
   clipboardCopied: boolean;
   warnings: string[];
@@ -106,6 +109,44 @@ export class AddError extends Error {
   }
 }
 
+// Compatibility-gate a set of resolved items before any install runs. Throws
+// an AddError on the first item that requires a newer CLI; otherwise returns
+// the accumulated (non-fatal) warnings from every item.
+function assertCompatibleOrThrow(items: RegistryItem[], cliVersion?: string): string[] {
+  const warnings: string[] = [];
+  for (const item of items) {
+    const compatibility = checkRegistryItemCompatibility(item, cliVersion);
+    if (compatibility.error) {
+      throw new AddError(compatibility.error, "incompatible-cli");
+    }
+    warnings.push(...compatibility.warnings);
+  }
+  return warnings;
+}
+
+// Install a topologically-ordered plan (dependencies first, requested item
+// last). The installer validates every target before any write; a failure on
+// any item surfaces as an install-failed AddError. Returns all written paths.
+async function installAll(
+  installPlan: RegistryItem[],
+  destDir: string,
+  baseUrl: string | undefined,
+): Promise<string[]> {
+  const written: string[] = [];
+  try {
+    for (const planItem of installPlan) {
+      const result = await installItem(planItem, { destDir, baseUrl });
+      written.push(...result.written);
+    }
+  } catch (err) {
+    throw new AddError(
+      `Install failed: ${err instanceof Error ? err.message : String(err)}`,
+      "install-failed",
+    );
+  }
+  return written;
+}
+
 export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
   const projectDir = resolve(opts.projectDir);
 
@@ -117,13 +158,18 @@ export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
     config = DEFAULT_PROJECT_CONFIG;
   }
 
-  // 2. Resolve the item from the registry.
-  let item: RegistryItem;
+  // 2. Resolve the requested item and its transitive registryDependencies.
+  //    The list comes back topologically sorted: dependencies first, the
+  //    requested item last.
+  let resolved: RegistryItem[];
   try {
-    item = await resolveItem(opts.name, { baseUrl: config.registry });
+    resolved = await resolveItemWithDependencies(opts.name, { baseUrl: config.registry });
   } catch (err) {
     throw new AddError(err instanceof Error ? err.message : String(err), "unknown-item");
   }
+  // `resolveItemWithDependencies` always pushes the requested item last (or throws),
+  // so the final element is the item the user asked for.
+  const item = resolved[resolved.length - 1]!;
 
   if (item.type === "hyperframes:example") {
     throw new AddError(
@@ -132,34 +178,24 @@ export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
     );
   }
 
-  const compatibility = checkRegistryItemCompatibility(item, opts.cliVersion);
-  if (compatibility.error) {
-    throw new AddError(compatibility.error, "incompatible-cli");
-  }
+  // 3. Compatibility-gate every item we're about to install (dependencies
+  //    included) before writing anything.
+  const warnings = assertCompatibleOrThrow(resolved, opts.cliVersion);
 
-  // 3. Remap targets per project config.
-  const remappedFiles = item.files.map((f) => ({
-    ...f,
-    target: remapTarget(item, f.target, config.paths),
+  // 4. Remap targets per project config — each item by its own type.
+  const installPlan: RegistryItem[] = resolved.map((resolvedItem) => ({
+    ...resolvedItem,
+    files: resolvedItem.files.map((f) => ({
+      ...f,
+      target: remapTarget(resolvedItem, f.target, config.paths),
+    })),
   }));
-  const itemForInstall: RegistryItem = { ...item, files: remappedFiles };
 
-  // 4. Install — the installer validates every target before any write.
-  let written: string[];
-  try {
-    const result = await installItem(itemForInstall, {
-      destDir: projectDir,
-      baseUrl: config.registry,
-    });
-    written = result.written;
-  } catch (err) {
-    throw new AddError(
-      `Install failed: ${err instanceof Error ? err.message : String(err)}`,
-      "install-failed",
-    );
-  }
+  // 5. Install — dependencies first, requested item last.
+  const written = await installAll(installPlan, projectDir, config.registry);
 
-  // 5. Build include snippet + clipboard copy.
+  // 6. Build include snippet + clipboard copy for the requested item.
+  const itemForInstall = installPlan[installPlan.length - 1]!;
   const primaryFile =
     itemForInstall.files.find((f) => f.type === "hyperframes:snippet") ??
     itemForInstall.files.find((f) => f.type === "hyperframes:composition") ??
@@ -174,9 +210,10 @@ export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
     type: item.type,
     typeDir: ITEM_TYPE_DIRS[item.type],
     written,
+    installed: installPlan.map((planItem) => planItem.name),
     snippet,
     clipboardCopied,
-    warnings: compatibility.warnings,
+    warnings,
   };
 }
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -16,7 +16,10 @@ import { ITEM_TYPE_DIRS, type RegistryItem } from "@hyperframes/core";
 import { c } from "../ui/colors.js";
 import { installItem, resolveItemsByTag } from "../registry/index.js";
 import { resolveItemWithDependencies } from "../registry/resolver.js";
-import { checkRegistryItemCompatibility } from "../registry/compatibility.js";
+import {
+  gateRegistryItemsCompatibility,
+  RegistryCompatibilityError,
+} from "../registry/compatibility.js";
 import {
   DEFAULT_PROJECT_CONFIG,
   loadProjectConfig,
@@ -109,19 +112,18 @@ export class AddError extends Error {
   }
 }
 
-// Compatibility-gate a set of resolved items before any install runs. Throws
-// an AddError on the first item that requires a newer CLI; otherwise returns
-// the accumulated (non-fatal) warnings from every item.
+// Compatibility-gate a set of resolved items before any install runs, mapping
+// the shared gate's error into an AddError so the command surfaces the right
+// exit code. Returns the accumulated (non-fatal) warnings from every item.
 function assertCompatibleOrThrow(items: RegistryItem[], cliVersion?: string): string[] {
-  const warnings: string[] = [];
-  for (const item of items) {
-    const compatibility = checkRegistryItemCompatibility(item, cliVersion);
-    if (compatibility.error) {
-      throw new AddError(compatibility.error, "incompatible-cli");
+  try {
+    return gateRegistryItemsCompatibility(items, cliVersion);
+  } catch (err) {
+    if (err instanceof RegistryCompatibilityError) {
+      throw new AddError(err.message, "incompatible-cli");
     }
-    warnings.push(...compatibility.warnings);
+    throw err;
   }
-  return warnings;
 }
 
 // Install a topologically-ordered plan (dependencies first, requested item

--- a/packages/cli/src/registry/compatibility.test.ts
+++ b/packages/cli/src/registry/compatibility.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { RegistryItem } from "@hyperframes/core";
-import { checkRegistryItemCompatibility } from "./compatibility.js";
+import {
+  checkRegistryItemCompatibility,
+  gateRegistryItemsCompatibility,
+  RegistryCompatibilityError,
+} from "./compatibility.js";
 
 const BASE_ITEM: RegistryItem = {
   name: "demo-block",
@@ -53,5 +57,40 @@ describe("checkRegistryItemCompatibility", () => {
       "0.6.79",
     );
     expect(result.error).toContain('declares invalid minCliVersion "next"');
+  });
+});
+
+describe("gateRegistryItemsCompatibility", () => {
+  const dep = (
+    name: string,
+    extra: { deprecated?: string; minCliVersion?: string } = {},
+  ): RegistryItem => ({
+    ...BASE_ITEM,
+    name,
+    ...extra,
+  });
+
+  it("returns no warnings when every item is compatible", () => {
+    expect(gateRegistryItemsCompatibility([dep("a"), dep("b")], "0.6.79")).toEqual([]);
+  });
+
+  it("accumulates deprecation warnings across all items", () => {
+    const warnings = gateRegistryItemsCompatibility(
+      [dep("a", { deprecated: "gone" }), dep("b"), dep("c", { deprecated: "also gone" })],
+      "0.6.79",
+    );
+    expect(warnings).toEqual([
+      'Registry item "a" is deprecated: gone',
+      'Registry item "c" is deprecated: also gone',
+    ]);
+  });
+
+  it("throws RegistryCompatibilityError on the first item requiring a newer CLI", () => {
+    expect(() =>
+      gateRegistryItemsCompatibility([dep("a"), dep("b", { minCliVersion: "999.0.0" })], "0.6.79"),
+    ).toThrow(RegistryCompatibilityError);
+    expect(() =>
+      gateRegistryItemsCompatibility([dep("a"), dep("b", { minCliVersion: "999.0.0" })], "0.6.79"),
+    ).toThrow(/requires hyperframes >= 999\.0\.0/);
   });
 });

--- a/packages/cli/src/registry/compatibility.ts
+++ b/packages/cli/src/registry/compatibility.ts
@@ -42,3 +42,37 @@ export function checkRegistryItemCompatibility(
       "or upgrade your installed hyperframes CLI.",
   };
 }
+
+/** Thrown by `gateRegistryItemsCompatibility` when an item requires a newer CLI. */
+export class RegistryCompatibilityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RegistryCompatibilityError";
+  }
+}
+
+/**
+ * Compatibility-gate a set of resolved items (e.g. an item plus its transitive
+ * `registryDependencies`) before any of them are installed. Throws a
+ * `RegistryCompatibilityError` on the first item that requires a newer CLI, so
+ * a partial install never happens; returns the accumulated (non-fatal)
+ * deprecation warnings from every item.
+ *
+ * Every install path — `add`, template fetch, and the Studio "add block"
+ * action — funnels through this so a dependency that ships `minCliVersion` is
+ * rejected uniformly, not just by `hyperframes add`.
+ */
+export function gateRegistryItemsCompatibility(
+  items: RegistryItem[],
+  currentCliVersion = VERSION,
+): string[] {
+  const warnings: string[] = [];
+  for (const item of items) {
+    const result = checkRegistryItemCompatibility(item, currentCliVersion);
+    if (result.error) {
+      throw new RegistryCompatibilityError(result.error);
+    }
+    warnings.push(...result.warnings);
+  }
+  return warnings;
+}

--- a/packages/cli/src/registry/resolver.test.ts
+++ b/packages/cli/src/registry/resolver.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { RegistryItem, RegistryManifest } from "@hyperframes/core";
-import { listRegistryItems, loadAllItems, resolveItem } from "./resolver.js";
+import {
+  listRegistryItems,
+  loadAllItems,
+  resolveItem,
+  resolveItemWithDependencies,
+} from "./resolver.js";
 
 const MANIFEST: RegistryManifest = {
   $schema: "https://hyperframes.heygen.com/schema/registry.json",
@@ -42,7 +47,14 @@ function buildItem(name: string, type: "hyperframes:example" | "hyperframes:bloc
   };
 }
 
-function mockFetch(overrides: Record<string, unknown> = {}): void {
+function mockFetch(
+  overrides: {
+    registryFails?: boolean;
+    missing?: string[];
+    /** Inject `registryDependencies` into served items, keyed by item name. */
+    dependencies?: Record<string, string[] | undefined>;
+  } = {},
+): void {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (urlInput: string | URL) => {
@@ -51,9 +63,13 @@ function mockFetch(overrides: Record<string, unknown> = {}): void {
         return new Response(JSON.stringify(MANIFEST), { status: 200 });
       }
       const m = /\/(examples|blocks|components)\/([^/]+)\/registry-item\.json$/.exec(url);
-      if (m && !(overrides.missing as string[] | undefined)?.includes(m[2]!)) {
+      if (m && !overrides.missing?.includes(m[2]!)) {
         const type = m[1] === "examples" ? "hyperframes:example" : "hyperframes:block";
-        return new Response(JSON.stringify(buildItem(m[2]!, type)), { status: 200 });
+        const item = buildItem(m[2]!, type);
+        if (overrides.dependencies && item.name in overrides.dependencies) {
+          item.registryDependencies = overrides.dependencies[item.name];
+        }
+        return new Response(JSON.stringify(item), { status: 200 });
       }
       return new Response("not found", { status: 404 });
     }),
@@ -138,6 +154,54 @@ describe("registry resolver", () => {
       );
       const baseUrl = uniqueBaseUrl();
       await expect(resolveItem("alpha", { baseUrl })).rejects.toThrow(/unreachable/);
+    });
+
+    it("refuses an item that declares registryDependencies", async () => {
+      mockFetch({ dependencies: { beta: ["alpha"] } });
+      const baseUrl = uniqueBaseUrl();
+      await expect(resolveItem("beta", { baseUrl })).rejects.toThrow(
+        /declares registryDependencies \(alpha\); use resolveItemWithDependencies/,
+      );
+    });
+  });
+
+  describe("resolveItemWithDependencies", () => {
+    it("returns dependencies first, then the requested item (linear chain)", async () => {
+      mockFetch({ dependencies: { beta: ["alpha"], gamma: ["beta"] } });
+      const baseUrl = uniqueBaseUrl();
+      const items = await resolveItemWithDependencies("gamma", { baseUrl });
+      expect(items.map((item) => item.name)).toEqual(["alpha", "beta", "gamma"]);
+    });
+
+    it("returns a single item when there are no dependencies", async () => {
+      const baseUrl = uniqueBaseUrl();
+      const items = await resolveItemWithDependencies("alpha", { baseUrl });
+      expect(items.map((item) => item.name)).toEqual(["alpha"]);
+    });
+
+    it("installs a shared transitive dependency exactly once (diamond)", async () => {
+      // gamma depends on both alpha and beta; beta also depends on alpha.
+      mockFetch({ dependencies: { gamma: ["alpha", "beta"], beta: ["alpha"] } });
+      const baseUrl = uniqueBaseUrl();
+      const items = await resolveItemWithDependencies("gamma", { baseUrl });
+      expect(items.map((item) => item.name)).toEqual(["alpha", "beta", "gamma"]);
+      expect(items.filter((item) => item.name === "alpha")).toHaveLength(1);
+    });
+
+    it("throws when a transitive dependency is missing from the registry", async () => {
+      mockFetch({ dependencies: { beta: ["does-not-exist"], gamma: ["beta"] } });
+      const baseUrl = uniqueBaseUrl();
+      await expect(resolveItemWithDependencies("gamma", { baseUrl })).rejects.toThrow(
+        /Dependency "does-not-exist" not found in registry/,
+      );
+    });
+
+    it("throws a clear cycle error for circular dependencies", async () => {
+      mockFetch({ dependencies: { alpha: ["gamma"], beta: ["alpha"], gamma: ["beta"] } });
+      const baseUrl = uniqueBaseUrl();
+      await expect(resolveItemWithDependencies("gamma", { baseUrl })).rejects.toThrow(
+        /Circular registryDependencies detected: gamma -> beta -> alpha -> gamma/,
+      );
     });
   });
 });

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -68,15 +68,53 @@ export async function loadAllItems(
 /**
  * Resolve a single item by name. Throws if unknown or unreachable.
  *
- * TODO: walk registryDependencies transitively and return a topo-sorted
- * list of items. Today examples have no deps so this returns a single item.
- * Blocks and components will need transitive resolution once they ship with
- * deps (seed items in Phase B).
+ * This is a thin guard around `resolveItemWithDependencies`: it refuses items
+ * that declare `registryDependencies`, throwing a clear error that points the
+ * caller at the dependency-aware API. That keeps single-item install paths
+ * from silently dropping a transitive dependency — any caller that wants deps
+ * installed must opt in via `resolveItemWithDependencies`.
  */
 export async function resolveItem(
   name: string,
   options: ResolveOptions = {},
 ): Promise<RegistryItem> {
+  const items = await resolveItemWithDependencies(name, options);
+  if (items.length > 1) {
+    const deps = items
+      .slice(0, -1)
+      .map((i) => i.name)
+      .join(", ");
+    throw new Error(
+      `Item "${name}" declares registryDependencies (${deps}); use resolveItemWithDependencies ` +
+        `to resolve and install them in order.`,
+    );
+  }
+  const item = items[items.length - 1];
+  if (!item) {
+    throw new Error(`Item "${name}" not found — registry unreachable or empty.`);
+  }
+  return item;
+}
+
+/**
+ * Resolve an item and all of its transitive `registryDependencies` in
+ * topological order — dependencies first, the requested item last — so callers
+ * can install the returned list front-to-back and have every prerequisite on
+ * disk before the item that needs it.
+ *
+ * Detects cycles (throws with the offending path) and missing dependencies
+ * (throws naming the absent item). Shared dependencies in a diamond graph are
+ * resolved and returned exactly once.
+ *
+ * Note: dependencies are fetched serially during the DFS walk. This keeps the
+ * cycle-detection bookkeeping (the `visiting` set) simple and correct; the
+ * registry is small enough that the extra round-trips don't matter. Switch to
+ * parallel sibling fetches only if graph depth ever becomes a real cost.
+ */
+export async function resolveItemWithDependencies(
+  name: string,
+  options: ResolveOptions = {},
+): Promise<RegistryItem[]> {
   const entries = await listRegistryItems(undefined, options);
   const entry = entries.find((e) => e.name === name);
   if (!entry) {
@@ -87,7 +125,52 @@ export async function resolveItem(
         : `Item "${name}" not found — registry unreachable or empty.`,
     );
   }
-  return fetchItemManifest(entry.name, entry.type, options.baseUrl);
+
+  const entryByName = new Map(entries.map((e) => [e.name, e]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const ordered: RegistryItem[] = [];
+  const itemCache = new Map<string, Promise<RegistryItem>>();
+
+  const getItem = (itemName: string): Promise<RegistryItem> => {
+    const existing = itemCache.get(itemName);
+    if (existing) return existing;
+
+    const registryEntry = entryByName.get(itemName);
+    if (!registryEntry) {
+      const available = entries.map((e) => e.name).join(", ");
+      throw new Error(
+        available.length > 0
+          ? `Dependency "${itemName}" not found in registry. Available: ${available}`
+          : `Dependency "${itemName}" not found — registry unreachable or empty.`,
+      );
+    }
+
+    const pending = fetchItemManifest(registryEntry.name, registryEntry.type, options.baseUrl);
+    itemCache.set(itemName, pending);
+    return pending;
+  };
+
+  const visit = async (itemName: string, path: string[]): Promise<void> => {
+    if (visited.has(itemName)) return;
+    if (visiting.has(itemName)) {
+      const cycleStart = path.indexOf(itemName);
+      const cyclePath = [...path.slice(cycleStart), itemName].join(" -> ");
+      throw new Error(`Circular registryDependencies detected: ${cyclePath}`);
+    }
+
+    visiting.add(itemName);
+    const item = await getItem(itemName);
+    for (const dep of item.registryDependencies ?? []) {
+      await visit(dep, [...path, itemName]);
+    }
+    visiting.delete(itemName);
+    visited.add(itemName);
+    ordered.push(item);
+  };
+
+  await visit(name, []);
+  return ordered;
 }
 
 /**

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -132,7 +132,11 @@ export async function resolveItemWithDependencies(
   const ordered: RegistryItem[] = [];
   const itemCache = new Map<string, Promise<RegistryItem>>();
 
-  const getItem = (itemName: string): Promise<RegistryItem> => {
+  // `async` so the missing-dependency path surfaces as a promise rejection
+  // rather than a synchronous throw, keeping the control flow consistent with
+  // the `Promise<RegistryItem>` return type. The body has no `await`, so the
+  // cache is still populated synchronously on first request (dedup intact).
+  const getItem = async (itemName: string): Promise<RegistryItem> => {
     const existing = itemCache.get(itemName);
     if (existing) return existing;
 

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -241,6 +241,39 @@ export async function loadPreviewServerBuildSignature(): Promise<string> {
   ]);
 }
 
+// Rewrite the viewport meta + inline width/height in every written .html to the
+// host composition's dimensions, so an installed fragment matches the host
+// canvas. Applies to ALL written files — including any .html a dependency ships,
+// not just the requested block's — which is intentional. No-op when the host
+// index.html is absent or carries no dimensions.
+function rewriteWrittenToHostViewport(projectDir: string, written: string[]): void {
+  const indexPath = join(projectDir, "index.html");
+  if (!existsSync(indexPath)) return;
+  const indexHtml = readFileSync(indexPath, "utf-8");
+  const hostW = indexHtml.match(/data-width="(\d+)"/)?.[1];
+  const hostH = indexHtml.match(/data-height="(\d+)"/)?.[1];
+  if (!hostW || !hostH) return;
+
+  for (const absPath of written) {
+    if (!absPath.endsWith(".html")) continue;
+    let content = readFileSync(absPath, "utf-8");
+    content = content.replace(
+      /(<meta\s+name="viewport"\s+content="width=)\d+(,\s*height=)\d+/i,
+      `$1${hostW}$2${hostH}`,
+    );
+    content = content.replace(
+      /(\bwidth:\s*)\d+(px;\s*\n?\s*height:\s*)\d+(px;)/g,
+      (match, pre, mid, post) => {
+        if (match.includes("1920") || match.includes("1080")) {
+          return `${pre}${hostW}${mid}${hostH}${post}`;
+        }
+        return match;
+      },
+    );
+    writeFileSync(absPath, content, "utf-8");
+  }
+}
+
 export function createStudioServer(options: StudioServerOptions): StudioServer {
   const { projectDir, projectName } = options;
   const projectId = projectName || basename(projectDir);
@@ -470,11 +503,16 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     async installRegistryBlock(opts) {
       const { resolveItemWithDependencies } = await import("../registry/resolver.js");
       const { installItem } = await import("../registry/installer.js");
-      const { readFileSync, writeFileSync, existsSync } = await import("node:fs");
-      const { join } = await import("node:path");
+      const { gateRegistryItemsCompatibility } = await import("../registry/compatibility.js");
       // Resolve transitive registryDependencies and install them first so a
       // block that depends on other registry items installs completely.
       const items = await resolveItemWithDependencies(opts.blockName);
+      // Compatibility-gate the whole set before writing anything (same gate as
+      // `hyperframes add`), so an incompatible block or dep aborts cleanly.
+      const warnings = gateRegistryItemsCompatibility(items);
+      for (const warning of warnings) {
+        process.stderr.write(`hyperframes:registry ${warning}\n`);
+      }
       const written: string[] = [];
       for (const dep of items) {
         const result = await installItem(dep, { destDir: opts.project.dir });
@@ -482,32 +520,7 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
       }
       const item = items[items.length - 1]!;
 
-      const indexPath = join(opts.project.dir, "index.html");
-      if (existsSync(indexPath)) {
-        const indexHtml = readFileSync(indexPath, "utf-8");
-        const hostW = indexHtml.match(/data-width="(\d+)"/)?.[1];
-        const hostH = indexHtml.match(/data-height="(\d+)"/)?.[1];
-        if (hostW && hostH) {
-          for (const absPath of written) {
-            if (!absPath.endsWith(".html")) continue;
-            let content = readFileSync(absPath, "utf-8");
-            content = content.replace(
-              /(<meta\s+name="viewport"\s+content="width=)\d+(,\s*height=)\d+/i,
-              `$1${hostW}$2${hostH}`,
-            );
-            content = content.replace(
-              /(\bwidth:\s*)\d+(px;\s*\n?\s*height:\s*)\d+(px;)/g,
-              (match, pre, mid, post) => {
-                if (match.includes("1920") || match.includes("1080")) {
-                  return `${pre}${hostW}${mid}${hostH}${post}`;
-                }
-                return match;
-              },
-            );
-            writeFileSync(absPath, content, "utf-8");
-          }
-        }
-      }
+      rewriteWrittenToHostViewport(opts.project.dir, written);
 
       const relativePaths = written.map((abs) => {
         const rel = abs.startsWith(opts.project.dir) ? abs.slice(opts.project.dir.length + 1) : abs;

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -468,12 +468,19 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     },
 
     async installRegistryBlock(opts) {
-      const { resolveItem } = await import("../registry/resolver.js");
+      const { resolveItemWithDependencies } = await import("../registry/resolver.js");
       const { installItem } = await import("../registry/installer.js");
       const { readFileSync, writeFileSync, existsSync } = await import("node:fs");
       const { join } = await import("node:path");
-      const item = await resolveItem(opts.blockName);
-      const { written } = await installItem(item, { destDir: opts.project.dir });
+      // Resolve transitive registryDependencies and install them first so a
+      // block that depends on other registry items installs completely.
+      const items = await resolveItemWithDependencies(opts.blockName);
+      const written: string[] = [];
+      for (const dep of items) {
+        const result = await installItem(dep, { destDir: opts.project.dir });
+        written.push(...result.written);
+      }
+      const item = items[items.length - 1]!;
 
       const indexPath = join(opts.project.dir, "index.html");
       if (existsSync(indexPath)) {

--- a/packages/cli/src/templates/remote.ts
+++ b/packages/cli/src/templates/remote.ts
@@ -5,7 +5,8 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { installItem, listRegistryItems, loadAllItems, resolveItem } from "../registry/index.js";
+import { installItem, listRegistryItems, loadAllItems } from "../registry/index.js";
+import { resolveItemWithDependencies } from "../registry/resolver.js";
 
 // Re-exported for the existing remote.test.ts regression guard. These paths
 // describe the repo layout under the default registry URL; updating them in
@@ -38,10 +39,16 @@ export async function listRemoteTemplates(): Promise<RemoteTemplateInfo[]> {
 
 /**
  * Download a template into destDir. Delegates to the registry installer.
+ *
+ * Resolves the template's transitive `registryDependencies` and installs them
+ * before the template itself, so a template that depends on other registry
+ * items gets a complete install rather than silently dropping its deps.
  */
 export async function fetchRemoteTemplate(templateId: string, destDir: string): Promise<void> {
-  const item = await resolveItem(templateId);
-  await installItem(item, { destDir });
+  const items = await resolveItemWithDependencies(templateId);
+  for (const item of items) {
+    await installItem(item, { destDir });
+  }
 
   // Safety check — an item with no index.html isn't a valid example.
   if (!existsSync(join(destDir, "index.html"))) {

--- a/packages/cli/src/templates/remote.ts
+++ b/packages/cli/src/templates/remote.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { installItem, listRegistryItems, loadAllItems } from "../registry/index.js";
 import { resolveItemWithDependencies } from "../registry/resolver.js";
+import { gateRegistryItemsCompatibility } from "../registry/compatibility.js";
 
 // Re-exported for the existing remote.test.ts regression guard. These paths
 // describe the repo layout under the default registry URL; updating them in
@@ -43,9 +44,17 @@ export async function listRemoteTemplates(): Promise<RemoteTemplateInfo[]> {
  * Resolves the template's transitive `registryDependencies` and installs them
  * before the template itself, so a template that depends on other registry
  * items gets a complete install rather than silently dropping its deps.
+ *
+ * Every resolved item is compatibility-gated up front (same gate as
+ * `hyperframes add`), so an incompatible template — or any of its deps —
+ * aborts before a single file is written.
  */
 export async function fetchRemoteTemplate(templateId: string, destDir: string): Promise<void> {
   const items = await resolveItemWithDependencies(templateId);
+  const warnings = gateRegistryItemsCompatibility(items);
+  for (const warning of warnings) {
+    process.stderr.write(`hyperframes:registry ${warning}\n`);
+  }
   for (const item of items) {
     await installItem(item, { destDir });
   }


### PR DESCRIPTION
## What

Resolve and install transitive `registryDependencies` for registry items. Adds `resolveItemWithDependencies` (topological DFS) and routes all three single-item install paths through it: `hyperframes add`, `hyperframes new` (`fetchRemoteTemplate`), and the Studio "add block" action.

This is a reworked, conflict-free, review-feedback-addressed version of #414 — which is stale (branched off an author fork's `main`, carries unrelated merge commits, has been merge-conflicting against `main` for ~7 weeks, and never addressed its two requested changes). This PR should **replace and close #414**.

## Why

`registryDependencies` has been declared on `RegistryItem` (`packages/core/src/registry/types.ts:62`) and in the JSON schema for a while, with an explicit TODO in the resolver to walk it — but nothing did. Every install path resolved exactly one item and silently dropped any dependencies it declared:

- `runAdd` (`hyperframes add`)
- `fetchRemoteTemplate` (`hyperframes new` / init template install) — flagged in #414's review
- `installRegistryBlock` (Studio "add block")

No catalog item ships deps *today*, so this scaffolds the install path before they do (the correct order). The first dep-bearing item would otherwise produce a silently incomplete install with no error or warning.

## How

- **`resolveItemWithDependencies(name, options)`** in `registry/resolver.ts`: DFS topological sort (dependencies first, requested item last) with cycle detection (throws with the offending path), missing-dependency errors (names the absent item), an item cache, and diamond dedup (a shared dep appears exactly once). Deps are fetched serially — a comment notes this is deliberate to keep the cycle bookkeeping simple; the registry is small.
- **`resolveItem`** becomes a thin guard: it throws if the item declares deps, pointing callers at the plural API. This removes the silent-discard footgun for *all* current and future single-item callers (directly addresses #414's review concern that the second caller — `fetchRemoteTemplate` — silently dropped deps).
- **`runAdd`** resolves deps, compatibility-gates every item before any write, installs in topo order, and returns an ordered `installed: string[]`. Extracted `assertCompatibleOrThrow` / `installAll` helpers keep it under the complexity gate.
- **`fetchRemoteTemplate`** and **`installRegistryBlock`** now install the full resolved list.

Review feedback from #414 (James + Vai), addressed here:
- ✅ `fetchRemoteTemplate` no longer silently discards deps *(required)*
- ✅ no out-of-scope `IMPROVEMENT_OPPORTUNITIES.md` / unrelated merge commits *(required)*
- ✅ dead null-checks dropped (`resolved[resolved.length - 1]!`)
- ✅ diamond-dependency test added
- ✅ serial-fetch tradeoff documented in a comment
- ➕ also fixed the third silent-discard path (`installRegistryBlock`), which the original PR didn't touch

I did **not** add a `remote.test.ts` dependency test: `fetchRemoteTemplate` can't pass `skipCache`, and the manifest/item cache is on-disk keyed by URL (`fetchItemManifest` reads it unconditionally), so such a test is flaky on any machine that's used the real CLI. The shared `resolveItemWithDependencies` engine — which `fetchRemoteTemplate` just loops over — is fully covered by the resolver tests.

## Test plan

How was this tested?

- [x] Unit tests added/updated — `resolver.test.ts`: linear-chain ordering, single-item (no deps), diamond dedup, missing transitive dep, cycle detection, and the `resolveItem` throw-on-deps guard. `add.test.ts`: transitive deps installed before the requested item with the correct `installed` order + files on disk.
- [x] Full CLI suite green (`bunx vitest run` → 741 passing), plus `tsc --noEmit`, `oxlint`, `oxfmt --check`, and `fallow audit --fail-on-issues` all clean.
- [ ] Manual testing performed — N/A (no catalog item declares deps yet; covered by unit tests against a mocked registry)

---
Co-authored with the original #414 author (@rakibulism), credited via `Co-authored-by` on the commit — the core DFS/cycle-detection algorithm is theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)