### PR TITLE
feat(cli): add keyframes command to surface motion paths

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -121,6 +121,7 @@ const commandLoaders = {
   lint: () => import("./commands/lint.js").then((m) => m.default),
   beats: () => import("./commands/beats.js").then((m) => m.default),
   inspect: () => import("./commands/inspect.js").then((m) => m.default),
+  keyframes: () => import("./commands/keyframes.js").then((m) => m.default),
   layout: () => import("./commands/layout.js").then((m) => m.default),
   info: () => import("./commands/info.js").then((m) => m.default),
   compositions: () => import("./commands/compositions.js").then((m) => m.default),

--- a/packages/cli/src/commands/keyframes.test.ts
+++ b/packages/cli/src/commands/keyframes.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { ensureDOMParser } from "../utils/dom.js";
+import { surfaceComposition } from "./keyframes.js";
+
+beforeAll(() => ensureDOMParser());
+
+const wrap = (script: string) =>
+  `<!doctype html><html><body><div id="root" data-composition-id="main" data-duration="4"><div id="dot" class="clip"></div></div><script>${script}</script></body></html>`;
+
+describe("keyframes multi-stroke traces", () => {
+  it("composites ≥2 position strokes on one element into a single trace", () => {
+    const html = wrap(`
+      const tl = gsap.timeline({ paused: true });
+      tl.to("#dot", { keyframes: { "0%": { x: -100, y: -150 }, "100%": { x: 80, y: -120 } }, duration: 1 });
+      tl.to("#dot", { keyframes: { "0%": { x: 80, y: 120 }, "100%": { x: 85, y: 140 } }, duration: 1 });
+      window.__timelines = [tl];
+    `);
+    const { traces } = surfaceComposition(html, "index.html", "index.html");
+    expect(traces).toHaveLength(1);
+    expect(traces[0]!.target).toBe("#dot");
+    expect(traces[0]!.strokes).toHaveLength(2);
+  });
+
+  it("treats a 0-duration set() between strokes as a pen-up jump, not a drawn stroke", () => {
+    const html = wrap(`
+      const tl = gsap.timeline({ paused: true });
+      tl.to("#dot", { keyframes: { "0%": { x: 0, y: 0 }, "100%": { x: 100, y: 0 } }, duration: 1 });
+      tl.set("#dot", { x: 200, y: 200 });
+      tl.to("#dot", { keyframes: { "0%": { x: 200, y: 200 }, "100%": { x: 250, y: 250 } }, duration: 1 });
+      window.__timelines = [tl];
+    `);
+    const { traces } = surfaceComposition(html, "index.html", "index.html");
+    expect(traces).toHaveLength(1);
+    // two DRAWN strokes; the set() is the pen-up gap and is excluded
+    expect(traces[0]!.strokes).toHaveLength(2);
+  });
+
+  it("leaves a single-stroke element untraced (normal per-tween output)", () => {
+    const html = wrap(`
+      const tl = gsap.timeline({ paused: true });
+      tl.to("#dot", { keyframes: { "0%": { x: 0, y: 0 }, "50%": { x: 200, y: -100 }, "100%": { x: 0, y: 0 } }, duration: 3 });
+      window.__timelines = [tl];
+    `);
+    const { traces, tweens } = surfaceComposition(html, "index.html", "index.html");
+    expect(traces).toHaveLength(0);
+    expect(tweens.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/src/commands/keyframes.ts
+++ b/packages/cli/src/commands/keyframes.ts
@@ -40,10 +40,30 @@ interface SurfacedTween {
   path: Array<{ x: number; y: number }> | null;
 }
 
+/** One drawn stroke of a multi-stroke trace — a single position tween. */
+interface TraceStroke {
+  id: string;
+  start: number;
+  end: number;
+  keyframes: KeyframePoint[];
+  points: Array<{ x: number; y: number }>;
+}
+
+/** An element's position motion composited into ordered strokes. The gaps
+ *  between strokes are pen-up jumps (a 0-duration `set`, or a discontinuity)
+ *  and are NOT drawn — this is how one element traces shapes with holes or
+ *  detached parts (a `?` dot, an icon counter, multi-letter words). */
+interface SurfacedTrace {
+  target: string;
+  strokes: TraceStroke[];
+}
+
 interface SurfacedComposition {
   composition: string;
   source: string;
   tweens: SurfacedTween[];
+  /** Multi-stroke traces: targets with ≥2 drawn position strokes, composited. */
+  traces: SurfacedTrace[];
 }
 
 // ── GSAP extraction ──────────────────────────────────────────────────────────
@@ -87,7 +107,7 @@ function baseProps(props: Record<string, number | string>): Record<string, numbe
 }
 
 // Flat tweens carry no explicit keyframes — synthesize a 0%/100% pair against the
-// element's rest pose so the surface (and ASCII path) is uniform. `from()` goes
+// element's rest pose so the surfaced keyframes are uniform. `from()` goes
 // fromProperties → base; `to()` goes base → properties.
 function flatKeyframes(anim: GsapAnimation): KeyframePoint[] {
   if (anim.method === "fromTo") {
@@ -180,73 +200,13 @@ function surfaceTween(anim: GsapAnimation): SurfacedTween {
   };
 }
 
-// ── ASCII motion path ────────────────────────────────────────────────────────
-
-/** Plot position points into a compact grid so an agent can SEE the motion
- *  shape. Each keyframe is marked with its index (0–9, then a–z); the path is
- *  traced with light dots. Coordinates are GSAP x/y offsets (px). */
-function asciiPath(points: Array<{ x: number; y: number }>, width = 48, height = 11): string[] {
-  if (points.length === 0) return [];
-  const xs = points.map((p) => p.x);
-  const ys = points.map((p) => p.y);
-  let minX = Math.min(...xs);
-  let maxX = Math.max(...xs);
-  let minY = Math.min(...ys);
-  let maxY = Math.max(...ys);
-  if (maxX - minX < 1) {
-    minX -= 1;
-    maxX += 1;
-  }
-  if (maxY - minY < 1) {
-    minY -= 1;
-    maxY += 1;
-  }
-  const cols = width;
-  const rows = height;
-  const toCol = (x: number) => Math.round(((x - minX) / (maxX - minX)) * (cols - 1));
-  // Screen y grows downward — invert so up on screen = smaller gsap y.
-  const toRow = (y: number) => Math.round(((y - minY) / (maxY - minY)) * (rows - 1));
-
-  const grid: string[][] = Array.from({ length: rows }, () =>
-    Array.from({ length: cols }, () => " "),
-  );
-  // Sparse paths (≤36 pts) index each keyframe (0–9, a–z) so an agent can map a
-  // mark to a keyframe to edit. Dense paths (gestures) only mark Start/End — the
-  // shape is the signal; per-point exact values live in the keyframe list / JSON.
-  const dense = points.length > 36;
-  const mark = (i: number) => {
-    if (dense) return i === 0 ? "S" : i === points.length - 1 ? "E" : "·";
-    return i < 10 ? String(i) : String.fromCharCode(97 + (i - 10));
-  };
-
-  // Trace segments with dots first, then overwrite endpoints with index marks.
-  for (let i = 0; i < points.length - 1; i++) {
-    const c0 = toCol(points[i]!.x);
-    const r0 = toRow(points[i]!.y);
-    const c1 = toCol(points[i + 1]!.x);
-    const r1 = toRow(points[i + 1]!.y);
-    const steps = Math.max(Math.abs(c1 - c0), Math.abs(r1 - r0), 1);
-    for (let s = 1; s < steps; s++) {
-      const cc = Math.round(c0 + ((c1 - c0) * s) / steps);
-      const rr = Math.round(r0 + ((r1 - r0) * s) / steps);
-      if (grid[rr]![cc] === " ") grid[rr]![cc] = "·";
-    }
-  }
-  points.forEach((p, i) => {
-    grid[toRow(p.y)]![toCol(p.x)] = mark(i);
-  });
-
-  const top = `    ┌${"─".repeat(cols)}┐`;
-  const body = grid.map((row) => `    │${row.join("")}│`);
-  const bottom = `    └${"─".repeat(cols)}┘`;
-  const legend = dense ? "S→E, · path" : "marks 0..n = keyframe order";
-  const axis = `    x ${Math.round(minX)}..${Math.round(maxX)}   y ${Math.round(minY)}..${Math.round(maxY)} (gsap px; ${legend})`;
-  return [top, ...body, bottom, c.dim(axis)];
-}
-
 // ── Composition surfacing ────────────────────────────────────────────────────
 
-function surfaceComposition(html: string, label: string, source: string): SurfacedComposition {
+export function surfaceComposition(
+  html: string,
+  label: string,
+  source: string,
+): SurfacedComposition {
   const script = inlineScriptText(html);
   let animations: GsapAnimation[] = [];
   try {
@@ -254,11 +214,38 @@ function surfaceComposition(html: string, label: string, source: string): Surfac
   } catch {
     animations = [];
   }
-  return {
-    composition: label,
-    source,
-    tweens: animations.filter((a) => !isHoldMarker(a)).map(surfaceTween),
-  };
+  const tweens = animations.filter((a) => !isHoldMarker(a)).map(surfaceTween);
+  return { composition: label, source, tweens, traces: groupTraces(tweens) };
+}
+
+// Group an element's DRAWN position strokes (to/from/fromTo/keyframes that carry
+// a path) into one ordered trace. A `set` with x/y is a pen-up jump — excluded
+// (not drawn). Only targets with ≥2 strokes become a composited trace; a single
+// stroke stays on the normal per-tween path so existing output is unchanged.
+function groupTraces(tweens: SurfacedTween[]): SurfacedTrace[] {
+  const byTarget = new Map<string, SurfacedTween[]>();
+  for (const t of tweens) {
+    if (t.method === "set") continue;
+    if (!t.path || t.path.length < 2) continue;
+    const list = byTarget.get(t.target);
+    if (list) list.push(t);
+    else byTarget.set(t.target, [t]);
+  }
+  const traces: SurfacedTrace[] = [];
+  for (const [target, list] of byTarget) {
+    if (list.length < 2) continue;
+    const strokes = [...list]
+      .sort((a, b) => a.start - b.start)
+      .map((t) => ({
+        id: t.id,
+        start: t.start,
+        end: t.end,
+        keyframes: t.keyframes,
+        points: t.path!,
+      }));
+    traces.push({ target, strokes });
+  }
+  return traces;
 }
 
 function collectCompositions(indexPath: string): SurfacedComposition[] {
@@ -282,18 +269,6 @@ function collectCompositions(indexPath: string): SurfacedComposition[] {
 
 // ── Render (human) ───────────────────────────────────────────────────────────
 
-// Plot the ASCII grid only for genuine motion paths — multi-keyframe, or a path
-// that moves on BOTH axes. Simple 2-point single-axis slides (entrances, a flat
-// `to(x)`) are clear enough from the keyframe line alone.
-function shouldPlotPath(path: Array<{ x: number; y: number }>): boolean {
-  const xs = path.map((p) => p.x);
-  const ys = path.map((p) => p.y);
-  const xVaries = Math.max(...xs) - Math.min(...xs) > 0.5;
-  const yVaries = Math.max(...ys) - Math.min(...ys) > 0.5;
-  const distinct = new Set(path.map((p) => `${p.x},${p.y}`)).size;
-  return distinct > 2 || (xVaries && yVaries);
-}
-
 function fmtProps(props: Record<string, number | string>): string {
   return Object.entries(props)
     .filter(([k]) => k !== "ease")
@@ -311,10 +286,82 @@ function printTween(t: SurfacedTween): void {
     const kfLine = t.keyframes.map((k) => `${k.pct}% {${fmtProps(k.properties)}}`).join("  ");
     console.log(`    ${c.dim(kfLine)}`);
   }
-  if (t.path && shouldPlotPath(t.path)) {
-    for (const line of asciiPath(t.path)) console.log(line);
-  }
   console.log();
+}
+
+function printTrace(tr: SurfacedTrace): void {
+  const start = Math.min(...tr.strokes.map((s) => s.start));
+  const end = Math.max(...tr.strokes.map((s) => s.end));
+  const n = tr.strokes.length;
+  console.log(
+    `  ${c.accent(tr.target)}${c.dim(" position")}  ${c.dim("trace")}  ${c.dim(`${n} strokes`)} ${c.dim(`@${start}s→${end}s`)}`,
+  );
+  tr.strokes.forEach((s, i) => {
+    const kfLine = s.keyframes.map((k) => `${k.pct}% {${fmtProps(k.properties)}}`).join("  ");
+    console.log(`    ${c.dim(`stroke ${i + 1}:`)} ${c.dim(kfLine)}`);
+  });
+  console.log();
+}
+
+// ── Onion-skin self-verify shot ──────────────────────────────────────────────
+
+interface ShotArgs {
+  shot?: string;
+  samples?: string;
+  layout?: string;
+  from?: string;
+  to?: string;
+  fit?: boolean;
+  angle?: string;
+}
+
+/** Render the 3D onion-skin screenshot for every animated element. Returns true
+ *  when the command should early-return (a guard failed). */
+async function runOnionShot(
+  comps: SurfacedComposition[],
+  projectDir: string | undefined,
+  args: ShotArgs,
+): Promise<boolean> {
+  const { captureMotionPathShot } = await import("./keyframesShot.js");
+  // Any animated element qualifies — the onion samples the live element and shows
+  // every channel (rotation / scale / opacity / colour / 3D), not just x/y. A
+  // 0-duration `set` is a pen-up marker, not motion.
+  const selectors = new Set<string>();
+  for (const cmp of comps) {
+    for (const tr of cmp.traces) selectors.add(tr.target);
+    for (const t of cmp.tweens) {
+      if (t.method !== "set") selectors.add(t.target);
+    }
+  }
+  const requests = [...selectors].map((selector) => ({ selector }));
+  if (!projectDir) {
+    console.log(c.dim("--shot needs a project directory (not a single .html file)."));
+    return true;
+  }
+  if (requests.length === 0) {
+    console.log(c.dim("--shot: no animated element to sample for the selection."));
+    return true;
+  }
+  const num = (v: string | undefined): number | null => {
+    const n = v == null ? NaN : Number.parseFloat(v);
+    return Number.isFinite(n) ? n : null;
+  };
+  const saved = await captureMotionPathShot(projectDir, requests, resolve(args.shot!), {
+    samples: num(args.samples) ?? 9,
+    layout: args.layout === "strip" ? "strip" : "path",
+    fit: args.fit ?? true,
+    from: num(args.from),
+    to: num(args.to),
+    angle: args.angle,
+  });
+  console.log(`${c.success("◇")}  onion-skin screenshot saved ${c.accent(saved)}`);
+  console.log(
+    c.dim(
+      `   ${requests.length} element${requests.length === 1 ? "" : "s"} · open it to verify the motion matches your target, then read the keyframes below.`,
+    ),
+  );
+  console.log();
+  return false;
 }
 
 // ── Command ──────────────────────────────────────────────────────────────────
@@ -332,6 +379,32 @@ export default defineCommand({
     },
     selector: { type: "string", description: "Only tweens matching this CSS selector" },
     json: { type: "boolean", description: "Machine-readable JSON (for agents)", default: false },
+    shot: {
+      type: "string",
+      description:
+        "Onion-skin screenshot to PNG: the real element sampled over the timeline (true 3D, every channel) for visual self-verify. Pair with --selector to focus one element.",
+    },
+    samples: {
+      type: "string",
+      description: "Onion samples (equal-time steps) for --shot. Default 9.",
+    },
+    layout: {
+      type: "string",
+      description:
+        "--shot layout: 'path' (ghosts at real positions + path, default) or 'strip' (filmstrip by time — for in-place/overlapping motion).",
+    },
+    from: { type: "string", description: "--shot: sample only from this time (seconds)." },
+    to: { type: "string", description: "--shot: sample only up to this time (seconds)." },
+    angle: {
+      type: "string",
+      description:
+        "--shot orbit camera: a preset (front|iso|top|side|rear-iso) or 'yaw,pitch' degrees — view 3D motion from the angle that reveals it.",
+    },
+    fit: {
+      type: "boolean",
+      description: "--shot: zoom the motion to fill the frame (default true; --no-fit to disable).",
+      default: true,
+    },
   },
   async run({ args }) {
     ensureDOMParser();
@@ -340,24 +413,33 @@ export default defineCommand({
     const raw = args.target?.trim();
     let comps: SurfacedComposition[];
     let projectName: string;
+    let projectDir: string | undefined;
     if (raw && raw.endsWith(".html") && existsSync(raw) && statSync(raw).isFile()) {
       comps = [surfaceComposition(readFileSync(raw, "utf-8"), basename(raw), raw)];
       projectName = basename(raw);
+      projectDir = dirname(raw);
     } else {
       const project = resolveProject(raw);
       comps = collectCompositions(project.indexPath);
       projectName = project.name;
+      projectDir = project.dir;
     }
 
     if (args.selector) {
       const sel = args.selector;
+      const matches = (target: string) => target.split(",").some((s) => s.trim() === sel);
       comps = comps
         .map((cmp) => ({
           ...cmp,
-          tweens: cmp.tweens.filter((t) => t.target.split(",").some((s) => s.trim() === sel)),
+          tweens: cmp.tweens.filter((t) => matches(t.target)),
+          traces: cmp.traces.filter((tr) => matches(tr.target)),
         }))
-        .filter((cmp) => cmp.tweens.length > 0);
+        .filter((cmp) => cmp.tweens.length > 0 || cmp.traces.length > 0);
     }
+
+    // --shot: 3D onion-skin self-verify screenshot. Returns true when the command
+    // should stop (guard failure) so run() stays small.
+    if (args.shot && (await runOnionShot(comps, projectDir, args))) return;
 
     if (args.json) {
       console.log(JSON.stringify(withMeta({ project: projectName, compositions: comps }), null, 2));
@@ -374,12 +456,21 @@ export default defineCommand({
     );
     console.log();
     for (const cmp of comps) {
-      if (cmp.tweens.length === 0) continue;
+      if (cmp.tweens.length === 0 && cmp.traces.length === 0) continue;
       console.log(c.bold(`${cmp.composition}`) + c.dim(`  (${cmp.source})`));
-      for (const t of cmp.tweens) printTween(t);
+      const tracedIds = new Set(cmp.traces.flatMap((tr) => tr.strokes.map((s) => s.id)));
+      const tracedTargets = new Set(cmp.traces.map((tr) => tr.target));
+      for (const tr of cmp.traces) printTrace(tr);
+      for (const t of cmp.tweens) {
+        if (tracedIds.has(t.id)) continue; // already shown as part of its trace
+        if (t.method === "set" && tracedTargets.has(t.target)) continue; // internal pen-up jump
+        printTween(t);
+      }
     }
     console.log(
-      c.dim("Tip: edit the keyframes: [...] / x/y values in source, then re-run to verify."),
+      c.dim(
+        "Tip: edit the keyframes in source, then `keyframes --shot out.png` to see the rendered motion.",
+      ),
     );
   },
 });

--- a/packages/cli/src/commands/keyframes.ts
+++ b/packages/cli/src/commands/keyframes.ts
@@ -1,0 +1,385 @@
+import { defineCommand } from "citty";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { resolve, dirname, basename } from "node:path";
+import { parseGsapScript, type GsapAnimation } from "@hyperframes/core/gsap-parser";
+import type { Example } from "./_examples.js";
+import { c } from "../ui/colors.js";
+import { ensureDOMParser } from "../utils/dom.js";
+import { resolveProject } from "../utils/project.js";
+import { withMeta } from "../utils/updateCheck.js";
+
+export const examples: Example[] = [
+  ["Surface every keyframe + motion path in the project", "hyperframes keyframes"],
+  ["Inspect one composition file", "hyperframes keyframes compositions/scene.html"],
+  ["Machine-readable output for an agent", "hyperframes keyframes --json"],
+  ["Only one element's tweens", "hyperframes keyframes --selector '#puck-a'"],
+];
+
+// ── Surfaced shapes ──────────────────────────────────────────────────────────
+
+interface KeyframePoint {
+  /** Tween-relative percentage (0–100). */
+  pct: number;
+  /** Absolute timeline time (seconds) = tweenStart + pct/100 * duration. */
+  time: number;
+  properties: Record<string, number | string>;
+}
+
+interface SurfacedTween {
+  id: string;
+  target: string;
+  method: string;
+  group?: string;
+  start: number;
+  duration: number;
+  end: number;
+  /** "keyframes" (array/object form), "flat" (to/from), or "motionPath". */
+  shape: "keyframes" | "flat" | "motionPath";
+  keyframes: KeyframePoint[];
+  /** x/y position points (gsap offsets) when this tween animates position. */
+  path: Array<{ x: number; y: number }> | null;
+}
+
+interface SurfacedComposition {
+  composition: string;
+  source: string;
+  tweens: SurfacedTween[];
+}
+
+// ── GSAP extraction ──────────────────────────────────────────────────────────
+
+function inlineScriptText(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return Array.from(doc.querySelectorAll("script"))
+    .filter((s) => !s.getAttribute("src"))
+    .map((s) => s.textContent ?? "")
+    .join("\n");
+}
+
+function num(v: number | string | undefined): number | null {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = Number.parseFloat(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function isPositionTween(anim: GsapAnimation): boolean {
+  if (anim.propertyGroup === "position") return true;
+  const has = (p: Record<string, number | string> | undefined) => !!p && ("x" in p || "y" in p);
+  if (has(anim.properties) || has(anim.fromProperties)) return true;
+  return (anim.keyframes?.keyframes ?? []).some(
+    (kf) => "x" in kf.properties || "y" in kf.properties,
+  );
+}
+
+// The rest-state value for an animated property (what GSAP animates to/from when
+// the other endpoint is the element's natural pose): 1 for scale/opacity, 0 for
+// translate/rotation.
+function baseProps(props: Record<string, number | string>): Record<string, number | string> {
+  const base: Record<string, number | string> = {};
+  for (const k of Object.keys(props)) {
+    if (k === "ease") continue;
+    base[k] = k === "opacity" || k.startsWith("scale") ? 1 : 0;
+  }
+  return base;
+}
+
+// Flat tweens carry no explicit keyframes — synthesize a 0%/100% pair against the
+// element's rest pose so the surface (and ASCII path) is uniform. `from()` goes
+// fromProperties → base; `to()` goes base → properties.
+function flatKeyframes(anim: GsapAnimation): KeyframePoint[] {
+  if (anim.method === "fromTo") {
+    return [
+      { pct: 0, time: 0, properties: anim.fromProperties ?? {} },
+      { pct: 100, time: 0, properties: anim.properties ?? {} },
+    ];
+  }
+  // to()/from() vars both live in anim.properties; from() plays them in reverse
+  // against the element's rest pose.
+  const vars = anim.properties ?? {};
+  const base = baseProps(vars);
+  return anim.method === "from"
+    ? [
+        { pct: 0, time: 0, properties: vars },
+        { pct: 100, time: 0, properties: base },
+      ]
+    : [
+        { pct: 0, time: 0, properties: base },
+        { pct: 100, time: 0, properties: vars },
+      ];
+}
+
+// Studio-internal markers that aren't user motion: the position-hold `set` GSAP
+// runs before a keyframed position tween (`data: "hf-hold"`).
+function isHoldMarker(anim: GsapAnimation): boolean {
+  return anim.properties?.data === "hf-hold" || anim.fromProperties?.data === "hf-hold";
+}
+
+// Drop internal / non-visual keys so they don't pollute the surfaced keyframes.
+function cleanProps(props: Record<string, number | string>): Record<string, number | string> {
+  const out: Record<string, number | string> = {};
+  for (const [k, v] of Object.entries(props)) {
+    if (k === "data" || k === "ease") continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+function surfaceTween(anim: GsapAnimation): SurfacedTween {
+  const start =
+    typeof anim.resolvedStart === "number" ? anim.resolvedStart : (num(anim.position) ?? 0);
+  const duration = anim.duration ?? 0;
+
+  let shape: SurfacedTween["shape"];
+  let rawKfs: Array<{ percentage: number; properties: Record<string, number | string> }>;
+  if (anim.keyframes?.keyframes?.length) {
+    shape = "keyframes";
+    rawKfs = anim.keyframes.keyframes;
+  } else if (anim.arcPath?.enabled) {
+    shape = "motionPath";
+    rawKfs = [];
+  } else {
+    shape = "flat";
+    rawKfs = flatKeyframes(anim).map((k) => ({ percentage: k.pct, properties: k.properties }));
+  }
+
+  const keyframes: KeyframePoint[] = rawKfs.map((kf) => ({
+    pct: kf.percentage,
+    time: Math.round((start + (kf.percentage / 100) * duration) * 1000) / 1000,
+    properties: cleanProps(kf.properties),
+  }));
+
+  // Carry x/y forward across keyframes that only set one axis, so the path is
+  // continuous (GSAP holds the last value for an unspecified property).
+  let path: Array<{ x: number; y: number }> | null = null;
+  if (isPositionTween(anim) && keyframes.length > 0) {
+    let lastX = 0;
+    let lastY = 0;
+    path = keyframes.map((kf) => {
+      const x = num(kf.properties.x);
+      const y = num(kf.properties.y);
+      if (x !== null) lastX = x;
+      if (y !== null) lastY = y;
+      return { x: lastX, y: lastY };
+    });
+  }
+
+  return {
+    id: anim.id,
+    target: anim.targetSelector,
+    method: anim.method,
+    group: anim.propertyGroup,
+    start: Math.round(start * 1000) / 1000,
+    duration,
+    end: Math.round((start + duration) * 1000) / 1000,
+    shape,
+    keyframes,
+    path,
+  };
+}
+
+// ── ASCII motion path ────────────────────────────────────────────────────────
+
+/** Plot position points into a compact grid so an agent can SEE the motion
+ *  shape. Each keyframe is marked with its index (0–9, then a–z); the path is
+ *  traced with light dots. Coordinates are GSAP x/y offsets (px). */
+function asciiPath(points: Array<{ x: number; y: number }>, width = 48, height = 11): string[] {
+  if (points.length === 0) return [];
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  let minX = Math.min(...xs);
+  let maxX = Math.max(...xs);
+  let minY = Math.min(...ys);
+  let maxY = Math.max(...ys);
+  if (maxX - minX < 1) {
+    minX -= 1;
+    maxX += 1;
+  }
+  if (maxY - minY < 1) {
+    minY -= 1;
+    maxY += 1;
+  }
+  const cols = width;
+  const rows = height;
+  const toCol = (x: number) => Math.round(((x - minX) / (maxX - minX)) * (cols - 1));
+  // Screen y grows downward — invert so up on screen = smaller gsap y.
+  const toRow = (y: number) => Math.round(((y - minY) / (maxY - minY)) * (rows - 1));
+
+  const grid: string[][] = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => " "),
+  );
+  // Sparse paths (≤36 pts) index each keyframe (0–9, a–z) so an agent can map a
+  // mark to a keyframe to edit. Dense paths (gestures) only mark Start/End — the
+  // shape is the signal; per-point exact values live in the keyframe list / JSON.
+  const dense = points.length > 36;
+  const mark = (i: number) => {
+    if (dense) return i === 0 ? "S" : i === points.length - 1 ? "E" : "·";
+    return i < 10 ? String(i) : String.fromCharCode(97 + (i - 10));
+  };
+
+  // Trace segments with dots first, then overwrite endpoints with index marks.
+  for (let i = 0; i < points.length - 1; i++) {
+    const c0 = toCol(points[i]!.x);
+    const r0 = toRow(points[i]!.y);
+    const c1 = toCol(points[i + 1]!.x);
+    const r1 = toRow(points[i + 1]!.y);
+    const steps = Math.max(Math.abs(c1 - c0), Math.abs(r1 - r0), 1);
+    for (let s = 1; s < steps; s++) {
+      const cc = Math.round(c0 + ((c1 - c0) * s) / steps);
+      const rr = Math.round(r0 + ((r1 - r0) * s) / steps);
+      if (grid[rr]![cc] === " ") grid[rr]![cc] = "·";
+    }
+  }
+  points.forEach((p, i) => {
+    grid[toRow(p.y)]![toCol(p.x)] = mark(i);
+  });
+
+  const top = `    ┌${"─".repeat(cols)}┐`;
+  const body = grid.map((row) => `    │${row.join("")}│`);
+  const bottom = `    └${"─".repeat(cols)}┘`;
+  const legend = dense ? "S→E, · path" : "marks 0..n = keyframe order";
+  const axis = `    x ${Math.round(minX)}..${Math.round(maxX)}   y ${Math.round(minY)}..${Math.round(maxY)} (gsap px; ${legend})`;
+  return [top, ...body, bottom, c.dim(axis)];
+}
+
+// ── Composition surfacing ────────────────────────────────────────────────────
+
+function surfaceComposition(html: string, label: string, source: string): SurfacedComposition {
+  const script = inlineScriptText(html);
+  let animations: GsapAnimation[] = [];
+  try {
+    animations = parseGsapScript(script).animations;
+  } catch {
+    animations = [];
+  }
+  return {
+    composition: label,
+    source,
+    tweens: animations.filter((a) => !isHoldMarker(a)).map(surfaceTween),
+  };
+}
+
+function collectCompositions(indexPath: string): SurfacedComposition[] {
+  const html = readFileSync(indexPath, "utf-8");
+  const baseDir = dirname(indexPath);
+  const out: SurfacedComposition[] = [
+    surfaceComposition(html, basename(indexPath), basename(indexPath)),
+  ];
+
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  for (const div of Array.from(doc.querySelectorAll("[data-composition-src]"))) {
+    const src = div.getAttribute("data-composition-src");
+    if (!src) continue;
+    const subPath = resolve(baseDir, src);
+    if (!existsSync(subPath)) continue;
+    const id = div.getAttribute("data-composition-id") ?? src;
+    out.push(surfaceComposition(readFileSync(subPath, "utf-8"), id, src));
+  }
+  return out;
+}
+
+// ── Render (human) ───────────────────────────────────────────────────────────
+
+// Plot the ASCII grid only for genuine motion paths — multi-keyframe, or a path
+// that moves on BOTH axes. Simple 2-point single-axis slides (entrances, a flat
+// `to(x)`) are clear enough from the keyframe line alone.
+function shouldPlotPath(path: Array<{ x: number; y: number }>): boolean {
+  const xs = path.map((p) => p.x);
+  const ys = path.map((p) => p.y);
+  const xVaries = Math.max(...xs) - Math.min(...xs) > 0.5;
+  const yVaries = Math.max(...ys) - Math.min(...ys) > 0.5;
+  const distinct = new Set(path.map((p) => `${p.x},${p.y}`)).size;
+  return distinct > 2 || (xVaries && yVaries);
+}
+
+function fmtProps(props: Record<string, number | string>): string {
+  return Object.entries(props)
+    .filter(([k]) => k !== "ease")
+    .map(([k, v]) => `${k}:${v}`)
+    .join(" ");
+}
+
+function printTween(t: SurfacedTween): void {
+  const timing = c.dim(`@${t.start}s→${t.end}s (${t.duration}s)`);
+  const group = t.group ? c.dim(` ${t.group}`) : "";
+  console.log(`  ${c.accent(t.target)}${group}  ${c.dim(t.method)}/${t.shape}  ${timing}`);
+  if (t.shape === "motionPath") {
+    console.log(c.dim(`    motionPath arc (${t.keyframes.length} stops)`));
+  } else {
+    const kfLine = t.keyframes.map((k) => `${k.pct}% {${fmtProps(k.properties)}}`).join("  ");
+    console.log(`    ${c.dim(kfLine)}`);
+  }
+  if (t.path && shouldPlotPath(t.path)) {
+    for (const line of asciiPath(t.path)) console.log(line);
+  }
+  console.log();
+}
+
+// ── Command ──────────────────────────────────────────────────────────────────
+
+export default defineCommand({
+  meta: {
+    name: "keyframes",
+    description: "Surface every GSAP tween, keyframe, and motion path for agent-driven editing",
+  },
+  args: {
+    target: {
+      type: "positional",
+      description: "Project dir or composition .html",
+      required: false,
+    },
+    selector: { type: "string", description: "Only tweens matching this CSS selector" },
+    json: { type: "boolean", description: "Machine-readable JSON (for agents)", default: false },
+  },
+  async run({ args }) {
+    ensureDOMParser();
+
+    // Accept either a project directory or a single .html file.
+    const raw = args.target?.trim();
+    let comps: SurfacedComposition[];
+    let projectName: string;
+    if (raw && raw.endsWith(".html") && existsSync(raw) && statSync(raw).isFile()) {
+      comps = [surfaceComposition(readFileSync(raw, "utf-8"), basename(raw), raw)];
+      projectName = basename(raw);
+    } else {
+      const project = resolveProject(raw);
+      comps = collectCompositions(project.indexPath);
+      projectName = project.name;
+    }
+
+    if (args.selector) {
+      const sel = args.selector;
+      comps = comps
+        .map((cmp) => ({
+          ...cmp,
+          tweens: cmp.tweens.filter((t) => t.target.split(",").some((s) => s.trim() === sel)),
+        }))
+        .filter((cmp) => cmp.tweens.length > 0);
+    }
+
+    if (args.json) {
+      console.log(JSON.stringify(withMeta({ project: projectName, compositions: comps }), null, 2));
+      return;
+    }
+
+    const total = comps.reduce((n, cmp) => n + cmp.tweens.length, 0);
+    if (total === 0) {
+      console.log(`${c.success("◇")}  ${c.accent(projectName)} ${c.dim("— no GSAP tweens found")}`);
+      return;
+    }
+    console.log(
+      `${c.success("◇")}  ${c.accent(projectName)} ${c.dim("—")} ${c.dim(`${total} tween${total === 1 ? "" : "s"}`)}`,
+    );
+    console.log();
+    for (const cmp of comps) {
+      if (cmp.tweens.length === 0) continue;
+      console.log(c.bold(`${cmp.composition}`) + c.dim(`  (${cmp.source})`));
+      for (const t of cmp.tweens) printTween(t);
+    }
+    console.log(
+      c.dim("Tip: edit the keyframes: [...] / x/y values in source, then re-run to verify."),
+    );
+  },
+});

--- a/packages/cli/src/commands/keyframesShot.ts
+++ b/packages/cli/src/commands/keyframesShot.ts
@@ -1,0 +1,264 @@
+// Onion-skin motion screenshot: seek the LIVE timeline at N equal-time steps and
+// project the REAL element at each step, so an agent can SELF-VERIFY motion (the
+// rendered result — every channel: position, rotation, scale, opacity, colour),
+// not just the authored x/y numbers. Reuses the headless-Chrome + static-server
+// pattern from layout.ts.
+//
+// 3D is captured for free: zero-size marker children at the element's corners are
+// projected by the browser, so a tilted/edge-on element renders as a real quad.
+// Framing controls (samples / time window / fit / filmstrip) let the agent frame
+// exactly what it's editing. All geometry + SVG live in ./keyframesShotLayout.ts
+// (pure, tested); this file only drives the browser and SAMPLES.
+
+import { writeFileSync } from "node:fs";
+import {
+  buildOnionSvg,
+  parseAngle,
+  sampleTimes,
+  type OnionElement,
+} from "./keyframesShotLayout.js";
+
+export interface ShotRequest {
+  /** CSS selector of the moving element to sample (e.g. "#dot"). */
+  selector: string;
+}
+
+export interface ShotOptions {
+  /** Equal-time samples across the (windowed) timeline. Default 9. */
+  samples?: number;
+  /** "path" = ghosts at real positions + path; "strip" = filmstrip by time. */
+  layout?: "path" | "strip";
+  /** Zoom the motion to fill the frame. Default true. */
+  fit?: boolean;
+  /** Sample only this time window (seconds) — dense inspection of one phase. */
+  from?: number | null;
+  to?: number | null;
+  /** Orbit camera: a preset (front|iso|top|side) or "yaw,pitch" degrees. */
+  angle?: string;
+}
+
+interface PageSample {
+  t: number;
+  q: Array<{ x: number; y: number }>;
+  c: { x: number; y: number };
+  color: string;
+  opacity: number;
+}
+
+/** Render `projectDir`'s index headless, sample each element's motion as a 3D
+ *  onion-skin, screenshot to `outPath` (PNG). Returns the saved path. */
+export async function captureMotionPathShot(
+  projectDir: string,
+  requests: ShotRequest[],
+  outPath: string,
+  opts: ShotOptions = {},
+): Promise<string> {
+  const samples = Math.max(1, Math.min(60, opts.samples ?? 9));
+  const layout = opts.layout ?? "path";
+  const fit = opts.fit ?? true;
+  const camera = parseAngle(opts.angle);
+
+  const { ensureBrowser } = await import("../browser/manager.js");
+  const { serveStaticProjectHtml } = await import("../utils/staticProjectServer.js");
+  const puppeteer = await import("puppeteer-core");
+  const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
+
+  const html = await bundleToSingleHtml(projectDir);
+  const server = await serveStaticProjectHtml(
+    projectDir,
+    html,
+    "Failed to bind keyframes shot server",
+  );
+  let browserInstance: import("puppeteer-core").Browser | undefined;
+  try {
+    const browser = await ensureBrowser();
+    browserInstance = await puppeteer.default.launch({
+      headless: true,
+      executablePath: browser.executablePath,
+      args: [
+        "--no-sandbox",
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+        "--enable-webgl",
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+      ],
+    });
+    const page = await browserInstance.newPage();
+    await page.goto(server.url, { waitUntil: "domcontentloaded", timeout: 10000 });
+
+    const size = await page.evaluate(() => {
+      const root = document.querySelector("[data-composition-id][data-width][data-height]");
+      const w = root ? parseInt(root.getAttribute("data-width") ?? "", 10) : 0;
+      const h = root ? parseInt(root.getAttribute("data-height") ?? "", 10) : 0;
+      return {
+        width: Number.isFinite(w) && w > 0 ? Math.min(w, 4096) : 1920,
+        height: Number.isFinite(h) && h > 0 ? Math.min(h, 4096) : 1080,
+      };
+    });
+    await page.setViewport(size);
+    await page.goto(server.url, { waitUntil: "domcontentloaded", timeout: 10000 });
+    await page
+      .waitForFunction(() => !!(window as unknown as { __timelines?: unknown }).__timelines, {
+        timeout: 10000,
+      })
+      .catch(() => {});
+    try {
+      await page.evaluate(async () => {
+        const d = document as unknown as { fonts?: { ready?: Promise<unknown> } };
+        if (d.fonts?.ready) await d.fonts.ready;
+      });
+    } catch {
+      // fonts API not present — proceed
+    }
+
+    const dur = await page.evaluate(() => {
+      const tls = Object.values(
+        (
+          window as unknown as {
+            __timelines?: Record<string, { duration?: () => number; totalDuration?: () => number }>;
+          }
+        ).__timelines ?? {},
+      );
+      let d = 0;
+      for (const tl of tls) {
+        try {
+          d = Math.max(d, (tl.totalDuration?.() ?? tl.duration?.() ?? 0) as number);
+        } catch {
+          // skip
+        }
+      }
+      return d;
+    });
+
+    const times = sampleTimes(dur, samples, opts.from ?? null, opts.to ?? null);
+
+    // Sample: seek to each time, read every element's projected corners. Marker
+    // children (zero-size) inherit the element's full transform chain, so their
+    // screen positions ARE the 3D projection of each corner.
+    const elements = (await page.evaluate(
+      (selectors: string[], ts: number[], cam: { yaw: number; pitch: number }) => {
+        const tls = Object.values(
+          (
+            window as unknown as {
+              __timelines?: Record<string, { pause?: () => void; seek?: (t: number) => void }>;
+            }
+          ).__timelines ?? {},
+        );
+        const seekAll = (t: number) =>
+          tls.forEach((tl) => {
+            try {
+              tl.pause?.();
+              tl.seek?.(t);
+            } catch {
+              // best-effort
+            }
+          });
+
+        // Orbit camera: make the whole ancestor chain of each element preserve-3d
+        // and strip any intermediate perspective, then put one perspective on the
+        // composition root's parent (the lens) and rotate the root. The element's
+        // own 3D survives and is viewed from the requested angle — works on any
+        // composition shape (no #stage assumption).
+        if (cam.yaw !== 0 || cam.pitch !== 0) {
+          const first = document.querySelector(selectors[0] ?? "");
+          const root =
+            (first?.closest("[data-composition-id]") as HTMLElement | null) ??
+            (document.querySelector("#stage") as HTMLElement | null) ??
+            (document.body.firstElementChild as HTMLElement | null) ??
+            document.body;
+          for (const sel of selectors) {
+            let n = document.querySelector(sel) as HTMLElement | null;
+            while (n && n !== root) {
+              n.style.transformStyle = "preserve-3d";
+              if (getComputedStyle(n).perspective !== "none") n.style.perspective = "none";
+              n = n.parentElement;
+            }
+          }
+          root.style.transformStyle = "preserve-3d";
+          root.style.perspective = "none";
+          root.style.transformOrigin = "50% 50%";
+          root.style.transform = `rotateX(${cam.pitch}deg) rotateY(${cam.yaw}deg)`;
+          const lens = root.parentElement ?? document.body;
+          lens.style.perspective = "1600px";
+          lens.style.perspectiveOrigin = "50% 50%";
+        }
+
+        const rigs = selectors.map((sel) => {
+          const el = document.querySelector(sel) as HTMLElement | null;
+          if (!el) return null;
+          const w = el.offsetWidth;
+          const h = el.offsetHeight;
+          const local: Array<[number, number]> = [
+            [0, 0],
+            [w, 0],
+            [w, h],
+            [0, h],
+            [w / 2, h / 2],
+          ];
+          const markers = local.map(([lx, ly]) => {
+            const m = document.createElement("div");
+            m.style.cssText = `position:absolute;left:${lx}px;top:${ly}px;width:0;height:0;pointer-events:none`;
+            el.appendChild(m);
+            return m;
+          });
+          return { el, markers };
+        });
+        const out = selectors.map((selector) => ({ selector, samples: [] as PageSample[] }));
+        for (const t of ts) {
+          seekAll(t);
+          rigs.forEach((rig, i) => {
+            if (!rig) return;
+            const pts = rig.markers.map((m) => {
+              const r = m.getBoundingClientRect();
+              return { x: r.left, y: r.top };
+            });
+            const cs = getComputedStyle(rig.el);
+            out[i]!.samples.push({
+              t: Math.round(t * 1000) / 1000,
+              q: pts.slice(0, 4),
+              c: pts[4]!,
+              color: cs.backgroundColor,
+              opacity: parseFloat(cs.opacity) || 0,
+            });
+          });
+        }
+        rigs.forEach((rig) => {
+          if (rig) rig.el.style.visibility = "hidden";
+        });
+        return out.filter((o) => o.samples.length > 0);
+      },
+      requests.map((r) => r.selector),
+      times,
+      camera,
+    )) as OnionElement[];
+
+    const windowStr =
+      opts.from != null || opts.to != null ? `  ·  t ${times[0]}–${times[times.length - 1]}s` : "";
+    const camLabel =
+      camera.yaw === 0 && camera.pitch === 0
+        ? "front"
+        : `yaw ${camera.yaw}° pitch ${camera.pitch}°`;
+    const label = `${camLabel}  ·  ${layout === "strip" ? "filmstrip" : fit ? "zoom-fit" : "1:1"}  ·  ${times.length} frames${windowStr}`;
+    const svg = buildOnionSvg(elements, {
+      layout,
+      fit,
+      width: size.width,
+      height: size.height,
+      label,
+    });
+
+    await page.evaluate((markup: string) => {
+      document.body.insertAdjacentHTML("beforeend", markup);
+    }, svg);
+    await new Promise((r) => setTimeout(r, 60));
+
+    const buf = await page.screenshot({ type: "png" });
+    if (!buf) throw new Error("screenshot returned no data");
+    writeFileSync(outPath, buf as Uint8Array);
+    return outPath;
+  } finally {
+    await browserInstance?.close().catch(() => {});
+    await server.close().catch(() => {});
+  }
+}

--- a/packages/cli/src/commands/keyframesShotLayout.test.ts
+++ b/packages/cli/src/commands/keyframesShotLayout.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOnionSvg,
+  fitTransform,
+  parseAngle,
+  sampleTimes,
+  stripCells,
+  type OnionElement,
+} from "./keyframesShotLayout.js";
+
+describe("sampleTimes", () => {
+  it("spreads N equal-time steps across the full duration", () => {
+    expect(sampleTimes(4, 5, null, null)).toEqual([0, 1, 2, 3, 4]);
+  });
+  it("samples only the requested window", () => {
+    expect(sampleTimes(4, 3, 2, 3)).toEqual([2, 2.5, 3]);
+  });
+  it("returns a single point at the window start when n=1", () => {
+    expect(sampleTimes(4, 1, 1.5, 3)).toEqual([1.5]);
+  });
+  it("clamps the window to [0, dur]", () => {
+    expect(sampleTimes(4, 2, -5, 99)).toEqual([0, 4]);
+  });
+});
+
+describe("fitTransform", () => {
+  it("centres on the bbox midpoint", () => {
+    const { cx, cy } = fitTransform(
+      [
+        { x: 100, y: 200 },
+        { x: 300, y: 400 },
+      ],
+      1000,
+      1000,
+    );
+    expect(cx).toBe(200);
+    expect(cy).toBe(300);
+  });
+  it("zooms a tiny cluster up (k > 1) but clamps the factor", () => {
+    const { k } = fitTransform(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      1000,
+      1000,
+    );
+    expect(k).toBeGreaterThan(1);
+    expect(k).toBeLessThanOrEqual(7);
+  });
+  it("shrinks an oversized span (k < 1)", () => {
+    const { k } = fitTransform(
+      [
+        { x: 0, y: 0 },
+        { x: 5000, y: 0 },
+      ],
+      1000,
+      1000,
+    );
+    expect(k).toBeLessThan(1);
+    expect(k).toBeGreaterThanOrEqual(0.3);
+  });
+  it("is safe on empty input", () => {
+    expect(fitTransform([], 800, 600)).toEqual({ k: 1, cx: 400, cy: 300 });
+  });
+});
+
+describe("stripCells", () => {
+  it("uses a single row for few samples", () => {
+    expect(stripCells(3, 900, 900)).toMatchObject({ cols: 3, rows: 1 });
+  });
+  it("uses a roughly square grid for many samples", () => {
+    expect(stripCells(9, 900, 900)).toMatchObject({ cols: 3, rows: 3 });
+    expect(stripCells(13, 1080, 1080)).toMatchObject({ cols: 4, rows: 4 });
+  });
+});
+
+describe("parseAngle", () => {
+  it("resolves named presets", () => {
+    expect(parseAngle("iso")).toEqual({ yaw: 30, pitch: -22 });
+    expect(parseAngle("top")).toEqual({ yaw: 0, pitch: -68 });
+  });
+  it("parses yaw,pitch pairs", () => {
+    expect(parseAngle("45,-30")).toEqual({ yaw: 45, pitch: -30 });
+  });
+  it("falls back to front on missing or garbage input", () => {
+    expect(parseAngle()).toEqual({ yaw: 0, pitch: 0 });
+    expect(parseAngle("nonsense")).toEqual({ yaw: 0, pitch: 0 });
+  });
+});
+
+const sample = (t: number) => ({
+  t,
+  q: [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ],
+  c: { x: 5, y: 5 },
+  color: "rgb(34, 211, 238)",
+  opacity: 1,
+});
+const oneElement: OnionElement[] = [{ selector: "#hero", samples: [sample(0), sample(2)] }];
+
+describe("buildOnionSvg", () => {
+  it("path layout: one ghost per sample, a connecting path, and centre dots", () => {
+    const svg = buildOnionSvg(oneElement, { layout: "path", fit: true, width: 1000, height: 1000 });
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect((svg.match(/<polygon/g) ?? []).length).toBe(2); // 2 ghosts
+    expect((svg.match(/<line/g) ?? []).length).toBe(3); // 2 ticks + 1 path segment
+    expect((svg.match(/<circle/g) ?? []).length).toBe(2); // 2 centre dots
+  });
+  it("strip layout: one framed cell per sample", () => {
+    const svg = buildOnionSvg(oneElement, {
+      layout: "strip",
+      fit: true,
+      width: 1000,
+      height: 1000,
+    });
+    expect((svg.match(/<rect/g) ?? []).length).toBe(2); // 2 cells
+    expect((svg.match(/<polygon/g) ?? []).length).toBe(2);
+  });
+  it("renders the caption label when provided", () => {
+    const svg = buildOnionSvg(oneElement, {
+      layout: "path",
+      fit: true,
+      width: 800,
+      height: 800,
+      label: "front · zoom-fit",
+    });
+    expect(svg).toContain("front");
+  });
+  it("is safe on empty input", () => {
+    const svg = buildOnionSvg([], { layout: "path", fit: true, width: 800, height: 800 });
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg.match(/<polygon/g)).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/keyframesShotLayout.ts
+++ b/packages/cli/src/commands/keyframesShotLayout.ts
@@ -1,0 +1,208 @@
+// Pure, Node-side geometry + SVG generation for the onion-skin motion shot.
+//
+// The headless step (keyframesShot.ts) only SAMPLES — it seeks the live timeline
+// and reads each element's projected corners. Everything else (which times to
+// sample, how to fit/lay them out, and the SVG markup) lives here as pure
+// functions so it can be unit-tested without a browser.
+
+export interface Pt {
+  x: number;
+  y: number;
+}
+
+/** One time-sample of one element: its 4 projected corners, centre, colour, opacity. */
+export interface OnionSample {
+  t: number;
+  q: Pt[];
+  c: Pt;
+  color: string;
+  opacity: number;
+}
+
+export interface OnionElement {
+  selector: string;
+  samples: OnionSample[];
+}
+
+export type ShotLayout = "path" | "strip";
+
+export interface ShotLayoutOptions {
+  layout: ShotLayout;
+  fit: boolean;
+  width: number;
+  height: number;
+  /** Caption drawn top-left (camera / framing / window info). */
+  label?: string;
+}
+
+export interface Camera {
+  yaw: number;
+  pitch: number;
+}
+
+const ANGLE_PRESETS: Record<string, [number, number]> = {
+  front: [0, 0],
+  iso: [30, -22],
+  top: [0, -68],
+  side: [78, 0],
+  "rear-iso": [205, -22],
+};
+
+/** Parse an angle preset name or "yaw,pitch" degrees into a Camera. */
+export function parseAngle(a?: string): Camera {
+  if (!a) return { yaw: 0, pitch: 0 };
+  const preset = ANGLE_PRESETS[a];
+  if (preset) return { yaw: preset[0], pitch: preset[1] };
+  const [y, p] = a.split(",").map((n) => Number.parseFloat(n));
+  return { yaw: Number.isFinite(y) ? y! : 0, pitch: Number.isFinite(p) ? p! : 0 };
+}
+
+/** N equal-time sample points across [from?, to?] within [0, dur]. */
+export function sampleTimes(
+  dur: number,
+  n: number,
+  from: number | null,
+  to: number | null,
+): number[] {
+  const t0 = from != null ? Math.max(0, Math.min(from, dur)) : 0;
+  const t1 = to != null ? Math.max(0, Math.min(to, dur)) : dur;
+  const count = Math.max(1, Math.floor(n));
+  if (count === 1) return [t0];
+  return Array.from({ length: count }, (_, i) => {
+    const t = t0 + (i / (count - 1)) * (t1 - t0);
+    return Math.round(t * 1000) / 1000;
+  });
+}
+
+/** Scale+centre transform that fits `pts` into a W×H frame (with padding). */
+export function fitTransform(
+  pts: Pt[],
+  width: number,
+  height: number,
+): { k: number; cx: number; cy: number } {
+  if (pts.length === 0) return { k: 1, cx: width / 2, cy: height / 2 };
+  const xs = pts.map((p) => p.x);
+  const ys = pts.map((p) => p.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const span = Math.max(maxX - minX, maxY - minY, 1);
+  const k = Math.max(0.3, Math.min(7, (Math.min(width, height) * 0.8) / span));
+  return { k, cx, cy };
+}
+
+/** Grid geometry for the filmstrip layout. */
+export function stripCells(n: number, width: number, height: number) {
+  const cols = n <= 5 ? Math.max(1, n) : Math.ceil(Math.sqrt(n));
+  const rows = Math.ceil(n / cols);
+  return { cols, rows, cellW: width / cols, cellH: height / rows };
+}
+
+const timeColor = (f: number) => `hsl(${190 + f * 150} 90% 65%)`;
+
+const attrs = (o: Record<string, string | number>) =>
+  Object.entries(o)
+    .map(([k, v]) => `${k}="${v}"`)
+    .join(" ");
+
+const polygon = (corners: Pt[], fill: string, fillOpacity: number, stroke: string) =>
+  `<polygon ${attrs({
+    points: corners.map((p) => `${round(p.x)},${round(p.y)}`).join(" "),
+    fill,
+    "fill-opacity": fillOpacity.toFixed(2),
+    stroke,
+    "stroke-width": 2.5,
+    "stroke-linejoin": "round",
+  })}/>`;
+
+const line = (a: Pt, b: Pt, stroke: string, w: number, o: number) =>
+  `<line ${attrs({ x1: round(a.x), y1: round(a.y), x2: round(b.x), y2: round(b.y), stroke, "stroke-width": w, opacity: o, "stroke-linecap": "round" })}/>`;
+
+const circle = (p: Pt, r: number, fill: string) =>
+  `<circle ${attrs({ cx: round(p.x), cy: round(p.y), r, fill })}/>`;
+
+const text = (p: Pt, s: string, fill: string, size = 15) =>
+  `<text ${attrs({ x: round(p.x), y: round(p.y), fill, "font-family": "ui-monospace,monospace", "font-size": size, "font-weight": 600 })}>${escapeXml(s)}</text>`;
+
+const round = (n: number) => Math.round(n * 100) / 100;
+const escapeXml = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const ghost = (corners: Pt[], center: Pt, color: string, opacity: number, f: number): string => {
+  const tickEnd = {
+    x: (corners[0]!.x + corners[1]!.x) / 2,
+    y: (corners[0]!.y + corners[1]!.y) / 2,
+  };
+  return (
+    polygon(corners, color, Math.max(0.08, opacity * 0.42), timeColor(f)) +
+    line(center, tickEnd, timeColor(f), 3, 0.9)
+  );
+};
+
+/** Build the full onion-skin SVG overlay markup from sampled elements. */
+export function buildOnionSvg(elements: OnionElement[], opt: ShotLayoutOptions): string {
+  const { width: W, height: H } = opt;
+  let body = "";
+
+  if (opt.layout === "strip") {
+    body = stripBody(elements[0]?.samples ?? [], W, H);
+  } else {
+    body = pathBody(elements, opt.fit, W, H);
+  }
+
+  if (opt.label) body += text({ x: 28, y: 40 }, opt.label, timeColor(0), 18);
+
+  return `<svg ${attrs({
+    xmlns: "http://www.w3.org/2000/svg",
+    style: "position:fixed;inset:0;width:100vw;height:100vh;pointer-events:none;z-index:2147483647",
+    viewBox: `0 0 ${W} ${H}`,
+  })}>${body}</svg>`;
+}
+
+function pathBody(elements: OnionElement[], fit: boolean, W: number, H: number): string {
+  const all = elements.flatMap((e) => e.samples.flatMap((s) => [...s.q, s.c]));
+  const { k, cx, cy } = fit ? fitTransform(all, W, H) : { k: 1, cx: W / 2, cy: H / 2 };
+  const M = (p: Pt): Pt => ({ x: (p.x - cx) * k + W / 2, y: (p.y - cy) * k + H / 2 });
+  let out = "";
+  for (const el of elements) {
+    const last = el.samples.length - 1;
+    const fOf = (i: number) => (last <= 0 ? 0 : i / last);
+    el.samples.forEach((s, i) => (out += ghost(s.q.map(M), M(s.c), s.color, s.opacity, fOf(i))));
+    for (let i = 0; i < last; i++)
+      out += line(M(el.samples[i]!.c), M(el.samples[i + 1]!.c), timeColor(fOf(i)), 3.5, 0.85);
+    el.samples.forEach((s, i) => {
+      const c = M(s.c);
+      out += circle(c, 4, timeColor(fOf(i)));
+      out += text({ x: c.x + 10, y: c.y + (i % 2 === 0 ? -10 : 18) }, `${s.t}s`, timeColor(fOf(i)));
+    });
+  }
+  return out;
+}
+
+function stripBody(samples: OnionSample[], W: number, H: number): string {
+  if (samples.length === 0) return "";
+  const { cols, cellW, cellH } = stripCells(samples.length, W, H);
+  let maxExt = 1;
+  for (const s of samples)
+    for (const p of s.q) maxExt = Math.max(maxExt, Math.hypot(p.x - s.c.x, p.y - s.c.y));
+  const cellScale = (Math.min(cellW, cellH) * 0.62) / maxExt;
+  const last = samples.length - 1;
+  let out = "";
+  samples.forEach((s, i) => {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const cc = { x: cellW * (col + 0.5), y: cellH * (row + 0.5) };
+    const f = last <= 0 ? 0 : i / last;
+    out += `<rect ${attrs({ x: round(col * cellW + 3), y: round(row * cellH + 3), width: round(cellW - 6), height: round(cellH - 6), fill: "none", stroke: "#1c2531", "stroke-width": 1, rx: 8 })}/>`;
+    const corners = s.q.map((p) => ({
+      x: cc.x + (p.x - s.c.x) * cellScale,
+      y: cc.y + (p.y - s.c.y) * cellScale,
+    }));
+    out += ghost(corners, cc, s.color, s.opacity, f);
+    out += text({ x: col * cellW + 12, y: row * cellH + 24 }, `${s.t}s`, timeColor(f), 16);
+  });
+  return out;
+}

--- a/skills/hyperframes-keyframes/SKILL.md
+++ b/skills/hyperframes-keyframes/SKILL.md
@@ -1,57 +1,78 @@
 ---
 name: hyperframes-keyframes
-description: Read and edit GSAP keyframes and motion paths in a HyperFrames composition. Use whenever a task involves an element's MOTION over time — adding/removing/moving keyframes, refining a motion path, changing where or when something travels, debugging "why does it move there", or understanding an existing animation before editing it. Run `npx hyperframes keyframes` to surface every tween's keyframes + an ASCII motion-path so you can see and edit motion as data instead of guessing at raw numbers.
+description: "See and edit GSAP motion as data in a HyperFrames composition. Run `npx hyperframes keyframes` to surface every tween's keyframes, then `--shot` to render a true-3D onion-skin of the real element, so you reason about an element's MOTION over time — add/move/remove keyframes, refine a path, trace a shape (logo / glyph / icon), tune a 3D flip/tumble, debug 'why does it move there', or read an animation before editing. Supports multi-stroke traces (pen-up gaps) for shapes with holes or detached parts. Use whenever the task is about where/when/how something moves; for authoring new scenes from scratch see hyperframes-animation, for the dev-loop CLI see hyperframes-cli."
 ---
 
 # HyperFrames Keyframes
 
-Editing motion by reading `keyframes: [{x:0},{x:-260}]` in source is guessing — you can't see the _shape_ a tween traces, only opaque numbers. `npx hyperframes keyframes` surfaces every GSAP tween, its keyframes (with absolute times), and an **ASCII motion-path drawing** so you can reason about motion, then edit precisely and verify.
+Editing motion by reading `keyframes: [{x:0},{x:-260}]` in source is guessing — the numbers don't show the _shape_, the timing, or what rotation/scale/3D actually look like. `npx hyperframes keyframes` surfaces every GSAP tween and its keyframes (with absolute times) as editable data; then `--shot` renders a **true-3D onion-skin of the real element** so you verify the motion by eye — all before you render.
+
+This is **read-then-edit-source**, not a mutation command — it never changes files. Pair it with `inspect` (layout over the timeline) and `render` to ship. For the composition contract (the single paused timeline, `data-duration`, determinism) see `hyperframes-core`; to author motion from scratch see `hyperframes-animation`.
 
 ## The loop
 
 1. **Surface** — `npx hyperframes keyframes [dir|file]` (defaults to `./index.html` + sub-compositions).
-2. **Read** the path shape + keyframe list (or `--json` for exact data).
-3. **Edit** the `keyframes` / `x`/`y` values in the composition source.
-4. **Verify** — re-run `npx hyperframes keyframes` to confirm the new shape, then `npx hyperframes inspect` / `render`.
+2. **Read** the keyframe list against your intent (add `--json` for exact data).
+3. **Edit** the `keyframes` / property values in the composition `<script>`.
+4. **Verify** — `keyframes --shot out.png` renders the motion; check it by eye, then `inspect` / `render`.
+
+**Stop condition (don't thrash).** Iterate until faithful and another edit wouldn't clearly help — usually **≤5 rounds, never more than ~8** (a 40-run grid showed quality flat past ~5; extra rounds just over-edit). Tracing a known target? Keep it in view and re-check each round. Past ~5 with no clear gain, **stop and ask the user**.
+
+**Formula shortcut.** If the shape has a known parametric form (heart, ∞/lemniscate, star, spiral, circle), author it directly from the formula and verify **once** — don't iterate. The loop's value is for non-formula shapes (objects, glyphs, words, icons) where you can't compute the points.
 
 ```bash
 npx hyperframes keyframes                      # whole project
 npx hyperframes keyframes --selector '#hero'   # one element
 npx hyperframes keyframes compositions/s2.html # one composition file
 npx hyperframes keyframes --json               # machine-readable (agents)
+npx hyperframes keyframes --shot path.png      # onion-skin screenshot (3D, all channels)
 ```
+
+**The shot is ground truth.** Numbers say what you wrote; `--shot <png>` shows what it does. It seeks the **live timeline** at N steps and renders the **real element** at each — true-3D ghosts (foreshortened/edge-on for rotationX/Y/Z + z, sized by scale, filled with its colour, faded by opacity; path coloured by time, ghost spacing = velocity). It reads what actually rendered, so it catches eased / dynamic / 3D motion the numbers hide. Works on **any** animated element. Author → `--shot` → open the PNG → check against your target, before render.
+
+**Frame what you're editing.** A head-on render lies twice — in-place motion collapses to a dot, 3D to a flat stack. Pick the framing:
+
+| Want to…                                                               | Flag                                                |
+| ---------------------------------------------------------------------- | --------------------------------------------------- |
+| make a small / centred motion legible (default on)                     | _(zoom-to-fit; `--no-fit` to disable)_              |
+| separate **in-place / overlapping** ghosts (a pulse, an in-place flip) | `--layout strip` (filmstrip, one cell per keyframe) |
+| inspect **one phase** densely (e.g. a single bounce)                   | `--from 2.0 --to 3.0`                               |
+| reveal **3D** that's ambiguous head-on (flips, tumbles)                | `--angle top` · `side` · `iso` · `yaw,pitch`        |
+| change sample count · focus one element                                | `--samples 13` · `--selector '#hero'`               |
+
+A vertical-axis flip reads from `top`; a horizontal-axis flip from `side`; a general tumble from `iso`. Render two angles if unsure.
 
 ## Reading the output
 
 ```
-#puck-b position  to/keyframes  @1s→4.4s (3.4s)
+#hero position  to/keyframes  @1s→4.4s (3.4s)
   0% {x:0 y:0}  33% {x:-180 y:-60}  67% {x:-320 y:40}  100% {x:-460 y:-20}
-  ┌──────────────────────┐
-  │              1·       │
-  │            ··  ··     │
-  │ 3·       ··      ·0   │
-  │    ·· ·2·             │
-  └──────────────────────┘
-  x -460..0   y -60..40 (gsap px; marks 0..n = keyframe order)
 ```
 
-- **`to/keyframes`** = method (`to`/`from`/`fromTo`/`set`) + shape (`keyframes` multi-stop, `flat` 2-point, `motionPath` arc).
-- **`@1s→4.4s`** = absolute timeline window; each `%` is **tween-relative** (0 % = tween start, 100 % = tween end).
-- **Keyframe line** = every stop with its properties.
-- **ASCII grid** = the position path in GSAP **x/y offset** pixels (the element's translate from its layout home; +x right, +y down). Marks `0,1,2,…` are keyframes in order; on dense gesture paths only `S`→`E` are marked and the path is traced with `·`.
-- `--json` gives exact `{ pct, time, properties }` per keyframe + the raw `path` points — use it when you need to compute edits.
+Each line is a tween — target, property group, method/shape, timing — then its keyframes as `pct% {props}`. x/y are GSAP **offset** pixels (the element's translate from its CSS home; +x right, +y down); rotation / scale / opacity / colour show too when animated. That's the data you edit. To _see_ the motion (shape, timing, 3D), use `--shot` (above). Full `--json` schema: **`references/reading-the-surface.md`**.
 
-## Editing keyframes (in source)
+## Multi-stroke / pen-up (shapes with gaps)
 
-Percentages are **tween-relative**, and edits go in the composition's `<script>`:
+A single element can trace a shape in **multiple strokes** with pen-up gaps between them — needed for anything with holes or detached parts (a `?`'s dot, an icon counter, separate letters/digits) where one continuous line would draw a wrong connector.
 
-- **Move a keyframe** — change its `x`/`y` (or any prop) at that `%`.
-- **Add a keyframe** — insert a new `"P%": { x, y }` entry (object form) keeping ascending order; convert a flat `to("#el", { x })` to `to("#el", { keyframes: { "0%": {x:0}, "100%": {x} } })` first if needed.
-- **Remove a keyframe** — delete its `"P%"` entry; if fewer than two remain, collapse back to a flat tween.
-- **Retime** — change the tween's `duration` / position argument (the `@start` shifts; the `%`s stay).
+**Convention: each stroke is its own position tween; a 0-duration `set()` between them is the pen-up jump.** The command composites an element's strokes into one shared-scale trace and **does not draw across the gaps**:
 
 ```js
-// object-form keyframes (each value is the element's gsap x/y OFFSET from its CSS layout position)
+tl.to("#pen", {
+  keyframes: { "0%": { x: -100, y: -150 }, "100%": { x: 80, y: -120 } },
+  duration: 1,
+}); // stroke 1
+tl.set("#pen", { x: 80, y: 120 }); // pen up → jump
+tl.to("#pen", { keyframes: { "0%": { x: 80, y: 120 }, "100%": { x: 85, y: 140 } }, duration: 0.5 }); // stroke 2
+```
+
+Full pattern (words, icons, holed glyphs, how it surfaces, and the single-stroke fallback): **`references/multi-stroke.md`**.
+
+## Editing keyframes
+
+Percentages are **tween-relative**; edits go in the composition `<script>`. Move = change `x`/`y` at that `%`; add = insert a new `"P%": { x, y }` keeping ascending order; remove = delete the `"P%"` entry; retime = change `duration` / position. Object-form, offset math, and converting a flat `to(x)` into keyframes: **`references/editing-keyframes.md`**.
+
+```js
 tl.to(
   "#hero",
   {
@@ -63,11 +84,27 @@ tl.to(
 );
 ```
 
-After any edit, re-run `npx hyperframes keyframes --selector '#hero'` — the new ASCII path is your confirmation the motion matches intent before you render.
+## Routing
 
-## Gotchas
+| Want to…                                           | Read                                |
+| -------------------------------------------------- | ----------------------------------- |
+| Understand the keyframe surface + `--json` shape   | `references/reading-the-surface.md` |
+| Trace a shape with holes / gaps / separate letters | `references/multi-stroke.md`        |
+| Add / move / remove / retime keyframes in source   | `references/editing-keyframes.md`   |
+| Avoid the common failure modes                     | `references/gotchas.md`             |
+| Author brand-new motion / pick a rule or blueprint | `hyperframes-animation`             |
+| Run `lint` / `inspect` / `preview` / `render`      | `hyperframes-cli`                   |
+
+## Gotchas (full list: `references/gotchas.md`)
 
 - **x/y are offsets, not absolute canvas coords.** `{x:0,y:0}` = the element's CSS layout spot; values are deltas from there.
-- **Studio holds.** A `set("#el", { …, data: "hf-hold" })` is an internal position-hold the Studio injects before a position tween — it's filtered from the surface; don't author or edit it by hand.
-- **Dynamic tweens** (computed selectors / data-driven keyframes) can't be statically resolved; they show with fewer details. Author literal `keyframes: {…}` when you want them editable.
-- This is **read-then-edit-source**, not a mutation command — it never changes files. Pair it with `inspect` (layout/overflow over the timeline) and `render` to ship.
+- **Head-on `--shot` can mislead** — in-place motion stacks on one spot and 3D flattens; reach for `--layout strip`, `--from/--to`, or `--angle` (above) to frame what you're editing.
+- **One continuous line can't do holes** — if you see a wrong connector across a gap, you want multi-stroke (above), not more keyframes.
+- **Studio holds are filtered.** A `set("#el", { …, data: "hf-hold" })` is an internal position-hold the Studio injects — never author or edit it by hand.
+- **Dynamic tweens** (computed selectors / data-driven keyframes) can't be statically resolved and surface with fewer details; author literal `keyframes: {…}` when you want them editable.
+
+## Boundaries
+
+- GSAP only. Lottie / Three.js / CSS / WAAPI motion does **not** surface here — see the relevant `hyperframes-animation` adapter.
+- It reads and screenshots; it never writes. All edits are yours to make in source, then `--shot` to verify.
+- Don't restate `hyperframes-core` rules (single paused timeline, determinism) — they still apply.

--- a/skills/hyperframes-keyframes/SKILL.md
+++ b/skills/hyperframes-keyframes/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: hyperframes-keyframes
+description: Read and edit GSAP keyframes and motion paths in a HyperFrames composition. Use whenever a task involves an element's MOTION over time — adding/removing/moving keyframes, refining a motion path, changing where or when something travels, debugging "why does it move there", or understanding an existing animation before editing it. Run `npx hyperframes keyframes` to surface every tween's keyframes + an ASCII motion-path so you can see and edit motion as data instead of guessing at raw numbers.
+---
+
+# HyperFrames Keyframes
+
+Editing motion by reading `keyframes: [{x:0},{x:-260}]` in source is guessing — you can't see the _shape_ a tween traces, only opaque numbers. `npx hyperframes keyframes` surfaces every GSAP tween, its keyframes (with absolute times), and an **ASCII motion-path drawing** so you can reason about motion, then edit precisely and verify.
+
+## The loop
+
+1. **Surface** — `npx hyperframes keyframes [dir|file]` (defaults to `./index.html` + sub-compositions).
+2. **Read** the path shape + keyframe list (or `--json` for exact data).
+3. **Edit** the `keyframes` / `x`/`y` values in the composition source.
+4. **Verify** — re-run `npx hyperframes keyframes` to confirm the new shape, then `npx hyperframes inspect` / `render`.
+
+```bash
+npx hyperframes keyframes                      # whole project
+npx hyperframes keyframes --selector '#hero'   # one element
+npx hyperframes keyframes compositions/s2.html # one composition file
+npx hyperframes keyframes --json               # machine-readable (agents)
+```
+
+## Reading the output
+
+```
+#puck-b position  to/keyframes  @1s→4.4s (3.4s)
+  0% {x:0 y:0}  33% {x:-180 y:-60}  67% {x:-320 y:40}  100% {x:-460 y:-20}
+  ┌──────────────────────┐
+  │              1·       │
+  │            ··  ··     │
+  │ 3·       ··      ·0   │
+  │    ·· ·2·             │
+  └──────────────────────┘
+  x -460..0   y -60..40 (gsap px; marks 0..n = keyframe order)
+```
+
+- **`to/keyframes`** = method (`to`/`from`/`fromTo`/`set`) + shape (`keyframes` multi-stop, `flat` 2-point, `motionPath` arc).
+- **`@1s→4.4s`** = absolute timeline window; each `%` is **tween-relative** (0 % = tween start, 100 % = tween end).
+- **Keyframe line** = every stop with its properties.
+- **ASCII grid** = the position path in GSAP **x/y offset** pixels (the element's translate from its layout home; +x right, +y down). Marks `0,1,2,…` are keyframes in order; on dense gesture paths only `S`→`E` are marked and the path is traced with `·`.
+- `--json` gives exact `{ pct, time, properties }` per keyframe + the raw `path` points — use it when you need to compute edits.
+
+## Editing keyframes (in source)
+
+Percentages are **tween-relative**, and edits go in the composition's `<script>`:
+
+- **Move a keyframe** — change its `x`/`y` (or any prop) at that `%`.
+- **Add a keyframe** — insert a new `"P%": { x, y }` entry (object form) keeping ascending order; convert a flat `to("#el", { x })` to `to("#el", { keyframes: { "0%": {x:0}, "100%": {x} } })` first if needed.
+- **Remove a keyframe** — delete its `"P%"` entry; if fewer than two remain, collapse back to a flat tween.
+- **Retime** — change the tween's `duration` / position argument (the `@start` shifts; the `%`s stay).
+
+```js
+// object-form keyframes (each value is the element's gsap x/y OFFSET from its CSS layout position)
+tl.to(
+  "#hero",
+  {
+    keyframes: { "0%": { x: 0, y: 0 }, "50%": { x: 120, y: -80 }, "100%": { x: 240, y: 0 } },
+    duration: 2,
+    ease: "power1.inOut",
+  },
+  1.0,
+);
+```
+
+After any edit, re-run `npx hyperframes keyframes --selector '#hero'` — the new ASCII path is your confirmation the motion matches intent before you render.
+
+## Gotchas
+
+- **x/y are offsets, not absolute canvas coords.** `{x:0,y:0}` = the element's CSS layout spot; values are deltas from there.
+- **Studio holds.** A `set("#el", { …, data: "hf-hold" })` is an internal position-hold the Studio injects before a position tween — it's filtered from the surface; don't author or edit it by hand.
+- **Dynamic tweens** (computed selectors / data-driven keyframes) can't be statically resolved; they show with fewer details. Author literal `keyframes: {…}` when you want them editable.
+- This is **read-then-edit-source**, not a mutation command — it never changes files. Pair it with `inspect` (layout/overflow over the timeline) and `render` to ship.

--- a/skills/hyperframes-keyframes/references/editing-keyframes.md
+++ b/skills/hyperframes-keyframes/references/editing-keyframes.md
@@ -1,0 +1,61 @@
+# Editing keyframes in source
+
+Edits go in the composition's `<script>`. The surface is read-only; you change the GSAP call, then re-run `keyframes` to verify.
+
+## Coordinate model
+
+`x`/`y` are the element's **offset from its CSS layout position** (a GSAP translate), in pixels: `{x:0,y:0}` is wherever the element sits by its CSS; `+x` right, `+y` down. They are **not** absolute canvas coordinates. Author offsets relative to the element's home, and read the surface's `x …` / `y …` ranges the same way.
+
+## Object-form keyframes (preferred)
+
+Each value is an offset; percentages are tween-relative and must ascend.
+
+```js
+tl.to(
+  "#hero",
+  {
+    keyframes: {
+      "0%": { x: 0, y: 0 },
+      "50%": { x: 120, y: -80 },
+      "100%": { x: 240, y: 0 },
+    },
+    duration: 2,
+    ease: "power1.inOut",
+  },
+  1.0,
+); // position arg = absolute start on the timeline
+```
+
+## The four edits
+
+- **Move a keyframe** — change its `x`/`y` (or any prop) at that `%`.
+- **Add a keyframe** — insert a new `"P%": { x, y }` entry, keeping ascending order. If the tween is a flat `to("#el", { x })`, convert it to keyframes first (below).
+- **Remove a keyframe** — delete its `"P%"` entry. If fewer than two stops remain, collapse back to a flat tween.
+- **Retime** — change the tween's `duration` or its position argument. The `@start` shifts; the `%`s stay put (they're relative).
+
+## Convert a flat tween into keyframes
+
+A flat `to`/`from` animates between the element's rest pose and one set of values. To shape its path, give it explicit stops:
+
+```js
+// before — a straight slide, no shapeable path
+tl.to("#el", { x: 240, duration: 2 });
+
+// after — an editable path
+tl.to("#el", {
+  keyframes: { "0%": { x: 0, y: 0 }, "50%": { x: 120, y: -80 }, "100%": { x: 240, y: 0 } },
+  duration: 2,
+});
+```
+
+## Single-axis keyframes carry forward
+
+If a keyframe sets only one axis, GSAP holds the other at its last value — and the surface's `path` does the same, so it stays continuous. Set both axes when you want an explicit point; set one when you intend "hold the other."
+
+## Easing
+
+`ease` shapes timing, not the spatial path. `--shot` samples at equal time steps, so an eased tween shows as **uneven ghost spacing** — bunched where it's slow, spread where it's fast — i.e. you see the ease directly. If the _spatial_ path needs more curve, add keyframes; reserve ease for feel.
+
+## Verify
+
+After each edit, `keyframes --shot out.png` and check the PNG before `inspect` / `render`. See the stop condition in `SKILL.md`: usually ≤5 rounds, then ship or ask.

--- a/skills/hyperframes-keyframes/references/gotchas.md
+++ b/skills/hyperframes-keyframes/references/gotchas.md
@@ -1,0 +1,35 @@
+# Gotchas & anti-patterns
+
+The failure modes that actually bite, each with the fix.
+
+## Coordinates
+
+- **x/y are offsets, not absolute coordinates.** `{x:0,y:0}` is the element's CSS layout spot, not the canvas origin. The #1 mistake is treating them as absolute and authoring a path that's translated off where you expect. Author deltas from the element's home.
+- **Center your tracer in CSS first.** If you're tracing a shape, put the element at the visual center via CSS (e.g. `left:50%;top:50%;margin:-h -w`), then author x/y as offsets around `0,0`. Keep offsets within the visible canvas (for 1080² centered, roughly ±480).
+
+## Reading the surface
+
+- **The text is data, not a picture.** The surface lists keyframes; to judge shape, timing, or 3D, render `--shot` and look at the PNG. (Equal-time sampling means ghost spacing already shows the ease — no need to flatten it to `ease: "none"` to preview.)
+- **A head-on `--shot` lies twice.** In-place motion stacks on one spot; 3D flattens to a stack. Frame the edit with `--layout strip`, `--from/--to`, or `--angle` (SKILL.md → Frame what you're editing).
+
+## Shape / strokes
+
+- **One continuous line can't make holes or gaps.** If the surface shows a connector across a gap you didn't want (the line from a `?` stem to its dot, or between two letters), the fix is **multi-stroke** (`multi-stroke.md`) — separate tweens with a `set()` pen-up — not more keyframes.
+- **A trace only forms with ≥2 strokes on one element.** A single stroke stays a normal per-tween block; that's expected.
+
+## Iterating
+
+- **Don't thrash.** Quality plateaus by ~5 rounds; beyond that, more iterations tend to over-edit a good path. Stop when faithful, or ask the user. (See `SKILL.md` → Stop condition.)
+- **Use the formula when one exists.** Heart, ∞, star, spiral, circle — author from the parametric form and verify once. Iterating a formula shape is wasted effort.
+- **Keep the target in view.** When tracing a known shape (logo/glyph/icon), re-check the path against the reference each round — reasoning from the actual target beats reasoning from memory.
+
+## Parser / runtime
+
+- **Studio holds are internal.** `set("#el", { …, data: "hf-hold" })` is a position-hold the Studio injects before a keyframed position tween; it's filtered from the surface. Never author or hand-edit it.
+- **Dynamic tweens don't fully resolve.** Computed selectors or data-driven keyframes can't be statically read and surface with fewer details. If you want a tween to be editable here, author literal `keyframes: { … }` with literal numbers.
+- **GSAP only.** Lottie / Three.js / CSS / WAAPI motion doesn't surface — use the matching `hyperframes-animation` adapter.
+
+## Workflow
+
+- **This command never writes.** It reads and screenshots; every edit is yours to make in source. `--shot` to verify.
+- **Pair it.** `keyframes` for the path, `inspect` for layout/overflow across the timeline, `render` to ship. Don't skip `inspect` — a path can be right while the element clips.

--- a/skills/hyperframes-keyframes/references/multi-stroke.md
+++ b/skills/hyperframes-keyframes/references/multi-stroke.md
@@ -1,0 +1,60 @@
+# Multi-stroke traces (pen-up / pen-down)
+
+One element, drawn in **several disconnected strokes**. Use it for any shape where a single continuous line would draw a connector that shouldn't exist:
+
+- a **`?`** (hook + a separate dot below)
+- a **counter / hole** (the bar gaps in an icon, the eye of an `e`)
+- **separate letters or digits** ("hi", "2026") without a trailing line linking them
+- a **detached part** (a logo's separate leaf, a dot over an `i`/`j`)
+
+## The convention
+
+**Each stroke is its own position tween. A 0-duration `set()` between strokes is the pen-up jump.**
+
+```js
+const tl = gsap.timeline({ paused: true });
+
+// stroke 1 — the hook
+tl.to("#pen", {
+  keyframes: { "0%": { x: -100, y: -150 }, "50%": { x: 0, y: -220 }, "100%": { x: 80, y: -120 } },
+  duration: 1.5,
+});
+
+// pen up — jump to where the next stroke starts (instant, not drawn)
+tl.set("#pen", { x: 80, y: 120 });
+
+// stroke 2 — the dot
+tl.to("#pen", { keyframes: { "0%": { x: 80, y: 120 }, "100%": { x: 85, y: 140 } }, duration: 0.5 });
+
+window.__timelines = [tl];
+```
+
+The `set()` is optional but recommended — it makes the jump explicit and keeps each stroke's `0%` at its true start. Strokes are ordered by their timeline start.
+
+## How it surfaces
+
+The command **groups an element's strokes into one trace**, listing each stroke's keyframes:
+
+```
+#pen position  trace  2 strokes @0s→2s
+  stroke 1: 0% {x:-100 y:-150}  50% {x:0 y:-220}  100% {x:80 y:-120}
+  stroke 2: 0% {x:80 y:120}  100% {x:85 y:140}
+```
+
+In `--json` the strokes appear under `traces[].strokes` (and, additively, as normal entries in `tweens`). To see the shape, `--shot` draws each stroke separately and **never connects across the pen-up gap** — no false connector.
+
+## Rules & tips
+
+- **A trace appears only with ≥2 drawn strokes on one element.** A single stroke keeps the normal per-tween output.
+- **The `set()` pen-up is hidden** from the human view (it's the jump, not a drawn segment) — don't be surprised it's not its own block.
+- **Order = timeline order.** Strokes draw in the order their tweens start; lay them left-to-right / first-to-last accordingly.
+- **Each stroke is listed separately** (`stroke 1:`, `stroke 2:` …) in timeline order.
+- **Keep each stroke simple.** Holes and detached bits are separate strokes — don't try to snake one line through them.
+
+## Words and icons
+
+For multi-letter words, make each letter (or each pen-down run within a letter) a stroke, with a `set()` jump to the next letter's start. For icons with a counter (a ring around a mark), the outer ring is one stroke and the inner mark another.
+
+## Scope note — visible drawn trail
+
+This surfaces and authors multi-stroke **motion**: the element moves through the strokes and teleports across gaps. Rendering a _persistent drawn line that itself has gaps_ (a self-drawing trace) is a separate effect, not part of this command. If you need the gaps visible in the final render, drive a stroke/trail effect from the same keyframes — ask for that explicitly.

--- a/skills/hyperframes-keyframes/references/reading-the-surface.md
+++ b/skills/hyperframes-keyframes/references/reading-the-surface.md
@@ -1,0 +1,53 @@
+# Reading the keyframes surface
+
+`npx hyperframes keyframes` prints one block per tween (and one per **trace** when an element draws in multiple strokes — see `multi-stroke.md`). It's data, not a picture — to _see_ the motion, use `--shot` (the onion-skin render). Use `--json` for exact numbers or when you're an agent computing edits.
+
+## A single tween block
+
+```
+#hero position  to/keyframes  @1s→4.4s (3.4s)
+  0% {x:0 y:0}  33% {x:-180 y:-60}  67% {x:-320 y:40}  100% {x:-460 y:-20}
+```
+
+- **`#hero position`** — target selector + property group (`position` / `scale` / `rotation` / …).
+- **`to/keyframes`** — method (`to` / `from` / `fromTo` / `set`) + shape: `keyframes` (multi-stop), `flat` (2-point to/from), or `motionPath` (arc).
+- **`@1s→4.4s (3.4s)`** — absolute timeline window. Each `%` on the keyframe line is **tween-relative** (0% = tween start, 100% = tween end).
+- **keyframe line** — every stop with its properties. x/y are GSAP **offset** pixels (translate from the element's CSS home; +x right, +y down); rotation / scale / opacity / colour appear when animated.
+
+## `--json` shape (for agents / exact edits)
+
+```jsonc
+{
+  "project": "my-project",
+  "compositions": [
+    {
+      "composition": "index.html",
+      "source": "index.html",
+      "tweens": [
+        {
+          "id": "#dot-to-0-position",
+          "target": "#dot",
+          "method": "to",
+          "group": "position",
+          "start": 0, "duration": 3, "end": 3,
+          "shape": "keyframes",
+          "keyframes": [
+            { "pct": 0,   "time": 0,   "properties": { "x": 0,   "y": 0 } },
+            { "pct": 50,  "time": 1.5, "properties": { "x": 200, "y": -100 } },
+            { "pct": 100, "time": 3,   "properties": { "x": 0,   "y": 0 } }
+          ],
+          "path": [ { "x": 0, "y": 0 }, { "x": 200, "y": -100 }, { "x": 0, "y": 0 } ]
+        }
+      ],
+      "traces": [
+        // present when an element has ≥2 drawn position strokes; see multi-stroke.md
+        { "target": "#dot", "strokes": [ { "id": "...", "start": 0, "end": 1, "keyframes": [ ... ], "points": [ ... ] }, ... ] }
+      ]
+    }
+  ]
+}
+```
+
+- `tweens` always lists every tween. `traces` is **additive** — the same strokes also appear as individual entries in `tweens`.
+- `path` carries x/y forward across keyframes that set only one axis (GSAP holds the last value), so it's continuous.
+- `time` is absolute seconds = `start + pct/100 * duration`.


### PR DESCRIPTION
**Stack:** GSAP keyframe + motion-path editing — CLI surface (#1553 → #1561).

## What

Add a `hyperframes keyframes` CLI command that surfaces an element's GSAP keyframes and motion-path geometry from a composition, plus an agent skill documenting it.

## Why

Lets users and agents inspect keyframe / motion-path data (and verify mutations) without opening the Studio UI — useful for scripting and for agent workflows.

## How

- `commands/keyframes.ts`: parses the composition's GSAP timeline via the core parser and prints per-element keyframes / paths; wired into `cli.ts`.
- `skills/hyperframes-keyframes/SKILL.md`: documents the command for agents.

## Test plan

- [x] Manual CLI run against sample compositions
- [x] Documentation (skill) added
