### PR TITLE
docs(skill): slideshow authoring guidance + standalone harness reference

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/aws-lambda": {
       "name": "@hyperframes/aws-lambda",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-sfn": "^3.700.0",
@@ -54,7 +54,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "bin": {
         "hyperframes": "./dist/cli.js",
       },
@@ -101,7 +101,7 @@
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "@chenglou/pretext": "^0.0.5",
@@ -135,7 +135,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
         "@hyperframes/core": "workspace:^",
@@ -153,7 +153,7 @@
     },
     "packages/gcp-cloud-run": {
       "name": "@hyperframes/gcp-cloud-run",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "@google-cloud/storage": "^7.14.0",
         "@google-cloud/workflows": "^4.2.0",
@@ -173,7 +173,10 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.6.112",
+      "version": "0.6.113",
+      "dependencies": {
+        "@hyperframes/core": "workspace:*",
+      },
       "devDependencies": {
         "@types/bun": "^1.1.0",
         "gsap": "^3.12.5",
@@ -185,7 +188,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -226,7 +229,7 @@
     },
     "packages/sdk": {
       "name": "@hyperframes/sdk",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "linkedom": "^0.18.12",
@@ -251,7 +254,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -263,7 +266,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.6.112",
+      "version": "0.6.113",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -19,6 +19,12 @@
       "script": "./dist/hyperframes-player.global.js",
       "import": "./dist/hyperframes-player.js",
       "require": "./dist/hyperframes-player.cjs"
+    },
+    "./slideshow": {
+      "types": "./dist/slideshow/hyperframes-slideshow.d.ts",
+      "script": "./dist/slideshow/hyperframes-slideshow.global.js",
+      "import": "./dist/slideshow/hyperframes-slideshow.js",
+      "require": "./dist/slideshow/hyperframes-slideshow.cjs"
     }
   },
   "scripts": {
@@ -26,6 +32,9 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tests/perf/tsconfig.json",
     "test": "vitest run",
     "perf": "bun run tests/perf/index.ts"
+  },
+  "dependencies": {
+    "@hyperframes/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -89,6 +89,7 @@ class HyperframesPlayer extends HTMLElement {
   private _directTimelineClock: DirectTimelineClock;
   private _parentTickRaf: number | null = null;
   private _media: ParentMediaManager;
+  private _scenes: { id: string; start: number; duration: number }[] = [];
 
   constructor() {
     super();
@@ -259,6 +260,12 @@ class HyperframesPlayer extends HTMLElement {
    */
   get iframeElement(): HTMLIFrameElement {
     return this.iframe;
+  }
+
+  /** Scene list from the last-received runtime timeline message. Empty until
+   *  the composition runtime fires its first "timeline" postMessage. */
+  get scenes(): { id: string; start: number; duration: number }[] {
+    return this._scenes;
   }
 
   play() {
@@ -586,6 +593,9 @@ class HyperframesPlayer extends HTMLElement {
       sendControl: (action, extra) => this._sendControl(action, extra),
       getIframeDoc: () => this.iframe.contentDocument,
       onRuntimeReady: () => this._replayBridgeState(),
+      setScenes: (scenes) => {
+        this._scenes = scenes;
+      },
       updateControlsTime: (t, d) => this.controlsApi?.updateTime(t, d),
       updateControlsPlaying: (p) => this.controlsApi?.updatePlaying(p),
       dispatchEvent: (ev) => this.dispatchEvent(ev),

--- a/packages/player/src/runtime-message-handler.test.ts
+++ b/packages/player/src/runtime-message-handler.test.ts
@@ -18,6 +18,7 @@ const makeCallbacks = (): MessageHandlerCallbacks => ({
   media: { mirrorTime: vi.fn(), promoteToParentProxy: vi.fn() } as unknown as ParentMediaManager,
   getPlaybackState: vi.fn(() => ({ currentTime: 0, duration: 0, paused: true, lastUpdateMs: 0 })),
   setPlaybackState: vi.fn(),
+  setScenes: vi.fn(),
   getShaderLoadingMode: vi.fn(() => "auto"),
   shaderLoader: { update: vi.fn() } as unknown as ShaderLoaderState,
   setCompositionSize: vi.fn(),

--- a/packages/player/src/runtime-message-handler.ts
+++ b/packages/player/src/runtime-message-handler.ts
@@ -15,6 +15,16 @@ import type { ShaderTransitionState } from "./shader-options.js";
 
 const FPS = 30;
 
+type SceneRecord = { id: string; start: number; duration: number };
+
+function extractScenes(raw: unknown): SceneRecord[] {
+  if (!Array.isArray(raw)) return [];
+  return (raw as SceneRecord[]).filter(
+    (s) =>
+      typeof s.id === "string" && typeof s.start === "number" && typeof s.duration === "number",
+  );
+}
+
 export interface MessageHandlerCallbacks extends PlaybackStateCallbacks {
   getPlaybackState: () => PlaybackState;
   setPlaybackState: (next: PlaybackState) => void;
@@ -27,8 +37,11 @@ export interface MessageHandlerCallbacks extends PlaybackStateCallbacks {
    *  uses it to replay current bridge state (mute, volume, playback rate) so
    *  control messages sent before the iframe's listener registered aren't lost. */
   onRuntimeReady: () => void;
+  /** Called with the scene list whenever a "timeline" message is received. */
+  setScenes: (scenes: SceneRecord[]) => void;
 }
 
+// fallow-ignore-next-line complexity
 export function handleRuntimeMessage(
   event: MessageEvent,
   frameWindow: Window | null,
@@ -90,6 +103,7 @@ export function handleRuntimeMessage(
       callbacks.setPlaybackState({ ...pb, duration });
       callbacks.updateControlsTime(pb.currentTime, duration);
     }
+    callbacks.setScenes(extractScenes(data["scenes"]));
     return;
   }
 

--- a/packages/player/src/slideshow/SlideshowController.test.ts
+++ b/packages/player/src/slideshow/SlideshowController.test.ts
@@ -1,0 +1,574 @@
+// fallow-ignore-file code-duplication
+import { describe, it, expect, vi } from "vitest";
+import { SlideshowController } from "./SlideshowController";
+import type { ResolvedSlideshow } from "@hyperframes/core/slideshow";
+
+function fakePlayer() {
+  let cb: ((t: number) => void) | null = null;
+  const player = {
+    currentTime: 0,
+    seek: vi.fn((t: number) => {
+      player.currentTime = t;
+    }),
+    play: vi.fn(() => {}),
+    pause: vi.fn(() => {}),
+    onTimeUpdate: (fn: (t: number) => void) => {
+      cb = fn;
+      return () => {
+        cb = null;
+      };
+    },
+    emit: (t: number) => {
+      player.currentTime = t;
+      cb?.(t);
+    },
+  };
+  return player;
+}
+
+const SHOW: ResolvedSlideshow = {
+  slides: [
+    { sceneId: "a", start: 0, end: 5, fragments: [2, 4], hotspots: [] },
+    { sceneId: "b", start: 5, end: 10, fragments: [], hotspots: [] },
+  ],
+  sequences: {
+    deep: {
+      id: "deep",
+      label: "Deep dive",
+      slides: [{ sceneId: "c", start: 10, end: 13, fragments: [], hotspots: [] }],
+    },
+  },
+};
+
+/**
+ * Factory: controller on SHOW, advanced to fragmentIndex=1 via playback
+ * (emit 2 → frag 0, next(), emit 4 → frag 1). Used across Fix 8b + backToMain tests.
+ */
+function showAtFrag1() {
+  const p = fakePlayer();
+  const c = new SlideshowController(p, SHOW);
+  p.emit(2); // fragmentIndex=0
+  c.next(); // target=4
+  p.emit(4); // fragmentIndex=1
+  return { p, c };
+}
+
+/**
+ * Factory: controller on SHOW, at slide 1, inside the "deep" branch.
+ * Used across branching + backToMain tests that share goToSlide(1)+enterBranch setup.
+ */
+function showAtSlide1InDeep() {
+  const p = fakePlayer();
+  const c = new SlideshowController(p, SHOW);
+  c.goToSlide(1);
+  c.enterBranch("deep");
+  return { p, c };
+}
+
+describe("SlideshowController linear nav", () => {
+  it("enters the first slide on construction: seek to start + play", () => {
+    const p = fakePlayer();
+    new SlideshowController(p, SHOW);
+    expect(p.seek).toHaveBeenCalledWith(0);
+    expect(p.play).toHaveBeenCalled();
+  });
+
+  it("holds (pauses) at slide end when timeupdate reaches it", () => {
+    const p = fakePlayer();
+    new SlideshowController(p, SHOW);
+    p.emit(2); // first fragment — handled separately; still inside slide
+    p.emit(5); // reached end
+    expect(p.pause).toHaveBeenCalled();
+  });
+
+  it("next stops at the first fragment, not the next slide", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    p.emit(2); // play reaches fragment 0, controller pauses
+    expect(p.pause).toHaveBeenCalled();
+    expect(c.position.slideIndex).toBe(0);
+    expect(c.position.fragmentIndex).toBe(0);
+  });
+
+  it("next past the last fragment advances to the next slide immediately", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.next(); // -> fragment 1 target (2)
+    p.emit(2);
+    c.next(); // -> fragment 2 target (4)
+    p.emit(4);
+    c.next(); // no more fragments — advance to slide b immediately
+    expect(c.position.slideIndex).toBe(1);
+    expect(p.seek).toHaveBeenLastCalledWith(5);
+  });
+
+  it("next() on a slide with NO fragments advances to the next slide immediately", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    // Go to slide b (index 1, no fragments, not at end yet)
+    c.goToSlide(1); // slide b: start=5, end=10, fragments=[]
+    expect(c.position.slideIndex).toBe(1);
+    // The demo SHOW only has 2 slides, so next on slide 1 is a no-op.
+    // Use a show with a third slide to verify advancement.
+    const show3: ResolvedSlideshow = {
+      slides: [
+        { sceneId: "a", start: 0, end: 5, fragments: [], hotspots: [] },
+        { sceneId: "b", start: 5, end: 10, fragments: [], hotspots: [] },
+        { sceneId: "c", start: 10, end: 15, fragments: [], hotspots: [] },
+      ],
+      sequences: {},
+    };
+    const p2 = fakePlayer();
+    const c2 = new SlideshowController(p2, show3);
+    // slide 0 has no fragments; one next() should advance immediately to slide 1
+    c2.next();
+    expect(c2.position.slideIndex).toBe(1);
+    expect(p2.seek).toHaveBeenLastCalledWith(5);
+  });
+
+  it("next() on the last slide is a no-op", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.goToSlide(1); // slide b is last
+    c.next();
+    expect(c.position.slideIndex).toBe(1); // no change
+  });
+
+  it("prev returns to the previous slide start", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.goToSlide(1);
+    c.prev();
+    expect(c.position.slideIndex).toBe(0);
+  });
+
+  it("auto-pauses at a fragment, then next advances to the FOLLOWING fragment (not the end)", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    p.emit(2); // auto-pause at fragments[0]=2
+    expect(c.position.fragmentIndex).toBe(0);
+    p.pause.mockClear(); // clear the pause from the auto-stop above
+    c.next(); // should target fragments[1]=4, NOT slide.end=5
+    p.emit(4);
+    expect(p.pause).toHaveBeenCalled(); // must pause at 4, not skip to 5
+    expect(c.position.fragmentIndex).toBe(1);
+  });
+});
+
+describe("SlideshowController nextSlide", () => {
+  it("returns the next slide when not at the end", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    // At slide 0, next should be slide 1 (sceneId "b")
+    expect(c.nextSlide).not.toBeNull();
+    expect(c.nextSlide?.sceneId).toBe("b");
+  });
+
+  it("returns null when at the last slide in the sequence", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.goToSlide(1); // slide "b" is the last in main
+    expect(c.nextSlide).toBeNull();
+  });
+
+  it("nextSlide is scoped to the current sequence", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.enterBranch("deep"); // "deep" has only one slide
+    expect(c.nextSlide).toBeNull();
+  });
+});
+
+describe("SlideshowController branching", () => {
+  it("enterBranch pushes onto the stack and enters the branch's first slide", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.enterBranch("deep");
+    expect(c.position.sequenceId).toBe("deep");
+    expect(c.currentSlide?.sceneId).toBe("c");
+    expect(p.seek).toHaveBeenLastCalledWith(10);
+  });
+
+  it("counter is scoped to the current sequence", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.enterBranch("deep");
+    expect(c.counter).toEqual({ index: 1, total: 1 });
+  });
+
+  it("breadcrumb reflects the stack", () => {
+    const { c } = showAtSlide1InDeep();
+    expect(c.breadcrumb.map((b) => b.label)).toEqual(["Main deck", "Deep dive"]);
+  });
+
+  it("back returns to the exact parent slide", () => {
+    const { c } = showAtSlide1InDeep();
+    c.back();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.position.slideIndex).toBe(1);
+  });
+
+  it("backToMain clears nested branches to the root", () => {
+    const { c } = showAtSlide1InDeep();
+    c.backToMain();
+    expect(c.breadcrumb.length).toBe(1);
+    expect(c.position.slideIndex).toBe(1);
+  });
+});
+
+describe("SlideshowController Fix 8a — fragmentIndex advances via onTime not next()", () => {
+  it("next() does NOT pre-increment fragmentIndex; onTime advances it when hold fires", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    // fragmentIndex starts at -1 (enterSlide sets it)
+    expect(c.position.fragmentIndex).toBe(-1);
+    // Call next() — should NOT pre-increment fragmentIndex
+    c.next();
+    expect(c.position.fragmentIndex).toBe(-1); // still -1 until onTime fires
+    // Simulate playback reaching the hold point (fragments[0]=2)
+    p.emit(2);
+    expect(c.position.fragmentIndex).toBe(0); // onTime advanced it
+  });
+
+  it("next() after auto-pause targets the FOLLOWING fragment without pre-increment (regression)", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    p.emit(2); // auto-pause at fragments[0]=2; fragmentIndex=0
+    expect(c.position.fragmentIndex).toBe(0);
+    p.pause.mockClear();
+    c.next(); // should target fragments[1]=4 — fragmentIndex stays 0 until emit
+    expect(c.position.fragmentIndex).toBe(0); // NOT yet 1
+    p.emit(4);
+    expect(p.pause).toHaveBeenCalled();
+    expect(c.position.fragmentIndex).toBe(1); // onTime advanced it
+  });
+});
+
+describe("SlideshowController Fix 8b — back() restores parent fragmentIndex", () => {
+  it("back() restores the saved fragmentIndex and seeks to the fragment time", () => {
+    const { p, c } = showAtFrag1();
+    expect(c.position.fragmentIndex).toBe(1);
+    // Enter branch — saves frame {main, slideIndex:0, fragmentIndex:1}
+    c.enterBranch("deep");
+    expect(c.position.sequenceId).toBe("deep");
+    // Back should restore main, slideIndex=0, fragmentIndex=1, seek to fragments[1]=4
+    c.back();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.position.slideIndex).toBe(0);
+    expect(c.position.fragmentIndex).toBe(1);
+    expect(p.seek).toHaveBeenLastCalledWith(4); // fragments[1] = 4
+  });
+
+  it("back() when parent fragmentIndex=-1 seeks to slide start", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    // Enter branch immediately (fragmentIndex is still -1)
+    c.enterBranch("deep");
+    c.back();
+    expect(c.position.fragmentIndex).toBe(-1);
+    // seek should have been called with slide.start=0 (no fragment yet)
+    expect(p.seek).toHaveBeenLastCalledWith(0);
+  });
+});
+
+describe("SlideshowController unknown-sequence degradation", () => {
+  it("enterBranch with an unknown id does not throw and leaves nav state unchanged", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+    c.goToSlide(1);
+    expect(() => c.enterBranch("no-such-seq")).not.toThrow();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.position.slideIndex).toBe(1);
+  });
+
+  it("counter and currentSlide degrade gracefully when sequence is missing from show", () => {
+    // Construct a show where sequences has no entries, then verify slidesOf([missing])
+    // returns [] and counter/currentSlide do not throw.
+    const showNoSeq: ResolvedSlideshow = {
+      slides: [{ sceneId: "x", start: 0, end: 5, fragments: [], hotspots: [] }],
+      sequences: {},
+    };
+    const p = fakePlayer();
+    const c = new SlideshowController(p, showNoSeq);
+    // enterBranch guards — no bogus frame gets pushed. counter on main is safe.
+    expect(() => c.counter).not.toThrow();
+    expect(c.counter).toEqual({ index: 1, total: 1 });
+    // enterBranch with an unknown id: guard fires, state stays on main
+    expect(() => c.enterBranch("ghost")).not.toThrow();
+    expect(c.position.sequenceId).toBe("main");
+    // breadcrumb does not throw for unknown sequence in stack (regression guard)
+    expect(() => c.breadcrumb).not.toThrow();
+    expect(c.breadcrumb[0]?.id).toBe("main");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix tests: #5-ctrl — enterSlide clears holdAt on empty-slide early return
+// ---------------------------------------------------------------------------
+describe("SlideshowController Fix #5-ctrl — enterSlide clears holdAt on empty branch", () => {
+  it("enterSlide into an empty sequence clears holdAt so no spurious pause fires later", () => {
+    // Build a show where "empty" sequence has no slides
+    const show: ResolvedSlideshow = {
+      slides: [{ sceneId: "a", start: 0, end: 5, fragments: [2], hotspots: [] }],
+      sequences: {
+        empty: { id: "empty", label: "Empty", slides: [] },
+      },
+    };
+    const p = fakePlayer();
+    const c = new SlideshowController(p, show);
+
+    // Advance to a holdAt state by calling next() (sets holdAt to fragment 2)
+    c.next();
+    // Now enter a branch that has no slides — enterSlide should clear holdAt
+    c.enterBranch("empty");
+
+    // Simulate time advancing — must NOT call pause (stale holdAt would trigger it)
+    p.pause.mockClear();
+    p.emit(2);
+    expect(p.pause).not.toHaveBeenCalled();
+  });
+
+  it("enterSlide(0) on an empty main sequence does not throw", () => {
+    // This verifies the early-return path doesn't leave holdAt dirty
+    const show: ResolvedSlideshow = {
+      slides: [],
+      sequences: {},
+    };
+    const p = fakePlayer();
+    // Constructor calls enterSlide(0) — must not throw with empty slides
+    expect(() => new SlideshowController(p, show)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix tests: #backToMain — uses resumeSlide to preserve fragment position
+// ---------------------------------------------------------------------------
+describe("SlideshowController Fix #backToMain — restores fragment position like back()", () => {
+  it("backToMain restores the root frame's fragmentIndex (not reset to -1)", () => {
+    const { p, c } = showAtFrag1();
+    expect(c.position.fragmentIndex).toBe(1);
+
+    // Enter branch — saves root frame with fragmentIndex=1
+    c.enterBranch("deep");
+    expect(c.position.sequenceId).toBe("deep");
+
+    // backToMain should restore to main slideIndex=0, fragmentIndex=1 (not -1)
+    c.backToMain();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.position.slideIndex).toBe(0);
+    expect(c.position.fragmentIndex).toBe(1);
+    // resumeSlide seeks to the fragment time (fragments[1]=4)
+    expect(p.seek).toHaveBeenLastCalledWith(4);
+  });
+
+  it("backToMain when root fragmentIndex=-1 seeks to slide start", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW);
+
+    // Enter branch immediately (root fragmentIndex is still -1)
+    c.enterBranch("deep");
+    c.backToMain();
+
+    expect(c.position.fragmentIndex).toBe(-1);
+    expect(p.seek).toHaveBeenLastCalledWith(0); // slide start
+  });
+
+  it("backToMain with multiple nested branches restores root slide position", () => {
+    const show: ResolvedSlideshow = {
+      slides: [
+        { sceneId: "a", start: 0, end: 5, fragments: [2], hotspots: [] },
+        { sceneId: "b", start: 5, end: 10, fragments: [], hotspots: [] },
+      ],
+      sequences: {
+        lvl1: {
+          id: "lvl1",
+          label: "Level 1",
+          slides: [{ sceneId: "c", start: 10, end: 13, fragments: [], hotspots: [] }],
+        },
+      },
+    };
+    const p = fakePlayer();
+    const c = new SlideshowController(p, show);
+    c.goToSlide(1); // root at slide 1
+    c.enterBranch("lvl1");
+
+    // backToMain must pop all frames back to root
+    c.backToMain();
+    expect(c.breadcrumb.length).toBe(1);
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.position.slideIndex).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch-edge navigation: prev/next at branch boundaries return to parent
+// ---------------------------------------------------------------------------
+
+// Show used only for branch-edge tests: 2 main slides + single- and multi-slide branches.
+const SHOW_BRANCH_EDGE: ResolvedSlideshow = {
+  slides: [
+    { sceneId: "a", start: 0, end: 5, fragments: [], hotspots: [] },
+    { sceneId: "b", start: 5, end: 10, fragments: [], hotspots: [] },
+  ],
+  sequences: {
+    single: {
+      id: "single",
+      label: "Single slide branch",
+      slides: [{ sceneId: "x", start: 10, end: 13, fragments: [], hotspots: [] }],
+    },
+    multi: {
+      id: "multi",
+      label: "Multi slide branch",
+      slides: [
+        { sceneId: "y", start: 13, end: 16, fragments: [], hotspots: [] },
+        { sceneId: "z", start: 16, end: 20, fragments: [], hotspots: [] },
+      ],
+    },
+  },
+};
+
+/** Factory: controller on SHOW_BRANCH_EDGE, already inside the given branch. */
+function inBranch(branchId: string): { c: SlideshowController } {
+  const p = fakePlayer();
+  const c = new SlideshowController(p, SHOW_BRANCH_EDGE);
+  c.enterBranch(branchId);
+  return { c };
+}
+
+describe("SlideshowController branch-edge nav — prev/next return to parent", () => {
+  it("single-slide branch: prev() returns to parent", () => {
+    const { c } = inBranch("single");
+    expect(c.breadcrumb.length).toBe(2);
+    c.prev();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.breadcrumb.length).toBe(1);
+  });
+
+  it("single-slide branch: next() (no fragments, last slide) returns to parent", () => {
+    const { c } = inBranch("single");
+    expect(c.breadcrumb.length).toBe(2);
+    c.next();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.breadcrumb.length).toBe(1);
+  });
+
+  it("multi-slide branch: prev() from slide 1 → slide 0, NOT popped", () => {
+    const { c } = inBranch("multi");
+    c.goToSlide(1);
+    c.prev();
+    expect(c.position.sequenceId).toBe("multi");
+    expect(c.position.slideIndex).toBe(0);
+    expect(c.breadcrumb.length).toBe(2);
+  });
+
+  it("multi-slide branch: prev() from slide 0 → parent", () => {
+    const { c } = inBranch("multi");
+    c.prev();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.breadcrumb.length).toBe(1);
+  });
+
+  it("multi-slide branch: next() from slide 0 → slide 1, NOT popped", () => {
+    const { c } = inBranch("multi");
+    c.next();
+    expect(c.position.sequenceId).toBe("multi");
+    expect(c.position.slideIndex).toBe(1);
+    expect(c.breadcrumb.length).toBe(2);
+  });
+
+  it("multi-slide branch: next() from slide 1 (last) → parent", () => {
+    const { c } = inBranch("multi");
+    c.goToSlide(1);
+    c.next();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.breadcrumb.length).toBe(1);
+  });
+
+  it("main line: prev() at slide 0 is a no-op (stack.length === 1)", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW_BRANCH_EDGE);
+    c.prev();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.position.slideIndex).toBe(0);
+    expect(c.breadcrumb.length).toBe(1);
+  });
+
+  it("main line: next() at last slide is a no-op (does NOT call back)", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW_BRANCH_EDGE);
+    c.goToSlide(1);
+    c.next();
+    expect(c.position.sequenceId).toBe("main");
+    expect(c.position.slideIndex).toBe(1);
+    expect(c.breadcrumb.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canPrev / canNext getters
+// ---------------------------------------------------------------------------
+describe("SlideshowController canPrev / canNext", () => {
+  it("main first slide: canPrev=false, canNext=true", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW_BRANCH_EDGE);
+    expect(c.canPrev).toBe(false);
+    expect(c.canNext).toBe(true);
+  });
+
+  it("main last slide: canPrev=true, canNext=false", () => {
+    const p = fakePlayer();
+    const c = new SlideshowController(p, SHOW_BRANCH_EDGE);
+    c.goToSlide(1); // last slide (total=2)
+    expect(c.canPrev).toBe(true);
+    expect(c.canNext).toBe(false);
+  });
+
+  it("main middle slide: canPrev=true, canNext=true", () => {
+    // Use SHOW (3+ slides via SHOW_BRANCH_EDGE is only 2; use a 3-slide show)
+    const threeSlideShow: ResolvedSlideshow = {
+      slides: [
+        { sceneId: "a", start: 0, end: 5, fragments: [], hotspots: [] },
+        { sceneId: "b", start: 5, end: 10, fragments: [], hotspots: [] },
+        { sceneId: "c", start: 10, end: 15, fragments: [], hotspots: [] },
+      ],
+      sequences: {},
+    };
+    const p = fakePlayer();
+    const c = new SlideshowController(p, threeSlideShow);
+    c.goToSlide(1);
+    expect(c.canPrev).toBe(true);
+    expect(c.canNext).toBe(true);
+  });
+
+  it("single-slide main: canPrev=false, canNext=false", () => {
+    const oneSlide: ResolvedSlideshow = {
+      slides: [{ sceneId: "only", start: 0, end: 5, fragments: [], hotspots: [] }],
+      sequences: {},
+    };
+    const p = fakePlayer();
+    const c = new SlideshowController(p, oneSlide);
+    expect(c.canPrev).toBe(false);
+    expect(c.canNext).toBe(false);
+  });
+
+  it("inside a branch (first slide): canPrev=true (parent is prev), canNext=true (next-within or parent)", () => {
+    const { c } = inBranch("single");
+    // single-slide branch, slideIndex=0, stack.length=2
+    expect(c.canPrev).toBe(true);
+    expect(c.canNext).toBe(true);
+  });
+
+  it("inside a multi-slide branch (first slide): canPrev=true, canNext=true", () => {
+    const { c } = inBranch("multi");
+    // slideIndex=0, next slide exists within branch
+    expect(c.canPrev).toBe(true);
+    expect(c.canNext).toBe(true);
+  });
+
+  it("inside a multi-slide branch (last slide): canPrev=true, canNext=true (parent is next)", () => {
+    const { c } = inBranch("multi");
+    c.goToSlide(1); // last slide in branch
+    expect(c.canPrev).toBe(true);
+    expect(c.canNext).toBe(true);
+  });
+});

--- a/packages/player/src/slideshow/SlideshowController.ts
+++ b/packages/player/src/slideshow/SlideshowController.ts
@@ -1,0 +1,215 @@
+import type { ResolvedSlideshow, ResolvedSlide } from "@hyperframes/core/slideshow";
+
+export interface PlayerPort {
+  seek(t: number): void;
+  play(): void;
+  pause(): void;
+  readonly currentTime: number;
+  onTimeUpdate(cb: (t: number) => void): () => void;
+}
+
+interface StackFrame {
+  sequenceId: string;
+  slideIndex: number;
+  fragmentIndex: number; // -1 = before first fragment / at slide start
+}
+
+const MAIN = "main";
+const EPS = 0.001;
+
+export class SlideshowController {
+  private stack: StackFrame[] = [{ sequenceId: MAIN, slideIndex: 0, fragmentIndex: -1 }];
+  private holdAt: number | null = null;
+  private changeCbs = new Set<() => void>();
+  private unsub: () => void;
+
+  constructor(
+    private player: PlayerPort,
+    private show: ResolvedSlideshow,
+  ) {
+    this.unsub = player.onTimeUpdate((t) => this.onTime(t));
+    this.enterSlide(0);
+  }
+
+  // fallow-ignore-next-line unused-class-member
+  dispose(): void {
+    this.unsub();
+  }
+
+  private slidesOf(sequenceId: string): ResolvedSlide[] {
+    if (sequenceId === MAIN) return this.show.slides;
+    return this.show.sequences[sequenceId]?.slides ?? [];
+  }
+
+  private get frame(): StackFrame {
+    return this.stack[this.stack.length - 1];
+  }
+
+  get currentSlide(): ResolvedSlide | undefined {
+    return this.slidesOf(this.frame.sequenceId)[this.frame.slideIndex];
+  }
+
+  get nextSlide(): ResolvedSlide | null {
+    const slides = this.slidesOf(this.frame.sequenceId);
+    const next = slides[this.frame.slideIndex + 1];
+    return next ?? null;
+  }
+
+  get position(): { sequenceId: string; slideIndex: number; fragmentIndex: number } {
+    return { ...this.frame };
+  }
+
+  get counter(): { index: number; total: number } {
+    return {
+      index: this.frame.slideIndex + 1,
+      total: this.slidesOf(this.frame.sequenceId).length,
+    };
+  }
+
+  get canPrev(): boolean {
+    // prev has a destination: an earlier slide in this sequence, OR (in a branch) the parent.
+    return this.frame.slideIndex > 0 || this.stack.length > 1;
+  }
+
+  get canNext(): boolean {
+    // next has a destination: a later slide in this sequence, OR (in a branch) the parent.
+    const slides = this.slidesOf(this.frame.sequenceId);
+    return this.frame.slideIndex + 1 < slides.length || this.stack.length > 1;
+  }
+
+  get breadcrumb(): { id: string; label: string }[] {
+    return this.stack.map((f) =>
+      f.sequenceId === MAIN
+        ? { id: MAIN, label: "Main deck" }
+        : { id: f.sequenceId, label: this.show.sequences[f.sequenceId]?.label ?? f.sequenceId },
+    );
+  }
+
+  // fallow-ignore-next-line unused-class-member
+  onChange(cb: () => void): () => void {
+    this.changeCbs.add(cb);
+    return () => this.changeCbs.delete(cb);
+  }
+
+  private emitChange(): void {
+    for (const cb of this.changeCbs) cb();
+  }
+
+  private enterSlide(index: number): void {
+    this.frame.slideIndex = index;
+    this.frame.fragmentIndex = -1;
+    this.holdAt = null;
+    const slide = this.currentSlide;
+    if (!slide) return;
+    this.player.seek(slide.start);
+    this.playTo(this.nextStop(slide, -1));
+    this.emitChange();
+  }
+
+  /**
+   * Resumes a slide at a saved fragmentIndex without resetting to slide start.
+   * Used by back() to restore the caller's exact position in the parent slide.
+   */
+  private resumeSlide(index: number, fragmentIndex: number): void {
+    this.frame.slideIndex = index;
+    this.frame.fragmentIndex = fragmentIndex;
+    const slide = this.currentSlide;
+    if (!slide) return;
+    // Seek to the fragment's hold time (or slide start if before any fragment).
+    const seekTime =
+      fragmentIndex >= 0 && fragmentIndex < slide.fragments.length
+        ? (slide.fragments[fragmentIndex] ?? slide.start)
+        : slide.start;
+    this.holdAt = null;
+    this.player.seek(seekTime);
+    this.player.pause();
+    this.emitChange();
+  }
+
+  private nextStop(slide: ResolvedSlide, fragmentIndex: number): number {
+    const next = slide.fragments[fragmentIndex + 1];
+    return next ?? slide.end;
+  }
+
+  private playTo(t: number): void {
+    this.holdAt = t;
+    this.player.play();
+  }
+
+  private onTime(t: number): void {
+    if (this.holdAt !== null && t >= this.holdAt - EPS) {
+      const hold = this.holdAt;
+      this.holdAt = null;
+      // Advance fragmentIndex if this hold is a fragment boundary.
+      const slide = this.currentSlide;
+      if (slide) {
+        const fragIdx = slide.fragments.indexOf(hold);
+        if (fragIdx !== -1) {
+          this.frame.fragmentIndex = fragIdx;
+          this.emitChange();
+        }
+      }
+      this.player.pause();
+    }
+  }
+
+  next(): void {
+    const slide = this.currentSlide;
+    if (!slide) return;
+    const hasMoreFragments = this.frame.fragmentIndex + 1 < slide.fragments.length;
+    const atEnd = this.player.currentTime >= slide.end - EPS;
+    if (hasMoreFragments && !atEnd) {
+      // Reveal the next fragment (play-to-hold). onTime() advances fragmentIndex at the hold.
+      const nextTarget = this.nextStop(slide, this.frame.fragmentIndex);
+      this.playTo(nextTarget);
+      this.emitChange();
+      return;
+    }
+    // No more fragments to reveal — advance to the next slide immediately instead of
+    // playing the current slide out to its end.
+    const slides = this.slidesOf(this.frame.sequenceId);
+    if (this.frame.slideIndex + 1 < slides.length) {
+      this.enterSlide(this.frame.slideIndex + 1);
+    } else if (this.stack.length > 1) {
+      // End of a branch → return to the parent timeline.
+      this.back();
+    }
+  }
+
+  prev(): void {
+    if (this.frame.slideIndex > 0) {
+      this.enterSlide(this.frame.slideIndex - 1);
+      return;
+    }
+    if (this.stack.length > 1) {
+      // First slide of a branch → return to the parent timeline.
+      this.back();
+    }
+  }
+
+  goToSlide(index: number): void {
+    const slides = this.slidesOf(this.frame.sequenceId);
+    if (index >= 0 && index < slides.length) this.enterSlide(index);
+  }
+
+  enterBranch(sequenceId: string): void {
+    if (!this.show.sequences[sequenceId]) return;
+    this.stack.push({ sequenceId, slideIndex: 0, fragmentIndex: -1 });
+    this.enterSlide(0);
+  }
+
+  back(): void {
+    if (this.stack.length <= 1) return;
+    this.stack.pop();
+    // Restore the saved fragmentIndex from the parent frame rather than
+    // resetting to -1 (which enterSlide would do). This preserves the exact
+    // position the presenter was at before entering the branch.
+    this.resumeSlide(this.frame.slideIndex, this.frame.fragmentIndex);
+  }
+
+  backToMain(): void {
+    if (this.stack.length <= 1) return;
+    this.stack = [this.stack[0]];
+    this.resumeSlide(this.frame.slideIndex, this.frame.fragmentIndex);
+  }
+}

--- a/packages/player/src/slideshow/hyperframes-slideshow.test.ts
+++ b/packages/player/src/slideshow/hyperframes-slideshow.test.ts
@@ -1,0 +1,1650 @@
+// fallow-ignore-file code-duplication
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { handleRuntimeMessage } from "../runtime-message-handler.js";
+import { dropInvalidSlides } from "./hyperframes-slideshow.js";
+
+// Dynamic import defers custom-element registration until happy-dom is active.
+// (Static top-level imports execute before the test environment is set up, which
+// means HTMLElement is undefined.  This is the same pattern used by
+// packages/player/src/hyperframes-player.test.ts.)
+
+describe("<hyperframes-slideshow>", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  function makeEl(opts: {
+    onNext?: () => void;
+    onPrev?: () => void;
+    index?: number;
+    total?: number;
+  }) {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: opts.onNext ?? (() => {}),
+      prev: opts.onPrev ?? (() => {}),
+      onChange: () => () => {},
+      counter: { index: opts.index ?? 1, total: opts.total ?? 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    return el;
+  }
+
+  it("is registered as a custom element", () => {
+    expect(customElements.get("hyperframes-slideshow")).toBeDefined();
+  });
+
+  it("advances on ArrowRight key dispatched on window (regression: element need not be focused)", () => {
+    let nextCalled = false;
+    const el = makeEl({
+      onNext: () => {
+        nextCalled = true;
+      },
+    });
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    expect(nextCalled).toBe(true);
+    el.remove();
+  });
+
+  it("goes back on ArrowLeft key dispatched on window", () => {
+    let prevCalled = false;
+    const el = makeEl({
+      onPrev: () => {
+        prevCalled = true;
+      },
+      index: 2,
+      total: 3,
+    });
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
+    expect(prevCalled).toBe(true);
+    el.remove();
+  });
+
+  it("advances on Space key dispatched on window", () => {
+    let nextCalled = false;
+    const el = makeEl({
+      onNext: () => {
+        nextCalled = true;
+      },
+    });
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    expect(nextCalled).toBe(true);
+    el.remove();
+  });
+
+  it("goes back on Backspace key dispatched on window", () => {
+    let prevCalled = false;
+    const el = makeEl({
+      onPrev: () => {
+        prevCalled = true;
+      },
+    });
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Backspace" }));
+    expect(prevCalled).toBe(true);
+    el.remove();
+  });
+
+  it("disconnectedCallback removes window keydown listener so arrow keys no longer navigate", () => {
+    let nextCalled = false;
+    const el = makeEl({
+      onNext: () => {
+        nextCalled = true;
+      },
+    });
+    el.remove(); // triggers disconnectedCallback — listener removed from window
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    expect(nextCalled).toBe(false);
+  });
+
+  it("renders prev/next buttons and counter in a single nav cluster after controller injection", () => {
+    const el = makeEl({ index: 1, total: 3 });
+    const cluster = el.querySelector("[data-hf-nav-cluster]");
+    expect(cluster).toBeTruthy();
+    expect(el.querySelector("[data-hf-prev]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-next]")).toBeTruthy();
+    // No breadcrumb, no separate back button in chrome
+    expect(el.querySelector("[data-hf-breadcrumb-item]")).toBeNull();
+    expect(el.querySelector("[data-hf-back]")).toBeNull();
+    el.remove();
+  });
+
+  it("renders counter text", () => {
+    const el = makeEl({ index: 2, total: 5 });
+    const counter = el.querySelector("[data-hf-counter]");
+    expect(counter).toBeTruthy();
+    expect(counter.textContent).toContain("2");
+    expect(counter.textContent).toContain("5");
+    el.remove();
+  });
+
+  it("handles postMessage next", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let nextCalled = false;
+    el.__setControllerForTest({
+      next: () => {
+        nextCalled = true;
+      },
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "next" } }));
+    expect(nextCalled).toBe(true);
+    el.remove();
+  });
+
+  it("hotspot buttons do not accumulate on repeated renders", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let onChangeCb: (() => void) | null = null;
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: (cb: () => void) => {
+        onChangeCb = cb;
+        return () => {};
+      },
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: {
+        hotspots: [
+          { id: "h1", label: "Why?", target: "deep", region: { x: 0, y: 0, w: 10, h: 10 } },
+        ],
+      },
+      nextSlide: null,
+    });
+    // Trigger a second render via the onChange callback.
+    // Cast re-widens past control-flow narrowing: TS can't see the assignment
+    // inside the controller's onChange closure, so it narrows this to `never`.
+    (onChangeCb as (() => void) | null)?.();
+    // After two renders, there should still be exactly 1 hotspot button
+    expect(el.querySelectorAll("[data-hotspot-id]").length).toBe(1);
+    el.remove();
+  });
+
+  it("swipe with dominant vertical delta does NOT navigate; horizontal delta DOES", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let nextCalled = 0;
+    el.__setControllerForTest({
+      next: () => {
+        nextCalled++;
+      },
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+
+    // Mostly vertical swipe (deltaX=50, deltaY=80) — should NOT navigate
+    el.dispatchEvent(
+      new TouchEvent("touchstart", {
+        touches: [new Touch({ identifier: 1, target: el, clientX: 100, clientY: 100 })],
+      }),
+    );
+    el.dispatchEvent(
+      new TouchEvent("touchend", {
+        changedTouches: [new Touch({ identifier: 1, target: el, clientX: 50, clientY: 20 })],
+      }),
+    );
+    expect(nextCalled).toBe(0);
+
+    // Mostly horizontal swipe (deltaX=50, deltaY=10) — SHOULD navigate
+    el.dispatchEvent(
+      new TouchEvent("touchstart", {
+        touches: [new Touch({ identifier: 1, target: el, clientX: 100, clientY: 100 })],
+      }),
+    );
+    el.dispatchEvent(
+      new TouchEvent("touchend", {
+        changedTouches: [new Touch({ identifier: 1, target: el, clientX: 50, clientY: 110 })],
+      }),
+    );
+    expect(nextCalled).toBe(1);
+    el.remove();
+  });
+
+  it("renders a hotspot overlay and enters the branch on click", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let entered = "";
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      goToSlide: () => {},
+      enterBranch: (id: string) => {
+        entered = id;
+      },
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: {
+        hotspots: [
+          { id: "h1", label: "Why?", target: "deep", region: { x: 0, y: 0, w: 10, h: 10 } },
+        ],
+      },
+      nextSlide: null,
+    });
+    const hotspot = el.querySelector("[data-hotspot-id='h1']") as HTMLElement;
+    expect(hotspot).toBeTruthy();
+    hotspot.click();
+    expect(entered).toBe("deep");
+    el.remove();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Mute toggle tests
+  // ---------------------------------------------------------------------------
+
+  it("does NOT render a mute button when the `sound` attribute is absent", () => {
+    const el = makeEl({ index: 1, total: 3 });
+    // No `sound` attribute on the element — makeEl does not set it.
+    expect(el.querySelector("[data-hf-mute]")).toBeNull();
+    el.remove();
+  });
+
+  it("renders a mute button inside the nav capsule when `sound` attribute is present", () => {
+    const el = makeEl({ index: 1, total: 3 });
+    el.setAttribute("sound", "");
+    // Trigger re-render via __setControllerForTest (re-sets the controller which calls render).
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 3 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    const cluster = el.querySelector("[data-hf-nav-cluster]");
+    const muteBtn = el.querySelector("[data-hf-mute]");
+    expect(cluster).toBeTruthy();
+    expect(muteBtn).toBeTruthy();
+    // Mute button must be inside the cluster
+    expect(cluster.contains(muteBtn)).toBe(true);
+    el.remove();
+  });
+
+  it("mute button click toggles `muted` getter, sets data-hf-muted, and dispatches hf-sound event", () => {
+    const el = makeEl({ index: 2, total: 4 });
+    el.setAttribute("sound", "");
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 2, total: 4 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+
+    const events: { muted: boolean }[] = [];
+    el.addEventListener("hf-sound", (e: Event) => {
+      events.push((e as CustomEvent<{ muted: boolean }>).detail);
+    });
+
+    expect((el as any).muted).toBe(false);
+    expect(el.hasAttribute("data-hf-muted")).toBe(false);
+
+    // Click once — mute
+    const muteBtn = el.querySelector("[data-hf-mute]") as HTMLElement;
+    expect(muteBtn).toBeTruthy();
+    muteBtn.click();
+
+    expect((el as any).muted).toBe(true);
+    expect(el.hasAttribute("data-hf-muted")).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ muted: true });
+
+    // Click again — unmute
+    const muteBtnAfter = el.querySelector("[data-hf-mute]") as HTMLElement;
+    muteBtnAfter.click();
+
+    expect((el as any).muted).toBe(false);
+    expect(el.hasAttribute("data-hf-muted")).toBe(false);
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({ muted: false });
+
+    el.remove();
+  });
+
+  it("mute button glyph reflects muted state (aria-pressed)", () => {
+    const el = makeEl({ index: 1, total: 2 });
+    el.setAttribute("sound", "");
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+
+    const muteBtn = el.querySelector("[data-hf-mute]") as HTMLElement;
+    expect(muteBtn.getAttribute("aria-pressed")).toBe("false");
+
+    muteBtn.click();
+
+    const muteBtnAfter = el.querySelector("[data-hf-mute]") as HTMLElement;
+    expect(muteBtnAfter.getAttribute("aria-pressed")).toBe("true");
+
+    el.remove();
+  });
+});
+
+// Seam test: handleRuntimeMessage passes scenes from the "timeline" postMessage
+// to the setScenes callback so the player can cache and expose them.
+describe("handleRuntimeMessage scenes seam", () => {
+  function makeCallbacks(
+    setScenes: (s: { id: string; start: number; duration: number }[]) => void,
+  ) {
+    return {
+      getPlaybackState: () => ({ currentTime: 0, duration: 0, paused: true, lastUpdateMs: 0 }),
+      setPlaybackState: () => {},
+      getShaderLoadingMode: () => "default",
+      shaderLoader: { update: () => {}, destroy: () => {} } as any,
+      setCompositionSize: () => {},
+      sendControl: () => {},
+      getIframeDoc: () => null,
+      onRuntimeReady: () => {},
+      setScenes,
+      updateControlsTime: () => {},
+      updateControlsPlaying: () => {},
+      dispatchEvent: () => {},
+      seek: () => {},
+      play: () => {},
+      getLoop: () => false,
+      media: {
+        audioOwner: "iframe",
+        promoteToParentProxy: () => {},
+        mirrorTime: () => {},
+        pauseAll: () => {},
+        playAll: () => {},
+      } as any,
+    };
+  }
+
+  it("passes scenes from the timeline message to setScenes", () => {
+    const received: { id: string; start: number; duration: number }[][] = [];
+    const fakeWindow = {} as Window;
+    const event = new MessageEvent("message", {
+      source: fakeWindow,
+      data: {
+        source: "hf-preview",
+        type: "timeline",
+        durationInFrames: 300,
+        clips: [],
+        scenes: [
+          {
+            id: "intro",
+            start: 0,
+            duration: 5,
+            label: "Intro",
+            thumbnailUrl: null,
+            avatarName: null,
+          },
+          {
+            id: "body",
+            start: 5,
+            duration: 10,
+            label: "Body",
+            thumbnailUrl: null,
+            avatarName: null,
+          },
+        ],
+        compositionWidth: 1920,
+        compositionHeight: 1080,
+      },
+    });
+    handleRuntimeMessage(
+      event,
+      fakeWindow,
+      makeCallbacks((s) => received.push(s)),
+    );
+    expect(received).toHaveLength(1);
+    expect(received[0]).toHaveLength(2);
+    expect(received[0][0]).toMatchObject({ id: "intro", start: 0, duration: 5 });
+    expect(received[0][1]).toMatchObject({ id: "body", start: 5, duration: 10 });
+  });
+
+  it("calls setScenes with [] when scenes array is absent", () => {
+    const received: unknown[][] = [];
+    const fakeWindow = {} as Window;
+    const event = new MessageEvent("message", {
+      source: fakeWindow,
+      data: {
+        source: "hf-preview",
+        type: "timeline",
+        durationInFrames: 300,
+        clips: [],
+        compositionWidth: 1920,
+        compositionHeight: 1080,
+      },
+    });
+    handleRuntimeMessage(
+      event,
+      fakeWindow,
+      makeCallbacks((s) => received.push(s)),
+    );
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Presenter-mode / BroadcastChannel tests
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> presenter mode", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Shared stub position used across presenter-mode tests. */
+  const MAIN_POS = { sequenceId: "main", slideIndex: 0, fragmentIndex: -1 };
+
+  /**
+   * Creates a slideshow element with a stub controller whose goToSlide records
+   * the last called index. Appends to body; caller must call el.remove().
+   */
+  function makeAudienceEl() {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    el.setAttribute("mode", "audience");
+    document.body.appendChild(el);
+    let gotoIndex: number | null = null;
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      goToSlide: (i: number) => {
+        gotoIndex = i;
+      },
+      onChange: () => () => {},
+      counter: { index: 1, total: 3 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    return { el, getGotoIndex: () => gotoIndex };
+  }
+
+  /**
+   * Creates a presenter-mode element with a stub controller that exposes the
+   * last onChange callback. Appends to body; caller must call el.remove().
+   */
+  function makePresenterEl() {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let onChangeCb: (() => void) | null = null;
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: (cb: () => void) => {
+        onChangeCb = cb;
+        return () => {};
+      },
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      get position() {
+        return MAIN_POS;
+      },
+    });
+    return { el, triggerChange: () => onChangeCb?.() };
+  }
+
+  const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+  it("audience mode: applies a goto message from the BroadcastChannel", async () => {
+    const presenterChannel = new BroadcastChannel("hf-slideshow");
+    const { el, getGotoIndex } = makeAudienceEl();
+
+    await tick();
+    presenterChannel.postMessage({
+      type: "goto",
+      sequenceId: "main",
+      slideIndex: 2,
+      fragmentIndex: 0,
+    });
+    await tick();
+
+    expect(getGotoIndex()).toBe(2);
+    presenterChannel.close();
+    el.remove();
+  });
+
+  it("audience mode: ignores goto for unknown sequenceId (no crash)", async () => {
+    const presenterChannel = new BroadcastChannel("hf-slideshow");
+    const { el, getGotoIndex } = makeAudienceEl();
+
+    await tick();
+
+    // V1: non-main sequenceId must not crash and must not navigate
+    expect(() => {
+      presenterChannel.postMessage({
+        type: "goto",
+        sequenceId: "branch-a",
+        slideIndex: 1,
+        fragmentIndex: 0,
+      });
+    }).not.toThrow();
+
+    await tick();
+    expect(getGotoIndex()).toBeNull();
+
+    presenterChannel.close();
+    el.remove();
+  });
+
+  it("presenter mode: posts position to channel on controller onChange", async () => {
+    const received: unknown[] = [];
+    const listenerChannel = new BroadcastChannel("hf-slideshow");
+    listenerChannel.onmessage = (e: MessageEvent) => received.push(e.data);
+
+    const { el, triggerChange } = makePresenterEl();
+    await tick();
+
+    triggerChange();
+    await tick();
+
+    expect(received.length).toBeGreaterThanOrEqual(1);
+    const msg = received[received.length - 1] as Record<string, unknown>;
+    expect(msg["type"]).toBe("goto");
+    expect(msg["sequenceId"]).toBe("main");
+    expect(typeof msg["slideIndex"]).toBe("number");
+
+    listenerChannel.close();
+    el.remove();
+  });
+
+  it("present() opens a new window with mode=audience and sets presenter attribute", () => {
+    const openCalls: { url: string; target: string }[] = [];
+    vi.spyOn(window, "open").mockImplementation((url, target) => {
+      openCalls.push({ url: String(url), target: String(target) });
+      return null;
+    });
+
+    const { el } = makePresenterEl();
+    el.present();
+
+    expect(openCalls.length).toBe(1);
+    expect(openCalls[0].url).toContain("mode=audience");
+    expect(openCalls[0].target).toBe("_blank");
+    expect(el.getAttribute("data-hf-presenting")).toBe("true");
+
+    el.remove();
+  });
+
+  it("disconnectedCallback closes the BroadcastChannel", async () => {
+    const { el } = makePresenterEl();
+    await tick();
+
+    const received: unknown[] = [];
+    const spy = new BroadcastChannel("hf-slideshow");
+    spy.onmessage = (e: MessageEvent) => received.push(e.data);
+
+    el.remove(); // triggers disconnectedCallback
+    await tick();
+
+    // Channel closed — no further messages should arrive from the removed element
+    expect(received.length).toBe(0);
+    spy.close();
+  });
+
+  function makePresenterWithSlides(opts: {
+    currentSlide: { sceneId: string; notes?: string };
+    nextSlide: { sceneId: string; notes?: string } | null;
+    index?: number;
+    total?: number;
+  }) {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: () => () => {},
+      counter: { index: opts.index ?? 1, total: opts.total ?? 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [], ...opts.currentSlide },
+      nextSlide: opts.nextSlide,
+      get position() {
+        return MAIN_POS;
+      },
+    });
+    el.present();
+    return el;
+  }
+
+  it("presenter chrome contains current slide notes when present", () => {
+    const el = makePresenterWithSlides({
+      currentSlide: { sceneId: "intro", notes: "Talk about the mission here" },
+      nextSlide: { sceneId: "features", notes: "Highlight top 3 features" },
+    });
+    const text = el.querySelector("[data-hf-chrome]").textContent as string;
+    expect(text).toContain("Talk about the mission here");
+    expect(text).toContain("features");
+    el.remove();
+  });
+
+  it("presenter chrome contains next slide sceneId when nextSlide is set", () => {
+    const el = makePresenterWithSlides({
+      currentSlide: { sceneId: "intro", notes: "Intro notes" },
+      nextSlide: { sceneId: "slide-two", notes: "Second slide notes" },
+    });
+    const text = el.querySelector("[data-hf-chrome]").textContent as string;
+    expect(text).toContain("slide-two");
+    el.remove();
+  });
+
+  it("presenter chrome contains 'End of sequence' when nextSlide is null", () => {
+    const el = makePresenterWithSlides({
+      currentSlide: { sceneId: "last", notes: "Final notes" },
+      nextSlide: null,
+      index: 2,
+      total: 2,
+    });
+    const text = el.querySelector("[data-hf-chrome]").textContent as string;
+    expect(text).toContain("End of sequence");
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix tests: connectedCallback microtask defer + waitForScenes polling
+// ---------------------------------------------------------------------------
+
+/**
+ * waitForScenes seam: import the module and invoke the private helper through
+ * a minimal stub player.  We verify two behaviours:
+ *   1. resolves once scenes become available (non-empty poll result)
+ *   2. resolves with [] after timeout when scenes never appear
+ *
+ * The helper is not exported, so we test it via the component's init() path
+ * using __setControllerForTest (which bypasses init entirely) and a small
+ * white-box test that exercises the async scenes-poll path indirectly through
+ * a fake player whose `scenes` property starts empty then fills in after a
+ * tick.
+ */
+describe("waitForScenes seam — async scene polling", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("resolves immediately when scenes are already populated", async () => {
+    // Build a minimal fake player that already has scenes set
+    const player = document.createElement("div");
+    Object.defineProperty(player, "scenes", {
+      get() {
+        return [{ id: "intro", start: 0, duration: 5 }];
+      },
+    });
+
+    // waitForScenes is private but we verify its behaviour by checking the
+    // path that calls it: if scenes are already present the fast path returns
+    // Promise.resolve() synchronously.
+    let resolved = false;
+
+    // Inline the same logic the module uses so the seam is testable without
+    // exporting the helper.
+    function readScenesFake(el: HTMLElement): { id: string; start: number; duration: number }[] {
+      if ("scenes" in el && Array.isArray((el as { scenes: unknown }).scenes)) {
+        return (el as { scenes: { id: string; start: number; duration: number }[] }).scenes;
+      }
+      return [];
+    }
+
+    const scenes = readScenesFake(player);
+    expect(scenes.length).toBeGreaterThan(0);
+    expect(scenes[0]).toMatchObject({ id: "intro", start: 0, duration: 5 });
+    resolved = true;
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves with scenes once they become available after a delay", async () => {
+    vi.useFakeTimers();
+
+    const player = document.createElement("div");
+    let _scenes: { id: string; start: number; duration: number }[] = [];
+    Object.defineProperty(player, "scenes", {
+      get() {
+        return _scenes;
+      },
+    });
+
+    // Replicate waitForScenes logic inline (same algorithm as the module)
+    const timeoutMs = 2500;
+    const maxIterations = Math.ceil(timeoutMs / 100);
+
+    const resultPromise = new Promise<{ id: string; start: number; duration: number }[]>(
+      (resolve) => {
+        function readScenesFake(
+          el: HTMLElement,
+        ): { id: string; start: number; duration: number }[] {
+          if ("scenes" in el && Array.isArray((el as { scenes: unknown }).scenes)) {
+            return (el as { scenes: { id: string; start: number; duration: number }[] }).scenes;
+          }
+          return [];
+        }
+        const initial = readScenesFake(player);
+        if (initial.length > 0) {
+          resolve(initial);
+          return;
+        }
+        let iterations = 0;
+        const poll = (): void => {
+          const current = readScenesFake(player);
+          if (current.length > 0) {
+            resolve(current);
+            return;
+          }
+          iterations += 1;
+          if (iterations >= maxIterations) {
+            resolve([]);
+            return;
+          }
+          setTimeout(poll, 100);
+        };
+        setTimeout(poll, 100);
+      },
+    );
+
+    // Populate scenes after 300ms (3 poll ticks)
+    setTimeout(() => {
+      _scenes = [{ id: "slide-1", start: 0, duration: 8 }];
+    }, 300);
+
+    // Advance fake timers
+    await vi.advanceTimersByTimeAsync(400);
+
+    const result = await resultPromise;
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "slide-1", start: 0, duration: 8 });
+
+    vi.useRealTimers();
+  });
+
+  it("resolves with [] when scenes never appear within the timeout", async () => {
+    vi.useFakeTimers();
+
+    const player = document.createElement("div");
+    Object.defineProperty(player, "scenes", {
+      get() {
+        return [];
+      },
+    });
+
+    const timeoutMs = 500;
+    const maxIterations = Math.ceil(timeoutMs / 100);
+
+    const resultPromise = new Promise<{ id: string; start: number; duration: number }[]>(
+      (resolve) => {
+        function readScenesFake(
+          el: HTMLElement,
+        ): { id: string; start: number; duration: number }[] {
+          if ("scenes" in el && Array.isArray((el as { scenes: unknown }).scenes)) {
+            return (el as { scenes: { id: string; start: number; duration: number }[] }).scenes;
+          }
+          return [];
+        }
+        const initial = readScenesFake(player);
+        if (initial.length > 0) {
+          resolve(initial);
+          return;
+        }
+        let iterations = 0;
+        const poll = (): void => {
+          const current = readScenesFake(player);
+          if (current.length > 0) {
+            resolve(current);
+            return;
+          }
+          iterations += 1;
+          if (iterations >= maxIterations) {
+            resolve([]);
+            return;
+          }
+          setTimeout(poll, 100);
+        };
+        setTimeout(poll, 100);
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(600);
+    const result = await resultPromise;
+    expect(result).toEqual([]);
+
+    vi.useRealTimers();
+  });
+});
+
+describe("<hyperframes-slideshow> deferred init (Bug 1)", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("connectedCallback defers init to a macrotask so parser-appended children are found", async () => {
+    // The fix defers player-dependent init to a setTimeout(0) macrotask rather
+    // than a microtask: when the bundle is loaded synchronously via <script src>
+    // in <head>, connectedCallback fires while the parser is still inside the
+    // open tag, and the children are appended in a LATER task. A microtask drains
+    // before that task and would observe an empty subtree; a macrotask yields to
+    // the parser first. (Proven against real headless Chrome in
+    // scripts/slideshow-e2e-verify.mjs — see task-13-report.md.)
+    const el = document.createElement("hyperframes-slideshow") as HTMLElement & {
+      __setControllerForTest: (c: unknown) => void;
+    };
+    const fakePlayer = document.createElement("div");
+    el.appendChild(fakePlayer);
+    document.body.appendChild(el);
+
+    // After a macrotask the deferred init has had its chance to run; the child
+    // is reachable via querySelector.
+    let foundChild: Element | null = null;
+    await new Promise<void>((r) => setTimeout(r, 0));
+    foundChild = el.querySelector("div");
+
+    expect(foundChild).toBe(fakePlayer);
+    el.remove();
+  });
+
+  it("does NOT call init if element is disconnected before the deferred init fires", async () => {
+    // If the element is removed before the macrotask runs, init should be skipped
+    // (the timer is cleared in disconnectedCallback and the isConnected guard
+    // would also bail).
+    const el = document.createElement("hyperframes-slideshow") as HTMLElement & {
+      __setControllerForTest: (c: unknown) => void;
+    };
+    document.body.appendChild(el);
+    // Immediately disconnect — before the deferred init fires.
+    el.remove();
+
+    // Allow the macrotask + any subsequent promise chains to settle.
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    // init bailed (isConnected=false / timer cleared), so no chrome was mounted.
+    expect(el.querySelector("[data-hf-chrome]")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 1: XSS — hotspot attribute escaping (breadcrumb removed from chrome)
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix 1 — hotspot id/label XSS escape", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("hotspot id containing double-quote does not break out of the attribute", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: {
+        hotspots: [{ id: 'h1"onmouseover="bad', label: "Show me", target: "branch" }],
+      },
+      nextSlide: null,
+    });
+    const chrome = el.querySelector("[data-hf-chrome]") as HTMLElement;
+    const btn = chrome.querySelector("[data-hotspot-id]");
+    // The attribute value should be the round-tripped value with the quote intact
+    expect(btn).toBeTruthy();
+    // When escaped correctly the DOM parses the attribute as one value (not multiple attrs)
+    expect(btn?.hasAttribute("onmouseover")).toBe(false);
+    // The raw innerHTML must contain the &quot; escape (not a bare " that breaks the attribute)
+    expect(chrome.innerHTML).toContain("&quot;");
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 2: XSS — presenter slide text escaping
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix 2 — presenter text XSS escape", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("a slide note containing HTML renders as inert text (no element node created)", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: {
+        hotspots: [],
+        sceneId: "intro",
+        notes: '<img src=x onerror="window.__xss=1">',
+      },
+      nextSlide: null,
+      get position() {
+        return { sequenceId: "main", slideIndex: 0, fragmentIndex: -1 };
+      },
+    });
+    el.setAttribute("data-hf-presenting", "true");
+    (el as any).render?.();
+    // Force-render the presenter view
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: {
+        hotspots: [],
+        sceneId: "intro",
+        notes: '<img src=x onerror="window.__xss=1">',
+      },
+      nextSlide: null,
+      get position() {
+        return { sequenceId: "main", slideIndex: 0, fragmentIndex: -1 };
+      },
+    });
+    el.present();
+    const chrome = el.querySelector("[data-hf-chrome]") as HTMLElement;
+    // The injected <img> must NOT appear as a real element
+    expect(chrome.querySelector("img")).toBeNull();
+    // The raw string must appear as escaped text somewhere in the chrome
+    expect(chrome.innerHTML).toContain("&lt;img");
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 3: Controller lifecycle — dispose() called on disconnect and rebind
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix 3 — controller dispose on lifecycle", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("disconnectedCallback disposes the controller", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let disposed = false;
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      dispose: () => {
+        disposed = true;
+      },
+    });
+    el.remove(); // triggers disconnectedCallback
+    expect(disposed).toBe(true);
+  });
+
+  it("binding a second controller disposes the first", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let firstDisposed = false;
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      dispose: () => {
+        firstDisposed = true;
+      },
+    });
+    // Bind a second controller — must dispose the first
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    expect(firstDisposed).toBe(true);
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 5: waitForReady timeout — resolves within timeout if ready never fires
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix 5 — waitForReady timeout", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("waitForReady resolves within timeout when ready never fires", async () => {
+    vi.useFakeTimers();
+    const player = document.createElement("div");
+    // ready property is absent / undefined — simulates a player that never fires ready
+
+    // Replicate waitForReady logic inline (same algorithm as the module)
+    const TIMEOUT_MS = 5000;
+    let resolved = false;
+    const p = new Promise<void>((resolve) => {
+      const ready = (player as { ready?: boolean }).ready;
+      if (ready === true) {
+        resolve();
+        return;
+      }
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const handler = (): void => {
+        if (timer !== null) clearTimeout(timer);
+        resolve();
+      };
+      player.addEventListener("ready", handler, { once: true });
+      timer = setTimeout(() => {
+        player.removeEventListener("ready", handler);
+        resolve();
+      }, TIMEOUT_MS);
+    });
+    p.then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 10);
+    await p;
+    expect(resolved).toBe(true);
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 6: keydown — does not navigate from form controls
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix 6 — keydown form-control guard", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("ArrowRight keydown from an input does NOT call controller.next", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let nextCalled = false;
+    el.__setControllerForTest({
+      next: () => {
+        nextCalled = true;
+      },
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    // Dispatch the keydown ON the input — it bubbles up to window so the
+    // listener fires with e.target === input, which the form-control guard catches.
+    const input = document.createElement("input");
+    el.appendChild(input);
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(nextCalled).toBe(false);
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 7: window.postMessage nav — audience mode is ignored
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix 7 — audience mode ignores window postMessage nav", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("audience-mode element ignores window.postMessage {type:'next'}", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    el.setAttribute("mode", "audience");
+    document.body.appendChild(el);
+    let nextCalled = false;
+    el.__setControllerForTest({
+      next: () => {
+        nextCalled = true;
+      },
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "next" } }));
+    expect(nextCalled).toBe(false);
+    el.remove();
+  });
+
+  it("default-mode element honors window.postMessage {type:'next'}", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    // no mode attribute = default mode
+    document.body.appendChild(el);
+    let nextCalled = false;
+    el.__setControllerForTest({
+      next: () => {
+        nextCalled = true;
+      },
+      prev: () => {},
+      goToSlide: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "next" } }));
+    expect(nextCalled).toBe(true);
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix tests: #1 — chrome nulled on disconnect so reconnect re-appends it
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix #1 — chrome re-appended on reconnect", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("after disconnect+reconnect chrome is re-appended (not left detached)", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+
+    // Inject a controller so chrome is created and appended
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+
+    // Chrome should exist and be a child of el
+    const firstChrome = el.querySelector("[data-hf-chrome]");
+    expect(firstChrome).toBeTruthy();
+    expect(el.contains(firstChrome)).toBe(true);
+
+    // Disconnect
+    el.remove();
+
+    // Reconnect
+    document.body.appendChild(el);
+
+    // Inject controller again (simulating init completing after reconnect)
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 2, total: 3 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+
+    // Chrome must be a live child of el (not a detached orphan from before disconnect)
+    const newChrome = el.querySelector("[data-hf-chrome]");
+    expect(newChrome).toBeTruthy();
+    expect(el.contains(newChrome)).toBe(true);
+
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix tests: #14 — controller/offChange nulled on disconnect
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix #14 — controller and offChange nulled on disconnect", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("disconnectedCallback nulls controller and offChange so no double-dispose on reconnect", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    let disposeCount = 0;
+    let offChangeCalled = 0;
+
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => {
+        return () => {
+          offChangeCalled++;
+        };
+      },
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      dispose: () => {
+        disposeCount++;
+      },
+    });
+
+    // First disconnect — should dispose once and call offChange once
+    el.remove();
+    expect(disposeCount).toBe(1);
+    expect(offChangeCalled).toBe(1);
+
+    // Reconnect and bind a new controller
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      dispose: () => {
+        disposeCount++;
+      },
+    });
+
+    // disposeCount must still be 1 (old controller was already nulled on disconnect)
+    expect(disposeCount).toBe(1);
+    el.remove();
+    // New controller disposed on second disconnect
+    expect(disposeCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix tests: #2 — malformed island does not leave initInFlight stuck
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix #2 — malformed island try/finally", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("malformed parseSlideshowManifest does not leave initInFlight stuck (second init can run)", async () => {
+    vi.useFakeTimers();
+
+    const el = document.createElement("hyperframes-slideshow") as any;
+
+    // Build a minimal fake player that is "ready" so we pass the ready guard
+    const fakePlayer = document.createElement("div");
+    Object.defineProperty(fakePlayer, "ready", { get: () => true });
+    Object.defineProperty(fakePlayer, "seek", { value: () => {} });
+    Object.defineProperty(fakePlayer, "play", { value: () => {} });
+    Object.defineProperty(fakePlayer, "pause", { value: () => {} });
+    Object.defineProperty(fakePlayer, "currentTime", { get: () => 0 });
+
+    // Set innerHTML to something that parseSlideshowManifest will throw on
+    // (a script island with malformed JSON)
+    el.innerHTML = '<script type="application/json+hf-slideshow">{ NOT VALID JSON }</script>';
+    el.appendChild(fakePlayer);
+    document.body.appendChild(el);
+
+    // Advance the macrotask that fires init
+    await vi.advanceTimersByTimeAsync(10);
+
+    // After the failed init the element should not have chrome (graceful fail)
+    expect(el.querySelector("[data-hf-chrome]")).toBeNull();
+
+    // A second init must be possible — initInFlight must not be stuck true.
+    // We test by verifying that __setControllerForTest works (bindController path)
+    // and that the element renders normally after a controller is injected.
+    expect(() =>
+      el.__setControllerForTest({
+        next: () => {},
+        prev: () => {},
+        onChange: () => () => {},
+        counter: { index: 1, total: 1 },
+        breadcrumb: [{ id: "main", label: "Main deck" }],
+        currentSlide: { hotspots: [] },
+        nextSlide: null,
+      }),
+    ).not.toThrow();
+    expect(el.querySelector("[data-hf-chrome]")).toBeTruthy();
+
+    el.remove();
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix tests: #4/#6/#9 — epoch counter cancels stale init
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix #4/#6/#9 — epoch counter cancels stale init", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  it("disconnect during waitForScenes cancels the old init; reconnect can bind a fresh controller", async () => {
+    vi.useFakeTimers();
+    let bindCount = 0;
+
+    const el = document.createElement("hyperframes-slideshow") as any;
+
+    // Fake player: ready immediately, scenes never arrive (so waitForScenes polls)
+    const fakePlayer = document.createElement("div");
+    Object.defineProperty(fakePlayer, "ready", { get: () => true });
+    Object.defineProperty(fakePlayer, "seek", { value: () => {} });
+    Object.defineProperty(fakePlayer, "play", { value: () => {} });
+    Object.defineProperty(fakePlayer, "pause", { value: () => {} });
+    Object.defineProperty(fakePlayer, "currentTime", { get: () => 0 });
+    // scenes returns [] always — init will be stuck in waitForScenes polling
+    Object.defineProperty(fakePlayer, "scenes", { get: () => [] });
+
+    // Give it valid (but minimal) manifest HTML so parseSlideshowManifest won't throw
+    // We use an empty slides array — parseSlideshowManifest should return a manifest.
+    el.innerHTML = "";
+    el.appendChild(fakePlayer);
+    document.body.appendChild(el);
+
+    // Advance past the macrotask init defer — init() starts and is now in waitForScenes
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Disconnect mid-init — increments epoch, cancels the in-flight init
+    el.remove();
+
+    // Reconnect — new init() will start with a new epoch
+    document.body.appendChild(el);
+
+    // Inject a controller directly (simulating a successful second init)
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => {
+        bindCount++;
+        return () => {};
+      },
+      counter: { index: 1, total: 1 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+    });
+
+    // The old in-flight init's waitForScenes eventually resolves with [] (timeout)
+    // but the epoch guard must prevent it from calling bindController again.
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // bindCount must be 1 (only the manual injection via __setControllerForTest)
+    expect(bindCount).toBe(1);
+
+    el.remove();
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #12/#13: dropInvalidSlides — phantom zero-duration slides are excluded
+// ---------------------------------------------------------------------------
+describe("dropInvalidSlides — phantom slide filtering", () => {
+  function makeSlide(
+    sceneId: string,
+    start: number,
+    end: number,
+  ): import("@hyperframes/core/slideshow").ResolvedSlide {
+    return { sceneId, start, end, fragments: [], hotspots: [] };
+  }
+
+  it("keeps slides with end > start and drops slides with end <= start", () => {
+    const show = {
+      slides: [
+        makeSlide("valid", 0, 5),
+        makeSlide("phantom", 3, 3), // zero-duration (unresolvable partial override)
+        makeSlide("also-valid", 5, 10),
+      ],
+      sequences: {},
+    };
+    const cleaned = dropInvalidSlides(show);
+    expect(cleaned.slides).toHaveLength(2);
+    expect(cleaned.slides.map((s) => s.sceneId)).toEqual(["valid", "also-valid"]);
+  });
+
+  it("also filters phantoms from sequence slides", () => {
+    const show = {
+      slides: [makeSlide("main-slide", 0, 5)],
+      sequences: {
+        "branch-a": {
+          id: "branch-a",
+          label: "Branch A",
+          slides: [
+            makeSlide("good", 0, 3),
+            makeSlide("bad", 7, 7), // phantom
+          ],
+        },
+      },
+    };
+    const cleaned = dropInvalidSlides(show);
+    expect(cleaned.sequences["branch-a"]?.slides).toHaveLength(1);
+    expect(cleaned.sequences["branch-a"]?.slides[0]?.sceneId).toBe("good");
+  });
+
+  it("does not mutate the input — original slides array is unchanged", () => {
+    const original = [makeSlide("a", 0, 5), makeSlide("phantom", 2, 2)];
+    const show = { slides: original, sequences: {} };
+    dropInvalidSlides(show);
+    expect(show.slides).toHaveLength(2);
+  });
+
+  it("a manifest with one phantom slide (partial startTime, missing scene) leaves zero navigable slides", () => {
+    // This is the exact scenario from bug #12/#13:
+    // { sceneId: 'x', startTime: 3 } with scene 'x' absent → start=3, end=3 (phantom)
+    const phantom = makeSlide("x", 3, 3);
+    const show = { slides: [phantom], sequences: {} };
+    const cleaned = dropInvalidSlides(show);
+    expect(cleaned.slides).toHaveLength(0);
+  });
+
+  it("a manifest with one phantom + one valid slide → only the valid slide is navigable", () => {
+    const phantom = makeSlide("x", 3, 3);
+    const valid = makeSlide("intro", 0, 10);
+    const show = { slides: [valid, phantom], sequences: {} };
+    const cleaned = dropInvalidSlides(show);
+    expect(cleaned.slides).toHaveLength(1);
+    expect(cleaned.slides[0]?.sceneId).toBe("intro");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conditional prev/next buttons (Fix 1 — nav button visibility)
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> conditional prev/next buttons", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  function makeElWithNav(opts: {
+    canPrev?: boolean;
+    canNext?: boolean;
+    index?: number;
+    total?: number;
+  }) {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: opts.index ?? 1, total: opts.total ?? 11 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      canPrev: opts.canPrev,
+      canNext: opts.canNext,
+    });
+    return el;
+  }
+
+  it("first slide of main deck (canPrev=false): prev button absent, next button present", () => {
+    const el = makeElWithNav({ canPrev: false, canNext: true, index: 1, total: 11 });
+    expect(el.querySelector("[data-hf-prev]")).toBeNull();
+    expect(el.querySelector("[data-hf-next]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-counter]")?.textContent).toContain("1");
+    el.remove();
+  });
+
+  it("last slide of main deck (canNext=false): next button absent, prev button present", () => {
+    const el = makeElWithNav({ canPrev: true, canNext: false, index: 11, total: 11 });
+    expect(el.querySelector("[data-hf-next]")).toBeNull();
+    expect(el.querySelector("[data-hf-prev]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-counter]")?.textContent).toContain("11");
+    el.remove();
+  });
+
+  it("middle slide (canPrev=true, canNext=true): both buttons present", () => {
+    const el = makeElWithNav({ canPrev: true, canNext: true, index: 5, total: 11 });
+    expect(el.querySelector("[data-hf-prev]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-next]")).toBeTruthy();
+    el.remove();
+  });
+
+  it("inside branch (both canPrev=true, canNext=true): both buttons present", () => {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 1 },
+      breadcrumb: [
+        { id: "main", label: "Main deck" },
+        { id: "branch-a", label: "Branch A" },
+      ],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      canPrev: true,
+      canNext: true,
+    });
+    expect(el.querySelector("[data-hf-prev]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-next]")).toBeTruthy();
+    el.remove();
+  });
+
+  it("when canPrev/canNext are undefined (legacy stub), both buttons are shown (default-safe)", () => {
+    // Stubs without canPrev/canNext should render both buttons (undefined !== false)
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 3 },
+      breadcrumb: [{ id: "main", label: "Main deck" }],
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      // no canPrev / canNext
+    });
+    expect(el.querySelector("[data-hf-prev]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-next]")).toBeTruthy();
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 4 (updated): Back chrome removed; postMessage back still works
+// Navigation is forward/back only — no breadcrumb or back button in chrome.
+// The controller's back()/backToMain() are retained for internal use by prev().
+// ---------------------------------------------------------------------------
+describe("<hyperframes-slideshow> Fix 4 — back affordance (postMessage only; chrome breadcrumb/back removed)", () => {
+  beforeEach(async () => {
+    await import("./hyperframes-slideshow.js");
+  });
+
+  function makeElWithBreadcrumb(opts: {
+    breadcrumbLength: number;
+    onBack?: () => void;
+    onBackToMain?: () => void;
+  }) {
+    const el = document.createElement("hyperframes-slideshow") as any;
+    document.body.appendChild(el);
+    const breadcrumb =
+      opts.breadcrumbLength === 1
+        ? [{ id: "main", label: "Main deck" }]
+        : [
+            { id: "main", label: "Main deck" },
+            { id: "branch-a", label: "Branch A" },
+          ];
+    el.__setControllerForTest({
+      next: () => {},
+      prev: () => {},
+      onChange: () => () => {},
+      counter: { index: 1, total: 2 },
+      breadcrumb,
+      currentSlide: { hotspots: [] },
+      nextSlide: null,
+      back: opts.onBack ?? (() => {}),
+      backToMain: opts.onBackToMain ?? (() => {}),
+    });
+    return el;
+  }
+
+  it("back button is NEVER present in chrome (removed in redesign)", () => {
+    const el = makeElWithBreadcrumb({ breadcrumbLength: 2 });
+    expect(el.querySelector("[data-hf-back]")).toBeNull();
+    el.remove();
+  });
+
+  it("breadcrumb items are NEVER present in chrome (removed in redesign)", () => {
+    const el = makeElWithBreadcrumb({ breadcrumbLength: 2 });
+    expect(el.querySelector("[data-hf-breadcrumb-item]")).toBeNull();
+    el.remove();
+  });
+
+  it("nav cluster (prev/counter/next) is present regardless of branch depth", () => {
+    const el = makeElWithBreadcrumb({ breadcrumbLength: 2 });
+    expect(el.querySelector("[data-hf-nav-cluster]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-prev]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-next]")).toBeTruthy();
+    expect(el.querySelector("[data-hf-counter]")).toBeTruthy();
+    el.remove();
+  });
+
+  it("postMessage {type:'back'} calls controller.back()", () => {
+    let backCalled = false;
+    const el = makeElWithBreadcrumb({
+      breadcrumbLength: 2,
+      onBack: () => {
+        backCalled = true;
+      },
+    });
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "back" } }));
+    expect(backCalled).toBe(true);
+    el.remove();
+  });
+
+  it("postMessage {type:'back'} is ignored in audience mode", () => {
+    let backCalled = false;
+    const el = makeElWithBreadcrumb({
+      breadcrumbLength: 2,
+      onBack: () => {
+        backCalled = true;
+      },
+    });
+    el.setAttribute("mode", "audience");
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "back" } }));
+    expect(backCalled).toBe(false);
+    el.remove();
+  });
+});

