### PR TITLE
feat(cli): emit sign-in lifecycle telemetry

### DIFF
--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -84,8 +84,13 @@ async function runOAuthLogin(): Promise<void> {
   try {
     await startAuthorizationCodeFlow();
   } catch (err) {
-    trackAuthLoginFailed("oauth", "flow_error");
-    console.error(c.error(`Sign-in failed: ${(err as Error).message}`));
+    const message = (err as Error).message ?? "";
+    // The loopback server rejects with "OAuth callback timed out after …" when
+    // the user never completes the browser step (closed the tab / walked away).
+    // That is the dominant non-error dropout, so split it from real failures
+    // (IdP misconfig, network) instead of lumping everything as flow_error.
+    trackAuthLoginFailed("oauth", /timed out/i.test(message) ? "flow_timeout" : "flow_error");
+    console.error(c.error(`Sign-in failed: ${message}`));
     process.exit(1);
   }
 
@@ -178,7 +183,18 @@ async function runApiKeyLogin(inlineKey: string): Promise<void> {
     await import("../../telemetry/index.js");
   trackAuthLoginStarted("api_key");
 
-  const key = await collectApiKey(inlineKey);
+  // collectApiKey throws when the user cancels the interactive prompt (Ctrl-C)
+  // or when no key arrives on stdin before the timeout — both are "user walked
+  // away", the abandonment signal we most want. Record it before the error
+  // propagates so `started` still reconciles to `completed + failed`.
+  let key: string;
+  try {
+    key = await collectApiKey(inlineKey);
+  } catch (err) {
+    trackAuthLoginFailed("api_key", "aborted");
+    console.error(c.error((err as Error).message || "Sign-in aborted."));
+    process.exit(1);
+  }
   if (!key) {
     trackAuthLoginFailed("api_key", "invalid_input");
     console.error(c.error("No API key provided."));
@@ -308,8 +324,9 @@ async function promptForKey(): Promise<string> {
     },
   });
   if (clack.isCancel(value)) {
-    console.error("Aborted.");
-    process.exit(1);
+    // Throw rather than exit here so the single catch in runApiKeyLogin records
+    // the abandonment (auth_login_failed: aborted) and then exits.
+    throw new Error("Aborted.");
   }
   return value.trim();
 }

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -78,9 +78,13 @@ export default defineCommand({
 async function runOAuthLogin(): Promise<void> {
   assertOAuthConfiguredOrExit();
 
+  const { trackAuthLoginStarted, trackAuthLoginFailed } = await import("../../telemetry/index.js");
+  trackAuthLoginStarted("oauth");
+
   try {
     await startAuthorizationCodeFlow();
   } catch (err) {
+    trackAuthLoginFailed("oauth", "flow_error");
     console.error(c.error(`Sign-in failed: ${(err as Error).message}`));
     process.exit(1);
   }
@@ -90,11 +94,18 @@ async function runOAuthLogin(): Promise<void> {
 
 // fallow-ignore-next-line complexity
 async function reportIdentity(): Promise<void> {
+  const { trackAuthLoginCompleted, trackAuthLoginFailed } =
+    await import("../../telemetry/index.js");
   const credential = await tryResolveCredential();
   if (!credential) {
+    trackAuthLoginFailed("oauth", "no_credential");
     console.error(c.warn("Sign-in completed but no credential was persisted."));
     process.exit(1);
   }
+  // A resolvable credential IS the success signal: the tokens are on disk and
+  // usable. The `/v3/users/me` probe below only fetches a display name, so its
+  // outcome is cosmetic and does not gate completion.
+  trackAuthLoginCompleted("oauth");
   // Wire the refresh hook here too — a freshly-minted token shouldn't
   // need it, but a fast IdP-side rotation (or a misconfigured short
   // TTL) shouldn't punish the user with a hard failure when the
@@ -163,8 +174,13 @@ async function clearUserInfoBestEffort(): Promise<void> {
 
 // fallow-ignore-next-line complexity
 async function runApiKeyLogin(inlineKey: string): Promise<void> {
+  const { trackAuthLoginStarted, trackAuthLoginCompleted, trackAuthLoginFailed } =
+    await import("../../telemetry/index.js");
+  trackAuthLoginStarted("api_key");
+
   const key = await collectApiKey(inlineKey);
   if (!key) {
+    trackAuthLoginFailed("api_key", "invalid_input");
     console.error(c.error("No API key provided."));
     process.exit(1);
   }
@@ -172,10 +188,12 @@ async function runApiKeyLogin(inlineKey: string): Promise<void> {
     // CR/LF in the value would smuggle headers when the key is sent
     // via `x-api-key`. The backend handles "wrong key" itself, but
     // header-injection has to be caught here.
+    trackAuthLoginFailed("api_key", "invalid_input");
     console.error(c.error("API key must not contain newline or control characters."));
     process.exit(1);
   }
   if (key.length < MIN_KEY_LENGTH) {
+    trackAuthLoginFailed("api_key", "invalid_input");
     console.error(c.error(`API key looks too short (got ${key.length} chars).`));
     process.exit(1);
   }
@@ -186,9 +204,11 @@ async function runApiKeyLogin(inlineKey: string): Promise<void> {
 
   const verifyOk = await verifyAndReport(key);
   if (!verifyOk) {
+    trackAuthLoginFailed("api_key", "rejected");
     await rollback(previous);
     process.exit(1);
   }
+  trackAuthLoginCompleted("api_key");
 }
 
 async function snapshotStore(): Promise<Credentials> {

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -237,27 +237,60 @@ describe("auth login telemetry events", () => {
 
   it("emits auth_login_started tagged with the method", () => {
     trackAuthLoginStarted("oauth");
-    expect(trackEvent).toHaveBeenCalledWith("auth_login_started", { method: "oauth" });
+    expect(trackEvent).toHaveBeenCalledWith("auth_login_started", { method: "oauth" }, undefined);
   });
 
   it("emits auth_login_completed tagged with the method", () => {
     trackAuthLoginCompleted("api_key");
-    expect(trackEvent).toHaveBeenCalledWith("auth_login_completed", { method: "api_key" });
+    expect(trackEvent).toHaveBeenCalledWith(
+      "auth_login_completed",
+      { method: "api_key" },
+      undefined,
+    );
   });
 
   it("emits auth_login_failed with the method and a low-cardinality reason", () => {
     trackAuthLoginFailed("oauth", "flow_error");
-    expect(trackEvent).toHaveBeenCalledWith("auth_login_failed", {
-      method: "oauth",
-      reason: "flow_error",
-    });
+    expect(trackEvent).toHaveBeenCalledWith(
+      "auth_login_failed",
+      { method: "oauth", reason: "flow_error" },
+      undefined,
+    );
+  });
+
+  it("distinguishes a timed-out browser flow from a real error", () => {
+    trackAuthLoginFailed("oauth", "flow_timeout");
+    expect(trackEvent).toHaveBeenCalledWith(
+      "auth_login_failed",
+      { method: "oauth", reason: "flow_timeout" },
+      undefined,
+    );
+  });
+
+  it("records an aborted prompt / stdin timeout as its own reason", () => {
+    trackAuthLoginFailed("api_key", "aborted");
+    expect(trackEvent).toHaveBeenCalledWith(
+      "auth_login_failed",
+      { method: "api_key", reason: "aborted" },
+      undefined,
+    );
   });
 
   it("carries only method + reason — never a key, token, or free text", () => {
     trackAuthLoginFailed("api_key", "rejected");
-    expect(trackEvent).toHaveBeenCalledWith("auth_login_failed", {
-      method: "api_key",
-      reason: "rejected",
-    });
+    expect(trackEvent).toHaveBeenCalledWith(
+      "auth_login_failed",
+      { method: "api_key", reason: "rejected" },
+      undefined,
+    );
+  });
+
+  it("forwards an explicit distinctId to trackEvent for future user-level attribution", () => {
+    trackAuthLoginCompleted("oauth", "heygen-user-123");
+    expect(trackEvent).toHaveBeenCalledWith(
+      "auth_login_completed",
+      { method: "oauth" },
+      "heygen-user-123",
+    );
   });
 });

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -14,6 +14,9 @@ const {
   trackFigmaImport,
   trackRenderFeedback,
   trackRenderPreflightRejected,
+  trackAuthLoginStarted,
+  trackAuthLoginCompleted,
+  trackAuthLoginFailed,
 } = await import("./events.js");
 
 describe("render telemetry events", () => {
@@ -224,5 +227,37 @@ describe("trackFigmaImport", () => {
       "figma_import",
       expect.objectContaining({ phase: "tokens", tokens_mode: "styles", entry_count: 0 }),
     );
+  });
+});
+
+describe("auth login telemetry events", () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+  });
+
+  it("emits auth_login_started tagged with the method", () => {
+    trackAuthLoginStarted("oauth");
+    expect(trackEvent).toHaveBeenCalledWith("auth_login_started", { method: "oauth" });
+  });
+
+  it("emits auth_login_completed tagged with the method", () => {
+    trackAuthLoginCompleted("api_key");
+    expect(trackEvent).toHaveBeenCalledWith("auth_login_completed", { method: "api_key" });
+  });
+
+  it("emits auth_login_failed with the method and a low-cardinality reason", () => {
+    trackAuthLoginFailed("oauth", "flow_error");
+    expect(trackEvent).toHaveBeenCalledWith("auth_login_failed", {
+      method: "oauth",
+      reason: "flow_error",
+    });
+  });
+
+  it("carries only method + reason — never a key, token, or free text", () => {
+    trackAuthLoginFailed("api_key", "rejected");
+    expect(trackEvent).toHaveBeenCalledWith("auth_login_failed", {
+      method: "api_key",
+      reason: "rejected",
+    });
   });
 });

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -316,26 +316,35 @@ export function trackBrowserInstall(): void {
 // `method` is "oauth" (the default browser PKCE flow) or "api_key". No token,
 // key, identity, email, or free text is ever attached — only the method and a
 // low-cardinality outcome/reason.
+//
+// The three trackers accept an optional `distinctId`, forwarded to trackEvent
+// exactly like trackRenderComplete/trackRenderError already do. It is unused
+// today (events attribute to the install's anonymousId), but pre-plumbing it
+// makes attributing a completed sign-in to a resolved identity later a one-line
+// change at the callsite rather than a signature sweep.
 export type AuthLoginMethod = "oauth" | "api_key";
 export type AuthLoginFailureReason =
-  | "flow_error" // OAuth authorization/exchange threw
+  | "flow_error" // OAuth authorization/exchange threw a real error
+  | "flow_timeout" // OAuth callback wait elapsed (user closed the tab / walked away)
   | "no_credential" // flow reported success but nothing was persisted
   | "rejected" // backend rejected the supplied API key (401)
-  | "invalid_input"; // no key provided, or header-unsafe / too short
+  | "invalid_input" // key was empty, header-unsafe, or too short
+  | "aborted"; // prompt cancelled, or no key arrived on stdin before timeout
 
-export function trackAuthLoginStarted(method: AuthLoginMethod): void {
-  trackEvent("auth_login_started", { method });
+export function trackAuthLoginStarted(method: AuthLoginMethod, distinctId?: string): void {
+  trackEvent("auth_login_started", { method }, distinctId);
 }
 
-export function trackAuthLoginCompleted(method: AuthLoginMethod): void {
-  trackEvent("auth_login_completed", { method });
+export function trackAuthLoginCompleted(method: AuthLoginMethod, distinctId?: string): void {
+  trackEvent("auth_login_completed", { method }, distinctId);
 }
 
 export function trackAuthLoginFailed(
   method: AuthLoginMethod,
   reason: AuthLoginFailureReason,
+  distinctId?: string,
 ): void {
-  trackEvent("auth_login_failed", { method, reason });
+  trackEvent("auth_login_failed", { method, reason }, distinctId);
 }
 
 // A render was rejected by the output-resolution/alpha/HDR pre-flight (P1-3)

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -308,6 +308,36 @@ export function trackBrowserInstall(): void {
   trackEvent("browser_install", {});
 }
 
+// Sign-in lifecycle. The CLI tracks command and render lifecycles but never
+// authentication, so `auth login` outcomes are invisible on the observability
+// dashboards — a completed sign-in, a browser flow the user abandoned, and a
+// rejected key all look identical (i.e. absent). These three events close that
+// gap so the sign-in funnel is measurable like the render funnel already is.
+// `method` is "oauth" (the default browser PKCE flow) or "api_key". No token,
+// key, identity, email, or free text is ever attached — only the method and a
+// low-cardinality outcome/reason.
+export type AuthLoginMethod = "oauth" | "api_key";
+export type AuthLoginFailureReason =
+  | "flow_error" // OAuth authorization/exchange threw
+  | "no_credential" // flow reported success but nothing was persisted
+  | "rejected" // backend rejected the supplied API key (401)
+  | "invalid_input"; // no key provided, or header-unsafe / too short
+
+export function trackAuthLoginStarted(method: AuthLoginMethod): void {
+  trackEvent("auth_login_started", { method });
+}
+
+export function trackAuthLoginCompleted(method: AuthLoginMethod): void {
+  trackEvent("auth_login_completed", { method });
+}
+
+export function trackAuthLoginFailed(
+  method: AuthLoginMethod,
+  reason: AuthLoginFailureReason,
+): void {
+  trackEvent("auth_login_failed", { method, reason });
+}
+
 // A render was rejected by the output-resolution/alpha/HDR pre-flight (P1-3)
 // before any browser/ffmpeg work. Counts the "caught early" saves on dashboard
 // 1783183, distinct from deep render failures. `kind` is the low-cardinality

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -9,5 +9,8 @@ export {
   trackCliError,
   trackCommandResult,
   trackFigmaImport,
+  trackAuthLoginStarted,
+  trackAuthLoginCompleted,
+  trackAuthLoginFailed,
 } from "./events.js";
 export { getSystemMeta, getShmSizeMb, getFreeDiskMb, bytesToMb } from "./system.js";


### PR DESCRIPTION
## What

The CLI already tracks command and render lifecycles via the anonymous telemetry client, but emits nothing for `auth login`. That leaves sign-in as a blind spot: a completed sign-in, an abandoned browser flow, and a rejected key all look identical on the dashboards (absent), so we can't see where the login flow drops off the way we can for renders.

Adds three events, mirroring the existing `trackX` pattern in `telemetry/events.ts`:

| Event | When | Props |
|---|---|---|
| `auth_login_started` | a login attempt begins | `method` |
| `auth_login_completed` | credential persisted + usable | `method` |
| `auth_login_failed` | attempt aborts | `method`, `reason` |

- `method` is `oauth` (default browser PKCE) or `api_key`.
- `reason` is a fixed low-cardinality enum: `flow_error` / `no_credential` / `rejected` / `invalid_input`.

Wired into both the OAuth and `--api-key` paths in `auth login`. For OAuth, completion fires when a credential resolves (the `/v3/users/me` identity probe is cosmetic and does not gate it).

## Privacy

No token, key, identity, email, or free text is ever attached — only `method` and the enum `reason`. Consistent with the existing anonymous telemetry and the `hyperframes telemetry disable` opt-out (events no-op when tracking is off).

## Tests

Unit coverage for the three new events in `telemetry/events.test.ts`; existing `auth login` tests still pass.