### PR TITLE
feat(studio): route GSAP tween add/update/delete through SDK (§3.5 PR1)

### DIFF
--- a/packages/studio/src/hooks/gsapScriptCommitTypes.ts
+++ b/packages/studio/src/hooks/gsapScriptCommitTypes.ts
@@ -1,4 +1,5 @@
 import type { ParsedGsap } from "@hyperframes/core/gsap-parser";
+import type { Composition } from "@hyperframes/sdk";
 import type { DomEditSelection } from "../components/editor/domEditingTypes";
 import type { EditHistoryKind } from "../utils/editHistory";
 
@@ -63,4 +64,7 @@ export interface GsapScriptCommitsParams {
   onCacheInvalidate: () => void;
   onFileContentChanged?: (path: string, content: string) => void;
   showToast: (message: string, tone?: "error" | "info") => void;
+  /** Stage 7 §3.5: SDK session for routing GSAP tween ops through addGsapTween/setGsapTween/removeGsapTween. */
+  sdkSession?: Composition | null;
+  writeProjectFile?: (path: string, content: string) => Promise<void>;
 }

--- a/packages/studio/src/hooks/useDomEditSession.ts
+++ b/packages/studio/src/hooks/useDomEditSession.ts
@@ -193,6 +193,8 @@ export function useDomEditSession({
     onCacheInvalidate: bumpGsapCache,
     onFileContentChanged: updateEditingFileContent,
     showToast,
+    sdkSession,
+    writeProjectFile,
   });
 
   // ── DOM commit handlers ──

--- a/packages/studio/src/hooks/useGsapAnimationOps.ts
+++ b/packages/studio/src/hooks/useGsapAnimationOps.ts
@@ -1,13 +1,31 @@
 import { useCallback } from "react";
+import type { Composition } from "@hyperframes/sdk";
 import type { DomEditSelection } from "../components/editor/domEditingTypes";
 import { roundTo3 } from "../utils/rounding";
+import { sdkGsapTweenPersist } from "../utils/sdkCutover";
 import {
   assignGsapTargetAutoIdIfNeeded,
   ensureElementAddressable,
 } from "./gsapScriptCommitHelpers";
 import type { CommitMutation, SafeGsapCommitMutation } from "./gsapScriptCommitTypes";
+import type { EditHistoryKind } from "../utils/editHistory";
 
