### PR TITLE
fix(cli): install skills into the agent's native dir 

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -800,11 +800,29 @@ export default defineCommand({
       for (const f of readdirSync(destDir).filter((f) => !f.startsWith("."))) {
         console.log(`  ${c.accent(f)}`);
       }
+
+      // Install AI coding skills now. Agents drive `init` non-interactively, so
+      // installing here (rather than only printing the command) is what makes
+      // the skills actually land — otherwise the agent later hits
+      // "Unknown skill: <workflow>". Target the detected agent so skills land in
+      // its native dir (e.g. `.claude/skills`), not the universal `.agents/skills`
+      // that Claude Code does not read. Opt out with --skip-skills.
+      if (!skipSkills) {
+        const { installAllSkills, resolveSkillsAgent } = await import("./skills.js");
+        await installAllSkills({ agent: resolveSkillsAgent() });
+      }
+
       console.log();
       console.log("Get started:");
       console.log();
-      console.log(`  ${c.accent("1.")} Install AI coding skills (one-time):`);
-      console.log(`     ${c.accent("npx skills add heygen-com/hyperframes")}`);
+      if (skipSkills) {
+        console.log(`  ${c.accent("1.")} Install AI coding skills (one-time):`);
+        console.log(`     ${c.accent("npx skills add heygen-com/hyperframes --yes")}`);
+      } else {
+        console.log(
+          `  ${c.accent("1.")} Restart your AI agent (new session) so it loads the skills.`,
+        );
+      }
       console.log();
       console.log(`  ${c.accent("2.")} Open this project with your AI coding agent:`);
       console.log(

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -3,6 +3,7 @@ import { execFileSync, spawn } from "node:child_process";
 import * as clack from "@clack/prompts";
 import { c } from "../ui/colors.js";
 import { buildNpxCommand } from "../utils/npxCommand.js";
+import { detectAgentRuntime, type AgentRuntime } from "../telemetry/agent_runtime.js";
 
 function hasNpx(): boolean {
   const npx = buildNpxCommand(["--version"]);
@@ -14,8 +15,30 @@ function hasNpx(): boolean {
   }
 }
 
-function runSkillsAdd(repo: string): Promise<void> {
-  const npx = buildNpxCommand(["skills", "add", repo, "--all"]);
+// Map the detected coding-agent runtime to the upstream `skills` CLI `--agent`
+// id. Naming a specific agent makes `skills add` install into that agent's
+// native dir (e.g. `.claude/skills` for Claude Code); the default multi-agent
+// install targets a universal `.agents/skills` that Claude Code does not read.
+const SKILLS_AGENT_ID: Partial<Record<NonNullable<AgentRuntime>, string>> = {
+  claude_code: "claude-code",
+  codex: "codex",
+  cursor: "cursor",
+};
+
+/** The `skills` CLI `--agent` id for the agent driving this process, if known. */
+export function resolveSkillsAgent(): string | undefined {
+  const runtime = detectAgentRuntime();
+  return runtime ? SKILLS_AGENT_ID[runtime] : undefined;
+}
+
+function runSkillsAdd(repo: string, opts: { agent?: string } = {}): Promise<void> {
+  // With a known agent, target it explicitly so skills land in that agent's
+  // native dir; `--yes` keeps it non-interactive. Otherwise install for all
+  // agents (`--all` is already non-interactive).
+  const addArgs = opts.agent
+    ? ["skills", "add", repo, "--agent", opts.agent, "--yes"]
+    : ["skills", "add", repo, "--all"];
+  const npx = buildNpxCommand(addArgs);
   return new Promise((resolve, reject) => {
     const child = spawn(npx.command, npx.args, {
       stdio: "inherit",
@@ -40,6 +63,29 @@ function runSkillsAdd(repo: string): Promise<void> {
 
 const SOURCES = [{ name: "HyperFrames", repo: "heygen-com/hyperframes" }];
 
+/**
+ * Install every HyperFrames skill source. Pass `{ agent }` (see
+ * `resolveSkillsAgent`) so skills land in that agent's native dir; with no
+ * agent it installs for all agents non-interactively.
+ */
+export async function installAllSkills(opts: { agent?: string } = {}): Promise<void> {
+  if (!hasNpx()) {
+    clack.log.error(c.error("npx not found. Install Node.js and retry."));
+    return;
+  }
+
+  for (const source of SOURCES) {
+    console.log();
+    console.log(c.bold(`Installing ${source.name} skills...`));
+    console.log();
+    try {
+      await runSkillsAdd(source.repo, opts);
+    } catch {
+      console.log(c.dim(`${source.name} skills skipped`));
+    }
+  }
+}
+
 export default defineCommand({
   meta: {
     name: "skills",
@@ -47,20 +93,6 @@ export default defineCommand({
   },
   args: {},
   async run() {
-    if (!hasNpx()) {
-      clack.log.error(c.error("npx not found. Install Node.js and retry."));
-      return;
-    }
-
-    for (const source of SOURCES) {
-      console.log();
-      console.log(c.bold(`Installing ${source.name} skills...`));
-      console.log();
-      try {
-        await runSkillsAdd(source.repo);
-      } catch {
-        console.log(c.dim(`${source.name} skills skipped`));
-      }
-    }
+    await installAllSkills();
   },
 });


### PR DESCRIPTION
…ve init

`hyperframes init` only installed AI coding skills on the interactive path (behind a clack confirm). When an agent drives it non-interactively (no TTY), it just printed `npx skills add ...` and returned — so skills were never installed and the agent later hit `Unknown skill: <workflow>` (e.g. product-launch-video) and free-handed a composition.

Also, the default `npx skills add --all` installs to a *universal* `.agents/skills` dir that Claude Code does not read; only an explicit `--agent <id>` lands in the agent's native dir (`.claude/skills`).

- init: in the non-interactive branch, install skills (unless --skip-skills) instead of only printing the command, and target the detected agent via `resolveSkillsAgent()` (reuses `detectAgentRuntime()`).
- skills: `runSkillsAdd` accepts `{ agent }` -> `--agent <id> --yes` so skills land in `.claude/skills`; falls back to `--all` when no agent is detected. The explicit `hyperframes skills` command is unchanged.

Verified: branch `hyperframes init` in a Claude Code env installs into `.claude/skills` and `Skill(product-launch-video)` loads.

## What

Brief description of the change.

## Why

Why is this change needed?

## How

How was this implemented? Any notable design decisions?

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)
