### PR TITLE
docs(registry): document installer metadata

### DIFF
--- a/docs/contributing/catalog.mdx
+++ b/docs/contributing/catalog.mdx
@@ -81,6 +81,29 @@ registry/blocks/my-block/
 }
 ```
 
+### Optional installer metadata
+
+Most registry items only need the fields above. Add these optional fields when
+the installer needs extra context:
+
+```json
+{
+  "minCliVersion": "0.6.96",
+  "registryDependencies": ["grain-overlay"],
+  "deprecated": "Use `my-block-v2` instead."
+}
+```
+
+- `minCliVersion` — use this when the item depends on a HyperFrames CLI/runtime
+  feature added in a recent release. The installer uses it to stop incompatible
+  installs before writing files and guide users to upgrade.
+- `registryDependencies` — list other registry item names that must be installed
+  first. Dependencies are resolved transitively; keep the graph small, reference
+  exact item names, and avoid cycles.
+- `deprecated` — show a warning during install while keeping the item available
+  for existing projects. Include a short migration note when there is a better
+  replacement.
+
 ## The Rules
 
 Five things that must be true for every registry item:

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -217,6 +217,8 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
 
     `add` reads [`hyperframes.json`](#hyperframes-json) at the project root to know which registry to pull from and where to drop files. If the file is missing but the directory looks like a Hyperframes project (has `index.html`), a default `hyperframes.json` is written the first time you run `add`.
 
+    If a registry item declares `registryDependencies`, `add` resolves them transitively and installs dependencies before the requested item. Compatibility metadata is checked for every resolved item before any files are written: `minCliVersion` stops incompatible installs with upgrade guidance, while `deprecated` shows a warning and still installs.
+
     Output for a block or component is a set of files plus a **paste snippet** — the `<iframe>` tag (for blocks) or the fragment path (for components) to include in your host composition. The snippet is copied to the clipboard by default; add `--no-clipboard` for CI or headless environments.
 
     Trying `add` with an example's name (e.g. `hyperframes add warm-grain`) emits a clear error pointing you at `init --example`.


### PR DESCRIPTION
## Summary

Documents registry item metadata that is already supported by the installer:

- `registryDependencies` for transitive registry installs
- `minCliVersion` for compatibility checks before files are written
- `deprecated` for install-time warnings

This keeps the catalog contribution guide and CLI docs aligned with the current registry installer behavior.

## Testing

- `bun run sync-schemas:check`
- `git diff --check`