### PR TITLE
fix(skills): reject empty or partial scene files at assembly time

### DIFF
--- a/skills/faceless-explainer/scripts/assemble-index.mjs
+++ b/skills/faceless-explainer/scripts/assemble-index.mjs
@@ -171,7 +171,17 @@ for (const visual of visualClips) {
   const start = Number(visual.start_s);
   if (!isFinite(start) || start < 0)
     die(`${visual.id}: visual start_s invalid (${visual.start_s})`);
-  const rootDur = rootDataDuration(readFileSync(compAbs, "utf8"));
+  // Guard against blank/partial scene files: a worker that errors or is
+  // interrupted mid-write leaves an empty (or markup-less) file that exists but
+  // fails at render with "Composition HTML is empty or could not be parsed".
+  // Catch it here — before emitting data-composition-src — and re-dispatch.
+  const compHtml = readFileSync(compAbs, "utf8");
+  if (!compHtml.trim() || !/<\w/.test(compHtml)) {
+    die(
+      `visual file ${compRel} is empty or has no HTML — the worker for ${visual.id} wrote a blank/partial file. Re-dispatch that scene worker before assembling.`,
+    );
+  }
+  const rootDur = rootDataDuration(compHtml);
   if (rootDur == null) {
     anomalies.push(
       `${visual.id}: could not read root data-duration from ${compRel} — skipped duration cross-check`,

--- a/skills/pr-to-video/scripts/assemble-index.mjs
+++ b/skills/pr-to-video/scripts/assemble-index.mjs
@@ -171,7 +171,17 @@ for (const visual of visualClips) {
   const start = Number(visual.start_s);
   if (!isFinite(start) || start < 0)
     die(`${visual.id}: visual start_s invalid (${visual.start_s})`);
-  const rootDur = rootDataDuration(readFileSync(compAbs, "utf8"));
+  // Guard against blank/partial scene files: a worker that errors or is
+  // interrupted mid-write leaves an empty (or markup-less) file that exists but
+  // fails at render with "Composition HTML is empty or could not be parsed".
+  // Catch it here — before emitting data-composition-src — and re-dispatch.
+  const compHtml = readFileSync(compAbs, "utf8");
+  if (!compHtml.trim() || !/<\w/.test(compHtml)) {
+    die(
+      `visual file ${compRel} is empty or has no HTML — the worker for ${visual.id} wrote a blank/partial file. Re-dispatch that scene worker before assembling.`,
+    );
+  }
+  const rootDur = rootDataDuration(compHtml);
   if (rootDur == null) {
     anomalies.push(
       `${visual.id}: could not read root data-duration from ${compRel} — skipped duration cross-check`,

--- a/skills/product-launch-video/scripts/assemble-index.mjs
+++ b/skills/product-launch-video/scripts/assemble-index.mjs
@@ -125,7 +125,17 @@ for (const { sid, scene } of playOrder) {
       `${sid}: group_spec estimatedDuration_s missing or non-positive (${scene.estimatedDuration_s})`,
     );
   }
-  const rootDur = rootDataDuration(readFileSync(compAbs, "utf8"));
+  // Guard against blank/partial scene files: a worker that errors or is
+  // interrupted mid-write leaves an empty (or markup-less) file that exists but
+  // fails at render with "Composition HTML is empty or could not be parsed".
+  // Catch it here — before emitting data-composition-src — and re-dispatch.
+  const compHtml = readFileSync(compAbs, "utf8");
+  if (!compHtml.trim() || !/<\w/.test(compHtml)) {
+    die(
+      `scene file ${compRel} is empty or has no HTML — the worker for ${sid} wrote a blank/partial file. Re-dispatch that scene worker before assembling.`,
+    );
+  }
+  const rootDur = rootDataDuration(compHtml);
   if (rootDur == null) {
     anomalies.push(
       `${sid}: could not read root data-duration from ${compRel} — skipped duration cross-check`,


### PR DESCRIPTION
## Summary

When a scene worker errors or is interrupted mid-write, it can leave an empty (or markup-less) `compositions/<scene>.html`. The assembler only checked that the file *existed*, so it still emitted a `data-composition-src` reference to it. The problem surfaced much later — at render — as the confusing compile error:

> Composition HTML is empty or could not be parsed: compositions/scene-*.html

By then the broken project had already shipped to the user, and the message pointed at the symptom rather than the cause.

## Changes

All three assemblers (`product-launch-video`, `faceless-explainer`, `pr-to-video`) now validate scene-file **content** — non-empty and contains markup — at the exact point they already read the file for the duration cross-check. If a scene file is blank or partial, assembly fails fast with an actionable message telling the author to re-dispatch that scene worker, before any reference to it is written into `index.html`.

This moves the failure from a late, opaque render error to an early, clear authoring error, and prevents an unrenderable project from being produced at all.

## Verification

- `node --check` passes on all three scripts.
- Repro against the real assembler: empty and whitespace-only scene files now fail at assembly with the new message (exit 1); a valid scene file passes the guard and assembles successfully (no false positives).