### PR TITLE
feat(cli): parakeet ASR engine for transcribe + HYPERFRAMES_PYTHON override

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,58 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.38"
+  description="Released - 2026-07-07"
+  tags={["Release", "Engine,producer,cli", "CLI", "Studio"]}
+>
+drawElement fast capture is now **on by default** for macOS hardware-GPU renders — roughly 2× faster capture, wrapped in a per-render self-verification net that automatically falls back to the classic screenshot path if a frame can't be proven correct (kill switch: `PRODUCER_EXPERIMENTAL_FAST_CAPTURE=false`). Also new: media color grading (Studio inspector + runtime shaders), end-to-end render cancel, and richer render telemetry.
+
+## Features
+
+- **Engine,producer,cli:** DrawElement release telemetry on render_complete ([100570344](https://github.com/heygen-com/hyperframes/commit/1005703441c122e5462f34e0212e52e5490407a0), [#2002](https://github.com/heygen-com/hyperframes/pull/2002))
+- **Studio,studio Server,cli:** Render cancel end-to-end + renders/nle/storyboard UX ([241f9d683](https://github.com/heygen-com/hyperframes/commit/241f9d683ec7f34c9c398cc2a6c2d272a6e38268), [#1963](https://github.com/heygen-com/hyperframes/pull/1963))
+- **Engine,producer:** DrawElement fast-capture default-on with runtime self-verification safety net ([ec06f4bf8](https://github.com/heygen-com/hyperframes/commit/ec06f4bf895d811b3b1cf140e53e79244bbd1f9a), [#1998](https://github.com/heygen-com/hyperframes/pull/1998))
+- **Lint,player:** Fast-capture lint rule + player media sync ([992a9b660](https://github.com/heygen-com/hyperframes/commit/992a9b660708e3c4ca17620fb01265db95aaca59), [#1921](https://github.com/heygen-com/hyperframes/pull/1921))
+- **Producer:** Fast-capture render stages + remote bg-image localizer ([1d0dbcd3b](https://github.com/heygen-com/hyperframes/commit/1d0dbcd3b2a81ce00ca2deef5d6cc44f3b22ef96), [#1920](https://github.com/heygen-com/hyperframes/pull/1920))
+- **Engine:** Frame-capture core — fast-capture routing, worker-encode, dedup extension ([0e58344dc](https://github.com/heygen-com/hyperframes/commit/0e58344dca3052ca1e83337d22c54b977852f5b3), [#1919](https://github.com/heygen-com/hyperframes/pull/1919))
+- **Engine:** 3D projection + compositor-effect risk gate ([4749fe571](https://github.com/heygen-com/hyperframes/commit/4749fe5716357b4c1521d6a1644ab0be013976c1), [#1918](https://github.com/heygen-com/hyperframes/pull/1918))
+- **Engine:** DrawElementImage capture service ([795934adb](https://github.com/heygen-com/hyperframes/commit/795934adbac849cba6ec0b0ea83dc69b509a4f4c), [#1917](https://github.com/heygen-com/hyperframes/pull/1917))
+- **Studio:** Harden ui primitives — focus rings, keyboard tooltips, dialog hook ([cd1adcb58](https://github.com/heygen-com/hyperframes/commit/cd1adcb581d4638433b4f8c4d43986b419256762), [#1962](https://github.com/heygen-com/hyperframes/pull/1962))
+- **Engine,cli:** DrawElement fast-capture config + CLI flag ([e04f6dda3](https://github.com/heygen-com/hyperframes/commit/e04f6dda37bf7dd2fe5bf564ecac55713869d2d5), [#1916](https://github.com/heygen-com/hyperframes/pull/1916))
+- **Lint:** Warn when \<html dir\> can blank render output ([afa7f292f](https://github.com/heygen-com/hyperframes/commit/afa7f292fb267bb6498bf58afba18369574eee92), [#1893](https://github.com/heygen-com/hyperframes/pull/1893))
+- **CLI:** Emit sign-in lifecycle telemetry ([769dc702c](https://github.com/heygen-com/hyperframes/commit/769dc702c1d62b86f1f5b2a05d76af39fc1be6b2), [#2000](https://github.com/heygen-com/hyperframes/pull/2000))
+- **Studio:** Add color grading inspector ([139cf568b](https://github.com/heygen-com/hyperframes/commit/139cf568b481cd50a7d9d80ac2c00b6ec1a6410b))
+- **Studio Server:** Add media processing routes ([a3bf7eb99](https://github.com/heygen-com/hyperframes/commit/a3bf7eb995ae1b6cc6f6c95a999d19e6df3526b6))
+- **Runtime:** Render media color grading shaders ([870964b0c](https://github.com/heygen-com/hyperframes/commit/870964b0cf190702c76066aaef7c81ea4424f7ab))
+- **Core:** Add media color grading contract ([7c1443849](https://github.com/heygen-com/hyperframes/commit/7c144384962e6f4ce55046884055f6f462d044cf))
+- **CLI:** Figma import telemetry — subcommand labels, typed error codes, figma_import event ([e9076324e](https://github.com/heygen-com/hyperframes/commit/e9076324e703fdd91142b7f138b2f2c96cba1376), [#1979](https://github.com/heygen-com/hyperframes/pull/1979))
+- **Cli/telemetry:** Surface unrecognized agents in the agent_runtime=null bucket ([232d59147](https://github.com/heygen-com/hyperframes/commit/232d591479448233a9a54097da0963fc1034e450), [#1978](https://github.com/heygen-com/hyperframes/pull/1978))
+
+## Fixes
+
+- **CLI:** Localize remote assets before validate so it matches render ([906c8d04f](https://github.com/heygen-com/hyperframes/commit/906c8d04f85b909252753b24102cdbad1780378d), [#2001](https://github.com/heygen-com/hyperframes/pull/2001))
+- **Studio:** Shell UX — data-loss guards, error surfacing, dialog contracts, toasts ([89e36da13](https://github.com/heygen-com/hyperframes/commit/89e36da13dcd5cda4455fa48e9cbb4d9b7f7dbda), [#1964](https://github.com/heygen-com/hyperframes/pull/1964))
+- **Compiler:** Don't scan media tags inside comments/scripts; DOM-check auto-start (#1938) ([1a3330a97](https://github.com/heygen-com/hyperframes/commit/1a3330a972d98de09a93e4cf6d1a61fcc1a63cb1), [#1940](https://github.com/heygen-com/hyperframes/pull/1940))
+- **Studio:** Share safe media path cleanup ([04f96da16](https://github.com/heygen-com/hyperframes/commit/04f96da16967eecff82dfb16e2e0cd238469ffb5))
+- **Studio:** Avoid regex in media asset path cleanup ([e0090efbf](https://github.com/heygen-com/hyperframes/commit/e0090efbf6946d8b28e54159e95dbd8b0a82484e))
+- **Studio:** Split color grading inspector files ([30a944de3](https://github.com/heygen-com/hyperframes/commit/30a944de342de0ff7715946a7d80c6f96d9e9074))
+- **Studio Server:** Share background removal job runner ([413ee07da](https://github.com/heygen-com/hyperframes/commit/413ee07da51c76a1430a58f40fb81021f1adb05c))
+- **Runtime:** Satisfy color grading audit ([644ae384a](https://github.com/heygen-com/hyperframes/commit/644ae384a549cea6a686c07344e99b87366c0480))
+- **Parsers,sdk,studio Server,studio:** Unify hf-id space across preview, disk, and SDK session ([3a717fa71](https://github.com/heygen-com/hyperframes/commit/3a717fa71997477c6f81dce7c9f2e63a4ad675ed), [#1981](https://github.com/heygen-com/hyperframes/pull/1981))
+
+## Performance
+
+- **Engine,producer:** Batch N drawElement frames per CDP round-trip (HF_DE_BATCH) ([d5ecb013d](https://github.com/heygen-com/hyperframes/commit/d5ecb013d71763891b8092c4bc081bb12b3d4782), [#1928](https://github.com/heygen-com/hyperframes/pull/1928))
+
+## Docs & Examples
+
+- **Figma:** Storyboard blurb reworded + frames-are-app-states escalation ([ccc130883](https://github.com/heygen-com/hyperframes/commit/ccc1308839a73e3a7d76fff4669a9a220b7eff11), [#2004](https://github.com/heygen-com/hyperframes/pull/2004))
+- Document Studio Color Grading ([b38c054ba](https://github.com/heygen-com/hyperframes/commit/b38c054baf97b90770f64310785fb514b0051de4))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.37...v0.7.38).
+</Update>
+
+<Update
   label="HyperFrames v0.7.37"
   description="Released - 2026-07-06"
   tags={["Release", "Lambda", "Sdk,studio", "Hyperframes Media"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/cli/src/audio/providers.ts
+++ b/packages/cli/src/audio/providers.ts
@@ -1,7 +1,7 @@
 /**
  * Which voice / music engine a workflow will actually use, and whether
  * its local dependencies are present. Mirrors the resolution order the
- * hyperframes-media skill scripts use, so `auth status` and `doctor`
+ * media-use skill scripts use, so `auth status` and `doctor`
  * report the same engine the render pipeline would pick:
  *
  *   voice: HeyGen Starfish → ElevenLabs (key + `elevenlabs`) → Kokoro (local)

--- a/packages/cli/src/commands/auth/status-guidance.ts
+++ b/packages/cli/src/commands/auth/status-guidance.ts
@@ -63,7 +63,7 @@ function offlineEngineLines(engines?: OfflineEngineLine[]): string[] {
  * so it's left to the docs — not dangled here as a command a fresh machine
  * can't run. Names the local fallback so "no key" never reads as a failure,
  * and never steers users toward a per-repo `.env`. Mirrors the
- * hyperframes-media skill's Preflight section.
+ * media-use skill's Preflight section.
  */
 export function buildUnconfiguredLines(
   ctx: UnconfiguredContext,

--- a/packages/cli/src/commands/transcribe.ts
+++ b/packages/cli/src/commands/transcribe.ts
@@ -1,6 +1,8 @@
+// fallow-ignore-file code-duplication
 import { defineCommand } from "citty";
 import type { Example } from "./_examples.js";
 import { existsSync, writeFileSync } from "node:fs";
+import { findParakeet, transcribeWithParakeet } from "../whisper/parakeet.js";
 
 type CaptionExportFormat = "srt" | "vtt";
 
@@ -40,6 +42,12 @@ export default defineCommand({
       type: "string",
       description: "Project directory (default: current directory)",
       alias: "d",
+    },
+    engine: {
+      type: "string",
+      description:
+        "ASR engine: auto (Parakeet if installed, else whisper), parakeet, or whisper. Default: auto. Parakeet is more accurate and faster; enable with `uv pip install parakeet-mlx`.",
+      alias: "e",
     },
     model: {
       type: "string",
@@ -111,8 +119,9 @@ export default defineCommand({
       return importTranscript(inputPath, dir, args.json);
     }
 
-    // ── Transcribe mode: run whisper ─────────────────────────────────────
+    // ── Transcribe mode: run the ASR engine ──────────────────────────────
     return transcribeAudio(inputPath, dir, {
+      engine: args.engine,
       model: args.model,
       language: args.language,
       json: args.json,
@@ -213,25 +222,45 @@ async function exportTranscript(
 // Transcribe audio/video with whisper
 // ---------------------------------------------------------------------------
 
+// fallow-ignore-next-line complexity
 async function transcribeAudio(
   inputPath: string,
   dir: string,
-  opts: { model?: string; language?: string; json?: boolean; optional?: boolean },
+  opts: { engine?: string; model?: string; language?: string; json?: boolean; optional?: boolean },
 ): Promise<void> {
   const { transcribe } = await import("../whisper/transcribe.js");
   const { loadTranscript, patchCaptionHtml, stripBeforeOnset } =
     await import("../whisper/normalize.js");
 
+  // Engine: auto (Parakeet if installed, else whisper), or forced parakeet/whisper.
+  const engine = (opts.engine ?? "auto").toLowerCase();
+  if (engine !== "auto" && engine !== "parakeet" && engine !== "whisper") {
+    failWith(`Unknown --engine: ${opts.engine}. Use auto, parakeet, or whisper.`, !!opts.json);
+  }
+  const useParakeet = engine === "parakeet" || (engine === "auto" && !!findParakeet());
+
   const model = opts.model ?? DEFAULT_MODEL;
+  // --model selects the whisper model only; Parakeet uses its own fixed model.
+  if (useParakeet && opts.model && !opts.json) {
+    console.error(
+      c.dim(`  Note: --model applies to the whisper engine only; ignored under Parakeet.`),
+    );
+  }
+  const label = useParakeet ? "Parakeet" : model;
   const spin = opts.json ? null : clack.spinner();
-  spin?.start(`Transcribing with ${c.accent(model)}...`);
+  spin?.start(`Transcribing with ${c.accent(label)}...`);
 
   try {
-    const result = await transcribe(inputPath, dir, {
-      model,
-      language: opts.language,
-      onProgress: spin ? (msg) => spin.message(msg) : undefined,
-    });
+    const result = useParakeet
+      ? transcribeWithParakeet(inputPath, dir, {
+          language: opts.language,
+          onProgress: spin ? (msg) => spin.message(msg) : undefined,
+        })
+      : await transcribe(inputPath, dir, {
+          model,
+          language: opts.language,
+          onProgress: spin ? (msg) => spin.message(msg) : undefined,
+        });
 
     let { words } = loadTranscript(result.transcriptPath);
 
@@ -253,7 +282,8 @@ async function transcribeAudio(
       console.log(
         JSON.stringify({
           ok: true,
-          model,
+          engine: useParakeet ? "parakeet" : "whisper",
+          model: useParakeet ? "parakeet-tdt-0.6b-v3" : model,
           wordCount: words.length,
           durationSeconds: result.durationSeconds,
           speechOnsetSeconds: result.speechOnsetSeconds,
@@ -272,7 +302,15 @@ async function transcribeAudio(
       );
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    // Surface the last few lines of the ASR subprocess's stderr, which
+    // execFileSync captures but otherwise drops on the floor — that's where
+    // parakeet-mlx / whisper report the actual failure cause.
+    const stderr =
+      err && typeof err === "object" && "stderr" in err && err.stderr
+        ? String(err.stderr).trim().split("\n").slice(-3).join("\n")
+        : "";
+    const base = err instanceof Error ? err.message : String(err);
+    const message = stderr ? `${base}\n${stderr}` : base;
 
     // whisper-cpp is an optional prerequisite, not part of the CLI. When it is
     // simply unavailable (no binary, no toolchain to build one), that is a setup

--- a/packages/cli/src/commands/tts.ts
+++ b/packages/cli/src/commands/tts.ts
@@ -1,3 +1,4 @@
+// fallow-ignore-file code-duplication
 import { defineCommand } from "citty";
 import type { Example } from "./_examples.js";
 import { existsSync, readFileSync } from "node:fs";
@@ -48,7 +49,7 @@ export default defineCommand({
     output: {
       type: "string",
       description: "Output file path (default: speech.wav in current directory)",
-      alias: "o",
+      alias: ["o", "out"],
     },
     voice: {
       type: "string",
@@ -76,6 +77,7 @@ export default defineCommand({
       default: false,
     },
   },
+  // fallow-ignore-next-line complexity
   async run({ args }) {
     // ── List voices mode ──────────────────────────────────────────────
     if (args.list) {

--- a/packages/cli/src/templates/_shared/AGENTS.md
+++ b/packages/cli/src/templates/_shared/AGENTS.md
@@ -17,7 +17,7 @@
 
 **Porting an existing composition?** `/remotion-to-hyperframes` translates a Remotion (React) composition into HyperFrames HTML — a source migration, separate from the creation workflows above.
 
-The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/hyperframes-media`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
+The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/media-use`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
 
 > **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
 

--- a/packages/cli/src/templates/_shared/CLAUDE.md
+++ b/packages/cli/src/templates/_shared/CLAUDE.md
@@ -17,7 +17,7 @@
 
 **Porting an existing composition?** `/remotion-to-hyperframes` translates a Remotion (React) composition into HyperFrames HTML — a source migration, separate from the creation workflows above.
 
-The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/hyperframes-media`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
+The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/media-use`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
 
 > **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
 

--- a/packages/cli/src/tts/python.ts
+++ b/packages/cli/src/tts/python.ts
@@ -8,8 +8,21 @@
 
 import { execFileSync } from "node:child_process";
 
-/** Locate a `python3` (or `python`) on PATH that reports as Python 3. */
+/** Locate a Python 3: `HYPERFRAMES_PYTHON` env override first, then PATH. */
 export function findPython(): string | undefined {
+  const override = process.env.HYPERFRAMES_PYTHON;
+  if (override) {
+    try {
+      const version = execFileSync(override, ["--version"], {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 5000,
+      });
+      if (/Python 3/.test(version)) return override;
+    } catch {
+      // fall through to the PATH probe
+    }
+  }
   for (const name of ["python3", "python"]) {
     try {
       const cmd = process.platform === "win32" ? "where" : "which";

--- a/packages/cli/src/tts/synthesize.ts
+++ b/packages/cli/src/tts/synthesize.ts
@@ -110,6 +110,7 @@ export interface SynthesizeResult {
 /**
  * Synthesize text to speech using Kokoro-82M via kokoro-onnx.
  */
+// fallow-ignore-next-line complexity
 export async function synthesize(
   text: string,
   outputPath: string,
@@ -124,13 +125,13 @@ export async function synthesize(
   const python = findPython();
   if (!python) {
     throw new Error(
-      "Python 3 is required for text-to-speech. Install Python 3.8+ and run: pip install kokoro-onnx soundfile",
+      "Python 3 is required for text-to-speech. Install Python 3.10+ and run: pip install kokoro-onnx soundfile (or point HYPERFRAMES_PYTHON at a venv python that has them)",
     );
   }
 
   if (!hasPythonPackage(python, "kokoro_onnx")) {
     throw new Error(
-      "The kokoro-onnx package is not installed. Run: pip install kokoro-onnx soundfile",
+      "The kokoro-onnx package is not installed. Run: pip install kokoro-onnx soundfile (or point HYPERFRAMES_PYTHON at a venv python that has them)",
     );
   }
 

--- a/packages/cli/src/whisper/parakeet.test.ts
+++ b/packages/cli/src/whisper/parakeet.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { mergeTokensToWords } from "./parakeet.js";
+
+describe("mergeTokensToWords", () => {
+  it("joins Parakeet sub-word tokens into words on the space boundary", () => {
+    const words = mergeTokensToWords({
+      text: "Hello everyone. Um,",
+      sentences: [
+        {
+          tokens: [
+            { text: " H", start: 0.0, end: 0.24 },
+            { text: "ello", start: 0.24, end: 0.48 },
+            { text: " everyone.", start: 0.48, end: 1.28 },
+            { text: " Um,", start: 1.28, end: 1.92 },
+          ],
+        },
+      ],
+    });
+    expect(words).toEqual([
+      { text: "Hello", start: 0.0, end: 0.48 },
+      { text: "everyone.", start: 0.48, end: 1.28 },
+      { text: "Um,", start: 1.28, end: 1.92 },
+    ]);
+  });
+
+  it("spans sentences and tolerates missing tokens", () => {
+    expect(mergeTokensToWords({}).length).toBe(0);
+    const words = mergeTokensToWords({
+      sentences: [
+        { tokens: [{ text: "Hi", start: 0, end: 0.2 }] },
+        { tokens: [{ text: " there", start: 0.5, end: 0.9 }] },
+      ],
+    });
+    expect(words.map((w) => w.text)).toEqual(["Hi", "there"]);
+    expect(words[1]!.start).toBe(0.5);
+  });
+});

--- a/packages/cli/src/whisper/parakeet.ts
+++ b/packages/cli/src/whisper/parakeet.ts
@@ -1,0 +1,151 @@
+/**
+ * Parakeet-TDT transcription engine (via parakeet-mlx on Apple Silicon).
+ *
+ * The higher-accuracy alternative to the whisper.cpp engine: NVIDIA Parakeet
+ * beats whisper-large-v3 on the Open ASR Leaderboard (~6.05% vs 7.44% avg WER,
+ * and 4.73% vs 5.96% on noisy audio where whisper-v3 hallucinates), while being
+ * 5-10x faster. Covers English + 25 European languages; whisper stays the
+ * multilingual fallback.
+ *
+ * Like the Kokoro TTS path, this is a user-installed local model: we DETECT it
+ * and, if absent, tell the user how to enable it (no auto-install). parakeet-mlx
+ * emits sub-word TOKENS; we merge them into the word timestamps the rest of the
+ * pipeline consumes.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, extname, join } from "node:path";
+import type { Word } from "./normalize.js";
+import type { TranscribeResult } from "./transcribe.js";
+
+const DEFAULT_MODEL = "mlx-community/parakeet-tdt-0.6b-v3";
+const PARAKEET_INSTALL =
+  "uv venv ~/.venvs/parakeet && VIRTUAL_ENV=~/.venvs/parakeet uv pip install parakeet-mlx";
+
+/** Verify a candidate binary actually runs (mirrors the --version gate on
+ *  HYPERFRAMES_PYTHON) so a stale $HYPERFRAMES_PARAKEET path can't shadow a
+ *  working install on PATH. */
+function isRunnable(bin: string): boolean {
+  try {
+    execFileSync(bin, ["--help"], { stdio: ["ignore", "ignore", "ignore"], timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Locate the `parakeet-mlx` runner: env override, the documented venv, then PATH. */
+export function findParakeet(): string | undefined {
+  const candidates = [
+    process.env.HYPERFRAMES_PARAKEET,
+    join(homedir(), ".venvs", "parakeet", "bin", "parakeet-mlx"),
+  ].filter((p): p is string => Boolean(p));
+
+  for (const path of candidates) {
+    if (existsSync(path) && isRunnable(path)) return path;
+  }
+  try {
+    const which = process.platform === "win32" ? "where" : "which";
+    const out = execFileSync(which, ["parakeet-mlx"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    });
+    const first = out
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find(Boolean);
+    if (first && existsSync(first)) return first;
+  } catch {
+    // not on PATH
+  }
+  return undefined;
+}
+
+interface ParakeetToken {
+  text?: string;
+  start?: number;
+  end?: number;
+}
+interface ParakeetJson {
+  text?: string;
+  sentences?: { tokens?: ParakeetToken[] }[];
+}
+
+/**
+ * Merge Parakeet's sub-word tokens (" H", "ello", ...) into words on the space
+ * boundary: a token starting with a space (or the first token) begins a word;
+ * the rest append. Produces the { text, start, end } words the pipeline uses.
+ */
+function tokenBounds(token: ParakeetToken): { text: string; start: number; end: number } {
+  const text = typeof token.text === "string" ? token.text : "";
+  const start = typeof token.start === "number" ? token.start : 0;
+  const end = typeof token.end === "number" ? token.end : start;
+  return { text, start, end };
+}
+
+export function mergeTokensToWords(parakeet: ParakeetJson): Word[] {
+  const words: Word[] = [];
+  for (const sentence of parakeet.sentences ?? []) {
+    for (const token of sentence.tokens ?? []) {
+      const { text, start, end } = tokenBounds(token);
+      if (text.startsWith(" ") || words.length === 0) {
+        words.push({ text: text.trim(), start, end });
+      } else {
+        const w = words[words.length - 1]!;
+        w.text += text;
+        w.end = end;
+      }
+    }
+  }
+  return words.filter((w) => w.text.length > 0);
+}
+
+interface ParakeetOptions {
+  language?: string;
+  model?: string;
+  onProgress?: (message: string) => void;
+}
+
+/** Transcribe with Parakeet and write `transcript.json` (Word[]) into `dir`. */
+export function transcribeWithParakeet(
+  inputPath: string,
+  dir: string,
+  options?: ParakeetOptions,
+): TranscribeResult {
+  const runner = findParakeet();
+  if (!runner) {
+    throw new Error(
+      `parakeet-mlx not found. Enable the Parakeet engine with:\n  ${PARAKEET_INSTALL}\n(or use --engine whisper)`,
+    );
+  }
+
+  const model = options?.model ?? DEFAULT_MODEL;
+  // First run pulls the model from HuggingFace (~600MB) — cue it so the wait
+  // doesn't read as a hang. HF caches at ~/.cache/huggingface/hub/models--<slug>.
+  const cached = existsSync(
+    join(homedir(), ".cache", "huggingface", "hub", `models--${model.replace(/\//g, "--")}`),
+  );
+  options?.onProgress?.(
+    cached ? "Transcribing with Parakeet..." : "Downloading Parakeet model (first run, ~600MB)...",
+  );
+  const workDir = mkdtempSync(join(tmpdir(), "hyperframes-parakeet-"));
+  try {
+    const argv = [inputPath, "--model", model, "--output-format", "json", "--output-dir", workDir];
+    if (options?.language) argv.push("--language", options.language);
+    execFileSync(runner, argv, { stdio: ["ignore", "pipe", "pipe"], timeout: 1_800_000 });
+
+    const produced = join(workDir, `${basename(inputPath, extname(inputPath))}.json`);
+    if (!existsSync(produced)) throw new Error("Parakeet did not produce output.");
+    const words = mergeTokensToWords(JSON.parse(readFileSync(produced, "utf-8")) as ParakeetJson);
+
+    const transcriptPath = join(dir, "transcript.json");
+    writeFileSync(transcriptPath, JSON.stringify(words, null, 2));
+    const durationSeconds = words.length > 0 ? words[words.length - 1]!.end : 0;
+    return { transcriptPath, wordCount: words.length, durationSeconds, speechOnsetSeconds: null };
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -1822,6 +1822,8 @@ export interface BrowserMediaElement {
   loop: boolean;
   hasAudio: boolean;
   volume: number;
+  /** The `muted` attribute/property. Preview silences muted media; the mix must too. */
+  muted: boolean;
 }
 
 export interface BrowserAudioVolumeAutomation {
@@ -1842,6 +1844,7 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
       loop: boolean;
       hasAudio: boolean;
       volume: number;
+      muted: boolean;
     }[] = [];
 
     const mediaEls = document.querySelectorAll("video[data-start], audio[data-start]");
@@ -1858,6 +1861,7 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
       const loop = htmlEl.hasAttribute("loop");
       const hasAudio = htmlEl.getAttribute("data-has-audio") === "true";
       const volume = parseFloat(htmlEl.getAttribute("data-volume") || "1");
+      const muted = htmlEl.hasAttribute("muted") || htmlEl.muted;
 
       results.push({
         id,
@@ -1870,6 +1874,7 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
         loop,
         hasAudio,
         volume,
+        muted,
       });
     });
 

--- a/packages/producer/src/services/render/stages/mutedParity.test.ts
+++ b/packages/producer/src/services/render/stages/mutedParity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { pruneMutedBrowserMedia } from "./probeStage.js";
+
+describe("pruneMutedBrowserMedia", () => {
+  it("drops muted audio from the mix and clears hasAudio on muted video", () => {
+    const composition = {
+      videos: [
+        { id: "clip", hasAudio: true },
+        { id: "other", hasAudio: true },
+      ],
+      audios: [{ id: "bgm" }, { id: "voice" }],
+    };
+    const ids = new Set(["bgm", "voice"]);
+    pruneMutedBrowserMedia(
+      composition,
+      [
+        { id: "clip", tagName: "video", muted: true },
+        { id: "voice", tagName: "audio", muted: true },
+        { id: "bgm", tagName: "audio", muted: false },
+      ],
+      ids,
+    );
+    expect(composition.audios.map((a) => a.id)).toEqual(["bgm"]);
+    expect(ids.has("voice")).toBe(false);
+    expect(composition.videos.find((v) => v.id === "clip")?.hasAudio).toBe(false);
+    expect(composition.videos.find((v) => v.id === "other")?.hasAudio).toBe(true);
+  });
+
+  it("is a no-op when nothing is muted", () => {
+    const composition = { videos: [{ id: "v", hasAudio: true }], audios: [{ id: "a" }] };
+    pruneMutedBrowserMedia(composition, [
+      { id: "v", tagName: "video", muted: false },
+      { id: "a", tagName: "audio" },
+    ]);
+    expect(composition.audios.length).toBe(1);
+    expect(composition.videos[0]?.hasAudio).toBe(true);
+  });
+});

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -375,8 +375,11 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
       const existingVideoIds = new Set(composition.videos.map((v) => v.id));
       const existingAudioIds = new Set(composition.audios.map((a) => a.id));
 
+      pruneMutedBrowserMedia(composition, browserMedia, existingAudioIds);
+
       for (const el of browserMedia) {
         if (!el.src || el.src === "about:blank") continue;
+        if (el.muted && el.tagName === "audio") continue;
 
         // Convert absolute localhost URLs back to relative paths
         let src = el.src;
@@ -411,7 +414,7 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
               ) {
                 existing.mediaStart = el.mediaStart;
               }
-              if (el.hasAudio && !existing.hasAudio) {
+              if (el.hasAudio && !el.muted && !existing.hasAudio) {
                 existing.hasAudio = true;
               }
               if (el.loop && !existing.loop) {
@@ -427,7 +430,7 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
               end: el.end,
               mediaStart: el.mediaStart,
               loop: el.loop,
-              hasAudio: el.hasAudio,
+              hasAudio: el.hasAudio && !el.muted,
             });
             existingVideoIds.add(el.id);
           }
@@ -609,4 +612,32 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
     browserProbeMs,
     beginFrameStalled,
   };
+}
+
+/**
+ * Preview/render parity for `muted` media: the runtime keeps muted elements
+ * silent, so the mixer must exclude their audio too (they used to be mixed at
+ * full volume). Muted video still renders frames but loses its audio track;
+ * muted audio drops out of the mix entirely. Pure over its inputs so the
+ * parity rule is testable without the probe-session harness.
+ */
+export function pruneMutedBrowserMedia(
+  composition: {
+    videos: { id: string; hasAudio?: boolean }[];
+    audios: { id: string }[];
+  },
+  browserMedia: { id: string; tagName: string; muted?: boolean }[],
+  existingAudioIds?: Set<string>,
+): void {
+  for (const el of browserMedia) {
+    if (!el.muted) continue;
+    if (el.tagName === "video") {
+      const existing = composition.videos.find((v) => v.id === el.id);
+      if (existing) existing.hasAudio = false;
+    } else {
+      const idx = composition.audios.findIndex((a) => a.id === el.id);
+      if (idx >= 0) composition.audios.splice(idx, 1);
+      existingAudioIds?.delete(el.id);
+    }
+  }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.38.md
+++ b/releases/v0.7.38.md
@@ -1,0 +1,51 @@
+# HyperFrames v0.7.38
+
+Released on 2026-07-07.
+
+drawElement fast capture is now **on by default** for macOS hardware-GPU renders — roughly 2× faster capture, wrapped in a per-render self-verification net that automatically falls back to the classic screenshot path if a frame can't be proven correct (kill switch: `PRODUCER_EXPERIMENTAL_FAST_CAPTURE=false`). Also new: media color grading (Studio inspector + runtime shaders), end-to-end render cancel, and richer render telemetry.
+
+## Features
+
+- **Engine,producer,cli:** DrawElement release telemetry on render_complete ([100570344](https://github.com/heygen-com/hyperframes/commit/1005703441c122e5462f34e0212e52e5490407a0), [#2002](https://github.com/heygen-com/hyperframes/pull/2002))
+- **Studio,studio Server,cli:** Render cancel end-to-end + renders/nle/storyboard UX ([241f9d683](https://github.com/heygen-com/hyperframes/commit/241f9d683ec7f34c9c398cc2a6c2d272a6e38268), [#1963](https://github.com/heygen-com/hyperframes/pull/1963))
+- **Engine,producer:** DrawElement fast-capture default-on with runtime self-verification safety net ([ec06f4bf8](https://github.com/heygen-com/hyperframes/commit/ec06f4bf895d811b3b1cf140e53e79244bbd1f9a), [#1998](https://github.com/heygen-com/hyperframes/pull/1998))
+- **Lint,player:** Fast-capture lint rule + player media sync ([992a9b660](https://github.com/heygen-com/hyperframes/commit/992a9b660708e3c4ca17620fb01265db95aaca59), [#1921](https://github.com/heygen-com/hyperframes/pull/1921))
+- **Producer:** Fast-capture render stages + remote bg-image localizer ([1d0dbcd3b](https://github.com/heygen-com/hyperframes/commit/1d0dbcd3b2a81ce00ca2deef5d6cc44f3b22ef96), [#1920](https://github.com/heygen-com/hyperframes/pull/1920))
+- **Engine:** Frame-capture core — fast-capture routing, worker-encode, dedup extension ([0e58344dc](https://github.com/heygen-com/hyperframes/commit/0e58344dca3052ca1e83337d22c54b977852f5b3), [#1919](https://github.com/heygen-com/hyperframes/pull/1919))
+- **Engine:** 3D projection + compositor-effect risk gate ([4749fe571](https://github.com/heygen-com/hyperframes/commit/4749fe5716357b4c1521d6a1644ab0be013976c1), [#1918](https://github.com/heygen-com/hyperframes/pull/1918))
+- **Engine:** DrawElementImage capture service ([795934adb](https://github.com/heygen-com/hyperframes/commit/795934adbac849cba6ec0b0ea83dc69b509a4f4c), [#1917](https://github.com/heygen-com/hyperframes/pull/1917))
+- **Studio:** Harden ui primitives — focus rings, keyboard tooltips, dialog hook ([cd1adcb58](https://github.com/heygen-com/hyperframes/commit/cd1adcb581d4638433b4f8c4d43986b419256762), [#1962](https://github.com/heygen-com/hyperframes/pull/1962))
+- **Engine,cli:** DrawElement fast-capture config + CLI flag ([e04f6dda3](https://github.com/heygen-com/hyperframes/commit/e04f6dda37bf7dd2fe5bf564ecac55713869d2d5), [#1916](https://github.com/heygen-com/hyperframes/pull/1916))
+- **Lint:** Warn when <html dir> can blank render output ([afa7f292f](https://github.com/heygen-com/hyperframes/commit/afa7f292fb267bb6498bf58afba18369574eee92), [#1893](https://github.com/heygen-com/hyperframes/pull/1893))
+- **CLI:** Emit sign-in lifecycle telemetry ([769dc702c](https://github.com/heygen-com/hyperframes/commit/769dc702c1d62b86f1f5b2a05d76af39fc1be6b2), [#2000](https://github.com/heygen-com/hyperframes/pull/2000))
+- **Studio:** Add color grading inspector ([139cf568b](https://github.com/heygen-com/hyperframes/commit/139cf568b481cd50a7d9d80ac2c00b6ec1a6410b))
+- **Studio Server:** Add media processing routes ([a3bf7eb99](https://github.com/heygen-com/hyperframes/commit/a3bf7eb995ae1b6cc6f6c95a999d19e6df3526b6))
+- **Runtime:** Render media color grading shaders ([870964b0c](https://github.com/heygen-com/hyperframes/commit/870964b0cf190702c76066aaef7c81ea4424f7ab))
+- **Core:** Add media color grading contract ([7c1443849](https://github.com/heygen-com/hyperframes/commit/7c144384962e6f4ce55046884055f6f462d044cf))
+- **CLI:** Figma import telemetry — subcommand labels, typed error codes, figma_import event ([e9076324e](https://github.com/heygen-com/hyperframes/commit/e9076324e703fdd91142b7f138b2f2c96cba1376), [#1979](https://github.com/heygen-com/hyperframes/pull/1979))
+- **Cli/telemetry:** Surface unrecognized agents in the agent_runtime=null bucket ([232d59147](https://github.com/heygen-com/hyperframes/commit/232d591479448233a9a54097da0963fc1034e450), [#1978](https://github.com/heygen-com/hyperframes/pull/1978))
+
+## Fixes
+
+- **CLI:** Localize remote assets before validate so it matches render ([906c8d04f](https://github.com/heygen-com/hyperframes/commit/906c8d04f85b909252753b24102cdbad1780378d), [#2001](https://github.com/heygen-com/hyperframes/pull/2001))
+- **Studio:** Shell UX — data-loss guards, error surfacing, dialog contracts, toasts ([89e36da13](https://github.com/heygen-com/hyperframes/commit/89e36da13dcd5cda4455fa48e9cbb4d9b7f7dbda), [#1964](https://github.com/heygen-com/hyperframes/pull/1964))
+- **Compiler:** Don't scan media tags inside comments/scripts; DOM-check auto-start (#1938) ([1a3330a97](https://github.com/heygen-com/hyperframes/commit/1a3330a972d98de09a93e4cf6d1a61fcc1a63cb1), [#1940](https://github.com/heygen-com/hyperframes/pull/1940))
+- **Studio:** Share safe media path cleanup ([04f96da16](https://github.com/heygen-com/hyperframes/commit/04f96da16967eecff82dfb16e2e0cd238469ffb5))
+- **Studio:** Avoid regex in media asset path cleanup ([e0090efbf](https://github.com/heygen-com/hyperframes/commit/e0090efbf6946d8b28e54159e95dbd8b0a82484e))
+- **Studio:** Split color grading inspector files ([30a944de3](https://github.com/heygen-com/hyperframes/commit/30a944de342de0ff7715946a7d80c6f96d9e9074))
+- **Studio Server:** Share background removal job runner ([413ee07da](https://github.com/heygen-com/hyperframes/commit/413ee07da51c76a1430a58f40fb81021f1adb05c))
+- **Runtime:** Satisfy color grading audit ([644ae384a](https://github.com/heygen-com/hyperframes/commit/644ae384a549cea6a686c07344e99b87366c0480))
+- **Parsers,sdk,studio Server,studio:** Unify hf-id space across preview, disk, and SDK session ([3a717fa71](https://github.com/heygen-com/hyperframes/commit/3a717fa71997477c6f81dce7c9f2e63a4ad675ed), [#1981](https://github.com/heygen-com/hyperframes/pull/1981))
+
+## Performance
+
+- **Engine,producer:** Batch N drawElement frames per CDP round-trip (HF_DE_BATCH) ([d5ecb013d](https://github.com/heygen-com/hyperframes/commit/d5ecb013d71763891b8092c4bc081bb12b3d4782), [#1928](https://github.com/heygen-com/hyperframes/pull/1928))
+
+## Docs & Examples
+
+- **Figma:** Storyboard blurb reworded + frames-are-app-states escalation ([ccc130883](https://github.com/heygen-com/hyperframes/commit/ccc1308839a73e3a7d76fff4669a9a220b7eff11), [#2004](https://github.com/heygen-com/hyperframes/pull/2004))
+- Document Studio Color Grading ([b38c054ba](https://github.com/heygen-com/hyperframes/commit/b38c054baf97b90770f64310785fb514b0051de4))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.37...v0.7.38


### PR DESCRIPTION
Adds NVIDIA Parakeet-TDT as a `hyperframes transcribe --engine parakeet|whisper|auto` engine (auto = Parakeet if installed, else whisper.cpp). Beats whisper.cpp on WER + speed. Plus a `HYPERFRAMES_PYTHON` override for local-model python.

Stack: media-use v2 (2/5). Depends on the producer PR below.

---
### 📚 Stack — media-use v2 (split from #1923, merge bottom-up)
1. #1969 · producer: muted preview↔render parity
2. #1970 · cli: Parakeet transcribe engine
3. #1971 · studio: non-destructive crop + asset view
4. #1972 · media-use core + retire hyperframes-media
5. #1973 · media-use edit tools (transcript-cut, audio-duck, Parakeet)