### PR TITLE
fix(release): stop advising 'git push --tags' in release next-steps

### DIFF
--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -319,7 +319,12 @@ function printReleaseNextSteps(version: string) {
     console.log(`Consumers install with: npm install @hyperframes/core@${distTag}`);
     console.log(`\nRun 'git push origin v${version}' to trigger the publish workflow.`);
   } else {
-    console.log(`Run 'git push origin main --tags' to trigger the publish workflow.`);
+    console.log(`\nRun the following to trigger the publish workflow:`);
+    console.log(`  git push origin main`);
+    console.log(`  git push origin v${version}`);
+    console.log(
+      `(push the specific tag, NOT 'git push --tags' — that fails on any pre-existing tag).`,
+    );
   }
 }
 


### PR DESCRIPTION
Follow-up to #1517. `set-version`'s stable-release next-steps still printed `git push origin main --tags` — pushes every local tag, fails the whole push on any pre-existing collision (it broke v0.6.107). #1517 fixed CONTRIBUTING.md + annotated tags but missed `printReleaseNextSteps`. Now prints `git push origin main` + `git push origin v<version>` (specific tag), matching the already-correct pre-release branch. Console-output only; set-version.test.ts 14/14, oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)