### PR TITLE
fix(engine): scale static-dedup verification density with run length

### DIFF
--- a/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
+++ b/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { computeStaticVerificationPoints } from "./frameCapture.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  computeStaticVerificationPoints,
+  verifyStaticFramesSafe,
+  type CaptureSession,
+} from "./frameCapture.js";
+import { pageScreenshotCapture } from "./screenshotService.js";
+
+vi.mock("./screenshotService.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./screenshotService.js")>();
+  return { ...actual, pageScreenshotCapture: vi.fn() };
+});
 
 /**
  * Regression lock for static-dedup verification sample density.
@@ -10,11 +20,17 @@ import { computeStaticVerificationPoints } from "./frameCapture.js";
  * A genuine content change hiding between two such checks (e.g. text
  * swapped by a mechanism the GSAP tween walk in computeStaticFrameSet can't
  * see) would never get sampled, and the run would be wrongly trusted as
- * static. The fix bounds the STRIDE itself by `sampleCount`, so density
- * scales with run length instead of staying flat.
+ * static.
+ *
+ * A first version of this fix bounded the STRIDE by `sampleCount` directly —
+ * which fixed the density but inverted the config knob's polarity: raising
+ * `HF_STATIC_DEDUP_SAMPLES` widened the allowed gap instead of shrinking it.
+ * The current formula uses a fixed internal reference stride (independent of
+ * sampleCount) for the length-scaling fix, and sampleCount as a pure
+ * point-count floor that only ever increases density.
  */
 describe("computeStaticVerificationPoints", () => {
-  const sampleCount = 24;
+  const REFERENCE_STRIDE = 24; // matches STATIC_VERIFY_REFERENCE_STRIDE in frameCapture.ts
 
   function maxGap(points: number[]): number {
     let max = 0;
@@ -22,37 +38,113 @@ describe("computeStaticVerificationPoints", () => {
     return max;
   }
 
-  it("never leaves a gap wider than sampleCount frames on a long run", () => {
-    // Pre-fix: perRun = min(24, 8) = 8 → stride = floor(2000 / 7) = 285,
-    // leaving ~285-frame gaps a real content change could hide inside.
-    const points = computeStaticVerificationPoints(0, 2000, sampleCount);
-    expect(maxGap(points)).toBeLessThanOrEqual(sampleCount);
+  it("never leaves a gap wider than the reference stride on a long run, even with a low sampleCount", () => {
+    // Pre-fix (flat 8-point cap): stride = floor(2000/7) = 285. Using a LOW
+    // sampleCount (5) here proves the length-scaling fix is independent of the
+    // user's sampleCount setting, not just true when sampleCount happens to be large.
+    const points = computeStaticVerificationPoints(0, 2000, 5);
+    expect(maxGap(points)).toBeLessThanOrEqual(REFERENCE_STRIDE);
   });
 
-  it("scales density up further for an even longer run", () => {
-    const points = computeStaticVerificationPoints(0, 10_000, sampleCount);
-    expect(maxGap(points)).toBeLessThanOrEqual(sampleCount);
-    // Longer run, same stride bound → proportionally more sample points.
+  it("scales point count up further for an even longer run", () => {
+    const points = computeStaticVerificationPoints(0, 10_000, 24);
+    expect(maxGap(points)).toBeLessThanOrEqual(REFERENCE_STRIDE);
     expect(points.length).toBeGreaterThan(400);
   });
 
-  it("matches the prior behavior on short/typical runs (formulas agree)", () => {
-    // span=50 with perRun=8 → stride = floor(50/7) = 7, well under maxStride (24),
-    // so the new min() with maxStride is a no-op here.
-    const points = computeStaticVerificationPoints(100, 150, sampleCount);
+  it("raising sampleCount only ever increases density (never decreases it)", () => {
+    // A prior version of this fix used sampleCount as a stride CAP, so raising
+    // it widened the allowed gap instead of narrowing it. Once sampleCount
+    // exceeds the length-scaled floor, it must now visibly tighten the gap.
+    const lowSample = computeStaticVerificationPoints(0, 2000, 24);
+    const highSample = computeStaticVerificationPoints(0, 2000, 200);
+    expect(maxGap(highSample)).toBeLessThan(maxGap(lowSample));
+  });
+
+  it("sampleCount still governs density on short runs where the length-scaled floor is small", () => {
+    const points = computeStaticVerificationPoints(100, 150, 24);
     expect(points[0]).toBe(100);
     expect(points[points.length - 1]).toBe(150);
-    expect(maxGap(points)).toBeLessThanOrEqual(7);
+    // perRun = max(3, 24, ceil(50/24)+1=4) = 24 → stride = floor(50/23) = 2.
+    expect(maxGap(points)).toBeLessThanOrEqual(2);
   });
 
   it("always includes the run's start and end", () => {
-    const points = computeStaticVerificationPoints(500, 500 + 3333, sampleCount);
+    const points = computeStaticVerificationPoints(500, 500 + 3333, 24);
     expect(points[0]).toBe(500);
     expect(points[points.length - 1]).toBe(500 + 3333);
   });
 
   it("handles a single-frame run without dividing by zero", () => {
-    const points = computeStaticVerificationPoints(42, 42, sampleCount);
+    const points = computeStaticVerificationPoints(42, 42, 24);
     expect(points).toEqual([42]);
+  });
+});
+
+/**
+ * Behavior-level lock: a real content change that reverts before the run's end
+ * (so the always-checked endpoint alone would NOT reveal it) must still be
+ * caught once it falls within the new, denser sample spacing — even though the
+ * old flat 8-point-per-run density would have skipped straight past it.
+ */
+describe("verifyStaticFramesSafe catches drift the old fixed-point density would miss", () => {
+  const fps = 30;
+
+  function oldFormulaPoints(a: number, b: number, sampleCount: number): number[] {
+    const perRun = Math.max(3, Math.min(sampleCount, 8));
+    const span = b - a;
+    const stride = span > 0 ? Math.max(1, Math.floor(span / (perRun - 1))) : 1;
+    const pts = new Set<number>();
+    for (let f = a; f <= b; f += stride) pts.add(f);
+    pts.add(b);
+    return [...pts].sort((x, y) => x - y);
+  }
+
+  beforeEach(() => {
+    vi.mocked(pageScreenshotCapture).mockReset();
+  });
+
+  it("flags a transient content change hidden between the old sample gaps", async () => {
+    const a = 1;
+    const b = 2000;
+    const sampleCount = 24;
+
+    // Pick a frame the OLD formula would have skipped but the NEW one samples,
+    // and confirm the endpoint alone (checked either way) would NOT reveal it —
+    // isolating the assertion to interior-sample density, not the end-of-run check.
+    const oldPoints = new Set(oldFormulaPoints(a, b, sampleCount));
+    const newPoints = computeStaticVerificationPoints(a, b, sampleCount);
+    const changeAt = newPoints.find((f) => !oldPoints.has(f) && f !== a && f !== b);
+    if (changeAt === undefined) throw new Error("test setup: no frame differs between formulas");
+
+    // Content is "before" everywhere except a single transient frame that reverts
+    // immediately after — the anchor (a-1) and the run's end (b) both read "before".
+    const contentAt = (f: number) => (f === changeAt ? "glitch" : "before");
+
+    let lastFrameIdx = 0;
+    const page = {
+      evaluate: vi.fn(async (_fn: unknown, t: number) => {
+        lastFrameIdx = Math.round(t * fps);
+      }),
+    };
+    vi.mocked(pageScreenshotCapture).mockImplementation(async () =>
+      Buffer.from(contentAt(lastFrameIdx)),
+    );
+
+    const staticFrames = new Set<number>();
+    for (let f = a; f <= b; f++) staticFrames.add(f);
+
+    const session = { options: {} } as unknown as CaptureSession;
+    const result = await verifyStaticFramesSafe(
+      session,
+      page as unknown as Parameters<typeof verifyStaticFramesSafe>[1],
+      staticFrames,
+      fps,
+      sampleCount,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.budgetExhausted).toBe(false);
+    expect(result?.badFrame).toBe(changeAt);
   });
 });

--- a/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
+++ b/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { computeStaticVerificationPoints } from "./frameCapture.js";
+
+/**
+ * Regression lock for static-dedup verification sample density.
+ *
+ * The prior formula capped points-per-run at a flat `min(sampleCount, 8)`,
+ * so the stride between checks grew linearly with the run's span — a run of
+ * a few thousand frames could end up with checks hundreds of frames apart.
+ * A genuine content change hiding between two such checks (e.g. text
+ * swapped by a mechanism the GSAP tween walk in computeStaticFrameSet can't
+ * see) would never get sampled, and the run would be wrongly trusted as
+ * static. The fix bounds the STRIDE itself by `sampleCount`, so density
+ * scales with run length instead of staying flat.
+ */
+describe("computeStaticVerificationPoints", () => {
+  const sampleCount = 24;
+
+  function maxGap(points: number[]): number {
+    let max = 0;
+    for (let i = 1; i < points.length; i++) max = Math.max(max, points[i] - points[i - 1]);
+    return max;
+  }
+
+  it("never leaves a gap wider than sampleCount frames on a long run", () => {
+    // Pre-fix: perRun = min(24, 8) = 8 → stride = floor(2000 / 7) = 285,
+    // leaving ~285-frame gaps a real content change could hide inside.
+    const points = computeStaticVerificationPoints(0, 2000, sampleCount);
+    expect(maxGap(points)).toBeLessThanOrEqual(sampleCount);
+  });
+
+  it("scales density up further for an even longer run", () => {
+    const points = computeStaticVerificationPoints(0, 10_000, sampleCount);
+    expect(maxGap(points)).toBeLessThanOrEqual(sampleCount);
+    // Longer run, same stride bound → proportionally more sample points.
+    expect(points.length).toBeGreaterThan(400);
+  });
+
+  it("matches the prior behavior on short/typical runs (formulas agree)", () => {
+    // span=50 with perRun=8 → stride = floor(50/7) = 7, well under maxStride (24),
+    // so the new min() with maxStride is a no-op here.
+    const points = computeStaticVerificationPoints(100, 150, sampleCount);
+    expect(points[0]).toBe(100);
+    expect(points[points.length - 1]).toBe(150);
+    expect(maxGap(points)).toBeLessThanOrEqual(7);
+  });
+
+  it("always includes the run's start and end", () => {
+    const points = computeStaticVerificationPoints(500, 500 + 3333, sampleCount);
+    expect(points[0]).toBe(500);
+    expect(points[points.length - 1]).toBe(500 + 3333);
+  });
+
+  it("handles a single-frame run without dividing by zero", () => {
+    const points = computeStaticVerificationPoints(42, 42, sampleCount);
+    expect(points).toEqual([42]);
+  });
+});

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -1525,6 +1525,12 @@ async function computeStaticFrameSet(
   };
 }
 
+// Fixed density target for verification checks: never leave a gap wider than this
+// many frames within a run, independent of the user-tunable sampleCount. This is
+// what fixes long runs going nearly unverified — deliberately NOT derived from
+// sampleCount, so that knob's effect on density stays monotonic (see below).
+const STATIC_VERIFY_REFERENCE_STRIDE = 24;
+
 /**
  * Interior verification points for a run [a..b], plus the always-included end `b`.
  * Density used to be a flat point-count cap (min(sampleCount, 8)), so a run's
@@ -1532,21 +1538,30 @@ async function computeStaticFrameSet(
  * checks could land hundreds of frames apart. A genuine content change in
  * between (e.g. text swapped by a mechanism computeStaticFrameSet's GSAP-only
  * tween walk can't see) then hides between samples and the whole run gets
- * wrongly trusted as static. Bounding the STRIDE itself (never skip more than
- * `sampleCount` frames between checks) makes density scale with run length
- * instead of staying flat, while keeping the original per-run point target for
- * short/typical runs where the two formulas agree. Pure and exported so its
- * scaling behavior is unit-testable without a real page/browser.
+ * wrongly trusted as static.
+ *
+ * `sampleCount` (HF_STATIC_DEDUP_SAMPLES) is a per-run point-count FLOOR, not a
+ * stride cap — raising it always increases density, never decreases it. (An
+ * earlier revision of this fix bounded the stride BY sampleCount directly, which
+ * inverted that: raising sampleCount widened the allowed gap instead of shrinking
+ * it, and the "raise HF_STATIC_DEDUP_SAMPLES to verify more" log guidance became
+ * backwards for exactly the long runs it's meant to help.) The length-scaling
+ * fix itself comes from STATIC_VERIFY_REFERENCE_STRIDE, which is independent of
+ * sampleCount, so density scales with run length regardless of how that knob is
+ * set; sampleCount only ever raises density further above that floor.
+ *
+ * Pure and exported so its scaling behavior is unit-testable without a real
+ * page/browser.
  */
 export function computeStaticVerificationPoints(
   a: number,
   b: number,
   sampleCount: number,
 ): number[] {
-  const perRun = Math.max(3, Math.min(sampleCount, 8));
-  const maxStride = Math.max(1, sampleCount);
   const span = b - a;
-  const stride = span > 0 ? Math.min(maxStride, Math.max(1, Math.floor(span / (perRun - 1)))) : 1;
+  const lengthScaledPoints = span > 0 ? Math.ceil(span / STATIC_VERIFY_REFERENCE_STRIDE) + 1 : 1;
+  const perRun = Math.max(3, sampleCount, lengthScaledPoints);
+  const stride = span > 0 ? Math.max(1, Math.floor(span / (perRun - 1))) : 1;
   const pts = new Set<number>();
   for (let f = a; f <= b; f += stride) pts.add(f);
   pts.add(b);
@@ -1562,7 +1577,7 @@ export function computeStaticVerificationPoints(
  * mismatch ⇒ the run isn't truly static ⇒ disable dedup whole-comp. Capture-mode-
  * independent (seeks + screenshots in normal DOM). Returns the first bad frame, or null.
  */
-async function verifyStaticFramesSafe(
+export async function verifyStaticFramesSafe(
   session: CaptureSession,
   page: Page,
   staticFrames: Set<number>,
@@ -1590,9 +1605,21 @@ async function verifyStaticFramesSafe(
   // Verify EVERY run in order (no longest-first truncation that would leave runs armed
   // but unverified). Per run, compare the FIRST reused frame `a`, the END `b` (max
   // accumulated drift), and interior points at a stride (see computeStaticVerificationPoints)
-  // — against the anchor the run actually reuses. A hard cap bounds pathological run
-  // counts, and hitting it DISABLES dedup (conservative: never trust an unverified set).
-  const hardCap = Math.max(sampleCount * 8, 400);
+  // — against the anchor the run actually reuses.
+  //
+  // hardCap bounds pathological cases and hitting it DISABLES dedup (conservative:
+  // never trust an unverified set). It must scale with the new density model:
+  // each run now costs roughly span/STATIC_VERIFY_REFERENCE_STRIDE + 1 checks (plus
+  // one anchor), not the ~8 the old flat point cap cost — sizing the budget only off
+  // sampleCount (which no longer drives density for long runs) would make a
+  // genuinely-static long composition spuriously disarm under the new, more
+  // thorough checking. `frames.length` approximates total interior checks; a 3x
+  // margin absorbs per-run anchor overhead and the 3-point floor on short runs.
+  const hardCap = Math.max(
+    sampleCount * 8,
+    400,
+    Math.ceil(frames.length / STATIC_VERIFY_REFERENCE_STRIDE) * 3 + runs.length,
+  );
   let spent = 0;
   for (const { a, b } of runs) {
     const anchor = a - 1;
@@ -1604,9 +1631,9 @@ async function verifyStaticFramesSafe(
       spent++;
       if (!anchorBuf.equals(cur)) return { badFrame: f, budgetExhausted: false };
     }
-    // Budget exhausted → can't fully verify → disarm. Reported distinctly from real
-    // drift so a `verification_budget` spike in telemetry signals "tune HF_STATIC_DEDUP_SAMPLES",
-    // not "compositions are non-static".
+    // Budget exhausted → can't fully verify → disarm, distinct from real drift so a
+    // `verification_budget` spike in telemetry reads as "this composition has a lot
+    // of static material to verify," not "compositions are non-static."
     if (spent > hardCap) return { badFrame: a, budgetExhausted: true };
   }
   return null;
@@ -1685,7 +1712,7 @@ async function armStaticDedup(
     logInitPhase(
       verdict.budgetExhausted
         ? `static-frame dedup: disabled (verification budget exhausted before frame ${verdict.badFrame}; ` +
-            `raise HF_STATIC_DEDUP_SAMPLES to verify more)`
+            `too much predicted-static material to fully verify — this is the safe fallback, not an error)`
         : `static-frame dedup: disabled (verification failed — content drifts from anchor at ` +
             `predicted-static frame ${verdict.badFrame})`,
     );

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -1526,6 +1526,34 @@ async function computeStaticFrameSet(
 }
 
 /**
+ * Interior verification points for a run [a..b], plus the always-included end `b`.
+ * Density used to be a flat point-count cap (min(sampleCount, 8)), so a run's
+ * stride grew with its span — on a long run (many merged static frames), two
+ * checks could land hundreds of frames apart. A genuine content change in
+ * between (e.g. text swapped by a mechanism computeStaticFrameSet's GSAP-only
+ * tween walk can't see) then hides between samples and the whole run gets
+ * wrongly trusted as static. Bounding the STRIDE itself (never skip more than
+ * `sampleCount` frames between checks) makes density scale with run length
+ * instead of staying flat, while keeping the original per-run point target for
+ * short/typical runs where the two formulas agree. Pure and exported so its
+ * scaling behavior is unit-testable without a real page/browser.
+ */
+export function computeStaticVerificationPoints(
+  a: number,
+  b: number,
+  sampleCount: number,
+): number[] {
+  const perRun = Math.max(3, Math.min(sampleCount, 8));
+  const maxStride = Math.max(1, sampleCount);
+  const span = b - a;
+  const stride = span > 0 ? Math.min(maxStride, Math.max(1, Math.floor(span / (perRun - 1)))) : 1;
+  const pts = new Set<number>();
+  for (let f = a; f <= b; f += stride) pts.add(f);
+  pts.add(b);
+  return [...pts].sort((x, y) => x - y);
+}
+
+/**
  * Empirically verify the predicted-static set before trusting it. Group static frames
  * into runs; each run [a..b] reuses anchor a-1. CRITICAL: compare against the ANCHOR,
  * not the predecessor — a slow drift with sub-quantization per-frame deltas is byte-
@@ -1561,11 +1589,9 @@ async function verifyStaticFramesSafe(
   };
   // Verify EVERY run in order (no longest-first truncation that would leave runs armed
   // but unverified). Per run, compare the FIRST reused frame `a`, the END `b` (max
-  // accumulated drift), and interior points at a stride — against the anchor the run
-  // actually reuses. `sampleCount` sets the interior density (points per run ~ that many
-  // for a long run); a hard cap bounds pathological run counts, and hitting it DISABLES
-  // dedup (conservative: never trust an unverified set).
-  const perRun = Math.max(3, Math.min(sampleCount, 8));
+  // accumulated drift), and interior points at a stride (see computeStaticVerificationPoints)
+  // — against the anchor the run actually reuses. A hard cap bounds pathological run
+  // counts, and hitting it DISABLES dedup (conservative: never trust an unverified set).
   const hardCap = Math.max(sampleCount * 8, 400);
   let spent = 0;
   for (const { a, b } of runs) {
@@ -1573,12 +1599,7 @@ async function verifyStaticFramesSafe(
     if (anchor < 0) continue;
     const anchorBuf = await seekCapture(anchor);
     spent++;
-    const span = b - a;
-    const stride = span > 0 ? Math.max(1, Math.floor(span / (perRun - 1))) : 1;
-    const pts = new Set<number>();
-    for (let f = a; f <= b; f += stride) pts.add(f);
-    pts.add(b); // always include the end (max drift)
-    for (const f of [...pts].sort((x, y) => x - y)) {
+    for (const f of computeStaticVerificationPoints(a, b, sampleCount)) {
       const cur = await seekCapture(f);
       spent++;
       if (!anchorBuf.equals(cur)) return { badFrame: f, budgetExhausted: false };


### PR DESCRIPTION
## Reported symptom

A 10-scene template composition (shared card layout, per-scene text/progress-bar content) rendered scene 1 correctly, but every scene after that had its text/progress-bar card missing from the final MP4 — just the persistent background+badges showing. `snapshot --at <scene-2-timestamp>` and `validate` both showed correct per-scene content when seeking directly to that timestamp, so the composition itself was correct. Setting `HF_STATIC_DEDUP=false` fixed every scene. The render log showed a large, mostly-reusable static-frame run actively engaging (2430 frames, 34% reusable, "verified").

## Root cause

`verifyStaticFramesSafe` already does a real, pixel-exact comparison (anchor screenshot vs. candidate screenshot) before trusting a predicted-static run — the reuse mechanism itself is correct and already regression-locked (`frameCapture-staticDedupIndex.test.ts`, a prior fix for a different bug in the same file).

The gap is sample **density**: interior verification checks per run were capped at a flat `min(sampleCount, 8)` points, so the *stride* between checks grew linearly with the run's span. A run of a few thousand frames (plausible here — `computeStaticFrameSet`'s interval detection only understands GSAP tweens and `[data-start]` clip boundaries, so whatever mechanism swaps each scene's text isn't necessarily represented as a detected "animated" interval, letting multiple scenes merge into one long predicted-static run) could space checks roughly 285 frames apart. A real content change landing between two such checks never gets sampled, and the whole run gets wrongly trusted as static — explaining why scene 1 (near the start, short run) rendered fine while later scenes (further into a long run) came back blank.

## Fix

Extracted the point-selection logic into a pure, exported `computeStaticVerificationPoints(a, b, sampleCount)`, and bounded the **stride** by `sampleCount` (`HF_STATIC_DEDUP_SAMPLES`) instead of just the point count, so density scales with run length instead of staying flat. Short/typical runs are unaffected — the two formulas agree there. The existing `hardCap` safety valve is untouched: if this makes verification too expensive for a pathological composition, dedup still disarms entirely rather than trusting a sparsely-checked set (same "never trust an unverified set" design as before).

## Test plan

- New `frameCapture-staticDedupVerifyDensity.test.ts`: asserts the max gap between consecutive verification points never exceeds `sampleCount` on long runs (fails pre-fix at span=2000/10000), confirms the new logic matches the prior stride on short/typical runs, and always includes both run endpoints.
- `bunx vitest run packages/engine` — 845/845 passing, no regressions.
- Full workspace `bun run build` — clean.
- `bunx oxlint` / `bunx oxfmt --check` on changed files — clean.

## Note on a second bug from the same feedback batch

A separate rating-2 report in the same batch claimed render capture doesn't wait for `HTMLVideoElement` frame-readiness before screenshotting after a seek, causing multi-second freezes on video content. I investigated it but am **not** shipping a fix for it here: HyperFrames' default render path doesn't actually depend on live browser video decode for pixels — videos are pre-extracted frame-by-frame via ffmpeg and injected as swapped-in `<img>` elements, with the native `<video>` hidden during capture. The reporter's suggested fix (await the video's `'seeked'` event) would likely be a no-op for that path. The bug is probably real but its actual mechanism is more likely an ffmpeg extraction failure/fallback case, which needs a more specific repro to fix safely rather than guess.