### PR TITLE
fix(hyperframes-media): fall back to ffmpeg when ffprobe is missing

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -38,8 +38,8 @@
       "files": 3
     },
     "hyperframes-media": {
-      "hash": "c991b6d3575e0f17",
-      "files": 42
+      "hash": "cefef0080fc780df",
+      "files": 43
     },
     "hyperframes-registry": {
       "hash": "e3b389526834109d",

--- a/skills/hyperframes-media/scripts/lib/tts.mjs
+++ b/skills/hyperframes-media/scripts/lib/tts.mjs
@@ -75,12 +75,35 @@ export function withWordIds(words) {
   return (words ?? []).map((w, i) => ({ id: `w${i}`, text: w.text, start: w.start, end: w.end }));
 }
 
+// `ffmpeg -i <file>` prints a `Duration: HH:MM:SS.ms` line to stderr even
+// though it exits non-zero with no output requested. Parsing pulled out as
+// a pure function so the ENOENT fallback below can be tested without
+// depending on whether ffprobe/ffmpeg are actually installed on the
+// machine running the tests.
+export function parseFfmpegDurationBanner(stderrText) {
+  const match = /Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/.exec(stderrText ?? "");
+  if (!match) return NaN;
+  const [, hours, minutes, seconds] = match;
+  return Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds);
+}
+
+// Some "essentials"-style ffmpeg distributions (common on Windows) ship
+// ffmpeg.exe without ffprobe.exe. ffprobeDuration's caller (audio.mjs)
+// otherwise reads a spurious NaN as "the WAV file is corrupt" and drops an
+// already-successfully-synthesized TTS line, rather than "the tool for
+// measuring it is missing".
+function ffmpegDurationFallback(absPath) {
+  const r = spawnSync("ffmpeg", ["-i", absPath], { encoding: "utf8" });
+  return parseFfmpegDurationBanner(r.stderr);
+}
+
 export function ffprobeDuration(absPath) {
   const r = spawnSync(
     "ffprobe",
     ["-v", "error", "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", absPath],
     { encoding: "utf8" },
   );
+  if (r.error?.code === "ENOENT") return ffmpegDurationFallback(absPath);
   if (r.status !== 0) return NaN;
   return parseFloat(String(r.stdout).trim());
 }

--- a/skills/hyperframes-media/scripts/lib/tts.test.mjs
+++ b/skills/hyperframes-media/scripts/lib/tts.test.mjs
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseFfmpegDurationBanner, ffprobeDuration } from "./tts.mjs";
+
+test("parseFfmpegDurationBanner reads ffmpeg's stderr Duration line", () => {
+  const stderr = [
+    "ffmpeg version 6.0",
+    "Input #0, wav, from 'a.wav':",
+    "  Duration: 00:00:03.42, bitrate: 705 kb/s",
+    "At least one output file must be specified",
+  ].join("\n");
+  assert.equal(parseFfmpegDurationBanner(stderr), 3.42);
+});
+
+test("parseFfmpegDurationBanner handles an hours component", () => {
+  const stderr = "  Duration: 01:02:03.50, start: 0.000000, bitrate: 128 kb/s";
+  assert.equal(parseFfmpegDurationBanner(stderr), 3723.5);
+});
+
+test("parseFfmpegDurationBanner returns NaN when there is no Duration line", () => {
+  assert.ok(Number.isNaN(parseFfmpegDurationBanner("ffmpeg: command not found")));
+  assert.ok(Number.isNaN(parseFfmpegDurationBanner("")));
+  assert.ok(Number.isNaN(parseFfmpegDurationBanner(undefined)));
+});
+
+// Regression for the actual bug: ffprobeDuration used to collapse "ffprobe
+// binary is missing" (ENOENT — the "essentials"-style Windows ffmpeg build
+// with no ffprobe.exe) and "file is genuinely unreadable" into the same NaN,
+// giving audio.mjs no way to tell "measure differently" from "give up".
+//
+// Builds an isolated PATH containing only a fake `ffmpeg` stub (no `ffprobe`
+// at all) so ffprobeDuration's spawnSync("ffprobe", ...) call ENOENTs for
+// real, then verifies it recovers the duration via the ffmpeg fallback
+// instead of returning NaN.
+test("ffprobeDuration falls back to ffmpeg when the ffprobe binary itself is missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tts-ffprobe-fallback-"));
+  const fakeFfmpeg = join(dir, "ffmpeg");
+  writeFileSync(
+    fakeFfmpeg,
+    "#!/bin/sh\necho 'Duration: 00:00:02.50, start: 0.000000, bitrate: 128 kb/s' 1>&2\nexit 1\n",
+  );
+  chmodSync(fakeFfmpeg, 0o755);
+  const originalPath = process.env.PATH;
+  try {
+    process.env.PATH = dir; // only the fake ffmpeg resolves; no real ffprobe on this PATH
+    assert.equal(ffprobeDuration("/does/not/matter.wav"), 2.5);
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ffprobeDuration returns NaN when neither ffprobe nor ffmpeg resolve", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tts-no-binaries-"));
+  const originalPath = process.env.PATH;
+  try {
+    process.env.PATH = dir; // empty directory — nothing resolves
+    assert.ok(Number.isNaN(ffprobeDuration("/does/not/matter.wav")));
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

`ffprobeDuration()` in `skills/hyperframes-media/scripts/lib/tts.mjs` returned `NaN` whenever the `ffprobe` spawn failed for any reason, conflating two very different situations: "the file is genuinely unreadable/corrupt" and "the `ffprobe` binary itself isn't installed."

Some ffmpeg-only distributions (a handful of curated Windows "essentials" builds) ship `ffmpeg.exe` without `ffprobe.exe`. On those installs, every TTS line hits the missing-binary case, and `audio.mjs`'s caller reads the resulting `NaN` as "bad voice duration" and silently omits an already-successfully-synthesized line from the final composition audio — with no indication the actual cause was a missing tool.

## Fix

`ffprobeDuration` now distinguishes the two cases: when the `ffprobe` spawn fails with `ENOENT` specifically, it falls back to `ffmpeg -i <file>`, which reliably prints a `Duration: HH:MM:SS.ms` banner to stderr even though it exits non-zero with no output requested. Any other non-zero exit (a real unreadable/corrupt file) still returns `NaN` as before — that path is unchanged.

The banner-parsing logic is extracted into a pure `parseFfmpegDurationBanner()` so it can be unit tested independently of what's actually installed on the machine running the tests.

## Test plan

- [x] `node --test skills/hyperframes-media/scripts/lib/tts.test.mjs` — 5 tests pass
- [x] New tests cover: banner parsing (with/without hours, malformed input), and an end-to-end fallback test that builds an isolated `PATH` with a fake `ffmpeg` stub and no `ffprobe` at all, proving the real `ENOENT` branch recovers a duration instead of returning `NaN`
- [x] A control test confirms `NaN` is still returned when neither tool resolves