### PR TITLE
fix(core): publish missing subpath exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -141,6 +141,15 @@
         "import": "./dist/index.js",
         "types": "./dist/index.d.ts"
       },
+      "./package.json": "./package.json",
+      "./beats": {
+        "import": "./dist/beats/index.js",
+        "types": "./dist/beats/index.d.ts"
+      },
+      "./html-attr-safety": {
+        "import": "./dist/utils/htmlAttrSafety.js",
+        "types": "./dist/utils/htmlAttrSafety.d.ts"
+      },
       "./lint": {
         "import": "./dist/lint/index.js",
         "types": "./dist/lint/index.d.ts"
@@ -161,7 +170,15 @@
         "import": "./dist/colorLuts.js",
         "types": "./dist/colorLuts.d.ts"
       },
+      "./storyboard": {
+        "import": "./dist/storyboard/index.js",
+        "types": "./dist/storyboard/index.d.ts"
+      },
       "./runtime": "./dist/hyperframe.runtime.iife.js",
+      "./runtime/clipTree": {
+        "import": "./dist/runtime/clipTree.js",
+        "types": "./dist/runtime/clipTree.d.ts"
+      },
       "./runtime/lottie-readiness": {
         "import": "./dist/lottieReadiness.js",
         "types": "./dist/lottieReadiness.d.ts"

--- a/packages/core/src/beats/index.ts
+++ b/packages/core/src/beats/index.ts
@@ -1,2 +1,2 @@
-export * from "./beatDetection";
-export * from "./beatFile";
+export * from "./beatDetection.js";
+export * from "./beatFile.js";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,7 +13,7 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "files": ["src/runtime/mediaVolumeEnvelope.ts"],
+  "files": ["src/runtime/clipTree.ts", "src/runtime/mediaVolumeEnvelope.ts"],
   "include": ["src/**/*"],
   "exclude": [
     "node_modules",

--- a/scripts/verify-packed-manifests.mjs
+++ b/scripts/verify-packed-manifests.mjs
@@ -29,6 +29,12 @@ function listWorkspaceRefs(pkg) {
   return refs;
 }
 
+function listMissingPublishedExports(pkg) {
+  if (!pkg.exports || !pkg.publishConfig?.exports) return [];
+
+  return Object.keys(pkg.exports).filter((exportKey) => !(exportKey in pkg.publishConfig.exports));
+}
+
 function parsePackJson(output, workspace) {
   try {
     const parsed = JSON.parse(output);
@@ -44,6 +50,14 @@ function main() {
       readFileSync(join(ROOT, workspace, "package.json"), "utf8"),
     );
     if (sourcePackageJson.private) continue;
+
+    const missingPublishedExports = listMissingPublishedExports(sourcePackageJson);
+    if (missingPublishedExports.length > 0) {
+      throw new Error(
+        `${workspace} publishConfig.exports is missing source exports: ${missingPublishedExports.join(", ")}`,
+      );
+    }
+
     if (listWorkspaceRefs(sourcePackageJson).length === 0) continue;
 
     const packDir = mkdtempSync(join(tmpdir(), "hyperframes-pack-"));


### PR DESCRIPTION
## Problem

`@hyperframes/studio@0.6.115` and `@hyperframes/sdk@0.6.115` import public `@hyperframes/core` subpaths that the published `@hyperframes/core` package does not expose. Next/Turbopack fails the consuming app build with missing modules for `@hyperframes/core/beats`, `@hyperframes/core/storyboard`, and `@hyperframes/core/html-attr-safety`.

## What this fixes

- Publishes the missing core subpath exports in `publishConfig.exports`: `./beats`, `./storyboard`, `./html-attr-safety`, `./package.json`, and `./runtime/clipTree`.
- Emits `dist/runtime/clipTree.{js,d.ts}` so the existing `./runtime/clipTree` source export has a valid published target.
- Updates the beats barrel to emit Node-resolvable ESM specifiers with `.js` extensions.
- Hardens `scripts/verify-packed-manifests.mjs` so release verification fails when a source export is missing from the published export map.

## Root cause

`packages/core/package.json` had the new subpaths in the development `exports` map, but `publishConfig.exports` was not updated alongside them. The release path applies `publishConfig` to the packed npm manifest, so the registry package hid files that were present in the tarball. The beats export also exposed a second packaging issue: once the subpath was visible, its emitted barrel imported extensionless relative modules, which installed Node ESM consumers cannot resolve.

## Verification

### Local checks

- `bun install`
- `bun run --filter @hyperframes/core build`
- `node scripts/verify-packed-manifests.mjs`
- `bun run --filter @hyperframes/core test -- src/beats src/storyboard src/runtime/clipTree.ts src/utils/htmlAttrSafety.ts`
- `git diff --check`
- `bunx oxfmt --check packages/core/package.json packages/core/src/beats/index.ts packages/core/tsconfig.json scripts/verify-packed-manifests.mjs`
- `bunx oxlint packages/core/src/beats/index.ts scripts/verify-packed-manifests.mjs`
- Pre-commit hook passed lint, format, fallow, typecheck, and commitlint. Fallow reported inherited warn-level complexity in `scripts/verify-packed-manifests.mjs`, but the gate passed.

### Packed package proof

Packed `packages/core` with `pnpm --dir packages/core pack`, installed the tarball into a throwaway consumer, and verified:

```text
./beats {"import":"./dist/beats/index.js","types":"./dist/beats/index.d.ts"}
./html-attr-safety {"import":"./dist/utils/htmlAttrSafety.js","types":"./dist/utils/htmlAttrSafety.d.ts"}
./storyboard {"import":"./dist/storyboard/index.js","types":"./dist/storyboard/index.d.ts"}
./runtime/clipTree {"import":"./dist/runtime/clipTree.js","types":"./dist/runtime/clipTree.d.ts"}
./package.json "./package.json"
import ok @hyperframes/core/beats
import ok @hyperframes/core/html-attr-safety
import ok @hyperframes/core/storyboard
import ok @hyperframes/core/runtime/clipTree
resolve ok @hyperframes/core/package.json
```

### Browser verification

No browser pass was run for this package-manifest fix. The affected Vercel app cannot consume the correction until a new HyperFrames package version is published and the internal app is bumped to that fixed version.

## Notes

- This fixes the root package publishing contract rather than adding a consuming-app alias or pnpm patch.
- After this lands, the deployment fix still needs a new HyperFrames release and an internal dependency bump away from the broken `0.6.115`/`0.6.116` artifacts.
