### PR TITLE
fix(cli): warn when snapshot --at is passed more than once

### DIFF
--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeSnapshotTimes, tailFrameTime } from "./snapshot.js";
+import { computeSnapshotTimes, countRepeatedAtFlag, tailFrameTime } from "./snapshot.js";
 
 describe("tailFrameTime", () => {
   it("backs off ~3% of duration so the final frame isn't the blank exact-end", () => {
@@ -57,5 +57,31 @@ describe("computeSnapshotTimes (FINDING [7]: tail is always captured)", () => {
     });
     expect(times).toEqual([1, 2]);
     expect(appendedTail).toBe(false);
+  });
+});
+
+describe("countRepeatedAtFlag", () => {
+  it("returns 0 when --at is absent", () => {
+    expect(countRepeatedAtFlag(["node", "cli.js", "snapshot"])).toBe(0);
+  });
+
+  it("returns 1 for a single --at usage", () => {
+    expect(countRepeatedAtFlag(["snapshot", "--at", "1,2,3"])).toBe(1);
+  });
+
+  it("returns 1 for a single --at=value usage", () => {
+    expect(countRepeatedAtFlag(["snapshot", "--at=1,2,3"])).toBe(1);
+  });
+
+  it("counts repeated --at occurrences (the actual bug shape)", () => {
+    expect(countRepeatedAtFlag(["snapshot", "--at", "1", "--at", "2", "--at", "3"])).toBe(3);
+  });
+
+  it("counts a mix of --at and --at= forms", () => {
+    expect(countRepeatedAtFlag(["snapshot", "--at", "1", "--at=2"])).toBe(2);
+  });
+
+  it("does not confuse an unrelated flag that merely starts with --at", () => {
+    expect(countRepeatedAtFlag(["snapshot", "--attempt", "1", "--attempt", "2"])).toBe(0);
   });
 });

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -53,6 +53,20 @@ function orbitStageSource(): string {
 const FFMPEG_EXTRACT_TIMEOUT_MS = 30_000;
 
 /**
+ * `--at` is declared as a single `type: "string"` citty arg, so Node's
+ * underlying `util.parseArgs` silently keeps only the LAST occurrence when
+ * the flag is repeated (`--at 1 --at 2` yields "2", not both) — citty has no
+ * `multiple: true` passthrough to opt into array accumulation. The
+ * documented usage is a single comma-separated value (`--at 1,2,3`), so
+ * repeating the flag is always a user mistake, not an alternate valid
+ * syntax; this only detects it in the raw argv so the mistake is loud
+ * instead of a silently truncated snapshot.
+ */
+export function countRepeatedAtFlag(argv: string[]): number {
+  return argv.filter((arg) => arg === "--at" || arg.startsWith("--at=")).length;
+}
+
+/**
  * Extract a single frame from a video file at `timeSeconds` via FFmpeg.
  * Used to work around Chrome-headless's inability to reliably seek
  * <video> elements during snapshot capture.
@@ -591,6 +605,14 @@ export default defineCommand({
     const project = resolveProject(args.dir);
     const frames = parseInt(args.frames as string, 10) || 5;
     const timeout = parseInt(args.timeout as string, 10) || 5000;
+    const repeatedAtCount = countRepeatedAtFlag(process.argv);
+    if (repeatedAtCount > 1) {
+      console.warn(
+        `   ${c.warn("⚠")} --at was passed ${repeatedAtCount} times; only the last one ` +
+          `("${String(args.at)}") is used. Pass every timestamp in one comma-separated flag ` +
+          `instead: --at 3.0,10.5,18.0`,
+      );
+    }
     const atTimestamps = args.at
       ? String(args.at)
           .split(",")


### PR DESCRIPTION
## Summary

`hyperframes snapshot --at` is declared as a single `type: "string"` citty arg. Node's underlying `util.parseArgs` silently keeps only the *last* occurrence when a non-`multiple` string flag is repeated — `--at 1 --at 2` resolves to `"2"`, not both. citty doesn't expose a `multiple: true` passthrough for this, so native repeated-flag support isn't feasible without a much bigger change (verified: no `multiple` handling anywhere in citty's own arg parser).

The documented usage is a single comma-separated value (`--at 3.0,10.5,18.0`), which already works correctly. Repeating the flag is always a mistake, but it silently drops timestamps with no indication to the user why fewer frames than expected were captured.

## Fix

Detects repeated `--at` occurrences directly in `process.argv` (independent of citty's already-collapsed parsed value) and warns with the actual value that ended up being used, pointing at the correct comma-separated syntax.

## Test plan

- [x] `bunx vitest run packages/cli/src/commands/snapshot.test.ts` — 6 new tests pass, covering: absent flag, single `--at`, single `--at=value`, repeated `--at`, mixed `--at`/`--at=` forms, and no false-positive on an unrelated flag that merely starts with the same prefix (`--attempt`)