### PR TITLE
fix(producer): shim CJS __dirname / __filename in ESM banner

### DIFF
--- a/packages/producer/build.mjs
+++ b/packages/producer/build.mjs
@@ -15,12 +15,16 @@ mkdirSync("dist", { recursive: true });
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
-// The banner provides a real `require` function via createRequire so that
-// esbuild's CJS interop (__require) works correctly in ESM output.
-// Without this, bundled CJS deps (recast, yauzl, etc.) that call
-// require("fs") throw "Dynamic require of 'fs' is not supported".
+// Shim `require` + `__dirname` / `__filename` for bundled CJS deps that expect them in ESM scope.
 const cjsBanner = {
-  js: "import { createRequire as __cjsRequire } from 'module'; const require = __cjsRequire(import.meta.url);",
+  js: [
+    "import { createRequire as __cjsRequire } from 'module';",
+    "import { fileURLToPath as __fileURLToPath } from 'url';",
+    "import { dirname as __pathDirname } from 'path';",
+    "const require = __cjsRequire(import.meta.url);",
+    "const __filename = __fileURLToPath(import.meta.url);",
+    "const __dirname = __pathDirname(__filename);",
+  ].join(" "),
 };
 
 const workspaceAliasPlugin = {


### PR DESCRIPTION
## Summary

Bundled CJS deps — notably the ffmpeg/Emscripten wasm glue, which does `scriptDirectory = __dirname + "/"` — were crashing at render time with `__dirname is not defined in ES module scope`.

The existing banner shimmed `require` from `import.meta.url` but missed `__dirname` / `__filename`. Adds both globals alongside the existing `createRequire` shim.

## Verification

- Verified by re-running a producer render after rebuild — ffmpeg pipeline completes cleanly
- `node packages/producer/build.mjs` esbuild bundles complete without errors

## Sibling PRs in this stack

- #1446 — fix(core/lint): findRootTag masks comment/style/script ranges
- #1447 — feat(cli): capture-video on-demand fetcher + capture pipeline robustness

All three independent; merge order doesn't matter.

## Test plan

- [ ] `bun run --filter @hyperframes/producer build` passes
- [ ] Producer render of an existing project completes without `__dirname` errors