### PR TITLE
fix(cli): install skills with --copy so check sees a faithful, correctly-placed set

### DIFF
--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -109,13 +109,13 @@ describe("hyperframes skills", () => {
       "linux",
       "npx",
       ["--version"],
-      ["skills", "add", "https://github.com/heygen-com/hyperframes", "--all"],
+      ["skills", "add", "https://github.com/heygen-com/hyperframes", "--all", "--copy"],
     ],
     [
       "darwin",
       "npx",
       ["--version"],
-      ["skills", "add", "https://github.com/heygen-com/hyperframes", "--all"],
+      ["skills", "add", "https://github.com/heygen-com/hyperframes", "--all", "--copy"],
     ],
     [
       "win32",
@@ -130,6 +130,7 @@ describe("hyperframes skills", () => {
         "add",
         "https://github.com/heygen-com/hyperframes",
         "--all",
+        "--copy",
       ],
     ],
   ] as const)(

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -52,7 +52,14 @@ function runSkillsAdd(
   source: string,
   opts: { cwd?: string; extraArgs?: string[] } = {},
 ): Promise<void> {
-  return spawnNpx(["skills", "add", source, ...(opts.extraArgs ?? ["--all"])], opts);
+  // `--copy` writes real files into each target agent's skills dir, instead of
+  // the upstream default (a canonical `.agents/skills` store + per-agent
+  // symlinks). That default re-serialises each SKILL.md's frontmatter, so an
+  // installed bundle no longer byte-matches the published manifest — `skills
+  // check` then reports a freshly-installed set as outdated, and the symlinked
+  // layout doesn't reliably land where the agent actually reads. Real copies
+  // keep the install faithful to the manifest and detectable by `skills check`.
+  return spawnNpx(["skills", "add", source, ...(opts.extraArgs ?? ["--all"]), "--copy"], opts);
 }
 
 // Skill names are kebab-case directory names. Refuse anything that isn't one


### PR DESCRIPTION
## What
hyperframes init / skills / skills update now pass --copy to the upstream skills add. Added in runSkillsAdd — the single chokepoint every install funnels through (installAllSkills → runSkillsAdd), so all three paths are covered with one change; the skills remove prune path from #1740 is untouched.
Effect: installs now write real files into each agent's skills dir — byte-faithful to the published skills-manifest.json, and in the directory the agent actually reads.
## Why
Without --copy, the upstream skills CLI installs via its canonical .agents/skills store plus per-agent symlinks. That layout re-serialises each SKILL.md's frontmatter (drops name:, reflows the folded description: > into a quoted scalar), so an installed bundle no longer byte-matches the manifest. Two user-facing failures fall out — both independent of the skills.sh registry lag (they reproduce on freshly-cloned, fully-current content):
skills check reports a brand-new install as entirely outdated— a permanent false positive;updatecan't clear it (re-install reproduces the same rewritten layout), socheck || updatenever converges.
Skills don't land where the agent reads(e.g.agent/skillsinstead of.claude/skills), so Claude Code may not pick them up.
This is the install-side complement to #1738 / #1740: detection is sound, but the default install format was defeating it.
## How
One-line change in runSkillsAdd: append --copy to the skills add argv. --copy copies real files into each target agent's dir instead of symlinking to the shared canonical store — sidestepping the frontmatter re-serialisation. Agent targeting unchanged (--agent claude-code when CLAUDECODE, upstream auto-detect otherwise); --copy only changes how files are written, not where.
## Test plan
scenariobefore (no --copy)after (--copy)init, fresh content (forced clone of main)0 current / 19 outdated @ agent/skills19 / 0 @ .claude/skillsinit, real (via skills.sh)0 / 19 @ agent/skills13 / 6 @ .claude/skills — the 6 are genuine skills.sh lag, unrelated
skills.test.tsinstall-arg assertions expect--copy(linux/darwin/win32); suite 10/10
oxlint/oxfmt --check/tsc/fallow auditclean
Docs follow-up: README /docs/guides/skills.mdxnpx skills addexamples should also recommend--copy