### PR TITLE
ci(publish): publish @hyperframes/sdk to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,6 +125,7 @@ jobs:
           }
 
           publish_pkg "@hyperframes/core" "@hyperframes/core"
+          publish_pkg "@hyperframes/sdk" "@hyperframes/sdk"
           publish_pkg "@hyperframes/engine" "@hyperframes/engine"
           publish_pkg "@hyperframes/player" "@hyperframes/player"
           publish_pkg "@hyperframes/producer" "@hyperframes/producer"


### PR DESCRIPTION
## Problem
`@hyperframes/sdk` is **version-bumped but never published**. `scripts/set-version.ts` includes `packages/sdk` in its `PACKAGES` list, so the SDK rides the shared version line (currently `0.6.112`) — but `.github/workflows/publish.yml`'s `Publish packages` step has a **hardcoded `publish_pkg` list that omits the SDK**. Result: `@hyperframes/sdk@0.6.112` resolves to a **404 on npm**, while `core` / `player` / `engine` / `producer` / `studio` / etc. all shipped at `0.6.112`.

This blocks consumers (e.g. Pacific / AI Studio) from `pnpm add @hyperframes/sdk` — the editing engine can't be installed.

## Fix
Add the one missing line to the publish list:
```
publish_pkg "@hyperframes/sdk" "@hyperframes/sdk"
```
(placed after `@hyperframes/core`, its runtime dep).

Nothing else gatekeeps it: `set-version.ts` already bumps it, `scripts/verify-packed-manifests.mjs` auto-discovers every dir under `packages/` (so the SDK's packed manifest is already verified publish-safe), and CI already runs the SDK test suite. The SDK's `package.json` has `publishConfig.access: public` + `files`/`main`/`types` — release-ready.

## Effect
- Future releases publish the SDK alongside the other packages.
- To backfill the current line **now**: after merge, run the `Publish to npm` workflow via `workflow_dispatch` with version `0.6.112` (tag `v0.6.112` exists). The step is idempotent — every already-published package is skipped, so **only `@hyperframes/sdk@0.6.112`** gets pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)