### PR TITLE
feat(producer,cli): drawElement priority inversion — single-worker streaming over auto-parallel

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1678,6 +1678,7 @@ function trackRenderMetrics(
     deCaptureMode: perf?.drawElement?.mode,
     deCompileGate: perf?.drawElement?.compileGate,
     deClampReason: perf?.drawElement?.clampReason,
+    deWorkerInversion: perf?.drawElement?.workerInversion,
     deGateReason: perf?.drawElement?.gateReason,
     deWorkerEncode: perf?.drawElement?.workerEncode,
     deVerifyArmed: perf?.drawElement?.verifyArmed,

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1679,6 +1679,7 @@ function trackRenderMetrics(
     deCompileGate: perf?.drawElement?.compileGate,
     deClampReason: perf?.drawElement?.clampReason,
     deWorkerInversion: perf?.drawElement?.workerInversion,
+    dePreInversionWorkers: perf?.drawElement?.preInversionWorkers,
     deGateReason: perf?.drawElement?.gateReason,
     deWorkerEncode: perf?.drawElement?.workerEncode,
     deVerifyArmed: perf?.drawElement?.verifyArmed,

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -120,7 +120,7 @@ export function trackRenderComplete(
     deCaptureMode?: string;
     deCompileGate?: string;
     deClampReason?: string;
-    deWorkerInversion?: boolean;
+    deWorkerInversion?: string;
     deGateReason?: string;
     deWorkerEncode?: boolean;
     deVerifyArmed?: number;

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -120,6 +120,7 @@ export function trackRenderComplete(
     deCaptureMode?: string;
     deCompileGate?: string;
     deClampReason?: string;
+    deWorkerInversion?: boolean;
     deGateReason?: string;
     deWorkerEncode?: boolean;
     deVerifyArmed?: number;
@@ -196,6 +197,7 @@ export function trackRenderComplete(
       de_capture_mode: props.deCaptureMode,
       de_compile_gate: props.deCompileGate,
       de_clamp_reason: props.deClampReason,
+      de_worker_inversion: props.deWorkerInversion,
       de_gate_reason: props.deGateReason,
       de_worker_encode: props.deWorkerEncode,
       de_verify_armed: props.deVerifyArmed,

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -121,6 +121,7 @@ export function trackRenderComplete(
     deCompileGate?: string;
     deClampReason?: string;
     deWorkerInversion?: string;
+    dePreInversionWorkers?: number;
     deGateReason?: string;
     deWorkerEncode?: boolean;
     deVerifyArmed?: number;
@@ -198,6 +199,7 @@ export function trackRenderComplete(
       de_compile_gate: props.deCompileGate,
       de_clamp_reason: props.deClampReason,
       de_worker_inversion: props.deWorkerInversion,
+      de_pre_inversion_workers: props.dePreInversionWorkers,
       de_gate_reason: props.deGateReason,
       de_worker_encode: props.deWorkerEncode,
       de_verify_armed: props.deVerifyArmed,

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -42,8 +42,8 @@ export interface RenderCaptureObservability {
   browserGpuMode?: string;
   /** drawElement per-render self-verification tripped → whole render re-ran via screenshot. */
   deSelfVerifyFallback?: boolean;
-  /** Auto-parallel inverted to single-worker verified DE streaming (final state — reset if the retry reverts it). */
-  deWorkerInversion?: boolean;
+  /** Auto-parallel inversion outcome: "inverted" (fired, held) | "reverted" (fired, self-verify retry rolled back). */
+  deWorkerInversion?: "inverted" | "reverted";
   protocolTimeoutMs?: number;
   pageNavigationTimeoutMs?: number;
   playerReadyTimeoutMs?: number;

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -42,6 +42,8 @@ export interface RenderCaptureObservability {
   browserGpuMode?: string;
   /** drawElement per-render self-verification tripped → whole render re-ran via screenshot. */
   deSelfVerifyFallback?: boolean;
+  /** Auto-parallel inverted to single-worker verified DE streaming (final state — reset if the retry reverts it). */
+  deWorkerInversion?: boolean;
   protocolTimeoutMs?: number;
   pageNavigationTimeoutMs?: number;
   playerReadyTimeoutMs?: number;

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -46,6 +46,8 @@ export interface DrawElementPerfInput {
   compileGate?: string;
   clampReason?: string;
   workerInversion?: "inverted" | "reverted";
+  /** Auto-resolved worker count before the inversion pinned it to 1 (set only when the inversion fired). */
+  preInversionWorkers?: number;
   selfVerifyFallback: boolean;
   fallbackReason?: string;
   drainStats?: {
@@ -74,6 +76,7 @@ function aggregateDrawElement(
     compileGate: de.compileGate,
     clampReason: de.clampReason,
     workerInversion: de.workerInversion ?? "none",
+    preInversionWorkers: de.preInversionWorkers,
     gateReason: gateReasons.length > 0 ? gateReasons.join("|") : undefined,
     workerEncode: perfs.some((p) => p.deWorkerEncode),
     verifyArmed: perfs.reduce((sum, p) => sum + (p.deVerifyArmed ?? 0), 0),

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -45,7 +45,7 @@ export function pushWorkerDedupPerfs(
 export interface DrawElementPerfInput {
   compileGate?: string;
   clampReason?: string;
-  workerInversion?: boolean;
+  workerInversion?: "inverted" | "reverted";
   selfVerifyFallback: boolean;
   fallbackReason?: string;
   drainStats?: {
@@ -73,7 +73,7 @@ function aggregateDrawElement(
     mode: modes.join("|") || "unknown",
     compileGate: de.compileGate,
     clampReason: de.clampReason,
-    workerInversion: de.workerInversion ?? false,
+    workerInversion: de.workerInversion ?? "none",
     gateReason: gateReasons.length > 0 ? gateReasons.join("|") : undefined,
     workerEncode: perfs.some((p) => p.deWorkerEncode),
     verifyArmed: perfs.reduce((sum, p) => sum + (p.deVerifyArmed ?? 0), 0),

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -40,24 +40,28 @@ export function pushWorkerDedupPerfs(
  * render-level drawElement outcome. mode/gateReason |-join distinct values
  * across workers (bounded cardinality); counters SUM.
  */
+/** Orchestrator-supplied render-level drawElement outcome (one shape, used by
+ * both the aggregate function and buildRenderPerfSummary's input). */
+export interface DrawElementPerfInput {
+  compileGate?: string;
+  clampReason?: string;
+  workerInversion?: boolean;
+  selfVerifyFallback: boolean;
+  fallbackReason?: string;
+  drainStats?: {
+    verifyChecked: number;
+    verifyMinDb?: number;
+    blankSuspects: number;
+    blankDeterministicAccepts: number;
+    blankRecaptures: number;
+  };
+}
+
 // Flat field mapping — branches are ?? fallbacks, not logic.
 // fallow-ignore-next-line complexity
 function aggregateDrawElement(
   perfs: CapturePerfSummary[],
-  de: {
-    compileGate?: string;
-    clampReason?: string;
-    workerInversion?: boolean;
-    selfVerifyFallback: boolean;
-    fallbackReason?: string;
-    drainStats?: {
-      verifyChecked: number;
-      verifyMinDb?: number;
-      blankSuspects: number;
-      blankDeterministicAccepts: number;
-      blankRecaptures: number;
-    };
-  },
+  de: DrawElementPerfInput,
 ): RenderPerfSummary["drawElement"] {
   if (perfs.length === 0) return undefined;
   const modes = [...new Set(perfs.map((p) => p.captureMode).filter(Boolean))].sort();
@@ -69,7 +73,7 @@ function aggregateDrawElement(
     mode: modes.join("|") || "unknown",
     compileGate: de.compileGate,
     clampReason: de.clampReason,
-    workerInversion: de.workerInversion || undefined,
+    workerInversion: de.workerInversion ?? false,
     gateReason: gateReasons.length > 0 ? gateReasons.join("|") : undefined,
     workerEncode: perfs.some((p) => p.deWorkerEncode),
     verifyArmed: perfs.reduce((sum, p) => sum + (p.deVerifyArmed ?? 0), 0),
@@ -137,20 +141,7 @@ export function buildRenderPerfSummary(input: {
   peakHeapUsedBytes: number;
   /** Per-session/per-worker static-dedup perf; aggregated into `staticDedup`. */
   dedupPerfs: CapturePerfSummary[];
-  drawElement?: {
-    compileGate?: string;
-    clampReason?: string;
-    workerInversion?: boolean;
-    selfVerifyFallback: boolean;
-    fallbackReason?: string;
-    drainStats?: {
-      verifyChecked: number;
-      verifyMinDb?: number;
-      blankSuspects: number;
-      blankDeterministicAccepts: number;
-      blankRecaptures: number;
-    };
-  };
+  drawElement?: DrawElementPerfInput;
 }): RenderPerfSummary {
   return {
     renderId: input.job.id,

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -47,6 +47,7 @@ function aggregateDrawElement(
   de: {
     compileGate?: string;
     clampReason?: string;
+    workerInversion?: boolean;
     selfVerifyFallback: boolean;
     fallbackReason?: string;
     drainStats?: {
@@ -68,6 +69,7 @@ function aggregateDrawElement(
     mode: modes.join("|") || "unknown",
     compileGate: de.compileGate,
     clampReason: de.clampReason,
+    workerInversion: de.workerInversion || undefined,
     gateReason: gateReasons.length > 0 ? gateReasons.join("|") : undefined,
     workerEncode: perfs.some((p) => p.deWorkerEncode),
     verifyArmed: perfs.reduce((sum, p) => sum + (p.deVerifyArmed ?? 0), 0),
@@ -138,6 +140,7 @@ export function buildRenderPerfSummary(input: {
   drawElement?: {
     compileGate?: string;
     clampReason?: string;
+    workerInversion?: boolean;
     selfVerifyFallback: boolean;
     fallbackReason?: string;
     drainStats?: {

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -1577,6 +1577,10 @@ describe("shouldPreferSingleWorkerDrawElement (DE priority inversion)", () => {
     totalFrames: 2380,
     minFrames: 900,
     singleWorkerStreamingOk: true,
+    layeredOrEffectRoute: false,
+    supersampling: false,
+    probeDeGated: false,
+    experimentalParallelDeOptIn: false,
   };
 
   it("inverts an auto-resolved multi-worker render for an eligible long comp", () => {
@@ -1585,6 +1589,32 @@ describe("shouldPreferSingleWorkerDrawElement (DE priority inversion)", () => {
 
   it("honors explicitly requested workers", () => {
     expect(shouldPreferSingleWorkerDrawElement({ ...eligible, requestedWorkers: 3 })).toBe(false);
+  });
+
+  it("inverts for requestedWorkers undefined — the value production actually passes for auto", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, requestedWorkers: undefined })).toBe(
+      true,
+    );
+  });
+
+  it("skips comps routed to layered/HDR/shader paths (drawElement never runs there)", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, layeredOrEffectRoute: true })).toBe(
+      false,
+    );
+  });
+
+  it("skips supersampled renders (engine init-time DE gate)", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, supersampling: true })).toBe(false);
+  });
+
+  it("skips when the probe session already shows DE gated out", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, probeDeGated: true })).toBe(false);
+  });
+
+  it("honors the explicit experimental parallel-DE opt-in", () => {
+    expect(
+      shouldPreferSingleWorkerDrawElement({ ...eligible, experimentalParallelDeOptIn: true }),
+    ).toBe(false);
   });
 
   it("skips below the amortization threshold (measured crossover ~900 frames)", () => {

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -28,6 +28,7 @@ import {
   MAX_TRANSIENT_CAPTURE_RETRIES,
   resolveCaptureForceScreenshotForPageSideCompositing,
   shouldDiscardProbeSessionForPageSideCompositing,
+  shouldPreferSingleWorkerDrawElement,
   shouldUseStreamingEncode,
 } from "./renderOrchestrator.js";
 import { ensureFrameWritten } from "./render/stages/captureHdrFrameShared.js";
@@ -1562,5 +1563,53 @@ describe("resolveDeviceScaleFactor", () => {
         outputResolution: "landscape",
       }),
     ).toThrow(/aspect ratio/);
+  });
+});
+
+describe("shouldPreferSingleWorkerDrawElement (DE priority inversion)", () => {
+  const eligible = {
+    workerCount: 5,
+    requestedWorkers: "auto" as const,
+    useDrawElement: true,
+    deCompileGate: undefined,
+    forceScreenshot: false,
+    outputFormat: "mp4" as const,
+    totalFrames: 2380,
+    minFrames: 900,
+    singleWorkerStreamingOk: true,
+  };
+
+  it("inverts an auto-resolved multi-worker render for an eligible long comp", () => {
+    expect(shouldPreferSingleWorkerDrawElement(eligible)).toBe(true);
+  });
+
+  it("honors explicitly requested workers", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, requestedWorkers: 3 })).toBe(false);
+  });
+
+  it("skips below the amortization threshold (measured crossover ~900 frames)", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, totalFrames: 360 })).toBe(false);
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, totalFrames: 900 })).toBe(true);
+  });
+
+  it("is disabled by minFrames <= 0 (HF_DE_SINGLE_MIN_FRAMES=0 kill switch)", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, minFrames: 0 })).toBe(false);
+  });
+
+  it("requires drawElement to be enabled and ungated", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, useDrawElement: false })).toBe(false);
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, deCompileGate: "3d" })).toBe(false);
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, forceScreenshot: true })).toBe(false);
+  });
+
+  it("only applies to the benchmarked configuration (mp4 + streaming-eligible)", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, outputFormat: "webm" })).toBe(false);
+    expect(
+      shouldPreferSingleWorkerDrawElement({ ...eligible, singleWorkerStreamingOk: false }),
+    ).toBe(false);
+  });
+
+  it("is a no-op when workers already resolved to 1", () => {
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, workerCount: 1 })).toBe(false);
   });
 });

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -28,6 +28,7 @@ import {
   MAX_TRANSIENT_CAPTURE_RETRIES,
   resolveCaptureForceScreenshotForPageSideCompositing,
   shouldDiscardProbeSessionForPageSideCompositing,
+  resolveInversionRetryPlan,
   shouldPreferSingleWorkerDrawElement,
   shouldUseStreamingEncode,
 } from "./renderOrchestrator.js";
