### PR TITLE
fix(cli): ship player + slideshow bundles so present/play work from npm

### DIFF
--- a/packages/cli/scripts/build-copy.mjs
+++ b/packages/cli/scripts/build-copy.mjs
@@ -109,6 +109,27 @@ async function main() {
     cpSync(motionSampleScript, join(DIST, "commands", "motion-sample.browser.js"));
   }
 
+  // Player bundles for the standalone browser player used by `present` and
+  // `play`. resolvePlayerPath/resolveSlideshowPath look for these alongside the
+  // built CLI (dist/<name>.global.js), so they must ship in the package — the
+  // monorepo-dev fallback paths don't exist once installed from npm. Without
+  // this, `npx hyperframes present` fails with "@hyperframes/player not found".
+  const playerDist = join(REPO_ROOT, "packages", "player", "dist");
+  const playerGlobals = [
+    [join(playerDist, "hyperframes-player.global.js"), join(DIST, "hyperframes-player.global.js")],
+    [
+      join(playerDist, "slideshow", "hyperframes-slideshow.global.js"),
+      join(DIST, "hyperframes-slideshow.global.js"),
+    ],
+  ];
+  for (const [src, dest] of playerGlobals) {
+    if (existsSync(src)) {
+      cpSync(src, dest);
+    } else {
+      console.warn(`[build-copy] player bundle not found, skipping: ${src}`);
+    }
+  }
+
   copyMdFiles(join(CLI_ROOT, "src", "docs"), join(DIST, "docs"));
 
   console.log("[build-copy] done");


### PR DESCRIPTION
## Problem

`npx hyperframes present` (and `play`) always fail with:

```
@hyperframes/player not found. Run `bun run --cwd packages/player build` first.
```

The only workaround has been to run the presenter from a monorepo checkout — which is exactly the "BIG GOTCHA" people writing decks have had to document and pass around.

## Root cause

`present`/`play` render compositions in the standalone browser player and resolve the player + slideshow IIFE bundles at runtime via `resolvePlayerPath` / `resolveSlideshowPath` (`packages/cli/src/utils/compositionServer.ts`). Those resolvers check, in order:

1. monorepo-dev path (`../../../player/dist/...`)
2. **alongside the built CLI** (`dist/hyperframes-player.global.js`, `dist/hyperframes-slideshow.global.js`)

In an npm install only #2 can ever hit — but `build-copy.mjs` never staged those two bundles into `dist/`, so the published package ships `present`/`play` with no player to load. (The runtime bundle is already handled by `build:runtime`, which is why only the player/slideshow globals were missing.)

## Fix

Copy both player globals from `packages/player/dist` into the CLI `dist/` during `build:copy`, `existsSync`-guarded with a warn-and-skip, matching the surrounding pattern in the file.

## Verification

- `npm pack --dry-run` now includes `dist/hyperframes-player.global.js` and `dist/hyperframes-slideshow.global.js`.
- `node dist/cli.js present <deck>` starts the presenter cleanly (HTTP 200) with no "@hyperframes/player not found".
- Confirmed end-to-end against a real 21-slide deck: slides render and step correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)