### PR TITLE
fix(lint): catch visible markup comments

### DIFF
--- a/packages/lint/src/context.ts
+++ b/packages/lint/src/context.ts
@@ -34,8 +34,15 @@ export function buildLintContext(html: string, options: HyperframeLinterOptions 
   // hijack the boundary match below. Linear + fixpoint (see stripHtmlComments) to
   // stay ReDoS-free and catch markers that re-form when a comment is removed.
   let source = stripHtmlComments(rawSource);
+  const sourceWithoutTemplates = source.replace(
+    /<template\b[^>]*>[\s\S]*?<\/template(?:\s[^>]*)?>/gi,
+    " ",
+  );
   const templateMatch = source.match(/<template[^>]*>([\s\S]*)<\/template>/i);
-  if (templateMatch?.[1]) source = templateMatch[1];
+  // Some sub-composition files are HTML shells whose real root lives inside a
+  // <template>. Keep nested templates intact when the visible document already
+  // has a composition root; only unwrap when no root exists outside templates.
+  if (templateMatch?.[1] && !findRootTag(sourceWithoutTemplates)) source = templateMatch[1];
 
   const tags = extractOpenTags(source);
   const styles = [

--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -387,14 +387,35 @@ body {
     expect(finding?.snippet).toContain("Main Content Block");
   });
 
+  it("reports error when a misbalanced style block leaves block comment syntax visible", async () => {
+    const html = compositionWithBodyPrefix(
+      "",
+      `
+    <style>
+      .editorial-block { color: #fff; }
+    </style>
+    </style>
+    /* Main Content Block */
+    <div class="editorial-block">Hello</div>
+`,
+    );
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "visible_markup_comment");
+
+    expect(finding).toBeDefined();
+    expect(finding?.snippet).toContain("Main Content Block");
+  });
+
   it("does not report block comments inside style or script blocks", async () => {
     const html = `
 <html>
 <head>
+  <title>/* tab name */ Particle Field</title>
   <style>
     /* Layout reset */
     body { margin: 0; }
   </style>
+  <noscript>/* fallback note */</noscript>
 </head>
 <body>
   <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
@@ -410,13 +431,17 @@ body {
     expect(finding).toBeUndefined();
   });
 
-  it("does not report block comments in attributes, html comments, or code examples", async () => {
+  it("does not report block comments in attributes, html comments, or protected text contexts", async () => {
     const html = compositionWithBodyPrefix(
       "",
       `
     <!-- /* hidden implementation note */ -->
     <div data-note="/* attribute note */"></div>
     <pre>/* visible code sample */</pre>
+    <code>/* visible inline code sample */</code>
+    <textarea>/* editable code sample */</textarea>
+    <template>/* template-only note */</template>
+    <svg viewBox="0 0 100 20"><text x="0" y="15">/* svg label */</text></svg>
 `,
     );
     const result = await lintHyperframeHtml(html);

--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -370,6 +370,61 @@ body {
     expect(finding).toBeUndefined();
   });
 
+  it("reports error when CSS block comment syntax leaks into visible markup", async () => {
+    const html = compositionWithBodyPrefix(
+      "",
+      `
+    /* Main Content Block */
+    <div class="editorial-block">Hello</div>
+`,
+    );
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "visible_markup_comment");
+
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+    expect(finding?.message).toContain("visible HTML markup");
+    expect(finding?.snippet).toContain("Main Content Block");
+  });
+
+  it("does not report block comments inside style or script blocks", async () => {
+    const html = `
+<html>
+<head>
+  <style>
+    /* Layout reset */
+    body { margin: 0; }
+  </style>
+</head>
+<body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>
+    /* Timeline registry */
+    window.__timelines = {};
+  </script>
+</body>
+</html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "visible_markup_comment");
+
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not report block comments in attributes, html comments, or code examples", async () => {
+    const html = compositionWithBodyPrefix(
+      "",
+      `
+    <!-- /* hidden implementation note */ -->
+    <div data-note="/* attribute note */"></div>
+    <pre>/* visible code sample */</pre>
+`,
+    );
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "visible_markup_comment");
+
+    expect(finding).toBeUndefined();
+  });
+
   it("reports error when a stray style close tag is left in the document head", async () => {
     const html = compositionWithHead(`
   <style>

--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -437,6 +437,7 @@ body {
       `
     <!-- /* hidden implementation note */ -->
     <div data-note="/* attribute note */"></div>
+    <div data-note="a > b /* quoted attribute note */"></div>
     <pre>/* visible code sample */</pre>
     <code>/* visible inline code sample */</code>
     <textarea>/* editable code sample */</textarea>

--- a/packages/lint/src/rules/core.ts
+++ b/packages/lint/src/rules/core.ts
@@ -137,9 +137,7 @@ function findLeakedTextBeforeCompositionRoot(
 
 function findProtectedVisibleMarkupRanges(source: string): SourceRange[] {
   const ranges: SourceRange[] = [];
-  VISIBLE_MARKUP_COMMENT_PROTECTED_BLOCK_PATTERN.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = VISIBLE_MARKUP_COMMENT_PROTECTED_BLOCK_PATTERN.exec(source)) !== null) {
+  for (const match of source.matchAll(VISIBLE_MARKUP_COMMENT_PROTECTED_BLOCK_PATTERN)) {
     ranges.push({ start: match.index, end: match.index + match[0].length });
   }
   return ranges;
@@ -150,17 +148,30 @@ function isInsideSourceRange(index: number, ranges: SourceRange[]): boolean {
 }
 
 function isInsideHtmlTag(source: string, index: number): boolean {
-  const lastOpen = source.lastIndexOf("<", index);
-  if (lastOpen === -1) return false;
-  const lastClose = source.lastIndexOf(">", index);
-  return lastOpen > lastClose;
+  let inTag = false;
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < index; i++) {
+    const char = source[i];
+    if (!inTag) {
+      if (char === "<") inTag = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      inTag = false;
+    }
+  }
+  return inTag;
 }
 
 function findVisibleMarkupCommentLeak(source: string): string | null {
   const protectedRanges = findProtectedVisibleMarkupRanges(source);
-  VISIBLE_MARKUP_COMMENT_PATTERN.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = VISIBLE_MARKUP_COMMENT_PATTERN.exec(source)) !== null) {
+  for (const match of source.matchAll(VISIBLE_MARKUP_COMMENT_PATTERN)) {
     if (isInsideHtmlTag(source, match.index)) continue;
     if (isInsideSourceRange(match.index, protectedRanges)) continue;
     return match[0];

--- a/packages/lint/src/rules/core.ts
+++ b/packages/lint/src/rules/core.ts
@@ -68,6 +68,14 @@ const ORPHAN_CSS_AT_RULE_PATTERN =
   /(?:^|\s)@(?:container|font-face|keyframes|layer|media|page|property|scope|supports)[^{<]*\{[\s\S]*?:[\s\S]*?\}/i;
 const ORPHAN_CSS_RULE_PATTERN =
   /(?:^|\s)(?:\/\*[\s\S]*?\*\/\s*)?(?:@[a-z-]+[^{}<]*|[.#][\w-]+[^{}<]*|[a-z][\w-]*(?:\s+[.#:[\w-][^{}<]*)?)\s*\{[^{}]*:[^{}]*\}/i;
+const VISIBLE_MARKUP_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
+const VISIBLE_MARKUP_COMMENT_PROTECTED_BLOCK_PATTERN =
+  /<(style|script|template|pre|code|textarea)\b[^>]*>[\s\S]*?<\/\1(?:\s[^>]*)?>/gi;
+
+interface SourceRange {
+  start: number;
+  end: number;
+}
 
 function findCodeFenceLeak(headWithoutValidBlocks: string): string | null {
   return MARKDOWN_CODE_FENCE_PATTERN.exec(headWithoutValidBlocks)?.[0] ?? null;
@@ -127,6 +135,39 @@ function findLeakedTextBeforeCompositionRoot(
   return findLeakedTextInHeadContent(source.slice(prefixStart, prefixEnd));
 }
 
+function findProtectedVisibleMarkupRanges(source: string): SourceRange[] {
+  const ranges: SourceRange[] = [];
+  VISIBLE_MARKUP_COMMENT_PROTECTED_BLOCK_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = VISIBLE_MARKUP_COMMENT_PROTECTED_BLOCK_PATTERN.exec(source)) !== null) {
+    ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return ranges;
+}
+
+function isInsideSourceRange(index: number, ranges: SourceRange[]): boolean {
+  return ranges.some((range) => range.start <= index && index < range.end);
+}
+
+function isInsideHtmlTag(source: string, index: number): boolean {
+  const lastOpen = source.lastIndexOf("<", index);
+  if (lastOpen === -1) return false;
+  const lastClose = source.lastIndexOf(">", index);
+  return lastOpen > lastClose;
+}
+
+function findVisibleMarkupCommentLeak(source: string): string | null {
+  const protectedRanges = findProtectedVisibleMarkupRanges(source);
+  VISIBLE_MARKUP_COMMENT_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = VISIBLE_MARKUP_COMMENT_PATTERN.exec(source)) !== null) {
+    if (isInsideHtmlTag(source, match.index)) continue;
+    if (isInsideSourceRange(match.index, protectedRanges)) continue;
+    return match[0];
+  }
+  return null;
+}
+
 export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
   // root_missing_composition_id + root_missing_dimensions
   ({ rootTag }) => {
@@ -169,6 +210,23 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
           "Detected leaked code or CSS text around the document `<head>` or before the composition root. Browsers render this as visible text in the video.",
         fixHint:
           "Move CSS into a single `<style>...</style>` block and remove stray close tags, markdown fences, or code text from `<head>`, the `</head>`/`<body>` boundary, or the pre-root body prefix.",
+        snippet: truncateSnippet(snippet),
+      },
+    ];
+  },
+
+  // visible_markup_comment
+  ({ source }) => {
+    const snippet = findVisibleMarkupCommentLeak(source);
+    if (!snippet) return [];
+    return [
+      {
+        code: "visible_markup_comment",
+        severity: "error",
+        message:
+          "CSS/JS block comment syntax (`/* ... */`) appears in visible HTML markup. HTML only treats `<!-- ... -->` as comments, so this renders as on-screen text.",
+        fixHint:
+          "Remove the text or convert it to a real HTML comment (`<!-- ... -->`). Keep CSS comments inside `<style>` and JS comments inside `<script>`.",
         snippet: truncateSnippet(snippet),
       },
     ];

--- a/packages/lint/src/rules/core.ts
+++ b/packages/lint/src/rules/core.ts
@@ -70,7 +70,7 @@ const ORPHAN_CSS_RULE_PATTERN =
   /(?:^|\s)(?:\/\*[\s\S]*?\*\/\s*)?(?:@[a-z-]+[^{}<]*|[.#][\w-]+[^{}<]*|[a-z][\w-]*(?:\s+[.#:[\w-][^{}<]*)?)\s*\{[^{}]*:[^{}]*\}/i;
 const VISIBLE_MARKUP_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
 const VISIBLE_MARKUP_COMMENT_PROTECTED_BLOCK_PATTERN =
-  /<(style|script|template|pre|code|textarea)\b[^>]*>[\s\S]*?<\/\1(?:\s[^>]*)?>/gi;
+  /<(style|script|template|title|noscript|pre|code|textarea|text)\b[^>]*>[\s\S]*?<\/\1(?:\s[^>]*)?>/gi;
 
 interface SourceRange {
   start: number;


### PR DESCRIPTION
## Summary
Final renders can show authoring comments as literal text when a composition contains CSS/JS block-comment syntax directly in HTML markup, because browsers only treat `<!-- ... -->` as HTML comments. This adds a shared `@hyperframes/lint` error so the failure class is caught before any HyperFrames producer reaches render.

The new `visible_markup_comment` rule catches `/* ... */` text nodes in visible markup while avoiding legitimate contexts: CSS/JS blocks, templates, attributes, real HTML comments, and intentional code/preformatted examples. It intentionally does not flag `//` text because URLs and normal prose make that too noisy; EF #40934 covers the Zephyr sanitizer/prompt side, and this PR adds the OSS preflight guard for the concrete render leak.

Related: https://github.com/heygen-com/experiment-framework/pull/40934

## Tests
- `bun run --filter @hyperframes/parsers build`
- `bun run --filter @hyperframes/lint test -- src/rules/core.test.ts`
- `bun run --filter @hyperframes/lint test`
- `bun run --filter @hyperframes/lint typecheck`
- `bun run format:check -- packages/lint/src/rules/core.ts packages/lint/src/rules/core.test.ts`
- `bun run --filter @hyperframes/lint build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
