### PR TITLE
perf(engine): write PNG frames at compression_level 1

### DIFF
--- a/packages/engine/src/services/videoFrameExtractor.ts
+++ b/packages/engine/src/services/videoFrameExtractor.ts
@@ -271,7 +271,8 @@ export async function extractVideoFramesRange(
   args.push("-vf", vfFilters.join(","));
 
   args.push("-q:v", format === "jpg" ? String(Math.ceil((100 - quality) / 3)) : "0");
-  if (format === "png") args.push("-compression_level", "6");
+  // Render-scoped temp frames are read once; level 1 measured 3-5x faster for ~14% larger files.
+  if (format === "png") args.push("-compression_level", "1");
   args.push("-y", outputPattern);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
**Stack 1/6**: this → #1899 → #1900 → #1901 → #1902 → #1885

## What

Extracted video frames written as PNG now use `-compression_level 1` instead of `6`.

## Why

Source-video frames are pre-extracted to image files before capture, read once, and deleted when the render ends (or evicted from the cache later in this stack). zlib effort above level 1 buys smaller temp files but nothing else, and it serializes the extraction pipeline on the PNG encoder. The PNG path is what alpha content (vp9/vp8/prores) is forced onto, so this is the alpha-extraction hot path.

## Measured

- 60 s of 1080p30 H.264 to PNG: 11.4 s → 3.5 s (3.3x)
- 20 s 720p vp9-alpha webm to PNG: 4.3 s → 0.79 s (5.4x)
- Temp frame files grow ~14%.

PNG is lossless at every compression level, so output pixels are unchanged by construction.

## Notes

One-line change plus rationale comment. No test changes: no test pins the compression level.
