### PR TITLE
docs(catalog): add missing flowchart-vertical and vfx-liquid-glass pages

### DIFF
--- a/docs/catalog/blocks/flowchart-vertical.mdx
+++ b/docs/catalog/blocks/flowchart-vertical.mdx
@@ -1,0 +1,44 @@
+---
+title: "Flowchart Vertical"
+description: "Portrait animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction"
+---
+
+# Flowchart Vertical
+
+Portrait animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction
+
+`diagram` `flowchart` `interactive` `portrait`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart-vertical.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart-vertical.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add flowchart-vertical
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1440×2560 |
+| Duration | 12s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `flowchart-vertical.html` | `compositions/flowchart-vertical.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="flowchart-vertical" data-composition-src="compositions/flowchart-vertical.html" data-start="0" data-duration="12" data-track-index="1" data-width="1440" data-height="2560"></div>
+```

--- a/docs/catalog/blocks/vfx-liquid-glass.mdx
+++ b/docs/catalog/blocks/vfx-liquid-glass.mdx
@@ -1,0 +1,48 @@
+---
+title: "Liquid Glass"
+description: "VFX composition block"
+---
+
+# Liquid Glass
+
+VFX composition block
+
+`html-in-canvas` `webgl`
+
+<Warning>
+**Requires Chrome flag.** Enable `chrome://flags/#canvas-draw-element` for live preview. Rendering via CLI enables the flag automatically. [Learn more](/guides/html-in-canvas).
+</Warning>
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-glass.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-glass.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add vfx-liquid-glass
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 20s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `vfx-liquid-glass.html` | `compositions/vfx-liquid-glass.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="vfx-liquid-glass" data-composition-src="compositions/vfx-liquid-glass.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -159,6 +159,7 @@
               "catalog/blocks/macos-tahoe-liquid-glass",
               "catalog/blocks/vfx-iphone-device",
               "catalog/blocks/vfx-liquid-background",
+              "catalog/blocks/vfx-liquid-glass",
               "catalog/blocks/vfx-magnetic",
               "catalog/blocks/vfx-portal",
               "catalog/blocks/vfx-shatter",
@@ -261,6 +262,7 @@
             "group": "Blocks",
             "pages": [
               "catalog/blocks/flowchart",
+              "catalog/blocks/flowchart-vertical",
               "catalog/blocks/logo-outro"
             ]
           },

--- a/docs/public/catalog-index.json
+++ b/docs/public/catalog-index.json
@@ -363,6 +363,20 @@
         "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart.png"
     },
     {
+        "name": "flowchart-vertical",
+        "type": "block",
+        "title": "Flowchart Vertical",
+        "description": "Portrait animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction",
+        "tags": [
+            "diagram",
+            "flowchart",
+            "interactive",
+            "portrait"
+        ],
+        "href": "/catalog/blocks/flowchart-vertical",
+        "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart-vertical.png"
+    },
+    {
         "name": "glitch",
         "type": "block",
         "title": "Glitch",
@@ -1032,6 +1046,18 @@
         ],
         "href": "/catalog/blocks/vfx-liquid-background",
         "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-background.png"
+    },
+    {
+        "name": "vfx-liquid-glass",
+        "type": "block",
+        "title": "Liquid Glass",
+        "description": "VFX composition block",
+        "tags": [
+            "html-in-canvas",
+            "webgl"
+        ],
+        "href": "/catalog/blocks/vfx-liquid-glass",
+        "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-glass.png"
     },
     {
         "name": "vfx-magnetic",


### PR DESCRIPTION
## What

Adds the two missing catalog doc pages — `flowchart-vertical` and `vfx-liquid-glass` — plus their entries in `docs/public/catalog-index.json` and the Catalog nav in `docs/docs.json`.

## Why

Both blocks are registered in `registry/registry.json` with complete `registry-item.json` manifests (and preview video/poster assets), so they're installable via `npx hyperframes add flowchart-vertical` / `vfx-liquid-glass`. But their generated catalog docs were never produced — the docs site lists **95 of the 97** registered blocks, and these two are invisible in the catalog grid and search index.

The catalog docs are generated from the registry by `scripts/generate-catalog-pages.ts`, which emits `docs/catalog/<kind>/<name>.mdx`, `docs/public/catalog-index.json`, and the Catalog nav in `docs/docs.json`. These two blocks were added to the registry without re-running it.

```
registry blocks:        97
catalog block doc pages: 95   ← flowchart-vertical, vfx-liquid-glass missing
```

## How

I ran `scripts/generate-catalog-pages.ts` and took **only** the output for these two items — the two `.mdx` pages are byte-identical to what the generator produces — then added their corresponding entries to `catalog-index.json` (alphabetical) and the Catalog nav groups (`vfx-liquid-glass` → HTML-in-Canvas, `flowchart-vertical` → Blocks). All other generated pages are left untouched, so the diff is just the two new pages + 28 added lines.

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed — confirmed both blocks have valid `registry-item.json` + preview assets in the registry; verified the two new `.mdx` pages are byte-identical to `generate-catalog-pages.ts` output; the added index/nav entries match the generator's output for these items exactly; `JSON.parse` succeeds for both edited JSON files; no other catalog page is modified.
- [ ] Documentation updated (if applicable)
