### PR TITLE
fix(studio): wire onTrySdkPersist to sdkCutoverPersist (cutover was unwired)

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -304,6 +304,7 @@ export function StudioApp() {
     openSourceForSelection: fileManager.openSourceForSelection,
     selectSidebarTab: selectSidebarTabStable,
     getSidebarTab: getSidebarTabStable,
+    sdkSession: sdkHandle.session,
   });
   domEditSelectionBridgeRef.current = domEditSession.domEditSelection;
   clearDomSelectionRef.current = domEditSession.clearDomSelection;

--- a/packages/studio/src/hooks/useDomEditCommits.ts
+++ b/packages/studio/src/hooks/useDomEditCommits.ts
@@ -77,6 +77,13 @@ export interface UseDomEditCommitsParams {
   onDomEditPersisted?: (selection: DomEditSelection, operations: PatchOperation[]) => void;
   /** Stage 7 Step 3b: called after a successful server-side element delete. */
   onElementDeleted?: (selection: DomEditSelection) => void;
+  /** Stage 7 Step 3c: called before the server-side patch path; returns true if SDK handled it. */
+  onTrySdkPersist?: (
+    selection: DomEditSelection,
+    operations: PatchOperation[],
+    originalContent: string,
+    targetPath: string,
+  ) => Promise<boolean>;
 }
 
 export function useDomEditCommits({
@@ -99,6 +106,7 @@ export function useDomEditCommits({
   buildDomSelectionFromTarget,
   onDomEditPersisted,
   onElementDeleted,
+  onTrySdkPersist,
 }: UseDomEditCommitsParams) {
   const resolveImportedFontAsset = useCallback(
     (fontFamilyValue: string): ImportedFontAsset | null => {
@@ -148,6 +156,18 @@ export function useDomEditCommits({
       }
 
       if (options?.shouldSave && !options.shouldSave()) return;
+
+      // Skip the SDK path when prepareContent is set (e.g. @font-face injection
+      // for a custom font): sdkCutoverPersist serializes only the patched DOM
+      // and would drop the injected content. Let the server path run prepareContent.
+      if (
+        onTrySdkPersist &&
+        !options?.prepareContent &&
+        (await onTrySdkPersist(selection, operations, originalContent, targetPath))
+      ) {
+        // SDK handled it — its in-memory doc is already current.
+        return;
+      }
 
       const patchTarget = buildDomEditPatchTarget(selection);
       const patchBody = { target: patchTarget, operations };
@@ -235,6 +255,7 @@ export function useDomEditCommits({
       reloadPreview,
       showToast,
       onDomEditPersisted,
+      onTrySdkPersist,
     ],
   );
 

--- a/packages/studio/src/hooks/useDomEditSession.ts
+++ b/packages/studio/src/hooks/useDomEditSession.ts
@@ -4,6 +4,8 @@ import type { EditHistoryKind } from "../utils/editHistory";
 import type { RightPanelTab } from "../utils/studioHelpers";
 import type { PatchTarget } from "../utils/sourcePatcher";
 import type { SidebarTab } from "../components/sidebar/LeftSidebar";
+import type { Composition } from "@hyperframes/sdk";
+import { sdkCutoverPersist } from "../utils/sdkCutover";
 import { useAskAgentModal } from "./useAskAgentModal";
 import { useDomSelection } from "./useDomSelection";
 import { usePreviewInteraction } from "./usePreviewInteraction";
@@ -58,6 +60,7 @@ export interface UseDomEditSessionParams {
   openSourceForSelection?: (sourceFile: string, target: PatchTarget) => void;
   selectSidebarTab?: (tab: SidebarTab) => void;
   getSidebarTab?: () => SidebarTab;
+  sdkSession?: Composition | null;
 }
 
 // ── Hook ──
@@ -96,6 +99,7 @@ export function useDomEditSession({
   openSourceForSelection,
   selectSidebarTab,
   getSidebarTab,
+  sdkSession,
 }: UseDomEditSessionParams) {
   void _setRefreshKey;
   void _readProjectFile;
@@ -228,6 +232,15 @@ export function useDomEditSession({
     clearDomSelection,
     refreshDomEditSelectionFromPreview,
     buildDomSelectionFromTarget,
+    onTrySdkPersist: sdkSession
+      ? (selection, operations, originalContent, targetPath) =>
+          sdkCutoverPersist(selection, operations, originalContent, targetPath, sdkSession, {
+            editHistory,
+            writeProjectFile,
+            reloadPreview,
+            domEditSaveTimestampRef,
+          })
+      : undefined,
   });
 
   // ── Wiring: selection sync, GSAP cache, preview sync, selection handlers ──


### PR DESCRIPTION
## What

Stage 7 s7.5 declared the SDK cutover \"always-on\" by removing the feature flag, but
`onTrySdkPersist` was never actually passed to `useDomEditCommits` — `sdkCutoverPersist` was
dead code in production. Every DOM edit still went through the server patch path.

This PR wires the cutover for the op types already supported by `sdkCutover.ts`:
`inline-style` → `setStyle`, `text-content` → `setText`, `attribute`/`html-attribute` → `setAttribute`.

## Why

Without this wiring, Stages 3.1–3.5 (delete, timing, GSAP panel) have no foundation to build on.
Also fixes a correctness gap: s7.5 said cutover was active but it wasn't.

## How

- Added `sdkSession?: Composition | null` to `UseDomEditSessionParams`
- In `useDomEditSession`, imported `sdkCutoverPersist` and built an `onTrySdkPersist` closure
  using deps already in scope (`editHistory`, `writeProjectFile`, `reloadPreview`, `domEditSaveTimestampRef`)
- Passed `sdkSession` from `App.tsx` into `useDomEditSession` (all other CutoverDeps were already threaded)
- `onTrySdkPersist` is `undefined` when `sdkSession` is null/absent — no behavior change without a session

`App.tsx` is exactly 600 lines (at the Studio file-size gate limit).

## Test plan

- [x] `bun run build` — passes (all packages)
- [x] `bun run test` in `packages/sdk` — 226/226 pass
- [x] `bun run test` in `packages/studio` — 3 pre-existing failures in `useDomEditSession.test.ts`
  (stale test calling `shouldUseSdkCutover` with a now-removed flag param); all other tests pass
- [x] `bunx oxlint` + `bunx oxfmt --check` — no warnings or errors on changed files
- [x] Pre-commit hooks (filesize, lint, format, fallow, typecheck) — all pass
- [ ] Manual Studio smoke: style/text edit → confirm `sdk_cutover_success` telemetry fires (not `_fallback`)