### PR TITLE
feat(lint): error on `crossorigin` on media (breaks preview)

### DIFF
--- a/packages/lint/src/rules/media.test.ts
+++ b/packages/lint/src/rules/media.test.ts
@@ -267,4 +267,32 @@ describe("media rules", () => {
     const finding = result.findings.find((f) => f.code === "media_in_subcomposition");
     expect(finding).toBeUndefined();
   });
+
+  it("reports error for media with crossorigin (breaks preview when host omits CORS)", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <video id="v1" crossorigin="anonymous" src="https://cdn.example.com/clip.mp4" data-start="0" data-duration="5" muted playsinline></video>
+  </div>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines["c1"] = gsap.timeline({ paused: true });</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "media_crossorigin_breaks_preview");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+    expect(finding?.elementId).toBe("v1");
+  });
+
+  it("does not flag media without crossorigin", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <video id="v1" src="https://cdn.example.com/clip.mp4" data-start="0" data-duration="5" muted playsinline></video>
+  </div>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines["c1"] = gsap.timeline({ paused: true });</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "media_crossorigin_breaks_preview");
+    expect(finding).toBeUndefined();
+  });
 });

--- a/packages/lint/src/rules/media.ts
+++ b/packages/lint/src/rules/media.ts
@@ -483,6 +483,33 @@ export const mediaRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = 
     return findings;
   },
 
+  // media_crossorigin_breaks_preview — `crossorigin` on <video>/<audio> forces a
+  // CORS-checked fetch. The server-side renderer downloads media directly (no CORS),
+  // so it always works there; but Studio preview runs in the browser, where a media
+  // host that omits Access-Control-Allow-Origin silently fails the load — the media
+  // shows BLANK/black in preview while renders look fine, hiding the bug. Plain
+  // displayed media never needs crossorigin; it's only required to read pixels/samples
+  // back (canvas/WebGL texture, WebAudio createMediaElementSource) AND only when the
+  // host is known CORS-enabled.
+  ({ tags }) => {
+    const findings: HyperframeLintFinding[] = [];
+    for (const tag of tags) {
+      if (tag.name !== "video" && tag.name !== "audio") continue;
+      if (!hasAttrName(tag.raw, "crossorigin")) continue;
+      const elementId = readAttr(tag.raw, "id") || undefined;
+      findings.push({
+        code: "media_crossorigin_breaks_preview",
+        severity: "error",
+        message: `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> has crossorigin, which forces a CORS-checked fetch. If the media host omits Access-Control-Allow-Origin, the load silently fails in Studio preview (media shows BLANK/black) while server-side renders still work — hiding the bug.`,
+        elementId,
+        fixHint:
+          "Remove the crossorigin attribute unless you read the media back via canvas/WebGL/WebAudio AND the host is known to send CORS headers. Plain displayed media never needs it.",
+        snippet: truncateSnippet(tag.raw),
+      });
+    }
+    return findings;
+  },
+
   // video_audio_double_source — catches audible <video> paired with a separate
   // <audio> pointing to the same file, which causes double playback at runtime
   ({ tags }) => {


### PR DESCRIPTION
## Problem

A `<video>`/`<audio>` element with `crossorigin` (e.g. `crossorigin="anonymous"`) **appears correctly in renders but shows blank/black in Studio preview** — a confusing, hard-to-spot failure.

Root cause: `crossorigin` forces the browser to do a CORS-checked fetch. The server-side renderer downloads media directly (no CORS involved), so renders always work. But Studio preview runs in the browser — if the media host omits `Access-Control-Allow-Origin`, the load silently fails and the media renders blank, while the render looks fine. The mismatch hides the bug.

This is exactly what bit a real composition whose S3 media host returns no CORS headers: the Avatar IV video was invisible in preview but fine in the render. The capture/import pipeline had stamped `crossorigin="anonymous"` onto a plain displayed `<video>` that never needed it.

## Fix

New lint rule **`media_crossorigin_breaks_preview`** (severity: `error`) flags `crossorigin` on `<video>`/`<audio>`.

Plain displayed media never needs `crossorigin` — it's only required to read pixels/samples back (canvas/WebGL texture, WebAudio `createMediaElementSource`) **and** only when the host is known CORS-enabled. The fix hint says exactly that, so the rare legitimate case is clearly explained.

Render gating is unchanged: like other `error` findings it only blocks renders under the existing strict flags (`shouldBlockRender`), so this surfaces the problem without breaking compositions that intentionally use `crossorigin`.

## Test plan

- Added two tests in `media.test.ts` (fires on `crossorigin`, silent without it)
- `bun run test` in `packages/lint` — **262 passed**
- `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)