### PR TITLE
fix(lint): recognize computed-key window.__timelines registrations

### DIFF
--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -1141,6 +1141,20 @@ describe("composition rules", () => {
       expect(find(result.findings)).toBeUndefined();
     });
 
+    it("does not error when a GSAP timeline is registered with a computed bracket key", async () => {
+      const html = `<html><body>
+        <div data-composition-id="main" data-start="0" data-width="1920" data-height="1080"></div>
+        <script>
+          var spec = { id: "main" };
+          window.__timelines = window.__timelines || {};
+          const tl = gsap.timeline({ paused: true });
+          window.__timelines[spec.id] = tl;
+        </script>
+      </body></html>`;
+      const result = await lintHyperframeHtml(html);
+      expect(find(result.findings)).toBeUndefined();
+    });
+
     it("does not error for a finite CSS animation (runtime auto-infers duration)", async () => {
       const html = `<html><body>
         <div data-composition-id="main" data-start="0" data-width="1920" data-height="1080">

--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -1296,6 +1296,26 @@ describe("GSAP rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does NOT warn when timeline is registered with a computed bracket key", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="root" data-width="1920" data-height="1080">
+    <div id="box">Hello</div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    var spec = { id: "root" };
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.to("#box", { opacity: 0.5, duration: 2 });
+    window.__timelines[spec.id] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_timeline_not_registered");
+    expect(finding).toBeUndefined();
+  });
+
   it("does NOT warn for sub-compositions (template-based)", async () => {
     const html = `
 <template>

--- a/packages/lint/src/utils.ts
+++ b/packages/lint/src/utils.ts
@@ -23,8 +23,16 @@ export const TIMELINE_REGISTRY_INIT_PATTERN =
   /window\.__timelines\s*=\s*window\.__timelines\s*\|\|\s*\{\}|window\.__timelines\s*=\s*\{\}|window\.__timelines\s*\?\?=\s*\{\}/i;
 export const TIMELINE_REGISTRY_ASSIGN_PATTERN =
   /window\.__timelines(?:\[[^\]]+\]|\.[A-Za-z_$][\w$]*)\s*=/i;
+// The bracket branch accepts either a quoted string key (`["root"]`) or a
+// computed key (`[spec.id]`, `[id]`) — a bare-identifier-only bracket branch
+// missed `window.__timelines[spec.id] = tl`, a pattern the shipped
+// code-particle-assemble/code-3d-extrude registry blocks actually use,
+// making gsap_timeline_not_registered false-fire on correctly registered
+// timelines. The computed-key alternative is deliberately non-capturing:
+// its text isn't a literal composition id, so callers reading group 1/2
+// (readRegisteredTimelineCompositionId) must keep falling back to null for it.
 export const WINDOW_TIMELINE_ASSIGN_PATTERN =
-  /window\.__timelines(?:\[\s*["']([^"']+)["']\s*\]|\.\s*([A-Za-z_$][\w$]*))\s*=\s*([A-Za-z_$][\w$]*)/i;
+  /window\.__timelines(?:\[\s*(?:["']([^"']+)["']|[A-Za-z_$][\w$.]*)\s*\]|\.\s*([A-Za-z_$][\w$]*))\s*=\s*([A-Za-z_$][\w$]*)/i;
 export const INVALID_SCRIPT_CLOSE_PATTERN = /<script[^>]*>[\s\S]*?<\s*\/\s*script(?!>)/i;
 
 const TIMELINE_REGISTRY_KEY_PATTERN =


### PR DESCRIPTION
## Summary

`WINDOW_TIMELINE_ASSIGN_PATTERN` only recognized `window.__timelines["literal"] = tl` (quoted string key) or `window.__timelines.prop = tl` (dot property). It missed the computed-key form `window.__timelines[spec.id] = tl`, which the shipped `code-particle-assemble` and `code-3d-extrude` registry blocks actually use.

That gap caused two false positives on code that registers its timeline correctly:
- `gsap_timeline_not_registered` fires even though a timeline was registered, just under a computed key.
- `root_composition_missing_duration_source` wrongly demands an explicit `data-duration`, since its "is a timeline registered" check reuses the same pattern.

## Fix

Broadened the bracket alternative in `WINDOW_TIMELINE_ASSIGN_PATTERN` to accept a bare identifier / dotted property path (`[spec.id]`, `[id]`) alongside the existing quoted-string form. The computed-key branch is non-capturing, so `readRegisteredTimelineCompositionId` (which resolves the registered composition id from the match) keeps falling back to `null` for it, exactly as it already did before this fix — no change to that call site's behavior.

Verified against the real `code-particle-assemble.html`/`code-3d-extrude.html` registry blocks: both still correctly flag their existing `gsap_timeline_registered_before_async_build` issue (register-before-build ordering, a separate pre-existing bug, out of scope here), and no longer spuriously flag `gsap_timeline_not_registered` once registration is moved after the build per that rule's own fix hint.

## Test plan

- [x] `bunx vitest run packages/lint/` — 308 tests pass
- [x] New test: computed-key registration does not trigger `gsap_timeline_not_registered`
- [x] New test: computed-key registration satisfies `root_composition_missing_duration_source`
- [x] Manually verified against both real registry blocks in their current and async-fixed forms