### PR TITLE
chore: release v0.7.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,40 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.6"
+  description="Released - 2026-06-25"
+  tags={["Release", "Runtime", "CLI", "Engine"]}
+>
+This release sharpens Studio's animation editing — per-keyframe ease presets, velocity fitting, gesture smoothing, and marquee multi-selection — and adds `.srt`/`.vtt` caption export to the CLI. It also improves preview and render fidelity: document-flow layouts now preview WYSIWYG, project-root-relative assets resolve in the preview iframe, and the CLI ships its player/slideshow bundles so `present`/`play` work from npm.
+
+## Features
+
+- **CLI:** Export .srt/.vtt caption sidecars from a transcript ([821bf292](https://github.com/heygen-com/hyperframes/commit/821bf2921a264538b90cb323e4248f29ffaa5d19), [#1704](https://github.com/heygen-com/hyperframes/pull/1704))
+- **Studio:** Per-keyframe ease presets, velocity fitting, gesture smoothing ([97db811a](https://github.com/heygen-com/hyperframes/commit/97db811a2f7e7261c555b2d9915ecf10e057d726), [#1694](https://github.com/heygen-com/hyperframes/pull/1694))
+- **Studio:** Marquee multi-selection + off-canvas indicators ([8ae010bf](https://github.com/heygen-com/hyperframes/commit/8ae010bf51ff577fcbf6a723b7078f10bef268d7), [#1693](https://github.com/heygen-com/hyperframes/pull/1693))
+- **CLI:** Shared TTS/BGM auth preflight + caption and skill-workflow fixes ([54cab331](https://github.com/heygen-com/hyperframes/commit/54cab331d0f4b88e9ffe73036f842d41d473cf32), [#1697](https://github.com/heygen-com/hyperframes/pull/1697))
+- **Telemetry:** Attribute renders to the authoring workflow skill ([5242dde2](https://github.com/heygen-com/hyperframes/commit/5242dde2dc82607051316aea2a91e7420b13433c), [#1695](https://github.com/heygen-com/hyperframes/pull/1695))
+
+## Fixes
+
+- **Runtime:** Keep stamped flow children in document flow in preview ([9bf1e1c2](https://github.com/heygen-com/hyperframes/commit/9bf1e1c298cdd346c923bbda09a098d7459dcd76), [#1702](https://github.com/heygen-com/hyperframes/pull/1702))
+- **CLI:** Ship player + slideshow bundles so present/play work from npm ([1c389983](https://github.com/heygen-com/hyperframes/commit/1c389983de16f73ce9f272f5d6e6ae4314ac9e17), [#1706](https://github.com/heygen-com/hyperframes/pull/1706))
+- **Engine:** Defend macOS regular Chrome screenshots ([89ff299a](https://github.com/heygen-com/hyperframes/commit/89ff299a11bd65213e583068622a9677d1d39008))
+- **Runtime:** ImmediateRender for set tweens + array timeline normalization ([6987447a](https://github.com/heygen-com/hyperframes/commit/6987447a75d897be493f4bd4992c4145efffa2c8), [#1692](https://github.com/heygen-com/hyperframes/pull/1692))
+- **Studio:** Resolve project-root-relative asset URLs in preview iframe ([c7b9bf33](https://github.com/heygen-com/hyperframes/commit/c7b9bf338676c48766a1a88e5c887f8eec74ea92), [#1698](https://github.com/heygen-com/hyperframes/pull/1698))
+
+## Docs & Examples
+
+- **Skills:** Route /slideshow as a workflow, not a domain capability ([ae8b94c5](https://github.com/heygen-com/hyperframes/commit/ae8b94c51841be8c4b53fe861adae9371db5eff3), [#1701](https://github.com/heygen-com/hyperframes/pull/1701))
+
+## Internal
+
+- **Studio:** Remove all console.* calls from studio package ([adb40321](https://github.com/heygen-com/hyperframes/commit/adb40321d675ed6058960803a99996c53f8248f0), [#1691](https://github.com/heygen-com/hyperframes/pull/1691))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.5...v0.7.6).
+</Update>
+
+<Update
   label="HyperFrames v0.7.5"
   description="Released - 2026-06-24"
   tags={["Release", "Player", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.6.md
+++ b/releases/v0.7.6.md
@@ -1,0 +1,33 @@
+# HyperFrames v0.7.6
+
+Released on 2026-06-25.
+
+This release sharpens Studio's animation editing — per-keyframe ease presets, velocity fitting, gesture smoothing, and marquee multi-selection — and adds `.srt`/`.vtt` caption export to the CLI. It also improves preview and render fidelity: document-flow layouts now preview WYSIWYG, project-root-relative assets resolve in the preview iframe, and the CLI ships its player/slideshow bundles so `present`/`play` work from npm.
+
+## Features
+
+- **CLI:** Export .srt/.vtt caption sidecars from a transcript ([821bf292](https://github.com/heygen-com/hyperframes/commit/821bf2921a264538b90cb323e4248f29ffaa5d19), [#1704](https://github.com/heygen-com/hyperframes/pull/1704))
+- **Studio:** Per-keyframe ease presets, velocity fitting, gesture smoothing ([97db811a](https://github.com/heygen-com/hyperframes/commit/97db811a2f7e7261c555b2d9915ecf10e057d726), [#1694](https://github.com/heygen-com/hyperframes/pull/1694))
+- **Studio:** Marquee multi-selection + off-canvas indicators ([8ae010bf](https://github.com/heygen-com/hyperframes/commit/8ae010bf51ff577fcbf6a723b7078f10bef268d7), [#1693](https://github.com/heygen-com/hyperframes/pull/1693))
+- **CLI:** Shared TTS/BGM auth preflight + caption and skill-workflow fixes ([54cab331](https://github.com/heygen-com/hyperframes/commit/54cab331d0f4b88e9ffe73036f842d41d473cf32), [#1697](https://github.com/heygen-com/hyperframes/pull/1697))
+- **Telemetry:** Attribute renders to the authoring workflow skill ([5242dde2](https://github.com/heygen-com/hyperframes/commit/5242dde2dc82607051316aea2a91e7420b13433c), [#1695](https://github.com/heygen-com/hyperframes/pull/1695))
+
+## Fixes
+
+- **Runtime:** Keep stamped flow children in document flow in preview ([9bf1e1c2](https://github.com/heygen-com/hyperframes/commit/9bf1e1c298cdd346c923bbda09a098d7459dcd76), [#1702](https://github.com/heygen-com/hyperframes/pull/1702))
+- **CLI:** Ship player + slideshow bundles so present/play work from npm ([1c389983](https://github.com/heygen-com/hyperframes/commit/1c389983de16f73ce9f272f5d6e6ae4314ac9e17), [#1706](https://github.com/heygen-com/hyperframes/pull/1706))
+- **Engine:** Defend macOS regular Chrome screenshots ([89ff299a](https://github.com/heygen-com/hyperframes/commit/89ff299a11bd65213e583068622a9677d1d39008))
+- **Runtime:** ImmediateRender for set tweens + array timeline normalization ([6987447a](https://github.com/heygen-com/hyperframes/commit/6987447a75d897be493f4bd4992c4145efffa2c8), [#1692](https://github.com/heygen-com/hyperframes/pull/1692))
+- **Studio:** Resolve project-root-relative asset URLs in preview iframe ([c7b9bf33](https://github.com/heygen-com/hyperframes/commit/c7b9bf338676c48766a1a88e5c887f8eec74ea92), [#1698](https://github.com/heygen-com/hyperframes/pull/1698))
+
+## Docs & Examples
+
+- **Skills:** Route /slideshow as a workflow, not a domain capability ([ae8b94c5](https://github.com/heygen-com/hyperframes/commit/ae8b94c51841be8c4b53fe861adae9371db5eff3), [#1701](https://github.com/heygen-com/hyperframes/pull/1701))
+
+## Internal
+
+- **Studio:** Remove all console.\* calls from studio package ([adb40321](https://github.com/heygen-com/hyperframes/commit/adb40321d675ed6058960803a99996c53f8248f0), [#1691](https://github.com/heygen-com/hyperframes/pull/1691))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.5...v0.7.6


### PR DESCRIPTION
## What

Stable release **v0.7.6**. Bumps all packages and plugin manifests from 0.7.5 → 0.7.6 and adds the changelog entry.

## Why

Cuts a stable release. Merging this `release/v*` PR triggers the publish workflow, which tags `v0.7.6` and publishes to npm `latest`.

## How

Generated by `bun run release:prepare 0.7.6` (changelog draft → reviewed summary → `set-version`). Code-identical to the current green `main`; only version fields and changelog change.

## Highlights

- **Studio:** per-keyframe ease presets, velocity fitting, gesture smoothing; marquee multi-selection + off-canvas indicators.
- **CLI:** `.srt`/`.vtt` caption sidecar export; player/slideshow bundles shipped so `present`/`play` work from npm.
- **Preview/render fidelity:** document-flow layouts preview WYSIWYG (#1702); project-root-relative assets resolve in the preview iframe; `set`-tween immediate render + array-timeline normalization; macOS Chrome screenshot hardening.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

No code changes vs `main` (which is green); this commit only bumps versions and the changelog.
