### PR TITLE
chore: gitignore local chrome-for-testing downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ docs/superpowers/
 .worktrees
 hyperframes-bench/
 tmp/
+
+# Local Chrome-for-Testing downloads (large binaries, never commit)
+chrome/

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ tmp/
 
 # Local editor settings
 .zed/
+
+# Local Chrome-for-Testing downloads (large binaries, never commit)
+chrome/


### PR DESCRIPTION
The `chrome/` directory holds Chrome-for-Testing binaries (~220MB each) pulled
locally for the drawElement fast-capture work. They must never be committed —
the framework binary exceeds GitHub's 100MB limit and an atomic push gets
rejected (already hit once during a rebase that swept the dir in via `git add -A`).

One line added to the root `.gitignore`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)