### PR TITLE
fix(sdk,studio): restore DOM edit cutover parity

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,10 @@
       "import": "./src/beats/index.ts",
       "types": "./src/beats/index.ts"
     },
+    "./html-attr-safety": {
+      "import": "./src/utils/htmlAttrSafety.ts",
+      "types": "./src/utils/htmlAttrSafety.ts"
+    },
     "./slideshow": {
       "import": "./src/slideshow/index.ts",
       "types": "./src/slideshow/index.ts"

--- a/packages/core/src/studio-api/helpers/sourceMutation.ts
+++ b/packages/core/src/studio-api/helpers/sourceMutation.ts
@@ -1,6 +1,7 @@
 import { parseHTML } from "linkedom";
 import postcss from "postcss";
 import selectorParser from "postcss-selector-parser";
+import { isAllowedHtmlAttribute, isSafeAttributeValue } from "../../utils/htmlAttrSafety";
 
 export interface SourceMutationTarget {
   id?: string | null;
@@ -131,96 +132,6 @@ export interface PatchOperation {
   type: "inline-style" | "attribute" | "html-attribute" | "text-content";
   property: string;
   value: string | null;
-}
-
-const ALLOWED_HTML_ATTRS = new Set([
-  // Identity & structure
-  "id",
-  "class",
-  "style",
-  "title",
-  "name",
-  "for",
-  "type",
-  // Internationalization
-  "lang",
-  "dir",
-  "translate",
-  // Interaction
-  "hidden",
-  "tabindex",
-  "draggable",
-  "contenteditable",
-  // Accessibility
-  "role",
-  "slot",
-  // Links & navigation
-  "href",
-  "target",
-  "rel",
-  // Media
-  "src",
-  "srcset",
-  "sizes",
-  "alt",
-  "poster",
-  "loading",
-  "decoding",
-  "crossorigin",
-  "preload",
-  "autoplay",
-  "loop",
-  "muted",
-  "controls",
-  "playsinline",
-  // Layout
-  "width",
-  "height",
-  "colspan",
-  "rowspan",
-  "scope",
-  // Form
-  "placeholder",
-  "value",
-  "min",
-  "max",
-  "step",
-  "pattern",
-  "required",
-  "disabled",
-  "readonly",
-  "checked",
-  "selected",
-  "multiple",
-  "accept",
-  "maxlength",
-  "minlength",
-  "rows",
-  "cols",
-  "wrap",
-]);
-
-const DANGEROUS_URI_SCHEMES = /^(?:javascript|vbscript):/i;
-const DANGEROUS_DATA_URI = /^data\s*:\s*text\/html/i;
-
-function isAllowedHtmlAttribute(name: string): boolean {
-  const lower = name.toLowerCase();
-  if (lower.startsWith("on")) return false;
-  if (ALLOWED_HTML_ATTRS.has(lower)) return true;
-  if (lower.startsWith("data-")) return true;
-  if (lower.startsWith("aria-")) return true;
-  return false;
-}
-
-const URI_ATTRS = new Set(["src", "href", "action", "formaction", "poster", "srcset"]);
-
-function isSafeAttributeValue(name: string, value: string): boolean {
-  if (URI_ATTRS.has(name.toLowerCase())) {
-    const trimmed = value.trim();
-    if (DANGEROUS_URI_SCHEMES.test(trimmed)) return false;
-    if (DANGEROUS_DATA_URI.test(trimmed)) return false;
-  }
-  return true;
 }
 
 // fallow-ignore-next-line complexity

--- a/packages/core/src/utils/htmlAttrSafety.ts
+++ b/packages/core/src/utils/htmlAttrSafety.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared HTML attribute safety constants.
+ *
+ * Single source of truth for attribute allowlists and dangerous-URI patterns
+ * used by sourceMutation (core), sdkCutover (studio), and mutate (sdk).
+ */
+
+export const ALLOWED_HTML_ATTRS = new Set([
+  "id",
+  "class",
+  "style",
+  "title",
+  "name",
+  "for",
+  "type",
+  "lang",
+  "dir",
+  "translate",
+  "hidden",
+  "tabindex",
+  "draggable",
+  "contenteditable",
+  "role",
+  "slot",
+  "href",
+  "target",
+  "rel",
+  "src",
+  "srcset",
+  "sizes",
+  "alt",
+  "poster",
+  "loading",
+  "decoding",
+  "crossorigin",
+  "preload",
+  "autoplay",
+  "loop",
+  "muted",
+  "controls",
+  "playsinline",
+  "width",
+  "height",
+  "colspan",
+  "rowspan",
+  "scope",
+  "placeholder",
+  "value",
+  "min",
+  "max",
+  "step",
+  "pattern",
+  "required",
+  "disabled",
+  "readonly",
+  "checked",
+  "selected",
+  "multiple",
+  "accept",
+  "maxlength",
+  "minlength",
+  "rows",
+  "cols",
+  "wrap",
+]);
+
+export const URI_BEARING_ATTRS = new Set([
+  "src",
+  "href",
+  "action",
+  "formaction",
+  "poster",
+  "srcset",
+  "xlink:href",
+]);
+
+export const DANGEROUS_URI_SCHEMES = /^(?:javascript|vbscript):/i;
+export const DANGEROUS_DATA_URI = /^data\s*:\s*text\/html/i;
+
+export function isAllowedHtmlAttribute(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (lower.startsWith("on")) return false;
+  if (ALLOWED_HTML_ATTRS.has(lower)) return true;
+  if (lower.startsWith("data-")) return true;
+  if (lower.startsWith("aria-")) return true;
+  return false;
+}
+
+export function isSafeAttributeValue(name: string, value: string): boolean {
+  if (URI_BEARING_ATTRS.has(name.toLowerCase())) {
+    const trimmed = value.trim();
+    if (DANGEROUS_URI_SCHEMES.test(trimmed)) return false;
+    if (DANGEROUS_DATA_URI.test(trimmed)) return false;
+  }
+  return true;
+}

--- a/packages/sdk/src/document.ts
+++ b/packages/sdk/src/document.ts
@@ -11,7 +11,7 @@
 import { parseHTML } from "linkedom";
 import { ensureHfIds } from "@hyperframes/core/hf-ids";
 import { parseGsapScriptAcornForWrite } from "@hyperframes/core/gsap-parser-acorn";
-import { findRoot, getElementStyles, isNewHostBoundary } from "./engine/model.js";
+import { findRoot, getElementStyles, getOwnText, isNewHostBoundary } from "./engine/model.js";
 import type { HyperFramesElement, SdkDocument } from "./types.js";
 
 // Tags that carry no editable content and must not enter the element tree.
@@ -27,14 +27,10 @@ const EXCLUDED_TAGS = new Set([
 ]);
 
 // Snapshot text is TRIMMED for display (markup indentation produces noisy
-// whitespace text nodes). setText writes verbatim — engine getOwnText/setOwnText
-// operate on raw text. el.text is a display value, not a round-trip identity.
-function ownText(el: Element): string | null {
-  let text = "";
-  el.childNodes.forEach((n) => {
-    if (n.nodeType === 3) text += (n as Text).nodeValue ?? "";
-  });
-  const trimmed = text.trim();
+// whitespace text nodes). The raw text target is shared with setText so shadow
+// value checks and dispatch serialization use the same DOM target.
+function snapshotText(el: Element): string | null {
+  const trimmed = getOwnText(el).trim();
   return trimmed.length > 0 ? trimmed : null;
 }
 
@@ -147,7 +143,7 @@ function buildElement(
     inlineStyles,
     classNames,
     attributes,
-    text: ownText(el),
+    text: snapshotText(el),
     start,
     duration,
     trackIndex,

--- a/packages/sdk/src/engine/model.ts
+++ b/packages/sdk/src/engine/model.ts
@@ -138,14 +138,58 @@ function toKebab(prop: string): string {
 }
 
 /** Parse style attribute string → camelCase map (custom props kept as-is). */
+interface StyleDeclarationScan {
+  depth: number;
+  quote: "'" | '"' | null;
+  skip: boolean;
+}
+
+function advanceStyleDeclarationScan(scan: StyleDeclarationScan, ch: string, next: string): void {
+  if (scan.quote) {
+    if (ch === "\\" && next) {
+      scan.skip = true;
+      return;
+    }
+    if (ch === scan.quote) scan.quote = null;
+    return;
+  }
+  if (ch === "'" || ch === '"') {
+    scan.quote = ch;
+    return;
+  }
+  if (ch === "(") scan.depth++;
+  else if (ch === ")") scan.depth = Math.max(0, scan.depth - 1);
+}
+
+function splitStyleDeclarations(style: string): string[] {
+  const declarations: string[] = [];
+  const scan: StyleDeclarationScan = { depth: 0, quote: null, skip: false };
+  let start = 0;
+  for (let i = 0; i < style.length; i++) {
+    if (scan.skip) {
+      scan.skip = false;
+      continue;
+    }
+    const ch = style[i] ?? "";
+    if (ch === ";" && scan.depth === 0 && scan.quote === null) {
+      declarations.push(style.slice(start, i));
+      start = i + 1;
+    } else {
+      advanceStyleDeclarationScan(scan, ch, style[i + 1] ?? "");
+    }
+  }
+  declarations.push(style.slice(start));
+  return declarations;
+}
+
 function parseStyleAttr(styleAttr: string): Record<string, string> {
   const result: Record<string, string> = {};
-  for (const decl of styleAttr.split(";")) {
+  for (const decl of splitStyleDeclarations(styleAttr)) {
     const idx = decl.indexOf(":");
     if (idx === -1) continue;
     const rawProp = decl.slice(0, idx).trim();
     const value = decl.slice(idx + 1).trim();
-    if (!rawProp || !value) continue;
+    if (!rawProp) continue;
     result[toCamel(rawProp)] = value;
   }
   return result;
@@ -185,8 +229,21 @@ export function setElementStyles(el: Element, updates: Record<string, string | n
 
 // ─── Text helpers ─────────────────────────────────────────────────────────────
 
-/** Read only direct (non-descendant) text node content. */
+function isHTMLElementTarget(el: Element): boolean {
+  const HTMLElementCtor = el.ownerDocument.defaultView?.HTMLElement;
+  if (HTMLElementCtor) return el instanceof HTMLElementCtor;
+  return "style" in el;
+}
+
+function resolveSingleChildTextTarget(el: Element): Element | null {
+  const inner = el.children.length === 1 ? el.firstElementChild : null;
+  return inner && isHTMLElementTarget(inner) ? inner : null;
+}
+
+/** Read the text target used by SDK setText. */
 export function getOwnText(el: Element): string {
+  const singleChild = resolveSingleChildTextTarget(el);
+  if (singleChild) return singleChild.textContent ?? "";
   let text = "";
   el.childNodes.forEach((n) => {
     if (n.nodeType === 3) text += (n as Text).nodeValue ?? "";
@@ -194,8 +251,14 @@ export function getOwnText(el: Element): string {
   return text;
 }
 
-/** Replace only direct text nodes — preserves child elements. */
+/** Replace the SDK text target without destroying multi-child element structure. */
 export function setOwnText(el: Element, text: string): void {
+  const singleChild = resolveSingleChildTextTarget(el);
+  if (singleChild) {
+    singleChild.textContent = text;
+    return;
+  }
+
   const doc = el.ownerDocument;
   const children = Array.from(el.childNodes);
   // Track original position of the first text node so we restore there, not at firstChild.

--- a/packages/sdk/src/engine/mutate.test.ts
+++ b/packages/sdk/src/engine/mutate.test.ts
@@ -221,6 +221,37 @@ describe("setText", () => {
     expect(result.forward[0]?.value).toBe("Added");
   });
 
+  it("matches legacy single-child text targeting", () => {
+    const parsed = parseMutable(
+      '<button data-hf-id="hf-target"><span data-hf-id="hf-child">Old</span></button>',
+    );
+    const result = applyOp(parsed, { type: "setText", target: "hf-target", value: "New" });
+    expect(serializeDocument(parsed)).toContain(
+      '<button data-hf-id="hf-target"><span data-hf-id="hf-child">New</span></button>',
+    );
+    expect(result.inverse[0]?.value).toBe("Old");
+  });
+
+  it("preserves parent text when the legacy target is a single child", () => {
+    const parsed = parseMutable(
+      '<div data-hf-id="hf-target">Lead <span data-hf-id="hf-child">Old</span></div>',
+    );
+    applyOp(parsed, { type: "setText", target: "hf-target", value: "New" });
+    expect(serializeDocument(parsed)).toContain(
+      '<div data-hf-id="hf-target">Lead <span data-hf-id="hf-child">New</span></div>',
+    );
+  });
+
+  it("keeps non-HTML single children out of the child text shortcut", () => {
+    const parsed = parseMutable(
+      '<div data-hf-id="hf-target"><svg data-hf-id="hf-child"><text>Old</text></svg></div>',
+    );
+    applyOp(parsed, { type: "setText", target: "hf-target", value: "New" });
+    const html = serializeDocument(parsed);
+    expect(html).toContain('<svg data-hf-id="hf-child"><text');
+    expect(html).toContain("Old</text></svg>New</div>");
+  });
+
   it("override-set key maps correctly", () => {
     expect(pathToKey("/elements/hf-title/text")).toBe("hf-title.text");
   });
@@ -694,6 +725,21 @@ describe("setElementStyles key normalization", () => {
     const el = elWith("");
     setElementStyles(el, { "transform-origin": "top left" });
     expect(getElementStyles(el).transformOrigin).toBe("top left");
+  });
+
+  it("preserves semicolon-bearing CSS values when updating another property", () => {
+    const el = elWith("background: url(data:image/svg+xml;utf8,<svg></svg>); color: red");
+    setElementStyles(el, { color: "blue" });
+    expect(el.getAttribute("style")).toContain("background: url(data:image/svg+xml;utf8");
+    expect(el.getAttribute("style")).toContain("color: blue");
+  });
+
+  it("handles escaped quotes inside CSS string values", () => {
+    const el = elWith("color: red");
+    el.setAttribute("style", 'content: "a\\";b"; color: red');
+    setElementStyles(el, { color: "blue" });
+    expect(getElementStyles(el).content).toBe('"a\\";b"');
+    expect(getElementStyles(el).color).toBe("blue");
   });
 });
 

--- a/packages/sdk/src/engine/mutate.ts
+++ b/packages/sdk/src/engine/mutate.ts
@@ -76,6 +76,11 @@ import {
 } from "@hyperframes/core/gsap-writer-acorn";
 import { deriveKeyframeBackfillDefaults } from "./keyframeBackfill.js";
 import { readVariableDefault, writeVariableDefault } from "./variableModel.js";
+import {
+  URI_BEARING_ATTRS,
+  DANGEROUS_URI_SCHEMES,
+  DANGEROUS_DATA_URI,
+} from "@hyperframes/core/html-attr-safety";
 
 export interface MutationResult {
   forward: JsonPatchOp[];
@@ -100,18 +105,6 @@ const RESERVED_ATTRS = new Set([
   "data-hold-start",
   "data-hold-end",
   "data-hold-fill",
-]);
-
-const DANGEROUS_URI_SCHEMES = /^(?:javascript|vbscript):/i;
-const DANGEROUS_DATA_URI = /^data\s*:\s*text\/html/i;
-const URI_BEARING_ATTRS = new Set([
-  "src",
-  "href",
-  "action",
-  "formaction",
-  "poster",
-  "srcset",
-  "xlink:href",
 ]);
 
 function validateSetAttribute(name: string, value: string | null): void {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -18,7 +18,7 @@ export interface HyperFramesElement {
   readonly classNames: readonly string[];
   /** All attributes except style, class, and data-hf-* (those are model-level) */
   readonly attributes: Readonly<Record<string, string>>;
-  /** Direct text node content (not descendant text) */
+  /** Display text for the SDK setText target, not a full descendant-text snapshot. */
   readonly text: string | null;
   // Timing — null when element has no data-start
   readonly start: number | null;

--- a/packages/studio/src/utils/htmlAttrSafety.ts
+++ b/packages/studio/src/utils/htmlAttrSafety.ts
@@ -1,0 +1,90 @@
+// keep-in-sync-with: packages/core/src/utils/htmlAttrSafety.ts
+const ALLOWED_HTML_ATTRS = new Set([
+  "id",
+  "class",
+  "style",
+  "title",
+  "name",
+  "for",
+  "type",
+  "lang",
+  "dir",
+  "translate",
+  "hidden",
+  "tabindex",
+  "draggable",
+  "contenteditable",
+  "role",
+  "slot",
+  "href",
+  "target",
+  "rel",
+  "src",
+  "srcset",
+  "sizes",
+  "alt",
+  "poster",
+  "loading",
+  "decoding",
+  "crossorigin",
+  "preload",
+  "autoplay",
+  "loop",
+  "muted",
+  "controls",
+  "playsinline",
+  "width",
+  "height",
+  "colspan",
+  "rowspan",
+  "scope",
+  "placeholder",
+  "value",
+  "min",
+  "max",
+  "step",
+  "pattern",
+  "required",
+  "disabled",
+  "readonly",
+  "checked",
+  "selected",
+  "multiple",
+  "accept",
+  "maxlength",
+  "minlength",
+  "rows",
+  "cols",
+  "wrap",
+]);
+
+const URI_BEARING_ATTRS = new Set([
+  "src",
+  "href",
+  "action",
+  "formaction",
+  "poster",
+  "srcset",
+  "xlink:href",
+]);
+
+const DANGEROUS_URI_SCHEMES = /^(?:javascript|vbscript):/i;
+const DANGEROUS_DATA_URI = /^data\s*:\s*text\/html/i;
+
+export function isAllowedHtmlAttribute(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (lower.startsWith("on")) return false;
+  if (ALLOWED_HTML_ATTRS.has(lower)) return true;
+  if (lower.startsWith("data-")) return true;
+  if (lower.startsWith("aria-")) return true;
+  return false;
+}
+
+export function isSafeAttributeValue(name: string, value: string): boolean {
+  if (URI_BEARING_ATTRS.has(name.toLowerCase())) {
+    const trimmed = value.trim();
+    if (DANGEROUS_URI_SCHEMES.test(trimmed)) return false;
+    if (DANGEROUS_DATA_URI.test(trimmed)) return false;
+  }
+  return true;
+}

--- a/packages/studio/src/utils/sdkCutover.test.ts
+++ b/packages/studio/src/utils/sdkCutover.test.ts
@@ -98,6 +98,36 @@ describe("shouldUseSdkCutover", () => {
     expect(shouldUseSdkCutover(true, true, "hf-abc", [htmlAttrOp("DATA-START", "1")])).toBe(false);
   });
 
+  it("declines html-attribute ops with event handler names", () => {
+    expect(shouldUseSdkCutover(true, true, "hf-abc", [htmlAttrOp("onclick", "alert(1)")])).toBe(
+      false,
+    );
+    expect(shouldUseSdkCutover(true, true, "hf-abc", [htmlAttrOp("onload", "fetch()")])).toBe(
+      false,
+    );
+  });
+
+  it("declines html-attribute ops with disallowed attribute names", () => {
+    expect(shouldUseSdkCutover(true, true, "hf-abc", [htmlAttrOp("formaction", "/x")])).toBe(false);
+  });
+
+  it("declines html-attribute ops with dangerous URI schemes", () => {
+    expect(
+      shouldUseSdkCutover(true, true, "hf-abc", [htmlAttrOp("href", "javascript:alert(1)")]),
+    ).toBe(false);
+    expect(shouldUseSdkCutover(true, true, "hf-abc", [htmlAttrOp("src", "vbscript:run")])).toBe(
+      false,
+    );
+  });
+
+  it("declines html-attribute ops with dangerous data URIs", () => {
+    expect(
+      shouldUseSdkCutover(true, true, "hf-abc", [
+        htmlAttrOp("href", "data:text/html,<script>alert(1)</script>"),
+      ]),
+    ).toBe(false);
+  });
+
   it("returns true when ops mix all supported types", () => {
     expect(
       shouldUseSdkCutover(true, true, "hf-abc", [
@@ -203,6 +233,27 @@ describe("sdkCutoverPersist", () => {
       target: "hf-abc",
       value: "Hello world",
     });
+  });
+
+  it.each([
+    { name: "multi-child targets", children: [{ id: "a" }, { id: "b" }] },
+    { name: "single non-html children", children: [{ id: "a", tag: "svg" }] },
+  ])("declines text-content cutover for $name", async ({ children }) => {
+    const deps = makeDeps();
+    const session = makeSession(true);
+    (session!.getElement as ReturnType<typeof vi.fn>).mockReturnValue({ children });
+    const sel = { hfId: "hf-abc" } as never;
+    const result = await sdkCutoverPersist(
+      sel,
+      [textOp("Hello world")],
+      "before",
+      "/comp.html",
+      session,
+      deps,
+    );
+    expect(result).toBe(false);
+    expect(session!.dispatch).not.toHaveBeenCalled();
+    expect(deps.writeProjectFile).not.toHaveBeenCalled();
   });
 
   it("dispatches setAttribute for attribute op with data- prefix", async () => {

--- a/packages/studio/src/utils/sdkCutover.ts
+++ b/packages/studio/src/utils/sdkCutover.ts
@@ -8,6 +8,7 @@ import { trackStudioEvent } from "./studioTelemetry";
 import { markSelfWrite } from "../hooks/sdkSelfWriteRegistry";
 import { patchOpsToSdkEditOps } from "./sdkOpMapping";
 import { recordResolverParity, recordAnimationResolverParity } from "./sdkResolverShadow";
+import { isAllowedHtmlAttribute, isSafeAttributeValue } from "./htmlAttrSafety";
 
 const CUTOVER_OP_TYPES = new Set<PatchOperation["type"]>([
   "inline-style",
@@ -52,6 +53,54 @@ function mapsToReservedAttr(op: PatchOperation): boolean {
   return name !== null && RESERVED_CUTOVER_ATTRS.has(name.toLowerCase());
 }
 
+// ─── html-attribute safety ───────────────────────────────────────────────────
+
+function hasUnsafeHtmlAttributeOp(ops: PatchOperation[]): boolean {
+  return ops.some(
+    (op) =>
+      op.type === "html-attribute" &&
+      (!isAllowedHtmlAttribute(op.property) ||
+        (op.value !== null && !isSafeAttributeValue(op.property, op.value))),
+  );
+}
+
+function hasTextContentOp(ops: PatchOperation[]): boolean {
+  return ops.some((op) => op.type === "text-content");
+}
+
+function targetChildren(target: unknown): unknown[] | null {
+  if (!target || typeof target !== "object" || !("children" in target)) return null;
+  const children = (target as { children?: unknown }).children;
+  return Array.isArray(children) ? children : null;
+}
+
+function elementTag(element: unknown): string | null {
+  if (!element || typeof element !== "object" || !("tag" in element)) return null;
+  const tag = (element as { tag?: unknown }).tag;
+  return typeof tag === "string" ? tag.toLowerCase() : null;
+}
+
+// Tags that are non-HTML namespace elements in a linkedom-parsed HTML body.
+// Mirrors the engine's `isHTMLElementTarget` (model.ts) which uses `instanceof
+// HTMLElement` — that runtime check catches the same set, but we can't use it
+// here because `target` is a plain SDK object, not a DOM Element. If linkedom
+// (or a future parser) surfaces additional foreign-content elements as
+// non-HTMLElement, add them here.
+const NON_HTML_CHILD_TAGS = new Set(["svg", "math"]);
+
+function shouldDeclineTextCutoverForTarget(target: unknown, ops: PatchOperation[]): boolean {
+  if (!hasTextContentOp(ops)) return false;
+  const children = targetChildren(target);
+  if (!children) return false;
+  // Legacy patch-element replaces the whole element for multi-child targets and
+  // for single non-HTML children. The SDK text patch stream stores a scalar
+  // inverse, so those shapes cannot be made both byte-identical and undo-safe
+  // here. Let the server path remain authoritative for them.
+  if (children.length > 1) return true;
+  const tag = elementTag(children[0]);
+  return tag !== null && NON_HTML_CHILD_TAGS.has(tag);
+}
+
 export function shouldUseSdkCutover(
   flagEnabled: boolean,
   hasSession: boolean,
@@ -64,7 +113,8 @@ export function shouldUseSdkCutover(
     !!hfId &&
     ops.length > 0 &&
     ops.every((o) => CUTOVER_OP_TYPES.has(o.type)) &&
-    !ops.some(mapsToReservedAttr)
+    !ops.some(mapsToReservedAttr) &&
+    !hasUnsafeHtmlAttributeOp(ops)
   );
 }
 
@@ -186,7 +236,9 @@ export async function sdkCutoverPersist(
   if (!sdkSession) return false;
   const hfId = selection.hfId;
   if (!hfId) return false;
-  if (!sdkSession.getElement(hfId)) return false;
+  const target = sdkSession.getElement(hfId);
+  if (!target) return false;
+  if (shouldDeclineTextCutoverForTarget(target, ops)) return false;
   if (wrongCompositionFile(deps, targetPath)) return false;
   try {
     const before = sdkSession.serialize();

--- a/packages/studio/src/utils/sdkCutoverParity.test.ts
+++ b/packages/studio/src/utils/sdkCutoverParity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { openComposition } from "@hyperframes/sdk";
+import { patchElementInHtml } from "../../../core/src/studio-api/helpers/sourceMutation.js";
+import type { PatchOperation } from "./sourcePatcher";
+import { patchOpsToSdkEditOps } from "./sdkOpMapping";
+
+const shell = (body: string) => `<!DOCTYPE html>
+<html><head></head><body>${body}</body></html>`;
+
+async function applySdkDomCutover(source: string, ops: PatchOperation[]): Promise<string> {
+  const session = await openComposition(source, { history: false });
+  session.batch(() => {
+    for (const op of patchOpsToSdkEditOps("hf-target", ops)) {
+      session.dispatch(op);
+    }
+  });
+  return session.serialize();
+}
+
+const cases: Array<{ name: string; source: string; ops: PatchOperation[] }> = [
+  {
+    name: "coalesces multi-property inline style including transform and custom props",
+    source: shell(
+      '<div data-hf-id="hf-target" style="opacity: 0.5; inset: 0; transform-origin: 0 0">Old<span data-hf-id="hf-child">Child</span></div>',
+    ),
+    ops: [
+      { type: "inline-style", property: "transform", value: "translateX(10px)" },
+      { type: "inline-style", property: "transform-origin", value: "50% 50%" },
+      { type: "inline-style", property: "--x", value: "12px" },
+    ],
+  },
+  {
+    name: "removes one inline style from a multi-property declaration",
+    source: shell(
+      '<div data-hf-id="hf-target" style="opacity: 0.5; inset: 0; transform-origin: 0 0">Old</div>',
+    ),
+    ops: [{ type: "inline-style", property: "opacity", value: null }],
+  },
+  {
+    name: "preserves semicolon-bearing CSS values when updating another style",
+    source: shell(
+      '<div data-hf-id="hf-target" style="background: url(data:image/svg+xml;utf8,<svg></svg>); color: red; opacity: 0.5">Old</div>',
+    ),
+    ops: [{ type: "inline-style", property: "color", value: "blue" }],
+  },
+  {
+    name: "sets direct text content",
+    source: shell('<div data-hf-id="hf-target">Old</div>'),
+    ops: [{ type: "text-content", property: "text", value: "New" }],
+  },
+  {
+    name: "sets text on the single child target used by the legacy path",
+    source: shell('<button data-hf-id="hf-target"><span data-hf-id="hf-child">Old</span></button>'),
+    ops: [{ type: "text-content", property: "text", value: "New" }],
+  },
+  {
+    name: "sets text on the single child target while preserving parent text",
+    source: shell('<div data-hf-id="hf-target">Lead <span data-hf-id="hf-child">Old</span></div>'),
+    ops: [{ type: "text-content", property: "text", value: "New" }],
+  },
+  {
+    name: "sets data attributes through attribute ops",
+    source: shell('<div data-hf-id="hf-target" data-old="1">Old</div>'),
+    ops: [{ type: "attribute", property: "mode", value: "hero" }],
+  },
+  {
+    name: "removes data attributes through attribute ops",
+    source: shell('<div data-hf-id="hf-target" data-mode="hero">Old</div>'),
+    ops: [{ type: "attribute", property: "mode", value: null }],
+  },
+  {
+    name: "sets allowed html attributes",
+    source: shell('<a data-hf-id="hf-target" href="https://example.com">Old</a>'),
+    ops: [{ type: "html-attribute", property: "aria-label", value: "Primary link" }],
+  },
+  {
+    name: "sets shorthand over existing longhands (inset over top/right/bottom/left)",
+    source: shell(
+      '<div data-hf-id="hf-target" style="top: 10px; right: 10px; bottom: 10px; left: 10px; opacity: 1">Old</div>',
+    ),
+    ops: [{ type: "inline-style", property: "inset", value: "0" }],
+  },
+  {
+    name: "sets longhand over existing shorthand (top over inset)",
+    source: shell('<div data-hf-id="hf-target" style="inset: 0; opacity: 1">Old</div>'),
+    ops: [{ type: "inline-style", property: "top", value: "10px" }],
+  },
+  {
+    name: "mixed-type batch: inline-style + text-content in one op list",
+    source: shell('<div data-hf-id="hf-target" style="color: red">Old</div>'),
+    ops: [
+      { type: "inline-style", property: "color", value: "blue" },
+      { type: "text-content", property: "text", value: "New" },
+    ],
+  },
+  {
+    name: "mixed-type batch: inline-style + attribute in one op list",
+    source: shell('<div data-hf-id="hf-target" style="opacity: 0.5" data-mode="default">Old</div>'),
+    ops: [
+      { type: "inline-style", property: "opacity", value: "1" },
+      { type: "attribute", property: "mode", value: "hero" },
+    ],
+  },
+];
+
+describe("SDK cutover DOM serialization parity", () => {
+  it.each(cases)("$name", async ({ source, ops }) => {
+    const legacy = patchElementInHtml(source, { hfId: "hf-target" }, ops);
+    expect(legacy.matched).toBe(true);
+
+    await expect(applySdkDomCutover(source, ops)).resolves.toBe(legacy.html);
+  });
+});


### PR DESCRIPTION
## Problem

Studio DOM-edit cutover could route `setStyle`, `setText`, and `setAttribute` through the SDK without byte-level proof that the serialized HTML matched the legacy `patch-element` server path. That left the cutover exposed to subtle drift in `style=""` bytes, especially data URLs with semicolons, style removal/coalescing, and nested text targets.

Fixes heygen-com/hyperframes#1550.

## What this fixes

- Adds a DOM-edit parity corpus that applies the same `PatchOperation[]` through `patchElementInHtml` and the SDK cutover mapping, then asserts exact serialized HTML equality.
- Makes SDK inline-style parsing quote/paren-aware so values like `url(data:image/svg+xml;utf8,...)` survive when a different style property changes.
- Aligns safe SDK text targeting with the legacy single-HTML-child behavior and makes resolver-shadow text snapshots read the same target the SDK mutates.
- Declines SDK cutover for text shapes that cannot be both byte-identical and undo-safe with the current scalar text patch model, keeping the legacy server path authoritative for multi-child and non-HTML single-child targets.

## Root cause

The SDK style parser split inline styles on every semicolon, so semicolons inside parenthesized CSS values were treated as declaration boundaries. The Studio cutover tests also proved dispatch shape, not final HTML bytes, so this drift was not caught. Text had a second mismatch: the legacy path redirects safe single-child text edits to the child element, while SDK snapshot/mutation helpers previously did not share that exact target model.

## Verification

### Local

- `bun run --filter @hyperframes/sdk test src/engine/mutate.test.ts`
- `bun run --filter @hyperframes/studio test src/utils/sdkCutoverParity.test.ts src/utils/sdkCutover.test.ts src/utils/sdkResolverShadow.test.ts`
- `bun run --filter @hyperframes/sdk typecheck`
- `bun run --filter @hyperframes/studio typecheck`
- `bunx oxfmt --check packages/sdk/src/document.ts packages/sdk/src/engine/model.ts packages/sdk/src/engine/mutate.test.ts packages/sdk/src/types.ts packages/studio/src/utils/sdkCutover.ts packages/studio/src/utils/sdkCutover.test.ts packages/studio/src/utils/sdkCutoverParity.test.ts`
- `bunx oxlint packages/sdk/src/document.ts packages/sdk/src/engine/model.ts packages/sdk/src/engine/mutate.test.ts packages/sdk/src/types.ts packages/studio/src/utils/sdkCutover.ts packages/studio/src/utils/sdkCutover.test.ts packages/studio/src/utils/sdkCutoverParity.test.ts`
- Lefthook pre-commit passed, including Fallow. Fallow still reports inherited duplication in `sdkCutover.test.ts`, but the gate excludes those inherited findings and reports no new issues in the changed files.

### Browser

- Built runtime inline assets with `bun run --filter @hyperframes/core build:hyperframes-runtime` before opening Studio.
- Started Studio at `http://127.0.0.1:5190/#/sdk-parity-proof` and used `agent-browser` to open the proof project, select the styled target, and inspect the Fill panel.
- Confirmed the Inspector preserved `data:image/svg+xml;utf8,%3Csvg%3E%3C/svg%3E` in the selected element's External URL field.
- Ran a browser-context SDK-vs-legacy parity assertion through Vite modules; it returned `matched: true`, `equal: true`, and `backgroundPreserved: true` while changing `color` from `red` to `blue`.
- No page errors were reported. The only console warnings during the parity assertion were Vite externalization warnings from deliberately importing the Node-oriented legacy mutation helper in the browser context.
- Local evidence artifacts: `tmp/sdk-parity-proof/browser-proof-final.png` and `tmp/sdk-parity-proof/dom-edit-parity-final.webm`.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is SDK/Studio serialization logic with no server-side runtime, migration, feature flag, or background job impact. Healthy signal is the new parity corpus and focused cutover tests staying green in CI. Failure signal is any regression in `sdkCutoverParity.test.ts`, `sdkCutover.test.ts`, or SDK mutation tests; rollback is reverting this PR to restore the previous server-fallback behavior.

## Notes

- This does not add a new public SDK API.
- The legacy `patchElementInHtml` path remains the byte oracle for DOM-edit cutover parity.
- The SDK still preserves undo-safe scalar text behavior outside the safe legacy-parity text shapes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
