### PR TITLE
chore: release v0.6.115

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,24 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.6.115"
+  description="Released - 2026-06-20"
+  tags={["Release", "Slideshow", "Player", "Studio", "Core"]}
+>
+This patch release hardens slideshow presenter mode so media stops when you leave a slide, the mute control applies consistently across embedded players and page audio, and presenter notes can be edited locally. It also improves Studio edit reliability and closes several playback and selector-safety edge cases.
+
+## Fixes
+
+- **Slideshow:** Presenter navigation now stops previous-slide media on slide or branch changes, keeps same-slide fragment reveals uninterrupted, and mirrors the mute control across child players, iframe media, parent sound effects, and page media. Presenter notes are now editable and saved per deck/slide in local storage. ([f0c4dee70](https://github.com/heygen-com/hyperframes/commit/f0c4dee70584f02a546c0cdb6d02d8b5542a4a4b), [#1601](https://github.com/heygen-com/hyperframes/pull/1601))
+- **Player:** Preview audio muting is tracked per media element so a slow-decoding track no longer causes unrelated preview audio to stay silenced. ([cd832f01a](https://github.com/heygen-com/hyperframes/commit/cd832f01ac953cad793da4e379302d2f1c60dc6a), [#1602](https://github.com/heygen-com/hyperframes/pull/1602))
+- **Studio:** DOM edit cutover behavior now matches the legacy editing path more closely, restoring parity for SDK-backed edits. ([758eda995](https://github.com/heygen-com/hyperframes/commit/758eda995c9c2dedb4d7939769f149209663f841), [#1565](https://github.com/heygen-com/hyperframes/pull/1565))
+- **Core/Studio:** User-provided selector values are escaped before building `querySelector` attribute selectors, avoiding invalid selectors and selector-injection edge cases. ([c0ffdc0fb](https://github.com/heygen-com/hyperframes/commit/c0ffdc0fb0d5adc4bf9df0afe07f4f5a23d2fb51))
+- **Core:** Test-only selector coverage now imports from Vitest consistently, keeping the package test suite aligned with the rest of the workspace. ([82b6ccde7](https://github.com/heygen-com/hyperframes/commit/82b6ccde7934836c100c47206bacca5455c8b3d8), [#1599](https://github.com/heygen-com/hyperframes/pull/1599))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.6.114...v0.6.115).
+</Update>
+
+<Update
   label="HyperFrames v0.6.114"
   description="Released - 2026-06-19"
   tags={["Release", "Slideshow", "Examples", "Skill"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.6.114",
+  "version": "0.6.115",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.6.115.md
+++ b/releases/v0.6.115.md
@@ -1,0 +1,17 @@
+# HyperFrames v0.6.115
+
+Released on 2026-06-20.
+
+This patch release hardens slideshow presenter mode so media stops when you leave a slide, the mute control applies consistently across embedded players and page audio, and presenter notes can be edited locally. It also improves Studio edit reliability and closes several playback and selector-safety edge cases.
+
+## Fixes
+
+- **Slideshow:** Presenter navigation now stops previous-slide media on slide or branch changes, keeps same-slide fragment reveals uninterrupted, and mirrors the mute control across child players, iframe media, parent sound effects, and page media. Presenter notes are now editable and saved per deck/slide in local storage. ([f0c4dee70](https://github.com/heygen-com/hyperframes/commit/f0c4dee70584f02a546c0cdb6d02d8b5542a4a4b), [#1601](https://github.com/heygen-com/hyperframes/pull/1601))
+- **Player:** Preview audio muting is tracked per media element so a slow-decoding track no longer causes unrelated preview audio to stay silenced. ([cd832f01a](https://github.com/heygen-com/hyperframes/commit/cd832f01ac953cad793da4e379302d2f1c60dc6a), [#1602](https://github.com/heygen-com/hyperframes/pull/1602))
+- **Studio:** DOM edit cutover behavior now matches the legacy editing path more closely, restoring parity for SDK-backed edits. ([758eda995](https://github.com/heygen-com/hyperframes/commit/758eda995c9c2dedb4d7939769f149209663f841), [#1565](https://github.com/heygen-com/hyperframes/pull/1565))
+- **Core/Studio:** User-provided selector values are escaped before building `querySelector` attribute selectors, avoiding invalid selectors and selector-injection edge cases. ([c0ffdc0fb](https://github.com/heygen-com/hyperframes/commit/c0ffdc0fb0d5adc4bf9df0afe07f4f5a23d2fb51))
+- **Core:** Test-only selector coverage now imports from Vitest consistently, keeping the package test suite aligned with the rest of the workspace. ([82b6ccde7](https://github.com/heygen-com/hyperframes/commit/82b6ccde7934836c100c47206bacca5455c8b3d8), [#1599](https://github.com/heygen-com/hyperframes/pull/1599))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.6.114...v0.6.115


### PR DESCRIPTION
## Summary
- bump all publishable HyperFrames packages and plugin manifests to 0.6.115
- add reviewed v0.6.115 release notes
- prepend the docs changelog entry for v0.6.115

## Verification
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bun run test:scripts`
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH EVENT_NAME=pull_request PR_HEAD_REF=release/v0.6.115 VERSION=0.6.115 DIST_TAG=latest node scripts/validate-release-channel.mjs`
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bunx oxfmt --check` on release files
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bun run verify:packed-manifests`
- `PATH=/Users/vanceingalls/.nvm/versions/node/v22.22.0/bin:$PATH bun run build`

Note: commit used `--no-verify` because local lefthook is missing its darwin binary; checks above were run manually.