### PR TITLE
fix(lambda): define dirname in handler bundle

### DIFF
--- a/packages/aws-lambda/scripts/build-zip.test.ts
+++ b/packages/aws-lambda/scripts/build-zip.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("build-zip handler banner", () => {
+  it("defines CommonJS path globals for inlined CJS dependencies", () => {
+    const source = readFileSync(fileURLToPath(new URL("./build-zip.ts", import.meta.url)), "utf8");
+
+    expect(source).toContain('import { fileURLToPath as __hf_fileURLToPath } from "url";');
+    expect(source).toContain('import { dirname as __hf_dirname } from "path";');
+    expect(source).toContain("const __filename = __hf_fileURLToPath(import.meta.url);");
+    expect(source).toContain("const __dirname = __hf_dirname(__filename);");
+  });
+});

--- a/packages/aws-lambda/scripts/build-zip.ts
+++ b/packages/aws-lambda/scripts/build-zip.ts
@@ -252,6 +252,10 @@ async function bundleHandler(stagingDir: string): Promise<void> {
         "// hyperframes-aws-lambda handler bundle",
         'import { createRequire as __hf_createRequire } from "module";',
         "const require = __hf_createRequire(import.meta.url);",
+        'import { fileURLToPath as __hf_fileURLToPath } from "url";',
+        'import { dirname as __hf_dirname } from "path";',
+        "const __filename = __hf_fileURLToPath(import.meta.url);",
+        "const __dirname = __hf_dirname(__filename);",
       ].join("\n"),
     },
   });


### PR DESCRIPTION
## Summary
- extend the existing Lambda handler esbuild banner with `__filename` and `__dirname` globals
- keep the existing `createRequire` shim intact; this does not add a second `banner` key
- add a regression test pinning the handler bundle banner requirements

Fixes #1932.

## Repro evidence
- Minimal esbuild ESM bundle importing `wawoff2` fails on current code with `ReferenceError: __dirname is not defined in ES module scope`.
- The dependency path matches the issue: `wawoff2/build/compress_binding.js` uses top-level `__dirname`.
- With the patched banner, the same minimal bundle imports successfully.

## Verification
- `bun test scripts/build-zip.test.ts`
- `bun test` in `packages/aws-lambda` — 114 tests pass
- `bun run typecheck` in `packages/aws-lambda`
- `bun run --filter @hyperframes/producer build`
- `bun run build` in `packages/aws-lambda`
- `bunx oxfmt --check packages/aws-lambda/scripts/build-zip.ts packages/aws-lambda/scripts/build-zip.test.ts`
- `bunx oxlint packages/aws-lambda/scripts/build-zip.ts packages/aws-lambda/scripts/build-zip.test.ts`