### PR TITLE
fix(engine): pre-create __render_frame__ siblings in initializeSession

### DIFF
--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -1650,10 +1650,20 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   // near-black flash). The tick time sits in the gap between the last warmup
   // tick and frame 0 (`beginFrameTimeTicks` carries +10 intervals of headroom),
   // so ticks stay monotonic and no render frame is consumed.
+  //
+  // It must land BELOW the producer's BeginFrame liveness probe, which fires
+  // from probeStage right after init at `beginFrameTimeTicks - 5·interval`
+  // (screenshotService.probeBeginFrameLiveness). This commit tick is sent during
+  // init — temporally before the probe — so if its tick were above the probe's,
+  // the probe would run backwards in BeginFrame time (non-monotonic) and
+  // chrome-headless-shell stalls it indefinitely (surfaced as a "SwiftShader
+  // heavy-layer" probe timeout, then routed to screenshot capture). At the
+  // original `-1·interval` that stalled every comp reaching the probe; at
+  // `-6·interval` the order stays warmup < commit < probe < capture.
   await ensureRenderFrameSiblings(page);
   const commitCdp = await getCdpSession(page);
   await commitCdp.send("HeadlessExperimental.beginFrame", {
-    frameTimeTicks: session.beginFrameTimeTicks - session.beginFrameIntervalMs,
+    frameTimeTicks: session.beginFrameTimeTicks - 6 * session.beginFrameIntervalMs,
     interval: session.beginFrameIntervalMs,
     noDisplayUpdates: false,
   });

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -25,6 +25,7 @@ import {
 } from "./browserManager.js";
 import {
   beginFrameCapture,
+  ensureRenderFrameSiblings,
   getCdpSession,
   pageScreenshotCapture,
   initTransparentBackground,
@@ -1478,6 +1479,7 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     await initDrawElementOrTransparentBackground(session, page, logInitPhase);
 
     await armStaticDedup(session, session.page, logInitPhase);
+    await ensureRenderFrameSiblings(session.page);
     session.isInitialized = true;
     return;
   }
@@ -1608,13 +1610,16 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
 
   await recordSessionInitTelemetry(session, initStart);
 
-  // Stop warmup. Unlocked mode exits on this flag; locked mode keeps ticking
-  // until LOCKED_WARMUP_TICKS, so we await its promise to ensure the count is
-  // exact before deriving the baseline.
+  // Stop warmup, then drain the loop in BOTH modes before any further
+  // BeginFrame on this session (drawElement init, the render-frame commit tick
+  // at the end of init, and frame 0). Clearing the flag only stops new
+  // iterations — a warmup `HeadlessExperimental.beginFrame` may still be in
+  // flight, and a second beginFrame on the same session while one is pending
+  // fails with "Another frame is pending". Locked mode additionally needs the
+  // await to reach the exact LOCKED_WARMUP_TICKS count before deriving the
+  // baseline below.
   warmupState.running = false;
-  if (lockWarmupTicks) {
-    await warmupLoopPromise.catch(() => {});
-  }
+  await warmupLoopPromise.catch(() => {});
 
   // Set base frame time ticks past warmup range. Locked mode pins to the
   // constant so chunk workers on different hosts compute the same baseline.
@@ -1632,6 +1637,27 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   await initDrawElementOrTransparentBackground(session, page, logInitPhase);
 
   await armStaticDedup(session, session.page, logInitPhase);
+
+  // Pre-create the hidden `__render_frame__` siblings so the first per-session
+  // `injectVideoFramesBatch` takes the `hasImg = true` (src-update) path instead
+  // of inserting a fresh `<img>` mid-capture. Then drive ONE non-capture,
+  // *visual* BeginFrame (`noDisplayUpdates: false`) to actually composite the
+  // new layers before the first real capture. The warmup ticks above are
+  // `noDisplayUpdates: true` (they advance the clock but don't paint), and the
+  // seek in `prepareFrameForCapture` doesn't tick, so without this commit tick
+  // the first *display-producing* BeginFrame would be the capture itself — and
+  // the freshly-inserted layers would miss it (the per-session worker-boundary
+  // near-black flash). The tick time sits in the gap between the last warmup
+  // tick and frame 0 (`beginFrameTimeTicks` carries +10 intervals of headroom),
+  // so ticks stay monotonic and no render frame is consumed.
+  await ensureRenderFrameSiblings(page);
+  const commitCdp = await getCdpSession(page);
+  await commitCdp.send("HeadlessExperimental.beginFrame", {
+    frameTimeTicks: session.beginFrameTimeTicks - session.beginFrameIntervalMs,
+    interval: session.beginFrameIntervalMs,
+    noDisplayUpdates: false,
+  });
+
   session.isInitialized = true;
 }
 

