### PR TITLE
chore(producer): shim __filename/__dirname in the CJS banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ hyperframes-bench/
 tmp/
 # Studio-generated preview thumbnails
 .thumbnails/
+
+# Local editor settings
+.zed/

--- a/packages/producer/build.mjs
+++ b/packages/producer/build.mjs
@@ -15,12 +15,20 @@ mkdirSync("dist", { recursive: true });
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
-// The banner provides a real `require` function via createRequire so that
-// esbuild's CJS interop (__require) works correctly in ESM output.
-// Without this, bundled CJS deps (recast, yauzl, etc.) that call
-// require("fs") throw "Dynamic require of 'fs' is not supported".
+// The banner provides a real `require` (via createRequire) plus the CJS-only
+// `__filename`/`__dirname` globals so esbuild's CJS interop works in ESM output.
+// Without `require`, bundled CJS deps (recast, yauzl, etc.) that call
+// require("fs") throw "Dynamic require of 'fs' is not supported"; without the
+// dirname shims, deps like wawoff2 throw "__dirname is not defined in ES module".
 const cjsBanner = {
-  js: "import { createRequire as __cjsRequire } from 'module'; const require = __cjsRequire(import.meta.url);",
+  js: [
+    "import { createRequire as __cjsRequire } from 'module';",
+    "import { fileURLToPath as __cjsFileURLToPath } from 'url';",
+    "import { dirname as __cjsDirname } from 'path';",
+    "const require = __cjsRequire(import.meta.url);",
+    "const __filename = __cjsFileURLToPath(import.meta.url);",
+    "const __dirname = __cjsDirname(__filename);",
+  ].join(" "),
 };
 
 const workspaceAliasPlugin = {

--- a/packages/producer/build.mjs
+++ b/packages/producer/build.mjs
@@ -21,14 +21,12 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 // require("fs") throw "Dynamic require of 'fs' is not supported"; without the
 // dirname shims, deps like wawoff2 throw "__dirname is not defined in ES module".
 const cjsBanner = {
-  js: [
-    "import { createRequire as __cjsRequire } from 'module';",
-    "import { fileURLToPath as __cjsFileURLToPath } from 'url';",
-    "import { dirname as __cjsDirname } from 'path';",
-    "const require = __cjsRequire(import.meta.url);",
-    "const __filename = __cjsFileURLToPath(import.meta.url);",
-    "const __dirname = __cjsDirname(__filename);",
-  ].join(" "),
+  js: `import { createRequire as __cjsRequire } from 'module';
+import { fileURLToPath as __cjsFileURLToPath } from 'url';
+import { dirname as __cjsDirname } from 'path';
+const require = __cjsRequire(import.meta.url);
+const __filename = __cjsFileURLToPath(import.meta.url);
+const __dirname = __cjsDirname(__filename);`,
 };
 
 const workspaceAliasPlugin = {


### PR DESCRIPTION
**Stack:** foundation of the GSAP keyframe + motion-path editing feature (#1553 → #1561).

## What

Extend the producer's ESM-output build banner to define the CJS-only `__filename` / `__dirname` globals (alongside the existing `require` shim), and gitignore local `.zed/` editor settings.

## Why

`packages/producer` is bundled to ESM, but several bundled CJS dependencies assume CommonJS globals. `require` was already shimmed; `wawoff2` (WOFF2 font subsetting) additionally reads `__dirname` and throws `__dirname is not defined in ES module` at render time.

## How

Build the banner from `import.meta.url`:
- `createRequire(import.meta.url)` → `require`
- `fileURLToPath(import.meta.url)` → `__filename`
- `dirname(__filename)` → `__dirname`

## Test plan

- [x] `bun run build` (producer) succeeds
- [x] Manual render exercising font subsetting (wawoff2) no longer throws
