### PR TITLE
test: add unit tests for rounding utils

### DIFF
--- a/packages/studio/src/utils/rounding.test.ts
+++ b/packages/studio/src/utils/rounding.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { roundTo3, roundToCenti } from "./rounding";
+
+describe("roundTo3", () => {
+  it("rounds to 3 decimal places", () => {
+    expect(roundTo3(1.23456)).toBe(1.235);
+  });
+
+  it("leaves values already at 3 decimal places unchanged", () => {
+    expect(roundTo3(1.5)).toBe(1.5);
+  });
+
+  it("handles negative values", () => {
+    expect(roundTo3(-1.23456)).toBe(-1.235);
+  });
+});
+
+describe("roundToCenti", () => {
+  it("rounds to 2 decimal places", () => {
+    expect(roundToCenti(1.2345)).toBe(1.23);
+  });
+
+  it("leaves values already at 2 decimal places unchanged", () => {
+    expect(roundToCenti(1.5)).toBe(1.5);
+  });
+
+  it("handles negative values", () => {
+    expect(roundToCenti(-1.2345)).toBe(-1.23);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for oundTo3 and oundToCenti in packages/studio/src/utils/rounding.ts, which had no direct test coverage despite being used across ~15 files in the studio package.

## Test plan
- [x] New tests follow the existing vitest pattern used in clipboardPayload.test.ts`n- [ ] CI test suite passes