### PR TITLE
docs: clarify transparent WebM shows as yuv420p under ffprobe (alpha is a VP9 side-channel)

### DIFF
--- a/docs/guides/rendering.mdx
+++ b/docs/guides/rendering.mdx
@@ -390,14 +390,14 @@ Only the visible elements (cards, text, images) will appear in the final video. 
 - **Online tool:** Use [rotato.app/tools/transparent-video](https://rotato.app/tools/transparent-video) to verify your MOV or WebM has working transparency.
 
 <Note>
-  **`ffprobe` reports a transparent WebM as `yuv420p`, not `yuva420p`.** This is expected and does not mean the alpha is missing. ffmpeg's native `vp9` decoder silently drops VP9's alpha side-channel, so `ffprobe` shows `pix_fmt=yuv420p` even on a file that genuinely has alpha. The WebM still carries alpha when its header reports `ALPHA_MODE=1`. To read the true pixel format and verify per-pixel alpha, force the VP9 library decoder:
+  **`ffprobe` reports a transparent WebM as `yuv420p`, not `yuva420p`.** This is expected and does not mean the alpha is missing. VP9 stores its alpha plane in a Matroska `BlockAdditional` sidecar, not in the primary stream's pixel format, so `ffprobe` reports the primary stream as `pix_fmt=yuv420p` even when the file genuinely carries alpha. First check that the WebM declares the alpha sidecar, then force the VP9 library decoder to verify per-pixel alpha:
 
   ```bash
-  ffprobe -c:v libvpx-vp9 -show_entries stream=pix_fmt -of csv=p=0 out.webm   # yuva420p
+  ffprobe -v error -show_streams out.webm | grep -i alpha_mode   # ALPHA_MODE=1 or alpha_mode=1
   ffmpeg -c:v libvpx-vp9 -i out.webm -frames:v 1 -f rawvideo -pix_fmt rgba frame.raw
   ```
 
-  A fully transparent corner pixel reads `00 00 00 00`. MOV (ProRes 4444) and `png-sequence` report their alpha directly, so this caveat is WebM-only.
+  A fully transparent corner pixel in `frame.raw` reads `00 00 00 00`. MOV (ProRes 4444) and `png-sequence` report their alpha directly, so this caveat is WebM-only.
 </Note>
 
 ## Tips

--- a/docs/guides/rendering.mdx
+++ b/docs/guides/rendering.mdx
@@ -389,6 +389,17 @@ Only the visible elements (cards, text, images) will appear in the final video. 
 - **In a video editor:** Import the MOV file and place it on a track above other footage. Transparent areas should show the footage below.
 - **Online tool:** Use [rotato.app/tools/transparent-video](https://rotato.app/tools/transparent-video) to verify your MOV or WebM has working transparency.
 
+<Note>
+  **`ffprobe` reports a transparent WebM as `yuv420p`, not `yuva420p`.** This is expected and does not mean the alpha is missing. ffmpeg's native `vp9` decoder silently drops VP9's alpha side-channel, so `ffprobe` shows `pix_fmt=yuv420p` even on a file that genuinely has alpha. The WebM still carries alpha when its header reports `ALPHA_MODE=1`. To read the true pixel format and verify per-pixel alpha, force the VP9 library decoder:
+
+  ```bash
+  ffprobe -c:v libvpx-vp9 -show_entries stream=pix_fmt -of csv=p=0 out.webm   # yuva420p
+  ffmpeg -c:v libvpx-vp9 -i out.webm -frames:v 1 -f rawvideo -pix_fmt rgba frame.raw
+  ```
+
+  A fully transparent corner pixel reads `00 00 00 00`. MOV (ProRes 4444) and `png-sequence` report their alpha directly, so this caveat is WebM-only.
+</Note>
+
 ## Tips
 
 <Tip>


### PR DESCRIPTION
## Problem

Multiple users rendering transparent overlays with `--format webm` concluded their output had no transparency because `ffprobe` reported `pix_fmt=yuv420p` instead of `yuva420p`. One even filed it as a bug ("webm bakes an opaque white background") when the render was actually correct.

The confusing bit is WebM/VP9-specific: VP9 stores the alpha plane in a Matroska `BlockAdditional` sidecar, not in the primary stream's pixel format. `ffprobe` inspects that primary stream, so a genuinely transparent VP9 WebM still reports `yuv420p`.

## Fix

Add a Note to the Transparent Video "Verifying transparency" section of the rendering guide explaining:

- `yuv420p` from `ffprobe` is expected for a transparent WebM and does not mean alpha is missing.
- VP9 alpha lives in the Matroska `BlockAdditional` sidecar, not the primary stream `pix_fmt`.
- Check for the sidecar with `ffprobe -show_streams | grep -i alpha_mode`, covering both `ALPHA_MODE=1` and older `alpha_mode=1` casing.
- To verify per-pixel alpha, force the VP9 library decoder (`-c:v libvpx-vp9`) and inspect an RGBA frame; a transparent corner reads `00 00 00 00`.
- MOV (ProRes 4444) and png-sequence report alpha directly, so this caveat is WebM-only.

Docs-only change.
