### PR TITLE
docs(pipeline): fix techniques reference link

### DIFF
--- a/docs/guides/pipeline.mdx
+++ b/docs/guides/pipeline.mdx
@@ -116,7 +116,7 @@ Each beat in `STORYBOARD.md` typically covers:
 | Narration line   | The exact words spoken during this beat |
 | Mood & camera    | One sentence describing the feel and the shot |
 | Assets           | Which captured images, icons, and fonts go in this beat, referenced by path |
-| Techniques       | 2-3 picks from the [techniques library](https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes/references/techniques.md): SVG path drawing, Canvas 2D, CSS 3D, per-word typography, Lottie, video compositing, typing effects, variable fonts, MotionPath, velocity transitions, audio-reactive |
+| Techniques       | 2-3 picks from the [techniques library](https://github.com/heygen-com/hyperframes/blob/main/skills/hyperframes-animation/techniques.md): SVG path drawing, Canvas 2D, CSS 3D, per-word typography, Lottie, video compositing, typing effects, variable fonts, MotionPath, velocity transitions, audio-reactive |
 | Transitions      | How this beat enters from the previous one and exits to the next |
 | SFX              | Short, specific sound effects (e.g. _"woosh on logo entry, soft tick on counter"_) |
 


### PR DESCRIPTION
## Summary

- Update the pipeline guide techniques-library link to the current hyperframes-animation skill path.

## Validation
- git diff --check -- docs/guides/pipeline.mdx

- test -f skills/hyperframes-animation/techniques.md


