### PR TITLE
test(core): align file-tree test with backup-only hiding (#1366)

### DIFF
--- a/packages/core/src/studio-api/routes/projects.test.ts
+++ b/packages/core/src/studio-api/routes/projects.test.ts
@@ -17,14 +17,15 @@ afterEach(() => {
 const COMPOSITION_HTML = '<html><body><div data-composition-id="main"></div></body></html>';
 
 // Project layout for #1384: real compositions at the root and under
-// compositions/, plus two kinds of dot-directory content that exercise
-// discovery gating differently:
-//   - .cache/        a vendored dot-directory. walkDir does NOT special-case it,
-//                    so its HTML stays listed in the file tree, but it must be
-//                    gated out of composition discovery by isInHiddenOrVendorDir.
-//   - .hyperframes/  Studio's own internal directory (backups, etc.) — already in
-//                    walkDir's IGNORE_DIRS, so it is hidden from the file tree
-//                    entirely (and therefore from compositions too).
+// compositions/, plus dot-directory content that exercises discovery gating
+// and the file tree's backup-only hiding (#1366):
+//   - .cache/examples/        a vendored dot-dir. walkDir does NOT special-case
+//                             it, so it stays listed in the file tree, but it is
+//                             gated out of composition discovery (isInHiddenOrVendorDir).
+//   - .hyperframes/examples/  vendored under Studio's dir — also listed in the
+//                             file tree, also gated out of discovery.
+//   - .hyperframes/backup/    Studio's internal snapshots — the only thing hidden
+//                             from the file tree (walkDir's shouldIgnoreDir).
 function createProjectDir(): string {
   const projectDir = mkdtempSync(join(tmpdir(), "hf-projects-test-"));
   tempDirs.push(projectDir);
@@ -35,6 +36,8 @@ function createProjectDir(): string {
   writeFileSync(join(projectDir, ".cache", "examples", "preset.html"), COMPOSITION_HTML);
   mkdirSync(join(projectDir, ".hyperframes", "examples"), { recursive: true });
   writeFileSync(join(projectDir, ".hyperframes", "examples", "preset.html"), COMPOSITION_HTML);
+  mkdirSync(join(projectDir, ".hyperframes", "backup"), { recursive: true });
+  writeFileSync(join(projectDir, ".hyperframes", "backup", "snapshot.html"), COMPOSITION_HTML);
   return projectDir;
 }
 
@@ -71,7 +74,7 @@ describe("registerProjectRoutes — composition discovery (#1384)", () => {
     expect(payload.compositions).not.toContain(".hyperframes/examples/preset.html");
   });
 
-  it("lists vendored dot-directory files in the file tree but hides Studio-internal ones", async () => {
+  it("lists vendored dot-directory files in the file tree but hides Studio backups", async () => {
     const projectDir = createProjectDir();
     const app = new Hono();
     registerProjectRoutes(app, createAdapter(projectDir));
@@ -81,7 +84,8 @@ describe("registerProjectRoutes — composition discovery (#1384)", () => {
 
     // Vendored dot-dirs stay browsable — discovery is gated, the file tree is not.
     expect(payload.files).toContain(".cache/examples/preset.html");
-    // Studio's internal dir is hidden from the tree entirely (walkDir IGNORE_DIRS).
-    expect(payload.files).not.toContain(".hyperframes/examples/preset.html");
+    expect(payload.files).toContain(".hyperframes/examples/preset.html");
+    // Only Studio's own backup snapshots are hidden from the tree (#1366).
+    expect(payload.files).not.toContain(".hyperframes/backup/snapshot.html");
   });
 });


### PR DESCRIPTION
## What

`main` is **red again** at `e2cc134c`. This restores green. **Test-only.**

```
e2cc134c  (#1399)   Test: FAILURE   ← current main HEAD
5f12e692  (#1366)   Test: success
```

## Why — my own #1399 regressed it

#1366 (5f12e692, green) is the authoritative fix for #1384: it refined `walkDir` to hide **only** `.hyperframes/backup` (`shouldIgnoreDir`) and removed `.hyperframes` from `IGNORE_DIRS`, so `.hyperframes/examples` — like any vendored dot-dir — stays visible in the file tree and is gated out of *composition discovery* by `isInHiddenOrVendorDir`. Its test asserted exactly that.

My #1399 branched off the **older** `84a56986` (where `.hyperframes` was wholesale-hidden) and rewrote `projects.test.ts` to assert `.hyperframes/examples` is *hidden*. When #1399 merged on top of #1366, it clobbered #1366's corrected test, and the assertion now contradicts `shouldIgnoreDir` → red. My bad.

## How (test-only)

Align the file-tree test with #1366's behavior:
- `.cache/examples/preset.html` **and** `.hyperframes/examples/preset.html` are both **visible** in `files` (kept the `.cache` fixture from #1399 — it genuinely exercises `isInHiddenOrVendorDir` gating for a non-special dot-dir).
- `.hyperframes/backup/snapshot.html` is the **only** thing hidden from the tree.
- Composition discovery still excludes every dot-dir example.

No production code changes; the `walkDir` "hides backups" test is untouched.

## Test plan

- [x] `projects.test.ts` (2/2), `safePath.test.ts`, `lint.test.ts` pass.
- [x] Full `bun run --filter '!@hyperframes/producer' test` green (exit 0); `oxlint` / `oxfmt --check` clean.

> Unblocks `main` (red blocks every PR's merge-test). #1397/#1398 rebase on top once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)