### PR TITLE
chore: release v0.6.119

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,22 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.6.119"
+  description="Released - 2026-06-21"
+  tags={["Release", "Slideshow"]}
+>
+This hotfix makes slideshow presenter decks more reliable when they contain interactive
+media. Presenter and audience views now keep media controls, muted autoplay fallback,
+global mute, editable speaker notes, and first-load navigation chrome in sync.
+
+## Fixes
+
+- **Slideshow:** Harden media controls in present decks ([341e65aea](https://github.com/heygen-com/hyperframes/commit/341e65aea2773235d2cd3482846bcd6ed7d24638), [#1619](https://github.com/heygen-com/hyperframes/pull/1619))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.6.118...v0.6.119).
+</Update>
+
+<Update
   label="HyperFrames v0.6.117"
   description="Released - 2026-06-20"
   tags={["Release", "Core"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.6.119.md
+++ b/releases/v0.6.119.md
@@ -1,0 +1,15 @@
+# HyperFrames v0.6.119
+
+Released on 2026-06-21.
+
+This hotfix makes slideshow presenter decks more reliable when they contain interactive
+media. Presenter and audience views now keep media controls, muted autoplay fallback,
+global mute, editable speaker notes, and first-load navigation chrome in sync.
+
+## Fixes
+
+- **Slideshow:** Harden media controls in present decks ([341e65aea](https://github.com/heygen-com/hyperframes/commit/341e65aea2773235d2cd3482846bcd6ed7d24638), [#1619](https://github.com/heygen-com/hyperframes/pull/1619))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.6.118...v0.6.119


### PR DESCRIPTION
## Summary
- bump HyperFrames packages and plugins to v0.6.119
- add reviewed release notes for slideshow presenter media fixes

## Publish
Merging this release/v0.6.119 PR triggers the npm publish workflow and creates tag v0.6.119.