### PR TITLE
fix(registry): add missing vscode-theme-visualizer to registry.json

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -36,6 +36,10 @@
       "type": "hyperframes:example"
     },
     {
+      "name": "vscode-theme-visualizer",
+      "type": "hyperframes:example"
+    },
+    {
       "name": "data-chart",
       "type": "hyperframes:block"
     },


### PR DESCRIPTION
## What

Add the missing `vscode-theme-visualizer` entry to the auto-generated top-level `registry/registry.json`.

## Why

The `vscode-theme-visualizer` example ships a complete manifest at `registry/examples/vscode-theme-visualizer/registry-item.json` (added in v0.6.104), along with its `index.html`, `DESIGN.md`, `assets/`, `render-entries/`, and `scripts/`. But it was never added to `registry/registry.json`.

The CLI resolver only knows about items listed in the top-level manifest — `resolveItemWithDependencies()` in `packages/cli/src/registry/resolver.ts` does `entries.find((e) => e.name === name)` and throws `Item "..." not found in registry` when there's no match. So `hyperframes add vscode-theme-visualizer` fails even though the item is fully present on disk.

All 9 example directories that carry a `registry-item.json` should appear in `registry.json`; before this change only 8 did:

```
registry examples in manifest: 8   ← missing vscode-theme-visualizer
example dirs with a manifest:  9
```

## How

Added the one missing entry in the example block, right after `nyt-graph`:

```json
{
  "name": "vscode-theme-visualizer",
  "type": "hyperframes:example"
},
```

This is exactly what re-running `scripts/generate-registry-items.ts` produces — its `scanExistingItems()` fallback picks up every example dir that has a `registry-item.json`, so the hand-applied entry matches the generator output and the manifest is back in sync (9/9).

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed — confirmed `JSON.parse` succeeds, item count 130 → 131, and the manifest's `hyperframes:example` set now exactly equals the set of example dirs that have a `registry-item.json` (was 8/9, now 9/9). Verified the entry matches what `generate-registry-items.ts` would emit.
- [ ] Documentation updated (if applicable)
