### PR TITLE
fix(lint): float slop in overlapping_clips_same_track compare

### DIFF
--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -389,6 +389,24 @@ describe("composition rules", () => {
       const finding = result.findings.find((f) => f.code === "overlapping_clips_same_track");
       expect(finding).toBeUndefined();
     });
+
+    it("does not flag adjacencies where parseFloat + add drifts by a few ulps", async () => {
+      // parseFloat("0.1") + parseFloat("0.2") = 0.30000000000000004
+      const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div class="clip" data-start="0.1" data-duration="0.2" data-track-index="0">A</div>
+    <div class="clip" data-start="0.3" data-duration="0.2" data-track-index="0">B</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["c1"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "overlapping_clips_same_track");
+      expect(finding).toBeUndefined();
+    });
   });
 
   describe("root_composition_missing_html_wrapper", () => {

--- a/packages/lint/src/rules/composition.ts
+++ b/packages/lint/src/rules/composition.ts
@@ -15,6 +15,14 @@ const MAX_COMPOSITION_LINES = 300;
 const MAX_TIMED_ELEMENTS_PER_TRACK = 3;
 const TRACK_DENSITY_EXEMPT_TAGS = new Set(["audio", "script", "style", "video"]);
 
+// `parseFloat("0.1") + parseFloat("0.2") = 0.30000000000000004`. Sub-second
+// authored adjacencies survive parse + add as a value a few ulps above the
+// next clip's start; a strict `>` fires the overlap rule on adjacencies that
+// are exact in the source HTML. 1μs sits ~11 orders of magnitude above the
+// observed drift (worst ~2e-16s across every realistic decimal pair) and 4
+// below one 60fps frame (~16.67ms), so this only ever swallows float slop.
+const OVERLAP_EPSILON_SECONDS = 1e-6;
+
 function countPhysicalLines(source: string): number {
   if (source.length === 0) return 0;
 
@@ -406,7 +414,7 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
         const current = clips[i];
         const next = clips[i + 1];
         if (!current || !next) continue;
-        if (current.end > next.start) {
+        if (current.end - next.start > OVERLAP_EPSILON_SECONDS) {
           findings.push({
             code: "overlapping_clips_same_track",
             severity: "error",


### PR DESCRIPTION
`overlapping_clips_same_track` fires on compositions with exact-decimal adjacencies because upstream `parseFloat` + addition drifts:

```
parseFloat("0.1") + parseFloat("0.2") = 0.30000000000000004
```

`composition.ts:409` compares `current.end > next.start` where `current.end = start + duration` is computed on parseFloat'd inputs. For a clip pair `{data-start: 0.1, data-duration: 0.2}` followed by `{data-start: 0.3, …}` on the same track, that reads `0.30000000000000004 > 0.3` and fires the rule on an adjacency that is exact in the source HTML.

Not a one-off — a quick sweep across sub-second decimal pairs turned up 55 that drift the same way: `0.1+0.7`, `0.2+0.4`, `0.3+0.6`, `0.4+0.8`, and so on. All authored routinely.

Compare on `current.end - next.start > 1e-6` instead. Worst observed drift across those 55 pairs is ~2e-16s; 1μs sits eleven orders of magnitude above the noise and four below one 60fps frame (~16.67ms), so it only ever swallows float slop and can't hide any overlap that would render as a same-track conflict.

Test added — `{0.1, 0.2}` + `{0.3, 0.2}` on track 0. Before the change `overlapping_clips_same_track` fired; after, no finding.