### PR TITLE
feat(sdk): stage 7 step 2 — setSelection API

### DIFF
--- a/packages/sdk/src/adapters/types.ts
+++ b/packages/sdk/src/adapters/types.ts
@@ -70,5 +70,7 @@ export interface PreviewAdapter {
   /** Set preview selection; fires selectionchange on the session */
   select(ids: string[], opts?: { additive?: boolean }): void;
 
+  // Stage 8 prep: fired when the preview host changes selection (e.g. user clicks an element).
+  // Not wired up in stage 7 — callers listen to the session's own selectionchange event instead.
   on(event: "selection", handler: (ids: string[]) => void): () => void;
 }

--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -403,4 +403,19 @@ describe("setSelection", () => {
     comp.setSelection(["hf-sub", "hf-title"]); // order differs — must fire
     expect(calls).toHaveLength(2);
   });
+
+  it("setSelection de-duplicates repeated ids", async () => {
+    const comp = await openComposition(BASE_HTML);
+    comp.setSelection(["hf-title", "hf-title", "hf-sub", "hf-title"]);
+    expect(comp.getSelection()).toEqual(["hf-title", "hf-sub"]);
+  });
+
+  it("setSelection with duplicates matching stored selection does not fire selectionchange", async () => {
+    const comp = await openComposition(BASE_HTML);
+    const calls: string[][] = [];
+    comp.on("selectionchange", (ids) => calls.push(ids));
+    comp.setSelection(["hf-title"]);
+    comp.setSelection(["hf-title", "hf-title"]); // de-duped = ["hf-title"] — no change
+    expect(calls).toHaveLength(1);
+  });
 });

--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -297,3 +297,92 @@ describe("override-set orphan cleanup on removeElement", () => {
     expect(overrides["hf-sub.style.opacity"]).toBe("1");
   });
 });
