### PR TITLE
Keep Codex plugin category as Creativity

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -33,7 +33,7 @@
     "shortDescription": "Write HTML, render video",
     "longDescription": "Build videos from HTML with HyperFrames. Author compositions with HTML, CSS, Tailwind v4 browser-runtime styles, GSAP, Anime.js, Lottie, Three.js, and WAAPI adapter patterns, use the CLI for the dev loop (init/preview/render), preprocess assets (tts/transcribe/remove-background) for compositions, install reusable registry blocks and components, and turn any website into a video with the 7-step capture-to-video pipeline.",
     "developerName": "HeyGen",
-    "category": "Design",
+    "category": "Creativity",
     "capabilities": ["Read", "Write"],
     "websiteURL": "https://hyperframes.heygen.com",
     "defaultPrompt": [


### PR DESCRIPTION
## Summary
- keep the Codex plugin manifest category aligned with the openai/plugins marketplace taxonomy
- use Creativity instead of Design for HyperFrames

## Validation
- python3 -m json.tool .codex-plugin/plugin.json