--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -6,6 +6,7 @@ import { type Page } from "puppeteer-core";
 import {
   pageScreenshotCapture,
   cdpSessionCache,
+  ensureRenderFrameSiblings,
   applyDomLayerMask,
   removeDomLayerMask,
   injectVideoFramesBatch,
@@ -742,5 +743,92 @@ describe("video-frame injection respects ancestor visibility", () => {
     } finally {
       teardown();
     }
+  });
+});
+
+describe("ensureRenderFrameSiblings", () => {
+  function passthroughPage(): Page {
+    return {
+      evaluate: async (fn: (...args: unknown[]) => unknown, ...args: unknown[]) =>
+        Promise.resolve((fn as (...a: unknown[]) => unknown)(...args)),
+    } as unknown as Page;
+  }
+
+  function withGlobalDom(setup: { window: Window; document: Document }): { teardown: () => void } {
+    const globals = globalThis as unknown as { window?: Window; document?: Document };
+    const previousWindow = globals.window;
+    const previousDocument = globals.document;
+    globals.window = setup.window;
+    globals.document = setup.document;
+    return {
+      teardown: () => {
+        globals.window = previousWindow;
+        globals.document = previousDocument;
+      },
+    };
+  }
+
+  it("creates a hidden __render_frame__ sibling for every video[data-start]", async () => {
+    const { window, document } = parseHTML(
+      `<html><body>
+        <div id="root">
+          <video id="v1" data-start="0" data-duration="2"></video>
+          <video id="v2" data-start="2" data-duration="2"></video>
+        </div>
+      </body></html>`,
+    );
+    const { teardown } = withGlobalDom({ window, document });
+    try {
+      await ensureRenderFrameSiblings(passthroughPage());
+    } finally {
+      teardown();
+    }
+
+    for (const id of ["v1", "v2"]) {
+      const video = document.getElementById(id) as HTMLVideoElement;
+      const sibling = video.nextElementSibling as HTMLElement | null;
+      expect(sibling).not.toBeNull();
+      expect(sibling?.tagName.toLowerCase()).toBe("img");
+      expect(sibling?.classList.contains("__render_frame__")).toBe(true);
+      expect(sibling?.id).toBe(`__render_frame_${id}__`);
+      expect(sibling?.style.visibility).toBe("hidden");
+    }
+  });
+
+  it("skips videos that already have a __render_frame__ sibling", async () => {
+    const { window, document } = parseHTML(
+      `<html><body>
+        <div id="root">
+          <video id="clip" data-start="0" data-duration="2"></video>
+          <img id="__render_frame_clip__" class="__render_frame__">
+        </div>
+      </body></html>`,
+    );
+    const preExisting = document.getElementById("__render_frame_clip__") as HTMLImageElement;
+    const { teardown } = withGlobalDom({ window, document });
+    try {
+      await ensureRenderFrameSiblings(passthroughPage());
+    } finally {
+      teardown();
+    }
+
+    const video = document.getElementById("clip") as HTMLVideoElement;
+    expect(video.nextElementSibling).toBe(preExisting);
+    expect(document.querySelectorAll(".__render_frame__").length).toBe(1);
+  });
+
+  it("does not touch <video> elements without data-start", async () => {
+    const { window, document } = parseHTML(
+      `<html><body><div id="root"><video id="raw"></video></div></body></html>`,
+    );
+    const { teardown } = withGlobalDom({ window, document });
+    try {
+      await ensureRenderFrameSiblings(passthroughPage());
+    } finally {
+      teardown();
+    }
+
+    const video = document.getElementById("raw") as HTMLVideoElement;
+    expect(video.nextElementSibling).toBeNull();
   });
 });

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -543,6 +543,46 @@ export async function removeDomLayerMask(page: Page, _extraHideIds: string[]): P
 }
 
 /**
+ * Pre-create hidden `__render_frame__` sibling `<img>`s for every
+ * `video[data-start]` in the page. Idempotent — videos that already
+ * have a sibling are skipped.
+ *
+ * `injectVideoFramesBatch` creates the sibling on the fly the first time
+ * it paints a given videoId (the `isNewImage = !hasImg` branch below).
+ * Under chrome-headless-shell's deterministic + `HeadlessExperimental.
+ * BeginFrame` mode, the immediately-next BeginFrame captures before the
+ * freshly-inserted `<img>` layer lands in the compositor's layer tree;
+ * the layer arrives a frame later. That single frame paints only the
+ * body background + previously-composed overlays.
+ *
+ * Called from `initializeSession`: in the screenshot path at the end (that
+ * capture path flushes paint, so timing doesn't matter), and in the BeginFrame
+ * path followed by one explicit visual `HeadlessExperimental.beginFrame`
+ * (`noDisplayUpdates: false`) that composites the new layers before the first
+ * capture — the warmup ticks are `noDisplayUpdates: true` and don't paint.
+ * Every subsequent `injectVideoFramesBatch` then takes the `hasImg = true` path
+ * (just an `img.src` update). The `isNewImage` branch stays as a fallback for
+ * callers that don't run through `initializeSession`.
+ */
+export async function ensureRenderFrameSiblings(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    for (const video of Array.from(
+      document.querySelectorAll<HTMLVideoElement>("video[data-start]"),
+    )) {
+      const next = video.nextElementSibling;
+      if (next !== null && next.classList.contains("__render_frame__")) continue;
+      const img = document.createElement("img");
+      img.classList.add("__render_frame__");
+      img.id = `__render_frame_${video.id}__`;
+      img.style.pointerEvents = "none";
+      img.style.position = "absolute";
+      img.style.visibility = "hidden";
+      video.parentNode?.insertBefore(img, video.nextSibling);
+    }
+  });
+}
+
+/**
  * Returns the subset of `updates.videoId`s that were actually painted in
  * this call. Videos skipped because of a hidden visual ancestor are NOT
  * included — the caller relies on this to avoid recording a `lastInjected`


### PR DESCRIPTION
Fixes #2007.

Chunk-lambda renders have been throwing a periodic near-black frame — one bad frame every `chunk_frames / worker_count` frames. On a single-video 4-worker chunk that's every 60 frames, and `signalstats` catches it cleanly: YAVG drops to ~22 while YMAX stays ~240. Local single-process renders never show it, which is the tell — they don't run under BeginFrame.

I tracked it to the `isNewImage` branch in `injectVideoFramesBatch`. The first time a session paints a given `videoId` there's no `__render_frame__` sibling yet, so it creates the `<img>` on the spot — `createElement` + `insertBefore`. `captureFrameCore` fires `beginFrameCapture` right after, and under `HeadlessExperimental.BeginFrame` the compositor doesn't have that freshly-inserted layer in the immediately-next frame, so the first captured frame per session paints only body background + whatever was already composited (the YAVG ~22 signature). Each lambda worker is its own session, so it recurs at every worker boundary.

The fix pre-creates the hidden sibling at the end of `initializeSession`, then drives one explicit non-capture visual `HeadlessExperimental.beginFrame` (`noDisplayUpdates: false`) to composite the new layers before frame 0. The warmup ticks can't do that — they're `noDisplayUpdates: true`, so they advance the clock but don't paint, and the seek in `prepareFrameForCapture` doesn't tick either; without the explicit commit frame the first *display-producing* BeginFrame would be the capture itself. The commit tick sits one interval below `beginFrameTimeTicks` (which already carries +10 intervals of headroom over the last warmup tick), so it stays monotonic and doesn't eat a render frame, and the warmup loop is now drained unconditionally before it so it can't race an in-flight warmup frame. Every subsequent inject then takes the `hasImg = true` (src-update) path; the `isNewImage` branch stays as a fallback for callers that don't go through `initializeSession`.
