### PR TITLE
fix(producer): split capture average timing

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1459,6 +1459,8 @@ function trackRenderMetrics(
     stageVideoExtractMs: stages.videoExtractMs,
     stageAudioProcessMs: stages.audioProcessMs,
     stageCaptureMs: stages.captureMs,
+    stageCaptureSetupMs: stages.captureSetupMs,
+    stageCaptureFrameMs: stages.captureFrameMs,
     stageEncodeMs: stages.encodeMs,
     stageAssembleMs: stages.assembleMs,
     extractResolveMs: extract?.resolveMs,

--- a/packages/cli/src/server/studioRenderTelemetry.test.ts
+++ b/packages/cli/src/server/studioRenderTelemetry.test.ts
@@ -93,6 +93,8 @@ const fullPerf: RenderPerfSummary = {
     videoExtractMs: 200,
     audioProcessMs: 50,
     captureMs: 4000,
+    captureSetupMs: 750,
+    captureFrameMs: 3250,
     encodeMs: 500,
     assembleMs: 150,
   },
@@ -161,6 +163,8 @@ describe("studioRenderTelemetry", () => {
       expect(p.stageVideoExtractMs).toBe(200);
       expect(p.stageAudioProcessMs).toBe(50);
       expect(p.stageCaptureMs).toBe(4000);
+      expect(p.stageCaptureSetupMs).toBe(750);
+      expect(p.stageCaptureFrameMs).toBe(3250);
       expect(p.stageEncodeMs).toBe(500);
       expect(p.stageAssembleMs).toBe(150);
       // video-extract breakdown

--- a/packages/cli/src/server/studioRenderTelemetry.ts
+++ b/packages/cli/src/server/studioRenderTelemetry.ts
@@ -41,6 +41,8 @@ function stagesPayload(stages: Record<string, number>): Partial<RenderCompletePr
     stageVideoExtractMs: stages.videoExtractMs,
     stageAudioProcessMs: stages.audioProcessMs,
     stageCaptureMs: stages.captureMs,
+    stageCaptureSetupMs: stages.captureSetupMs,
+    stageCaptureFrameMs: stages.captureFrameMs,
     stageEncodeMs: stages.encodeMs,
     stageAssembleMs: stages.assembleMs,
   };

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -5,8 +5,13 @@ vi.mock("./client.js", () => ({
   trackEvent: (...args: unknown[]) => trackEvent(...args),
 }));
 
-const { trackRenderError, trackRenderObservation, trackCommandFailure, trackCliError } =
-  await import("./events.js");
+const {
+  trackRenderComplete,
+  trackRenderError,
+  trackRenderObservation,
+  trackCommandFailure,
+  trackCliError,
+} = await import("./events.js");
 
 describe("render telemetry events", () => {
   beforeEach(() => {
@@ -46,6 +51,31 @@ describe("render telemetry events", () => {
       "render_error",
       expect.objectContaining({ source: "studio" }),
       "browser-user-123",
+    );
+  });
+
+  it("sends split capture-stage timing fields on render_complete", () => {
+    trackRenderComplete({
+      durationMs: 6000,
+      fps: 30,
+      quality: "standard",
+      docker: false,
+      gpu: false,
+      stageCaptureMs: 5100,
+      stageCaptureSetupMs: 1860,
+      stageCaptureFrameMs: 3240,
+      captureAvgMs: 27,
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "render_complete",
+      expect.objectContaining({
+        stage_capture_ms: 5100,
+        stage_capture_setup_ms: 1860,
+        stage_capture_frame_ms: 3240,
+        capture_avg_ms: 27,
+      }),
+      undefined,
     );
   });
 

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -129,6 +129,8 @@ export function trackRenderComplete(
     stageVideoExtractMs?: number;
     stageAudioProcessMs?: number;
     stageCaptureMs?: number;
+    stageCaptureSetupMs?: number;
+    stageCaptureFrameMs?: number;
     stageEncodeMs?: number;
     stageAssembleMs?: number;
     // Video-extraction breakdown (from RenderPerfSummary.videoExtractBreakdown)
@@ -176,6 +178,8 @@ export function trackRenderComplete(
       stage_video_extract_ms: props.stageVideoExtractMs,
       stage_audio_process_ms: props.stageAudioProcessMs,
       stage_capture_ms: props.stageCaptureMs,
+      stage_capture_setup_ms: props.stageCaptureSetupMs,
+      stage_capture_frame_ms: props.stageCaptureFrameMs,
       stage_encode_ms: props.stageEncodeMs,
       stage_assemble_ms: props.stageAssembleMs,
       extract_resolve_ms: props.extractResolveMs,

--- a/packages/producer/src/services/render/perfSummary-dedup.test.ts
+++ b/packages/producer/src/services/render/perfSummary-dedup.test.ts
@@ -3,7 +3,10 @@ import type { CapturePerfSummary } from "@hyperframes/engine";
 import { buildRenderPerfSummary } from "./perfSummary.js";
 import { createRenderJob } from "../renderOrchestrator.js";
 
-function baseInput(dedupPerfs: CapturePerfSummary[]) {
+function baseInput(
+  dedupPerfs: CapturePerfSummary[],
+  overrides: Partial<Parameters<typeof buildRenderPerfSummary>[0]> = {},
+) {
   return {
     job: createRenderJob({ fps: { num: 30, den: 1 }, quality: "high" }),
     workerCount: dedupPerfs.length || 1,
@@ -24,6 +27,7 @@ function baseInput(dedupPerfs: CapturePerfSummary[]) {
     peakRssBytes: 0,
     peakHeapUsedBytes: 0,
     dedupPerfs,
+    ...overrides,
   };
 }
 
@@ -126,5 +130,35 @@ describe("buildRenderPerfSummary static-dedup aggregation", () => {
       reusedFrames: 0,
       skipReason: undefined,
     });
+  });
+});
+
+describe("buildRenderPerfSummary capture average attribution", () => {
+  it("uses frame-capture time for captureAvgMs instead of setup-inclusive captureMs", () => {
+    const summary = buildRenderPerfSummary(
+      baseInput([], {
+        totalFrames: 120,
+        perfStages: {
+          captureMs: 5_100,
+          captureSetupMs: 1_860,
+          captureFrameMs: 3_240,
+        },
+      }),
+    );
+
+    expect(summary.captureAvgMs).toBe(27);
+  });
+
+  it("falls back to legacy captureMs when captureFrameMs is absent", () => {
+    const summary = buildRenderPerfSummary(
+      baseInput([], {
+        totalFrames: 120,
+        perfStages: {
+          captureMs: 5_100,
+        },
+      }),
+    );
+
+    expect(summary.captureAvgMs).toBe(43);
   });
 });

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -122,7 +122,10 @@ export function buildRenderPerfSummary(input: {
     observability: input.observability,
     captureAvgMs:
       input.totalFrames > 0
-        ? Math.round((input.perfStages.captureMs ?? 0) / input.totalFrames)
+        ? Math.round(
+            (input.perfStages.captureFrameMs ?? input.perfStages.captureMs ?? 0) /
+              input.totalFrames,
+          )
         : undefined,
     peakRssMb: Math.round(input.peakRssBytes / (1024 * 1024)),
     peakHeapUsedMb: Math.round(input.peakHeapUsedBytes / (1024 * 1024)),

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -293,6 +293,14 @@ export interface RenderPerfSummary {
   videoExtractBreakdown?: ExtractionPhaseBreakdown;
   /** Bytes on disk in the render's workDir at assembly time (sampled before cleanup). Lets callers correlate peak temp usage with render duration. */
   tmpPeakBytes?: number;
+  /**
+   * Average wall-clock capture time per output frame.
+   *
+   * Uses `stages.captureFrameMs` when present so fixed Stage 4 setup costs
+   * (file server creation, calibration, readiness/session init, strategy
+   * resolution) do not get amortized into a per-frame metric. Older summaries
+   * without the split fall back to `stages.captureMs`.
+   */
   captureAvgMs?: number;
   capturePeakMs?: number;
   captureCalibration?: {
@@ -1488,6 +1496,8 @@ export async function executeRenderJob(
       lastBrowserConsole = hdrRes.lastBrowserConsole;
       hdrPerf = hdrRes.hdrPerf;
       perfStages.captureMs = hdrRes.captureDurationMs;
+      perfStages.captureFrameMs = hdrRes.captureDurationMs;
+      perfStages.captureSetupMs = Math.max(0, Date.now() - stage4Start - hdrRes.captureDurationMs);
       perfStages.encodeMs = hdrRes.encodeMs;
     } else {
       // ── Standard capture paths (SDR or DOM-only HDR) ──────────────────
@@ -1497,6 +1507,7 @@ export async function executeRenderJob(
       // and we fall back to the disk path below.
       let streamingHandled = false;
       if (useStreamingEncode) {
+        const captureFrameStart = Date.now();
         const streamingRes = await observeRenderStage(
           observability,
           "capture_streaming",
@@ -1537,6 +1548,7 @@ export async function executeRenderJob(
               dedupPerfs,
             }),
         );
+        const captureFrameMs = Date.now() - captureFrameStart;
         if (streamingRes.success) {
           streamingHandled = true;
           workerCount = streamingRes.workerCount;
@@ -1544,6 +1556,8 @@ export async function executeRenderJob(
           probeSession = streamingRes.probeSession;
           lastBrowserConsole = streamingRes.lastBrowserConsole;
           perfStages.captureMs = Date.now() - stage4Start;
+          perfStages.captureFrameMs = captureFrameMs;
+          perfStages.captureSetupMs = Math.max(0, perfStages.captureMs - captureFrameMs);
           perfStages.encodeMs = streamingRes.encodeMs; // Overlapped with capture
         } else {
           useStreamingEncode = false;
@@ -1554,6 +1568,7 @@ export async function executeRenderJob(
 
       if (!streamingHandled) {
         // ── Disk-based capture (original flow) ────────────────────────────
+        const captureFrameStart = Date.now();
         const captureRes = await observeRenderStage(
           observability,
           "capture_disk",
@@ -1580,12 +1595,15 @@ export async function executeRenderJob(
               onProgress,
             }),
         );
+        const captureFrameMs = Date.now() - captureFrameStart;
         workerCount = captureRes.workerCount;
         updateCaptureObservability({ workerCount });
         probeSession = captureRes.probeSession;
         lastBrowserConsole = captureRes.lastBrowserConsole;
 
         perfStages.captureMs = Date.now() - stage4Start;
+        perfStages.captureFrameMs = captureFrameMs;
+        perfStages.captureSetupMs = Math.max(0, perfStages.captureMs - captureFrameMs);
 
         const encodeRes = await observeRenderStage(
           observability,


### PR DESCRIPTION
## Problem

Issue #1653 reports a `capture_avg_ms` regression after 0.7.0. The investigation showed that `captureAvgMs` was not measuring only per-frame capture work: standard capture paths set `stages.captureMs` from `stage4Start`, before file server setup, capture calibration, capture strategy resolution, and capture-session initialization. The summary then divided that setup-inclusive duration by `totalFrames`, so short renders inflated a per-frame metric with fixed init cost.

## What this fixes

This splits Stage 4 timing into:

- `stages.captureMs` — existing broad Stage 4 duration, preserved for current telemetry consumers.
- `stages.captureSetupMs` — setup/calibration/readiness overhead before the frame capture stage completes.
- `stages.captureFrameMs` — the actual `capture_streaming`, `capture_disk`, or HDR layered capture phase duration.

`captureAvgMs` now uses `captureFrameMs / totalFrames` when the split field exists, with a fallback to legacy `captureMs` for older serialized summaries. CLI and Studio telemetry now forward the split fields as `stage_capture_setup_ms` and `stage_capture_frame_ms`.

## Root cause

The 0.7.0 line added useful correctness work in render initialization, including image readiness/decode, static-frame dedup arming, and stricter render-readiness gating. Those costs landed inside the old `stage4Start` timing window. The metric made them look like per-frame capture slowdown because it amortized fixed setup time across every frame.

This PR does not disable any correctness path. It fixes attribution first so the next affected render can tell us whether remaining cost is setup, calibration/readiness, dedup verification, or actual frame capture.

## Verification

### Local checks

- `bun test packages/producer/src/services/render/perfSummary-dedup.test.ts`
- `bun test packages/cli/src/telemetry/events.test.ts`
- `bun test packages/cli/src/server/studioRenderTelemetry.test.ts`
- `bunx oxfmt --check packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/render/perfSummary.ts packages/producer/src/services/render/perfSummary-dedup.test.ts packages/cli/src/telemetry/events.ts packages/cli/src/telemetry/events.test.ts packages/cli/src/commands/render.ts packages/cli/src/server/studioRenderTelemetry.ts packages/cli/src/server/studioRenderTelemetry.test.ts`
- `bunx oxlint packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/render/perfSummary.ts packages/producer/src/services/render/perfSummary-dedup.test.ts packages/cli/src/telemetry/events.ts packages/cli/src/telemetry/events.test.ts packages/cli/src/commands/render.ts packages/cli/src/server/studioRenderTelemetry.ts packages/cli/src/server/studioRenderTelemetry.test.ts`
- `bun run --filter @hyperframes/producer typecheck`
- `bun run --filter @hyperframes/cli typecheck`
- `bun run build:producer`
- lefthook pre-commit: lint, format, fallow, typecheck, commitlint

Real render check:

```json
{
  "fixture": "packages/producer/tests/gsap-letters-render-compat/src",
  "totalFrames": 120,
  "captureAvgMs": 21,
  "captureMs": 3900,
  "captureSetupMs": 1347,
  "captureFrameMs": 2553
}
```

### Browser verification

- Rendered `/tmp/hf-1653-gsap-letters.mp4` from the real producer path.
- Opened a local proof page in `agent-browser` that embeds the MP4 and displays the split timing fields.
- Screenshot: `/tmp/hf-1653-browser-proof.png`
- Recording: `/tmp/hf-1653-browser-proof.webm`

## Notes

- `stages.captureMs` stays backward-compatible as the existing broad Stage 4 number.
- `captureAvgMs` is the corrected per-frame metric.
- If the reporter still sees a regression after this, ask for the new perf summary fields so we can target the actual phase instead of guessing.

Addresses #1653.
