### PR TITLE
fix(cli): prefer real ffmpeg exe over cmd shim

### DIFF
--- a/packages/cli/src/browser/ffmpeg.test.ts
+++ b/packages/cli/src/browser/ffmpeg.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({ execSync: vi.fn() }));
@@ -23,6 +24,14 @@ afterEach(() => {
 });
 
 describe("findFFmpeg", () => {
+  it("prefers the real Windows exe when where lists a cmd shim first", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    mockExec.mockReturnValue("C:\\tools\\ffmpeg.cmd\r\nC:\\tools\\ffmpeg.exe\r\n");
+
+    const { findFFmpeg } = await import("./ffmpeg.js");
+    expect(findFFmpeg()).toBe(resolve("C:\\tools\\ffmpeg.exe"));
+  });
+
   it("falls back to a common install dir when `which` fails (GUI-launched PATH)", async () => {
     // Simulate a process whose PATH lacks /opt/homebrew/bin: `which ffmpeg` throws.
     mockExec.mockImplementation(() => {

--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -7,6 +7,26 @@ import { detectLinuxDistro, ffmpegInstallCommand } from "./linuxDeps.js";
 export const FFMPEG_PATH_ENV = "HYPERFRAMES_FFMPEG_PATH";
 export const FFPROBE_PATH_ENV = "HYPERFRAMES_FFPROBE_PATH";
 
+function chooseBestPathCandidate(
+  name: "ffmpeg" | "ffprobe",
+  candidates: string[],
+): string | undefined {
+  const normalized = candidates.map((s) => s.trim()).filter(Boolean);
+  if (normalized.length === 0) return undefined;
+  const lowerName = name.toLowerCase();
+  const preferredExe = normalized.find((candidate) =>
+    candidate.toLowerCase().endsWith(`${lowerName}.exe`),
+  );
+  if (preferredExe) return preferredExe;
+  const exact = normalized.find((candidate) => candidate.toLowerCase().endsWith(lowerName));
+  if (exact) return exact;
+  const nonShellShim = normalized.find((candidate) => {
+    const lower = candidate.toLowerCase();
+    return !lower.endsWith(".cmd") && !lower.endsWith(".bat");
+  });
+  return nonShellShim ?? normalized[0];
+}
+
 function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
   try {
     const cmd = process.platform === "win32" ? `where ${name}` : `which ${name}`;
@@ -15,11 +35,8 @@ function findOnPath(name: "ffmpeg" | "ffprobe"): string | undefined {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
     });
-    const first = output
-      .split(/\r?\n/)
-      .map((s) => s.trim())
-      .find(Boolean);
-    return first ? resolve(first) : undefined;
+    const candidate = chooseBestPathCandidate(name, output.split(/\r?\n/));
+    return candidate ? resolve(candidate) : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

CLI preflight now chooses the real Windows `ffmpeg.exe`/`ffprobe.exe` when `where` lists a `.cmd` shim before the executable. Before this, `hyperframes render` could export `HYPERFRAMES_FFMPEG_PATH=...ffmpeg.cmd`, which bypassed the engine-side resolver hardening from #1955 and handed the producer a shell shim instead of the executable.

The CLI path selection now matches the engine resolver ordering: prefer `.exe`, then exact binary names, then non-shell-shim candidates, with the first candidate as the final fallback.

## Test Plan

- `bun run --filter @hyperframes/cli test -- src/browser/ffmpeg.test.ts`
- `bun run --filter @hyperframes/engine test -- src/utils/ffmpegBinaries.test.ts`
- `bun run --filter @hyperframes/cli typecheck`
- `bunx oxfmt --check packages/cli/src/browser/ffmpeg.ts packages/cli/src/browser/ffmpeg.test.ts`
- `bunx oxlint packages/cli/src/browser/ffmpeg.ts packages/cli/src/browser/ffmpeg.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
