### PR TITLE
docs(core): fix frame adapter reference links

### DIFF
--- a/packages/core/docs/core.md
+++ b/packages/core/docs/core.md
@@ -4,7 +4,7 @@ Reference for generating and editing HyperFrames HTML compositions. This is your
 
 **New to HyperFrames?** Start with the [quickstart template](./quickstart-template.html) — a copy-paste composition with inline comments explaining every required piece. See [common mistakes](./common-mistakes.md) for pitfalls that break compositions.
 
-For Frame adapters and deterministic frame rendering direction, see [`../../FRAME.md`](../../FRAME.md) and [`../adapters/README.md`](../adapters/README.md).
+For frame adapters and deterministic frame rendering direction, see the [frame adapters](../../../docs/concepts/frame-adapters.mdx) and [determinism](../../../docs/concepts/determinism.mdx) concept docs.
 
 Producer-canonical parity note:
 


### PR DESCRIPTION
## What changed

- Replaces two stale links in packages/core/docs/core.md with existing concept docs for frame adapters and deterministic rendering.

## Why

- The old links pointed at files that are no longer present in the repository, so readers landed on broken references.
## Validation

- Ran a local relative-link check for packages/core/docs/core.md.




