### PR TITLE
docs(skills): fix creative house style links

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -34,7 +34,7 @@
       "files": 17
     },
     "hyperframes-creative": {
-      "hash": "b9e2cbfa49e6ed6c",
+      "hash": "0bfb0ec7f8e67062",
       "files": 78
     },
     "hyperframes-keyframes": {

--- a/skills/hyperframes-creative/references/house-style.md
+++ b/skills/hyperframes-creative/references/house-style.md
@@ -6,7 +6,7 @@ Creative direction for compositions when no design spec (`frame.md` or `design.m
 
 1. **Interpret the prompt.** Generate real content. A recipe lists real ingredients. A HUD has real readouts.
 2. **Pick a palette.** Light or dark? Declare bg, fg, accent before writing code.
-3. **Pick typefaces.** Run the font discovery script in [references/typography.md](references/typography.md) — or pick a font you already know that fits the theme. The script broadens your options; it's not the only source.
+3. **Pick typefaces.** Run the font discovery script in [typography.md](typography.md) — or pick a font you already know that fits the theme. The script broadens your options; it's not the only source.
 
 ## Lazy Defaults to Question
 
@@ -18,7 +18,7 @@ These patterns are AI design tells — the first thing every LLM reaches for. If
 - Pure `#000` or `#fff` (tint toward your accent hue instead)
 - Identical card grids (same-size cards repeated)
 - Everything centered with equal weight (lead the eye somewhere)
-- Banned fonts (see [references/typography.md](references/typography.md) for full list)
+- Banned fonts (see [typography.md](typography.md) for full list)
 
 If the content genuinely calls for one of these — centered layout for a solemn closing, cards for a real product UI mockup, a banned font because it's the perfect thematic match — use it. The goal is intentionality, not avoidance.
 
@@ -48,26 +48,26 @@ All decoratives should have slow ambient GSAP animation — breathing, drift, pu
 
 ## Motion
 
-See [references/motion-principles.md](references/motion-principles.md) for full rules. Quick: 0.3–0.6s, vary eases, combine transforms on entrances, overlap entries.
+See [motion-principles.md](motion-principles.md) for full rules. Quick: 0.3–0.6s, vary eases, combine transforms on entrances, overlap entries.
 
 ## Typography
 
-See [references/typography.md](references/typography.md) for full rules. Quick: 700-900 headlines / 300-400 body, serif + sans (not two sans), 60px+ headlines / 20px+ body.
+See [typography.md](typography.md) for full rules. Quick: 700-900 headlines / 300-400 body, serif + sans (not two sans), 60px+ headlines / 20px+ body.
 
 ## Palettes
 
 Declare one background, one foreground, one accent before writing HTML.
 
-| Category          | Use for                                       | File                                                       |
-| ----------------- | --------------------------------------------- | ---------------------------------------------------------- |
-| Bold / Energetic  | Product launches, social media, announcements | [palettes/bold-energetic.md](palettes/bold-energetic.md)   |
-| Warm / Editorial  | Storytelling, documentaries, case studies     | [palettes/warm-editorial.md](palettes/warm-editorial.md)   |
-| Dark / Premium    | Tech, finance, luxury, cinematic              | [palettes/dark-premium.md](palettes/dark-premium.md)       |
-| Clean / Corporate | Explainers, tutorials, presentations          | [palettes/clean-corporate.md](palettes/clean-corporate.md) |
-| Nature / Earth    | Sustainability, outdoor, organic              | [palettes/nature-earth.md](palettes/nature-earth.md)       |
-| Neon / Electric   | Gaming, tech, nightlife                       | [palettes/neon-electric.md](palettes/neon-electric.md)     |
-| Pastel / Soft     | Fashion, beauty, lifestyle, wellness          | [palettes/pastel-soft.md](palettes/pastel-soft.md)         |
-| Jewel / Rich      | Luxury, events, sophisticated                 | [palettes/jewel-rich.md](palettes/jewel-rich.md)           |
-| Monochrome        | Dramatic, typography-focused                  | [palettes/monochrome.md](palettes/monochrome.md)           |
+| Category          | Use for                                       | File                                                          |
+| ----------------- | --------------------------------------------- | ------------------------------------------------------------- |
+| Bold / Energetic  | Product launches, social media, announcements | [palettes/bold-energetic.md](../palettes/bold-energetic.md)   |
+| Warm / Editorial  | Storytelling, documentaries, case studies     | [palettes/warm-editorial.md](../palettes/warm-editorial.md)   |
+| Dark / Premium    | Tech, finance, luxury, cinematic              | [palettes/dark-premium.md](../palettes/dark-premium.md)       |
+| Clean / Corporate | Explainers, tutorials, presentations          | [palettes/clean-corporate.md](../palettes/clean-corporate.md) |
+| Nature / Earth    | Sustainability, outdoor, organic              | [palettes/nature-earth.md](../palettes/nature-earth.md)       |
+| Neon / Electric   | Gaming, tech, nightlife                       | [palettes/neon-electric.md](../palettes/neon-electric.md)     |
+| Pastel / Soft     | Fashion, beauty, lifestyle, wellness          | [palettes/pastel-soft.md](../palettes/pastel-soft.md)         |
+| Jewel / Rich      | Luxury, events, sophisticated                 | [palettes/jewel-rich.md](../palettes/jewel-rich.md)           |
+| Monochrome        | Dramatic, typography-focused                  | [palettes/monochrome.md](../palettes/monochrome.md)           |
 
 Or derive from OKLCH — pick a hue, build bg/fg/accent at different lightnesses, tint everything toward that hue.


### PR DESCRIPTION
## What changed

- Fixes relative links in the hyperframes-creative house style reference.

- Updates the generated skills manifest for the changed skill content.

## Why
- The document lived under `references/`, so links like `references/typography.md` and `palettes/...` pointed at non-existent nested paths.

## Validation

- Ran a local relative-link check for `skills/hyperframes-creative/references/house-style.md`.

- `git diff --check -- skills/hyperframes-creative/references/house-style.md`
