### PR TITLE
fix(core): import cssSelector test from vitest, not bun:test

### DIFF
--- a/packages/core/src/utils/cssSelector.test.ts
+++ b/packages/core/src/utils/cssSelector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect } from "vitest";
 import { queryByAttr } from "./cssSelector";
 
 function makeDoc(html: string) {


### PR DESCRIPTION
## Problem

`c0ffdc0fb` ("escape user values in querySelector") added `packages/core/src/utils/cssSelector.test.ts` importing from **`bun:test`**, but core runs its suite via `vitest run` (`include: ["src/**/*.test.ts"]`). Vitest can't load `bun:test` (`Module "bun:test" has been externalized for browser compatibility`), so the file errors at collection — turning **core CI red on main and on every open PR** (PRs build against the merge ref).

## Fix

Import `describe, it, expect` from `vitest` instead — the APIs are identical, no test logic changes. All 10 tests pass under vitest.