### PR TITLE
fix(engine): remove -shortest from muxVideoWithAudio

### DIFF
--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -394,10 +394,10 @@ describe("muxVideoWithAudio audio codec handling", () => {
       "make_zero",
       "-r",
       "30",
-      "-shortest",
       "-y",
       "/tmp/output.mp4",
     ]);
+    expect(calls[0]!.args).not.toContain("-shortest");
     expect(calls[0]!.args).not.toContain("-use_editlist");
 
     emitClose(calls[0]!.proc, 0);
@@ -543,6 +543,30 @@ describe("muxVideoWithAudio audio codec handling", () => {
 
     emitClose(calls[0]!.proc, 0);
     await expect(muxPromise).resolves.toMatchObject({ success: true });
+  });
+
+  it("does not pass -shortest to ffmpeg (regression #1648)", async () => {
+    const { spawn, calls } = createSpawnSpy();
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { muxVideoWithAudio } = await import("./chunkEncoder.js");
+
+    for (const ext of [".mp4", ".mov", ".webm"] as const) {
+      const muxPromise = muxVideoWithAudio(
+        `/tmp/video-only${ext}`,
+        "/tmp/audio.aac",
+        `/tmp/output${ext}`,
+        undefined,
+        undefined,
+        { num: 30, den: 1 },
+      );
+      if (ext !== ".webm") await flushMuxCodecResolution();
+      const call = calls[calls.length - 1]!;
+      expect(call.args).not.toContain("-shortest");
+      emitClose(call.proc, 0);
+      await muxPromise;
+    }
   });
 
   it("keeps WebM audio on the Opus transcode path", async () => {

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -768,7 +768,7 @@ export async function muxVideoWithAudio(
     // output container metadata. `-c:v copy` is retained; no re-encode.
     args.push("-r", fpsToFfmpegArg(fps));
   }
-  args.push("-shortest", "-y", outputPath);
+  args.push("-y", outputPath);
 
   const processTimeout = config?.ffmpegProcessTimeout ?? DEFAULT_CONFIG.ffmpegProcessTimeout;
   const result = await runFfmpeg(args, { signal, timeout: processTimeout });


### PR DESCRIPTION
## Summary

Removes the `-shortest` flag from the FFmpeg mux command in `muxVideoWithAudio()` (`chunkEncoder.ts:771`).

FFmpeg 6.0 (bundled by `ffmpeg-static`, used by many users) has a regression where `-shortest` combined with `-c:v copy` over-truncates the video stream while leaving audio untouched. Reproduced: a 60s composition with audio renders as **1.4s video / 60s audio** under ffmpeg-static 6.0, while the same composition renders correctly with FFmpeg 8.x.

The flag is also redundant — the audio mixer already pads every track to `totalDuration` via `apad=whole_dur` and caps output with `-t totalDuration`. Both streams are duration-matched before they reach the mux step.

**One-line fix:** delete `-shortest` from the ffmpeg args array.

## Repro

```bash
# In a composition with <audio> elements:
HYPERFRAMES_FFMPEG_PATH=$(node -e "console.log(require('ffmpeg-static'))") \
  npx hyperframes render -o out.mp4 --fps 30

ffprobe -v error -show_entries stream=codec_type,duration,nb_frames -count_packets out.mp4
# video: 1.4s/42 frames (should be 60s/1800)
# audio: 60s/2814 frames (correct)
```

## Test plan

- [x] Updated existing `muxVideoWithAudio` args snapshot to remove `-shortest`
- [x] Added regression test asserting `-shortest` is absent for all container formats (mp4, mov, webm)
- [x] `bun run build` passes
- [x] Engine test suite passes (79 tests)

Closes #1648