### PR TITLE
chore: release v0.7.40

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,32 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.40"
+  description="Released - 2026-07-07"
+  tags={["Release", "CLI", "Engine,producer", "Studio"]}
+>
+The headline this release is a Studio timeline revamp: clips visible at the playhead are highlighted, tracks and individual elements can be hidden with a non-destructive `data-hidden` toggle that carries through to renders, and ruler zoom and gutter behavior are cleaner. It also fixes static-position dragging beside an animated rotation and keeps off-canvas indicators in sync with live layout.
+
+## Features
+
+- **Studio:** Timeline revamp with active-clip highlighting and hide controls ([037266e7](https://github.com/heygen-com/hyperframes/commit/037266e72bd808491a82008ca2520299fecef381), [#2017](https://github.com/heygen-com/hyperframes/pull/2017))
+- **CLI:** Associate signed-in HeyGen account with telemetry ([3d8372f8](https://github.com/heygen-com/hyperframes/commit/3d8372f880a6739ee3e0beea484905d76e5ad3a9), [#2020](https://github.com/heygen-com/hyperframes/pull/2020))
+
+## Fixes
+
+- **CLI:** Figma component import survives unrenderable nodes ([4c8064d4](https://github.com/heygen-com/hyperframes/commit/4c8064d4d3d1ffe51a10b1c7eee79a49b2fc468f), [#2022](https://github.com/heygen-com/hyperframes/pull/2022))
+- **Studio:** Off-canvas indicators track live layout instead of going stale ([574da2b2](https://github.com/heygen-com/hyperframes/commit/574da2b215b29cc3e8288551ce37e7a06cdaa194), [#2018](https://github.com/heygen-com/hyperframes/pull/2018))
+- **Studio:** Static-position drag no longer freezes an element beside an animated rotation ([5d598354](https://github.com/heygen-com/hyperframes/commit/5d59835446bb426def56a791d19a99a6ebe283d3), [#2016](https://github.com/heygen-com/hyperframes/pull/2016))
+- **Skills:** Audit descriptions — trim routing prose, fix stale facts, add missing triggers ([306a291d](https://github.com/heygen-com/hyperframes/commit/306a291deaf8796cd2e9e34c406d707a7bdf3f7f), [#1990](https://github.com/heygen-com/hyperframes/pull/1990))
+
+## Internal
+
+- **Engine,producer:** Adopt requestPaint contract, retire autoAlpha rewrite ([337d0b51](https://github.com/heygen-com/hyperframes/commit/337d0b51bcd81184520b23259799d42aaa366ed2), [#2021](https://github.com/heygen-com/hyperframes/pull/2021))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.39...v0.7.40).
+</Update>
+
+<Update
   label="HyperFrames v0.7.39"
   description="Released - 2026-07-07"
   tags={["Release", "Engine,producer,cli", "Skills", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.40.md
+++ b/releases/v0.7.40.md
@@ -1,0 +1,25 @@
+# HyperFrames v0.7.40
+
+Released on 2026-07-07.
+
+The headline this release is a Studio timeline revamp: clips visible at the playhead are highlighted, tracks and individual elements can be hidden with a non-destructive `data-hidden` toggle that carries through to renders, and ruler zoom and gutter behavior are cleaner. It also fixes static-position dragging beside an animated rotation and keeps off-canvas indicators in sync with live layout.
+
+## Features
+
+- **Studio:** Timeline revamp with active-clip highlighting and hide controls ([037266e7](https://github.com/heygen-com/hyperframes/commit/037266e72bd808491a82008ca2520299fecef381), [#2017](https://github.com/heygen-com/hyperframes/pull/2017))
+- **CLI:** Associate signed-in HeyGen account with telemetry ([3d8372f8](https://github.com/heygen-com/hyperframes/commit/3d8372f880a6739ee3e0beea484905d76e5ad3a9), [#2020](https://github.com/heygen-com/hyperframes/pull/2020))
+
+## Fixes
+
+- **CLI:** Figma component import survives unrenderable nodes ([4c8064d4](https://github.com/heygen-com/hyperframes/commit/4c8064d4d3d1ffe51a10b1c7eee79a49b2fc468f), [#2022](https://github.com/heygen-com/hyperframes/pull/2022))
+- **Studio:** Off-canvas indicators track live layout instead of going stale ([574da2b2](https://github.com/heygen-com/hyperframes/commit/574da2b215b29cc3e8288551ce37e7a06cdaa194), [#2018](https://github.com/heygen-com/hyperframes/pull/2018))
+- **Studio:** Static-position drag no longer freezes an element beside an animated rotation ([5d598354](https://github.com/heygen-com/hyperframes/commit/5d59835446bb426def56a791d19a99a6ebe283d3), [#2016](https://github.com/heygen-com/hyperframes/pull/2016))
+- **Skills:** Audit descriptions — trim routing prose, fix stale facts, add missing triggers ([306a291d](https://github.com/heygen-com/hyperframes/commit/306a291deaf8796cd2e9e34c406d707a7bdf3f7f), [#1990](https://github.com/heygen-com/hyperframes/pull/1990))
+
+## Internal
+
+- **Engine,producer:** Adopt requestPaint contract, retire autoAlpha rewrite ([337d0b51](https://github.com/heygen-com/hyperframes/commit/337d0b51bcd81184520b23259799d42aaa366ed2), [#2021](https://github.com/heygen-com/hyperframes/pull/2021))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.39...v0.7.40


### PR DESCRIPTION
Stable release **v0.7.40**.

Headline: Studio timeline revamp (active-clip highlighting, per-track and per-element hide via non-destructive `data-hidden`, cleaner ruler zoom/gutter), plus fixes for static-position drag beside animated rotation and off-canvas indicator staleness.

Bumps all package + plugin versions 0.7.39 → 0.7.40, adds `releases/v0.7.40.md`, and prepends the v0.7.40 entry to `docs/changelog.mdx`.

Merging this PR (branch `release/v0.7.40`) triggers the publish workflow: it tags `v0.7.40` and publishes every package to npm at dist-tag `latest`.

Full changelog: https://github.com/heygen-com/hyperframes/compare/v0.7.39...v0.7.40