### PR TITLE
feat(registry): yt-* family — 11 retro-broadcast creator items (6 blocks, 5 components)

### DIFF
--- a/docs/catalog/blocks/yt-comment-card.mdx
+++ b/docs/catalog/blocks/yt-comment-card.mdx
@@ -1,0 +1,44 @@
+---
+title: "Comment Cards"
+description: "Social comments typing on over footage: avatar pop, username and time, per-character typewriter, likes row; image avatars or initials chips"
+---
+
+# Comment Cards
+
+Social comments typing on over footage: avatar pop, username and time, per-character typewriter, likes row; image avatars or initials chips
+
+`social` `comments` `creator` `overlay`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-comment-card.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-comment-card.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-comment-card
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 8s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-comment-card.html` | `compositions/yt-comment-card.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="yt-comment-card" data-composition-src="compositions/yt-comment-card.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/yt-doc-lower-third.mdx
+++ b/docs/catalog/blocks/yt-doc-lower-third.mdx
@@ -1,0 +1,44 @@
+---
+title: "Documentary Lower Third"
+description: "Name and role lower third: accent bar draws down, text slides in, hairline rule grows; overlay and light schemes"
+---
+
+# Documentary Lower Third
+
+Name and role lower third: accent bar draws down, text slides in, hairline rule grows; overlay and light schemes
+
+`lower-third` `title` `creator`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-doc-lower-third.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-doc-lower-third.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-doc-lower-third
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 6s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-doc-lower-third.html` | `compositions/yt-doc-lower-third.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="yt-doc-lower-third" data-composition-src="compositions/yt-doc-lower-third.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/yt-lcd-background.mdx
+++ b/docs/catalog/blocks/yt-lcd-background.mdx
@@ -1,0 +1,44 @@
+---
+title: "Scanline Board Background"
+description: "Textured paper board: scanlines with slow drift, optional pixel grid, static grain, and display text with a blur-focus entrance and chromatic-fringe title"
+---
+
+# Scanline Board Background
+
+Textured paper board: scanlines with slow drift, optional pixel grid, static grain, and display text with a blur-focus entrance and chromatic-fringe title
+
+`background` `texture` `creator`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lcd-background.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lcd-background.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-lcd-background
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 10s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-lcd-background.html` | `compositions/yt-lcd-background.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="yt-lcd-background" data-composition-src="compositions/yt-lcd-background.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/yt-logo-intro.mdx
+++ b/docs/catalog/blocks/yt-logo-intro.mdx
@@ -1,0 +1,44 @@
+---
+title: "Logo Intro Sequence"
+description: "Logo stamp pops on a lined board, a kicker line gives way to the title with an accent arrow chip; seeded line distortion"
+---
+
+# Logo Intro Sequence
+
+Logo stamp pops on a lined board, a kicker line gives way to the title with an accent arrow chip; seeded line distortion
+
+`logo` `intro` `creator`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-logo-intro.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-logo-intro.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-logo-intro
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 6s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-logo-intro.html` | `compositions/yt-logo-intro.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="yt-logo-intro" data-composition-src="compositions/yt-logo-intro.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/yt-prism-title.mdx
+++ b/docs/catalog/blocks/yt-prism-title.mdx
@@ -1,0 +1,44 @@
+---
+title: "Chromatic Fringe Title"
+description: "Display title on a transparent root: blur-focus entrance, red/blue fringe that settles then breathes, perspective bow, slow scale drift"
+---
+
+# Chromatic Fringe Title
+
+Display title on a transparent root: blur-focus entrance, red/blue fringe that settles then breathes, perspective bow, slow scale drift
+
+`typography` `title-card` `creator`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-prism-title.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-prism-title.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-prism-title
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 6s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-prism-title.html` | `compositions/yt-prism-title.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="yt-prism-title" data-composition-src="compositions/yt-prism-title.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/yt-vertical-fill.mdx
+++ b/docs/catalog/blocks/yt-vertical-fill.mdx
@@ -1,0 +1,44 @@
+---
+title: "Vertical Media Filler"
+description: "Portrait media filling a widescreen frame via blurred-scale, mirror, or copy side fills; grid texture and foreground contrast lift (images inside the block; keep live footage in the host)"
+---
+
+# Vertical Media Filler
+
+Portrait media filling a widescreen frame via blurred-scale, mirror, or copy side fills; grid texture and foreground contrast lift (images inside the block; keep live footage in the host)
+
+`placeholder` `vertical` `media`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-vertical-fill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-vertical-fill.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-vertical-fill
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 8s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-vertical-fill.html` | `compositions/yt-vertical-fill.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="yt-vertical-fill" data-composition-src="compositions/yt-vertical-fill.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/components/yt-avatar-pip.mdx
+++ b/docs/catalog/components/yt-avatar-pip.mdx
@@ -1,0 +1,38 @@
+---
+title: "Circle PiP Window"
+description: "Circular or rounded-rect masked picture-in-picture window with ring and shadow for a second video or image; pop in/out helpers"
+---
+
+# Circle PiP Window
+
+Circular or rounded-rect masked picture-in-picture window with ring and shadow for a second video or image; pop in/out helpers
+
+`pip` `overlay` `creator`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-avatar-pip.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-avatar-pip.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-avatar-pip
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-avatar-pip.html` | `compositions/components/yt-avatar-pip.html` | hyperframes:snippet |
+
+## Usage
+
+Read the installed file and copy its CSS, markup pattern, and helper functions into your host composition — the parent timeline owns all timing. The file's header comment documents the wiring calls.

--- a/docs/catalog/components/yt-camera-move.mdx
+++ b/docs/catalog/components/yt-camera-move.mdx
@@ -1,0 +1,38 @@
+---
+title: "Camera Punch-In"
+description: "Dynamic zoom, slide, and 3D tilt-pan helpers for any wrapper (video, include, card) with cubic-easing defaults and an edge-defocus pulse overlay"
+---
+
+# Camera Punch-In
+
+Dynamic zoom, slide, and 3D tilt-pan helpers for any wrapper (video, include, card) with cubic-easing defaults and an edge-defocus pulse overlay
+
+`camera` `zoom` `effect` `creator`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-camera-move.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-camera-move.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-camera-move
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-camera-move.html` | `compositions/components/yt-camera-move.html` | hyperframes:snippet |
+
+## Usage
+
+Read the installed file and copy its CSS, markup pattern, and helper functions into your host composition — the parent timeline owns all timing. The file's header comment documents the wiring calls.

--- a/docs/catalog/components/yt-circle-pointer.mdx
+++ b/docs/catalog/components/yt-circle-pointer.mdx
@@ -1,0 +1,38 @@
+---
+title: "Pointer Circle + Countdown"
+description: "Draw-on annotation ellipse around a target plus a countdown chip that pulses each tick"
+---
+
+# Pointer Circle + Countdown
+
+Draw-on annotation ellipse around a target plus a countdown chip that pulses each tick
+
+`annotation` `countdown` `overlay`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-circle-pointer.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-circle-pointer.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-circle-pointer
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-circle-pointer.html` | `compositions/components/yt-circle-pointer.html` | hyperframes:snippet |
+
+## Usage
+
+Read the installed file and copy its CSS, markup pattern, and helper functions into your host composition — the parent timeline owns all timing. The file's header comment documents the wiring calls.

--- a/docs/catalog/components/yt-feather-highlight.mdx
+++ b/docs/catalog/components/yt-feather-highlight.mdx
@@ -1,0 +1,38 @@
+---
+title: "Feathered Spotlight"
+description: "Dims the frame except a feathered ellipse; the hole's position and size are CSS variables, so helpers glide the spotlight between targets"
+---
+
+# Feathered Spotlight
+
+Dims the frame except a feathered ellipse; the hole's position and size are CSS variables, so helpers glide the spotlight between targets
+
+`highlight` `spotlight` `effect` `overlay`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-feather-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-feather-highlight.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-feather-highlight
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-feather-highlight.html` | `compositions/components/yt-feather-highlight.html` | hyperframes:snippet |
+
+## Usage
+
+Read the installed file and copy its CSS, markup pattern, and helper functions into your host composition — the parent timeline owns all timing. The file's header comment documents the wiring calls.

--- a/docs/catalog/components/yt-screen-warp.mdx
+++ b/docs/catalog/components/yt-screen-warp.mdx
@@ -1,0 +1,38 @@
+---
+title: "On-Screen Display Effect"
+description: "Grid, scanline, vignette, and sheen overlay plus a 3D-warp wrapper class that makes footage read as if playing on a physical display"
+---
+
+# On-Screen Display Effect
+
+Grid, scanline, vignette, and sheen overlay plus a 3D-warp wrapper class that makes footage read as if playing on a physical display
+
+`effect` `overlay` `texture`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-screen-warp.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-screen-warp.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add yt-screen-warp
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Component |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `yt-screen-warp.html` | `compositions/components/yt-screen-warp.html` | hyperframes:snippet |
+
+## Usage
+
+Read the installed file and copy its CSS, markup pattern, and helper functions into your host composition — the parent timeline owns all timing. The file's header comment documents the wiring calls.

