### PR TITLE
fix(engine): resolve ffmpeg/ffprobe via a PATH scan when where/which fails

### DIFF
--- a/packages/engine/src/services/streamingEncoder.test.ts
+++ b/packages/engine/src/services/streamingEncoder.test.ts
@@ -12,7 +12,7 @@
 import { EventEmitter } from "events";
 import { mkdtempSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { basename, join } from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -490,7 +490,7 @@ describe("spawnStreamingEncoder lifecycle and cleanup", () => {
     const encoder = await spawnStreamingEncoder(join(dir, "out.mp4"), baseOptions);
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.command).toBe("ffmpeg");
+    expect(basename(calls[0]?.command ?? "")).toMatch(/^ffmpeg(?:\.exe)?$/);
 
     const proc = calls[0]!.proc;
     const closePromise = encoder.close();

--- a/packages/engine/src/utils/ffmpegBinaries.test.ts
+++ b/packages/engine/src/utils/ffmpegBinaries.test.ts
@@ -1,8 +1,11 @@
 // fallow-ignore-file code-duplication
-import { resolve } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   assertConfiguredFfmpegBinariesExist,
+  findViaPathScan,
   getFfmpegBinary,
   getFfprobeBinary,
 } from "./ffmpegBinaries.js";
@@ -39,5 +42,56 @@ describe("ffmpeg binary env resolution", () => {
     process.env.HYPERFRAMES_FFPROBE_PATH = process.execPath;
 
     expect(() => assertConfiguredFfmpegBinariesExist()).not.toThrow();
+  });
+});
+
+// Regression: findOnPath used to rely entirely on shelling out to
+// `where`/`which`, so a restricted/sandboxed shell without that helper
+// binary made a genuinely-on-PATH ffmpeg/ffprobe look unresolvable, even
+// though a pure PATH-directory scan would have found it fine. findViaPathScan
+// is the fallback that needs no external helper process — tested directly
+// (bypassing findOnPath's module-level cache and the real `where`/`which`
+// call) with a real fake binary on a controlled PATH.
+describe("findViaPathScan", () => {
+  it("finds a binary that exists in a PATH directory", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ffmpeg-path-scan-"));
+    const fakeFfmpeg = join(dir, "ffmpeg");
+    writeFileSync(fakeFfmpeg, "#!/bin/sh\necho fake\n");
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = dir;
+      expect(findViaPathScan("ffmpeg")).toBe(fakeFfmpeg);
+    } finally {
+      process.env.PATH = originalPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when the binary is not on any PATH directory", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ffmpeg-path-scan-empty-"));
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = dir;
+      expect(findViaPathScan("ffmpeg")).toBeUndefined();
+    } finally {
+      process.env.PATH = originalPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("checks multiple PATH directories in order", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "ffmpeg-path-scan-a-"));
+    const realDir = mkdtempSync(join(tmpdir(), "ffmpeg-path-scan-b-"));
+    const fakeFfprobe = join(realDir, "ffprobe");
+    writeFileSync(fakeFfprobe, "#!/bin/sh\necho fake\n");
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = [emptyDir, realDir].join(delimiter);
+      expect(findViaPathScan("ffprobe")).toBe(fakeFfprobe);
+    } finally {
+      process.env.PATH = originalPath;
+      rmSync(emptyDir, { recursive: true, force: true });
+      rmSync(realDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/engine/src/utils/ffmpegBinaries.ts
+++ b/packages/engine/src/utils/ffmpegBinaries.ts
@@ -1,15 +1,14 @@
 // fallow-ignore-file code-duplication
 import { execFileSync } from "child_process";
 import { existsSync } from "fs";
-import { resolve } from "path";
+import { delimiter, join, resolve } from "path";
 
 export const FFMPEG_PATH_ENV = "HYPERFRAMES_FFMPEG_PATH";
 export const FFPROBE_PATH_ENV = "HYPERFRAMES_FFPROBE_PATH";
 
 const pathCache = new Map<string, string | undefined>();
 
-function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
-  if (pathCache.has(name)) return pathCache.get(name);
+function findViaWhereOrWhich(name: "ffmpeg" | "ffprobe"): string | undefined {
   try {
     const command = process.platform === "win32" ? "where" : "which";
     const output = execFileSync(command, [name], {
@@ -21,13 +20,37 @@ function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
       .split(/\r?\n/)
       .map((s) => s.trim())
       .find(Boolean);
-    const resolved = first ? resolve(first) : undefined;
-    pathCache.set(name, resolved);
-    return resolved;
+    return first ? resolve(first) : undefined;
   } catch {
-    pathCache.set(name, undefined);
     return undefined;
   }
+}
+
+// `where`/`which` themselves can be unavailable (a restricted/sandboxed shell
+// without cmd.exe's where.exe on PATH) even when the target binary is
+// directly executable and genuinely on PATH. Scanning PATH directories
+// ourselves needs no external helper process, so it still resolves the
+// binary in that case instead of falling through to a bare command name that
+// a later non-shell `spawn()` can't resolve on its own.
+export function findViaPathScan(name: "ffmpeg" | "ffprobe"): string | undefined {
+  const pathEnv = process.env.PATH ?? process.env.Path ?? process.env.path;
+  if (!pathEnv) return undefined;
+  const candidateNames = process.platform === "win32" ? [`${name}.exe`, name] : [name];
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const candidateName of candidateNames) {
+      const candidate = join(dir, candidateName);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
+  if (pathCache.has(name)) return pathCache.get(name);
+  const resolved = findViaWhereOrWhich(name) ?? findViaPathScan(name);
+  pathCache.set(name, resolved);
+  return resolved;
 }
 
 function getConfiguredBinary(envName: string, binaryName: "ffmpeg" | "ffprobe"): string {

--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -1,7 +1,7 @@
 // fallow-ignore-file code-duplication
 import { EventEmitter } from "events";
 import { readFileSync } from "fs";
-import { resolve } from "path";
+import { basename, resolve } from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { extractMediaMetadata, extractPngMetadataFromBuffer } from "./ffprobe.js";
 
@@ -209,7 +209,7 @@ describe("ffprobe missing-binary fallback", () => {
     const meta = await extractMediaMetadataMocked(fixture);
 
     expect(calls.length).toBe(1);
-    expect(calls[0]?.command).toBe("ffprobe");
+    expect(basename(calls[0]?.command ?? "")).toMatch(/^ffprobe(?:\.exe)?$/);
     expect(meta.videoCodec).toBe("png");
     expect(meta.durationSeconds).toBe(0);
     expect(meta.fps).toBe(0);
@@ -313,7 +313,7 @@ describe("ffprobe missing-binary fallback", () => {
       /ffprobe not found/,
     );
     expect(calls.length).toBe(1);
-    expect(calls[0]?.command).toBe("ffprobe");
+    expect(basename(calls[0]?.command ?? "")).toMatch(/^ffprobe(?:\.exe)?$/);
   });
 
   it("analyzeKeyframeIntervals surfaces a ffprobe-missing error verbatim", async () => {
@@ -327,7 +327,7 @@ describe("ffprobe missing-binary fallback", () => {
       /ffprobe not found/,
     );
     expect(calls.length).toBe(1);
-    expect(calls[0]?.command).toBe("ffprobe");
+    expect(basename(calls[0]?.command ?? "")).toMatch(/^ffprobe(?:\.exe)?$/);
   });
 
   it("ffprobe-missing error message includes install hint", async () => {


### PR DESCRIPTION
## Summary

`findOnPath()` resolved `ffmpeg`/`ffprobe` by shelling out to `where` (Windows) or `which` (POSIX). In a restricted/sandboxed shell where that helper binary itself isn't runnable — even though the target binary is directly executable and genuinely on PATH — resolution silently failed and `getConfiguredBinary()` fell back to a bare command name (`"ffmpeg"`). A later non-shell `spawn(command, args)` can't resolve a bare command name via PATH the way an interactive shell does, so render failed hard for an install that works fine when invoked directly.

## Fix

Added `findViaPathScan()` as a fallback: scans `process.env.PATH`'s directories directly with `existsSync`, needing no external helper process at all. `findOnPath` now tries `where`/`which` first (keeps the existing fast path and behavior everywhere it already works) and only falls back to the manual scan when that fails.

Related but independent from #1878 (which only improved the diagnostic message on the fail-fast preflight check) — this fixes the actual resolution mechanism the reporter's environment hit.

## Test plan

- [x] `bunx vitest run packages/engine/src/utils/ffmpegBinaries.test.ts` — 6 tests pass (3 existing + 3 new)
- [x] New tests exercise `findViaPathScan` directly (exported for testability, bypassing `findOnPath`'s cache and the real `where`/`which` call): finds a binary via a controlled PATH, returns `undefined` when absent, and checks multiple PATH directories in order