### PR TITLE
fix(core/lint): findRootTag ignores <video>-like tokens inside HTML comments / <style> / <script>

### DIFF
--- a/packages/core/src/lint/utils.ts
+++ b/packages/core/src/lint/utils.ts
@@ -79,6 +79,20 @@ export function findHtmlTag(source: string): OpenTag | null {
   };
 }
 
+// Same-length whitespace keeps downstream offsets aligned.
+function maskRanges(src: string, pattern: RegExp): string {
+  const p = new RegExp(
+    pattern.source,
+    pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g",
+  );
+  let out = src;
+  let m: RegExpExecArray | null;
+  while ((m = p.exec(out)) !== null) {
+    out = out.slice(0, m.index) + " ".repeat(m[0].length) + out.slice(m.index + m[0].length);
+  }
+  return out;
+}
+
 export function findRootTag(source: string): OpenTag | null {
   const bodyOpenMatch = /<body\b[^>]*>/i.exec(source);
   const bodyCloseMatch = /<\/body>/i.exec(source);
@@ -88,7 +102,12 @@ export function findRootTag(source: string): OpenTag | null {
       ? bodyCloseMatch.index
       : source.length;
   const bodyContent = bodyOpenMatch ? source.slice(bodyStart, bodyEnd) : source;
-  const bodyTags = extractOpenTags(bodyContent);
+  // Mask comments / <style> / <script> so a `<video>` token inside any of them isn't picked as root.
+  const masked = maskRanges(
+    maskRanges(maskRanges(bodyContent, /<!--[\s\S]*?-->/g), STYLE_BLOCK_PATTERN),
+    SCRIPT_BLOCK_PATTERN,
+  );
+  const bodyTags = extractOpenTags(masked);
   for (const tag of bodyTags) {
     if (["script", "style", "meta", "link", "title"].includes(tag.name)) continue;
     return { ...tag, index: tag.index + bodyStart };


### PR DESCRIPTION
## Summary

A literal `<video>` token written inside a CSS comment block (e.g. `/* card uses <video> as surface */`) was being picked as the composition root, producing two cascading false errors: `root_missing_composition_id` + `root_missing_dimensions`.

`findRootTag` now masks `<!-- -->` / `<style>…</style>` / `<script>…</script>` ranges with same-length whitespace (so tag offsets stay aligned for downstream consumers) before running the tag scan.

## Verification

- Existing `stripJsComments` / `extractScriptTextsAndSrcs` exports preserved (downstream rule consumers in `rules/{adapters,composition,core,gsap}.ts` read `rootTag.raw` + `rootTag.index` against the real source offsets — safe under the new masking)
- `bun run --filter @hyperframes/core test` passes

## Sibling PRs in this stack

- #1445 — fix(producer): __dirname ESM banner shim
- #1447 — feat(cli): capture-video on-demand fetcher + capture pipeline robustness

All three independent; merge order doesn't matter.

## Test plan

- [ ] `bun run --filter @hyperframes/core typecheck` passes
- [ ] `bun run --filter @hyperframes/core test` passes