+
+// ─── setSelection / getSelection / selectionchange ───────────────────────────
+
+describe("setSelection", () => {
+  it("getSelection returns empty array before any setSelection call", async () => {
+    const comp = await openComposition(BASE_HTML);
+    expect(comp.getSelection()).toEqual([]);
+  });
+
+  it("setSelection updates getSelection", async () => {
+    const comp = await openComposition(BASE_HTML);
+    comp.setSelection(["hf-title"]);
+    expect(comp.getSelection()).toEqual(["hf-title"]);
+  });
+
+  it("setSelection with multiple ids", async () => {
+    const comp = await openComposition(BASE_HTML);
+    comp.setSelection(["hf-title", "hf-sub"]);
+    expect(comp.getSelection()).toEqual(["hf-title", "hf-sub"]);
+  });
+
+  it("setSelection([]) clears selection", async () => {
+    const comp = await openComposition(BASE_HTML);
+    comp.setSelection(["hf-title"]);
+    comp.setSelection([]);
+    expect(comp.getSelection()).toEqual([]);
+  });
+
+  it("setSelection fires selectionchange with new ids", async () => {
+    const comp = await openComposition(BASE_HTML);
+    const calls: string[][] = [];
+    comp.on("selectionchange", (ids) => calls.push(ids));
+    comp.setSelection(["hf-title"]);
+    expect(calls).toEqual([["hf-title"]]);
+  });
+
+  it("setSelection fires selectionchange with empty array when clearing", async () => {
+    const comp = await openComposition(BASE_HTML);
+    comp.setSelection(["hf-title"]);
+    const calls: string[][] = [];
+    comp.on("selectionchange", (ids) => calls.push(ids));
+    comp.setSelection([]);
+    expect(calls).toEqual([[]]);
+  });
+
+  it("selectionchange listener receives a fresh copy each call", async () => {
+    const comp = await openComposition(BASE_HTML);
+    const snapshots: string[][] = [];
+    comp.on("selectionchange", (ids) => snapshots.push(ids));
+    comp.setSelection(["hf-title"]);
+    comp.setSelection(["hf-sub"]);
+    expect(snapshots[0]).toEqual(["hf-title"]);
+    expect(snapshots[1]).toEqual(["hf-sub"]);
+  });
+
+  it("unsubscribed listener does not fire", async () => {
+    const comp = await openComposition(BASE_HTML);
+    const calls: string[][] = [];
+    const off = comp.on("selectionchange", (ids) => calls.push(ids));
+    off();
+    comp.setSelection(["hf-title"]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("selection() proxy operates on ids at call time", async () => {
+    const comp = await openComposition(BASE_HTML);
+    comp.setSelection(["hf-title"]);
+    const proxy = comp.selection();
+    expect(proxy.ids).toEqual(["hf-title"]);
+  });
+
+  it("setSelection does not affect undo stack", async () => {
+    const comp = await openComposition(BASE_HTML);
+    comp.setStyle("hf-title", { color: "#ff0000" });
+    comp.setSelection(["hf-sub"]);
+    expect(comp.canUndo()).toBe(true);
+    comp.undo();
+    // selection must not have been pushed to history
+    expect(comp.canUndo()).toBe(false);
+  });
+
+  it("setSelection does not emit a patch event", async () => {
+    const comp = await openComposition(BASE_HTML);
+    const patches: unknown[] = [];
+    comp.on("patch", (e) => patches.push(e));
+    comp.setSelection(["hf-title"]);
+    expect(patches).toHaveLength(0);
+  });
+});

--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -385,4 +385,22 @@ describe("setSelection", () => {
     comp.setSelection(["hf-title"]);
     expect(patches).toHaveLength(0);
   });
+
+  it("setSelection with same ids does not fire selectionchange again", async () => {
+    const comp = await openComposition(BASE_HTML);
+    const calls: string[][] = [];
+    comp.on("selectionchange", (ids) => calls.push(ids));
+    comp.setSelection(["hf-title"]);
+    comp.setSelection(["hf-title"]); // same ids — must be a no-op
+    expect(calls).toHaveLength(1);
+  });
+
+  it("setSelection with same ids in different order fires selectionchange", async () => {
+    const comp = await openComposition(BASE_HTML);
+    const calls: string[][] = [];
+    comp.on("selectionchange", (ids) => calls.push(ids));
+    comp.setSelection(["hf-title", "hf-sub"]);
+    comp.setSelection(["hf-sub", "hf-title"]); // order differs — must fire
+    expect(calls).toHaveLength(2);
+  });
 });

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -224,6 +224,16 @@ class CompositionImpl implements Composition {
     return [...this.currentSelection];
   }
 
+  setSelection(ids: string[]): void {
+    if (
+      ids.length === this.currentSelection.length &&
+      ids.every((id, i) => id === this.currentSelection[i])
+    ) {
+      return;
+    }
+    this.updateSelection(ids);
+  }
+
   private updateSelection(ids: readonly string[]): void {
     this.currentSelection = [...ids];
     for (const handler of this.selectionHandlers) {

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -225,13 +225,14 @@ class CompositionImpl implements Composition {
   }
 
   setSelection(ids: string[]): void {
+    const deduped = Array.from(new Set(ids));
     if (
-      ids.length === this.currentSelection.length &&
-      ids.every((id, i) => id === this.currentSelection[i])
+      deduped.length === this.currentSelection.length &&
+      deduped.every((id, i) => id === this.currentSelection[i])
     ) {
       return;
     }
-    this.updateSelection(ids);
+    this.updateSelection(deduped);
   }
 
   private updateSelection(ids: readonly string[]): void {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -253,6 +253,8 @@ export interface Composition {
   /** Curried handle — holds only the id, no stale-ref hazard */
   element(id: HfId): ElementHandle;
   getSelection(): string[];
+  /** Replace the current selection; fires selectionchange. Pass [] to clear. */
+  setSelection(ids: string[]): void;
 
   // ── Advanced / agent layer (F10 layer 2) ──────────────────────────────────
   dispatch(op: EditOp, opts?: { origin?: unknown }): void;


### PR DESCRIPTION
## What

Adds `session.setSelection(ids: string[])` to the SDK `Composition` API. Fires a `selectionchange` event on the session; does not create an undo entry or emit a patch.

## Why

Studio needs to mirror canvas selection state into the SDK session so downstream consumers (agent context, inspector panels, future collaborative cursors) can read who is selected without polling the DOM. Selection is metadata, not content — it must not appear in the undo stack or trigger a persist write.

## How

- `setSelection` stores the id array in session state and emits `selectionchange`
- No patch event, no history entry, no persist write
- `session.getSelection()` returns the current ids
- 11 unit tests covering: set/get round-trip, selectionchange fires, multiple calls replace not append, empty array clears, no patch event emitted

## Test plan

- `session.subcomp.test.ts` / `session.test.ts`: all 11 selection tests pass
- Integration: `useSdkSelectionSync` (PR #1443) calls `setSelection` on every canvas selection change and the session reflects it correctly