### PR TITLE
fix(cli): localize remote assets before validate so it matches render (no false CORS failures)

### DIFF
--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -9,6 +9,25 @@ import {
 } from "./validate.js";
 import type { ProjectLintResult } from "../utils/lintProject.js";
 
+// validateInBrowser lazy-loads the producer localize helpers via loadProducer;
+// mock it so these unit tests never resolve @hyperframes/producer's built dist.
+vi.mock("../utils/producer.js", () => ({
+  loadProducer: vi.fn(async () => ({
+    localizeRemoteMediaSources: vi.fn(async (html: string) => ({
+      html,
+      remoteMediaAssets: new Map(),
+    })),
+    localizeRemoteImageSources: vi.fn(async (html: string) => ({
+      html,
+      remoteMediaAssets: new Map(),
+    })),
+    localizeRemoteFontFaces: vi.fn(async (html: string) => ({
+      html,
+      remoteMediaAssets: new Map(),
+    })),
+  })),
+}));
+
 // Regression for the validate audio-duration-probe timeout: a slow-loading
 // media element's duration was snapshotted once, at a fixed point in time,
 // and any element still mid-load was permanently misreported as unreadable.

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "citty";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveProject, type ProjectDir } from "../utils/project.js";
@@ -334,6 +335,37 @@ export function extractCompositionErrorsFromLint(
     .map((f) => ({ level: "error" as const, text: f.message }));
 }
 
