### PR TITLE
fix(engine): parallelize forced screenshot workers

### DIFF
--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -4,6 +4,7 @@ import {
   distributeFrames,
   formatWorkerFailure,
   selectWorkerDiagnostics,
+  shouldDisableBrowserPoolForParallelWorker,
   shouldVerifyWorkerGpu,
 } from "./parallelCoordinator.js";
 import type { EngineConfig } from "../config.js";
@@ -73,6 +74,44 @@ describe("calculateOptimalWorkers", () => {
     });
 
     expect(workers).toBe(4);
+  });
+});
+
+describe("shouldDisableBrowserPoolForParallelWorker", () => {
+  const linuxHeadlessWorker = {
+    parallel: true,
+    platform: "linux" as NodeJS.Platform,
+    deviceScaleFactor: 1,
+    headlessShellPath: "/tmp/chrome-headless-shell",
+  };
+
+  it.each([
+    ["BeginFrame", false],
+    ["forced screenshot", true],
+  ])(
+    "disables the browser pool for parallel Linux/headless %s workers",
+    (_mode, forceScreenshot) => {
+      expect(
+        shouldDisableBrowserPoolForParallelWorker({
+          ...linuxHeadlessWorker,
+          forceScreenshot,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    ["non-parallel", { parallel: false, forceScreenshot: true }],
+    ["non-linux", { platform: "darwin" as NodeJS.Platform, forceScreenshot: true }],
+    ["no headless shell", { headlessShellPath: undefined, forceScreenshot: true }],
+    ["supersampled", { deviceScaleFactor: 2, forceScreenshot: false }],
+  ])("keeps the shared pool for %s workers", (_case, overrides) => {
+    expect(
+      shouldDisableBrowserPoolForParallelWorker({
+        ...linuxHeadlessWorker,
+        ...overrides,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -76,6 +76,15 @@ export interface WorkerSizingConfig extends Partial<
   captureCostMultiplier?: number;
 }
 
+type WorkerBrowserPoolDecision = {
+  parallel?: boolean;
+  platform: NodeJS.Platform;
+  // Deliberately accepted but not used: forceScreenshot is not an exclusion.
+  forceScreenshot?: boolean;
+  deviceScaleFactor?: number;
+  headlessShellPath?: string;
+};
+
 const MEMORY_PER_WORKER_MB = 256;
 const MIN_WORKERS = 1;
 const MAX_WORKER_DIAGNOSTIC_LINES = 8;
@@ -97,6 +106,21 @@ function defaultSafeMaxWorkers(): number {
   return Math.max(6, Math.min(16, Math.floor(cpus().length / 8)));
 }
 const MIN_FRAMES_PER_WORKER = 30;
+
+// Linux/headless parallel workers need isolated browser processes: BeginFrame
+// crashes when shared, while forceScreenshot is safe but serializes
+// Page.captureScreenshot per browser. Supersampling keeps the existing path
+// until browser-pool compatibility is keyed by DPR.
+export function shouldDisableBrowserPoolForParallelWorker({
+  parallel,
+  platform,
+  deviceScaleFactor,
+  headlessShellPath,
+}: WorkerBrowserPoolDecision): boolean {
+  return Boolean(
+    parallel && platform === "linux" && headlessShellPath && (deviceScaleFactor ?? 1) <= 1,
+  );
+}
 
 export function selectWorkerDiagnostics(
   lines: readonly string[],
@@ -266,18 +290,13 @@ async function executeWorkerTask(
   let session: CaptureSession | null = null;
   let perf: CapturePerfSummary | undefined;
 
-  // BeginFrame's compositor is process-global — multiple pages driving
-  // beginFrame in the same browser race it and crash with "Target closed".
-  // Only disable the pool when BeginFrame mode would actually be active.
-  // Must match the predicate in createCaptureSession (frameCapture.ts):
-  // Linux + headless-shell + !forceScreenshot + !supersampling.
-  const supersampling = (captureOptions.deviceScaleFactor ?? 1) > 1;
-  const needsSeparateBrowsers =
-    parallel &&
-    process.platform === "linux" &&
-    !config?.forceScreenshot &&
-    !supersampling &&
-    resolveHeadlessShellPath(config) !== undefined;
+  const needsSeparateBrowsers = shouldDisableBrowserPoolForParallelWorker({
+    parallel,
+    platform: process.platform,
+    forceScreenshot: config?.forceScreenshot,
+    deviceScaleFactor: captureOptions.deviceScaleFactor,
+    headlessShellPath: resolveHeadlessShellPath(config),
+  });
   const workerConfig: Partial<EngineConfig> | undefined = needsSeparateBrowsers
     ? { ...config, enableBrowserPool: false }
     : config;


### PR DESCRIPTION
## Summary
- Fixes #1837 by removing `forceScreenshot` as an exclusion from the parallel-worker browser-pool disable path.
- Extracts the browser-pool decision into a small tested helper so Linux/headless-shell forced screenshot workers get dedicated browser processes instead of sharing one pooled browser.
- Preserves the existing non-parallel, non-Linux, no-headless-shell, and supersampling exclusions.

## Verification
- `bunx oxfmt --write packages/engine/src/services/parallelCoordinator.ts packages/engine/src/services/parallelCoordinator.test.ts`
- `bunx oxlint packages/engine/src/services/parallelCoordinator.ts packages/engine/src/services/parallelCoordinator.test.ts`
- `bun run --filter @hyperframes/engine test -- src/services/parallelCoordinator.test.ts`
- `bun run --filter @hyperframes/engine typecheck`

## Notes
- Full `bun run --filter @hyperframes/engine test` reached the suite but failed two unrelated `videoFrameExtractor` VFR cases because this host has ffmpeg 4.2.7, which does not support `-fps_mode`.
