### PR TITLE
chore: release v0.7.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,34 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.7"
+  description="Released - 2026-06-25"
+  tags={["Release", "Plugin", "Producer", "Slideshow"]}
+>
+This release ships the post-0.7.6 fixes that unblock stable adoption: producer probe navigation timeouts now retry, and the Claude plugin fixture no longer trips compression guards during install. It also improves slideshow player interactivity and includes the latest Studio motion-editing and media-use provider work.
+
+## Features
+
+- **Slideshow:** Auto-set interactive on inner player ([64eaad7d](https://github.com/heygen-com/hyperframes/commit/64eaad7d69b3c11b9e95b912f2c0b5070994078b), [#1712](https://github.com/heygen-com/hyperframes/pull/1712))
+- **Studio:** Motion editing — speed-curve editor, class-tween attribution, per-keyframe size & ease ([36499220](https://github.com/heygen-com/hyperframes/commit/364992203e39288b92d60c044c2849866ef02976), [#1705](https://github.com/heygen-com/hyperframes/pull/1705))
+- **Studio:** Redesign Asset tab + fix beat analysis auto-trigger ([92befea3](https://github.com/heygen-com/hyperframes/commit/92befea305e923f081d51592abfdc0278a7e840b), [#1684](https://github.com/heygen-com/hyperframes/pull/1684))
+- **Media Use:** Resolve engine + BGM/SFX/image/icon providers ([b2dc3537](https://github.com/heygen-com/hyperframes/commit/b2dc353725049a0ccecc45db4db8dc8629dc5f5c), [#1683](https://github.com/heygen-com/hyperframes/pull/1683))
+- **Media Use:** Core infrastructure — manifest, cache, adopt, probe ([73f6d3e5](https://github.com/heygen-com/hyperframes/commit/73f6d3e5bed284f80e7a865e4cf2142817f1160c), [#1682](https://github.com/heygen-com/hyperframes/pull/1682))
+
+## Fixes
+
+- **Plugin:** Avoid high compression silence fixture ([96ab4b18](https://github.com/heygen-com/hyperframes/commit/96ab4b18a4f20ff2b7961e64a3771092f92f78fb), [#1717](https://github.com/heygen-com/hyperframes/pull/1717))
+- **Producer:** Retry probe navigation timeouts ([0558b876](https://github.com/heygen-com/hyperframes/commit/0558b8761e48683887816cc1c290f46dc4c32745), [#1713](https://github.com/heygen-com/hyperframes/pull/1713))
+- **Skills:** Make media-use frontmatter valid YAML so `skills add` works ([814c96ce](https://github.com/heygen-com/hyperframes/commit/814c96cefaa149d397a18184ed244178a6f1e46d), [#1709](https://github.com/heygen-com/hyperframes/pull/1709))
+
+## Internal
+
+- **Media Use:** Resolve tests + eval harness ([34bb4965](https://github.com/heygen-com/hyperframes/commit/34bb496566bc1fcccd06a2c9c3f099a5b41d585c), [#1685](https://github.com/heygen-com/hyperframes/pull/1685))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.6...v0.7.7).
+</Update>
+
+<Update
   label="HyperFrames v0.7.6"
   description="Released - 2026-06-25"
   tags={["Release", "Runtime", "CLI", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.7.md
+++ b/releases/v0.7.7.md
@@ -1,0 +1,27 @@
+# HyperFrames v0.7.7
+
+Released on 2026-06-25.
+
+This release ships the post-0.7.6 fixes that unblock stable adoption: producer probe navigation timeouts now retry, and the Claude plugin fixture no longer trips compression guards during install. It also improves slideshow player interactivity and includes the latest Studio motion-editing and media-use provider work.
+
+## Features
+
+- **Slideshow:** Auto-set interactive on inner player ([64eaad7d](https://github.com/heygen-com/hyperframes/commit/64eaad7d69b3c11b9e95b912f2c0b5070994078b), [#1712](https://github.com/heygen-com/hyperframes/pull/1712))
+- **Studio:** Motion editing — speed-curve editor, class-tween attribution, per-keyframe size & ease ([36499220](https://github.com/heygen-com/hyperframes/commit/364992203e39288b92d60c044c2849866ef02976), [#1705](https://github.com/heygen-com/hyperframes/pull/1705))
+- **Studio:** Redesign Asset tab + fix beat analysis auto-trigger ([92befea3](https://github.com/heygen-com/hyperframes/commit/92befea305e923f081d51592abfdc0278a7e840b), [#1684](https://github.com/heygen-com/hyperframes/pull/1684))
+- **Media Use:** Resolve engine + BGM/SFX/image/icon providers ([b2dc3537](https://github.com/heygen-com/hyperframes/commit/b2dc353725049a0ccecc45db4db8dc8629dc5f5c), [#1683](https://github.com/heygen-com/hyperframes/pull/1683))
+- **Media Use:** Core infrastructure — manifest, cache, adopt, probe ([73f6d3e5](https://github.com/heygen-com/hyperframes/commit/73f6d3e5bed284f80e7a865e4cf2142817f1160c), [#1682](https://github.com/heygen-com/hyperframes/pull/1682))
+
+## Fixes
+
+- **Plugin:** Avoid high compression silence fixture ([96ab4b18](https://github.com/heygen-com/hyperframes/commit/96ab4b18a4f20ff2b7961e64a3771092f92f78fb), [#1717](https://github.com/heygen-com/hyperframes/pull/1717))
+- **Producer:** Retry probe navigation timeouts ([0558b876](https://github.com/heygen-com/hyperframes/commit/0558b8761e48683887816cc1c290f46dc4c32745), [#1713](https://github.com/heygen-com/hyperframes/pull/1713))
+- **Skills:** Make media-use frontmatter valid YAML so `skills add` works ([814c96ce](https://github.com/heygen-com/hyperframes/commit/814c96cefaa149d397a18184ed244178a6f1e46d), [#1709](https://github.com/heygen-com/hyperframes/pull/1709))
+
+## Internal
+
+- **Media Use:** Resolve tests + eval harness ([34bb4965](https://github.com/heygen-com/hyperframes/commit/34bb496566bc1fcccd06a2c9c3f099a5b41d585c), [#1685](https://github.com/heygen-com/hyperframes/pull/1685))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.6...v0.7.7


### PR DESCRIPTION
## Summary
- Bump publishable HyperFrames packages and plugin manifests from `0.7.6` to `0.7.7`.
- Add reviewed `v0.7.7` release notes.
- Prepend the `v0.7.7` docs changelog entry.

## Includes
- Producer retry for probe navigation timeouts (#1713).
- Claude plugin install compression fix (#1717).
- Slideshow inner-player interactivity (#1712).
- Latest Studio motion-editing and media-use provider work since `v0.7.6`.

## Validation
- `bun install --frozen-lockfile`
- `bun run release:prepare 0.7.7`

## Publish path
Merging this `release/v0.7.7` PR should trigger the existing publish workflow, create/push tag `v0.7.7`, publish npm packages with dist-tag `latest`, and create the GitHub Release.
