### PR TITLE
fix(engine): prefer ffmpeg.exe over a .cmd/.bat shim on Windows PATH [P1]

### DIFF
--- a/packages/cli/src/browser/ffmpeg.test.ts
+++ b/packages/cli/src/browser/ffmpeg.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({ execSync: vi.fn() }));
@@ -42,5 +43,20 @@ describe("findFFmpeg", () => {
 
     const { findFFmpeg } = await import("./ffmpeg.js");
     expect(findFFmpeg()).toBeUndefined();
+  });
+
+  it("on win32, prefers ffmpeg.exe over a ffmpeg.cmd shim listed first", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    mockExec.mockReturnValue("C:\\tools\\bin\\ffmpeg.cmd\r\nC:\\ffmpeg\\bin\\ffmpeg.exe\r\n");
+
+    const { findFFmpeg } = await import("./ffmpeg.js");
+    expect(findFFmpeg()).toBe(resolve("C:\\ffmpeg\\bin\\ffmpeg.exe"));
+  });
+
+  it("on non-win32, returns the first ffmpeg path from which unchanged", async () => {
+    mockExec.mockReturnValue("/usr/local/bin/ffmpeg\n/usr/bin/ffmpeg\n");
+
+    const { findFFmpeg } = await import("./ffmpeg.js");
+    expect(findFFmpeg()).toBe("/usr/local/bin/ffmpeg");
   });
 });

--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -1,4 +1,5 @@
 // fallow-ignore-file code-duplication
+import { selectBinaryFromPathResults } from "@hyperframes/engine";
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
@@ -15,10 +16,7 @@ function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
     });
-    const first = output
-      .split(/\r?\n/)
-      .map((s) => s.trim())
-      .find(Boolean);
+    const first = selectBinaryFromPathResults(output, process.platform);
     return first ? resolve(first) : undefined;
   } catch {
     return undefined;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -216,6 +216,7 @@ export {
   assertConfiguredFfmpegBinariesExist,
   getFfmpegBinary,
   getFfprobeBinary,
+  selectBinaryFromPathResults,
   FFMPEG_PATH_ENV,
   FFPROBE_PATH_ENV,
 } from "./utils/ffmpegBinaries.js";

--- a/packages/engine/src/utils/ffmpegBinaries.test.ts
+++ b/packages/engine/src/utils/ffmpegBinaries.test.ts
@@ -5,6 +5,7 @@ import {
   assertConfiguredFfmpegBinariesExist,
   getFfmpegBinary,
   getFfprobeBinary,
+  selectBinaryFromPathResults,
 } from "./ffmpegBinaries.js";
 
 describe("ffmpeg binary env resolution", () => {
@@ -39,5 +40,33 @@ describe("ffmpeg binary env resolution", () => {
     process.env.HYPERFRAMES_FFPROBE_PATH = process.execPath;
 
     expect(() => assertConfiguredFfmpegBinariesExist()).not.toThrow();
+  });
+});
+
+describe("selectBinaryFromPathResults", () => {
+  it("on win32, prefers the .exe over a .cmd shim listed first (spawn EINVAL fix)", () => {
+    // The exact reported layout: `where ffmpeg` lists a .cmd wrapper first.
+    const out = "C:\\tools\\bin\\ffmpeg.cmd\r\nC:\\ffmpeg\\bin\\ffmpeg.exe\r\n";
+    expect(selectBinaryFromPathResults(out, "win32")).toBe("C:\\ffmpeg\\bin\\ffmpeg.exe");
+  });
+
+  it("on win32, also skips a .bat shim in favor of a later .exe", () => {
+    const out = "C:\\a\\ffmpeg.bat\nC:\\b\\ffmpeg.exe\n";
+    expect(selectBinaryFromPathResults(out, "win32")).toBe("C:\\b\\ffmpeg.exe");
+  });
+
+  it("on win32, falls back to the first result when no .exe/.com is listed", () => {
+    // No directly-spawnable exe present — keep prior behavior (don't drop it).
+    const out = "C:\\tools\\bin\\ffmpeg.cmd\r\n";
+    expect(selectBinaryFromPathResults(out, "win32")).toBe("C:\\tools\\bin\\ffmpeg.cmd");
+  });
+
+  it("on non-win32, returns the first result unchanged", () => {
+    const out = "/usr/local/bin/ffmpeg\n/usr/bin/ffmpeg\n";
+    expect(selectBinaryFromPathResults(out, "linux")).toBe("/usr/local/bin/ffmpeg");
+  });
+
+  it("returns undefined for empty output", () => {
+    expect(selectBinaryFromPathResults("\r\n  \n", "win32")).toBeUndefined();
   });
 });

--- a/packages/engine/src/utils/ffmpegBinaries.ts
+++ b/packages/engine/src/utils/ffmpegBinaries.ts
@@ -8,6 +8,31 @@ export const FFPROBE_PATH_ENV = "HYPERFRAMES_FFPROBE_PATH";
 
 const pathCache = new Map<string, string | undefined>();
 
+/**
+ * Pick the binary path to use from `where`/`which`'s (newline-separated) output.
+ *
+ * On Windows `where ffmpeg` frequently lists a `.cmd`/`.bat` shim (npm/scoop/
+ * winget wrappers) AHEAD of the real `.exe`. Node's spawn (no `shell:true`)
+ * cannot execute a `.cmd`/`.bat` directly — it throws `spawn EINVAL` — which
+ * surfaces as a render (and audio-mux) failure even though FFmpeg is installed.
+ * So on win32 prefer the first directly-spawnable executable (`.exe`/`.com`),
+ * falling back to the first result only when no such executable is listed
+ * (preserving prior behavior rather than dropping a usable-via-shell path).
+ * Pure and exported so the platform-specific selection is unit-testable.
+ */
+export function selectBinaryFromPathResults(output: string, platform: string): string | undefined {
+  const candidates = output
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (candidates.length === 0) return undefined;
+  if (platform === "win32") {
+    const spawnable = candidates.find((p) => /\.(exe|com)$/i.test(p));
+    return spawnable ?? candidates[0];
+  }
+  return candidates[0];
+}
+
 function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
   if (pathCache.has(name)) return pathCache.get(name);
   try {
@@ -17,11 +42,8 @@ function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
     });
