### PR TITLE
fix(render): seek single-composition (-c) renders at the requested fps

### DIFF
--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -42,6 +42,14 @@ const AUTHORED_END_ATTR = "data-hf-authored-end";
 
 export function initSandboxRuntimeModular(): void {
   const state = createRuntimeState();
+  // Export harness injects the render fps (window.__hfCanonicalFps) so the
+  // deterministic seek quantizes on the export grid, not the preview default.
+  {
+    const injectedFps = (window as unknown as { __hfCanonicalFps?: number }).__hfCanonicalFps;
+    if (typeof injectedFps === "number" && Number.isFinite(injectedFps) && injectedFps > 0) {
+      state.canonicalFps = injectedFps;
+    }
+  }
   let colorGradingRuntime: RuntimeColorGradingApi | null = null;
   let runtimeErrorListener: ((event: ErrorEvent) => void) | null = null;
   let runtimeUnhandledRejectionListener: ((event: PromiseRejectionEvent) => void) | null = null;
@@ -1034,6 +1042,19 @@ export function initSandboxRuntimeModular(): void {
     state.capturedTimeline = resolution.timeline;
     if (typeof state.capturedTimeline.timeScale === "function") {
       state.capturedTimeline.timeScale(state.playbackRate);
+    }
+    // `render -c <scene>` mounts the composition under a synthetic wrapper root
+    // whose host has no own timeline; only the inner composition registers in
+    // window.__timelines. The export poll then waits forever for the root's own
+    // timeline and child seeks never engage. Publish the resolved (composite)
+    // timeline under the root id so the poll resolves. No-op for full reels,
+    // whose root already registers its own timeline.
+    const resolvedRootId = resolveRootCompositionElement()?.getAttribute("data-composition-id");
+    const timelineRegistry = window.__timelines as
+      | Record<string, RuntimeTimelineLike | undefined>
+      | undefined;
+    if (resolvedRootId && timelineRegistry && !timelineRegistry[resolvedRootId]) {
+      timelineRegistry[resolvedRootId] = state.capturedTimeline;
     }
     const boundDuration = getSafeTimelineDurationSeconds(state.capturedTimeline, 0);
     if (boundDuration <= 0) {

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -429,6 +429,15 @@ export async function createCaptureSession(
       }
     }, variablesJson);
   }
+  // Tell the runtime the export fps so its deterministic seek quantizes on the
+  // export grid, not its preview default (otherwise single-composition renders,
+  // which have no authored fps, snap to the 30fps grid). Set before page scripts.
+  const exportFps = fpsToNumber(options.fps);
+  if (Number.isFinite(exportFps) && exportFps > 0) {
+    await page.evaluateOnNewDocument((fps: number) => {
+      (window as unknown as { __hfCanonicalFps?: number }).__hfCanonicalFps = fps;
+    }, exportFps);
+  }
   const browserVersion = await browser.version();
   const sessionOptions = resolveCaptureSessionOptions(options, browserVersion);
   const expectedMajor = config?.expectedChromiumMajor;


### PR DESCRIPTION
## What

`render -c <scene> -f 60` outputs a 60fps file whose motion only advances at 30fps (every other frame is a duplicate). The same scene in the full reel is fine. Verified it is not dedup and not VFR.

## Why

A single `<template>` composition rendered with `-c` mounts under a synthetic wrapper root that has no timeline of its own; only the inner composition registers in `window.__timelines`. So:

1. The export poll waits for the root host's own timeline, times out, and the child timeline is never nested/seeked — the scene free-runs at the capture tick rate.
2. The deterministic seek quantizes to the runtime's default `canonicalFps` (30), not the export fps.

## How

- **runtime**: when a wrapper root resolves a composite timeline but its host id has no registered timeline, publish it under that id so the poll resolves and the seek drives the nested children. No-op for full reels.
- **engine**: inject the export fps (`window.__hfCanonicalFps`) before page scripts so the runtime seeks on the export grid. Honors `--fps`.

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
