### PR TITLE
feat(registry): add podcast/interview lower-thirds pack (10 blocks)

### DIFF
--- a/registry/blocks/lt-accent-underline/lt-accent-underline.html
+++ b/registry/blocks/lt-accent-underline/lt-accent-underline.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      body {
+        width: 1920px;
+        height: 1080px;
+      }
+
+      #root .lt {
+        position: absolute;
+        left: 130px;
+        bottom: 120px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 14px;
+      }
+      #root .lt-name {
+        font-family: "Oswald", sans-serif;
+        font-size: 76px;
+        font-weight: 700;
+        color: #ffffff;
+        line-height: 0.96;
+        letter-spacing: 0.005em;
+        text-transform: uppercase;
+        white-space: nowrap;
+        text-shadow: 0 2px 22px rgba(0, 0, 0, 0.45);
+      }
+      #root .lt-rule {
+        height: 6px;
+        width: 100%;
+        background: #46e5b7;
+        border-radius: 3px;
+        transform-origin: 0% 50%;
+      }
+      #root .lt-role {
+        font-family: "Space Mono", monospace;
+        font-size: 28px;
+        font-weight: 400;
+        color: #e7eaf0;
+        line-height: 1.2;
+        letter-spacing: 0.04em;
+        white-space: nowrap;
+        text-shadow: 0 2px 16px rgba(0, 0, 0, 0.45);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lt-accent-underline"
+      data-width="1920"
+      data-height="1080"
+      data-start="0"
+      data-duration="4.8"
+    >
+      <div
+        id="lt-clip"
+        class="clip"
+        data-start="0"
+        data-duration="4.8"
+        data-track-index="0"
+      >
+        <div id="lt" class="lt">
+          <div id="lt-name" class="lt-name">Dr. Maya Chen</div>
+          <div id="lt-rule" class="lt-rule"></div>
+          <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var nameEl = document.getElementById("lt-name");
+      var rule = document.getElementById("lt-rule");
+      var role = document.getElementById("lt-role");
+
+      // Name slides up, accent rule draws left→right, role fades up under it.
+      gsap.set(nameEl, { y: 28, opacity: 0 });
+      gsap.set(rule, { scaleX: 0 });
+      gsap.set(role, { y: 16, opacity: 0 });
+
+      tl.to(nameEl, { y: 0, opacity: 1, duration: 0.55, ease: "power3.out" }, 0.1);
+      tl.to(rule, { scaleX: 1, duration: 0.5, ease: "power4.out" }, 0.3);
+      tl.to(role, { y: 0, opacity: 1, duration: 0.5, ease: "power3.out" }, 0.46);
+
+      // Exit: role fades, rule retracts, name lifts, then hard kill.
+      tl.to(role, { opacity: 0, duration: 0.3, ease: "power2.in" }, 4.25);
+      tl.to(rule, { scaleX: 0, duration: 0.3, ease: "power2.in" }, 4.3);
+      tl.to(nameEl, { y: -16, opacity: 0, duration: 0.32, ease: "power2.in" }, 4.35);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-accent-underline"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-accent-underline/registry-item.json
+++ b/registry/blocks/lt-accent-underline/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-accent-underline",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Accent Underline",
+  "description": "Cardless lower third for footage overlay: name rises, an accent rule draws left-to-right, role fades in; text-shadowed for legibility",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "minimal"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 4.8,
+  "files": [
+    {
+      "path": "lt-accent-underline.html",
+      "target": "compositions/lt-accent-underline.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lt-bold-block/lt-bold-block.html
+++ b/registry/blocks/lt-bold-block/lt-bold-block.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      body {
+        width: 1920px;
+        height: 1080px;
+      }
+
+      #root .lt {
+        position: absolute;
+        left: 120px;
+        bottom: 116px;
+      }
+      #root .lt-block {
+        background: #141518;
+        padding: 18px 34px 22px 30px;
+        display: inline-flex;
+        flex-direction: column;
+        gap: 12px;
+        will-change: clip-path;
+      }
+      #root .lt-name {
+        font-family: "Archivo Black", sans-serif;
+        font-size: 58px;
+        font-weight: 400;
+        color: #ffffff;
+        line-height: 0.98;
+        letter-spacing: -0.015em;
+        text-transform: uppercase;
+        white-space: nowrap;
+      }
+      #root .lt-tagwrap {
+        overflow: hidden;
+      }
+      #root .lt-tag {
+        display: inline-block;
+        background: #ffd23f;
+        color: #141518;
+        font-family: "Space Mono", monospace;
+        font-size: 24px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        padding: 7px 16px;
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lt-bold-block"
+      data-width="1920"
+      data-height="1080"
+      data-start="0"
+      data-duration="4.8"
+    >
+      <div
+        id="lt-clip"
+        class="clip"
+        data-start="0"
+        data-duration="4.8"
+        data-track-index="0"
+      >
+        <div id="lt" class="lt">
+          <div id="lt-block" class="lt-block">
+            <div id="lt-name" class="lt-name">Maya Chen</div>
+            <div class="lt-tagwrap">
+              <span id="lt-tag" class="lt-tag">Host · Neuroscientist</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var block = document.getElementById("lt-block");
+      var nameEl = document.getElementById("lt-name");
+      var tag = document.getElementById("lt-tag");
+
+      // Solid block wipes in from the left, name slams up inside it, tag pops up after.
+      gsap.set(block, { clipPath: "inset(0 100% 0 0)" });
+      gsap.set(nameEl, { y: 30, opacity: 0 });
+      gsap.set(tag, { y: 40 });
+
+      tl.to(block, { clipPath: "inset(0 0% 0 0)", duration: 0.5, ease: "power4.out" }, 0.1);
+      tl.to(nameEl, { y: 0, opacity: 1, duration: 0.42, ease: "back.out(1.6)" }, 0.26);
+      tl.to(tag, { y: 0, duration: 0.45, ease: "back.out(2)" }, 0.5);
+
+      // Exit: block wipes out to the left, then hard kill.
+      tl.to(block, { clipPath: "inset(0 0 0 100%)", duration: 0.4, ease: "power3.in" }, 4.3);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-bold-block"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-bold-block/registry-item.json
+++ b/registry/blocks/lt-bold-block/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-bold-block",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Bold Block",
+  "description": "High-energy podcast lower third: solid dark block wipes in, uppercase name slams up, accent tag pops",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "bold"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 4.8,
+  "files": [
+    {
+      "path": "lt-bold-block.html",
+      "target": "compositions/lt-bold-block.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lt-clean-bar/lt-clean-bar.html
+++ b/registry/blocks/lt-clean-bar/lt-clean-bar.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      body {
+        width: 1920px;
+        height: 1080px;
+        font-family: "Montserrat", sans-serif;
+      }
+
+      #root .lt {
+        position: absolute;
+        left: 120px;
+        bottom: 110px;
+        display: flex;
+        align-items: stretch;
+        border-radius: 16px;
+        overflow: hidden;
+        box-shadow: 0 14px 44px rgba(15, 17, 21, 0.18);
+        will-change: clip-path;
+      }
+      #root .lt-tab {
+        width: 12px;
+        background: #ff5a36;
+        flex-shrink: 0;
+      }
+      #root .lt-body {
+        background: #ffffff;
+        padding: 22px 40px 24px 30px;
+        display: flex;
+        flex-direction: column;
+        gap: 7px;
+      }
+      #root .lt-name {
+        font-size: 52px;
+        font-weight: 700;
+        color: #0f1115;
+        line-height: 1.06;
+        letter-spacing: -0.015em;
+        white-space: nowrap;
+      }
+      #root .lt-role {
+        font-size: 27px;
+        font-weight: 400;
+        color: #5a6170;
+        line-height: 1.2;
+        letter-spacing: 0.01em;
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lt-clean-bar"
+      data-width="1920"
+      data-height="1080"
+      data-start="0"
+      data-duration="4.8"
+    >
+      <div
+        id="lt-clip"
+        class="clip"
+        data-start="0"
+        data-duration="4.8"
+        data-track-index="0"
+      >
+        <div id="lt" class="lt">
+          <div id="lt-tab" class="lt-tab"></div>
+          <div class="lt-body">
+            <div id="lt-name" class="lt-name">Dr. Maya Chen</div>
+            <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var card = document.getElementById("lt");
+      var tab = document.getElementById("lt-tab");
+      var nameEl = document.getElementById("lt-name");
+      var role = document.getElementById("lt-role");
+
+      // Card wipes in from the left (clip-path), accent tab grows, text rises with a small stagger.
+      gsap.set(card, { clipPath: "inset(0 100% 0 0)" });
+      gsap.set(tab, { scaleY: 0, transformOrigin: "50% 0%" });
+      gsap.set(nameEl, { y: 22, opacity: 0 });
+      gsap.set(role, { y: 22, opacity: 0 });
+
+      tl.to(card, { clipPath: "inset(0 0% 0 0)", duration: 0.55, ease: "power3.out" }, 0.1);
+      tl.to(tab, { scaleY: 1, duration: 0.45, ease: "power2.out" }, 0.28);
+      tl.to(nameEl, { y: 0, opacity: 1, duration: 0.5, ease: "power3.out" }, 0.34);
+      tl.to(role, { y: 0, opacity: 1, duration: 0.5, ease: "power3.out" }, 0.44);
+
+      // Exit: settle out, then hard kill the inner element.
+      tl.to(card, { y: 18, opacity: 0, duration: 0.35, ease: "power2.in" }, 4.3);
+      tl.set(card, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-clean-bar"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-clean-bar/registry-item.json
+++ b/registry/blocks/lt-clean-bar/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-clean-bar",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Clean Bar",
+  "description": "Minimal white-card lower third for podcasts/interviews: accent tab, name + role, clip-wipe entrance",
+  "tags": ["lower-third", "overlay", "podcast", "interview"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 4.8,
+  "files": [
+    {
+      "path": "lt-clean-bar.html",
+      "target": "compositions/lt-clean-bar.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lt-color-block/lt-color-block.html
+++ b/registry/blocks/lt-color-block/lt-color-block.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { background: transparent; overflow: hidden; }
+      body { width: 1920px; height: 1080px; }
+
+      #root .lt { position: absolute; left: 120px; bottom: 116px; }
+      #root .lt-block {
+        background: #2756ff;
+        padding: 20px 36px 24px 32px;
+        box-shadow: 0 16px 44px rgba(39, 86, 255, 0.34);
+        display: inline-flex; flex-direction: column; gap: 8px;
+      }
+      #root .lt-name {
+        font-family: "League Gothic", sans-serif;
+        font-size: 84px; font-weight: 400; color: #ffffff;
+        line-height: 0.86; letter-spacing: 0.01em; text-transform: uppercase; white-space: nowrap;
+      }
+      #root .lt-role {
+        font-family: "Space Mono", monospace;
+        font-size: 24px; font-weight: 400; color: rgba(255, 255, 255, 0.86);
+        line-height: 1.2; letter-spacing: 0.05em; white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="lt-color-block" data-width="1920" data-height="1080" data-start="0" data-duration="4.8">
+      <div id="lt-clip" class="clip" data-start="0" data-duration="4.8" data-track-index="0">
+        <div id="lt" class="lt">
+          <div id="lt-block" class="lt-block">
+            <div id="lt-name" class="lt-name">Dr. Maya Chen</div>
+            <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var block = document.getElementById("lt-block");
+      var nameEl = document.getElementById("lt-name");
+      var role = document.getElementById("lt-role");
+
+      // Color block slides in from the left and overshoots slightly; name and role rise inside it.
+      gsap.set(block, { x: -80, opacity: 0 });
+      gsap.set(nameEl, { y: 24, opacity: 0 });
+      gsap.set(role, { y: 18, opacity: 0 });
+
+      tl.to(block, { x: 0, opacity: 1, duration: 0.5, ease: "back.out(1.4)" }, 0.1);
+      tl.to(nameEl, { y: 0, opacity: 1, duration: 0.42, ease: "power3.out" }, 0.3);
+      tl.to(role, { y: 0, opacity: 1, duration: 0.42, ease: "power3.out" }, 0.4);
+
+      // Exit: slide out left, hard kill.
+      tl.to(block, { x: -60, opacity: 0, duration: 0.35, ease: "power2.in" }, 4.3);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-color-block"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-color-block/registry-item.json
+++ b/registry/blocks/lt-color-block/registry-item.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-color-block",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Color Block",
+  "description": "High-energy lower third: bold accent-color block slides in with overshoot, condensed name + mono role",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "bold"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 4.8,
+  "files": [
+    { "path": "lt-color-block.html", "target": "compositions/lt-color-block.html", "type": "hyperframes:composition" }
+  ]
+}

--- a/registry/blocks/lt-dark-card/lt-dark-card.html
+++ b/registry/blocks/lt-dark-card/lt-dark-card.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { background: transparent; overflow: hidden; }
+      body { width: 1920px; height: 1080px; font-family: "Montserrat", sans-serif; }
+
+      #root .lt { position: absolute; left: 120px; bottom: 110px; }
+      #root .lt-card {
+        background: #16181d;
+        border-radius: 14px;
+        padding: 24px 38px 26px 32px;
+        box-shadow: 0 18px 50px rgba(0, 0, 0, 0.40);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      #root .lt-name {
+        font-size: 48px; font-weight: 700; color: #ffffff;
+        line-height: 1.02; letter-spacing: -0.015em; white-space: nowrap;
+      }
+      #root .lt-underline { height: 4px; width: 100%; background: #f5b942; border-radius: 2px; transform-origin: 0% 50%; }
+      #root .lt-role {
+        font-size: 25px; font-weight: 400; color: #aeb6c2;
+        line-height: 1.2; letter-spacing: 0.02em; white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="lt-dark-card" data-width="1920" data-height="1080" data-start="0" data-duration="4.8">
+      <div id="lt-clip" class="clip" data-start="0" data-duration="4.8" data-track-index="0">
+        <div id="lt" class="lt">
+          <div id="lt-card" class="lt-card">
+            <div id="lt-name" class="lt-name">Dr. Maya Chen</div>
+            <div id="lt-underline" class="lt-underline"></div>
+            <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var card = document.getElementById("lt-card");
+      var nameEl = document.getElementById("lt-name");
+      var underline = document.getElementById("lt-underline");
+      var role = document.getElementById("lt-role");
+
+      // Card slides up from below, name fades, accent underline draws, role fades.
+      gsap.set(card, { y: 60, opacity: 0 });
+      gsap.set(nameEl, { y: 14, opacity: 0 });
+      gsap.set(underline, { scaleX: 0 });
+      gsap.set(role, { opacity: 0 });
+
+      tl.to(card, { y: 0, opacity: 1, duration: 0.5, ease: "power3.out" }, 0.1);
+      tl.to(nameEl, { y: 0, opacity: 1, duration: 0.45, ease: "power3.out" }, 0.26);
+      tl.to(underline, { scaleX: 1, duration: 0.5, ease: "power4.out" }, 0.42);
+      tl.to(role, { opacity: 1, duration: 0.45, ease: "power2.out" }, 0.56);
+
+      // Exit: slide down + hard kill.
+      tl.to(card, { y: 24, opacity: 0, duration: 0.35, ease: "power2.in" }, 4.3);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-dark-card"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-dark-card/registry-item.json
+++ b/registry/blocks/lt-dark-card/registry-item.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-dark-card",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Dark Card",
+  "description": "Charcoal card lower third for bright footage: name, drawn accent underline, role; slide-up entrance",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "dark"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 4.8,
+  "files": [
+    { "path": "lt-dark-card.html", "target": "compositions/lt-dark-card.html", "type": "hyperframes:composition" }
+  ]
+}

