### PR TITLE
fix(cli): snapshot renders remote http(s) <video> frames (not just local files)

### DIFF
--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -361,6 +361,7 @@ async function captureSnapshots(
             // — FFmpeg reads http(s) input directly, and Chrome-headless can't seek
             // it either, so without this those videos render blank in snapshots.
             let ffmpegInput: string | null = null;
+            let inputIsLocal = false;
             try {
               const url = new URL(v.src);
               const decodedPath = decodeURIComponent(url.pathname).replace(/^\//, "");
@@ -368,6 +369,7 @@ async function captureSnapshots(
               const rel = relative(projectDir, candidate);
               if (!rel.startsWith("..") && !isAbsolute(rel) && existsSync(candidate)) {
                 ffmpegInput = candidate;
+                inputIsLocal = true;
               } else if (url.protocol === "http:" || url.protocol === "https:") {
                 ffmpegInput = url.href;
               }
@@ -375,10 +377,19 @@ async function captureSnapshots(
               /* unresolvable src (e.g. blob:, data:) — skip */
             }
             if (!ffmpegInput) continue;
+            // VP9-alpha detection shells out to ffprobe, which has no timeout.
+            // Only probe local files (filesystem-bounded); for remote URLs skip it
+            // (pass false) so a stalled host can't wedge snapshot in ffprobe before
+            // the bounded extractVideoFrameToBuffer below ever runs. Remote
+            // VP9-alpha overlays aren't a current path — revisit with a bounded
+            // ffprobe if one appears.
+            const useVp9AlphaDecoder = inputIsLocal
+              ? await shouldUseVp9AlphaDecoder(ffmpegInput)
+              : false;
             const png = await extractVideoFrameToBuffer(
               ffmpegInput,
               Math.max(0, v.relTime),
-              await shouldUseVp9AlphaDecoder(ffmpegInput),
+              useVp9AlphaDecoder,
             );
             if (!png) continue;
             updates.push({

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -355,23 +355,30 @@ async function captureSnapshots(
 
           const updates: Array<{ videoId: string; dataUri: string }> = [];
           for (const v of active) {
-            let filePath: string | null = null;
+            // Resolve the <video> src to an FFmpeg input. Prefer a project-local
+            // file (fast, sandboxed); fall back to the absolute http(s) URL for
+            // remote assets (e.g. an S3-hosted clip embedded by an upstream agent)
+            // — FFmpeg reads http(s) input directly, and Chrome-headless can't seek
+            // it either, so without this those videos render blank in snapshots.
+            let ffmpegInput: string | null = null;
             try {
               const url = new URL(v.src);
               const decodedPath = decodeURIComponent(url.pathname).replace(/^\//, "");
               const candidate = resolve(projectDir, decodedPath);
               const rel = relative(projectDir, candidate);
               if (!rel.startsWith("..") && !isAbsolute(rel) && existsSync(candidate)) {
-                filePath = candidate;
+                ffmpegInput = candidate;
+              } else if (url.protocol === "http:" || url.protocol === "https:") {
+                ffmpegInput = url.href;
               }
             } catch {
               /* unresolvable src (e.g. blob:, data:) — skip */
             }
-            if (!filePath) continue;
+            if (!ffmpegInput) continue;
             const png = await extractVideoFrameToBuffer(
-              filePath,
+              ffmpegInput,
               Math.max(0, v.relTime),
-              await shouldUseVp9AlphaDecoder(filePath),
+              await shouldUseVp9AlphaDecoder(ffmpegInput),
             );
             if (!png) continue;
             updates.push({


### PR DESCRIPTION
## Problem

`hyperframes snapshot` works around Chrome-headless's inability to seek `<video>` elements by extracting a frame via FFmpeg and injecting it as an overlay (`packages/cli/src/commands/snapshot.ts`, the `video[data-start]` loop).

That path resolved `<video src>` **only** to a project-local file (`resolve(projectDir, url.pathname)` + `existsSync`) and `continue`d past everything else. So a composition whose embedded `<video>` points at a **remote http(s) URL** (e.g. an S3-hosted clip embedded by an upstream agent) renders as a **blank box** in every snapshot frame — even though `render` shows it fine (render plays the element in-browser; the network fetch is the browser's job).

This silently breaks any downstream consumer that relies on snapshots to *see* the composition — e.g. an AI overlap/occlusion check reading the frames will think the video region is empty and pass an overlay that actually covers the subject.

## Fix

When the src doesn't resolve to a project-local file but **is** an http(s) URL, pass the absolute URL straight to FFmpeg — it reads http(s) input directly. `file://`/`blob:`/`data:` still skip. Local-first is preserved (a project-local file always wins before the remote branch).

VP9-alpha detection (`shouldUseVp9AlphaDecoder` → `extractMediaMetadata`) shells out to **ffprobe, which has no timeout**, so it is only run for **local** inputs; for remote URLs it is skipped (pass `false`). This keeps the unbounded network call out of the new path — `extractVideoFrameToBuffer` itself remains bounded by `FFMPEG_EXTRACT_TIMEOUT_MS` (30s). Local alpha behavior is unchanged. (Remote VP9-alpha overlays aren't a current path; revisit with a bounded ffprobe if one appears.)

## Validation

Reproduced on a real composition (hyperframes@0.7.13):
- `snapshot` with the embedded `<video>` at its **remote** S3 URL → blank box.
- Same composition with the clip downloaded locally + src rewritten to a relative path → video renders.
- `ffmpeg -ss N -i <https-url> -frames:v 1` extracts the remote frame in ~0.5s — confirming FFmpeg handles http(s) input, which is exactly what the fix routes to.

Note: full monorepo build (tsup + runtime) not run locally; change is self-contained and type-preserving. CI build/typecheck covers it.