### PR TITLE
fix(producer): derive duration from sub-composition timing

### DIFF
--- a/packages/producer/src/services/fileServer.test.ts
+++ b/packages/producer/src/services/fileServer.test.ts
@@ -567,4 +567,42 @@ describe("HF_EARLY_STUB + HF_BRIDGE_SCRIPT integration", () => {
     sandbox.window.__hfTimelinesBuilding = true;
     expect(sandbox.window.__hf?.duration).toBe(0);
   });
+
+  it("derives duration from sub-composition data-start + data-duration when root has none", () => {
+    const sandbox: any = {
+      window: {
+        setInterval: globalThis.setInterval,
+        clearInterval: globalThis.clearInterval,
+      },
+      document: {
+        querySelector: () => ({
+          getAttribute: () => null,
+        }),
+        querySelectorAll: () => [
+          {
+            getAttribute: (n: string) =>
+              n === "data-start" ? "0" : n === "data-duration" ? "5" : null,
+          },
+          {
+            getAttribute: (n: string) =>
+              n === "data-start" ? "5" : n === "data-duration" ? "8" : null,
+          },
+        ],
+      },
+    };
+    sandbox.window.window = sandbox.window;
+    sandbox.window.document = sandbox.document;
+    sandbox.window.__player = {
+      renderSeek: () => {},
+      getDuration: () => 0,
+    };
+    sandbox.window.__renderReady = true;
+
+    new Function("window", "document", `with (window) {\n${HF_BRIDGE_SCRIPT}\n}`)(
+      sandbox.window,
+      sandbox.document,
+    );
+
+    expect(sandbox.window.__hf?.duration).toBe(13);
+  });
 });

--- a/packages/producer/src/services/fileServer.ts
+++ b/packages/producer/src/services/fileServer.ts
@@ -474,7 +474,16 @@ const HF_BRIDGE_SCRIPT = `(function() {
     var root = document.querySelector('[data-composition-id]');
     if (!root) return 0;
     var d = Number(root.getAttribute('data-duration'));
-    return Number.isFinite(d) && d > 0 ? d : 0;
+    if (Number.isFinite(d) && d > 0) return d;
+    var comps = document.querySelectorAll('[data-composition-src]');
+    var maxEnd = 0;
+    for (var i = 0; i < comps.length; i++) {
+      var start = Number(comps[i].getAttribute('data-start')) || 0;
+      var dur = Number(comps[i].getAttribute('data-duration')) || 0;
+      if (dur > 0) maxEnd = Math.max(maxEnd, start + dur);
+    }
+    if (maxEnd > 0) console.warn('[HF Bridge] No root data-duration; derived ' + maxEnd + 's from sub-compositions');
+    return maxEnd;
   }
   function seekSameOriginChildFrames(frameWindow, nextTimeMs) {
     var frames;


### PR DESCRIPTION
## Summary

- `getDeclaredDuration()` in the bridge script now computes `max(data-start + data-duration)` across all sub-compositions when the root element has no explicit `data-duration`
- Fixes renders that fail with "zero duration" when sub-compositions carry their own timing but the root doesn't declare an overall duration

## Test plan

- [x] fileServer tests pass (39/39)
- [x] Build, lint, typecheck pass