--- a/registry/blocks/lt-kicker-name/lt-kicker-name.html
+++ b/registry/blocks/lt-kicker-name/lt-kicker-name.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { background: transparent; overflow: hidden; }
+      body { width: 1920px; height: 1080px; }
+
+      #root .lt { position: absolute; left: 130px; bottom: 122px; display: flex; flex-direction: column; align-items: flex-start; gap: 14px; }
+      #root .lt-kickwrap { overflow: hidden; }
+      #root .lt-kicker {
+        display: inline-block;
+        font-family: "Space Mono", monospace;
+        font-size: 22px; font-weight: 700; color: #141518;
+        background: #46e5b7; padding: 6px 14px;
+        letter-spacing: 0.10em; text-transform: uppercase; white-space: nowrap;
+      }
+      #root .lt-name {
+        font-family: "Archivo Black", sans-serif;
+        font-size: 70px; font-weight: 400; color: #ffffff;
+        line-height: 0.98; letter-spacing: -0.015em; text-transform: uppercase; white-space: nowrap;
+        text-shadow: 0 2px 22px rgba(0, 0, 0, 0.5);
+      }
+      #root .lt-baseline { height: 5px; width: 100%; background: #46e5b7; border-radius: 3px; transform-origin: 0% 50%; }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="lt-kicker-name" data-width="1920" data-height="1080" data-start="0" data-duration="4.8">
+      <div id="lt-clip" class="clip" data-start="0" data-duration="4.8" data-track-index="0">
+        <div id="lt" class="lt">
+          <div class="lt-kickwrap">
+            <span id="lt-kicker" class="lt-kicker">Episode 47</span>
+          </div>
+          <div id="lt-name" class="lt-name">Maya Chen</div>
+          <div id="lt-baseline" class="lt-baseline"></div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var kicker = document.getElementById("lt-kicker");
+      var nameEl = document.getElementById("lt-name");
+      var baseline = document.getElementById("lt-baseline");
+
+      // Kicker drops in, name slams up, accent baseline draws.
+      gsap.set(kicker, { y: -40 });
+      gsap.set(nameEl, { y: 34, opacity: 0 });
+      gsap.set(baseline, { scaleX: 0 });
+
+      tl.to(kicker, { y: 0, duration: 0.42, ease: "back.out(2)" }, 0.1);
+      tl.to(nameEl, { y: 0, opacity: 1, duration: 0.45, ease: "back.out(1.5)" }, 0.32);
+      tl.to(baseline, { scaleX: 1, duration: 0.5, ease: "power4.out" }, 0.5);
+
+      // Exit: baseline retracts, text lifts, hard kill.
+      tl.to(baseline, { scaleX: 0, duration: 0.3, ease: "power2.in" }, 4.25);
+      tl.to(nameEl, { y: -16, opacity: 0, duration: 0.32, ease: "power2.in" }, 4.3);
+      tl.to(kicker, { y: -40, duration: 0.3, ease: "power2.in" }, 4.32);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-kicker-name"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-kicker-name/registry-item.json
+++ b/registry/blocks/lt-kicker-name/registry-item.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-kicker-name",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Kicker Name",
+  "description": "Cardless lower third with an accent eyebrow/kicker tag, heavy name, and a drawn baseline; for footage",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "bold"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 4.8,
+  "files": [
+    { "path": "lt-kicker-name.html", "target": "compositions/lt-kicker-name.html", "type": "hyperframes:composition" }
+  ]
+}

