### PR TITLE
fix(player): remove host listeners in controls destroy

### DIFF
--- a/packages/player/src/controls.test.ts
+++ b/packages/player/src/controls.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { type ControlsCallbacks, createControls } from "./controls";
+
+function noopCallbacks(): ControlsCallbacks {
+  return {
+    onPlay: () => {},
+    onPause: () => {},
+    onSeek: () => {},
+    onSpeedChange: () => {},
+    onMuteToggle: () => {},
+    onVolumeChange: () => {},
+  };
+}
+
+describe("createControls host listeners", () => {
+  it("removes every host listener it added on destroy", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const addSpy = vi.spyOn(host, "addEventListener");
+    const removeSpy = vi.spyOn(host, "removeEventListener");
+
+    const api = createControls(host, noopCallbacks());
+
+    // Capture the exact handler references registered on the host element.
+    const added = new Map<string, EventListenerOrEventListenerObject>();
+    for (const [type, handler] of addSpy.mock.calls) {
+      added.set(type, handler as EventListenerOrEventListenerObject);
+    }
+    expect(added.has("mousemove")).toBe(true);
+    expect(added.has("mouseleave")).toBe(true);
+
+    api.destroy();
+
+    // Each host listener must be torn down with the same reference; anonymous
+    // handlers (the previous bug) could never be removed, so toggling the
+    // `controls` attribute leaked a duplicate pair on every cycle.
+    for (const [type, handler] of added) {
+      expect(removeSpy).toHaveBeenCalledWith(type, handler);
+    }
+
+    host.remove();
+  });
+
+  it("stops reacting to host mousemove after destroy", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const api = createControls(host, noopCallbacks());
+    const controls = host.querySelector<HTMLElement>(".hfp-controls");
+    expect(controls).not.toBeNull();
+
+    api.destroy();
+
+    // A mousemove after destroy must not revive the controls overlay.
+    controls!.classList.add("hfp-hidden");
+    host.dispatchEvent(new Event("mousemove"));
+    expect(controls!.classList.contains("hfp-hidden")).toBe(true);
+
+    host.remove();
+  });
+});

--- a/packages/player/src/controls.ts
+++ b/packages/player/src/controls.ts
@@ -330,13 +330,15 @@ export function createControls(
   };
 
   const host = parent instanceof ShadowRoot ? (parent.host as HTMLElement) : parent;
-  host.addEventListener("mousemove", () => {
+  const onHostMouseMove = () => {
     controls.classList.remove("hfp-hidden");
     startHideTimer();
-  });
-  host.addEventListener("mouseleave", () => {
+  };
+  const onHostMouseLeave = () => {
     if (isPlaying) controls.classList.add("hfp-hidden");
-  });
+  };
+  host.addEventListener("mousemove", onHostMouseMove);
+  host.addEventListener("mouseleave", onHostMouseLeave);
 
   return {
     updateTime(current: number, duration: number) {
@@ -389,6 +391,8 @@ export function createControls(
       document.removeEventListener("touchmove", onVolumeTouchMove);
       document.removeEventListener("touchend", onVolumeTouchEnd);
       document.removeEventListener("click", onDocClick);
+      host.removeEventListener("mousemove", onHostMouseMove);
+      host.removeEventListener("mouseleave", onHostMouseLeave);
       if (hideTimeout) clearTimeout(hideTimeout);
     },
   };


### PR DESCRIPTION
## Problem

`createControls` attaches `mousemove` and `mouseleave` listeners to the host element to drive the controls auto-hide, but `destroy()` only removed the `document`-level listeners. The host handlers were also anonymous, so they could not have been removed even if `destroy()` tried.

When the `controls` attribute is toggled off then on, `attributeChangedCallback` calls `destroy()` and then re-runs `createControls` on the same persistent host. Every cycle leaks a duplicate `mousemove`/`mouseleave` pair. The stale and fresh handlers then fight over the `hfp-hidden` class, so the overlay flickers on mouse movement instead of hiding cleanly after the idle timeout.

## Fix

Name the two host handlers and remove them in `destroy()`, mirroring how the `document` listeners are already torn down. These were the only listeners `createControls` adds to the host, so this closes the leak fully.

## Tests

Adds `controls.test.ts`:
- asserts every listener added to the host is removed with the same reference on `destroy()` (fails against the old anonymous handlers, which were never removed),
- a behavioral test that a `mousemove` after `destroy()` no longer revives the overlay.

Full player suite green (139 tests).