### PR TITLE
docs(sdk-playground): accurate README with stage coverage and CanResult

### DIFF
--- a/packages/sdk-playground/README.md
+++ b/packages/sdk-playground/README.md
@@ -10,18 +10,18 @@ bun run --cwd packages/sdk-playground dev
 
 Serves at `http://localhost:5173`. On first load it reads `packages/sdk-playground/composition.html` from disk (if present) or falls back to a built-in demo composition.
 
-## What this demonstrates
+## Stage coverage
 
 The playground exercises the full SDK surface end-to-end in a real browser against a
-file-backed persist adapter. It was built to verify SDK stages 3b and 4 before Studio
-migration begins:
+file-backed persist adapter:
 
-| SDK stage              | What is exercised                                                                                                                                                                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Stage 3a — Session API | `openComposition`, `dispatch`, `undo`/`redo`, `batch`, `on('patch')`, `on('selectionchange')`, `on('persist:error')`, `flush`                                                                                                           |
-| Stage 3b — GSAP engine | `addGsapTween`, `setGsapTween`, `removeGsapTween`, `addLabel`, `removeLabel`, `setClassStyle`, `setTiming` (GSAP-script sync)                                                                                                           |
-| Stage 4                | `canUndo()`/`canRedo()` (live button + Ops badge), `removeElement` GSAP cascade (logs override-set after cascade to confirm orphan cleanup), `can()` → `CanResult`, `getOverrides()`, `selection()` proxy, `find()`, `setVariableValue` |
-| Stage 5 (partial)      | `FsAdapter` — file-backed persistence with version history; `FileAdapter` — browser fetch adapter; `PlaygroundPreview` — concrete `PreviewAdapter` impl                                                                                 |
+| SDK stage              | What is exercised                                                                                                                                                                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stage 3a — Session API | `openComposition`, `dispatch`, `undo`/`redo`, `batch`, `on('patch')`, `on('selectionchange')`, `on('persist:error')`, `flush`                                                                                                             |
+| Stage 3b — GSAP engine | `addGsapTween`, `setGsapTween`, `removeGsapTween`, `addLabel`, `removeLabel`, `setClassStyle`, `setTiming` (GSAP-script sync)                                                                                                             |
+| Stage 4                | `canUndo()`/`canRedo()` (live button + Ops badge), `removeElement` GSAP cascade (logs override-set after cascade to confirm orphan cleanup), `can()` → `CanResult`, `getOverrides()`, `selection()` proxy, `find()`, `setVariableValue`   |
+| Stage 5                | `createHeadlessAdapter()` and `createMemoryAdapter()` exported from package root; `FsAdapter` — file-backed persistence with version history; `FileAdapter` — browser fetch adapter; `PlaygroundPreview` — concrete `PreviewAdapter` impl |
+| Stage 6                | Scoped ids (`hf-HOST/hf-LEAF`), `find({ composition })` filter, ops targeting sub-composition elements via `comp.setStyle("hf-card/hf-card-title", styles)`                                                                               |
 
 ## Features
 
@@ -39,7 +39,7 @@ Full composition rendered in a sandboxed `<iframe>`. Supports:
 
 ### Element tree
 
-Lists all non-root elements. Click any row to select it.
+Lists all non-root elements. Click any row to select it. Sub-composition elements show their scoped id (`hf-HOST/hf-LEAF`) in indigo alongside the bare element id.
 
 ### Properties panel
 
@@ -73,10 +73,12 @@ Full op surface, grouped by feature:
 | setClassStyle                  | `comp.dispatch({ type: "setClassStyle", selector, styles })`                                                                                     |
 | setAttribute / removeElement   | `comp.element(id).setAttribute()` / `.removeElement()`                                                                                           |
 | setVariableValue               | `comp.setVariableValue(id, value)`                                                                                                               |
-| find(query)                    | `comp.find({ tag, text })`                                                                                                                       |
+| find(query)                    | `comp.find({ tag, text, name, track, composition })` — Stage 6: `composition` filter scopes results to a sub-composition host                    |
+| Scoped dispatch                | `comp.setStyle("hf-card/hf-card-title", styles)` — Stage 6: address elements inside inlined sub-compositions                                     |
 | selection() proxy              | `comp.selection().setStyle()` / `.removeElement()`                                                                                               |
 | listVersions / loadFrom        | `adapter.listVersions(path)` / `adapter.loadFrom(path, key)`                                                                                     |
 | History / inspect              | `comp.canUndo()`/`comp.canRedo()` (live badges), `comp.undo()`, `comp.redo()`, `comp.can(op) → CanResult`, `comp.getOverrides()`, `comp.flush()` |
+| Adapters                       | `createHeadlessAdapter()`, `createMemoryAdapter()` — Stage 5: exported from package root; both shown with live demo in the Adapters section      |
 
 `canUndo()`/`canRedo()` drive both the header buttons (disabled when false) and live status badges in the Ops panel that update on every patch.
 

--- a/packages/sdk-playground/README.md
+++ b/packages/sdk-playground/README.md
@@ -10,6 +10,19 @@ bun run --cwd packages/sdk-playground dev
 
 Serves at `http://localhost:5173`. On first load it reads `packages/sdk-playground/composition.html` from disk (if present) or falls back to a built-in demo composition.
 
+## What this demonstrates
+
+The playground exercises the full SDK surface end-to-end in a real browser against a
+file-backed persist adapter. It was built to verify SDK stages 3b and 4 before Studio
+migration begins:
+
+| SDK stage              | What is exercised                                                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stage 3a — Session API | `openComposition`, `dispatch`, `undo`/`redo`, `batch`, `on('patch')`, `on('selectionchange')`, `on('persist:error')`, `flush`                           |
+| Stage 3b — GSAP engine | `addGsapTween`, `setGsapTween`, `removeGsapTween`, `addLabel`, `removeLabel`, `setClassStyle`, `setTiming` (GSAP-script sync)                           |
+| Stage 4 (partial)      | `can()` returning `CanResult`, `getOverrides()`, `selection()` proxy, `find()`, `setVariableValue`                                                      |
+| Stage 5 (partial)      | `FsAdapter` — file-backed persistence with version history; `FileAdapter` — browser fetch adapter; `PlaygroundPreview` — concrete `PreviewAdapter` impl |
+
 ## Features
 
 ### File persistence
@@ -22,7 +35,7 @@ Full composition rendered in a sandboxed `<iframe>`. Supports:
 
 - **Play / Pause / Seek** via the transport bar
 - **Click-to-select** elements (highlights in the tree and properties panel)
-- **Drag-to-reposition** — drag any element to a new position; on drop the playground calls `comp.setStyle(id, { left, top })`
+- **Drag-to-reposition** — drag any element; on drop calls `comp.setStyle(id, { left, top })`
 
 ### Element tree
 
@@ -35,50 +48,55 @@ Editable per-element properties for the selected element:
 | Section    | SDK op                                                                      |
 | ---------- | --------------------------------------------------------------------------- |
 | Content    | `comp.setText(id, value)`                                                   |
-| Typography | `comp.setStyle(id, { fontSize, fontWeight, color, fontFamily })`            |
-| Box        | `comp.setStyle(id, { top, left, width, height })`                           |
-| Attributes | `comp.element(id).setAttribute(name, value)` — shows all non-internal attrs |
+| Typography | `comp.setStyle(id, { fontSize, fontWeight, color })`                        |
+| Box        | `comp.setStyle(id, { background, opacity, left, top })`                     |
+| Attributes | `comp.element(id).setAttribute(name, value)` — all non-internal attrs       |
 | Danger     | `comp.element(id).removeElement()`                                          |
-| Animations | `comp.setTiming(id, { start, duration })` — inline form per GSAP tween      |
+| Animations | Lists tween IDs + inline "Add tween" form via `comp.addGsapTween(id, spec)` |
 
 ### Timeline
 
-DAW-style per-element tween blocks. Drag handles to trim start/end; drag body to move. All edits go through `comp.setTiming(id, { start, duration })` which keeps the GSAP script and DOM attributes in sync.
+DAW-style per-element tween blocks. Drag handles to trim start/end; drag body to move. All edits go through `comp.setTiming(id, { start, duration })`, which keeps the GSAP script and `data-start`/`data-end` attributes in sync.
 
 ### Ops panel
 
 Full op surface, grouped by feature:
 