--- a/registry/blocks/yt-comment-card/registry-item.json
+++ b/registry/blocks/yt-comment-card/registry-item.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-comment-card",
+  "type": "hyperframes:block",
+  "title": "Comment Cards",
+  "description": "Social comments typing on over footage: avatar pop, username and time, per-character typewriter, likes row; image avatars or initials chips",
+  "tags": [
+    "social",
+    "comments",
+    "creator",
+    "overlay"
+  ],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 8,
+  "files": [
+    {
+      "path": "yt-comment-card.html",
+      "target": "compositions/yt-comment-card.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/yt-comment-card/yt-comment-card.html
+++ b/registry/blocks/yt-comment-card/yt-comment-card.html
@@ -1,0 +1,312 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      #yt-cc-root {
+        /* ---- yt tokens: override in the host to re-skin the family ---- */
+        --yt-font: "Inter", -apple-system, sans-serif;
+        --yt-ink: #1d1d1f;
+        --yt-ink-dim: #5a5a5f;
+        /* overlay-scheme text over footage — distinct from the --yt-ink board tokens */
+        --yt-text: #ffffff;
+        --yt-text-dim: rgba(255, 255, 255, 0.72);
+        --yt-red: #e62e2e;
+        --yt-cyan: #35c8d9;
+        --yt-scanline-alpha: 0.04;
+        --yt-scanline-gap: 3px;
+
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: transparent; /* overlays footage or a yt-lcd board */
+        font-family: var(--yt-font);
+      }
+      /* optional full-frame LCD pass while comments are up */
+      #yt-cc-scan {
+        position: absolute;
+        inset: 0;
+        display: none;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, var(--yt-scanline-alpha)) 0 1px,
+          transparent 1px var(--yt-scanline-gap)
+        );
+      }
+      #yt-cc-col {
+        position: absolute;
+        display: flex;
+        flex-direction: column;
+        gap: 40px;
+      }
+      .yt-cc-card {
+        display: flex;
+        gap: 22px;
+        align-items: flex-start;
+      }
+      .yt-cc-avatar {
+        flex: none;
+        width: 64px;
+        height: 64px;
+        border-radius: 50%;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 26px;
+        color: #ffffff;
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+      }
+      .yt-cc-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .yt-cc-meta {
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+      }
+      .yt-cc-user {
+        font-weight: 700;
+        font-size: 27px;
+      }
+      .yt-cc-time {
+        font-weight: 400;
+        font-size: 23px;
+      }
+      .yt-cc-text {
+        margin-top: 8px;
+        font-weight: 500;
+        font-size: 34px;
+        line-height: 1.35;
+        letter-spacing: -0.01em;
+        max-width: 860px;
+      }
+      .yt-cc-text .ch {
+        opacity: 0;
+      }
+      .yt-cc-row {
+        margin-top: 12px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-weight: 600;
+        font-size: 22px;
+        opacity: 0;
+      }
+      .yt-cc-row svg {
+        width: 24px;
+        stroke-width: 2.4;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        fill: none;
+      }
+      .yt-cc-reply {
+        margin-left: 18px;
+        letter-spacing: 0.1em;
+      }
+      /* scheme: overlay (white over footage, w/ shadow) vs light (ink on boards) */
+      .yt-overlay .yt-cc-user,
+      .yt-overlay .yt-cc-text {
+        color: var(--yt-text);
+        text-shadow: 0 2px 16px rgba(0, 0, 0, 0.55);
+      }
+      .yt-overlay .yt-cc-time,
+      .yt-overlay .yt-cc-row {
+        color: var(--yt-text-dim);
+        text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
+      }
+      .yt-overlay .yt-cc-row svg {
+        stroke: var(--yt-text-dim);
+      }
+      .yt-light .yt-cc-user,
+      .yt-light .yt-cc-text {
+        color: var(--yt-ink);
+      }
+      .yt-light .yt-cc-time,
+      .yt-light .yt-cc-row {
+        color: var(--yt-ink-dim);
+      }
+      .yt-light .yt-cc-row svg {
+        stroke: var(--yt-ink-dim);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="yt-cc-root"
+      data-composition-id="yt-comment-card"
+      data-start="0"
+      data-duration="8"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-cc-scan"></div>
+      <div id="yt-cc-col"></div>
+      <div
+        id="yt-cc-drv"
+        class="clip"
+        data-start="0"
+        data-duration="8"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        /* ---- published parameters (inspector-style CONFIG) ----
+           Social comments typing on over footage — creator-style
+           comment cards. avatar: image path, or null -> initials chip. */
+        var CONFIG = {
+          scheme: "overlay", // "overlay" (white over footage) | "light" (ink on boards)
+          comments: [
+            {
+              avatar: null,
+              initials: "PW",
+              avatarHue: 210, // initials-chip hue when no image
+              username: "@pixelwaves",
+              time: "2 days ago",
+              text: "Your videos are the best!",
+              likes: 47,
+            },
+            {
+              avatar: null,
+              initials: "FR",
+              avatarHue: 340,
+              username: "@framerate",
+              time: "1 day ago",
+              text: "That camera move at 0:12 though 🔥",
+              likes: 12,
+            },
+          ],
+          x: 140,
+          y: null, // null = vertically centered
+          typeCharDelay: 0.024, // s per character (capped so a comment types <= 2.2s)
+          scanlines: false, // full-frame LCD pass while comments are up
+          animationIn: true,
+          animationOut: true,
+        };
+
+        var DUR = 8;
+        function clamp(v, lo, hi) {
+          return Math.min(hi, Math.max(lo, v));
+        }
+        var OUT = clamp(DUR * 0.06, 0.25, 0.6);
+
+        var root = document.getElementById("yt-cc-root");
+        var col = document.getElementById("yt-cc-col");
+        root.classList.add(CONFIG.scheme === "light" ? "yt-light" : "yt-overlay");
+        if (CONFIG.scanlines) document.getElementById("yt-cc-scan").style.display = "block";
+
+        var THUMB =
+          '<svg viewBox="0 0 24 24"><path d="M7 11v9M7 11l3.2-6.4a2 2 0 0 1 3.6 1.2V9h4.6a2 2 0 0 1 2 2.4l-1.2 6a2 2 0 0 1-2 1.6H7M7 11H4a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h3"/></svg>';
+
+        /* build cards */
+        CONFIG.comments.forEach(function (c, i) {
+          var card = document.createElement("div");
+          card.className = "yt-cc-card";
+          card.id = "yt-cc-card-" + i;
+
+          var av = document.createElement("div");
+          av.className = "yt-cc-avatar";
+          av.id = "yt-cc-av-" + i;
+          if (c.avatar) {
+            var img = document.createElement("img");
+            img.src = c.avatar;
+            av.appendChild(img);
+          } else {
+            av.textContent = c.initials || "?";
+            av.style.background =
+              "linear-gradient(135deg, hsl(" + (c.avatarHue || 210) + ", 62%, 52%), hsl(" + ((c.avatarHue || 210) + 40) + ", 62%, 42%))";
+          }
+          card.appendChild(av);
+
+          var body = document.createElement("div");
+          var meta = document.createElement("div");
+          meta.className = "yt-cc-meta";
+          meta.id = "yt-cc-meta-" + i;
+          var user = document.createElement("span");
+          user.className = "yt-cc-user";
+          user.textContent = c.username;
+          var time = document.createElement("span");
+          time.className = "yt-cc-time";
+          time.textContent = c.time || "";
+          meta.appendChild(user);
+          meta.appendChild(time);
+          body.appendChild(meta);
+
+          var text = document.createElement("div");
+          text.className = "yt-cc-text";
+          text.id = "yt-cc-text-" + i;
+          Array.from(c.text).forEach(function (ch) {
+            var span = document.createElement("span");
+            span.className = "ch";
+            span.textContent = ch;
+            text.appendChild(span);
+          });
+          body.appendChild(text);
+
+          var row = document.createElement("div");
+          row.className = "yt-cc-row";
+          row.id = "yt-cc-row-" + i;
+          row.innerHTML = THUMB + "<span>" + (c.likes || 0) + '</span><span class="yt-cc-reply">REPLY</span>';
+          body.appendChild(row);
+          card.appendChild(body);
+          col.appendChild(card);
+        });
+
+        /* position (measure after building) */
+        col.style.left = CONFIG.x + "px";
+        var rect = col.getBoundingClientRect();
+        col.style.top = (CONFIG.y === null ? Math.round((1080 - rect.height) / 2) : CONFIG.y) + "px";
+
+        var tl = gsap.timeline({ paused: true });
+
+        /* comments enter sequentially: avatar pops, meta fades, text types, row fades */
+        var t = CONFIG.animationIn ? 0.3 : 0;
+        CONFIG.comments.forEach(function (c, i) {
+          var av = "#yt-cc-av-" + i,
+            meta = "#yt-cc-meta-" + i,
+            row = "#yt-cc-row-" + i;
+          var chars = document.querySelectorAll("#yt-cc-text-" + i + " .ch");
+          var delay = Math.min(CONFIG.typeCharDelay, 2.2 / Math.max(1, chars.length));
+
+          gsap.set(av, { opacity: 0, scale: 0.5 });
+          gsap.set(meta, { opacity: 0, y: 10 });
+          tl.to(av, { opacity: 1, scale: 1, duration: 0.45, ease: "back.out(1.6)" }, t);
+          tl.to(meta, { opacity: 1, y: 0, duration: 0.4, ease: "power2.out" }, t + 0.12);
+          t += 0.4;
+          tl.to(chars, { opacity: 1, duration: 0.02, stagger: delay, ease: "none" }, t);
+          t += chars.length * delay + 0.15;
+          tl.to(row, { opacity: 1, duration: 0.35, ease: "power2.out" }, t);
+          t += 0.5;
+        });
+
+        /* exit + hard kill (auto-scaled out) */
+        if (CONFIG.animationOut) {
+          tl.to(col, { opacity: 0, y: -18, duration: OUT, ease: "power2.in" }, DUR - OUT - 0.05);
+        }
+        tl.set(root, { visibility: "hidden" }, DUR - 0.02);
+
+        window.__timelines["yt-comment-card"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/yt-doc-lower-third/registry-item.json
+++ b/registry/blocks/yt-doc-lower-third/registry-item.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-doc-lower-third",
+  "type": "hyperframes:block",
+  "title": "Documentary Lower Third",
+  "description": "Name and role lower third: accent bar draws down, text slides in, hairline rule grows; overlay and light schemes",
+  "tags": [
+    "lower-third",
+    "title",
+    "creator"
+  ],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 6,
+  "files": [
+    {
+      "path": "yt-doc-lower-third.html",
+      "target": "compositions/yt-doc-lower-third.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/yt-doc-lower-third/yt-doc-lower-third.html
+++ b/registry/blocks/yt-doc-lower-third/yt-doc-lower-third.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      #yt-lt-root {
+        /* ---- yt tokens ---- */
+        --yt-font: "Inter", -apple-system, sans-serif;
+        --yt-ink: #1d1d1f;
+        --yt-ink-dim: #5a5a5f;
+        /* overlay-scheme text over footage — distinct from the --yt-ink board tokens */
+        --yt-text: #ffffff;
+        --yt-text-dim: rgba(255, 255, 255, 0.75);
+        --yt-red: #e62e2e;
+
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: transparent; /* overlays footage */
+        font-family: var(--yt-font);
+      }
+      #yt-lt-group {
+        position: absolute;
+        display: flex;
+        gap: 26px;
+        align-items: stretch;
+      }
+      #yt-lt-bar {
+        flex: none;
+        width: 7px;
+        border-radius: 4px;
+        background: var(--yt-red);
+        transform-origin: top center;
+      }
+      #yt-lt-name {
+        font-weight: 700;
+        font-size: 56px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+      }
+      #yt-lt-role {
+        margin-top: 8px;
+        font-weight: 500;
+        font-size: 30px;
+        letter-spacing: 0.02em;
+      }
+      #yt-lt-rule {
+        margin-top: 14px;
+        height: 2px;
+        width: 320px;
+        border-radius: 1px;
+        transform-origin: left center;
+      }
+      .yt-overlay #yt-lt-name {
+        color: var(--yt-text);
+        text-shadow: 0 2px 18px rgba(0, 0, 0, 0.55);
+      }
+      .yt-overlay #yt-lt-role {
+        color: var(--yt-text-dim);
+        text-shadow: 0 2px 14px rgba(0, 0, 0, 0.5);
+      }
+      .yt-overlay #yt-lt-rule {
+        background: rgba(255, 255, 255, 0.35);
+      }
+      .yt-light #yt-lt-name {
+        color: var(--yt-ink);
+      }
+      .yt-light #yt-lt-role {
+        color: var(--yt-ink-dim);
+      }
+      .yt-light #yt-lt-rule {
+        background: rgba(0, 0, 0, 0.18);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="yt-lt-root"
+      data-composition-id="yt-doc-lower-third"
+      data-start="0"
+      data-duration="6"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-lt-group">
+        <div id="yt-lt-bar"></div>
+        <div>
+          <div id="yt-lt-name"></div>
+          <div id="yt-lt-role"></div>
+          <div id="yt-lt-rule"></div>
+        </div>
+      </div>
+      <div
+        id="yt-lt-drv"
+        class="clip"
+        data-start="0"
+        data-duration="6"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        /* ---- published parameters ----
+           The documentary lower third ("Lower 03" energy): red bar draws
+           down, name slides in, role follows, hairline rule grows. */
+        var CONFIG = {
+          scheme: "overlay", // "overlay" (white over footage) | "light" (ink)
+          name: "Alex Winters",
+          role: "Field Producer",
+          x: 120,
+          y: 800, // top of the group
+          animationIn: true,
+          animationOut: true,
+        };
+
+        var DUR = 6;
+        function clamp(v, lo, hi) {
+          return Math.min(hi, Math.max(lo, v));
+        }
+        var OUT = clamp(DUR * 0.06, 0.25, 0.6);
+
+        var root = document.getElementById("yt-lt-root");
+        var group = document.getElementById("yt-lt-group");
+        root.classList.add(CONFIG.scheme === "light" ? "yt-light" : "yt-overlay");
+        document.getElementById("yt-lt-name").textContent = CONFIG.name;
+        document.getElementById("yt-lt-role").textContent = CONFIG.role;
+        group.style.left = CONFIG.x + "px";
+        group.style.top = CONFIG.y + "px";
+
+        var tl = gsap.timeline({ paused: true });
+
+        if (CONFIG.animationIn) {
+          gsap.set("#yt-lt-bar", { scaleY: 0 });
+          gsap.set(["#yt-lt-name", "#yt-lt-role"], { opacity: 0, x: -28 });
+          gsap.set("#yt-lt-rule", { scaleX: 0 });
+          tl.to("#yt-lt-bar", { scaleY: 1, duration: 0.5, ease: "power2.inOut" }, 0.15);
+          tl.to("#yt-lt-name", { opacity: 1, x: 0, duration: 0.55, ease: "power3.out" }, 0.4);
+          tl.to("#yt-lt-role", { opacity: 1, x: 0, duration: 0.55, ease: "power3.out" }, 0.55);
+          tl.to("#yt-lt-rule", { scaleX: 1, duration: 0.6, ease: "power2.inOut" }, 0.7);
+        } else {
+          gsap.set("#yt-lt-bar", { scaleY: 1 });
+        }
+
+        if (CONFIG.animationOut) {
+          tl.to(group, { opacity: 0, x: -20, duration: OUT, ease: "power2.in" }, DUR - OUT - 0.05);
+        }
+        tl.set(root, { visibility: "hidden" }, DUR - 0.02);
+
+        window.__timelines["yt-doc-lower-third"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/yt-lcd-background/registry-item.json
+++ b/registry/blocks/yt-lcd-background/registry-item.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-lcd-background",
+  "type": "hyperframes:block",
+  "title": "Scanline Board Background",
+  "description": "Textured paper board: scanlines with slow drift, optional pixel grid, static grain, and display text with a blur-focus entrance and chromatic-fringe title",
+  "tags": [
+    "background",
+    "texture",
+    "creator"
+  ],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 10,
+  "files": [
+    {
+      "path": "yt-lcd-background.html",
+      "target": "compositions/yt-lcd-background.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/yt-lcd-background/yt-lcd-background.html
+++ b/registry/blocks/yt-lcd-background/yt-lcd-background.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      #yt-lcd-root {
+        /* ---- yt tokens: override in the host to re-skin the family ---- */
+        --yt-font: "Inter", -apple-system, sans-serif;
+        --yt-paper: #e9e9e6;
+        --yt-paper-dark: #1c1c1e;
+        --yt-ink: #1d1d1f;
+        --yt-ink-dark: #e8e8e4;
+        --yt-cyan: #35c8d9;
+        --yt-prism-r: #ff2a4d;
+        --yt-prism-b: #2a7fff;
+        --yt-scanline-alpha: 0.05;
+        --yt-scanline-gap: 3px;
+        --yt-grid-size: 28px;
+        --yt-grid-alpha: 0.06;
+        --yt-grain-alpha: 0.08;
+
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: var(--yt-paper);
+        font-family: var(--yt-font);
+      }
+      #yt-lcd-root.yt-dark {
+        background: var(--yt-paper-dark);
+      }
+      /* the LCD surface: scanlines + optional pixel grid + static grain */
+      #yt-lcd-scan {
+        position: absolute;
+        inset: -20px;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, var(--yt-scanline-alpha)) 0 1px,
+          transparent 1px var(--yt-scanline-gap)
+        );
+      }
+      .yt-dark #yt-lcd-scan {
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(255, 255, 255, calc(var(--yt-scanline-alpha) * 1.4)) 0 1px,
+          transparent 1px var(--yt-scanline-gap)
+        );
+      }
+      #yt-lcd-grid {
+        position: absolute;
+        inset: 0;
+        background:
+          repeating-linear-gradient(0deg, rgba(0, 0, 0, var(--yt-grid-alpha)) 0 1px, transparent 1px var(--yt-grid-size)),
+          repeating-linear-gradient(90deg, rgba(0, 0, 0, var(--yt-grid-alpha)) 0 1px, transparent 1px var(--yt-grid-size));
+      }
+      .yt-dark #yt-lcd-grid {
+        background:
+          repeating-linear-gradient(0deg, rgba(255, 255, 255, var(--yt-grid-alpha)) 0 1px, transparent 1px var(--yt-grid-size)),
+          repeating-linear-gradient(90deg, rgba(255, 255, 255, var(--yt-grid-alpha)) 0 1px, transparent 1px var(--yt-grid-size));
+      }
+      #yt-lcd-grain {
+        position: absolute;
+        inset: 0;
+        opacity: var(--yt-grain-alpha);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='7' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E");
+      }
+      /* the display text: prism copies behind the main fill, optional bow */
+      #yt-lcd-bow {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 26px;
+      }
+      .yt-lcd-line {
+        position: relative;
+        font-weight: 700;
+        line-height: 1;
+        letter-spacing: -0.02em;
+        white-space: nowrap;
+      }
+      .yt-lcd-copy {
+        position: absolute;
+        inset: 0;
+      }
+      .yt-lcd-copy.r {
+        color: var(--yt-prism-r);
+      }
+      .yt-lcd-copy.b {
+        color: var(--yt-prism-b);
+      }
+      .yt-lcd-main {
+        position: relative;
+      }
+      #yt-lcd-sub {
+        font-weight: 500;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="yt-lcd-root"
+      data-composition-id="yt-lcd-background"
+      data-start="0"
+      data-duration="10"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-lcd-scan" data-layout-allow-overflow></div>
+      <div id="yt-lcd-grid"></div>
+      <div id="yt-lcd-grain"></div>
+      <div id="yt-lcd-bow"></div>
+      <div
+        id="yt-lcd-drv"
+        class="clip"
+        data-start="0"
+        data-duration="10"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        /* ---- published parameters (inspector-style CONFIG) ---- */
+        var CONFIG = {
+          scheme: "light", // "light" | "dark" (light/dark toggle)
+          title: "yt-lcd",
+          subtitle: "background 01",
+          fontSize: 230,
+          subSize: 34,
+          color: null, // null = scheme ink (AA). Cyan "#35c8d9" is dark-scheme only: 1.66:1 on light paper fails AA
+          blur: 2.2, // resting text blur px (blur amount)
+          prism: { enabled: true, offset: 3 }, // chromatic fringe (chromatic fringe)
+          bow: { enabled: true, deg: 7 }, // perspective bow (safe CRT-bow variant)
+          grid: { enabled: true }, // pixel grid (pixel grid)
+          scanDrift: true, // slow scanline scroll for life
+          animationIn: true,
+          animationOut: true,
+        };
+
+        var DUR = 10;
+        /* the yt- family improvement: in/out durations auto-scale to block
+           length (animations adjust to the layer length) */
+        function clamp(v, lo, hi) {
+          return Math.min(hi, Math.max(lo, v));
+        }
+        var IN = clamp(DUR * 0.08, 0.3, 0.8);
+        var OUT = clamp(DUR * 0.06, 0.25, 0.6);
+
+        var root = document.getElementById("yt-lcd-root");
+        var bow = document.getElementById("yt-lcd-bow");
+        var grid = document.getElementById("yt-lcd-grid");
+        var scan = document.getElementById("yt-lcd-scan");
+
+        if (CONFIG.scheme === "dark") root.classList.add("yt-dark");
+        if (!CONFIG.grid.enabled) grid.style.display = "none";
+
+        var mainColor =
+          CONFIG.color || (CONFIG.scheme === "dark" ? "var(--yt-ink-dark)" : "var(--yt-ink)");
+
+        /* build a line: prism copies behind + main fill */
+        function buildLine(text, size, idBase, prismOn) {
+          var line = document.createElement("div");
+          line.className = "yt-lcd-line";
+          line.style.fontSize = size + "px";
+          ["r", "b"].forEach(function (ch) {
+            if (!CONFIG.prism.enabled || !prismOn) return;
+            var c = document.createElement("div");
+            c.className = "yt-lcd-copy " + ch;
+            c.id = idBase + "-" + ch;
+            c.textContent = text;
+            line.appendChild(c);
+          });
+          var main = document.createElement("div");
+          main.className = "yt-lcd-main";
+          main.id = idBase + "-main";
+          main.textContent = text;
+          main.style.color = mainColor;
+          line.appendChild(main);
+          return line;
+        }
+
+        var titleLine = buildLine(CONFIG.title, CONFIG.fontSize, "yt-lcd-t", true);
+        bow.appendChild(titleLine);
+        if (CONFIG.subtitle) {
+          var sub = buildLine(CONFIG.subtitle, CONFIG.subSize, "yt-lcd-s", false); /* fringe is title-only */
+          sub.id = "yt-lcd-sub";
+          bow.appendChild(sub);
+        }
+        if (CONFIG.bow.enabled) {
+          bow.style.transform = "perspective(950px) rotateX(" + CONFIG.bow.deg + "deg)";
+        }
+
+        var O = CONFIG.prism.offset;
+        var tl = gsap.timeline({ paused: true });
+
+        /* entrance: board fades, text focuses in from heavy blur while the
+           prism fringe settles from wide to resting offset */
+        if (CONFIG.animationIn) {
+          tl.from(root, { opacity: 0, duration: IN, ease: "power2.out" }, 0);
+          gsap.set(bow, { opacity: 0, filter: "blur(16px)" });
+          tl.to(bow, { opacity: 1, duration: IN * 1.4, ease: "power2.out" }, IN * 0.4);
+          tl.to(
+            bow,
+            { filter: "blur(" + CONFIG.blur + "px)", duration: IN * 2.2, ease: "power2.out" },
+            IN * 0.4
+          );
+          if (CONFIG.prism.enabled) {
+            gsap.set(".yt-lcd-copy.r", { x: -O * 4, opacity: 0.5 });
+            gsap.set(".yt-lcd-copy.b", { x: O * 4, opacity: 0.5 });
+            tl.to(".yt-lcd-copy.r", { x: -O, opacity: 0.85, duration: IN * 2.2, ease: "power2.out" }, IN * 0.4);
+            tl.to(".yt-lcd-copy.b", { x: O, opacity: 0.85, duration: IN * 2.2, ease: "power2.out" }, IN * 0.4);
+          }
+        } else {
+          gsap.set(bow, { filter: "blur(" + CONFIG.blur + "px)" });
+          if (CONFIG.prism.enabled) {
+            gsap.set(".yt-lcd-copy.r", { x: -O, opacity: 0.85 });
+            gsap.set(".yt-lcd-copy.b", { x: O, opacity: 0.85 });
+          }
+        }
+
+        /* ambient: slow scanline drift + a breath of prism wobble */
+        if (CONFIG.scanDrift) {
+          tl.to(scan, { y: 14, duration: 3.1, ease: "sine.inOut", yoyo: true, repeat: Math.max(1, Math.floor((DUR - 1) / 3.1) - 0) }, 0.5);
+        }
+        if (CONFIG.prism.enabled) {
+          tl.to(".yt-lcd-copy.r", { x: -O - 1.2, duration: 2.4, ease: "sine.inOut", yoyo: true, repeat: 2 }, 2.0);
+          tl.to(".yt-lcd-copy.b", { x: O + 1.2, duration: 2.4, ease: "sine.inOut", yoyo: true, repeat: 2 }, 2.0);
+        }
+
+        /* exit + hard kill */
+        if (CONFIG.animationOut) {
+          tl.to(root, { opacity: 0, duration: OUT, ease: "power2.in" }, DUR - OUT - 0.05);
+        }
+        tl.set(root, { visibility: "hidden" }, DUR - 0.02);
+
+        window.__timelines["yt-lcd-background"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/yt-logo-intro/registry-item.json
+++ b/registry/blocks/yt-logo-intro/registry-item.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-logo-intro",
+  "type": "hyperframes:block",
+  "title": "Logo Intro Sequence",
+  "description": "Logo stamp pops on a lined board, a kicker line gives way to the title with an accent arrow chip; seeded line distortion",
+  "tags": [
+    "logo",
+    "intro",
+    "creator"
+  ],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 6,
+  "files": [
+    {
+      "path": "yt-logo-intro.html",
+      "target": "compositions/yt-logo-intro.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/yt-logo-intro/yt-logo-intro.html
+++ b/registry/blocks/yt-logo-intro/yt-logo-intro.html
@@ -1,0 +1,241 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      #yt-li-root {
+        /* ---- yt tokens ---- */
+        --yt-font: "Inter", -apple-system, sans-serif;
+        --yt-paper: #e9e9e6;
+        --yt-paper-dark: #1c1c1e;
+        --yt-ink: #1d1d1f;
+        --yt-ink-dark: #e8e8e4;
+        --yt-red: #e62e2e;
+        --yt-line-alpha: 0.1;
+
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: var(--yt-paper);
+        font-family: var(--yt-font);
+      }
+      #yt-li-root.yt-dark {
+        background: var(--yt-paper-dark);
+      }
+      #yt-li-lines {
+        position: absolute;
+        inset: 0;
+      }
+      .yt-li-line {
+        position: absolute;
+        left: -40px;
+        right: -40px;
+        height: 2px;
+        background: rgba(0, 0, 0, var(--yt-line-alpha));
+      }
+      .yt-dark .yt-li-line {
+        background: rgba(255, 255, 255, var(--yt-line-alpha));
+      }
+      #yt-li-center {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 42px;
+      }
+      #yt-li-logo {
+        width: 220px;
+        height: 220px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--yt-ink);
+        color: #ffffff;
+        font-weight: 700;
+        font-size: 92px;
+        letter-spacing: -0.03em;
+        overflow: hidden;
+      }
+      .yt-dark #yt-li-logo {
+        background: var(--yt-ink-dark);
+        color: var(--yt-paper-dark);
+      }
+      #yt-li-logo img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+      }
+      .yt-li-shadow #yt-li-logo,
+      .yt-li-shadow #yt-li-text {
+        filter: drop-shadow(0 14px 30px rgba(0, 0, 0, 0.22));
+      }
+      #yt-li-textrow {
+        display: flex;
+        align-items: center;
+        gap: 26px;
+        min-height: 96px;
+      }
+      #yt-li-text {
+        font-weight: 700;
+        font-size: 74px;
+        letter-spacing: -0.015em;
+        color: var(--yt-ink);
+        white-space: nowrap;
+      }
+      .yt-dark #yt-li-text {
+        color: var(--yt-ink-dark);
+      }
+      #yt-li-arrow {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 84px;
+        height: 64px;
+        border-radius: 16px;
+        background: var(--yt-red);
+        opacity: 0;
+      }
+      #yt-li-arrow svg {
+        width: 38px;
+        stroke: #ffffff;
+        stroke-width: 3.2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        fill: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="yt-li-root"
+      data-composition-id="yt-logo-intro"
+      data-start="0"
+      data-duration="6"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-li-lines"></div>
+      <div id="yt-li-center">
+        <div id="yt-li-logo"></div>
+        <div id="yt-li-textrow">
+          <div id="yt-li-text"></div>
+          <div id="yt-li-arrow"><svg viewBox="0 0 24 24"><path d="M4 12h15M13 5l7 7-7 7" /></svg></div>
+        </div>
+      </div>
+      <div
+        id="yt-li-drv"
+        class="clip"
+        data-start="0"
+        data-duration="6"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        /* ---- published parameters ----
+           A logo intro: logo drops in, a kicker line, then the title
+           with an accent-red arrow. Background lines with frequency +
+           distortion (seeded offsets — no randomness). */
+        var CONFIG = {
+          scheme: "light", // "light" | "dark"
+          logoType: "text", // "text" | "image"
+          logoText: "YT",
+          logoSrc: null,
+          kicker: "LET'S DIVE IN",
+          title: "yt-logo-intro",
+          arrow: { enabled: true },
+          lines: { enabled: true, count: 12, distort: 10 },
+          dropShadow: true,
+          animationIn: true,
+          animationOut: true,
+        };
+
+        var DUR = 6;
+        function clamp(v, lo, hi) {
+          return Math.min(hi, Math.max(lo, v));
+        }
+        var IN = clamp(DUR * 0.08, 0.3, 0.8);
+        var OUT = clamp(DUR * 0.06, 0.25, 0.6);
+
+        var root = document.getElementById("yt-li-root");
+        var lines = document.getElementById("yt-li-lines");
+        var logo = document.getElementById("yt-li-logo");
+        var text = document.getElementById("yt-li-text");
+        var arrow = document.getElementById("yt-li-arrow");
+
+        if (CONFIG.scheme === "dark") root.classList.add("yt-dark");
+        if (CONFIG.dropShadow) root.classList.add("yt-li-shadow");
+
+        /* background lines: even spacing + seeded sine distortion */
+        if (CONFIG.lines.enabled) {
+          var gap = 1080 / (CONFIG.lines.count + 1);
+          for (var i = 1; i <= CONFIG.lines.count; i++) {
+            var l = document.createElement("div");
+            l.className = "yt-li-line";
+            var wobble = Math.sin(i * 2.399) * CONFIG.lines.distort;
+            l.style.top = Math.round(i * gap + wobble) + "px";
+            l.style.transform = "rotate(" + (Math.sin(i * 1.7) * 0.35).toFixed(2) + "deg)";
+            lines.appendChild(l);
+          }
+        }
+
+        if (CONFIG.logoType === "image" && CONFIG.logoSrc) {
+          var img = document.createElement("img");
+          img.src = CONFIG.logoSrc;
+          logo.appendChild(img);
+        } else {
+          logo.textContent = CONFIG.logoText;
+        }
+        if (!CONFIG.arrow.enabled) arrow.style.display = "none";
+
+        var tl = gsap.timeline({ paused: true });
+
+        if (CONFIG.animationIn) tl.from(root, { opacity: 0, duration: IN, ease: "power2.out" }, 0);
+
+        /* logo pops */
+        gsap.set(logo, { opacity: 0, scale: 0.55, y: 24 });
+        tl.to(logo, { opacity: 1, scale: 1, y: 0, duration: 0.55, ease: "back.out(1.5)" }, IN * 0.6);
+
+        /* kicker -> swap -> title + arrow */
+        gsap.set(text, { opacity: 0, y: 14 });
+        tl.set(text, { textContent: CONFIG.kicker, letterSpacing: "0.22em", fontSize: "40px" }, 0);
+        tl.to(text, { opacity: 1, y: 0, duration: 0.45, ease: "power2.out" }, IN * 0.6 + 0.45);
+        tl.to(text, { opacity: 0, y: -12, duration: 0.3, ease: "power2.in" }, 2.3);
+        tl.set(text, { textContent: CONFIG.title, letterSpacing: "-0.015em", fontSize: "74px", y: 14 }, 2.62);
+        tl.to(text, { opacity: 1, y: 0, duration: 0.5, ease: "power3.out" }, 2.66);
+        gsap.set(arrow, { scale: 0.5, x: -14 });
+        tl.to(arrow, { opacity: 1, scale: 1, x: 0, duration: 0.45, ease: "back.out(1.6)" }, 2.9);
+
+        /* ambient: lines breathe */
+        tl.to(lines, { y: 8, duration: 2.2, ease: "sine.inOut", yoyo: true, repeat: 1 }, 0.8);
+
+        /* exit + hard kill */
+        if (CONFIG.animationOut) {
+          tl.to(root, { opacity: 0, duration: OUT, ease: "power2.in" }, DUR - OUT - 0.05);
+        }
+        tl.set(root, { visibility: "hidden" }, DUR - 0.02);
+
+        window.__timelines["yt-logo-intro"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/yt-prism-title/registry-item.json
+++ b/registry/blocks/yt-prism-title/registry-item.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-prism-title",
+  "type": "hyperframes:block",
+  "title": "Chromatic Fringe Title",
+  "description": "Display title on a transparent root: blur-focus entrance, red/blue fringe that settles then breathes, perspective bow, slow scale drift",
+  "tags": [
+    "typography",
+    "title-card",
+    "creator"
+  ],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 6,
+  "files": [
+    {
+      "path": "yt-prism-title.html",
+      "target": "compositions/yt-prism-title.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/yt-prism-title/yt-prism-title.html
+++ b/registry/blocks/yt-prism-title/yt-prism-title.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      #yt-pt-root {
+        /* ---- yt tokens: override in the host to re-skin the family ---- */
+        --yt-font: "Inter", -apple-system, sans-serif;
+        --yt-cyan: #35c8d9;
+        --yt-prism-r: #ff2a4d;
+        --yt-prism-b: #2a7fff;
+
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: transparent; /* overlays footage, a yt-lcd board, anything */
+        font-family: var(--yt-font);
+      }
+      #yt-pt-bow {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #yt-pt-line {
+        position: relative;
+        font-weight: 700;
+        line-height: 1;
+        letter-spacing: -0.02em;
+        white-space: nowrap;
+      }
+      .yt-pt-copy {
+        position: absolute;
+        inset: 0;
+      }
+      .yt-pt-copy.r {
+        color: var(--yt-prism-r);
+      }
+      .yt-pt-copy.b {
+        color: var(--yt-prism-b);
+      }
+      #yt-pt-main {
+        position: relative;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="yt-pt-root"
+      data-composition-id="yt-prism-title"
+      data-start="0"
+      data-duration="6"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-pt-bow"></div>
+      <div
+        id="yt-pt-drv"
+        class="clip"
+        data-start="0"
+        data-duration="6"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        /* ---- published parameters (inspector-style CONFIG) ----
+           The cyan hero title with the full treatment stack, on a
+           transparent root — drop it over footage or a yt-lcd board. */
+        var CONFIG = {
+          title: "yt-prism",
+          fontSize: 260,
+          color: "#35c8d9", // bright cyan, for dark footage/boards (1.66:1 on light paper fails AA); use a darker cyan e.g. "#0f7d8a" on light boards
+          blur: 2.5, // resting blur px
+          prism: { enabled: true, offset: 4 },
+          bow: { enabled: true, deg: 6 },
+          drift: true, // slow scale breath while held
+          x: null, // null = centered
+          y: null,
+          animationIn: true,
+          animationOut: true,
+        };
+
+        var DUR = 6;
+        function clamp(v, lo, hi) {
+          return Math.min(hi, Math.max(lo, v));
+        }
+        var IN = clamp(DUR * 0.08, 0.3, 0.8);
+        var OUT = clamp(DUR * 0.06, 0.25, 0.6);
+
+        var root = document.getElementById("yt-pt-root");
+        var bow = document.getElementById("yt-pt-bow");
+
+        /* build: prism copies behind the main fill */
+        var line = document.createElement("div");
+        line.id = "yt-pt-line";
+        line.style.fontSize = CONFIG.fontSize + "px";
+        ["r", "b"].forEach(function (ch) {
+          if (!CONFIG.prism.enabled) return;
+          var c = document.createElement("div");
+          c.className = "yt-pt-copy " + ch;
+          c.textContent = CONFIG.title;
+          line.appendChild(c);
+        });
+        var main = document.createElement("div");
+        main.id = "yt-pt-main";
+        main.textContent = CONFIG.title;
+        main.style.color = CONFIG.color;
+        line.appendChild(main);
+        bow.appendChild(line);
+
+        if (CONFIG.bow.enabled) {
+          bow.style.transform = "perspective(950px) rotateX(" + CONFIG.bow.deg + "deg)";
+        }
+        if (CONFIG.x !== null || CONFIG.y !== null) {
+          bow.style.justifyContent = CONFIG.x === null ? "center" : "flex-start";
+          bow.style.alignItems = CONFIG.y === null ? "center" : "flex-start";
+          if (CONFIG.x !== null) line.style.marginLeft = CONFIG.x + "px";
+          if (CONFIG.y !== null) line.style.marginTop = CONFIG.y + "px";
+        }
+
+        var O = CONFIG.prism.offset;
+        var tl = gsap.timeline({ paused: true });
+
+        /* entrance: focus in from heavy blur, prism settles wide -> resting */
+        if (CONFIG.animationIn) {
+          gsap.set(bow, { opacity: 0, filter: "blur(18px)" });
+          tl.to(bow, { opacity: 1, duration: IN * 1.4, ease: "power2.out" }, 0.1);
+          tl.to(bow, { filter: "blur(" + CONFIG.blur + "px)", duration: IN * 2.4, ease: "power2.out" }, 0.1);
+          if (CONFIG.prism.enabled) {
+            gsap.set(".yt-pt-copy.r", { x: -O * 4.5, opacity: 0.45 });
+            gsap.set(".yt-pt-copy.b", { x: O * 4.5, opacity: 0.45 });
+            tl.to(".yt-pt-copy.r", { x: -O, opacity: 0.85, duration: IN * 2.4, ease: "power2.out" }, 0.1);
+            tl.to(".yt-pt-copy.b", { x: O, opacity: 0.85, duration: IN * 2.4, ease: "power2.out" }, 0.1);
+          }
+        } else {
+          gsap.set(bow, { filter: "blur(" + CONFIG.blur + "px)" });
+          if (CONFIG.prism.enabled) {
+            gsap.set(".yt-pt-copy.r", { x: -O, opacity: 0.85 });
+            gsap.set(".yt-pt-copy.b", { x: O, opacity: 0.85 });
+          }
+        }
+
+        /* ambient: slow scale breath + prism wobble */
+        if (CONFIG.drift) {
+          tl.to(line, { scale: 1.035, duration: DUR - 1, ease: "sine.out" }, 0.4);
+        }
+        if (CONFIG.prism.enabled) {
+          tl.to(".yt-pt-copy.r", { x: -O - 1.4, duration: 1.9, ease: "sine.inOut", yoyo: true, repeat: 1 }, 1.4);
+          tl.to(".yt-pt-copy.b", { x: O + 1.4, duration: 1.9, ease: "sine.inOut", yoyo: true, repeat: 1 }, 1.4);
+        }
+
+        /* exit + hard kill */
+        if (CONFIG.animationOut) {
+          tl.to(bow, { opacity: 0, filter: "blur(12px)", duration: OUT, ease: "power2.in" }, DUR - OUT - 0.05);
+        }
+        tl.set(root, { visibility: "hidden" }, DUR - 0.02);
+
+        window.__timelines["yt-prism-title"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/yt-vertical-fill/registry-item.json
+++ b/registry/blocks/yt-vertical-fill/registry-item.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-vertical-fill",
+  "type": "hyperframes:block",
+  "title": "Vertical Media Filler",
+  "description": "Portrait media filling a widescreen frame via blurred-scale, mirror, or copy side fills; grid texture and foreground contrast lift (images inside the block; keep live footage in the host)",
+  "tags": [
+    "placeholder",
+    "vertical",
+    "media"
+  ],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 8,
+  "files": [
+    {
+      "path": "yt-vertical-fill.html",
+      "target": "compositions/yt-vertical-fill.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/yt-vertical-fill/yt-vertical-fill.html
+++ b/registry/blocks/yt-vertical-fill/yt-vertical-fill.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      #yt-vf-root {
+        /* ---- yt tokens ---- */
+        --yt-font: "Inter", -apple-system, sans-serif;
+        --yt-grid-size: 28px;
+        --yt-grid-alpha: 0.05;
+        --yt-stage: #101012;
+        --yt-scrim: rgba(8, 8, 10, 0.28);
+        --yt-cyan: #35c8d9;
+        --yt-prism-b: #2a7fff;
+        --yt-violet: #7d5cff;
+
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: var(--yt-stage);
+        font-family: var(--yt-font);
+      }
+      .yt-vf-media {
+        position: absolute;
+        overflow: hidden;
+      }
+      .yt-vf-media img,
+      .yt-vf-media .yt-vf-fill {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      #yt-vf-bg {
+        inset: -60px;
+        filter: blur(42px) brightness(0.75);
+      }
+      .yt-vf-side {
+        top: 0;
+        bottom: 0;
+        width: 656px;
+      }
+      #yt-vf-scrim {
+        position: absolute;
+        inset: 0;
+        background: var(--yt-scrim);
+      }
+      #yt-vf-grid {
+        position: absolute;
+        inset: 0;
+        background:
+          repeating-linear-gradient(0deg, rgba(255, 255, 255, var(--yt-grid-alpha)) 0 1px, transparent 1px var(--yt-grid-size)),
+          repeating-linear-gradient(90deg, rgba(255, 255, 255, var(--yt-grid-alpha)) 0 1px, transparent 1px var(--yt-grid-size));
+      }
+      #yt-vf-fg {
+        top: 0;
+        bottom: 0;
+        left: 656px;
+        width: 608px;
+        box-shadow: 0 0 90px rgba(0, 0, 0, 0.55);
+      }
+      /* stand-in portrait when no media is configured (self-demo) */
+      .yt-vf-fill {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 120px;
+        color: rgba(255, 255, 255, 0.9);
+        background: linear-gradient(160deg, var(--yt-cyan) 0%, var(--yt-prism-b) 50%, var(--yt-violet) 100%);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="yt-vf-root"
+      data-composition-id="yt-vertical-fill"
+      data-start="0"
+      data-duration="8"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="yt-vf-media" id="yt-vf-bg" data-layout-allow-overflow></div>
+      <div class="yt-vf-media yt-vf-side" id="yt-vf-side-l" style="left: 0"></div>
+      <div class="yt-vf-media yt-vf-side" id="yt-vf-side-r" style="right: 0"></div>
+      <div id="yt-vf-scrim"></div>
+      <div id="yt-vf-grid"></div>
+      <div class="yt-vf-media" id="yt-vf-fg"></div>
+      <div
+        id="yt-vf-drv"
+        class="clip"
+        data-start="0"
+        data-duration="8"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        /* ---- published parameters ----
+           Vertical media filling a 16:9 frame — three fill modes:
+           mode "scale" (big blurred copy behind), "mirror" (flanking
+           mirrored copies), "copy" (flanking straight copies).
+           IMAGES ONLY inside this block: the runtime never seeks media
+           elements inside a sub-composition (renders black). For live
+           vertical FOOTAGE, keep the media element in the HOST root
+           positioned over the fg slot (left:656px width:608px) and feed
+           this block a representative still for the fill layers. */
+        var CONFIG = {
+          src: null, // portrait IMAGE path; null -> stand-in gradient (demo)
+          mode: "scale", // "scale" | "mirror" | "copy"
+          fgContrast: 1.06,
+          fgBrightness: 1.03,
+          fgSaturation: 1.08,
+          grid: { enabled: true },
+          kenBurns: true,
+          animationIn: true,
+          animationOut: true,
+        };
+
+        var DUR = 8;
+        function clamp(v, lo, hi) {
+          return Math.min(hi, Math.max(lo, v));
+        }
+        var IN = clamp(DUR * 0.08, 0.3, 0.8);
+        var OUT = clamp(DUR * 0.06, 0.25, 0.6);
+
+        var root = document.getElementById("yt-vf-root");
+        var bg = document.getElementById("yt-vf-bg");
+        var sideL = document.getElementById("yt-vf-side-l");
+        var sideR = document.getElementById("yt-vf-side-r");
+        var fg = document.getElementById("yt-vf-fg");
+        var grid = document.getElementById("yt-vf-grid");
+
+        if (!CONFIG.grid.enabled) grid.style.display = "none";
+
+        function media(id) {
+          if (!CONFIG.src) {
+            var d = document.createElement("div");
+            d.className = "yt-vf-fill";
+            d.textContent = "9:16";
+            return d;
+          }
+          var img = document.createElement("img");
+          img.src = CONFIG.src;
+          img.id = id;
+          return img;
+        }
+
+        fg.appendChild(media("yt-vf-m-fg"));
+        fg.style.filter =
+          "contrast(" + CONFIG.fgContrast + ") brightness(" + CONFIG.fgBrightness + ") saturate(" + CONFIG.fgSaturation + ")";
+
+        if (CONFIG.mode === "scale") {
+          bg.appendChild(media("yt-vf-m-bg"));
+          sideL.style.display = "none";
+          sideR.style.display = "none";
+        } else {
+          bg.style.display = "none";
+          sideL.appendChild(media("yt-vf-m-l"));
+          sideR.appendChild(media("yt-vf-m-r"));
+          if (CONFIG.mode === "mirror") {
+            sideL.firstChild.style.transform = "scaleX(-1)";
+            sideR.firstChild.style.transform = "scaleX(-1)";
+          }
+          sideL.style.filter = "blur(6px) brightness(0.72)";
+          sideR.style.filter = "blur(6px) brightness(0.72)";
+        }
+
+        var tl = gsap.timeline({ paused: true });
+
+        if (CONFIG.animationIn) {
+          tl.from(root, { opacity: 0, duration: IN, ease: "power2.out" }, 0);
+          gsap.set(fg, { y: 34, opacity: 0 });
+          tl.to(fg, { y: 0, opacity: 1, duration: IN * 1.6, ease: "power3.out" }, IN * 0.5);
+        }
+        if (CONFIG.kenBurns) {
+          tl.fromTo(fg.firstChild, { scale: 1.05 }, { scale: 1, duration: DUR - 1, ease: "sine.out" }, 0.4);
+        }
+
+        if (CONFIG.animationOut) {
+          tl.to(root, { opacity: 0, duration: OUT, ease: "power2.in" }, DUR - OUT - 0.05);
+        }
+        tl.set(root, { visibility: "hidden" }, DUR - 0.02);
+
+        window.__timelines["yt-vertical-fill"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/components/yt-avatar-pip/registry-item.json
+++ b/registry/components/yt-avatar-pip/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-avatar-pip",
+  "type": "hyperframes:component",
+  "title": "Circle PiP Window",
+  "description": "Circular or rounded-rect masked picture-in-picture window with ring and shadow for a second video or image; pop in/out helpers",
+  "tags": [
+    "pip",
+    "overlay",
+    "creator"
+  ],
+  "files": [
+    {
+      "path": "yt-avatar-pip.html",
+      "target": "compositions/components/yt-avatar-pip.html",
+      "type": "hyperframes:snippet"
+    }
+  ]
+}

--- a/registry/components/yt-avatar-pip/yt-avatar-pip.html
+++ b/registry/components/yt-avatar-pip/yt-avatar-pip.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      /* ---- yt-avatar-pip ---------------------------------------------------
+         The screen-recording PiP: a circular (or rounded-rect) masked window
+         for a second video/image — one drop replaces the manual
+         crop-mask-resize dance. Size via --yt-pip-size, framing via an
+         inline transform scale on the inner media (an "inside scale"). */
+      .yt-pip {
+        --yt-pip-size: 300px;
+        --yt-pip-ring: rgba(255, 255, 255, 0.92);
+        --yt-pip-ring-w: 4px;
+
+        position: absolute;
+        width: var(--yt-pip-size);
+        height: var(--yt-pip-size);
+        border-radius: 50%;
+        overflow: hidden;
+        border: var(--yt-pip-ring-w) solid var(--yt-pip-ring);
+        box-shadow: 0 18px 50px rgba(0, 0, 0, 0.4);
+        pointer-events: none;
+      }
+      .yt-pip--rect {
+        border-radius: 22px;
+        width: calc(var(--yt-pip-size) * 1.55);
+      }
+      .yt-pip > img,
+      .yt-pip > video,
+      .yt-pip > .yt-pip-fill {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      /* self-preview stand-in (not part of the snippet) */
+      .yt-pip-fill {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: "Inter", ui-sans-serif, sans-serif;
+        font-weight: 700;
+        font-size: 92px;
+        color: rgba(255, 255, 255, 0.95);
+        background: linear-gradient(135deg, #ff8fb8 0%, #7d5cff 100%);
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Self-preview wrapper. WIRING: copy the .yt-pip CSS and the markup
+         pattern below into your host; put a <video data-start ...> or <img>
+         inside. The media element must live in the HOST root (this pattern
+         is copied in) — never inside a mounted sub-composition: sub-comps
+         are never seeked, so framework-owned media there renders black. Position via top/right/bottom/left; add class="clip" +
+         data-start/duration/track-index for host windowing. Framing: style
+         the inner media with transform: scale(1.15) etc. Then:
+
+           ytPipIn(tl, "#yt-my-pip", 2.0);
+           ytPipOut(tl, "#yt-my-pip", 12.0);
+    -->
+    <div
+      id="yt-pip-root"
+      data-composition-id="yt-avatar-pip"
+      data-start="0"
+      data-duration="4"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="yt-pip" id="yt-pip-demo" style="left: 120px; bottom: 100px">
+        <div class="yt-pip-fill">AB</div>
+      </div>
+      <div
+        id="yt-pip-drv"
+        class="clip"
+        data-start="0"
+        data-duration="4"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        // ---- copy these helpers into the host script ----
+        window.ytPipIn = function (tl, target, at) {
+          gsap.set(target, { opacity: 0, scale: 0.55, y: 26 });
+          tl.to(target, { opacity: 1, scale: 1, y: 0, duration: 0.55, ease: "back.out(1.5)" }, at);
+        };
+        window.ytPipOut = function (tl, target, at) {
+          tl.to(target, { opacity: 0, scale: 0.75, y: 18, duration: 0.35, ease: "power2.in" }, at);
+        };
+
+        // Self-preview timeline (not part of the snippet you copy).
+        var tl = gsap.timeline({ paused: true });
+        window.ytPipIn(tl, "#yt-pip-demo", 0.4);
+        window.ytPipOut(tl, "#yt-pip-demo", 3.4);
+        tl.set("#yt-pip-root", { visibility: "hidden" }, 3.98);
+        window.__timelines["yt-avatar-pip"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/components/yt-camera-move/registry-item.json
+++ b/registry/components/yt-camera-move/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-camera-move",
+  "type": "hyperframes:component",
+  "title": "Camera Punch-In",
+  "description": "Dynamic zoom, slide, and 3D tilt-pan helpers for any wrapper (video, include, card) with cubic-easing defaults and an edge-defocus pulse overlay",
+  "tags": [
+    "camera",
+    "zoom",
+    "effect",
+    "creator"
+  ],
+  "files": [
+    {
+      "path": "yt-camera-move.html",
+      "target": "compositions/components/yt-camera-move.html",
+      "type": "hyperframes:snippet"
+    }
+  ]
+}

--- a/registry/components/yt-camera-move/yt-camera-move.html
+++ b/registry/components/yt-camera-move/yt-camera-move.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      /* ---- yt-camera-move --------------------------------------------------
+         The creator-video punch-in as reusable GSAP helpers: dynamic
+         zoom + slide + 3D tilt/pan on any wrapper (a #video-wrap, a
+         sub-composition include, an image card). A talking-head recipe
+         is the default: cubic easing, ~11% zoom.
+
+         Optional: .yt-cm-defocus is an edge-blur overlay that pulses during
+         the move to sell the 3D feel — place it ABOVE the moving layer,
+         covering the same region. */
+      .yt-cm-defocus {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        opacity: 0;
+        backdrop-filter: blur(7px);
+        -webkit-backdrop-filter: blur(7px);
+        /* blur only the frame edges; center stays sharp */
+        -webkit-mask-image: radial-gradient(
+          ellipse 62% 58% at 50% 50%,
+          transparent 58%,
+          rgba(0, 0, 0, 0.85) 92%
+        );
+        mask-image: radial-gradient(
+          ellipse 62% 58% at 50% 50%,
+          transparent 58%,
+          rgba(0, 0, 0, 0.85) 92%
+        );
+      }
+      /* ---- self-preview stand-in "footage" (not part of the snippet) ---- */
+      #yt-cm-stage {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+        background: linear-gradient(135deg, #35c8d9 0%, #2a7fff 55%, #7d5cff 100%);
+      }
+      #yt-cm-stage .yt-cm-grid {
+        position: absolute;
+        inset: -60px;
+        background:
+          repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.14) 0 2px, transparent 2px 120px),
+          repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.14) 0 2px, transparent 2px 120px);
+      }
+      #yt-cm-stage .yt-cm-label {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: "Inter", ui-sans-serif, sans-serif;
+        font-weight: 700;
+        font-size: 120px;
+        letter-spacing: -0.02em;
+        color: rgba(255, 255, 255, 0.92);
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Self-preview wrapper. WIRING: copy the .yt-cm-defocus CSS (if you want
+         the edge blur), add <div class="yt-cm-defocus" id="yt-my-defocus"></div>
+         as a sibling ABOVE your moving layer, and copy the helpers into your
+         host script. Then drive any wrapper:
+
+           ytCameraMove(tl, "#video-wrap", 5.0, { zoom: 0.11, slideY: -24 });
+           ytDefocusPulse(tl, "#yt-my-defocus", 5.0, 1.2);
+           ytCameraReset(tl, "#video-wrap", 9.0);
+    -->
+    <div
+      id="yt-cm-root"
+      data-composition-id="yt-camera-move"
+      data-start="0"
+      data-duration="4"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-cm-stage">
+        <div class="yt-cm-grid" data-layout-allow-overflow></div>
+        <div class="yt-cm-label">FOOTAGE</div>
+      </div>
+      <div class="yt-cm-defocus" id="yt-cm-defocus"></div>
+      <div
+        id="yt-cm-drv"
+        class="clip"
+        data-start="0"
+        data-duration="4"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        // ---- copy these helpers into the host script ----
+        // Punch-in / camera move on any wrapper. A talking-head base:
+        // zoom 0.11, cubic ease. tilt/pan are degrees (rotationX/rotationY,
+        // perspective is set for you); slideX/slideY in px; roll in degrees.
+        window.ytCameraMove = function (tl, target, at, opts) {
+          opts = opts || {};
+          var dur = opts.dur === undefined ? 1.2 : opts.dur;
+          gsap.set(target, { transformPerspective: 1200, transformOrigin: opts.origin || "50% 50%" });
+          tl.to(
+            target,
+            {
+              scale: 1 + (opts.zoom === undefined ? 0.11 : opts.zoom),
+              x: opts.slideX || 0,
+              y: opts.slideY || 0,
+              rotationX: opts.tilt || 0,
+              rotationY: opts.pan || 0,
+              rotation: opts.roll || 0,
+              duration: dur,
+              ease: opts.ease || "power2.inOut",
+            },
+            at
+          );
+        };
+        // Return to rest (same easing family).
+        window.ytCameraReset = function (tl, target, at, opts) {
+          opts = opts || {};
+          tl.to(
+            target,
+            {
+              scale: 1,
+              x: 0,
+              y: 0,
+              rotationX: 0,
+              rotationY: 0,
+              rotation: 0,
+              duration: opts.dur === undefined ? 1.2 : opts.dur,
+              ease: opts.ease || "power2.inOut",
+            },
+            at
+          );
+        };
+        // Edge-defocus pulse synced to a move (overlay fades in then out).
+        window.ytDefocusPulse = function (tl, target, at, dur) {
+          dur = dur === undefined ? 1.2 : dur;
+          tl.to(target, { opacity: 1, duration: dur * 0.45, ease: "power2.out" }, at);
+          tl.to(target, { opacity: 0, duration: dur * 0.55, ease: "power2.in" }, at + dur * 0.45);
+        };
+
+        // Self-preview timeline (not part of the snippet you copy):
+        // punch in with a slight tilt, hold, return.
+        var tl = gsap.timeline({ paused: true });
+        window.ytCameraMove(tl, "#yt-cm-stage", 0.4, { zoom: 0.11, slideY: -26, tilt: 3, pan: -2 });
+        window.ytDefocusPulse(tl, "#yt-cm-defocus", 0.4, 1.2);
+        window.ytCameraReset(tl, "#yt-cm-stage", 2.5);
+        window.ytDefocusPulse(tl, "#yt-cm-defocus", 2.5, 1.2);
+        tl.set("#yt-cm-root", { visibility: "hidden" }, 3.98);
+        window.__timelines["yt-camera-move"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/components/yt-circle-pointer/registry-item.json
+++ b/registry/components/yt-circle-pointer/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-circle-pointer",
+  "type": "hyperframes:component",
+  "title": "Pointer Circle + Countdown",
+  "description": "Draw-on annotation ellipse around a target plus a countdown chip that pulses each tick",
+  "tags": [
+    "annotation",
+    "countdown",
+    "overlay"
+  ],
+  "files": [
+    {
+      "path": "yt-circle-pointer.html",
+      "target": "compositions/components/yt-circle-pointer.html",
+      "type": "hyperframes:snippet"
+    }
+  ]
+}

