### PR TITLE
chore: release v0.7.16

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,34 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.16"
+  description="Released - 2026-06-27"
+  tags={["Release", "Studio", "Gsap"]}
+>
+Studio gains **element groups**: select multiple elements and group them into a single editable unit — on the canvas and in the timeline — then ungroup back to their original positions. This release also reads inline-authored GSAP timelines and fixes keyframe commit routing, 3D-transform edits, and ungroup positioning.
+
+## Features
+
+- **Studio:** Expand sub-composition groups + children in the timeline ([6a729b7e](https://github.com/heygen-com/hyperframes/commit/6a729b7e035e79ef08d41ec55e5df5623c98cbfa), [#1761](https://github.com/heygen-com/hyperframes/pull/1761))
+- **Gsap:** Read timelines authored inline (acorn read path) ([2e02bcf7](https://github.com/heygen-com/hyperframes/commit/2e02bcf77af55db4b60e4504bcd2dd0033dc337a), [#1760](https://github.com/heygen-com/hyperframes/pull/1760))
+- **Studio:** Element groups — studio UI ([1eed7a9b](https://github.com/heygen-com/hyperframes/commit/1eed7a9b1f8bf7b93ad8cc22bcc7125c644c43d9), [#1759](https://github.com/heygen-com/hyperframes/pull/1759))
+- **Studio:** Element groups — source mutations ([4c461b4a](https://github.com/heygen-com/hyperframes/commit/4c461b4a55dbd3a200386f3efa724cf251cf6f37), [#1758](https://github.com/heygen-com/hyperframes/pull/1758))
+
+## Fixes
+
+- **Studio:** Keep useGsapTweenCache under the size cap + correct non-sticky drill test ([a44ef47e](https://github.com/heygen-com/hyperframes/commit/a44ef47e1aabea7369ad98ea95ec7358111f7028), [#1770](https://github.com/heygen-com/hyperframes/pull/1770))
+- **Studio:** Bake the group transform into members on ungroup ([bc5a51a6](https://github.com/heygen-com/hyperframes/commit/bc5a51a6ee3277ad1f86bc542388a87b0252348a), [#1764](https://github.com/heygen-com/hyperframes/pull/1764))
+- **Studio:** Remove keyframe dragging from the timeline ([cf8f8aa5](https://github.com/heygen-com/hyperframes/commit/cf8f8aa568e751ccb18d5929bc2a9568724715a3), [#1763](https://github.com/heygen-com/hyperframes/pull/1763))
+- **Studio:** Keyframe commit routing for 3D and cross-group edits ([2d3b19d2](https://github.com/heygen-com/hyperframes/commit/2d3b19d2559d93ef5623bbd155573d10f695de05), [#1762](https://github.com/heygen-com/hyperframes/pull/1762))
+
+## Internal
+
+- **Studio:** Remove debug logging ([de42af43](https://github.com/heygen-com/hyperframes/commit/de42af438aab6b145dfe2727d1611df567cc8bf7), [#1765](https://github.com/heygen-com/hyperframes/pull/1765))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.15...v0.7.16).
+</Update>
+
+<Update
   label="HyperFrames v0.7.15"
   description="Released - 2026-06-27"
   tags={["Release", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.16.md
+++ b/releases/v0.7.16.md
@@ -1,0 +1,27 @@
+# HyperFrames v0.7.16
+
+Released on 2026-06-27.
+
+Studio gains **element groups**: select multiple elements and group them into a single editable unit — on the canvas and in the timeline — then ungroup back to their original positions. This release also reads inline-authored GSAP timelines and fixes keyframe commit routing, 3D-transform edits, and ungroup positioning.
+
+## Features
+
+- **Studio:** Expand sub-composition groups + children in the timeline ([6a729b7e](https://github.com/heygen-com/hyperframes/commit/6a729b7e035e79ef08d41ec55e5df5623c98cbfa), [#1761](https://github.com/heygen-com/hyperframes/pull/1761))
+- **Gsap:** Read timelines authored inline (acorn read path) ([2e02bcf7](https://github.com/heygen-com/hyperframes/commit/2e02bcf77af55db4b60e4504bcd2dd0033dc337a), [#1760](https://github.com/heygen-com/hyperframes/pull/1760))
+- **Studio:** Element groups — studio UI ([1eed7a9b](https://github.com/heygen-com/hyperframes/commit/1eed7a9b1f8bf7b93ad8cc22bcc7125c644c43d9), [#1759](https://github.com/heygen-com/hyperframes/pull/1759))
+- **Studio:** Element groups — source mutations ([4c461b4a](https://github.com/heygen-com/hyperframes/commit/4c461b4a55dbd3a200386f3efa724cf251cf6f37), [#1758](https://github.com/heygen-com/hyperframes/pull/1758))
+
+## Fixes
+
+- **Studio:** Keep useGsapTweenCache under the size cap + correct non-sticky drill test ([a44ef47e](https://github.com/heygen-com/hyperframes/commit/a44ef47e1aabea7369ad98ea95ec7358111f7028), [#1770](https://github.com/heygen-com/hyperframes/pull/1770))
+- **Studio:** Bake the group transform into members on ungroup ([bc5a51a6](https://github.com/heygen-com/hyperframes/commit/bc5a51a6ee3277ad1f86bc542388a87b0252348a), [#1764](https://github.com/heygen-com/hyperframes/pull/1764))
+- **Studio:** Remove keyframe dragging from the timeline ([cf8f8aa5](https://github.com/heygen-com/hyperframes/commit/cf8f8aa568e751ccb18d5929bc2a9568724715a3), [#1763](https://github.com/heygen-com/hyperframes/pull/1763))
+- **Studio:** Keyframe commit routing for 3D and cross-group edits ([2d3b19d2](https://github.com/heygen-com/hyperframes/commit/2d3b19d2559d93ef5623bbd155573d10f695de05), [#1762](https://github.com/heygen-com/hyperframes/pull/1762))
+
+## Internal
+
+- **Studio:** Remove debug logging ([de42af43](https://github.com/heygen-com/hyperframes/commit/de42af438aab6b145dfe2727d1611df567cc8bf7), [#1765](https://github.com/heygen-com/hyperframes/pull/1765))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.15...v0.7.16


### PR DESCRIPTION
Release **v0.7.16** — element groups in Studio.

Headline: select multiple elements and group them into a single editable unit (canvas + timeline), then ungroup back to original positions. Also: inline-authored GSAP timeline reading, plus keyframe/3D-transform/ungroup fixes.

Bumps all 13 packages + 3 plugin manifests 0.7.15 → 0.7.16, updates `docs/changelog.mdx`, adds `releases/v0.7.16.md`. Tag pushed after merge triggers publish.