-| Section                      | SDK op                                                                            |
-| ---------------------------- | --------------------------------------------------------------------------------- |
-| PreviewAdapter.select()      | `preview.select([id])`                                                            |
-| setStyle                     | `comp.setStyle(id, styles)`                                                       |
-| setText                      | `comp.setText(id, value)`                                                         |
-| addGsapTween                 | `comp.addGsapTween(target, spec)`                                                 |
-| setTiming                    | `comp.setTiming(id, { start, duration })`                                         |
-| setGsapTween                 | `comp.setGsapTween(animId, updates)`                                              |
-| moveElement                  | `comp.moveElement(id, { parent, index })`                                         |
-| setClassStyle                | `comp.dispatch({ type: "setClassStyle", selector, styles })`                      |
-| setAttribute / removeElement | `comp.element(id).setAttribute()` / `.removeElement()`                            |
-| setVariableValue             | `comp.setVariableValue(id, value)`                                                |
-| find(query)                  | `comp.find({ tag, text, name, track })`                                           |
-| selection() proxy            | `comp.selection().setStyle()` / `.removeElement()`                                |
-| listVersions / loadFrom      | `adapter.listVersions()` / `adapter.loadFrom()`                                   |
-| History / inspect            | `comp.undo()`, `comp.redo()`, `comp.can()`, `comp.getOverrides()`, `comp.flush()` |
+| Section                        | SDK op                                                                                          |
+| ------------------------------ | ----------------------------------------------------------------------------------------------- |
+| PreviewAdapter.select()        | `preview.select([id])`                                                                          |
+| setStyle                       | `comp.setStyle(id, styles)`                                                                     |
+| setText                        | `comp.setText(id, value)`                                                                       |
+| addGsapTween                   | `comp.addGsapTween(target, spec)`                                                               |
+| setGsapTween / removeGsapTween | `comp.setGsapTween(animId, { duration })` / `comp.removeGsapTween(animId)`                      |
+| addLabel / removeLabel         | `comp.dispatch({ type: "addLabel", name, position })` / `removeLabel`                           |
+| setClassStyle                  | `comp.dispatch({ type: "setClassStyle", selector, styles })`                                    |
+| setAttribute / removeElement   | `comp.element(id).setAttribute()` / `.removeElement()`                                          |
+| setVariableValue               | `comp.setVariableValue(id, value)`                                                              |
+| find(query)                    | `comp.find({ tag, text })`                                                                      |
+| selection() proxy              | `comp.selection().setStyle()` / `.removeElement()`                                              |
+| listVersions / loadFrom        | `adapter.listVersions(path)` / `adapter.loadFrom(path, key)`                                    |
+| History / inspect              | `comp.undo()`, `comp.redo()`, `comp.can(op) → CanResult`, `comp.getOverrides()`, `comp.flush()` |
+
+`can(op)` returns a `CanResult`: `{ok: true}` or `{ok: false, code, message, hint?}`. The ops panel logs the full result object so you can inspect validation failures in real time.
 
 ### Editor modal
 
-Click "Open editor" to view and directly edit the raw composition HTML. Saving re-opens the composition through the SDK.
+Click "Open editor" to view and directly edit the raw composition HTML. Saving re-opens the composition through the SDK, so all patches and history are reset cleanly.
+
+### Event log
+
+Every `patch`, `undo`, `redo`, `selectionchange`, and `persist:error` event is logged with its payload. Useful for verifying RFC 6902 patch shape and override-set accumulation.
 
 ---
 
 ## Planned / not yet wired
 
+- `addGsapKeyframe` / `setGsapKeyframe` / `removeGsapKeyframe` — ops are implemented in the SDK; not yet exposed in the UI
 - `comp.setTrackVariable(trackId, variableId)` — variable binding per track
 - `comp.addElement(spec)` — create new elements from the UI
 - `comp.duplicateElement(id)` — duplicate with offset
 - Selection multi-select (current: single-select only)
 - Timeline zoom and horizontal scroll for long compositions
-- Version history browser — list/preview/restore past versions inline (API is implemented; UI shows only list + load-oldest)
-- `comp.on('change', cb)` live event log fed from SDK event stream
+- Version history browser — list/preview/restore past versions inline (listVersions/loadFrom API is implemented; UI shows raw list + load-oldest button only)
 - Render to video via `@hyperframes/producer` integration

--- a/packages/sdk-playground/README.md
+++ b/packages/sdk-playground/README.md
@@ -16,12 +16,12 @@ The playground exercises the full SDK surface end-to-end in a real browser again
 file-backed persist adapter. It was built to verify SDK stages 3b and 4 before Studio
 migration begins:
 
-| SDK stage              | What is exercised                                                                                                                                       |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Stage 3a — Session API | `openComposition`, `dispatch`, `undo`/`redo`, `batch`, `on('patch')`, `on('selectionchange')`, `on('persist:error')`, `flush`                           |
-| Stage 3b — GSAP engine | `addGsapTween`, `setGsapTween`, `removeGsapTween`, `addLabel`, `removeLabel`, `setClassStyle`, `setTiming` (GSAP-script sync)                           |
-| Stage 4 (partial)      | `can()` returning `CanResult`, `getOverrides()`, `selection()` proxy, `find()`, `setVariableValue`                                                      |
-| Stage 5 (partial)      | `FsAdapter` — file-backed persistence with version history; `FileAdapter` — browser fetch adapter; `PlaygroundPreview` — concrete `PreviewAdapter` impl |
+| SDK stage              | What is exercised                                                                                                                                                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stage 3a — Session API | `openComposition`, `dispatch`, `undo`/`redo`, `batch`, `on('patch')`, `on('selectionchange')`, `on('persist:error')`, `flush`                                                                                                           |
+| Stage 3b — GSAP engine | `addGsapTween`, `setGsapTween`, `removeGsapTween`, `addLabel`, `removeLabel`, `setClassStyle`, `setTiming` (GSAP-script sync)                                                                                                           |
+| Stage 4                | `canUndo()`/`canRedo()` (live button + Ops badge), `removeElement` GSAP cascade (logs override-set after cascade to confirm orphan cleanup), `can()` → `CanResult`, `getOverrides()`, `selection()` proxy, `find()`, `setVariableValue` |
+| Stage 5 (partial)      | `FsAdapter` — file-backed persistence with version history; `FileAdapter` — browser fetch adapter; `PlaygroundPreview` — concrete `PreviewAdapter` impl                                                                                 |
 
 ## Features
 
@@ -45,14 +45,14 @@ Lists all non-root elements. Click any row to select it.
 
 Editable per-element properties for the selected element:
 
-| Section    | SDK op                                                                      |
-| ---------- | --------------------------------------------------------------------------- |
-| Content    | `comp.setText(id, value)`                                                   |
-| Typography | `comp.setStyle(id, { fontSize, fontWeight, color })`                        |
-| Box        | `comp.setStyle(id, { background, opacity, left, top })`                     |
-| Attributes | `comp.element(id).setAttribute(name, value)` — all non-internal attrs       |
-| Danger     | `comp.element(id).removeElement()`                                          |
-| Animations | Lists tween IDs + inline "Add tween" form via `comp.addGsapTween(id, spec)` |
+| Section    | SDK op                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Content    | `comp.setText(id, value)`                                                                                                                              |
+| Typography | `comp.setStyle(id, { fontSize, fontWeight, color })`                                                                                                   |
+| Box        | `comp.setStyle(id, { background, opacity, left, top })`                                                                                                |
+| Attributes | `comp.element(id).setAttribute(name, value)` — all non-internal attrs                                                                                  |
+| Danger     | `comp.element(id).removeElement()` — Stage 4: cascades to remove targeting GSAP animations; logs override-set so you can verify orphan keys are purged |
+| Animations | Lists tween IDs + inline "Add tween" form via `comp.addGsapTween(id, spec)`                                                                            |
 
 ### Timeline
 
@@ -62,21 +62,23 @@ DAW-style per-element tween blocks. Drag handles to trim start/end; drag body to
 
 Full op surface, grouped by feature:
 
-| Section                        | SDK op                                                                                          |
-| ------------------------------ | ----------------------------------------------------------------------------------------------- |
-| PreviewAdapter.select()        | `preview.select([id])`                                                                          |
-| setStyle                       | `comp.setStyle(id, styles)`                                                                     |
-| setText                        | `comp.setText(id, value)`                                                                       |
-| addGsapTween                   | `comp.addGsapTween(target, spec)`                                                               |
-| setGsapTween / removeGsapTween | `comp.setGsapTween(animId, { duration })` / `comp.removeGsapTween(animId)`                      |
-| addLabel / removeLabel         | `comp.dispatch({ type: "addLabel", name, position })` / `removeLabel`                           |
-| setClassStyle                  | `comp.dispatch({ type: "setClassStyle", selector, styles })`                                    |
-| setAttribute / removeElement   | `comp.element(id).setAttribute()` / `.removeElement()`                                          |
-| setVariableValue               | `comp.setVariableValue(id, value)`                                                              |
-| find(query)                    | `comp.find({ tag, text })`                                                                      |
-| selection() proxy              | `comp.selection().setStyle()` / `.removeElement()`                                              |
-| listVersions / loadFrom        | `adapter.listVersions(path)` / `adapter.loadFrom(path, key)`                                    |
-| History / inspect              | `comp.undo()`, `comp.redo()`, `comp.can(op) → CanResult`, `comp.getOverrides()`, `comp.flush()` |
+| Section                        | SDK op                                                                                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| PreviewAdapter.select()        | `preview.select([id])`                                                                                                                           |
+| setStyle                       | `comp.setStyle(id, styles)`                                                                                                                      |
+| setText                        | `comp.setText(id, value)`                                                                                                                        |
+| addGsapTween                   | `comp.addGsapTween(target, spec)`                                                                                                                |
+| setGsapTween / removeGsapTween | `comp.setGsapTween(animId, { duration })` / `comp.removeGsapTween(animId)`                                                                       |
+| addLabel / removeLabel         | `comp.dispatch({ type: "addLabel", name, position })` / `removeLabel`                                                                            |
+| setClassStyle                  | `comp.dispatch({ type: "setClassStyle", selector, styles })`                                                                                     |
+| setAttribute / removeElement   | `comp.element(id).setAttribute()` / `.removeElement()`                                                                                           |
+| setVariableValue               | `comp.setVariableValue(id, value)`                                                                                                               |
+| find(query)                    | `comp.find({ tag, text })`                                                                                                                       |
+| selection() proxy              | `comp.selection().setStyle()` / `.removeElement()`                                                                                               |
+| listVersions / loadFrom        | `adapter.listVersions(path)` / `adapter.loadFrom(path, key)`                                                                                     |
+| History / inspect              | `comp.canUndo()`/`comp.canRedo()` (live badges), `comp.undo()`, `comp.redo()`, `comp.can(op) → CanResult`, `comp.getOverrides()`, `comp.flush()` |
+
+`canUndo()`/`canRedo()` drive both the header buttons (disabled when false) and live status badges in the Ops panel that update on every patch.
 
 `can(op)` returns a `CanResult`: `{ok: true}` or `{ok: false, code, message, hint?}`. The ops panel logs the full result object so you can inspect validation failures in real time.
 

