### PR TITLE
test(core): fix contradictory composition-discovery file-tree test (#1385)

### DIFF
--- a/packages/core/src/studio-api/routes/projects.test.ts
+++ b/packages/core/src/studio-api/routes/projects.test.ts
@@ -17,14 +17,22 @@ afterEach(() => {
 const COMPOSITION_HTML = '<html><body><div data-composition-id="main"></div></body></html>';
 
 // Project layout for #1384: real compositions at the root and under
-// compositions/, plus vendored example HTML inside dot-directories that
-// must not surface as compositions.
+// compositions/, plus two kinds of dot-directory content that exercise
+// discovery gating differently:
+//   - .cache/        a vendored dot-directory. walkDir does NOT special-case it,
+//                    so its HTML stays listed in the file tree, but it must be
+//                    gated out of composition discovery by isInHiddenOrVendorDir.
+//   - .hyperframes/  Studio's own internal directory (backups, etc.) — already in
+//                    walkDir's IGNORE_DIRS, so it is hidden from the file tree
+//                    entirely (and therefore from compositions too).
 function createProjectDir(): string {
   const projectDir = mkdtempSync(join(tmpdir(), "hf-projects-test-"));
   tempDirs.push(projectDir);
   writeFileSync(join(projectDir, "index.html"), COMPOSITION_HTML);
   mkdirSync(join(projectDir, "compositions"));
   writeFileSync(join(projectDir, "compositions", "scene.html"), COMPOSITION_HTML);
+  mkdirSync(join(projectDir, ".cache", "examples"), { recursive: true });
+  writeFileSync(join(projectDir, ".cache", "examples", "preset.html"), COMPOSITION_HTML);
   mkdirSync(join(projectDir, ".hyperframes", "examples"), { recursive: true });
   writeFileSync(join(projectDir, ".hyperframes", "examples", "preset.html"), COMPOSITION_HTML);
   return projectDir;
@@ -59,10 +67,11 @@ describe("registerProjectRoutes — composition discovery (#1384)", () => {
     expect(response.status).toBe(200);
     expect(payload.compositions).toContain("index.html");
     expect(payload.compositions).toContain("compositions/scene.html");
+    expect(payload.compositions).not.toContain(".cache/examples/preset.html");
     expect(payload.compositions).not.toContain(".hyperframes/examples/preset.html");
   });
 
-  it("keeps dot-directory files visible in the file tree", async () => {
+  it("lists vendored dot-directory files in the file tree but hides Studio-internal ones", async () => {
     const projectDir = createProjectDir();
     const app = new Hono();
     registerProjectRoutes(app, createAdapter(projectDir));
@@ -70,6 +79,9 @@ describe("registerProjectRoutes — composition discovery (#1384)", () => {
     const response = await app.request("http://localhost/projects/demo");
     const payload = (await response.json()) as { files?: string[] };
 
-    expect(payload.files).toContain(".hyperframes/examples/preset.html");
+    // Vendored dot-dirs stay browsable — discovery is gated, the file tree is not.
+    expect(payload.files).toContain(".cache/examples/preset.html");
+    // Studio's internal dir is hidden from the tree entirely (walkDir IGNORE_DIRS).
+    expect(payload.files).not.toContain(".hyperframes/examples/preset.html");
   });
 });


### PR DESCRIPTION
## What

`main` is currently **red** — `CI / Test` (and `Tests on windows-latest`) have failed on every commit since #1385 (b952dc9c). This makes one test consistent with the implementation, restoring a green `main`. **Test-only; no production code changes.**

```
b952dc9c  (#1385)        Test: FAILURE   Tests on windows-latest: FAILURE   ← introduced
84a56986  (main HEAD)    Test: FAILURE   Tests on windows-latest: FAILURE
aec3c3b5  (before #1385) success
```

## Why

#1385's commit message states *"walkDir only skipped three exact names (.thumbnails, node_modules, .git)"* — but `.hyperframes` had **already** been added to `walkDir`'s `IGNORE_DIRS` by the backup feature (which has its own passing `walkDir` test: *"hides internal HyperFrames backup files from project listings"*).

Working from that stale assumption, #1385 added:

```ts
it("keeps dot-directory files visible in the file tree", async () => {
  // creates .hyperframes/examples/preset.html
  expect(payload.files).toContain(".hyperframes/examples/preset.html");
});
```

`projects.ts` builds `files = walkDir(project.dir)`, and `walkDir` filters `.hyperframes` — so `files` can **never** contain it. The assertion is impossible, the test failed, and #1385 merged red anyway.

The implementation is actually coherent. `.hyperframes` is special-cased as hidden; *other* dot-dirs (`.cache`, …) stay in the file tree but are gated out of composition discovery by `isInHiddenOrVendorDir`. The test simply picked the one dot-dir that's hidden, so it never exercised the gating it was meant to verify.

## How (test-only)

- Add a genuinely-vendored dot-dir fixture `.cache/examples/preset.html`. `walkDir` does **not** special-case `.cache`, so it stays listed in the file tree but must be excluded from compositions by `isInHiddenOrVendorDir` — exactly what #1385 targets, now actually exercised.
- Keep `.hyperframes/examples/preset.html` and assert it's **hidden from the file tree** (`IGNORE_DIRS`), documenting the deliberate split between Studio-internal dirs (backups) and browsable vendored dot-dirs so the two features don't silently collide again.
- The backup feature's `walkDir` test is untouched.

## Test plan

- [x] `projects.test.ts` now passes (2/2); `safePath.test.ts` walkDir test and `lint.test.ts` still pass.
- [x] Full `bun run --filter '!@hyperframes/producer' test` suite is green (exit 0); `tsc --noEmit`, `oxlint`, `oxfmt --check` clean.
- [ ] Docs — n/a

> Note: this unblocks every open PR, since GitHub merge-tests each PR against `main`. Found while diagnosing red CI on #1397/#1398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)