### PR TITLE
fix(engine): Linux GPU path uses deprecated EGL + NVENC probe fails on data-center GPUs

### DIFF
--- a/packages/engine/src/services/browserManager.test.ts
+++ b/packages/engine/src/services/browserManager.test.ts
@@ -45,11 +45,13 @@ describe("buildChromeArgs browser GPU mode", () => {
     expect(args).not.toContain("--use-angle=swiftshader");
   });
 
-  it("uses EGL for hardware browser GPU mode on Linux", () => {
+  it("uses ANGLE-EGL for hardware browser GPU mode on Linux", () => {
     const args = buildChromeArgs({ ...base, platform: "linux" }, { browserGpuMode: "hardware" });
-    expect(args).toContain("--use-gl=egl");
+    expect(args).toContain("--use-gl=angle");
+    expect(args).toContain("--use-angle=gl-egl");
     expect(args).toContain("--enable-gpu-rasterization");
-    expect(args).not.toContain("--use-gl=angle");
+    expect(args).toContain("--ignore-gpu-blocklist");
+    expect(args).toContain("--disable-software-rasterizer");
     expect(args).not.toContain("--use-angle=swiftshader");
   });
 

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -378,8 +378,11 @@ async function launchBrowser(
   });
 
   const browserVersion = await browser.version().catch(() => "unknown");
+  const gpuFlags = chromeArgs.filter(
+    (a) => a.startsWith("--use-gl=") || a.startsWith("--use-angle="),
+  );
   console.log(
-    `[BrowserManager] Browser launched (${browserVersion}, ${captureMode}, headlessShell=${!!headlessShell}, platform=${process.platform})`,
+    `[BrowserManager] Browser launched (${browserVersion}, ${captureMode}, gl=${gpuFlags.join(" ") || "default"}, headlessShell=${!!headlessShell}, platform=${process.platform})`,
   );
 
   if (captureMode === "beginframe") {
@@ -650,6 +653,10 @@ function getBrowserGpuArgs(
     case "win32":
       return ["--use-gl=angle", "--use-angle=d3d11", "--enable-gpu-rasterization"];
     case "linux":
+      // Chrome 131+ headless shell only accepts (gl=angle, angle=gl-egl);
+      // the old --use-gl=egl causes the GPU process to exit silently.
+      // --ignore-gpu-blocklist: the operator explicitly opted into
+      // browserGpuMode="hardware", so trust their driver/GPU choice.
       return [
         "--use-gl=angle",
         "--use-angle=gl-egl",

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -650,7 +650,13 @@ function getBrowserGpuArgs(
     case "win32":
       return ["--use-gl=angle", "--use-angle=d3d11", "--enable-gpu-rasterization"];
     case "linux":
-      return ["--use-gl=egl", "--enable-gpu-rasterization"];
+      return [
+        "--use-gl=angle",
+        "--use-angle=gl-egl",
+        "--enable-gpu-rasterization",
+        "--ignore-gpu-blocklist",
+        "--disable-software-rasterizer",
+      ];
     default:
       return ["--enable-gpu-rasterization"];
   }

--- a/packages/engine/src/utils/gpuEncoder.test.ts
+++ b/packages/engine/src/utils/gpuEncoder.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getCompiledGpuEncoders,
   getGpuEncoderName,
+  getProbeArgs,
   mapPresetForGpuEncoder,
   selectUsableGpuEncoder,
 } from "./gpuEncoder.js";
@@ -125,5 +126,15 @@ describe("mapPresetForGpuEncoder", () => {
     it("passes preset through unchanged when encoder is null (CPU)", () => {
       expect(mapPresetForGpuEncoder(null, "ultrafast")).toBe("ultrafast");
     });
+  });
+});
+
+describe("getProbeArgs", () => {
+  it("uses 320x240 probe dimensions for all GPU encoders", () => {
+    const encoders = ["nvenc", "videotoolbox", "vaapi", "qsv", "amf"] as const;
+    for (const encoder of encoders) {
+      const args = getProbeArgs(encoder);
+      expect(args).toContain("color=size=320x240:rate=1:duration=1");
+    }
   });
 });

--- a/packages/engine/src/utils/gpuEncoder.ts
+++ b/packages/engine/src/utils/gpuEncoder.ts
@@ -116,7 +116,7 @@ function getProbeArgs(encoder: ConcreteGpuEncoder): string[] {
     "-f",
     "lavfi",
     "-i",
-    "color=size=16x16:rate=1:duration=1",
+    "color=size=320x240:rate=1:duration=1",
     "-frames:v",
     "1",
     "-an",

--- a/packages/engine/src/utils/gpuEncoder.ts
+++ b/packages/engine/src/utils/gpuEncoder.ts
@@ -108,7 +108,17 @@ export function getGpuEncoderName(encoder: GpuEncoder, codec: "h264" | "h265"): 
   }
 }
 
-function getProbeArgs(encoder: ConcreteGpuEncoder): string[] {
+// Minimum probe dimensions must clear every GPU encoder's hardware minimum.
+// NVIDIA data-center SKUs (L4/T4/A10/A100) reject frames below ~257px on
+// either dimension with "Frame Dimension less than the minimum supported
+// value" (observed on driver 595.58.03, CUDA 13.2). The documented SDK
+// minimums (145×49 H.264, 129×33 HEVC) are lower, but the driver enforces
+// a stricter per-SKU alignment. 320×240 clears all known GPU encoder
+// minimums (NVENC, VideoToolbox, VAAPI, QSV, AMF) while staying cheap.
+const GPU_PROBE_WIDTH = 320;
+const GPU_PROBE_HEIGHT = 240;
+
+export function getProbeArgs(encoder: ConcreteGpuEncoder): string[] {
   const args = [
     "-hide_banner",
     "-loglevel",
@@ -116,7 +126,7 @@ function getProbeArgs(encoder: ConcreteGpuEncoder): string[] {
     "-f",
     "lavfi",
     "-i",
-    "color=size=320x240:rate=1:duration=1",
+    `color=size=${GPU_PROBE_WIDTH}x${GPU_PROBE_HEIGHT}:rate=1:duration=1`,
     "-frames:v",
     "1",
     "-an",


### PR DESCRIPTION
## Summary

Fixes three related bugs in the hardware GPU acceleration path that prevent NVIDIA data-center GPUs (L4/T4/A10/A100) from being used on modern Chrome:

- **Linux hardware path uses `--use-gl=egl`** — Chrome 131+ headless shell rejects this; only `(gl=angle, angle=gl-egl)` is on the allowlist. The GPU process exits silently and the renderer falls back to SwiftShader.
- **NVENC probe frame too small** — 16×16 is below the 257×257 minimum for NVIDIA data-center NVENC encoders, causing the probe to fail and silently fall back to libx264.

### Changes

1. `getBrowserGpuArgs` Linux branch: `--use-gl=egl` → `--use-gl=angle --use-angle=gl-egl` + `--ignore-gpu-blocklist` + `--disable-software-rasterizer`
2. `getProbeArgs`: `color=size=16x16` → `color=size=320x240` (above the 257 minimum, still cheap)
3. Updated test expectations for the new Linux hardware args

## Test plan

- [x] `browserManager.test.ts` — 58 tests pass, including updated Linux GPU args assertion
- [x] `gpuEncoder.test.ts` — all tests pass
- [ ] CI green
- [ ] Manual verification on an L4/T4 instance: `nvidia-smi` shows real GPU utilization during render

Closes #1493