### PR TITLE
chore: release v0.7.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,24 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.10"
+  description="Released - 2026-06-26"
+  tags={["Release", "Producer"]}
+>
+This producer reliability release blocks impossible distributed plans before they
+fan out to chunk workers, preventing unbounded runtime timelines from turning
+into runaway render work. It also fixes distributed frame-path indexing so
+reconstructed extracted-frame assets resolve from the correct zero-based keys.
+
+## Fixes
+
+- **Producer:** Reject impossible distributed durations ([dca5fa90](https://github.com/heygen-com/hyperframes/commit/dca5fa90cb230adddbb2c9a02da80fa6a209c88b), [#1732](https://github.com/heygen-com/hyperframes/pull/1732))
+- **Producer:** RebuildExtractedFramesFromPlanDir off-by-one in framePaths key indexing ([7db84fc0](https://github.com/heygen-com/hyperframes/commit/7db84fc0ad9e642c4890dd0d99e32b1126c065d8), [#1730](https://github.com/heygen-com/hyperframes/pull/1730))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.9...v0.7.10).
+</Update>
+
+<Update
   label="HyperFrames v0.7.9"
   description="Released - 2026-06-26"
   tags={["Release", "Studio", "Core", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.10.md
+++ b/releases/v0.7.10.md
@@ -1,0 +1,17 @@
+# HyperFrames v0.7.10
+
+Released on 2026-06-26.
+
+This producer reliability release blocks impossible distributed plans before they
+fan out to chunk workers, preventing unbounded runtime timelines from turning
+into runaway render work. It also fixes distributed frame-path indexing so
+reconstructed extracted-frame assets resolve from the correct zero-based keys.
+
+## Fixes
+
+- **Producer:** Reject impossible distributed durations ([dca5fa90](https://github.com/heygen-com/hyperframes/commit/dca5fa90cb230adddbb2c9a02da80fa6a209c88b), [#1732](https://github.com/heygen-com/hyperframes/pull/1732))
+- **Producer:** RebuildExtractedFramesFromPlanDir off-by-one in framePaths key indexing ([7db84fc0](https://github.com/heygen-com/hyperframes/commit/7db84fc0ad9e642c4890dd0d99e32b1126c065d8), [#1730](https://github.com/heygen-com/hyperframes/pull/1730))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.9...v0.7.10


### PR DESCRIPTION
## What

Bumps all HyperFrames publishable packages and plugin manifests to `0.7.10`, with reviewed release notes for the two producer fixes included in this stable cut.

## Why

`0.7.10` ships the distributed-render root fix that rejects impossible probed durations before chunk fanout, plus the distributed frame-path indexing fix from #1730. Publishing this stable version gives `hyperframes-internal` a versioned package set to consume for the next producer-internal deployment.

## How

Ran the canonical release flow on `release/v0.7.10`: drafted/reviewed the changelog, reran `release:prepare`, and let the script update package/plugin versions and create the release commit. The local `v0.7.10` tag was not pushed; the publish workflow will create/push the tag when this `release/v0.7.10` PR merges.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Verification run:

- `PATH="/tmp/node22-bin:$PATH" bun run release:prepare 0.7.10`
- `PATH="/tmp/node22-bin:$PATH" bun run format:check`
- `PATH="/tmp/node22-bin:$PATH" bun run test:scripts`
- `VERSION=0.7.10 DIST_TAG=latest EVENT_NAME=pull_request PR_HEAD_REF=release/v0.7.10 PATH="/tmp/node22-bin:$PATH" bun run validate:release-channel`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
