### PR TITLE
fix(compiler): preserve authored root classes when producer inlines sub-compositions

### DIFF
--- a/packages/core/src/compiler/compositionScoping.test.ts
+++ b/packages/core/src/compiler/compositionScoping.test.ts
@@ -661,3 +661,71 @@ window.__timelines['intro'] = tl;
     expect(gsapTargets).toEqual([["HELLO"]]);
   });
 });
+
+describe("authored root class selectors (issue #1847)", () => {
+  it("rewrites a root-class-anchored selector to the :is() dual form in compound mode", () => {
+    const scoped = scopeCssToComposition(
+      ".scene-wrapper .title { color: red; }",
+      "scene",
+      undefined,
+      "scene-root",
+      { compoundAuthoredRoot: true, authoredRootClasses: ["scene-wrapper"] },
+    );
+
+    // Must match both the merged host (compound) and a descendant carrying
+    // the same class, mirroring the preview/runtime DOM shape.
+    expect(scoped).toContain(
+      ':is([data-composition-id="scene"].scene-wrapper, [data-composition-id="scene"] .scene-wrapper) .title',
+    );
+  });
+
+  it("keeps compound chains on the root class intact", () => {
+    const scoped = scopeCssToComposition(
+      ".scene-wrapper.dark > .title { color: red; }",
+      "scene",
+      undefined,
+      null,
+      { compoundAuthoredRoot: true, authoredRootClasses: ["scene-wrapper", "dark"] },
+    );
+
+    expect(scoped).toContain(
+      ':is([data-composition-id="scene"].scene-wrapper.dark, [data-composition-id="scene"] .scene-wrapper.dark) > .title',
+    );
+  });
+
+  it("leaves selectors anchored on non-root classes as plain descendants", () => {
+    const scoped = scopeCssToComposition(".title { color: red; }", "scene", undefined, null, {
+      compoundAuthoredRoot: true,
+      authoredRootClasses: ["scene-wrapper"],
+    });
+
+    expect(scoped).toContain('[data-composition-id="scene"] .title');
+    expect(scoped).not.toContain(":is(");
+  });
+
+  it("does not rewrite when a root class only appears as a substring of another class", () => {
+    const scoped = scopeCssToComposition(
+      ".scene-wrapper-inner .title { color: red; }",
+      "scene",
+      undefined,
+      null,
+      { compoundAuthoredRoot: true, authoredRootClasses: ["scene-wrapper"] },
+    );
+
+    expect(scoped).toContain('[data-composition-id="scene"] .scene-wrapper-inner .title');
+    expect(scoped).not.toContain(":is(");
+  });
+
+  it("does not rewrite root-class selectors outside compound mode", () => {
+    const scoped = scopeCssToComposition(
+      ".scene-wrapper .title { color: red; }",
+      "scene",
+      undefined,
+      null,
+      { authoredRootClasses: ["scene-wrapper"] },
+    );
+
+    expect(scoped).toContain('[data-composition-id="scene"] .scene-wrapper .title');
+    expect(scoped).not.toContain(":is(");
+  });
+});

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -102,6 +102,7 @@ function scopeSelector(
   compositionId: string,
   authoredRootId?: string | null,
   compoundAuthoredRoot?: boolean,
+  authoredRootClasses?: readonly string[],
 ): string {
   const selectorWithoutAuthoredRootId = normalizeAuthoredRootIdSelector(selector, authoredRootId);
   const selectorWithoutRootTiming = normalizeCompositionRootSelector(
@@ -129,8 +130,43 @@ function scopeSelector(
       const rest = trimmed.slice(authoredRootAttr.length);
       return `${leading}${scope}${authoredRootAttr}${rest}${trailing}`;
     }
+    // Selectors anchored on one of the authored root's classes. After
+    // producer inlining the root element merges onto the host, so its
+    // classes live on the scope element itself. Rewrite to an :is() dual so
+    // the rule matches both the merged host (compound) and any descendant
+    // that legitimately carries the same class (issue #1847).
+    const rootClassRewrite = rewriteAuthoredRootClassSelector(trimmed, scope, authoredRootClasses);
+    if (rootClassRewrite) {
+      return `${leading}${rootClassRewrite}${trailing}`;
+    }
   }
   return `${leading}${scope} ${trimmed}${trailing}`;
+}
+
+/**
+ * When `selector` starts with a class-anchored compound containing one of the
+ * authored root's classes (e.g. `.scene-wrapper .title` where the root is
+ * `<div class="scene-wrapper">`), return the :is() dual form; otherwise null.
+ */
+function rewriteAuthoredRootClassSelector(
+  trimmed: string,
+  scope: string,
+  authoredRootClasses?: readonly string[],
+): string | null {
+  if (!authoredRootClasses || authoredRootClasses.length === 0) return null;
+  if (!trimmed.startsWith(".")) return null;
+
+  const match = trimmed.match(/^([^\s>+~]+)([\s\S]*)$/);
+  if (!match) return null;
+  const firstCompound = match[1] ?? "";
+  const rest = match[2] ?? "";
+
+  const anchoredOnRootClass = authoredRootClasses.some((cls) =>
+    new RegExp(`\\.${escapeRegExp(cls)}(?![\\w-])`).test(firstCompound),
+  );
+  if (!anchoredOnRootClass) return null;
+
+  return `:is(${scope}${firstCompound}, ${scope} ${firstCompound})${rest}`;
 }
 
 function normalizeCompositionRootSelector(
@@ -168,7 +204,7 @@ export function scopeCssToComposition(
   compositionId: string,
   scopeSelectorOverride?: string,
   authoredRootId?: string | null,
-  options?: { compoundAuthoredRoot?: boolean },
+  options?: { compoundAuthoredRoot?: boolean; authoredRootClasses?: readonly string[] },
 ): string {
   const trimmedCompositionId = compositionId.trim();
   if (!css || !trimmedCompositionId) return css;
@@ -186,6 +222,7 @@ export function scopeCssToComposition(
         trimmedCompositionId,
         authoredRootId,
         options?.compoundAuthoredRoot,
+        options?.authoredRootClasses,
       ),
     );
   });