--- a/registry/components/yt-circle-pointer/yt-circle-pointer.html
+++ b/registry/components/yt-circle-pointer/yt-circle-pointer.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      /* ---- yt-circle-pointer -----------------------------------------------
+         Annotation tools: a hand-drawn-feel circle that draws on around a
+         target, and a countdown chip. Position instances via top/left with
+         explicit width/height. */
+      .yt-circle {
+        --yt-red: #e62e2e;
+        position: absolute;
+        pointer-events: none;
+      }
+      .yt-circle svg {
+        width: 100%;
+        height: 100%;
+        overflow: visible;
+      }
+      .yt-circle ellipse {
+        fill: none;
+        stroke: var(--yt-ptr-color, var(--yt-red));
+        stroke-width: 6;
+        stroke-linecap: round;
+        transform: rotate(-6deg);
+        transform-origin: 50% 50%;
+      }
+      .yt-count {
+        position: absolute;
+        display: inline-flex;
+        align-items: center;
+        gap: 14px;
+        padding: 16px 32px;
+        border-radius: 999px;
+        font-family: "Inter", ui-sans-serif, sans-serif;
+        font-weight: 700;
+        font-size: 40px;
+        background: var(--yt-count-bg, var(--yt-red));
+        color: #ffffff;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
+        pointer-events: none;
+        opacity: 0;
+      }
+      .yt-count .num {
+        font-variant-numeric: tabular-nums;
+        min-width: 1.2em;
+        text-align: center;
+      }
+      /* self-preview scene */
+      #yt-ptr-scene {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(135deg, #35c8d9 0%, #2a7fff 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: "Inter", ui-sans-serif, sans-serif;
+        font-weight: 700;
+        font-size: 60px;
+        color: rgba(255, 255, 255, 0.92);
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Self-preview wrapper. WIRING: copy the .yt-circle / .yt-count CSS and
+         markup patterns, position over your target, then:
+
+           ytCircleOn(tl, "#yt-my-circle", 3.0);          // draws the ring
+           ytCircleOff(tl, "#yt-my-circle", 6.0);
+           ytCountIn(tl, "#yt-my-count", 2.0);
+           ytCountdown(tl, "#yt-my-count", 2.4, 5);       // 5 -> 0, pulsing each tick
+    -->
+    <div
+      id="yt-ptr-root"
+      data-composition-id="yt-circle-pointer"
+      data-start="0"
+      data-duration="5"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-ptr-scene"><span>the thing</span></div>
+      <div class="yt-circle" id="yt-ptr-circle" style="left: 760px; top: 440px; width: 420px; height: 210px">
+        <svg viewBox="0 0 420 210"><ellipse cx="210" cy="105" rx="196" ry="88"></ellipse></svg>
+      </div>
+      <div class="yt-count" id="yt-ptr-count" style="right: 140px; top: 110px">
+        <span class="num">5</span><span>sec</span>
+      </div>
+      <div
+        id="yt-ptr-drv"
+        class="clip"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        // ---- copy these helpers into the host script ----
+        window.ytCircleOn = function (tl, target, at, dur) {
+          var el = document.querySelector(target + " ellipse");
+          var len = el.getTotalLength();
+          gsap.set(el, { strokeDasharray: len, strokeDashoffset: len });
+          tl.to(el, { strokeDashoffset: 0, duration: dur === undefined ? 0.7 : dur, ease: "power2.inOut" }, at);
+        };
+        window.ytCircleOff = function (tl, target, at) {
+          tl.to(target, { opacity: 0, duration: 0.35, ease: "power2.in" }, at);
+        };
+        window.ytCountIn = function (tl, target, at) {
+          gsap.set(target, { y: -18, scale: 0.9 });
+          tl.to(target, { opacity: 1, y: 0, scale: 1, duration: 0.45, ease: "back.out(1.5)" }, at);
+        };
+        window.ytCountdown = function (tl, target, at, from) {
+          var num = document.querySelector(target + " .num");
+          var st = { v: from };
+          tl.to(
+            st,
+            {
+              v: 0,
+              duration: from,
+              ease: "none",
+              onUpdate: function () {
+                num.textContent = String(Math.ceil(st.v));
+              },
+            },
+            at
+          );
+          for (var i = 1; i <= from; i++) {
+            tl.to(target, { scale: 1.07, duration: 0.09, ease: "sine.out" }, at + i - 0.09);
+            tl.to(target, { scale: 1, duration: 0.14, ease: "sine.in" }, at + i);
+          }
+        };
+
+        // Self-preview timeline.
+        var tl = gsap.timeline({ paused: true });
+        window.ytCountIn(tl, "#yt-ptr-count", 0.3);
+        window.ytCountdown(tl, "#yt-ptr-count", 0.7, 3);
+        window.ytCircleOn(tl, "#yt-ptr-circle", 1.0);
+        window.ytCircleOff(tl, "#yt-ptr-circle", 4.2);
+        tl.to("#yt-ptr-count", { opacity: 0, duration: 0.3, ease: "power2.in" }, 4.3);
+        tl.set("#yt-ptr-root", { visibility: "hidden" }, 4.98);
+        window.__timelines["yt-circle-pointer"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/components/yt-feather-highlight/registry-item.json
+++ b/registry/components/yt-feather-highlight/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-feather-highlight",
+  "type": "hyperframes:component",
+  "title": "Feathered Spotlight",
+  "description": "Dims the frame except a feathered ellipse; the hole's position and size are CSS variables, so helpers glide the spotlight between targets",
+  "tags": [
+    "highlight",
+    "spotlight",
+    "effect",
+    "overlay"
+  ],
+  "files": [
+    {
+      "path": "yt-feather-highlight.html",
+      "target": "compositions/components/yt-feather-highlight.html",
+      "type": "hyperframes:snippet"
+    }
+  ]
+}