--- a/registry/blocks/lt-mask-reveal/lt-mask-reveal.html
+++ b/registry/blocks/lt-mask-reveal/lt-mask-reveal.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { background: transparent; overflow: hidden; }
+      body { width: 1920px; height: 1080px; font-family: "Montserrat", sans-serif; }
+
+      #root .lt { position: absolute; left: 130px; bottom: 122px; display: flex; flex-direction: column; align-items: flex-start; gap: 14px; }
+      #root .lt-namewrap { position: relative; overflow: hidden; padding: 2px 0; }
+      #root .lt-name {
+        font-size: 72px; font-weight: 900; color: #ffffff;
+        line-height: 0.98; letter-spacing: -0.02em; white-space: nowrap;
+        text-shadow: 0 2px 22px rgba(0, 0, 0, 0.45); will-change: clip-path;
+      }
+      #root .lt-sweep { position: absolute; top: 0; bottom: 0; width: 8px; background: #ffd23f; }
+      #root .lt-role {
+        font-size: 28px; font-weight: 500; color: #e7eaf0;
+        line-height: 1.2; letter-spacing: 0.02em; white-space: nowrap;
+        text-shadow: 0 2px 16px rgba(0, 0, 0, 0.45);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="lt-mask-reveal" data-width="1920" data-height="1080" data-start="0" data-duration="4.8">
+      <div id="lt-clip" class="clip" data-start="0" data-duration="4.8" data-track-index="0">
+        <div id="lt" class="lt">
+          <div class="lt-namewrap">
+            <div id="lt-name" class="lt-name">Dr. Maya Chen</div>
+            <div id="lt-sweep" class="lt-sweep"></div>
+          </div>
+          <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var nameEl = document.getElementById("lt-name");
+      var sweep = document.getElementById("lt-sweep");
+      var role = document.getElementById("lt-role");
+
+      // An accent sweep crosses left→right; the name is revealed by a clip-path wipe behind it; role fades up.
+      gsap.set(nameEl, { clipPath: "inset(0 100% 0 0)" });
+      gsap.set(sweep, { left: "0%", opacity: 0 });
+      gsap.set(role, { y: 14, opacity: 0 });
+
+      tl.to(sweep, { opacity: 1, duration: 0.12, ease: "none" }, 0.1);
+      tl.to(sweep, { left: "100%", duration: 0.55, ease: "power2.inOut" }, 0.12);
+      tl.to(nameEl, { clipPath: "inset(0 0% 0 0)", duration: 0.5, ease: "power2.inOut" }, 0.16);
+      tl.to(sweep, { opacity: 0, duration: 0.15, ease: "none" }, 0.6);
+      tl.to(role, { y: 0, opacity: 1, duration: 0.5, ease: "power3.out" }, 0.55);
+
+      // Exit: name un-wipes, role fades, hard kill.
+      tl.to(role, { opacity: 0, duration: 0.3, ease: "power2.in" }, 4.25);
+      tl.to(nameEl, { clipPath: "inset(0 0 0 100%)", duration: 0.4, ease: "power2.in" }, 4.3);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-mask-reveal"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-mask-reveal/registry-item.json
+++ b/registry/blocks/lt-mask-reveal/registry-item.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-mask-reveal",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Mask Reveal",
+  "description": "Cardless lower third: an accent sweep crosses and clip-path-reveals a heavy name, role fades up; for footage",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "bold"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 4.8,
+  "files": [
+    { "path": "lt-mask-reveal.html", "target": "compositions/lt-mask-reveal.html", "type": "hyperframes:composition" }
+  ]
+}

