### PR TITLE
fix(studio): preserve click selection during marquee gestures

### DIFF
--- a/packages/studio/src/components/editor/DomEditOverlay.test.ts
+++ b/packages/studio/src/components/editor/DomEditOverlay.test.ts
@@ -225,6 +225,97 @@ describe("DomEditOverlay", () => {
     host.remove();
   });
 
+  it("keeps the normal click path when marquee starts below threshold", async () => {
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function (): DOMRect {
+      return {
+        left: 0,
+        top: 0,
+        right: 800,
+        bottom: 450,
+        width: 800,
+        height: 450,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+    };
+
+    const originalPointerCapture = HTMLDivElement.prototype.setPointerCapture;
+    const originalReleasePointerCapture = HTMLDivElement.prototype.releasePointerCapture;
+    HTMLDivElement.prototype.setPointerCapture = () => {};
+    HTMLDivElement.prototype.releasePointerCapture = () => {};
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    const iframeRef = { current: document.createElement("iframe") as HTMLIFrameElement | null };
+    const onCanvasMouseDown = vi.fn();
+    const onMarqueeSelect = vi.fn();
+
+    act(() => {
+      root.render(
+        React.createElement(DomEditOverlay, {
+          ...createOverlayProps({
+            iframeRef,
+            selection: null,
+            hoverSelection: null,
+            onSelectionChange: () => {},
+          }),
+          onCanvasMouseDown,
+          onMarqueeSelect,
+        }),
+      );
+    });
+
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      });
+    });
+
+    const overlay = host.querySelector('[aria-label="Composition canvas"]') as HTMLDivElement;
+    expect(overlay).toBeTruthy();
+
+    act(() => {
+      overlay.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          clientX: 120,
+          clientY: 80,
+        }),
+      );
+      overlay.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 0,
+          clientX: 120,
+          clientY: 80,
+        }),
+      );
+      overlay.dispatchEvent(
+        new PointerEvent("pointerup", {
+          bubbles: true,
+          button: 0,
+          clientX: 120,
+          clientY: 80,
+        }),
+      );
+    });
+
+    expect(onCanvasMouseDown).toHaveBeenCalled();
+    expect(onMarqueeSelect).not.toHaveBeenCalled();
+
+    act(() => {
+      root.unmount();
+    });
+    HTMLDivElement.prototype.setPointerCapture = originalPointerCapture;
+    HTMLDivElement.prototype.releasePointerCapture = originalReleasePointerCapture;
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    host.remove();
+  });
+
   it("starts movement from the selected bounds", async () => {
     // The overlay's compRect updates via a RAF loop reading iframe + overlay
     // getBoundingClientRect. happy-dom returns all zeros for newly-created

--- a/packages/studio/src/components/editor/DomEditOverlay.tsx
+++ b/packages/studio/src/components/editor/DomEditOverlay.tsx
@@ -377,9 +377,6 @@ export const DomEditOverlay = memo(function DomEditOverlay({
           cy >= compRect.top &&
           cy <= compRect.top + compRect.height;
         if (inComp) {
-          event.preventDefault();
-          event.stopPropagation();
-          suppressNextOverlayMouseDownRef.current = true;
           (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
           marquee.marqueeRef.current = {
             startX: cx,

--- a/packages/studio/src/components/editor/marqueeCommit.ts
+++ b/packages/studio/src/components/editor/marqueeCommit.ts
@@ -145,6 +145,8 @@ export function useMarqueeGestures(deps: MarqueeGesturesDeps) {
           if (Math.hypot(dx, dy) < MARQUEE_THRESHOLD_PX) return;
           m.pastThreshold = true;
         }
+        event.preventDefault();
+        event.stopPropagation();
         const rect: Rect = {
           left: Math.min(m.startX, m.currentX),
           top: Math.min(m.startY, m.currentY),
@@ -185,8 +187,6 @@ export function useMarqueeGestures(deps: MarqueeGesturesDeps) {
             },
             event.shiftKey,
           );
-        } else {
-          deps.onMarqueeSelectRef.current?.([], false);
         }
         setMarqueeRect(null);
         setCandidateRects([]);
@@ -194,7 +194,7 @@ export function useMarqueeGestures(deps: MarqueeGesturesDeps) {
       }
       deps.gestures.onPointerUp(event);
     },
-    [deps.gestures, commitMarquee, deps.onMarqueeSelectRef],
+    [deps.gestures, commitMarquee],
   );
 
   const onPointerCancel = useCallback(() => {


### PR DESCRIPTION
## What
- Preserve click-only element selection when the marquee gesture starts but never crosses the drag threshold.
- Add a regression test covering click selection after pointer down/up.

## Why
The Design canvas should still select elements from normal clicks while keeping drag marquee behavior for real drags.

## How
Track whether the gesture became a drag before suppressing click selection.

## Test plan
- [x] Unit tests: `bun run --filter @hyperframes/studio test src/components/editor/DomEditOverlay.test.ts`
- [ ] Manual testing
- [ ] Documentation