-    const first = output
-      .split(/\r?\n/)
-      .map((s) => s.trim())
-      .find(Boolean);
-    const resolved = first ? resolve(first) : undefined;
+    const selected = selectBinaryFromPathResults(output, process.platform);
+    const resolved = selected ? resolve(selected) : undefined;
     pathCache.set(name, resolved);
     return resolved;
   } catch {


### PR DESCRIPTION
## Root cause

When `HYPERFRAMES_FFMPEG_PATH` is unset, `findOnPath()` auto-detects ffmpeg/ffprobe via `where` (Windows) / `which` and used the **first** result. On Windows `where ffmpeg` frequently lists a `.cmd`/`.bat` wrapper (npm/scoop/winget shims) **ahead of** the real `.exe`, and Node's `spawn` without `shell:true` cannot execute a `.cmd`/`.bat` — it throws `spawn EINVAL`. So render capture/encode **and** audio muxing failed with "spawn EINVAL" even though FFmpeg was installed.

Two independent reports of this exact EINVAL, one explicitly tracing it to `where` returning `ffmpeg.cmd` before `ffmpeg.exe` (their workaround was renaming the `.cmd` wrappers so `ffmpeg.exe` resolved first).

## Fix

Extract `selectBinaryFromPathResults(output, platform)`:
- **win32**: prefer the first directly-spawnable executable (`.exe`/`.com`) among the results, falling back to the first result only when none is listed (so a shell-runnable `.cmd`-only setup isn't dropped).
- **non-win32**: unchanged (first result).

Scoped to selection. The `.cmd`-only case (still EINVALs on `spawn`) is left for a separate shell-spawn change — the common, reported case is both a `.cmd` shim and a real `.exe` on PATH, which this fixes.

## Test plan

- New `selectBinaryFromPathResults` unit tests: win32 prefers `.exe` over a leading `.cmd` and over a `.bat`; falls back to the first result when no `.exe`/`.com` is listed; returns the first on non-win32; returns `undefined` for empty output.
- Existing env-resolution tests unchanged; `bunx vitest run packages/engine/src/utils/ffmpegBinaries.test.ts` — 8/8 passing.
- Full `bun run build` clean; `oxlint`/`oxfmt` clean.