### PR TITLE
fix(cli): omit render duration when feedback command has none

### DIFF
--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -42,9 +42,10 @@ export default defineCommand({
 
     const doctorSummary = await getDoctorSummary();
 
+    // The standalone command runs separately from `render`, so it has no real
+    // elapsed time to report. Omit it rather than recording a fake duration.
     trackRenderFeedback({
       rating,
-      renderDurationMs: 0,
       comment: args.comment || undefined,
       doctorSummary,
     });

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -11,6 +11,7 @@ const {
   trackRenderObservation,
   trackCommandFailure,
   trackCliError,
+  trackRenderFeedback,
 } = await import("./events.js");
 
 describe("render telemetry events", () => {
@@ -95,6 +96,29 @@ describe("render telemetry events", () => {
         composition_hash: "abc123",
         message: "Navigation failed for [path]",
       }),
+    );
+  });
+});
+
+describe("trackRenderFeedback", () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+  });
+
+  it("omits render_duration_ms when no duration is known (standalone feedback)", () => {
+    trackRenderFeedback({ rating: 4, comment: "great" });
+
+    const [, props] = trackEvent.mock.calls[0] as [string, Record<string, unknown>];
+    expect(props).not.toHaveProperty("render_duration_ms");
+    expect(props.$survey_response).toBe(4);
+  });
+
+  it("includes render_duration_ms when a real duration is supplied", () => {
+    trackRenderFeedback({ rating: 5, renderDurationMs: 6000 });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "survey sent",
+      expect.objectContaining({ render_duration_ms: 6000 }),
     );
   });
 });

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -350,7 +350,7 @@ export function trackTranscribeUnavailable(props: { optional: boolean }): void {
 
 export function trackRenderFeedback(props: {
   rating: number;
-  renderDurationMs: number;
+  renderDurationMs?: number;
   comment?: string;
   doctorSummary?: string;
 }): void {
@@ -358,7 +358,7 @@ export function trackRenderFeedback(props: {
     $survey_id: "render_satisfaction",
     $survey_response: props.rating,
     ...(props.comment ? { $survey_response_2: props.comment } : {}),
-    render_duration_ms: props.renderDurationMs,
+    ...(props.renderDurationMs !== undefined ? { render_duration_ms: props.renderDurationMs } : {}),
     ...(props.doctorSummary ? { doctor_summary: props.doctorSummary } : {}),
   });
 }


### PR DESCRIPTION
## Problem

The standalone `hyperframes feedback` command always passed `renderDurationMs: 0` to the feedback analytics event. The command runs separately from `render`, so it has no access to the prior render's elapsed time. Because the auto-prompt path returns early for agent and non-interactive runtimes, the standalone command is the one used in practice, so nearly every feedback event recorded a render duration of exactly 0. A hardcoded 0 is misleading: it reads as a real measurement when the value is simply unknown. Absent data is more honest than a fake zero.

## Fix

Make `renderDurationMs` optional on `trackRenderFeedback` and only include the `render_duration_ms` field in the event when a real value is supplied. The standalone command no longer passes a duration, so the field is omitted; the auto-prompt path still forwards the real elapsed time after a render.

## Tests

Added unit coverage in `events.test.ts`:
- standalone feedback (no duration) emits no `render_duration_ms` property
- a supplied duration is still included

`bunx vitest run` for the telemetry suite is green; oxfmt + oxlint clean; pre-commit fallow/typecheck/commitlint gates passed.