### PR TITLE
fix(core): restore backup-only file-tree hiding reverted by #1389

### DIFF
--- a/packages/core/src/studio-api/helpers/safePath.test.ts
+++ b/packages/core/src/studio-api/helpers/safePath.test.ts
@@ -19,7 +19,7 @@ function createProjectDir(): string {
 }
 
 describe("walkDir", () => {
-  it("hides internal HyperFrames files from project listings", () => {
+  it("hides only internal HyperFrames backups, not vendored dot-directory files", () => {
     const projectDir = createProjectDir();
     mkdirSync(join(projectDir, ".hyperframes", "backup"), { recursive: true });
     mkdirSync(join(projectDir, ".hyperframes", "examples"), { recursive: true });
@@ -31,9 +31,11 @@ describe("walkDir", () => {
     writeFileSync(join(projectDir, "compositions", "scene.html"), "scene");
 
     const files = walkDir(projectDir);
+    // Vendored dot-dir files stay browsable in the file tree (#1366) — only
+    // Studio's own backup snapshots are hidden (shouldIgnoreDir).
     expect(files).toContain(".cache/examples/preset.html");
+    expect(files).toContain(".hyperframes/examples/preset.html");
     expect(files).toContain("compositions/scene.html");
     expect(files).not.toContain(".hyperframes/backup/snapshot.html");
-    expect(files).not.toContain(".hyperframes/examples/preset.html");
   });
 });

--- a/packages/core/src/studio-api/helpers/safePath.ts
+++ b/packages/core/src/studio-api/helpers/safePath.ts
@@ -6,7 +6,11 @@ import { readdirSync } from "node:fs";
 // Re-exported here for back-compat with existing `../helpers/safePath.js` imports.
 export { isSafePath } from "../../safePath.js";
 
-const IGNORE_DIRS = new Set([".thumbnails", ".hyperframes", "node_modules", ".git"]);
+const IGNORE_DIRS = new Set([".thumbnails", "node_modules", ".git"]);
+
+function shouldIgnoreDir(rel: string): boolean {
+  return rel === ".hyperframes/backup";
+}
 
 /**
  * True when any directory segment of a relative path is a dot-directory or
@@ -25,7 +29,7 @@ export function walkDir(dir: string, prefix = ""): string[] {
   const files: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
-    if (IGNORE_DIRS.has(entry.name)) continue;
+    if (IGNORE_DIRS.has(entry.name) || shouldIgnoreDir(rel)) continue;
     if (entry.isDirectory()) {
       files.push(...walkDir(join(dir, entry.name), rel));
     } else {


### PR DESCRIPTION
## What

`main` is **red** (`CI / Test`) and has been since **#1389** (3bcab3dc). This restores green. Small, mostly test-only (2-line helper change).

```
953bab31  (#1397)  Test: FAILURE   ← current main
3bcab3dc  (#1389)  Test: FAILURE   ← regression introduced here
ab7f69c1  (#1400)  green
```

## Why

#1389 ("reject unsafe keyframe values") is unrelated to studio composition discovery, but it branched off **pre-#1366** `main` and its squash **reverted #1366's `walkDir` refinement**: `.hyperframes` went back into `IGNORE_DIRS` and `shouldIgnoreDir` was dropped, so the entire `.hyperframes/` tree is hidden again instead of just `.hyperframes/backup`.

That breaks #1366's intent (vendored dot-directory HTML stays browsable in the file tree, gated only out of *composition discovery*), so the file-tree test from #1400 fails on `main`. The helper and the `walkDir` test ended up in the "hide-all-`.hyperframes`" world while `projects.test.ts` (#1400) is in the "hide-only-backup" world — an incoherent mix.

## How

Restore #1366's behavior, **keeping #1397's `isSafePath` promotion**:
- `IGNORE_DIRS` → `.thumbnails` / `node_modules` / `.git` (drop `.hyperframes`).
- Reinstate `shouldIgnoreDir(rel) === ".hyperframes/backup"` + the `|| shouldIgnoreDir(rel)` guard in `walkDir`.
- Realign the `walkDir` test to assert `.hyperframes/examples` stays visible and only `.hyperframes/backup` is hidden.

## Test plan

- [x] `projects.test.ts`, `safePath.test.ts` (walkDir), `lint.test.ts` pass.
- [x] Full `bun run --filter '!@hyperframes/producer' test` green (exit 0); `oxlint` / `oxfmt --check` clean.

> ⚠️ `studio-api/helpers/safePath.ts` is a recurring conflict hotspot — #1366's fix has now been reverted **twice** by stale-base PRs (#1389, and earlier #1399). Worth rebasing in-flight branches onto current `main` before squashing. Unblocks everyone (red `main` fails every PR's merge-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)