### PR TITLE
fix(lint): mention src: local() for system fonts in font_family_without_font_face

### DIFF
--- a/packages/lint/src/rules/fonts.test.ts
+++ b/packages/lint/src/rules/fonts.test.ts
@@ -146,6 +146,30 @@ describe("font rules", () => {
       expect(findings).toHaveLength(0);
     });
 
+    it("does not flag a system font declared via @font-face src: local()", async () => {
+      // Regression: two independent reports of this rule hard-erroring on OS
+      // system fonts (Hiragino Sans, Microsoft YaHei) that have no downloadable
+      // file. src: local(...) already satisfies the check (extractFontFaceFamilies
+      // only looks at the font-family declaration, not the src value) — the gap
+      // was that the fixHint didn't mention this as an option.
+      const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+        <style>
+          @font-face { font-family: 'Microsoft YaHei'; src: local('Microsoft YaHei'); }
+          body { font-family: 'Microsoft YaHei', sans-serif; }
+        </style>
+      </div>`;
+      const findings = await findByCode(html, "font_family_without_font_face");
+      expect(findings).toHaveLength(0);
+    });
+
+    it("fixHint mentions the local() pattern for system fonts", async () => {
+      const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+        <style>body { font-family: 'GT Walsheim', sans-serif; }</style>
+      </div>`;
+      const findings = await findByCode(html, "font_family_without_font_face");
+      expect(findings[0]!.fixHint).toContain("local(");
+    });
+
     it("does not flag generic font families", async () => {
       const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
         <style>body { font-family: monospace; }</style>

--- a/packages/lint/src/rules/fonts.ts
+++ b/packages/lint/src/rules/fonts.ts
@@ -232,7 +232,10 @@ export const fontRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
         "Text will fall back to a generic font, producing incorrect typography in the video.",
       fixHint:
         "Add @font-face { font-family: '...'; src: url('capture/assets/fonts/...woff2'); } " +
-        "for each font family, pointing to the captured .woff2 files.",
+        "for each font family, pointing to the captured .woff2 files. For an OS-bundled " +
+        "system font (e.g. Hiragino Sans, Microsoft YaHei) that has no downloadable file, " +
+        "use src: local('Exact Font Name') instead — the declaration alone satisfies this " +
+        "check without needing a font file.",
     });
     return findings;
   },


### PR DESCRIPTION
Root-caused from two independent post-release feedback reports of `font_family_without_font_face` hard-erroring on OS system fonts (Hiragino Sans, Microsoft YaHei) that have no downloadable file.

> "'Anton' appears in dist strings but is NOT in the linter's auto-resolved font set (font_family_without_font_face error)... " — different specific font, same rule, run 2 asked for "an allowlist for common system fonts."

> "lint font_family_without_font_face hard-errors on system CJK fonts (Microsoft YaHei) - worked around with @font-face src:local(); a documented allowance for local() system fonts would help."

## What's actually going on
`@font-face { font-family: 'X'; src: local('X'); }` **already satisfies the check** — `extractFontFaceFamilies` only looks at the `font-family` declaration inside `@font-face`, never the `src` value. One reporter found this workaround themselves; the gap is discoverability: the `fixHint` only described bundling a real font file, so nobody would think to try `local()` unless they already knew about it.

## Fix
Mention the `local()` pattern in the `fixHint`. No detection-logic change.

## What I considered and rejected
Adding CJK system-font names (Hiragino, Microsoft YaHei, etc.) to the shared `FONT_ALIAS_MAP` — the mechanism that already exempts *Latin* system fonts (Segoe UI, Verdana, ...) by aliasing them to a bundled fallback. That map has no CJK-equivalent bundled font to alias to (only Japanese has one, `noto-sans-jp`). Aliasing "Microsoft YaHei" (Simplified Chinese) to a Japanese font would silently swap in the wrong glyph shapes for shared Han characters — and would specifically break **distributed/Lambda rendering** (where system-font capture is disabled, per `system_font_will_alias`'s own comment) by removing the warning that currently prompts a real fix. That's a plausible-looking fix that would have been actively wrong. The `local()` message fix has none of that risk: zero detection-logic change, just surfaces an already-correct existing escape hatch.

## Tests
`local()` font-face no longer flags (proves the advice is accurate, not just documented); `fixHint` contains `"local("`. Full lint suite (308 tests) passes.