### PR TITLE
fix: correct misleading lint hint for crypto.getRandomValues

### DIFF
--- a/packages/core/src/lint/rules/core.ts
+++ b/packages/core/src/lint/rules/core.ts
@@ -374,7 +374,7 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
       {
         pattern: /crypto\.getRandomValues\s*\(/,
         label: "crypto.getRandomValues()",
-        hint: "Remove time-dependent code. Use a seeded PRNG for deterministic renders.",
+        hint: "Replace with a seeded PRNG (e.g. a simple mulberry32) so renders are deterministic across frames.",
       },
     ];
 


### PR DESCRIPTION
## What

Corrects the `fixHint` message for the `crypto.getRandomValues()` pattern in the `non_deterministic_code` lint rule (`packages/core/src/lint/rules/core.ts`).

## Why

The previous hint said "Remove time-dependent code. Use a seeded PRNG for deterministic renders." but `crypto.getRandomValues()` is not time-dependent — it is a source of randomness. The "time-dependent" label is accurate for `Date.now()`, `new Date()`, and `performance.now()`, but is factually wrong for the crypto case.

## Change

The new hint follows the same pattern as the `Math.random()` entry:

> Replace with a seeded PRNG (e.g. a simple mulberry32) so renders are deterministic across frames.

No logic changes — lint behaviour, severity, and error codes are untouched.