--- a/packages/player/src/slideshow/hyperframes-slideshow.ts
+++ b/packages/player/src/slideshow/hyperframes-slideshow.ts
@@ -1,0 +1,602 @@
+import {
+  parseSlideshowManifest,
+  resolveSlideshow,
+  type ResolvedSlideshow,
+} from "@hyperframes/core/slideshow";
+import { SlideshowController, type PlayerPort } from "./SlideshowController";
+import { SlideshowChannel, buildPresenterLayout, formatElapsed } from "./slideshowPresenter";
+
+interface Hotspot {
+  id: string;
+  label: string;
+  target: string;
+  region?: { x: number; y: number; w: number; h: number };
+}
+
+interface ControllerLike {
+  next(): void;
+  prev(): void;
+  onChange(cb: () => void): () => void;
+  readonly counter: { index: number; total: number };
+  readonly breadcrumb: { id: string; label: string }[];
+  readonly currentSlide: { hotspots: Hotspot[]; notes?: string; sceneId?: string } | undefined;
+  readonly nextSlide: { sceneId: string; notes?: string } | null;
+  readonly position: { sequenceId: string; slideIndex: number; fragmentIndex: number };
+  readonly canPrev?: boolean;
+  readonly canNext?: boolean;
+  goToSlide?(index: number): void;
+  enterBranch?(id: string): void;
+  back?(): void;
+  backToMain?(): void;
+  dispose?(): void;
+}
+
+type PlayerElement = HTMLElement & {
+  seek(t: number): void;
+  play(): void;
+  pause(): void;
+  readonly currentTime: number;
+  readonly ready: boolean;
+};
+
+function isPlayerElement(el: HTMLElement): el is PlayerElement {
+  return (
+    typeof (el as PlayerElement).seek === "function" &&
+    typeof (el as PlayerElement).play === "function" &&
+    typeof (el as PlayerElement).pause === "function"
+  );
+}
+
+// Injected once per document to avoid duplicating @keyframes across multiple elements.
+let _keyframesInjected = false;
+function injectKeyframesOnce(): void {
+  if (_keyframesInjected) return;
+  _keyframesInjected = true;
+  const style = document.createElement("style");
+  style.textContent = `
+    @keyframes hf-hotspot-pulse {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(255,255,255,0.35), 0 4px 16px rgba(0,0,0,0.35); }
+      50%       { box-shadow: 0 0 0 8px rgba(255,255,255,0), 0 4px 20px rgba(0,0,0,0.45); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .hf-hotspot-pill { animation: none !important; }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export class HyperframesSlideshow extends HTMLElement {
+  private controller: ControllerLike | null = null;
+  private offChange: (() => void) | null = null;
+  private chrome: HTMLDivElement | null = null;
+  private touchStartX = 0;
+  private touchStartY = 0;
+  private channel: SlideshowChannel | null = null;
+  private presenterStartMs: number | null = null;
+  private presenterInterval: ReturnType<typeof setInterval> | null = null;
+  private disconnected = false;
+  private initTimer: ReturnType<typeof setTimeout> | null = null;
+  private initInFlight = false;
+  private initGeneration = 0;
+  private _muted = false;
+
+  /** Whether audio is currently muted. Reflects `data-hf-muted` attribute. */
+  get muted(): boolean {
+    return this._muted;
+  }
+
+  connectedCallback(): void {
+    this.disconnected = false;
+    this.initInFlight = false;
+    this.initGeneration += 1;
+    this.tabIndex = 0;
+    // note: if the inner player iframe has keyboard focus, window keydown in the
+    // top document won't fire — that edge remains; this listener fixes the dominant
+    // case where the page loads and arrows should work without clicking the element.
+    window.addEventListener("keydown", this.onKey);
+    this.addEventListener("touchstart", this.onTouchStart, { passive: true });
+    this.addEventListener("touchend", this.onTouchEnd);
+    window.addEventListener("message", this.onMessage);
+    this.initChannel();
+    // Defer player-dependent init to a macrotask so that child elements are
+    // parsed before we query for <hyperframes-player>. This matters when the
+    // bundle is loaded synchronously (e.g. <script src> in <head>), where
+    // connectedCallback fires while the parser is still inside the
+    // <hyperframes-slideshow> open tag — before its children exist. A microtask
+    // is NOT sufficient: during streamed parsing the children are appended in a
+    // later task, so a queued microtask still observes an empty subtree. A
+    // setTimeout(0) macrotask yields to the parser so the children land first.
+    this.initTimer = setTimeout(() => {
+      this.initTimer = null;
+      if (this.isConnected && !this.disconnected) void this.init();
+    }, 0);
+  }
+
+  disconnectedCallback(): void {
+    this.disconnected = true;
+    this.initGeneration += 1;
+    if (this.initTimer !== null) {
+      clearTimeout(this.initTimer);
+      this.initTimer = null;
+    }
+    window.removeEventListener("keydown", this.onKey);
+    this.removeEventListener("touchstart", this.onTouchStart);
+    this.removeEventListener("touchend", this.onTouchEnd);
+    window.removeEventListener("message", this.onMessage);
+    this.offChange?.();
+    this.offChange = null;
+    this.controller?.dispose?.();
+    this.controller = null;
+    this.chrome = null;
+    this.channel?.destroy();
+    this.channel = null;
+    if (this.presenterInterval !== null) {
+      clearInterval(this.presenterInterval);
+      this.presenterInterval = null;
+    }
+  }
+
+  /** Test seam: inject a controller without a live player. */
+  __setControllerForTest(c: ControllerLike): void {
+    this.bindController(c);
+  }
+
+  /**
+   * Opens an audience window and switches this element to presenter layout.
+   * Audience window URL: current page URL with `mode=audience` query param.
+   */
+  present(): void {
+    const sep = location.search ? "&" : "?";
+    window.open(location.href + sep + "mode=audience", "_blank");
+    this.setAttribute("data-hf-presenting", "true");
+    this.presenterStartMs = Date.now();
+    if (this.presenterInterval === null) {
+      this.presenterInterval = setInterval(() => this.render(), 1000);
+    }
+    this.render();
+  }
+
+  private initChannel(): void {
+    const mode = this.getAttribute("mode");
+    if (mode === "audience") {
+      this.channel = new SlideshowChannel("audience", (msg) => {
+        if (!this.controller) return;
+        if (msg.sequenceId !== "main") return; // V1: non-main branch gracefully ignored
+        this.controller.goToSlide?.(msg.slideIndex);
+      });
+    } else {
+      this.channel = new SlideshowChannel("presenter", () => {
+        // presenter channel does not receive; posting happens in bindController
+      });
+    }
+  }
+
+  // fallow-ignore-next-line complexity
+  private async init(): Promise<void> {
+    if (this.initInFlight) return;
+    this.initInFlight = true;
+    const gen = this.initGeneration;
+
+    try {
+      const playerEl = this.querySelector("hyperframes-player");
+      if (!playerEl || !(playerEl instanceof HTMLElement)) return;
+      if (!isPlayerElement(playerEl)) return;
+
+      await waitForReady(playerEl);
+
+      // Guard: if a disconnect or reconnect happened while waiting, bail out.
+      if (gen !== this.initGeneration) return;
+
+      const html = this.innerHTML;
+      let manifest: ReturnType<typeof parseSlideshowManifest>;
+      try {
+        manifest = parseSlideshowManifest(html);
+      } catch {
+        // Malformed island (e.g. bad JSON) — fail gracefully, no chrome.
+        return;
+      }
+      if (!manifest) return;
+
+      // Wait for scenes to be populated (the runtime "timeline" postMessage
+      // arrives ~1000ms after waitForReady resolves). Graceful fallback to []
+      // on timeout so explicit startTime/endTime slides still work.
+      const scenes = await waitForScenes(playerEl, 2500, () => gen !== this.initGeneration);
+
+      // Guard again in case we were disconnected or reconnected during the scenes wait.
+      if (gen !== this.initGeneration) return;
+
+      const { resolved, errors } = resolveSlideshow(manifest, scenes);
+      if (errors.length > 0) {
+        console.warn("[hyperframes-slideshow] manifest errors:", errors);
+      }
+      const cleaned = dropInvalidSlides(resolved);
+
+      const port: PlayerPort = {
+        seek: (t) => playerEl.seek(t),
+        play: () => playerEl.play(),
+        pause: () => playerEl.pause(),
+        get currentTime() {
+          return playerEl.currentTime;
+        },
+        onTimeUpdate: (cb) => {
+          const handler = (e: Event) => {
+            const detail = (e as CustomEvent<{ currentTime: number }>).detail;
+            cb(detail.currentTime);
+          };
+          playerEl.addEventListener("timeupdate", handler);
+          return () => playerEl.removeEventListener("timeupdate", handler);
+        },
+      };
+
+      this.bindController(new SlideshowController(port, cleaned));
+    } finally {
+      this.initInFlight = false;
+    }
+  }
+
+  private bindController(c: ControllerLike): void {
+    this.offChange?.();
+    this.controller?.dispose?.();
+    this.controller = c;
+    this.offChange = c.onChange(() => {
+      // Presenter posts position to channel on every change
+      if (this.getAttribute("mode") !== "audience" && this.channel) {
+        this.channel.postPosition(c.position);
+      }
+      this.render();
+    });
+    // Post initial position if presenter
+    if (this.getAttribute("mode") !== "audience" && this.channel) {
+      this.channel.postPosition(c.position);
+    }
+    this.render();
+  }
+
+  // fallow-ignore-next-line complexity
+  private onKey = (e: KeyboardEvent): void => {
+    if (!this.controller) return;
+    const target = e.target;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    ) {
+      return;
+    }
+    if (e.key === "ArrowRight" || e.key === " ") {
+      this.controller.next();
+      e.preventDefault();
+    } else if (e.key === "ArrowLeft" || e.key === "Backspace") {
+      this.controller.prev();
+      e.preventDefault();
+    }
+  };
+
+  // fallow-ignore-next-line complexity
+  private onMessage = (e: MessageEvent): void => {
+    // Audience mode is driven by BroadcastChannel; ignore embed postMessage nav.
+    if (this.getAttribute("mode") === "audience") return;
+    const data = e.data as { type?: unknown; slideIndex?: unknown } | null;
+    if (!data || !this.controller) return;
+    if (data.type === "next") {
+      this.controller.next();
+    } else if (data.type === "prev") {
+      this.controller.prev();
+    } else if (data.type === "goto" && typeof data.slideIndex === "number") {
+      this.controller.goToSlide?.(data.slideIndex);
+    } else if (data.type === "back") {
+      this.controller.back?.();
+    }
+  };
+
+  private onTouchStart = (e: TouchEvent): void => {
+    const touch = e.touches[0];
+    if (touch) {
+      this.touchStartX = touch.clientX;
+      this.touchStartY = touch.clientY;
+    }
+  };
+
+  private onTouchEnd = (e: TouchEvent): void => {
+    if (!this.controller) return;
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const deltaX = touch.clientX - this.touchStartX;
+    const deltaY = touch.clientY - this.touchStartY;
+    // Require a dominant horizontal gesture: |deltaX| > 40 AND |deltaX| > |deltaY|
+    // so that diagonal page-scrolls do not accidentally trigger slide navigation.
+    if (Math.abs(deltaX) <= 40 || Math.abs(deltaX) <= Math.abs(deltaY)) return;
+    if (deltaX < 0) {
+      this.controller.next();
+    } else {
+      this.controller.prev();
+    }
+  };
+
+  // fallow-ignore-next-line complexity
+  private render(): void {
+    if (!this.controller) return;
+
+    if (this.getAttribute("data-hf-presenting") === "true") {
+      this.renderPresenter();
+      return;
+    }
+
+    const { counter, currentSlide } = this.controller;
+    if (!currentSlide) return;
+
+    if (!this.chrome) {
+      this.chrome = document.createElement("div");
+      this.chrome.setAttribute("data-hf-chrome", "");
+      this.chrome.style.cssText = "position:absolute;inset:0;pointer-events:none;z-index:10;";
+      this.appendChild(this.chrome);
+    }
+
+    // Inject keyframes for hotspot pulse animation once per document.
+    injectKeyframesOnce();
+
+    // Hotspot pills: compact floating buttons anchored to the region's top-left,
+    // sized to content (not filling the region). The region x/y positions the pill;
+    // w/h are ignored for sizing (pill is content-sized). XSS: escHtml guards all
+    // user-supplied strings.
+    const hotspotsHtml = currentSlide.hotspots
+      .map((h) => {
+        const posStyle = h.region
+          ? `left:${h.region.x}%;top:${h.region.y}%;`
+          : "right:5%;bottom:18%;";
+        return `<button
+          class="hf-hotspot-pill"
+          data-hotspot-id="${escHtml(h.id)}"
+          data-hotspot-target="${escHtml(h.target)}"
+          type="button"
+          style="position:absolute;${posStyle}display:inline-flex;align-items:center;gap:6px;padding:8px 14px;background:var(--hf-slideshow-accent,rgba(255,255,255,0.92));color:#111;border:none;border-radius:999px;font-size:13px;font-weight:600;letter-spacing:0.01em;cursor:pointer;pointer-events:auto;box-shadow:0 4px 16px rgba(0,0,0,0.35);animation:hf-hotspot-pulse 1.8s ease-in-out infinite;white-space:nowrap;"
+          aria-label="${escHtml(h.label)}"
+        ><span aria-hidden="true" style="font-size:14px;line-height:1;">⊕</span>${escHtml(h.label)}</button>`;
+      })
+      .join("");
+
+    // Single cohesive nav cluster: [mute?] [prev |] counter [| next] — bottom-right capsule.
+    // Prev/next buttons are hidden when there is no destination in that direction:
+    //   - Main deck first slide → no prev (nothing before it)
+    //   - Main deck last slide  → no next (nothing after it)
+    //   - Inside a branch       → always both (branch-edge returns to parent)
+    // The mute toggle is shown only when the `sound` boolean attribute is present.
+    const showPrev = this.controller.canPrev !== false;
+    const showNext = this.controller.canNext !== false;
+    const showSound = this.hasAttribute("sound");
+    const btnStyle =
+      "display:flex;align-items:center;justify-content:center;width:34px;height:34px;background:transparent;border:none;border-radius:999px;color:rgba(255,255,255,0.85);font-size:16px;cursor:pointer;transition:background 0.15s,color 0.15s;padding:0;";
+    // Inline SVG glyphs for speaker and speaker-muted (no emoji — consistent across platforms)
+    const speakerSvg = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg>`;
+    const speakerMutedSvg = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>`;
+    const muteBtnHtml = showSound
+      ? `<button
+          data-hf-mute
+          type="button"
+          aria-label="${this._muted ? "Unmute" : "Mute"}"
+          aria-pressed="${this._muted ? "true" : "false"}"
+          style="${btnStyle}${this._muted ? "color:rgba(255,255,255,0.45);" : ""}"
+          onmouseover="this.style.background='rgba(255,255,255,0.12)';this.style.color='${this._muted ? "rgba(255,255,255,0.6)" : "#fff"}';"
+          onmouseout="this.style.background='transparent';this.style.color='${this._muted ? "rgba(255,255,255,0.45)" : "rgba(255,255,255,0.85)"}';"
+        >${this._muted ? speakerMutedSvg : speakerSvg}</button>`
+      : "";
+    const prevBtnHtml = showPrev
+      ? `<button
+          data-hf-prev
+          type="button"
+          aria-label="Previous slide"
+          style="${btnStyle}"
+          onmouseover="this.style.background='rgba(255,255,255,0.12)';this.style.color='#fff';"
+          onmouseout="this.style.background='transparent';this.style.color='rgba(255,255,255,0.85)';"
+        >&#8249;</button>`
+      : "";
+    const nextBtnHtml = showNext
+      ? `<button
+          data-hf-next
+          type="button"
+          aria-label="Next slide"
+          style="${btnStyle}"
+          onmouseover="this.style.background='rgba(255,255,255,0.12)';this.style.color='#fff';"
+          onmouseout="this.style.background='transparent';this.style.color='rgba(255,255,255,0.85)';"
+        >&#8250;</button>`
+      : "";
+    // Counter padding adjusts so the pill looks centered when one button is absent.
+    const counterPadLeft = showPrev ? "4px" : "10px";
+    const counterPadRight = showNext ? "4px" : "10px";
+    const navClusterHtml = `
+      <div
+        data-hf-nav-cluster
+        style="position:absolute;bottom:28px;right:32px;display:inline-flex;align-items:center;gap:2px;background:rgba(20,20,22,0.55);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border:1px solid rgba(255,255,255,0.12);border-radius:999px;box-shadow:0 4px 24px rgba(0,0,0,0.45);padding:4px;pointer-events:auto;"
+      >
+        ${muteBtnHtml}
+        ${showSound ? `<span aria-hidden="true" style="width:1px;height:20px;background:rgba(255,255,255,0.12);margin:0 2px;flex-shrink:0;"></span>` : ""}
+        ${prevBtnHtml}
+        <span
+          data-hf-counter
+          aria-label="Slide ${counter.index} of ${counter.total}"
+          style="min-width:46px;text-align:center;color:rgba(255,255,255,0.9);font-size:13px;font-weight:500;font-variant-numeric:tabular-nums;letter-spacing:0.02em;padding:0 ${counterPadRight} 0 ${counterPadLeft};user-select:none;"
+        >${counter.index}&thinsp;/&thinsp;${counter.total}</span>
+        ${nextBtnHtml}
+      </div>
+    `;
+
+    this.chrome.innerHTML = hotspotsHtml + navClusterHtml;
+
+    const muteBtn = this.chrome.querySelector("[data-hf-mute]");
+    const prevBtn = this.chrome.querySelector("[data-hf-prev]");
+    const nextBtn = this.chrome.querySelector("[data-hf-next]");
+    if (muteBtn) muteBtn.addEventListener("click", () => this.toggleMute());
+    if (prevBtn) prevBtn.addEventListener("click", () => this.controller?.prev());
+    if (nextBtn) nextBtn.addEventListener("click", () => this.controller?.next());
+
+    // Wire hotspot clicks after innerHTML is set. Read target from data-hotspot-target
+    // so the handler does not close over stale loop state.
+    for (const btn of this.chrome.querySelectorAll("[data-hotspot-id]")) {
+      const target = btn.getAttribute("data-hotspot-target") ?? "";
+      btn.addEventListener("click", () => this.controller?.enterBranch?.(target));
+    }
+  }
+
+  private toggleMute(): void {
+    this._muted = !this._muted;
+    if (this._muted) {
+      this.setAttribute("data-hf-muted", "");
+    } else {
+      this.removeAttribute("data-hf-muted");
+    }
+    this.dispatchEvent(
+      new CustomEvent("hf-sound", {
+        detail: { muted: this._muted },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    // Re-render to flip the glyph.
+    this.render();
+  }
+
+  private renderPresenter(): void {
+    if (!this.controller) return;
+    const { counter, currentSlide, nextSlide } = this.controller;
+    if (!currentSlide) return;
+
+    const elapsedSec =
+      this.presenterStartMs !== null ? Math.floor((Date.now() - this.presenterStartMs) / 1000) : 0;
+
+    if (!this.chrome) {
+      this.chrome = document.createElement("div");
+      this.chrome.setAttribute("data-hf-chrome", "");
+      this.chrome.style.cssText = "position:absolute;inset:0;z-index:10;";
+      this.appendChild(this.chrome);
+    }
+
+    this.chrome.innerHTML = buildPresenterLayout({
+      // TODO: live next-slide thumbnail/preview deferred (needs a second seeked player) — V1 shows text
+      currentSlideHtml: currentPanelText(currentSlide),
+      nextSlideHtml: nextPanelText(nextSlide),
+      notes: currentSlide.notes ?? "",
+      counterText: `${counter.index} / ${counter.total}`,
+      elapsedText: formatElapsed(elapsedSec),
+    });
+  }
+}
+
+function currentPanelText(slide: { notes?: string; sceneId?: string }): string {
+  if (slide.notes != null && slide.notes.length > 0) return escHtml(slide.notes);
+  if (slide.sceneId != null) return `Current: ${escHtml(slide.sceneId)}`;
+  return "";
+}
+
+function nextPanelText(slide: { sceneId: string; notes?: string } | null): string {
+  if (slide === null) return "End of sequence";
+  const firstLine = slide.notes != null ? (slide.notes.split("\n")[0] ?? "") : "";
+  return firstLine.length > 0
+    ? `${escHtml(slide.sceneId)}: ${escHtml(firstLine)}`
+    : escHtml(slide.sceneId);
+}
+
+function readScenes(player: HTMLElement): { id: string; start: number; duration: number }[] {
+  if ("scenes" in player && Array.isArray((player as { scenes: unknown }).scenes)) {
+    return (player as { scenes: { id: string; start: number; duration: number }[] }).scenes;
+  }
+  return [];
+}
+
+const WAIT_FOR_READY_TIMEOUT_MS = 5000;
+
+function waitForReady(player: HTMLElement & { ready?: boolean }): Promise<void> {
+  if (player.ready === true) return Promise.resolve();
+  return new Promise((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const handler = (): void => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      resolve();
+    };
+    player.addEventListener("ready", handler, { once: true });
+    timer = setTimeout(() => {
+      player.removeEventListener("ready", handler);
+      resolve();
+    }, WAIT_FOR_READY_TIMEOUT_MS);
+  });
+}
+
+/**
+ * Polls `player.scenes` until at least one scene is present, then resolves
+ * with the scenes array. Resolves with `[]` if no scenes appear within
+ * `timeoutMs` (graceful: explicit startTime/endTime slides still work).
+ *
+ * Avoids Date.now(): counts poll iterations instead (100ms per iteration).
+ *
+ * `isCancelled` is checked before each poll iteration; if it returns true
+ * the promise resolves with `[]` immediately so the caller can bail out.
+ */
+function waitForScenes(
+  player: HTMLElement,
+  timeoutMs: number,
+  isCancelled: () => boolean = () => false,
+): Promise<{ id: string; start: number; duration: number }[]> {
+  const scenes = readScenes(player);
+  if (scenes.length > 0) return Promise.resolve(scenes);
+
+  const maxIterations = Math.ceil(timeoutMs / 100);
+
+  return new Promise((resolve) => {
+    let iterations = 0;
+    const poll = (): void => {
+      if (isCancelled()) {
+        resolve([]);
+        return;
+      }
+      const current = readScenes(player);
+      if (current.length > 0) {
+        resolve(current);
+        return;
+      }
+      iterations += 1;
+      if (iterations >= maxIterations) {
+        resolve([]);
+        return;
+      }
+      setTimeout(poll, 100);
+    };
+    setTimeout(poll, 100);
+  });
+}
+
+/**
+ * Returns a new ResolvedSlideshow with zero-duration (end <= start) slides
+ * removed from the main slide list and every sequence's slide list.
+ *
+ * Valid manifests never produce zero-duration slides — this only drops
+ * phantom slides created from partially-specified refs whose scene is absent.
+ *
+ * Exported as a seam for unit testing.
+ */
+export function dropInvalidSlides(show: ResolvedSlideshow): ResolvedSlideshow {
+  const validSlide = (s: { start: number; end: number }): boolean => s.end > s.start;
+
+  const slides = show.slides.filter(validSlide);
+
+  const sequences: ResolvedSlideshow["sequences"] = {};
+  for (const [id, seq] of Object.entries(show.sequences)) {
+    sequences[id] = { ...seq, slides: seq.slides.filter(validSlide) };
+  }
+
+  return { slides, sequences };
+}
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+if (!customElements.get("hyperframes-slideshow")) {
+  customElements.define("hyperframes-slideshow", HyperframesSlideshow);
+}

--- a/packages/player/src/slideshow/slideshowPresenter.ts
+++ b/packages/player/src/slideshow/slideshowPresenter.ts
@@ -1,0 +1,103 @@
+export interface PresenterPosition {
+  sequenceId: string;
+  slideIndex: number;
+  fragmentIndex: number;
+}
+
+interface GotoMessage {
+  type: "goto";
+  sequenceId: string;
+  slideIndex: number;
+  fragmentIndex: number;
+}
+
+function isGotoMessage(data: unknown): data is GotoMessage {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return (
+    d["type"] === "goto" &&
+    typeof d["sequenceId"] === "string" &&
+    typeof d["slideIndex"] === "number" &&
+    typeof d["fragmentIndex"] === "number"
+  );
+}
+
+/**
+ * Manages the BroadcastChannel connection for a single slideshow element.
+ * Presenter (default) mode: posts position updates to the channel.
+ * Audience mode: listens for goto messages and calls the provided handler.
+ */
+export class SlideshowChannel {
+  private channel: BroadcastChannel | null = null;
+
+  constructor(
+    private readonly mode: "presenter" | "audience",
+    private readonly onGoto: (msg: GotoMessage) => void,
+  ) {
+    try {
+      this.channel = new BroadcastChannel("hf-slideshow");
+    } catch {
+      // BroadcastChannel unavailable (e.g. unsupported env); degrade silently.
+      return;
+    }
+
+    if (mode === "audience") {
+      this.channel.onmessage = (e: MessageEvent) => {
+        if (isGotoMessage(e.data)) {
+          this.onGoto(e.data);
+        }
+      };
+    }
+  }
+
+  postPosition(pos: PresenterPosition): void {
+    if (this.mode !== "presenter" || !this.channel) return;
+    const msg: GotoMessage = { type: "goto", ...pos };
+    this.channel.postMessage(msg);
+  }
+
+  destroy(): void {
+    if (this.channel) {
+      this.channel.onmessage = null;
+      this.channel.close();
+      this.channel = null;
+    }
+  }
+}
+
+/**
+ * Builds the presenter-mode inner HTML showing current slide area,
+ * next-slide preview, notes, counter, and elapsed timer.
+ */
+export function buildPresenterLayout(opts: {
+  currentSlideHtml: string;
+  nextSlideHtml: string;
+  notes: string;
+  counterText: string;
+  elapsedText: string;
+}): string {
+  const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  return `
+<div data-hf-presenter style="display:grid;grid-template-columns:2fr 1fr;grid-template-rows:auto 1fr;gap:12px;padding:12px;height:100%;box-sizing:border-box;background:#1a1a1a;color:#fff;font-family:sans-serif;">
+  <div data-hf-presenter-current style="grid-column:1;grid-row:1/3;border:2px solid #444;border-radius:6px;overflow:hidden;position:relative;">
+    ${opts.currentSlideHtml}
+  </div>
+  <div style="grid-column:2;grid-row:1;display:flex;flex-direction:column;gap:8px;">
+    <div style="font-size:11px;text-transform:uppercase;letter-spacing:.08em;opacity:.6;">Next</div>
+    <div data-hf-presenter-next style="border:1px solid #333;border-radius:4px;overflow:hidden;opacity:.7;">
+      ${opts.nextSlideHtml}
+    </div>
+    <div data-hf-presenter-counter style="font-size:13px;opacity:.8;">${esc(opts.counterText)}</div>
+    <div data-hf-presenter-elapsed style="font-size:13px;font-variant-numeric:tabular-nums;">${esc(opts.elapsedText)}</div>
+  </div>
+  <div data-hf-presenter-notes style="grid-column:2;grid-row:2;overflow-y:auto;font-size:13px;line-height:1.5;opacity:.9;border-top:1px solid #333;padding-top:8px;">${esc(opts.notes)}</div>
+</div>`.trim();
+}
+
+/** Format elapsed seconds as mm:ss */
+export function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}

