### PR TITLE
chore: sync bun.lock with workspace package.json

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/aws-lambda": {
       "name": "@hyperframes/aws-lambda",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-sfn": "^3.700.0",
@@ -54,7 +54,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "bin": {
         "hyperframes": "./dist/cli.js",
       },
@@ -69,12 +69,10 @@
         "fontkit": "^2.0.4",
         "giget": "^3.2.0",
         "hono": "^4.0.0",
-        "onnxruntime-node": "^1.20.0",
         "open": "^10.0.0",
         "postcss": "^8.5.8",
         "prettier": "^3.8.1",
         "puppeteer-core": "^24.39.1",
-        "sharp": "^0.34.5",
       },
       "devDependencies": {
         "@clack/prompts": "^1.1.0",
@@ -97,11 +95,13 @@
       },
       "optionalDependencies": {
         "@google/genai": "^1.50.1",
+        "onnxruntime-node": "^1.20.0",
+        "sharp": "^0.34.5",
       },
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "@chenglou/pretext": "^0.0.5",
@@ -135,7 +135,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
         "@hyperframes/core": "workspace:^",
@@ -153,7 +153,7 @@
     },
     "packages/gcp-cloud-run": {
       "name": "@hyperframes/gcp-cloud-run",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "dependencies": {
         "@google-cloud/storage": "^7.14.0",
         "@google-cloud/workflows": "^4.2.0",
@@ -173,7 +173,7 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "devDependencies": {
         "@types/bun": "^1.1.0",
         "gsap": "^3.12.5",
@@ -185,7 +185,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -226,7 +226,7 @@
     },
     "packages/sdk": {
       "name": "@hyperframes/sdk",
-      "version": "0.6.91",
+      "version": "0.6.100",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "linkedom": "^0.18.12",
@@ -239,6 +239,7 @@
     },
     "packages/sdk-playground": {
       "name": "@hyperframes/sdk-playground",
+      "version": "0.6.99",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/sdk": "workspace:*",
@@ -250,7 +251,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -262,7 +263,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.6.98",
+      "version": "0.6.100",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
@@ -276,6 +277,7 @@
         "@codemirror/view": "6.40.0",
         "@hyperframes/core": "workspace:*",
         "@hyperframes/player": "workspace:*",
+        "@hyperframes/sdk": "workspace:*",
         "@phosphor-icons/react": "^2.1.10",
         "bpm-detective": "^2.0.5",
         "mediabunny": "^1.45.3",


### PR DESCRIPTION
## Summary

Regenerate `bun.lock` so it matches the current workspace `package.json`. Two pieces of pre-existing drift:

1. **`sharp` / `onnxruntime-node` → `optionalDependencies`** — the earlier CLI change moved these but didn't update the lockfile's workspace mirror.
2. **Workspace version mirror** lagging behind recent releases.

**No resolved dependency-graph change** — same packages, same versions. This is a pure metadata sync; the only practical effect is stopping the recurring `bun install` diff that shows up in `git status` for monorepo devs. CI (`bun install --frozen-lockfile`) was already green through this drift, so nothing was broken — this just keeps the lockfile honest.

Only `bun.lock` is touched.