### PR TITLE
fix(core): escape author-controlled values in bundler attribute selectors

### DIFF
--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -125,6 +125,35 @@ describe("bundleToSingleHtml", () => {
     expect(bundled).not.toContain("SECRET_MARKER_LEAKED");
   });
 
+  it("bundles a sub-composition external script whose src contains a double quote", async () => {
+    // The external-script dedup interpolated src into a `script[src="..."]`
+    // selector unescaped, so a `"` in the URL (a quoted query param) built a
+    // malformed selector that threw in css-select and aborted the whole bundle.
+    // The sibling link[href] path already escapes; align the script path.
+    const quotedSrc = `https://cdn.example.com/lib.js?cb="x`;
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="scene-host"
+      data-composition-id="scene"
+      data-composition-src="compositions/scene.html"
+      data-start="0" data-duration="5"></div>
+  </div>
+  <script>window.__timelines={};</script>
+</body></html>`,
+      "compositions/scene.html": `<template id="scene-template">
+  <div data-composition-id="scene" data-width="1920" data-height="1080">
+    <script src='${quotedSrc}'></script>
+  </div>
+</template>`,
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+    // Does not throw, and the external script survives into the bundle.
+    expect(bundled).toContain(`cb=`);
+  });
+
   it("produces a self-contained runtime script when no HYPERFRAME_RUNTIME_URL is set", async () => {
     // Regression guard: hf#XXX. The bundler used to emit
     // <script ... src=""></script> when no runtime URL was configured. An

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -624,7 +624,7 @@ export interface BundleOptions {
  */
 
 function ensureExternalScriptTag(doc: Document, src: string): void {
-  if (doc.querySelector(`script[src="${src}"]`)) return;
+  if (doc.querySelector(`script${cssAttributeSelector("src", src)}`)) return;
   const el = doc.createElement("script");
   el.setAttribute("src", src);
   doc.body.appendChild(el);
@@ -825,7 +825,7 @@ export async function bundleToSingleHtml(
         continue;
       }
     }
-    if (!document.querySelector(`script[src="${extSrc}"]`)) {
+    if (!document.querySelector(`script${cssAttributeSelector("src", extSrc)}`)) {
       const extScript = document.createElement("script");
       extScript.setAttribute("src", extSrc);
       document.body.appendChild(extScript);
@@ -857,7 +857,7 @@ export async function bundleToSingleHtml(
       const hostIdentity = hostIdentityByElement.get(host);
       const runtimeCompId = hostIdentity?.runtimeCompositionId || compId;
       const innerDoc = parseHTMLContent(templateHtml);
-      const innerRoot = innerDoc.querySelector(`[data-composition-id="${compId}"]`);
+      const innerRoot = innerDoc.querySelector(cssAttributeSelector("data-composition-id", compId));
       const authoredRootId = innerRoot?.getAttribute("id")?.trim() || null;
       const runtimeScope = runtimeCompId
         ? cssAttributeSelector("data-composition-id", runtimeCompId)


### PR DESCRIPTION
## Problem

`bundleToSingleHtml` interpolated raw attribute values into `querySelector` attribute selectors at three sites: the external-script dedup (`htmlBundler.ts:627`, `:828`) and the sub-composition root lookup (`:860`). A value containing a `"` (a quoted query param in a `<script src>`, or a `data-composition-id`) produced a malformed selector that throws `Attribute selector didn't terminate` in css-select, aborting the whole bundle. Since `render`, `validate`, `snapshot`, and `layout` all call `bundleToSingleHtml`, one such sub-composition crashes every one of them with an opaque error.

The sibling `link[href]` dedup (`:927`) already escapes via `.replace(/\\/g, "\\\\").replace(/"/g, '\\"')`, and the `cssAttributeSelector` helper (`:279`) does exactly that and is already used for `data-composition-id` at `:799` and `:863`. The three crashing sites just did not use it.

## Change

Route all three through `cssAttributeSelector`. No behavior change for values without `"` or `\` (the escape is a no-op there).

## Tests

A bundler test for a sub-composition whose external `<script src>` contains a `"`: it now bundles instead of throwing. Verified load-bearing (reverting the fix reproduces `Attribute selector didn't terminate`). Full core suite green (1912 tests).