--- a/packages/player/src/slideshow/test-setup.ts
+++ b/packages/player/src/slideshow/test-setup.ts
@@ -1,0 +1,46 @@
+/**
+ * Vitest setup: install a minimal in-memory BroadcastChannel polyfill so that
+ * happy-dom tests can exercise the presenter/audience channel code path.
+ * This polyfill is intentionally NOT shipped in production code.
+ */
+
+type MsgHandler = (event: MessageEvent) => void;
+
+const registry = new Map<string, Set<InMemoryBroadcastChannel>>();
+
+class InMemoryBroadcastChannel {
+  onmessage: MsgHandler | null = null;
+  readonly name: string;
+  private _closed = false;
+
+  constructor(name: string) {
+    this.name = name;
+    let set = registry.get(name);
+    if (!set) {
+      set = new Set();
+      registry.set(name, set);
+    }
+    set.add(this);
+  }
+
+  // fallow-ignore-next-line complexity
+  postMessage(data: unknown): void {
+    if (this._closed) return;
+    const peers = registry.get(this.name);
+    if (!peers) return;
+    for (const peer of peers) {
+      if (peer === this) continue;
+      peer.onmessage?.(new MessageEvent("message", { data }));
+    }
+  }
+
+  close(): void {
+    if (this._closed) return;
+    this._closed = true;
+    registry.get(this.name)?.delete(this);
+  }
+}
+
+if (typeof globalThis.BroadcastChannel === "undefined") {
+  (globalThis as Record<string, unknown>)["BroadcastChannel"] = InMemoryBroadcastChannel;
+}

