### PR TITLE
fix(cli): serve project media with HTTP Range so validate reads WAV duration

### DIFF
--- a/packages/cli/src/utils/staticProjectServer.test.ts
+++ b/packages/cli/src/utils/staticProjectServer.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { serveStaticProjectHtml, type StaticProjectServer } from "./staticProjectServer.js";
+
+let server: StaticProjectServer | undefined;
+let dir: string | undefined;
+
+afterEach(async () => {
+  await server?.close();
+  server = undefined;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = undefined;
+});
+
+async function serveWith(bytes: Buffer): Promise<{ url: string }> {
+  dir = mkdtempSync(join(tmpdir(), "hf-static-"));
+  writeFileSync(join(dir, "tone.wav"), bytes);
+  server = await serveStaticProjectHtml(dir, "<html></html>");
+  return { url: server.url };
+}
+
+describe("serveStaticProjectHtml range support", () => {
+  it("answers a Range request with 206 + the requested byte slice", async () => {
+    // Chromium needs byte-range seekability or WAV `.duration` reports Infinity,
+    // which makes `hyperframes validate` falsely warn it cannot read the duration.
+    const body = Buffer.from("0123456789", "utf-8");
+    const { url } = await serveWith(body);
+
+    const res = await fetch(`${url}tone.wav`, { headers: { Range: "bytes=2-5" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(res.headers.get("content-range")).toBe(`bytes 2-5/${body.length}`);
+    expect(await res.text()).toBe("2345");
+  });
+
+  it("advertises Accept-Ranges even on a full 200 response", async () => {
+    const { url } = await serveWith(Buffer.from("abcdef", "utf-8"));
+    const res = await fetch(`${url}tone.wav`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(await res.text()).toBe("abcdef");
+  });
+
+  it("returns 416 for an unsatisfiable range", async () => {
+    const body = Buffer.from("abc", "utf-8");
+    const { url } = await serveWith(body);
+    const res = await fetch(`${url}tone.wav`, { headers: { Range: "bytes=99-200" } });
+    expect(res.status).toBe(416);
+    expect(res.headers.get("content-range")).toBe(`bytes */${body.length}`);
+  });
+});

--- a/packages/cli/src/utils/staticProjectServer.test.ts
+++ b/packages/cli/src/utils/staticProjectServer.test.ts
@@ -43,6 +43,21 @@ describe("serveStaticProjectHtml range support", () => {
     expect(await res.text()).toBe("abcdef");
   });
 
+  it("streams a small slice out of a large file without buffering the whole thing", async () => {
+    // 8MB file, ask for 4 bytes deep inside it. The handler must createReadStream
+    // the [start,end] window only, not readFileSync the whole 8MB and slice.
+    const size = 8 * 1024 * 1024;
+    const big = Buffer.alloc(size, 0x61); // 'a' everywhere...
+    big.write("WXYZ", 5_000_000); // ...except a 4-byte marker
+    const { url } = await serveWith(big);
+
+    const res = await fetch(`${url}tone.wav`, { headers: { Range: "bytes=5000000-5000003" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe(`bytes 5000000-5000003/${size}`);
+    expect(res.headers.get("content-length")).toBe("4");
+    expect(await res.text()).toBe("WXYZ");
+  });
+
   it("returns 416 for an unsatisfiable range", async () => {
     const body = Buffer.from("abc", "utf-8");
     const { url } = await serveWith(body);

--- a/packages/cli/src/utils/staticProjectServer.ts
+++ b/packages/cli/src/utils/staticProjectServer.ts
@@ -1,5 +1,5 @@
 import { createServer, type ServerResponse } from "node:http";
-import { existsSync, readFileSync } from "node:fs";
+import { createReadStream, existsSync, statSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
 import { getMimeType } from "@hyperframes/core/studio-api";
 
@@ -22,38 +22,49 @@ function serveFileWithRange(
   rangeHeader: string | undefined,
   res: ServerResponse,
 ) {
-  const body = readFileSync(filePath);
+  const size = statSync(filePath).size;
   const headers: Record<string, string> = {
     "Content-Type": getMimeType(filePath),
     "Accept-Ranges": "bytes",
   };
 
+  // Resolve the requested byte window. Absent/malformed Range serves the
+  // whole file (200); a valid `bytes=start-end` (including the open-ended
+  // `start-` and suffix `-N` forms) serves a 206 slice.
+  const last = size - 1;
+  let start = 0;
+  let end = last;
+  let status = 200;
   const match = rangeHeader ? /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim()) : null;
-  if (!match) {
-    res.writeHead(200, { ...headers, "Content-Length": String(body.length) });
-    res.end(body);
-    return;
+  if (match) {
+    const hasStart = match[1] !== "";
+    start = hasStart ? Number(match[1]) : Math.max(0, size - Number(match[2]));
+    end = !hasStart ? last : match[2] !== "" ? Math.min(Number(match[2]), last) : last;
+
+    if (start > end || start > last) {
+      res.writeHead(416, { ...headers, "Content-Range": `bytes */${size}` });
+      res.end();
+      return;
+    }
+    status = 206;
+    headers["Content-Range"] = `bytes ${start}-${end}/${size}`;
   }
+  headers["Content-Length"] = String(end - start + 1);
 
-  // Resolve `bytes=start-end`, including the open-ended (`start-`) and
-  // suffix (`-N`, last N bytes) forms.
-  const last = body.length - 1;
-  const hasStart = match[1] !== "";
-  const start = hasStart ? Number(match[1]) : Math.max(0, body.length - Number(match[2]));
-  const end = !hasStart ? last : match[2] !== "" ? Math.min(Number(match[2]), last) : last;
-
-  if (start > end || start > last) {
-    res.writeHead(416, { ...headers, "Content-Range": `bytes */${body.length}` });
-    res.end();
-    return;
-  }
-
-  res.writeHead(206, {
-    ...headers,
-    "Content-Range": `bytes ${start}-${end}/${body.length}`,
-    "Content-Length": String(end - start + 1),
+  // Stream only the requested window instead of buffering the whole file: a
+  // 1KB Range of a 50MB asset must not allocate 50MB. createReadStream reads
+  // just `[start, end]` and closes its own fd on end/error. writeHead is
+  // deferred to `open` so a failed open can still answer 500.
+  const stream = createReadStream(filePath, { start, end });
+  stream.on("open", () => {
+    res.writeHead(status, headers);
+    stream.pipe(res);
   });
-  res.end(body.subarray(start, end + 1));
+  stream.on("error", () => {
+    if (!res.headersSent) res.writeHead(500);
+    res.end();
+    stream.destroy();
+  });
 }
 
 export async function serveStaticProjectHtml(

--- a/packages/cli/src/utils/staticProjectServer.ts
+++ b/packages/cli/src/utils/staticProjectServer.ts
@@ -1,4 +1,4 @@
-import { createServer } from "node:http";
+import { createServer, type ServerResponse } from "node:http";
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
 import { getMimeType } from "@hyperframes/core/studio-api";
@@ -7,6 +7,53 @@ export interface StaticProjectServer {
   url: string;
   port: number;
   close: () => Promise<void>;
+}
+
+/**
+ * Serve a file with HTTP Range support. Chromium needs byte-range seekability
+ * to determine the duration of formats that carry it in a trailing/implicit
+ * position (notably WAV, which otherwise reports `.duration` as `Infinity`
+ * however long it buffers). A plain 200 with no `Accept-Ranges` makes the
+ * media element non-seekable, so `hyperframes validate` would spuriously warn
+ * that a perfectly valid local WAV's duration "could not be read".
+ */
+function serveFileWithRange(
+  filePath: string,
+  rangeHeader: string | undefined,
+  res: ServerResponse,
+) {
+  const body = readFileSync(filePath);
+  const headers: Record<string, string> = {
+    "Content-Type": getMimeType(filePath),
+    "Accept-Ranges": "bytes",
+  };
+
+  const match = rangeHeader ? /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim()) : null;
+  if (!match) {
+    res.writeHead(200, { ...headers, "Content-Length": String(body.length) });
+    res.end(body);
+    return;
+  }
+
+  // Resolve `bytes=start-end`, including the open-ended (`start-`) and
+  // suffix (`-N`, last N bytes) forms.
+  const last = body.length - 1;
+  const hasStart = match[1] !== "";
+  const start = hasStart ? Number(match[1]) : Math.max(0, body.length - Number(match[2]));
+  const end = !hasStart ? last : match[2] !== "" ? Math.min(Number(match[2]), last) : last;
+
+  if (start > end || start > last) {
+    res.writeHead(416, { ...headers, "Content-Range": `bytes */${body.length}` });
+    res.end();
+    return;
+  }
+
+  res.writeHead(206, {
+    ...headers,
+    "Content-Range": `bytes ${start}-${end}/${body.length}`,
+    "Content-Length": String(end - start + 1),
+  });
+  res.end(body.subarray(start, end + 1));
 }
 
 export async function serveStaticProjectHtml(
@@ -31,8 +78,7 @@ export async function serveStaticProjectHtml(
       return;
     }
     if (existsSync(filePath)) {
-      res.writeHead(200, { "Content-Type": getMimeType(filePath) });
-      res.end(readFileSync(filePath));
+      serveFileWithRange(filePath, req.headers.range, res);
       return;
     }
     res.writeHead(404);


### PR DESCRIPTION
## Problem

`hyperframes validate` reports `Could not read the duration of N media element(s) within the validate timeout` for a perfectly valid LOCAL `.wav` audio element, even though the same audio renders fine. Raising `--timeout` does not help: the warning persists no matter how long it waits. MP3/AAC/MP4 sources are unaffected.

## Root cause

The local static server (`serveStaticProjectHtml`, used by `validate`, `snapshot`, and `layout`) answered every asset request with a plain `200` and no `Accept-Ranges` header, ignoring the `Range` request header Chromium sends for media. Chromium treats a resource served without range support as non-seekable. For WAV that makes the `<audio>`/`<video>` element report `.duration` as `Infinity` no matter how long it buffers (the element reaches `readyState` 4 / `HAVE_ENOUGH_DATA`, but duration never resolves). The duration audit then sees a non-finite value and emits the spurious "could not read duration" warning. MP3/MP4 carry duration in their container metadata, so they resolve without range support.

Verified directly in headless Chrome with the same local WAV:
- served without Range support: `.duration = Infinity` (readyState 4)
- served with Range support (`206` + `Content-Range`): `.duration = 3`

## Fix

Serve project files with HTTP Range support: `206` + `Content-Range` for range requests (open-ended and suffix forms handled), `Accept-Ranges: bytes` advertised on the full `200` too, and `416` for an unsatisfiable range. The media element becomes seekable, so WAV duration resolves.

## Verification

Minimal project with a local 3s WAV (`<audio data-duration>`), built CLI:
- Before: `validate` warned "Could not read the duration of 1 media element(s)..." (persisted even at `--timeout 10000`, ~11.7s run).
- After: no warning, `validate` clean in ~4.8s. MP3 and no-media variants unchanged.
- The genuine "media is Xs but its slot is Ys" warning now also works for WAV for the first time (slot 10s vs 3s source correctly flagged).
- `vitest run packages/cli`: 1061 passed, including a new focused `staticProjectServer.test.ts` (206 slice, Accept-Ranges on 200, 416 unsatisfiable).