### PR TITLE
docs(cli): document publish command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,6 +49,22 @@ npx hyperframes render -o output.mp4
 npx hyperframes render -c ./my-composition.html -o output.mp4
 ```
 
+### `publish`
+
+Upload a project and create a stable public URL:
+
+```bash
+npx hyperframes publish
+npx hyperframes publish ./my-video
+npx hyperframes publish --public
+npx hyperframes publish --update <url-or-id>
+npx hyperframes publish --space <space-id>
+npx hyperframes publish --yes
+```
+
+Use `--public` to make a claimed project available to anyone, rather than only
+to the user who claimed it.
+
 ### `lint`
 
 Validate your Hyperframes HTML:


### PR DESCRIPTION
## Summary

- Document the existing `hyperframes publish` command in the CLI README.

## Validation
- git diff --check -- packages/cli/README.md

- verified the publish command metadata and examples in packages/cli/src/commands/publish.ts


