### PR TITLE
fix(studio): resume drag-paused timelines instead of only re-seeking

### DIFF
--- a/packages/studio/src/components/editor/manualOffsetDrag.test.ts
+++ b/packages/studio/src/components/editor/manualOffsetDrag.test.ts
@@ -2,6 +2,7 @@ import { Window } from "happy-dom";
 import { describe, expect, it } from "vitest";
 import {
   applyManualOffsetDragCommit,
+  resumeGsapTimelines,
   applyManualOffsetDragDraft,
   applyManualOffsetDragMatrix,
   createManualOffsetDragMember,
@@ -358,5 +359,53 @@ describe("GSAP-element drag — dot-a flies regressions", () => {
     expect(element.hasAttribute("data-hf-studio-path-offset")).toBe(false);
     // ...and the position survives in the GSAP transform (no stale var to compose).
     expect(element.style.getPropertyValue("transform")).toMatch(/translate\(/);
+  });
+});
+
+describe("resumeGsapTimelines", () => {
+  it("unpauses exactly the timelines the drag start paused, then re-seeks the player", () => {
+    const window = new Window();
+    const element = window.document.createElement("div");
+    element.setAttribute("data-hf-drag-paused-timelines", "figma-demo-unlock,figma-demo-stagger");
+    window.document.body.append(element);
+
+    const pausedState: Record<string, boolean> = {
+      "figma-demo-unlock": true,
+      "figma-demo-stagger": true,
+      main: true,
+    };
+    const makeTl = (id: string) => ({
+      paused: (value?: boolean) => {
+        if (value !== undefined) pausedState[id] = value;
+        return pausedState[id]!;
+      },
+    });
+    const seeks: number[] = [];
+    const win = element.ownerDocument.defaultView as unknown as {
+      __timelines?: Record<string, unknown>;
+      __player?: { seek: (t: number) => void; getTime: () => number };
+    };
+    win.__timelines = {
+      "figma-demo-unlock": makeTl("figma-demo-unlock"),
+      "figma-demo-stagger": makeTl("figma-demo-stagger"),
+      main: makeTl("main"),
+    };
+    win.__player = { seek: (t: number) => seeks.push(t), getTime: () => 3.5 };
+
+    resumeGsapTimelines(element);
+
+    expect(pausedState["figma-demo-unlock"]).toBe(false);
+    expect(pausedState["figma-demo-stagger"]).toBe(false);
+    // main was NOT paused by the drag — leave its state alone
+    expect(pausedState["main"]).toBe(true);
+    expect(seeks).toEqual([3.5]);
+    expect(element.hasAttribute("data-hf-drag-paused-timelines")).toBe(false);
+  });
+
+  it("is a no-op without the paused-timelines attribute", () => {
+    const window = new Window();
+    const element = window.document.createElement("div");
+    window.document.body.append(element);
+    expect(() => resumeGsapTimelines(element)).not.toThrow();
   });
 });

--- a/packages/studio/src/components/editor/manualOffsetDrag.ts
+++ b/packages/studio/src/components/editor/manualOffsetDrag.ts
@@ -513,11 +513,23 @@ export function resumeGsapTimelines(element: HTMLElement): void {
   if (!ids) return;
   const win = element.ownerDocument.defaultView as
     | (Window & {
-        __timelines?: Record<string, { pause?: () => void }>;
+        __timelines?: Record<string, { paused?: (value?: boolean) => boolean }>;
         __player?: { seek?: (t: number) => void; getTime?: () => number };
       })
     | null;
   if (!win) return;
+  // Unpause exactly the timelines the drag start paused. The player seek below
+  // repositions them, but a seek alone leaves play-state-driven sub-composition
+  // timelines paused forever — the "selecting a piece kills its animation" bug:
+  // main survives (seek-driven every frame) while every scene timeline freezes,
+  // and deselecting can't recover because nothing else ever resumes them.
+  for (const id of ids.split(",")) {
+    try {
+      win.__timelines?.[id]?.paused?.(false);
+    } catch {
+      /* cross-origin guard */
+    }
+  }
   const t = win.__player?.getTime?.() ?? 0;
   win.__player?.seek?.(t);
 }


### PR DESCRIPTION
## What

One-cause fix for "selecting/dragging an element permanently kills its animations" in Studio.

`createManualOffsetDragMember` (drag start) pauses **every** timeline in `window.__timelines` and records the list in `data-hf-drag-paused-timelines`. `resumeGsapTimelines` then removed the attribute and only re-seeked the player — **it never unpaused anything**. The `main` timeline survives because the player seeks it every frame (seek works on paused timelines), but play-state-driven sub-composition timelines froze permanently after any drag gesture, and deselecting couldn't recover them — nothing else ever resumes them. Symptom set reported: scrubbing still works, the container still animates in, the scene timelines are dead until a full reload.

## Fix

Resume exactly the recorded ids (`tl.paused(false)`) before the player re-seek — timelines the drag didn't pause are never touched, so a deliberately-paused timeline stays paused.

## Verified

- 2 regression tests (unpauses recorded ids only, leaves un-recorded timelines alone, clears the attribute, still re-seeks; no-op without the attribute) — 16/16 in `manualOffsetDrag.test.ts`.
- Live end-to-end with a rebuilt studio: real drag gesture on an animated element in a 4-scene GSAP composition → all scene timelines remain `paused:false` afterward (previously all read `paused:true` and never recovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)