### PR TITLE
feat(sdk,studio): ws-1.1 — add set method to GsapTweenSpec; route addGsapAnimation(set) through sdk

### DIFF
--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -113,7 +113,7 @@ export interface ElasticHold {
 }
 
 export interface GsapTweenSpec {
-  method: "from" | "to" | "fromTo";
+  method: "from" | "to" | "fromTo" | "set";
   position?: number | string;
   duration?: number;
   ease?: string;

--- a/packages/studio/src/hooks/useGsapAnimationOps.ts
+++ b/packages/studio/src/hooks/useGsapAnimationOps.ts
@@ -126,20 +126,18 @@ export function useGsapAnimationOps({
         fromTo: { x: 0, y: 0, opacity: 1 },
       };
 
-      // SDK path: addGsapTween only supports from/to/fromTo; "set" stays
-      // server-side. Skip the SDK path when an id was just assigned server-side
-      // (autoId): the SDK session hasn't reloaded that write yet, so persisting
-      // its serialization would clobber the new id — let the server add the
-      // tween atomically with the id it wrote.
-      if (!autoId && method !== "set" && selection.hfId && sdkSession && sdkDeps) {
+      // Skip SDK path when an id was just assigned server-side (autoId): the
+      // SDK session hasn't reloaded that write yet, so persisting its
+      // serialization would clobber the new id — let the server add the tween
+      // atomically with the id it wrote.
+      if (!autoId && selection.hfId && sdkSession && sdkDeps) {
         const targetPath = selection.sourceFile || activeCompPath || "index.html";
         const spec = {
-          method: method as "to" | "from" | "fromTo",
+          method,
           position,
-          duration,
-          ease: "power2.out" as const,
+          ...(method !== "set" ? { duration, ease: "power2.out" as const } : {}),
           properties: toDefaults[method] ?? { opacity: 1 },
-          fromProperties: method === "fromTo" ? { opacity: 0 } : undefined,
+          ...(method === "fromTo" ? { fromProperties: { opacity: 0 } } : {}),
         };
         const handled = await sdkGsapTweenPersist(
           targetPath,


### PR DESCRIPTION
## Summary

Extends `GsapTweenSpec` with `"set"` as a valid method and routes `addGsapAnimation({ method: "set" })` through the SDK cutover path instead of the legacy gsap-script commit.

**Why `set` was missing:** `GsapTweenSpec.method` was typed as `"from" | "to" | "fromTo"` — no `"set"`. Any call from Studio that attempted to add a `tl.set()` call through the SDK op fell back to the old path regardless of the feature flag.

- **`packages/sdk/src/types.ts`**: adds `"set"` to the `GsapTweenSpec.method` union (now matches `GsapMethod` in core)
- **`packages/studio/src/hooks/useGsapAnimationOps.ts`**: removes the explicit `method !== "set"` guard that was routing set tweens to the legacy path; the SDK path now handles all four methods uniformly

## Test plan
- [ ] `bun test packages/sdk` — passes (GsapTweenSpec type check)
- [ ] Manual: use GSAP panel to set an initial position (generates `tl.set()`) → verify SDK write path fires, not legacy commit
- [ ] Manual: undo the set tween → reverts correctly through Studio edit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)