### PR TITLE
fix(player): treat runtime timeline as cross-origin ready

### DIFF
--- a/packages/player/src/hyperframes-player.test.ts
+++ b/packages/player/src/hyperframes-player.test.ts
@@ -1807,6 +1807,9 @@ describe("HyperframesPlayer runtime ready handshake", () => {
     volume: number;
     audioLocked: boolean;
     playbackRate: number;
+    ready: boolean;
+    duration: number;
+    paused: boolean;
     iframe: HTMLIFrameElement;
     _onMessage: (event: MessageEvent) => void;
   }
@@ -1819,6 +1822,18 @@ describe("HyperframesPlayer runtime ready handshake", () => {
     return new MessageEvent("message", {
       source: frameWindow,
       data: { source: "hf-preview", type: "ready" },
+    });
+  }
+
+  function timelineMessage(durationInFrames = 120) {
+    return new MessageEvent("message", {
+      source: frameWindow,
+      data: {
+        source: "hf-preview",
+        type: "timeline",
+        durationInFrames,
+        scenes: [],
+      },
     });
   }
 
@@ -1950,6 +1965,29 @@ describe("HyperframesPlayer runtime ready handshake", () => {
     );
 
     expect(findControlCalls("set-muted")).toHaveLength(0);
+  });
+
+  it("treats a cross-origin runtime timeline message as player ready", () => {
+    const readyEvents: Array<{ duration: number }> = [];
+    player.addEventListener("ready", (event) => {
+      readyEvents.push((event as CustomEvent<{ duration: number }>).detail);
+    });
+
+    player._onMessage(timelineMessage(120));
+
+    expect(player.ready).toBe(true);
+    expect(player.duration).toBe(4);
+    expect(readyEvents).toEqual([{ duration: 4 }]);
+  });
+
+  it("honors autoplay after cross-origin runtime timeline readiness", () => {
+    player.setAttribute("autoplay", "");
+    postSpy.mockClear();
+
+    player._onMessage(timelineMessage(120));
+
+    expect(player.paused).toBe(false);
+    expect(findControlCalls("play")).toHaveLength(1);
   });
 });
 

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -643,6 +643,7 @@ class HyperframesPlayer extends HTMLElement {
       sendControl: (action, extra) => this._sendControl(action, extra),
       getIframeDoc: () => this.iframe.contentDocument,
       onRuntimeReady: () => this._replayBridgeState(),
+      onRuntimeTimelineReady: (duration) => this._onRuntimeTimelineReady(duration),
       shouldPromoteMediaAutoplayFallback: () => !this._isSlideshowPlayer(),
       setScenes: (scenes) => {
         this._scenes = scenes;
@@ -656,6 +657,23 @@ class HyperframesPlayer extends HTMLElement {
       getLoop: () => this.loop,
       media: this._media,
     });
+  }
+
+  private _onRuntimeTimelineReady(duration: number) {
+    if (this._ready) return;
+    this.probe.stop();
+    this._duration = duration;
+    this._directTimelineAdapter = null;
+    this._ready = true;
+    this.controlsApi?.updateTime(this._currentTime, duration);
+    this.dispatchEvent(new CustomEvent("ready", { detail: { duration } }));
+
+    const doc = this._getSameOriginIframeDocument();
+    if (doc) this._media.setupFromIframe(doc);
+
+    this._replayBridgeState();
+    this._setIframeMediaMuted(this.muted);
+    if (this.hasAttribute("autoplay")) this.play();
   }
 
   private _onProbeReady({ duration, adapter, compositionSize }: ProbeResult) {

--- a/packages/player/src/runtime-message-handler.test.ts
+++ b/packages/player/src/runtime-message-handler.test.ts
@@ -12,6 +12,7 @@ const makeCallbacks = (): MessageHandlerCallbacks => ({
   updateControlsPlaying: vi.fn(),
   dispatchEvent: vi.fn(),
   onRuntimeReady: vi.fn(),
+  onRuntimeTimelineReady: vi.fn(),
   seek: vi.fn(),
   play: vi.fn(),
   getLoop: vi.fn(() => false),
@@ -99,5 +100,31 @@ describe("handleRuntimeMessage media autoplay fallback", () => {
     expect(callbacks.shouldPromoteMediaAutoplayFallback).toHaveBeenCalled();
     expect(callbacks.media.promoteToParentProxy).not.toHaveBeenCalled();
     expect(callbacks.sendControl).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleRuntimeMessage timeline ready", () => {
+  const timelineEvent = (durationInFrames: unknown, source: object): MessageEvent =>
+    ({
+      source,
+      data: { source: "hf-preview", type: "timeline", durationInFrames, scenes: [] },
+    }) as unknown as MessageEvent;
+
+  it("reports a finite positive timeline duration in seconds", () => {
+    const frameWindow = {} as Window;
+    const callbacks = makeCallbacks();
+
+    handleRuntimeMessage(timelineEvent(120, frameWindow), frameWindow, callbacks);
+
+    expect(callbacks.onRuntimeTimelineReady).toHaveBeenCalledWith(4);
+  });
+
+  it("does not report invalid timeline durations as ready", () => {
+    const frameWindow = {} as Window;
+    const callbacks = makeCallbacks();
+
+    handleRuntimeMessage(timelineEvent(Infinity, frameWindow), frameWindow, callbacks);
+
+    expect(callbacks.onRuntimeTimelineReady).not.toHaveBeenCalled();
   });
 });

--- a/packages/player/src/runtime-message-handler.ts
+++ b/packages/player/src/runtime-message-handler.ts
@@ -41,6 +41,10 @@ export interface MessageHandlerCallbacks extends PlaybackStateCallbacks {
    *  uses it to replay current bridge state (mute, volume, playback rate) so
    *  control messages sent before the iframe's listener registered aren't lost. */
   onRuntimeReady: () => void;
+  /** Invoked when the runtime posts a finite positive timeline duration. The
+   *  player uses this as the cross-origin readiness signal because the
+   *  same-origin composition probe cannot inspect CDN iframes. */
+  onRuntimeTimelineReady: (duration: number) => void;
   /** Called with the scene list whenever a "timeline" message is received. */
   setScenes: (scenes: SceneRecord[]) => void;
   /** Return false to ignore the iframe runtime's audible-media autoplay fallback.
@@ -111,6 +115,7 @@ export function handleRuntimeMessage(
       const duration = (data["durationInFrames"] as number) / FPS;
       callbacks.setPlaybackState({ ...pb, duration });
       callbacks.updateControlsTime(pb.currentTime, duration);
+      callbacks.onRuntimeTimelineReady(duration);
     }
     callbacks.setScenes(extractScenes(data["scenes"]));
     return;

--- a/packages/player/src/slideshow/hyperframes-slideshow.test.ts
+++ b/packages/player/src/slideshow/hyperframes-slideshow.test.ts
@@ -466,6 +466,7 @@ describe("handleRuntimeMessage scenes seam", () => {
       sendControl: () => {},
       getIframeDoc: () => null,
       onRuntimeReady: () => {},
+      onRuntimeTimelineReady: () => {},
       setScenes,
       updateControlsTime: () => {},
       updateControlsPlaying: () => {},


### PR DESCRIPTION
## Summary

Fixes cross-origin HyperFrames playback in `<hyperframes-player>` by treating the runtime `timeline` postMessage as the readiness signal.

This removes the need for embedders to fetch composition HTML into an app-origin `blob:` just so the player can inspect same-origin iframe state. That blob workaround makes generated HyperFrames HTML inherit the host app CSP, which blocks the inline scripts that build and register GSAP timelines.

## What changed

- Add a runtime timeline-ready callback in the player message handler.
- Mark the player ready from the first finite runtime timeline duration.
- Stop the same-origin composition probe once runtime readiness is confirmed, avoiding a later stale timeout error.
- Replay bridge state and honor `autoplay` after cross-origin runtime readiness.
- Add regressions for runtime timeline readiness and autoplay from the runtime postMessage path.

## Validation

- Failed-first regression: `ready` stayed `false` before the player readiness patch.
- `bun run --filter @hyperframes/player test -- src/runtime-message-handler.test.ts src/hyperframes-player.test.ts src/slideshow/hyperframes-slideshow.test.ts`
- `bun run --filter @hyperframes/player test`
- `bun run --filter @hyperframes/player typecheck`
- `bun run --filter @hyperframes/player build`
- `bunx oxfmt --check packages/player/src/runtime-message-handler.ts packages/player/src/runtime-message-handler.test.ts packages/player/src/hyperframes-player.ts packages/player/src/hyperframes-player.test.ts packages/player/src/slideshow/hyperframes-slideshow.test.ts`

Note: slideshow tests emit existing localhost retry stderr, but the test process exits successfully.