### PR TITLE
fix(producer): copy extracted frames on Windows to avoid symlink EPERM [P0]

### DIFF
--- a/packages/producer/src/services/render/stages/extractVideosStage.test.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { appendAutoDetectedVideoAudio } from "./extractVideosStage.js";
+import { appendAutoDetectedVideoAudio, shouldCopyExtractedFrames } from "./extractVideosStage.js";
 import type { ExtractedFrames, VideoElement } from "@hyperframes/engine";
 
 function makeVideo(overrides: Partial<VideoElement> = {}): VideoElement {
@@ -79,5 +79,16 @@ describe("appendAutoDetectedVideoAudio", () => {
     };
     appendAutoDetectedVideoAudio(composition, [makeExtracted("v1", true)]);
     expect(composition.audios).toHaveLength(1);
+  });
+});
+
+describe("shouldCopyExtractedFrames", () => {
+  it("copies frames on Windows (symlinkSync throws EPERM without Developer Mode)", () => {
+    expect(shouldCopyExtractedFrames("win32")).toBe(true);
+  });
+
+  it("symlinks on macOS and Linux (cheaper, symlinks allowed)", () => {
+    expect(shouldCopyExtractedFrames("darwin")).toBe(false);
+    expect(shouldCopyExtractedFrames("linux")).toBe(false);
   });
 });

--- a/packages/producer/src/services/render/stages/extractVideosStage.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.ts
@@ -96,6 +96,18 @@ export interface ExtractVideosStageResult {
   videoExtractMs: number;
 }
 
+/**
+ * Whether the extract stage should COPY frames into the compiled dir instead of
+ * symlinking them. Windows without Developer Mode / Administrator can't create
+ * symlinks (`symlinkSync` throws EPERM), which failed local video renders; copy
+ * there instead. Elsewhere symlinking is cheaper, so keep it. (The distributed
+ * `plan()` path already forces copying for a different reason — a self-contained
+ * planDir — by passing `materializeSymlinks: true` explicitly.)
+ */
+export function shouldCopyExtractedFrames(platform: NodeJS.Platform): boolean {
+  return platform === "win32";
+}
+
 export async function runExtractVideosStage(
   input: ExtractVideosStageInput,
 ): Promise<ExtractVideosStageResult> {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -110,7 +110,10 @@ import {
 import { type HdrPerfCollector, type HdrPerfSummary } from "./render/hdrPerf.js";
 import { runCompileStage } from "./render/stages/compileStage.js";
 import { runProbeStage } from "./render/stages/probeStage.js";
-import { runExtractVideosStage } from "./render/stages/extractVideosStage.js";
+import {
+  runExtractVideosStage,
+  shouldCopyExtractedFrames,
+} from "./render/stages/extractVideosStage.js";
 import { runAudioStage } from "./render/stages/audioStage.js";
 import { runCaptureStage } from "./render/stages/captureStage.js";
 import { runCaptureStreamingStage } from "./render/stages/captureStreamingStage.js";
@@ -1350,6 +1353,9 @@ export async function executeRenderJob(
           composition,
           abortSignal,
           assertNotAborted,
+          // Copy (don't symlink) extracted frames on Windows — symlinkSync throws
+          // EPERM there without Developer Mode/admin, which failed local renders.
+          materializeSymlinks: shouldCopyExtractedFrames(process.platform),
         }),
     );
     const {


### PR DESCRIPTION
## Problem

Local video renders on **Windows without Developer Mode/Administrator** fail at the `video_extract` stage: `renderOrchestrator → runExtractVideosStage` materializes each video's extracted frames into the compiled dir via `symlinkSync` with no `materializeSymlinks` flag, and `symlinkSync` throws **EPERM** there. Reported repeatedly (users worked around it by patching `cli.js` to pass `materializeSymlinks: process.platform==='win32'`, or by falling back to snapshot-frame + manual ffmpeg mux).

The distributed `plan()` path already copies (`materializeSymlinks: true`) — only the local render caller was missing it.

## Fix

Pass `materializeSymlinks: shouldCopyExtractedFrames(process.platform)` at the local `runExtractVideosStage` call in `renderOrchestrator.ts`:
- **win32** → copy the frames (symlinks need privilege there)
- **darwin/linux** → symlink (cheap; unchanged)

New pure `shouldCopyExtractedFrames(platform)` helper in `extractVideosStage.ts` documents the rationale and is unit-tested. This sidesteps the symlink entirely on Windows — independent of, and complementary to, the EPERM→`cpSync` fallback in open PR #1959 (which catches the throw if a symlink is ever attempted elsewhere).

## Tests

`extractVideosStage.test.ts` — `shouldCopyExtractedFrames`: win32 → copy (true), darwin/linux → symlink (false). Pre-commit typecheck + fallow + oxlint/oxfmt all green.