### PR TITLE
fix(producer): inline base64 frames in injector to unblock video-heavy renders

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -79,12 +79,7 @@ import {
   VIRTUAL_TIME_SHIM,
 } from "./fileServer.js";
 import { defaultLogger, type ProducerLogger } from "../logger.js";
-import {
-  createCompiledFrameSrcResolver,
-  createMemorySampler,
-  type MemorySampler,
-  updateJobStatus,
-} from "./render/shared.js";
+import { createMemorySampler, type MemorySampler, updateJobStatus } from "./render/shared.js";
 import { buildRenderErrorDetails, cleanupRenderResources, safeCleanup } from "./render/cleanup.js";
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
 import { formatCaptureFrameName } from "../utils/paths.js";
@@ -1235,8 +1230,11 @@ export async function executeRenderJob(
     // page has zero fileServer-bound `<video>.src` traffic), the inline
     // path is the safe default. The cache memory ceiling
     // (`frameDataUriCacheBytesLimitMb`, default 1500 MB above 8 GB
-    // hosts) already bounds the cost.
-    void createCompiledFrameSrcResolver(compiledDir);
+    // hosts) already bounds the cost. `createCompiledFrameSrcResolver`
+    // and the `frameSrcResolver` option remain in their respective
+    // modules (`packages/producer/src/services/render/shared.ts`,
+    // `packages/engine/src/services/videoFrameInjector.ts`); the gating
+    // PR will re-import the builder here.
     const createRenderVideoFrameInjector = (): BeforeCaptureHook | null =>
       createVideoFrameInjector(frameLookup, {
         frameDataUriCacheLimit: cfg.frameDataUriCacheLimit,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1210,12 +1210,37 @@ export async function executeRenderJob(
       videoMetadataHints,
       skipReadinessVideoIds: videoReadinessSkipIds,
     });
-    const frameSrcResolver = createCompiledFrameSrcResolver(compiledDir);
+    // The URL-served frame path (PR #596) hands each injected `<img>` a
+    // fileServer URL instead of a base64 data URI, on the theory that
+    // shipping a short URL through `page.evaluate` beats shipping a
+    // multi-MB base64 string per frame. That holds when the fileServer
+    // is otherwise idle — but on video-heavy compositions, the same
+    // fileServer also serves every `<video>.src`. The runtime's
+    // drift-recovery branch (`runtime/media.ts:294-302`) issues
+    // `el.load()` on the underlying `<video>` during seeks, kicking off
+    // full-file downloads that occupy the fileServer's single Node
+    // event loop (it uses `readFileSync` and offers no `Accept-Ranges`).
+    // The injector's `<img>.decode()` then queues behind those video
+    // fetches and is never serviced before puppeteer's protocol timeout
+    // fires (`Runtime.callFunctionOn timed out`).
+    //
+    // Repro: synth 30 × 32 MB videos / 90 s comp on an 8-core / 30 GB
+    // host = 537 s wall (broken corpus) / 428 s (corpus-fixed), every
+    // render fails. Disabling the resolver (force base64-inline) gives
+    // 1:59 (119 s) wall and a clean MP4 on the same comp, with no
+    // regression on the 30 × 1.6 MB control corpus (137 s vs 135 s
+    // baseline).
+    //
+    // Until this is properly gated (e.g. only enable URL-served when the
+    // page has zero fileServer-bound `<video>.src` traffic), the inline
+    // path is the safe default. The cache memory ceiling
+    // (`frameDataUriCacheBytesLimitMb`, default 1500 MB above 8 GB
+    // hosts) already bounds the cost.
+    void createCompiledFrameSrcResolver(compiledDir);
     const createRenderVideoFrameInjector = (): BeforeCaptureHook | null =>
       createVideoFrameInjector(frameLookup, {
         frameDataUriCacheLimit: cfg.frameDataUriCacheLimit,
         frameDataUriCacheBytesLimitMb: cfg.frameDataUriCacheBytesLimitMb,
-        frameSrcResolver,
       });
 
     let captureCalibration:


### PR DESCRIPTION
## What

Drop the `frameSrcResolver` arg from the `createVideoFrameInjector` call site in `renderOrchestrator.ts`. That stops the injector from pointing `<img>` srcs at fileServer URLs and forces it back to base64-inline data URIs.

One-line code change. The `createCompiledFrameSrcResolver` builder + the `frameSrcResolver` option stay in the codebase, just unused — re-enabling them behind a proper gate is a follow-up.

## Why

PR #596 added URL-served frames as a speedup: hand the injector a fileServer URL instead of base64-inlining each ~1 MB frame through `page.evaluate`. That holds when the fileServer is otherwise idle.

But on video-heavy compositions the same fileServer also serves every `<video>.src`. The runtime's drift-recovery branch (`runtime/media.ts:294-302`) issues `el.load()` on the underlying `<video>` during seeks, kicking off full-file downloads that occupy the fileServer's single Node event loop (it uses `readFileSync` and offers no `Accept-Ranges`). The injector's `<img>.decode()` then queues behind those video fetches and is never serviced before puppeteer's protocol timeout fires, surfacing as `Runtime.callFunctionOn timed out` in `capture_streaming`.

This is the failure shape OSS user @daybreakdeath hit on a 24 GB WSL host, and the failure Rahino sees on heavy real-world comps.

## How

Per-phase instrumentation localised the hang. Frame 0 succeeds (~290 ms total, beforeCapture 199 ms). Frame 1 hangs in `session.onBeforeCapture` for the full 300 s protocol timeout. Splitting the injector hook's four `page.evaluate` calls (`syncVideoFrameVisibility`, `injectVideoFramesBatch`, `__hfReseekGpu`, `redrawRuntimeColorGrading`) showed `injectVideoFramesBatch` was the one that never returned. That function ends with `await Promise.all(pendingDecodes)` where each `pendingDecode` is `img.decode()` on an `<img>` whose new `src` is a fileServer URL. With 30 concurrent `<video>.src` downloads already in flight, the PNG fetch never returns.

Disabling the resolver (force base64 inline mode) — `dataUri` becomes `data:image/png;base64,...` of 137-284 KB — collapses the hang to a 5-50 ms `injectVideoFramesBatch` call.

## Test plan

Repro corpus: synth 30 × 32 MB videos / 90 s comp on an 8-core / 30 GB host.

| Setup | Wall | Outcome |
|---|---|---|
| baseline, broken corpus (no `window.__timelines` + no `<video id>`) | 537 s | render fails (`Runtime.callFunctionOn timed out`) |
| baseline, corpus-fixed | 428 s | render fails (same cascade, faster init) |
| **this fix (drop `frameSrcResolver`)** | **121 s** | **render succeeds, 69 MB MP4, calibration succeeds in 11 s** |

Control corpus: synth 30 × 1.6 MB / 60 s — **137 s with this change vs ~135 s on `main`**, no regression on the no-bottleneck case.

ffprobe on the heavy-comp output confirms 90.000 s duration, 1920×1080, 30 fps, h264 High profile, mid-clip frames extract to legitimate 880 KB PNGs (not black/empty).

- [ ] Manual testing performed (synth-30 heavy + synth-30 small, both confirmed above)
- [ ] Real-world video-heavy comps regression test (pending — alpha release to be cut after this lands)
- [ ] Follow-up PR: gate `frameSrcResolver` re-enable behind "no fileServer-bound `<video>.src` traffic" check, so the PR #596 optimization still pays on the comps it was designed for

## Notes

* Draft until James + Miguel weigh in on whether to land as-is (default off) or wait for the gated version.
* `createCompiledFrameSrcResolver` and the option are untouched in the codebase — this change is the single arg deletion at the producer call site.
* Branch-based alpha release proposed before merge to `main`, per James's standing request for OSS-heavy changes.

_Authored by Jerrai (Rames team)._