### PR TITLE
fix(lint): stop a leading <svg> defs block from being mistaken for the composition root

### DIFF
--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -112,6 +112,37 @@ describe("core rules", () => {
     expect(result.findings.find((f) => f.code === "root_missing_dimensions")).toBeUndefined();
   });
 
+  it("skips a leading <svg> defs block when detecting the composition root", async () => {
+    // Regression: two independent reports of a leading <svg><defs><filter>...
+    // block (icon/gradient/filter plumbing referenced via url(#id) elsewhere)
+    // getting mistaken for the composition root, since findRootTag returned
+    // the first non-script/style/meta/link/title body child unconditionally.
+    // The <svg> here carries no composition markers, so it must be skipped in
+    // favor of the real root that follows it.
+    const html = `
+<html><body>
+  <svg width="0" height="0" style="position:absolute">
+    <defs><filter id="glow"><feGaussianBlur stdDeviation="4" /></filter></defs>
+  </svg>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080"></div>
+  <script>window.__timelines = window.__timelines || {};</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    expect(result.findings.find((f) => f.code === "root_missing_composition_id")).toBeUndefined();
+    expect(result.findings.find((f) => f.code === "root_missing_dimensions")).toBeUndefined();
+  });
+
+  it("still treats an <svg> as the root when it carries composition markers itself", async () => {
+    const html = `
+<html><body>
+  <svg id="root" data-composition-id="c1" data-width="1920" data-height="1080"></svg>
+  <script>window.__timelines = window.__timelines || {};</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    expect(result.findings.find((f) => f.code === "root_missing_composition_id")).toBeUndefined();
+    expect(result.findings.find((f) => f.code === "root_missing_dimensions")).toBeUndefined();
+  });
+
   it("reports error when timeline registry is missing", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/utils.ts
+++ b/packages/lint/src/utils.ts
@@ -79,6 +79,7 @@ export function findHtmlTag(source: string): OpenTag | null {
   };
 }
 
+// fallow-ignore-next-line complexity
 export function findRootTag(source: string): OpenTag | null {
   const bodyOpenMatch = /<body\b([^>]*)>/i.exec(source);
   const bodyCloseMatch = /<\/body>/i.exec(source);
@@ -102,8 +103,34 @@ export function findRootTag(source: string): OpenTag | null {
       : source.length;
   const bodyContent = bodyOpenMatch ? source.slice(bodyStart, bodyEnd) : source;
   const bodyTags = extractOpenTags(bodyContent);
+  // Set when a leading <svg> defs block is skipped (see below) — extractOpenTags
+  // is a flat, nesting-unaware scan, so without this the very next tag it
+  // returns is the svg's own nested child (<defs>, <filter>, ...), not the
+  // sibling that follows the closed </svg>.
+  let skipBefore = -1;
   for (const tag of bodyTags) {
+    if (tag.index < skipBefore) continue;
     if (["script", "style", "meta", "link", "title"].includes(tag.name)) continue;
+    // A leading <svg> block (icon/gradient/filter <defs>, referenced by url(#id)
+    // from elsewhere in the document) is shared visual plumbing, not the
+    // composition root — two independent reports of this being mistaken for
+    // the root, manufacturing root_missing_composition_id/root_missing_dimensions
+    // on an otherwise-correct composition. Only skip it when it carries none of
+    // the composition markers itself, so an intentionally SVG-rooted composition
+    // (data-composition-id/data-width/data-height directly on the <svg>) is
+    // still eligible as the root.
+    if (
+      tag.name === "svg" &&
+      !readAttr(tag.raw, "data-composition-id") &&
+      !readAttr(tag.raw, "data-width") &&
+      !readAttr(tag.raw, "data-height")
+    ) {
+      const closeMatch = /<\/svg\s*>/i.exec(bodyContent.slice(tag.index));
+      // No closing tag found (malformed HTML) — skip everything rather than
+      // risk returning one of the svg's own children as the root.
+      skipBefore = closeMatch ? tag.index + closeMatch.index + closeMatch[0].length : Infinity;
+      continue;
+    }
     return { ...tag, index: tag.index + bodyStart };
   }
   return null;


### PR DESCRIPTION
Root-caused from two independent post-release feedback reports of the exact same mechanism, one this run and one from an earlier loop run.

> "lint mis-detected the composition root when an inline `<svg><filter>` defs block preceded the `[data-composition-id]` root in `<body>`... reported root_missing_composition_id + root_missing_dimensions... Root detection should skip leading `<svg>` defs / non-composition siblings."

> "placing an `<svg defs>` block before #root in body made lint report 'root missing composition-id' (linter treats first body child as root)."

## Root cause
`findRootTag` returned the first body child that wasn't `script`/`style`/`meta`/`link`/`title`, unconditionally. `<svg>` was never in that skip list, so a leading defs-only `<svg>` (icon/gradient/filter plumbing referenced via `url(#id)` elsewhere in the document — a very ordinary pattern) got treated as the composition root, manufacturing both findings on an otherwise-correct composition. Moving the `<svg>` after the root cleared both findings for each reporter.

## Fix
Skip a leading `<svg>` when it carries none of the composition markers itself (`data-composition-id`/`data-width`/`data-height`), so an intentionally SVG-rooted composition is still eligible as the root.

The first attempt at this only skipped the `<svg>` open tag, which surfaced a second, more subtle bug: `extractOpenTags` is a flat, nesting-unaware regex scan, so the very next tag it returns after skipping `<svg>` is the svg's own nested child (`<defs>`, `<filter>`, ...) — not the sibling that follows `</svg>`. Fixed by tracking the svg's closing-tag position and skipping every tag before it, not just the `<svg>` tag itself.

## Tests
Skips a leading svg defs block (no false root findings); still treats an `<svg>` as the root when composition markers are declared directly on it. Full lint suite (308 tests) passes.