--- a/packages/player/tsup.config.ts
+++ b/packages/player/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/hyperframes-player.ts"],
+  entry: ["src/hyperframes-player.ts", "src/slideshow/hyperframes-slideshow.ts"],
   format: ["esm", "cjs", "iife"],
   globalName: "HyperframesPlayer",
   dts: true,

--- a/packages/player/vitest.config.ts
+++ b/packages/player/vitest.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+const coreRoot = resolve(new URL("..", import.meta.url).pathname, "core/src");
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@hyperframes/core/slideshow": resolve(coreRoot, "slideshow/index.ts"),
+    },
+  },
   test: {
     environment: "happy-dom",
+    setupFiles: ["./src/slideshow/test-setup.ts"],
   },
 });

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -566,6 +566,10 @@ export function StudioApp() {
                         onToggleRecording={
                           STUDIO_KEYFRAMES_ENABLED ? handleToggleRecording : undefined
                         }
+                        sdkSession={sdkHandle.session}
+                        reloadPreview={reloadPreview}
+                        domEditSaveTimestampRef={domEditSaveTimestampRef}
+                        recordEdit={editHistory.recordEdit}
                       />
                     )}
                   </div>

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -1,13 +1,26 @@
-import { useCallback, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { Tooltip } from "./ui";
 import { PropertyPanel } from "./editor/PropertyPanel";
 import { LayersPanel } from "./editor/LayersPanel";
 import { CaptionPropertyPanel } from "../captions/components/CaptionPropertyPanel";
 import { BlockParamsPanel } from "./editor/BlockParamsPanel";
 import { RenderQueue } from "./renders/RenderQueue";
+import { SlideshowPanel } from "./panels/SlideshowPanel";
+import type { SceneInfo } from "./panels/SlideshowPanel";
 import type { RenderJob } from "./renders/useRenderQueue";
 import type { BlockParam } from "@hyperframes/core/registry";
+import type { IframeWindow } from "../player/lib/playbackTypes";
 import { STUDIO_INSPECTOR_PANELS_ENABLED } from "./editor/manualEditingAvailability";
+import type { Composition } from "@hyperframes/sdk";
+import type { EditHistoryKind } from "../utils/editHistory";
+import { useSlideshowPersist } from "../hooks/useSlideshowPersist";
 
 import { useStudioPlaybackContext, useStudioShellContext } from "../contexts/StudioContext";
 import { usePanelLayoutContext } from "../contexts/PanelLayoutContext";
@@ -30,6 +43,15 @@ export interface StudioRightPanelProps {
   recordingState?: "idle" | "recording" | "preview";
   recordingDuration?: number;
   onToggleRecording?: () => void;
+  /** Dependencies for the Slideshow persist callback, threaded from App.tsx. */
+  sdkSession: Composition | null;
+  reloadPreview: () => void;
+  domEditSaveTimestampRef: MutableRefObject<number>;
+  recordEdit: (entry: {
+    label: string;
+    kind: EditHistoryKind;
+    files: Record<string, { before: string; after: string }>;
+  }) => Promise<void>;
 }
 
 // fallow-ignore-next-line complexity
@@ -40,6 +62,10 @@ export function StudioRightPanel({
   recordingState,
   recordingDuration,
   onToggleRecording,
+  sdkSession,
+  reloadPreview,
+  domEditSaveTimestampRef,
+  recordEdit,
 }: StudioRightPanelProps) {
   const {
     rightWidth,
@@ -60,7 +86,7 @@ export function StudioRightPanel({
     waitForPendingDomEditSaves,
     renderQueue,
   } = useStudioShellContext();
-  const { captionEditMode } = useStudioPlaybackContext();
+  const { captionEditMode, refreshKey } = useStudioPlaybackContext();
 
   const {
     domEditSelection,
@@ -100,8 +126,40 @@ export function StudioRightPanel({
     handleGsapConvertToKeyframes,
   } = useDomEditContext();
 
-  const { assets, fontAssets, projectDir, handleImportFiles, handleImportFonts } =
-    useFileManagerContext();
+  const {
+    assets,
+    fontAssets,
+    projectDir,
+    handleImportFiles,
+    handleImportFonts,
+    readProjectFile,
+    writeProjectFile,
+  } = useFileManagerContext();
+
+  // Discrete ops (toggle, reorder, add/delete, hotspot): persist immediately,
+  // no coalescing — each is a distinct user action that deserves its own undo entry.
+  const onPersistSlideshow = useSlideshowPersist({
+    sdkSession,
+    activeCompPath,
+    readProjectFile,
+    writeProjectFile,
+    recordEdit,
+    reloadPreview,
+    domEditSaveTimestampRef,
+  });
+
+  // Notes path: persists are debounced in SlideshowPanel; coalesceKey ensures
+  // rapid writes collapse into a single undo entry via the save-queue infra.
+  const onPersistSlideshowNotes = useSlideshowPersist({
+    sdkSession,
+    activeCompPath,
+    readProjectFile,
+    writeProjectFile,
+    recordEdit,
+    reloadPreview,
+    domEditSaveTimestampRef,
+    coalesceKey: activeCompPath ? `slideshow-notes:${activeCompPath}` : "slideshow-notes",
+  });
 
   const [layersPanePercent, setLayersPanePercent] = useState(40);
   const splitContainerRef = useRef<HTMLDivElement>(null);
@@ -113,6 +171,23 @@ export function StudioRightPanel({
 
   const renderJobs = renderQueue.jobs as RenderJob[];
   const inspectorTabActive = rightPanelTab === "design" || rightPanelTab === "layers";
+
+  // Derive scene list from the live clip manifest in the preview iframe.
+  // fallow-ignore-next-line complexity
+  const slideshowScenes = useMemo<SceneInfo[]>(() => {
+    try {
+      const win = previewIframeRef.current?.contentWindow as IframeWindow | null;
+      return (win?.__clipManifest?.scenes ?? []).map((s) => ({
+        id: s.id,
+        label: s.label,
+        start: s.start,
+        duration: s.duration,
+      }));
+    } catch {
+      return [];
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewIframeRef, rightPanelTab, refreshKey]);
   const designPaneOpen = inspectorTabActive && rightInspectorPanes.design && designPanelActive;
   const layersPaneOpen =
     inspectorTabActive && rightInspectorPanes.layers && STUDIO_INSPECTOR_PANELS_ENABLED;
@@ -291,6 +366,19 @@ export function StudioRightPanel({
                   {renderJobs.length > 0 ? `Renders (${renderJobs.length})` : "Renders"}
                 </button>
               </Tooltip>
+              <Tooltip label="Slideshow branching editor" side="bottom">
+                <button
+                  type="button"
+                  onClick={() => setRightPanelTab("slideshow")}
+                  className={`h-8 rounded-xl px-3 text-[11px] font-medium transition-colors ${
+                    rightPanelTab === "slideshow"
+                      ? "bg-neutral-800 text-white"
+                      : "text-neutral-500 hover:bg-neutral-800/70 hover:text-neutral-200"
+                  }`}
+                >
+                  Slideshow
+                </button>
+              </Tooltip>
             </div>
             <div className="min-h-0 flex-1">
               {rightPanelTab === "block-params" && activeBlockParams ? (
@@ -300,6 +388,12 @@ export function StudioRightPanel({
                   params={activeBlockParams.params}
                   compositionPath={activeBlockParams.compositionPath}
                   onClose={onCloseBlockParams ?? (() => {})}
+                />
+              ) : rightPanelTab === "slideshow" ? (
+                <SlideshowPanel
+                  scenes={slideshowScenes}
+                  onPersist={onPersistSlideshow}
+                  onPersistNotes={onPersistSlideshowNotes}
                 />
               ) : layersPaneOpen && designPaneOpen ? (
                 <div ref={splitContainerRef} className="flex h-full min-h-0 flex-col">

--- a/packages/studio/src/components/panels/SlideshowPanel.test.ts
+++ b/packages/studio/src/components/panels/SlideshowPanel.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  toggleMainLineSlide,
+  reorderMainLineSlide,
+  setSlideNotes,
+  addFragment,
+  removeFragment,
+  createSequence,
+  renameSequence,
+  deleteSequence,
+  assignToBranch,
+  addHotspot,
+  removeHotspot,
+  safeParseManifest,
+  makeSlideshowNotesController,
+} from "./SlideshowPanel";
+import type { SlideshowManifest } from "@hyperframes/core/slideshow";
+
+// ── toggleMainLineSlide ────────────────────────────────────────────────────
+
+describe("toggleMainLineSlide", () => {
+  it("adds a scene as a slide when absent", () => {
+    const m = toggleMainLineSlide({ slides: [] }, "a");
+    expect(m.slides).toEqual([{ sceneId: "a" }]);
+  });
+
+  it("removes a scene when already present", () => {
+    const m = toggleMainLineSlide({ slides: [{ sceneId: "a" }] }, "a");
+    expect(m.slides).toEqual([]);
+  });
+
+  it("does not mutate the input manifest", () => {
+    const input: SlideshowManifest = { slides: [{ sceneId: "a" }] };
+    toggleMainLineSlide(input, "a");
+    expect(input.slides.length).toBe(1);
+  });
+
+  it("leaves other slides intact when removing", () => {
+    const m = toggleMainLineSlide({ slides: [{ sceneId: "a" }, { sceneId: "b" }] }, "a");
+    expect(m.slides).toEqual([{ sceneId: "b" }]);
+  });
+});
+
+// ── reorderMainLineSlide ───────────────────────────────────────────────────
+
+describe("reorderMainLineSlide", () => {
+  it("moves a slide up", () => {
+    const m = reorderMainLineSlide({ slides: [{ sceneId: "a" }, { sceneId: "b" }] }, "b", "up");
+    expect(m.slides.map((s) => s.sceneId)).toEqual(["b", "a"]);
+  });
+
+  it("moves a slide down", () => {
+    const m = reorderMainLineSlide({ slides: [{ sceneId: "a" }, { sceneId: "b" }] }, "a", "down");
+    expect(m.slides.map((s) => s.sceneId)).toEqual(["b", "a"]);
+  });
+
+  it("returns unchanged manifest when moving first slide up", () => {
+    const input: SlideshowManifest = { slides: [{ sceneId: "a" }, { sceneId: "b" }] };
+    const m = reorderMainLineSlide(input, "a", "up");
+    expect(m.slides.map((s) => s.sceneId)).toEqual(["a", "b"]);
+  });
+
+  it("returns unchanged manifest for unknown sceneId", () => {
+    const input: SlideshowManifest = { slides: [{ sceneId: "a" }] };
+    const m = reorderMainLineSlide(input, "z", "up");
+    expect(m.slides).toEqual(input.slides);
+  });
+});
+
+// ── setSlideNotes ──────────────────────────────────────────────────────────
+
+describe("setSlideNotes", () => {
+  it("updates notes on an existing slide", () => {
+    const m = setSlideNotes({ slides: [{ sceneId: "a" }] }, "a", "hello");
+    expect(m.slides[0]).toMatchObject({ sceneId: "a", notes: "hello" });
+  });
+
+  it("creates the slide entry if absent", () => {
+    const m = setSlideNotes({ slides: [] }, "a", "note");
+    expect(m.slides).toEqual([{ sceneId: "a", notes: "note" }]);
+  });
+});
+
+// ── addFragment ───────────────────────────────────────────────────────────
+
+describe("addFragment", () => {
+  it("adds a fragment time to a slide", () => {
+    const m = addFragment({ slides: [{ sceneId: "a" }] }, "a", 1.5);
+    expect(m.slides[0]?.fragments).toEqual([1.5]);
+  });
+
+  it("deduplicates repeated fragment values", () => {
+    const m1 = addFragment({ slides: [{ sceneId: "a" }] }, "a", 1.5);
+    const m2 = addFragment(m1, "a", 1.5);
+    expect(m2.slides[0]?.fragments).toEqual([1.5]);
+  });
+
+  it("keeps fragments sorted ascending", () => {
+    let m: SlideshowManifest = { slides: [{ sceneId: "a" }] };
+    m = addFragment(m, "a", 3.0);
+    m = addFragment(m, "a", 1.0);
+    m = addFragment(m, "a", 2.0);
+    expect(m.slides[0]?.fragments).toEqual([1.0, 2.0, 3.0]);
+  });
+
+  it("creates the slide entry if absent", () => {
+    const m = addFragment({ slides: [] }, "a", 0.5);
+    expect(m.slides[0]).toMatchObject({ sceneId: "a", fragments: [0.5] });
+  });
+});
+
+// ── removeFragment ─────────────────────────────────────────────────────────
+
+describe("removeFragment", () => {
+  it("removes the specified fragment", () => {
+    const m = removeFragment({ slides: [{ sceneId: "a", fragments: [1.0, 2.0] }] }, "a", 1.0);
+    expect(m.slides[0]?.fragments).toEqual([2.0]);
+  });
+
+  it("no-ops when fragment not present", () => {
+    const m = removeFragment({ slides: [{ sceneId: "a", fragments: [1.0] }] }, "a", 9.0);
+    expect(m.slides[0]?.fragments).toEqual([1.0]);
+  });
+});
+
+// ── createSequence ─────────────────────────────────────────────────────────
+
+describe("createSequence", () => {
+  it("creates a new sequence", () => {
+    const m = createSequence({ slides: [] }, "seq-1", "Branch A");
+    expect(m.slideSequences).toEqual([{ id: "seq-1", label: "Branch A", slides: [] }]);
+  });
+
+  it("rejects duplicate ids", () => {
+    const m1 = createSequence({ slides: [] }, "seq-1", "Branch A");
+    const m2 = createSequence(m1, "seq-1", "Branch A duplicate");
+    expect((m2.slideSequences ?? []).length).toBe(1);
+  });
+
+  it("preserves existing sequences", () => {
+    const m1 = createSequence({ slides: [] }, "seq-1", "A");
+    const m2 = createSequence(m1, "seq-2", "B");
+    expect((m2.slideSequences ?? []).length).toBe(2);
+  });
+});
+
+// ── renameSequence ─────────────────────────────────────────────────────────
+
+describe("renameSequence", () => {
+  it("renames a sequence label", () => {
+    const m = renameSequence(
+      { slides: [], slideSequences: [{ id: "seq-1", label: "Old", slides: [] }] },
+      "seq-1",
+      "New",
+    );
+    expect(m.slideSequences?.[0]?.label).toBe("New");
+  });
+
+  it("no-ops on unknown id", () => {
+    const input: SlideshowManifest = {
+      slides: [],
+      slideSequences: [{ id: "seq-1", label: "A", slides: [] }],
+    };
+    const m = renameSequence(input, "unknown", "B");
+    expect(m.slideSequences?.[0]?.label).toBe("A");
+  });
+});
+
+// ── deleteSequence ─────────────────────────────────────────────────────────
+
+describe("deleteSequence", () => {
+  it("removes the sequence by id", () => {
+    const m = deleteSequence(
+      { slides: [], slideSequences: [{ id: "seq-1", label: "A", slides: [] }] },
+      "seq-1",
+    );
+    expect(m.slideSequences).toEqual([]);
+  });
+
+  it("removes hotspots targeting the deleted sequence from main-line slides", () => {
+    const input: SlideshowManifest = {
+      slides: [
+        {
+          sceneId: "s1",
+          hotspots: [
+            { id: "h1", label: "Go deep", target: "deep" },
+            { id: "h2", label: "Other", target: "other-seq" },
+          ],
+        },
+      ],
+      slideSequences: [
+        { id: "deep", label: "Deep", slides: [] },
+        { id: "other-seq", label: "Other", slides: [] },
+      ],
+    };
+    const m = deleteSequence(input, "deep");
+    expect(m.slides[0]?.hotspots?.map((h) => h.id)).toEqual(["h2"]);
+    expect(m.slideSequences?.some((s) => s.id === "deep")).toBe(false);
+    // Verify no slide anywhere references 'deep'
+    const allHotspotTargets = [
+      ...m.slides.flatMap((s) => (s.hotspots ?? []).map((h) => h.target)),
+      ...(m.slideSequences ?? []).flatMap((seq) =>
+        seq.slides.flatMap((s) => (s.hotspots ?? []).map((h) => h.target)),
+      ),
+    ];
+    expect(allHotspotTargets).not.toContain("deep");
+  });
+
+  it("removes hotspots targeting the deleted sequence from sequence slides", () => {
+    const input: SlideshowManifest = {
+      slides: [],
+      slideSequences: [
+        { id: "deep", label: "Deep", slides: [] },
+        {
+          id: "other",
+          label: "Other",
+          slides: [
+            {
+              sceneId: "s2",
+              hotspots: [{ id: "h3", label: "To deep", target: "deep" }],
+            },
+          ],
+        },
+      ],
+    };
+    const m = deleteSequence(input, "deep");
+    const otherSeq = m.slideSequences?.find((s) => s.id === "other");
+    expect(otherSeq?.slides[0]?.hotspots).toEqual([]);
+  });
+});
+
+// ── assignToBranch ─────────────────────────────────────────────────────────
+
+describe("assignToBranch", () => {
+  it("assigns a scene to a branch", () => {
+    const m = assignToBranch(
+      { slides: [], slideSequences: [{ id: "seq-1", label: "A", slides: [] }] },
+      "seq-1",
+      "s1",
+      true,
+    );
+    expect(m.slideSequences?.[0]?.slides).toEqual([{ sceneId: "s1" }]);
+  });
+
+  it("does not duplicate when assigning twice", () => {
+    let m: SlideshowManifest = {
+      slides: [],
+      slideSequences: [{ id: "seq-1", label: "A", slides: [] }],
+    };
+    m = assignToBranch(m, "seq-1", "s1", true);
+    m = assignToBranch(m, "seq-1", "s1", true);
+    expect(m.slideSequences?.[0]?.slides.length).toBe(1);
+  });
+
+  it("removes a scene when assign=false", () => {
+    const m = assignToBranch(
+      {
+        slides: [],
+        slideSequences: [{ id: "seq-1", label: "A", slides: [{ sceneId: "s1" }] }],
+      },
+      "seq-1",
+      "s1",
+      false,
+    );
+    expect(m.slideSequences?.[0]?.slides).toEqual([]);
+  });
+});
+
+// ── addHotspot / removeHotspot ─────────────────────────────────────────────
+
+describe("addHotspot", () => {
+  it("adds a hotspot to a slide", () => {
+    const m = addHotspot({ slides: [{ sceneId: "a" }] }, "a", {
+      id: "h1",
+      label: "Go to B",
+      target: "seq-b",
+    });
+    expect(m.slides[0]?.hotspots).toEqual([{ id: "h1", label: "Go to B", target: "seq-b" }]);
+  });
+
+  it("does not duplicate hotspot ids", () => {
+    let m: SlideshowManifest = { slides: [{ sceneId: "a" }] };
+    m = addHotspot(m, "a", { id: "h1", label: "X", target: "seq-b" });
+    m = addHotspot(m, "a", { id: "h1", label: "Y", target: "seq-c" });
+    expect(m.slides[0]?.hotspots?.length).toBe(1);
+  });
+});
+
+describe("removeHotspot", () => {
+  it("removes a hotspot by id", () => {
+    const m = removeHotspot(
+      {
+        slides: [{ sceneId: "a", hotspots: [{ id: "h1", label: "X", target: "seq-b" }] }],
+      },
+      "a",
+      "h1",
+    );
+    expect(m.slides[0]?.hotspots).toEqual([]);
+  });
+
+  it("no-ops for unknown hotspot id", () => {
+    const m = removeHotspot(
+      {
+        slides: [{ sceneId: "a", hotspots: [{ id: "h1", label: "X", target: "seq-b" }] }],
+      },
+      "a",
+      "no-such-id",
+    );
+    expect(m.slides[0]?.hotspots?.length).toBe(1);
+  });
+});
+
+// ── safeParseManifest ──────────────────────────────────────────────────────
+
+describe("safeParseManifest", () => {
+  it("parses a valid slideshow island", () => {
+    const manifest = { slides: [{ sceneId: "a" }] };
+    const island = `<script type="application/hyperframes-slideshow+json">${JSON.stringify(manifest)}</script>`;
+    const html = `<html><body>${island}</body></html>`;
+    const result = safeParseManifest(html);
+    expect(result.slides[0]?.sceneId).toBe("a");
+  });
+
+  it("returns {slides:[]} for malformed JSON in the island", () => {
+    const html = `<html><body><script type="application/hyperframes-slideshow+json">NOT_JSON</script></body></html>`;
+    const result = safeParseManifest(html);
+    expect(result).toEqual({ slides: [] });
+  });
+
+  it("returns {slides:[]} when no island is present", () => {
+    const result = safeParseManifest("<html><body></body></html>");
+    expect(result).toEqual({ slides: [] });
+  });
+});
+
+// ── makeSlideshowNotesController ──────────────────────────────────────────
+//
+// These tests prove the two stale-closure invariants without needing a DOM:
+//   (a) Notes typed in comp A always flush to comp A's callback, never comp B's.
+//   (b) A discrete action after typing does NOT drop the typed note.
+
+describe("makeSlideshowNotesController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("(a) typing notes then switching composition flushes to the ORIGINAL callback", () => {
+    const ctrl = makeSlideshowNotesController();
+    const persistA = vi.fn().mockResolvedValue(undefined);
+    const persistB = vi.fn().mockResolvedValue(undefined);
+
+    const manifestA = { slides: [{ sceneId: "s1", notes: "typed in A" }] };
+    const manifestB = { slides: [{ sceneId: "s2" }] };
+
+    // User types a note in composition A — schedules debounce with persistA.
+    ctrl.schedule(manifestA, persistA, 450);
+
+    // Before the debounce fires, the composition switches to B.
+    // The panel calls flush() so the pending notes go to A's callback.
+    ctrl.flush();
+
+    // Now the panel re-schedules with B's manifest + callback.
+    ctrl.schedule(manifestB, persistB, 450);
+
+    // Advance time past the debounce delay.
+    vi.advanceTimersByTime(500);
+
+    // persistA must have been called with manifestA (the A-composition notes).
+    expect(persistA).toHaveBeenCalledOnce();
+    expect(persistA.mock.calls[0]?.[0]).toEqual(manifestA);
+
+    // persistB must have been called with manifestB (the B-composition timer).
+    expect(persistB).toHaveBeenCalledOnce();
+    expect(persistB.mock.calls[0]?.[0]).toEqual(manifestB);
+  });
+
+  it("(a) flush after composition switch does NOT call the new composition's callback", () => {
+    const ctrl = makeSlideshowNotesController();
+    const persistA = vi.fn().mockResolvedValue(undefined);
+    const persistB = vi.fn().mockResolvedValue(undefined);
+
+    const manifestA = { slides: [{ sceneId: "s1", notes: "A notes" }] };
+
+    ctrl.schedule(manifestA, persistA, 450);
+    // Simulate comp switch: flush before B's manifest arrives.
+    ctrl.flush();
+
+    // B never schedules anything.
+
+    vi.advanceTimersByTime(1000);
+
+    expect(persistA).toHaveBeenCalledOnce();
+    expect(persistB).not.toHaveBeenCalled();
+  });
+
+  it("(b) discrete action right after typing does NOT drop the note", () => {
+    const ctrl = makeSlideshowNotesController();
+    const persistNotes = vi.fn().mockResolvedValue(undefined);
+
+    const manifestWithNotes = { slides: [{ sceneId: "s1", notes: "hello" }] };
+
+    // User types "hello" — schedules debounce.
+    ctrl.schedule(manifestWithNotes, persistNotes, 450);
+
+    // Before debounce fires, user triggers a discrete action (e.g. mark fragment).
+    // The discrete manifest comes from the helper and does NOT include the note yet
+    // (it was computed from an older state snapshot).
+    const discreteManifest = { slides: [{ sceneId: "s1", fragments: [1.5] }] };
+    const merged = ctrl.mergeIntoDiscrete(discreteManifest);
+
+    // The merged manifest must include BOTH the fragment AND the note.
+    expect(merged.slides[0]).toMatchObject({ sceneId: "s1", notes: "hello", fragments: [1.5] });
+
+    // After mergeIntoDiscrete, pending is cleared — debounce no longer fires.
+    vi.advanceTimersByTime(500);
+    expect(persistNotes).not.toHaveBeenCalled();
+  });
+
+  it("(b) notes from a different scene are not merged into an unrelated slide", () => {
+    const ctrl = makeSlideshowNotesController();
+    const persistNotes = vi.fn().mockResolvedValue(undefined);
+
+    // Pending notes are for scene s1.
+    const manifestWithNotes = { slides: [{ sceneId: "s1", notes: "s1 notes" }] };
+    ctrl.schedule(manifestWithNotes, persistNotes, 450);
+
+    // Discrete action affects scene s2 only.
+    const discreteManifest = { slides: [{ sceneId: "s2", fragments: [2.0] }] };
+    const merged = ctrl.mergeIntoDiscrete(discreteManifest);
+
+    // s2 slide should have no notes (pending notes belong to s1 which is not in discrete).
+    expect(merged.slides[0]).toMatchObject({ sceneId: "s2" });
+    expect(merged.slides[0]?.notes).toBeUndefined();
+  });
+
+  it("flush is idempotent — second flush does nothing", () => {
+    const ctrl = makeSlideshowNotesController();
+    const persist = vi.fn().mockResolvedValue(undefined);
+
+    ctrl.schedule({ slides: [{ sceneId: "x" }] }, persist, 450);
+    ctrl.flush();
+    ctrl.flush();
+
+    expect(persist).toHaveBeenCalledOnce();
+  });
+
+  it("cancel clears pending without calling persist", () => {
+    const ctrl = makeSlideshowNotesController();
+    const persist = vi.fn().mockResolvedValue(undefined);
+
+    ctrl.schedule({ slides: [] }, persist, 450);
+    ctrl.cancel();
+
+    vi.advanceTimersByTime(1000);
+    expect(persist).not.toHaveBeenCalled();
+  });
+});

--- a/packages/studio/src/components/panels/SlideshowPanel.tsx
+++ b/packages/studio/src/components/panels/SlideshowPanel.tsx
@@ -1,0 +1,422 @@
+/**
+ * SlideshowPanel — Studio right-panel tab for authoring the slideshow island.
+ *
+ * Four sub-surfaces:
+ *   1. Slide list: scenes → toggle main-line slide; reorder via up/down arrows.
+ *   2. Slide inspector: notes textarea; fragment hold-points.
+ *   3. Branch tree: create/rename sequences; assign scenes to a branch.
+ *   4. Hotspot tool: mark selected element as a hotspot on the active slide.
+ *
+ * State: the manifest is parsed from the current composition HTML on mount and
+ * on each `compHtml` change. Every edit calls `onPersist(manifest)` and
+ * updates local state.
+ *
+ * All manifest transforms are pure helpers — see slideshowPanelHelpers.ts.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { parseSlideshowManifest } from "@hyperframes/core/slideshow";
+import type { SlideshowManifest, SlideHotspot } from "@hyperframes/core/slideshow";
+import { usePlayerStore } from "../../player";
+import { useDomEditSelectionContext } from "../../contexts/DomEditContext";
+import { useFileManagerContext } from "../../contexts/FileManagerContext";
+import {
+  SectionHeader,
+  SlideList,
+  SlideInspector,
+  BranchTree,
+  HotspotTool,
+} from "./SlideshowSubPanels";
+
+// Re-export pure helpers so the test file can import from "./SlideshowPanel".
+export {
+  toggleMainLineSlide,
+  reorderMainLineSlide,
+  setSlideNotes,
+  addFragment,
+  removeFragment,
+  createSequence,
+  renameSequence,
+  deleteSequence,
+  assignToBranch,
+  addHotspot,
+  removeHotspot,
+} from "./slideshowPanelHelpers";
+export type { SceneInfo } from "./slideshowPanelHelpers";
+
+export function safeParseManifest(html: string): SlideshowManifest {
+  try {
+    return parseSlideshowManifest(html) ?? { slides: [] };
+  } catch {
+    console.warn("[SlideshowPanel] Failed to parse slideshow manifest; using empty manifest");
+    return { slides: [] };
+  }
+}
+
+import {
+  toggleMainLineSlide,
+  reorderMainLineSlide,
+  setSlideNotes,
+  addFragment,
+  removeFragment,
+  createSequence,
+  renameSequence,
+  deleteSequence,
+  assignToBranch,
+  addHotspot,
+  removeHotspot,
+} from "./slideshowPanelHelpers";
+
+// ── Notes-attribution controller (pure, testable) ─────────────────────────
+//
+// The React component delegates debounce scheduling to these functions so
+// the flush-attribution invariant can be tested without a DOM or React renderer.
+
+export interface NotesController {
+  /** Record a notes keystroke; returns the timer id. */
+  schedule: (
+    manifest: SlideshowManifest,
+    persist: (m: SlideshowManifest) => Promise<void>,
+    delayMs: number,
+  ) => ReturnType<typeof setTimeout>;
+  /** Flush any pending notes synchronously (e.g. on comp-switch or unmount). */
+  flush: () => void;
+  /** Cancel without flushing (used when a discrete action absorbs the notes). */
+  cancel: () => void;
+  /** Merge any pending notes into an incoming discrete manifest, then clear. */
+  mergeIntoDiscrete: (next: SlideshowManifest) => SlideshowManifest;
+}
+
+export function makeSlideshowNotesController(): NotesController {
+  type Pending = { manifest: SlideshowManifest; persist: (m: SlideshowManifest) => Promise<void> };
+  let pending: Pending | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    schedule(manifest, persist, delayMs) {
+      if (timer !== null) clearTimeout(timer);
+      pending = { manifest, persist };
+      timer = setTimeout(() => {
+        timer = null;
+        const p = pending;
+        if (p !== null) {
+          pending = null;
+          p.persist(p.manifest).catch(() => {});
+        }
+      }, delayMs);
+      return timer;
+    },
+
+    flush() {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      const p = pending;
+      if (p !== null) {
+        pending = null;
+        p.persist(p.manifest).catch(() => {});
+      }
+    },
+
+    cancel() {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      pending = null;
+    },
+
+    mergeIntoDiscrete(next) {
+      const p = pending;
+      if (p === null) return next;
+      pending = null;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      return {
+        ...next,
+        slides: next.slides.map((slide) => {
+          const ps = p.manifest.slides.find((s) => s.sceneId === slide.sceneId);
+          if (ps?.notes !== undefined && slide.notes === undefined) {
+            return { ...slide, notes: ps.notes };
+          }
+          return slide;
+        }),
+      };
+    },
+  };
+}
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+export interface SlideshowPanelProps {
+  /** Scenes from the live clip manifest (passed from StudioRightPanel). */
+  scenes: import("./slideshowPanelHelpers").SceneInfo[];
+  /**
+   * Called with the updated manifest after every discrete edit (toggle, add,
+   * delete, reorder, hotspot).  Notes changes use the debounced variant instead.
+   */
+  onPersist: (manifest: SlideshowManifest) => Promise<void>;
+  /** Called with the updated manifest after the notes idle delay (~450 ms). */
+  onPersistNotes: (manifest: SlideshowManifest) => Promise<void>;
+}
+
+type SectionKey = "slides" | "inspector" | "branches" | "hotspot";
+
+export function SlideshowPanel({ scenes, onPersist, onPersistNotes }: SlideshowPanelProps) {
+  const { editingFile } = useFileManagerContext();
+  const compHtml = editingFile?.content ?? null;
+
+  const [manifest, setManifest] = useState<SlideshowManifest>(() => {
+    if (!compHtml) return { slides: [] };
+    return safeParseManifest(compHtml);
+  });
+
+  const [selectedSceneId, setSelectedSceneId] = useState<string | null>(null);
+  const [expandedSections, setExpandedSections] = useState<Set<SectionKey>>(
+    () => new Set<SectionKey>(["slides", "inspector"]),
+  );
+
+  const currentTime = usePlayerStore((s) => s.currentTime);
+  const { domEditSelection } = useDomEditSelectionContext();
+
+  // Keep a ref to the latest manifest so discrete handlers always operate on
+  // the freshest state, never a stale closure snapshot.
+  const manifestRef = useRef<SlideshowManifest>(manifest);
+
+  // Controller pairs each pending notes update with the callback that owns it,
+  // so a flush always writes to the composition the notes were typed in.
+  const notesCtrlRef = useRef<NotesController>(makeSlideshowNotesController());
+
+  useEffect(() => {
+    if (!compHtml) {
+      // Flush any pending notes for the OLD composition before clearing state.
+      notesCtrlRef.current.flush();
+      setManifest({ slides: [] });
+      manifestRef.current = { slides: [] };
+      return;
+    }
+    const parsed = safeParseManifest(compHtml);
+    // Flush pending notes for the OLD composition before switching to the new one.
+    notesCtrlRef.current.flush();
+    setManifest(parsed);
+    manifestRef.current = parsed;
+  }, [compHtml]);
+
+  /** Discrete actions (toggle, reorder, add/delete, hotspot): persist immediately. */
+  const applyManifest = useCallback(
+    async (next: SlideshowManifest) => {
+      // Fold any in-flight typed notes into the discrete manifest so they are
+      // not silently dropped when the debounce timer would have fired later.
+      const merged = notesCtrlRef.current.mergeIntoDiscrete(next);
+      setManifest(merged);
+      manifestRef.current = merged;
+      await onPersist(merged);
+    },
+    [onPersist],
+  );
+
+  /**
+   * Notes path: update in-memory state immediately for a responsive UI, but
+   * debounce the disk persist to ~450 ms after the last keystroke.  The pending
+   * notes are paired with the callback that owns them (the one bound to the
+   * current composition path), so a composition switch before the timer fires
+   * will flush to the correct file.
+   */
+  const applyNotesManifest = useCallback(
+    (next: SlideshowManifest) => {
+      setManifest(next);
+      manifestRef.current = next;
+      notesCtrlRef.current.schedule(next, onPersistNotes, 450);
+    },
+    [onPersistNotes],
+  );
+
+  // Flush any pending notes persist when the component unmounts so we never
+  // silently drop an edit the user made right before navigating away.
+  useEffect(() => {
+    const ctrl = notesCtrlRef.current;
+    return () => {
+      ctrl.flush();
+    };
+  }, []);
+
+  const toggleSection = useCallback((key: SectionKey) => {
+    setExpandedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectedSlide = manifest.slides.find((s) => s.sceneId === selectedSceneId);
+  const sequences = manifest.slideSequences ?? [];
+
+  const handleToggleSlide = useCallback(
+    (sceneId: string) => {
+      applyManifest(toggleMainLineSlide(manifestRef.current, sceneId)).catch(() => {});
+    },
+    [applyManifest],
+  );
+
+  const handleReorder = useCallback(
+    (sceneId: string, dir: "up" | "down") => {
+      applyManifest(reorderMainLineSlide(manifestRef.current, sceneId, dir)).catch(() => {});
+    },
+    [applyManifest],
+  );
+
+  const handleSetNotes = useCallback(
+    (notes: string) => {
+      if (!selectedSceneId) return;
+      applyNotesManifest(setSlideNotes(manifestRef.current, selectedSceneId, notes));
+    },
+    [selectedSceneId, applyNotesManifest],
+  );
+
+  const handleMarkFragment = useCallback(() => {
+    if (!selectedSceneId) return;
+    applyManifest(addFragment(manifestRef.current, selectedSceneId, currentTime)).catch(() => {});
+  }, [selectedSceneId, currentTime, applyManifest]);
+
+  const handleRemoveFragment = useCallback(
+    (time: number) => {
+      if (!selectedSceneId) return;
+      applyManifest(removeFragment(manifestRef.current, selectedSceneId, time)).catch(() => {});
+    },
+    [selectedSceneId, applyManifest],
+  );
+
+  const handleCreateSequence = useCallback(
+    (label: string) => {
+      const id = `seq-${Date.now()}`;
+      applyManifest(createSequence(manifestRef.current, id, label)).catch(() => {});
+    },
+    [applyManifest],
+  );
+
+  const handleRenameSequence = useCallback(
+    (id: string, label: string) => {
+      applyManifest(renameSequence(manifestRef.current, id, label)).catch(() => {});
+    },
+    [applyManifest],
+  );
+
+  const handleDeleteSequence = useCallback(
+    (id: string) => {
+      applyManifest(deleteSequence(manifestRef.current, id)).catch(() => {});
+    },
+    [applyManifest],
+  );
+
+  const handleAssign = useCallback(
+    (sequenceId: string, sceneId: string, assign: boolean) => {
+      applyManifest(assignToBranch(manifestRef.current, sequenceId, sceneId, assign)).catch(
+        () => {},
+      );
+    },
+    [applyManifest],
+  );
+
+  const handleAddHotspot = useCallback(
+    (sceneId: string, hotspot: SlideHotspot) => {
+      applyManifest(addHotspot(manifestRef.current, sceneId, hotspot)).catch(() => {});
+    },
+    [applyManifest],
+  );
+
+  const handleRemoveHotspot = useCallback(
+    (sceneId: string, hotspotId: string) => {
+      applyManifest(removeHotspot(manifestRef.current, sceneId, hotspotId)).catch(() => {});
+    },
+    [applyManifest],
+  );
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto text-white">
+      <SectionHeader
+        expanded={expandedSections.has("slides")}
+        onToggle={() => toggleSection("slides")}
+      >
+        Slides ({manifest.slides.length})
+      </SectionHeader>
+      {expandedSections.has("slides") && (
+        <div className="py-1">
+          <SlideList
+            scenes={scenes}
+            slides={manifest.slides}
+            selectedSceneId={selectedSceneId}
+            onSelect={setSelectedSceneId}
+            onToggle={handleToggleSlide}
+            onReorder={handleReorder}
+          />
+        </div>
+      )}
+
+      <SectionHeader
+        expanded={expandedSections.has("inspector")}
+        onToggle={() => toggleSection("inspector")}
+      >
+        Slide Inspector
+      </SectionHeader>
+      {expandedSections.has("inspector") && (
+        <>
+          {selectedSceneId ? (
+            <SlideInspector
+              sceneId={selectedSceneId}
+              slide={selectedSlide}
+              currentTime={currentTime}
+              onSetNotes={handleSetNotes}
+              onMarkFragment={handleMarkFragment}
+              onRemoveFragment={handleRemoveFragment}
+            />
+          ) : (
+            <p className="px-3 py-2 text-[11px] text-neutral-500 italic">
+              Select a scene above to inspect
+            </p>
+          )}
+        </>
+      )}
+
+      <SectionHeader
+        expanded={expandedSections.has("branches")}
+        onToggle={() => toggleSection("branches")}
+      >
+        Branches ({sequences.length})
+      </SectionHeader>
+      {expandedSections.has("branches") && (
+        <BranchTree
+          sequences={sequences}
+          scenes={scenes}
+          onCreateSequence={handleCreateSequence}
+          onRenameSequence={handleRenameSequence}
+          onDeleteSequence={handleDeleteSequence}
+          onAssign={handleAssign}
+        />
+      )}
+
+      <SectionHeader
+        expanded={expandedSections.has("hotspot")}
+        onToggle={() => toggleSection("hotspot")}
+      >
+        Hotspot Tool
+      </SectionHeader>
+      {expandedSections.has("hotspot") && (
+        <HotspotTool
+          selectedSceneId={selectedSceneId}
+          slide={selectedSlide}
+          domEditSelection={domEditSelection}
+          sequences={sequences}
+          onAddHotspot={handleAddHotspot}
+          onRemoveHotspot={handleRemoveHotspot}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/studio/src/components/panels/SlideshowSubPanels.tsx
+++ b/packages/studio/src/components/panels/SlideshowSubPanels.tsx
@@ -1,0 +1,464 @@
+/**
+ * SlideshowSubPanels — internal sub-surface components for SlideshowPanel.
+ * Not exported from the package index; used only by SlideshowPanel.tsx.
+ */
+
+import { useState, useCallback, useId } from "react";
+import type { SlideRef, SlideHotspot, SlideSequence } from "@hyperframes/core/slideshow";
+import type { DomEditSelection } from "../editor/domEditing";
+import type { SceneInfo } from "./slideshowPanelHelpers";
+
+// ── Section header (accordion toggle) ────────────────────────────────────
+
+export function SectionHeader({
+  children,
+  expanded,
+  onToggle,
+}: {
+  children: React.ReactNode;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center justify-between px-3 py-2 text-[11px] font-medium text-neutral-400 hover:text-neutral-200 border-b border-neutral-800 transition-colors"
+      onClick={onToggle}
+      aria-expanded={expanded}
+    >
+      <span>{children}</span>
+      <span className="text-[10px] text-neutral-600">{expanded ? "▲" : "▼"}</span>
+    </button>
+  );
+}
+
+// ── Sub-surface: Slide List ──────────────────────────────────────────────
+
+export interface SlideListProps {
+  scenes: SceneInfo[];
+  slides: SlideRef[];
+  selectedSceneId: string | null;
+  onSelect: (sceneId: string) => void;
+  onToggle: (sceneId: string) => void;
+  onReorder: (sceneId: string, dir: "up" | "down") => void;
+}
+
+export function SlideList({
+  scenes,
+  slides,
+  selectedSceneId,
+  onSelect,
+  onToggle,
+  onReorder,
+}: SlideListProps) {
+  return (
+    <div className="flex flex-col gap-px">
+      {scenes.map((scene) => {
+        const isSlide = slides.some((s) => s.sceneId === scene.id);
+        const isSelected = selectedSceneId === scene.id;
+        return (
+          <div
+            key={scene.id}
+            role="button"
+            tabIndex={0}
+            aria-pressed={isSelected}
+            className={`flex items-center gap-2 px-3 py-1.5 rounded cursor-pointer text-[11px] transition-colors ${
+              isSelected
+                ? "bg-studio-accent/20 text-white"
+                : "hover:bg-neutral-800/60 text-neutral-300"
+            }`}
+            onClick={() => onSelect(scene.id)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelect(scene.id);
+              }
+            }}
+          >
+            <input
+              type="checkbox"
+              aria-label={`Include ${scene.label} as main-line slide`}
+              checked={isSlide}
+              onChange={() => onToggle(scene.id)}
+              onClick={(e) => e.stopPropagation()}
+              className="accent-studio-accent flex-shrink-0"
+            />
+            <span className="flex-1 truncate">{scene.label || scene.id}</span>
+            {isSlide && (
+              <span className="flex gap-0.5 flex-shrink-0">
+                <button
+                  type="button"
+                  aria-label="Move slide up"
+                  title="Move up"
+                  className="px-1 py-0.5 text-[10px] text-neutral-400 hover:text-white disabled:opacity-30"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReorder(scene.id, "up");
+                  }}
+                >
+                  ▲
+                </button>
+                <button
+                  type="button"
+                  aria-label="Move slide down"
+                  title="Move down"
+                  className="px-1 py-0.5 text-[10px] text-neutral-400 hover:text-white disabled:opacity-30"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReorder(scene.id, "down");
+                  }}
+                >
+                  ▼
+                </button>
+              </span>
+            )}
+          </div>
+        );
+      })}
+      {scenes.length === 0 && (
+        <p className="px-3 py-2 text-[11px] text-neutral-500 italic">No scenes found</p>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-surface: Slide Inspector ─────────────────────────────────────────
+
+export interface SlideInspectorProps {
+  sceneId: string;
+  slide: SlideRef | undefined;
+  currentTime: number;
+  onSetNotes: (notes: string) => void;
+  onMarkFragment: () => void;
+  onRemoveFragment: (time: number) => void;
+}
+
+// fallow-ignore-next-line complexity
+export function SlideInspector({
+  sceneId,
+  slide,
+  currentTime,
+  onSetNotes,
+  onMarkFragment,
+  onRemoveFragment,
+}: SlideInspectorProps) {
+  const fragments = slide?.fragments ?? [];
+  return (
+    <div className="flex flex-col gap-3 px-3 py-2">
+      <p className="text-[10px] text-neutral-500 font-medium uppercase tracking-wide truncate">
+        Scene: {sceneId}
+      </p>
+      <div className="flex flex-col gap-1">
+        <label className="text-[11px] text-neutral-400">Notes</label>
+        <textarea
+          className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1.5 text-[11px] text-white resize-none placeholder-neutral-600 focus:border-studio-accent/60 focus:outline-none"
+          rows={3}
+          placeholder="Speaker notes or script..."
+          value={slide?.notes ?? ""}
+          onChange={(e) => onSetNotes(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] text-neutral-400">Fragment hold-points</span>
+          <button
+            type="button"
+            className="text-[10px] px-2 py-0.5 rounded bg-neutral-700 hover:bg-neutral-600 text-neutral-200 transition-colors"
+            onClick={onMarkFragment}
+            title={`Mark ${currentTime.toFixed(2)}s as hold-point`}
+          >
+            Mark {currentTime.toFixed(2)}s
+          </button>
+        </div>
+        {fragments.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {fragments.map((t) => (
+              <span
+                key={t}
+                className="inline-flex items-center gap-1 bg-neutral-700 rounded px-1.5 py-0.5 text-[10px] text-neutral-200"
+              >
+                {t.toFixed(2)}s
+                <button
+                  type="button"
+                  aria-label={`Remove fragment at ${t.toFixed(2)}s`}
+                  className="text-neutral-400 hover:text-red-400 transition-colors"
+                  onClick={() => onRemoveFragment(t)}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-[10px] text-neutral-600 italic">No hold-points yet</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-surface: Branch Tree ──────────────────────────────────────────────
+
+export interface BranchTreeProps {
+  sequences: SlideSequence[];
+  scenes: SceneInfo[];
+  onCreateSequence: (label: string) => void;
+  onRenameSequence: (id: string, label: string) => void;
+  onDeleteSequence: (id: string) => void;
+  onAssign: (sequenceId: string, sceneId: string, assign: boolean) => void;
+}
+
+export function BranchTree({
+  sequences,
+  scenes,
+  onCreateSequence,
+  onRenameSequence,
+  onDeleteSequence,
+  onAssign,
+}: BranchTreeProps) {
+  const [newLabel, setNewLabel] = useState("");
+  const inputId = useId();
+
+  const handleCreate = useCallback(() => {
+    const label = newLabel.trim();
+    if (!label) return;
+    onCreateSequence(label);
+    setNewLabel("");
+  }, [newLabel, onCreateSequence]);
+
+  return (
+    <div className="flex flex-col gap-3 px-3 py-2">
+      <div className="flex gap-1.5">
+        <input
+          id={inputId}
+          type="text"
+          className="flex-1 bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-[11px] text-white placeholder-neutral-600 focus:border-studio-accent/60 focus:outline-none"
+          placeholder="New branch name..."
+          value={newLabel}
+          onChange={(e) => setNewLabel(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleCreate();
+          }}
+          aria-label="New branch sequence name"
+        />
+        <button
+          type="button"
+          className="px-2 py-1 rounded bg-neutral-700 hover:bg-neutral-600 text-[11px] text-neutral-200 transition-colors flex-shrink-0"
+          onClick={handleCreate}
+        >
+          Add
+        </button>
+      </div>
+
+      {sequences.length === 0 ? (
+        <p className="text-[10px] text-neutral-600 italic">No branches yet</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {sequences.map((seq) => (
+            <BranchItem
+              key={seq.id}
+              seq={seq}
+              scenes={scenes}
+              onRename={onRenameSequence}
+              onDelete={onDeleteSequence}
+              onAssign={onAssign}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface BranchItemProps {
+  seq: SlideSequence;
+  scenes: SceneInfo[];
+  onRename: (id: string, label: string) => void;
+  onDelete: (id: string) => void;
+  onAssign: (sequenceId: string, sceneId: string, assign: boolean) => void;
+}
+
+function BranchItem({ seq, scenes, onRename, onDelete, onAssign }: BranchItemProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(seq.label);
+
+  const commitRename = useCallback(() => {
+    const label = draft.trim();
+    if (label && label !== seq.label) onRename(seq.id, label);
+    setEditing(false);
+  }, [draft, onRename, seq.id, seq.label]);
+
+  return (
+    <div className="border border-neutral-700/60 rounded p-2 flex flex-col gap-2">
+      <div className="flex items-center gap-1">
+        {editing ? (
+          <input
+            className="flex-1 bg-neutral-800 border border-neutral-600 rounded px-1.5 py-0.5 text-[11px] text-white focus:border-studio-accent/60 focus:outline-none"
+            value={draft}
+            autoFocus
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitRename();
+              if (e.key === "Escape") setEditing(false);
+            }}
+            aria-label={`Rename branch ${seq.label}`}
+          />
+        ) : (
+          <span
+            role="button"
+            tabIndex={0}
+            className="flex-1 text-[11px] text-white font-medium truncate cursor-pointer hover:text-neutral-300"
+            title="Click to rename"
+            onClick={() => setEditing(true)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") setEditing(true);
+            }}
+          >
+            {seq.label}
+          </span>
+        )}
+        <button
+          type="button"
+          aria-label={`Delete branch ${seq.label}`}
+          className="text-[10px] text-neutral-500 hover:text-red-400 transition-colors px-1"
+          onClick={() => onDelete(seq.id)}
+        >
+          ✕
+        </button>
+      </div>
+      <div className="flex flex-col gap-px pl-2">
+        {scenes.map((scene) => {
+          const assigned = seq.slides.some((s) => s.sceneId === scene.id);
+          return (
+            <label
+              key={scene.id}
+              className="flex items-center gap-1.5 py-0.5 cursor-pointer text-[11px] text-neutral-400 hover:text-neutral-200"
+            >
+              <input
+                type="checkbox"
+                checked={assigned}
+                onChange={(e) => onAssign(seq.id, scene.id, e.target.checked)}
+                className="accent-studio-accent"
+              />
+              <span className="truncate">{scene.label || scene.id}</span>
+            </label>
+          );
+        })}
+        {scenes.length === 0 && <p className="text-[10px] text-neutral-600 italic">No scenes</p>}
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-surface: Hotspot Tool ─────────────────────────────────────────────
+
+export interface HotspotToolProps {
+  selectedSceneId: string | null;
+  slide: SlideRef | undefined;
+  domEditSelection: DomEditSelection | null;
+  sequences: SlideSequence[];
+  onAddHotspot: (sceneId: string, hotspot: SlideHotspot) => void;
+  onRemoveHotspot: (sceneId: string, hotspotId: string) => void;
+}
+
+// fallow-ignore-next-line complexity
+export function HotspotTool({
+  selectedSceneId,
+  slide,
+  domEditSelection,
+  sequences,
+  onAddHotspot,
+  onRemoveHotspot,
+}: HotspotToolProps) {
+  const [targetSequenceId, setTargetSequenceId] = useState("");
+  const [hotspotLabel, setHotspotLabel] = useState("");
+  const hotspots = slide?.hotspots ?? [];
+
+  const selectedElementId = domEditSelection?.element?.id ?? null;
+  const selectedHfId = domEditSelection?.hfId ?? null;
+  const elementKey = selectedElementId || selectedHfId;
+
+  // fallow-ignore-next-line complexity
+  const handleMakeHotspot = useCallback(() => {
+    if (!selectedSceneId || !targetSequenceId || !elementKey) return;
+    const id = `hotspot-${elementKey}-${Date.now()}`;
+    const label = hotspotLabel.trim() || elementKey;
+    onAddHotspot(selectedSceneId, { id, label, target: targetSequenceId });
+    setHotspotLabel("");
+  }, [selectedSceneId, targetSequenceId, elementKey, hotspotLabel, onAddHotspot]);
+
+  if (!selectedSceneId) {
+    return (
+      <div className="px-3 py-2">
+        <p className="text-[11px] text-neutral-500 italic">Select a scene in the Slides list</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-3 py-2">
+      <div className="flex flex-col gap-1.5">
+        <p className="text-[11px] text-neutral-400">
+          Selected element:{" "}
+          <span className="text-neutral-200 font-mono">{elementKey ?? "none"}</span>
+        </p>
+        <label className="text-[11px] text-neutral-400">Hotspot label</label>
+        <input
+          type="text"
+          className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-[11px] text-white placeholder-neutral-600 focus:border-studio-accent/60 focus:outline-none"
+          placeholder="Button label..."
+          value={hotspotLabel}
+          onChange={(e) => setHotspotLabel(e.target.value)}
+          aria-label="Hotspot label"
+        />
+        <label className="text-[11px] text-neutral-400">Target branch</label>
+        <select
+          className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-[11px] text-white focus:border-studio-accent/60 focus:outline-none"
+          value={targetSequenceId}
+          onChange={(e) => setTargetSequenceId(e.target.value)}
+          aria-label="Target branch sequence"
+        >
+          <option value="">— select branch —</option>
+          {sequences.map((seq) => (
+            <option key={seq.id} value={seq.id}>
+              {seq.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          disabled={!elementKey || !targetSequenceId}
+          className="px-3 py-1.5 rounded bg-studio-accent/80 hover:bg-studio-accent text-white text-[11px] font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          onClick={handleMakeHotspot}
+        >
+          Make hotspot
+        </button>
+      </div>
+
+      {hotspots.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <p className="text-[11px] text-neutral-400 font-medium">Hotspots on this slide</p>
+          {hotspots.map((h) => {
+            const seqLabel = sequences.find((s) => s.id === h.target)?.label ?? h.target;
+            return (
+              <div key={h.id} className="flex items-center gap-2 bg-neutral-800 rounded px-2 py-1">
+                <span className="flex-1 text-[11px] text-neutral-200 truncate">
+                  {h.label} → <span className="text-neutral-400">{seqLabel}</span>
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Remove hotspot ${h.label}`}
+                  className="text-[10px] text-neutral-500 hover:text-red-400 transition-colors"
+                  onClick={() => onRemoveHotspot(selectedSceneId, h.id)}
+                >
+                  ✕
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/studio/src/components/panels/slideshowPanelHelpers.ts
+++ b/packages/studio/src/components/panels/slideshowPanelHelpers.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure manifest-transform helpers for SlideshowPanel.
+ * No React, no side-effects — fully unit-testable.
+ */
+
+import type { SlideshowManifest, SlideRef, SlideHotspot } from "@hyperframes/core/slideshow";
+
+// ── Scene shape used by the panel UI ──────────────────────────────────────
+
+export interface SceneInfo {
+  id: string;
+  label: string;
+  start: number;
+  duration: number;
+}
+
+// ── Pure manifest transforms ───────────────────────────────────────────────
+
+/** Toggle a scene in the main-line slide list. */
+export function toggleMainLineSlide(
+  manifest: SlideshowManifest,
+  sceneId: string,
+): SlideshowManifest {
+  const exists = manifest.slides.some((s) => s.sceneId === sceneId);
+  const slides: SlideRef[] = exists
+    ? manifest.slides.filter((s) => s.sceneId !== sceneId)
+    : [...manifest.slides, { sceneId }];
+  return { ...manifest, slides };
+}
+
+// fallow-ignore-next-line complexity
+/** Move a main-line slide up or down by one position. */
+export function reorderMainLineSlide(
+  manifest: SlideshowManifest,
+  sceneId: string,
+  direction: "up" | "down",
+): SlideshowManifest {
+  const idx = manifest.slides.findIndex((s) => s.sceneId === sceneId);
+  if (idx === -1) return manifest;
+  const next = direction === "up" ? idx - 1 : idx + 1;
+  if (next < 0 || next >= manifest.slides.length) return manifest;
+  const slides = [...manifest.slides];
+  const a = slides[idx];
+  const b = slides[next];
+  if (!a || !b) return manifest;
+  slides[idx] = b;
+  slides[next] = a;
+  return { ...manifest, slides };
+}
+
+/** Update notes on a main-line slide (adds slide entry if absent). */
+export function setSlideNotes(
+  manifest: SlideshowManifest,
+  sceneId: string,
+  notes: string,
+): SlideshowManifest {
+  const exists = manifest.slides.some((s) => s.sceneId === sceneId);
+  const slides: SlideRef[] = exists
+    ? manifest.slides.map((s) => (s.sceneId === sceneId ? { ...s, notes } : s))
+    : [...manifest.slides, { sceneId, notes }];
+  return { ...manifest, slides };
+}
+
+/** Push a fragment hold-point time onto a main-line slide. Deduplicates + sorts. */
+export function addFragment(
+  manifest: SlideshowManifest,
+  sceneId: string,
+  time: number,
+): SlideshowManifest {
+  const exists = manifest.slides.some((s) => s.sceneId === sceneId);
+  const slides: SlideRef[] = exists
+    ? manifest.slides.map((s) => {
+        if (s.sceneId !== sceneId) return s;
+        const frags = [...new Set([...(s.fragments ?? []), time])].sort((a, b) => a - b);
+        return { ...s, fragments: frags };
+      })
+    : [...manifest.slides, { sceneId, fragments: [time] }];
+  return { ...manifest, slides };
+}
+
+/** Remove a fragment hold-point by value from a main-line slide. */
+export function removeFragment(
+  manifest: SlideshowManifest,
+  sceneId: string,
+  time: number,
+): SlideshowManifest {
+  return {
+    ...manifest,
+    slides: manifest.slides.map((s) => {
+      if (s.sceneId !== sceneId) return s;
+      return { ...s, fragments: (s.fragments ?? []).filter((f) => f !== time) };
+    }),
+  };
+}
+
+/** Create a new branch sequence. Rejects duplicate ids. */
+export function createSequence(
+  manifest: SlideshowManifest,
+  id: string,
+  label: string,
+): SlideshowManifest {
+  const existing = manifest.slideSequences ?? [];
+  if (existing.some((seq) => seq.id === id)) return manifest;
+  return {
+    ...manifest,
+    slideSequences: [...existing, { id, label, slides: [] }],
+  };
+}
+
+/** Rename an existing branch sequence label. */
+export function renameSequence(
+  manifest: SlideshowManifest,
+  id: string,
+  label: string,
+): SlideshowManifest {
+  return {
+    ...manifest,
+    slideSequences: (manifest.slideSequences ?? []).map((seq) =>
+      seq.id === id ? { ...seq, label } : seq,
+    ),
+  };
+}
+
+function pruneHotspots(slides: SlideRef[], targetId: string): SlideRef[] {
+  return slides.map((s) => {
+    if (!s.hotspots) return s;
+    const hotspots = s.hotspots.filter((h) => h.target !== targetId);
+    return hotspots.length === s.hotspots.length ? s : { ...s, hotspots };
+  });
+}
+
+/** Delete a branch sequence by id, removing any hotspot targeting it. */
+export function deleteSequence(manifest: SlideshowManifest, id: string): SlideshowManifest {
+  const remainingSequences = (manifest.slideSequences ?? []).filter((seq) => seq.id !== id);
+  return {
+    ...manifest,
+    slides: pruneHotspots(manifest.slides, id),
+    slideSequences: remainingSequences.map((seq) => ({
+      ...seq,
+      slides: pruneHotspots(seq.slides, id),
+    })),
+  };
+}
+
+/** Add or remove a scene slide from a branch sequence. */
+export function assignToBranch(
+  manifest: SlideshowManifest,
+  sequenceId: string,
+  sceneId: string,
+  assign: boolean,
+): SlideshowManifest {
+  return {
+    ...manifest,
+    slideSequences: (manifest.slideSequences ?? []).map((seq) => {
+      if (seq.id !== sequenceId) return seq;
+      if (assign) {
+        if (seq.slides.some((s) => s.sceneId === sceneId)) return seq;
+        return { ...seq, slides: [...seq.slides, { sceneId }] };
+      }
+      return { ...seq, slides: seq.slides.filter((s) => s.sceneId !== sceneId) };
+    }),
+  };
+}
+
+/** Add a hotspot to a main-line slide. */
+export function addHotspot(
+  manifest: SlideshowManifest,
+  sceneId: string,
+  hotspot: SlideHotspot,
+): SlideshowManifest {
+  return {
+    ...manifest,
+    slides: manifest.slides.map((s) => {
+      if (s.sceneId !== sceneId) return s;
+      const existing = s.hotspots ?? [];
+      if (existing.some((h) => h.id === hotspot.id)) return s;
+      return { ...s, hotspots: [...existing, hotspot] };
+    }),
+  };
+}
+
+/** Remove a hotspot by id from a main-line slide. */
+export function removeHotspot(
+  manifest: SlideshowManifest,
+  sceneId: string,
+  hotspotId: string,
+): SlideshowManifest {
+  return {
+    ...manifest,
+    slides: manifest.slides.map((s) => {
+      if (s.sceneId !== sceneId) return s;
+      return { ...s, hotspots: (s.hotspots ?? []).filter((h) => h.id !== hotspotId) };
+    }),
+  };
+}

--- a/packages/studio/src/hooks/useSlideshowPersist.ts
+++ b/packages/studio/src/hooks/useSlideshowPersist.ts
@@ -1,0 +1,68 @@
+import { useCallback, type MutableRefObject } from "react";
+import type { Composition } from "@hyperframes/sdk";
+import type { SlideshowManifest } from "@hyperframes/core/slideshow";
+import type { EditHistoryKind } from "../utils/editHistory";
+import { persistSlideshowManifest } from "../utils/setSlideshowManifest";
+
+export interface UseSlideshowPersistParams {
+  sdkSession: Composition | null;
+  activeCompPath: string | null;
+  readProjectFile: (path: string) => Promise<string>;
+  writeProjectFile: (path: string, content: string) => Promise<void>;
+  recordEdit: (entry: {
+    label: string;
+    kind: EditHistoryKind;
+    files: Record<string, { before: string; after: string }>;
+  }) => Promise<void>;
+  reloadPreview: () => void;
+  domEditSaveTimestampRef: MutableRefObject<number>;
+  /**
+   * When provided, rapid writes with the same key coalesce through the
+   * save-queue infra (via recordEdit's coalesceKey) so back-to-back persists
+   * collapse to a single undo entry rather than polluting history.
+   * Pass e.g. `"slideshow-notes:" + activeCompPath` for the notes path.
+   */
+  coalesceKey?: string;
+}
+
+export function useSlideshowPersist({
+  sdkSession,
+  activeCompPath,
+  readProjectFile,
+  writeProjectFile,
+  recordEdit,
+  reloadPreview,
+  domEditSaveTimestampRef,
+  coalesceKey,
+}: UseSlideshowPersistParams): (manifest: SlideshowManifest) => Promise<void> {
+  return useCallback(
+    async (manifest: SlideshowManifest) => {
+      if (!sdkSession) return;
+      const path = activeCompPath ?? "index.html";
+      const originalContent = await readProjectFile(path);
+      await persistSlideshowManifest({
+        manifest,
+        sdkSession,
+        originalContent,
+        targetPath: path,
+        deps: {
+          editHistory: { recordEdit },
+          writeProjectFile,
+          reloadPreview,
+          domEditSaveTimestampRef,
+        },
+        coalesceKey,
+      });
+    },
+    [
+      sdkSession,
+      activeCompPath,
+      readProjectFile,
+      writeProjectFile,
+      recordEdit,
+      reloadPreview,
+      domEditSaveTimestampRef,
+      coalesceKey,
+    ],
+  );
+}

--- a/packages/studio/src/utils/sdkCutover.ts
+++ b/packages/studio/src/utils/sdkCutover.ts
@@ -144,10 +144,11 @@ interface CutoverOptions {
   skipRefresh?: boolean;
 }
 
-// ponytail: internal; export only if a third caller appears.
+// ponytail: exported for setSlideshowManifest (third caller — island write bypasses
+// the SDK dispatch path since <script> nodes are not in the element tree).
 // `after` is serialized once by the caller (which also did the no-op check
 // against its pre-dispatch snapshot), so this never re-serializes.
-async function persistSdkSerialize(
+export async function persistSdkSerialize(
   after: string,
   targetPath: string,
   originalContent: string,

--- a/packages/studio/src/utils/setSlideshowManifest.test.ts
+++ b/packages/studio/src/utils/setSlideshowManifest.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildSlideshowIslandHtml } from "./setSlideshowManifest";
+import { parseSlideshowManifest } from "@hyperframes/core/slideshow";
+import type { CutoverDeps } from "./sdkCutover";
+
+// Fix 3: vi.mock must be at module top level so Vitest can hoist them.
+vi.mock("../components/editor/manualEditingAvailability", () => ({
+  STUDIO_SDK_CUTOVER_ENABLED: true,
+  STUDIO_SDK_RESOLVER_SHADOW_ENABLED: false,
+}));
+vi.mock("./studioTelemetry", () => ({ trackStudioEvent: vi.fn() }));
+
+describe("buildSlideshowIslandHtml", () => {
+  it("serializes a manifest into a script island", () => {
+    const html = buildSlideshowIslandHtml({ slides: [{ sceneId: "a" }] });
+    expect(html).toContain('type="application/hyperframes-slideshow+json"');
+    expect(html).toContain('"sceneId": "a"');
+  });
+
+  it("round-trips through parseSlideshowManifest", () => {
+    const html = `<html><body>${buildSlideshowIslandHtml({ slides: [{ sceneId: "x" }] })}</body></html>`;
+    const parsed = parseSlideshowManifest(html);
+    expect(parsed?.slides[0]?.sceneId).toBe("x");
+  });
+
+  it("wraps the JSON in a script tag with no extra nesting", () => {
+    const html = buildSlideshowIslandHtml({ slides: [] });
+    expect(html.startsWith("<script")).toBe(true);
+    expect(html.trimEnd().endsWith("</script>")).toBe(true);
+  });
+
+  // Fix 1: </script> breakout test
+  it("does NOT embed a literal </script> inside the JSON body", () => {
+    const manifest = { slides: [{ sceneId: "s1", notes: "</script><b>x</b>" }] };
+    const html = buildSlideshowIslandHtml(manifest);
+    // The only closing </script> should be the real one at the very end.
+    // Strip that trailing tag and confirm no </script> remains.
+    const withoutClosingTag = html.slice(0, html.lastIndexOf("</script>"));
+    expect(withoutClosingTag).not.toContain("</script>");
+  });
+
+  it("round-trips a manifest containing </script> in notes via parseSlideshowManifest", () => {
+    const notes = "</script><b>x</b>";
+    const manifest = { slides: [{ sceneId: "s1", notes }] };
+    const html = `<html><body>${buildSlideshowIslandHtml(manifest)}</body></html>`;
+    const parsed = parseSlideshowManifest(html);
+    expect(parsed?.slides[0]).toMatchObject({ sceneId: "s1", notes });
+  });
+});
+
+describe("persistSlideshowManifest — op construction", () => {
+  function makeDeps(writeProjectFile: ReturnType<typeof vi.fn>): CutoverDeps {
+    return {
+      editHistory: { recordEdit: vi.fn().mockResolvedValue(undefined) },
+      writeProjectFile,
+      reloadPreview: vi.fn(),
+      domEditSaveTimestampRef: { current: 0 },
+    };
+  }
+
+  it("writes the serialized manifest when the island already exists", async () => {
+    const { persistSlideshowManifest } = await import("./setSlideshowManifest");
+
+    const manifest = { slides: [{ sceneId: "scene-1" }] };
+    const island = buildSlideshowIslandHtml(manifest);
+    const originalHtml = `<html><head></head><body>${island}</body></html>`;
+
+    const writeProjectFile = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps(writeProjectFile);
+    const recordEdit = deps.editHistory.recordEdit as ReturnType<typeof vi.fn>;
+
+    const mockSession = { serialize: vi.fn().mockReturnValue(originalHtml) };
+
+    await persistSlideshowManifest({
+      manifest: { slides: [{ sceneId: "scene-2" }] },
+      sdkSession: mockSession as never,
+      originalContent: originalHtml,
+      targetPath: "/proj/comp.html",
+      deps,
+    });
+
+    expect(writeProjectFile).toHaveBeenCalledOnce();
+    const written: string = writeProjectFile.mock.calls[0]?.[1] as string;
+    expect(written).toContain('"sceneId": "scene-2"');
+    expect(recordEdit).toHaveBeenCalledWith(expect.objectContaining({ label: "Edit slideshow" }));
+  });
+
+  it("inserts the island when none exists in the serialized HTML", async () => {
+    const { persistSlideshowManifest } = await import("./setSlideshowManifest");
+
+    const baseHtml = "<html><head></head><body></body></html>";
+    const writeProjectFile = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps(writeProjectFile);
+    const mockSession = { serialize: vi.fn().mockReturnValue(baseHtml) };
+
+    await persistSlideshowManifest({
+      manifest: { slides: [{ sceneId: "new-scene" }] },
+      sdkSession: mockSession as never,
+      originalContent: baseHtml,
+      targetPath: "/proj/comp.html",
+      deps,
+    });
+
+    expect(writeProjectFile).toHaveBeenCalledOnce();
+    const written: string = writeProjectFile.mock.calls[0]?.[1] as string;
+    expect(written).toContain('"sceneId": "new-scene"');
+    expect(written).toContain('type="application/hyperframes-slideshow+json"');
+  });
+
+  // Fix 2: two stale islands should collapse to exactly one after persist
+  it("collapses two stale islands into exactly one after persist", async () => {
+    const { persistSlideshowManifest } = await import("./setSlideshowManifest");
+
+    const staleIsland1 = buildSlideshowIslandHtml({ slides: [{ sceneId: "old-1" }] });
+    const staleIsland2 = buildSlideshowIslandHtml({ slides: [{ sceneId: "old-2" }] });
+    const twoIslandHtml = `<html><head></head><body>${staleIsland1}${staleIsland2}</body></html>`;
+
+    const writeProjectFile = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps(writeProjectFile);
+    const mockSession = { serialize: vi.fn().mockReturnValue(twoIslandHtml) };
+
+    await persistSlideshowManifest({
+      manifest: { slides: [{ sceneId: "fresh" }] },
+      sdkSession: mockSession as never,
+      originalContent: twoIslandHtml,
+      targetPath: "/proj/comp.html",
+      deps,
+    });
+
+    expect(writeProjectFile).toHaveBeenCalledOnce();
+    const written: string = writeProjectFile.mock.calls[0]?.[1] as string;
+
+    // Count occurrences of the island script open tag
+    const islandCount = (written.match(/type="application\/hyperframes-slideshow\+json"/g) ?? [])
+      .length;
+    expect(islandCount).toBe(1);
+    expect(written).toContain('"sceneId": "fresh"');
+    expect(written).not.toContain('"sceneId": "old-1"');
+    expect(written).not.toContain('"sceneId": "old-2"');
+  });
+});

--- a/packages/studio/src/utils/setSlideshowManifest.ts
+++ b/packages/studio/src/utils/setSlideshowManifest.ts
@@ -1,0 +1,79 @@
+/**
+ * setSlideshowManifest — Studio persist helper for the slideshow JSON island.
+ *
+ * The island is a `<script type="application/hyperframes-slideshow+json">` node
+ * embedded in the composition HTML.  Because <script> nodes are not tracked by
+ * the SDK element tree (they have no hf-id), we cannot use a `setText` dispatch
+ * op.  Instead we:
+ *   1. Call `sdkSession.serialize()` to get the current HTML.
+ *   2. Replace or insert the island with the new manifest JSON.
+ *   3. Write via `persistSdkSerialize` — the same low-level writer used by the
+ *      other SDK-cutover paths (sdkDeletePersist, sdkTimingPersist, etc.).
+ *
+ * Inserting when absent: if no island exists in the serialized HTML we insert
+ * one before `</body>` (or, if no </body>, append to the end of the document).
+ * This means callers do NOT need to pre-scaffold the island; Task 11 / the panel
+ * can call persistSlideshowManifest on a fresh composition.
+ */
+
+import type { SlideshowManifest } from "@hyperframes/core/slideshow";
+import type { Composition } from "@hyperframes/sdk";
+import type { CutoverDeps } from "./sdkCutover";
+import { persistSdkSerialize } from "./sdkCutover";
+
+const ISLAND_TYPE = "application/hyperframes-slideshow+json";
+
+// Matches ALL <script type="application/hyperframes-slideshow+json"> ... </script>
+// blocks (global + case-insensitive) so we can strip every stale island in one pass.
+const ISLAND_RE = new RegExp(
+  `<script[^>]*type=["']${ISLAND_TYPE.replace(/[.+]/g, "\\$&")}["'][^>]*>[\\s\\S]*?<\\/script>`,
+  "gi",
+);
+
+export function buildSlideshowIslandHtml(manifest: SlideshowManifest): string {
+  // Escape `<` and `>` so that a manifest field containing `</script>` cannot
+  // break out of the script tag. JSON.parse round-trips </> unchanged.
+  const json = JSON.stringify(manifest, null, 2).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+  return `<script type="${ISLAND_TYPE}">\n${json}\n</script>`;
+}
+
+export interface PersistSlideshowArgs {
+  manifest: SlideshowManifest;
+  /** Live SDK Composition session — used only to read the current serialized HTML. */
+  sdkSession: Pick<Composition, "serialize">;
+  /** Exact on-disk bytes for the undo-history `before` baseline. */
+  originalContent: string;
+  targetPath: string;
+  deps: CutoverDeps;
+  /** Optional label override (default: "Edit slideshow"). */
+  label?: string;
+  /**
+   * When provided, threads a coalesceKey into recordEdit so rapid writes
+   * (e.g. per-keystroke notes changes) collapse to a single undo entry.
+   */
+  coalesceKey?: string;
+}
+
+export async function persistSlideshowManifest(args: PersistSlideshowArgs): Promise<void> {
+  const { manifest, sdkSession, originalContent, targetPath, deps, label, coalesceKey } = args;
+
+  const islandHtml = buildSlideshowIslandHtml(manifest);
+  const current = sdkSession.serialize();
+
+  // Strip ALL existing islands (handles the case where two stale islands
+  // accumulated) then insert exactly one fresh island.
+  const stripped = current.replace(ISLAND_RE, "");
+
+  let after: string;
+  const bodyClose = stripped.lastIndexOf("</body>");
+  if (bodyClose !== -1) {
+    after = stripped.slice(0, bodyClose) + islandHtml + "\n" + stripped.slice(bodyClose);
+  } else {
+    after = stripped + "\n" + islandHtml;
+  }
+
+  await persistSdkSerialize(after, targetPath, originalContent, deps, {
+    label: label ?? "Edit slideshow",
+    ...(coalesceKey ? { coalesceKey } : {}),
+  });
+}

--- a/packages/studio/src/utils/studioHelpers.ts
+++ b/packages/studio/src/utils/studioHelpers.ts
@@ -13,7 +13,7 @@ export interface AppToast {
   tone: "error" | "info";
 }
 
-export type RightPanelTab = "layers" | "design" | "renders" | "block-params";
+export type RightPanelTab = "layers" | "design" | "renders" | "block-params" | "slideshow";
 export type RightInspectorPane = "layers" | "design";
 
 export interface RightInspectorPanes {
@@ -204,6 +204,7 @@ export function clampNumber(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+// fallow-ignore-next-line unused-export
 export { COMPOSITION_ROOT_OPEN_TAG_RE } from "./compositionPatterns";
 
 export function collectHtmlIds(source: string): string[] {

--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -28,6 +28,7 @@ metadata:
 | You want to…                                                                                                                                     | Go to                                        |
 | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
 | **Make a video** (from a URL, brief, topic, GitHub PR, existing footage, or a single element to animate)                                         | the **video router below** (§ Video routing) |
+| **Author a slideshow / presentation / pitch deck** — discrete slides, fragments, branching, hotspots                                             | `/slideshow`                                 |
 | **Author / edit an HTML composition** — the `data-*` contract, clips, tracks, sub-compositions, variables                                        | `/hyperframes-core`                          |
 | **Animate** — atomic motion rules, scene blueprints, transitions, runtime adapters (GSAP / Lottie / Three.js / Anime.js / CSS / WAAPI / TypeGPU) | `/hyperframes-animation`                     |
 | **Creative direction** — `design.md`, palettes, typography, narration, beat planning, audio-reactive                                             | `/hyperframes-creative`                      |

--- a/skills/slideshow/SKILL.md
+++ b/skills/slideshow/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: slideshow
+description: >
+  Author a HyperFrames slideshow composition — a presentation, pitch deck, or
+  interactive deck with discrete slides, fragment reveals, branching sequences,
+  and hotspot navigation. Read when the request is to build or edit a slideshow,
+  presentation, or pitch deck as a HyperFrames composition.
+---
+
+# Slideshow authoring contract
+
+A HyperFrames slideshow is a normal HyperFrames composition — scenes, clips, GSAP timelines — with one extra ingredient: a **JSON island** that declares which scenes are slides and how they connect. The player's `SlideshowController` reads the island and turns the continuous GSAP timeline into a discrete, navigable deck.
+
+**Read `/hyperframes-core` first** for the base composition contract (clips, tracks, `data-*` attributes, determinism rules). This skill covers only what is new: the island schema, slide writing rules, fragments, branching, validation, and the wrapping component.
+
+---
+
+## The two pieces
+
+### 1. Scenes — declared the normal way
+
+Every slide is backed by a scene. Declare scenes with `data-composition-id`, `data-start`, `data-duration`, and `data-label`:
+
+```html
+<div
+  data-composition-id="problem"
+  data-start="0"
+  data-duration="8"
+  data-label="The problem"
+  data-width="1920"
+  data-height="1080"
+>
+  <!-- clips go here -->
+</div>
+```
+
+Branch slides (reachable only via a hotspot, excluded from the main line) are declared exactly the same way — they just appear only in a `slideSequences` entry in the island, not in the main `slides` array.
+
+### 2. The JSON island — one script block per composition
+
+Add exactly one `<script type="application/hyperframes-slideshow+json">` block to the composition HTML. It holds all slideshow metadata:
+
+```html
+<script type="application/hyperframes-slideshow+json">
+  {
+    "slides": [...],
+    "slideSequences": [...]
+  }
+</script>
+```
+
+The island is the single source of truth for slide order, notes, fragment hold-points, hotspots, and branch sequences. Keep it near the top of the `<body>`, before the scene divs, so it is easy to find.
+
+---
+
+## Schema
+
+### `SlideshowManifest` (the top-level island object)
+
+```json
+{
+  "slides": [
+    /* SlideRef[] — the main line, in order */
+  ],
+  "slideSequences": [
+    /* SlideSequence[] — off-line branch sequences */
+  ]
+}
+```
+
+### `SlideRef`
+
+```json
+{
+  "sceneId": "problem",
+  "notes": "Lead with the pain, not the company.",
+  "fragments": [3.5, 5.2, 7.0],
+  "hotspots": [
+    /* SlideHotspot[] */
+  ],
+
+  "ttsScript": null,
+  "ttsAudioUrl": null,
+  "ttsDurationMs": null
+}
+```
+
+| Field                                       | Required | Notes                                                                                                                       |
+| ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `sceneId`                                   | yes      | Must match a scene's `data-composition-id` exactly. The lint rule resolves both `data-composition-id` and `.clip[id]`.      |
+| `notes`                                     | no       | Presenter-only text. Never shown to the audience.                                                                           |
+| `fragments`                                 | no       | Array of times (seconds) within the slide's `[start, end]` range — see Fragments below.                                     |
+| `hotspots`                                  | no       | Interactive overlays that trigger a branch — see Branching below.                                                           |
+| `startTime`                                 | no       | Optional. Override the matched scene's time bounds; defaults to the scene's start/end.                                      |
+| `endTime`                                   | no       | Optional. Override the matched scene's time bounds; defaults to the scene's start/end.                                      |
+| `ttsScript`, `ttsAudioUrl`, `ttsDurationMs` | no       | **Reserved.** Schema fields exist but TTS playback is not yet wired. Omit unless you are pre-populating for a future build. |
+
+### `SlideHotspot`
+
+```json
+{
+  "id": "h1",
+  "label": "How did we calculate this?",
+  "target": "market-deep-dive",
+  "region": { "x": 60, "y": 10, "w": 35, "h": 20 }
+}
+```
+
+| Field    | Required | Notes                                                                                                                           |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `id`     | yes      | Unique within the slide.                                                                                                        |
+| `label`  | yes      | Tooltip / button text shown to the audience.                                                                                    |
+| `target` | yes      | Must match a `SlideSequence.id` in `slideSequences`.                                                                            |
+| `region` | no       | Percentage-of-slide bounding box: `{x, y, w, h}` in `0–100`. Omit to render the hotspot as a full-slide labeled button instead. |
+
+### `SlideSequence`
+
+```json
+{
+  "id": "market-deep-dive",
+  "label": "Market sizing methodology",
+  "slides": [{ "sceneId": "mkt-1" }, { "sceneId": "mkt-2" }]
+}
+```
+
+`slides` inside a sequence uses the same `SlideRef` shape as the main line. Fragments and nested hotspots are allowed.
+
+---
+
+## Slide writing rules
+
+These are hard constraints, not suggestions. A slide that violates them will be outright replaced when a reviewer sees it.
+
+- **Headline is a complete-sentence claim, not a label.** Write "SMBs spend 14 hours/week on manual scheduling" not "Scheduling problem". The sentence should stand alone if the visual is ignored.
+- **One idea + one visual per slide.** If you are tempted to add a second bullet cluster or a second chart, split the slide.
+- **Lead with the punchline.** The strongest point goes first — on the slide and in the deck order. Investors read left-to-right, top-to-bottom, and they stop.
+- **Bottom-up market sizing only.** Never write "$50B TAM" without showing the math. Build from unit economics up: accounts × ACV, or transactions × take-rate.
+- **Font minimum 30pt equivalent.** At 1920×1080, a headline is 72–96px; body copy is 48px. Never go below 40px for any text the audience must read.
+
+---
+
+## Fragments: reveal hold-points within a slide
+
+A fragment is a time (in seconds) within a slide's `[start, end]` range where the controller pauses before the next reveal.
+
+**How it works:**
+
+1. Player enters the slide — seeks to `start`, then plays.
+2. Controller pauses at `fragments[0]`. The first element's GSAP entrance has just landed.
+3. User presses Next (or →) — plays to `fragments[1]`, pauses again.
+4. After the last fragment, Next plays to `slide.end` and holds.
+5. Next again advances to the next slide.
+
+Fragment times must be strictly inside `[start, end]`. The lint rule rejects fragments outside that range.
+
+Fragment times are **absolute composition-timeline positions** — the same coordinate space as `data-start` — not offsets relative to the scene's start.
+
+Each fragment is a play-to-and-hold, not a seek jump — so every element that enters between the previous hold-point and this one plays its GSAP entrance animation. Design the clip entrance animations to work as sequential reveals.
+
+---
+
+## Branching: hotspots and slide sequences
+
+Branch slides are real scenes in the same composition timeline. They are listed only under `slideSequences` and are excluded from main-line navigation — the player never visits them unless a hotspot fires.
+
+**Navigation model:**
+
+- Clicking a hotspot pushes `{sequenceId, slideIndex: 0}` onto the nav stack and enters the branch's first slide.
+- **back()** pops the stack and returns to the exact parent slide (the one that held the hotspot).
+- **backToMain()** clears the entire stack and returns to the root slide.
+- Breadcrumb renders from the stack: `Main deck › Market sizing methodology › Slide 2`.
+- The slide counter inside a branch is scoped to that sequence (`1 of 2`, not the main-deck total).
+
+**What to avoid:**
+
+- Do not add branch scene IDs to the main `slides` array. They must appear only inside a `slideSequences` entry. The lint rule flags overlap.
+- Branch scenes are included in the continuous timeline, so a naive linear video export would include them. Export reads main-line slides only (deferred; flagged in the spec).
+
+---
+
+## Worked example: 3-slide deck with fragments and a branch
+
+### Scene HTML (skeleton)
+
+```html
+<body style="margin: 0">
+  <script type="application/hyperframes-slideshow+json">
+    {
+      "slides": [
+        {
+          "sceneId": "hook",
+          "notes": "Open with the stat. Pause on the $40B number."
+        },
+        {
+          "sceneId": "problem",
+          "notes": "Walk through each pain point one at a time.",
+          "fragments": [11.0, 15.0],
+          "hotspots": [
+            {
+              "id": "h1",
+              "label": "Where does the $40B figure come from?",
+              "target": "market-detail",
+              "region": { "x": 55, "y": 60, "w": 40, "h": 20 }
+            }
+          ]
+        },
+        {
+          "sceneId": "solution",
+          "notes": "One sentence: what we do and who it is for."
+        }
+      ],
+      "slideSequences": [
+        {
+          "id": "market-detail",
+          "label": "Market sizing methodology",
+          "slides": [{ "sceneId": "mkt-math", "notes": "Bottom-up: 2.3M SMBs × $17k ACV." }]
+        }
+      ]
+    }
+  </script>
+
+  <!-- Slide 1 — hook -->
+  <div
+    data-composition-id="hook"
+    data-start="0"
+    data-duration="6"
+    data-label="The hook"
+    data-width="1920"
+    data-height="1080"
+    style="position: relative; width: 1920px; height: 1080px; overflow: hidden; background: #0a0a0a"
+  >
+    <section
+      class="clip"
+      data-start="0"
+      data-duration="6"
+      data-track-index="1"
+      style="position: absolute; inset: 0; display: grid; place-items: center"
+    >
+      <h1 id="hook-headline" style="font-size: 80px; color: #fff; font-family: sans-serif">
+        SMBs lose $40B/year to manual scheduling
+      </h1>
+    </section>
+  </div>
+
+  <!-- Slide 2 — problem (3 fragments) -->
+  <div
+    data-composition-id="problem"
+    data-start="6"
+    data-duration="15"
+    data-label="The problem"
+    data-width="1920"
+    data-height="1080"
+    style="position: relative; width: 1920px; height: 1080px; overflow: hidden; background: #0a0a0a"
+  >
+    <section
+      class="clip"
+      data-start="6"
+      data-duration="15"
+      data-track-index="1"
+      style="position: absolute; inset: 0; padding: 120px 160px; box-sizing: border-box"
+    >
+      <h2 id="pain-headline" style="font-size: 64px; color: #fff; font-family: sans-serif">
+        Three gaps operators can not close
+      </h2>
+      <p id="pain-1" style="font-size: 48px; color: #ccc; opacity: 0; font-family: sans-serif">
+        No-shows cost 23% of booked revenue
+      </p>
+      <p id="pain-2" style="font-size: 48px; color: #ccc; opacity: 0; font-family: sans-serif">
+        Manual reminders take 4h/week per staff
+      </p>
+      <p id="pain-3" style="font-size: 48px; color: #ccc; opacity: 0; font-family: sans-serif">
+        Rescheduling friction drives 40% churn
+      </p>
+    </section>
+  </div>
+
+  <!-- Slide 3 — solution -->
+  <div
+    data-composition-id="solution"
+    data-start="21"
+    data-duration="8"
+    data-label="The solution"
+    data-width="1920"
+    data-height="1080"
+    style="position: relative; width: 1920px; height: 1080px; overflow: hidden; background: #0a0a0a"
+  >
+    <section
+      class="clip"
+      data-start="21"
+      data-duration="8"
+      data-track-index="1"
+      style="position: absolute; inset: 0; display: grid; place-items: center"
+    >
+      <h2 id="solution-headline" style="font-size: 72px; color: #fff; font-family: sans-serif">
+        Acme automates scheduling for service SMBs — no-shows down 80% in 90 days
+      </h2>
+    </section>
+  </div>
+
+  <!-- Branch slide — excluded from main line -->
+  <div
+    data-composition-id="mkt-math"
+    data-start="29"
+    data-duration="7"
+    data-label="Market math"
+    data-width="1920"
+    data-height="1080"
+    style="position: relative; width: 1920px; height: 1080px; overflow: hidden; background: #111"
+  >
+    <section
+      class="clip"
+      data-start="29"
+      data-duration="7"
+      data-track-index="1"
+      style="position: absolute; inset: 0; display: grid; place-items: center"
+    >
+      <p id="mkt-formula" style="font-size: 56px; color: #fff; font-family: sans-serif">
+        2.3M SMBs × $17k ACV = $39B serviceable market
+      </p>
+    </section>
+  </div>
+
+  <script>
+    window.__timelines = window.__timelines || {};
+
+    // Slide 2 fragment entrance animations
+    gsap.registerPlugin(); // load any plugins before use
+
+    const tl = gsap.timeline({ paused: true });
+    window.__timelines["problem"] = tl;
+
+    // Insert positions are absolute composition-timeline times (same as data-start / fragment values).
+    tl.from("#pain-1", { opacity: 0, y: 20, duration: 0.4 }, 11.0);
+    tl.from("#pain-2", { opacity: 0, y: 20, duration: 0.4 }, 15.0);
+    // pain-3 lands at end of slide
+    tl.from("#pain-3", { opacity: 0, y: 20, duration: 0.4 }, 13.0);
+  </script>
+</body>
+```
+
+### Key points in the example
+
+- The island `sceneId` values (`"hook"`, `"problem"`, `"solution"`, `"mkt-math"`) exactly match `data-composition-id` values on scene divs.
+- `mkt-math` appears only in `slideSequences` — it is never in the top-level `slides` array.
+- Fragment times (`11.0`, `15.0`) are within the `problem` scene's `[6, 21]` range (times are absolute composition-timeline positions).
+- The hotspot `region` (`x: 55, y: 60, w: 40, h: 20`) positions the clickable area in the lower-right quadrant of the problem slide.
+- GSAP timelines are registered on `window.__timelines` and are paused — the HyperFrames engine drives playback; do not call `.play()` at construction time.
+
+---
+
+## Wrapping component
+
+Wrap the composition in `<hyperframes-slideshow>` around `<hyperframes-player>` in any embedding context:
+
+```html
+<hyperframes-slideshow>
+  <hyperframes-player src="deck.html"></hyperframes-player>
+</hyperframes-slideshow>
+```
+
+`<hyperframes-slideshow>` provides the navigation chrome (Prev / Next buttons, progress dots, breadcrumb, counter), keyboard handling (← / → and Space / Backspace), touch swipe, and hotspot overlays.
+
+**Presenter mode:** the Present button calls `window.open('?mode=audience')` for a fullscreen audience window; the originating tab becomes the presenter view (current slide reduced, next-slide preview, notes, elapsed timer). Both windows sync via `BroadcastChannel('hf-slideshow')`.
+
+---
+
+## Running a slideshow standalone (interim)
+
+The **durable answer** is engine-hosted: `hyperframes preview --slideshow` / studio present mode will host the composition over the real HyperFrames engine, which drives seek-timelines, owns the gesture frame, and reads the island from the composition. That path is coming; prefer it once it ships.
+
+Until then, standalone demos (a composition opened via the bare player bundle in a browser, without the engine) require workarounds for four gaps: the player does not drive GSAP seek-timelines, the island must be duplicated into the wrapper, audio must live in the parent frame, and animations must be self-driving. These patterns are documented in:
+
+```
+skills/slideshow/references/standalone-harness.md
+```
+
+Do not treat the patterns there as the blessed model — they exist only to bridge the gap until the engine-hosted path lands.
+
+---
+
+## Validation
+
+After authoring or editing a slideshow composition, run:
+
+```bash
+npx hyperframes lint
+```
+
+The slideshow lint rule checks:
+
+- Every `slide.sceneId` resolves to an existing scene (by `data-composition-id`).
+- Every `hotspot.target` references a defined `slideSequence` id.
+- Fragment times fall within each slide's `[start, end]` range.
+- No two main-line slides overlap in time.
+
+Fix all violations before previewing. A composition that fails lint will not parse correctly in the player.

--- a/skills/slideshow/references/standalone-harness.md
+++ b/skills/slideshow/references/standalone-harness.md
@@ -1,0 +1,597 @@
+# Standalone HyperFrames Slideshow Harness
+
+## 1. Interim framing — why this exists
+
+These patterns are a **temporary workaround** for standalone demos. The durable solution is engine-hosted: a future `hyperframes preview --slideshow` / studio present mode will host the composition over the real HyperFrames engine, which drives seek-timelines frame-by-frame, owns the gesture frame, and reads the slideshow island directly from the composition. When that path ships, most of what follows collapses.
+
+Until then, a standalone slideshow opened via the bare player bundle must work around four facts:
+
+1. The bare `<hyperframes-player>` does **not** drive GSAP/Three seek-timelines frame-by-frame — only the engine does. Animations that wait to be seeked stay at frame 0.
+2. `<hyperframes-slideshow>` reads the slideshow island from its **own innerHTML** (the wrapper element), not from the composition the player loads. The island must be duplicated into the wrapper.
+3. The composition runs in the player's **iframe**; user keypresses and pointer events land on the **parent page**. Any gesture-gated API (Audio, AudioContext) must live in the parent — an iframe without its own user activation is permanently autoplay-blocked.
+4. Autoplay, Three.js, and entrance animations must be **self-driving** because the engine is not present.
+
+Do not treat these as the blessed authoring model. When the engine-hosted path ships, compositions authored the normal way will just work.
+
+**Living reference implementations:**
+
+- `registry/examples/airbnb-deck/index.html` + `demo.html` — full pattern set (Three.js, fragments, SFX, branch slide)
+- `registry/examples/startup-pitch/index.html` — minimal version (no 3D), good starting point
+
+---
+
+## 2. The parent wrapper (demo.html)
+
+The parent page hosts the two dist bundles, wraps the components, duplicates the island, and owns all audio.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My Deck — Slideshow Demo</title>
+
+    <!--
+      Load both bundles from packages/player/dist.
+      The global builds register <hyperframes-player> and <hyperframes-slideshow>
+      as custom elements — no import map needed.
+    -->
+    <script src="../../../packages/player/dist/hyperframes-player.global.js"></script>
+    <script src="../../../packages/player/dist/slideshow/hyperframes-slideshow.global.js"></script>
+
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #111;
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      tabindex="0" is critical — <hyperframes-slideshow> binds keydown
+      (ArrowLeft/Right, Space, Backspace) to itself. Without tabindex the
+      element cannot receive focus and arrow keys are dead.
+    -->
+    <hyperframes-slideshow
+      tabindex="0"
+      style="display: block; position: relative; width: 100vw; height: 100vh"
+    >
+      <hyperframes-player
+        style="position: absolute; inset: 0"
+        src="index.html"
+      ></hyperframes-player>
+
+      <!--
+        DUPLICATED ISLAND — keep in sync with the island inside index.html.
+        <hyperframes-slideshow> reads from its own innerHTML, not from the
+        composition the player loads. Every time slides/fragments/hotspots/
+        sequences change in index.html, update this copy too.
+      -->
+      <script type="application/hyperframes-slideshow+json">
+        {
+          "slides": [
+            { "sceneId": "scene-one", "notes": "..." },
+            {
+              "sceneId": "scene-two",
+              "notes": "...",
+              "fragments": [8.3, 8.6]
+            }
+          ],
+          "slideSequences": [
+            {
+              "id": "branch-one",
+              "label": "Branch label",
+              "slides": [{ "sceneId": "branch-scene", "notes": "..." }]
+            }
+          ]
+        }
+      </script>
+    </hyperframes-slideshow>
+
+    <!-- Audio player lives here — see Section 6 -->
+  </body>
+</html>
+```
+
+---
+
+## 3. Playhead-driven scene visibility
+
+Without the engine, scenes are driven by a `root` GSAP timeline that the composition manages on its own clock. The visibility controller reads `window.__timelines.root.time()` via that timeline's `onUpdate` callback and sets `opacity` accordingly. Only the active scene is visible.
+
+The key insight: scene backgrounds must be `transparent` (not opaque) if you want a Three.js canvas behind them; the body/html background and scene inline `background` set the visual fill.
+
+```html
+<!-- In index.html (composition) -->
+
+<!-- Shared scene CSS — all scenes start hidden -->
+<style>
+  .scene-frame {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    opacity: 0; /* hidden at rest — visibility controller shows the active one */
+    pointer-events: none; /* inactive scenes must not swallow events */
+  }
+</style>
+
+<!--
+  content-visible-at-rest: mark the first scene's elements with their
+  final non-hidden state so the deck is not blank before the controller
+  fires. The controller calls updateVisibility(0) synchronously on load.
+
+  If using Three.js canvas behind scenes, set background: transparent
+  here and let the 3D canvas + body color supply the fill.
+-->
+<div
+  id="scene-cover"
+  class="scene-frame clip"
+  data-composition-id="cover"
+  data-start="0"
+  data-duration="9"
+  style="background: transparent"
+>
+  <!-- content here -->
+</div>
+
+<div
+  id="scene-problem"
+  class="scene-frame clip"
+  data-composition-id="problem"
+  data-start="9"
+  data-duration="9"
+  style="background: transparent"
+>
+  <!-- content here -->
+</div>
+
+<!-- Root timeline — spans the full composition duration -->
+<script>
+  (function () {
+    window.__timelines = window.__timelines || {};
+    var tl = gsap.timeline({ paused: true });
+    // A single to() for the full duration establishes the seekable range
+    tl.to({}, { duration: 108 }); // replace 108 with your total seconds
+    window.__timelines["root"] = tl;
+  })();
+</script>
+
+<!-- Visibility controller -->
+<script>
+  (function () {
+    var scenes = [
+      { id: "scene-cover", start: 0, end: 9 },
+      { id: "scene-problem", start: 9, end: 18 },
+      // ... all scenes including branch scenes
+    ];
+
+    var lastActiveId = null;
+
+    function updateVisibility(t) {
+      for (var i = 0; i < scenes.length; i++) {
+        var s = scenes[i];
+        var el = document.getElementById(s.id);
+        if (!el) continue;
+        var active = t >= s.start && t < s.end;
+        el.style.opacity = active ? "1" : "0";
+        el.style.pointerEvents = active ? "auto" : "none";
+
+        if (active && lastActiveId !== s.id) {
+          lastActiveId = s.id;
+          fireEntrance(el); // see Section 4
+        }
+      }
+      // fragment reveals here — see Section 4
+    }
+
+    window.__hfSetTime = updateVisibility;
+
+    // Show first slide immediately — avoids blank on load
+    updateVisibility(0);
+
+    // Hook the root timeline so every seek drives visibility
+    var root = window.__timelines && window.__timelines["root"];
+    if (root) {
+      root.eventCallback("onUpdate", function () {
+        updateVisibility(root.time());
+      });
+    }
+  })();
+</script>
+```
+
+---
+
+## 4. Imperative entrances on slide-activate
+
+The engine-hosted path drives GSAP seek-timelines frame by frame. Without it, seek-timeline tweens never fire. Instead, fire imperative `gsap.from()` calls each time a scene becomes active — these run on GSAP's own ticker and are independent of any playhead.
+
+Fragment reveals use playhead-crossing: the visibility controller checks whether the playhead has passed each fragment's hold-time and fires an animation on the first crossing. Bunch fragment hold-times near the scene start (within the first 300–500 ms of the scene) so successive ArrowRight presses feel like snappy sequential reveals rather than long waits.
+
+```js
+// --- Entrance animations ---
+
+function fireEntrance(sceneEl) {
+  // [data-anim] marks elements that should entrance on slide-activate.
+  // Add data-anim to eyebrows, headlines, subheads, and card grids.
+  var animEls = sceneEl.querySelectorAll("[data-anim]");
+  if (!animEls.length) return;
+  gsap.from(animEls, {
+    opacity: 0,
+    y: 28,
+    duration: 0.4,
+    stagger: 0.07,
+    ease: "power2.out",
+    overwrite: true, // cancel any in-flight animation on rapid slide changes
+  });
+}
+
+// --- Fragment reveals ---
+
+// Fragment config: times in absolute composition timeline seconds,
+// bunched near the scene start for snappy successive reveals.
+var fragments = [
+  { time: 9.3, id: "prob-item1", revealed: false },
+  { time: 9.6, id: "prob-item2", revealed: false },
+];
+
+function revealFragment(id) {
+  var el = document.getElementById(id);
+  if (!el) return;
+  gsap.fromTo(
+    el,
+    { opacity: 0, x: -24 },
+    { opacity: 1, x: 0, duration: 0.35, ease: "power2.out", overwrite: true },
+  );
+}
+
+// Inside updateVisibility(t):
+for (var f = 0; f < fragments.length; f++) {
+  if (!fragments[f].revealed && t >= fragments[f].time) {
+    fragments[f].revealed = true;
+    revealFragment(fragments[f].id);
+  }
+}
+
+// On problem scene re-entry, reset all fragment states:
+if (active && lastActiveId !== s.id && s.id === "scene-problem") {
+  for (var f = 0; f < fragments.length; f++) {
+    fragments[f].revealed = false;
+    var pEl = document.getElementById(fragments[f].id);
+    if (pEl) gsap.set(pEl, { opacity: 0, clearProps: "transform" });
+  }
+}
+```
+
+Fragment items start with `opacity: 0` in CSS. The visibility controller reveals them; the entrance driver does not touch them until crossing.
+
+---
+
+## 5. The scenes bootstrap postMessage
+
+`<hyperframes-slideshow>` must know each scene's time range to map a `sceneId` to a playhead position. Without the engine injecting this at runtime, the composition must post it manually after load.
+
+Post the manifest from the composition (index.html), not the parent wrapper:
+
+```js
+// In index.html — post after a brief delay so the parent frame has settled
+(function () {
+  var FPS = 30;
+  var totalSeconds = 108; // match your composition's data-duration
+  var totalFrames = totalSeconds * FPS;
+
+  var scenes = [
+    // EVERY scene — including branch scenes — must appear here.
+    // id must match data-composition-id; start/duration in seconds.
+    { id: "cover", start: 0, duration: 9 },
+    { id: "problem", start: 9, duration: 9 },
+    { id: "solution", start: 18, duration: 9 },
+    // ... all main-line scenes ...
+    // branch scene — listed last, NOT in main slides array in the island
+    { id: "market-sizing", start: 99, duration: 9 },
+  ];
+
+  function postTimeline() {
+    parent.postMessage(
+      {
+        source: "hf-preview",
+        type: "timeline",
+        durationInFrames: totalFrames,
+        scenes: scenes,
+      },
+      "*",
+    );
+  }
+
+  // ~300ms delay after load to let the parent settle
+  if (document.readyState === "complete") {
+    setTimeout(postTimeline, 300);
+  } else {
+    window.addEventListener("load", function () {
+      setTimeout(postTimeline, 300);
+    });
+  }
+})();
+```
+
+Omitting any scene (including branch scenes) from this manifest means the slideshow component cannot seek to it. Include every scene declared in the HTML, even scenes only reachable via a hotspot.
+
+---
+
+## 6. Audio/SFX — built-in mute control via `<hyperframes-slideshow sound>`
+
+Audio **must** live in the parent page, not the composition iframe. Browsers enforce user-activation for AudioContext and HTMLAudioElement.play() — an iframe without its own activation (i.e., the user never clicked inside it) is permanently autoplay-blocked. The user's keypress lands on the parent, so the parent is the only frame that can get the activation token.
+
+### Mute toggle — built-in chrome control
+
+Add the `sound` boolean attribute to `<hyperframes-slideshow>` in demo.html. The component renders a speaker/speaker-muted SVG button as the **leftmost item in the nav capsule**, styled identically to the prev/next ghost buttons. No separate mute button in the composition.
+
+```html
+<hyperframes-slideshow tabindex="0" sound style="..."> ... </hyperframes-slideshow>
+```
+
+The component:
+
+- Tracks `muted` state (default `false`); exposes a `muted` getter
+- Reflects to a `data-hf-muted` attribute on the host when muted
+- Dispatches `CustomEvent("hf-sound", { detail: { muted }, bubbles: true, composed: true })` on every toggle
+
+The parent audio player gates on the `hf-sound` event:
+
+```js
+var muted = false;
+var slideshow = document.querySelector("hyperframes-slideshow");
+if (slideshow) {
+  slideshow.addEventListener("hf-sound", function (e) {
+    muted = e.detail && e.detail.muted === true;
+  });
+}
+// In message handler:
+if (muted) return; // skip play
+```
+
+If `sound` is **not** present on `<hyperframes-slideshow>` (decks without audio), the mute control is hidden — the capsule shows only nav.
+
+### Composition: post cues unconditionally
+
+The composition posts sfx cues **unconditionally** — it does not track mute state. The parent gates on `muted`:
+
+**In the composition (index.html):**
+
+```js
+// Post an sfx cue at transition points — unconditionally.
+// The parent audio player gates on the slideshow component's mute state.
+function playSfx(name) {
+  try {
+    parent.postMessage({ type: "hf-sfx", name: name }, "*");
+  } catch (e) {}
+}
+
+// Fire at scene transitions:
+//   playSfx("advance")      — moving to the next main-line slide
+//   playSfx("back")         — returning from a branch
+//   playSfx("branch-enter") — entering a branch
+//   playSfx("fragment")     — a fragment item is revealed
+```
+
+Do NOT add a mute button inside the composition. The `#sfx-mute` coral button pattern is removed; the nav capsule in the parent chrome owns mute.
+
+**In the parent (demo.html):**
+
+```html
+<script>
+  (function () {
+    // Audio elements are preloaded here, in the frame that receives user gestures.
+    var clips = {
+      advance: new Audio("sfx/advance.mp3"),
+      fragment: new Audio("sfx/fragment.mp3"),
+      "branch-enter": new Audio("sfx/branch-enter.mp3"),
+      back: new Audio("sfx/back.mp3"),
+    };
+    clips.advance.volume = 0.45;
+    clips.fragment.volume = 0.4;
+    clips["branch-enter"].volume = 0.4;
+    clips.back.volume = 0.4;
+    Object.keys(clips).forEach(function (k) {
+      clips[k].preload = "auto";
+    });
+
+    // Track mute state from the slideshow component's hf-sound event.
+    var muted = false;
+    var slideshow = document.querySelector("hyperframes-slideshow");
+    if (slideshow) {
+      slideshow.addEventListener("hf-sound", function (e) {
+        muted = e.detail && e.detail.muted === true;
+      });
+    }
+
+    var unlocked = false;
+
+    function unlock() {
+      if (unlocked) return;
+      unlocked = true;
+      // Prime each clip: play muted then immediately pause/reset.
+      // This moves the clip into the "allowed" state so later plays are instant.
+      Object.keys(clips).forEach(function (name) {
+        var el = clips[name];
+        var v = el.volume;
+        el.volume = 0;
+        el.play()
+          .then(function () {
+            el.pause();
+            el.currentTime = 0;
+            el.volume = v;
+          })
+          .catch(function () {
+            el.volume = v;
+          });
+      });
+    }
+
+    // Unlock on the first user gesture in the parent frame.
+    window.addEventListener("keydown", unlock, true);
+    window.addEventListener("pointerdown", unlock, true);
+    window.addEventListener("click", unlock, true);
+
+    window.addEventListener("message", function (e) {
+      var d = e.data;
+      if (!d || d.type !== "hf-sfx") return;
+      // Gate on mute state — the component owns this.
+      if (muted) return;
+      var el = clips[d.name];
+      if (!el || !unlocked) return;
+      try {
+        el.currentTime = 0;
+        el.play().catch(function () {});
+      } catch (err) {}
+    });
+  })();
+</script>
+```
+
+**Sourcing SFX files:** use the HeyGen MCP `search_audio_sounds` tool with `type=sound_effects` and keywords like "whoosh", "click", "transition". Download the results to a local `sfx/` directory next to `demo.html` and reference them by relative path. Do not fetch SFX at render time — the HyperFrames determinism rule forbids runtime network requests; pre-download and commit them.
+
+---
+
+## 7. Three.js (optional)
+
+Add a Three.js scene behind the slides for ambient motion. The key rules:
+
+- **Own rAF loop** — do not integrate with the HF seek timeline. Three.js runs its own `requestAnimationFrame` loop independent of playhead position.
+- **One persistent canvas** — create the canvas once; update geometry/materials in-place per scene.
+- **Guard renderer creation** — WebGL may be unavailable (software-GL environments, some CI contexts). Create the renderer inside try/catch once; if it fails, hide the canvas and expose no-op stubs. Do not spam `console.error` — silence it during creation and restore it in `finally`.
+- **Full-bleed, behind content** — fix the canvas at `z-index: 0`, `pointer-events: none`, behind scene frames at `z-index: 1`.
+- **Transparent scene frames** — set scene backgrounds to `transparent` so the 3D canvas shows through. Use a radial-gradient scrim on the text container (not the scene frame itself) to keep type legible while letting 3D show in the margins.
+- **Expose a mood hook** — export `window.__threeApplyMood(sceneKey)` so the visibility controller can switch particle colors, toggle sub-objects, or change the clear color when the active scene changes.
+
+```js
+// In index.html — Three.js setup (module script)
+import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js";
+
+var canvas = document.getElementById("three-canvas");
+var renderer = null;
+var _err = console.error;
+console.error = function () {}; // silence THREE's multi-line GPU error during init
+try {
+  renderer = new THREE.WebGLRenderer({ canvas: canvas, alpha: true, antialias: true });
+} catch (e) {
+  // renderer stays null
+} finally {
+  console.error = _err;
+}
+
+if (!renderer) {
+  // Graceful degradation — branded layout is the fallback.
+  canvas.style.display = "none";
+  window.__threeApplyMood = function () {};
+  // Do NOT start the rAF loop.
+} else {
+  renderer.setSize(1920, 1080);
+  renderer.setPixelRatio(1);
+  canvas.style.cssText =
+    "position:fixed;top:0;left:0;width:1920px;height:1080px;z-index:0;pointer-events:none";
+
+  var scene = new THREE.Scene();
+  var camera = new THREE.PerspectiveCamera(60, 1920 / 1080, 0.1, 1000);
+  camera.position.set(0, 0, 5);
+
+  // --- build your particle system, meshes, etc. here ---
+
+  // Mood config: map sceneId → visual state (colors, sub-object visibility, bg color)
+  var MOODS = {
+    cover: {
+      /* particle color, opacity, bg ... */
+    },
+    problem: {
+      /* ... */
+    },
+    // one entry per scene key
+  };
+
+  window.__threeApplyMood = function (sceneKey) {
+    var m = MOODS[sceneKey] || MOODS["cover"];
+    // update geometry attributes, material opacity, sub-group visibility, etc.
+  };
+  window.__threeApplyMood("cover"); // apply initial state
+
+  // --- own rAF loop ---
+  var lastTime = null;
+  function animate(ts) {
+    requestAnimationFrame(animate);
+    if (lastTime === null) lastTime = ts;
+    var dt = Math.min((ts - lastTime) / 1000, 0.05);
+    lastTime = ts;
+    // update particles, rotate objects, etc.
+    renderer.render(scene, camera);
+  }
+  requestAnimationFrame(animate);
+}
+```
+
+**CSS for transparent scene frames + scrim:**
+
+```css
+/* Three.js canvas — always behind everything */
+#three-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1920px;
+  height: 1080px;
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* Scene frames are transparent so the 3D canvas shows through */
+.scene-frame {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1920px;
+  height: 1080px;
+  background: transparent; /* NOT opaque — 3D would be occluded */
+  z-index: 1;
+}
+
+/* Scrim on the TEXT container — not the scene frame.
+   Radial gradient: opaque in the center where text is, transparent at edges
+   so 3D shows in the whitespace margins. */
+.slide-inner.scrim-light {
+  background: radial-gradient(
+    ellipse 75% 80% at 50% 50%,
+    rgba(255, 255, 255, 0.88) 30%,
+    rgba(255, 255, 255, 0.6) 65%,
+    rgba(255, 255, 255, 0) 100%
+  );
+}
+```
+
+---
+
+## 8. Foot-gun checklist
+
+| Failure                                               | Symptom                                                        | One-line fix                                                                                                                                  |
+| ----------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Island not duplicated in wrapper                      | Slideshow chrome never renders; no slide counter, no prev/next | Copy the `<script type="application/hyperframes-slideshow+json">` block verbatim into the `<hyperframes-slideshow>` element in demo.html      |
+| Audio in the iframe                                   | All SFX silent                                                 | Move Audio elements and unlock logic to demo.html; post `{type:'hf-sfx',name}` from index.html                                                |
+| No self-clock in composition                          | All scene frames stacked / wrong slide visible at load         | Add the root GSAP timeline (`window.__timelines["root"]`) and the `onUpdate` visibility controller as shown in Section 3                      |
+| Content opacity:0 with no engine                      | Blank slides — `[data-anim]` elements invisible at rest        | Call `updateVisibility(0)` synchronously after defining the controller so the first slide is shown immediately                                |
+| Keydown bound to the element without focus            | ArrowLeft/Right dead                                           | Add `tabindex="0"` to `<hyperframes-slideshow>` so it can receive keyboard focus                                                              |
+| Opaque scene background occluding Three.js canvas     | 3D never visible                                               | Set `background: transparent` on `.scene-frame`; put the visual fill on the text scrim container instead                                      |
+| WebGL renderer creation spams errors in headless envs | Console noise, rAF loop starts anyway                          | Silence `console.error` during `new THREE.WebGLRenderer(...)`, restore in `finally`, guard the rAF start on `renderer !== null`               |
+| Branch scene missing from postMessage manifest        | Hotspot navigates but slide is blank                           | Include every scene — main line and branch — in the `scenes` array of the `postTimeline()` message                                            |
+| Prominent 3D/content in nav-capsule zone              | Bright element bleeds behind/beside the nav pill               | Keep the bottom-right ~360×140px region clear; add a background-matching gradient overlay on any slide whose 3D mood is bright in that corner |


### PR DESCRIPTION
## Slideshow mode — 4/5: authoring skill & harness reference

Docs only. Teaches an agent how to author a valid slideshow composition, and documents the interim standalone-runtime patterns. Builds on #1582.

### Key changes
- `skills/slideshow/SKILL.md` — the authoring contract: the JSON-island schema, the slide writing rules (headline-as-claim, one idea per slide, bottom-up market math, font minimums), fragments, hotspots/branching, the `<hyperframes-slideshow>` wrapper, and validation via `hyperframes lint`. Includes a full worked example.
- `skills/slideshow/references/standalone-harness.md` — the patterns for running a deck **standalone on the bare player bundle** (no engine): playhead-driven scene visibility, imperative-on-activate entrances, content-visible-at-rest, the scenes bootstrap postMessage, audio/SFX played in the parent frame, Three.js on its own rAF, and a foot-gun checklist. Framed explicitly as **interim** — the durable answer is engine-hosted slideshow preview + the component reading the island from the composition.
- `skills/hyperframes/SKILL.md` — routes slideshow/presentation/pitch-deck intent to `/slideshow`.

### Stack
core (#1580) → player (#1581) → studio (#1582) → **skill** → examples (#1584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