--- a/packages/sdk-playground/index.html
+++ b/packages/sdk-playground/index.html
@@ -1,455 +1,654 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>@hyperframes/sdk editor</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@hyperframes/sdk editor</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-    body {
-      font-family: system-ui, -apple-system, sans-serif;
-      background: #0f1117;
-      color: #e5e7eb;
-      height: 100vh;
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-    }
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        background: #0f1117;
+        color: #e5e7eb;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
 
-    /* ── Header ── */
-    #header {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      padding: 8px 14px;
-      background: #161b27;
-      border-bottom: 1px solid #1f2937;
-      flex-shrink: 0;
-    }
-    #header h1 { font-size: 14px; font-weight: 600; color: #f9fafb; }
-    #header .badge { font-size: 11px; background: #1d4ed8; color: #bfdbfe; padding: 2px 7px; border-radius: 10px; }
-    #header .spacer { flex: 1; }
-    #header .sel-label { font-size: 12px; color: #4b5563; }
-    #header #sel-display { font-size: 12px; color: #a78bfa; font-family: monospace; min-width: 80px; }
+      /* ── Header ── */
+      #header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 14px;
+        background: #161b27;
+        border-bottom: 1px solid #1f2937;
+        flex-shrink: 0;
+      }
+      #header h1 {
+        font-size: 14px;
+        font-weight: 600;
+        color: #f9fafb;
+      }
+      #header .badge {
+        font-size: 11px;
+        background: #1d4ed8;
+        color: #bfdbfe;
+        padding: 2px 7px;
+        border-radius: 10px;
+      }
+      #header .spacer {
+        flex: 1;
+      }
+      #header .sel-label {
+        font-size: 12px;
+        color: #4b5563;
+      }
+      #header #sel-display {
+        font-size: 12px;
+        color: #a78bfa;
+        font-family: monospace;
+        min-width: 80px;
+      }
 
-    /* ── Main grid ── */
-    #app-main {
-      display: grid;
-      grid-template-columns: 1fr 310px 260px;
-      flex: 1;
-      min-height: 0;
-      overflow: hidden;
-    }
+      /* ── Main grid ── */
+      #app-main {
+        display: grid;
+        grid-template-columns: 1fr 310px 260px;
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+      }
 
-    /* ── Preview panel ── */
-    #preview-panel {
-      display: flex;
-      flex-direction: column;
-      padding: 10px;
-      gap: 8px;
-      overflow: hidden;
-      border-right: 1px solid #1f2937;
-    }
-    #preview-scaler-outer {
-      position: relative;
-      width: 100%;
-      background: #000;
-      border: 1px solid #1f2937;
-      border-radius: 4px;
-      overflow: hidden;
-      flex-shrink: 0;
-    }
-    #preview-scaler-inner { transform-origin: top left; }
-    #preview-frame { width: 1280px; height: 720px; border: none; display: block; }
-    #preview-hint {
-      font-size: 11px;
-      color: #374151;
-      text-align: center;
-    }
+      /* ── Preview panel ── */
+      #preview-panel {
+        display: flex;
+        flex-direction: column;
+        padding: 10px;
+        gap: 8px;
+        overflow: hidden;
+        border-right: 1px solid #1f2937;
+      }
+      #preview-scaler-outer {
+        position: relative;
+        width: 100%;
+        background: #000;
+        border: 1px solid #1f2937;
+        border-radius: 4px;
+        overflow: hidden;
+        flex-shrink: 0;
+      }
+      #preview-scaler-inner {
+        transform-origin: top left;
+      }
+      #preview-frame {
+        width: 1280px;
+        height: 720px;
+        border: none;
+        display: block;
+      }
+      #preview-hint {
+        font-size: 11px;
+        color: #374151;
+        text-align: center;
+      }
 
-    /* ── Inspector panel ── */
-    #inspector-panel {
-      display: flex;
-      flex-direction: column;
-      border-right: 1px solid #1f2937;
-      overflow: hidden;
-    }
-    #inspector-tabs {
-      display: flex;
-      border-bottom: 1px solid #1f2937;
-      flex-shrink: 0;
-    }
-    .ins-tab {
-      padding: 7px 16px;
-      font-size: 12px;
-      cursor: pointer;
-      color: #6b7280;
-      border-bottom: 2px solid transparent;
-      user-select: none;
-    }
-    .ins-tab.active { color: #60a5fa; border-bottom-color: #60a5fa; }
+      /* ── Inspector panel ── */
+      #inspector-panel {
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid #1f2937;
+        overflow: hidden;
+      }
+      #inspector-tabs {
+        display: flex;
+        border-bottom: 1px solid #1f2937;
+        flex-shrink: 0;
+      }
+      .ins-tab {
+        padding: 7px 16px;
+        font-size: 12px;
+        cursor: pointer;
+        color: #6b7280;
+        border-bottom: 2px solid transparent;
+        user-select: none;
+      }
+      .ins-tab.active {
+        color: #60a5fa;
+        border-bottom-color: #60a5fa;
+      }
 
