### PR TITLE
fix(studio-server): preserve binary bodies in file PUT/POST

### DIFF
--- a/packages/studio-server/src/routes/files.test.ts
+++ b/packages/studio-server/src/routes/files.test.ts
@@ -83,6 +83,36 @@ describe("registerFileRoutes", () => {
     expect(readFileSync(join(projectDir, "index.html"), "utf-8")).toBe("after");
   });
 
+  it("preserves binary bodies byte-for-byte on PUT and POST", async () => {
+    const projectDir = createProjectDir();
+    const app = new Hono();
+    registerFileRoutes(app, createAdapter(projectDir));
+
+    // Bytes that are invalid UTF-8 (e.g. font/image data): a UTF-8 text decode
+    // would replace them with U+FFFD and corrupt the file.
+    const binary = Uint8Array.from([0x4f, 0x54, 0x54, 0x4f, 0x00, 0x98, 0xff, 0xfe, 0x80, 0x01]);
+
+    const created = await app.request("http://localhost/projects/demo/files/assets/font.otf", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: binary,
+    });
+    expect(created.status).toBe(201);
+    expect(new Uint8Array(readFileSync(join(projectDir, "assets/font.otf")))).toEqual(binary);
+
+    const reversed = Uint8Array.from([...binary].reverse());
+    const overwritten = await app.request(
+      "http://localhost/projects/demo/files/assets/font.otf",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: reversed,
+      },
+    );
+    expect(overwritten.status).toBe(200);
+    expect(new Uint8Array(readFileSync(join(projectDir, "assets/font.otf")))).toEqual(reversed);
+  });
+
   it("backs up the previous file content before delete", async () => {
     const projectDir = createProjectDir();
     writeFileSync(join(projectDir, "index.html"), "before delete");

--- a/packages/studio-server/src/routes/files.ts
+++ b/packages/studio-server/src/routes/files.ts
@@ -1604,10 +1604,13 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
     if ("error" in res) return res.error;
 
     ensureDir(res.absPath);
-    const body = await c.req.text();
+    // Read raw bytes: c.req.text() decodes the body as UTF-8, which corrupts
+    // binary uploads (fonts, images) by replacing non-UTF-8 bytes. Writing the
+    // raw buffer is byte-exact for text bodies too.
+    const body = Buffer.from(await c.req.arrayBuffer());
     const backup = snapshotBeforeWrite(res.project.dir, res.absPath);
     if (backup.error) console.warn(`Failed to create backup for ${res.filePath}: ${backup.error}`);
-    writeFileSync(res.absPath, body, "utf-8");
+    writeFileSync(res.absPath, body);
 
     return c.json({
       ok: true,
@@ -1627,8 +1630,11 @@ export function registerFileRoutes(api: Hono, adapter: StudioApiAdapter): void {
     }
 
     ensureDir(res.absPath);
-    const body = await c.req.text().catch(() => "");
-    writeFileSync(res.absPath, body, "utf-8");
+    const body = await c.req
+      .arrayBuffer()
+      .then((b) => Buffer.from(b))
+      .catch(() => Buffer.alloc(0));
+    writeFileSync(res.absPath, body);
 
     return c.json({ ok: true, path: res.filePath }, 201);
   });


### PR DESCRIPTION
## Problem

`PUT`/`POST /api/projects/:id/files/*` in `@hyperframes/studio-server` read the request body with `c.req.text()` and write it with `writeFileSync(path, body, "utf-8")`. Any body that is not valid UTF-8 — fonts, images, any binary asset — gets its non-UTF-8 bytes replaced with U+FFFD during the decode, so the file on disk is silently corrupted (and typically inflated). The `Content-Type` header is ignored.

### Repro

```bash
curl -X PUT -H "Content-Type: application/octet-stream" \
  --data-binary @font.otf \
  http://localhost:3002/api/projects/<id>/files/assets/font.otf
# → 200, but the file on disk has a different sha256 and a larger size
```

Observed with a 20 828-byte OTF font arriving as 37 041 bytes on disk; `@font-face` then falls back silently, which makes this painful to diagnose.

## Fix

Read the raw bytes (`Buffer.from(await c.req.arrayBuffer())`) and write the buffer without an encoding. This is byte-exact for text bodies too (UTF-8 text round-trips unchanged), so existing text uploads keep working — no content-type sniffing needed.

## Testing

- Added a vitest case in `files.test.ts`: POST + PUT with bodies containing invalid-UTF-8 bytes round-trip byte-for-byte.
- Verified on a live studio-server deployment: sha256 of an uploaded OTF/PNG now matches the source exactly; HTML/text uploads (including non-ASCII content) unchanged.
