### PR TITLE
fix(engine): call out a mangled replacement character in ffmpeg path errors

### DIFF
--- a/packages/engine/src/utils/ffmpegBinaries.test.ts
+++ b/packages/engine/src/utils/ffmpegBinaries.test.ts
@@ -40,4 +40,21 @@ describe("ffmpeg binary env resolution", () => {
 
     expect(() => assertConfiguredFfmpegBinariesExist()).not.toThrow();
   });
+
+  // Regression: a path containing U+FFFD (the Unicode replacement character)
+  // means a non-ASCII character was mangled somewhere before this process
+  // read it (e.g. an accented character in a Windows WinGet Links path) —
+  // the error should say so instead of just "not found", since the path
+  // itself gives no hint that the real fix is an ASCII/short-path override.
+  it("calls out a mangled replacement character in a missing FFmpeg path", () => {
+    process.env.HYPERFRAMES_FFMPEG_PATH = "/tools/f�mpeg/ffmpeg.exe";
+
+    expect(() => assertConfiguredFfmpegBinariesExist()).toThrow(/replacement character/);
+  });
+
+  it("does not mention a replacement character for an ordinary missing path", () => {
+    process.env.HYPERFRAMES_FFMPEG_PATH = "/missing/ffmpeg.exe";
+
+    expect(() => assertConfiguredFfmpegBinariesExist()).not.toThrow(/replacement character/);
+  });
 });

--- a/packages/engine/src/utils/ffmpegBinaries.ts
+++ b/packages/engine/src/utils/ffmpegBinaries.ts
@@ -44,20 +44,39 @@ export function getFfprobeBinary(): string {
   return getConfiguredBinary(FFPROBE_PATH_ENV, "ffprobe");
 }
 
+// A literal U+FFFD in a configured path is never a real path component — it's
+// the Unicode replacement character, which only appears when some layer
+// (shell, subprocess env passthrough, code page mismatch) failed to decode a
+// non-ASCII character in the original path. Windows installer link paths
+// (e.g. WinGet Links) commonly contain accented characters, so this is the
+// single most useful diagnostic to surface before the generic "not found".
+function mangledPathHint(path: string): string {
+  if (!path.includes("�")) return "";
+  return (
+    ` This path contains a "�" (Unicode replacement character), which means a ` +
+    "non-ASCII character in the real path got mangled before reaching this process " +
+    "— common with accented characters in Windows install paths. Try the short " +
+    '8.3 path (e.g. via `for %I in ("<path>") do @echo %~sI`) or move the binary ' +
+    "to an ASCII-only path."
+  );
+}
+
 export function assertConfiguredFfmpegBinariesExist(): void {
   const ffmpegPath = process.env[FFMPEG_PATH_ENV]?.trim();
   if (ffmpegPath && !existsSync(ffmpegPath)) {
     throw new Error(
-      `[FFmpeg] FFmpeg binary not found at ${FFMPEG_PATH_ENV}="${ffmpegPath}". ` +
-        "Install FFmpeg or unset the override.",
+      `[FFmpeg] FFmpeg binary not found at ${FFMPEG_PATH_ENV}="${ffmpegPath}".` +
+        mangledPathHint(ffmpegPath) +
+        " Install FFmpeg or unset the override.",
     );
   }
 
   const ffprobePath = process.env[FFPROBE_PATH_ENV]?.trim();
   if (ffprobePath && !existsSync(ffprobePath)) {
     throw new Error(
-      `[FFmpeg] FFprobe binary not found at ${FFPROBE_PATH_ENV}="${ffprobePath}". ` +
-        "Install FFmpeg or unset the override.",
+      `[FFmpeg] FFprobe binary not found at ${FFPROBE_PATH_ENV}="${ffprobePath}".` +
+        mangledPathHint(ffprobePath) +
+        " Install FFmpeg or unset the override.",
     );
   }
 }


### PR DESCRIPTION
## Summary

`HYPERFRAMES_FFMPEG_PATH`/`HYPERFRAMES_FFPROBE_PATH` overrides that fail the existence check just say "binary not found" — no hint when the real cause is an encoding problem rather than a typo or a missing install.

Windows install paths (e.g. WinGet Links) commonly contain accented characters. When such a path gets passed through an intermediate layer that isn't UTF-8-safe, the non-ASCII character can be replaced with U+FFFD (the Unicode replacement character) before this process ever sees it — so a perfectly valid ffmpeg install ends up looking "not found," with the actual override value giving no clue why.

## Fix

`assertConfiguredFfmpegBinariesExist`'s error message now detects a literal U+FFFD in the configured path and calls it out specifically, pointing at the fix (an ASCII/short 8.3 path) instead of leaving the user to rediscover it by hand.

Deliberately scoped narrow: `getFfmpegBinary`/`getFfprobeBinary` still trust a configured override as-is when it exists, by design (an explicit user-supplied path is never silently second-guessed) — this only improves the diagnostic on the existing fail-fast preflight check, it doesn't change resolution behavior.

## Test plan

- [x] `bunx vitest run packages/engine/src/utils/ffmpegBinaries.test.ts` — 5 tests pass (3 existing + 2 new)
- [x] New tests: a path containing U+FFFD gets the replacement-character hint; an ordinary missing path does not