### PR TITLE
chore: release v0.7.19

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,37 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.19"
+  description="Released - 2026-06-29"
+  tags={["Release", "Studio", "Skills", "CLI"]}
+>
+Studio editing reliability fixes: dragging and keyframing an element now keep a single position write, so elements no longer get stuck, snap back, or fly off-screen, and Delete All Keyframes leaves a clean state. This release also busts stale thumbnail caches after composition edits and adds Studio selection through the preview command plus local-studio (Vite) preview discovery over IPv6.
+
+## Features
+
+- **CLI:** Expose Studio selection through preview ([9983f37c](https://github.com/heygen-com/hyperframes/commit/9983f37c13dc7d8fbd35da21e88229e3500cee9a), [#1777](https://github.com/heygen-com/hyperframes/pull/1777))
+
+## Fixes
+
+- **Studio:** Keyframe/position editing correctness + thumbnail cache busting + local-studio preview discovery ([0a9555a0](https://github.com/heygen-com/hyperframes/commit/0a9555a0f7176583c1ac04d0f3cd4db977e0c023), [#1781](https://github.com/heygen-com/hyperframes/pull/1781))
+- **Render:** Avoid empty WAAPI scans and llvmpipe auto GPU ([fc0f8c31](https://github.com/heygen-com/hyperframes/commit/fc0f8c315102812a9629bcdeec09f75e26027da2), [#1775](https://github.com/heygen-com/hyperframes/pull/1775))
+
+## Performance
+
+- **Engine:** Reduce init overhead in headless capture sessions ([35a01d90](https://github.com/heygen-com/hyperframes/commit/35a01d9058fca2c4f5e9a4aa13a86d2eafc77c68), [#1718](https://github.com/heygen-com/hyperframes/pull/1718))
+
+## Docs & Examples
+
+- Trim README motion hero ([38c6cd11](https://github.com/heygen-com/hyperframes/commit/38c6cd1113738a95f2f360dc9d70571a47629151), [#1780](https://github.com/heygen-com/hyperframes/pull/1780))
+
+## Internal
+
+- **Skills:** Rebuild faceless-explainer + pr-to-video on the shot-sequence architecture ([7cb83865](https://github.com/heygen-com/hyperframes/commit/7cb83865390d642e4e09bc162ad8c4a002545c6b), [#1778](https://github.com/heygen-com/hyperframes/pull/1778))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.17...v0.7.19).
+</Update>
+
+<Update
   label="HyperFrames v0.7.18"
   description="Released - 2026-06-28"
   tags={["Release", "CLI", "Render", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.19.md
+++ b/releases/v0.7.19.md
@@ -1,0 +1,30 @@
+# HyperFrames v0.7.19
+
+Released on 2026-06-29.
+
+Studio editing reliability fixes: dragging and keyframing an element now keep a single position write, so elements no longer get stuck, snap back, or fly off-screen, and Delete All Keyframes leaves a clean state. This release also busts stale thumbnail caches after composition edits and adds Studio selection through the preview command plus local-studio (Vite) preview discovery over IPv6.
+
+## Features
+
+- **CLI:** Expose Studio selection through preview ([9983f37c](https://github.com/heygen-com/hyperframes/commit/9983f37c13dc7d8fbd35da21e88229e3500cee9a), [#1777](https://github.com/heygen-com/hyperframes/pull/1777))
+
+## Fixes
+
+- **Studio:** Keyframe/position editing correctness + thumbnail cache busting + local-studio preview discovery ([0a9555a0](https://github.com/heygen-com/hyperframes/commit/0a9555a0f7176583c1ac04d0f3cd4db977e0c023), [#1781](https://github.com/heygen-com/hyperframes/pull/1781))
+- **Render:** Avoid empty WAAPI scans and llvmpipe auto GPU ([fc0f8c31](https://github.com/heygen-com/hyperframes/commit/fc0f8c315102812a9629bcdeec09f75e26027da2), [#1775](https://github.com/heygen-com/hyperframes/pull/1775))
+
+## Performance
+
+- **Engine:** Reduce init overhead in headless capture sessions ([35a01d90](https://github.com/heygen-com/hyperframes/commit/35a01d9058fca2c4f5e9a4aa13a86d2eafc77c68), [#1718](https://github.com/heygen-com/hyperframes/pull/1718))
+
+## Docs & Examples
+
+- Trim README motion hero ([38c6cd11](https://github.com/heygen-com/hyperframes/commit/38c6cd1113738a95f2f360dc9d70571a47629151), [#1780](https://github.com/heygen-com/hyperframes/pull/1780))
+
+## Internal
+
+- **Skills:** Rebuild faceless-explainer + pr-to-video on the shot-sequence architecture ([7cb83865](https://github.com/heygen-com/hyperframes/commit/7cb83865390d642e4e09bc162ad8c4a002545c6b), [#1778](https://github.com/heygen-com/hyperframes/pull/1778))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.17...v0.7.19


### PR DESCRIPTION
Stable release **v0.7.19** (patch over v0.7.18). Bumps all packages + plugins, adds `releases/v0.7.19.md`, and prepends the `docs/changelog.mdx` entry.

Studio editing reliability fixes: dragging and keyframing an element now keep a single position write, so elements no longer get stuck, snap back, or fly off-screen, and "Delete All Keyframes" leaves a clean state. This release also busts stale thumbnail caches after composition edits and adds Studio selection through the preview command plus local-studio (Vite) preview discovery over IPv6.

## Highlights
- **fix(studio):** keyframe/position editing correctness — one position write per element + clean remove-all-keyframes (#1781)
- **fix(studio-server):** bust thumbnail cache on composition edits (#1781)
- **fix(cli):** local-studio (Vite) preview discovery over IPv6 loopback (#1781)
- **feat(cli):** expose Studio selection through preview (#1777)
- **fix(render):** avoid empty WAAPI scans and llvmpipe auto GPU (#1775)
- **perf(engine):** reduce init overhead in headless capture sessions (#1718)

Full notes: `releases/v0.7.19.md`. Merging this `release/v*` PR triggers the npm publish workflow (tags `v0.7.19`).