### PR TITLE
feat(skills): guide install when a matched workflow isn't installed

### DIFF
--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -70,6 +70,15 @@ Routing needs to know **what the video is about** — its input and subject. If 
 - **Existing footage** — plain spoken-word subtitles → `/embedded-captions`; designed overlay cards → `/graphic-overlays`. Neither edits the footage itself (re-timing / recolor / reframe / reorder / audio is NLE editing — out of scope).
 - **Length is a guide, not a gate** — intent picks the workflow; go to `/general-video` only when the piece is clearly longer than ~3 min, or is a static / loop / custom format.
 
+## If the matched workflow isn't installed
+
+Once you've picked a workflow, check it's actually available to you. If the matched workflow skill isn't installed, don't fall back to guessing — tell the user to install it first:
+
+- **Just this workflow:** `npx skills add heygen-com/hyperframes --skill <workflow-name>` (e.g. `--skill pr-to-video` — bare name, no leading `/`).
+- **All workflows at once:** `npx skills add heygen-com/hyperframes --all` (core + every workflow, skips the picker).
+
+After they run it, re-read the workflow's skill and continue.
+
 ## Workflow details
 
 ### `/product-launch-video`


### PR DESCRIPTION
## What

Adds an **"If the matched workflow isn't installed"** rule to the `/hyperframes` entry skill. After routing picks a workflow, the agent checks whether that workflow's skill is actually available; if it isn't, it tells the user to install it instead of silently falling back to a guess, then re-reads the skill and continues.

## Why

During the skills launch, existing users won't yet have newly published workflow skills (e.g. `/pr-to-video`, `/product-launch-video`) installed. The entry skill is the natural single place to detect that and point the user at the one install command.

## What it says

- **Just this workflow:** `npx skills add heygen-com/hyperframes --skill <workflow-name>` (bare name, no leading `/`)
- **All workflows at once:** `npx skills add heygen-com/hyperframes --all` (core + every workflow, skips the picker)

`--all` is deliberate for the "everything" path: bare `npx skills add heygen-com/hyperframes` opens an interactive picker in a human terminal rather than installing everything, so it is not a reliable "all at once" command.

## Scope

Skill-content only — one section added to `skills/hyperframes/SKILL.md`, no code changes. oxfmt + commitlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
