### PR TITLE
fix(engine): honor producer BeginFrame disable env

### DIFF
--- a/packages/engine/src/config.test.ts
+++ b/packages/engine/src/config.test.ts
@@ -114,6 +114,36 @@ describe("resolveConfig", () => {
     expect(config.disableGpu).toBe(false);
   });
 
+  describe("forceScreenshot / BeginFrame env compatibility", () => {
+    it("disables BeginFrame when PRODUCER_ENABLE_BEGIN_FRAME is falsey", () => {
+      setEnv("PRODUCER_ENABLE_BEGIN_FRAME", "false");
+      for (const v of ["false", "off", "0", "FALSE"]) {
+        process.env.PRODUCER_ENABLE_BEGIN_FRAME = v;
+        expect(resolveConfig().forceScreenshot).toBe(true);
+      }
+    });
+
+    it("keeps BeginFrame eligible when PRODUCER_ENABLE_BEGIN_FRAME is truthy or invalid", () => {
+      setEnv("PRODUCER_ENABLE_BEGIN_FRAME", "true");
+      for (const v of ["true", "on", "1", "maybe"]) {
+        process.env.PRODUCER_ENABLE_BEGIN_FRAME = v;
+        expect(resolveConfig().forceScreenshot).toBe(false);
+      }
+    });
+
+    it("preserves PRODUCER_FORCE_SCREENSHOT as the direct force-screenshot knob", () => {
+      setEnv("PRODUCER_FORCE_SCREENSHOT", "true");
+      setEnv("PRODUCER_ENABLE_BEGIN_FRAME", "true");
+
+      expect(resolveConfig().forceScreenshot).toBe(true);
+    });
+
+    it("lets explicit overrides beat both env knobs", () => {
+      setEnv("PRODUCER_ENABLE_BEGIN_FRAME", "false");
+      expect(resolveConfig({ forceScreenshot: false }).forceScreenshot).toBe(false);
+    });
+  });
+
   it("reads browser GPU mode from env", () => {
     setEnv("PRODUCER_BROWSER_GPU_MODE", "hardware");
 

--- a/packages/engine/src/config.ts
+++ b/packages/engine/src/config.ts
@@ -284,6 +284,10 @@ export function resolveConfig(overrides?: Partial<EngineConfig>): EngineConfig {
     if (raw === undefined) return fallback;
     return raw === "true";
   };
+  const envFalse = (key: string): boolean => {
+    const raw = env(key)?.trim().toLowerCase();
+    return raw === "false" || raw === "off" || raw === "0";
+  };
   const envVp9CpuUsed = (): number => {
     const raw = env("PRODUCER_VP9_CPU_USED");
     if (raw === undefined || raw === "") return DEFAULT_CONFIG.vp9CpuUsed;
@@ -306,6 +310,9 @@ export function resolveConfig(overrides?: Partial<EngineConfig>): EngineConfig {
     const raw = env("HF_STATIC_DEDUP")?.trim().toLowerCase();
     return !(raw === "false" || raw === "off" || raw === "0");
   };
+  const resolveForceScreenshot = (): boolean =>
+    envBool("PRODUCER_FORCE_SCREENSHOT", DEFAULT_CONFIG.forceScreenshot) ||
+    envFalse("PRODUCER_ENABLE_BEGIN_FRAME");
 
   // Env-var layer (backward compat)
   const fromEnv: Partial<EngineConfig> = {
@@ -330,7 +337,7 @@ export function resolveConfig(overrides?: Partial<EngineConfig>): EngineConfig {
       ? Number(env("PRODUCER_EXPECTED_CHROMIUM_MAJOR"))
       : undefined,
 
-    forceScreenshot: envBool("PRODUCER_FORCE_SCREENSHOT", DEFAULT_CONFIG.forceScreenshot),
+    forceScreenshot: resolveForceScreenshot(),
     staticFrameDedup: resolveStaticFrameDedup(),
     lowMemoryMode: resolveLowMemoryMode(),
     enablePageSideCompositing: envBool(


### PR DESCRIPTION
## Summary

Fixes the producer/browser-crash root cause by making the engine honor the existing production env knob:

- `PRODUCER_ENABLE_BEGIN_FRAME=false|off|0` now resolves to `forceScreenshot=true`
- `PRODUCER_FORCE_SCREENSHOT=true` remains the direct screenshot-mode knob
- explicit `resolveConfig({ forceScreenshot })` overrides still win over env defaults

## Production evidence

The failing Temporal activities surfaced as browser/session failures:

- `Navigation timeout of 60000 ms exceeded`
- `Navigating frame was detached`
- `Protocol error (Runtime.evaluate): Target closed`

Root finding from prod:

- `temporal-hyperframes-producer-worker-sidecar-configmap` already sets `PRODUCER_ENABLE_BEGIN_FRAME=false`
- every inspected producer sidecar process had `PRODUCER_ENABLE_BEGIN_FRAME=false` in PID 1 env
- the shipped sidecar bundle only read `PRODUCER_FORCE_SCREENSHOT`; it did not read `PRODUCER_ENABLE_BEGIN_FRAME`
- prod logs still showed `captureMode:"beginframe"` and `forceScreenshot:false`
- the failed pod had fresh Chrome core files at the exact failure minute, plus defunct `chrome-headless` children

So prod was configured to avoid BeginFrame, but the engine ignored that compatibility env and kept taking the BeginFrame path.

## Verification

- `bun test packages/engine/src/config.test.ts packages/engine/src/services/frameCapture-transientErrors.test.ts packages/producer/src/services/render/stages/probeStage.test.ts` — 58 pass, 0 fail
- `bunx oxfmt --check packages/engine/src/config.ts packages/engine/src/config.test.ts`
- `bunx oxlint packages/engine/src/config.ts packages/engine/src/config.test.ts`
- `git diff --check`
- pre-commit hooks passed: lint, format, fallow audit, typecheck, commitlint
- direct probe: `PRODUCER_ENABLE_BEGIN_FRAME=false` now returns `resolveConfig().forceScreenshot === true`
- direct probe: `PRODUCER_ENABLE_BEGIN_FRAME=true` keeps `forceScreenshot === false`

I also pulled the exact failed production artifacts and rendered all three locally through the built CLI with `PRODUCER_ENABLE_BEGIN_FRAME=false`; all selected screenshot mode and completed:

- `nav-timeout-23c1` — rendered successfully
- `frame-detached-1a80` — rendered successfully
- `target-closed-40c8` — rendered successfully

## Deploy / rerun plan

After a producer sidecar image with this patch is deployed, reset or rerun the failed Temporal workflows to verify they no longer hit the browser crash path. I did not reset them before this deploy because current prod would still run the old sidecar image and old config behavior.
