### PR TITLE
docs(figma): storyboard blurb reworded + frames-are-app-states escalation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Atomic capabilities the creation workflows compose against — pull one when you
 - `/media-use` — resolve any media need (BGM, SFX, image, icon) into a frozen local file + ledger record. One verb (`resolve`) over the HeyGen catalog with manifest tracking; keeps search noise on disk.
 - `/hyperframes-cli` — CLI dev loop: `init`, `add`, `lint`, `validate`, `inspect`, `preview`, `render`, `publish`, `doctor`, `lambda` (AWS Lambda cloud rendering).
 - `/hyperframes-registry` — install and wire registry blocks and components into compositions via `hyperframes add`. Covers authoring a new block or component to contribute upstream.
-- `/figma` — import Figma assets, tokens, components, and storyboard sections → animatics (REST/CLI) plus Motion animations and shaders (MCP) into a composition.
+- `/figma` — import Figma assets, tokens, components, and storyboard sections → reconstructed motion (frames read as states, not slides) (REST/CLI) plus Motion animations and shaders (MCP) into a composition.
 
 ## Skill catalog maintenance
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Atomic capabilities the creation workflows compose against — pull one when you
 | `/media-use`             | Resolve any media need (BGM, SFX, image, icon) into a frozen local file + ledger record. One verb (`resolve`) over the HeyGen catalog with manifest tracking.                                               |
 | `/hyperframes-cli`       | CLI dev loop — `init`, `lint`, `validate`, `inspect`, `preview`, `render`, `publish`, `doctor`, plus AWS Lambda cloud rendering (`lambda deploy / render / progress`).                                      |
 | `/hyperframes-registry`  | Install and wire registry blocks and components into compositions via `hyperframes add`. Authoring a new block or component to contribute upstream.                                                         |
