### PR TITLE
fix(studio): sync GSAP positions when timeline clip is moved

### DIFF
--- a/packages/core/src/studio-api/routes/files.test.ts
+++ b/packages/core/src/studio-api/routes/files.test.ts
@@ -394,4 +394,80 @@ const tl = gsap.timeline();
     // The variable target was not flattened to a string-literal selector
     expect(result.after).toContain("tl.to(kicker,");
   });
+
+  function setupShiftTest(html: string) {
+    const projectDir = createProjectDir();
+    writeHtml(projectDir, "index.html", html);
+    const app = new Hono();
+    registerFileRoutes(app, createAdapter(projectDir));
+    return async (mutation: Record<string, unknown>) => {
+      const res = await app.request("http://localhost/projects/demo/gsap-mutations/index.html", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(mutation),
+      });
+      return {
+        status: res.status,
+        ...((await res.json()) as {
+          ok: boolean;
+          parsed: { animations: Array<{ targetSelector: string; position?: number }> };
+        }),
+      };
+    };
+  }
+
+  it("shift-positions shifts all animations targeting a selector by the given delta", async () => {
+    const mutate = setupShiftTest(`<!DOCTYPE html><html><body>
+<div id="hero" data-start="0" data-duration="4"></div>
+<script data-hyperframes-gsap>
+const tl = gsap.timeline();
+tl.to("#hero", { x: 100, duration: 2 }, 0);
+tl.to("#hero", { opacity: 1, duration: 1 }, 1);
+tl.to("#other", { y: 50, duration: 1 }, 0);
+</script></body></html>`);
+
+    const result = await mutate({ type: "shift-positions", targetSelector: "#hero", delta: 2 });
+    expect(result.status).toBe(200);
+    expect(result.ok).toBe(true);
+    const heroAnims = result.parsed.animations.filter((a) => a.targetSelector === "#hero");
+    expect(heroAnims).toHaveLength(2);
+    expect(heroAnims[0].position).toBe(2);
+    expect(heroAnims[1].position).toBe(3);
+    const otherAnims = result.parsed.animations.filter((a) => a.targetSelector === "#other");
+    expect(otherAnims).toHaveLength(1);
+    expect(otherAnims[0].position).toBe(0);
+  });
+
+  it("shift-positions clamps negative positions to 0", async () => {
+    const mutate = setupShiftTest(`<!DOCTYPE html><html><body>
+<div id="box" data-start="2" data-duration="4"></div>
+<script data-hyperframes-gsap>
+const tl = gsap.timeline();
+tl.to("#box", { x: 100, duration: 2 }, 1);
+</script></body></html>`);
+
+    const result = await mutate({ type: "shift-positions", targetSelector: "#box", delta: -3 });
+    expect(result.status).toBe(200);
+    expect(result.ok).toBe(true);
+    expect(result.parsed.animations[0].position).toBe(0);
+  });
+
+  it("shift-positions returns unchanged script when no animations match", async () => {
+    const mutate = setupShiftTest(`<!DOCTYPE html><html><body>
+<div id="hero" data-start="0" data-duration="4"></div>
+<script data-hyperframes-gsap>
+const tl = gsap.timeline();
+tl.to("#hero", { x: 100, duration: 2 }, 0);
+</script></body></html>`);
+
+    const result = await mutate({
+      type: "shift-positions",
+      targetSelector: "#nonexistent",
+      delta: 1,
+    });
+    expect(result.status).toBe(200);
+    expect(result.ok).toBe(true);
+    expect(result.parsed.animations[0].targetSelector).toBe("#hero");
+    expect(result.parsed.animations[0].position).toBe(0);
+  });
 });

--- a/packages/core/src/studio-api/routes/files.ts
+++ b/packages/core/src/studio-api/routes/files.ts
@@ -416,6 +416,11 @@ type GsapMutationRequest =
       splitTime: number;
       elementStart: number;
       elementDuration: number;
+    }
+  | {
+      type: "shift-positions";
+      targetSelector: string;
+      delta: number;
     };
 
 // ── GSAP mutation executor ──────────────────────────────────────────────────
@@ -646,6 +651,24 @@ async function executeGsapMutation(
         elementStart: body.elementStart,
         elementDuration: body.elementDuration,
       });
+    }
+    case "shift-positions": {
+      if (typeof body.targetSelector !== "string" || !body.targetSelector) {
+        return respond({ error: "shift-positions requires a non-empty targetSelector" }, 400);
+      }
+      if (typeof body.delta !== "number" || !Number.isFinite(body.delta) || body.delta === 0) {
+        return respond({ error: "shift-positions requires a finite non-zero delta" }, 400);
+      }
+      const parsed = parseGsapScript(block.scriptText);
+      const matching = parsed.animations.filter((a) => a.targetSelector === body.targetSelector);
+      if (matching.length === 0) return block.scriptText;
+      let script = block.scriptText;
+      for (const anim of matching) {
+        const oldPos = typeof anim.position === "number" ? anim.position : 0;
+        const newPos = Math.max(0, Math.round((oldPos + body.delta) * 1000) / 1000);
+        script = updateAnimationInScript(script, anim.id, { position: newPos });
+      }
+      return script;
     }
     default:
       return respond({ error: `unknown mutation type: ${(body as { type: string }).type}` }, 400);

