### PR TITLE
feat(sdk): ws-c elastic timing + word-alignment resolver (WS-C)

### DIFF
--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -1,3 +1,15 @@
+// Timing resolver — shared pure resolver for word-anchored elastic timing (WS-C).
+// Consumed by both preview (sdk) and render (timingCompiler) paths.
+export {
+  resolveTimings,
+  type WordTiming,
+  type ElementAnchor,
+  type AuthoredTiming,
+  type ResolvedTiming,
+  type ResolveTimingsInput,
+  type ResolveTimingsResult,
+} from "./timingResolver";
+
 // Timing compiler (browser-safe)
 export {
   compileTimingAttrs,

--- a/packages/core/src/compiler/timingResolver.test.ts
+++ b/packages/core/src/compiler/timingResolver.test.ts
@@ -1,0 +1,214 @@
+/**
+ * WS-C — timingResolver tests.
+ *
+ * The resolver is pure (no DOM, no Date.now, no Math.random) so it can be
+ * unit-tested directly. These tests also serve as the preview==render parity
+ * fixture: the resolver produces the exact same output regardless of whether
+ * it is called from the preview path (session layer) or the render path
+ * (timingCompiler). A golden parity test at the end confirms both paths
+ * produce identical enter/exit from the same resolver call.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveTimings,
+  type AuthoredTiming,
+  type WordTiming,
+  type ElementAnchor,
+} from "./timingResolver.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function authored(hfId: string, start: number, duration: number): AuthoredTiming {
+  return { hfId, start, duration };
+}
+
+function word(index: number, start: number, end: number): WordTiming {
+  return { index, start, end };
+}
+
+function anchor(
+  hfId: string,
+  wordIndex: number,
+  enterDuration: number,
+  exitDuration: number,
+  slotEnd: number,
+  enterOffset?: number,
+): ElementAnchor {
+  return { hfId, wordIndex, enterDuration, exitDuration, slotEnd, enterOffset };
+}
+
+// ─── Un-anchored elements keep authored timing ────────────────────────────────
+
+describe("resolveTimings — un-anchored elements", () => {
+  it("returns authored start/duration unchanged when no anchors supplied", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-a", 1, 2), authored("hf-b", 3, 1.5)],
+      wordTimings: [],
+      anchors: [],
+    });
+    expect(result["hf-a"]).toEqual({ enterAt: 1, exitAt: 3, holdDuration: 0 });
+    expect(result["hf-b"]).toEqual({ enterAt: 3, exitAt: 4.5, holdDuration: 0 });
+  });
+
+  it("align-on-adjust: anchored and un-anchored elements in same call", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-anchored", 0, 3), authored("hf-free", 4, 2)],
+      wordTimings: [word(0, 1.0, 1.5)],
+      anchors: [anchor("hf-anchored", 0, 0.5, 0.5, 3.0)],
+    });
+
+    // Anchored: enters at word 0 start (1.0), enterDuration=0.5, exitDuration=0.5
+    // slot=3.0 → holdDuration = max(0, 3.0 - (1.0 + 0.5 + 0.5)) = 1.0
+    // exitAt = 1.0 + 0.5 + 1.0 + 0.5 = 3.0
+    expect(result["hf-anchored"]).toEqual({ enterAt: 1.0, exitAt: 3.0, holdDuration: 1.0 });
+
+    // Un-anchored: keeps authored timing
+    expect(result["hf-free"]).toEqual({ enterAt: 4, exitAt: 6, holdDuration: 0 });
+  });
+});
+
+// ─── Word-anchored elements ───────────────────────────────────────────────────
+
+describe("resolveTimings — word-anchored elements", () => {
+  it("anchors element enterAt to word start", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-x", 0, 2)],
+      wordTimings: [word(0, 0.5, 1.0), word(1, 1.5, 2.0)],
+      anchors: [anchor("hf-x", 1, 0.3, 0.2, 2.5)],
+    });
+    // enterAt = wordTimings[1].start = 1.5; enterDuration=0.3, exitDuration=0.2
+    // holdDuration = max(0, 2.5 - (1.5 + 0.3 + 0.2)) = max(0, 0.5) = 0.5
+    // exitAt = 1.5 + 0.3 + 0.5 + 0.2 = 2.5
+    expect(result["hf-x"]).toEqual({ enterAt: 1.5, exitAt: 2.5, holdDuration: 0.5 });
+  });
+
+  it("enterOffset shifts enterAt relative to word start", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-y", 0, 1)],
+      wordTimings: [word(0, 2.0, 2.5)],
+      anchors: [anchor("hf-y", 0, 0.2, 0.1, 4.0, 0.3)],
+    });
+    // enterAt = 2.0 + 0.3 = 2.3
+    // holdDuration = max(0, 4.0 - (2.3 + 0.2 + 0.1)) = 1.4
+    // exitAt = 2.3 + 0.2 + 1.4 + 0.1 = 4.0
+    expect(result["hf-y"]?.enterAt).toBeCloseTo(2.3);
+    expect(result["hf-y"]?.exitAt).toBeCloseTo(4.0);
+    expect(result["hf-y"]?.holdDuration).toBeCloseTo(1.4);
+  });
+});
+
+// ─── Elastic hold math ────────────────────────────────────────────────────────
+
+describe("resolveTimings — elastic hold math", () => {
+  it("holdDuration = max(0, slotEnd - (enterAt + enterDuration + exitDuration))", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-z", 0, 1)],
+      wordTimings: [word(0, 0.0, 0.5)],
+      anchors: [anchor("hf-z", 0, 0.5, 0.5, 3.0)],
+    });
+    // enterAt=0, holdDuration = max(0, 3.0 - (0 + 0.5 + 0.5)) = 2.0
+    expect(result["hf-z"]).toEqual({ enterAt: 0, exitAt: 3.0, holdDuration: 2.0 });
+  });
+
+  it("clamps holdDuration >= 0 when slot is too tight", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-tight", 0, 2)],
+      wordTimings: [word(0, 5.0, 5.5)],
+      // enter=1.0, exit=1.0, slotEnd=5.5 → slot=5.5-(5.0+1.0+1.0)=-1.5 → clamp to 0
+      anchors: [anchor("hf-tight", 0, 1.0, 1.0, 5.5)],
+    });
+    expect(result["hf-tight"]?.holdDuration).toBe(0);
+    // exitAt = 5.0 + 1.0 + 0 + 1.0 = 7.0 (element exits after its natural duration)
+    expect(result["hf-tight"]?.exitAt).toBe(7.0);
+  });
+
+  it("holdDuration is zero (not negative) when exactly at slot boundary", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-exact", 0, 1)],
+      wordTimings: [word(0, 1.0, 1.5)],
+      // enterAt=1.0, slotEnd=1.0+0.3+0.2=1.5 → holdDuration=0
+      anchors: [anchor("hf-exact", 0, 0.3, 0.2, 1.5)],
+    });
+    expect(result["hf-exact"]?.holdDuration).toBe(0);
+    expect(result["hf-exact"]?.exitAt).toBeCloseTo(1.5);
+  });
+});
+
+// ─── Missing word index falls back gracefully ────────────────────────────────
+
+describe("resolveTimings — missing word index", () => {
+  it("falls back to wordStart=0 when word index is not in wordTimings", () => {
+    const result = resolveTimings({
+      elements: [authored("hf-missing", 5, 2)],
+      wordTimings: [word(0, 1.0, 1.5)],
+      // wordIndex 99 doesn't exist → wordStart defaults to 0
+      anchors: [anchor("hf-missing", 99, 0.5, 0.5, 2.0)],
+    });
+    // enterAt = 0 + 0 = 0
+    // holdDuration = max(0, 2.0 - (0 + 0.5 + 0.5)) = 1.0
+    expect(result["hf-missing"]?.enterAt).toBe(0);
+    expect(result["hf-missing"]?.holdDuration).toBe(1.0);
+  });
+});
+
+// ─── Determinism ─────────────────────────────────────────────────────────────
+
+describe("resolveTimings — determinism", () => {
+  it("produces identical output for identical input (no hidden state)", () => {
+    const input = {
+      elements: [authored("hf-det", 0, 2), authored("hf-free2", 3, 1)],
+      wordTimings: [word(0, 0.5, 1.0)],
+      anchors: [anchor("hf-det", 0, 0.3, 0.2, 2.0)],
+    };
+    const r1 = resolveTimings(input);
+    const r2 = resolveTimings(input);
+    expect(r1).toEqual(r2);
+  });
+});
+
+// ─── Preview == render parity golden test ────────────────────────────────────
+//
+// This test mirrors the contract of time_control.py in the backend render path.
+// Both the preview path (SDK session) and the render path (timingCompiler
+// consumer) call resolveTimings() with the same input and MUST produce the
+// same output. Since there is exactly one implementation, calling it twice with
+// the same args is the parity test: they cannot diverge.
+//
+// NOTE: happy-dom cannot do GSAP layout/seek operations so the GSAP-seek path
+// (smart-seek) is exercised by timingCompiler.test.ts (Node.js) separately.
+// The purity of resolveTimings() means this test fully covers resolver logic.
+
+describe("preview == render parity golden test", () => {
+  it("resolver output is identical for preview and render call sites (shared single impl)", () => {
+    // Golden fixture: 3 elements, 2 words, 1 anchored, 2 free.
+    const elements: AuthoredTiming[] = [
+      authored("hf-title", 0, 2.0), // anchored
+      authored("hf-sub", 3.0, 1.5), // free
+      authored("hf-cta", 5.0, 1.0), // free
+    ];
+    const wordTimings: WordTiming[] = [word(0, 0.0, 0.5), word(1, 1.0, 1.8)];
+    const anchors: ElementAnchor[] = [
+      anchor("hf-title", 1, 0.4, 0.3, 3.5), // anchored to word 1
+    ];
+
+    // Simulate preview call (same input as would arrive from session layer)
+    const previewResult = resolveTimings({ elements, wordTimings, anchors });
+
+    // Simulate render call (same input as would arrive from timingCompiler)
+    const renderResult = resolveTimings({ elements, wordTimings, anchors });
+
+    // They must be identical — this is the "preview == render" guarantee.
+    expect(previewResult).toEqual(renderResult);
+
+    // Spot-check the anchored element's resolved values:
+    // enterAt = word[1].start = 1.0 (no offset)
+    // holdDuration = max(0, 3.5 - (1.0 + 0.4 + 0.3)) = max(0, 1.8) = 1.8
+    // exitAt = 1.0 + 0.4 + 1.8 + 0.3 = 3.5
+    expect(previewResult["hf-title"]).toEqual({ enterAt: 1.0, exitAt: 3.5, holdDuration: 1.8 });
+
+    // Free elements keep authored timing
+    expect(previewResult["hf-sub"]).toEqual({ enterAt: 3.0, exitAt: 4.5, holdDuration: 0 });
+    expect(previewResult["hf-cta"]).toEqual({ enterAt: 5.0, exitAt: 6.0, holdDuration: 0 });
+  });
+});

--- a/packages/core/src/compiler/timingResolver.ts
+++ b/packages/core/src/compiler/timingResolver.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared pure timing resolver — WS-C.
+ *
+ * resolveTimings() is the SINGLE implementation of word-anchored elastic timing.
+ * It is consumed by both:
+ *   1. The preview path (session layer in @hyperframes/sdk)
+ *   2. The render path (timingCompiler.ts + htmlBundler in @hyperframes/core)
+ *
+ * "preview == render" guarantee: there is exactly one code path for anchor
+ * resolution so both environments produce identical enter/exit times.
+ *
+ * Constraints:
+ * - Deterministic + pure: no Date.now(), no Math.random(), no DOM, no I/O.
+ * - Never timescale animated content: elastic hold extends the hold window,
+ *   not tween durations.
+ * - Align-on-adjust: only explicitly anchored elements become word-locked;
+ *   un-anchored elements keep their authored start/duration unchanged.
+ * - Elastic hold: holdDuration = max(0, slot − (enter + exit)), clamped ≥ 0.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface WordTiming {
+  /** Word index (0-based) */
+  index: number;
+  /** Absolute start time of this word in seconds */
+  start: number;
+  /** Absolute end time of this word in seconds */
+  end: number;
+}
+
+export interface ElementAnchor {
+  /** Which element this anchor applies to */
+  hfId: string;
+  /**
+   * Index of the word in `wordTimings` this element is anchored to.
+   * The element's enterAt = wordTimings[wordIndex].start + enterOffset.
+   */
+  wordIndex: number;
+  /**
+   * Offset in seconds from the anchored word's start time to the element's enter.
+   * Defaults to 0.
+   */
+  enterOffset?: number;
+  /**
+   * The authored enter duration (time from element start until hold begins).
+   * Used to compute the hold slot.
+   */
+  enterDuration: number;
+  /**
+   * The authored exit duration (time from hold end until element exits).
+   * Used to compute the hold slot.
+   */
+  exitDuration: number;
+  /**
+   * The "slot" end time: the element must finish by this time.
+   * holdDuration = max(0, slotEnd - (enterAt + enterDuration + exitDuration))
+   */
+  slotEnd: number;
+}
+
+export interface AuthoredTiming {
+  hfId: string;
+  /** Authored data-start value in seconds */
+  start: number;
+  /** Authored duration in seconds (data-duration or data-end - data-start) */
+  duration: number;
+}
+
+export interface ResolvedTiming {
+  enterAt: number;
+  exitAt: number;
+  /** Computed elastic hold duration (>= 0). Non-anchored elements have holdDuration = 0. */
+  holdDuration: number;
+}
+
+export interface ResolveTimingsInput {
+  /** All authored element timings (both anchored and un-anchored). */
+  elements: AuthoredTiming[];
+  /** TTS word timings from the backend. */
+  wordTimings: WordTiming[];
+  /** The set of elements that are word-anchored. Only these get word-locked. */
+  anchors: ElementAnchor[];
+}
+
+export type ResolveTimingsResult = Record<string, ResolvedTiming>;
+
+// ── Resolver ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve element timings for a composition with optional word-anchored elements.
+ *
+ * Align-on-adjust rule: only elements with an explicit anchor in `anchors` are
+ * word-locked. All others keep their authored start/duration unchanged.
+ *
+ * Elastic hold: for anchored elements, the hold window is expanded to fill the
+ * slot without timescaling animated content. The hold duration is:
+ *   holdDuration = max(0, slotEnd - (enterAt + enterDuration + exitDuration))
+ *
+ * @param input - Elements, word timings, and anchor map.
+ * @returns A map from hfId to resolved { enterAt, exitAt, holdDuration }.
+ */
+export function resolveTimings(input: ResolveTimingsInput): ResolveTimingsResult {
+  const { elements, wordTimings, anchors } = input;
+
+  // Build anchor lookup by hfId for O(1) access.
+  const anchorMap = new Map<string, ElementAnchor>();
+  for (const anchor of anchors) {
+    anchorMap.set(anchor.hfId, anchor);
+  }
+
+  // Build word timing lookup by index for O(1) access.
+  const wordMap = new Map<number, WordTiming>();
+  for (const wt of wordTimings) {
+    wordMap.set(wt.index, wt);
+  }
+
+  const result: ResolveTimingsResult = {};
+
+  for (const el of elements) {
+    const anchor = anchorMap.get(el.hfId);
+
+    if (anchor === undefined) {
+      // Un-anchored: keep authored timing exactly as-is.
+      result[el.hfId] = {
+        enterAt: el.start,
+        exitAt: el.start + el.duration,
+        holdDuration: 0,
+      };
+      continue;
+    }
+
+    // Word-anchored: compute enter from the word timing.
+    const word = wordMap.get(anchor.wordIndex);
+    const wordStart = word !== undefined ? word.start : 0;
+    const enterOffset = anchor.enterOffset ?? 0;
+    const enterAt = wordStart + enterOffset;
+
+    // Elastic hold: expand hold to fill the slot, clamped >= 0.
+    // holdDuration = max(0, slotEnd - (enterAt + enterDuration + exitDuration))
+    const holdDuration = Math.max(
+      0,
+      anchor.slotEnd - (enterAt + anchor.enterDuration + anchor.exitDuration),
+    );
+
+    // exitAt = enterAt + enterDuration + hold + exitDuration
+    const exitAt = enterAt + anchor.enterDuration + holdDuration + anchor.exitDuration;
+
+    result[el.hfId] = { enterAt, exitAt, holdDuration };
+  }
+
+  return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,17 @@ export type {
   CompilationResult,
 } from "./compiler/timingCompiler";
 
+// Timing resolver — shared pure resolver for word-anchored elastic timing (WS-C).
+export type {
+  WordTiming,
+  ElementAnchor,
+  AuthoredTiming,
+  ResolvedTiming,
+  ResolveTimingsInput,
+  ResolveTimingsResult,
+} from "./compiler/timingResolver";
+export { resolveTimings } from "./compiler/timingResolver";
+
 export {
   compileTimingAttrs,
   injectDurations,

--- a/packages/core/src/parsers/gsapParserAcorn.ts
+++ b/packages/core/src/parsers/gsapParserAcorn.ts
@@ -1144,3 +1144,61 @@ export function parseGsapScriptAcorn(script: string): ParsedGsap {
     return { animations: [], timelineVar: "tl", preamble: "", postamble: "" };
   }
 }
+
+// ── Label extraction (WS-C) ──────────────────────────────────────────────────
+
+export interface GsapLabelEntry {
+  name: string;
+  position: number;
+}
+
+/**
+ * Extract all `tl.addLabel("name", position)` calls from a GSAP script.
+ *
+ * Returns labels in source order. Position must be a numeric literal; labels
+ * with non-numeric positions (e.g. label-relative offsets) are skipped.
+ *
+ * Pure — no side effects, no DOM, no Date.now.
+ */
+export function extractGsapLabels(script: string): GsapLabelEntry[] {
+  try {
+    const ast = acorn.parse(script, {
+      ecmaVersion: "latest",
+      sourceType: "script",
+      locations: true,
+    });
+    const scope = collectScopeBindings(ast);
+    const detection = findTimelineVar(ast, scope);
+    const timelineVar = detection.timelineVar ?? "tl";
+
+    const labels: GsapLabelEntry[] = [];
+
+    acornWalk.simple(ast, {
+      // fallow-ignore-next-line complexity
+      ExpressionStatement(node: any) {
+        const expr = node.expression;
+        if (!expr || expr.type !== "CallExpression") return;
+        const callee = expr.callee;
+        // Match tl.addLabel(...)
+        if (
+          callee?.type !== "MemberExpression" ||
+          callee.object?.name !== timelineVar ||
+          callee.property?.name !== "addLabel"
+        )
+          return;
+        const args = expr.arguments ?? [];
+        const nameNode = args[0];
+        const posNode = args[1];
+        if (nameNode?.type !== "Literal" || typeof nameNode.value !== "string") return;
+        if (!posNode) return;
+        const pos = resolveNode(posNode, scope);
+        if (typeof pos !== "number" || !Number.isFinite(pos)) return;
+        labels.push({ name: nameNode.value, position: pos });
+      },
+    });
+
+    return labels;
+  } catch {
+    return [];
+  }
+}

--- a/packages/sdk/src/engine/apply-patches.ts
+++ b/packages/sdk/src/engine/apply-patches.ts
@@ -183,6 +183,10 @@ function applyOne(parsed: ParsedDocument, patch: JsonPatchOp, p: ParsedPath): vo
       if (p.field === "start") {
         if (patch.op === "remove") el.removeAttribute("data-start");
         else el.setAttribute("data-start", String(patch.value));
+      } else if (p.field === "duration") {
+        // Patch value is the data-duration value — set directly.
+        if (patch.op === "remove") el.removeAttribute("data-duration");
+        else el.setAttribute("data-duration", String(patch.value));
       } else if (p.field === "end") {
         // Patch value is the absolute data-end time — set directly, no re-derivation.
         if (patch.op === "remove") el.removeAttribute("data-end");

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,6 +12,7 @@ export type {
   PatchEvent,
   PersistErrorEvent,
   ElementSnapshot,
+  ElementTimingSnapshot,
   FindQuery,
   SelectionProxy,
   ElementHandle,

--- a/packages/sdk/src/session.timings.test.ts
+++ b/packages/sdk/src/session.timings.test.ts
@@ -1,0 +1,237 @@
+/**
+ * WS-C — getElementTimings / setElementTiming / setHold tests.
+ *
+ * Tests the session-layer wiring for the new typed methods.
+ * happy-dom can't do GSAP seek/layout so we test DOM attribute reads and
+ * dispatch behavior directly.
+ */
+
+import { describe, it, expect } from "vitest";
+import { openComposition } from "./session.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Duration-authored clip (data-duration preferred by handleSetTiming). */
+const DURATION_AUTHORED_HTML = `
+<div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px" data-duration="10">
+  <h1 data-hf-id="hf-title" data-start="0" data-duration="3">Hello</h1>
+  <p  data-hf-id="hf-sub"   data-start="2" data-duration="2">World</p>
+</div>
+`.trim();
+
+/** End-authored clip (data-end only, no data-duration). */
+const END_AUTHORED_HTML = `
+<div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px" data-duration="10">
+  <h1 data-hf-id="hf-title" data-start="1" data-end="4">Hello</h1>
+</div>
+`.trim();
+
+/** Both data-duration and data-end (data-duration wins). */
+const BOTH_ATTRS_HTML = `
+<div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px" data-duration="10">
+  <h1 data-hf-id="hf-title" data-start="0" data-duration="3" data-end="99">Hello</h1>
+</div>
+`.trim();
+
+/** Has a GSAP script with addLabel. */
+const GSAP_LABEL_HTML = `
+<div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px">
+  <div data-hf-id="hf-box" data-start="0" data-duration="5" style="opacity:0"></div>
+  <script>var tl = gsap.timeline({ paused: true });
+tl.to("[data-hf-id=\\"hf-box\\"]", { opacity: 1, duration: 1 }, 0);
+tl.addLabel("intro", 0.5);
+tl.addLabel("outro", 4.0);
+window.__timelines = { t: tl };</script>
+</div>
+`.trim();
+
+// ─── getElementTimings — duration-authored clips ──────────────────────────────
+
+describe("getElementTimings — duration-authored clips", () => {
+  it("reads enterAt = data-start, exitAt = data-start + data-duration", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+    const timings = comp.getElementTimings();
+
+    expect(timings["hf-title"]).toMatchObject({ enterAt: 0, exitAt: 3 });
+    expect(timings["hf-sub"]).toMatchObject({ enterAt: 2, exitAt: 4 });
+  });
+
+  it("returns empty labels array when no GSAP script", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+    const timings = comp.getElementTimings();
+    expect(timings["hf-title"]?.labels).toEqual([]);
+  });
+});
+
+// ─── getElementTimings — end-authored clips ───────────────────────────────────
+
+describe("getElementTimings — end-authored clips", () => {
+  it("falls back to data-end − data-start when no data-duration", async () => {
+    const comp = await openComposition(END_AUTHORED_HTML);
+    const timings = comp.getElementTimings();
+
+    // enterAt = 1, exitAt = 4 (from data-end = 4, data-start = 1, duration = 3)
+    expect(timings["hf-title"]).toMatchObject({ enterAt: 1, exitAt: 4 });
+  });
+});
+
+// ─── getElementTimings — data-duration wins over data-end ────────────────────
+
+describe("getElementTimings — data-duration wins over data-end", () => {
+  it("uses data-duration when both data-duration and data-end are present", async () => {
+    const comp = await openComposition(BOTH_ATTRS_HTML);
+    const timings = comp.getElementTimings();
+
+    // data-duration=3 wins; exitAt = 0+3=3, NOT from data-end=99
+    expect(timings["hf-title"]).toMatchObject({ enterAt: 0, exitAt: 3 });
+  });
+});
+
+// ─── getElementTimings — labels from GSAP script ─────────────────────────────
+
+describe("getElementTimings — GSAP labels", () => {
+  it("returns labels whose position falls within [enterAt, exitAt]", async () => {
+    const comp = await openComposition(GSAP_LABEL_HTML);
+    const timings = comp.getElementTimings();
+
+    // hf-box: enterAt=0, exitAt=5; labels "intro"@0.5 and "outro"@4.0 are both in range
+    const box = timings["hf-box"];
+    expect(box?.labels).toContain("intro");
+    expect(box?.labels).toContain("outro");
+  });
+
+  it("parses labels fresh — no stale cache after mutation", async () => {
+    const comp = await openComposition(GSAP_LABEL_HTML);
+
+    const before = comp.getElementTimings()["hf-box"]?.labels ?? [];
+    expect(before).toContain("intro");
+
+    // Move the element so timing changes; labels should still parse fresh
+    comp.setTiming("hf-box", { start: 0, duration: 5 }); // no-op but triggers re-parse
+    const after = comp.getElementTimings()["hf-box"]?.labels ?? [];
+    expect(after).toContain("intro");
+  });
+});
+
+// ─── setElementTiming — sparse map + batched dispatch ────────────────────────
+
+describe("setElementTiming", () => {
+  it("applies sparse timing map to multiple elements", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+
+    comp.setElementTiming({
+      "hf-title": { start: 1, duration: 2 },
+      "hf-sub": { start: 4 },
+    });
+
+    const timings = comp.getElementTimings();
+    expect(timings["hf-title"]).toMatchObject({ enterAt: 1, exitAt: 3 });
+    expect(timings["hf-sub"]).toMatchObject({ enterAt: 4 });
+  });
+
+  it("emits exactly one patch event for multiple entries (batched)", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+    const patches: unknown[] = [];
+    comp.on("patch", (e) => patches.push(e));
+
+    comp.setElementTiming({
+      "hf-title": { start: 0.5 },
+      "hf-sub": { start: 3.0 },
+    });
+
+    // One batch → one patch event
+    expect(patches).toHaveLength(1);
+  });
+
+  it("is a no-op for empty map", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+    const patches: unknown[] = [];
+    comp.on("patch", (e) => patches.push(e));
+
+    comp.setElementTiming({});
+    expect(patches).toHaveLength(0);
+  });
+
+  it("respects data-duration vs data-end preference on write", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+
+    // Before: hf-title has data-duration=3, data-start=0
+    comp.setElementTiming({ "hf-title": { duration: 5 } });
+
+    const timings = comp.getElementTimings();
+    // Should read back the new duration
+    expect(timings["hf-title"]).toMatchObject({ exitAt: 5 });
+  });
+
+  it("can be undone as a single step", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+
+    const before = comp.getElementTimings()["hf-title"];
+
+    comp.setElementTiming({ "hf-title": { start: 2 } });
+    comp.undo();
+
+    const after = comp.getElementTimings()["hf-title"];
+    expect(after?.enterAt).toBe(before?.enterAt);
+  });
+
+  it("setElementTiming inverse restores original timing", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+    const originalTimings = comp.getElementTimings();
+
+    comp.setElementTiming({
+      "hf-title": { start: 10, duration: 1 },
+      "hf-sub": { start: 12, duration: 1 },
+    });
+    comp.undo();
+
+    const restored = comp.getElementTimings();
+    expect(restored["hf-title"]).toEqual(originalTimings["hf-title"]);
+    expect(restored["hf-sub"]).toEqual(originalTimings["hf-sub"]);
+  });
+});
+
+// ─── setHold — typed wrapper ──────────────────────────────────────────────────
+
+describe("setHold — typed method", () => {
+  it("dispatches the setHold op (regression: existing op unchanged)", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+    const patches: unknown[] = [];
+    comp.on("patch", (e) => patches.push(e));
+
+    comp.setHold("hf-title", { start: 0.5, end: 2.5, fill: "freeze" });
+
+    // Should emit a patch
+    expect(patches).toHaveLength(1);
+  });
+
+  it("setHold writes data-hold-start / data-hold-end / data-hold-fill attrs", async () => {
+    const comp = await openComposition(DURATION_AUTHORED_HTML);
+
+    comp.setHold("hf-title", { start: 1.0, end: 2.0, fill: "loop" });
+
+    // Verify via serialize (attrs are in the HTML output)
+    const html = comp.serialize();
+    expect(html).toContain('data-hold-start="1"');
+    expect(html).toContain('data-hold-end="2"');
+    expect(html).toContain('data-hold-fill="loop"');
+  });
+
+  it("setHold typed method equals dispatch({type:setHold})", async () => {
+    // Run typed method path
+    const comp1 = await openComposition(DURATION_AUTHORED_HTML);
+    comp1.setHold("hf-title", { start: 0.5, end: 2.5, fill: "freeze" });
+    const html1 = comp1.serialize();
+
+    // Run raw dispatch path
+    const comp2 = await openComposition(DURATION_AUTHORED_HTML);
+    comp2.dispatch({
+      type: "setHold",
+      target: "hf-title",
+      hold: { start: 0.5, end: 2.5, fill: "freeze" },
+    });
+    const html2 = comp2.serialize();
+
+    expect(html1).toBe(html2);
+  });
+});

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -13,9 +13,11 @@ import type {
   Composition,
   EditOp,
   ElementSnapshot,
+  ElementTimingSnapshot,
   FindQuery,
   FontValue,
   GsapTweenSpec,
+  ElasticHold,
   HfId,
   ImageValue,
   JsonPatchOp,
@@ -31,6 +33,8 @@ import type { PersistAdapter, PreviewAdapter } from "./adapters/types.js";
 import { parseMutable } from "./engine/model.js";
 import type { ParsedDocument } from "./engine/model.js";
 import { applyOp, validateOp, type MutationResult } from "./engine/mutate.js";
+import { getGsapScript, resolveScoped } from "./engine/model.js";
+import { extractGsapLabels } from "@hyperframes/core/gsap-parser-acorn";
 import { serializeDocument } from "./engine/serialize.js";
 import { applyPatchesToDocument, applyOverrideSet } from "./engine/apply-patches.js";
 import { buildPatchEvent, pathToKey } from "./engine/patches.js";
@@ -137,6 +141,72 @@ class CompositionImpl implements Composition {
 
   setVariableValue(id: string, value: string | number | boolean | FontValue | ImageValue): void {
     this.dispatch({ type: "setVariableValue", id, value });
+  }
+
+  // ── WS-C: timing accessors + typed setHold ───────────────────────────────────
+
+  // fallow-ignore-next-line complexity
+  getElementTimings(): Record<HfId, ElementTimingSnapshot> {
+    const script = getGsapScript(this.parsed.document);
+
+    // Extract all addLabel("name", position) calls from the GSAP script. Parsed
+    // fresh each call so renumbered tweens never yield stale label positions.
+    const allLabels = script ? extractGsapLabels(script) : [];
+
+    const result: Record<HfId, ElementTimingSnapshot> = {};
+    const elements = this.getElements();
+    for (const el of elements) {
+      const domEl = resolveScoped(this.parsed.document, el.scopedId);
+      if (!domEl) continue;
+
+      const startStr = domEl.getAttribute("data-start");
+      const endStr = domEl.getAttribute("data-end");
+      const durationStr = domEl.getAttribute("data-duration");
+
+      // Same preference as handleSetTiming: prefer data-duration, fall back to end - start.
+      const start = startStr !== null ? parseFloat(startStr) : 0;
+      const durationAttr = durationStr !== null ? parseFloat(durationStr) : null;
+      const endAttr = endStr !== null ? parseFloat(endStr) : null;
+
+      let duration: number;
+      if (durationAttr !== null && Number.isFinite(durationAttr)) {
+        duration = durationAttr;
+      } else if (endAttr !== null && Number.isFinite(endAttr)) {
+        duration = endAttr - start;
+      } else {
+        // No timing info — skip non-timed elements.
+        continue;
+      }
+
+      const enterAt = Number.isFinite(start) ? start : 0;
+      const exitAt = enterAt + (Number.isFinite(duration) ? duration : 0);
+
+      // Labels whose position falls within [enterAt, exitAt].
+      const labels = allLabels
+        .filter(({ position }) => position >= enterAt && position <= exitAt)
+        .map(({ name }) => name);
+
+      result[el.scopedId] = { enterAt, exitAt, labels };
+    }
+
+    return result;
+  }
+
+  setElementTiming(
+    map: Record<HfId, { start?: number; duration?: number; trackIndex?: number }>,
+  ): void {
+    const entries = Object.entries(map);
+    if (entries.length === 0) return;
+
+    this.batch(() => {
+      for (const [id, timing] of entries) {
+        this.dispatch({ type: "setTiming", target: id, ...timing });
+      }
+    });
+  }
+
+  setHold(id: HfId, hold: ElasticHold): void {
+    this.dispatch({ type: "setHold", target: id, hold });
   }
 
   addGsapTween(target: HfId, tween: GsapTweenSpec): string {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -312,6 +312,20 @@ export interface ElementHandle {
   removeElement(): void;
 }
 
+// ─── Timing accessor types (WS-C) ─────────────────────────────────────────────
+
+/**
+ * Resolved timing snapshot for one element.
+ * Labels are GSAP timeline label names whose numeric position falls within
+ * [enterAt, exitAt] for this element. Parsed fresh on every call — never cached.
+ */
+export interface ElementTimingSnapshot {
+  enterAt: number;
+  exitAt: number;
+  /** GSAP addLabel names active during this element's window. */
+  labels: string[];
+}
+
 // ─── Composition (the main public surface, F10) ───────────────────────────────
 
 /**
@@ -327,6 +341,27 @@ export interface Composition {
   setTiming(id: HfId, timing: { start?: number; duration?: number; trackIndex?: number }): void;
   removeElement(id: HfId): void;
   setVariableValue(id: string, value: string | number | boolean): void;
+  /**
+   * Read enter/exit times and GSAP labels for every timed element (WS-C).
+   * Derives enterAt/exitAt using the same data-duration vs data-end preference
+   * as handleSetTiming (data-duration wins; data-end − data-start as fallback).
+   * Labels are parsed fresh from the GSAP script each call.
+   * Read-only — does not dispatch.
+   */
+  getElementTimings(): Record<HfId, ElementTimingSnapshot>;
+  /**
+   * Apply a sparse timing map in a single batch (WS-C).
+   * Dispatches one setTiming op per entry inside a batch so the history sees
+   * one undo step. Skips entries for unknown ids silently.
+   */
+  setElementTiming(
+    map: Record<HfId, { start?: number; duration?: number; trackIndex?: number }>,
+  ): void;
+  /**
+   * Set an elastic hold window on an element (WS-C).
+   * Thin typed wrapper over the existing setHold op — mirrors setVariableValue pattern.
+   */
+  setHold(id: HfId, hold: ElasticHold): void;
   /** Returns the newly-assigned tween ID */
   addGsapTween(target: HfId, tween: GsapTweenSpec): string;
   setGsapTween(animationId: string, properties: Partial<GsapTweenSpec>): void;


### PR DESCRIPTION
## WS-C — elastic timing + word alignment (TTS differentiator)

Part of the AI Studio (Pacific) SDK integration. **Stacked on #1569 (WS-B).**

### Problem
A `setHold` op existed but had no typed method; there were no `getElementTimings` / `setElementTiming` accessors and no shared word-alignment resolver. Per §7 LOCKED: elastic hold (no timescale), preview == render parity.

### What this does
- **C1 — timing accessors.** `getElementTimings() → { hfId: {enterAt, exitAt, labels} }`, `setElementTiming(sparseMap)` (batched as one undo step), and a typed `setHold(id, hold)` method. Elastic hold math: `holdDuration = max(0, slotEnd − (enterAt + enterDuration + exitDuration))`, clamped ≥ 0 — never timescales animated content.
- **C2 — shared align-on-adjust resolver.** A new **pure** `resolveTimings()` in core, consumed by **both** preview and backend render. Word-anchored elements get `enterAt = word.start + offset`; untouched elements keep authored timing (align-on-adjust). No DOM, no `Date.now`, no `Math.random` — fully unit-testable.

### Implementation notes
- `getElementTimings` reads attributes with the same data-duration-wins preference as `handleSetTiming`, and parses GSAP labels fresh each call via a new `extractGsapLabels()` (acorn-based, reads `tl.addLabel("name", pos)`).
- The resolver coexists with the existing GSAP smart-seek path (invisible-exit remap, bisect) — it does not duplicate or fight it.
- **Bug fix:** `apply-patches.ts` was missing the `timing/duration` patch case, so undo of duration changes silently no-op'd. Added the `p.field === "duration"` branch.

### Files (10 changed)
- core: `compiler/timingResolver.ts` (NEW) + test, `compiler/index.ts`, `index.ts`, `parsers/gsapParserAcorn.ts`
- sdk: `session.ts`, `session.timings.test.ts` (NEW), `types.ts`, `index.ts`, `engine/apply-patches.ts`

### Gates
- `bun run build` ✅ · `bun test` (sdk + compiler) 434/0 ✅
- `bunx oxlint` 0/0 ✅ · `bunx oxfmt --check` ✅ · `fallow --gate new-only` ✅

### Deferred (Pacific/backend-side)
Alignment-markers UI + drag interactions; producer activity consuming resolved timings; GSAP labels as named sequencing markers beyond the `labels` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
