### PR TITLE
fix(player): add onRuntimeReady to test callbacks mock

### DIFF
--- a/packages/player/src/runtime-message-handler.test.ts
+++ b/packages/player/src/runtime-message-handler.test.ts
@@ -10,6 +10,7 @@ import type { ShaderLoaderState } from "./shader-loader-state.js";
 const makeCallbacks = (): MessageHandlerCallbacks => ({
   updateControlsTime: vi.fn(),
   updateControlsPlaying: vi.fn(),
+  onRuntimeReady: vi.fn(),
   dispatchEvent: vi.fn(),
   seek: vi.fn(),
   play: vi.fn(),


### PR DESCRIPTION
`MessageHandlerCallbacks` requires `onRuntimeReady` (`runtime-message-handler.ts:29`) but the test mock in `runtime-message-handler.test.ts` omitted it. This **TS2741** error broke the CI `Typecheck` job on `main` — and therefore on every open PR (e.g. #1533). One-line fix: add the missing `vi.fn()`.

Verified: `tsc --noEmit` (both player tsconfig projects) + `oxfmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)