### PR TITLE
fix(engine): restore fast screenshot path for viewport captures

### DIFF
--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -41,7 +41,29 @@ describe("pageScreenshotCapture supersample plumbing", () => {
     expect(send).toHaveBeenCalledWith(
       "Page.captureScreenshot",
       expect.objectContaining({
+        captureBeyondViewport: false,
         clip: { x: 0, y: 0, width: 1920, height: 1080, scale: 1 },
+      }),
+    );
+  });
+
+  it("uses captureBeyondViewport only when callers opt in", async () => {
+    const send = vi.fn().mockResolvedValue({ data: ONE_PIXEL_PNG_B64 });
+    const page = makeFakePageWithCdp(send);
+
+    await pageScreenshotCapture(page, {
+      width: 1080,
+      height: 1920,
+      fps: { num: 30, den: 1 },
+      format: "jpeg",
+      captureBeyondViewport: true,
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      "Page.captureScreenshot",
+      expect.objectContaining({
+        captureBeyondViewport: true,
+        clip: { x: 0, y: 0, width: 1080, height: 1920, scale: 1 },
       }),
     );
   });

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -135,11 +135,10 @@ export async function pageScreenshotCapture(page: Page, options: CaptureOptions)
     format: isPng ? "png" : "jpeg",
     quality: isPng ? undefined : (options.quality ?? 80),
     fromSurface: true,
-    // The explicit clip rect constrains output to exact composition
-    // dimensions. The viewport-boundary pre-clip from captureBeyondViewport:
-    // false is redundant, and Chrome's compositor rounds it inward under
-    // multi-tab load — clipping the bottom/right edge of tall viewports.
-    captureBeyondViewport: true,
+    // Use Chrome's faster viewport-bound screenshot path by default. Callers
+    // opt into the beyond-viewport path only for known compositor edge cases,
+    // such as native video surfaces in tall portrait renders.
+    captureBeyondViewport: options.captureBeyondViewport ?? false,
     optimizeForSpeed: !isPng,
     clip,
   });
