### PR TITLE
fix(hyperframes-media): surface the real HeyGen TTS error instead of a generic message

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -42,7 +42,7 @@
       "files": 3
     },
     "hyperframes-media": {
-      "hash": "eb72d0765185b36d",
+      "hash": "9cf2c41b10147eba",
       "files": 44
     },
     "hyperframes-registry": {

--- a/skills/hyperframes-media/scripts/audio.mjs
+++ b/skills/hyperframes-media/scripts/audio.mjs
@@ -145,7 +145,7 @@ if (only.has("tts") && lines.length) {
     }
     const rel = `assets/voice/${id}.wav`;
     const abs = join(hyperframesDir, rel);
-    const { ok, words } = await synthesizeOne({
+    const { ok, words, error } = await synthesizeOne({
       provider: ttsProvider,
       text,
       voiceId,
@@ -155,7 +155,7 @@ if (only.has("tts") && lines.length) {
       hyperframesDir,
     });
     if (!ok) {
-      anomalies.push(`line ${id}: TTS failed — omitted`);
+      anomalies.push(`line ${id}: TTS failed${error ? ` (${error})` : ""} — omitted`);
       return null;
     }
     let wordArr = words; // heygen: native; else transcribe

--- a/skills/hyperframes-media/scripts/heygen-tts.mjs
+++ b/skills/hyperframes-media/scripts/heygen-tts.mjs
@@ -94,7 +94,7 @@ const voiceId = await resolveVoiceId({ provider: "heygen", userVoice, lang });
 if (!userVoice) console.error(`· using voice ${voiceId}`);
 
 // ---------- synthesize (shared engine code) ----------
-const { ok, words } = await synthesizeOne({
+const { ok, words, error } = await synthesizeOne({
   provider: "heygen",
   text,
   voiceId,
@@ -103,7 +103,9 @@ const { ok, words } = await synthesizeOne({
   wavAbs: output,
   hyperframesDir: process.cwd(),
 });
-if (!ok) die("synthesis failed (HeyGen request/transcode error)");
+if (!ok) {
+  die(error ? `synthesis failed: ${error}` : "synthesis failed (HeyGen request/transcode error)");
+}
 
 let wordCount = 0;
 if (wordsPath) {

--- a/skills/hyperframes-media/scripts/lib/tts.mjs
+++ b/skills/hyperframes-media/scripts/lib/tts.mjs
@@ -200,9 +200,13 @@ save(audio, sys.argv[3])
 `;
 
 // ── synthesize one line ───────────────────────────────────────────────────────
-// Writes wav at wavAbs. Returns { ok, words } — words is the raw
+// Writes wav at wavAbs. Returns { ok, words, error? } — words is the raw
 // [{text,start,end}] array for HeyGen (native), or null for ElevenLabs/Kokoro
 // (caller must transcribeWav). Never throws; failures return { ok:false }.
+// `error` is only populated for the heygen provider, where the underlying
+// HTTP failure (e.g. a 402 plan-upgrade response) carries a real diagnostic
+// message worth surfacing — a spawned CLI's bare exit code for the other two
+// providers doesn't.
 export async function synthesizeOne({
   provider,
   text,
@@ -239,14 +243,24 @@ async function synthesizeHeygen({ text, voiceId, lang, speed, wavAbs }) {
       body,
     });
     const inner = payload.data ?? payload;
-    if (!inner.audio_url) return { ok: false, words: null };
+    if (!inner.audio_url) {
+      return { ok: false, words: null, error: "HeyGen response had no audio_url" };
+    }
     const res = await fetch(inner.audio_url);
-    if (!res.ok) return { ok: false, words: null };
+    if (!res.ok) {
+      return {
+        ok: false,
+        words: null,
+        error: `failed to download synthesized audio: HTTP ${res.status}`,
+      };
+    }
     const bytes = Buffer.from(await res.arrayBuffer());
     // .wav output → transcode to 44.1k mono; .mp3 → raw bytes (no ffmpeg). The
     // engine always asks for .wav; the standalone heygen-tts CLI may ask for .mp3.
     if (wavAbs.endsWith(".wav")) {
-      if (!transcodeToWav(bytes, wavAbs)) return { ok: false, words: null };
+      if (!transcodeToWav(bytes, wavAbs)) {
+        return { ok: false, words: null, error: "ffmpeg transcode to wav failed" };
+      }
     } else {
       mkdirSync(dirname(wavAbs), { recursive: true });
       writeFileSync(wavAbs, bytes);
@@ -258,8 +272,13 @@ async function synthesizeHeygen({ text, voiceId, lang, speed, wavAbs }) {
           .map((w) => ({ text: w.word, start: w.start, end: w.end }))
       : [];
     return { ok: true, words };
-  } catch {
-    return { ok: false, words: null };
+  } catch (e) {
+    // heygenJSON's own thrown Error already carries the HTTP status and
+    // response body (e.g. "HeyGen POST /voices/speech → HTTP 402
+    // plan_upgrade_required..."). Surfacing it here, not swallowing it, is
+    // the whole fix — callers used to see nothing but a generic "synthesis
+    // failed" with no way to tell a plan-upgrade 402 from a transient 500.
+    return { ok: false, words: null, error: e.message };
   }
 }
 

--- a/skills/hyperframes-media/scripts/lib/tts.test.mjs
+++ b/skills/hyperframes-media/scripts/lib/tts.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { parseFfmpegDurationBanner, ffprobeDuration } from "./tts.mjs";
+import { parseFfmpegDurationBanner, ffprobeDuration, synthesizeOne } from "./tts.mjs";
 
 test("parseFfmpegDurationBanner reads ffmpeg's stderr Duration line", () => {
   const stderr = [
@@ -61,6 +61,75 @@ test("ffprobeDuration returns NaN when neither ffprobe nor ffmpeg resolve", () =
     assert.ok(Number.isNaN(ffprobeDuration("/does/not/matter.wav")));
   } finally {
     process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Regression: synthesizeHeygen used to collapse every failure (a real HTTP
+// error from HeyGen, a missing audio_url, a failed transcode) into a bare
+// { ok: false }, so callers could never tell a 402 plan-upgrade response
+// from a transient 500 or a local ffmpeg problem. heygenJSON already throws
+// a message carrying the HTTP status and response body — the fix is just to
+// stop swallowing it. Exercised via the real synthesizeOne() -> heygenJSON()
+// -> global fetch() path (heygenJSON has no seam to mock other than fetch
+// itself, which is a real global here, not a per-module import).
+test("synthesizeOne surfaces the real HeyGen HTTP error instead of a bare ok:false", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "heygen-tts-error-"));
+  const originalFetch = globalThis.fetch;
+  const originalApiKey = process.env.HEYGEN_API_KEY;
+  try {
+    process.env.HEYGEN_API_KEY = "fake-key-for-test";
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 402,
+      text: async () => JSON.stringify({ error: "plan_upgrade_required" }),
+    });
+
+    const result = await synthesizeOne({
+      provider: "heygen",
+      text: "hello",
+      voiceId: "some-voice",
+      wavAbs: join(dir, "out.wav"),
+      hyperframesDir: dir,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.error, /HTTP 402/);
+    assert.match(result.error, /plan_upgrade_required/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) delete process.env.HEYGEN_API_KEY;
+    else process.env.HEYGEN_API_KEY = originalApiKey;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("synthesizeOne reports a missing audio_url distinctly from an HTTP error", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "heygen-tts-no-url-"));
+  const originalFetch = globalThis.fetch;
+  const originalApiKey = process.env.HEYGEN_API_KEY;
+  try {
+    process.env.HEYGEN_API_KEY = "fake-key-for-test";
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: {} }),
+    });
+
+    const result = await synthesizeOne({
+      provider: "heygen",
+      text: "hello",
+      voiceId: "some-voice",
+      wavAbs: join(dir, "out.wav"),
+      hyperframesDir: dir,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.error, /no audio_url/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) delete process.env.HEYGEN_API_KEY;
+    else process.env.HEYGEN_API_KEY = originalApiKey;
     rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

`synthesizeHeygen`'s catch block collapsed every failure into a bare `{ ok: false }`, discarding `heygenJSON`'s own thrown error — which already carries the HTTP status and response body (e.g. `HeyGen POST /voices/speech → HTTP 402\nplan_upgrade_required...`). Callers only ever saw a generic `"synthesis failed (HeyGen request/transcode error)"` or `"TTS failed — omitted"`, with no way to distinguish a free-plan 402 from a transient 500 — one report specifically had to call the REST API manually just to figure out why synthesis failed, several runs of feedback corroborate the same underlying free-plan-402 friction with no diagnostic surfaced.

## Fix

Threaded an `error` field through `synthesizeOne`'s return value for every `heygen`-provider failure branch (missing `audio_url`, failed audio download, failed transcode, and the underlying HTTP error itself), and updated both callers (`heygen-tts.mjs`, `audio.mjs`) to surface it when present instead of falling back to the generic message. The other two providers (elevenlabs/kokoro) are unchanged — a spawned CLI's bare exit code doesn't carry a comparably useful message to surface.

## Test plan

- [x] `node --test skills/hyperframes-media/scripts/lib/tts.test.mjs` — 2 new tests pass
- [x] Tests exercise the real `synthesizeOne()` → `heygenJSON()` → `fetch()` path (mocking the global `fetch`, the only seam `heygenJSON` has, rather than the module import) to confirm a real HTTP 402 response surfaces its status and body, and that a missing `audio_url` is reported distinctly from an HTTP error