### PR TITLE
fix(lint): recognize Three.js loaded via ESM URL/path imports

### DIFF
--- a/packages/lint/src/rules/adapters.test.ts
+++ b/packages/lint/src/rules/adapters.test.ts
@@ -124,6 +124,88 @@ describe("adapter rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does not report missing_three_script for an ESM +esm CDN import (jsdelivr)", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"></div>
+  <script type="module">
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160/+esm';
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+    const scene = new THREE.Scene();
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "missing_three_script");
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not report missing_three_script for an esm.sh/three import", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"></div>
+  <script type="module">
+    import * as THREE from 'https://esm.sh/three';
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+    const scene = new THREE.Scene();
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "missing_three_script");
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not report missing_three_script for a local three.module.js import", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"></div>
+  <script type="module">
+    import { Scene } from './vendor/three.module.js';
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+    const scene = new Scene();
+    THREE.foo();
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "missing_three_script");
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not report missing_three_script for a bare 'three' import (regression)", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"></div>
+  <script type="module">
+    import * as THREE from 'three';
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+    const scene = new THREE.Scene();
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "missing_three_script");
+    expect(finding).toBeUndefined();
+  });
+
+  it("still reports missing_three_script when THREE is used with no three loaded", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"></div>
+  <script type="module">
+    import { gsap } from 'https://cdn.jsdelivr.net/npm/gsap@3/+esm';
+    window.__timelines = window.__timelines || {};
+    window.__timelines["main"] = gsap.timeline({ paused: true });
+    const scene = new THREE.Scene();
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "missing_three_script");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+  });
+
   it("does not report any adapter errors for composition with no adapter usage", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/rules/adapters.ts
+++ b/packages/lint/src/rules/adapters.ts
@@ -36,8 +36,11 @@ export const adapterRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> 
         /["']three["']/.test(t) &&
         /importmap/.test(scripts.find((s) => s.content === t)?.attrs || ""),
     );
-    const hasThreeModuleImport = texts.some(
-      (t) => /\bimport\b.*['"]three['"]/.test(t) || /\bfrom\s+['"]three['"]/.test(t),
+    // Matches any import/from whose specifier contains "three" (bare 'three', or a
+    // URL/path like .../+esm, esm.sh/three, three.module.js), mirroring the loose
+    // /three/i treatment of <script src>.
+    const hasThreeModuleImport = texts.some((t) =>
+      /\b(?:import|from)\s*[^;\n]*['"][^'"]*three[^'"]*['"]/i.test(t),
     );
 
     if (!usesThree || hasThreeScript || hasThreeImportMap || hasThreeModuleImport) return [];


### PR DESCRIPTION
## Problem

The `missing_three_script` lint rule raised a blocking ERROR for compositions that use `THREE.` but load Three.js via an ESM module import whose specifier is a URL or path rather than the bare `'three'` token. The module-import check only matched `import ... 'three'` / `from 'three'`, so these realistic forms were not recognized:

- `import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160/+esm'`
- `import * as THREE from 'https://esm.sh/three'`
- `import { Scene } from 'https://unpkg.com/three@0.160/build/three.module.js'`
- `import { Scene } from './vendor/three.module.js'`

The false error pushed authors onto the deprecated UMD `three.min.js` global build, which then emits a Three.js deprecation warning.

## Fix

Generalize the module-import detection so an `import`/`from` whose specifier contains "three" (case-insensitive) counts as loading Three.js, mirroring the already-loose `/three/i` treatment of `<script src>`. The specifier must still contain "three", so unrelated imports do not satisfy it. Bare `'three'`, importmap, and `<script src>` paths are unchanged.

## Tests

Extended `packages/lint/src/rules/adapters.test.ts`:
1. ESM `+esm` CDN import does NOT error
2. `esm.sh/three` import does NOT error
3. local `three.module.js` import does NOT error
4. bare `from 'three'` still does NOT error (regression)
5. `THREE.` usage with no Three.js loaded at all STILL errors (true positive preserved)

`bunx vitest run packages/lint` is green (268 passed).