### PR TITLE
fix(release): annotate version tag + correct release push instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,10 +140,15 @@ All packages use **fixed versioning** — every release bumps all packages to th
 
 ```bash
 bun run release:prepare 0.2.0        # drafts changelog if needed, then creates the release commit/tag after review
-git push origin main --tags           # triggers the publish workflow
+git push origin main                  # push the release commit
+git push origin v0.2.0                # push the tag → triggers the publish workflow
 ```
 
+> Push the **specific tag**, not `git push --tags` — the latter pushes every local tag and the whole push is rejected if any one already exists on the remote.
+
 The `release:prepare` script drafts missing release notes on the first run and stops for manual review. After the generated TODO summary is rewritten, rerun the same command; it delegates to `set-version`, which creates a `chore: release v<version>` commit and a `v<version>` git tag. Pushing the tag triggers CI to publish all packages to npm and create a GitHub Release.
+
+`set-version` also refuses to tag if a **higher** semver tag already exists (a stale higher tag would hijack tag-sorting installers like `npx skills`). Delete the stray tag (`git tag -d <tag> && git push origin :refs/tags/<tag>`) or, only if intentional, pass `--skip-monotonicity-check`.
 
 ### Pre-releases (alpha / beta / rc)
 

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -130,7 +130,13 @@ function createReleaseCommitAndTag(version: string, skipMonotonicityCheck: boole
     cwd: ROOT,
     stdio: "inherit",
   });
-  execFileSync("git", ["tag", `v${version}`], { cwd: ROOT, stdio: "inherit" });
+  // Annotated tag (-a -m): works regardless of a contributor's git config; a
+  // lightweight `git tag` fails ("no tag message?") when tag.forceSignAnnotated
+  // or similar is set globally.
+  execFileSync("git", ["tag", "-a", `v${version}`, "-m", `v${version}`], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
   console.log(`\nCreated commit and tag v${version}`);
 }
 


### PR DESCRIPTION
## What
Two release-flow fixes surfaced while cutting v0.6.107.

1. **`set-version` creates an annotated tag** (`git tag -a -m`) instead of a lightweight `git tag`, which fails with `fatal: no tag message?` when a contributor has `tag.forceSignAnnotated` (or equivalent) set globally — it silently broke the v0.6.107 tag step (release commit landed, tag didn't).
2. **CONTRIBUTING release steps** no longer say `git push origin main --tags` (pushes every local tag → whole push rejected on any pre-existing collision). Now: push the release commit, then the **specific** tag. Also documents the monotonicity guard (a stale higher semver tag blocks tagging because it would hijack `npx skills`-style version resolution).

## Verify
`oxlint` clean · `scripts/set-version.test.ts` 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)