### PR TITLE
fix(skills): make media-use frontmatter valid YAML so `skills add` works

### DIFF
--- a/scripts/lint-skills.ts
+++ b/scripts/lint-skills.ts
@@ -56,6 +56,43 @@ function collectSkillFiles(dir: string): string[] {
   return files;
 }
 
+/**
+ * Flag YAML frontmatter that won't parse, which aborts `skills add` for the
+ * WHOLE repo (one bad SKILL.md blocks installing every skill).
+ *
+ * ponytail: targets the one failure mode we've actually hit — an unquoted
+ * top-level scalar whose value contains `: ` (colon-space), which YAML 1.2
+ * reads as a nested mapping ("Nested mappings are not allowed in compact
+ * mappings"). Not a full YAML parse; if a different malformation appears,
+ * swap this for a real parser (the `yaml` package).
+ */
+function lintFrontmatter(content: string): Omit<Violation, "file">[] {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return [];
+  const violations: Omit<Violation, "file">[] = [];
+  const fmLines = match[1].split("\n");
+  for (let i = 0; i < fmLines.length; i++) {
+    const line = fmLines[i];
+    // Top-level `key: value` (no indentation). Skip block scalars (> |),
+    // already-quoted values, and flow collections — those handle colons fine.
+    const m = line.match(/^([A-Za-z0-9_-]+):[ \t]+(.+)$/);
+    if (!m) continue;
+    const value = m[2].trim();
+    if (/^["'>|[{]/.test(value)) continue;
+    if (/:[ \t]/.test(value)) {
+      violations.push({
+        line: i + 2, // +1 for the opening `---`, +1 for 1-based
+        message:
+          `Unquoted frontmatter value for "${m[1]}" contains ": " — YAML reads ` +
+          `this as a nested mapping and the parse fails, which aborts ` +
+          `\`skills add\` for the entire repo. Quote the value or rephrase the colon.`,
+        text: line.trim(),
+      });
+    }
+  }
+  return violations;
+}
+
 /** Strip fenced code blocks so we only lint prose + inline code. */
 function stripFencedBlocks(content: string): string {
   return content.replace(/^```[\s\S]*?^```/gm, (match) =>
@@ -68,9 +105,14 @@ function stripFencedBlocks(content: string): string {
 
 function lintFile(filePath: string): Violation[] {
   const raw = readFileSync(filePath, "utf-8");
+  const file = relative(process.cwd(), filePath);
+  const violations: Violation[] = lintFrontmatter(raw).map((v) => ({
+    ...v,
+    file,
+  }));
+
   const stripped = stripFencedBlocks(raw);
   const lines = stripped.split("\n");
-  const violations: Violation[] = [];
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];

--- a/skills/media-use/SKILL.md
+++ b/skills/media-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: media-use
-description: Agent Media OS — resolve any media need (BGM, SFX, image, icon) into a frozen local file + ledger record. One verb (`resolve`) handles the full cascade: project cache, global cache, HeyGen catalog search, freeze, register. Keeps search noise on disk, hands the agent a path. Use when a composition needs background music, sound effects, images, or icons.
+description: Agent Media OS — resolve any media need (BGM, SFX, image, icon) into a frozen local file + ledger record. One verb (`resolve`) handles the full cascade — project cache, global cache, HeyGen catalog search, freeze, register. Keeps search noise on disk, hands the agent a path. Use when a composition needs background music, sound effects, images, or icons.
 ---
 
 # media-use


### PR DESCRIPTION
## Problem

`npx skills add heygen-com/hyperframes` — the install command in the README — **fails for everyone**:

```
■  Nested mappings are not allowed in compact mappings at line 2, column 14:
   description: Agent Media OS — resolve any media need (BGM, SFX, image, icon) in…
└  Installation failed
```

`skills/media-use/SKILL.md`'s `description:` is an unquoted YAML scalar containing a mid-value `: ` (`…handles the full cascade: project cache…`). YAML 1.2 reads `: ` as a nested mapping, so the parse throws. The `skills` CLI aborts the **whole** install when any single skill fails to parse — so this one file blocks installing **all 19 skills** for every user following the docs.

Confirmed with the same parser the CLI uses (`yaml` 2.x): only `media-use` breaks; the other 18 parse fine.

## Fix

- **`skills/media-use/SKILL.md`** — replace the offending `: ` with ` — `. Keeps the plain-scalar style of the other 18 skills (the description already uses `—` as a separator) and changes no meaning.
- **`scripts/lint-skills.ts`** — add a frontmatter guard that flags unquoted top-level scalars containing `: ` (the exact ambiguity) so this can't regress. No new dependency.

## Verification

With `yaml` 2.9.0 against all 19 skills:

| | before | after |
|---|---|---|
| parser failures | 1 (`media-use`) | **0** |
| new guard flags | 1 (`media-use`) | **0** |

The guard flags the original bad content and passes the fixed content — no false positives across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)