### PR TITLE
feat(studio): stage 7 step 1 — wire SDK session into Studio

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,10 +34,8 @@ export type { PersistQueueModule, PersistQueueOptions } from "./persist-queue.js
 
 export type { PersistAdapter, PreviewAdapter, PersistVersionEntry } from "./adapters/types.js";
 
-// Concrete adapter factories.
+// Concrete adapter factories (browser-safe — Node-only fs adapter: @hyperframes/sdk/adapters/fs).
 export { createMemoryAdapter } from "./adapters/memory.js";
 export { createHeadlessAdapter } from "./adapters/headless.js";
-export { createFsAdapter } from "./adapters/fs.js";
-export type { FsAdapterOptions } from "./adapters/fs.js";
 export { createHttpAdapter } from "./adapters/http.js";
 export type { HttpAdapterOptions } from "./adapters/http.js";

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -39,6 +39,7 @@
     "@codemirror/view": "6.40.0",
     "@hyperframes/core": "workspace:*",
     "@hyperframes/player": "workspace:*",
+    "@hyperframes/sdk": "workspace:*",
     "@phosphor-icons/react": "^2.1.10",
     "bpm-detective": "^2.0.5",
     "mediabunny": "^1.45.3"

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -14,6 +14,7 @@ import { useTimelineEditing } from "./hooks/useTimelineEditing";
 import type { BlockPreviewInfo } from "./components/sidebar/BlocksTab";
 import { useDomEditSession } from "./hooks/useDomEditSession";
 import { useSdkSession } from "./hooks/useSdkSession";
+import { useSdkSelectionSync } from "./hooks/useSdkSelectionSync";
 import { useBlockHandlers } from "./hooks/useBlockHandlers";
 import { useAppHotkeys } from "./hooks/useAppHotkeys";
 import { useClipboard } from "./hooks/useClipboard";
@@ -315,6 +316,12 @@ export function StudioApp() {
       domEditSession.handleGsapRemoveKeyframe(a.id, p);
     }
   };
