### PR TITLE
fix(core): route renders/file serving through resolveWithinProject chokepoint

### DIFF
--- a/packages/core/src/studio-api/routes/render.test.ts
+++ b/packages/core/src/studio-api/routes/render.test.ts
@@ -354,3 +354,77 @@ describe("POST /projects/:id/render — composition path safety", () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 });
+
+describe("GET /projects/:id/renders/file/* — path safety", () => {
+  const tmpDirs: string[] = [];
+
+  function buildApp(): { app: Hono; rendersDir: string } {
+    const rendersDir = mkdtempSync(join(tmpdir(), "hf-renders-out-"));
+    tmpDirs.push(rendersDir);
+    const adapter: StudioApiAdapter = {
+      listProjects: () => [],
+      resolveProject: async (id: string) => ({ id, dir: tmpdir() }),
+      bundle: async () => null,
+      lint: async () => ({ findings: [] }),
+      runtimeUrl: "/api/runtime.js",
+      rendersDir: () => rendersDir,
+      startRender: (opts) => ({
+        id: opts.jobId,
+        status: "rendering",
+        progress: 0,
+        outputPath: opts.outputPath,
+      }),
+    };
+    const app = new Hono();
+    registerRenderRoutes(app, adapter);
+    return { app, rendersDir };
+  }
+
+  // Mirror the repo convention (preview.test.ts / composition tests above):
+  // skip symlink cases on non-symlink-privileged Windows runners.
+  function tryCreateSymlink(target: string, path: string, type: "dir" | "file"): boolean {
+    try {
+      symlinkSync(target, path, type);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  afterEach(() => {
+    for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+    tmpDirs.length = 0;
+  });
+
+  it("serves a render file that lives inside rendersDir", async () => {
+    const { app, rendersDir } = buildApp();
+    writeFileSync(join(rendersDir, "demo.mp4"), "render-bytes");
+    const res = await app.request("http://localhost/projects/demo/renders/file/demo.mp4");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("render-bytes");
+  });
+
+  it("rejects a file reached through a symlink inside rendersDir pointing outside it", async () => {
+    const { app, rendersDir } = buildApp();
+    // A bare join()+readFileSync followed the symlink and leaked the target;
+    // the resolveWithinProject chokepoint canonicalizes with realpath first.
+    const external = mkdtempSync(join(tmpdir(), "hf-renders-external-"));
+    tmpDirs.push(external);
+    writeFileSync(join(external, "secret.txt"), "TOP-SECRET");
+    if (!tryCreateSymlink(join(external, "secret.txt"), join(rendersDir, "leak.txt"), "file"))
+      return;
+    const res = await app.request("http://localhost/projects/demo/renders/file/leak.txt");
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain("TOP-SECRET");
+  });
+
+  it("serves a render file reached through a symlink that stays inside rendersDir", async () => {
+    const { app, rendersDir } = buildApp();
+    mkdirSync(join(rendersDir, "nested"));
+    writeFileSync(join(rendersDir, "nested", "clip.mp4"), "nested-bytes");
+    if (!tryCreateSymlink(join(rendersDir, "nested"), join(rendersDir, "alias"), "dir")) return;
+    const res = await app.request("http://localhost/projects/demo/renders/file/alias/clip.mp4");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("nested-bytes");
+  });
+});

--- a/packages/core/src/studio-api/routes/render.ts
+++ b/packages/core/src/studio-api/routes/render.ts
@@ -216,7 +216,13 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
     const filename = c.req.path.split("/renders/file/")[1];
     if (!filename) return c.json({ error: "missing filename" }, 400);
     const rendersDir = adapter.rendersDir(project);
-    const fp = join(rendersDir, filename);
+    // Containment guard: the filename is attacker-controlled wildcard input, so
+    // route it through the same chokepoint every other project-scoped path uses.
+    // Literal `..` is collapsed upstream by the URL parser, but a bare join() +
+    // readFileSync still followed an in-rendersDir symlink pointing outside the
+    // dir; resolveWithinProject canonicalizes with realpath before serving.
+    const fp = resolveWithinProject(rendersDir, filename);
+    if (!fp) return c.json({ error: "forbidden" }, 403);
     if (!existsSync(fp)) return c.json({ error: "not found" }, 404);
     const contentType = renderContentType(fp);
     const content = readFileSync(fp);


### PR DESCRIPTION
## What

Route the `/projects/:id/renders/file/*` handler's attacker-controlled filename
through the shared `resolveWithinProject` containment chokepoint instead of a
bare `join()` + `readFileSync`.

## Why

This was the **only** project-scoped filesystem route that joined wildcard path
input straight onto a base dir with no containment check — every sibling route
(files, file-mutations, the `composition` field on this same render route) goes
through `resolveWithinProject`.

I verified the behavior empirically before/after:

- **Literal/encoded `../` traversal is NOT reachable over HTTP.** Hono's WHATWG
  URL layer normalizes `../` and decodes+collapses `%2e%2e` before routing, and
  `c.req.path` is otherwise not percent-decoded — a battery of `../`, `%2e%2e`,
  `%252e`, `..%2f`, `..\`, `/abs` payloads all 404'd without leaking. So the
  plain LFI described in #621 is already mitigated upstream.
- **A symlink escape *was* live.** A symlink placed inside `rendersDir` pointing
  outside it was followed and served verbatim (an external secret leaked, `200 OK`).
  After the fix it returns `403`.

So this is hardening + symlink-escape closure + making the route's safety
independent of the URL layer's normalization (defense-in-depth), rather than the
live `../` LFI the original report assumed.

Supersedes #621 (same route; uses the existing chokepoint helper rather than an
ad-hoc `includes("..")` + `startsWith` check, which is symlink-unsafe and would
reject legitimate filenames containing a `..` substring). Thanks to @hobostay
for surfacing the unguarded route.

## How

`const fp = resolveWithinProject(rendersDir, filename)` (returns `null` →
`403`), replacing `const fp = join(rendersDir, filename)`. `resolveWithinProject`
resolves `..`, then canonicalizes both sides with `realpathSync` before the
prefix check, so an in-dir symlink can't redirect outside the renders directory.

## Test plan

- [x] Unit tests added/updated — new `GET /projects/:id/renders/file/* — path safety`
      block: serves an in-dir file, **rejects an escaping symlink (403)**, and still
      serves a symlink that stays inside `rendersDir`. (`render.test.ts`, 19/19 pass)
- [x] `bunx oxlint` / `bunx oxfmt --check` clean; `tsc --noEmit` clean
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)