-    /* Elements list */
-    #element-list {
-      border-bottom: 1px solid #1f2937;
-      overflow-y: auto;
-      max-height: 160px;
-      flex-shrink: 0;
-    }
-    .el-item {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 5px 10px;
-      cursor: pointer;
-      font-size: 12px;
-      border-bottom: 1px solid #111827;
-    }
-    .el-item:hover { background: #1a2235; }
-    .el-item.selected { background: #172554; }
-    .el-item .el-tag { color: #6b7280; font-family: monospace; font-size: 11px; }
-    .el-item .el-id { color: #d1d5db; font-family: monospace; }
-    .el-item .el-text { color: #4b5563; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100px; }
+      /* Elements list */
+      #element-list {
+        border-bottom: 1px solid #1f2937;
+        overflow-y: auto;
+        max-height: 160px;
+        flex-shrink: 0;
+      }
+      .el-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 10px;
+        cursor: pointer;
+        font-size: 12px;
+        border-bottom: 1px solid #111827;
+      }
+      .el-item:hover {
+        background: #1a2235;
+      }
+      .el-item.selected {
+        background: #172554;
+      }
+      .el-item .el-tag {
+        color: #6b7280;
+        font-family: monospace;
+        font-size: 11px;
+      }
+      .el-item .el-id {
+        color: #d1d5db;
+        font-family: monospace;
+      }
+      .el-item .el-text {
+        color: #4b5563;
+        font-size: 11px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 100px;
+      }
+      .el-item .el-scoped {
+        color: #6366f1;
+        font-family: monospace;
+        font-size: 10px;
+        margin-left: 4px;
+      }
 
-    /* Properties / Ops content */
-    #inspector-content {
-      flex: 1;
-      overflow-y: auto;
-      padding: 10px;
-    }
-    .prop-section { margin-bottom: 12px; }
-    .prop-section-title {
-      font-size: 10px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: #374151;
-      margin-bottom: 6px;
-    }
-    .prop-row {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      margin-bottom: 5px;
-    }
-    .prop-label {
-      font-size: 11px;
-      color: #6b7280;
-      width: 64px;
-      flex-shrink: 0;
-    }
-    .prop-input {
-      flex: 1;
-      padding: 3px 6px;
-      background: #111827;
-      color: #f9fafb;
-      border: 1px solid #374151;
-      border-radius: 3px;
-      font-size: 12px;
-      font-family: monospace;
-      min-width: 0;
-    }
-    .prop-input:focus { outline: none; border-color: #3b82f6; }
-    .prop-input.wide { width: 100%; }
-    input[type="color"].prop-color { width: 28px; height: 24px; padding: 1px 2px; cursor: pointer; flex-shrink: 0; border-radius: 3px; }
-    textarea.prop-input { resize: vertical; min-height: 48px; font-family: system-ui, sans-serif; }
-    select.prop-input { cursor: pointer; }
-    .prop-no-selection { font-size: 12px; color: #374151; padding: 8px 0; }
+      /* Properties / Ops content */
+      #inspector-content {
+        flex: 1;
+        overflow-y: auto;
+        padding: 10px;
+      }
+      .prop-section {
+        margin-bottom: 12px;
+      }
+      .prop-section-title {
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #374151;
+        margin-bottom: 6px;
+      }
+      .prop-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 5px;
+      }
+      .prop-label {
+        font-size: 11px;
+        color: #6b7280;
+        width: 64px;
+        flex-shrink: 0;
+      }
+      .prop-input {
+        flex: 1;
+        padding: 3px 6px;
+        background: #111827;
+        color: #f9fafb;
+        border: 1px solid #374151;
+        border-radius: 3px;
+        font-size: 12px;
+        font-family: monospace;
+        min-width: 0;
+      }
+      .prop-input:focus {
+        outline: none;
+        border-color: #3b82f6;
+      }
+      .prop-input.wide {
+        width: 100%;
+      }
+      input[type="color"].prop-color {
+        width: 28px;
+        height: 24px;
+        padding: 1px 2px;
+        cursor: pointer;
+        flex-shrink: 0;
+        border-radius: 3px;
+      }
+      textarea.prop-input {
+        resize: vertical;
+        min-height: 48px;
+        font-family: system-ui, sans-serif;
+      }
+      select.prop-input {
+        cursor: pointer;
+      }
+      .prop-no-selection {
+        font-size: 12px;
+        color: #374151;
+        padding: 8px 0;
+      }
 
-    /* Tween list */
-    .tween-id {
-      font-size: 11px;
-      font-family: monospace;
-      color: #34d399;
-      background: #064e3b;
-      padding: 2px 6px;
-      border-radius: 3px;
-      margin-bottom: 3px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    #add-tween-form { margin-top: 6px; display: none; }
-    #add-tween-form.open { display: block; }
+      /* Tween list */
+      .tween-id {
+        font-size: 11px;
+        font-family: monospace;
+        color: #34d399;
+        background: #064e3b;
+        padding: 2px 6px;
+        border-radius: 3px;
+        margin-bottom: 3px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      #add-tween-form {
+        margin-top: 6px;
+        display: none;
+      }
+      #add-tween-form.open {
+        display: block;
+      }
 
-    /* Op sections (test panel) */
-    .op-section {
-      border: 1px solid #1f2937;
-      border-radius: 5px;
-      padding: 8px;
-      margin-bottom: 7px;
-    }
-    .op-title {
-      font-size: 10px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: #374151;
-      margin-bottom: 6px;
-      font-family: monospace;
-    }
-    .op-row { display: flex; flex-wrap: wrap; gap: 5px; align-items: center; margin-bottom: 4px; }
-    .op-note { font-size: 11px; color: #374151; margin-top: 3px; }
-    #anim-id-display {
-      font-size: 11px; font-family: monospace; color: #34d399;
-      background: #064e3b; padding: 2px 6px; border-radius: 3px; margin-top: 3px;
-    }
+      /* Op sections (test panel) */
+      .op-section {
+        border: 1px solid #1f2937;
+        border-radius: 5px;
+        padding: 8px;
+        margin-bottom: 7px;
+      }
+      .op-title {
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #374151;
+        margin-bottom: 6px;
+        font-family: monospace;
+      }
+      .op-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px;
+        align-items: center;
+        margin-bottom: 4px;
+      }
+      .op-note {
+        font-size: 11px;
+        color: #374151;
+        margin-top: 3px;
+      }
+      #anim-id-display {
+        font-size: 11px;
+        font-family: monospace;
+        color: #34d399;
+        background: #064e3b;
+        padding: 2px 6px;
+        border-radius: 3px;
+        margin-top: 3px;
+      }
 
-    /* Shared button / input */
-    button {
-      padding: 4px 10px;
-      background: #1f2937;
-      color: #d1d5db;
-      border: 1px solid #374151;
-      border-radius: 4px;
-      cursor: pointer;
-      font-size: 12px;
-    }
-    button:hover { background: #374151; color: #f9fafb; }
-    button.primary { background: #1d4ed8; border-color: #2563eb; color: #fff; }
-    button.primary:hover { background: #2563eb; }
-    button.danger { background: #7f1d1d; border-color: #991b1b; color: #fca5a5; }
-    button.danger:hover { background: #991b1b; }
-    button.ghost { background: transparent; border-color: transparent; color: #6b7280; }
-    button.ghost:hover { background: #1f2937; color: #d1d5db; }
-    button:disabled { opacity: 0.3; cursor: not-allowed; pointer-events: none; }
-    input[type="text"], input[type="number"] {
-      padding: 3px 7px;
-      background: #111827;
-      color: #f9fafb;
-      border: 1px solid #374151;
-      border-radius: 4px;
-      font-size: 12px;
-      font-family: monospace;
-    }
-    input[type="text"] { width: 130px; }
-    input[type="number"] { width: 65px; }
+      /* Shared button / input */
+      button {
+        padding: 4px 10px;
+        background: #1f2937;
+        color: #d1d5db;
+        border: 1px solid #374151;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+      }
+      button:hover {
+        background: #374151;
+        color: #f9fafb;
+      }
+      button.primary {
+        background: #1d4ed8;
+        border-color: #2563eb;
+        color: #fff;
+      }
+      button.primary:hover {
+        background: #2563eb;
+      }
+      button.danger {
+        background: #7f1d1d;
+        border-color: #991b1b;
+        color: #fca5a5;
+      }
+      button.danger:hover {
+        background: #991b1b;
+      }
+      button.ghost {
+        background: transparent;
+        border-color: transparent;
+        color: #6b7280;
+      }
+      button.ghost:hover {
+        background: #1f2937;
+        color: #d1d5db;
+      }
+      button:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+        pointer-events: none;
+      }
+      input[type="text"],
+      input[type="number"] {
+        padding: 3px 7px;
+        background: #111827;
+        color: #f9fafb;
+        border: 1px solid #374151;
+        border-radius: 4px;
+        font-size: 12px;
+        font-family: monospace;
+      }
+      input[type="text"] {
+        width: 130px;
+      }
+      input[type="number"] {
+        width: 65px;
+      }
 
-    /* ── Log panel ── */
-    #log-panel { display: flex; flex-direction: column; overflow: hidden; }
-    .panel-title {
-      font-size: 10px; font-weight: 700; text-transform: uppercase;
-      letter-spacing: 0.07em; color: #374151; padding: 7px 10px;
-      border-bottom: 1px solid #1f2937; flex-shrink: 0;
-    }
-    #log-entries { overflow-y: auto; padding: 6px; flex: 1; }
-    .log-entry {
-      border-left: 3px solid #374151;
-      padding: 3px 7px;
-      margin-bottom: 4px;
-      font-size: 11px;
-      font-family: monospace;
-      background: #111827;
-      border-radius: 0 3px 3px 0;
-    }
-    .log-entry .log-type { font-weight: 700; margin-right: 5px; }
-    .log-entry pre { color: #6b7280; white-space: pre-wrap; word-break: break-all; margin-top: 2px; font-size: 10px; }
+      /* ── Log panel ── */
+      #log-panel {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      .panel-title {
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: #374151;
+        padding: 7px 10px;
+        border-bottom: 1px solid #1f2937;
+        flex-shrink: 0;
+      }
+      #log-entries {
+        overflow-y: auto;
+        padding: 6px;
+        flex: 1;
+      }
+      .log-entry {
+        border-left: 3px solid #374151;
+        padding: 3px 7px;
+        margin-bottom: 4px;
+        font-size: 11px;
+        font-family: monospace;
+        background: #111827;
+        border-radius: 0 3px 3px 0;
+      }
+      .log-entry .log-type {
+        font-weight: 700;
+        margin-right: 5px;
+      }
+      .log-entry pre {
+        color: #6b7280;
+        white-space: pre-wrap;
+        word-break: break-all;
+        margin-top: 2px;
+        font-size: 10px;
+      }
 
-    /* ── Timeline panel ── */
-    #timeline-panel {
-      flex-shrink: 0;
-      height: 158px;
-      border-top: 1px solid #1f2937;
-      display: flex;
-      flex-direction: column;
-      background: #0a0d14;
-    }
-    #tl-controls {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 4px 10px;
-      border-bottom: 1px solid #1f2937;
-      flex-shrink: 0;
-    }
-    #tl-scrubber {
-      flex: 1;
-      accent-color: #3b82f6;
-      cursor: pointer;
-    }
-    #tl-time, #tl-dur {
-      font-size: 11px;
-      font-family: monospace;
-      color: #4b5563;
-      white-space: nowrap;
-      min-width: 32px;
-    }
-    #tl-dur { text-align: right; }
-    #tl-body {
-      flex: 1;
-      position: relative;
-      overflow: hidden;
-    }
-    #tl-tracks {
-      position: absolute;
-      inset: 0;
-      overflow-y: auto;
-      overflow-x: hidden;
-    }
-    .tl-row {
-      display: flex;
-      align-items: center;
-      height: 26px;
-      border-bottom: 1px solid #111827;
-    }
-    .tl-row:hover { background: rgba(255,255,255,0.02); }
-    .tl-label {
-      width: 120px;
-      flex-shrink: 0;
-      font-size: 11px;
-      font-family: monospace;
-      color: #4b5563;
-      padding: 0 8px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      border-right: 1px solid #1f2937;
-    }
-    .tl-track {
-      flex: 1;
-      position: relative;
-      height: 100%;
-    }
-    .tl-block {
-      position: absolute;
-      top: 4px;
-      height: 17px;
-      border-radius: 3px;
-      cursor: grab;
-      opacity: 0.75;
-      min-width: 4px;
-      user-select: none;
-    }
-    .tl-block:hover { opacity: 1; }
-    .tl-block.dragging { opacity: 1; cursor: grabbing; }
-    .tl-handle {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: 6px;
-      cursor: ew-resize;
-    }
-    .tl-handle-l { left: 0; border-radius: 3px 0 0 3px; }
-    .tl-handle-r { right: 0; border-radius: 0 3px 3px 0; }
-    .tl-handle:hover { background: rgba(255,255,255,0.25); }
-    #tl-playhead {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: 1px;
-      background: #f87171;
-      pointer-events: none;
-      left: 120px;
-      z-index: 10;
-    }
+      /* ── Timeline panel ── */
+      #timeline-panel {
+        flex-shrink: 0;
+        height: 158px;
+        border-top: 1px solid #1f2937;
+        display: flex;
+        flex-direction: column;
+        background: #0a0d14;
+      }
+      #tl-controls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 10px;
+        border-bottom: 1px solid #1f2937;
+        flex-shrink: 0;
+      }
+      #tl-scrubber {
+        flex: 1;
+        accent-color: #3b82f6;
+        cursor: pointer;
+      }
+      #tl-time,
+      #tl-dur {
+        font-size: 11px;
+        font-family: monospace;
+        color: #4b5563;
+        white-space: nowrap;
+        min-width: 32px;
+      }
+      #tl-dur {
+        text-align: right;
+      }
+      #tl-body {
+        flex: 1;
+        position: relative;
+        overflow: hidden;
+      }
+      #tl-tracks {
+        position: absolute;
+        inset: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+      }
+      .tl-row {
+        display: flex;
+        align-items: center;
+        height: 26px;
+        border-bottom: 1px solid #111827;
+      }
+      .tl-row:hover {
+        background: rgba(255, 255, 255, 0.02);
+      }
+      .tl-label {
+        width: 120px;
+        flex-shrink: 0;
+        font-size: 11px;
+        font-family: monospace;
+        color: #4b5563;
+        padding: 0 8px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        border-right: 1px solid #1f2937;
+      }
+      .tl-track {
+        flex: 1;
+        position: relative;
+        height: 100%;
+      }
+      .tl-block {
+        position: absolute;
+        top: 4px;
+        height: 17px;
+        border-radius: 3px;
+        cursor: grab;
+        opacity: 0.75;
+        min-width: 4px;
+        user-select: none;
+      }
+      .tl-block:hover {
+        opacity: 1;
+      }
+      .tl-block.dragging {
+        opacity: 1;
+        cursor: grabbing;
+      }
+      .tl-handle {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 6px;
+        cursor: ew-resize;
+      }
+      .tl-handle-l {
+        left: 0;
+        border-radius: 3px 0 0 3px;
+      }
+      .tl-handle-r {
+        right: 0;
+        border-radius: 0 3px 3px 0;
+      }
+      .tl-handle:hover {
+        background: rgba(255, 255, 255, 0.25);
+      }
+      #tl-playhead {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 1px;
+        background: #f87171;
+        pointer-events: none;
+        left: 120px;
+        z-index: 10;
+      }
 