-interface GsapAnimationOpsParams {
+interface SdkAnimationDeps {
+  sdkSession?: Composition | null;
+  writeProjectFile?: (path: string, content: string) => Promise<void>;
+  editHistory?: {
+    recordEdit: (entry: {
+      label: string;
+      kind: EditHistoryKind;
+      coalesceKey?: string;
+      files: Record<string, { before: string; after: string }>;
+    }) => Promise<void>;
+  };
+  reloadPreview?: () => void;
+  domEditSaveTimestampRef?: React.MutableRefObject<number>;
+}
+
+interface GsapAnimationOpsParams extends SdkAnimationDeps {
   projectIdRef: React.MutableRefObject<string | null>;
   activeCompPath: string | null;
   commitMutation: CommitMutation;
@@ -21,39 +39,91 @@ export function useGsapAnimationOps({
   commitMutation,
   commitMutationSafely,
   showToast,
+  sdkSession,
+  writeProjectFile,
+  editHistory,
+  reloadPreview,
+  domEditSaveTimestampRef,
 }: GsapAnimationOpsParams) {
   const updateGsapMeta = useCallback(
-    (
+    async (
       selection: DomEditSelection,
       animationId: string,
       updates: { duration?: number; ease?: string; position?: number },
     ) => {
-      // coalesceKey groups rapid meta edits into one history entry. Request
-      // serialization is now handled per-file at the commitMutation chokepoint
-      // (useGsapScriptCommits), so no per-op serializeKey is needed here.
-      const metaKey = `gsap:${animationId}:meta`;
+      if (
+        sdkSession &&
+        writeProjectFile &&
+        editHistory &&
+        reloadPreview &&
+        domEditSaveTimestampRef
+      ) {
+        const targetPath = selection.sourceFile || activeCompPath || "index.html";
+        const handled = await sdkGsapTweenPersist(
+          targetPath,
+          { kind: "set", animationId, properties: updates },
+          sdkSession,
+          { editHistory, writeProjectFile, reloadPreview, domEditSaveTimestampRef },
+          { label: "Edit GSAP animation", coalesceKey: `gsap:${animationId}:meta` },
+        );
+        if (handled) return;
+      }
       commitMutationSafely(
         selection,
         { type: "update-meta", animationId, updates },
-        { label: "Edit GSAP animation", coalesceKey: metaKey },
+        { label: "Edit GSAP animation", coalesceKey: `gsap:${animationId}:meta` },
       );
     },
-    [commitMutationSafely],
+    [
+      commitMutationSafely,
+      activeCompPath,
+      sdkSession,
+      writeProjectFile,
+      editHistory,
+      reloadPreview,
+      domEditSaveTimestampRef,
+    ],
   );
 
   const deleteGsapAnimation = useCallback(
-    (selection: DomEditSelection, animationId: string) => {
+    async (selection: DomEditSelection, animationId: string) => {
+      if (
+        sdkSession &&
+        writeProjectFile &&
+        editHistory &&
+        reloadPreview &&
+        domEditSaveTimestampRef
+      ) {
+        const targetPath = selection.sourceFile || activeCompPath || "index.html";
+        const handled = await sdkGsapTweenPersist(
+          targetPath,
+          { kind: "remove", animationId },
+          sdkSession,
+          { editHistory, writeProjectFile, reloadPreview, domEditSaveTimestampRef },
+          { label: "Delete GSAP animation" },
+        );
+        if (handled) return;
+      }
       commitMutationSafely(
         selection,
         { type: "delete", animationId, stripStudioEdits: true },
         { label: "Delete GSAP animation" },
       );
     },
-    [commitMutationSafely],
+    [
+      commitMutationSafely,
+      activeCompPath,
+      sdkSession,
+      writeProjectFile,
+      editHistory,
+      reloadPreview,
+      domEditSaveTimestampRef,
+    ],
   );
 
   const deleteAllForSelector = useCallback(
     (selection: DomEditSelection, targetSelector: string) => {
+      // ponytail: no SDK op for delete-all-for-selector; stays server-authoritative
       void commitMutation(
         selection,
         { type: "delete-all-for-selector", targetSelector },
@@ -63,6 +133,7 @@ export function useGsapAnimationOps({
     [commitMutation],
   );
 
+  // fallow-ignore-next-line complexity
   const addGsapAnimation = useCallback(
     // fallow-ignore-next-line complexity
     async (
@@ -97,6 +168,35 @@ export function useGsapAnimationOps({
         fromTo: { x: 0, y: 0, opacity: 1 },
       };
 
+      // SDK path: addGsapTween only supports from/to/fromTo; "set" stays server-side
+      if (
+        method !== "set" &&
+        selection.hfId &&
+        sdkSession &&
+        writeProjectFile &&
+        editHistory &&
+        reloadPreview &&
+        domEditSaveTimestampRef
+      ) {
+        const targetPath = selection.sourceFile || activeCompPath || "index.html";
+        const spec = {
+          method: method as "to" | "from" | "fromTo",
+          position,
+          duration,
+          ease: "power2.out" as const,
+          properties: toDefaults[method] ?? { opacity: 1 },
+          fromProperties: method === "fromTo" ? { opacity: 0 } : undefined,
+        };
+        const handled = await sdkGsapTweenPersist(
+          targetPath,
+          { kind: "add", target: selection.hfId, spec },
+          sdkSession,
+          { editHistory, writeProjectFile, reloadPreview, domEditSaveTimestampRef },
+          { label: `Add GSAP ${method} animation` },
+        );
+        if (handled) return;
+      }
+
       await commitMutation(
         selection,
         {
@@ -112,7 +212,17 @@ export function useGsapAnimationOps({
         { label: `Add GSAP ${method} animation` },
       );
     },
-    [activeCompPath, commitMutation, projectIdRef, showToast],
+    [
+      activeCompPath,
+      commitMutation,
+      projectIdRef,
+      showToast,
+      sdkSession,
+      writeProjectFile,
+      editHistory,
+      reloadPreview,
+      domEditSaveTimestampRef,
+    ],
   );
 
   return {

--- a/packages/studio/src/hooks/useGsapPropertyDebounce.ts
+++ b/packages/studio/src/hooks/useGsapPropertyDebounce.ts
@@ -1,11 +1,33 @@
 import { useCallback, useEffect, useRef } from "react";
+import type { Composition } from "@hyperframes/sdk";
 import type { DomEditSelection } from "../components/editor/domEditingTypes";
+import { sdkGsapTweenPersist } from "../utils/sdkCutover";
 import { PROPERTY_DEFAULTS } from "./gsapScriptCommitHelpers";
 import type { SafeGsapCommitMutation } from "./gsapScriptCommitTypes";
+import type { EditHistoryKind } from "../utils/editHistory";
 
 const DEBOUNCE_MS = 150;
 
-export function useGsapPropertyDebounce(commitMutationSafely: SafeGsapCommitMutation) {
+interface SdkPropertyDeps {
+  sdkSession?: Composition | null;
+  writeProjectFile?: (path: string, content: string) => Promise<void>;
+  editHistory?: {
+    recordEdit: (entry: {
+      label: string;
+      kind: EditHistoryKind;
+      coalesceKey?: string;
+      files: Record<string, { before: string; after: string }>;
+    }) => Promise<void>;
+  };
+  reloadPreview?: () => void;
+  domEditSaveTimestampRef?: React.MutableRefObject<number>;
+  activeCompPath?: string | null;
+}
+
+export function useGsapPropertyDebounce(
+  commitMutationSafely: SafeGsapCommitMutation,
+  sdkDeps?: SdkPropertyDeps,
+) {
   const pendingPropertyEditRef = useRef<{
     selection: DomEditSelection;
     animationId: string;
@@ -14,21 +36,51 @@ export function useGsapPropertyDebounce(commitMutationSafely: SafeGsapCommitMuta
   } | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const flushPendingPropertyEdit = useCallback(() => {
-    const pending = pendingPropertyEditRef.current;
-    if (!pending) return;
-    pendingPropertyEditRef.current = null;
-    const { selection, animationId, property, value } = pending;
-    commitMutationSafely(
-      selection,
-      { type: "update-property", animationId, property, value },
-      {
-        label: `Edit GSAP ${property}`,
-        coalesceKey: `gsap:${animationId}:${property}`,
-        softReload: true,
-      },
-    );
-  }, [commitMutationSafely]);
+  // fallow-ignore-next-line complexity
+  const flushPendingPropertyEdit = useCallback(
+    // fallow-ignore-next-line complexity
+    async () => {
+      const pending = pendingPropertyEditRef.current;
+      if (!pending) return;
+      pendingPropertyEditRef.current = null;
+      const { selection, animationId, property, value } = pending;
+      const {
+        sdkSession,
+        writeProjectFile,
+        editHistory,
+        reloadPreview,
+        domEditSaveTimestampRef,
+        activeCompPath,
+      } = sdkDeps ?? {};
+      if (
+        sdkSession &&
+        writeProjectFile &&
+        editHistory &&
+        reloadPreview &&
+        domEditSaveTimestampRef
+      ) {
+        const targetPath = selection.sourceFile || activeCompPath || "index.html";
+        const handled = await sdkGsapTweenPersist(
+          targetPath,
+          { kind: "set", animationId, properties: { properties: { [property]: value } } },
+          sdkSession,
+          { editHistory, writeProjectFile, reloadPreview, domEditSaveTimestampRef },
+          { label: `Edit GSAP ${property}`, coalesceKey: `gsap:${animationId}:${property}` },
+        );
+        if (handled) return;
+      }
+      commitMutationSafely(
+        selection,
+        { type: "update-property", animationId, property, value },
+        {
+          label: `Edit GSAP ${property}`,
+          coalesceKey: `gsap:${animationId}:${property}`,
+          softReload: true,
+        },
+      );
+    },
+    [commitMutationSafely, sdkDeps],
+  );
 
   const updateGsapProperty = useCallback(
     (
@@ -39,7 +91,9 @@ export function useGsapPropertyDebounce(commitMutationSafely: SafeGsapCommitMuta
     ) => {
       pendingPropertyEditRef.current = { selection, animationId, property, value };
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = setTimeout(flushPendingPropertyEdit, DEBOUNCE_MS);
+      debounceTimerRef.current = setTimeout(() => {
+        void flushPendingPropertyEdit();
+      }, DEBOUNCE_MS);
     },
     [flushPendingPropertyEdit],
   );
@@ -47,12 +101,14 @@ export function useGsapPropertyDebounce(commitMutationSafely: SafeGsapCommitMuta
   useEffect(() => {
     return () => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
-      flushPendingPropertyEdit();
+      void flushPendingPropertyEdit();
     };
   }, [flushPendingPropertyEdit]);
 
+  // fallow-ignore-next-line complexity
   const addGsapProperty = useCallback(
-    (selection: DomEditSelection, animationId: string, property: string) => {
+    // fallow-ignore-next-line complexity
+    async (selection: DomEditSelection, animationId: string, property: string) => {
       let defaultValue = PROPERTY_DEFAULTS[property] ?? 0;
       const el = selection.element;
       if (property === "width" || property === "height") {
@@ -62,17 +118,43 @@ export function useGsapPropertyDebounce(commitMutationSafely: SafeGsapCommitMuta
         const cs = el.ownerDocument.defaultView?.getComputedStyle(el);
         defaultValue = cs ? Number.parseFloat(cs.opacity) || 1 : 1;
       }
+      const {
+        sdkSession,
+        writeProjectFile,
+        editHistory,
+        reloadPreview,
+        domEditSaveTimestampRef,
+        activeCompPath,
+      } = sdkDeps ?? {};
+      if (
+        sdkSession &&
+        writeProjectFile &&
+        editHistory &&
+        reloadPreview &&
+        domEditSaveTimestampRef
+      ) {
+        const targetPath = selection.sourceFile || activeCompPath || "index.html";
+        const handled = await sdkGsapTweenPersist(
+          targetPath,
+          { kind: "set", animationId, properties: { properties: { [property]: defaultValue } } },
+          sdkSession,
+          { editHistory, writeProjectFile, reloadPreview, domEditSaveTimestampRef },
+          { label: `Add GSAP ${property}` },
+        );
+        if (handled) return;
+      }
       commitMutationSafely(
         selection,
         { type: "add-property", animationId, property, defaultValue },
         { label: `Add GSAP ${property}` },
       );
     },
-    [commitMutationSafely],
+    [commitMutationSafely, sdkDeps],
   );
 
   const removeGsapProperty = useCallback(
     (selection: DomEditSelection, animationId: string, property: string) => {
+      // ponytail: null ≠ removal in upsertProp; remove-property stays server-authoritative
       commitMutationSafely(
         selection,
         { type: "remove-property", animationId, property },
@@ -82,13 +164,43 @@ export function useGsapPropertyDebounce(commitMutationSafely: SafeGsapCommitMuta
     [commitMutationSafely],
   );
 
+  // fallow-ignore-next-line complexity
   const updateGsapFromProperty = useCallback(
-    (
+    // fallow-ignore-next-line complexity
+    async (
       selection: DomEditSelection,
       animationId: string,
       property: string,
       value: number | string,
     ) => {
+      const {
+        sdkSession,
+        writeProjectFile,
+        editHistory,
+        reloadPreview,
+        domEditSaveTimestampRef,
+        activeCompPath,
+      } = sdkDeps ?? {};
+      if (
+        sdkSession &&
+        writeProjectFile &&
+        editHistory &&
+        reloadPreview &&
+        domEditSaveTimestampRef
+      ) {
+        const targetPath = selection.sourceFile || activeCompPath || "index.html";
+        const handled = await sdkGsapTweenPersist(
+          targetPath,
+          { kind: "set", animationId, properties: { fromProperties: { [property]: value } } },
+          sdkSession,
+          { editHistory, writeProjectFile, reloadPreview, domEditSaveTimestampRef },
+          {
+            label: `Edit GSAP from-${property}`,
+            coalesceKey: `gsap:${animationId}:from:${property}`,
+          },
+        );
+        if (handled) return;
+      }
       commitMutationSafely(
         selection,
         { type: "update-from-property", animationId, property, value },
@@ -98,23 +210,55 @@ export function useGsapPropertyDebounce(commitMutationSafely: SafeGsapCommitMuta
         },
       );
     },
-    [commitMutationSafely],
+    [commitMutationSafely, sdkDeps],
   );
 
+  // fallow-ignore-next-line complexity
   const addGsapFromProperty = useCallback(
-    (selection: DomEditSelection, animationId: string, property: string) => {
+    // fallow-ignore-next-line complexity
+    async (selection: DomEditSelection, animationId: string, property: string) => {
       const defaultValue = PROPERTY_DEFAULTS[property] ?? 0;
+      const {
+        sdkSession,
+        writeProjectFile,
+        editHistory,
+        reloadPreview,
+        domEditSaveTimestampRef,
+        activeCompPath,
+      } = sdkDeps ?? {};
+      if (
+        sdkSession &&
+        writeProjectFile &&
+        editHistory &&
+        reloadPreview &&
+        domEditSaveTimestampRef
+      ) {
+        const targetPath = selection.sourceFile || activeCompPath || "index.html";
+        const handled = await sdkGsapTweenPersist(
+          targetPath,
+          {
+            kind: "set",
+            animationId,
+            properties: { fromProperties: { [property]: defaultValue } },
+          },
+          sdkSession,
+          { editHistory, writeProjectFile, reloadPreview, domEditSaveTimestampRef },
+          { label: `Add GSAP from-${property}` },
+        );
+        if (handled) return;
+      }
       commitMutationSafely(
         selection,
         { type: "add-from-property", animationId, property, defaultValue },
         { label: `Add GSAP from-${property}` },
       );
     },
-    [commitMutationSafely],
+    [commitMutationSafely, sdkDeps],
   );
 
   const removeGsapFromProperty = useCallback(
     (selection: DomEditSelection, animationId: string, property: string) => {
+      // ponytail: null ≠ removal in upsertProp; remove-from-property stays server-authoritative
       commitMutationSafely(
         selection,
         { type: "remove-from-property", animationId, property },

--- a/packages/studio/src/hooks/useGsapScriptCommits.ts
+++ b/packages/studio/src/hooks/useGsapScriptCommits.ts
@@ -44,7 +44,7 @@ async function mutateGsapScript(
 
 // oxfmt-ignore
 // fallow-ignore-next-line complexity
-export function useGsapScriptCommits({ projectIdRef, activeCompPath, previewIframeRef, editHistory, domEditSaveTimestampRef, reloadPreview, onCacheInvalidate, onFileContentChanged, showToast }: GsapScriptCommitsParams) {
+export function useGsapScriptCommits({ projectIdRef, activeCompPath, previewIframeRef, editHistory, domEditSaveTimestampRef, reloadPreview, onCacheInvalidate, onFileContentChanged, showToast, sdkSession, writeProjectFile }: GsapScriptCommitsParams) {
   // Serializer for per-key commits (options.serializeKey). Keyed by
   // `gsap:${animationId}:meta`, it chains a meta commit onto the prior one for
   // the same animationId so their POSTs can't interleave. Held in a ref so the
@@ -98,8 +98,26 @@ export function useGsapScriptCommits({ projectIdRef, activeCompPath, previewIfra
   );
   const trackGsapSaveFailure = useGsapSaveFailureTelemetry(activeCompPath);
   const commitMutationSafely = useSafeGsapCommitMutation(commitMutation, trackGsapSaveFailure, showToast);
-  const propertyOps = useGsapPropertyDebounce(commitMutationSafely);
-  const animationOps = useGsapAnimationOps({ projectIdRef, activeCompPath, commitMutation, commitMutationSafely, showToast });
+  const propertyOps = useGsapPropertyDebounce(commitMutationSafely, {
+    sdkSession,
+    writeProjectFile,
+    editHistory,
+    reloadPreview,
+    domEditSaveTimestampRef,
+    activeCompPath,
+  });
+  const animationOps = useGsapAnimationOps({
+    projectIdRef,
+    activeCompPath,
+    commitMutation,
+    commitMutationSafely,
+    showToast,
+    sdkSession,
+    writeProjectFile,
+    editHistory,
+    reloadPreview,
+    domEditSaveTimestampRef,
+  });
   const keyframeOps = useGsapKeyframeOps({ activeCompPath, commitMutation, commitMutationSafely, trackGsapSaveFailure });
   const arcPathOps = useGsapArcPathOps(commitMutationSafely);
   return { commitMutation, ...propertyOps, ...animationOps, ...keyframeOps, ...arcPathOps };

--- a/packages/studio/src/utils/sdkCutover.test.ts
+++ b/packages/studio/src/utils/sdkCutover.test.ts
@@ -4,6 +4,7 @@ import {
   sdkCutoverPersist,
   sdkDeletePersist,
   sdkTimingPersist,
+  sdkGsapTweenPersist,
 } from "./sdkCutover";
 import { openComposition } from "@hyperframes/sdk";
 import { createMemoryAdapter } from "@hyperframes/sdk/adapters/memory";
@@ -440,6 +441,116 @@ describe("sdkTimingPersist", () => {
       throw new Error("timing error");
     });
     const result = await sdkTimingPersist("hf-clip", "/comp.html", { start: 1 }, session, deps);
+    expect(result).toBe(false);
+    expect(deps.writeProjectFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("sdkGsapTweenPersist", () => {
+  const makeRef = <T>(val: T): MutableRefObject<T> => ({ current: val });
+  const makeDeps = () => ({
+    editHistory: { recordEdit: vi.fn().mockResolvedValue(undefined) },
+    writeProjectFile: vi.fn().mockResolvedValue(undefined),
+    reloadPreview: vi.fn(),
+    domEditSaveTimestampRef: makeRef(0),
+  });
+
+  const makeSession = (opts?: { addGsapTween?: string; hasEl?: boolean }) =>
+    ({
+      getElement: vi.fn().mockReturnValue(opts?.hasEl !== false ? { id: "hf-box" } : null),
+      addGsapTween: vi.fn().mockReturnValue(opts?.addGsapTween ?? "tw-1"),
+      setGsapTween: vi.fn(),
+      removeGsapTween: vi.fn(),
+      serialize: vi
+        .fn()
+        .mockReturnValueOnce("<html>before</html>")
+        .mockReturnValue("<html>after</html>"),
+    }) as unknown as Parameters<typeof sdkGsapTweenPersist>[2];
+
+  it("returns false when session is null", async () => {
+    expect(
+      await sdkGsapTweenPersist(
+        "/comp.html",
+        { kind: "remove", animationId: "tw-1" },
+        null,
+        makeDeps(),
+      ),
+    ).toBe(false);
+  });
+
+  it("calls addGsapTween and writes for kind=add", async () => {
+    const deps = makeDeps();
+    const session = makeSession();
+    const result = await sdkGsapTweenPersist(
+      "/comp.html",
+      {
+        kind: "add",
+        target: "hf-box",
+        spec: { method: "to", duration: 1, properties: { opacity: 1 } },
+      },
+      session,
+      deps,
+    );
+    expect(result).toBe(true);
+    expect(session!.addGsapTween).toHaveBeenCalledWith(
+      "hf-box",
+      expect.objectContaining({ method: "to" }),
+    );
+    expect(deps.writeProjectFile).toHaveBeenCalledWith("/comp.html", "<html>after</html>");
+  });
+
+  it("returns false for kind=add when element not found", async () => {
+    const deps = makeDeps();
+    const session = makeSession({ hasEl: false });
+    const result = await sdkGsapTweenPersist(
+      "/comp.html",
+      { kind: "add", target: "hf-box", spec: { method: "to", properties: { x: 100 } } },
+      session,
+      deps,
+    );
+    expect(result).toBe(false);
+    expect(deps.writeProjectFile).not.toHaveBeenCalled();
+  });
+
+  it("calls setGsapTween and writes for kind=set", async () => {
+    const deps = makeDeps();
+    const session = makeSession();
+    const result = await sdkGsapTweenPersist(
+      "/comp.html",
+      { kind: "set", animationId: "tw-1", properties: { ease: "power3.in" } },
+      session,
+      deps,
+    );
+    expect(result).toBe(true);
+    expect(session!.setGsapTween).toHaveBeenCalledWith("tw-1", { ease: "power3.in" });
+    expect(deps.reloadPreview).toHaveBeenCalled();
+  });
+
+  it("calls removeGsapTween for kind=remove", async () => {
+    const deps = makeDeps();
+    const session = makeSession();
+    const result = await sdkGsapTweenPersist(
+      "/comp.html",
+      { kind: "remove", animationId: "tw-1" },
+      session,
+      deps,
+    );
+    expect(result).toBe(true);
+    expect(session!.removeGsapTween).toHaveBeenCalledWith("tw-1");
+  });
+
+  it("returns false and does not write on SDK error", async () => {
+    const deps = makeDeps();
+    const session = makeSession();
+    (session!.removeGsapTween as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("gsap error");
+    });
+    const result = await sdkGsapTweenPersist(
+      "/comp.html",
+      { kind: "remove", animationId: "tw-1" },
+      session,
+      deps,
+    );
     expect(result).toBe(false);
     expect(deps.writeProjectFile).not.toHaveBeenCalled();
   });

--- a/packages/studio/src/utils/sdkCutover.ts
+++ b/packages/studio/src/utils/sdkCutover.ts
@@ -1,5 +1,5 @@
 import type { MutableRefObject } from "react";
-import type { Composition, EditOp } from "@hyperframes/sdk";
+import type { Composition, EditOp, GsapTweenSpec } from "@hyperframes/sdk";
 import type { DomEditSelection } from "../components/editor/domEditing";
 import type { EditHistoryKind } from "./editHistory";
 import type { PatchOperation } from "./sourcePatcher";
@@ -153,6 +153,38 @@ export async function sdkTimingPersist(
     return true;
   } catch (err) {
     trackStudioEvent("sdk_cutover_fallback", { hfId, error: String(err) });
+    return false;
+  }
+}
+
+type SdkGsapTweenOp =
+  | { kind: "add"; target: string; spec: GsapTweenSpec }
+  | { kind: "set"; animationId: string; properties: Partial<GsapTweenSpec> }
+  | { kind: "remove"; animationId: string };
+
+export async function sdkGsapTweenPersist(
+  targetPath: string,
+  op: SdkGsapTweenOp,
+  sdkSession: Composition | null | undefined,
+  deps: CutoverDeps,
+  options?: CutoverOptions,
+): Promise<boolean> {
+  if (!sdkSession) return false;
+  try {
+    const before = sdkSession.serialize();
+    if (op.kind === "add") {
+      if (!sdkSession.getElement(op.target)) return false;
+      sdkSession.addGsapTween(op.target, op.spec);
+    } else if (op.kind === "set") {
+      sdkSession.setGsapTween(op.animationId, op.properties);
+    } else {
+      sdkSession.removeGsapTween(op.animationId);
+    }
+    await persistSdkSerialize(sdkSession, targetPath, before, deps, options);
+    trackStudioEvent("sdk_cutover_success", { opCount: 1 });
+    return true;
+  } catch (err) {
+    trackStudioEvent("sdk_cutover_fallback", { error: String(err) });
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- `sdkGsapTweenPersist` helper added to `sdkCutover.ts` — routes `add`/`set`/`remove` GSAP tween ops through the SDK's acorn/magic-string path, with server fallback on SDK miss/error
- `addGsapAnimation` (`from`/`to`/`fromTo` only), `updateGsapMeta`, `deleteGsapAnimation` in `useGsapAnimationOps` now try SDK first
- `updateGsapProperty`, `addGsapProperty`, `updateGsapFromProperty`, `addGsapFromProperty` in `useGsapPropertyDebounce` now try SDK first
- `removeGsapProperty` / `removeGsapFromProperty` stay server-authoritative: `null ≠ removal` in `upsertProp`; `deleteAllForSelector` stays server-authoritative: no SDK op
- `addGsapAnimation` with `method = "set"` stays server-authoritative: `GsapTweenSpec` has no `set` method
- 5 new unit tests for `sdkGsapTweenPersist`

## Open decisions

- **`removeGsapProperty`/`removeGsapFromProperty`**: `upsertProp` in the acorn writer treats null as a literal `null` value, not removal. To support removal via SDK, a `removeGsapProperty` SDK op would be needed (separate PR or accepted as server-authoritative for now).
- **`deleteAllForSelector`**: no SDK op exists. Stays server-authoritative.
- **`addGsapAnimation` with `method = "set"`**: `GsapTweenSpec` doesn't have a `set` method; stays server-authoritative.

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] Tests pass (`bun run test`) — 37 sdkCutover tests
- [ ] Lint/format clean
- [ ] 600-line Studio gate passes
- [ ] Manual: open Studio on a GSAP comp, add/edit/delete a tween, confirm `sdk_cutover_success` telemetry fires and undo works

🤖 Generated with [Claude Code](https://claude.com/claude-code)