### PR TITLE
feat(studio): GSAP runtime read layer + shared helpers

### DIFF
--- a/packages/studio/src/hooks/gsapRuntimeKeyframes.test.ts
+++ b/packages/studio/src/hooks/gsapRuntimeKeyframes.test.ts
@@ -1,5 +1,98 @@
 import { describe, expect, it } from "vitest";
-import { arcPathFromMotionPathValue } from "./gsapRuntimeKeyframes";
+import { arcPathFromMotionPathValue, readRuntimeKeyframes } from "./gsapRuntimeKeyframes";
+
+// Build a fake preview iframe whose runtime timeline holds the given child tweens
+// and resolves `selector` to `el`.
+function fakeIframe(el: { id: string }, children: unknown[], now?: number): HTMLIFrameElement {
+  const timeline = {
+    getChildren: () => children,
+    duration: () => 14.6,
+    ...(now != null ? { time: () => now } : {}),
+  };
+  return {
+    contentWindow: { __timelines: { "index.html": timeline } },
+    contentDocument: { querySelector: (sel: string) => (sel === `#${el.id}` ? el : null) },
+  } as unknown as HTMLIFrameElement;
+}
+
+describe("readRuntimeKeyframes — zero-duration set must not shadow the keyframed tween", () => {
+  const el = { id: "puck-b" };
+  const holdSet = {
+    targets: () => [el],
+    vars: { x: 0, y: 0, data: "hf-hold" },
+    duration: () => 0,
+    startTime: () => 0,
+  };
+  const kfTween = {
+    targets: () => [el],
+    vars: {
+      keyframes: [
+        { x: 0, y: 0 },
+        { x: -180, y: -60 },
+        { x: -320, y: 40 },
+        { x: -460, y: -20 },
+      ],
+      duration: 3.4,
+      ease: "power1.inOut",
+    },
+    duration: () => 3.4,
+    startTime: () => 1.0,
+  };
+
+  it("reads all 4 keyframes from the to() even when a hold-set precedes it", () => {
+    const read = readRuntimeKeyframes(fakeIframe(el, [holdSet, kfTween]), "#puck-b");
+    expect(read?.keyframes).toHaveLength(4);
+  });
+
+  it("returns null when the element only has a zero-duration set (no real motion)", () => {
+    expect(readRuntimeKeyframes(fakeIframe(el, [holdSet]), "#puck-b")).toBeNull();
+  });
+});
+
+describe("readRuntimeKeyframes — multiple tweens pick the one under the playhead", () => {
+  const el = { id: "puck-a" };
+  // Two non-overlapping gesture recordings → two separate keyframed tweens.
+  const gestureA = {
+    targets: () => [el],
+    vars: {
+      keyframes: [
+        { x: 0, y: 0 },
+        { x: -100, y: 50 },
+      ],
+      duration: 2.03,
+    },
+    duration: () => 2.03,
+    startTime: () => 1.033, // range [1.033, 3.063]
+  };
+  const gestureB = {
+    targets: () => [el],
+    vars: {
+      keyframes: [
+        { x: 10, y: 10 },
+        { x: 20, y: 20 },
+        { x: 30, y: 30 },
+      ],
+      duration: 1.129,
+    },
+    duration: () => 1.129,
+    startTime: () => 3.342, // range [3.342, 4.471]
+  };
+
+  it("playhead inside the SECOND tween reads the second tween (not the first)", () => {
+    const read = readRuntimeKeyframes(fakeIframe(el, [gestureA, gestureB], 3.373), "#puck-a");
+    expect(read?.keyframes).toHaveLength(3); // gestureB
+  });
+
+  it("playhead inside the FIRST tween reads the first tween", () => {
+    const read = readRuntimeKeyframes(fakeIframe(el, [gestureA, gestureB], 2.0), "#puck-a");
+    expect(read?.keyframes).toHaveLength(2); // gestureA
+  });
+
+  it("playhead outside every range falls back to the first keyframed tween", () => {
+    const read = readRuntimeKeyframes(fakeIframe(el, [gestureA, gestureB], 9.0), "#puck-a");
+    expect(read?.keyframes).toHaveLength(2); // gestureA (first)
+  });
+});
 
 describe("arcPathFromMotionPathValue", () => {
   it("builds arc config from object form { path, curviness }", () => {

--- a/packages/studio/src/hooks/gsapRuntimeKeyframes.test.ts
+++ b/packages/studio/src/hooks/gsapRuntimeKeyframes.test.ts
@@ -19,6 +19,9 @@ describe("readRuntimeKeyframes — zero-duration set must not shadow the keyfram
   const el = { id: "puck-b" };
   const holdSet = {
     targets: () => [el],
+    // `data` is the STUDIO_HOLD_MARKER sentinel ("hf-hold") from core's gsapParser.
+    // TODO(core follow-up): re-export STUDIO_HOLD_MARKER via the @hyperframes/core/
+    // gsap-parser subpath so this fixture can import the const instead of the literal.
     vars: { x: 0, y: 0, data: "hf-hold" },
     duration: () => 0,
     startTime: () => 0,

--- a/packages/studio/src/hooks/gsapRuntimeKeyframes.ts
+++ b/packages/studio/src/hooks/gsapRuntimeKeyframes.ts
@@ -22,10 +22,11 @@ interface RuntimeTween {
 interface RuntimeTimeline {
   getChildren?: (deep: boolean) => RuntimeTween[];
   duration?: () => number;
+  time?: () => number;
 }
 
 type Pct = { percentage: number; properties: Record<string, number | string> };
-type ReadTween = { keyframes: Pct[]; easeEach?: string; arcPath?: ArcPathConfig };
+export type ReadTween = { keyframes: Pct[]; easeEach?: string; arcPath?: ArcPathConfig };
 
 export interface RuntimeKeyframeEntry {
   keyframes: Pct[];
@@ -160,7 +161,11 @@ export function readRuntimeKeyframes(
 ): ReadTween | null {
   const timelines = timelinesOf(iframe);
   if (!timelines) return null;
-  const tlId = compositionId || Object.keys(timelines)[0];
+  // Skip non-timeline markers (e.g. the studio's `__proxied` flag) when no
+  // explicit composition id is given — picking those yields no getChildren.
+  const tlId =
+    compositionId ||
+    Object.keys(timelines).find((k) => typeof timelines[k]?.getChildren === "function");
   if (!tlId) return null;
   const timeline = timelines[tlId];
   if (!timeline?.getChildren) return null;
@@ -173,12 +178,32 @@ export function readRuntimeKeyframes(
   }
   if (!targetEl) return null;
 
+  // The element can have MORE THAN ONE keyframed tween at disjoint time ranges
+  // (e.g. two non-overlapping gesture recordings → two separate `to()`s). The
+  // overlay must draw the segment under the PLAYHEAD, not blindly the first one
+  // — otherwise recording a second gesture leaves the path stuck on the first.
+  const now = typeof timeline.time === "function" ? timeline.time() : null;
+  let firstRead: ReadTween | null = null;
   for (const tween of timeline.getChildren(true)) {
     if (!tween.vars || !matchesElement(tween, targetEl)) continue;
+    // Skip zero-duration tweens (`tl.set(...)`, incl. the studio position-hold
+    // `data:"hf-hold"`). They sit before the real keyframed tween and otherwise
+    // shadow it — `readTween` falls back to a degenerate 2-point flat path from
+    // the set's values, hiding the actual multi-keyframe motion.
+    const dur = typeof tween.duration === "function" ? tween.duration() : 0;
+    if (!(dur > 0)) continue;
     const read = readTween(tween.vars);
-    if (read) return read;
+    if (!read) continue;
+    if (firstRead === null) firstRead = read;
+    // Prefer the tween whose [start, start+dur] contains the playhead.
+    if (now != null) {
+      const start = typeof tween.startTime === "function" ? tween.startTime() : 0;
+      if (now >= start - 1e-3 && now <= start + dur + 1e-3) return read;
+    }
   }
-  return null;
+  // Playhead outside every tween's range (or timeline has no clock): the element
+  // still has motion, so fall back to the first keyframed tween.
+  return firstRead;
 }
 
 /** Convert tween-relative keyframes to clip-relative % using the element's clip dims. */
@@ -217,9 +242,12 @@ function addScanEntry(
   clipById?: ClipDims,
 ): void {
   if (!tween.targets || !tween.vars) return;
+  const { start, duration } = tweenTiming(tween);
+  // Skip zero-duration sets/holds — they shadow the real keyframed tween (see
+  // readRuntimeKeyframes).
+  if (!(duration > 0)) return;
   const read = readTween(tween.vars);
   if (!read) return;
-  const { start, duration } = tweenTiming(tween);
   for (const target of tween.targets()) {
     const id = (target as HTMLElement).id;
     if (id && !result.has(id)) result.set(id, buildEntry(read, start, duration, clipById?.get(id)));

--- a/packages/studio/src/hooks/gsapRuntimeKeyframes.ts
+++ b/packages/studio/src/hooks/gsapRuntimeKeyframes.ts
@@ -72,6 +72,17 @@ function isXY(p: unknown): p is { x: number; y: number } {
   return !!p && typeof (p as any).x === "number" && typeof (p as any).y === "number";
 }
 
+/**
+ * A tween we must skip when reading keyframes: a zero-duration `set`/hold (incl.
+ * the studio pre-keyframe position hold, tagged `data: STUDIO_HOLD_MARKER`).
+ * These sit before the real keyframed tween and otherwise shadow it — `readTween`
+ * would fall back to a degenerate 2-point flat path from the set's values, hiding
+ * the actual multi-keyframe motion. `!(duration > 0)` also rejects NaN durations.
+ */
+function isZeroDurationSet(duration: number): boolean {
+  return !(duration > 0);
+}
+
 /** Coordinates + curviness from a live `vars.motionPath` value (object or array form), or null. */
 function coordsFromMotionPath(mp: unknown): {
   coords: Array<{ x: number; y: number }>;
@@ -186,12 +197,8 @@ export function readRuntimeKeyframes(
   let firstRead: ReadTween | null = null;
   for (const tween of timeline.getChildren(true)) {
     if (!tween.vars || !matchesElement(tween, targetEl)) continue;
-    // Skip zero-duration tweens (`tl.set(...)`, incl. the studio position-hold
-    // `data:"hf-hold"`). They sit before the real keyframed tween and otherwise
-    // shadow it — `readTween` falls back to a degenerate 2-point flat path from
-    // the set's values, hiding the actual multi-keyframe motion.
     const dur = typeof tween.duration === "function" ? tween.duration() : 0;
-    if (!(dur > 0)) continue;
+    if (isZeroDurationSet(dur)) continue; // skip hold/set tweens (see isZeroDurationSet)
     const read = readTween(tween.vars);
     if (!read) continue;
     if (firstRead === null) firstRead = read;
@@ -243,9 +250,7 @@ function addScanEntry(
 ): void {
   if (!tween.targets || !tween.vars) return;
   const { start, duration } = tweenTiming(tween);
-  // Skip zero-duration sets/holds — they shadow the real keyframed tween (see
-  // readRuntimeKeyframes).
-  if (!(duration > 0)) return;
+  if (isZeroDurationSet(duration)) return; // skip hold/set tweens (see isZeroDurationSet)
   const read = readTween(tween.vars);
   if (!read) return;
   for (const target of tween.targets()) {

--- a/packages/studio/src/hooks/gsapShared.test.ts
+++ b/packages/studio/src/hooks/gsapShared.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { parsePercentageKeyframes } from "./gsapShared";
+
+describe("parsePercentageKeyframes", () => {
+  it("parses the object/percentage form", () => {
+    const out = parsePercentageKeyframes({ "0%": { x: 0, y: 0 }, "100%": { x: 9, y: 4 } });
+    expect(out?.keyframes).toEqual([
+      { percentage: 0, properties: { x: 0, y: 0 } },
+      { percentage: 100, properties: { x: 9, y: 4 } },
+    ]);
+  });
+
+  it("parses GSAP array-form keyframes as evenly-distributed steps", () => {
+    // Regression: a multi-point shuttle path authored as `keyframes: [...]` used to
+    // read as null (no `N%` keys) → no motion path. Steps map to i/(n-1)*100%.
+    const out = parsePercentageKeyframes([
+      { x: 0, y: 0 },
+      { x: 520, y: 120 },
+      { x: 1040, y: 0 },
+      { x: 1480, y: 160 },
+    ] as unknown as Record<string, unknown>);
+    expect(out?.keyframes.map((k) => k.percentage)).toEqual([0, 33.3, 66.7, 100]);
+    expect(out?.keyframes[1]!.properties).toEqual({ x: 520, y: 120 });
+  });
+
+  it("returns null for keyframes with no positional/animatable props", () => {
+    expect(parsePercentageKeyframes([] as unknown as Record<string, unknown>)).toBeNull();
+    expect(parsePercentageKeyframes({})).toBeNull();
+  });
+});

--- a/packages/studio/src/hooks/gsapShared.test.ts
+++ b/packages/studio/src/hooks/gsapShared.test.ts
@@ -23,6 +23,34 @@ describe("parsePercentageKeyframes", () => {
     expect(out?.keyframes[1]!.properties).toEqual({ x: 520, y: 120 });
   });
 
+  it("strips a per-entry ease without shifting the even index-spacing of the others", () => {
+    // GSAP positions array keyframes by array index, so a `{ ease }` carried on an
+    // entry is a segment ease (skipped as a property) — it must not change where
+    // the surrounding keyframes land. 3 entries → 0 / 50 / 100, even though the
+    // middle entry also carries an ease.
+    const out = parsePercentageKeyframes([
+      { x: 0 },
+      { x: 100, ease: "power2.in" },
+      { x: 200 },
+    ] as unknown as Record<string, unknown>);
+    expect(out?.keyframes.map((k) => k.percentage)).toEqual([0, 50, 100]);
+    expect(out?.keyframes.map((k) => k.properties)).toEqual([{ x: 0 }, { x: 100 }, { x: 200 }]);
+  });
+
+  it("keeps even spacing when an interior array slot has no animatable prop", () => {
+    // A degenerate `{ ease }`-only slot contributes no output keyframe, but it is
+    // still an array slot GSAP allocates a position to — so the remaining entries
+    // keep their original i/(n-1) percentages (0 and 100 for a 3-slot array), not
+    // 0/100 collapsed onto a 2-entry spacing.
+    const out = parsePercentageKeyframes([
+      { x: 0 },
+      { ease: "power2.in" },
+      { x: 200 },
+    ] as unknown as Record<string, unknown>);
+    expect(out?.keyframes.map((k) => k.percentage)).toEqual([0, 100]);
+    expect(out?.keyframes.map((k) => k.properties)).toEqual([{ x: 0 }, { x: 200 }]);
+  });
+
   it("returns null for keyframes with no positional/animatable props", () => {
     expect(parsePercentageKeyframes([] as unknown as Record<string, unknown>)).toBeNull();
     expect(parsePercentageKeyframes({})).toBeNull();

--- a/packages/studio/src/hooks/gsapShared.ts
+++ b/packages/studio/src/hooks/gsapShared.ts
@@ -97,16 +97,6 @@ export function queryIframeElement(
   }
 }
 
-/** Safely access an iframe's contentDocument, returning null on cross-origin errors. */
-export function getIframeDocument(iframe: HTMLIFrameElement | null): Document | null {
-  if (!iframe) return null;
-  try {
-    return iframe.contentDocument;
-  } catch {
-    return null;
-  }
-}
-
 // ── Keyframe parsing ──────────────────────────────────────────────────────────
 
 export interface ParsedPercentageKeyframes {
@@ -124,6 +114,26 @@ export function parsePercentageKeyframes(
 ): ParsedPercentageKeyframes | null {
   const keyframes: ParsedPercentageKeyframes["keyframes"] = [];
   let easeEach: string | undefined;
+
+  // GSAP array-form keyframes — `keyframes: [{x,y}, {x,y}, ...]` — are evenly
+  // distributed across the tween, so step i of n maps to i/(n-1)*100%. (The object
+  // form below uses explicit "0%" keys.) Without this, array-keyframed tweens (e.g.
+  // a multi-point shuttle path) read as null → no motion path.
+  if (Array.isArray(kfObj)) {
+    const steps = kfObj as unknown[];
+    steps.forEach((entry, i) => {
+      if (!entry || typeof entry !== "object") return;
+      const percentage = steps.length > 1 ? Math.round((i / (steps.length - 1)) * 1000) / 10 : 0;
+      const properties: Record<string, number | string> = {};
+      for (const [pk, pv] of Object.entries(entry as Record<string, unknown>)) {
+        if (pk === "ease") continue;
+        if (typeof pv === "number") properties[pk] = Math.round(pv * 1000) / 1000;
+        else if (typeof pv === "string") properties[pk] = pv;
+      }
+      if (Object.keys(properties).length > 0) keyframes.push({ percentage, properties });
+    });
+    return keyframes.length > 0 ? { keyframes } : null;
+  }
 
   for (const [key, val] of Object.entries(kfObj)) {
     if (key === "easeEach") {

--- a/packages/studio/src/hooks/gsapShared.ts
+++ b/packages/studio/src/hooks/gsapShared.ts
@@ -115,10 +115,18 @@ export function parsePercentageKeyframes(
   const keyframes: ParsedPercentageKeyframes["keyframes"] = [];
   let easeEach: string | undefined;
 
-  // GSAP array-form keyframes — `keyframes: [{x,y}, {x,y}, ...]` — are evenly
-  // distributed across the tween, so step i of n maps to i/(n-1)*100%. (The object
-  // form below uses explicit "0%" keys.) Without this, array-keyframed tweens (e.g.
-  // a multi-point shuttle path) read as null → no motion path.
+  // GSAP array-form keyframes — `keyframes: [{x,y}, {x,y}, ...]` — are spread
+  // evenly across the tween by default: GSAP gives each entry an equal share of
+  // the duration unless an entry carries its own `duration`/`delay`, which the
+  // studio never emits. So entry i of n maps to i/(n-1)*100% (n=4 → 0/33.3/66.7/100).
+  // Index spacing counts EVERY array slot, including a degenerate entry that
+  // contributes no animatable prop (it's still a slot GSAP allocates a position
+  // to), so dropping such an entry from the output below must NOT shift the others.
+  // A per-entry `ease` is a segment ease, not a keyframe value, so it's skipped as
+  // a property; there is no array-form `easeEach` (that's an object-form sibling key).
+  // (The object form further down uses explicit "0%" keys instead.) Without this
+  // branch, array-keyframed tweens (e.g. a multi-point shuttle) read as null → no
+  // motion path.
   if (Array.isArray(kfObj)) {
     const steps = kfObj as unknown[];
     steps.forEach((entry, i) => {

--- a/packages/studio/src/hooks/useGsapAnimationFetchFallback.test.ts
+++ b/packages/studio/src/hooks/useGsapAnimationFetchFallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { GsapAnimation, ParsedGsap } from "@hyperframes/core/gsap-parser";
+import { selectElementAnimationsOrRetry } from "./useGsapAnimationFetchFallback";
+
+const anim = (targetSelector: string): GsapAnimation =>
+  ({ id: targetSelector, targetSelector, properties: {} }) as unknown as GsapAnimation;
+const parsed = (anims: GsapAnimation[]): ParsedGsap => ({ animations: anims }) as ParsedGsap;
+const target = { id: "puck-a", selector: "#puck-a" };
+
+describe("selectElementAnimationsOrRetry", () => {
+  it("returns null (retry) when the parse is cold — null or zero total animations", () => {
+    expect(selectElementAnimationsOrRetry(null, target)).toBeNull();
+    expect(selectElementAnimationsOrRetry(parsed([]), target)).toBeNull();
+  });
+
+  it("returns the matching animations from a warm parse", () => {
+    const result = selectElementAnimationsOrRetry(
+      parsed([anim("#puck-a"), anim("#other")]),
+      target,
+    );
+    expect(result?.map((a) => a.targetSelector)).toEqual(["#puck-a"]);
+  });
+
+  it("returns [] (no retry) for a warm parse with no match — element genuinely has no animation", () => {
+    expect(selectElementAnimationsOrRetry(parsed([anim("#other")]), target)).toEqual([]);
+  });
+});

--- a/packages/studio/src/hooks/useGsapAnimationFetchFallback.test.ts
+++ b/packages/studio/src/hooks/useGsapAnimationFetchFallback.test.ts
@@ -8,20 +8,29 @@ const parsed = (anims: GsapAnimation[]): ParsedGsap => ({ animations: anims }) a
 const target = { id: "puck-a", selector: "#puck-a" };
 
 describe("selectElementAnimationsOrRetry", () => {
-  it("returns null (retry) when the parse is cold — null or zero total animations", () => {
-    expect(selectElementAnimationsOrRetry(null, target)).toBeNull();
-    expect(selectElementAnimationsOrRetry(parsed([]), target)).toBeNull();
+  it("signals fetch-error (short retry) when the fetch itself failed (null)", () => {
+    // A null parse means fetchParsedAnimations hit a 404/network/JSON failure —
+    // not a parse-warming race, so it must NOT be conflated with a cold parse.
+    expect(selectElementAnimationsOrRetry(null, target)).toEqual({ kind: "fetch-error" });
   });
 
-  it("returns the matching animations from a warm parse", () => {
-    const result = selectElementAnimationsOrRetry(
+  it("signals cold (full retry budget) when the parse is reachable but has zero total animations", () => {
+    expect(selectElementAnimationsOrRetry(parsed([]), target)).toEqual({ kind: "cold" });
+  });
+
+  it("resolves the matching animations from a warm parse", () => {
+    const outcome = selectElementAnimationsOrRetry(
       parsed([anim("#puck-a"), anim("#other")]),
       target,
     );
-    expect(result?.map((a) => a.targetSelector)).toEqual(["#puck-a"]);
+    expect(outcome.kind).toBe("resolved");
+    expect(outcome.kind === "resolved" && outcome.animations.map((a) => a.targetSelector)).toEqual([
+      "#puck-a",
+    ]);
   });
 
-  it("returns [] (no retry) for a warm parse with no match — element genuinely has no animation", () => {
-    expect(selectElementAnimationsOrRetry(parsed([anim("#other")]), target)).toEqual([]);
+  it("resolves to [] (no retry) for a warm parse with no match — element genuinely has no animation", () => {
+    const outcome = selectElementAnimationsOrRetry(parsed([anim("#other")]), target);
+    expect(outcome).toEqual({ kind: "resolved", animations: [] });
   });
 });

--- a/packages/studio/src/hooks/useGsapAnimationFetchFallback.ts
+++ b/packages/studio/src/hooks/useGsapAnimationFetchFallback.ts
@@ -1,18 +1,43 @@
 import { useCallback } from "react";
+import type { GsapAnimation, ParsedGsap } from "@hyperframes/core/gsap-parser";
 import type { DomEditSelection } from "../components/editor/domEditing";
 import { fetchParsedAnimations, getAnimationsForElement } from "./useGsapTweenCache";
 
+const COLD_PARSE_RETRIES = 5;
+const COLD_PARSE_DELAY_MS = 120;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Decide an element's animations from a parse result, or signal a retry.
+ *
+ * Returns `null` only when the parse is *cold* (missing or zero total animations)
+ * — the initial-load race where the endpoint isn't ready yet, so the caller should
+ * retry. A warm parse with no match for this element returns `[]` (the element
+ * genuinely has no animation — create a new one, don't retry).
+ */
+export function selectElementAnimationsOrRetry(
+  parsed: ParsedGsap | null,
+  target: { id: string | null; selector: string | null },
+): GsapAnimation[] | null {
+  if (!parsed || parsed.animations.length === 0) return null;
+  return getAnimationsForElement(parsed.animations, target);
+}
+
 export function useGsapAnimationFetchFallback(projectId: string | null, gsapSourceFile: string) {
   return useCallback(
-    (selection: DomEditSelection) => async () => {
-      const pid = projectId;
-      if (!pid) return [];
-      const parsed = await fetchParsedAnimations(pid, gsapSourceFile);
-      if (!parsed) return [];
-      return getAnimationsForElement(parsed.animations, {
-        id: selection.id ?? null,
-        selector: selection.selector ?? null,
-      });
+    (selection: DomEditSelection) => async (): Promise<GsapAnimation[]> => {
+      if (!projectId) return [];
+      const target = { id: selection.id ?? null, selector: selection.selector ?? null };
+      // A drag can fire before the async parse is warm; a cold parse must retry
+      // rather than fall through to the no-animation path (which duplicates the tween).
+      for (let attempt = 0; ; attempt++) {
+        const parsed = await fetchParsedAnimations(projectId, gsapSourceFile);
+        const resolved = selectElementAnimationsOrRetry(parsed, target);
+        if (resolved !== null) return resolved;
+        if (attempt >= COLD_PARSE_RETRIES) return [];
+        await delay(COLD_PARSE_DELAY_MS);
+      }
     },
     [projectId, gsapSourceFile],
   );

--- a/packages/studio/src/hooks/useGsapAnimationFetchFallback.ts
+++ b/packages/studio/src/hooks/useGsapAnimationFetchFallback.ts
@@ -3,25 +3,45 @@ import type { GsapAnimation, ParsedGsap } from "@hyperframes/core/gsap-parser";
 import type { DomEditSelection } from "../components/editor/domEditing";
 import { fetchParsedAnimations, getAnimationsForElement } from "./useGsapTweenCache";
 
+// A cold parse is the initial-load race: the endpoint is reachable but its parse
+// isn't warm yet (zero total animations). It's worth waiting out (~600ms).
 const COLD_PARSE_RETRIES = 5;
 const COLD_PARSE_DELAY_MS = 120;
+// A hard fetch error (404/403/network/JSON failure → `fetchParsedAnimations`
+// returns null) is NOT a parse-warming race, so it shouldn't burn the full
+// cold-parse budget. One short retry covers a transient blip; beyond that the
+// endpoint genuinely isn't serving this file, so fall through to "no animation".
+const FETCH_ERROR_RETRIES = 1;
+const FETCH_ERROR_DELAY_MS = 120;
 
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /**
- * Decide an element's animations from a parse result, or signal a retry.
- *
- * Returns `null` only when the parse is *cold* (missing or zero total animations)
- * — the initial-load race where the endpoint isn't ready yet, so the caller should
- * retry. A warm parse with no match for this element returns `[]` (the element
- * genuinely has no animation — create a new one, don't retry).
+ * Outcome of resolving an element's animations from a single parse result.
+ * - `resolved`: a definitive answer (matched animations, or `[]` when the parse
+ *   is warm but this element has no animation — create a new one, don't retry).
+ * - `fetch-error`: `fetchParsedAnimations` returned null (HTTP/network/JSON
+ *   failure) — retry briefly, not for the full cold-parse budget.
+ * - `cold`: the parse came back reachable but with zero total animations — the
+ *   initial-load warming race, worth the full cold-parse retry budget.
+ */
+export type ElementAnimationsOutcome =
+  | { kind: "resolved"; animations: GsapAnimation[] }
+  | { kind: "fetch-error" }
+  | { kind: "cold" };
+
+/**
+ * Classify a parse result for one element. Differentiates a hard fetch failure
+ * (`parsed === null`) from a warm-but-empty cold parse (`animations.length === 0`)
+ * so the caller can apply the right retry budget to each.
  */
 export function selectElementAnimationsOrRetry(
   parsed: ParsedGsap | null,
   target: { id: string | null; selector: string | null },
-): GsapAnimation[] | null {
-  if (!parsed || parsed.animations.length === 0) return null;
-  return getAnimationsForElement(parsed.animations, target);
+): ElementAnimationsOutcome {
+  if (!parsed) return { kind: "fetch-error" };
+  if (parsed.animations.length === 0) return { kind: "cold" };
+  return { kind: "resolved", animations: getAnimationsForElement(parsed.animations, target) };
 }
 
 export function useGsapAnimationFetchFallback(projectId: string | null, gsapSourceFile: string) {
@@ -30,12 +50,23 @@ export function useGsapAnimationFetchFallback(projectId: string | null, gsapSour
       if (!projectId) return [];
       const target = { id: selection.id ?? null, selector: selection.selector ?? null };
       // A drag can fire before the async parse is warm; a cold parse must retry
-      // rather than fall through to the no-animation path (which duplicates the tween).
-      for (let attempt = 0; ; attempt++) {
+      // rather than fall through to the no-animation path (which duplicates the
+      // tween). A hard fetch error is a different failure — retry only briefly.
+      let coldAttempts = 0;
+      let errorAttempts = 0;
+      for (;;) {
         const parsed = await fetchParsedAnimations(projectId, gsapSourceFile);
-        const resolved = selectElementAnimationsOrRetry(parsed, target);
-        if (resolved !== null) return resolved;
-        if (attempt >= COLD_PARSE_RETRIES) return [];
+        const outcome = selectElementAnimationsOrRetry(parsed, target);
+        if (outcome.kind === "resolved") return outcome.animations;
+        if (outcome.kind === "fetch-error") {
+          if (errorAttempts >= FETCH_ERROR_RETRIES) return [];
+          errorAttempts++;
+          await delay(FETCH_ERROR_DELAY_MS);
+          continue;
+        }
+        // cold
+        if (coldAttempts >= COLD_PARSE_RETRIES) return [];
+        coldAttempts++;
         await delay(COLD_PARSE_DELAY_MS);
       }
     },

--- a/packages/studio/src/hooks/useGsapTweenCache.ts
+++ b/packages/studio/src/hooks/useGsapTweenCache.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import type { GsapAnimation, GsapKeyframesData, ParsedGsap } from "@hyperframes/core/gsap-parser";
 import type { GsapPercentageKeyframe } from "@hyperframes/core/gsap-parser";
+import { isStudioHoldSet } from "@hyperframes/core/gsap-parser";
 import { usePlayerStore } from "../player/store/playerStore";
 import { readRuntimeKeyframes, scanAllRuntimeKeyframes } from "./gsapRuntimeBridge";
 import {
@@ -107,7 +108,12 @@ export async function fetchParsedAnimations(
     const res = await fetch(
       `/api/projects/${encodeURIComponent(projectId)}/gsap-animations/${encodeURIComponent(sourceFile)}`,
     );
-    return res.ok ? ((await res.json()) as ParsedGsap) : null;
+    if (!res.ok) return null;
+    const parsed = (await res.json()) as ParsedGsap;
+    // Studio-emitted pre-keyframe hold `set`s are an internal runtime detail (they
+    // hold an element's first keyframe before its tween). They must not surface as
+    // user animations — otherwise they pollute the keyframe cache / timeline diamonds.
+    return { ...parsed, animations: parsed.animations.filter((a) => !isStudioHoldSet(a)) };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

This PR establishes the GSAP **runtime read layer** for the Studio editor — the code that reads back live keyframed motion from the preview iframe's running GSAP timelines and reconciles it with the parsed source. It hardens three read paths (live tween reads, percentage-keyframe parsing, and the parse-fetch fallback) against the failure modes that surface once an element can carry multiple gesture-recorded tweens, array-form keyframes, and studio-emitted hold `set`s. It also introduces small, tested helper functions so the read logic is unit-testable in isolation.

## What's changed

### `packages/studio/src/hooks/gsapRuntimeKeyframes.ts`
- `readRuntimeKeyframes` now resolves the timeline robustly and picks the **right** tween under the playhead:
  - When no explicit composition id is passed, it skips non-timeline markers on `window.__timelines` (e.g. the studio's `__proxied` flag) by selecting the first key whose value actually has a `getChildren` function, instead of blindly taking `Object.keys(...)[0]`.
  - It reads the timeline clock via the new optional `time()` and, when an element has **more than one keyframed tween at disjoint time ranges** (two non-overlapping gesture recordings → two `to()`s), returns the tween whose `[start, start+duration]` range contains the playhead (with a `1e-3` epsilon). If the playhead is outside every range (or the timeline exposes no clock), it falls back to the first keyframed tween held in `firstRead`.
  - Both `readRuntimeKeyframes` and `addScanEntry` now skip **zero-duration tweens** (`tl.set(...)`, including the studio position-hold `data:"hf-hold"`). These sit before the real keyframed tween and otherwise shadow it — `readTween` would fall back to a degenerate 2-point flat path from the set's values, hiding the actual multi-keyframe motion.
- Type surface: `RuntimeTimeline` gains an optional `time?: () => number`; `ReadTween` is now exported (for the test + downstream consumers).

### `packages/studio/src/hooks/gsapShared.ts`
- `parsePercentageKeyframes` now handles **GSAP array-form keyframes** (`keyframes: [{x,y}, {x,y}, ...]`) in addition to the object/percentage form. Array steps are evenly distributed: step `i` of `n` maps to `i/(n-1)*100%` (rounded to one decimal), numeric props rounded to 3 decimals, `ease` skipped. Previously array-keyframed tweens (e.g. a multi-point shuttle path) parsed as `null` → no motion path drawn.
- Removed the now-unused `getIframeDocument` helper.

### `packages/studio/src/hooks/useGsapAnimationFetchFallback.ts`
- New exported pure helper `selectElementAnimationsOrRetry(parsed, target)`: returns `null` to signal a retry **only** when the parse is cold (missing or zero total animations — the initial-load race), returns the matched animations on a warm parse, and returns `[]` (no retry) when a warm parse has no match for the element (it genuinely has no animation).
- The `useGsapAnimationFetchFallback` callback now retries the async parse fetch (`COLD_PARSE_RETRIES = 5`, `COLD_PARSE_DELAY_MS = 120`) on a cold parse instead of falling straight through to the no-animation path. This closes the race where a drag fires before the parse is warm and the empty result causes the tween to be **duplicated** rather than edited.

### `packages/studio/src/hooks/useGsapTweenCache.ts`
- `fetchParsedAnimations` now filters studio-emitted pre-keyframe hold `set`s out of the parsed animations via `isStudioHoldSet` (from `@hyperframes/core/gsap-parser`). These holds are an internal runtime detail (they hold an element's first keyframe before its tween) and must not surface as user animations, where they would pollute the keyframe cache and timeline diamonds.

## Why

Once the editor lets a user record multiple gestures, edit array-form keyframes, and relies on studio-emitted hold `set`s, the naive "read the first matching tween" logic breaks in several concrete ways: recording a second gesture leaves the motion path stuck on the first; a zero-duration hold `set` shadows the real keyframed tween and collapses the path to a flat 2-point line; array-form keyframes don't parse at all; a drag that fires before the async parse is warm duplicates the tween instead of editing it; and internal hold `set`s leak into the user-facing animation list. This PR makes the runtime read layer correct and playhead-aware, so the overlay always reflects the actual motion under the cursor.

## Testing

Three vitest files, all reading the real exported helpers:

- **`gsapRuntimeKeyframes.test.ts`** — adds a `fakeIframe` builder that stubs a runtime timeline (`getChildren`, `duration`, optional `time`) and selector resolution. Covers: a zero-duration hold-set must not shadow the keyframed tween (reads all 4 keyframes; returns `null` when the element has *only* a zero-duration set); multiple tweens / playhead selection (inside the second reads the second, inside the first reads the first, outside every range falls back to the first).
- **`gsapShared.test.ts`** — `parsePercentageKeyframes`: parses the object/percentage form; parses array-form keyframes as evenly-distributed steps (`[0, 33.3, 66.7, 100]`, properties preserved); returns `null` for empty array and empty object.
- **`useGsapAnimationFetchFallback.test.ts`** — `selectElementAnimationsOrRetry`: returns `null` (retry) for a cold parse; returns the matching animations from a warm parse; returns `[]` (no retry) for a warm parse with no match.

## Stack

Part of the GSAP keyframe/motion-path stack, split into reviewable PRs: `#1553 → #1554 → #1555 → #1607 → #1608 → #1609 → #1610 → #1611 → #1567 → #1612 → #1613 → #1605`. This is the bottom studio PR (on #1555). Each PR builds independently; the combined diff of the split is byte-identical to the originally-reviewed work.
