### PR TITLE
ci: auto-publish changed skills to ClawHub on push to main

### DIFF
--- a/.github/workflows/sync-skills-to-clawhub.yml
+++ b/.github/workflows/sync-skills-to-clawhub.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Install ClawHub CLI
         run: npm i -g clawhub@0.23.1

--- a/.github/workflows/sync-skills-to-clawhub.yml
+++ b/.github/workflows/sync-skills-to-clawhub.yml
@@ -1,0 +1,66 @@
+name: Sync skills to ClawHub
+
+# Publishes changed skills under skills/ to ClawHub (https://clawhub.ai/heygen-com)
+# whenever they land on main. `clawhub sync` only publishes skills whose content
+# changed vs. the registry, auto-bumping the patch version — unchanged skills are
+# a no-op, so this is safe to run on every push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview what would publish without publishing"
+        type: boolean
+        default: false
+
+# Serialize runs so two pushes don't race on the same skill version.
+concurrency:
+  group: clawhub-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Publish changed skills
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLAWHUB_DISABLE_TELEMETRY: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      - name: Install ClawHub CLI
+        run: npm i -g clawhub@0.23.1
+
+      - name: Authenticate
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: clawhub login --token "$CLAWHUB_TOKEN" --no-input --label "hyperframes CI"
+
+      - name: Sync skills
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          FLAGS=(
+            --all
+            --owner heygen-com
+            --bump patch
+            --changelog "Synced from ${GITHUB_SHA:0:7} (${GITHUB_REF_NAME})"
+            --source-repo "$GITHUB_REPOSITORY"
+            --source-commit "$GITHUB_SHA"
+            --source-ref "$GITHUB_REF"
+          )
+          if [ "$DRY_RUN" = "true" ]; then
+            FLAGS+=(--dry-run)
+          fi
+          clawhub sync "${FLAGS[@]}"


### PR DESCRIPTION
## What

Add a GitHub Actions workflow ([`.github/workflows/sync-skills-to-clawhub.yml`](.github/workflows/sync-skills-to-clawhub.yml)) that mirrors this repo's skills to the [ClawHub](https://clawhub.ai/heygen-com) registry. On every push to `main` that touches `skills/**`, it runs `clawhub sync`, which publishes **only the skills whose content changed** vs. the registry and auto-bumps their patch version. Unchanged skills are a no-op, so the job is safe to run on every push. Also dispatchable manually with a `dry_run` toggle.

## Why

The 19 skills under `skills/` are published to ClawHub under the `heygen-com` publisher, but until now that had to be done by hand from a maintainer's machine after each change — easy to forget, and the registry drifts behind `main`. This closes the loop so the published catalog tracks `main` automatically.

## How it works

| Aspect | Choice |
| --- | --- |
| Trigger | `push` to `main` filtered to `paths: ["skills/**"]`, plus `workflow_dispatch` |
| Publish engine | `clawhub sync --all --owner heygen-com` — diffs local skills against the registry, publishes only changed ones |
| Versioning | `--bump patch` (skills carry no version field in frontmatter; ClawHub tracks semver and auto-increments) |
| Provenance | `--source-repo` / `--source-commit` / `--source-ref` stamp each release with its GitHub origin |
| Concurrency | `concurrency: clawhub-sync` (no cancel) serializes runs so two pushes can't race the same version |
| Auth | `clawhub login --token "$CLAWHUB_TOKEN"` from the `CLAWHUB_TOKEN` repo secret |

Supply-chain hygiene consistent with the rest of `.github/workflows`: `actions/checkout` + `actions/setup-node` pinned to the same SHAs used by `publish.yml`, and `clawhub` pinned to `@0.23.1`.

## Prerequisite (done)

- [x] `CLAWHUB_TOKEN` repo secret is set (a ClawHub API token with publish rights to the `heygen-com` publisher).

## Test plan

- [x] Dry-run verified locally against the current tree: `clawhub sync --all --owner heygen-com --dry-run` detects all 19 skills, reports them already synced at their current versions, and correctly reports **"Nothing to sync"** with no changes — confirming the changed-only detection.
- [x] `permissions: contents: read` only; the token is the sole write credential and lives in a secret.
- [ ] After merge: manually dispatch with `dry_run: true` from the Actions tab to confirm the CI environment authenticates and previews correctly before the first real publish.

## Notes

- The `CLAWHUB_TOKEN` repo secret holds the live credential; rotate it (ClawHub → regenerate → `gh secret set CLAWHUB_TOKEN`) on any suspected exposure.
- Default bump is `patch`. If a skill needs a `minor`/`major` release, `workflow_dispatch` semantics can be extended later, or publish that skill manually with the desired `--bump`.
