### PR TITLE
test(lint): resolve parsers source in vitest

### DIFF
--- a/packages/lint/vitest.config.ts
+++ b/packages/lint/vitest.config.ts
@@ -1,6 +1,35 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@hyperframes\/parsers$/,
+        replacement: resolve(__dirname, "../parsers/src/index.ts"),
+      },
+      {
+        find: /^@hyperframes\/parsers\/asset-paths$/,
+        replacement: resolve(__dirname, "../parsers/src/assets.ts"),
+      },
+      {
+        find: /^@hyperframes\/parsers\/composition$/,
+        replacement: resolve(__dirname, "../parsers/src/composition.ts"),
+      },
+      {
+        find: /^@hyperframes\/parsers\/gsap-parser-acorn$/,
+        replacement: resolve(__dirname, "../parsers/src/gsapParserAcorn.ts"),
+      },
+      {
+        find: /^@hyperframes\/parsers\/slideshow$/,
+        replacement: resolve(__dirname, "../parsers/src/slideshow/index.ts"),
+      },
+      {
+        find: /^@hyperframes\/parsers\/sub-composition-validity$/,
+        replacement: resolve(__dirname, "../parsers/src/subCompositionValidity.ts"),
+      },
+    ],
+  },
   test: {
     include: ["src/**/*.test.ts"],
     environment: "jsdom",


### PR DESCRIPTION
## What changed

- Adds Vitest source aliases for the @hyperframes/parsers entry points used by @hyperframes/lint tests.

## Why
- `bun run --filter @hyperframes/lint test` failed in a clean checkout because Vite tried to resolve parser package exports through dist files that do not exist until @hyperframes/parsers is built.


## Validation

- `bun run --filter @hyperframes/lint test`

