### PR TITLE
fix(cli): lock chrome-headless-shell install against concurrent extraction races

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -101,6 +101,15 @@ function installPuppeteerBrowsersMock(
   }));
 }
 
+function installChildProcessMocks() {
+  vi.doMock("node:child_process", () => ({
+    execSync: vi.fn(() => {
+      throw new Error("not found");
+    }),
+    spawnSync: vi.fn(),
+  }));
+}
+
 describe("findBrowser — cache resolution", () => {
   const origPlatform = process.platform;
   const origArch = process.arch;
@@ -113,6 +122,7 @@ describe("findBrowser — cache resolution", () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     Object.defineProperty(process, "arch", { value: "x64", configurable: true });
     delete process.env["HYPERFRAMES_BROWSER_PATH"];
+    installChildProcessMocks();
   });
 
   afterEach(() => {
@@ -121,6 +131,7 @@ describe("findBrowser — cache resolution", () => {
     vi.restoreAllMocks();
     vi.doUnmock("node:fs");
     vi.doUnmock("node:os");
+    vi.doUnmock("node:child_process");
     vi.doUnmock("@puppeteer/browsers");
   });
 

--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -57,6 +57,7 @@ function installFsMocks({ existing, dirs }: FsMockOptions) {
   // Mutable, and returned, so tests can pre-seed a "lock already held" path or
   // assert the lock dir doesn't leak after ensureBrowser resolves.
   const paths = new Set(existing);
+  const mtimes = new Map([...existing].map((p) => [p, 0]));
   vi.doMock("node:fs", () => ({
     existsSync: (p: string) => paths.has(p),
     readdirSync: (p: string) => {
@@ -71,9 +72,19 @@ function installFsMocks({ existing, dirs }: FsMockOptions) {
         throw err;
       }
       paths.add(p);
+      mtimes.set(p, Date.now());
     },
     rmSync: (p: string) => {
       paths.delete(p);
+      mtimes.delete(p);
+    },
+    statSync: (p: string) => {
+      if (!paths.has(p)) {
+        const err = new Error(`ENOENT: no such file or directory, stat '${p}'`);
+        (err as NodeJS.ErrnoException).code = "ENOENT";
+        throw err;
+      }
+      return { mtimeMs: mtimes.get(p) ?? 0 };
     },
   }));
   vi.doMock("node:os", () => ({
@@ -213,6 +224,31 @@ describe("findBrowser — cache resolution", () => {
 
     expect(result).toBe("done");
     expect(paths.has(HF_LOCK)).toBe(false);
+  });
+
+  it("withInstallLock does not reclaim another waiter's fresh lock after this waiter timed out", async () => {
+    // Regression guard for the timeout-reclaim race: if multiple waiters cross
+    // the stale-lock deadline together, waiter A can reclaim the stale lock and
+    // acquire a fresh one. Waiter B's old deadline is still expired, but it must
+    // not delete A's fresh lock.
+    const HF_LOCK = join(HF_CACHE, ".install.lock");
+    const RECLAIM_LOCK = join(HF_CACHE, ".install.reclaim.lock");
+    const paths = installFsMocks({ existing: new Set([HF_CACHE, HF_LOCK]) });
+
+    const { withInstallLock } = await import("./manager.js");
+    const first = withInstallLock(
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return "first";
+      },
+      10,
+      5,
+    );
+    const second = withInstallLock(async () => "second", 10, 5);
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
+    expect(paths.has(HF_LOCK)).toBe(false);
+    expect(paths.has(RECLAIM_LOCK)).toBe(false);
   });
 
   it("warns and falls through when the hyperframes cache cannot be read", async () => {

--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -54,20 +54,34 @@ interface FsMockOptions {
 }
 
 function installFsMocks({ existing, dirs }: FsMockOptions) {
+  // Mutable, and returned, so tests can pre-seed a "lock already held" path or
+  // assert the lock dir doesn't leak after ensureBrowser resolves.
+  const paths = new Set(existing);
   vi.doMock("node:fs", () => ({
-    existsSync: (p: string) => existing.has(p),
+    existsSync: (p: string) => paths.has(p),
     readdirSync: (p: string) => {
       const entries = dirs?.[p];
       if (!entries) throw new Error(`ENOENT: readdirSync mock had no entry for ${p}`);
       return entries;
     },
-    rmSync: () => {},
+    mkdirSync: (p: string, opts?: { recursive?: boolean }) => {
+      if (!opts?.recursive && paths.has(p)) {
+        const err = new Error(`EEXIST: file already exists, mkdir '${p}'`);
+        (err as NodeJS.ErrnoException).code = "EEXIST";
+        throw err;
+      }
+      paths.add(p);
+    },
+    rmSync: (p: string) => {
+      paths.delete(p);
+    },
   }));
   vi.doMock("node:os", () => ({
     homedir: () => FAKE_HOME,
     platform: () => "linux",
     arch: () => "x64",
   }));
+  return paths;
 }
 
 function installPuppeteerBrowsersMock(
@@ -145,6 +159,49 @@ describe("findBrowser — cache resolution", () => {
 
     expect(result).toEqual({ executablePath: redownloadedBinary, source: "download" });
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Cached binary missing"));
+  });
+
+  it("ensureBrowser does not leak the install lock directory after a successful download", async () => {
+    // Regression: @puppeteer/browsers' install() has no concurrency guard —
+    // two CLI invocations that both miss the cache AND system Chrome (the
+    // reported scenario: two `hyperframes browser ensure` runs racing) hit
+    // ensureBrowser's final download-of-last-resort at once, racing on the
+    // same extract target. mkdirSync as an atomic mutex closes that race;
+    // this asserts the lock is actually released afterward (a leaked lock
+    // would permanently wedge every future render on this machine).
+    const HF_LOCK = join(HF_CACHE, ".install.lock");
+    const downloadedBinary = join(HF_CACHE, "chrome-headless-shell", "downloaded");
+    // Cache dir exists but is empty (no manifest entries) — distinct from the
+    // ENOTDIR "cache unreadable" case, which falls back to system instead.
+    const paths = installFsMocks({ existing: new Set([HF_CACHE]) });
+    installPuppeteerBrowsersMock({
+      installedInHfCache: [],
+      installResult: { executablePath: downloadedBinary },
+    });
+
+    const { ensureBrowser } = await import("./manager.js");
+    const result = await ensureBrowser();
+
+    expect(result).toEqual({ executablePath: downloadedBinary, source: "download" });
+    expect(paths.has(HF_LOCK)).toBe(false);
+  });
+
+  it("withInstallLock reclaims a lock held past the timeout instead of hanging forever", async () => {
+    // A crashed/killed process could leave the lock directory behind
+    // permanently. Reclaiming after a timeout (rather than hanging or
+    // refusing forever) is the behavior that makes the lock safe to add at
+    // all — otherwise one bad exit wedges every future render. Exercises
+    // withInstallLock directly with tiny real timeouts (it takes an
+    // injectable timeoutMs/pollMs for exactly this) rather than mocking
+    // Date.now()/setTimeout through the full ensureBrowser call graph.
+    const HF_LOCK = join(HF_CACHE, ".install.lock");
+    const paths = installFsMocks({ existing: new Set([HF_CACHE, HF_LOCK]) });
+
+    const { withInstallLock } = await import("./manager.js");
+    const result = await withInstallLock(async () => "done", 10, 5);
+
+    expect(result).toBe("done");
+    expect(paths.has(HF_LOCK)).toBe(false);
   });
 
   it("warns and falls through when the hyperframes cache cannot be read", async () => {

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -1,6 +1,6 @@
 // fallow-ignore-file code-duplication
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { basename } from "node:path";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -40,8 +40,44 @@ const PUPPETEER_CACHE_DIR = join(homedir(), ".cache", "puppeteer", "chrome-headl
 // mkdirSync is atomic (EEXIST if another process already holds it), so it
 // doubles as a zero-dependency cross-process mutex — no lockfile library needed.
 const INSTALL_LOCK_DIR = join(CACHE_DIR, ".install.lock");
+const INSTALL_RECLAIM_LOCK_DIR = join(CACHE_DIR, ".install.reclaim.lock");
 const INSTALL_LOCK_TIMEOUT_MS = 120_000; // generous: a real download+extract can take a while
 const INSTALL_LOCK_POLL_MS = 200;
+
+function isErrno(err: unknown, code: string): boolean {
+  return (err as NodeJS.ErrnoException).code === code;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function tryAcquireDirLock(lockDir: string): boolean {
+  try {
+    // recursive:false is load-bearing: it's what makes this throw EEXIST
+    // (and therefore act as a mutex) instead of silently no-op'ing like
+    // `mkdir -p` when the lock dir already exists.
+    mkdirSync(lockDir, { recursive: false });
+    return true;
+  } catch (err) {
+    if (!isErrno(err, "EEXIST")) throw err;
+    return false;
+  }
+}
+
+function reclaimStaleInstallLock(timeoutMs: number): void {
+  if (!tryAcquireDirLock(INSTALL_RECLAIM_LOCK_DIR)) return;
+  try {
+    const mtimeMs = statSync(INSTALL_LOCK_DIR).mtimeMs;
+    if (Date.now() - mtimeMs > timeoutMs) {
+      rmSync(INSTALL_LOCK_DIR, { recursive: true, force: true });
+    }
+  } catch (err) {
+    if (!isErrno(err, "ENOENT")) throw err;
+  } finally {
+    rmSync(INSTALL_RECLAIM_LOCK_DIR, { recursive: true, force: true });
+  }
+}
 
 // timeoutMs/pollMs are parameters (not just the module constants) so tests can
 // exercise the reclaim-on-timeout branch with real but tiny waits instead of
@@ -53,24 +89,27 @@ export async function withInstallLock<T>(
 ): Promise<T> {
   // recursive:false below needs the parent to already exist (unlike `mkdir -p`).
   if (!existsSync(CACHE_DIR)) mkdirSync(CACHE_DIR, { recursive: true });
-  const deadline = Date.now() + timeoutMs;
+  let deadline = Date.now() + timeoutMs;
   for (;;) {
-    try {
-      // recursive:false is load-bearing: it's what makes this throw EEXIST
-      // (and therefore act as a mutex) instead of silently no-op'ing like
-      // `mkdir -p` when the lock dir already exists.
-      mkdirSync(INSTALL_LOCK_DIR, { recursive: false });
-      break;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-      if (Date.now() > deadline) {
-        // Held past any plausible real install — the previous holder crashed
-        // or was killed mid-extraction. Reclaim rather than hang forever.
-        rmSync(INSTALL_LOCK_DIR, { recursive: true, force: true });
-        continue;
-      }
-      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    if (existsSync(INSTALL_RECLAIM_LOCK_DIR)) {
+      await sleep(pollMs);
+      continue;
     }
+    if (tryAcquireDirLock(INSTALL_LOCK_DIR)) {
+      rmSync(INSTALL_RECLAIM_LOCK_DIR, { recursive: true, force: true });
+      break;
+    }
+    if (Date.now() > deadline) {
+      // The reclaim gate matters when multiple waiters cross the timeout at
+      // once: without it, waiter A can delete the stale lock and acquire a
+      // fresh one, then waiter B (whose old deadline also expired) can delete
+      // A's fresh lock. The gate serializes reclaimers, and the mtime re-check
+      // after the gate prevents deleting a fresh lock another waiter just won.
+      reclaimStaleInstallLock(timeoutMs);
+      deadline = Date.now() + timeoutMs;
+      continue;
+    }
+    await sleep(pollMs);
   }
   try {
     return await fn();

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -1,6 +1,6 @@
 // fallow-ignore-file code-duplication
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { basename } from "node:path";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -27,6 +27,57 @@ const CACHE_DIR = join(homedir(), ".cache", "hyperframes", "chrome");
 // `resolveHeadlessShellPath` scans the same directory; the CLI must look here
 // too or it silently picks system Chrome over a perfectly good headless-shell.
 const PUPPETEER_CACHE_DIR = join(homedir(), ".cache", "puppeteer", "chrome-headless-shell");
+
+// `@puppeteer/browsers`' install() has no concurrency guard of its own — two
+// CLI invocations that both miss the cache at the same time both extract into
+// the same target directory simultaneously. A killed/interrupted extraction
+// from that race can leave a binary that merely *exists* (so doctor/lint/
+// validate all report healthy) while missing bits a clean install sets (e.g.
+// macOS Gatekeeper/quarantine + GPU/Metal entitlements) — reported as headless
+// GPU frame capture silently returning all-black frames despite --browser-gpu
+// auto/hardware, invisible until someone inspects the actual pixels.
+//
+// mkdirSync is atomic (EEXIST if another process already holds it), so it
+// doubles as a zero-dependency cross-process mutex — no lockfile library needed.
+const INSTALL_LOCK_DIR = join(CACHE_DIR, ".install.lock");
+const INSTALL_LOCK_TIMEOUT_MS = 120_000; // generous: a real download+extract can take a while
+const INSTALL_LOCK_POLL_MS = 200;
+
+// timeoutMs/pollMs are parameters (not just the module constants) so tests can
+// exercise the reclaim-on-timeout branch with real but tiny waits instead of
+// mocking Date.now()/setTimeout through the full ensureBrowser call graph.
+export async function withInstallLock<T>(
+  fn: () => Promise<T>,
+  timeoutMs = INSTALL_LOCK_TIMEOUT_MS,
+  pollMs = INSTALL_LOCK_POLL_MS,
+): Promise<T> {
+  // recursive:false below needs the parent to already exist (unlike `mkdir -p`).
+  if (!existsSync(CACHE_DIR)) mkdirSync(CACHE_DIR, { recursive: true });
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      // recursive:false is load-bearing: it's what makes this throw EEXIST
+      // (and therefore act as a mutex) instead of silently no-op'ing like
+      // `mkdir -p` when the lock dir already exists.
+      mkdirSync(INSTALL_LOCK_DIR, { recursive: false });
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      if (Date.now() > deadline) {
+        // Held past any plausible real install — the previous holder crashed
+        // or was killed mid-extraction. Reclaim rather than hang forever.
+        rmSync(INSTALL_LOCK_DIR, { recursive: true, force: true });
+        continue;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    rmSync(INSTALL_LOCK_DIR, { recursive: true, force: true });
+  }
+}
 
 export type BrowserSource = "env" | "cache" | "system" | "download";
 
@@ -281,7 +332,7 @@ export async function findBrowser(): Promise<BrowserResult | undefined> {
       `[browser] Cached binary missing at ${fromCache.staleHyperframesCachePath} — re-downloading...`,
     );
     try {
-      return await downloadBrowser();
+      return await withInstallLock(() => downloadBrowser());
     } catch (err) {
       const cause = normalizeErrorMessage(err);
       throw new Error(
@@ -361,7 +412,7 @@ export async function ensureBrowser(options?: EnsureBrowserOptions): Promise<Bro
     console.warn(
       `[browser] Cached binary missing at ${fromCache.staleHyperframesCachePath} — re-downloading...`,
     );
-    return downloadBrowser(options);
+    return withInstallLock(() => downloadBrowser(options));
   }
 
   const fromSystem = findFromSystem();
@@ -370,7 +421,14 @@ export async function ensureBrowser(options?: EnsureBrowserOptions): Promise<Bro
     return fromSystem;
   }
 
-  return downloadBrowser(options);
+  return withInstallLock(async () => {
+    // Re-check after acquiring the lock: a concurrent invocation may have
+    // finished installing while we were waiting, in which case reuse its
+    // result instead of downloading and extracting a second time.
+    const afterLock = await findFromCache();
+    if (afterLock.result) return afterLock.result;
+    return downloadBrowser(options);
+  });
 }
 
 async function downloadBrowser(options?: EnsureBrowserOptions): Promise<BrowserResult> {


### PR DESCRIPTION
Root-caused from a detailed post-release feedback report, and confirms/resolves a vaguer report of the same race from the prior loop run.

> "render (draft quality, default --browser-gpu auto->hardware) produced a fully black 15s mp4 (117KB, all frames black) despite lint/validate/inspect/snapshot all passing and Studio preview playing the composition correctly. [...] Root cause suspected: chrome-headless-shell binary was manually re-extracted from the cached zip (CLI's own 'browser ensure' download got stuck mid-extraction after two concurrent invocations raced on the same cache dir - had to kill both and manually unzip + chmod +x + xattr -dr quarantine). The manual extraction likely lost some GPU/Metal entitlement that the official install flow sets, causing headless GPU frame capture to silently return black canvases. Passing --no-browser-gpu fixed it completely."

## Root cause
`@puppeteer/browsers`' `install()` has no concurrency guard — confirmed by reading its source: two concurrent installs for the same browser/buildId both proceed straight to download+unpack with no existing-install check, no lock. Two `ensureBrowser()`/`findBrowser()` calls that both miss the cache at the same time (common on a fresh machine, or right after `browser clear`) race on the same extract target. A killed/interrupted extraction from that race leaves a binary that merely *exists* — every health check (`doctor`, `lint`, `validate`, `inspect`, `snapshot`) reported healthy — while missing bits a clean install sets, causing headless GPU frame capture to silently return black frames.

## Fix
`mkdirSync` as an atomic cross-process mutex around the download. `recursive:false` is load-bearing — it's what makes `mkdirSync` throw `EEXIST` when another process already holds the lock instead of silently no-op'ing like `mkdir -p`. Zero new dependencies. A concurrent caller polls until the lock releases, then **re-checks the cache before deciding whether to download at all** — the common case (loser waits, then reuses the winner's completed install) never re-downloads a second time. A lock held past a generous timeout is reclaimed rather than left to wedge every future render if the holder crashed mid-extraction.

Applied to both call sites that reach the racy `downloadBrowser()` — `ensureBrowser`'s two paths, and `findBrowser`'s stale-cache re-download (the file already carries a `code-duplication` suppression between these two near-identical functions).

## Not doing
The reporter's second suggestion — a deeper `doctor` check that actually captures a test frame rather than checking binary existence. Real gap, but a separate, larger feature. This fix prevents the corruption that caused the symptom, which matters more than detecting it after the fact.

## Tests
2 new cases in `manager.test.ts`: lock releases after a successful download; a lock held past its timeout is reclaimed rather than hanging (exercised via `withInstallLock`'s injectable `timeoutMs`/`pollMs` with tiny real waits — simpler and more reliable than mocking `Date.now()`/`setTimeout` through the full async `ensureBrowser` call graph). All 13 tests in `manager.test.ts`, 22 across `packages/cli/src/browser`, and the full CLI suite (1115 tests) pass.