### PR TITLE
fix(hyperframes-media): install MusicGen deps via python3 -m pip, not bare pip

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -42,7 +42,7 @@
       "files": 3
     },
     "hyperframes-media": {
-      "hash": "b753e640f35e2d33",
+      "hash": "e7d7ed17b27ffa26",
       "files": 46
     },
     "hyperframes-registry": {

--- a/skills/hyperframes-media/scripts/lib/bgm.mjs
+++ b/skills/hyperframes-media/scripts/lib/bgm.mjs
@@ -30,8 +30,15 @@ function pyOk(probe) {
   const { cmd, args } = pythonInvocation(["-c", probe]);
   return spawnSync(cmd, args, { stdio: "ignore" }).status === 0;
 }
+// `python -m pip`, not a bare `pip` binary: a Homebrew/system Python often
+// exposes only `python3`/`pip3` on PATH, so a plain `pip` spawn silently
+// no-ops (ENOENT) and the documented "auto-installed on demand" path never
+// actually installs. `-m pip` also guarantees the packages land in the SAME
+// interpreter pyOk() probes — a bare `pip`/`pip3` could resolve to a
+// different Python installation than `python3` if more than one is on PATH.
 function pipInstall(deps) {
-  return spawnSync("pip", ["install", "-q", ...deps], { stdio: "ignore" }).status === 0;
+  const { cmd, args } = pythonInvocation(["-m", "pip", "install", "-q", ...deps]);
+  return spawnSync(cmd, args, { stdio: "ignore" }).status === 0;
 }
 
 // ── retrieval (HeyGen music library) ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

> "audio.mjs's local MusicGen fallback calls spawnSync('pip', ...) not 'pip3' - silently no-ops on machines where only pip3 is on PATH (Homebrew Python), so the documented 'auto-installed on demand' MusicGen path never actually installs; worked around with a manual venv."

`pipInstall()` in `bgm.mjs` spawned a bare `pip` binary. Many Homebrew/system Python installs expose only `python3`/`pip3` on PATH, so the spawn silently `ENOENT`s and the "auto-installed on demand" local MusicGen path never actually installs anything — indistinguishable from any other install failure, since `spawnSync`'s status just comes back non-zero either way.

## Fix

Switched to `python3 -m pip install`, matching this same file's own `pyOk()` helper, which already always invokes `python3` explicitly (never a bare `python`). This also closes a second, more subtle latent bug: even with a working `pip`/`pip3` on PATH, it could resolve to a *different* Python installation than the `python3` binary `pyOk()` probes against if more than one is installed — `-m pip` guarantees the install lands in the exact interpreter being checked.

## Test plan

- [x] Manually verified `python3 -m pip --version` succeeds in this environment
- [x] No automated test added — this is a literal command-array swap with no new branching logic, and `spawnSync` is a named import from `node:child_process` with no clean mocking path available here without a refactor disproportionate to the fix's size (this Node version doesn't support `node:test`'s `mock.module()` without an experimental flag, confirmed by trying it)