### PR TITLE
fix(shader-transitions): show the from-scene at gravitational-lens start

### DIFF
--- a/packages/shader-transitions/src/shaders/registry.ts
+++ b/packages/shader-transitions/src/shaders/registry.ts
@@ -98,7 +98,13 @@ const shaders: Record<string, ShaderDef> = {
       "float shift=pull*.02/(dist+.2);" +
       "float r=texture2D(u_from,clamp(v_uv-uv*(warpStr+shift),0.,1.)).r;" +
       "float b=texture2D(u_from,clamp(v_uv-uv*(warpStr-shift),0.,1.)).b;" +
-      "vec3 lensed=vec3(r,A.g,b)*horizon;" +
+      // The horizon term darkens the center to black, but it is not gated by
+      // progress, so at progress 0 the from-scene rendered as a black-hole
+      // vignette instead of the clean outgoing frame. Ramp the darkening in from
+      // progress 0 so lensed == from-scene at the transition start, matching
+      // every other shader in this file.
+      "float horizonRamp=smoothstep(0.,.3,u_progress);" +
+      "vec3 lensed=vec3(r,A.g,b)*mix(1.,horizon,horizonRamp);" +
       "gl_FragColor=vec4(mix(lensed,B.rgb,smoothstep(.3,.9,u_progress)),1.);}",
   },
 


### PR DESCRIPTION
## Problem

The `gravitational-lens` frag (`registry.ts`) computes `lensed = vec3(r, A.g, b) * horizon`, where `horizon = smoothstep(0., .3, dist / (1. - u_progress*.85 + .001))` darkens the center toward black. That term is not gated by `u_progress`, so at `u_progress = 0` the center is multiplied by ~0 (pure black at the center, fading to 1 only near the corners) while the rest of the math already resolves to the untouched from-scene. The viewer sees a black-hole vignette flash at the transition start (a paused seek at the start, and the first rendered frame, both hit progress 0). The 13 other shaders in the file collapse cleanly to the from-scene at progress 0; this is the only one that does not.

## Change

Ramp the horizon darkening in from progress 0: `lensed = vec3(r, A.g, b) * mix(1., horizon, smoothstep(0., .3, u_progress))`. At progress 0 the factor is 1 (clean from-scene); by progress 0.3 the full lens darkening is in effect, unchanged from before. The progress-1 endpoint is unaffected (the outer `mix(..., smoothstep(.3, .9, u_progress))` already selects the to-scene there).

## Verification

The center darkening factor at progress 0 goes from 0 (black) to 1 (from-scene); progress 0.3+ and the progress-1 endpoint are unchanged. This package has no headless-GL test path, so shader behavior here is verified by the math and visual inspection, consistent with how the other shaders in the file are maintained.
