### PR TITLE
fix(shader-transitions): page-side render dropped shader transitions and final-scene content

### DIFF
--- a/packages/shader-transitions/src/engineModePageComposite.ts
+++ b/packages/shader-transitions/src/engineModePageComposite.ts
@@ -196,6 +196,16 @@ export function installPageSideCompositor(options: PageCompositorInstallOptions)
     return null;
   }
 
+  // Scene on screen at a non-transition time: after the last transition whose
+  // window has passed. Full transitions list so the index matches scene order.
+  function settledSceneIdAt(time: number): string | undefined {
+    let idx = 0;
+    for (const t of transitions) {
+      if (time >= t.time + (t.duration ?? defaultDuration)) idx += 1;
+    }
+    return scenes[Math.min(idx, scenes.length - 1)];
+  }
+
   let currentActive: ResolvedTransition | null = null;
   let currentProgress = 0;
 
@@ -224,8 +234,24 @@ export function installPageSideCompositor(options: PageCompositorInstallOptions)
     }
     while (fromStaging.firstChild) fromStaging.removeChild(fromStaging.firstChild);
     while (toStaging.firstChild) toStaging.removeChild(toStaging.firstChild);
-    fromStaging.appendChild(fromEl.cloneNode(true));
-    toStaging.appendChild(toEl.cloneNode(true));
+    const fromClone = fromEl.cloneNode(true) as HTMLElement;
+    const toClone = toEl.cloneNode(true) as HTMLElement;
+    fromStaging.appendChild(fromClone);
+    toStaging.appendChild(toClone);
+
+    // cloneNode copies the GSAP opacity-fade (opacity:0 / hidden data-start), and
+    // Chrome won't paint hidden elements — drawElementImage then throws "No cached
+    // paint record" and the shader degrades to a hard cut. The shader blends from
+    // full-opacity textures via u_progress, so force the clones visible. Cf.
+    // forceSceneVisibleInClone (html2canvas path).
+    for (const clone of [fromClone, toClone]) {
+      clone.style.opacity = "1";
+      clone.style.visibility = "visible";
+      clone.querySelectorAll<HTMLElement>("[data-start]").forEach((el) => {
+        el.style.opacity = "1";
+        el.style.visibility = "visible";
+      });
+    }
 
     // Decode any data-URI images in clones so the browser has current
     // bitmaps before the micro-screenshot forces a paint pass.
@@ -326,6 +352,14 @@ export function installPageSideCompositor(options: PageCompositorInstallOptions)
         pWin.__hf_page_composite_pending = false;
         while (fromStaging.firstChild) fromStaging.removeChild(fromStaging.firstChild);
         while (toStaging.firstChild) toStaging.removeChild(toStaging.firstChild);
+        // Live-page screenshot parity with the layered path's forceVisible: the
+        // core clip runtime hides the final scene a beat before the comp ends, so
+        // un-hide the settled scene (others stay at opacity 0).
+        const settledId = settledSceneIdAt(time);
+        const settled = settledId ? document.getElementById(settledId) : null;
+        if (settled instanceof HTMLElement && settled.style.visibility === "hidden") {
+          settled.style.visibility = "visible";
+        }
         return result;
       }
       currentActive = active;


### PR DESCRIPTION
## What

Two page-side compositing fixes for the engine render path:

1. HyperShader.init shader transitions came out as **hard cuts** in exported MP4s (they play fine in studio preview).
2. The **final scene's content** dropped in the last beat of the render, leaving only the background.

## Why

Both come from page-side compositing (`HF_PAGE_SIDE_COMPOSITING`, default on) capturing the live page without forcing scene visibility the way the layered path does:

1. **Transitions:** the compositor clones the from/to scenes to feed `drawElementImage`, but `cloneNode` copies the GSAP opacity-fade (`opacity:0` / hidden `data-start`). Chrome doesn't paint hidden elements, so `drawElementImage` throws `InvalidStateError: No cached paint record for element` and the shader silently degrades to a hard cut. The html2canvas capture path already guards this via `forceSceneVisibleInClone`; page-side never did.
2. **Final scene:** the `@hyperframes/core` clip runtime sets the last scene `visibility:hidden` a beat before the composition ends. The layered path survives because `captureLiveScene` captures each scene with `forceVisible: true`; page-side screenshots the live page and captures the blank.

## How

`engineModePageComposite.ts`, page-side only:

1. In `prepareComposite`, force the cloned scenes (and their `data-start` descendants) to `opacity:1; visibility:visible` before capture. The shader blends from full-opacity source textures via `u_progress`, so this is the correct input.
2. In the seek wrapper's non-transition branch, un-hide the settled scene (`settledSceneIdAt`). The opacity-flip timeline keeps non-settled scenes at `opacity:0`, so un-hiding only the settled scene is safe.

No engine/producer changes. Retains the page-side speedup (no fallback to the layered path).

## Test plan

Verified on a Hyperion composition (5 scenes, 4 shader transitions: cross-warp-morph / whip-pan / sdf-iris / gravitational-lens):

- `drawElementImage` failures **60 → 0**; transition frames now blend correctly and match the layered render.
- Final-scene content holds to the last frame (matches layered).
- Mid-scene and transition frames unchanged vs the layered render.
- Wall time unchanged: page-side **28.8s** vs layered **187.5s** (~6.5x).

- [ ] Unit tests added/updated (feature-detection suite unchanged, 10/10 pass; compositing behaviour is validated by render, same as #832 — jsdom can't reproduce Chrome paint/screenshot)
- [x] Manual testing performed (page-side vs layered, before/after frames)
- [ ] Documentation updated (if applicable)