--- a/registry/components/yt-feather-highlight/yt-feather-highlight.html
+++ b/registry/components/yt-feather-highlight/yt-feather-highlight.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      /* ---- yt-feather-highlight --------------------------------------------
+         Spotlight part of the frame: a dim layer with a feathered ellipse
+         hole. The hole's position/size are CSS variables, so the helpers
+         tween them directly (GSAP animates CSS vars). */
+      .yt-hl {
+        --yt-hl-x: 50%;
+        --yt-hl-y: 50%;
+        --yt-hl-rx: 22%;
+        --yt-hl-ry: 26%;
+        --yt-hl-dim: 0.55;
+
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        opacity: 0;
+        background: rgba(6, 8, 12, var(--yt-hl-dim));
+        -webkit-mask-image: radial-gradient(
+          ellipse var(--yt-hl-rx) var(--yt-hl-ry) at var(--yt-hl-x) var(--yt-hl-y),
+          transparent 0%,
+          transparent 52%,
+          black 88%
+        );
+        mask-image: radial-gradient(
+          ellipse var(--yt-hl-rx) var(--yt-hl-ry) at var(--yt-hl-x) var(--yt-hl-y),
+          transparent 0%,
+          transparent 52%,
+          black 88%
+        );
+      }
+      /* self-preview stand-in scene (not part of the snippet) */
+      #yt-hl-scene {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(135deg, #2a7fff 0%, #7d5cff 100%);
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+        font-family: "Inter", ui-sans-serif, sans-serif;
+        font-weight: 700;
+        font-size: 64px;
+        color: rgba(255, 255, 255, 0.92);
+      }
+      #yt-hl-scene .box {
+        width: 420px;
+        height: 300px;
+        border-radius: 24px;
+        background: rgba(255, 255, 255, 0.16);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Self-preview wrapper. WIRING: copy the .yt-hl CSS and drop
+         <div class="yt-hl" id="yt-my-hl"></div> ABOVE the content to spotlight
+         (same region). Then:
+
+           ytHighlightIn(tl, "#yt-my-hl", 3.0, { x: "28%", y: "50%", rx: "20%", ry: "30%" });
+           ytHighlightTo(tl, "#yt-my-hl", 5.0, { x: "72%" }, 0.8);   // glide to the next target
+           ytHighlightOut(tl, "#yt-my-hl", 8.0);
+    -->
+    <div
+      id="yt-hl-root"
+      data-composition-id="yt-feather-highlight"
+      data-start="0"
+      data-duration="5"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-hl-scene">
+        <div class="box">A</div>
+        <div class="box">B</div>
+      </div>
+      <div class="yt-hl" id="yt-hl-demo"></div>
+      <div
+        id="yt-hl-drv"
+        class="clip"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        // ---- copy these helpers into the host script ----
+        window.ytHighlightIn = function (tl, target, at, opts) {
+          opts = opts || {};
+          var vars = { opacity: 1, duration: 0.5, ease: "power2.out" };
+          if (opts.x !== undefined) vars["--yt-hl-x"] = opts.x;
+          if (opts.y !== undefined) vars["--yt-hl-y"] = opts.y;
+          if (opts.rx !== undefined) vars["--yt-hl-rx"] = opts.rx;
+          if (opts.ry !== undefined) vars["--yt-hl-ry"] = opts.ry;
+          gsap.set(target, {
+            "--yt-hl-x": opts.x !== undefined ? opts.x : "50%",
+            "--yt-hl-y": opts.y !== undefined ? opts.y : "50%",
+            "--yt-hl-rx": opts.rx !== undefined ? opts.rx : "22%",
+            "--yt-hl-ry": opts.ry !== undefined ? opts.ry : "26%",
+          });
+          tl.to(target, { opacity: 1, duration: 0.5, ease: "power2.out" }, at);
+        };
+        window.ytHighlightTo = function (tl, target, at, opts, dur) {
+          opts = opts || {};
+          var vars = { duration: dur === undefined ? 0.8 : dur, ease: "power2.inOut" };
+          if (opts.x !== undefined) vars["--yt-hl-x"] = opts.x;
+          if (opts.y !== undefined) vars["--yt-hl-y"] = opts.y;
+          if (opts.rx !== undefined) vars["--yt-hl-rx"] = opts.rx;
+          if (opts.ry !== undefined) vars["--yt-hl-ry"] = opts.ry;
+          tl.to(target, vars, at);
+        };
+        window.ytHighlightOut = function (tl, target, at) {
+          tl.to(target, { opacity: 0, duration: 0.4, ease: "power2.in" }, at);
+        };
+
+        // Self-preview timeline: spotlight box A, glide to box B, release.
+        var tl = gsap.timeline({ paused: true });
+        window.ytHighlightIn(tl, "#yt-hl-demo", 0.5, { x: "26%", y: "50%", rx: "17%", ry: "24%" });
+        window.ytHighlightTo(tl, "#yt-hl-demo", 2.2, { x: "74%" }, 0.9);
+        window.ytHighlightOut(tl, "#yt-hl-demo", 4.2);
+        tl.set("#yt-hl-root", { visibility: "hidden" }, 4.98);
+        window.__timelines["yt-feather-highlight"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/components/yt-screen-warp/registry-item.json
+++ b/registry/components/yt-screen-warp/registry-item.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "yt-screen-warp",
+  "type": "hyperframes:component",
+  "title": "On-Screen Display Effect",
+  "description": "Grid, scanline, vignette, and sheen overlay plus a 3D-warp wrapper class that makes footage read as if playing on a physical display",
+  "tags": [
+    "effect",
+    "overlay",
+    "texture"
+  ],
+  "files": [
+    {
+      "path": "yt-screen-warp.html",
+      "target": "compositions/components/yt-screen-warp.html",
+      "type": "hyperframes:snippet"
+    }
+  ]
+}