-    /* ── Open overlay ── */
-    #open-overlay {
-      position: fixed; inset: 0;
-      background: rgba(0,0,0,0.7);
-      display: none;
-      align-items: center;
-      justify-content: center;
-      z-index: 100;
-    }
-    #open-overlay.visible { display: flex; }
-    #open-dialog {
-      background: #161b27;
-      border: 1px solid #1f2937;
-      border-radius: 8px;
-      padding: 20px;
-      width: 680px;
-      max-height: 80vh;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-    #open-dialog h2 { font-size: 15px; font-weight: 600; color: #f9fafb; }
-    #open-dialog p { font-size: 12px; color: #6b7280; }
-    #open-textarea {
-      flex: 1;
-      min-height: 300px;
-      background: #0f1117;
-      color: #d1d5db;
-      border: 1px solid #374151;
-      border-radius: 4px;
-      padding: 10px;
-      font-size: 12px;
-      font-family: monospace;
-      resize: vertical;
-    }
-    #open-dialog .dialog-actions { display: flex; gap: 8px; justify-content: flex-end; }
-  </style>
-</head>
-<body>
-  <div id="header">
-    <h1>@hyperframes/sdk</h1>
-    <span class="badge">editor</span>
-    <span id="comp-name" style="font-size:12px;color:#4b5563;font-family:monospace;">demo</span>
-    <span class="spacer"></span>
-    <span class="sel-label">selection:</span>
-    <span id="sel-display">(none)</span>
-    <button id="btn-undo" class="ghost">← Undo</button>
-    <button id="btn-redo" class="ghost">Redo →</button>
-    <button id="btn-open" class="primary">Open…</button>
-  </div>
+      /* ── Open overlay ── */
+      #open-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.7);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 100;
+      }
+      #open-overlay.visible {
+        display: flex;
+      }
+      #open-dialog {
+        background: #161b27;
+        border: 1px solid #1f2937;
+        border-radius: 8px;
+        padding: 20px;
+        width: 680px;
+        max-height: 80vh;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      #open-dialog h2 {
+        font-size: 15px;
+        font-weight: 600;
+        color: #f9fafb;
+      }
+      #open-dialog p {
+        font-size: 12px;
+        color: #6b7280;
+      }
+      #open-textarea {
+        flex: 1;
+        min-height: 300px;
+        background: #0f1117;
+        color: #d1d5db;
+        border: 1px solid #374151;
+        border-radius: 4px;
+        padding: 10px;
+        font-size: 12px;
+        font-family: monospace;
+        resize: vertical;
+      }
+      #open-dialog .dialog-actions {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="header">
+      <h1>@hyperframes/sdk</h1>
+      <span class="badge">editor</span>
+      <span id="comp-name" style="font-size: 12px; color: #4b5563; font-family: monospace"
+        >demo</span
+      >
+      <span class="spacer"></span>
+      <span class="sel-label">selection:</span>
+      <span id="sel-display">(none)</span>
+      <button id="btn-undo" class="ghost">← Undo</button>
+      <button id="btn-redo" class="ghost">Redo →</button>
+      <button id="btn-open" class="primary">Open…</button>
+    </div>
 
-  <div id="app-main">
-    <!-- Preview -->
-    <div id="preview-panel">
-      <div id="preview-scaler-outer">
-        <div id="preview-scaler-inner">
-          <iframe id="preview-frame" sandbox="allow-scripts" title="composition preview"></iframe>
+    <div id="app-main">
+      <!-- Preview -->
+      <div id="preview-panel">
+        <div id="preview-scaler-outer">
+          <div id="preview-scaler-inner">
+            <iframe id="preview-frame" sandbox="allow-scripts" title="composition preview"></iframe>
+          </div>
+        </div>
+        <div id="preview-hint">click to select</div>
+      </div>
+
+      <!-- Inspector -->
+      <div id="inspector-panel">
+        <div id="inspector-tabs">
+          <div class="ins-tab active" data-tab="properties">Properties</div>
+          <div class="ins-tab" data-tab="ops">Ops</div>
+        </div>
+        <div id="element-list"><!-- populated by JS --></div>
+        <div id="inspector-content"><!-- populated by JS --></div>
+      </div>
+
+      <!-- Log -->
+      <div id="log-panel">
+        <div class="panel-title">Patch log</div>
+        <div id="log-entries"><!-- populated by JS --></div>
+      </div>
+    </div>
+
+    <!-- Timeline -->
+    <div id="timeline-panel">
+      <div id="tl-controls">
+        <button id="btn-play" class="ghost" style="padding: 4px 8px; font-size: 13px">▶</button>
+        <span id="tl-time">0.0s</span>
+        <input type="range" id="tl-scrubber" min="0" max="1000" value="0" step="1" />
+        <span id="tl-dur">–</span>
+      </div>
+      <div id="tl-body">
+        <div id="tl-tracks"><!-- populated by JS --></div>
+        <div id="tl-playhead"></div>
+      </div>
+    </div>
+
+    <!-- Open dialog -->
+    <div id="open-overlay">
+      <div id="open-dialog">
+        <h2>Open composition</h2>
+        <p>
+          Paste any HyperFrames composition HTML — the outer <code>data-hf-root</code> element and
+          its contents.
+        </p>
+        <textarea
+          id="open-textarea"
+          spellcheck="false"
+          placeholder='<div data-hf-id="hf-stage" data-hf-root ...>'
+        ></textarea>
+        <div class="dialog-actions">
+          <button id="btn-open-cancel">Cancel</button>
+          <button id="btn-open-confirm" class="primary">Open</button>
         </div>
       </div>
-      <div id="preview-hint">click to select</div>
     </div>
 
