### PR TITLE
fix(player): clean up controls on destroy

### DIFF
--- a/packages/player/src/controls.test.ts
+++ b/packages/player/src/controls.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { type ControlsCallbacks, createControls } from "./controls";
+
+function noopCallbacks(): ControlsCallbacks {
+  return {
+    onPlay: () => {},
+    onPause: () => {},
+    onSeek: () => {},
+    onSpeedChange: () => {},
+    onMuteToggle: () => {},
+    onVolumeChange: () => {},
+  };
+}
+
+describe("createControls host listeners", () => {
+  it("removes every host listener it added on destroy", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const addSpy = vi.spyOn(host, "addEventListener");
+    const removeSpy = vi.spyOn(host, "removeEventListener");
+
+    const api = createControls(host, noopCallbacks());
+
+    // Capture the exact handler references registered on the host element.
+    const added = new Map<string, EventListenerOrEventListenerObject>();
+    for (const [type, handler] of addSpy.mock.calls) {
+      added.set(type, handler as EventListenerOrEventListenerObject);
+    }
+    expect(added.has("mousemove")).toBe(true);
+    expect(added.has("mouseleave")).toBe(true);
+
+    api.destroy();
+
+    // Each host listener must be torn down with the same reference; anonymous
+    // handlers (the previous bug) could never be removed, so toggling the
+    // `controls` attribute leaked a duplicate pair on every cycle.
+    for (const [type, handler] of added) {
+      expect(removeSpy).toHaveBeenCalledWith(type, handler);
+    }
+
+    host.remove();
+  });
+
+  it("stops reacting to host mousemove after destroy", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const api = createControls(host, noopCallbacks());
+    const controls = host.querySelector<HTMLElement>(".hfp-controls");
+    expect(controls).not.toBeNull();
+
+    api.destroy();
+
+    // A mousemove after destroy must not revive the controls overlay.
+    controls!.classList.add("hfp-hidden");
+    host.dispatchEvent(new Event("mousemove"));
+    expect(controls!.classList.contains("hfp-hidden")).toBe(true);
+
+    host.remove();
+  });
+
+  it("removes its controls element from the host on destroy", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const api = createControls(host, noopCallbacks());
+    const controls = host.querySelector<HTMLElement>(".hfp-controls");
+    expect(controls).not.toBeNull();
+
+    api.destroy();
+
+    expect(host.querySelector(".hfp-controls")).toBeNull();
+    expect(controls!.isConnected).toBe(false);
+
+    host.remove();
+  });
+});

--- a/packages/player/src/controls.ts
+++ b/packages/player/src/controls.ts
@@ -330,13 +330,15 @@ export function createControls(
   };
 
   const host = parent instanceof ShadowRoot ? (parent.host as HTMLElement) : parent;
-  host.addEventListener("mousemove", () => {
+  const onHostMouseMove = () => {
     controls.classList.remove("hfp-hidden");
     startHideTimer();
-  });
-  host.addEventListener("mouseleave", () => {
+  };
+  const onHostMouseLeave = () => {
     if (isPlaying) controls.classList.add("hfp-hidden");
-  });
+  };
+  host.addEventListener("mousemove", onHostMouseMove);
+  host.addEventListener("mouseleave", onHostMouseLeave);
 
   return {
     updateTime(current: number, duration: number) {
@@ -389,7 +391,10 @@ export function createControls(
       document.removeEventListener("touchmove", onVolumeTouchMove);
       document.removeEventListener("touchend", onVolumeTouchEnd);
       document.removeEventListener("click", onDocClick);
+      host.removeEventListener("mousemove", onHostMouseMove);
+      host.removeEventListener("mouseleave", onHostMouseLeave);
       if (hideTimeout) clearTimeout(hideTimeout);
+      controls.remove();
     },
   };
 }

--- a/packages/player/src/hyperframes-player.test.ts
+++ b/packages/player/src/hyperframes-player.test.ts
@@ -1467,6 +1467,19 @@ describe("HyperframesPlayer volume and mute", () => {
     expect(slider.getAttribute("tabindex")).toBe("0");
   });
 
+  it("removes and recreates one controls bar when the controls attribute toggles", () => {
+    document.body.appendChild(player);
+
+    player.setAttribute("controls", "");
+    expect(player.shadowRoot!.querySelectorAll(".hfp-controls")).toHaveLength(1);
+
+    player.removeAttribute("controls");
+    expect(player.shadowRoot!.querySelectorAll(".hfp-controls")).toHaveLength(0);
+
+    player.setAttribute("controls", "");
+    expect(player.shadowRoot!.querySelectorAll(".hfp-controls")).toHaveLength(1);
+  });
+
   it("dispatches volumechange when muted toggles (HTML5 spec)", () => {
     document.body.appendChild(player);
 


### PR DESCRIPTION
## Problem

`createControls()` owned more than document-level listeners. It also appended a `.hfp-controls` root into the player shadow tree and registered host-level auto-hide listeners. When the `controls` attribute was removed, `<hyperframes-player>` called `destroy()` and nulled the API, but the old controls DOM stayed attached. Re-adding `controls` then created another controls bar on the same persistent host.

## What this fixes

- Removes the host `mousemove` / `mouseleave` listeners with stable handler references.
- Removes the owned `.hfp-controls` element during `destroy()`, so element-scoped listeners and UI do not survive a controls teardown.
- Adds low-level controls tests plus a `<hyperframes-player>` attribute lifecycle test that proves toggling `controls` off/on leaves exactly one controls bar.

## Root cause

`destroy()` treated only document-level listeners and timers as teardown work. The controls root was still referenced by the shadow DOM after `destroy()`, so toggling the attribute left stale controls UI and its element listeners behind. The host auto-hide handlers were also anonymous before #1405, so they could not be removed with matching references.

## Verification

### Local checks

- `bun run --cwd packages/player test src/controls.test.ts src/hyperframes-player.test.ts`
- `bunx oxlint packages/player/src/controls.ts packages/player/src/controls.test.ts packages/player/src/hyperframes-player.test.ts`
- `bunx oxfmt --check packages/player/src/controls.ts packages/player/src/controls.test.ts packages/player/src/hyperframes-player.test.ts`
- `bun run --cwd packages/player test`
- `bun run --cwd packages/player typecheck`
- `bun run --cwd packages/player build`
- `bun run build:hyperframes-runtime` to satisfy the root pre-commit typecheck dependency on generated runtime inline artifacts
- `git commit --amend` pre-commit hook: lint, format, fallow, typecheck, commitlint passed

### Browser verification

`agent-browser` loaded a minimal real `<hyperframes-player controls>` page against built player bundles and toggled the `controls` attribute.

Before the full cleanup on `main` / original #1405 state, the repro showed stale lifecycle state:

```json
{
  "before": 1,
  "afterRemove": 1,
  "hiddenAfterDestroyedMousemove": false,
  "afterReadd": 2
}
```

After this fix:

```json
{
  "before": 1,
  "afterRemove": 0,
  "hiddenAfterDestroyedMousemove": true,
  "afterReadd": 1
}
```

### Browser artifacts

- Screenshot: `/tmp/pr1405-fixed-browser.png`
- Recording: `/tmp/pr1405-fixed-browser.webm`

## Notes

Supersedes #1405. I could not push directly to the contributor fork from this checkout even though the PR reports `maintainerCanModify: true`, so this branch carries the same fix forward on the upstream repo with the root DOM cleanup included.