### PR TITLE
fix(video-workflows): pad the frame's own duration to match the transition tail

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,7 +6,7 @@
       "files": 144
     },
     "faceless-explainer": {
-      "hash": "be76879a1767d957",
+      "hash": "6dac80491c3db278",
       "files": 18
     },
     "general-video": {
@@ -58,11 +58,11 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "5ccd858be7682dea",
+      "hash": "d40ba25aa5af30e1",
       "files": 22
     },
     "product-launch-video": {
-      "hash": "751b45501b974a3d",
+      "hash": "b1895d518ec04da5",
       "files": 20
     },
     "remotion-to-hyperframes": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,8 +6,8 @@
       "files": 144
     },
     "faceless-explainer": {
-      "hash": "844c54a06fd16d3c",
-      "files": 17
+      "hash": "be76879a1767d957",
+      "files": 18
     },
     "general-video": {
       "hash": "a30225e30ec7b06c",
@@ -58,12 +58,12 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "132b44ddda774fef",
-      "files": 21
+      "hash": "5ccd858be7682dea",
+      "files": 22
     },
     "product-launch-video": {
-      "hash": "32cab842cc7a6b76",
-      "files": 18
+      "hash": "751b45501b974a3d",
+      "files": 20
     },
     "remotion-to-hyperframes": {
       "hash": "9d959b31fa0fc9d0",

--- a/skills/faceless-explainer/scripts/lib/pad-frame-duration.mjs
+++ b/skills/faceless-explainer/scripts/lib/pad-frame-duration.mjs
@@ -10,13 +10,18 @@
 // content-end instead of fading gracefully through the wrapper's extended
 // fade-out tween. Pad the frame's own file to match so both durations agree.
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 export function padFrameInternalDuration(hyperframesDir, frameSrc, frameId, newDuration) {
   const framePath = resolve(hyperframesDir, frameSrc);
-  if (!existsSync(framePath)) return;
-  const html = readFileSync(framePath, "utf8");
+  let html;
+  try {
+    html = readFileSync(framePath, "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") return;
+    throw err;
+  }
   const tagRe = /<[a-z][\w:-]*\s[^<>]*?>/gi;
   let m;
   while ((m = tagRe.exec(html)) !== null) {

--- a/skills/faceless-explainer/scripts/lib/pad-frame-duration.mjs
+++ b/skills/faceless-explainer/scripts/lib/pad-frame-duration.mjs
@@ -1,0 +1,31 @@
+// pad-frame-duration.mjs — keeps a frame's own #root/clip data-duration in
+// sync with the padded index.html wrapper duration transitions.mjs computes.
+//
+// The frame's OWN internal file declares its #root/clip data-duration to the
+// STORYBOARD's content-only length (frame-worker.md: duration is "fixed
+// upstream"). When an outgoing transition pads the index.html WRAPPER's
+// data-duration to cover the transition tail, the frame's own internal
+// duration is left short — the render engine clip-gates the sub-composition's
+// visible content at that shorter value, so content vanishes abruptly at
+// content-end instead of fading gracefully through the wrapper's extended
+// fade-out tween. Pad the frame's own file to match so both durations agree.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function padFrameInternalDuration(hyperframesDir, frameSrc, frameId, newDuration) {
+  const framePath = resolve(hyperframesDir, frameSrc);
+  if (!existsSync(framePath)) return;
+  const html = readFileSync(framePath, "utf8");
+  const tagRe = /<[a-z][\w:-]*\s[^<>]*?>/gi;
+  let m;
+  while ((m = tagRe.exec(html)) !== null) {
+    const tag = m[0];
+    if (!tag.includes(`data-composition-id="${frameId}"`)) continue;
+    if (!/data-duration="[\d.]+"/.test(tag)) continue;
+    const newTag = tag.replace(/data-duration="[\d.]+"/, `data-duration="${newDuration}"`);
+    if (newTag === tag) return;
+    writeFileSync(framePath, html.slice(0, m.index) + newTag + html.slice(m.index + tag.length));
+    return;
+  }
+}

--- a/skills/faceless-explainer/scripts/transitions.mjs
+++ b/skills/faceless-explainer/scripts/transitions.mjs
@@ -28,6 +28,7 @@ import { join, resolve } from "node:path";
 import { parseStoryboard } from "./lib/storyboard.mjs";
 import { parseFormat } from "./lib/dimensions.mjs";
 import { loadTransitionRegistry, transitionsByName } from "./lib/transition-registry.mjs";
+import { padFrameInternalDuration } from "./lib/pad-frame-duration.mjs";
 
 const flag = (argv, name, def) => {
   const i = argv.indexOf(`--${name}`);
@@ -183,6 +184,12 @@ function runInject(argv) {
     const dur = resolveDur(spec, rec, reg);
     const T = r3(incoming.start); // cut = incoming start (frames tile)
     outgoing.duration = r3(outgoing.duration + dur); // extend outgoing only
+    padFrameInternalDuration(
+      hyperframesDir,
+      order[i - 1].frame.src,
+      outgoing.id,
+      outgoing.duration,
+    );
     gsapLines.push(
       ...buildGsap(rec, outgoing.id, incoming.id, dur, T, spec.direction, CW, CH, die),
     );

--- a/skills/pr-to-video/scripts/lib/pad-frame-duration.mjs
+++ b/skills/pr-to-video/scripts/lib/pad-frame-duration.mjs
@@ -10,13 +10,18 @@
 // content-end instead of fading gracefully through the wrapper's extended
 // fade-out tween. Pad the frame's own file to match so both durations agree.
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 export function padFrameInternalDuration(hyperframesDir, frameSrc, frameId, newDuration) {
   const framePath = resolve(hyperframesDir, frameSrc);
-  if (!existsSync(framePath)) return;
-  const html = readFileSync(framePath, "utf8");
+  let html;
+  try {
+    html = readFileSync(framePath, "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") return;
+    throw err;
+  }
   const tagRe = /<[a-z][\w:-]*\s[^<>]*?>/gi;
   let m;
   while ((m = tagRe.exec(html)) !== null) {

--- a/skills/pr-to-video/scripts/lib/pad-frame-duration.mjs
+++ b/skills/pr-to-video/scripts/lib/pad-frame-duration.mjs
@@ -1,0 +1,31 @@
+// pad-frame-duration.mjs — keeps a frame's own #root/clip data-duration in
+// sync with the padded index.html wrapper duration transitions.mjs computes.
+//
+// The frame's OWN internal file declares its #root/clip data-duration to the
+// STORYBOARD's content-only length (frame-worker.md: duration is "fixed
+// upstream"). When an outgoing transition pads the index.html WRAPPER's
+// data-duration to cover the transition tail, the frame's own internal
+// duration is left short — the render engine clip-gates the sub-composition's
+// visible content at that shorter value, so content vanishes abruptly at
+// content-end instead of fading gracefully through the wrapper's extended
+// fade-out tween. Pad the frame's own file to match so both durations agree.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function padFrameInternalDuration(hyperframesDir, frameSrc, frameId, newDuration) {
+  const framePath = resolve(hyperframesDir, frameSrc);
+  if (!existsSync(framePath)) return;
+  const html = readFileSync(framePath, "utf8");
+  const tagRe = /<[a-z][\w:-]*\s[^<>]*?>/gi;
+  let m;
+  while ((m = tagRe.exec(html)) !== null) {
+    const tag = m[0];
+    if (!tag.includes(`data-composition-id="${frameId}"`)) continue;
+    if (!/data-duration="[\d.]+"/.test(tag)) continue;
+    const newTag = tag.replace(/data-duration="[\d.]+"/, `data-duration="${newDuration}"`);
+    if (newTag === tag) return;
+    writeFileSync(framePath, html.slice(0, m.index) + newTag + html.slice(m.index + tag.length));
+    return;
+  }
+}

--- a/skills/pr-to-video/scripts/transitions.mjs
+++ b/skills/pr-to-video/scripts/transitions.mjs
@@ -28,6 +28,7 @@ import { join, resolve } from "node:path";
 import { parseStoryboard } from "./lib/storyboard.mjs";
 import { parseFormat } from "./lib/dimensions.mjs";
 import { loadTransitionRegistry, transitionsByName } from "./lib/transition-registry.mjs";
+import { padFrameInternalDuration } from "./lib/pad-frame-duration.mjs";
 
 const flag = (argv, name, def) => {
   const i = argv.indexOf(`--${name}`);
@@ -183,6 +184,12 @@ function runInject(argv) {
     const dur = resolveDur(spec, rec, reg);
     const T = r3(incoming.start); // cut = incoming start (frames tile)
     outgoing.duration = r3(outgoing.duration + dur); // extend outgoing only
+    padFrameInternalDuration(
+      hyperframesDir,
+      order[i - 1].frame.src,
+      outgoing.id,
+      outgoing.duration,
+    );
     gsapLines.push(
       ...buildGsap(rec, outgoing.id, incoming.id, dur, T, spec.direction, CW, CH, die),
     );

--- a/skills/product-launch-video/scripts/lib/pad-frame-duration.mjs
+++ b/skills/product-launch-video/scripts/lib/pad-frame-duration.mjs
@@ -10,13 +10,18 @@
 // content-end instead of fading gracefully through the wrapper's extended
 // fade-out tween. Pad the frame's own file to match so both durations agree.
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 export function padFrameInternalDuration(hyperframesDir, frameSrc, frameId, newDuration) {
   const framePath = resolve(hyperframesDir, frameSrc);
-  if (!existsSync(framePath)) return;
-  const html = readFileSync(framePath, "utf8");
+  let html;
+  try {
+    html = readFileSync(framePath, "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") return;
+    throw err;
+  }
   const tagRe = /<[a-z][\w:-]*\s[^<>]*?>/gi;
   let m;
   while ((m = tagRe.exec(html)) !== null) {

--- a/skills/product-launch-video/scripts/lib/pad-frame-duration.mjs
+++ b/skills/product-launch-video/scripts/lib/pad-frame-duration.mjs
@@ -1,0 +1,31 @@
+// pad-frame-duration.mjs — keeps a frame's own #root/clip data-duration in
+// sync with the padded index.html wrapper duration transitions.mjs computes.
+//
+// The frame's OWN internal file declares its #root/clip data-duration to the
+// STORYBOARD's content-only length (frame-worker.md: duration is "fixed
+// upstream"). When an outgoing transition pads the index.html WRAPPER's
+// data-duration to cover the transition tail, the frame's own internal
+// duration is left short — the render engine clip-gates the sub-composition's
+// visible content at that shorter value, so content vanishes abruptly at
+// content-end instead of fading gracefully through the wrapper's extended
+// fade-out tween. Pad the frame's own file to match so both durations agree.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function padFrameInternalDuration(hyperframesDir, frameSrc, frameId, newDuration) {
+  const framePath = resolve(hyperframesDir, frameSrc);
+  if (!existsSync(framePath)) return;
+  const html = readFileSync(framePath, "utf8");
+  const tagRe = /<[a-z][\w:-]*\s[^<>]*?>/gi;
+  let m;
+  while ((m = tagRe.exec(html)) !== null) {
+    const tag = m[0];
+    if (!tag.includes(`data-composition-id="${frameId}"`)) continue;
+    if (!/data-duration="[\d.]+"/.test(tag)) continue;
+    const newTag = tag.replace(/data-duration="[\d.]+"/, `data-duration="${newDuration}"`);
+    if (newTag === tag) return;
+    writeFileSync(framePath, html.slice(0, m.index) + newTag + html.slice(m.index + tag.length));
+    return;
+  }
+}

--- a/skills/product-launch-video/scripts/lib/pad-frame-duration.test.mjs
+++ b/skills/product-launch-video/scripts/lib/pad-frame-duration.test.mjs
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { padFrameInternalDuration } from "./pad-frame-duration.mjs";
+
+// Regression: an outgoing transition pads the index.html WRAPPER's
+// data-duration to cover the transition tail, but the frame's own internal
+// file kept its shorter content-only duration, so the render engine
+// clip-gated the sub-composition's visible content at the shorter value —
+// content vanished abruptly instead of fading through the wrapper's
+// extended fade-out tween. A user diagnosed and verified this fix
+// themselves: pad the frame's own #root/clip data-duration to match.
+test("padFrameInternalDuration pads the matching frame's own data-duration", () => {
+  const dir = mkdtempSync(join(tmpdir(), "transitions-pad-"));
+  const framesDir = join(dir, "compositions", "frames");
+  mkdirSync(framesDir, { recursive: true });
+  const frameSrc = "compositions/frames/scene-1.html";
+  const framePath = join(dir, frameSrc);
+  writeFileSync(
+    framePath,
+    `<template>
+  <div
+    id="root"
+    data-composition-id="scene-1"
+    data-width="1920"
+    data-height="1080"
+    data-duration="4.2"
+  ></div>
+</template>`,
+  );
+
+  try {
+    padFrameInternalDuration(dir, frameSrc, "scene-1", 4.7);
+    const updated = readFileSync(framePath, "utf8");
+    assert.match(updated, /data-duration="4\.7"/);
+    assert.doesNotMatch(updated, /data-duration="4\.2"/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("padFrameInternalDuration only touches the tag matching the given frame id", () => {
+  const dir = mkdtempSync(join(tmpdir(), "transitions-pad-scope-"));
+  const framesDir = join(dir, "compositions", "frames");
+  mkdirSync(framesDir, { recursive: true });
+  const frameSrc = "compositions/frames/scene-2.html";
+  const framePath = join(dir, frameSrc);
+  const original = `<template>
+  <div id="root" data-composition-id="scene-2" data-duration="3.0">
+    <div data-composition-id="unrelated-child" data-duration="1.0"></div>
+  </div>
+</template>`;
+  writeFileSync(framePath, original);
+
+  try {
+    padFrameInternalDuration(dir, frameSrc, "scene-2", 3.5);
+    const updated = readFileSync(framePath, "utf8");
+    assert.match(updated, /data-composition-id="scene-2" data-duration="3\.5"/);
+    assert.match(updated, /data-composition-id="unrelated-child" data-duration="1\.0"/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("padFrameInternalDuration is a no-op when the frame file does not exist", () => {
+  const dir = mkdtempSync(join(tmpdir(), "transitions-pad-missing-"));
+  try {
+    assert.doesNotThrow(() =>
+      padFrameInternalDuration(dir, "compositions/frames/missing.html", "missing", 5),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/skills/product-launch-video/scripts/transitions.mjs
+++ b/skills/product-launch-video/scripts/transitions.mjs
@@ -28,6 +28,7 @@ import { join, resolve } from "node:path";
 import { parseStoryboard } from "./lib/storyboard.mjs";
 import { parseFormat } from "./lib/dimensions.mjs";
 import { loadTransitionRegistry, transitionsByName } from "./lib/transition-registry.mjs";
+import { padFrameInternalDuration } from "./lib/pad-frame-duration.mjs";
 
 const flag = (argv, name, def) => {
   const i = argv.indexOf(`--${name}`);
@@ -183,6 +184,12 @@ function runInject(argv) {
     const dur = resolveDur(spec, rec, reg);
     const T = r3(incoming.start); // cut = incoming start (frames tile)
     outgoing.duration = r3(outgoing.duration + dur); // extend outgoing only
+    padFrameInternalDuration(
+      hyperframesDir,
+      order[i - 1].frame.src,
+      outgoing.id,
+      outgoing.duration,
+    );
     gsapLines.push(
       ...buildGsap(rec, outgoing.id, incoming.id, dur, T, spec.direction, CW, CH, die),
     );


### PR DESCRIPTION
## Summary

`transitions.mjs` extends the `index.html` WRAPPER's `data-duration` to cover an outgoing transition's tail (deliberately, by design — "EXTEND-OUTGOING-ONLY" per the script's own header comment). But the frame's own internal composition file (`compositions/frames/<id>.html`) keeps its shorter, content-only `data-duration`, authored per `frame-worker.md`'s instruction that duration is "fixed upstream; never change it."

The render engine clip-gates a sub-composition's visible content at its own declared duration, so content vanishes abruptly at content-end instead of fading gracefully through the wrapper's extended fade-out tween.

A user root-caused and verified this fix themselves: padding one frame's internal duration to match the wrapper made the bug disappear; applying the same padding to every non-final frame fixed it project-wide. They also named the exact fix location — `transitions.mjs`'s inject step already computes the correct padded duration for the wrapper, so it can just as easily write the same value into the frame's own file.

## Fix

`transitions.mjs` now calls `padFrameInternalDuration()` right after computing the wrapper's extended duration, rewriting the matching frame file's own `data-composition-id="<id>"` element's `data-duration` to the same value.

Extracted to a new shared `lib/pad-frame-duration.mjs` (mirroring the existing `lib/transition-registry.mjs` convention) rather than inlining it in `transitions.mjs`, since that script has unconditional top-level CLI-dispatch code that runs on any import — making the file untestable directly without this extraction.

All three `transitions.mjs` copies (`pr-to-video`, `faceless-explainer`, `product-launch-video`) are byte-identical apart from a one-line header comment (confirmed via `diff`), so this is one root cause with one fix, applied identically everywhere it lives.

## Test plan

- [x] `node --test skills/product-launch-video/scripts/lib/pad-frame-duration.test.mjs` — 3 tests pass: pads the matching frame's duration, only touches the tag matching the given frame id (doesn't clobber an unrelated nested `data-composition-id`), and is a safe no-op when the frame file doesn't exist
- [x] `node --check` on all three updated `transitions.mjs` files
- [x] Confirmed all three `transitions.mjs` copies remain identical (bar the header comment) after the fix