--- a/registry/blocks/lt-side-rule/lt-side-rule.html
+++ b/registry/blocks/lt-side-rule/lt-side-rule.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { background: transparent; overflow: hidden; }
+      body { width: 1920px; height: 1080px; }
+
+      #root .lt { position: absolute; left: 130px; bottom: 120px; display: flex; align-items: stretch; gap: 26px; }
+      #root .lt-bar { width: 8px; background: #46e5b7; border-radius: 4px; transform-origin: 50% 0%; flex-shrink: 0; }
+      #root .lt-text { display: flex; flex-direction: column; justify-content: center; gap: 12px; }
+      #root .lt-name {
+        font-family: "League Gothic", sans-serif;
+        font-size: 92px; font-weight: 400; color: #ffffff;
+        line-height: 0.86; letter-spacing: 0.01em; text-transform: uppercase;
+        white-space: nowrap; text-shadow: 0 2px 22px rgba(0, 0, 0, 0.5);
+      }
+      #root .lt-role {
+        font-family: "JetBrains Mono", monospace;
+        font-size: 26px; font-weight: 400; color: #e7eaf0;
+        line-height: 1.2; letter-spacing: 0.04em; white-space: nowrap;
+        text-shadow: 0 2px 16px rgba(0, 0, 0, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="lt-side-rule" data-width="1920" data-height="1080" data-start="0" data-duration="4.8">
+      <div id="lt-clip" class="clip" data-start="0" data-duration="4.8" data-track-index="0">
+        <div id="lt" class="lt">
+          <div id="lt-bar" class="lt-bar"></div>
+          <div class="lt-text">
+            <div id="lt-name" class="lt-name">Dr. Maya Chen</div>
+            <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var bar = document.getElementById("lt-bar");
+      var nameEl = document.getElementById("lt-name");
+      var role = document.getElementById("lt-role");
+
+      // Vertical accent bar draws top→down, name and role slide in from the left.
+      gsap.set(bar, { scaleY: 0 });
+      gsap.set(nameEl, { x: -24, opacity: 0 });
+      gsap.set(role, { x: -24, opacity: 0 });
+
+      tl.to(bar, { scaleY: 1, duration: 0.5, ease: "power3.out" }, 0.1);
+      tl.to(nameEl, { x: 0, opacity: 1, duration: 0.5, ease: "power3.out" }, 0.26);
+      tl.to(role, { x: 0, opacity: 1, duration: 0.5, ease: "power3.out" }, 0.38);
+
+      // Exit: bar retracts, text lifts, hard kill.
+      tl.to(role, { opacity: 0, duration: 0.3, ease: "power2.in" }, 4.25);
+      tl.to(nameEl, { y: -14, opacity: 0, duration: 0.32, ease: "power2.in" }, 4.3);
+      tl.to(bar, { scaleY: 0, duration: 0.32, ease: "power2.in" }, 4.32);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-side-rule"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-side-rule/registry-item.json
+++ b/registry/blocks/lt-side-rule/registry-item.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-side-rule",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Side Rule",
+  "description": "Cardless lower third with a vertical accent bar; condensed display name + mono role, text-shadowed for footage",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "minimal"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 4.8,
+  "files": [
+    { "path": "lt-side-rule.html", "target": "compositions/lt-side-rule.html", "type": "hyperframes:composition" }
+  ]
+}

