### PR TITLE
fix(hyperframes-media): sfx offline path skips (loudly) a missing bundled file

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -42,8 +42,8 @@
       "files": 3
     },
     "hyperframes-media": {
-      "hash": "e7d7ed17b27ffa26",
-      "files": 46
+      "hash": "60f73ecb91858ea3",
+      "files": 47
     },
     "hyperframes-registry": {
       "hash": "e3b389526834109d",

--- a/skills/hyperframes-media/scripts/lib/sfx.mjs
+++ b/skills/hyperframes-media/scripts/lib/sfx.mjs
@@ -113,7 +113,22 @@ export async function resolveSfx({ cues, heygenOK, headers, hyperframesDir, sfxL
     const src = join(sfxLibDir, hit.file);
     const destRel = `assets/sfx/${hit.file}`;
     const dest = join(hyperframesDir, destRel);
-    if (existsSync(src) && !existsSync(dest)) copyFileSync(src, dest);
+    // The bundled library may be incomplete: some installs of the skill ship
+    // manifest.json without the actual mp3s. Pushing an sfx entry that points at
+    // a file we never copied produces a dangling reference that silently drops
+    // downstream ("not on disk"). Surface it as a loud anomaly and skip the cue
+    // instead, so the audio_meta never references a missing file.
+    if (!existsSync(dest)) {
+      if (!existsSync(src)) {
+        anomalies.push(
+          `sfx "${name}" (id ${id}): bundled file ${hit.file} missing from the offline ` +
+            `library (${sfxLibDir}) — skipped. Reinstall the hyperframes-media skill to ` +
+            `restore assets/sfx/*.mp3, or configure a HeyGen credential for retrieval.`,
+        );
+        continue;
+      }
+      copyFileSync(src, dest);
+    }
     sfx.push({
       id,
       name,

--- a/skills/hyperframes-media/scripts/lib/sfx.test.mjs
+++ b/skills/hyperframes-media/scripts/lib/sfx.test.mjs
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveSfx } from "./sfx.mjs";
+
+// Offline (no HeyGen) SFX resolution: the bundled library may ship manifest.json
+// without the actual mp3s. The old code copied only when the source existed but
+// pushed the sfx entry unconditionally — producing a dangling reference that
+// silently dropped downstream ("not on disk"). These tests lock in the loud
+// behavior: a present file is copied + referenced; a missing file yields an
+// anomaly and NO dangling entry.
+
+async function withDirs(fn) {
+  const root = mkdtempSync(join(tmpdir(), "hf-sfx-"));
+  const libDir = join(root, "lib");
+  const projDir = join(root, "proj");
+  mkdirSync(libDir, { recursive: true });
+  mkdirSync(projDir, { recursive: true });
+  try {
+    // `await` is load-bearing: without it the finally cleanup runs before the
+    // async test body resolves, deleting the temp dir mid-assertion.
+    return await fn({ libDir, projDir });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("offline: copies and references a present bundled file", async () => {
+  await withDirs(async ({ libDir, projDir }) => {
+    writeFileSync(
+      join(libDir, "manifest.json"),
+      JSON.stringify({ whoosh: { file: "whoosh.mp3", duration: 0.8 } }),
+    );
+    writeFileSync(join(libDir, "whoosh.mp3"), "ID3-fake-bytes");
+    const { sfx, anomalies } = await resolveSfx({
+      cues: [{ id: "s1", name: "whoosh" }],
+      heygenOK: false,
+      hyperframesDir: projDir,
+      sfxLibDir: libDir,
+    });
+    assert.equal(sfx.length, 1);
+    assert.equal(sfx[0].file, "assets/sfx/whoosh.mp3");
+    assert.equal(sfx[0].source, "local");
+    assert.ok(existsSync(join(projDir, "assets/sfx/whoosh.mp3")), "mp3 copied into project");
+    assert.equal(anomalies.length, 0);
+  });
+});
+
+test("offline: a matched-but-missing bundled file yields an anomaly and NO dangling entry", async () => {
+  await withDirs(async ({ libDir, projDir }) => {
+    // Manifest names whoosh.mp3, but the mp3 was never shipped (the reported bug).
+    writeFileSync(
+      join(libDir, "manifest.json"),
+      JSON.stringify({ whoosh: { file: "whoosh.mp3", duration: 0.8 } }),
+    );
+    const { sfx, anomalies } = await resolveSfx({
+      cues: [{ id: "s1", name: "whoosh" }],
+      heygenOK: false,
+      hyperframesDir: projDir,
+      sfxLibDir: libDir,
+    });
+    assert.equal(sfx.length, 0, "no dangling entry for a file that was never copied");
+    assert.equal(anomalies.length, 1);
+    assert.match(anomalies[0], /missing from the offline library/);
+    assert.ok(!existsSync(join(projDir, "assets/sfx/whoosh.mp3")), "nothing copied");
+  });
+});


### PR DESCRIPTION
## Root cause

The offline (no-HeyGen) SFX path in `sfx.mjs` copied a matched bundled mp3 into the project only `if (existsSync(src) && !existsSync(dest))`, but then pushed the `sfx` entry **unconditionally**. When the bundled library is incomplete — some installs of the skill ship `assets/sfx/manifest.json` without the actual mp3s — the copy was silently skipped while a `sfx` entry still referenced `assets/sfx/<file>.mp3` that was never written.

That dangling reference then silently drops downstream ("not on disk"), so **every offline cue vanished with no working offline SFX path and no signal why** (reported).

## Fix

In the offline branch: if the matched file is neither already at the destination nor present in the library, push a clear anomaly naming the missing file and the remedy (reinstall the skill, or set a HeyGen credential) and **skip the cue** — so `audio_meta` never references a file that isn't there. Loud failure over a silent dangling reference, matching how TTS/BGM already surface their gaps.

Note: the repo's own `skills/hyperframes-media/assets/sfx/` **does** contain all 19 mp3s (real committed files, not LFS), so the source is fine — this hardens the code against an incomplete *install* rather than restoring assets.

## Test plan

New `sfx.test.mjs` (`node:test`) exercises `resolveSfx`'s offline branch against a temp library:
- a present bundled file is copied into the project and referenced, with no anomaly;
- a matched-but-missing file yields exactly one anomaly and **no** dangling `sfx` entry (and copies nothing).

`node --test skills/hyperframes-media/scripts/lib/sfx.test.mjs` — 2/2 passing. `node --check` + `oxlint`/`oxfmt` clean; full `bun run build` clean.