### PR TITLE
fix(producer): retry probe navigation timeouts

### DIFF
--- a/packages/engine/src/services/frameCapture-transientErrors.test.ts
+++ b/packages/engine/src/services/frameCapture-transientErrors.test.ts
@@ -14,13 +14,13 @@ describe("isTransientBrowserError", () => {
     "Cannot find context with specified id",
     "Failed to launch the browser process! TROUBLESHOOTING: https://pptr.dev/troubleshooting",
     "connect ECONNREFUSED 127.0.0.1:9222",
+    "Navigation timeout of 60000 ms exceeded",
   ])("returns true for transient error: %s", (message) => {
     expect(isTransientBrowserError(new Error(message))).toBe(true);
   });
 
   it.each([
     "net::ERR_NAME_NOT_RESOLVED",
-    "TimeoutError: Navigation timeout of 30000 ms exceeded",
     "FONT_FETCH_FAILED: Inter",
     "Composition duration is 0",
     "SYSTEM_FONT_USED: -apple-system",

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -1961,6 +1961,7 @@ const TRANSIENT_BROWSER_ERROR_PATTERNS = [
   /Execution context was destroyed/i,
   /Cannot find context with specified id/i,
   /Failed to launch the browser process/i,
+  /Navigation timeout of \d+ ms exceeded/i,
   /ECONNREFUSED/i,
 ];
 

--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -69,7 +69,7 @@ mock.module("@hyperframes/engine", () => ({
   // live in frameCapture-transientErrors.test.ts — update both if patterns change.
   isTransientBrowserError: (error: unknown) => {
     const msg = error instanceof Error ? error.message : String(error);
-    return /Navigating frame was detached|Target closed|Session closed|browser has disconnected|Page crashed|Execution context was destroyed|Cannot find context with specified id|Failed to launch the browser process|ECONNREFUSED/i.test(
+    return /Navigating frame was detached|Target closed|Session closed|browser has disconnected|Page crashed|Execution context was destroyed|Cannot find context with specified id|Failed to launch the browser process|Navigation timeout of \d+ ms exceeded|ECONNREFUSED/i.test(
       msg,
     );
   },
@@ -263,6 +263,23 @@ describe("runProbeStage — transient browser error retry (#1687)", () => {
     resetRetryMocks();
     capturedCfgs.length = 0;
     initializeSessionError = new Error("Navigating frame was detached");
+    initializeSessionFailUntilAttempt = 1;
+
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({ cfgForceScreenshot: false, stageForceScreenshot: false });
+
+    const result = await runProbeStage(input);
+
+    expect(initializeSessionCallCount).toBe(2);
+    expect(closeCaptureSessionCallCount).toBe(1);
+    expect(result.duration).toBe(5);
+    expect(result.probeSession).not.toBeNull();
+  });
+
+  it("retries once on a browser-probe navigation timeout and succeeds", async () => {
+    resetRetryMocks();
+    capturedCfgs.length = 0;
+    initializeSessionError = new Error("Navigation timeout of 60000 ms exceeded");
     initializeSessionFailUntilAttempt = 1;
 
     const { runProbeStage } = await import("./probeStage.js");


### PR DESCRIPTION
## Summary

Treat Chromium navigation timeouts during browser probe/init as transient browser failures so `runProbeStage` retries once with a fresh browser session.

This preserves the preferred Linux BeginFrame path. It does not force screenshot mode.

## Why

Render-streaming probe/init failures can surface as browser lifecycle errors such as:

- `Navigating frame was detached`
- `Protocol error (Runtime.evaluate): Target closed`
- `Navigation timeout of 60000 ms exceeded`

Main already retries the first two classes through `isTransientBrowserError`, but navigation timeout was explicitly excluded. This PR closes that gap so probe-stage navigation timeouts use the same fresh-browser retry path before the producer emits a terminal render error.

## Validation

- Adds classifier coverage for `Navigation timeout of 60000 ms exceeded`.
- Adds producer probe-stage coverage showing a transient navigation timeout retries with a fresh browser session and succeeds.
- Operational prod-path validation was performed separately and is tracked in the internal incident notes; workflow/run identifiers are intentionally omitted from this public PR description.

## Verification

- `bun test packages/engine/src/services/frameCapture-transientErrors.test.ts packages/producer/src/services/render/stages/probeStage.test.ts` — 30 pass, 0 fail
- `bunx oxfmt --check packages/engine/src/services/frameCapture.ts packages/engine/src/services/frameCapture-transientErrors.test.ts packages/producer/src/services/render/stages/probeStage.test.ts`
- `bunx oxlint packages/engine/src/services/frameCapture.ts packages/engine/src/services/frameCapture-transientErrors.test.ts packages/producer/src/services/render/stages/probeStage.test.ts`
- `git diff --check HEAD~1..HEAD`
- pre-commit hooks passed: lint, format, fallow audit, typecheck, commitlint

Note: I also tried the broader render-stage test bundle including `captureStreamingStage.test.ts`; that test file has unrelated mock drift in isolation (`getCapturePerfSummary` export/session `options` mocks), so I did not treat it as verification for this PR.
