### PR TITLE
fix(lint): stop CSS comments in <style> from manufacturing phantom root tags

### DIFF
--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -143,6 +143,29 @@ describe("core rules", () => {
     expect(result.findings.find((f) => f.code === "root_missing_dimensions")).toBeUndefined();
   });
 
+  it("does not mistake a <tag>-shaped CSS comment inside <style> for the composition root", async () => {
+    // Regression: a CSS comment referencing an SVG tag name (e.g. `/* <g> wrapper */`)
+    // inside a <style> block reads as a real open tag to the flat TAG_PATTERN scan,
+    // manufacturing a phantom root before the real composition root and firing
+    // root_missing_composition_id/root_missing_dimensions/head_leaked_text on an
+    // otherwise valid sub-composition.
+    const html = `
+<html><body>
+  <style>
+    /* <g> wrapper for icon groups */
+    .icon { fill: currentColor; }
+  </style>
+  <svg id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <g class="icon"></g>
+  </svg>
+  <script>window.__timelines = window.__timelines || {};</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    expect(result.findings.find((f) => f.code === "root_missing_composition_id")).toBeUndefined();
+    expect(result.findings.find((f) => f.code === "root_missing_dimensions")).toBeUndefined();
+    expect(result.findings.find((f) => f.code === "head_leaked_text")).toBeUndefined();
+  });
+
   it("reports error when timeline registry is missing", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/utils.ts
+++ b/packages/lint/src/utils.ts
@@ -51,13 +51,34 @@ const TIMELINE_REGISTRY_OBJECT_BODY_PATTERN = /window\.__timelines\s*=\s*\{([\s\
 const TIMELINE_REGISTRY_OBJECT_ENTRY_PATTERN =
   /(?:["']([^"']+)["']|([A-Za-z_$][\w$]*))\s*:\s*[A-Za-z_$][\w$]*/g;
 
+// <style>/<script> content is CSS/JS text, not markup — a CSS comment like
+// `/* <g> wrapper */` or a JS comment mentioning a tag name otherwise reads as
+// a real open tag to TAG_PATTERN's flat regex scan, throwing off every
+// consumer that relies on tag order/position (findRootTag in particular:
+// a phantom tag from inside a <style> block can outrank the real
+// composition root). Compute the content spans up front and skip any match
+// that falls inside one, the same way findRootTag already special-cases
+// <style>/<script> tags themselves.
+function findStyleAndScriptContentRanges(source: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (const pattern of [STYLE_BLOCK_PATTERN, SCRIPT_BLOCK_PATTERN]) {
+    for (const block of extractBlocks(source, pattern)) {
+      const contentStart = block.index + block.raw.indexOf(block.content);
+      ranges.push([contentStart, contentStart + block.content.length]);
+    }
+  }
+  return ranges;
+}
+
 export function extractOpenTags(source: string): OpenTag[] {
   const tags: OpenTag[] = [];
+  const skipRanges = findStyleAndScriptContentRanges(source);
   let match: RegExpExecArray | null;
   const pattern = new RegExp(TAG_PATTERN.source, TAG_PATTERN.flags);
   while ((match = pattern.exec(source)) !== null) {
     const raw = match[0];
     if (raw.startsWith("</") || raw.startsWith("<!")) continue;
+    if (skipRanges.some(([start, end]) => match!.index >= start && match!.index < end)) continue;
     tags.push({
       raw,
       name: (match[1] || "").toLowerCase(),


### PR DESCRIPTION
## Root cause

`extractOpenTags` in `packages/lint/src/utils.ts` scans raw source text with a flat regex (`TAG_PATTERN`) that has no concept of `<style>`/`<script>` block boundaries. A CSS comment like `/* <g> wrapper */` inside a `<style>` block reads as a real open tag to that scan.

`findRootTag` consumes that flat tag list and returns the first tag not literally named `script`/`style`/`meta`/`link`/`title` as the composition root. A phantom `<g>` tag surfaced from inside a `<style>` block's comment isn't in that skip list, so it wins the search and gets returned instead of the real root that follows.

This manufactured three findings on an otherwise valid sub-composition:
- `root_missing_composition_id` / `root_missing_dimensions` — the phantom tag has neither.
- `head_leaked_text` — the leaked-text scan slices source up to the phantom tag's position, which lands *inside* the `<style>` block before its real closing tag, so the raw CSS text reads as leaked visible markup.

Reported with an exact bisected repro: a `<template>`-wrapped SVG sub-composition whose `<style>` block comments reference an inner `<g>` element.

This is the same class of bug as `8ee4b7df` (a leading `<svg>` defs block being mistaken for the root) — `findRootTag`'s flat tag list can be poisoned by tags that were never real HTML elements in the first place.

## Fix

Compute `<style>`/`<script>` content spans up front (reusing the existing `extractBlocks` + `STYLE_BLOCK_PATTERN`/`SCRIPT_BLOCK_PATTERN`, no new parsing logic) and skip any `TAG_PATTERN` match that falls inside one, before it ever reaches `findRootTag` or any other `extractOpenTags` consumer. This fixes the bug at the source rather than special-casing each of the three affected rules individually.

## Test plan

- New regression test in `packages/lint/src/rules/core.test.ts`: a `<style>` block containing a `/* <g> */` comment ahead of an `<svg data-composition-id>` root, asserting none of the three findings fire.
- `bunx vitest run packages/lint` — 318/318 passing (full package suite, no regressions).
- `bunx tsc --noEmit` via the workspace build — clean.
- `bunx oxlint` / `bunx oxfmt --check` on the changed files — clean.