### PR TITLE
fix(producer): recognize frame-detach/browser-disconnect as recoverable parallel-capture errors

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -1031,6 +1031,33 @@ describe("adaptive missing-frame retry helpers", () => {
       false,
     );
   });
+
+  it("retries transient browser errors even when they aren't in the timeout regex", () => {
+    // Regression: this drifted from isTransientBrowserError's pattern list, so
+    // a shared-file-server-died-under-memory-pressure symptom like "Navigating
+    // frame was detached" matched isTransientBrowserError but silently skipped
+    // the adaptive worker-count-halving retry here.
+    expect(
+      isRecoverableParallelCaptureError(
+        new Error("[Parallel] Capture failed: Worker 0: Navigating frame was detached"),
+      ),
+    ).toBe(true);
+    expect(
+      isRecoverableParallelCaptureError(
+        new Error("[Parallel] Capture failed: Worker 5: Connection closed"),
+      ),
+    ).toBe(false); // "Connection closed" alone isn't in either pattern list — deliberately not matched.
+    expect(
+      isRecoverableParallelCaptureError(
+        new Error("[Parallel] Capture failed: Worker 0: browser has disconnected"),
+      ),
+    ).toBe(true);
+    // Still requires the "[Parallel] Capture failed" prefix — a transient
+    // message from an unrelated stage must not trigger this retry path.
+    expect(isRecoverableParallelCaptureError(new Error("Navigating frame was detached"))).toBe(
+      false,
+    );
+  });
 });
 
 describe("projectBrowserEndToCompositionTimeline", () => {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -60,6 +60,7 @@ import {
   getEncoderPreset,
   distributeFrames,
   executeParallelCapture,
+  isTransientBrowserError,
   mergeWorkerFrames,
   type ParallelProgress,
   type WorkerTask,
@@ -570,8 +571,15 @@ export function captureAttemptMadeProgress(
 
 export function isRecoverableParallelCaptureError(error: unknown): boolean {
   const message = normalizeErrorMessage(error);
+  if (!message.includes("[Parallel] Capture failed")) return false;
+  // Reuse the engine's transient-error classification (frame detachment,
+  // browser disconnects, OOM kills) instead of a second, narrower pattern
+  // list — the two had drifted apart, so errors like "Navigating frame was
+  // detached" (a shared-file-server-died-under-memory-pressure symptom that
+  // IS transient) matched isTransientBrowserError but not this function,
+  // silently skipping the adaptive worker-count-halving retry below.
   return (
-    message.includes("[Parallel] Capture failed") &&
+    isTransientBrowserError(error) ||
     /Runtime\.callFunctionOn timed out|HeadlessExperimental\.beginFrame timed out|Waiting failed|timeout exceeded|timed out|Navigation timeout|Protocol error|Target closed/i.test(
       message,
     )


### PR DESCRIPTION
## Summary
- `isRecoverableParallelCaptureError` had its own narrow timeout-only regex that drifted from `isTransientBrowserError`, the engine's canonical transient-browser-error classification. Errors like `Navigating frame was detached` and `browser has disconnected` (frame/browser death under host resource pressure — e.g. a shared local file server or a Chrome worker getting OOM-killed mid-render) matched the engine's classifier but not this one.
- Because of that drift, the disk-capture adaptive retry (halve worker count, retry) never triggered for this whole class of transient infra failures — a recoverable, transient error crashed the entire render instead of retrying at lower parallelism.
- Fix: `isRecoverableParallelCaptureError` now delegates to `isTransientBrowserError` (still gated behind the existing `"[Parallel] Capture failed"` prefix check, so composition bugs and unrelated errors are unaffected).

## Test plan
- [x] New regression test confirms `"Navigating frame was detached"` and `"browser has disconnected"` are now classified recoverable, while `"Connection closed"` alone (not in either pattern list) and messages without the `[Parallel] Capture failed` prefix are correctly left unmatched.
- [x] `bunx tsc --noEmit` clean.
- [x] `bunx vitest run src/services/renderOrchestrator.test.ts` — 69/69 pass.
- [x] `bunx oxlint` / `bunx oxfmt` clean on touched files.