### PR TITLE
feat(studio): AE-correct Easy Ease presets + speed curve plan

### DIFF
--- a/packages/studio/src/components/editor/EaseCurveSection.tsx
+++ b/packages/studio/src/components/editor/EaseCurveSection.tsx
@@ -3,14 +3,14 @@ import { EASE_CURVES, EASE_LABELS, parseCustomEaseFromString } from "./gsapAnima
 import { roundToCenti } from "../../utils/rounding";
 
 const PRESET_GRID_EASES = [
+  "ae-ease",
+  "ae-ease-in",
+  "ae-ease-out",
   "none",
   "power2.out",
   "power2.in",
-  "power2.inOut",
-  "power3.out",
   "back.out",
   "expo.out",
-  "elastic.out",
 ] as const;
 
 function MiniCurveSvg({

--- a/packages/studio/src/components/editor/gsapAnimationConstants.ts
+++ b/packages/studio/src/components/editor/gsapAnimationConstants.ts
@@ -119,6 +119,9 @@ export const EASE_LABELS: Record<string, string> = {
   "spring-stiff": "Stiff spring",
   "spring-wobbly": "Wobbly spring",
   "spring-heavy": "Heavy spring",
+  "ae-ease": "Easy Ease (AE)",
+  "ae-ease-in": "Easy Ease In (AE)",
+  "ae-ease-out": "Easy Ease Out (AE)",
 };
 
 export const EASE_CURVES: Record<string, [number, number, number, number]> = {
@@ -141,6 +144,9 @@ export const EASE_CURVES: Record<string, [number, number, number, number]> = {
   "expo.out": [0.16, 1, 0.3, 1],
   "expo.in": [0.7, 0, 0.84, 0],
   "expo.inOut": [0.87, 0, 0.13, 1],
+  "ae-ease": [0.333, 0, 0.667, 1],
+  "ae-ease-in": [0.333, 0, 0.667, 0.667],
+  "ae-ease-out": [0.333, 0.333, 0.667, 1],
 };
 
 export function parseCustomEaseFromString(ease: string): {


### PR DESCRIPTION
## Summary

- **AE Easy Ease presets**: adds After Effects' mathematically correct bezier values as first-class presets in the Animation panel — Easy Ease `(0.333, 0, 0.667, 1)`, Easy Ease In, Easy Ease Out. These produce the softer deceleration AE users expect, vs GSAP's `power2.inOut` which is noticeably stiffer.
- **Preset grid reorder**: the top row now leads with the three AE presets, pushing rarely-used GSAP eases down.
- **Plan for full speed curve system**: `docs/plans/2026-06-23-001-feat-ae-style-speed-curves-plan.md` covers the phased approach — per-keyframe bezier editing (Phase 1), velocity-based post-recording fitting, and a mini graph editor (Phase 2).

This is the first PR in the speed curves track. The parser already supports per-keyframe `ease` writes (the `update-keyframe` mutation accepts an `ease` field) — the follow-up PR wires the UI to expose per-keyframe bezier editing in the Animation panel.

## Context

User feedback on Twitter: "needs to be smoothable and controllable with time speed curves in general, do a quick readup on how AE does all of its curves." Research found AE uses speed=0, influence=33.33% for Easy Ease, mapping to `cubic-bezier(0.333, 0, 0.667, 1)` — significantly different from CSS `ease` or GSAP `power2.inOut`.

## Test plan

- [ ] Open Animation panel → Speed curve section shows AE presets (Easy Ease, Easy Ease In, Easy Ease Out) in the top row
- [ ] Click Easy Ease → preview curve matches AE's softer deceleration profile
- [ ] Existing named eases (power2.out, back.out, etc.) still work