### PR TITLE
fix(core): lint leaked head text in compositions

### DIFF
--- a/packages/core/src/lint/rules/core.test.ts
+++ b/packages/core/src/lint/rules/core.test.ts
@@ -134,6 +134,125 @@ describe("core rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("reports error when CSS text is left outside a style block in the document head", async () => {
+    const html = `
+<html>
+<head>
+  <style>
+    body { margin: 0; }
+  </style>
+  </style>
+  /* Decorative Elements */
+  .particle {
+    position: absolute;
+    width: 4px;
+    height: 4px;
+    background: #fff;
+  }
+</head>
+<body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>window.__timelines = {};</script>
+</body>
+</html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+    expect(finding?.message).toContain("<head>");
+    expect(finding?.snippet).toContain(".particle");
+  });
+
+  it("reports error when a stray style close tag is left in the document head", async () => {
+    const html = `
+<html>
+<head>
+  <style>
+    body { margin: 0; }
+  </style>
+  </style>
+</head>
+<body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>window.__timelines = {};</script>
+</body>
+</html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeDefined();
+    expect(finding?.snippet).toContain("</style>");
+  });
+
+  it("reports error when markdown code fences leak into the document head", async () => {
+    const withLanguage = `
+<html>
+<head>
+  \`\`\`css
+  .particle {
+    position: absolute;
+  }
+  \`\`\`
+</head>
+<body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>window.__timelines = {};</script>
+</body>
+</html>`;
+    const withoutLanguage = `
+<html>
+<head>
+  \`\`\`
+  .particle {
+    position: absolute;
+  }
+  \`\`\`
+</head>
+<body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>window.__timelines = {};</script>
+</body>
+</html>`;
+    const withLanguageResult = await lintHyperframeHtml(withLanguage);
+    const withoutLanguageResult = await lintHyperframeHtml(withoutLanguage);
+    const languageFinding = withLanguageResult.findings.find((f) => f.code === "head_leaked_text");
+    const unlabeledFinding = withoutLanguageResult.findings.find(
+      (f) => f.code === "head_leaked_text",
+    );
+
+    expect(languageFinding).toBeDefined();
+    expect(languageFinding?.snippet).toContain("```css");
+    expect(unlabeledFinding).toBeDefined();
+    expect(unlabeledFinding?.snippet).toContain("```");
+  });
+
+  it("does not report orphan CSS for valid head metadata and style blocks", async () => {
+    const html = `
+<html>
+<head>
+  <title>Particle Field</title>
+  <meta name="description" content="Particle field">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <style>
+    .particle {
+      position: absolute;
+      width: 4px;
+      height: 4px;
+    }
+  </style>
+</head>
+<body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>window.__timelines = {};</script>
+</body>
+</html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeUndefined();
+  });
+
   describe("timeline_id_mismatch", () => {
     it("accepts dot timeline registration", async () => {
       const html = `

--- a/packages/core/src/lint/rules/core.test.ts
+++ b/packages/core/src/lint/rules/core.test.ts
@@ -1,6 +1,33 @@
 import { describe, it, expect } from "vitest";
 import { lintHyperframeHtml } from "../hyperframeLinter.js";
 
+function compositionWithHead(headContent: string): string {
+  return `
+<html>
+<head>
+${headContent}
+</head>
+<body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>window.__timelines = {};</script>
+</body>
+</html>`;
+}
+
+function templateCompositionWithHead(headContent: string): string {
+  return `
+<template>
+  <html>
+    <head>
+${headContent}
+    </head>
+    <body>
+      <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+    </body>
+  </html>
+</template>`;
+}
+
 describe("core rules", () => {
   it("reports error when root is missing data-composition-id", async () => {
     const html = `
@@ -135,9 +162,7 @@ describe("core rules", () => {
   });
 
   it("reports error when CSS text is left outside a style block in the document head", async () => {
-    const html = `
-<html>
-<head>
+    const html = compositionWithHead(`
   <style>
     body { margin: 0; }
   </style>
@@ -149,12 +174,7 @@ describe("core rules", () => {
     height: 4px;
     background: #fff;
   }
-</head>
-<body>
-  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
-  <script>window.__timelines = {};</script>
-</body>
-</html>`;
+`);
     const result = await lintHyperframeHtml(html);
     const finding = result.findings.find((f) => f.code === "head_leaked_text");
 
@@ -165,19 +185,12 @@ describe("core rules", () => {
   });
 
   it("reports error when a stray style close tag is left in the document head", async () => {
-    const html = `
-<html>
-<head>
+    const html = compositionWithHead(`
   <style>
     body { margin: 0; }
   </style>
   </style>
-</head>
-<body>
-  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
-  <script>window.__timelines = {};</script>
-</body>
-</html>`;
+`);
     const result = await lintHyperframeHtml(html);
     const finding = result.findings.find((f) => f.code === "head_leaked_text");
 
@@ -185,39 +198,67 @@ describe("core rules", () => {
     expect(finding?.snippet).toContain("</style>");
   });
 
+  it("reports error when a stray script close tag is left in the document head", async () => {
+    const html = compositionWithHead(`
+  <script>
+    window.__headReady = true;
+  </script>
+  </script>
+`);
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeDefined();
+    expect(finding?.snippet).toContain("</script>");
+  });
+
+  it("does not report leaked head text for valid closing tags with trailing whitespace", async () => {
+    const html = compositionWithHead(`
+  <style>
+    body { margin: 0; }
+  </style >
+  <script>
+    window.__headReady = true;
+  </script
+  >
+  <title>Particle Field</title	>
+`);
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeUndefined();
+  });
+
   it("reports error when markdown code fences leak into the document head", async () => {
-    const withLanguage = `
-<html>
-<head>
+    const withLanguage = compositionWithHead(`
   \`\`\`css
   .particle {
     position: absolute;
   }
   \`\`\`
-</head>
-<body>
-  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
-  <script>window.__timelines = {};</script>
-</body>
-</html>`;
-    const withoutLanguage = `
-<html>
-<head>
+`);
+    const withoutLanguage = compositionWithHead(`
   \`\`\`
   .particle {
     position: absolute;
   }
   \`\`\`
-</head>
-<body>
-  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
-  <script>window.__timelines = {};</script>
-</body>
-</html>`;
+`);
+    const withTsxLanguage = compositionWithHead(`
+  \`\`\`tsx
+  export function Particle() {
+    return <div className="particle" />;
+  }
+  \`\`\`
+`);
     const withLanguageResult = await lintHyperframeHtml(withLanguage);
     const withoutLanguageResult = await lintHyperframeHtml(withoutLanguage);
+    const withTsxLanguageResult = await lintHyperframeHtml(withTsxLanguage);
     const languageFinding = withLanguageResult.findings.find((f) => f.code === "head_leaked_text");
     const unlabeledFinding = withoutLanguageResult.findings.find(
+      (f) => f.code === "head_leaked_text",
+    );
+    const tsxLanguageFinding = withTsxLanguageResult.findings.find(
       (f) => f.code === "head_leaked_text",
     );
 
@@ -225,15 +266,67 @@ describe("core rules", () => {
     expect(languageFinding?.snippet).toContain("```css");
     expect(unlabeledFinding).toBeDefined();
     expect(unlabeledFinding?.snippet).toContain("```");
+    expect(tsxLanguageFinding).toBeDefined();
+    expect(tsxLanguageFinding?.snippet).toContain("```tsx");
+  });
+
+  it("reports error when CSS at-rules leak into the document head", async () => {
+    const html = compositionWithHead(`
+  @media (min-width: 800px) {
+    .particle {
+      transform: scale(1.2);
+    }
+  }
+`);
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeDefined();
+    expect(finding?.snippet).toContain("@media");
+  });
+
+  it("reports leaked CSS when a style block is unclosed in the document head", async () => {
+    const html = compositionWithHead(`
+  <style>
+    .particle {
+      color: white;
+    }
+`);
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeDefined();
+    expect(finding?.snippet).toContain(".particle");
+  });
+
+  it("does not report leaked head text for commented CSS", async () => {
+    const html = compositionWithHead(`
+  <!-- .particle { color: red; } -->
+`);
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not report leaked head text for valid noscript content", async () => {
+    const html = compositionWithHead(`
+  <noscript>
+    .no-js { display: block; }
+  </noscript>
+`);
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeUndefined();
   });
 
   it("does not report orphan CSS for valid head metadata and style blocks", async () => {
-    const html = `
-<html>
-<head>
+    const html = compositionWithHead(`
   <title>Particle Field</title>
   <meta name="description" content="Particle field">
   <link rel="preconnect" href="https://fonts.gstatic.com">
+  <base href="https://example.com/">
   <style>
     .particle {
       position: absolute;
@@ -241,16 +334,23 @@ describe("core rules", () => {
       height: 4px;
     }
   </style>
-</head>
-<body>
-  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
-  <script>window.__timelines = {};</script>
-</body>
-</html>`;
+`);
     const result = await lintHyperframeHtml(html);
     const finding = result.findings.find((f) => f.code === "head_leaked_text");
 
     expect(finding).toBeUndefined();
+  });
+
+  it("reports leaked head text inside template-wrapped sub-compositions", async () => {
+    const html = templateCompositionWithHead(`
+      </style>
+      .particle { color: white; }
+`);
+    const result = await lintHyperframeHtml(html, { isSubComposition: true });
+    const finding = result.findings.find((f) => f.code === "head_leaked_text");
+
+    expect(finding).toBeDefined();
+    expect(finding?.snippet).toContain(".particle");
   });
 
   describe("timeline_id_mismatch", () => {

--- a/packages/core/src/lint/rules/core.test.ts
+++ b/packages/core/src/lint/rules/core.test.ts
@@ -216,11 +216,11 @@ describe("core rules", () => {
     const html = compositionWithHead(`
   <style>
     body { margin: 0; }
-  </style >
+  </style data-parser-error-close>
   <script>
     window.__headReady = true;
   </script
-  >
+    data-parser-error-close>
   <title>Particle Field</title	>
 `);
     const result = await lintHyperframeHtml(html);

--- a/packages/core/src/lint/rules/core.ts
+++ b/packages/core/src/lint/rules/core.ts
@@ -57,6 +57,38 @@ function describeStudioElement(tag: { raw: string; name: string }): string {
   return parts.join("");
 }
 
+const HEAD_BLOCKS_TO_IGNORE_PATTERN =
+  /<(?:style|script|template|title)\b[^>]*>[\s\S]*?<\/(?:style|script|template|title)>/gi;
+const HTML_TAG_PATTERN = /<[^>]+>/g;
+const STRAY_HEAD_CLOSE_PATTERN = /<\/(?:style|script)\s*>/i;
+const MARKDOWN_CODE_FENCE_PATTERN =
+  /```(?:html|css|js|javascript|typescript|ts)?(?:\s|$)[\s\S]*?```/i;
+const ORPHAN_CSS_RULE_PATTERN =
+  /(?:^|\s)(?:\/\*[\s\S]*?\*\/\s*)?(?:@[a-z-]+[^{}<]*|[.#][\w-]+[^{}<]*|[a-z][\w-]*(?:\s+[.#:[\w-][^{}<]*)?)\s*\{[^{}]*:[^{}]*\}/i;
+
+function findLeakedTextInHead(rawSource: string): string | null {
+  const headMatches = [...rawSource.matchAll(/<head\b[^>]*>([\s\S]*?)<\/head>/gi)];
+  for (const match of headMatches) {
+    const headContent = match[1] ?? "";
+    const withoutValidBlocks = headContent.replace(HEAD_BLOCKS_TO_IGNORE_PATTERN, " ");
+
+    const codeFenceMatch = MARKDOWN_CODE_FENCE_PATTERN.exec(withoutValidBlocks);
+    if (codeFenceMatch?.[0]) return codeFenceMatch[0];
+
+    const residualText = headContent
+      .replace(HEAD_BLOCKS_TO_IGNORE_PATTERN, " ")
+      .replace(HTML_TAG_PATTERN, " ");
+    const orphanCssMatch = ORPHAN_CSS_RULE_PATTERN.exec(residualText);
+    if (orphanCssMatch?.[0]) return orphanCssMatch[0];
+
+    const strayCloseMatch = STRAY_HEAD_CLOSE_PATTERN.exec(withoutValidBlocks);
+    if (strayCloseMatch) {
+      return withoutValidBlocks.slice(strayCloseMatch.index, strayCloseMatch.index + 160);
+    }
+  }
+  return null;
+}
+
 export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
   // root_missing_composition_id + root_missing_dimensions
   ({ rootTag }) => {
@@ -82,6 +114,23 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
       });
     }
     return findings;
+  },
+
+  // head_leaked_text
+  ({ rawSource }) => {
+    const snippet = findLeakedTextInHead(rawSource);
+    if (!snippet) return [];
+    return [
+      {
+        code: "head_leaked_text",
+        severity: "error",
+        message:
+          "Detected leaked code or CSS text in the document `<head>`. Browsers render this as visible text in the video.",
+        fixHint:
+          "Move CSS into a single `<style>...</style>` block and remove stray close tags, markdown fences, or code text from `<head>`.",
+        snippet: truncateSnippet(snippet),
+      },
+    ];
   },
 
   // missing_timeline_registry + timeline_registry_missing_init

--- a/packages/core/src/lint/rules/core.ts
+++ b/packages/core/src/lint/rules/core.ts
@@ -58,10 +58,10 @@ function describeStudioElement(tag: { raw: string; name: string }): string {
 }
 
 const HEAD_BLOCKS_TO_IGNORE_PATTERN =
-  /<(?:style|script|template|title|noscript)\b[^>]*>[\s\S]*?<\/(?:style|script|template|title|noscript)\s*>/gi;
+  /<(?:style|script|template|title|noscript)\b[^>]*>[\s\S]*?<\/(?:style|script|template|title|noscript)(?:\s[^>]*)?>/gi;
 const HTML_TAG_PATTERN = /<[^>]+>/g;
 const HEAD_CONTENT_PATTERN = /<head\b[^>]*>([\s\S]*?)(?:<\/head>|<body\b|$)/gi;
-const STRAY_HEAD_CLOSE_PATTERN = /<\/(?:style|script)\s*>/i;
+const STRAY_HEAD_CLOSE_PATTERN = /<\/(?:style|script)(?:\s[^>]*)?>/i;
 const MARKDOWN_CODE_FENCE_PATTERN = /```[^\r\n`]*(?:\r?\n|$)[\s\S]*?```/i;
 const ORPHAN_CSS_AT_RULE_PATTERN =
   /(?:^|\s)@(?:container|font-face|keyframes|layer|media|page|property|scope|supports)[^{<]*\{[\s\S]*?:[\s\S]*?\}/i;

--- a/packages/core/src/lint/rules/core.ts
+++ b/packages/core/src/lint/rules/core.ts
@@ -58,33 +58,49 @@ function describeStudioElement(tag: { raw: string; name: string }): string {
 }
 
 const HEAD_BLOCKS_TO_IGNORE_PATTERN =
-  /<(?:style|script|template|title)\b[^>]*>[\s\S]*?<\/(?:style|script|template|title)>/gi;
+  /<(?:style|script|template|title|noscript)\b[^>]*>[\s\S]*?<\/(?:style|script|template|title|noscript)\s*>/gi;
 const HTML_TAG_PATTERN = /<[^>]+>/g;
+const HEAD_CONTENT_PATTERN = /<head\b[^>]*>([\s\S]*?)(?:<\/head>|<body\b|$)/gi;
 const STRAY_HEAD_CLOSE_PATTERN = /<\/(?:style|script)\s*>/i;
-const MARKDOWN_CODE_FENCE_PATTERN =
-  /```(?:html|css|js|javascript|typescript|ts)?(?:\s|$)[\s\S]*?```/i;
+const MARKDOWN_CODE_FENCE_PATTERN = /```[^\r\n`]*(?:\r?\n|$)[\s\S]*?```/i;
+const ORPHAN_CSS_AT_RULE_PATTERN =
+  /(?:^|\s)@(?:container|font-face|keyframes|layer|media|page|property|scope|supports)[^{<]*\{[\s\S]*?:[\s\S]*?\}/i;
 const ORPHAN_CSS_RULE_PATTERN =
   /(?:^|\s)(?:\/\*[\s\S]*?\*\/\s*)?(?:@[a-z-]+[^{}<]*|[.#][\w-]+[^{}<]*|[a-z][\w-]*(?:\s+[.#:[\w-][^{}<]*)?)\s*\{[^{}]*:[^{}]*\}/i;
 
+function findCodeFenceLeak(headWithoutValidBlocks: string): string | null {
+  return MARKDOWN_CODE_FENCE_PATTERN.exec(headWithoutValidBlocks)?.[0] ?? null;
+}
+
+function findOrphanCssLeak(headContent: string): string | null {
+  const residualText = headContent
+    .replace(HEAD_BLOCKS_TO_IGNORE_PATTERN, " ")
+    .replace(HTML_TAG_PATTERN, " ");
+  return (
+    ORPHAN_CSS_AT_RULE_PATTERN.exec(residualText)?.[0] ??
+    ORPHAN_CSS_RULE_PATTERN.exec(residualText)?.[0] ??
+    null
+  );
+}
+
+function findStrayCloseLeak(headWithoutValidBlocks: string): string | null {
+  return STRAY_HEAD_CLOSE_PATTERN.exec(headWithoutValidBlocks)?.[0] ?? null;
+}
+
+function findLeakedTextInHeadContent(headContent: string): string | null {
+  const withoutValidBlocks = headContent.replace(HEAD_BLOCKS_TO_IGNORE_PATTERN, " ");
+  return (
+    findCodeFenceLeak(withoutValidBlocks) ??
+    findOrphanCssLeak(headContent) ??
+    findStrayCloseLeak(withoutValidBlocks)
+  );
+}
+
 function findLeakedTextInHead(rawSource: string): string | null {
-  const headMatches = [...rawSource.matchAll(/<head\b[^>]*>([\s\S]*?)<\/head>/gi)];
+  const headMatches = [...rawSource.matchAll(HEAD_CONTENT_PATTERN)];
   for (const match of headMatches) {
-    const headContent = match[1] ?? "";
-    const withoutValidBlocks = headContent.replace(HEAD_BLOCKS_TO_IGNORE_PATTERN, " ");
-
-    const codeFenceMatch = MARKDOWN_CODE_FENCE_PATTERN.exec(withoutValidBlocks);
-    if (codeFenceMatch?.[0]) return codeFenceMatch[0];
-
-    const residualText = headContent
-      .replace(HEAD_BLOCKS_TO_IGNORE_PATTERN, " ")
-      .replace(HTML_TAG_PATTERN, " ");
-    const orphanCssMatch = ORPHAN_CSS_RULE_PATTERN.exec(residualText);
-    if (orphanCssMatch?.[0]) return orphanCssMatch[0];
-
-    const strayCloseMatch = STRAY_HEAD_CLOSE_PATTERN.exec(withoutValidBlocks);
-    if (strayCloseMatch) {
-      return withoutValidBlocks.slice(strayCloseMatch.index, strayCloseMatch.index + 160);
-    }
+    const leakedText = findLeakedTextInHeadContent(match[1] ?? "");
+    if (leakedText) return leakedText;
   }
   return null;
 }
@@ -117,8 +133,8 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
   },
 
   // head_leaked_text
-  ({ rawSource }) => {
-    const snippet = findLeakedTextInHead(rawSource);
+  ({ source }) => {
+    const snippet = findLeakedTextInHead(source);
     if (!snippet) return [];
     return [
       {


### PR DESCRIPTION
## Summary
- add a `head_leaked_text` HyperFrames lint error for code/CSS text leaked into `<head>` outside valid blocks
- catch malformed patterns that can make source text visible in rendered video: orphan CSS rules, stray `</style>` / `</script>` closes, and markdown code fences
- keep valid `<title>`, metadata, links, and normal `<style>` blocks clean

## Root cause
A composition can contain malformed head markup such as a duplicated `</style>` followed by CSS rules. Browsers treat the remaining text as visible document text, so it appears in the rendered frame. The existing linter parsed valid `<style>` blocks but did not scan residual raw `<head>` text after those blocks were removed.

## Validation
- `bunx oxfmt packages/core/src/lint/rules/core.ts packages/core/src/lint/rules/core.test.ts`
- `bunx oxlint packages/core/src/lint/rules/core.ts packages/core/src/lint/rules/core.test.ts`
- `bun run --filter @hyperframes/core test --run src/lint` (234 tests)
- `bun run --filter @hyperframes/core build:hyperframes-runtime`
- `bun run --filter @hyperframes/core typecheck`
- Verified a malformed raw HTML fixture reports `head_leaked_text` before preview/render bundling

## Notes
This PR adds the OSS lint rule. Downstream generation paths should run HyperFrames lint before accepting generated composition artifacts once this rule is available in their installed `@hyperframes/core` package.
