### PR TITLE
test(cli): de-flake cold-import tests under CI contention via vitest timeouts

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -62,19 +62,16 @@ vi.mock("../browser/preflight.js", () => ({
 describe("renderLocal browser GPU config", () => {
   const savedEnv = new Map<string, string | undefined>();
   // Pre-resolve once. The first dynamic `import("./render.js")` in this file
-  // cold-loads a heavy module graph (core + engine + producer, incl. linkedom)
-  // and takes >5 s on Windows runners — and materially longer under the full
-  // parallel monorepo test run, where it can exceed the default 10 s hook
-  // timeout on a contended CI runner. Importing once in `beforeAll` keeps every
-  // test fast and isolated; the explicit 30 s hook timeout absorbs cold-import
-  // contention so this doesn't flake (the failure was a pre-existing
-  // `Hook timed out in 10000ms`, reproducible on `main` under load).
+  // cold-loads a heavy module graph (core + engine + producer, incl. linkedom),
+  // slow under the parallel monorepo run — the generous hook timeout that
+  // absorbs that contention now lives in vitest.config.ts (shared by all CLI
+  // suites). Importing once in `beforeAll` keeps every test fast and isolated.
   let renderLocal: typeof import("./render.js").renderLocal;
   let resolveBrowserGpuForCli: typeof import("./render.js").resolveBrowserGpuForCli;
 
   beforeAll(async () => {
     ({ renderLocal, resolveBrowserGpuForCli } = await import("./render.js"));
-  }, 30_000);
+  });
 
   function setEnv(key: string, value: string) {
     if (!savedEnv.has(key)) savedEnv.set(key, process.env[key]);
@@ -420,12 +417,11 @@ describe("renderLocal browser GPU config", () => {
 describe("checkRenderResolutionPreflight", () => {
   let checkRenderResolutionPreflight: typeof import("./render.js").checkRenderResolutionPreflight;
 
-  // 30 s hook timeout: cold-importing render.js (heavy graph) can exceed the
-  // default 10 s under parallel CI contention. See the note on the
-  // "renderLocal browser GPU config" beforeAll above.
+  // Cold-imports render.js (heavy graph); the generous hook timeout for parallel
+  // CI contention lives in vitest.config.ts. See the note above.
   beforeAll(async () => {
     ({ checkRenderResolutionPreflight } = await import("./render.js"));
-  }, 30_000);
+  });
 
   // Dims must be read the same way the producer's compiler reads them:
   // `data-width` / `data-height` on the `[data-composition-id]` root.

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -18,5 +18,15 @@ export default defineConfig({
   },
   test: {
     include: ["src/**/*.test.ts"],
+    // Many CLI tests cold-import a heavy command module graph via dynamic
+    // `import()` (e.g. render.js, auth/status.js, telemetry/system.js). Under
+    // the full parallel monorepo run (`bun run --filter '!@hyperframes/producer'
+    // test`) that cold load contends for CPU and routinely blows vitest's 5s
+    // default test timeout / 10s hook timeout on CI runners — a recurring
+    // flake that has failed unrelated PRs (see PRs #1843, #1850). These
+    // generous ceilings absorb the contention while still catching a genuine
+    // hang. Prefer this one config knob over per-test/per-hook timeout bandaids.
+    testTimeout: 20_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

The CLI **`Test`** job (`bun run --filter '!@hyperframes/producer' test`) has intermittently failed **several unrelated PRs** — #1843 (3×) and #1850 — with `Test timed out in 5000ms` / `Hook timed out in 10000ms`. It's a recurring tax: each hit needs a re-run, and it briefly blocked otherwise-green, approved PRs.

## Root cause (one cause, several symptoms)

Multiple CLI tests cold-import a heavy command module graph via dynamic `import()`:
- `render.test.ts` → `render.js` (core + engine + producer + linkedom)
- `auth/status-user.test.ts` → `status.js`
- `telemetry/system.test.ts` → `system.js` (already mocks the subprocess — it's the *import* that's slow, not `vm_stat`)

Under the full parallel monorepo run these cold loads contend for CPU on constrained CI runners and blow vitest's **5s test / 10s hook** defaults. **Not a product bug** — each command passes in isolation and the timeout reproduces on `main` under load (verified).

## Fix (right altitude — one knob, not bandaids)

Set generous `testTimeout: 20_000` and `hookTimeout: 30_000` once in `packages/cli/vitest.config.ts`. This covers every CLI suite (present and future) instead of per-test patches, and still fails a genuine hang. Also **removed the now-redundant explicit 30s `beforeAll` timeouts** added to `render.test.ts` in #1843, so the config is the single source of truth.

## Verification

The three formerly-flaky files pass (36 tests); full gate green (build / typecheck / lint / oxfmt / fallow). A timeout ceiling can't be unit-tested, so the justification is the diagnosis above.

Supports the render-reliability effort's CI hygiene (dashboard 1783183 work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)