### PR TITLE
fix(ci): build @hyperframes/lint before core in Test and Studio jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,7 @@ jobs:
       - uses: ./.github/actions/prepare-ffmpeg-bin
       - run: bun install --frozen-lockfile
       - run: bun run test:scripts
-      - run: bun run --filter '@hyperframes/parsers' build
-      - run: bun run --filter '@hyperframes/studio-server' build
+      - run: bun run --filter '@hyperframes/{parsers,lint,studio-server}' build
       - run: bun run --cwd packages/core build
       - run: bun run --cwd packages/core build:hyperframes-runtime
       - run: bun run --filter '!@hyperframes/producer' test
@@ -361,8 +360,7 @@ jobs:
       # Build workspace deps so the studio vite.config.ts (loaded by Node) can
       # resolve @hyperframes/core and @hyperframes/studio-server via the "node"
       # export condition (dist).
-      - run: bun run --filter '@hyperframes/parsers' build
-      - run: bun run --filter '@hyperframes/studio-server' build
+      - run: bun run --filter '@hyperframes/{parsers,lint,studio-server}' build
       - run: bun run --cwd packages/core build
       - run: bun run --cwd packages/core build:hyperframes-runtime
       - name: Start studio and check for runtime errors


### PR DESCRIPTION
## Summary

`main` has been **red on every PR since #1756** (the `@hyperframes/lint` extraction). The `Test` and `Studio: load smoke` CI jobs pre-build the wrong dependency set before `packages/core`, so loading core's compiled `dist` fails at test / dev-server time.

## Root cause

`#1756` made `@hyperframes/lint` a runtime dependency of core: `packages/core/src/compiler/staticGuard.ts` does `import { lintHyperframeHtml } from "@hyperframes/lint"`. The lint package's `exports` resolve the **`node`** condition to `./dist/index.js` (only `bun`/`import` use `src`), so when CI runs **Node against core's built `dist`**, `@hyperframes/lint/dist/` must exist.

But both jobs pre-build only `@hyperframes/{parsers,studio-server}` before core — **`lint` is never built** — so:

```
ERR_MODULE_NOT_FOUND: Cannot find module .../@hyperframes/lint/dist/index.js
  imported from .../packages/core/dist/compiler/staticGuard.js
```

- **Test** (`bun run --filter '!@hyperframes/producer' test`) — `@hyperframes/studio` test crashes loading core's dist.
- **Studio: load smoke** — studio's `vite.config.ts` (loaded by Node) imports core → same crash; dev server never starts.

The `Build` and Windows jobs were never affected — they run the full `bun run build` (which includes lint). The `SDK` job pre-builds `parsers+core` only and passes (its path never loads `staticGuard`), so it's left untouched.

## Fix

Build the canonical pre-core dependency set — `@hyperframes/{parsers,lint,studio-server}`, the same glob the root `build` script uses — in both jobs, so the set can't silently drift again the next time a package is extracted from core.

```diff
-      - run: bun run --filter '@hyperframes/parsers' build
-      - run: bun run --filter '@hyperframes/studio-server' build
+      - run: bun run --filter '@hyperframes/{parsers,lint,studio-server}' build
       - run: bun run --cwd packages/core build
```

## Test plan

- [x] **Reproduced locally**: `rm -rf packages/lint/dist` → `node -e "import('packages/core/dist/compiler/staticGuard.js')"` fails with the exact `ERR_MODULE_NOT_FOUND` for `@hyperframes/lint/dist/index.js`; `bun run --filter '@hyperframes/lint' build` → loads cleanly.
- [x] Confirmed main is red from #1756 onward (#1755 parsers = green; #1756 lint = first failure).
- [x] `ci.yml` parses (`yaml.safe_load`); SDK job intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)