### PR TITLE
fix(cli): restore sharp + onnxruntime-node as dependencies (unbreak remove-background)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/aws-lambda": {
       "name": "@hyperframes/aws-lambda",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-sfn": "^3.700.0",
@@ -54,7 +54,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "bin": {
         "hyperframes": "./dist/cli.js",
       },
@@ -69,10 +69,12 @@
         "fontkit": "^2.0.4",
         "giget": "^3.2.0",
         "hono": "^4.0.0",
+        "onnxruntime-node": "^1.20.0",
         "open": "^10.0.0",
         "postcss": "^8.5.8",
         "prettier": "^3.8.1",
         "puppeteer-core": "^24.39.1",
+        "sharp": "^0.34.5",
       },
       "devDependencies": {
         "@clack/prompts": "^1.1.0",
@@ -95,13 +97,11 @@
       },
       "optionalDependencies": {
         "@google/genai": "^1.50.1",
-        "onnxruntime-node": "^1.20.0",
-        "sharp": "^0.34.5",
       },
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "@chenglou/pretext": "^0.0.5",
@@ -135,7 +135,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
         "@hyperframes/core": "workspace:^",
@@ -153,7 +153,7 @@
     },
     "packages/gcp-cloud-run": {
       "name": "@hyperframes/gcp-cloud-run",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "@google-cloud/storage": "^7.14.0",
         "@google-cloud/workflows": "^4.2.0",
@@ -173,7 +173,7 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "devDependencies": {
         "@types/bun": "^1.1.0",
         "gsap": "^3.12.5",
@@ -185,7 +185,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -226,7 +226,7 @@
     },
     "packages/sdk": {
       "name": "@hyperframes/sdk",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "linkedom": "^0.18.12",
@@ -239,7 +239,7 @@
     },
     "packages/sdk-playground": {
       "name": "@hyperframes/sdk-playground",
-      "version": "0.6.99",
+      "version": "0.6.103",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/sdk": "workspace:*",
@@ -251,7 +251,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -263,7 +263,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.6.100",
+      "version": "0.6.104",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,10 +35,12 @@
     "fontkit": "^2.0.4",
     "giget": "^3.2.0",
     "hono": "^4.0.0",
+    "onnxruntime-node": "^1.20.0",
     "open": "^10.0.0",
     "postcss": "^8.5.8",
     "prettier": "^3.8.1",
-    "puppeteer-core": "^24.39.1"
+    "puppeteer-core": "^24.39.1",
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@clack/prompts": "^1.1.0",
@@ -60,9 +62,7 @@
     "vitest": "^3.2.4"
   },
   "optionalDependencies": {
-    "@google/genai": "^1.50.1",
-    "onnxruntime-node": "^1.20.0",
-    "sharp": "^0.34.5"
+    "@google/genai": "^1.50.1"
   },
   "engines": {
     "node": ">=22"

--- a/packages/cli/src/commands/remove-background.ts
+++ b/packages/cli/src/commands/remove-background.ts
@@ -5,6 +5,7 @@ import * as clack from "@clack/prompts";
 import { c } from "../ui/colors.js";
 import { isDevice, DEVICES } from "../background-removal/manager.js";
 import { DEFAULT_QUALITY, QUALITIES, isQuality } from "../background-removal/pipeline.js";
+import { trackCommandFailure } from "../telemetry/events.js";
 import type { Example } from "./_examples.js";
 
 export const examples: Example[] = [
@@ -175,6 +176,9 @@ export default defineCommand({
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // Self-exits, so the cli.ts dispatch wrapper never sees it — report the
+      // reason inline (e.g. a missing native module) before exiting.
+      trackCommandFailure("remove-background", err);
       if (args.json) {
         console.log(JSON.stringify({ ok: false, error: message }));
       } else {


### PR DESCRIPTION
## Problem

An earlier change moved `sharp` and `onnxruntime-node` to `optionalDependencies` (part of hardening capture against native-module load failures). But `remove-background` genuinely **requires** both native modules — as optional deps they're skipped on most installs, so the command now hits the guarded "module not available" path and fails for nearly everyone who runs it. This is a regression: `remove-background` was healthy when these were regular dependencies.

## Why optional was the wrong lever

The capture crash that motivated the move is fixed by the **lazy, guarded `await import()`** in `contentExtractor` / `inference` — that holds regardless of dependency classification. Making the modules optional was an over-correction; the lazy import alone was sufficient to keep capture crash-safe.

`sharp` ships its own platform binaries as optional sub-dependencies, so it installs cleanly as a hard dependency without failing installs on unsupported platforms. It was a hard dependency historically with `remove-background` working fine.

## Fix

- **Move `sharp` + `onnxruntime-node` back to `dependencies`** so they install for everyone again. `@google/genai` stays optional — it's genuinely optional, lazy-loaded, and not part of this regression.
- **Keep the lazy guarded imports** — they remain the crash-safety for capture (a missing/unloadable binary still degrades gracefully there).
- **Add `trackCommandFailure` to `remove-background`'s catch.** The command self-exits, so the central dispatch wrapper never saw its failures (its error-reason stream was blind). Now its failures carry a reason — closing it from the wrapper-blind follow-up.

## Verification
- `tsc --noEmit` clean
- background-removal + remove-background suites pass (40 tests)
- full build green; lint / format / fallow / commitlint green
- `bun.lock` updated for the dependency reclassification (clean — only the two packages moved)