--- a/registry/blocks/lt-soft-pill/lt-soft-pill.html
+++ b/registry/blocks/lt-soft-pill/lt-soft-pill.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { background: transparent; overflow: hidden; }
+      body { width: 1920px; height: 1080px; font-family: "Montserrat", sans-serif; }
+
+      #root .lt { position: absolute; left: 120px; bottom: 120px; }
+      #root .lt-pill {
+        display: flex;
+        align-items: center;
+        gap: 22px;
+        background: #ffffff;
+        border-radius: 999px;
+        padding: 20px 40px 20px 26px;
+        box-shadow: 0 16px 46px rgba(15, 17, 21, 0.20);
+        transform-origin: 0% 100%;
+        will-change: transform;
+      }
+      #root .lt-dot { width: 18px; height: 18px; border-radius: 50%; background: #ff5a36; flex-shrink: 0; }
+      #root .lt-text { display: flex; flex-direction: column; gap: 4px; }
+      #root .lt-name {
+        font-size: 46px; font-weight: 700; color: #0f1115;
+        line-height: 1.04; letter-spacing: -0.015em; white-space: nowrap;
+      }
+      #root .lt-role {
+        font-size: 25px; font-weight: 400; color: #5a6170;
+        line-height: 1.2; letter-spacing: 0.01em; white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="lt-soft-pill" data-width="1920" data-height="1080" data-start="0" data-duration="4.8">
+      <div id="lt-clip" class="clip" data-start="0" data-duration="4.8" data-track-index="0">
+        <div id="lt" class="lt">
+          <div id="lt-pill" class="lt-pill">
+            <div id="lt-dot" class="lt-dot"></div>
+            <div class="lt-text">
+              <div id="lt-name" class="lt-name">Dr. Maya Chen</div>
+              <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var pill = document.getElementById("lt-pill");
+      var dot = document.getElementById("lt-dot");
+      var nameEl = document.getElementById("lt-name");
+      var role = document.getElementById("lt-role");
+
+      // Pill scales up from the lower-left anchor, dot pulses in, text settles.
+      gsap.set(pill, { scale: 0.88, y: 18, opacity: 0 });
+      gsap.set(dot, { scale: 0 });
+      gsap.set([nameEl, role], { opacity: 0, x: -10 });
+
+      tl.to(pill, { scale: 1, y: 0, opacity: 1, duration: 0.55, ease: "back.out(1.7)" }, 0.1);
+      tl.to(dot, { scale: 1, duration: 0.4, ease: "back.out(3)" }, 0.4);
+      tl.to(nameEl, { opacity: 1, x: 0, duration: 0.45, ease: "power3.out" }, 0.42);
+      tl.to(role, { opacity: 1, x: 0, duration: 0.45, ease: "power3.out" }, 0.5);
+
+      // Exit: settle down + hard kill.
+      tl.to(pill, { scale: 0.94, y: 14, opacity: 0, duration: 0.35, ease: "power2.in" }, 4.3);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-soft-pill"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-soft-pill/registry-item.json
+++ b/registry/blocks/lt-soft-pill/registry-item.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-soft-pill",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Soft Pill",
+  "description": "Rounded white pill lower third for podcasts/interviews: status dot, name + role, scale-pop entrance",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "minimal"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 4.8,
+  "files": [
+    { "path": "lt-soft-pill.html", "target": "compositions/lt-soft-pill.html", "type": "hyperframes:composition" }
+  ]
+}

