### PR TITLE
fix(runtime): size a clip from data-end when it has no data-duration

### DIFF
--- a/packages/core/src/runtime/timeline.test.ts
+++ b/packages/core/src/runtime/timeline.test.ts
@@ -41,6 +41,26 @@ describe("collectRuntimeTimelinePayload", () => {
     expect(result.clips[0].kind).toBe("element");
   });
 
+  it("derives a clip's duration from data-end when data-duration is absent", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-duration", "20");
+    document.body.appendChild(root);
+
+    const clip = document.createElement("div");
+    clip.id = "text-1";
+    clip.setAttribute("data-start", "2");
+    clip.setAttribute("data-end", "8");
+    clip.setAttribute("data-track-index", "0");
+    root.appendChild(clip);
+
+    const result = collectRuntimeTimelinePayload(defaultParams);
+    expect(result.clips).toHaveLength(1);
+    expect(result.clips[0].start).toBe(2);
+    // 8 - 2 = 6, not the inherited root duration (20 - 2 = 18)
+    expect(result.clips[0].duration).toBe(6);
+  });
+
   it("identifies video clips by tag", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");

--- a/packages/core/src/runtime/timeline.ts
+++ b/packages/core/src/runtime/timeline.ts
@@ -389,6 +389,14 @@ export function collectRuntimeTimelinePayload(params: {
     );
     const nodeCompositionId = node.getAttribute("data-composition-id");
     let duration = parseElementDurationAttr(node);
+    if (duration == null || duration <= 0) {
+      // Mirror the scene loop: an explicit data-end sets the clip's duration
+      // when no data-duration is present. Without this the clip fell through to
+      // the inherited (composition) duration and was sized start..rootEnd, so a
+      // 2s..8s clip rendered as start..20s on the timeline.
+      const endAttr = parseElementEndAttr(node);
+      if (endAttr != null) duration = Math.max(0, endAttr - start);
+    }
     if (
       (duration == null || duration <= 0) &&
       nodeCompositionId &&


### PR DESCRIPTION
## Problem

`collectRuntimeTimelinePayload`'s clip loop (`timeline.ts`) resolved a clip's duration from `data-duration`, then fell straight through to the inherited (composition) duration when it was absent. So a clip authored with `data-start` + `data-end` but no `data-duration` (a valid, compiler-emitted shape that the linter only warns about) was sized `start..compositionEnd` instead of `start..end`. A `data-start="2" data-end="8"` clip under a 20s composition rendered as an 18s bar (20 - 2) on the Studio timeline instead of 6s, overrunning every later clip on its track.

The scene loop (same file) and `startResolver.resolveDurationForElement` already read `data-end`; the clip loop was the sibling that did not.

## Change

Read `data-end` as the duration source between `data-duration` and the inherited fallback, mirroring the scene loop (`Math.max(0, end - start)`). No change for clips that carry `data-duration`.

## Tests

A clip with `data-start="2" data-end="8"` and no `data-duration` under a 20s composition now reports duration 6, not 18. Verified load-bearing (reverting the fix produces 18). Full core suite green.
