### PR TITLE
fix(engine): pre-create __render_frame__ siblings in initializeSession

### DIFF
--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -25,6 +25,7 @@ import {
 } from "./browserManager.js";
 import {
   beginFrameCapture,
+  ensureRenderFrameSiblings,
   getCdpSession,
   pageScreenshotCapture,
   initTransparentBackground,
@@ -1085,6 +1086,7 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     }
 
     await armStaticDedup(session, session.page, logInitPhase);
+    await ensureRenderFrameSiblings(session.page);
     session.isInitialized = true;
     return;
   }
@@ -1239,6 +1241,7 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   }
 
   await armStaticDedup(session, session.page, logInitPhase);
+  await ensureRenderFrameSiblings(session.page);
   session.isInitialized = true;
 }
 

--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -5,6 +5,7 @@ import { type Page } from "puppeteer-core";
 import {
   pageScreenshotCapture,
   cdpSessionCache,
+  ensureRenderFrameSiblings,
   injectVideoFramesBatch,
   syncVideoFrameVisibility,
   shouldDefaultCaptureBeyondViewport,
@@ -545,5 +546,92 @@ describe("video-frame injection respects ancestor visibility", () => {
 
     expect(seededImg.style.visibility).toBe("hidden");
     expect(setPropertySpy).toHaveBeenCalledWith("visibility", "hidden", "important");
+  });
+});
+
+describe("ensureRenderFrameSiblings", () => {
+  function passthroughPage(): Page {
+    return {
+      evaluate: async (fn: (...args: unknown[]) => unknown, ...args: unknown[]) =>
+        Promise.resolve((fn as (...a: unknown[]) => unknown)(...args)),
+    } as unknown as Page;
+  }
+
+  function withGlobalDom(setup: { window: Window; document: Document }): { teardown: () => void } {
+    const globals = globalThis as unknown as { window?: Window; document?: Document };
+    const previousWindow = globals.window;
+    const previousDocument = globals.document;
+    globals.window = setup.window;
+    globals.document = setup.document;
+    return {
+      teardown: () => {
+        globals.window = previousWindow;
+        globals.document = previousDocument;
+      },
+    };
+  }
+
+  it("creates a hidden __render_frame__ sibling for every video[data-start]", async () => {
+    const { window, document } = parseHTML(
+      `<html><body>
+        <div id="root">
+          <video id="v1" data-start="0" data-duration="2"></video>
+          <video id="v2" data-start="2" data-duration="2"></video>
+        </div>
+      </body></html>`,
+    );
+    const { teardown } = withGlobalDom({ window, document });
+    try {
+      await ensureRenderFrameSiblings(passthroughPage());
+    } finally {
+      teardown();
+    }
+
+    for (const id of ["v1", "v2"]) {
+      const video = document.getElementById(id) as HTMLVideoElement;
+      const sibling = video.nextElementSibling as HTMLElement | null;
+      expect(sibling).not.toBeNull();
+      expect(sibling?.tagName.toLowerCase()).toBe("img");
+      expect(sibling?.classList.contains("__render_frame__")).toBe(true);
+      expect(sibling?.id).toBe(`__render_frame_${id}__`);
+      expect(sibling?.style.visibility).toBe("hidden");
+    }
+  });
+
+  it("skips videos that already have a __render_frame__ sibling", async () => {
+    const { window, document } = parseHTML(
+      `<html><body>
+        <div id="root">
+          <video id="clip" data-start="0" data-duration="2"></video>
+          <img id="__render_frame_clip__" class="__render_frame__">
+        </div>
+      </body></html>`,
+    );
+    const preExisting = document.getElementById("__render_frame_clip__") as HTMLImageElement;
+    const { teardown } = withGlobalDom({ window, document });
+    try {
+      await ensureRenderFrameSiblings(passthroughPage());
+    } finally {
+      teardown();
+    }
+
+    const video = document.getElementById("clip") as HTMLVideoElement;
+    expect(video.nextElementSibling).toBe(preExisting);
+    expect(document.querySelectorAll(".__render_frame__").length).toBe(1);
+  });
+
+  it("does not touch <video> elements without data-start", async () => {
+    const { window, document } = parseHTML(
+      `<html><body><div id="root"><video id="raw"></video></div></body></html>`,
+    );
+    const { teardown } = withGlobalDom({ window, document });
+    try {
+      await ensureRenderFrameSiblings(passthroughPage());
+    } finally {
+      teardown();
+    }
+
+    const video = document.getElementById("raw") as HTMLVideoElement;
+    expect(video.nextElementSibling).toBeNull();
   });
 });

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -386,6 +386,45 @@ export async function removeDomLayerMask(page: Page, extraHideIds: string[]): Pr
 }
 
 /**
+ * Pre-create hidden `__render_frame__` sibling `<img>`s for every
+ * `video[data-start]` in the page. Idempotent — videos that already
+ * have a sibling are skipped.
+ *
+ * `injectVideoFramesBatch` creates the sibling on the fly the first time
+ * it paints a given videoId (the `isNewImage = !hasImg` branch below).
+ * Under chrome-headless-shell's deterministic + `HeadlessExperimental.
+ * BeginFrame` mode, the immediately-next BeginFrame captures before the
+ * freshly-inserted `<img>` layer lands in the compositor's layer tree;
+ * the layer arrives a frame later. That single frame paints only the
+ * body background + previously-composed overlays.
+ *
+ * Called once at the end of `initializeSession` — by the time the first
+ * capture BeginFrame fires, several BeginFrame ticks have already elapsed
+ * through warmup / GSAP flush / readiness polls, so the pre-created
+ * layers are committed and every subsequent `injectVideoFramesBatch`
+ * takes the `hasImg = true` path (just an `img.src` update). The
+ * `isNewImage` branch stays as a fallback for callers that don't run
+ * through `initializeSession`.
+ */
+export async function ensureRenderFrameSiblings(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    for (const video of Array.from(
+      document.querySelectorAll<HTMLVideoElement>("video[data-start]"),
+    )) {
+      const next = video.nextElementSibling;
+      if (next !== null && next.classList.contains("__render_frame__")) continue;
+      const img = document.createElement("img");
+      img.classList.add("__render_frame__");
+      img.id = `__render_frame_${video.id}__`;
+      img.style.pointerEvents = "none";
+      img.style.position = "absolute";
+      img.style.visibility = "hidden";
+      video.parentNode?.insertBefore(img, video.nextSibling);
+    }
+  });
+}
+
+/**
  * Returns the subset of `updates.videoId`s that were actually painted in
  * this call. Videos skipped because of a hidden visual ancestor are NOT
  * included — the caller relies on this to avoid recording a `lastInjected`


### PR DESCRIPTION
Hit a periodic single-frame near-black flash in chunk-lambda renders — every `chunk_frames / worker_count` frames one frame comes out as body background + previously-composed overlays only. On a single-video 4-worker chunk that's every 60 frames; `signalstats` reports YAVG ~22 with YMAX ~240. Single-process local renders don't see it because they don't run under BeginFrame control.

It's the `isNewImage` branch of `injectVideoFramesBatch` at `screenshotService.ts:473`. First inject for a given `videoId` per session sees `hasImg === false` and creates the replacement `<img>` on the fly — `document.createElement("img") + insertBefore` at lines 482-487. `captureFrameCore` fires `beginFrameCapture` immediately after: no intermediate BeginFrame, and no paint flush either, since the flush at `frameCapture.ts:1328` is gated on `captureMode !== "beginframe"`.

Under `HeadlessExperimental.beginFrame` deterministic mode, chrome's compositor doesn't include the freshly-inserted `<img>` layer in that immediately-next BeginFrame — it lands a tick later. So the captured PNG shows just what was already in there: body background + persistent overlays. That's the YAVG ~22 signature.

Pre-creating the `__render_frame__` sibling once at the end of `initializeSession` — right before `session.isInitialized = true` in both branches — fixes it. By the time the first `beginFrameCapture` fires, warmup + GSAP flush + readiness polls have driven several BeginFrame ticks, so the layers are already committed. `injectVideoFramesBatch` sees `hasImg === true` every time and just updates `img.src`. The `isNewImage` branch stays as a fallback.

FWIW things we tried before landing here: `willChange` / `translateZ` promotion hints on the freshly-inserted `<img>`, dataUri preload, awaiting `img.decode()` on the pending frame, and a second BeginFrame at the same `frameTimeTicks`. Chrome refuses two BeginFrames at the same tick — the CDP call just protocol-times-out at 60s. Only avoiding the on-the-fly DOM mutation resolved it.

Tests cover: creates a hidden sibling for every `video[data-start]` on first call, no-op for videos that already have one, leaves plain `<video>` (no `data-start`) alone.