### PR TITLE
docs(changelog): weekly digest 2026-06-29–2026-07-06

### DIFF
--- a/docs/weekly-updates.mdx
+++ b/docs/weekly-updates.mdx
@@ -9,3 +9,75 @@ Weekly HyperFrames highlights across releases, examples, docs, and community upd
 For exact versioned release notes, see the [Changelog](/changelog).
 
 {/* New weekly digest entries are prepended by `bun run changelog:weekly --from YYYY-MM-DD --to YYYY-MM-DD --write`. */}
+
+<Update
+  label="Week of June 29, 2026"
+  description="Weekly digest - June 29, 2026 - July 6, 2026"
+  tags={["Weekly update", "Highlights"]}
+>
+This was a heavy week. The headline is a new Figma import pipeline that brings a Figma file into HyperFrames end to end, from design tokens and components to motion. Cloud render now accepts uploads up to 200MB, website capture pulls richer UI detail, and the engine gains a video extraction cache that speeds up repeat renders. A large batch of reliability fixes lands across capture, audio, Windows setup, sub-compositions, and Studio.
+
+## Features
+
+- **Figma import, foundations.** Core Figma module with reference parsing, frozen snapshots, a manifest, and an asset snippet ([397c3ba7a](https://github.com/heygen-com/hyperframes/commit/397c3ba7a84211bfa52a93a410f34368f7ab5110), [#1868](https://github.com/heygen-com/hyperframes/pull/1868)).
+- **Figma motion to GSAP.** Translates Figma motion into GSAP and adds the first `/figma` skill ([e92700acd](https://github.com/heygen-com/hyperframes/commit/e92700acded50469d3fb35da3a8b198d2cdc36d8), [#1869](https://github.com/heygen-com/hyperframes/pull/1869)).
+- **Figma REST client.** Adds a Figma REST client, an asset import command, and a binding index ([fb13797d2](https://github.com/heygen-com/hyperframes/commit/fb13797d2f2715dc38649add1aea577d214d42f8), [#1870](https://github.com/heygen-com/hyperframes/pull/1870)).
+- **Figma design tokens.** Imports Figma tokens with alias-aware binding records ([4d60792ad](https://github.com/heygen-com/hyperframes/commit/4d60792adc0cc9c807f5734b492052a8598d6d4e), [#1871](https://github.com/heygen-com/hyperframes/pull/1871)).
+- **Figma components.** Imports components through a binding-aware node-to-HTML mapper ([ee7a96147](https://github.com/heygen-com/hyperframes/commit/ee7a96147a5d71797ef041e48395ed1918a375a9), [#1872](https://github.com/heygen-com/hyperframes/pull/1872)).
+- **Figma routing.** Routes `/figma` by capability, using REST and the CLI for phases 1 to 3 and MCP for phases 4 and 5 ([566d49382](https://github.com/heygen-com/hyperframes/commit/566d49382c9cb5c0f690e29f3cd1014b8e69e39a), [#1873](https://github.com/heygen-com/hyperframes/pull/1873)).
+- **Figma interop.** Imports regenerate the shared `index.md` and carry a description and entity for media-use interop ([3900caaaa](https://github.com/heygen-com/hyperframes/commit/3900caaaa94443efb01597dac26df1533f8add35), [#1927](https://github.com/heygen-com/hyperframes/pull/1927)).
+- **Figma telemetry.** Adds import telemetry with subcommand labels, typed error codes, and a `figma_import` event ([e9076324e](https://github.com/heygen-com/hyperframes/commit/e9076324e703fdd91142b7f138b2f2c96cba1376), [#1979](https://github.com/heygen-com/hyperframes/pull/1979)).
+- **Larger cloud uploads.** Cloud render uploads assets through `/v3/assets/direct-uploads`, raising the per-file limit to 200MB ([a59ff0d91](https://github.com/heygen-com/hyperframes/commit/a59ff0d91b4074bd16b7e4d41fb9a9ffbc9eab8e), [#1844](https://github.com/heygen-com/hyperframes/pull/1844)).
+- **Richer website capture.** Capture now extracts gradient washes, glass panels, and nav CTAs ([dd774b369](https://github.com/heygen-com/hyperframes/commit/dd774b3692e71656b038cb2d5a11f05ba52c2880), [#1879](https://github.com/heygen-com/hyperframes/pull/1879)), plus chips, stat cells, and tabs, with icon-font detection and transparent grounds ([6cc87312d](https://github.com/heygen-com/hyperframes/commit/6cc87312d4dffba9df531f6f156c0d0d1462aa82), [#1827](https://github.com/heygen-com/hyperframes/pull/1827)).
+- **Storyboard by default.** Studio's storyboard view is now available by default ([f24a1a9ce](https://github.com/heygen-com/hyperframes/commit/f24a1a9ce7250965df8e89ece4403d373c9d01e9), [#1794](https://github.com/heygen-com/hyperframes/pull/1794)).
+- **Keyframe retiming.** Studio restores keyframe retiming with drag-to-retime and Move to Playhead ([b403c54ae](https://github.com/heygen-com/hyperframes/commit/b403c54ae7b8d3f58808600f7cc69a004fbd93f5), [#1784](https://github.com/heygen-com/hyperframes/pull/1784)).
+- **Keyframes command.** New CLI `keyframes` command surfaces GSAP, CSS, and Anime keyframes, with a 3D onion-skin shot view ([a908af11a](https://github.com/heygen-com/hyperframes/commit/a908af11a814d6fd2c9d3b65d8311e5c3f3742b9), [#1603](https://github.com/heygen-com/hyperframes/pull/1603)).
+- **Publish public.** `hyperframes publish` gains a `--public` flag ([856bb0980](https://github.com/heygen-com/hyperframes/commit/856bb0980fc9f85244cd1d0c8233cb7390642b0b), [#1815](https://github.com/heygen-com/hyperframes/pull/1815)).
+- **Issue from feedback.** File a GitHub issue with a published repro directly from feedback ([010df6a0a](https://github.com/heygen-com/hyperframes/commit/010df6a0a4edbf7179d634fb12805f47ef89ec6e), [#1816](https://github.com/heygen-com/hyperframes/pull/1816)).
+- **Shared telemetry identity.** CLI and Studio now share one PostHog identity ([9c4d9e50a](https://github.com/heygen-com/hyperframes/commit/9c4d9e50a01e0e139d95a80f6c2216867036d905), [#1829](https://github.com/heygen-com/hyperframes/pull/1829)).
+
+## Fixes
+
+- **Capture hardening.** Capture is hardened against timeouts, transient tab deaths, and out-of-memory ([c0c3abf0f](https://github.com/heygen-com/hyperframes/commit/c0c3abf0f16ca41e5dfebcf6b70bd6845127130c), [#1842](https://github.com/heygen-com/hyperframes/pull/1842)).
+- **Doctor checks.** `doctor` detects missing Chrome libraries and FFmpeg on Linux and WSL ([180f368af](https://github.com/heygen-com/hyperframes/commit/180f368af1dd6b4d949d182805644077feaa81bc), [#1841](https://github.com/heygen-com/hyperframes/pull/1841)).
+- **Preflight guidance.** Render pre-flight flags aspect-ratio and alpha preset mismatches with actionable guidance ([6be46813a](https://github.com/heygen-com/hyperframes/commit/6be46813a213cdd1ef605f2efd93c76bb18deda9), [#1843](https://github.com/heygen-com/hyperframes/pull/1843)).
+- **Browser install recovery.** Stale or partial browser installs are purged instead of wedging retries ([78069da14](https://github.com/heygen-com/hyperframes/commit/78069da1403669cb3f68a475da128d0b0ce14a97), [#1913](https://github.com/heygen-com/hyperframes/pull/1913)).
+- **Clearer encode timeout.** The FFmpeg encode-timeout error now names the fix ([eef469075](https://github.com/heygen-com/hyperframes/commit/eef469075299439c0c79b38d8488639106a42dca), [#1858](https://github.com/heygen-com/hyperframes/pull/1858)).
+- **Windows npx.** A clear error surfaces when `npx` cannot be resolved on Windows ([dfa6fedbc](https://github.com/heygen-com/hyperframes/commit/dfa6fedbcdaf8478b4be99d907d88fd079d9bc0a), [#1961](https://github.com/heygen-com/hyperframes/pull/1961)).
+- **Windows python.** `python3` resolves to `python` or `py` on Windows ([3388635f1](https://github.com/heygen-com/hyperframes/commit/3388635f1d1431de0b2a2e7d132f834f7614557c), [#1922](https://github.com/heygen-com/hyperframes/pull/1922)).
+- **ffprobe fallback.** FFmpeg is used as a fallback when `ffprobe` is missing ([e2b43583f](https://github.com/heygen-com/hyperframes/commit/e2b43583fc2480aa9511cd5e606a58841c4f211e), [#1877](https://github.com/heygen-com/hyperframes/pull/1877)).
+- **MusicGen install.** MusicGen dependencies install through `python3 -m pip` ([942080fa8](https://github.com/heygen-com/hyperframes/commit/942080fa8e8e77de93ef6546690b5b5421d80e88), [#1894](https://github.com/heygen-com/hyperframes/pull/1894)).
+- **Audio-mix errors.** Audio-mix failures surface their reason instead of silently shipping video-only ([f40dbd86c](https://github.com/heygen-com/hyperframes/commit/f40dbd86cf2df77a26004578a66b4035e4d742c5), [#1854](https://github.com/heygen-com/hyperframes/pull/1854)).
+- **Mix filter graph.** The audio mix filter graph is written to a file rather than the command line ([8a3227f54](https://github.com/heygen-com/hyperframes/commit/8a3227f5482320907edcb47972c3d7f6e25c6d62), [#1890](https://github.com/heygen-com/hyperframes/pull/1890)).
+- **TTS concurrency.** TTS synthesis concurrency is capped instead of firing every line at once ([2e9a33ca7](https://github.com/heygen-com/hyperframes/commit/2e9a33ca719a2b28bd8bb51083df32b8f74ca437), [#1862](https://github.com/heygen-com/hyperframes/pull/1862)).
+- **Preview parity.** Producer render no longer diverges from preview for sub-composition root styling ([7e8a1466c](https://github.com/heygen-com/hyperframes/commit/7e8a1466c3b058071c5ed89241ed70e2d0878645), [#1886](https://github.com/heygen-com/hyperframes/pull/1886)).
+- **Sub-comp validation.** Added pre-flight validation for empty or malformed sub-compositions ([cf573f7f3](https://github.com/heygen-com/hyperframes/commit/cf573f7f3f8bfcc68b99c514afba4de0655436fc), [#1831](https://github.com/heygen-com/hyperframes/pull/1831)).
+- **Scoped globals.** `window.__hyperframes` routes to the scoped variant inside sub-comps ([f7c9c35d8](https://github.com/heygen-com/hyperframes/commit/f7c9c35d8b1095037402cc55539084d514691b28), [#1931](https://github.com/heygen-com/hyperframes/pull/1931)).
+- **Id-less media.** Root-caused id-less media rendering a blank wash instead of footage ([74f9c31b3](https://github.com/heygen-com/hyperframes/commit/74f9c31b3fdeacf3a5700b17cbe718d7b00e54d2), [#1790](https://github.com/heygen-com/hyperframes/pull/1790), [0dfedd111](https://github.com/heygen-com/hyperframes/commit/0dfedd111c49948c531f2e2b0b290e50024176e7), [#1792](https://github.com/heygen-com/hyperframes/pull/1792)).
+- **Consistent ids.** Unified the hf-id space across preview, disk, and SDK sessions ([3a717fa71](https://github.com/heygen-com/hyperframes/commit/3a717fa71997477c6f81dce7c9f2e63a4ad675ed), [#1981](https://github.com/heygen-com/hyperframes/pull/1981)).
+- **Animation id resolution.** Animation ids resolve from the parsed script, not only DOM-matched elements ([c5d725abd](https://github.com/heygen-com/hyperframes/commit/c5d725abd0407761dc4a44de95417688ca6a4af2), [#1957](https://github.com/heygen-com/hyperframes/pull/1957)).
+- **Canvas selection.** Canvas selection now hits the intended elements ([02e9d6142](https://github.com/heygen-com/hyperframes/commit/02e9d6142d8e3d812c1d8525753355793a3b9988), [#1907](https://github.com/heygen-com/hyperframes/pull/1907)).
+- **Persist feedback.** Persist failures surface with a toast and a guarded revert ([e6e0d97cc](https://github.com/heygen-com/hyperframes/commit/e6e0d97cc560ebca57a28f5c0872e706679f568d), [#1910](https://github.com/heygen-com/hyperframes/pull/1910)).
+- **Optional duration.** Composition duration is auto-inferred for CSS, WAAPI, and Lottie, so `data-duration` is optional ([24edb1509](https://github.com/heygen-com/hyperframes/commit/24edb15095d2343fcd20c0468d2591b075810507), [#1830](https://github.com/heygen-com/hyperframes/pull/1830)).
+- **Even dimensions.** Odd output dimensions pad up to even for H.264 and H.265 encode ([3a2f05288](https://github.com/heygen-com/hyperframes/commit/3a2f0528890c0de4ac0bb31629323ed7f00133d9), [#1802](https://github.com/heygen-com/hyperframes/pull/1802)).
+- **Presenter mode.** Slideshow presenter mode works over Google Meet and Zoom screen share ([a7c3cc7d6](https://github.com/heygen-com/hyperframes/commit/a7c3cc7d689b13c5bb96559f9bad713205edb194), [#1865](https://github.com/heygen-com/hyperframes/pull/1865)).
+- **Media lint.** Lint now errors on `crossorigin` for media, which breaks preview ([1faeba4aa](https://github.com/heygen-com/hyperframes/commit/1faeba4aa5e309c1ea688e37e833ffaba60429eb), [#1793](https://github.com/heygen-com/hyperframes/pull/1793)).
+
+## Performance
+
+- **Extraction cache.** Video extraction caches by default, with atomic publish and LRU cleanup ([34590649a](https://github.com/heygen-com/hyperframes/commit/34590649a05594914b98d4cc6198a2e5aac953c6), [#1901](https://github.com/heygen-com/hyperframes/pull/1901)).
+- **Dedup extractions.** Identical extractions are deduped within a single render ([8d64d48e4](https://github.com/heygen-com/hyperframes/commit/8d64d48e4a9ae620771e331d83bd74eb1716d66b), [#1900](https://github.com/heygen-com/hyperframes/pull/1900)).
+- **Overlapping trims.** Overlapping trims of one source share a single superset extraction ([1a7002f20](https://github.com/heygen-com/hyperframes/commit/1a7002f208353239f0e10596fa1decc897fed34f), [#1885](https://github.com/heygen-com/hyperframes/pull/1885)).
+- **One-pass VFR.** Variable-frame-rate extraction runs in one pass with `-fps_mode cfr` ([786058334](https://github.com/heygen-com/hyperframes/commit/78605833415e9f80097a773b949c146f4e1a5e9d), [#1899](https://github.com/heygen-com/hyperframes/pull/1899)).
+- **One-pass HDR.** SDR-to-HDR extraction runs in one pass with a cache-key transform ([48f158a0c](https://github.com/heygen-com/hyperframes/commit/48f158a0c2cd27bfc114903a37560cd4db872fe8), [#1902](https://github.com/heygen-com/hyperframes/pull/1902)).
+- **Faster PNG frames.** PNG frames are written at compression level 1 ([557a27027](https://github.com/heygen-com/hyperframes/commit/557a270271372d458d5adb944473a485d47e3079), [#1898](https://github.com/heygen-com/hyperframes/pull/1898)).
+
+## Docs & Examples
+
+- **Accuracy pass.** Fixed 53 inaccuracies across the documentation ([52d586dd3](https://github.com/heygen-com/hyperframes/commit/52d586dd31cfcc2d436d046f71907c2655617552), [#1976](https://github.com/heygen-com/hyperframes/pull/1976)).
+- **SDK reference.** Added a comprehensive SDK reference and guides ([26e9283f6](https://github.com/heygen-com/hyperframes/commit/26e9283f6b7c660c0f76a3b82143a226cde70702), [#1817](https://github.com/heygen-com/hyperframes/pull/1817)).
+- **Transparent WebM note.** Clarified that transparent WebM shows as yuv420p under ffprobe, since alpha is a VP9 side channel ([534d6177b](https://github.com/heygen-com/hyperframes/commit/534d6177b65bfd7aadc74d1a0632410e03b1d8ac), [#1823](https://github.com/heygen-com/hyperframes/pull/1823)).
+- **Duration is compile-time.** Documented that root composition duration is compile-time and not parameterizable through `--variables` ([bdd0084c2](https://github.com/heygen-com/hyperframes/commit/bdd0084c2a778b541b89af09689fd7a997408cdc), [#1818](https://github.com/heygen-com/hyperframes/pull/1818)).
+
+For exact versioned release notes, see the [Changelog](/changelog).
+</Update>


### PR DESCRIPTION
Auto-generated weekly HyperFrames digest for **June 29 to July 6, 2026**, then hand-cleaned to publish quality so review should only need comments, not a rewrite.

## What this is
- Generated with `bun run changelog:weekly --from 2026-06-29 --to 2026-07-06 --write`, which prepends a draft `<Update>` entry to `docs/weekly-updates.mdx`.
- Rewrote the draft: dropped the `TODO` marker, grouped changes into **Features / Fixes / Performance / Docs & Examples**, turned terse commit subjects into readable one-liners, and kept every commit + PR link. No em-dashes, per house style.

## Week highlights
- New **Figma import pipeline** (foundations, REST client, tokens, components, motion to GSAP, capability-based `/figma` routing, media-use interop, telemetry).
- **Cloud render** uploads move to `/v3/assets/direct-uploads` (200MB cap); **website capture** extracts richer UI detail.
- **Engine extraction cache** on by default plus one-pass VFR/HDR extraction for faster repeat renders.
- Large reliability batch across capture, audio, Windows setup, sub-compositions, and Studio.

## Scope
- Touches only `docs/weekly-updates.mdx`. The generator's editorial packet files under `updates/` (weekly notes + Discord/X social drafts) are left uncommitted, as they are human-edited distribution copy that is not published automatically.

Ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)