--- a/packages/core/src/compiler/inlineSubCompositions.test.ts
+++ b/packages/core/src/compiler/inlineSubCompositions.test.ts
@@ -312,3 +312,75 @@ describe("inlineSubCompositions – #ID selector scoping divergence", () => {
     );
   });
 });
+
+describe("inlineSubCompositions – authored root class wrapper (issue #1847)", () => {
+  const WRAPPER_SUB_COMP = `<template id="scene-template">
+  <div id="scene-root" class="scene-wrapper dark" data-composition-id="scene" data-width="1920" data-height="1080">
+    <div class="title">STYLED BY WRAPPER</div>
+    <style>
+      .scene-wrapper .title { color: red; }
+      .other .title { color: blue; }
+    </style>
+  </div>
+</template>`;
+
+  function makeSceneHost() {
+    const { document } = parseHTML(`<!DOCTYPE html>
+<html><body>
+  <div data-composition-id="main">
+    <div data-composition-id="scene" data-composition-src="scene.html"
+         data-start="0" data-duration="4" data-track-index="0"></div>
+  </div>
+</body></html>`);
+    return document;
+  }
+
+  it("producer path: merges the authored root's classes onto the host", () => {
+    const document = makeSceneHost();
+    const host = document.querySelector('[data-composition-src="scene.html"]')!;
+
+    inlineSubCompositions(document, [host], {
+      resolveHtml: () => WRAPPER_SUB_COMP,
+      parseHtml: (html) => parseHTML(html).document,
+      compoundAuthoredRoot: true,
+    });
+
+    const hostClasses = (host.getAttribute("class") || "").split(/\s+/);
+    expect(hostClasses).toContain("scene-wrapper");
+    expect(hostClasses).toContain("dark");
+  });
+
+  it("producer path: root-class rules are rewritten so they still match the merged host", () => {
+    const document = makeSceneHost();
+    const host = document.querySelector('[data-composition-src="scene.html"]')!;
+
+    const result = inlineSubCompositions(document, [host], {
+      resolveHtml: () => WRAPPER_SUB_COMP,
+      parseHtml: (html) => parseHTML(html).document,
+      compoundAuthoredRoot: true,
+    });
+
+    const scopedCss = result.styles.join("\n");
+    // The wrapper rule must use the :is() dual form (compound + descendant).
+    expect(scopedCss).toContain(
+      ':is([data-composition-id="scene"].scene-wrapper, [data-composition-id="scene"] .scene-wrapper) .title',
+    );
+    // Rules on non-root classes stay plain descendants.
+    expect(scopedCss).toContain('[data-composition-id="scene"] .other .title');
+  });
+
+  it("bundler path (flattenInnerRoot): host classes are not touched", () => {
+    const document = makeSceneHost();
+    const host = document.querySelector('[data-composition-src="scene.html"]')!;
+
+    inlineSubCompositions(document, [host], {
+      resolveHtml: () => WRAPPER_SUB_COMP,
+      parseHtml: (html) => parseHTML(html).document,
+      flattenInnerRoot: (innerRoot) => innerRoot,
+    });
+
+    // The wrapper survives as a child, so the host needs no class merge.
+    expect((host.getAttribute("class") || "").trim()).toBe("");
+    expect(host.querySelector(".scene-wrapper")).not.toBeNull();
+  });
+});

