### PR TITLE
fix(engine): pad odd output dimensions up to even for H.264/H.265 encode

### DIFF
--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -904,16 +904,55 @@ describe("buildEncoderArgs color space", () => {
     expect(args[vfIdx + 1]).toBe("scale=in_range=pc:out_range=tv,format=nv12,hwupload");
   });
 
-  it("skips range conversion filter for non-VAAPI GPU encoding", () => {
+  it("pads odd dimensions (no range scale) for non-VAAPI GPU encoding", () => {
+    for (const gpu of ["nvenc", "videotoolbox", "qsv", "amf"] as const) {
+      const args = buildEncoderArgs(
+        { ...baseOptions, codec: "h264", preset: "medium", quality: 23, useGpu: true },
+        inputArgs,
+        "out.mp4",
+        gpu,
+      );
+      const vfIdx = args.indexOf("-vf");
+      // 4:2:0 HW encode still aborts on odd dims, so the pad must be present —
+      // but the range scale belongs to the SW path only.
+      expect(args[vfIdx + 1]).toBe("pad=ceil(iw/2)*2:ceil(ih/2)*2");
+      expect(args[vfIdx + 1]).not.toContain("scale=in_range");
+      // but still has color metadata
+      expect(args).toContain("-colorspace:v");
+    }
+  });
+
+  it("pads odd dimensions for 10-bit (yuv420p10le) GPU HDR encoding", () => {
     const args = buildEncoderArgs(
-      { ...baseOptions, codec: "h264", preset: "medium", quality: 23, useGpu: true },
+      {
+        ...baseOptions,
+        codec: "h265",
+        preset: "medium",
+        quality: 23,
+        useGpu: true,
+        pixelFormat: "yuv420p10le",
+      },
       inputArgs,
       "out.mp4",
       "nvenc",
     );
+    expect(args[args.indexOf("-vf") + 1]).toBe("pad=ceil(iw/2)*2:ceil(ih/2)*2");
+  });
+
+  it("leaves alpha ProRes untouched (no even-dim pad)", () => {
+    const args = buildEncoderArgs(
+      {
+        ...baseOptions,
+        codec: "prores",
+        preset: "4",
+        quality: 23,
+        pixelFormat: "yuva444p10le",
+      },
+      inputArgs,
+      "out.mov",
+    );
     expect(args.indexOf("-vf")).toBe(-1);
-    // but still has color metadata
-    expect(args).toContain("-colorspace:v");
+    expect(args.join(" ")).not.toContain("pad=");
   });
 
   it("does not add color metadata for VP9", () => {

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -396,11 +396,20 @@ export function buildEncoderArgs(
 
     // Range conversion: Chrome's full-range RGB → limited/TV range.
     if (gpuEncoder === "vaapi") {
+      // vaapi already runs `format=nv12,hwupload`; the nv12 conversion aligns
+      // odd dimensions before upload, so only prepend the range conversion.
       const vfIdx = args.indexOf("-vf");
       if (vfIdx !== -1) {
         args[vfIdx + 1] = `scale=in_range=pc:out_range=tv,${args[vfIdx + 1]}`;
       }
-    } else if (!shouldUseGpu) {
+    } else if (shouldUseGpu) {
+      // nvenc/videotoolbox/qsv/amf feed software frames straight to the HW
+      // encoder with no `-vf`. They hit the same "height not divisible by 2"
+      // abort as libx264 on an odd-sized 4:2:0 canvas, so pad odd dimensions
+      // up to even on the software side before the encode.
+      const vf = withEvenDimensionPad("", pixelFormat);
+      if (vf) args.push("-vf", vf);
+    } else {
       // Range conversion: Chrome screenshots are full-range RGB.
       // The scale filter handles both 8-bit and 10-bit correctly. Pad odd
       // dimensions up to even so libx264/libx265 (4:2:0) don't abort with

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -18,6 +18,7 @@ import {
   mapPresetForGpuEncoder,
 } from "../utils/gpuEncoder.js";
 import { type HdrTransfer, getHdrEncoderColorParams } from "../utils/hdr.js";
+import { withEvenDimensionPad } from "../utils/evenDimensions.js";
 import { formatFfmpegError, runFfmpeg } from "../utils/runFfmpeg.js";
 import { getFfmpegBinary } from "../utils/ffmpegBinaries.js";
 import { extractAudioMetadata } from "../utils/ffprobe.js";
@@ -401,8 +402,10 @@ export function buildEncoderArgs(
       }
     } else if (!shouldUseGpu) {
       // Range conversion: Chrome screenshots are full-range RGB.
-      // The scale filter handles both 8-bit and 10-bit correctly.
-      args.push("-vf", "scale=in_range=pc:out_range=tv");
+      // The scale filter handles both 8-bit and 10-bit correctly. Pad odd
+      // dimensions up to even so libx264/libx265 (4:2:0) don't abort with
+      // "height not divisible by 2" on an odd-sized composition canvas.
+      args.push("-vf", withEvenDimensionPad("scale=in_range=pc:out_range=tv", pixelFormat));
     }
 
     // Fixed timescale for consistent A/V timing across platforms.

--- a/packages/engine/src/services/streamingEncoder.test.ts
+++ b/packages/engine/src/services/streamingEncoder.test.ts
@@ -309,6 +309,24 @@ describe("buildStreamingArgs", () => {
       expect(h265Args[h265Args.indexOf("-c:v") + 1]).toBe("hevc_amf");
       expect(h265Args[h265Args.indexOf("-qp_i") + 1]).toBe("23");
     });
+
+    // 4:2:0 HW encode aborts on odd dims just like libx264, and these paths
+    // feed software frames straight to the encoder with no `-vf`, so the
+    // even-dim pad (and only the pad, not the SW range scale) must be added.
+    it("pads odd dimensions (no range scale) for non-VAAPI GPU encoding", () => {
+      for (const gpu of ["nvenc", "videotoolbox", "qsv", "amf"] as const) {
+        const args = buildStreamingArgs(baseGpu, "/tmp/out.mp4", gpu);
+        const vfIdx = args.indexOf("-vf");
+        expect(args[vfIdx + 1]).toBe("pad=ceil(iw/2)*2:ceil(ih/2)*2");
+        expect(args[vfIdx + 1]).not.toContain("scale=in_range");
+      }
+    });
+
+    it("prepends range conversion to VAAPI chain (nv12 covers even-dim)", () => {
+      const args = buildStreamingArgs(baseGpu, "/tmp/out.mp4", "vaapi");
+      const vfIdx = args.indexOf("-vf");
+      expect(args[vfIdx + 1]).toBe("scale=in_range=pc:out_range=tv,format=nv12,hwupload");
+    });
   });
 });
 

--- a/packages/engine/src/services/streamingEncoder.ts
+++ b/packages/engine/src/services/streamingEncoder.ts
@@ -351,11 +351,20 @@ export function buildStreamingArgs(
     if (options.rawInputFormat) {
       // No filter needed — PQ data goes straight to encoder
     } else if (gpuEncoder === "vaapi") {
+      // vaapi already runs `format=nv12,hwupload`; the nv12 conversion aligns
+      // odd dimensions before upload, so only prepend the range conversion.
       const vfIdx = args.indexOf("-vf");
       if (vfIdx !== -1) {
         args[vfIdx + 1] = `scale=in_range=pc:out_range=tv,${args[vfIdx + 1]}`;
       }
-    } else if (!shouldUseGpu) {
+    } else if (shouldUseGpu) {
+      // nvenc/videotoolbox/qsv/amf feed software frames straight to the HW
+      // encoder with no `-vf`. They hit the same "height not divisible by 2"
+      // abort as libx264 on an odd-sized 4:2:0 canvas, so pad odd dimensions
+      // up to even on the software side before the encode.
+      const vf = withEvenDimensionPad("", pixelFormat);
+      if (vf) args.push("-vf", vf);
+    } else {
       // Range conversion: Chrome screenshots are full-range RGB. Pad odd
       // dimensions up to even so libx264/libx265 (4:2:0) don't abort with
       // "height not divisible by 2" on an odd-sized composition canvas.

--- a/packages/engine/src/services/streamingEncoder.ts
+++ b/packages/engine/src/services/streamingEncoder.ts
@@ -28,6 +28,7 @@ import {
 import { formatFfmpegError } from "../utils/runFfmpeg.js";
 import { getFfmpegBinary } from "../utils/ffmpegBinaries.js";
 import { getHdrEncoderColorParams } from "../utils/hdr.js";
+import { withEvenDimensionPad } from "../utils/evenDimensions.js";
 import { DEFAULT_CONFIG, type EngineConfig } from "../config.js";
 import { fpsToFfmpegArg, type Fps } from "@hyperframes/core";
 import { appendVp9CpuUsedArg } from "./vp9Options.js";
@@ -355,8 +356,10 @@ export function buildStreamingArgs(
         args[vfIdx + 1] = `scale=in_range=pc:out_range=tv,${args[vfIdx + 1]}`;
       }
     } else if (!shouldUseGpu) {
-      // Range conversion: Chrome screenshots are full-range RGB.
-      args.push("-vf", "scale=in_range=pc:out_range=tv");
+      // Range conversion: Chrome screenshots are full-range RGB. Pad odd
+      // dimensions up to even so libx264/libx265 (4:2:0) don't abort with
+      // "height not divisible by 2" on an odd-sized composition canvas.
+      args.push("-vf", withEvenDimensionPad("scale=in_range=pc:out_range=tv", pixelFormat));
     }
 
     // Fixed timescale for consistent A/V timing across platforms.

--- a/packages/engine/src/utils/evenDimensions.test.ts
+++ b/packages/engine/src/utils/evenDimensions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { requiresEvenDimensions, withEvenDimensionPad } from "./evenDimensions.js";
+
+describe("requiresEvenDimensions", () => {
+  it("flags 4:2:0 subsampled formats", () => {
+    expect(requiresEvenDimensions("yuv420p")).toBe(true);
+    expect(requiresEvenDimensions("yuv420p10le")).toBe(true);
+    expect(requiresEvenDimensions("yuvj420p")).toBe(true);
+  });
+
+  it("leaves 4:4:4 / alpha formats alone", () => {
+    expect(requiresEvenDimensions("yuva444p10le")).toBe(false); // ProRes 4444
+    expect(requiresEvenDimensions("yuva420p")).toBe(false); // VP9 alpha (own branch)
+    expect(requiresEvenDimensions("rgb48le")).toBe(false);
+  });
+});
+
+describe("withEvenDimensionPad", () => {
+  it("appends the even-up pad for subsampled output (odd dims bumped to even)", () => {
+    const vf = withEvenDimensionPad("scale=in_range=pc:out_range=tv", "yuv420p");
+    expect(vf).toBe("scale=in_range=pc:out_range=tv,pad=ceil(iw/2)*2:ceil(ih/2)*2");
+  });
+
+  it("returns just the pad when there is no existing filter chain", () => {
+    expect(withEvenDimensionPad("", "yuv420p")).toBe("pad=ceil(iw/2)*2:ceil(ih/2)*2");
+  });
+
+  it("leaves the filter chain unchanged for alpha output (even in, unchanged)", () => {
+    const vf = "scale=in_range=pc:out_range=tv";
+    expect(withEvenDimensionPad(vf, "yuva444p10le")).toBe(vf);
+  });
+
+  it("pad rounds UP to even: ceil(n/2)*2 is a no-op for even and +1 for odd", () => {
+    const evenUp = (n: number) => Math.ceil(n / 2) * 2;
+    expect(evenUp(1080)).toBe(1080); // even in, unchanged
+    expect(evenUp(723)).toBe(724); // odd in, bumped to even
+    expect(evenUp(1)).toBe(2);
+  });
+});

--- a/packages/engine/src/utils/evenDimensions.ts
+++ b/packages/engine/src/utils/evenDimensions.ts
@@ -1,0 +1,45 @@
+/**
+ * Even-dimension normalization for chroma-subsampled encodes.
+ *
+ * libx264 / libx265 with 4:2:0 chroma subsampling (yuv420p, yuv420p10le)
+ * require both width and height to be even. An odd output dimension makes the
+ * encoder abort before writing a single packet:
+ *
+ *   [libx264] height not divisible by 2 (1080x723)
+ *   Error while opening encoder ... Invalid argument
+ *
+ * A composition with an odd data-width / data-height (e.g. a custom 3:1 canvas
+ * at 1080x723) therefore fails to encode to H.264. The fix pads the odd
+ * dimension up by a single pixel inside the encode filter chain, so the
+ * encoder always receives even dimensions. Padding (not scaling) means content
+ * is never resampled — at most one transparent/black row or column is added at
+ * the bottom-right edge.
+ */
+
+// `pad=ceil(iw/2)*2:ceil(ih/2)*2` rounds each dimension UP to the next even
+// value (a no-op when already even) and keeps content at the top-left (x=0,y=0
+// default), so nothing shifts. iw/ih are evaluated by FFmpeg at runtime, so
+// this works whether or not the caller knows the frame size up front.
+const EVEN_DIMENSION_PAD = "pad=ceil(iw/2)*2:ceil(ih/2)*2";
+
+/**
+ * Pixel formats whose chroma subsampling requires even width AND height.
+ * 4:2:0 family only: yuv420p (H.264 SDR), yuv420p10le (H.265 HDR), and the
+ * full-range yuvj420p Chrome screenshots arrive as. ProRes 4444
+ * (yuva444p10le) and other 4:4:4 / alpha formats sample chroma per-pixel and
+ * accept odd dimensions, so they are deliberately excluded — padding them
+ * would needlessly distort transparent output.
+ */
+export function requiresEvenDimensions(pixelFormat: string): boolean {
+  return pixelFormat.startsWith("yuv420") || pixelFormat.startsWith("yuvj420");
+}
+
+/**
+ * Append the even-dimension pad to an FFmpeg `-vf` chain when the target pixel
+ * format requires it. Returns the chain unchanged for formats that accept odd
+ * dimensions, and returns just the pad when there is no existing chain.
+ */
+export function withEvenDimensionPad(vfChain: string, pixelFormat: string): string {
+  if (!requiresEvenDimensions(pixelFormat)) return vfChain;
+  return vfChain ? `${vfChain},${EVEN_DIMENSION_PAD}` : EVEN_DIMENSION_PAD;
+}


### PR DESCRIPTION
## Problem

A composition with an odd `data-width` or `data-height` (e.g. a custom 3:1 canvas at `1080x723`) fails to render to MP4. The render gets through capture, then the H.264 encode aborts before writing a single packet:

```
[libx264] height not divisible by 2 (1080x723)
[enc:libx264] Error while opening encoder ... Invalid argument
Conversion failed!
```

libx264 / libx265 with 4:2:0 chroma subsampling (`yuv420p`, `yuv420p10le`) require both width and height to be even. Any odd-sized canvas takes the whole render down. The same constraint applies to the hardware encoders (nvenc / videotoolbox / qsv / amf), which abort identically on `--gpu` with an odd-sized 4:2:0 canvas.

## Root cause

Both the streaming encoder (`buildStreamingArgs`) and the chunk encoder (`buildEncoderArgs`) build their encode filter chains with no even-dimension enforcement:

- The **software** paths (libx264 / libx265) build `scale=in_range=pc:out_range=tv` with no pad, so an odd frame reaches libx264 unmodified.
- The **GPU** paths (nvenc / videotoolbox / qsv / amf) feed software frames straight to the hardware encoder with no `-vf` chain at all, so an odd-sized 4:2:0 canvas hits the same `height not divisible by 2` abort.

There was no even-dimension guard anywhere on the encode path.

## Fix

Add a shared `withEvenDimensionPad` helper that appends `pad=ceil(iw/2)*2:ceil(ih/2)*2` to the filter chain, but only for 4:2:0 pixel formats. The pad rounds each odd dimension up by one pixel (a no-op when already even) without scaling, so content is never resampled. Formats that accept odd dimensions (ProRes 4444 `yuva444p10le`, VP9 `yuva420p`) are excluded by `requiresEvenDimensions`, so transparent / alpha output is untouched.

The pad is wired into every 4:2:0 encode path that needs it, in both encoders:

- **Software** (libx264 / libx265): appended after the range-conversion scale.
- **GPU nvenc / videotoolbox / qsv / amf**: added as a CPU-side `-vf` pad before the encode (these previously had no `-vf` at all).
- **GPU vaapi**: left as-is. Its existing `format=nv12,hwupload` conversion already aligns odd dimensions before upload, so it is deliberately not double-padded.

## Verification

- Repro project with `data-width="1080" data-height="723"`:
  - Before: `render` fails with `height not divisible by 2 (1080x723)`.
  - After: `render` succeeds; `ffprobe` reports `1080,724,yuv420p` (height padded up by 1px, no scaling).
- Unit tests assert the built arg lists across all paths: software, the four GPU paths (8-bit and 10-bit 4:2:0), and the vaapi chain, plus alpha / 4:4:4 formats left unchanged.
- The software fix is render-verified (repro above). The GPU paths (nvenc / videotoolbox / qsv / amf) are logic-tested at the arg-construction level only; no hardware encoder is available to run them here.
- `vitest run` for the `evenDimensions`, `streamingEncoder`, and `chunkEncoder` suites pass.
