### PR TITLE
feat(cli): forward feedback submissions to the backend feedback endpoint

### DIFF
--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -7,6 +7,7 @@ import { trackRenderFeedback } from "../telemetry/events.js";
 import { shouldTrack, flush } from "../telemetry/client.js";
 import { getDoctorSummary } from "../telemetry/feedback.js";
 import { publishProjectArchive } from "../utils/publishProject.js";
+import { submitFeedback } from "../utils/submitFeedback.js";
 import { buildIssueUrl, HYPERFRAMES_REPO_URL } from "../utils/feedbackIssue.js";
 import { VERSION } from "../version.js";
 import { c } from "../ui/colors.js";
@@ -164,6 +165,7 @@ export default defineCommand({
     trackRenderFeedback({ rating, comment, doctorSummary });
 
     await flush();
+    await submitFeedback({ rating, comment, cliVersion: VERSION, env: doctorSummary });
     console.log(c.dim("Thanks for the feedback!"));
 
     if (args["file-issue"] === true) {

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -165,8 +165,10 @@ export default defineCommand({
     trackRenderFeedback({ rating, comment, doctorSummary });
 
     await flush();
-    await submitFeedback({ rating, comment, cliVersion: VERSION, env: doctorSummary });
+    // Ack first so the user isn't kept waiting on the best-effort forward (which
+    // is bounded to a few seconds and never surfaces an error either way).
     console.log(c.dim("Thanks for the feedback!"));
+    await submitFeedback({ rating, comment, cliVersion: VERSION, env: doctorSummary });
 
     if (args["file-issue"] === true) {
       await fileGithubIssue({

--- a/packages/cli/src/utils/submitFeedback.test.ts
+++ b/packages/cli/src/utils/submitFeedback.test.ts
@@ -47,6 +47,23 @@ describe("submitFeedback", () => {
     );
   });
 
+  it("truncates over-long fields to the backend caps", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback({
+      rating: 3,
+      comment: "x".repeat(2500),
+      cliVersion: "v".repeat(200),
+      env: "e".repeat(600),
+    });
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.comment).toHaveLength(2000);
+    expect(body.cli_version).toHaveLength(100);
+    expect(body.env).toHaveLength(500);
+  });
+
   it("does not reject when fetch rejects", async () => {
     const fetchMock = vi.fn().mockRejectedValueOnce(new TypeError("fetch failed"));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/cli/src/utils/submitFeedback.test.ts
+++ b/packages/cli/src/utils/submitFeedback.test.ts
@@ -19,7 +19,7 @@ describe("submitFeedback", () => {
   });
 
   it("posts feedback to the backend endpoint", async () => {
-    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 202 }));
     vi.stubGlobal("fetch", fetchMock);
 
     await submitFeedback({
@@ -48,7 +48,7 @@ describe("submitFeedback", () => {
   });
 
   it("truncates over-long fields to the backend caps", async () => {
-    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 202 }));
     vi.stubGlobal("fetch", fetchMock);
 
     await submitFeedback({
@@ -58,7 +58,9 @@ describe("submitFeedback", () => {
       env: "e".repeat(600),
     });
 
-    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    const requestInit = fetchMock.mock.calls[0]?.[1];
+    expect(requestInit).toBeDefined();
+    const body = JSON.parse(requestInit?.body as string);
     expect(body.comment).toHaveLength(2000);
     expect(body.cli_version).toHaveLength(100);
     expect(body.env).toHaveLength(500);

--- a/packages/cli/src/utils/submitFeedback.test.ts
+++ b/packages/cli/src/utils/submitFeedback.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getPublishApiBaseUrlMock = vi.hoisted(() => vi.fn(() => "https://api.example.com"));
+
+vi.mock("./publishProject.js", () => ({
+  getPublishApiBaseUrl: getPublishApiBaseUrlMock,
+}));
+
+import { submitFeedback } from "./submitFeedback.js";
+
+describe("submitFeedback", () => {
+  beforeEach(() => {
+    getPublishApiBaseUrlMock.mockReturnValue("https://api.example.com");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("posts feedback to the backend endpoint", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback({
+      rating: 4,
+      comment: "fast but font missing",
+      cliVersion: "1.2.3",
+      env: "os=darwin/arm64 node=v22.11.0",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(getPublishApiBaseUrlMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v1/hyperframes/feedback",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json", heygen_route: "canary" },
+        body: JSON.stringify({
+          rating: 4,
+          comment: "fast but font missing",
+          cli_version: "1.2.3",
+          env: "os=darwin/arm64 node=v22.11.0",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("does not reject when fetch rejects", async () => {
+    const fetchMock = vi.fn().mockRejectedValueOnce(new TypeError("fetch failed"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitFeedback({ rating: 1, cliVersion: "1.2.3", env: "os=linux" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("always resolves regardless of fetch outcome", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockRejectedValueOnce(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(submitFeedback({ rating: 2, cliVersion: "1.2.3" })).resolves.toBeUndefined();
+    await expect(submitFeedback({ rating: 3, cliVersion: "1.2.3" })).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/utils/submitFeedback.ts
+++ b/packages/cli/src/utils/submitFeedback.ts
@@ -1,0 +1,28 @@
+import { getPublishApiBaseUrl } from "./publishProject.js";
+
+export async function submitFeedback(input: {
+  rating: number;
+  comment?: string;
+  cliVersion: string;
+  env?: string;
+}): Promise<void> {
+  try {
+    const apiBaseUrl = getPublishApiBaseUrl();
+    await fetch(`${apiBaseUrl}/v1/hyperframes/feedback`, {
+      method: "POST",
+      body: JSON.stringify({
+        rating: input.rating,
+        comment: input.comment,
+        cli_version: input.cliVersion,
+        env: input.env,
+      }),
+      headers: {
+        "content-type": "application/json",
+        heygen_route: "canary",
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/packages/cli/src/utils/submitFeedback.ts
+++ b/packages/cli/src/utils/submitFeedback.ts
@@ -1,5 +1,17 @@
 import { getPublishApiBaseUrl } from "./publishProject.js";
 
+// Match the backend DTO caps (HyperframesFeedbackRequest). Truncate here so an
+// over-long field (e.g. a pasted stack trace) is still forwarded truncated,
+// rather than rejected by the backend with a 422 the best-effort path swallows.
+const MAX_COMMENT = 2000;
+const MAX_CLI_VERSION = 100;
+const MAX_ENV = 500;
+
+function cap(value: string | undefined, max: number): string | undefined {
+  if (value === undefined) return undefined;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
 export async function submitFeedback(input: {
   rating: number;
   comment?: string;
@@ -12,9 +24,9 @@ export async function submitFeedback(input: {
       method: "POST",
       body: JSON.stringify({
         rating: input.rating,
-        comment: input.comment,
-        cli_version: input.cliVersion,
-        env: input.env,
+        comment: cap(input.comment, MAX_COMMENT),
+        cli_version: cap(input.cliVersion, MAX_CLI_VERSION),
+        env: cap(input.env, MAX_ENV),
       }),
       headers: {
         "content-type": "application/json",


### PR DESCRIPTION
## What

After a `hyperframes feedback` submission, also forward the rating/comment to the HyperFrames backend feedback endpoint (`POST /v1/hyperframes/feedback`), in addition to the existing telemetry. This lets the team route real CLI/agent feedback to an internal destination server-side.

## How

- New `packages/cli/src/utils/submitFeedback.ts`: resolves the base URL via the existing `getPublishApiBaseUrl()` (same resolver `publish` uses) and POSTs `{ rating, comment, cli_version, env }` with the `heygen_route: canary` header and a 5s timeout.
- **Best-effort:** every error is swallowed in a try/catch — a backend/endpoint outage never breaks `hyperframes feedback`.
- **Consent-gated:** only called when `shouldTrack()` is true (same gate as the existing telemetry), after `flush()`. No other behavior changes.
- The CLI stays backend-agnostic — it only posts generic feedback JSON; all downstream routing lives server-side.

## Tests

`submitFeedback.test.ts` (vitest, 3/3): asserts the POST URL/header/body shape, that a rejected `fetch` does not throw (best-effort), and that it always resolves. oxfmt/oxlint clean.

## Rollout

Best-effort by design, so this can merge independently of the backend route (a 404 before the endpoint exists is harmless).