### PR TITLE
fix(lint): match @font-face when a comment inside the block holds a brace

### DIFF
--- a/packages/core/src/lint/rules/fonts.test.ts
+++ b/packages/core/src/lint/rules/fonts.test.ts
@@ -215,5 +215,16 @@ describe("font rules", () => {
       const findings = await findByCode(html, "font_family_without_font_face");
       expect(findings).toHaveLength(0);
     });
+
+    it("matches @font-face even when a CSS comment inside the block contains a brace (#1534)", async () => {
+      const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+        <style>
+          @font-face { /* weight 400 } regular */ font-family: 'Noto Sans SC'; src: url('../fonts/noto-400.woff2'); }
+          .title { font-family: 'Noto Sans SC'; }
+        </style>
+      </div>`;
+      const findings = await findByCode(html, "font_family_without_font_face");
+      expect(findings).toHaveLength(0);
+    });
   });
 });

--- a/packages/core/src/lint/rules/fonts.ts
+++ b/packages/core/src/lint/rules/fonts.ts
@@ -22,13 +22,25 @@ const GENERIC_FAMILIES = new Set([
   "revert",
 ]);
 
+// A CSS comment can contain a `}` (e.g. `@font-face { /* 400 } regular */
+// font-family: 'X'; ... }`), which truncates the naive `@font-face\s*\{[^}]*\}`
+// block match at the comment's brace — so the rule never sees the real
+// `font-family` and reports a false-positive font_family_without_font_face.
+// Large/"framework" stylesheets hit this far more often than minimal ones,
+// which is why a simple <style> passes while a complex one fails. Strip
+// comments before scanning so a brace inside one cannot split a block. See #1534.
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, " ");
+}
+
 function extractFontFaceFamilies(styles: Array<{ content: string }>): Set<string> {
   const families = new Set<string>();
   const fontFaceRe = /@font-face\s*\{[^}]*\}/gi;
   const familyRe = /font-family\s*:\s*(['"]?)([^;'"]+)\1/i;
   for (const style of styles) {
+    const content = stripCssComments(style.content);
     let match: RegExpExecArray | null;
-    while ((match = fontFaceRe.exec(style.content)) !== null) {
+    while ((match = fontFaceRe.exec(content)) !== null) {
       const familyMatch = match[0].match(familyRe);
       if (familyMatch?.[2]) {
         families.add(familyMatch[2].trim().toLowerCase());
@@ -43,7 +55,7 @@ function extractUsedFontFamilies(styles: Array<{ content: string }>): string[] {
   const seen = new Set<string>();
   const propRe = /font-family\s*:\s*([^;}{]+)/gi;
   for (const style of styles) {
-    const withoutFontFace = style.content.replace(/@font-face\s*\{[^}]*\}/gi, "");
+    const withoutFontFace = stripCssComments(style.content).replace(/@font-face\s*\{[^}]*\}/gi, "");
     let match: RegExpExecArray | null;
     while ((match = propRe.exec(withoutFontFace)) !== null) {
       const stack = match[1]!;


### PR DESCRIPTION
## What

`font_family_without_font_face` (and `system_font_will_alias`) collect declared
`@font-face` families with `@font-face\s*\{[^}]*\}`. `[^}]*` stops at the **first**
`}`, so a CSS comment inside the block that contains a brace truncates the match
before `font-family:` is reached:

```css
@font-face { /* weight 400 } regular */ font-family: 'Noto Sans SC'; src: url('...'); }
```

The family is never recorded as declared, and a later literal
`font-family: 'Noto Sans SC'` is then reported as used without an `@font-face` —
a blocking error since 0.6.109, where #1495 promoted this rule from warning to error.

**Fix:** strip CSS comments before scanning. In valid CSS the only source of a `}`
inside an `@font-face` block is a comment, so this closes the gap. It's the same
technique #1495 already applied to `scene_layer_missing_visibility_kill` ("strip
JS comments before pattern matching") and `caption_transcript_parse_error`
("balanced-bracket scanner replaces non-greedy regex") — just never applied to the
font rules.

## Honest note on #1534

I believe this is the cause of #1534, but I want to be upfront: I could **not**
reproduce it with a *clean* `@font-face`, no matter how large/complex the
surrounding CSS was (tested 139-line blocks, 15 `@keyframes`, Fontsource-style
multi-line faces, comments that mention `@font-face`, two `<style>` blocks). The
only thing that reproduces the exact error is a brace **inside** the `@font-face`
block — realistically a comment. The reporter says the `@font-face` is byte-identical
between the passing and failing cases; if so, the failing file most likely has an
inline comment in the block that was dropped when minimizing the repro.

@Johnson-Jia — could you share the exact failing `@font-face` block (or the minimal
HTML) verbatim? If it carries a comment with a `}` inside, this fixes it; if not,
I'd like to track down the remaining mechanism. Marked `Refs #1534` rather than
`Fixes` until that's confirmed.

## Verification

- Added a regression test (comment-with-brace inside `@font-face`); confirmed it
  goes **red on `main`** and **green** with this change.
- `packages/core`: full lint suite **191/191**, `tsc --noEmit` clean, and the
  pre-commit gate (oxlint + oxfmt + `fallow audit`) clean.
