### PR TITLE
fix: dead code cleanup, missing MIME types, partial download leak

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperframes/core",
   "version": "0.7.22",
-  "description": "",
+  "description": "Types, parsers, generators, linter, and runtime for HyperFrames",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/engine/src/services/fileServer.ts
+++ b/packages/engine/src/services/fileServer.ts
@@ -33,6 +33,11 @@ const MIME_TYPES: Record<string, string> = {
   ".woff2": "font/woff2",
   ".ttf": "font/ttf",
   ".otf": "font/otf",
+  ".avif": "image/avif",
+  ".flac": "audio/flac",
+  ".m4a": "audio/mp4",
+  ".mov": "video/quicktime",
+  ".ico": "image/x-icon",
 };
 
 export interface FileServerOptions {

--- a/packages/engine/src/utils/alphaBlit.ts
+++ b/packages/engine/src/utils/alphaBlit.ts
@@ -687,7 +687,6 @@ function parseObjectPositionAxis(value: string, axis: "x" | "y"): number {
   // Pixel values (e.g. "10px") aren't fractional; without the slack-space
   // numerator we can't honor them precisely. Fall back to center — this is
   // strictly worse than the browser but matches what we'd render today.
-  if (axis === "x" || axis === "y") return 0.5;
   return 0.5;
 }
 

--- a/packages/engine/src/utils/urlDownloader.ts
+++ b/packages/engine/src/utils/urlDownloader.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, existsSync, mkdirSync } from "fs";
+import { createWriteStream, existsSync, mkdirSync, rmSync } from "fs";
 import { createHash } from "crypto";
 import { join, extname } from "path";
 import { Readable } from "stream";
@@ -125,6 +125,7 @@ export async function downloadToTemp(
       downloadPathCache.set(url, localPath);
       return localPath;
     } catch (err) {
+      try { rmSync(localPath, { force: true }); } catch {}
       const message = err instanceof Error ? err.message : String(err);
       if (message.includes("aborted")) {
         throw new Error(`[URLDownloader] Download timeout after ${timeoutMs / 1000}s: ${url}`);

--- a/packages/player/src/controls.ts
+++ b/packages/player/src/controls.ts
@@ -32,7 +32,7 @@ export interface ControlsOptions {
 }
 
 export function formatSpeed(speed: number): string {
-  return Number.isInteger(speed) ? `${speed}x` : `${speed}x`;
+  return `${speed}x`;
 }
 
 export function formatTime(seconds: number): string {


### PR DESCRIPTION
A few things I noticed while going through the codebase:

- \`formatSpeed\` had a ternary where both branches returned the exact same string — simplified it
- the file server's MIME type map was missing avif, flac, m4a, mov, and ico, so those formats were being served as \`application/octet-stream\` which breaks browser rendering
- \`parseObjectPositionAxis\` had an unreachable branch — the axis param is typed as \`"x" | "y"\` so the guard is always true
- when a download fails midway in \`downloadToTemp\`, the partial file was left on disk. on the next call it would find that partial file and return it as if it succeeded. now cleans up the partial in the catch block
- added a description to @hyperframes/core package.json — it was empty