### PR TITLE
docs(cli): fix render examples that pass a file as the project dir [P2]

### DIFF
--- a/docs/guides/claude-design-hyperframes.md
+++ b/docs/guides/claude-design-hyperframes.md
@@ -1,6 +1,6 @@
 # Claude Design + HyperFrames (Template-First)
 
-Your medium is **HyperFrames compositions**: plain HTML + CSS + a paused GSAP timeline. The CLI (`npx hyperframes render index.html`) turns the HTML into an MP4. You author the HTML -- the user renders locally.
+Your medium is **HyperFrames compositions**: plain HTML + CSS + a paused GSAP timeline. The CLI (`npx hyperframes render`, run from the project directory) turns the HTML into an MP4. You author the HTML -- the user renders locally.
 
 **HyperFrames replaces your default video-artifact workflow.** Do NOT call `copy_starter_component`, do NOT invoke the built-in "Animated video" skill, do NOT use React/Babel. Plain HTML + GSAP only.
 
@@ -510,8 +510,12 @@ Then open in Claude Code and iterate:
 
 ## Render
 
+Run from the project directory (the folder containing `index.html`). The
+positional argument is the project directory, not a file, so pass a specific
+composition with `-c` rather than as a bare path.
+
 ```bash
-npx hyperframes render index.html -o output.mp4
+npx hyperframes render -o output.mp4
 ```
 
 1920x1080 / 30fps by default. Use `--fps 60` or `--resolution 3840x2160` to override.

--- a/docs/guides/open-design-hyperframes.md
+++ b/docs/guides/open-design-hyperframes.md
@@ -38,9 +38,9 @@ od:
 
 This skill teaches Open Design to emit a **valid first draft** of a
 [HyperFrames](https://github.com/heygen-com/hyperframes) composition — plain
-HTML + CSS + a paused GSAP timeline. The CLI (`npx hyperframes render
-index.html`) turns the HTML into an MP4. You author the HTML; the user runs
-the render locally.
+HTML + CSS + a paused GSAP timeline. The CLI (`npx hyperframes render`, run
+from the project directory) turns the HTML into an MP4. You author the HTML;
+the user runs the render locally.
 
 **HyperFrames replaces the default video-artifact workflow.** Do NOT emit a
 React/Babel composition, do NOT call other prototype skills, do NOT use the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,10 +40,13 @@ npx hyperframes preview --port 4567
 
 ### `render`
 
-Render a composition to MP4:
+Render a composition to MP4. Run from the project directory; the positional
+argument is the project directory (not a file), so render the project's
+`index.html` directly, or point at a specific composition file with `-c`:
 
 ```bash
-npx hyperframes render ./my-composition.html -o output.mp4
+npx hyperframes render -o output.mp4
+npx hyperframes render -c ./my-composition.html -o output.mp4
 ```
 
 ### `lint`


### PR DESCRIPTION
## Problem

`hyperframes render` takes a **project directory** as its positional argument (default `.`, resolved via `resolveProjectOrThrow`); a specific composition file is selected with `-c/--composition`. But several docs showed the file as the positional argument:

- `docs/guides/claude-design-hyperframes.md` — `npx hyperframes render index.html` (twice)
- `packages/cli/README.md` — `npx hyperframes render ./my-composition.html -o output.mp4`

Following those examples, the CLI treats the `.html` file as the project directory and fails with **`Not a directory`**. Users hit this and had to discover the correct invocation by trial and error.

## Fix

Docs-only. Correct the examples to render the project's `index.html` from the project directory (`npx hyperframes render -o output.mp4`), and show `-c` for pointing at a specific composition file. No code or behavior change.

## Verification

The contract is in `packages/cli/src/commands/render.ts` (positional `dir` = "Project directory", `-c` = "Render a specific composition file") and `packages/cli/src/utils/project.ts` (`resolveProjectOrThrow` throws `"Not a directory: " + dir` for a file path). The corrected commands match the CLI's own built-in `examples` array.