### PR TITLE
fix(engine): name the fix in the ffmpeg encode-timeout error message

### DIFF
--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -154,6 +154,11 @@ describe("encodeFramesFromDir ffmpegEncodeTimeout", () => {
     expect(result.error).toContain("FFmpeg exited with code 143");
     expect(result.error).toContain("terminated by timeout");
     expect(result.error).toContain(encodeTimeoutMessage(1000));
+    // Regression: the timeout message used to just state what happened, leaving
+    // the user to independently discover FFMPEG_ENCODE_TIMEOUT_MS and
+    // PRODUCER_ENABLE_CHUNKED_ENCODE (both already existed) on their own.
+    expect(result.error).toContain("FFMPEG_ENCODE_TIMEOUT_MS");
+    expect(result.error).toContain("PRODUCER_ENABLE_CHUNKED_ENCODE");
   });
 
   it("keeps non-timeout ffmpeg failures unchanged", async () => {

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -44,7 +44,17 @@ export interface EncoderPreset {
 
 function appendEncodeTimeoutMessage(error: string, timedOut: boolean, timeoutMs: number): string {
   if (!timedOut) return error;
-  return `${error}\nFFmpeg killed after exceeding ffmpegEncodeTimeout (${timeoutMs} ms)`;
+  // Two independent reports of this exact timeout, both resolved by env vars
+  // that already exist but aren't named anywhere the user would see them at
+  // the point of failure — they had to go find FFMPEG_ENCODE_TIMEOUT_MS and
+  // PRODUCER_ENABLE_CHUNKED_ENCODE themselves. Name both here instead of
+  // just stating what happened.
+  return (
+    `${error}\nFFmpeg killed after exceeding ffmpegEncodeTimeout (${timeoutMs} ms). ` +
+    "Long or high-frame-count renders may need more time: set FFMPEG_ENCODE_TIMEOUT_MS " +
+    "to a higher value (ms), or set PRODUCER_ENABLE_CHUNKED_ENCODE=true to encode in " +
+    "smaller chunks instead of one long-running ffmpeg process."
+  );
 }
 
 function isAacSidecar(audioPath: string): boolean {


### PR DESCRIPTION
Root-caused from two independent post-release feedback reports of hitting `ffmpegEncodeTimeout` (600000ms default) on long or high-frame-count renders — both resolved the same way, but had to find the fix themselves.

> "Initial non-chunked encode hit ffmpegEncodeTimeout 600000ms after full capture; retry succeeded with FFMPEG_ENCODE_TIMEOUT_MS=1800000 and PRODUCER_ENABLE_CHUNKED_ENCODE=true."

> "60fps draft render needed manual recovery. HyperFrames completed [...] but assemble/encode path hit ffmpegEncodeTimeout (600000 ms). Manual ffmpeg mux with -c copy produced the final [...] MP4 successfully."

## Root cause
`appendEncodeTimeoutMessage` only stated what happened ("FFmpeg killed after exceeding ffmpegEncodeTimeout"). It didn't name `FFMPEG_ENCODE_TIMEOUT_MS` or `PRODUCER_ENABLE_CHUNKED_ENCODE` — both of which already exist and already solve this — so both users had to independently discover them (source dive or docs search) rather than reading the fix off the failure itself.

## Fix
Name both knobs directly in the message. One function, six call sites (chunked + streaming encode paths), fixed once.

## Tests
Existing 81 tests in `chunkEncoder.test.ts` assert with `toContain`, so the appended text doesn't break them. Added two assertions confirming both env var names appear in the message.