### PR TITLE
fix(cli): install skills into project dir on init

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -800,11 +800,27 @@ export default defineCommand({
       for (const f of readdirSync(destDir).filter((f) => !f.startsWith("."))) {
         console.log(`  ${c.accent(f)}`);
       }
+
+      if (!skipSkills) {
+        const { installAllSkills } = await import("./skills.js");
+        // --yes keeps it non-interactive. When Claude Code is driving
+        // (CLAUDECODE env var), target its native dir so skills land in
+        // .claude/skills/ instead of only .agents/skills/.
+        const args = process.env["CLAUDECODE"] ? ["--agent", "claude-code", "--yes"] : ["--yes"];
+        await installAllSkills({ cwd: destDir, extraArgs: args });
+      }
+
       console.log();
       console.log("Get started:");
       console.log();
-      console.log(`  ${c.accent("1.")} Install AI coding skills (one-time):`);
-      console.log(`     ${c.accent("npx skills add heygen-com/hyperframes")}`);
+      if (skipSkills) {
+        console.log(`  ${c.accent("1.")} Install AI coding skills (one-time):`);
+        console.log(`     ${c.accent("npx skills add heygen-com/hyperframes --yes")}`);
+      } else {
+        console.log(
+          `  ${c.accent("1.")} Restart your AI agent (new session) so it loads the skills.`,
+        );
+      }
       console.log();
       console.log(`  ${c.accent("2.")} Open this project with your AI coding agent:`);
       console.log(
@@ -1018,8 +1034,8 @@ export default defineCommand({
         process.exit(0);
       }
       if (installSkills) {
-        const skillsCmd = await import("./skills.js").then((m) => m.default);
-        await runCommand(skillsCmd, { rawArgs: [] });
+        const { installAllSkills } = await import("./skills.js");
+        await installAllSkills({ cwd: destDir });
       }
     }
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -14,12 +14,16 @@ function hasNpx(): boolean {
   }
 }
 
-function runSkillsAdd(repo: string): Promise<void> {
-  const npx = buildNpxCommand(["skills", "add", repo, "--all"]);
+function runSkillsAdd(
+  repo: string,
+  opts: { cwd?: string; extraArgs?: string[] } = {},
+): Promise<void> {
+  const npx = buildNpxCommand(["skills", "add", repo, ...(opts.extraArgs ?? ["--all"])]);
   return new Promise((resolve, reject) => {
     const child = spawn(npx.command, npx.args, {
       stdio: "inherit",
       timeout: 120_000,
+      cwd: opts.cwd,
       // GH #316 — the upstream `skills` CLI shells out to `git clone`.
       // When Git's clone-hook protection is active (shipped on by
       // default in 2.45.1, reverted in 2.45.2, still present on many
@@ -40,6 +44,26 @@ function runSkillsAdd(repo: string): Promise<void> {
 
 const SOURCES = [{ name: "HyperFrames", repo: "heygen-com/hyperframes" }];
 
+export async function installAllSkills(
+  opts: { cwd?: string; extraArgs?: string[] } = {},
+): Promise<void> {
+  if (!hasNpx()) {
+    clack.log.error(c.error("npx not found. Install Node.js and retry."));
+    return;
+  }
+
+  for (const source of SOURCES) {
+    console.log();
+    console.log(c.bold(`Installing ${source.name} skills...`));
+    console.log();
+    try {
+      await runSkillsAdd(source.repo, opts);
+    } catch {
+      console.log(c.dim(`${source.name} skills skipped`));
+    }
+  }
+}
+
 export default defineCommand({
   meta: {
     name: "skills",
@@ -47,20 +71,6 @@ export default defineCommand({
   },
   args: {},
   async run() {
-    if (!hasNpx()) {
-      clack.log.error(c.error("npx not found. Install Node.js and retry."));
-      return;
-    }
-
-    for (const source of SOURCES) {
-      console.log();
-      console.log(c.bold(`Installing ${source.name} skills...`));
-      console.log();
-      try {
-        await runSkillsAdd(source.repo);
-      } catch {
-        console.log(c.dim(`${source.name} skills skipped`));
-      }
-    }
+    await installAllSkills();
   },
 });

--- a/packages/cli/src/templates/_shared/AGENTS.md
+++ b/packages/cli/src/templates/_shared/AGENTS.md
@@ -21,8 +21,8 @@ The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-
 
 > **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
 
-> **Skills not available?** Ask the user to run `npx hyperframes skills` and restart their
-> agent session, or install manually: `npx skills add heygen-com/hyperframes`.
+> **Skills not available or need updating?** Run `npx skills add heygen-com/hyperframes`
+> and restart the agent session so the new skills load.
 
 ## Commands
 

--- a/packages/cli/src/templates/_shared/CLAUDE.md
+++ b/packages/cli/src/templates/_shared/CLAUDE.md
@@ -21,8 +21,8 @@ The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-
 
 > **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
 
-> **Skills not available?** Ask the user to run `npx hyperframes skills` and restart their
-> agent session, or install manually: `npx skills add heygen-com/hyperframes`.
+> **Skills not available or need updating?** Run `npx skills add heygen-com/hyperframes`
+> and restart the agent session so the new skills load.
 
 ## Commands
 


### PR DESCRIPTION
Supersedes #1667. Incorporates the original fix from @kiritowoo (non-interactive init now installs skills), simplified and with additional fixes found during outside-the-monorepo testing.

## What

Both interactive and non-interactive `hyperframes init` now install skills into the correct project directory.

## Why

Three things were broken:

1. **Non-interactive init skipped skill install** — it printed `npx skills add ...` but never ran it. Agents hit `Unknown skill: <workflow>` and free-handed compositions.

2. **Wrong CWD (both paths)** — neither the interactive nor non-interactive branch set `cwd` when spawning `npx skills add`. Skills landed in the caller's working directory, not inside the scaffolded project.

3. **Template pointed to wrong command** — CLAUDE.md / AGENTS.md told agents to run `npx hyperframes skills`, but the canonical path is `npx skills add heygen-com/hyperframes`.

## How

- `runSkillsAdd` accepts `cwd` and `extraArgs` — `cwd` sets the install target, `extraArgs` lets callers pass flags like `--agent claude-code --yes`.
- Both init paths (interactive confirm + non-interactive auto-install) now pass `cwd: destDir`. Non-interactive also detects Claude Code via the `CLAUDECODE` env var to pass `--agent claude-code`.
- CLAUDE.md / AGENTS.md templates now point to `npx skills add heygen-com/hyperframes`.

## Test plan

Built the branch, tested outside the monorepo with `CLAUDECODE=1`:

- [x] `hyperframes init test-project --non-interactive` → 18 skills in `test-project/.claude/skills/`, nothing in parent CWD
- [x] `--skip-skills` flag still skips installation
- [x] CLAUDE.md in scaffolded project says `npx skills add heygen-com/hyperframes`
- [x] Build, lint, format, typecheck all pass