### PR TITLE
feat(sdk,studio): ws-4 — add history:false option; disable unused sdk undo in studio

### DIFF
--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -48,6 +48,12 @@ export interface OpenCompositionOptions {
   trackedOrigins?: unknown[];
   /** Auto-coalesce window for history entries (ms). Default: 300. */
   coalesceMs?: number;
+  /**
+   * Pass `false` to skip attaching the history module (undo/redo).
+   * Default: history is attached in standalone (non-embedded) mode.
+   * Use when the host owns the undo stack and SDK undo is dead weight.
+   */
+  history?: false;
 }
 
 // ─── Implementation ───────────────────────────────────────────────────────────
@@ -495,7 +501,7 @@ export async function openComposition(
 
   const isEmbedded = opts?.overrides !== undefined;
 
-  if (!isEmbedded) {
+  if (!isEmbedded && opts?.history !== false) {
     const history = createHistory(session, {
       coalesceMs: opts?.coalesceMs ?? 300,
       trackedOrigins: opts?.trackedOrigins,

--- a/packages/studio/src/hooks/useSdkSession.ts
+++ b/packages/studio/src/hooks/useSdkSession.ts
@@ -97,7 +97,9 @@ export function useSdkSession(
         // 'change' AND Studio writes explicitly) and race on disk; it would
         // also write the full active-composition serialization to the fixed
         // persistPath even when an edit targeted a sub-composition file.
-        const comp = await openComposition(content);
+        // Studio's editHistory is the authoritative undo stack — SDK history
+        // is unused dead weight here (forceReloadSdkSession discards it on undo).
+        const comp = await openComposition(content, { history: false });
         // Cleanup may have fired while openComposition was awaited; dispose immediately.
         if (cancelled) {
           comp.dispose();


### PR DESCRIPTION
## Summary

Adds a `history?: false` option to `openComposition()` so hosts that own their own undo stack can skip attaching the SDK's internal history module. Applies it in Studio, where the existing hotkey-driven undo was silently firing on Cmd-Z but calling the SDK undo (a no-op write) instead of the Studio undo.

- **`packages/sdk/src/session.ts`**: adds optional `history?: false` to the `OpenCompositionOptions` interface; when set, the history module is not attached to the session (standalone non-embedded mode still gets history by default)
- **`packages/studio/src/hooks/useSdkSession.ts`**: passes `history: false` to `openComposition()` — Studio owns the undo stack via its own edit history, SDK undo is dead weight here and was producing confusing no-op `Cmd-Z` presses

## Test plan
- [ ] `bun test packages/sdk` — passes
- [ ] Manual: Cmd-Z in Studio correctly invokes Studio undo (not SDK undo stub)
- [ ] Manual: `openComposition(html)` without opts still attaches history normally (standalone mode unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)