--- a/packages/studio/src/hooks/useTimelineEditing.ts
+++ b/packages/studio/src/hooks/useTimelineEditing.ts
@@ -53,6 +53,43 @@ interface UseTimelineEditingOptions {
   isRecordingRef?: React.RefObject<boolean>;
 }
 
+// fallow-ignore-next-line complexity
+async function shiftGsapPositions(
+  projectId: string,
+  sourceFile: string,
+  targetSelector: string,
+  delta: number,
+  recordEdit: (input: RecordEditInput) => Promise<void>,
+  domEditSaveTimestampRef: React.MutableRefObject<number>,
+): Promise<void> {
+  try {
+    const res = await fetch(
+      `/api/projects/${encodeURIComponent(projectId)}/gsap-mutations/${encodeURIComponent(sourceFile)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "shift-positions", targetSelector, delta }),
+      },
+    );
+    if (!res.ok) return;
+    const data = (await res.json()) as {
+      ok?: boolean;
+      before?: string;
+      after?: string;
+    };
+    if (!data.ok || data.before == null || data.after == null) return;
+    if (data.before === data.after) return;
+    domEditSaveTimestampRef.current = Date.now();
+    await recordEdit({
+      label: "Shift GSAP positions with clip",
+      kind: "manual",
+      files: { [sourceFile]: { before: data.before, after: data.after } },
+    });
+  } catch {
+    // GSAP shift is best-effort — the clip move already succeeded
+  }
+}
+
 // ── Hook ──
 
 export function useTimelineEditing({
@@ -116,13 +153,15 @@ export function useTimelineEditing({
     ],
   );
 
+  // fallow-ignore-next-line complexity
   const handleTimelineElementMove = useCallback(
     (element: TimelineElement, updates: Pick<TimelineElement, "start" | "track">) => {
       patchIframeDomTiming(previewIframeRef.current, element, [
         ["data-start", formatTimelineAttributeNumber(updates.start)],
         ["data-track-index", String(updates.track)],
       ]);
-      return enqueueEdit(element, "Move timeline clip", (original, target) => {
+      const delta = updates.start - element.start;
+      const editPromise = enqueueEdit(element, "Move timeline clip", (original, target) => {
         let patched = applyPatchByTarget(original, target, {
           type: "attribute",
           property: "start",
@@ -134,8 +173,33 @@ export function useTimelineEditing({
           value: String(updates.track),
         });
       });
+      const domId = element.domId;
+      if (delta !== 0 && domId) {
+        const pid = projectIdRef.current;
+        const sourceFile = element.sourceFile || activeCompPath || "index.html";
+        if (pid) {
+          editPromise.then(() =>
+            shiftGsapPositions(
+              pid,
+              sourceFile,
+              `#${domId}`,
+              delta,
+              recordEdit,
+              domEditSaveTimestampRef,
+            ),
+          );
+        }
+      }
+      return editPromise;
     },
-    [previewIframeRef, enqueueEdit],
+    [
+      previewIframeRef,
+      enqueueEdit,
+      projectIdRef,
+      activeCompPath,
+      recordEdit,
+      domEditSaveTimestampRef,
+    ],
   );
 
   const handleTimelineElementResize = useCallback(


### PR DESCRIPTION
## Summary

- When dragging a timeline clip, `data-start` was updated but GSAP animation `position` parameters stayed fixed, causing animations to play during the wrong time window relative to element visibility
- Adds a `shift-positions` GSAP mutation type that shifts all animations targeting a selector by a delta, clamping to 0
- Wires the mutation into `handleTimelineElementMove` so GSAP positions stay in sync with clip timing automatically
- The GSAP shift is recorded as a separate undo history entry

## Root cause

Two independent timing systems (HTML `data-start` attributes and GSAP script `position` parameters) only sync at animation creation time. After that, moving a clip on the timeline updated `data-start` via `patchIframeDomTiming` but never called `updateGsapMeta` to shift the GSAP positions. This caused:
- Animations playing while the element is invisible (GSAP starts before `data-start`)
- Keyframe diamonds rendering at incorrect positions on the timeline
- Elements snapping to mid-animation state on first visible frame

## Test plan

- [x] Server-side `shift-positions` mutation: 3 new tests covering delta shift, negative clamping, and no-match passthrough
- [x] Type checks pass for both `core` and `studio` packages
- [x] Build passes across all packages
- [x] Reproduced the bug with agent-browser before the fix (screenshots shared in thread)