@@ -1624,6 +1625,7 @@ describe("shouldPreferSingleWorkerDrawElement (DE priority inversion)", () => {
 
   it("is disabled by minFrames <= 0 (HF_DE_SINGLE_MIN_FRAMES=0 kill switch)", () => {
     expect(shouldPreferSingleWorkerDrawElement({ ...eligible, minFrames: 0 })).toBe(false);
+    expect(shouldPreferSingleWorkerDrawElement({ ...eligible, minFrames: -1 })).toBe(false);
   });
 
   it("requires drawElement to be enabled and ungated", () => {
@@ -1641,5 +1643,62 @@ describe("shouldPreferSingleWorkerDrawElement (DE priority inversion)", () => {
 
   it("is a no-op when workers already resolved to 1", () => {
     expect(shouldPreferSingleWorkerDrawElement({ ...eligible, workerCount: 1 })).toBe(false);
+  });
+});
+
+describe("resolveInversionRetryPlan (self-verify retry rollback)", () => {
+  const cfg = { enableStreamingEncode: true, streamingEncodeMaxDurationSeconds: 240 };
+
+  it("returns null when the render was never inverted", () => {
+    expect(
+      resolveInversionRetryPlan({
+        deWorkerInversion: undefined,
+        preInversionWorkerCount: 5,
+        cfg,
+        outputFormat: "mp4",
+        durationSeconds: 80,
+      }),
+    ).toBe(null);
+    expect(
+      resolveInversionRetryPlan({
+        deWorkerInversion: "reverted",
+        preInversionWorkerCount: 5,
+        cfg,
+        outputFormat: "mp4",
+        durationSeconds: 80,
+      }),
+    ).toBe(null);
+  });
+
+  it("restores the pre-inversion worker count and routes multi-worker retries to disk", () => {
+    const plan = resolveInversionRetryPlan({
+      deWorkerInversion: "inverted",
+      preInversionWorkerCount: 5,
+      cfg,
+      outputFormat: "mp4",
+      durationSeconds: 80,
+    });
+    expect(plan).toEqual({
+      workerCount: 5,
+      // shouldUseStreamingEncode is workerCount===1-only — parallel retry
+      // goes through the disk path.
+      useStreamingEncode: false,
+      deWorkerInversion: "reverted",
+    });
+  });
+
+  it("keeps streaming when the pre-inversion resolution was already single-worker", () => {
+    const plan = resolveInversionRetryPlan({
+      deWorkerInversion: "inverted",
+      preInversionWorkerCount: 1,
+      cfg,
+      outputFormat: "mp4",
+      durationSeconds: 80,
+    });
+    expect(plan).toEqual({
+      workerCount: 1,
+      useStreamingEncode: true,
+      deWorkerInversion: "reverted",
+    });
   });
 });

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -116,7 +116,10 @@ import {
 } from "./render/stages/extractVideosStage.js";
 import { runAudioStage } from "./render/stages/audioStage.js";
 import { runCaptureStage } from "./render/stages/captureStage.js";
-import { runCaptureStreamingStage } from "./render/stages/captureStreamingStage.js";
+import {
+  type CaptureStreamingStageResult,
+  runCaptureStreamingStage,
+} from "./render/stages/captureStreamingStage.js";
 import { runCaptureHdrStage } from "./render/stages/captureHdrStage.js";
 import { runEncodeStage } from "./render/stages/encodeStage.js";
 import { runAssembleStage } from "./render/stages/assembleStage.js";
@@ -975,6 +978,27 @@ export function shouldPreferSingleWorkerDrawElement(args: {
   minFrames: number;
   /** shouldUseStreamingEncode(cfg, format, 1, duration) at the call site. */
   singleWorkerStreamingOk: boolean;
+  /**
+   * Comp routes to the layered-composite / page-side-compositing paths
+   * (HDR content or shader transitions) — those force screenshots and never
+   * run drawElement or streaming, so an inversion would only mislabel
+   * telemetry and keep the probe session alive through the heaviest stage.
+   */
+  layeredOrEffectRoute: boolean;
+  /** deviceScaleFactor > 1 — the engine's supersampling gate blocks DE. */
+  supersampling: boolean;
+  /**
+   * The probe session already ran the engine's init-time DE gates and DE did
+   * NOT engage (not drawelement mode, not a deferred video comp) — inverting
+   * would pin a known-screenshot render to one worker.
+   */
+  probeDeGated: boolean;
+  /**
+   * PRODUCER_EXPERIMENTAL_FAST_CAPTURE=true is an explicit opt-in that
+   * deliberately allows parallel drawElement (bypassing the downstream
+   * clamp) — honor it like an explicit --workers request.
+   */
+  experimentalParallelDeOptIn: boolean;
 }): boolean {
   return (
     args.workerCount > 1 &&
@@ -985,7 +1009,11 @@ export function shouldPreferSingleWorkerDrawElement(args: {
     args.outputFormat === "mp4" &&
     args.minFrames > 0 &&
     args.totalFrames >= args.minFrames &&
-    args.singleWorkerStreamingOk
+    args.singleWorkerStreamingOk &&
+    !args.layeredOrEffectRoute &&
+    !args.supersampling &&
+    !args.probeDeGated &&
+    !args.experimentalParallelDeOptIn
   );
 }
 
@@ -1590,11 +1618,52 @@ export async function executeRenderJob(
     const htmlInCanvasDetected = compiled.renderModeHints.reasons.some(
       (r) => r.code === "htmlInCanvas",
     );
+    // Only use the HDR encoder preset when there's HDR content to pass through —
+    // either native HDR videos OR native HDR images. For SDR-only compositions,
+    // auto mode stays SDR since H.265 10-bit causes browser color management
+    // issues (orange shift) with no quality benefit. (Computed here, ahead of
+    // worker resolution, because the DE inversion below must not fire for
+    // comps that route to the layered/HDR paths.)
+    const nativeHdrIds = new Set([...nativeHdrVideoIds, ...nativeHdrImageIds]);
+    const hasHdrContent = Boolean(effectiveHdr && nativeHdrIds.size > 0);
+    // DE priority inversion eligibility — evaluated BEFORE capture calibration
+    // because when every multi-worker resolution would be inverted to 1 anyway,
+    // the calibration stage (a throwaway Chrome launch + timeline-spread sample
+    // captures, seconds of wall clock) buys nothing and is skipped.
+    // Threshold override: HF_DE_SINGLE_MIN_FRAMES (0 disables the inversion;
+    // a set-but-empty var falls back to the default, it is NOT the kill switch).
+    const deSingleMinFramesRaw = process.env.HF_DE_SINGLE_MIN_FRAMES;
+    const deSingleMinFramesNum =
+      deSingleMinFramesRaw === undefined || deSingleMinFramesRaw.trim() === ""
+        ? 900
+        : Number(deSingleMinFramesRaw);
+    const deSingleMinFrames = Number.isFinite(deSingleMinFramesNum) ? deSingleMinFramesNum : 900;
+    const deInversionEligible = shouldPreferSingleWorkerDrawElement({
+      // Sentinel 2: "would a multi-worker resolution be inverted?" — if workers
+      // resolve to 1 naturally the outcome is identical either way.
+      workerCount: 2,
+      requestedWorkers: job.config.workers,
+      useDrawElement: cfg.useDrawElement,
+      deCompileGate,
+      forceScreenshot: captureForceScreenshot,
+      outputFormat,
+      totalFrames,
+      minFrames: deSingleMinFrames,
+      singleWorkerStreamingOk: shouldUseStreamingEncode(cfg, outputFormat, 1, job.duration),
+      layeredOrEffectRoute: hasHdrContent || compiled.hasShaderTransitions,
+      supersampling: deviceScaleFactor > 1,
+      probeDeGated:
+        probeSession !== null &&
+        probeSession.captureMode !== "drawelement" &&
+        !probeSession.deInitDeferred,
+      experimentalParallelDeOptIn: process.env.PRODUCER_EXPERIMENTAL_FAST_CAPTURE === "true",
+    });
     if (
       job.config.workers === undefined &&
       totalFrames >= 60 &&
       !htmlInCanvasDetected &&
-      !cfg.lowMemoryMode
+      !cfg.lowMemoryMode &&
+      !deInversionEligible
     ) {
       const outcome = await observeRenderStage(
         observability,
@@ -1633,6 +1702,7 @@ export async function executeRenderJob(
         totalFrames,
         htmlInCanvasDetected,
         lowMemoryMode: Boolean(cfg.lowMemoryMode),
+        deInversionEligible,
       });
     }
 
@@ -1647,26 +1717,15 @@ export async function executeRenderJob(
       captureCalibration?.estimate,
     );
     // DE priority inversion — see shouldPreferSingleWorkerDrawElement for the
-    // policy and benchmark rationale. Comps that later hit an INIT-time gate
-    // (css-effects / at-risk, ~1.5% of local renders) render single-worker
-    // screenshot streaming — slower than parallel would have been, accepted
-    // for the routing win everywhere else.
-    // Threshold override: HF_DE_SINGLE_MIN_FRAMES (0 disables the inversion).
-    const deSingleMinFramesRaw = Number(process.env.HF_DE_SINGLE_MIN_FRAMES ?? "900");
-    const deSingleMinFrames = Number.isFinite(deSingleMinFramesRaw) ? deSingleMinFramesRaw : 900;
-    if (
-      shouldPreferSingleWorkerDrawElement({
-        workerCount,
-        requestedWorkers: job.config.workers,
-        useDrawElement: cfg.useDrawElement,
-        deCompileGate,
-        forceScreenshot: captureForceScreenshot,
-        outputFormat,
-        totalFrames,
-        minFrames: deSingleMinFrames,
-        singleWorkerStreamingOk: shouldUseStreamingEncode(cfg, outputFormat, 1, job.duration),
-      })
-    ) {
+    // policy and benchmark rationale (eligibility resolved above, before
+    // calibration). Comps that pass every static check but hit an engine
+    // INIT-time gate at capture (css-effects / at-risk, ~1.5% of local
+    // renders) render single-worker screenshot streaming — slower than
+    // parallel would have been, accepted for the routing win everywhere else.
+    // `preInversionWorkerCount` lets the self-verify retry return to the
+    // parallel path when the drawElement bet loses.
+    const preInversionWorkerCount = workerCount;
+    if (deInversionEligible && workerCount > 1) {
       deWorkerInversion = true;
       log.info(
         "[Render] Fast capture: single-worker drawElement streaming preferred over " +
@@ -1676,7 +1735,7 @@ export async function executeRenderJob(
       );
       workerCount = 1;
     }
-    updateCaptureObservability({ workerCount });
+    updateCaptureObservability({ workerCount, deWorkerInversion });
     observability.checkpoint("worker_resolution", "resolved", {
       workerCount,
       deWorkerInversion,
@@ -1745,12 +1804,8 @@ export async function executeRenderJob(
     };
     const videoExt = FORMAT_EXT[outputFormat] ?? ".mp4";
     const videoOnlyPath = join(workDir, `video-only${videoExt}`);
-    // Only use the HDR encoder preset when there's HDR content to pass through —
-    // either native HDR videos OR native HDR images. For SDR-only compositions,
-    // auto mode stays SDR since H.265 10-bit causes browser color management
-    // issues (orange shift) with no quality benefit.
-    const nativeHdrIds = new Set([...nativeHdrVideoIds, ...nativeHdrImageIds]);
-    const hasHdrContent = Boolean(effectiveHdr && nativeHdrIds.size > 0);
+    // (nativeHdrIds / hasHdrContent are computed above, ahead of worker
+    // resolution, for the DE inversion eligibility check.)
     // Page-side compositing opt-in: when the engine is configured to run the
     // shader blend inside Chrome via a page-side WebGL canvas, the layered
     // Node-side composite path is unnecessary for SDR shader transitions.
@@ -1984,9 +2039,37 @@ export async function executeRenderJob(
             deSelfVerifyFallback: true,
           });
           probeSession = null;
-          streamingRes = await invokeStreaming();
+          if (deWorkerInversion) {
+            // The inversion bet on drawElement and lost — re-render on the
+            // pre-inversion parallel screenshot path instead of single-worker
+            // screenshot streaming (the slowest capture shape for this size).
+            deWorkerInversion = false;
+            workerCount = preInversionWorkerCount;
+            useStreamingEncode = shouldUseStreamingEncode(
+              cfg,
+              outputFormat,
+              workerCount,
+              job.duration,
+            );
+            updateCaptureObservability({
+              workerCount,
+              useStreamingEncode,
+              deWorkerInversion: false,
+            });
+            log.info(
+              `[Render] Reverting worker inversion for the retry: ${workerCount} workers, ` +
+                `streaming=${useStreamingEncode}.`,
+            );
+          }
+          if (useStreamingEncode) {
+            streamingRes = await invokeStreaming();
+          } else {
+            // Parallel retry goes through the disk path below.
+            streamingRes = { success: false } satisfies CaptureStreamingStageResult;
+          }
           // The first attempt's error marked the phase failed; the retry
-          // recovered it — don't brand the render as failed in telemetry.
+          // recovered it (or was rerouted to disk) — don't brand the render
+          // as failed in telemetry.
           observability.clearFailure("capture_streaming");
         }
         const captureFrameMs = Date.now() - captureFrameStart;
@@ -2008,6 +2091,29 @@ export async function executeRenderJob(
           perfStages.encodeMs = streamingRes.encodeMs; // Overlapped with capture
         } else {
           useStreamingEncode = false;
+          // The disk path has no drain-time self-verification — clamp
+          // default-on drawElement here exactly like the pre-capture clamp
+          // (verified-path confinement). Skipped when screenshots are already
+          // forced (nothing to clamp) or under the explicit experimental
+          // opt-in, mirroring the clamp above.
+          if (
+            cfg.useDrawElement &&
+            !captureForceScreenshot &&
+            process.env.PRODUCER_EXPERIMENTAL_FAST_CAPTURE !== "true"
+          ) {
+            cfg.useDrawElement = false;
+            deClampReason = deClampReason ?? "disk_path";
+            log.info(
+              "[Render] Fast capture: drawElement disabled for the disk fallback — " +
+                "streaming encoder spawn failed and the disk path has no runtime " +
+                "self-verification.",
+            );
+            if (probeSession && probeSession.captureMode === "drawelement") {
+              lastBrowserConsole = probeSession.browserConsoleBuffer;
+              await closeCaptureSession(probeSession);
+              probeSession = null;
+            }
+          }
           updateCaptureObservability({ useStreamingEncode });
           observability.checkpoint("capture_streaming", "spawn failed; falling back to disk");
         }
@@ -2257,10 +2363,14 @@ export async function executeRenderJob(
       errorMessage.includes("Waiting failed") ||
       errorMessage.includes("timeout exceeded") ||
       errorMessage.includes("Navigation timeout");
-    const wasParallel = job.config.workers !== 1;
+    // Use the RESOLVED worker count (auto renders — and inverted ones — may
+    // have run single-worker even though job.config.workers is unset), so the
+    // "--workers 1" advisory never points at the configuration that just failed.
+    const wasParallel =
+      (captureObservability.workerCount ?? (job.config.workers === 1 ? 1 : 2)) > 1;
     if (isTimeoutError && wasParallel) {
       log.warn(
-        `Parallel capture timed out with ${job.config.workers ?? "auto"} workers. ` +
+        `Parallel capture timed out with ${captureObservability.workerCount ?? "auto"} workers. ` +
           `Video-heavy compositions often need sequential capture. Retry with --workers 1`,
       );
     }

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -373,6 +373,8 @@ export interface RenderPerfSummary {
     compileGate?: string;
     /** Producer clamp that disabled default DE: parallel | disk_path. */
     clampReason?: string;
+    /** Auto-parallel was inverted to single-worker verified DE streaming. */
+    workerInversion?: boolean;
     /** Engine init-time gate: swiftshader | css_effect:* | at_risk_timeline | 3d_init_failed | supersampling | render_mode_hint. */
     gateReason?: string;
     /** Worker-encode drain (the verified path) was active. */
@@ -950,6 +952,43 @@ export function shouldUseStreamingEncode(
   return workerCount === 1;
 }
 
+/**
+ * DE priority inversion predicate: should an AUTO-resolved multi-worker render
+ * drop to single-worker verified drawElement streaming?
+ *
+ * Benchmarked 2026-07-08: above ~900 frames DE-single beats screenshot-parallel
+ * at every worker count (2,380f: 66s vs 109–127s at W2–W5); below it DE's fixed
+ * init cost (verify + dedup arming) loses by a small margin. Only fires for the
+ * exact benchmarked configuration: default-on DE, mp4, streaming-eligible,
+ * no compile gate, no forced screenshot, workers not explicitly requested.
+ */
+export function shouldPreferSingleWorkerDrawElement(args: {
+  workerCount: number;
+  /** job.config.workers — a number means the user explicitly chose. */
+  requestedWorkers: number | "auto" | undefined;
+  useDrawElement: boolean;
+  deCompileGate: string | undefined;
+  forceScreenshot: boolean;
+  outputFormat: NonNullable<RenderConfig["format"]>;
+  totalFrames: number;
+  /** Amortization threshold; <=0 disables the inversion. */
+  minFrames: number;
+  /** shouldUseStreamingEncode(cfg, format, 1, duration) at the call site. */
+  singleWorkerStreamingOk: boolean;
+}): boolean {
+  return (
+    args.workerCount > 1 &&
+    typeof args.requestedWorkers !== "number" &&
+    args.useDrawElement &&
+    !args.deCompileGate &&
+    !args.forceScreenshot &&
+    args.outputFormat === "mp4" &&
+    args.minFrames > 0 &&
+    args.totalFrames >= args.minFrames &&
+    args.singleWorkerStreamingOk
+  );
+}
+
 export function resolveCaptureForceScreenshotForPageSideCompositing(args: {
   forceScreenshot: boolean;
   usePageSideCompositing: boolean;
@@ -1217,6 +1256,7 @@ export async function executeRenderJob(
     // whether self-verify fell back, and the drain-side counters.
     const deCompileGate = compileResult.deCompileGate;
     let deClampReason: string | undefined;
+    let deWorkerInversion = false;
     let deSelfVerifyFallback = false;
     let deFallbackReason: string | undefined;
     let deDrainStats: import("./render/stages/captureStreamingStage.js").DeDrainStats | undefined;
@@ -1606,8 +1646,41 @@ export async function executeRenderJob(
       log,
       captureCalibration?.estimate,
     );
+    // DE priority inversion — see shouldPreferSingleWorkerDrawElement for the
+    // policy and benchmark rationale. Comps that later hit an INIT-time gate
+    // (css-effects / at-risk, ~1.5% of local renders) render single-worker
+    // screenshot streaming — slower than parallel would have been, accepted
+    // for the routing win everywhere else.
+    // Threshold override: HF_DE_SINGLE_MIN_FRAMES (0 disables the inversion).
+    const deSingleMinFramesRaw = Number(process.env.HF_DE_SINGLE_MIN_FRAMES ?? "900");
+    const deSingleMinFrames = Number.isFinite(deSingleMinFramesRaw) ? deSingleMinFramesRaw : 900;
+    if (
+      shouldPreferSingleWorkerDrawElement({
+        workerCount,
+        requestedWorkers: job.config.workers,
+        useDrawElement: cfg.useDrawElement,
+        deCompileGate,
+        forceScreenshot: captureForceScreenshot,
+        outputFormat,
+        totalFrames,
+        minFrames: deSingleMinFrames,
+        singleWorkerStreamingOk: shouldUseStreamingEncode(cfg, outputFormat, 1, job.duration),
+      })
+    ) {
+      deWorkerInversion = true;
+      log.info(
+        "[Render] Fast capture: single-worker drawElement streaming preferred over " +
+          `${workerCount}-worker screenshot capture (${totalFrames} frames >= ` +
+          `${deSingleMinFrames}; verified path, measured faster at every worker count). ` +
+          "Set HF_DE_SINGLE_MIN_FRAMES=0 or --workers N to override.",
+      );
+      workerCount = 1;
+    }
     updateCaptureObservability({ workerCount });
-    observability.checkpoint("worker_resolution", "resolved", { workerCount });
+    observability.checkpoint("worker_resolution", "resolved", {
+      workerCount,
+      deWorkerInversion,
+    });
 
     if (workerCount > 1 && probeSession) {
       lastBrowserConsole = probeSession.browserConsoleBuffer;
@@ -2091,6 +2164,7 @@ export async function executeRenderJob(
       drawElement: {
         compileGate: deCompileGate,
         clampReason: deClampReason,
+        workerInversion: deWorkerInversion,
         selfVerifyFallback: deSelfVerifyFallback,
         fallbackReason: deFallbackReason,
         drainStats: deDrainStats,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -378,6 +378,8 @@ export interface RenderPerfSummary {
     clampReason?: string;
     /** Auto-parallel inversion outcome: "inverted" (fired, held), "reverted" (fired, self-verify retry rolled back), "none". */
     workerInversion?: string;
+    /** Worker count the auto-resolution chose BEFORE the inversion pinned it to 1 — the parallel counterfactual for speedup math. Only set when the inversion fired. */
+    preInversionWorkers?: number;
     /** Engine init-time gate: swiftshader | css_effect:* | at_risk_timeline | 3d_init_failed | supersampling | render_mode_hint. */
     gateReason?: string;
     /** Worker-encode drain (the verified path) was active. */
@@ -2308,6 +2310,7 @@ export async function executeRenderJob(
         compileGate: deCompileGate,
         clampReason: deClampReason,
         workerInversion: deWorkerInversion,
+        preInversionWorkers: deWorkerInversion ? preInversionWorkerCount : undefined,
         selfVerifyFallback: deSelfVerifyFallback,
         fallbackReason: deFallbackReason,
         drainStats: deDrainStats,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -376,8 +376,8 @@ export interface RenderPerfSummary {
     compileGate?: string;
     /** Producer clamp that disabled default DE: parallel | disk_path. */
     clampReason?: string;
-    /** Auto-parallel was inverted to single-worker verified DE streaming. */
-    workerInversion?: boolean;
+    /** Auto-parallel inversion outcome: "inverted" (fired, held), "reverted" (fired, self-verify retry rolled back), "none". */
+    workerInversion?: string;
     /** Engine init-time gate: swiftshader | css_effect:* | at_risk_timeline | 3d_init_failed | supersampling | render_mode_hint. */
     gateReason?: string;
     /** Worker-encode drain (the verified path) was active. */
@@ -1017,6 +1017,36 @@ export function shouldPreferSingleWorkerDrawElement(args: {
   );
 }
 
+/**
+ * Plan the self-verify retry for an inverted render: the inversion bet on
+ * drawElement and lost, so the re-render returns to the pre-inversion parallel
+ * screenshot path (streaming re-resolved for that worker count — multi-worker
+ * routes to the disk stage). Returns null when the render was not inverted.
+ */
+export function resolveInversionRetryPlan(args: {
+  deWorkerInversion: "inverted" | "reverted" | undefined;
+  preInversionWorkerCount: number;
+  cfg: Pick<EngineConfig, "enableStreamingEncode" | "streamingEncodeMaxDurationSeconds">;
+  outputFormat: NonNullable<RenderConfig["format"]>;
+  durationSeconds: number;
+}): {
+  workerCount: number;
+  useStreamingEncode: boolean;
+  deWorkerInversion: "reverted";
+} | null {
+  if (args.deWorkerInversion !== "inverted") return null;
+  return {
+    workerCount: args.preInversionWorkerCount,
+    useStreamingEncode: shouldUseStreamingEncode(
+      args.cfg,
+      args.outputFormat,
+      args.preInversionWorkerCount,
+      args.durationSeconds,
+    ),
+    deWorkerInversion: "reverted",
+  };
+}
+
 export function resolveCaptureForceScreenshotForPageSideCompositing(args: {
   forceScreenshot: boolean;
   usePageSideCompositing: boolean;
@@ -1284,7 +1314,9 @@ export async function executeRenderJob(
     // whether self-verify fell back, and the drain-side counters.
     const deCompileGate = compileResult.deCompileGate;
     let deClampReason: string | undefined;
-    let deWorkerInversion = false;
+    // "inverted" = fired and held; "reverted" = fired but the self-verify
+    // retry rolled back to the parallel path; undefined = never fired.
+    let deWorkerInversion: "inverted" | "reverted" | undefined;
     let deSelfVerifyFallback = false;
     let deFallbackReason: string | undefined;
     let deDrainStats: import("./render/stages/captureStreamingStage.js").DeDrainStats | undefined;
@@ -1638,10 +1670,11 @@ export async function executeRenderJob(
         ? 900
         : Number(deSingleMinFramesRaw);
     const deSingleMinFrames = Number.isFinite(deSingleMinFramesNum) ? deSingleMinFramesNum : 900;
+    // "Would ANY multi-worker resolution be inverted?" — if workers resolve
+    // to 1 naturally the outcome is identical either way.
+    const WOULD_RESOLVE_MULTI_WORKER = 2;
     const deInversionEligible = shouldPreferSingleWorkerDrawElement({
-      // Sentinel 2: "would a multi-worker resolution be inverted?" — if workers
-      // resolve to 1 naturally the outcome is identical either way.
-      workerCount: 2,
+      workerCount: WOULD_RESOLVE_MULTI_WORKER,
       requestedWorkers: job.config.workers,
       useDrawElement: cfg.useDrawElement,
       deCompileGate,
@@ -1726,7 +1759,7 @@ export async function executeRenderJob(
     // parallel path when the drawElement bet loses.
     const preInversionWorkerCount = workerCount;
     if (deInversionEligible && workerCount > 1) {
-      deWorkerInversion = true;
+      deWorkerInversion = "inverted";
       log.info(
         "[Render] Fast capture: single-worker drawElement streaming preferred over " +
           `${workerCount}-worker screenshot capture (${totalFrames} frames >= ` +
@@ -1738,7 +1771,7 @@ export async function executeRenderJob(
     updateCaptureObservability({ workerCount, deWorkerInversion });
     observability.checkpoint("worker_resolution", "resolved", {
       workerCount,
-      deWorkerInversion,
+      deWorkerInversion: deWorkerInversion ?? "none",
     });
 
     if (workerCount > 1 && probeSession) {
@@ -2039,22 +2072,26 @@ export async function executeRenderJob(
             deSelfVerifyFallback: true,
           });
           probeSession = null;
-          if (deWorkerInversion) {
+          const inversionRetryPlan = resolveInversionRetryPlan({
+            deWorkerInversion,
+            preInversionWorkerCount,
+            cfg,
+            outputFormat,
+            durationSeconds: job.duration,
+          });
+          if (inversionRetryPlan) {
             // The inversion bet on drawElement and lost — re-render on the
             // pre-inversion parallel screenshot path instead of single-worker
             // screenshot streaming (the slowest capture shape for this size).
-            deWorkerInversion = false;
-            workerCount = preInversionWorkerCount;
-            useStreamingEncode = shouldUseStreamingEncode(
-              cfg,
-              outputFormat,
-              workerCount,
-              job.duration,
-            );
+            // "reverted" (not cleared) so telemetry keeps the lost-inversion
+            // cohort distinguishable from renders that never inverted.
+            deWorkerInversion = inversionRetryPlan.deWorkerInversion;
+            workerCount = inversionRetryPlan.workerCount;
+            useStreamingEncode = inversionRetryPlan.useStreamingEncode;
             updateCaptureObservability({
               workerCount,
               useStreamingEncode,
-              deWorkerInversion: false,
+              deWorkerInversion,
             });
             log.info(
               `[Render] Reverting worker inversion for the retry: ${workerCount} workers, ` +


### PR DESCRIPTION
## Why

`clamp:parallel` is the single biggest drawElement engagement eater: **50% of all local renders** (1,326/fortnight on dashboard [1807532](https://us.posthog.com/project/356858/dashboard/1807532)) auto-resolve to multi-worker capture and get routed to *unverified* screenshot rendering, pinning DE engagement at 3.8%.

Benchmarks (2026-07-08, M4 Pro, 4 comp types × W1/W2/W3/W5, render totals, all verified with 0 fallbacks):

| Comp | Frames | DE-single | SS W2 | SS W3 | SS W5 |
|---|---|---|---|---|---|
| dense motion | 360 | 9.2s | 9.1s | **7.3s** | 8.6s |
| 3-video | 390 | 22.7s | 22.3s | 21.5s | **20.5s** |
| crossover probe | 915 | 57.6s | — | 57.9s (tie) | — |
| graphics | 2,380 | **66.3s** | 126.8s | 117.0s | 109.3s |
| 39%-static | 3,600 | **33.3s** | 56.4s | 50.3s | 38.9s |

Above the **~900-frame crossover**, single-worker verified DE streaming beats screenshot-parallel at *every* worker count (parallel scaling flattens hard past W2). Below it, DE's fixed init cost (verify + dedup arming, ~2–3s) loses by ≤2.2s — so the inversion is threshold-gated and never fires where it would lose.

## What

- **`shouldPreferSingleWorkerDrawElement`** (exported predicate, 7 unit tests): inverts an **auto-resolved** multi-worker render to `workerCount=1` when the comp matches the benchmarked configuration — default-on DE (darwin-hardware clamp upstream), no compile gate, no forced-screenshot hint, mp4 output, single-worker streaming-eligible duration, `totalFrames ≥ HF_DE_SINGLE_MIN_FRAMES` (default **900**; `0` disables). An explicit `--workers N` is always honored.
- Inverted renders keep the probe session and land on the worker-encode streaming drain — the only path with runtime self-verification. Net effect: **~40% of previously-clamped renders move onto the verified fast path**, with 50–60s absolute wins on the long tail.
- Known accepted trade: comps that pass compile checks but hit an init-time gate (css-effects/at-risk, ~1.5% of local renders) render single-worker screenshot streaming instead of parallel.
- Telemetry: `de_worker_inversion` on `render_complete` — a tri-state string `"inverted" | "reverted" | "none"` (the self-verify retry marks lost inversions `"reverted"` instead of clearing the flag, so the lost-bet cohort is first-class queryable) — plus `deWorkerInversion` in capture observability so failed renders are attributable.
- **Also in scope** (landed with the review-fix round, same verified-path thesis): the streaming spawn-failure → disk fallback now clamps default-on drawElement (`deClampReason=disk_path`, DE-mode probe closed) — pre-PR that edge case carried `useDrawElement=true` onto the unverified disk path.

## Validation

- E2E on a 2,381-frame comp: auto → 5 workers → **inverted to 1**, DE verified 4×∞ PSNR, RENDER_OK
- Short comp (360f): auto stays 5-worker (below threshold) ✓
- Explicit `WORKERS=3`: honored, no inversion ✓
- `HF_DE_SINGLE_MIN_FRAMES=0`: disabled ✓
- Canary suite 7/7, PSNRs identical to baseline; renderOrchestrator tests 86/86; tsc/oxlint/oxfmt clean

Full investigation + benchmark methodology: `plans/drawelement-fast-capture/2026-07-08-parallel-de-engagement-plan.md` (step 1 of 2; step 2 = interleaved DE-parallel streaming, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