-| `/figma`                 | Import Figma assets, tokens, components, and storyboard sections → animatics (REST/CLI) plus Motion animations and shaders (MCP) into a composition.                                                        |
+| `/figma`                 | Import Figma assets, tokens, components, and storyboard sections → reconstructed motion (frames read as states, not slides) (REST/CLI) plus Motion animations and shaders (MCP) into a composition.         |
 
 For visual design handoff workflows, see the [Claude Design guide](https://hyperframes.heygen.com/guides/claude-design) and [Open Design guide](https://hyperframes.heygen.com/guides/open-design).
 

--- a/docs/guides/figma.mdx
+++ b/docs/guides/figma.mdx
@@ -1,6 +1,6 @@
 ---
 title: Figma Import
-description: "Bring Figma designs into HyperFrames — frozen assets, brand tokens, editable components, storyboard animatics, and Figma Motion timelines translated to GSAP."
+description: "Bring Figma designs into HyperFrames — frozen assets, brand tokens, editable components, storyboard reconstruction, and Figma Motion timelines translated to GSAP."
 ---
 
 The work your designer already did in Figma — layout, color, type, motion — becomes the starting point of a composition instead of a thing to rebuild by hand. Point at a Figma URL; the artifact lands as a native HyperFrames piece: a frozen local file, a composition variable, editable HTML, or a paused GSAP timeline.
@@ -14,7 +14,7 @@ The work your designer already did in Figma — layout, color, type, motion — 
 | **Components** | A frame as editable HTML with brand-linked colors | `hyperframes figma component` |
 | **Motion** | A Figma Motion timeline as an editable, paused GSAP timeline | `/figma` skill (agent, MCP) |
 | **Shaders** | A shader fill/effect as a frozen still or clip | `/figma` skill (agent, MCP) |
-| **Storyboards** | A section of scene frames reconstructed as an animatic | `/figma` skill (agent) |
+| **Storyboards** | Scene frames reconstructed as motion — frames read as states, not slides | `/figma` skill (agent) |
 
 Two transports, split by what Figma exposes: assets, tokens, and components run over the **REST API** (headless, works in CI, generous per-minute rate limits). Motion and shaders exist only on Figma's **MCP server**, so an agent drives those. Every path freezes files locally — **renders never call Figma**.
 
@@ -98,7 +98,7 @@ These run through the `/figma` agent skill:
 
 - **Motion** — a Figma Motion timeline (keyframes, easing, repeats) translates structurally into a paused, finite GSAP timeline registered on `window.__timelines`, seekable frame-by-frame like any hand-authored animation, and editable afterward. Tracks that can't translate faithfully fall back to a baked video clip — the agent tells you which path it took and why.
 - **Shaders** — Figma's export path doesn't execute shaders, so the default is a native Figma export (PNG or Motion MP4) imported as an asset/clip.
-- **Storyboards** — a section of scene frames is decoded, not slideshowed: frames sharing an element are treated as that element's keyframes over time, diffed into element chains and tweened, with text under the strip read as director notes. See the `/figma` skill for the full grammar.
+- **Storyboards** — a section of scene frames is decoded, not slideshowed: frames sharing an element are treated as that element's keyframes over time, diffed into element chains and tweened, with text under the strip read as director notes. When the frames depict one product UI in successive states, the agent escalates further — rebuilds the UI as live DOM and performs each frame delta as a real interaction (cursor, click, navigation), so the result reads as a continuous screen recording. See the `/figma` skill for the full grammar.
 
 ## Provenance and refresh
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -84,7 +84,7 @@ Atomic capabilities the creation workflows compose against — pull one when you
 | `/media-use`             | Resolve any media need (BGM, SFX, image, icon) into a frozen local file + ledger record. One verb (`resolve`) over the HeyGen catalog with manifest tracking.          |
 | `/hyperframes-cli`       | CLI dev loop — `init`, `lint`, `validate`, `inspect`, `preview`, `render`, `publish`, `doctor`, plus AWS Lambda cloud rendering (`lambda deploy / render / progress / destroy / policies`). |
 | `/hyperframes-registry`  | Install and wire registry blocks and components into compositions via `hyperframes add`. Authoring a new block or component to contribute upstream.                   |
-| `/figma`                 | Import Figma assets, tokens, components, and storyboard sections → animatics (REST/CLI) plus Motion animations and shaders (MCP) into a composition.                                                                        |
+| `/figma`                 | Import Figma assets, tokens, components, and storyboard sections → reconstructed motion (frames read as states, not slides) (REST/CLI) plus Motion animations and shaders (MCP) into a composition.                                                                        |
 
 ## Source of truth
 

--- a/packages/cli/src/commands/figma/skillContent.test.ts
+++ b/packages/cli/src/commands/figma/skillContent.test.ts
@@ -9,20 +9,9 @@ import { fileURLToPath } from "node:url";
 // wording in SKILL.md is the only thing that produces their usage signal. The
 // manifest hash proves the skill changed; this proves a future prompt edit
 // didn't silently drop the beacon slugs or the completion event.
-const SKILL_MD = readFileSync(
-  join(
-    fileURLToPath(new URL(".", import.meta.url)),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "skills",
-    "figma",
-    "SKILL.md",
-  ),
-  "utf8",
-);
+const REPO_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..", "..", "..", "..");
+const read = (...parts: string[]): string => readFileSync(join(REPO_ROOT, ...parts), "utf8");
+const SKILL_MD = read("skills", "figma", "SKILL.md");
 
 describe("figma SKILL.md telemetry beacons", () => {
   it("instructs the beacon for every MCP-only phase", () => {
@@ -35,5 +24,39 @@ describe("figma SKILL.md telemetry beacons", () => {
   it("instructs the completion beacon with an outcome", () => {
     expect(SKILL_MD).toContain("--event=skill_completed");
     expect(SKILL_MD).toMatch(/--outcome=success\|error/);
+  });
+});
+
+// Routing pin: the catalog blurb once said "storyboard sections → animatics",
+// which encodes the frames-as-pictures slideshow the skill's own cardinal rule
+// forbids — a field agent routed by that word and concluded the shipped
+// behavior was the PNG-sequence architecture. These assertions keep the
+// frames-are-states framing on every discovery surface and keep the doctrine
+// in the skill body, so a future sync can't silently reintroduce the old word.
+describe("figma storyboard doctrine pins", () => {
+  const CATALOG_SURFACES: Array<[string, string[]]> = [
+    ["skills/figma/SKILL.md", ["skills", "figma", "SKILL.md"]],
+    ["CLAUDE.md", ["CLAUDE.md"]],
+    ["README.md", ["README.md"]],
+    ["docs/guides/skills.mdx", ["docs", "guides", "skills.mdx"]],
+    ["skills/hyperframes/SKILL.md", ["skills", "hyperframes", "SKILL.md"]],
+  ];
+
+  it("every catalog surface says reconstructed motion, never animatics", () => {
+    for (const [label, parts] of CATALOG_SURFACES) {
+      const content = read(...parts);
+      expect(content, label).toContain("reconstructed motion");
+      expect(content, label).not.toContain("animatics");
+    }
+  });
+
+  it("the source-of-truth description carries the frames-as-states framing", () => {
+    expect(SKILL_MD).toContain("frames read as states, not slides");
+  });
+
+  it("keeps the cardinal rule and the app-states escalation (rule 10)", () => {
+    expect(SKILL_MD).toContain("KEYFRAMES, not slides");
+    expect(SKILL_MD).toContain("code what changes state, freeze what doesn't");
+    expect(SKILL_MD).toContain("interaction to perform");
   });
 });

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -10,7 +10,7 @@
       "files": 18
     },
     "figma": {
-      "hash": "4c3977e79a17d498",
+      "hash": "39ef9778614b4f08",
       "files": 1
     },
     "general-video": {
@@ -18,7 +18,7 @@
       "files": 1
     },
     "hyperframes": {
-      "hash": "2bd5cdf9f851b4d2",
+      "hash": "e4e2f137d492c6d7",
       "files": 1
     },
     "hyperframes-animation": {

--- a/skills/figma/SKILL.md
+++ b/skills/figma/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma
-description: Import Figma content into a HyperFrames composition — rendered assets, brand tokens, components, storyboard sections → animatics (REST/CLI), and Figma Motion animations + shaders (MCP). Use when the user pastes a figma.com link or asks to bring a Figma design, frame, logo, brand, or animation into a video/composition.
+description: Import Figma content into a HyperFrames composition — rendered assets, brand tokens, components, storyboard sections → reconstructed motion (frames read as states, not slides) (REST/CLI), and Figma Motion animations + shaders (MCP). Use when the user pastes a figma.com link or asks to bring a Figma design, frame, logo, brand, or animation into a video/composition.
 ---
 
 # Figma → HyperFrames
@@ -15,7 +15,7 @@ Bring the user's Figma work into a composition. **Split by capability** (design 
 | 4     | Motion → GSAP       | **MCP only**                 | you, via `get_motion_context` |
 | 5     | Shaders             | **MCP only** / manual export | you                           |
 
-REST is used wherever it can be (usable at volume, headless); MCP only where Figma exposes no REST equivalent (motion, shaders). Every path freezes assets locally so renders stay deterministic. Storyboard animatics compose Phase-1 asset exports (REST) with agent-driven timeline assembly — no MCP needed. Existing frozen assets, manifest records, and bindings are unaffected by routing changes — the split only changes which credential the next import uses.
+REST is used wherever it can be (usable at volume, headless); MCP only where Figma exposes no REST equivalent (motion, shaders). Every path freezes assets locally so renders stay deterministic. Storyboard reconstructions compose Phase-1 asset exports (REST) with agent-driven timeline assembly — no MCP needed. Existing frozen assets, manifest records, and bindings are unaffected by routing changes — the split only changes which credential the next import uses.
 
 ## Auth — two credentials, scoped
 
@@ -115,6 +115,7 @@ Storyboard files follow a grammar you can parse mechanically — don't eyeball, 
 
 8. **Stills vs. components routing**: a note describing motion _between_ scenes → transition on the still (above). A note describing motion _inside_ a scene ("TEXT LINES REVEAL ONE AFTER THE OTHER", "PILLS ANIMATE IN") → that frame deserves a Phase-3 component import (real elements) animated per the note, not a flat PNG. Do the animatic pass first with stills, then upgrade the scenes the notes single out.
 9. One `main` timeline sequences everything (opacity/x/y per scene at absolute times) — no per-scene sub-compositions needed for an animatic.
+10. **Escalation — frames depict ONE product UI → rebuild the app, not element chains.** When every frame is the same application screen in successive states (a signup flow, a settings panel, a player), element chains undersell it. Rebuild the UI as live DOM — Phase-3 component import for the parts that change state, real exported pixels for static chrome (**code what changes state, freeze what doesn't**) — and treat each frame delta as an **interaction to perform**, not a tween to apply: the cursor enters, clicks the control, the state responds, screens push/slide as real navigation. The result reads as one continuous screen recording of a working app. This is the cardinal rule taken to its conclusion for UI flows; the stills/element-chain treatments are for storyboards that aren't one coherent application.
 
 ## Determinism
 

--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -35,7 +35,7 @@ Atomic capabilities you load **on demand** — not full video workflows. For "ma
 | **Media resolve** — find + freeze BGM, SFX, images, icons from HeyGen catalog into `.media/` with manifest tracking                                                     | `/media-use`             |
 | **CLI dev loop** — init, lint, validate, inspect, preview, render, publish, doctor                                                                                      | `/hyperframes-cli`       |
 | **Install registry blocks / components** (`hyperframes add`)                                                                                                            | `/hyperframes-registry`  |
-| **Import Figma content** — assets, tokens, components, storyboards→animatics (REST/CLI); Motion, shaders (MCP)                                                          | `/figma`                 |
+| **Import Figma content** — assets, tokens, components, storyboards→reconstructed motion (REST/CLI); Motion, shaders (MCP)                                               | `/figma`                 |
 
 ---
 


### PR DESCRIPTION
## What

Docs-only. Field feedback from an agent that built a Figma product-flow video **without** the `/figma` skill installed surfaced two things: our catalog blurb misdescribes the storyboard architecture, and that agent demonstrated a doctrine rung stronger than the one the skill teaches.

### 1. "Animatics" was the wrong word

The catalog blurb said "storyboard sections → animatics". An animatic IS the frames-as-pictures slideshow — the exact failure mode the skill body's cardinal rule forbids ("storyboard frames are KEYFRAMES, not slides"). Agents route by these one-line blurbs: the field agent read "animatic," concluded the shipped behavior was the PNG-sequence architecture, and told its user so — while the skill it never read already codified the opposite. One word encoding the wrong architecture, propagated to every discovery surface.

Reworded to **"reconstructed motion (frames read as states, not slides)"** everywhere the blurb lives: `skills/figma/SKILL.md` frontmatter (source of truth), `CLAUDE.md`, `README.md`, `docs/guides/skills.mdx`, the `/hyperframes` router capability map, and `docs/guides/figma.mdx` (frontmatter + capability table + storyboards bullet). Body uses of "animatic" for the stills *fallback* remain — that treatment genuinely is one.

### 2. Storyboard rule 10 — frames are app STATES

The field build (`join-the-world-flow`, a multi-frame product UI flow) showed the cardinal rule taken to its conclusion: when every frame is the **same application screen in successive states**, element chains undersell it. New escalation rule in the skill's storyboard grammar:

- rebuild the UI as live DOM — Phase-3 component import for the stateful parts, real exported pixels for static chrome (**code what changes state, freeze what doesn't**)
- treat each frame delta as an **interaction to perform** (cursor enters, clicks, screens push as real navigation), not a tween to apply
- result reads as one continuous screen recording of a working app

Spec §5.1 records the escalation and field origin. Deliberately NOT codified: the field agent's private choreography stack (idle-motion bans, cursor entry/exit laws, seam gates) — per the teach-philosophy-not-techniques rule, the skill carries the architectural insight and leaves taste to the user's layer.

## Testing

Docs/skill text only — no runtime surface. `skills-manifest.json` regenerated by the pre-commit hook; grep confirms zero remaining "animatic" on catalog surfaces. Note: the SKILL.md telemetry-beacon pin test lands in #1979 and is unaffected (beacon wording untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
