### PR TITLE
chore: release v0.6.121

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,23 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.6.121"
+  description="Released - 2026-06-21"
+  tags={["Release", "CLI"]}
+>
+This hotfix restores `hyperframes skills` on Windows by invoking npm's `npx.cmd`
+shim through `cmd.exe`, while preserving direct `npx` execution on Linux and macOS.
+The same resolver also covers the local Studio preview's `npx vite` path and is
+verified by CI on all three operating systems.
+
+## Fixes
+
+- **CLI:** Resolve npx shims on Windows ([25b717dd](https://github.com/heygen-com/hyperframes/commit/25b717dd9c0e1777adafa23dcfb4ad87c4989d91), [#1626](https://github.com/heygen-com/hyperframes/pull/1626))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.6.120...v0.6.121).
+</Update>
+
+<Update
   label="HyperFrames v0.6.120"
   description="Released - 2026-06-21"
   tags={["Release", "Shader Transitions"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.6.120",
+  "version": "0.6.121",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.6.121.md
+++ b/releases/v0.6.121.md
@@ -1,0 +1,16 @@
+# HyperFrames v0.6.121
+
+Released on 2026-06-21.
+
+This hotfix restores `hyperframes skills` on Windows by invoking npm's `npx.cmd`
+shim through `cmd.exe`, while preserving direct `npx` execution on Linux and macOS.
+The same resolver also covers the local Studio preview's `npx vite` path and is
+verified by CI on all three operating systems.
+
+## Fixes
+
+- **CLI:** Resolve npx shims on Windows ([25b717dd](https://github.com/heygen-com/hyperframes/commit/25b717dd9c0e1777adafa23dcfb4ad87c4989d91), [#1626](https://github.com/heygen-com/hyperframes/pull/1626))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.6.120...v0.6.121


### PR DESCRIPTION
## Summary
- bump HyperFrames packages and plugins to v0.6.121
- add reviewed release notes for the Windows `npx.cmd` shim fix in `hyperframes skills` and the sibling `hyperframes preview` `npx vite` path

## Verification
- `volta run --node 22.20.0 bun run test:scripts`

## Publish
Merging this `release/v0.6.121` PR triggers the npm publish workflow and creates tag `v0.6.121`.

Depends on #1626.