### PR TITLE
fix(sdk): agree removeElement/getElement on duplicate bare ids

### DIFF
--- a/packages/sdk/src/engine/model.ts
+++ b/packages/sdk/src/engine/model.ts
@@ -29,9 +29,12 @@ export function parseMutable(html: string): ParsedDocument {
 // ─── Element lookup ───────────────────────────────────────────────────────────
 
 export function findById(document: Document, id: string): Element | null {
-  // CSS.escape is browser-only; hf-ids are restricted identifiers so simple quote-escaping is safe.
-  const escaped = id.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  return document.querySelector(`[data-hf-id="${escaped}"]`);
+  // Delegate to resolveScoped so patch replay (undo/redo, override-set apply)
+  // resolves an id the SAME way forward dispatch does: canonical-first for an
+  // ambiguous bare id, and scoped-path ("hf-host/hf-leaf") aware. Otherwise the
+  // two paths disagree on which duplicate a bare id targets and undo reverts the
+  // wrong element. (function declaration is hoisted.)
+  return resolveScoped(document, id);
 }
 
 function escapeHfId(id: string): string {
@@ -39,15 +42,44 @@ function escapeHfId(id: string): string {
 }
 
 /**
+ * True when an element lives at the top-level (canonical) scope — i.e. its
+ * scopedId equals its bare id because no ancestor opens a sub-composition
+ * boundary. This mirrors document.ts's scopedId construction (childPrefix only
+ * changes at isNewHostBoundary elements) without rebuilding the snapshot tree.
+ */
+function isCanonicalScope(el: Element): boolean {
+  for (let cur = el.parentElement; cur; cur = cur.parentElement) {
+    if (isNewHostBoundary(cur)) return false;
+  }
+  return true;
+}
+
+/**
  * Resolve a bare or scoped hf-id to its DOM element.
  *
- * Bare id ("hf-x"): equivalent to findById — top-level document search.
+ * Bare id ("hf-x"): top-level document search. When the bare id is ambiguous
+ * (duplicated across a sub-composition and the top level), prefer the canonical
+ * (top-level) instance — the one whose scopedId equals the bare id — falling
+ * back to document order when no canonical match exists. This matches
+ * getElement()'s resolution rule so removeElement / getElement agree on which
+ * instance an ambiguous bare id targets.
+ *
  * Scoped id ("hf-HOST/hf-LEAF", any depth): each segment narrows the search
  * into the subtree of the previous match. This unambiguously addresses an
  * element inside a sub-composition even when bare ids collide.
  */
 export function resolveScoped(document: Document, id: string): Element | null {
   const parts = id.split("/");
+
+  // Bare id: prefer the canonical (top-level) match when one exists, so
+  // resolution agrees with getElement (scopedId === id wins over document order).
+  if (parts.length === 1) {
+    const escaped = escapeHfId(id);
+    const matches = Array.from(document.querySelectorAll(`[data-hf-id="${escaped}"]`));
+    if (matches.length === 0) return null;
+    return matches.find((el) => isCanonicalScope(el)) ?? matches[0] ?? null;
+  }
+
   let context: Element | Document = document;
   for (const part of parts) {
     const escaped = escapeHfId(part);

--- a/packages/sdk/src/engine/model.ts
+++ b/packages/sdk/src/engine/model.ts
@@ -88,7 +88,7 @@ export function findRoot(document: Document): Element | null {
 
 // ─── Inline style helpers ─────────────────────────────────────────────────────
 
-function toCamel(prop: string): string {
+export function toCamel(prop: string): string {
   if (prop.startsWith("--")) return prop;
   return prop.replace(/-([a-z])/g, (_, c: string) => (c as string).toUpperCase());
 }
@@ -127,10 +127,13 @@ export function getElementStyles(el: Element): Record<string, string> {
 export function setElementStyles(el: Element, updates: Record<string, string | null>): void {
   const current = getElementStyles(el);
   for (const [prop, value] of Object.entries(updates)) {
+    // Stored map is keyed camelCase (parseStyleAttr); custom props (--foo) stay
+    // verbatim. Normalize the incoming key the same way for both set and delete.
+    const key = toCamel(prop);
     if (value === null) {
-      delete current[prop];
+      delete current[key];
     } else {
-      current[prop] = value;
+      current[key] = value;
     }
   }
   const serialized = serializeStyleAttr(current);

--- a/packages/sdk/src/engine/mutate.test.ts
+++ b/packages/sdk/src/engine/mutate.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { parseMutable } from "./model.js";
+import { parseMutable, getElementStyles, setElementStyles } from "./model.js";
 import { applyOp, validateOp } from "./mutate.js";
 import { applyPatchesToDocument } from "./apply-patches.js";
 import { pathToKey } from "./patches.js";
@@ -105,6 +105,42 @@ describe("setStyle", () => {
   it("override-set key maps correctly", () => {
     const key = pathToKey("/elements/hf-title/inlineStyles/fontSize");
     expect(key).toBe("hf-title.style.fontSize");
+  });
+
+  // Regression: a HYPHENATED (kebab) style key must derive its inverse against
+  // the camelCase-keyed store, or oldValue is null → undo deletes the prior
+  // value instead of restoring it, and a removal skips the inverse entirely.
+  it("derives correct inverse for a kebab style key (change)", () => {
+    const parsed = fresh();
+    const result = applyOp(parsed, {
+      type: "setStyle",
+      target: "hf-title",
+      styles: { "font-size": "96px" },
+    });
+    // inverse restores the prior 64px (replace), not a remove
+    expect(result.inverse[0]).toEqual({
+      op: "replace",
+      path: "/elements/hf-title/inlineStyles/fontSize",
+      value: "64px",
+    });
+  });
+
+  it("emits the inverse for a kebab style removal (no DOM/patch desync)", () => {
+    const parsed = fresh();
+    const result = applyOp(parsed, {
+      type: "setStyle",
+      target: "hf-title",
+      styles: { "font-size": null },
+    });
+    // removal must be recorded (forward remove + inverse add restoring 64px)
+    expect(result.forward[0]?.op).toBe("remove");
+    expect(result.inverse[0]).toEqual({
+      op: "add",
+      path: "/elements/hf-title/inlineStyles/fontSize",
+      value: "64px",
+    });
+    const el = parsed.document.querySelector('[data-hf-id="hf-title"]');
+    expect(el?.getAttribute("style") ?? "").not.toContain("font-size");
   });
 });
 
@@ -283,6 +319,50 @@ describe("removeElement", () => {
     expect(restored?.parentElement?.getAttribute("data-hf-id")).toBe("hf-sub");
     expect(restored?.getAttribute("style")).toBe("opacity: 0.5");
     expect(restored?.textContent).toBe("sub text");
+  });
+});
+
+// ─── setElementStyles (model helper) ──────────────────────────────────────────
+
+describe("setElementStyles key normalization", () => {
+  function elWith(style: string): Element {
+    const parsed = parseMutable(`<div data-hf-id="hf-x" data-hf-root style="${style}"></div>`);
+    const el = parsed.document.querySelector('[data-hf-id="hf-x"]');
+    if (!el) throw new Error("fixture element missing");
+    return el;
+  }
+
+  it("removes a hyphenated property when value is null", () => {
+    const el = elWith("transform-origin: center center; opacity: 0.5");
+    setElementStyles(el, { "transform-origin": null });
+    const styles = getElementStyles(el);
+    expect(styles.transformOrigin).toBeUndefined();
+    expect(el.getAttribute("style")).not.toContain("transform-origin");
+    // sibling prop untouched
+    expect(styles.opacity).toBe("0.5");
+  });
+
+  it("removes a CSS custom property when value is null", () => {
+    const el = elWith("--brand-color: #f00; opacity: 0.5");
+    setElementStyles(el, { "--brand-color": null });
+    const styles = getElementStyles(el);
+    expect(styles["--brand-color"]).toBeUndefined();
+    expect(el.getAttribute("style")).not.toContain("--brand-color");
+    expect(styles.opacity).toBe("0.5");
+  });
+
+  it("sets a camelCase property and keeps existing props", () => {
+    const el = elWith("color: #fff");
+    setElementStyles(el, { fontSize: "96px" });
+    const styles = getElementStyles(el);
+    expect(styles.fontSize).toBe("96px");
+    expect(styles.color).toBe("#fff");
+  });
+
+  it("sets a hyphenated property under its camelCase key", () => {
+    const el = elWith("");
+    setElementStyles(el, { "transform-origin": "top left" });
+    expect(getElementStyles(el).transformOrigin).toBe("top left");
   });
 });
 

--- a/packages/sdk/src/engine/mutate.ts
+++ b/packages/sdk/src/engine/mutate.ts
@@ -14,6 +14,7 @@ import {
   findRoot,
   getElementStyles,
   setElementStyles,
+  toCamel,
   getOwnText,
   setOwnText,
   getSiblingIndex,
@@ -199,8 +200,14 @@ function handleSetStyle(
     const old = getElementStyles(el);
     setElementStyles(el, styles);
     for (const [prop, value] of Object.entries(styles)) {
-      const path = stylePath(id, prop);
-      const oldValue = old[prop] ?? null;
+      // Normalize to the camelCase key the style map + patch grammar use. A
+      // hyphenated op key ("transform-origin") otherwise misses the camelCase
+      // store, so oldValue is always null → undo deletes/loses the prior value,
+      // a removal skips its inverse patch entirely (DOM/patch-log desync), and
+      // the patch path/override-set key diverge from the camelCase grammar.
+      const key = toCamel(prop);
+      const path = stylePath(id, key);
+      const oldValue = old[key] ?? null;
       if (value !== null) {
         const p = scalarChange(path, oldValue, value);
         result.forward.push(p.forward);

--- a/packages/sdk/src/session.subcomp.test.ts
+++ b/packages/sdk/src/session.subcomp.test.ts
@@ -13,7 +13,7 @@
 import { describe, it, expect } from "vitest";
 import { parseHTML } from "linkedom";
 import { ensureHfIds } from "@hyperframes/core/hf-ids";
-import { resolveScoped } from "./engine/model.js";
+import { resolveScoped, findById } from "./engine/model.js";
 import { parseMutable } from "./engine/model.js";
 import { buildRoots, flatElements } from "./document.js";
 import { openComposition } from "./session.js";
@@ -48,6 +48,24 @@ describe("resolveScoped — flat id", () => {
       `<!DOCTYPE html><html><body><div data-hf-id="hf-aaaa"></div></body></html>`,
     );
     expect(resolveScoped(doc as unknown as Document, "hf-xxxx")).toBeNull();
+  });
+
+  // Regression: findById is the patch-replay/undo resolver. It must agree with
+  // resolveScoped (forward dispatch) on an ambiguous bare id — both pick the
+  // canonical (top-level) instance — or undo reverts the wrong duplicate.
+  it("findById resolves an ambiguous bare id to the canonical instance (== resolveScoped)", () => {
+    const doc = makeDoc(
+      inlinedHtml(`
+      <div data-hf-id="hf-host" data-composition-file="sub.html">
+        <p data-hf-id="hf-dup" class="inside">inside</p>
+      </div>
+      <p data-hf-id="hf-dup" class="outside">outside</p>
+    `),
+    ) as unknown as Document;
+    const viaFind = findById(doc, "hf-dup");
+    const viaResolve = resolveScoped(doc, "hf-dup");
+    expect(viaFind).toBe(viaResolve);
+    expect(viaFind?.getAttribute("class")).toBe("outside");
   });
 });
 
@@ -363,6 +381,70 @@ describe("find({ composition })", () => {
     const comp = await openComposition(html);
     const ids = comp.find({ composition: "hf-host", tag: "p" });
     expect(ids).toEqual(["hf-host/hf-a"]);
+  });
+});
+
+// ─── 5b. Ambiguous bare id: removeElement / getElement agreement ──────────────
+
+describe("ambiguous bare id — removeElement and getElement agree", () => {
+  // Inner sub-comp dup appears FIRST in document order; the canonical top-level
+  // dup appears AFTER it. querySelector document-order would return the inner one,
+  // but getElement prefers the canonical (top-level) match. The two APIs must agree.
+  const ambiguousHtml = () =>
+    inlinedHtml(`
+      <div data-hf-id="hf-root" data-hf-root>
+        <div data-hf-id="hf-host" data-composition-file="sub.html">
+          <p data-hf-id="hf-dup" class="inner">inner</p>
+        </div>
+        <p data-hf-id="hf-dup" class="outer">outer</p>
+      </div>
+    `);
+
+  it("bare id resolves to the canonical (top-level) instance, matching getElement", async () => {
+    const comp = await openComposition(ambiguousHtml());
+
+    // getElement prefers the canonical match (scopedId === id) → top-level "outer".
+    const got = comp.getElement("hf-dup");
+    expect(got?.scopedId).toBe("hf-dup");
+    expect(got?.classNames).toContain("outer");
+
+    // removeElement(bareId) must remove the SAME instance getElement returned.
+    comp.removeElement("hf-dup");
+
+    // The canonical top-level instance is gone — getElement(bareId) no longer
+    // finds it (and does NOT silently fall through to the inner sub-comp dup).
+    expect(comp.getElement("hf-dup")).toBeNull();
+
+    // The inner instance survives, addressable only via its fully-scoped path.
+    const inner = comp.getElement("hf-host/hf-dup");
+    expect(inner?.classNames).toContain("inner");
+  });
+
+  it("fully-scoped path still targets the inner instance exactly", async () => {
+    const comp = await openComposition(ambiguousHtml());
+    comp.removeElement("hf-host/hf-dup");
+
+    // Inner gone; canonical top-level survives.
+    const inner = comp.getElement("hf-host/hf-dup");
+    expect(inner).toBeNull();
+    const top = comp.getElement("hf-dup");
+    expect(top?.scopedId).toBe("hf-dup");
+    expect(top?.classNames).toContain("outer");
+  });
+
+  it("non-duplicated bare id still resolves and removes normally", async () => {
+    const html = inlinedHtml(`
+      <div data-hf-id="hf-root" data-hf-root>
+        <div data-hf-id="hf-host" data-composition-file="sub.html">
+          <p data-hf-id="hf-leaf">inside</p>
+        </div>
+        <p data-hf-id="hf-solo">solo</p>
+      </div>
+    `);
+    const comp = await openComposition(html);
+    expect(comp.getElement("hf-solo")?.scopedId).toBe("hf-solo");
+    comp.removeElement("hf-solo");
+    expect(comp.getElement("hf-solo")).toBeNull();
   });
 });
 

--- a/packages/studio/src/utils/sdkShadow.test.ts
+++ b/packages/studio/src/utils/sdkShadow.test.ts
@@ -181,32 +181,26 @@ describe("sdkShadowDispatch (integration)", () => {
 
   // Fix 3 verdict (REAL DIVERGENCE, not a readback artifact): the inline-style
   // read-back already reads only the AUTHORED style attribute (getElementStyles →
-  // parseStyleAttr), never computed styles. The transform-origin event
-  // (expected null actual "center center") is a genuine SDK bug: setStyle removal
-  // of a HYPHENATED property silently no-ops because setElementStyles deletes the
-  // kebab key while the style map is keyed camelCase. The shadow CORRECTLY flags
-  // it; the fix belongs in the SDK (packages/sdk/src/engine/model.ts), not here.
-  it("CORRECTLY flags the SDK transform-origin removal no-op (real divergence)", async () => {
+  // parseStyleAttr), never computed styles. The transform-origin divergence
+  // (expected null actual "center center") was a genuine SDK bug — setStyle
+  // removal of a HYPHENATED property silently no-opped because setElementStyles
+  // deleted the kebab key while the style map is keyed camelCase. Now FIXED in
+  // the SDK (model.ts setElementStyles normalizes the key via toCamel), so the
+  // shadow sees parity: removal applies and there is no mismatch.
+  it("reports clean removal of a hyphenated style (SDK setStyle kebab/camel fix)", async () => {
     const { sdkShadowDispatch } = await import("./sdkShadow");
     const TO_HTML = /* html */ `<!DOCTYPE html>
 <html><body><div data-hf-id="hf-box" style="transform-origin: center center">x</div></body></html>`;
     const session = await openComposition(TO_HTML);
 
-    // op intends to REMOVE transform-origin (value null) ...
     const ops: PatchOperation[] = [
       { type: "inline-style", property: "transform-origin", value: null },
     ];
     const result = sdkShadowDispatch(session, "hf-box", ops);
 
-    // ... but the SDK still has it → genuine value_mismatch, not suppressed.
+    // The SDK now removes the hyphenated property, so the shadow read-back agrees.
     expect(result.dispatched).toBe(true);
-    expect(result.mismatches).toHaveLength(1);
-    expect(result.mismatches[0]).toMatchObject({
-      kind: "value_mismatch",
-      property: "transform-origin",
-      expected: null,
-      actual: "center center",
-    });
+    expect(result.mismatches).toHaveLength(0);
   });
 
   it("applies attribute op and reads back via session.getElement", async () => {

--- a/packages/studio/src/utils/sdkShadow.test.ts
+++ b/packages/studio/src/utils/sdkShadow.test.ts
@@ -312,12 +312,15 @@ describe("runShadowDelete", () => {
     </div>
   </body></html>`;
 
-  it("CORRECTLY reports present/removed for the SDK duplicate-bare-id delete divergence", async () => {
+  it("reports clean delete for a duplicate bare id (SDK resolves removeElement/getElement to the same instance)", async () => {
     const session = await openComposition(DUP_ID_HTML);
     runShadowDelete(session, "hf-dup");
-    // removeElement dropped the inner instance; the top-level one survives, so the
-    // readback truthfully flags one mismatch (not silently passed).
-    expect(lastShadow()).toMatchObject({ op: "delete", dispatched: true, mismatchCount: 1 });
+    // SDK fix (agree removeElement/getElement on duplicate bare ids): both now
+    // resolve a bare id to the canonical (top-level) instance, so removeElement
+    // drops exactly the element the readback checks → no mismatch. (Previously
+    // removeElement dropped the inner instance while the top-level survived,
+    // which this shadow correctly flagged; that divergence is now fixed.)
+    expect(lastShadow()).toMatchObject({ op: "delete", dispatched: true, mismatchCount: 0 });
   });
 });
 


### PR DESCRIPTION
## What
A bare hf-id duplicated across a sub-composition element and a top-level element resolved to **different instances**: `removeElement` → `resolveScoped` → `querySelector` (document-order-first, inner dup) while `getElement` preferred the canonical (`scopedId === id`, top-level). So `removeElement(bareId)` removed one and `getElement(bareId)` still found the other.

Fix: `resolveScoped` resolves an ambiguous bare id to the canonical (top-level) instance via `isCanonicalScope`, falling back to document order when no canonical match — matching `getElement`. Fully-scoped paths (`hf-host/hf-dup`) and non-duplicated bare ids unchanged.

## Why
Found via SDK shadow telemetry: `op:delete expected removed actual present`. Real SDK id-resolution bug — **cutover risk**. TDD.

## Tests
3 cases (canonical resolve+remove, scoped-path exactness, non-dup). Also updates the studio shadow test that had documented the divergence to assert the now-clean behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Code-review fixes (folded in)
- Unified the **patch-replay path**: `findById` (undo/redo, override-set apply) now delegates to `resolveScoped`, so it resolves an ambiguous bare id canonical-first like forward dispatch — otherwise undo reverted the wrong duplicate. Regression test asserts `findById === resolveScoped` on the canonical instance.