### PR TITLE
fix(cli): keep doctor resilient to a corrupt browser cache

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -73,13 +73,16 @@ function installFsMocks({ existing, dirs }: FsMockOptions) {
 function installPuppeteerBrowsersMock(
   opts: {
     installedInHfCache?: Array<{ browser: string; executablePath: string }>;
+    installedInHfCacheError?: Error;
     installResult?: { executablePath: string };
   } = {},
 ) {
   vi.doMock("@puppeteer/browsers", () => ({
     Browser: { CHROMEHEADLESSSHELL: "chrome-headless-shell" },
     detectBrowserPlatform: () => "linux",
-    getInstalledBrowsers: vi.fn().mockResolvedValue(opts.installedInHfCache ?? []),
+    getInstalledBrowsers: opts.installedInHfCacheError
+      ? vi.fn().mockRejectedValue(opts.installedInHfCacheError)
+      : vi.fn().mockResolvedValue(opts.installedInHfCache ?? []),
     install: vi.fn().mockResolvedValue(opts.installResult ?? { executablePath: HF_BINARY }),
   }));
 }
@@ -142,6 +145,24 @@ describe("findBrowser — cache resolution", () => {
 
     expect(result).toEqual({ executablePath: redownloadedBinary, source: "download" });
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Cached binary missing"));
+  });
+
+  it("warns and falls through when the hyperframes cache cannot be read", async () => {
+    installFsMocks({ existing: new Set([HF_CACHE, SYSTEM_CHROME]) });
+    installPuppeteerBrowsersMock({
+      installedInHfCacheError: Object.assign(new Error("ENOTDIR: not a directory"), {
+        code: "ENOTDIR",
+      }),
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { findBrowser, _resetSystemFallbackWarnForTests } = await import("./manager.js");
+    _resetSystemFallbackWarnForTests();
+    const result = await findBrowser();
+
+    expect(result).toEqual({ executablePath: SYSTEM_CHROME, source: "system" });
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("Browser cache read failed (ENOTDIR)");
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("Falling back to system Chrome");
   });
 
   it("falls back to the puppeteer-managed cache when hyperframes cache is empty", async () => {

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -112,7 +112,12 @@ async function findFromCache(): Promise<CacheLookupResult> {
     let installed: Awaited<ReturnType<typeof getInstalledBrowsers>>;
     try {
       installed = await getInstalledBrowsers({ cacheDir: CACHE_DIR });
-    } catch {
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      const suffix = code ? ` (${code})` : "";
+      console.warn(
+        `[hyperframes] Browser cache read failed${suffix}: ${normalizeErrorMessage(err)}. Falling back to system Chrome or a fresh download.`,
+      );
       installed = [];
     }
     const match = installed.find((b) => b.browser === Browser.CHROMEHEADLESSSHELL);

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -105,7 +105,16 @@ async function findFromCache(): Promise<CacheLookupResult> {
   // no puppeteer-cache binary exists.
   if (existsSync(CACHE_DIR)) {
     const { Browser, getInstalledBrowsers } = await loadPuppeteerBrowsers();
-    const installed = await getInstalledBrowsers({ cacheDir: CACHE_DIR });
+    // A corrupt cache (stub file where a browser dir is expected, malformed
+    // metadata) makes getInstalledBrowsers throw. Treat that as "no cached
+    // browser" so resolution falls through to system/download instead of
+    // crashing every caller.
+    let installed: Awaited<ReturnType<typeof getInstalledBrowsers>>;
+    try {
+      installed = await getInstalledBrowsers({ cacheDir: CACHE_DIR });
+    } catch {
+      installed = [];
+    }
     const match = installed.find((b) => b.browser === Browser.CHROMEHEADLESSSHELL);
     if (match && existsSync(match.executablePath)) {
       return { result: { executablePath: match.executablePath, source: "cache" } };

--- a/packages/cli/src/browser/preflight.test.ts
+++ b/packages/cli/src/browser/preflight.test.ts
@@ -1,6 +1,7 @@
 // fallow-ignore-file code-duplication
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseToolVersion, runEnvironmentChecks } from "./preflight.js";
+import * as manager from "./manager.js";
 
 describe("runEnvironmentChecks", () => {
   const originalFfmpegPath = process.env.HYPERFRAMES_FFMPEG_PATH;
@@ -65,6 +66,27 @@ describe("runEnvironmentChecks", () => {
       ok: true,
       path: process.execPath,
     });
+  });
+
+  it("reports Chrome as not found (no throw) when browser discovery throws on a corrupt cache", async () => {
+    const spy = vi.spyOn(manager, "findBrowser").mockRejectedValue(
+      Object.assign(new Error("ENOTDIR: not a directory, scandir 'chrome-headless-shell'"), {
+        code: "ENOTDIR",
+      }),
+    );
+
+    try {
+      const result = await runEnvironmentChecks({ includeBrowser: true });
+
+      expect(result.outcomes.find((outcome) => outcome.name === "Chrome")).toMatchObject({
+        ok: false,
+        title: "Chrome not found",
+        hint: "Run: npx hyperframes browser ensure",
+      });
+      expect(result.browser).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("reports an explicit missing browser path before render starts", async () => {

--- a/packages/cli/src/browser/preflight.ts
+++ b/packages/cli/src/browser/preflight.ts
@@ -139,7 +139,17 @@ async function checkChrome(browserPath?: string): Promise<EnvironmentCheckOutcom
     };
   }
 
-  const info = await findBrowser();
+  // A corrupt/partial browser cache (stub files where a version dir is
+  // expected, missing executable, malformed metadata) makes findBrowser throw.
+  // That is the exact condition this check exists to report, so treat any
+  // failure as "Chrome not found" rather than letting it crash the caller
+  // (notably `doctor`, which is documented to exit 0 even when checks fail).
+  let info: Awaited<ReturnType<typeof findBrowser>>;
+  try {
+    info = await findBrowser();
+  } catch {
+    info = undefined;
+  }
   if (info) {
     return {
       name: "Chrome",


### PR DESCRIPTION
## Problem

`hyperframes doctor --json` is documented to exit 0 even when individual checks fail (a stale-version check returning `ok:false` must not poison a CI pipeline running `doctor --json`). But when the Chrome headless shell cache is corrupt or partial (folder present, stub files, no real executable), `doctor` crashes with exit 1 and prints no JSON at all, instead of reporting "Chrome not found" and exiting 0.

## Root cause

`doctor.run()` calls `runEnvironmentChecks({ includeBrowser: true })` as its first line, before any try/catch or the `--json` output branch. That reaches `checkChrome()`, which calls `await findBrowser()` with no error handling. `findBrowser` -> `findFromCache` calls `getInstalledBrowsers({ cacheDir })`, which does `fs.readdirSync` on each browser sub-directory. A stub file where the `chrome-headless-shell` directory is expected makes that throw `ENOTDIR`, and the unguarded throw propagates up to the CLI runner, producing an exit-1 crash on the exact condition the check exists to report.

## Corruption source

This PR treats the observed state as external/partial-cache corruption and keeps the CLI resilient when it happens. The writer-side path still has the existing recovery command: `hyperframes browser clear` removes the managed cache, and `hyperframes browser ensure` recreates it. If we later find `browser ensure` itself leaves this stub state on interrupt/download failure, that should be handled as a sibling writer-side cleanup PR; this PR keeps `doctor`, render, preview, and inspect from crashing on the read side.

## Reproduce

Plant a stub file where the cached browser directory belongs, then run the built CLI:

```
mkdir -p ~/.cache/hyperframes/chrome
echo stub > ~/.cache/hyperframes/chrome/chrome-headless-shell   # file, not a dir
node packages/cli/dist/cli.js doctor --json
```

Before: exits 1 with `ENOTDIR: not a directory, scandir '.../chrome-headless-shell'`, no JSON printed.

## Fix

- `checkChrome` (preflight.ts) wraps the `findBrowser()` call: any error is caught and converted into the existing clean `ok:false` "Chrome not found" outcome with the `npx hyperframes browser ensure` hint. `runEnvironmentChecks` no longer throws for a missing or corrupt browser.
- `findFromCache` (manager.ts) treats a throwing `getInstalledBrowsers` as "no cached browser", so resolution falls through to system/download instead of crashing every caller (the render path benefits too, not just `doctor`).
- The `findFromCache` fallback now emits a warning with the cache-read error code/message, so corrupt-cache recovery is visible instead of silently looking like a normal cache miss.

The documented `--json` exit-0 behavior is unchanged, and `doctor` does not swallow any unrelated error. A healthy browser still reports `ok:true`.

## Verification

- Repro re-run after the fix: `doctor --json` exits 0, prints its full report, and the Chrome check is `ok:false` with the ensure hint. A healthy cache still reports `ok:true`.
- New preflight test asserts an `ok:false` "Chrome not found" outcome when browser discovery throws, instead of propagating.
- New manager test asserts the corrupt-cache warning is emitted and browser resolution falls through to system Chrome.
- `bun run --filter @hyperframes/cli test -- src/browser/manager.test.ts src/browser/preflight.test.ts` green locally (18 tests).
- `oxfmt` + `oxlint` clean on changed files. Pre-commit fallow / typecheck / commitlint gates pass.