--- a/registry/blocks/lt-stack-bars/lt-stack-bars.html
+++ b/registry/blocks/lt-stack-bars/lt-stack-bars.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { background: transparent; overflow: hidden; }
+      body { width: 1920px; height: 1080px; }
+
+      #root .lt { position: absolute; left: 120px; bottom: 116px; display: flex; flex-direction: column; align-items: flex-start; gap: 8px; }
+      #root .lt-namebar {
+        background: #141518; padding: 14px 30px;
+        will-change: clip-path;
+      }
+      #root .lt-name {
+        font-family: "Archivo Black", sans-serif;
+        font-size: 52px; font-weight: 400; color: #ffffff;
+        line-height: 1.0; letter-spacing: -0.015em; text-transform: uppercase; white-space: nowrap;
+      }
+      #root .lt-rolebar {
+        background: #ffd23f; padding: 9px 22px; margin-left: 14px;
+        will-change: clip-path;
+      }
+      #root .lt-role {
+        font-family: "Space Mono", monospace;
+        font-size: 23px; font-weight: 700; color: #141518;
+        line-height: 1.0; letter-spacing: 0.06em; text-transform: uppercase; white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-composition-id="lt-stack-bars" data-width="1920" data-height="1080" data-start="0" data-duration="4.8">
+      <div id="lt-clip" class="clip" data-start="0" data-duration="4.8" data-track-index="0">
+        <div id="lt" class="lt">
+          <div id="lt-namebar" class="lt-namebar">
+            <div id="lt-name" class="lt-name">Maya Chen</div>
+          </div>
+          <div id="lt-rolebar" class="lt-rolebar">
+            <div id="lt-role" class="lt-role">Host · Neuroscientist</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      var tl = gsap.timeline({ paused: true });
+
+      var wrap = document.getElementById("lt");
+      var namebar = document.getElementById("lt-namebar");
+      var rolebar = document.getElementById("lt-rolebar");
+
+      // Name bar wipes in from the left; role bar wipes in from the right (opposing).
+      gsap.set(namebar, { clipPath: "inset(0 100% 0 0)" });
+      gsap.set(rolebar, { clipPath: "inset(0 0 0 100%)" });
+
+      tl.to(namebar, { clipPath: "inset(0 0% 0 0)", duration: 0.5, ease: "power4.out" }, 0.1);
+      tl.to(rolebar, { clipPath: "inset(0 0% 0 0%)", duration: 0.5, ease: "power4.out" }, 0.34);
+
+      // Exit: both wipe back out, hard kill.
+      tl.to(rolebar, { clipPath: "inset(0 0 0 100%)", duration: 0.32, ease: "power3.in" }, 4.25);
+      tl.to(namebar, { clipPath: "inset(0 100% 0 0)", duration: 0.36, ease: "power3.in" }, 4.32);
+      tl.set(wrap, { visibility: "hidden" }, 4.75);
+
+      window.__timelines["lt-stack-bars"] = tl;
+    </script>
+  </body>
+</html>