@@ -172,7 +171,8 @@ export async function captureScreenshotWithAlpha(
     const result = await client.send("Page.captureScreenshot", {
       format: "png",
       fromSurface: true,
-      captureBeyondViewport: true, // see pageScreenshotCapture for rationale
+      // Preserve the #1094 tall-portrait edge-clipping guard on HDR alpha captures.
+      captureBeyondViewport: true,
       optimizeForSpeed: false, // `true` uses a zero-alpha-aware fast path that crushes real alpha values — observed empirically, CDP docs don't spell it out
       clip: { x: 0, y: 0, width, height, scale: 1 },
     });
@@ -237,7 +237,8 @@ export async function captureAlphaPng(page: Page, width: number, height: number)
   const result = await client.send("Page.captureScreenshot", {
     format: "png",
     fromSurface: true,
-    captureBeyondViewport: true, // see pageScreenshotCapture for rationale
+    // Preserve the #1094 tall-portrait edge-clipping guard on HDR alpha captures.
+    captureBeyondViewport: true,
     optimizeForSpeed: false, // must be false to preserve alpha
     clip: { x: 0, y: 0, width, height, scale: 1 },
   });

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -93,6 +93,13 @@ export interface CaptureOptions {
   quality?: number;
   deviceScaleFactor?: number;
   /**
+   * Opt into Chrome's capture-beyond-viewport screenshot path. Keep this off
+   * for ordinary viewport-sized captures because it is substantially slower in
+   * Chrome's screenshot compositor path. Enable for known compositor edge cases
+   * such as native video surfaces in tall portrait renders.
+   */
+  captureBeyondViewport?: boolean;
+  /**
    * FFmpeg-probed intrinsic dimensions for videos whose frames are injected
    * out-of-band. Applied before the readiness wait so layout that depends on
    * video aspect ratio (e.g. `height:auto`) stays stable even if Chromium never

--- a/packages/producer/src/services/distributed/renderChunk.ts
+++ b/packages/producer/src/services/distributed/renderChunk.ts
@@ -507,6 +507,7 @@ export async function renderChunk(
       // declare `data-composition-variables` leave this undefined and the
       // engine skips the `evaluateOnNewDocument` injection.
       variables: encoder.variables,
+      captureBeyondViewport: (planVideos?.videos.length ?? 0) > 0,
       // lock the BeginFrame warmup loop to a fixed iteration count so
       // `beginFrameTimeTicks` is host-independent. Only chunks ever set this.
       lockWarmupTicks: true,

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -33,6 +33,7 @@ export interface BrowserDiagnosticSummary {
 export interface RenderCaptureObservability {
   forceScreenshot: boolean;
   captureMode: "screenshot" | "beginframe";
+  captureBeyondViewport?: boolean;
   workerCount?: number;
   useStreamingEncode?: boolean;
   useLayeredComposite?: boolean;

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1212,7 +1212,11 @@ export async function executeRenderJob(
       quality: needsAlpha ? undefined : job.config.quality === "draft" ? 80 : 95,
       variables: job.config.variables,
       deviceScaleFactor,
+      captureBeyondViewport: composition.videos.length > 0,
     };
+    updateCaptureObservability({
+      captureBeyondViewport: captureOptions.captureBeyondViewport ?? false,
+    });
 
     // Capture sessions do not need native browser metadata for videos whose
     // pixels come from out-of-band FFmpeg frame extraction. Waiting on those
@@ -1437,6 +1441,7 @@ export async function executeRenderJob(
     observability.checkpoint("capture_strategy", "resolved", {
       workerCount,
       forceScreenshot: captureForceScreenshot,
+      captureBeyondViewport: captureOptions.captureBeyondViewport ?? false,
       useStreamingEncode,
       useLayeredComposite,
       usePageSideCompositing: usePageSideCompositingForTransitions,


### PR DESCRIPTION
## Problem

Issue #1653 is still reproducible after the metric attribution fix: the reporter's new 0.7.3 summary shows setup is tiny (`captureSetupMs: 64`) while actual frame capture is slow (`captureFrameMs: 15641`, `captureAvgMs: 174`) on a pure DOM/GSAP waveform composition with no video, audio, or images.

Local reproduction matched that shape. On the reporter fixture, 0.6.42 captured 90 frames in ~11.0s locally while 0.7.3 captured the same frames in ~17.3s with `workers: 4`. A temporary timing probe showed seek stayed ~1-2ms/frame; the extra time was in `Page.captureScreenshot`.

## What this fixes

This restores Chrome's faster viewport-bound screenshot path for ordinary viewport-sized captures by defaulting `pageScreenshotCapture` back to `captureBeyondViewport: false`.

The slower `captureBeyondViewport: true` path is now explicit on `CaptureOptions` and producer opts into it when a composition contains `<video>` elements. Distributed chunks use the same rule from the serialized video plan. That keeps the previous portrait video edge-clipping protection scoped to the class of renders it was added for instead of applying it to pure DOM/GSAP renders.

The chosen path is now also surfaced in render observability: `capture_strategy` checkpoints and render-level `capture` summaries include `captureBeyondViewport`, so future reports can tell whether a render used the fast viewport-bound path or the slower beyond-viewport compositor path.

## Root cause

PR #1094 changed all CDP screenshot call sites to `captureBeyondViewport: true` to avoid bottom/right clipping on tall portrait video renders under multi-tab load. That fixed the edge case, but it also moved every normal screenshot capture onto Chrome's slower beyond-viewport compositor path even when the explicit clip rect exactly matched the page viewport.

For pure DOM/GSAP compositions like the #1653 waveform fixture, there is no video compositor surface edge case to protect. The global flag was the regression: it made the screenshot phase substantially more expensive while leaving the seek/runtime phase essentially unchanged.

This specifically targets the screenshot-capture cohort: macOS/Windows screenshot mode, and Linux renders that are forced onto screenshot capture. BeginFrame renders are unchanged because `HeadlessExperimental.beginFrame` does not use this CDP flag.

## Verification

### Local checks

- `bun run --filter @hyperframes/engine test -- src/services/screenshotService.test.ts`
- `bun test packages/producer/src/services/render/observability.test.ts`
- `bun run build:producer`
- Reporter fixture render, `workers: 1`: `captureFrameMs: 13184`, `captureAvgMs: 146`, `totalFrames: 90`
- Reporter fixture render, `workers: 4`: `captureFrameMs: 14495`, `captureAvgMs: 161`, `totalFrames: 90`
- `bun run --filter @hyperframes/engine typecheck`
- `bun run --filter @hyperframes/producer typecheck`
- `bunx oxlint packages/engine/src/types.ts packages/engine/src/services/screenshotService.ts packages/engine/src/services/screenshotService.test.ts packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/distributed/renderChunk.ts`
- `bunx oxfmt --check packages/engine/src/types.ts packages/engine/src/services/screenshotService.ts packages/engine/src/services/screenshotService.test.ts packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/distributed/renderChunk.ts`
- Follow-up review changes:
  - `bunx oxlint packages/engine/src/services/screenshotService.ts packages/producer/src/services/render/observability.ts packages/producer/src/services/renderOrchestrator.ts`
  - `bunx oxfmt --check packages/engine/src/services/screenshotService.ts packages/producer/src/services/render/observability.ts packages/producer/src/services/renderOrchestrator.ts`
- lefthook pre-commit: lint, format, fallow, typecheck, commitlint

### Browser verification

- Rendered `/tmp/hf-1653-audio-wave-fix-w4.mp4` from the real producer path.
- Opened the rendered MP4 with `agent-browser`.
- Screenshot: `/tmp/hf-1653-browser-proof/rendered-waveform.png`
- Recording: `/tmp/hf-1653-browser-proof/rendered-waveform.webm`

### Review follow-up

- Re-ran `portrait-edge-bleed` on clean `origin/main` (`20d7200b8`) in `/Users/miguel07code/dev/hyperframes-oss/.worktrees/repro-1653-main-portrait`.
- Main produced the same local macOS/Chrome 151 failure as this PR: `PSNR 26.736581` for all checkpoints, below the fixture's `minPsnr: 30`.
- That disambiguates the local portrait fixture result as pre-existing macOS/Chrome-151 golden drift, not a regression introduced by this PR. CI's Linux regression shards remain the canonical guard and passed.

## Notes

- `bun test packages/engine/src/services/screenshotService.test.ts` runs the file under Bun's test runner and fails two pre-existing `vi` spy assertions. The package's Vitest command passes the same file.
- `captureScreenshotWithAlpha` and `captureAlphaPng` intentionally keep `captureBeyondViewport: true` for HDR alpha captures to preserve the #1094 tall-portrait edge-clipping guard. Extending the opt-in plumbing to HDR alpha captures can be a follow-up, but this PR keeps that smaller correctness-sensitive cohort unchanged.
- This does not implement the reporter's original init-overhead hypotheses (GSAP proxy drain, `__renderReady` polling, static-dedup verification, image decode readiness). The new split timing shows their current reproduction is dominated by frame screenshot time, not setup time.

Addresses #1653.
