### PR TITLE
fix(studio): disable the rotation field when the element can't be rotated

### DIFF
--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -144,6 +144,7 @@ export const PropertyPanel = memo(function PropertyPanel({
 
   const manualOffsetEditingDisabled = !element.capabilities.canApplyManualOffset;
   const manualSizeEditingDisabled = !element.capabilities.canApplyManualSize;
+  const manualRotationEditingDisabled = !element.capabilities.canApplyManualRotation;
   const sourceLabel = element.id ? `#${element.id}` : element.selector;
   const showEditableSections = element.capabilities.canEditStyles;
   const manualOffset = readStudioPathOffset(element.element);
@@ -495,6 +496,7 @@ export const PropertyPanel = memo(function PropertyPanel({
                 <MetricField
                   label="R"
                   value={`${displayR}°`}
+                  disabled={manualRotationEditingDisabled}
                   onCommit={(next) => commitManualRotation(next.replace("°", ""))}
                 />
               </div>


### PR DESCRIPTION
## Problem

In the PropertyPanel transform section, X/Y and W/H disable themselves when the element lacks the matching capability:

```tsx
<MetricField label="X" disabled={manualOffsetEditingDisabled} ... />
<MetricField label="W" disabled={manualSizeEditingDisabled} ... />
```

The rotation field "R" had no `disabled` guard at all. So on an element where `canApplyManualRotation` is false (locked composition, script-generated, composition root/host), you could still type a rotation into the R field, even though that same capability already gates:
- the rotate gesture (`domEditOverlayStartGesture.ts:110`), and
- the overlay rotate button (`DomEditOverlay.tsx:414`).

## Fix

Add `manualRotationEditingDisabled = !element.capabilities.canApplyManualRotation` and apply it to the R field, matching the sibling fields and the gesture/overlay gating.

## Notes

- Scope is the manual rotation field only. The rotation **keyframe** path below it (`KeyframeNavigation`) is a separate concern, already gated by `STUDIO_KEYFRAMES_ENABLED && gsapAnimId`.
- No test added: the existing `PropertyPanel.test.ts` covers pure style helpers only; the X/Y/W/H `disabled` props have no render-test coverage either, and this mirrors them exactly.