### PR TITLE
fix(studio): surface save failures when deleting all animations for an element

### DIFF
--- a/packages/studio/src/hooks/useGsapScriptCommits.ts
+++ b/packages/studio/src/hooks/useGsapScriptCommits.ts
@@ -287,13 +287,13 @@ export function useGsapScriptCommits({
   );
   const deleteAllForSelector = useCallback(
     (selection: DomEditSelection, targetSelector: string) => {
-      void commitMutation(
+      commitMutationSafely(
         selection,
         { type: "delete-all-for-selector", targetSelector },
         { label: "Delete all animations for element" },
       );
     },
-    [commitMutation],
+    [commitMutationSafely],
   );
   const addGsapAnimation = useCallback(
     // fallow-ignore-next-line complexity


### PR DESCRIPTION
## Problem

`deleteAllForSelector` in `useGsapScriptCommits` fired its mutation with `void commitMutation(...)`:

```ts
void commitMutation(
  selection,
  { type: "delete-all-for-selector", targetSelector },
  { label: "Delete all animations for element" },
);
```

A failed "Delete all animations for element" was therefore swallowed — no error toast and no `trackGsapSaveFailure` telemetry — leaving the user believing the operation succeeded. Every sibling mutation in the hook (`deleteGsapAnimation`, `removeGsapProperty`, `removeAllKeyframes`, `updateGsapProperty`, …) routes through `commitMutationSafely`, which `.catch`es the rejection, records `trackGsapSaveFailure`, and shows an error toast. This one handler was the only mutation that did not.

## Fix

Route `deleteAllForSelector` through `commitMutationSafely`, matching its siblings. It is a single user action (one context-menu invocation per element), so the failure toast fires at most once — no spam.

## Notes

- Swept the hook and the rest of `studio/src` for the same fire-and-forget pattern: this was the only user-facing mutation that surfaced nothing. The remaining bare `commitMutation` calls either return the promise for the caller to handle or have their own `.catch(trackGsapSaveFailure)`.
- No test added: there is no existing render harness for this hook, and the change is a one-line routing fix to the already-used `commitMutationSafely` wrapper that ~10 sibling handlers rely on.