### PR TITLE
docs(registry): clarify catalog preview asset path

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -42,7 +42,7 @@
       "files": 3
     },
     "hyperframes-registry": {
-      "hash": "3a864992e765b9bf",
+      "hash": "ed9c109625e59cd6",
       "files": 10
     },
     "media-use": {

--- a/skills/hyperframes-registry/references/contributing.md
+++ b/skills/hyperframes-registry/references/contributing.md
@@ -114,7 +114,7 @@ hyperframes snapshot --at "1.0,3.0,5.0,7.0"
 npx hyperframes publish
 ```
 
-**Catalog preview image** — The catalog card uses a PNG at `docs/images/catalog/{kind}/{name}.png` (where `{kind}` is `blocks` or `components`). Generate it from a snapshot, then:
+**Catalog preview image** — The catalog card uses the uploaded PNG at `https://static.heygen.ai/hyperframes-oss/docs/images/catalog/{kind}/{name}.png` (where `{kind}` is `blocks` or `components`). Generate it from a snapshot, then:
 
 - **HeyGen internal contributors:** run `scripts/upload-docs-images.sh` (requires AWS profile `engineering-767398024897`)
 - **External contributors:** attach the preview MP4 to your PR description. A maintainer will generate and upload the catalog image before merging.


### PR DESCRIPTION
## Summary

- Clarify that catalog preview cards use uploaded static asset URLs.
- Include the generated skills manifest hash update from the pre-commit hook.

## Validation
- git diff --check -- skills/hyperframes-registry/references/contributing.md