-    <!-- Inspector -->
-    <div id="inspector-panel">
-      <div id="inspector-tabs">
-        <div class="ins-tab active" data-tab="properties">Properties</div>
-        <div class="ins-tab" data-tab="ops">Ops</div>
-      </div>
-      <div id="element-list"><!-- populated by JS --></div>
-      <div id="inspector-content"><!-- populated by JS --></div>
-    </div>
-
-    <!-- Log -->
-    <div id="log-panel">
-      <div class="panel-title">Patch log</div>
-      <div id="log-entries"><!-- populated by JS --></div>
-    </div>
-  </div>
-
-  <!-- Timeline -->
-  <div id="timeline-panel">
-    <div id="tl-controls">
-      <button id="btn-play" class="ghost" style="padding:4px 8px;font-size:13px;">▶</button>
-      <span id="tl-time">0.0s</span>
-      <input type="range" id="tl-scrubber" min="0" max="1000" value="0" step="1" />
-      <span id="tl-dur">–</span>
-    </div>
-    <div id="tl-body">
-      <div id="tl-tracks"><!-- populated by JS --></div>
-      <div id="tl-playhead"></div>
-    </div>
-  </div>
-
-  <!-- Open dialog -->
-  <div id="open-overlay">
-    <div id="open-dialog">
-      <h2>Open composition</h2>
-      <p>Paste any HyperFrames composition HTML — the outer <code>data-hf-root</code> element and its contents.</p>
-      <textarea id="open-textarea" spellcheck="false" placeholder="<div data-hf-id=&quot;hf-stage&quot; data-hf-root ...>"></textarea>
-      <div class="dialog-actions">
-        <button id="btn-open-cancel">Cancel</button>
-        <button id="btn-open-confirm" class="primary">Open</button>
-      </div>
-    </div>
-  </div>
-
-  <script type="module" src="/src/main.ts"></script>
-</body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/packages/sdk-playground/index.html
+++ b/packages/sdk-playground/index.html
@@ -213,6 +213,7 @@
     button.danger:hover { background: #991b1b; }
     button.ghost { background: transparent; border-color: transparent; color: #6b7280; }
     button.ghost:hover { background: #1f2937; color: #d1d5db; }
+    button:disabled { opacity: 0.3; cursor: not-allowed; pointer-events: none; }
     input[type="text"], input[type="number"] {
       padding: 3px 7px;
       background: #111827;

--- a/packages/sdk-playground/src/main.ts
+++ b/packages/sdk-playground/src/main.ts
@@ -1,4 +1,4 @@
-import { openComposition } from "@hyperframes/sdk";
+import { openComposition, createHeadlessAdapter, createMemoryAdapter } from "@hyperframes/sdk";
 import { createFileAdapter } from "./fileAdapter.js";
 import type { Composition, GsapTweenSpec, PreviewAdapter, FindQuery } from "@hyperframes/sdk";
 import { parseGsapScriptAcorn } from "@hyperframes/core/gsap-parser-acorn";
@@ -9,18 +9,26 @@ import gsapRaw from "gsap/dist/gsap.min.js?raw";
 
 const DEMO_HTML = `
 <div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px;background:#111827;position:relative;" data-duration="6">
-  <style>.badge{background:#3b82f6;border-radius:6px;}</style>
-  <div data-hf-id="hf-headline" style="position:absolute;top:200px;left:140px;font-size:72px;font-weight:700;color:#f9fafb;font-family:system-ui,sans-serif;">SDK Playground</div>
-  <div data-hf-id="hf-sub" style="position:absolute;top:300px;left:142px;font-size:28px;color:#9ca3af;font-family:system-ui,sans-serif;">@hyperframes/sdk &middot; Phase 3b + 4</div>
-  <div data-hf-id="hf-badge" class="badge" style="position:absolute;top:390px;left:142px;padding:10px 24px;font-size:20px;font-weight:600;color:#fff;font-family:system-ui,sans-serif;">v0.6</div>
+  <style>.badge{background:#3b82f6;border-radius:6px;} .card{background:#1f2937;border-radius:12px;}</style>
+  <div data-hf-id="hf-headline" style="position:absolute;top:160px;left:140px;font-size:72px;font-weight:700;color:#f9fafb;font-family:system-ui,sans-serif;">SDK Playground</div>
+  <div data-hf-id="hf-sub" style="position:absolute;top:260px;left:142px;font-size:28px;color:#9ca3af;font-family:system-ui,sans-serif;">@hyperframes/sdk &middot; Stages 1–6</div>
+  <div data-hf-id="hf-badge" class="badge" style="position:absolute;top:350px;left:142px;padding:10px 24px;font-size:20px;font-weight:600;color:#fff;font-family:system-ui,sans-serif;">v0.6</div>
+  <!-- Simulated inlined sub-composition — data-composition-file marks the host boundary.
+       Elements inside get scoped ids: hf-card/hf-card-title, hf-card/hf-card-body. -->
+  <div data-hf-id="hf-card" data-composition-file="card.html" class="card" style="position:absolute;top:470px;left:140px;padding:24px 32px;width:400px;">
+    <div data-hf-id="hf-card-title" style="font-size:20px;font-weight:600;color:#f9fafb;font-family:system-ui,sans-serif;">Sub-composition</div>
+    <div data-hf-id="hf-card-body" style="font-size:14px;color:#9ca3af;font-family:system-ui,sans-serif;margin-top:8px;">Target with hf-card/hf-card-title</div>
+  </div>
   <script>
 var tl = gsap.timeline({ paused: true });
 var headline = document.querySelector("[data-hf-id='hf-headline']");
 var sub = document.querySelector("[data-hf-id='hf-sub']");
 var badge = document.querySelector("[data-hf-id='hf-badge']");
+var card = document.querySelector("[data-hf-id='hf-card']");
 tl.from(headline, { y: 40, opacity: 0, duration: 0.7, ease: "power3.out" }, 0);
 tl.from(sub, { y: 20, opacity: 0, duration: 0.5, ease: "power3.out" }, 0.2);
 tl.from(badge, { scale: 0.85, opacity: 0, duration: 0.4, ease: "back.out(1.5)" }, 0.4);
+tl.from(card, { y: 20, opacity: 0, duration: 0.4, ease: "power2.out" }, 0.6);
 window.__timelines = window.__timelines || {};
 window.__timelines["demo"] = tl;
   </script>
@@ -366,14 +374,21 @@ function renderTimeline() {
 
 // ── Element list ──────────────────────────────────────────────────────────────
 
-function buildElItem(el: { id: string; tag: string; text: string | null }): HTMLDivElement {
+function buildElItem(el: {
+  id: string;
+  scopedId: string;
+  tag: string;
+  text: string | null;
+}): HTMLDivElement {
   const item = document.createElement("div");
-  item.className = "el-item" + (el.id === selectedId ? " selected" : "");
+  item.className = "el-item" + (el.scopedId === selectedId ? " selected" : "");
+  const scopeLabel = el.scopedId !== el.id ? `<span class="el-scoped">${el.scopedId}</span>` : "";
   item.innerHTML =
     `<span class="el-tag">&lt;${el.tag}&gt;</span>` +
     `<span class="el-id">${el.id}</span>` +
+    scopeLabel +
     (el.text ? `<span class="el-text">${el.text}</span>` : "");
-  item.addEventListener("click", () => setSelection(el.id));
+  item.addEventListener("click", () => setSelection(el.scopedId));
   return item;
 }
 
@@ -901,21 +916,34 @@ function buildVariableSection(): HTMLDivElement {
   return opSection("setVariableValue", opRow(id, val, set));
 }
 
+function buildFindQuery(tag: string, text: string, composition: string): FindQuery {
+  const q: FindQuery = {};
+  if (tag) q.tag = tag;
+  if (text) q.text = text;
+  if (composition) q.composition = composition;
+  return q;
+}
+
 function buildFindSection(): HTMLDivElement {
   const tag = mkInput("tag", "");
   tag.style.width = "60px";
   const text = mkInput("text", "");
   text.style.width = "80px";
+  const composition = mkInput("composition (host id)", "");
+  composition.style.width = "140px";
   const results = mkNote("");
   const find = mkBtn("Find", "primary", () => {
-    const query: FindQuery = {};
-    if (tag.value.trim()) query.tag = tag.value.trim();
-    if (text.value.trim()) query.text = text.value.trim();
+    const query = buildFindQuery(tag.value.trim(), text.value.trim(), composition.value.trim());
     const ids = comp!.find(query);
-    results.textContent = ids.length ? ids.join(", ") : "(none)";
+    results.textContent = ids.join(", ") || "(none)";
     logEntry("op", { find: { query, result: ids } });
   });
-  return opSection("find(query)", opRow(mkLabel("tag"), tag, mkLabel("text"), text, find), results);
+  return opSection(
+    "find(query)",
+    opRow(mkLabel("tag"), tag, mkLabel("text"), text),
+    opRow(mkLabel("composition"), composition, find),
+    results,
+  );
 }
 
 function buildSelectionProxySection(): HTMLDivElement {
@@ -1038,6 +1066,53 @@ function buildHistorySection(): HTMLDivElement {
   );
 }
 
+function buildScopedDispatchSection(): HTMLDivElement {
+  const idInput = mkInput("scopedId (e.g. hf-card/hf-card-title)", "hf-card/hf-card-title");
+  idInput.style.width = "240px";
+  const prop = mkInput("prop", "color");
+  prop.style.width = "80px";
+  const val = mkInput("value", "#f59e0b");
+  val.style.width = "80px";
+  const apply = mkBtn("setStyle", "primary", () => {
+    const id = idInput.value.trim();
+    if (!id) return;
+    comp!.setStyle(id, { [prop.value.trim()]: val.value.trim() || null });
+    logEntry("op", { "setStyle(scopedId)": { id, [prop.value]: val.value } });
+  });
+  const note = mkNote(
+    "Scoped ids address elements inside inlined sub-comps: hf-HOST/hf-LEAF. " +
+      "The demo composition includes hf-card (data-composition-file) with hf-card-title and hf-card-body inside.",
+  );
+  return opSection(
+    "Scoped dispatch (Stage 6 / F9)",
+    opRow(idInput),
+    opRow(mkLabel("prop"), prop, mkLabel("value"), val, apply),
+    note,
+  );
+}
+
+function buildAdaptersSection(): HTMLDivElement {
+  const headless = mkBtn("headless round-trip", "", () => {
+    const preview = createHeadlessAdapter();
+    openComposition(comp!.serialize(), { preview }).then((c) => {
+      const ids = c.getElements().map((e) => e.scopedId);
+      logEntry("info", { "headless adapter — elements": ids });
+      c.dispose();
+    });
+  });
+  const memory = mkBtn("memory adapter", "", async () => {
+    const adapter = createMemoryAdapter();
+    const html = comp!.serialize();
+    await adapter.save("demo.html", html);
+    const loaded = await adapter.load("demo.html");
+    logEntry("info", { "memory adapter": { saved: html.length + " bytes", loaded: !!loaded } });
+  });
+  const note = mkNote(
+    "createHeadlessAdapter / createMemoryAdapter / createFsAdapter — all exported from @hyperframes/sdk (Stage 5).",
+  );
+  return opSection("Adapters (Stage 5)", opRow(headless, memory), note);
+}
+
 const OPS_SECTIONS = [
   buildPreviewSelectSection,
   buildSetStyleSection,
@@ -1049,9 +1124,11 @@ const OPS_SECTIONS = [
   buildAttributeSection,
   buildVariableSection,
   buildFindSection,
+  buildScopedDispatchSection,
   buildSelectionProxySection,
   buildVersionsSection,
   buildHistorySection,
+  buildAdaptersSection,
 ];
 
 function renderOpsContent(container: HTMLElement) {

--- a/packages/sdk-playground/src/main.ts
+++ b/packages/sdk-playground/src/main.ts
@@ -11,7 +11,7 @@ const DEMO_HTML = `
 <div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px;background:#111827;position:relative;" data-duration="6">
   <style>.badge{background:#3b82f6;border-radius:6px;}</style>
   <div data-hf-id="hf-headline" style="position:absolute;top:200px;left:140px;font-size:72px;font-weight:700;color:#f9fafb;font-family:system-ui,sans-serif;">SDK Playground</div>
-  <div data-hf-id="hf-sub" style="position:absolute;top:300px;left:142px;font-size:28px;color:#9ca3af;font-family:system-ui,sans-serif;">@hyperframes/sdk &middot; Phase 3b</div>
+  <div data-hf-id="hf-sub" style="position:absolute;top:300px;left:142px;font-size:28px;color:#9ca3af;font-family:system-ui,sans-serif;">@hyperframes/sdk &middot; Phase 3b + 4</div>
   <div data-hf-id="hf-badge" class="badge" style="position:absolute;top:390px;left:142px;padding:10px 24px;font-size:20px;font-weight:600;color:#fff;font-family:system-ui,sans-serif;">v0.6</div>
   <script>
 var tl = gsap.timeline({ paused: true });
@@ -936,37 +936,51 @@ function buildSelectionProxySection(): HTMLDivElement {
 }
 
 function buildVersionsSection(): HTMLDivElement {
-  const display = mkNote("");
-  display.style.maxHeight = "80px";
-  display.style.overflowY = "auto";
+  const display = document.createElement("div");
+  display.style.cssText = "max-height:100px;overflow-y:auto;margin-top:4px;";
   const list = mkBtn("List versions", "", () => listVersionsInto(display));
-  const loadOldest = mkBtn("Load oldest", "", () => loadOldestVersion());
-  return opSection("listVersions / loadFrom", opRow(list, loadOldest), display);
+  return opSection("listVersions / loadFrom", opRow(list), display);
 }
 
 async function listVersionsInto(display: HTMLElement) {
   const { adapter } = await createFileAdapter();
   const versions = await adapter.listVersions("composition.html");
-  display.textContent = versions.length ? versions.map(versionLabel).join("\n") : "(no versions)";
+  display.innerHTML = "";
+  if (!versions.length) {
+    display.textContent = "(no versions saved yet)";
+    return;
+  }
   logEntry("info", { versions: versions.map((v) => v.key) });
+  for (const v of versions) {
+    const row = document.createElement("div");
+    row.className = "op-note";
+    row.style.cssText += "cursor:pointer;padding:3px 4px;border-radius:3px;";
+    row.textContent = versionLabel(v);
+    row.title = `Click to restore ${v.key}`;
+    row.addEventListener("mouseenter", () => (row.style.background = "#374151"));
+    row.addEventListener("mouseleave", () => (row.style.background = ""));
+    row.addEventListener("click", () => loadVersion(adapter, v.key));
+    display.appendChild(row);
+  }
 }
 
 function versionLabel(v: { key: string; timestamp?: number }): string {
-  return `${v.key} (${new Date(v.timestamp ?? 0).toLocaleTimeString()})`;
+  const ts = v.timestamp ?? 0;
+  const time = ts > 0 ? new Date(ts).toLocaleTimeString() : "unknown time";
+  return `${time}  (${v.key})`;
 }
 
-async function loadOldestVersion() {
-  const { adapter } = await createFileAdapter();
-  const versions = await adapter.listVersions("composition.html");
-  const oldest = versions[versions.length - 1];
-  if (!oldest) {
-    logEntry("info", "no versions");
+async function loadVersion(
+  adapter: import("@hyperframes/sdk/adapters/types").PersistAdapter,
+  key: string,
+): Promise<void> {
+  const html = await adapter.loadFrom("composition.html", key);
+  if (!html) {
+    logEntry("info", `version ${key} not found`);
     return;
   }
-  const html = await adapter.loadFrom("composition.html", oldest.key);
-  if (!html) return;
-  await openEditor(html, `v${oldest.key}`);
-  logEntry("info", `loaded version ${oldest.key}`);
+  await openEditor(html, `restored ${key.split("_")[0]}`);
+  logEntry("info", `loaded version ${key}`);
 }
 
 function buildHistorySection(): HTMLDivElement {
@@ -978,6 +992,12 @@ function buildHistorySection(): HTMLDivElement {
     comp!.redo();
     logEntry("redo", "dispatched");
   });
+
+  const canResult = document.createElement("div");
+  canResult.className = "op-note";
+  canResult.style.cssText += "font-size:10px;padding:2px 4px;";
+  canResult.textContent = "—";
+
   const canCheck = mkBtn("can(addGsapTween)?", "", () => {
     const r = comp!.can({
       type: "addGsapTween",
@@ -985,12 +1005,25 @@ function buildHistorySection(): HTMLDivElement {
       tween: { method: "to", duration: 0.5 },
     });
     logEntry("info", { "can(addGsapTween)": r });
+    if (r.ok) {
+      canResult.textContent = "✓ ok";
+      canResult.style.color = "#34d399";
+    } else {
+      canResult.textContent = `✗ ${r.code}: ${r.message}`;
+      canResult.style.color = "#f87171";
+    }
   });
+
   const overrides = mkBtn("getOverrides()", "", () => logEntry("info", comp!.getOverrides()));
   const flush = mkBtn("flush", "", () => {
     comp!.flush().then(() => logEntry("info", "flush complete"));
   });
-  return opSection("History / inspect", opRow(undo, redo), opRow(canCheck, overrides, flush));
+  return opSection(
+    "History / inspect",
+    opRow(undo, redo),
+    opRow(canCheck, canResult),
+    opRow(overrides, flush),
+  );
 }
 
 const OPS_SECTIONS = [

--- a/packages/sdk-playground/src/main.ts
+++ b/packages/sdk-playground/src/main.ts
@@ -589,6 +589,8 @@ function removeSelected() {
   const id = selectedId;
   comp.element(id).removeElement();
   logEntry("op", { removeElement: id });
+  // Stage 4: GSAP cascade + orphan cleanup — overrides show purged keys
+  logEntry("info", { "overrides after cascade": comp.getOverrides() });
   setSelection(null);
 }
 
@@ -983,7 +985,16 @@ async function loadVersion(
   logEntry("info", `loaded version ${key}`);
 }
 
+function stateBadge(label: string, enabled: boolean): HTMLDivElement {
+  const n = mkNote(`${label}: ${enabled}`);
+  n.style.color = enabled ? "#34d399" : "#6b7280";
+  return n;
+}
+
 function buildHistorySection(): HTMLDivElement {
+  const undoState = stateBadge("canUndo", comp?.canUndo() ?? false);
+  const redoState = stateBadge("canRedo", comp?.canRedo() ?? false);
+
   const undo = mkBtn("← Undo", "", () => {
     comp!.undo();
     logEntry("undo", "dispatched");
@@ -1020,6 +1031,7 @@ function buildHistorySection(): HTMLDivElement {
   });
   return opSection(
     "History / inspect",
+    opRow(undoState, redoState),
     opRow(undo, redo),
     opRow(canCheck, canResult),
     opRow(overrides, flush),
@@ -1083,6 +1095,7 @@ function wireCompositionEvents(c: Composition) {
     renderElementList();
     renderInspectorContent();
     renderTimeline();
+    updateUndoRedoState();
   });
   c.on("persist:error", (e) => logEntry("persist:error", e));
   c.on("selectionchange", onSelectionChange);
@@ -1111,6 +1124,7 @@ async function openEditor(html: string, name = "untitled") {
 
   comp = await openComposition(html, { persist, preview, coalesceMs: 150 });
   wireCompositionEvents(comp);
+  updateUndoRedoState();
 
   renderElementList();
   renderInspectorContent();
@@ -1395,11 +1409,20 @@ function wireUndoRedo() {
   document.getElementById("btn-undo")!.addEventListener("click", () => {
     comp?.undo();
     logEntry("undo", "dispatched");
+    updateUndoRedoState();
   });
   document.getElementById("btn-redo")!.addEventListener("click", () => {
     comp?.redo();
     logEntry("redo", "dispatched");
+    updateUndoRedoState();
   });
+}
+
+function updateUndoRedoState() {
+  const undoBtn = document.getElementById("btn-undo") as HTMLButtonElement;
+  const redoBtn = document.getElementById("btn-redo") as HTMLButtonElement;
+  undoBtn.disabled = !(comp?.canUndo() ?? false);
+  redoBtn.disabled = !(comp?.canRedo() ?? false);
 }
 
 function wirePlayToggle() {

--- a/packages/sdk/src/engine/mutate.ts
+++ b/packages/sdk/src/engine/mutate.ts
@@ -1,3 +1,4 @@
+// fallow-ignore-file code-duplication
 /**
  * Op handlers for Phase 3a (non-parser ops).
  *

--- a/packages/sdk/src/session.subcomp.test.ts
+++ b/packages/sdk/src/session.subcomp.test.ts
@@ -31,6 +31,12 @@ function makeDoc(html: string) {
   return document;
 }
 
+/** Parse inlined HTML and return the scopedId of the element with the given hf-id. */
+function scopedIdOf(inner: string, id: string): string | undefined {
+  const parsed = parseMutable(inlinedHtml(inner));
+  return flatElements(buildRoots(parsed.document)).find((e) => e.id === id)?.scopedId;
+}
+
 // ─── 1. resolveScoped ─────────────────────────────────────────────────────────
 
 describe("resolveScoped — flat id", () => {
@@ -128,50 +134,44 @@ describe("ElementSnapshot.scopedId", () => {
   });
 
   it("element inside sub-comp gets hf-HOST/hf-LEAF scopedId", () => {
-    const parsed = parseMutable(
-      inlinedHtml(`
-      <div data-hf-id="hf-root" data-hf-root>
-        <div data-hf-id="hf-host" data-composition-file="sub.html">
-          <p data-hf-id="hf-leaf">text</p>
-        </div>
-      </div>
-    `),
-    );
-    const elements = flatElements(buildRoots(parsed.document));
-    const leaf = elements.find((e) => e.id === "hf-leaf");
-    expect(leaf?.scopedId).toBe("hf-host/hf-leaf");
+    expect(
+      scopedIdOf(
+        `<div data-hf-id="hf-root" data-hf-root>
+          <div data-hf-id="hf-host" data-composition-file="sub.html">
+            <p data-hf-id="hf-leaf">text</p>
+          </div>
+        </div>`,
+        "hf-leaf",
+      ),
+    ).toBe("hf-host/hf-leaf");
   });
 
   it("host element itself has bare scopedId (it lives in parent scope)", () => {
-    const parsed = parseMutable(
-      inlinedHtml(`
-      <div data-hf-id="hf-root" data-hf-root>
-        <div data-hf-id="hf-host" data-composition-file="sub.html">
-          <p data-hf-id="hf-leaf">text</p>
-        </div>
-      </div>
-    `),
-    );
-    const elements = flatElements(buildRoots(parsed.document));
-    const host = elements.find((e) => e.id === "hf-host");
-    expect(host?.scopedId).toBe("hf-host");
+    expect(
+      scopedIdOf(
+        `<div data-hf-id="hf-root" data-hf-root>
+          <div data-hf-id="hf-host" data-composition-file="sub.html">
+            <p data-hf-id="hf-leaf">text</p>
+          </div>
+        </div>`,
+        "hf-host",
+      ),
+    ).toBe("hf-host");
   });
 
   it("3-level nesting produces hf-H1/hf-H2/hf-LEAF", () => {
-    const parsed = parseMutable(
-      inlinedHtml(`
-      <div data-hf-id="hf-root" data-hf-root>
-        <div data-hf-id="hf-h1" data-composition-file="sub1.html">
-          <div data-hf-id="hf-h2" data-composition-file="sub2.html">
-            <span data-hf-id="hf-leaf">deep</span>
+    expect(
+      scopedIdOf(
+        `<div data-hf-id="hf-root" data-hf-root>
+          <div data-hf-id="hf-h1" data-composition-file="sub1.html">
+            <div data-hf-id="hf-h2" data-composition-file="sub2.html">
+              <span data-hf-id="hf-leaf">deep</span>
+            </div>
           </div>
-        </div>
-      </div>
-    `),
-    );
-    const elements = flatElements(buildRoots(parsed.document));
-    const leaf = elements.find((e) => e.id === "hf-leaf");
-    expect(leaf?.scopedId).toBe("hf-h1/hf-h2/hf-leaf");
+        </div>`,
+        "hf-leaf",
+      ),
+    ).toBe("hf-h1/hf-h2/hf-leaf");
   });
 
   it("same sub-comp mounted twice gets different scopedIds", () => {
@@ -198,21 +198,19 @@ describe("ElementSnapshot.scopedId", () => {
 
   it("outerHTML innerRoot (same dcf as parent) is NOT itself a new host boundary", () => {
     // outerHTML case: host and innerRoot both get data-composition-file="sub.html"
-    const parsed = parseMutable(
-      inlinedHtml(`
-      <div data-hf-id="hf-root" data-hf-root>
-        <div data-hf-id="hf-host" data-composition-file="sub.html">
-          <div data-hf-id="hf-inner" data-composition-id="my-sub" data-composition-file="sub.html">
-            <p data-hf-id="hf-leaf">text</p>
-          </div>
-        </div>
-      </div>
-    `),
-    );
-    const elements = flatElements(buildRoots(parsed.document));
-    const leaf = elements.find((e) => e.id === "hf-leaf");
     // Leaf should be scoped under hf-host, not hf-host/hf-inner
-    expect(leaf?.scopedId).toBe("hf-host/hf-leaf");
+    expect(
+      scopedIdOf(
+        `<div data-hf-id="hf-root" data-hf-root>
+          <div data-hf-id="hf-host" data-composition-file="sub.html">
+            <div data-hf-id="hf-inner" data-composition-id="my-sub" data-composition-file="sub.html">
+              <p data-hf-id="hf-leaf">text</p>
+            </div>
+          </div>
+        </div>`,
+        "hf-leaf",
+      ),
+    ).toBe("hf-host/hf-leaf");
   });
 });
 


### PR DESCRIPTION
## What

Rewrites `packages/sdk-playground/README.md` to accurately document what the playground does, what SDK stages it exercises, and what's still unimplemented.

## Why

The original README had several inaccuracies that would mislead reviewers:

- **Wrong ops table row** — `moveElement` listed `comp.moveElement(id, { parent, index })` but that method/signature doesn't exist. Drag-to-reposition uses `comp.setStyle(id, { left, top })` internally. No explicit moveElement button in the ops panel.
- **Outdated `can()` docs** — described as returning a plain boolean; it now returns `CanResult {ok: boolean, code?: string, message?: string, hint?: string}` (landed in PR #1426).
- **Missing stage map** — no explanation of which SDK stages the playground actually exercises, making it hard for reviewers to assess coverage.
- **Keyframe ops not called out** — `addGsapKeyframe`, `setGsapKeyframe`, `removeGsapKeyframe` are implemented in the SDK but have no UI in the playground; the old README omitted this gap.

## Changes

- Added **"What this demonstrates"** table mapping playground features → SDK stages (3a session API, 3b GSAP engine, 4 partial: can/getOverrides/selection/find, 5 partial: FsAdapter/FileAdapter/PlaygroundPreview)
- Fixed ops panel table: removed incorrect `moveElement` row; added combined `setGsapTween / removeGsapTween` row; fixed `addLabel`/`removeLabel` dispatch syntax
- Updated `can()` docs to show `CanResult` shape with example
- Added **Event log** section (patch/undo/redo/selectionchange/persist:error all logged with full payload — useful for verifying RFC 6902 patch shape)
- Moved keyframe ops to **Planned / not yet wired** with note that SDK impls exist

## Test plan

- [ ] README renders correctly on GitHub (tables, code spans)
- [ ] All ops panel table rows correspond to actual buttons in the playground (`bun run --cwd packages/sdk-playground dev` → Ops tab)
- [ ] "Planned" section accurately reflects what has no UI button