--- a/registry/components/yt-screen-warp/yt-screen-warp.html
+++ b/registry/components/yt-screen-warp/yt-screen-warp.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: transparent;
+        overflow: hidden;
+      }
+      /* ---- yt-screen-warp ---------------------------------------------------
+         Make footage read as a physical display: add .yt-screen-warp3d to the
+         media WRAPPER (subtle perspective), and place .yt-screen-fx overlay
+         inside it (pixel grid + scanlines + vignette + sheen). */
+      .yt-screen-warp3d {
+        transform: perspective(1400px) rotateY(-3.5deg) rotateX(1.6deg);
+      }
+      .yt-screen-fx {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        opacity: 0;
+        background:
+          /* sheen */
+          linear-gradient(115deg, rgba(255, 255, 255, 0.09) 0%, transparent 30%),
+          /* scanlines */
+          repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0 1px, transparent 1px 3px),
+          /* pixel grid */
+          repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.06) 0 1px, transparent 1px 4px);
+        box-shadow:
+          inset 0 0 90px rgba(0, 0, 0, 0.4),
+          inset 0 0 8px rgba(0, 0, 0, 0.5);
+      }
+      /* self-preview stand-in */
+      #yt-sw-wrap {
+        position: absolute;
+        left: 360px;
+        top: 190px;
+        width: 1200px;
+        height: 700px;
+        border-radius: 18px;
+        overflow: hidden;
+      }
+      #yt-sw-fill {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(150deg, #ff8fb8 0%, #7d5cff 60%, #2a7fff 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: "Inter", ui-sans-serif, sans-serif;
+        font-weight: 700;
+        font-size: 92px;
+        color: rgba(255, 255, 255, 0.93);
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Self-preview wrapper. WIRING: copy the two CSS classes; add
+         class="yt-screen-warp3d" to your media wrapper and
+         <div class="yt-screen-fx" id="yt-my-fx"></div> as its LAST child. Then:
+
+           ytScreenOn(tl, "#yt-my-fx", 2.0);
+           ytScreenOff(tl, "#yt-my-fx", 8.0);
+    -->
+    <div
+      id="yt-sw-root"
+      data-composition-id="yt-screen-warp"
+      data-start="0"
+      data-duration="4"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="yt-sw-wrap" class="yt-screen-warp3d">
+        <div id="yt-sw-fill">on screen</div>
+        <div class="yt-screen-fx" id="yt-sw-fx"></div>
+      </div>
+      <div
+        id="yt-sw-drv"
+        class="clip"
+        data-start="0"
+        data-duration="4"
+        data-track-index="0"
+        style="position:absolute;width:1px;height:1px;opacity:0;pointer-events:none"
+      ></div>
+    </div>
+    <script>
+      (function () {
+        window.__timelines = window.__timelines || {};
+
+        // ---- copy these helpers into the host script ----
+        window.ytScreenOn = function (tl, target, at) {
+          tl.to(target, { opacity: 1, duration: 0.5, ease: "power2.out" }, at);
+        };
+        window.ytScreenOff = function (tl, target, at) {
+          tl.to(target, { opacity: 0, duration: 0.4, ease: "power2.in" }, at);
+        };
+
+        // Self-preview timeline.
+        var tl = gsap.timeline({ paused: true });
+        gsap.set("#yt-sw-wrap", { opacity: 0, scale: 0.96 });
+        tl.to("#yt-sw-wrap", { opacity: 1, scale: 1, duration: 0.5, ease: "power2.out" }, 0.2);
+        window.ytScreenOn(tl, "#yt-sw-fx", 0.8);
+        window.ytScreenOff(tl, "#yt-sw-fx", 3.1);
+        tl.to("#yt-sw-wrap", { opacity: 0, duration: 0.35, ease: "power2.in" }, 3.5);
+        tl.set("#yt-sw-root", { visibility: "hidden" }, 3.98);
+        window.__timelines["yt-screen-warp"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -584,6 +584,10 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "yt-doc-lower-third",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -582,6 +582,10 @@
     {
       "name": "yt-camera-move",
       "type": "hyperframes:component"
+    },
+    {
+      "name": "yt-avatar-pip",
+      "type": "hyperframes:component"
     }
   ]
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -576,6 +576,10 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "yt-logo-intro",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -594,6 +594,10 @@
     {
       "name": "yt-avatar-pip",
       "type": "hyperframes:component"
+    },
+    {
+      "name": "yt-feather-highlight",
+      "type": "hyperframes:component"
     }
   ]
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -598,6 +598,10 @@
     {
       "name": "yt-feather-highlight",
       "type": "hyperframes:component"
+    },
+    {
+      "name": "yt-circle-pointer",
+      "type": "hyperframes:component"
     }
   ]
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -564,6 +564,10 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "yt-lcd-background",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -580,6 +580,10 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "yt-vertical-fill",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -572,6 +572,10 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "yt-prism-title",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -606,6 +606,10 @@
     {
       "name": "yt-circle-pointer",
       "type": "hyperframes:component"
+    },
+    {
+      "name": "yt-screen-warp",
+      "type": "hyperframes:component"
     }
   ]
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -568,6 +568,10 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "yt-comment-card",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "parallax-zoom",
       "type": "hyperframes:component"
     },

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -570,6 +570,10 @@
     {
       "name": "parallax-unzoom",
       "type": "hyperframes:component"
+    },
+    {
+      "name": "yt-camera-move",
+      "type": "hyperframes:component"
     }
   ]
 }