--- a/registry/blocks/lt-stack-bars/registry-item.json
+++ b/registry/blocks/lt-stack-bars/registry-item.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lt-stack-bars",
+  "type": "hyperframes:block",
+  "title": "Lower Third — Stack Bars",
+  "description": "Two stacked bars: a dark name bar wipes from the left, an accent role bar wipes from the right",
+  "tags": ["lower-third", "overlay", "podcast", "interview", "bold"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 4.8,
+  "files": [
+    { "path": "lt-stack-bars.html", "target": "compositions/lt-stack-bars.html", "type": "hyperframes:composition" }
+  ]
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -522,6 +522,46 @@
     {
       "name": "parallax-unzoom",
       "type": "hyperframes:component"
+    },
+    {
+      "name": "lt-clean-bar",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-soft-pill",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-dark-card",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-accent-underline",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-side-rule",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-mask-reveal",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-bold-block",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-color-block",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-stack-bars",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lt-kicker-name",
+      "type": "hyperframes:block"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a **podcast / interview lower-thirds pack** — 10 blocks across three families — to the registry. Fills the catalog's stated gap: *"What's Needed Right Now → Lower thirds: 10 variations for podcasts/interviews (Easy)."*

The only existing lower third, `yt-lower-third`, is a YouTube **subscribe** widget; these are **name / role identifiers** (bottom-left broadcast convention), so there's no overlap.

## The pack

**Clean** (light cards)
- `lt-clean-bar` — white card + accent tab, clip-wipe entrance
- `lt-soft-pill` — rounded pill + status dot, scale-pop
- `lt-dark-card` — charcoal card + drawn accent underline, slide-up

**Underline** (cardless — for footage; text-shadowed)
- `lt-accent-underline` — condensed caps + an accent rule that draws left→right
- `lt-side-rule` — vertical accent bar draws top→down
- `lt-mask-reveal` — accent sweep clip-path-reveals a heavy name

**Bold** (podcast)
- `lt-bold-block` — dark block wipes in, caps slam, mono tag pops
- `lt-color-block` — accent-color block slides in with overshoot
- `lt-stack-bars` — name bar wipes from the left, accent role bar from the right
- `lt-kicker-name` — accent kicker/eyebrow, heavy name, drawn baseline

## Preview

Labeled 2×5 grid — all 10 blocks in motion (4.8s loop):

![Podcast/interview lower-thirds — all 10 blocks in motion](https://raw.githubusercontent.com/sunlesshalo/hyperframes/preview-assets/lower-thirds-preview.gif)

## Conventions

- **1920×1080, 4.8s**, transparent overlay (overlay-ready), single `data-composition-id`.
- **Bundled auto-resolve fonts only** (Montserrat, Oswald, League Gothic, Archivo Black, Space Mono, JetBrains Mono) — **no Google Fonts `<link>`**, so they render offline / deterministically with **zero font lint warnings**.
- Determinism: paused GSAP timeline on `window.__timelines`; no `Math.random()` / `Date.now()` / timers; `class="clip"` timing wrapper (with id) + an inner animated element; hard-killed exit; `#root`-scoped CSS.
- **Original, generic design** — no third-party branding; placeholder copy only (`Dr. Maya Chen` / `Host · Neuroscientist`).

## Verification

Every block passes:
- `hyperframes lint` → **0 errors / 0 warnings**
- `hyperframes validate` → **no console errors**

(The cardless variants log advisory WCAG contrast warnings — expected for transparent overlays, where contrast depends on the underlying footage; the text-shadows handle legibility.)

Renders are deterministic, so any block reproduces identically via:

```
hyperframes render registry/blocks/<name> -o <name>.mp4
```

## Notes for maintainers

- `registry/registry.json` updated with the 10 `hyperframes:block` entries.
- I did **not** run `scripts/generate-catalog-pages.ts` (to avoid generated-page churn) — happy to run it, split into smaller PRs, or adjust naming / grouping per your preference.
- Per the contributing guide, `preview` hosting is left to maintainers.