--- a/packages/core/src/compiler/inlineSubCompositions.ts
+++ b/packages/core/src/compiler/inlineSubCompositions.ts
@@ -233,6 +233,11 @@ export function inlineSubCompositions(
       : contentDoc.querySelector("[data-composition-id]");
     const inferredCompId = innerRoot?.getAttribute("data-composition-id")?.trim() || "";
     const authoredRootId = innerRoot?.getAttribute("id")?.trim() || null;
+    // The authored root's classes: CSS rules anchored on them must keep
+    // working after the producer path merges the root onto the host (#1847).
+    const authoredRootClasses = (innerRoot?.getAttribute("class") || "")
+      .split(/\s+/)
+      .filter(Boolean);
     const scopeCompId = compId || inferredCompId;
     const runtimeScope = runtimeCompId ? buildScopeSelector(runtimeCompId) : "";
 
@@ -258,6 +263,7 @@ export function inlineSubCompositions(
           scopeCompId
             ? scopeCssToComposition(css, scopeCompId, runtimeScope || undefined, authoredRootId, {
                 compoundAuthoredRoot: compoundAuthoredRoot === true,
+                authoredRootClasses,
               })
             : css,
         );
@@ -293,6 +299,7 @@ export function inlineSubCompositions(
         scopeCompId
           ? scopeCssToComposition(css, scopeCompId, runtimeScope || undefined, authoredRootId, {
               compoundAuthoredRoot: compoundAuthoredRoot === true,
+              authoredRootClasses,
             })
           : css,
       );
@@ -380,6 +387,14 @@ export function inlineSubCompositions(
         // rewritten #ID selectors ([data-hf-authored-id="X"]) still resolve.
         if (compId && authoredRootId) {
           hostEl.setAttribute("data-hf-authored-id", authoredRootId);
+        }
+        // Same for the authored root's classes: merge them onto the host so
+        // class-anchored rules (rewritten to :is(scope.cls, scope .cls))
+        // still match after the wrapper is stripped (#1847).
+        if (compId && authoredRootClasses.length > 0) {
+          const merged = new Set((hostEl.getAttribute("class") || "").split(/\s+/).filter(Boolean));
+          for (const cls of authoredRootClasses) merged.add(cls);
+          hostEl.setAttribute("class", [...merged].join(" "));
         }
       }
     } else {


### PR DESCRIPTION
## Summary

Fixes #1847.

When the producer inlines a sub-composition, the authored root element is merged into the host via `innerHTML` injection, so the authored root's classes disappear from the DOM. Any CSS rule anchored on those classes (e.g. `.scene-wrapper { ... }`) silently stops matching in the rendered output, while the same composition looks correct in the bundler/preview path (which keeps the wrapper as a child).

## Changes

- `inlineSubCompositions.ts`: capture the authored root's classes during inlining and merge them onto the host element in the producer branch (mirrors the existing `data-hf-authored-id` propagation for `#id` selectors).
- `compositionScoping.ts`: in compound-authored-root mode, rewrite selectors whose first compound is anchored on an authored root class to `:is(<scope><compound>, <scope> <compound>)` so both the merged-host semantics (producer) and descendant semantics (bundler) keep working.
- Regression tests for both the scoper unit behavior and the inlining integration (host class merge, `:is()` rewrite, bundler path unchanged).

## Testing

- `packages/core` compiler suite passes (including 8 new tests across `compositionScoping.test.ts` and `inlineSubCompositions.test.ts`).
- `packages/producer/src/services/htmlCompiler.test.ts` passes (77 tests) against the updated compiler.
- TypeScript typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TXJXMe4QmSBnmYoR3brtk