+// Match the render pipeline: localize remote <img>/<video>/<audio>/@font-face
+// into a temp dir (served as an extra asset root) so validate resolves them
+// same-origin and doesn't false-fail on cross-origin (crossorigin/CORS) fetches
+// the real render never makes. Best-effort: no-op on any failure.
+async function localizeRemoteAssets(
+  html: string,
+): Promise<{ html: string; assetRoots: string[]; cleanup: () => void }> {
+  let dir: string | undefined;
+  try {
+    const { loadProducer } = await import("../utils/producer.js");
+    const { localizeRemoteMediaSources, localizeRemoteImageSources, localizeRemoteFontFaces } =
+      await loadProducer();
+    dir = mkdtempSync(join(tmpdir(), "hf-validate-assets-"));
+    const assetDir = dir;
+    const media = await localizeRemoteMediaSources(html, assetDir);
+    const images = await localizeRemoteImageSources(media.html, assetDir);
+    const fonts = await localizeRemoteFontFaces(images.html, assetDir);
+    const count =
+      media.remoteMediaAssets.size + images.remoteMediaAssets.size + fonts.remoteMediaAssets.size;
+    return {
+      html: fonts.html,
+      assetRoots: count > 0 ? [assetDir] : [],
+      cleanup: () => rmSync(assetDir, { recursive: true, force: true }),
+    };
+  } catch {
+    // Best-effort: drop any partial temp dir before falling back to remote URLs.
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    return { html, assetRoots: [], cleanup: () => {} };
+  }
+}
+
 async function validateInBrowser(
   project: ProjectDir,
   opts: { timeout?: number; contrast?: boolean },
@@ -359,7 +391,17 @@ async function validateInBrowser(
   // runtime tag) is no longer needed — there's no `src` attribute to match.
   const html = await bundleToSingleHtml(projectDir);
 
-  const server = await serveStaticProjectHtml(projectDir, html);
+  const localized = await localizeRemoteAssets(html);
+  const server = await serveStaticProjectHtml(
+    projectDir,
+    localized.html,
+    undefined,
+    localized.assetRoots,
+  ).catch((err) => {
+    // Server never started — the finally below won't run, so clean up here.
+    localized.cleanup();
+    throw err;
+  });
 
   const errors: ConsoleEntry[] = [...compositionErrors];
   const warnings: ConsoleEntry[] = [];
@@ -445,6 +487,7 @@ async function validateInBrowser(
     await chromeBrowser.close();
   } finally {
     await server.close();
+    localized.cleanup();
   }
 
   return { errors, warnings, contrast };

--- a/packages/cli/src/utils/staticProjectServer.test.ts
+++ b/packages/cli/src/utils/staticProjectServer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serveStaticProjectHtml, type StaticProjectServer } from "./staticProjectServer.js";
@@ -64,5 +64,48 @@ describe("serveStaticProjectHtml range support", () => {
     const res = await fetch(`${url}tone.wav`, { headers: { Range: "bytes=99-200" } });
     expect(res.status).toBe(416);
     expect(res.headers.get("content-range")).toBe(`bytes */${body.length}`);
+  });
+});
+
+describe("serveStaticProjectHtml asset roots", () => {
+  const extraDirs: string[] = [];
+  const mk = (): string => {
+    const d = mkdtempSync(join(tmpdir(), "hf-static-root-"));
+    extraDirs.push(d);
+    return d;
+  };
+  afterEach(() => {
+    for (const d of extraDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  it("serves files from an extra asset root when the project dir lacks them", async () => {
+    // extra root (e.g. localized-assets temp dir) resolves same-origin
+    const projectDir = mk();
+    const assetDir = mk();
+    mkdirSync(join(assetDir, "_remote_media"), { recursive: true });
+    writeFileSync(join(assetDir, "_remote_media", "img.jpg"), "PIXELS");
+    server = await serveStaticProjectHtml(projectDir, "<html></html>", undefined, [assetDir]);
+
+    const res = await fetch(`${server.url}_remote_media/img.jpg`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("PIXELS");
+  });
+
+  it("prefers the project dir over an asset root for the same path", async () => {
+    const projectDir = mk();
+    const assetDir = mk();
+    writeFileSync(join(projectDir, "a.txt"), "PROJECT");
+    writeFileSync(join(assetDir, "a.txt"), "ASSET");
+    server = await serveStaticProjectHtml(projectDir, "<html></html>", undefined, [assetDir]);
+
+    const res = await fetch(`${server.url}a.txt`);
+    expect(await res.text()).toBe("PROJECT");
+  });
+
+  it("404s a path present in no root", async () => {
+    const projectDir = mk();
+    server = await serveStaticProjectHtml(projectDir, "<html></html>", undefined, [mk()]);
+    const res = await fetch(`${server.url}nope.txt`);
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/cli/src/utils/staticProjectServer.ts
+++ b/packages/cli/src/utils/staticProjectServer.ts
@@ -71,7 +71,11 @@ export async function serveStaticProjectHtml(
   projectDir: string,
   html: string,
   bindErrorMessage = "Failed to bind local HTTP server",
+  // Extra dirs to resolve non-index requests against, after projectDir (e.g. a
+  // temp dir of localized remote assets).
+  assetRoots: readonly string[] = [],
 ): Promise<StaticProjectServer> {
+  const roots = [projectDir, ...assetRoots];
   // fallow-ignore-next-line complexity
   const server = createServer((req, res) => {
     const url = req.url ?? "/";
@@ -81,16 +85,15 @@ export async function serveStaticProjectHtml(
       return;
     }
 
-    const filePath = resolve(projectDir, decodeURIComponent(url).replace(/^\//, ""));
-    const rel = relative(projectDir, filePath);
-    if (rel.startsWith("..") || isAbsolute(rel)) {
-      res.writeHead(403);
-      res.end();
-      return;
-    }
-    if (existsSync(filePath)) {
-      serveFileWithRange(filePath, req.headers.range, res);
-      return;
+    const requestPath = decodeURIComponent(url).replace(/^\//, "");
+    for (const root of roots) {
+      const filePath = resolve(root, requestPath);
+      const rel = relative(root, filePath);
+      if (rel.startsWith("..") || isAbsolute(rel)) continue; // traversal guard; try next root
+      if (existsSync(filePath)) {
+        serveFileWithRange(filePath, req.headers.range, res);
+        return;
+      }
     }
     res.writeHead(404);
     res.end();

--- a/packages/producer/src/index.ts
+++ b/packages/producer/src/index.ts
@@ -27,6 +27,15 @@ export {
   type RenderObservationStatus,
 } from "./services/render/observability.js";
 
+// ── HTML asset localization ─────────────────────────────────────────────────
+// Rewrite remote <img>/<video>/<audio>/@font-face to same-origin local paths
+// before capture. Shared by render and `validate` so both resolve assets alike.
+export {
+  localizeRemoteMediaSources,
+  localizeRemoteImageSources,
+  localizeRemoteFontFaces,
+} from "./services/htmlCompiler.js";
+
 // ── Frame capture (lower-level) ─────────────────────────────────────────────
 export {
   createCaptureSession,


### PR DESCRIPTION
## Summary

`hyperframes validate` reports **false** `net::ERR_FAILED` / CORS errors for remote `<img crossorigin>` and `@font-face` assets that render perfectly fine. It happens because `validate` serves the composition over a loopback origin and lets headless Chrome fetch those assets **cross-origin**, whereas the real render pipeline **downloads them to disk first**. Validate and render therefore disagree, and the false error pushes authors (and agent pipelines) to "fix" it by deleting `crossorigin` — which silently disables WebGL color-grading/shaders for that asset.

This PR makes `validate` localize remote `<img>` / `<video>` / `<audio>` / `@font-face` sources before serving — **reusing the exact `producer` functions the render pipeline already uses** — so validate sees the same same-origin assets the final render does.

## Root cause (full chain)

1. A composition references a legit remote asset, e.g. `<img src="https://bucket.s3.../x.jpg" crossorigin="anonymous">`. The URL is fine (HTTP 200).
2. The bucket has CORS configured, but its `AllowedOrigins` don't include validate's loopback origin (`http://127.0.0.1:<random-port>`).
3. `crossorigin="anonymous"` is **correct and needed** — WebGL color-grading / shaders can only sample a texture from a CORS-clean image.
4. **The render pipeline localizes first.** `producer`'s `localizeRemoteMediaSources` / `localizeRemoteImageSources` / `localizeRemoteFontFaces` download remote sources to disk and rewrite them to same-origin local paths *before* capture (`packages/producer/src/services/htmlCompiler.ts`). At render time the asset is a local file → no CORS, image present, shader works.
5. **`validate` does not localize.** It serves the project over a loopback file server and lets Chrome fetch the remote asset cross-origin. The bucket doesn't allow that origin → the CORS-mode request fails → validate reports `net::ERR_FAILED`. **This failure is specific to validate's environment; it never happens in the real render.**
6. Authors/agents "fix" the false error by deleting `crossorigin`. The image then loads (a plain `<img>` needs no CORS) but permanently loses shader / color-grading eligibility — and every remote asset costs extra edit/validate round-trips.

## Fix

Before starting the static server in `validate`, run the same localize step the render pipeline uses, downloading into a **temp dir served as an extra asset root** — the user's project directory is never written to, and the temp dir is cleaned up in `finally`. Best-effort: on any failure it falls back to the original HTML (unchanged behavior).

- **`producer`**: export `localizeRemoteMediaSources` / `localizeRemoteImageSources` / `localizeRemoteFontFaces` from the package index (already implemented and used by render; now reusable by the CLI).
- **`cli/utils/staticProjectServer`**: optional `assetRoots` param to resolve non-index requests against extra dirs after the project dir (backward compatible; defaults to none; per-root traversal guard preserved).
- **`cli/commands/validate`**: localize remote sources into a temp dir, serve it as an extra root, clean up afterward.

## Verification

- `hyperframes render` on a composition with a remote `<img crossorigin="anonymous">`: **image present** (render localizes).
- `hyperframes validate` on the same composition **before** this change:
  ```
  ✗ ...blocked by CORS policy: No 'Access-Control-Allow-Origin' header...
  ✗ Failed to load ...jpg: net::ERR_FAILED
  ◇  2 error(s)
  ```
- **After** this change:
  ```
  [INFO] [Compiler] Localized remote image source(s) 1 to _remote_media/
  ◇  No console errors · 4 text elements pass WCAG AA
  ```
- Added unit tests for `serveStaticProjectHtml` asset roots (7/7 pass); full monorepo `build` passes.