### PR DESCRIPTION
## What

The **yt- family**: retro-broadcast creator-video items — scanline LCD boards, chromatic-fringe display type, and annotation overlays.

**Blocks (6):** `yt-lcd-background` (scanline board with pixel grid, light/dark schemes), `yt-comment-card` (stacked comment cards, light + overlay schemes), `yt-prism-title` (chromatic-fringe hero title for footage), `yt-logo-intro` (logo intro sequence), `yt-vertical-fill` (vertical media filling a 16:9 frame, three fill modes), `yt-doc-lower-third` (documentary name/role lower third).

**Components (5):** `yt-camera-move` (camera punch-in with edge defocus), `yt-avatar-pip` (circle PiP window), `yt-feather-highlight` (feathered spotlight), `yt-circle-pointer` (draw-on ring + countdown chip), `yt-screen-warp` (on-screen display effect).

- Shared `--yt-*` token block per item (paper/ink/red/cyan/prism channels/scanline…); all palette values tokenized
- Accessibility-checked defaults: board text resolves to scheme ink (AA); the bright cyan is documented dark-scheme/dark-footage-only; dim text tuned to pass 4.5:1 on the light board
- Seek-safe: single paused GSAP timeline per item, no rAF / randomness

## Why

A second, deliberately louder design language next to the minimal mk- set (#1992): CRT-flavored boards and creator-annotation tools re-implemented clean-room from broadcast-vernacular conventions. No third-party assets or code copied.

## Validation

- `hyperframes lint` → 0 errors
- `hyperframes validate` (contrast checks **enabled**) → no console errors, text passes WCAG AA
- Layout inspector → 0 issues
- The animated opacity + backdrop-filter combination in `yt-camera-move` snapshot byte-identical across independent headless runs

## Notes for maintainers

- 11 commits, one per item — cherry-pickable
- The lower third is named `yt-doc-lower-third` to stay clear of the registry's existing `yt-lower-third` block — no overlap with or changes to that item
- External contribution — catalog PNG/MP4 upload needs a maintainer, per CONTRIBUTING; docs.json / catalog-index.json regeneration churn not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)