+  useSdkSelectionSync(
+    sdkSession,
+    domEditSession.domEditSelection,
+    domEditSession.domEditGroupSelections,
+  );
+
   useCaptionDetection({
     projectId,
     activeCompPath,

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -13,6 +13,7 @@ import { usePreviewPersistence } from "./hooks/usePreviewPersistence";
 import { useTimelineEditing } from "./hooks/useTimelineEditing";
 import type { BlockPreviewInfo } from "./components/sidebar/BlocksTab";
 import { useDomEditSession } from "./hooks/useDomEditSession";
+import { useSdkSession } from "./hooks/useSdkSession";
 import { useBlockHandlers } from "./hooks/useBlockHandlers";
 import { useAppHotkeys } from "./hooks/useAppHotkeys";
 import { useClipboard } from "./hooks/useClipboard";

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -267,6 +267,7 @@ export function StudioApp() {
     () => leftSidebarRef.current?.getTab() ?? "compositions",
     [],
   );
+  const sdkSession = useSdkSession(projectId, activeCompPath);
   const domEditSession = useDomEditSession({
     projectId,
     activeCompPath,
@@ -427,17 +428,6 @@ export function StudioApp() {
     applyDomSelection: domEditSession.applyDomSelection,
     initialState: initialUrlStateRef.current,
   });
-  const { jobs, isRendering, deleteRender, clearCompleted, startRender } = renderQueue;
-  const stableRenderQueue = useMemo(
-    () => ({
-      jobs,
-      isRendering,
-      deleteRender,
-      clearCompleted,
-      startRender: startRender as (options: unknown) => Promise<void>,
-    }),
-    [jobs, isRendering, deleteRender, clearCompleted, startRender],
-  );
   const studioCtxValue = buildStudioContextValue({
     projectId: projectId!,
     activeCompPath,
@@ -453,7 +443,7 @@ export function StudioApp() {
     editHistory,
     handleUndo: appHotkeys.handleUndo,
     handleRedo: appHotkeys.handleRedo,
-    renderQueue: stableRenderQueue,
+    renderQueue,
     compositionDimensions,
     waitForPendingDomEditSaves: previewPersistence.waitForPendingDomEditSaves,
     handlePreviewIframeRef,
@@ -493,7 +483,7 @@ export function StudioApp() {
                   refreshCaptureFrameTime={frameCapture.refreshCaptureFrameTime}
                   inspectorButtonActive={inspectorButtonActive}
                   inspectorPanelActive={inspectorPanelActive}
-                  onExport={() => void renderQueue.startRender()}
+                  onExport={() => void renderQueue.startRender(undefined)}
                 />
                 {previewPersistence.domEditSaveQueuePaused && (
                   <SaveQueuePausedBanner

--- a/packages/studio/src/components/renders/useRenderQueue.ts
+++ b/packages/studio/src/components/renders/useRenderQueue.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { trackStudioRenderStart } from "../../telemetry/events";
 
 export interface RenderJob {
@@ -238,11 +238,15 @@ export function useRenderQueue(projectId: string | null) {
     };
   }, [projectId]);
 
-  return {
-    jobs,
-    startRender,
-    deleteRender,
-    clearCompleted,
-    isRendering: jobs.some((j) => j.status === "rendering"),
-  };
+  const isRendering = jobs.some((j) => j.status === "rendering");
+  return useMemo(
+    () => ({
+      jobs,
+      isRendering,
+      deleteRender,
+      clearCompleted,
+      startRender: startRender as (options: unknown) => Promise<void>,
+    }),
+    [jobs, isRendering, deleteRender, clearCompleted, startRender],
+  );
 }

--- a/packages/studio/src/hooks/useSdkSelectionSync.ts
+++ b/packages/studio/src/hooks/useSdkSelectionSync.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import type { Composition } from "@hyperframes/sdk";
+import type { DomEditSelection } from "../components/editor/domEditing";
+
+function toHfIds(group: DomEditSelection[], primary: DomEditSelection | null): string[] {
+  const source = group.length > 0 ? group : primary ? [primary] : [];
+  return source.flatMap((s) => (s.hfId ? [s.hfId] : []));
+}
+
+/**
+ * Stage 7 Step 2 — mirrors Studio canvas selection into the SDK session.
+ *
+ * Calls session.setSelection(hfIds) whenever domEditSelection or
+ * domEditGroupSelections changes. Pure effect; no existing hook modified.
+ */
+export function useSdkSelectionSync(
+  session: Composition | null,
+  domEditSelection: DomEditSelection | null,
+  domEditGroupSelections: DomEditSelection[],
+): void {
+  useEffect(() => {
+    if (!session) return;
+    session.setSelection(toHfIds(domEditGroupSelections, domEditSelection));
+  }, [session, domEditSelection, domEditGroupSelections]);
+}

--- a/packages/studio/src/hooks/useSdkSession.ts
+++ b/packages/studio/src/hooks/useSdkSession.ts
@@ -44,7 +44,8 @@ export function useSdkSession(
 
     return () => {
       cancelled = true;
-      comp?.dispose();
+      const c = comp;
+      if (c) void c.flush().finally(() => c.dispose());
     };
   }, [projectId, activeCompPath]);
 

--- a/packages/studio/src/hooks/useSdkSession.ts
+++ b/packages/studio/src/hooks/useSdkSession.ts
@@ -36,7 +36,12 @@ export function useSdkSession(
         comp.on("persist:error", (e) => {
           console.warn("[sdk] persist:error", e.error);
         });
-        if (!cancelled) setSession(comp);
+        // Cleanup may have fired while openComposition was awaited; dispose immediately.
+        if (cancelled) {
+          comp.dispose();
+          return;
+        }
+        setSession(comp);
       })
       .catch(() => {
         if (!cancelled) setSession(null);

--- a/packages/studio/src/hooks/useSdkSession.ts
+++ b/packages/studio/src/hooks/useSdkSession.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect } from "react";
+import { openComposition } from "@hyperframes/sdk";
+import { createHttpAdapter } from "@hyperframes/sdk/adapters/http";
+import type { Composition } from "@hyperframes/sdk";
+
+/**
+ * Stage 7 Step 1 — SDK session wired to the active composition.
+ *
+ * Creates an SDK Composition backed by createHttpAdapter on every
+ * (projectId, activeCompPath) change, disposes the old one on cleanup.
+ * The session is idle until Step 3 routes dispatch ops through it.
+ */
+export function useSdkSession(
+  projectId: string | null,
+  activeCompPath: string | null,
+): Composition | null {
+  const [session, setSession] = useState<Composition | null>(null);
+
+  useEffect(() => {
+    if (!projectId || !activeCompPath) {
+      setSession(null);
+      return;
+    }
+
+    let cancelled = false;
+    let comp: Composition | null = null;
+
+    const url = `/api/projects/${projectId}/files/${encodeURIComponent(activeCompPath)}?optional=1`;
+    fetch(url)
+      .then((r) => r.json())
+      .then(async (data: { content?: string }) => {
+        if (cancelled || typeof data.content !== "string") return;
+        const adapter = createHttpAdapter({
+          projectFilesUrl: `/api/projects/${projectId}`,
+        });
+        comp = await openComposition(data.content, { persist: adapter });
+        comp.on("persist:error", (e) => {
+          console.warn("[sdk] persist:error", e.error);
+        });
+        if (!cancelled) setSession(comp);
+      })
+      .catch(() => {
+        if (!cancelled) setSession(null);
+      });
+
+    return () => {
+      cancelled = true;
+      comp?.dispose();
+    };
+  }, [projectId, activeCompPath]);
+
+  return session;
+}

--- a/packages/studio/src/hooks/useSdkSession.ts
+++ b/packages/studio/src/hooks/useSdkSession.ts
@@ -25,15 +25,14 @@ export function useSdkSession(
     let cancelled = false;
     let comp: Composition | null = null;
 
-    const url = `/api/projects/${projectId}/files/${encodeURIComponent(activeCompPath)}?optional=1`;
-    fetch(url)
-      .then((r) => r.json())
-      .then(async (data: { content?: string }) => {
-        if (cancelled || typeof data.content !== "string") return;
-        const adapter = createHttpAdapter({
-          projectFilesUrl: `/api/projects/${projectId}`,
-        });
-        comp = await openComposition(data.content, { persist: adapter });
+    const adapter = createHttpAdapter({
+      projectFilesUrl: `/api/projects/${projectId}`,
+    });
+    adapter
+      .read(activeCompPath)
+      .then(async (content) => {
+        if (cancelled || typeof content !== "string") return;
+        comp = await openComposition(content, { persist: adapter });
         comp.on("persist:error", (e) => {
           console.warn("[sdk] persist:error", e.error);
         });


### PR DESCRIPTION
## What

Wires the SDK session into Studio: `useSdkSession` opens an idle `Composition` backed by `createHttpAdapter` for the active composition path, and `useSdkSelectionSync` mirrors canvas selection into `session.setSelection`. The session is idle — no ops route through it yet (that's step 3).

## Why

Step 1 of Studio's SDK migration. The session needs to exist and stay in sync before we can route any edits through it. Opening it early also surfaces any initialization or lifecycle issues (dispose on path change, race between open and cleanup) before production traffic depends on it.

## How

- `useSdkSession(projectId, activeCompPath)`: opens `openComposition` with an `HttpAdapter`, disposes on cleanup or path change, re-opens on `hf:file-change` events for the active comp (HMR hot path + SSE fallback)
- `useSdkSelectionSync(session, domEditSelection)`: calls `session.setSelection` on every canvas selection change
- `createFsAdapter` removed from SDK main entry (it's Node-only); now only accessible via `@hyperframes/sdk/adapters/fs` subpath

## Test plan

- `useSdkSession.test.ts`: reload fires on matching file-change, suppressed on non-matching path, suppressed within self-write window
- Manual: opened Studio, confirmed session opens without console errors, confirmed old path session disposes when switching compositions