### PR TITLE
fix(studio): shadow resolves bare leaf via dispatch path, not getElement

### DIFF
--- a/packages/studio/src/utils/sdkResolverShadow.test.ts
+++ b/packages/studio/src/utils/sdkResolverShadow.test.ts
@@ -189,7 +189,7 @@ describe("C. Resolver-parity detection", () => {
   it("C8: element_not_found fires when SDK resolver returns null (v0.6.110 class)", () => {
     // Simulate the regression: SDK session cannot resolve the hfId the server
     // would address (e.g. scoped-id mismatch, resolver bug).
-    const session = { getElement: () => null } as unknown as Parameters<
+    const session = { getElement: () => null, getElements: () => [] } as unknown as Parameters<
       typeof sdkResolverShadowCheck
     >[0];
     const mismatches = sdkResolverShadowCheck(
@@ -362,5 +362,48 @@ describe("G. recordAnimationResolverParity", () => {
     const session = await openComposition(GSAP_HTML);
     recordAnimationResolverParity(session, "no-such-anim", "setGsapTween");
     expect(trackedEvents).toHaveLength(0);
+  });
+});
+
+// ─── H. Inlined sub-composition: bare leaf id resolves (regression) ───────────
+
+// PostHog showed ~445 false `element_not_found` events, all on a bare leaf id
+// (hf-0ytc / #subscribe-btn) inside an inlined sub-composition. The studio reads
+// the bare data-hf-id off the DOM and the cutover dispatch resolves it via
+// resolveScoped (which locates the leaf inside the host subtree). But the shadow
+// resolved via Composition.getElement, which is canonical-only for a bare id and
+// returns null for a scoped element — so it flagged a divergence the real
+// dispatch path would not hit. The shadow now mirrors dispatch via resolveSnapshot.
+describe("H. inlined sub-composition leaf", () => {
+  // host carries data-composition-file → new scope; leaf's scopedId is
+  // "hf-host/hf-leaf" but its raw data-hf-id (what the studio reads) is bare.
+  const INLINED_HTML = /* html */ `<!DOCTYPE html>
+<html><body>
+  <div data-hf-id="hf-root" data-hf-root>
+    <div data-hf-id="hf-host" data-composition-file="sub.html">
+      <div data-hf-id="hf-leaf" style="color: red">Subscribe</div>
+    </div>
+  </div>
+</body></html>`;
+
+  it("getElement(bareLeaf) is null (canonical-only) — the trap the shadow used to hit", async () => {
+    const session = await openComposition(INLINED_HTML);
+    expect(session.getElement("hf-leaf")).toBeNull();
+    expect(session.getElement("hf-host/hf-leaf")).not.toBeNull();
+  });
+
+  it("recordResolverParity emits NOTHING for a bare leaf inside a sub-comp", async () => {
+    mockFlags.STUDIO_SDK_RESOLVER_SHADOW_ENABLED = true;
+    const session = await openComposition(INLINED_HTML);
+    recordResolverParity(session, "hf-leaf", "setTiming");
+    expect(trackedEvents.filter((e) => e.event === "sdk_resolver_shadow")).toHaveLength(0);
+  });
+
+  it("sdkResolverShadowCheck does not flag element_not_found for a bare leaf in a sub-comp", async () => {
+    const session = await openComposition(INLINED_HTML);
+    const mismatches = sdkResolverShadowCheck(session, "hf-leaf", [
+      { type: "inline-style", property: "color", value: "blue" },
+    ]);
+    expect(mismatches.some((m) => m.kind === "element_not_found")).toBe(false);
   });
 });

--- a/packages/studio/src/utils/sdkResolverShadow.ts
+++ b/packages/studio/src/utils/sdkResolverShadow.ts
@@ -65,6 +65,31 @@ function normalizeText(v: string | null | undefined): string | null {
 type FlatEl = NonNullable<ReturnType<Composition["getElement"]>>;
 type AttrMap = Record<string, string | null>;
 
+/**
+ * Resolve an hf-id to its snapshot the SAME way the SDK dispatch path does
+ * (engine/model.ts resolveScoped), NOT via Composition.getElement.
+ *
+ * getElement is canonical-only for a bare id by design — it deliberately will
+ * not resolve a bare id to a non-canonical (sub-composition) element, so that
+ * removeElement(bareId) and getElement(bareId) agree on the same instance
+ * (session.subcomp.test "ambiguous bare id" suite). But the cutover persist
+ * path dispatches the studio's bare data-hf-id, and dispatch resolves it via
+ * resolveScoped, which locates the leaf anywhere (canonical preferred, else
+ * first match). So getElement under-resolves a bare leaf that lives inside an
+ * inlined sub-composition (scopedId "host/leaf") — exactly the false
+ * `element_not_found` this tripwire was emitting for inlined compositions.
+ *
+ * Mirror resolveScoped here: exact scoped-path match, then canonical bare
+ * match, then first bare match — the resolvability dispatch actually has.
+ */
+function resolveSnapshot(session: Composition, id: string): FlatEl | null {
+  const els = session.getElements();
+  const exact = els.find((el) => el.scopedId === id);
+  if (exact) return exact;
+  const matches = els.filter((el) => el.id === id);
+  return matches.find((el) => el.scopedId === el.id) ?? matches[0] ?? null;
+}
+
 function checkStyleOp(
   op: PatchOperation,
   el: FlatEl,
@@ -140,7 +165,7 @@ export function sdkResolverShadowCheck(
   hfId: string,
   ops: PatchOperation[],
 ): SdkResolverMismatch[] {
-  if (!session.getElement(hfId)) {
+  if (!resolveSnapshot(session, hfId)) {
     return [{ kind: "element_not_found", hfId }];
   }
 
@@ -172,7 +197,7 @@ export function sdkResolverShadowCheck(
       return [{ kind: "dispatch_error", hfId, error: String(err) }];
     }
 
-    const el = session.getElement(hfId);
+    const el = resolveSnapshot(session, hfId);
     if (!el) return [{ kind: "element_not_found", hfId }];
 
     return shadowable
@@ -253,7 +278,7 @@ export function recordResolverParity(
   if (!STUDIO_SDK_RESOLVER_SHADOW_ENABLED) return;
   if (!session || !hfId) return;
   try {
-    if (session.getElement(hfId)) return; // resolves — parity, nothing to record
+    if (resolveSnapshot(session, hfId)) return; // resolves — parity, nothing to record
     trackStudioEvent("sdk_resolver_shadow", {
       hfId,
       opLabel,


### PR DESCRIPTION
## Summary

The resolver-parity shadow tripwire (`packages/studio/src/utils/sdkResolverShadow.ts`) was emitting **false `element_not_found` divergences** for any element edited inside an **inlined sub-composition**. PostHog showed ~445 such events — all one user editing an inlined `yt-lower-third` (selecting `#subscribe-btn` / `hf-0ytc`). The real cutover path would have resolved these fine; the shadow used the wrong resolver.

This PR makes the shadow resolve ids the **same way the cutover dispatch path does**, eliminating the false positives. No behavior change to the SDK or to the user-visible edit path — telemetry-only correctness fix.

## Root cause

Two resolvers exist in the SDK, with deliberately different semantics:

- **`resolveScoped`** (`engine/model.ts`) — used by the dispatch path (`mutate.ts`, every op handler). For a bare id it does a whole-document `querySelectorAll`, so it locates a leaf **anywhere** (canonical instance preferred, else first match). This is what cutover persist actually uses.
- **`Composition.getElement`** (`session.ts`) — canonical-only for a bare id **by design**: it will not resolve a bare id to a non-canonical (sub-composition) element, so that `removeElement(bareId)` and `getElement(bareId)` agree on the same instance (`session.subcomp.test.ts` "ambiguous bare id" suite, e.g. the post-removal null at line 472).

When a composition **inlines a sub-composition** (host element carries `data-composition-file`, opening a new scope), a child element gets `scopedId = "hf-host/hf-leaf"` — but its raw `data-hf-id` attribute (what the studio reads off the live DOM and passes around) stays the **bare leaf** (`hf-0ytc`).

The studio selection flows the bare leaf id everywhere:
- **Cutover dispatch** → `resolveScoped(bareLeaf)` → finds the scoped element → works.
- **Shadow** → `session.getElement(bareLeaf)` → canonical-only → **null** → emits `element_not_found`.

So the shadow reported a divergence the real dispatch path never experiences. The pristine standalone `yt-lower-third` block has no host boundary (`scopedId === id`), so it resolves fine — which is why this only reproduced against an inlined composition, not the registry block.

## Reproduction

```
host (data-composition-file="sub.html")  →  new scope
  └─ leaf (data-hf-id="hf-leaf")          →  scopedId "hf-host/hf-leaf"

session.getElement("hf-leaf")        → null    ← shadow saw this → false element_not_found
session.getElement("hf-host/hf-leaf")→ FOUND
resolveScoped(doc, "hf-leaf")        → FOUND    ← what dispatch actually uses
```

## Fix

Add `resolveSnapshot(session, id)` in the shadow module, mirroring `resolveScoped` against the element snapshots: exact `scopedId` match → canonical bare match → first bare match. Use it at all three `element_not_found` sites (`sdkResolverShadowCheck` pre-guard + post-dispatch read-back, and `recordResolverParity`).

`getElement` is **unchanged** — its canonical-only contract is correct and load-bearing for `removeElement`/`getElement` agreement. (Verified: adding a leaf fallback to `getElement` directly breaks the "ambiguous bare id" suite by resurrecting the inner dup.)

## Why fix the shadow, not `getElement`

The shadow's job is to detect whether the SDK would resolve what the studio selected the way **dispatch** resolves it. Dispatch uses `resolveScoped`. So the faithful check is `resolveScoped`-equivalent. `getElement` answers a different question ("which instance does a bare id canonically own") and must keep doing so.

## Tests

New group **H. inlined sub-composition leaf** in `sdkResolverShadow.test.ts`:
- documents the trap: `getElement(bareLeaf)` is null while `getElement(scoped)` resolves;
- `recordResolverParity` emits nothing for a bare leaf inside a sub-comp;
- `sdkResolverShadowCheck` does not flag `element_not_found` for that case.

`C8`'s mock updated to expose `getElements` (the resolver now reads snapshots). All 59 tests pass (shadow + `session.subcomp`). Lint, format, fallow (0 issues on changed files), typecheck, and full build all green.

## Impact

- PostHog `studio:sdk_resolver_shadow` / `element_not_found` noise stops; the tripwire now flags only genuine divergences.
- No change to SDK public API, cutover behavior, or the on-disk edit path. `STUDIO_SDK_RESOLVER_SHADOW_ENABLED` stays default-on (telemetry-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
