### PR TITLE
chore: release v0.7.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,33 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.11"
+  description="Released - 2026-06-26"
+  tags={["Release", "CLI", "Runtime", "Producer"]}
+>
+This release keeps the `hyperframes skills` CLI honest about what's installed. `skills check` now flags skills that were renamed or dropped upstream, `skills update` prunes them and installs with `--copy` so a freshly installed set matches the published manifest, and login persists and shows a friendly user identity. It also lands producer and runtime reliability work: render fps is honored when seeking, `/health` is served from a worker thread so probes survive main-thread stalls, and binary file responses now stream.
+
+## Features
+
+- **CLI:** Persist + show friendly user identity; preserve unknown credential fields ([b9b578039](https://github.com/heygen-com/hyperframes/commit/b9b57803969c3fd02f80682e11d6190496cbb4eb), [#1741](https://github.com/heygen-com/hyperframes/pull/1741))
+- **CLI:** Surface and prune skills removed upstream ([88fffb04d](https://github.com/heygen-com/hyperframes/commit/88fffb04d1f1b5e564c88ac92b8b3cddd6340b5e), [#1740](https://github.com/heygen-com/hyperframes/pull/1740))
+- **CLI:** Add skills version check, update, and freshness manifest ([d70ee134c](https://github.com/heygen-com/hyperframes/commit/d70ee134cc132cae868fe68d61e0b25cf2ebcf31), [#1738](https://github.com/heygen-com/hyperframes/pull/1738))
+
+## Fixes
+
+- **CLI:** Install skills with --copy so check sees a faithful, correctly-placed set ([51f8231eb](https://github.com/heygen-com/hyperframes/commit/51f8231eb57f887f4647a7e859de69e314beb30b), [#1744](https://github.com/heygen-com/hyperframes/pull/1744))
+- **CLI:** Close skills removed-detection power-user gaps (follow-up to #1740) ([13b115e00](https://github.com/heygen-com/hyperframes/commit/13b115e00684a8b6ed1ebed952b6fec2868d5c86), [#1743](https://github.com/heygen-com/hyperframes/pull/1743))
+- **Runtime:** Honor render fps when seeking ([c9e8dd386](https://github.com/heygen-com/hyperframes/commit/c9e8dd38624a2eec6a89469e33d596dba254c8a2), [#1739](https://github.com/heygen-com/hyperframes/pull/1739))
+- **Producer:** Serve /health from a worker_thread so probes survive main-thread stalls ([01a10cdc5](https://github.com/heygen-com/hyperframes/commit/01a10cdc539c10b3cda6675f38a4a481380ce2f8), [#1733](https://github.com/heygen-com/hyperframes/pull/1733))
+
+## Performance
+
+- **Producer:** Stream binary file responses, async-read HTML ([ca9e1316b](https://github.com/heygen-com/hyperframes/commit/ca9e1316be598b0d93343c66500af455c1ea2678), [#1735](https://github.com/heygen-com/hyperframes/pull/1735))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.10...v0.7.11).
+</Update>
+
+<Update
   label="HyperFrames v0.7.10"
   description="Released - 2026-06-26"
   tags={["Release", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.11.md
+++ b/releases/v0.7.11.md
@@ -1,0 +1,26 @@
+# HyperFrames v0.7.11
+
+Released on 2026-06-26.
+
+This release keeps the `hyperframes skills` CLI honest about what's installed. `skills check` now flags skills that were renamed or dropped upstream, `skills update` prunes them and installs with `--copy` so a freshly installed set matches the published manifest, and login persists and shows a friendly user identity. It also lands producer and runtime reliability work: render fps is honored when seeking, `/health` is served from a worker thread so probes survive main-thread stalls, and binary file responses now stream.
+
+## Features
+
+- **CLI:** Persist + show friendly user identity; preserve unknown credential fields ([b9b578039](https://github.com/heygen-com/hyperframes/commit/b9b57803969c3fd02f80682e11d6190496cbb4eb), [#1741](https://github.com/heygen-com/hyperframes/pull/1741))
+- **CLI:** Surface and prune skills removed upstream ([88fffb04d](https://github.com/heygen-com/hyperframes/commit/88fffb04d1f1b5e564c88ac92b8b3cddd6340b5e), [#1740](https://github.com/heygen-com/hyperframes/pull/1740))
+- **CLI:** Add skills version check, update, and freshness manifest ([d70ee134c](https://github.com/heygen-com/hyperframes/commit/d70ee134cc132cae868fe68d61e0b25cf2ebcf31), [#1738](https://github.com/heygen-com/hyperframes/pull/1738))
+
+## Fixes
+
+- **CLI:** Install skills with --copy so check sees a faithful, correctly-placed set ([51f8231eb](https://github.com/heygen-com/hyperframes/commit/51f8231eb57f887f4647a7e859de69e314beb30b), [#1744](https://github.com/heygen-com/hyperframes/pull/1744))
+- **CLI:** Close skills removed-detection power-user gaps (follow-up to #1740) ([13b115e00](https://github.com/heygen-com/hyperframes/commit/13b115e00684a8b6ed1ebed952b6fec2868d5c86), [#1743](https://github.com/heygen-com/hyperframes/pull/1743))
+- **Runtime:** Honor render fps when seeking ([c9e8dd386](https://github.com/heygen-com/hyperframes/commit/c9e8dd38624a2eec6a89469e33d596dba254c8a2), [#1739](https://github.com/heygen-com/hyperframes/pull/1739))
+- **Producer:** Serve /health from a worker_thread so probes survive main-thread stalls ([01a10cdc5](https://github.com/heygen-com/hyperframes/commit/01a10cdc539c10b3cda6675f38a4a481380ce2f8), [#1733](https://github.com/heygen-com/hyperframes/pull/1733))
+
+## Performance
+
+- **Producer:** Stream binary file responses, async-read HTML ([ca9e1316b](https://github.com/heygen-com/hyperframes/commit/ca9e1316be598b0d93343c66500af455c1ea2678), [#1735](https://github.com/heygen-com/hyperframes/pull/1735))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.10...v0.7.11


### PR DESCRIPTION
Release **v0.7.11**. Merging this PR triggers `publish.yml` (tags `v0.7.11` and publishes all `@hyperframes/*` packages to npm).

This release keeps the `hyperframes skills` CLI honest about what's installed. `skills check` now flags skills that were renamed or dropped upstream, `skills update` prunes them and installs with `--copy` so a freshly installed set matches the published manifest, and login persists and shows a friendly user identity. It also lands producer and runtime reliability work: render fps is honored when seeking, `/health` is served from a worker thread so probes survive main-thread stalls, and binary file responses now stream.

### Features
- CLI: persist + show friendly user identity (#1741)
- CLI: surface and prune skills removed upstream (#1740)
- CLI: skills version check, update, and freshness manifest (#1738)

### Fixes
- CLI: install skills with `--copy` so check sees a faithful set (#1744)
- CLI: close skills removed-detection power-user gaps (#1743)
- Runtime: honor render fps when seeking (#1739)
- Producer: serve `/health` from a worker_thread (#1733)

### Performance
- Producer: stream binary file responses, async-read HTML (#1735)

Full changelog: https://github.com/heygen-com/hyperframes/compare/v0.7.10...v0.7.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)