### PR TITLE
feat(media-use): agent-driven asset reuse (candidates + reuse)

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,8 +46,8 @@
       "files": 10
     },
     "media-use": {
-      "hash": "db5787c5ff2bd852",
-      "files": 97
+      "hash": "caf64c363a39ad9b",
+      "files": 98
     },
     "motion-graphics": {
       "hash": "f5a432862116b39a",

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,8 +46,8 @@
       "files": 10
     },
     "media-use": {
-      "hash": "caf64c363a39ad9b",
-      "files": 98
+      "hash": "d28c7979e727a6a9",
+      "files": 101
     },
     "motion-graphics": {
       "hash": "f5a432862116b39a",

--- a/skills/media-use/SKILL.md
+++ b/skills/media-use/SKILL.md
@@ -111,8 +111,8 @@ leaving the project + global cache and any local provider.
 
 ## How it works
 
-1. Check project `.media/manifest.jsonl` for exact-prompt match
-2. Scan existing `assets/` directory for unregistered files matching the need
+1. Check project `.media/manifest.jsonl` for a prompt match (case- and whitespace-insensitive)
+2. Scan existing `assets/` directory for unregistered files that share a word with the need
 3. Check global cache `~/.media/` for reusable asset
 4. Search via provider (HeyGen audio catalog, HeyGen asset search)
 5. Freeze file to `.media/<type>/`, register in manifest, regenerate `index.md`
@@ -148,7 +148,7 @@ icon_001   icon   -     200×200    .media/images/icon_001.png    rocket
 
 ## Cross-project reuse
 
-Assets are cached automatically on resolve. Every resolved/ingested asset is auto-promoted to the global cache at `~/.media/`, so subsequent resolves for the same prompt, in any project, hit the cache with no re-download and no provider call.
+Assets are cached automatically on resolve. Every resolved/ingested asset is auto-promoted to the global cache at `~/.media/`, so subsequent resolves for the same (or near-identical) prompt, in any project, hit the cache with no re-download and no provider call.
 
 ## Files
 

--- a/skills/media-use/SKILL.md
+++ b/skills/media-use/SKILL.md
@@ -68,17 +68,41 @@ node <SKILL_DIR>/scripts/resolve.mjs --type icon --intent "rocket" --project .
 
 ### Flags
 
-| Flag            | Description                                                     |
-| --------------- | --------------------------------------------------------------- |
-| `--type, -t`    | Media type: bgm, sfx, image, icon, voice                        |
-| `--intent, -i`  | What you need (natural language)                                |
-| `--entity, -e`  | Entity name for cache matching (optional)                       |
-| `--project, -p` | Project directory (default: .)                                  |
-| `--from`        | Freeze a local file or direct public URL (ingest)               |
-| `--local-only`  | Offline: skip every network provider (cache + local only)       |
-| `--provider`    | Force one generator (e.g. `codex`, `mflux`, `kokoro`, `heygen`) |
-| `--adopt`       | Bulk-import existing assets/ into manifest                      |
-| `--json`        | Output JSON instead of one-line result                          |
+| Flag            | Description                                                                          |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `--type, -t`    | Media type: bgm, sfx, image, icon, voice                                             |
+| `--intent, -i`  | What you need (natural language)                                                     |
+| `--entity, -e`  | Entity name for cache matching (optional)                                            |
+| `--project, -p` | Project directory (default: .)                                                       |
+| `--candidates`  | List reusable assets (project + global cache) for `--type`; no download, no mutation |
+| `--reuse <sha>` | Import a specific global-cache asset (by content sha/prefix, from `--candidates`)    |
+| `--from`        | Freeze a local file or direct public URL (ingest)                                    |
+| `--local-only`  | Offline: skip every network provider (cache + local only)                            |
+| `--provider`    | Force one generator (e.g. `codex`, `mflux`, `kokoro`, `heygen`)                      |
+| `--adopt`       | Bulk-import existing assets/ into manifest                                           |
+| `--json`        | Output JSON instead of one-line result                                               |
+
+## Reuse before you resolve
+
+Before resolving bgm/sfx/image/icon, **check what already exists and reuse it when it fits.** media-use does not semantically match for you — you are the judge. It surfaces candidates; you decide.
+
+```bash
+node <SKILL_DIR>/scripts/resolve.mjs --type bgm --intent "upbeat tech launch" --candidates --project .
+#   [project] upbeat tech launch (25s, heygen.audio.sounds)
+#           .media/audio/bgm/bgm_001.wav
+#   [global]  energetic tech intro (22s, heygen.audio.sounds)
+#           --reuse 06e052c075fd2b80
+```
+
+Read the list and judge semantic fit yourself — "upbeat tech launch" ≈ "energetic tech intro" is a call only you can make from the descriptions. Then:
+
+- **A project candidate fits** → just reference its path in your composition. Nothing else to run.
+- **A global candidate fits** → `resolve --type bgm --reuse <sha>` copies it into this project (self-contained render) and records it.
+- **Nothing fits** → resolve fresh (`--type ... --intent ...`).
+
+**Trust guardrail — when unsure, resolve fresh.** A redundant download is cheap; shipping the wrong asset is not. Judge fit from description + prompt + type + duration/dims. For **brand/entity** assets, reuse a _global_ candidate only when the entity matches exactly — the global cache aggregates every project you have worked on, so a `--candidates` list can surface another client's brand mark and its prompt text. Never reuse a cross-project brand asset on a loose match.
+
+The deterministic floor still runs automatically: an identical (case/whitespace-insensitive) repeat auto-reuses with no `--candidates` step. `--candidates` is only for the semantic layer above that floor — and a fuzzy match is **never** auto-applied; reuse is always your explicit call. On a resolve that misses the floor and is about to fetch, media-use prints a one-line stderr hint when similar cached assets exist, pointing you back here.
 
 ## Providers
 
@@ -111,13 +135,15 @@ leaving the project + global cache and any local provider.
 
 ## How it works
 
-1. Check project `.media/manifest.jsonl` for a prompt match (case- and whitespace-insensitive)
-2. Scan existing `assets/` directory for unregistered files that share a word with the need
-3. Check global cache `~/.media/` for reusable asset
-4. Search via provider (HeyGen audio catalog, HeyGen asset search)
-5. Freeze file to `.media/<type>/`, register in manifest, regenerate `index.md`
+`resolve` runs an automatic floor, then falls through to fetching:
 
-The agent gets back **one line**. Candidates, scores, provenance stay on disk.
+1. Check project `.media/manifest.jsonl` for a prompt match (case- and whitespace-insensitive) — auto-reuse
+2. Scan existing `assets/` directory for unregistered files that share a word with the need
+3. Check global cache `~/.media/` for a reusable asset matched on the same normalized prompt — auto-reuse
+4. Search via provider (HeyGen audio catalog, HeyGen asset search), then generate
+5. Freeze file to `.media/<type>/`, register in manifest, regenerate `index.md`, auto-promote to `~/.media/`
+
+Steps 1 and 3 are the **deterministic floor**: they only auto-reuse an exact-normalized match, never a fuzzy one. Semantic reuse ("close enough") is the agent's explicit call via [Reuse before you resolve](#reuse-before-you-resolve) — it never happens automatically. The agent gets back **one line**; candidates, scores, provenance stay on disk.
 
 ## Adopt existing projects
 
@@ -149,6 +175,8 @@ icon_001   icon   -     200×200    .media/images/icon_001.png    rocket
 ## Cross-project reuse
 
 Assets are cached automatically on resolve. Every resolved/ingested asset is auto-promoted to the global cache at `~/.media/`, so subsequent resolves for the same (or near-identical) prompt, in any project, hit the cache with no re-download and no provider call.
+
+For a _semantically_ similar (not identical) need in another project, the exact-match floor won't fire — use [Reuse before you resolve](#reuse-before-you-resolve): `--candidates` lists the global assets, and `--reuse <sha>` imports the one you pick. This is how a track resolved in one project gets reused in the next when the wording differs.
 
 ## Files
 

--- a/skills/media-use/scripts/lib/adopt.mjs
+++ b/skills/media-use/scripts/lib/adopt.mjs
@@ -96,16 +96,49 @@ export function adoptExistingAssets(projectDir) {
   return adopted;
 }
 
+// Common filler words that should never, on their own, make a filename match an
+// intent (e.g. intent "the rocket" must not adopt "the-video.mp4").
+const MATCH_STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "this",
+  "that",
+  "your",
+  "our",
+]);
+
+// Split into lowercased word tokens of length >= 3, minus stopwords.
+function matchTokens(text) {
+  return new Set(
+    String(text)
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 3 && !MATCH_STOPWORDS.has(t)),
+  );
+}
+
+// Adopt a pre-existing assets/ file only when it shares a meaningful word with
+// the intent. The old test — `name.includes(intent) || intent.includes(name)` —
+// silently returned the WRONG file: "whoosh" grabbed a stray who.mp3, and a
+// one-letter filename matched every intent. A false negative just falls through
+// to a catalog search (safe); a false positive ships the wrong asset. So bias to
+// precision: require a shared token, don't guess from substrings.
 export function findExistingAsset(projectDir, intent, type) {
   const assetsDir = join(projectDir, "assets");
   if (!existsSync(assetsDir)) return null;
-  const lower = intent.toLowerCase();
+  const intentTokens = matchTokens(intent);
+  if (intentTokens.size === 0) return null;
   for (const rel of walkDir(assetsDir)) {
     const t = inferType(rel);
     if (!t || (type && t !== type)) continue;
-    const name = basename(rel, extname(rel)).toLowerCase().replace(/[-_]/g, " ");
-    if (name.includes(lower) || lower.includes(name)) {
-      return { relativePath: `assets/${rel}`, type: t, name: basename(rel, extname(rel)) };
+    const stem = basename(rel, extname(rel));
+    for (const tok of matchTokens(stem)) {
+      if (intentTokens.has(tok)) {
+        return { relativePath: `assets/${rel}`, type: t, name: stem };
+      }
     }
   }
   return null;

--- a/skills/media-use/scripts/lib/adopt.mjs
+++ b/skills/media-use/scripts/lib/adopt.mjs
@@ -3,6 +3,7 @@ import { join, extname, basename } from "node:path";
 import { readManifest, appendRecord, nextId } from "./manifest.mjs";
 import { regenerateIndex } from "./index-gen.mjs";
 import { probe } from "./probe.mjs";
+import { matchTokens } from "./match.mjs";
 
 const AUDIO_EXT = new Set([".mp3", ".wav", ".ogg", ".m4a", ".aac"]);
 const IMAGE_EXT = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".ico"]);
@@ -94,30 +95,6 @@ export function adoptExistingAssets(projectDir) {
 
   if (adopted.length > 0) regenerateIndex(projectDir);
   return adopted;
-}
-
-// Common filler words that should never, on their own, make a filename match an
-// intent (e.g. intent "the rocket" must not adopt "the-video.mp4").
-const MATCH_STOPWORDS = new Set([
-  "the",
-  "and",
-  "for",
-  "with",
-  "from",
-  "this",
-  "that",
-  "your",
-  "our",
-]);
-
-// Split into lowercased word tokens of length >= 3, minus stopwords.
-function matchTokens(text) {
-  return new Set(
-    String(text)
-      .toLowerCase()
-      .split(/[^a-z0-9]+/)
-      .filter((t) => t.length >= 3 && !MATCH_STOPWORDS.has(t)),
-  );
 }
 
 // Adopt a pre-existing assets/ file only when it shares a meaningful word with

--- a/skills/media-use/scripts/lib/adopt.test.mjs
+++ b/skills/media-use/scripts/lib/adopt.test.mjs
@@ -1,0 +1,95 @@
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { findExistingAsset, adoptExistingAssets } from "./adopt.mjs";
+
+let tmp;
+function setup() {
+  tmp = mkdtempSync(join(tmpdir(), "mu-adopt-test-"));
+}
+function cleanup() {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+}
+function drop(rel) {
+  const full = join(tmp, "assets", rel);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, "x");
+}
+
+function runTests() {
+  const tests = [];
+  const test = (name, fn) => tests.push({ name, fn });
+
+  test("does NOT false-match a short filename stem (who.mp3 vs 'whoosh')", () => {
+    setup();
+    drop("sfx/who.mp3");
+    assert.equal(findExistingAsset(tmp, "whoosh", "sfx"), null);
+    cleanup();
+  });
+
+  test("does NOT match a one-letter filename against any intent", () => {
+    setup();
+    drop("images/a.jpg");
+    assert.equal(findExistingAsset(tmp, "gradient tech background", "image"), null);
+    cleanup();
+  });
+
+  test("matches on a shared meaningful word", () => {
+    setup();
+    drop("images/hero-shot.jpg");
+    const hit = findExistingAsset(tmp, "hero image", "image");
+    assert.ok(hit);
+    assert.equal(hit.relativePath, "assets/images/hero-shot.jpg");
+    cleanup();
+  });
+
+  test("matches multi-word overlap", () => {
+    setup();
+    drop("images/gradient-tech-bg.jpg");
+    assert.ok(findExistingAsset(tmp, "gradient tech background", "image"));
+    cleanup();
+  });
+
+  test("a shared stopword alone does not match", () => {
+    setup();
+    drop("video/the-video.mp4");
+    assert.equal(findExistingAsset(tmp, "the rocket", null), null);
+    cleanup();
+  });
+
+  test("respects the type filter", () => {
+    setup();
+    drop("sfx/rocket.mp3");
+    assert.equal(findExistingAsset(tmp, "rocket", "image"), null, "wrong type is skipped");
+    assert.ok(findExistingAsset(tmp, "rocket", "sfx"), "right type matches");
+    cleanup();
+  });
+
+  test("adoptExistingAssets still imports every typed file (unaffected by match rule)", () => {
+    setup();
+    drop("sfx/who.mp3");
+    drop("images/a.jpg");
+    assert.equal(adoptExistingAssets(tmp).length, 2);
+    cleanup();
+  });
+
+  let passed = 0;
+  let failed = 0;
+  for (const { name, fn } of tests) {
+    try {
+      fn();
+      passed++;
+      console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+    } catch (err) {
+      failed++;
+      console.log(`  \x1b[31m✗\x1b[0m ${name}`);
+      console.log(`    ${err.message}`);
+    }
+  }
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+console.log("media-use · adopt / findExistingAsset tests\n");
+runTests();

--- a/skills/media-use/scripts/lib/cache.mjs
+++ b/skills/media-use/scripts/lib/cache.mjs
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from
 import { join, basename } from "node:path";
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { readManifest, appendRecord } from "./manifest.mjs";
+import { readManifest, appendRecord, normalizePrompt } from "./manifest.mjs";
 
 const SCHEMA_PREFIX = "mu-v1-";
 const KEY_HEX_CHARS = 16;
@@ -43,9 +43,14 @@ function validateCacheHit(match) {
 }
 
 export function cacheGet(prompt, type) {
+  const key = normalizePrompt(prompt);
+  if (!key) return null;
   return validateCacheHit(
     readGlobalManifest().find(
-      (r) => r.reusable && r.provenance?.prompt === prompt && (type == null || r.type === type),
+      (r) =>
+        r.reusable &&
+        normalizePrompt(r.provenance?.prompt) === key &&
+        (type == null || r.type === type),
     ),
   );
 }

--- a/skills/media-use/scripts/lib/cache.mjs
+++ b/skills/media-use/scripts/lib/cache.mjs
@@ -33,8 +33,30 @@ function markComplete(entryDir) {
 // global manifest must be addressed by HOME, not by globalMediaDir() — passing
 // the latter nested it at ~/.media/.media/manifest.jsonl, invisible to the
 // Studio /api/assets/global route (which reads the documented flat path).
-function readGlobalManifest() {
+export function readGlobalManifest() {
   return readManifest(homedir());
+}
+
+// Resolve a content-sha (full or unambiguous prefix) to a reusable global-cache
+// record, for `resolve --reuse <sha>`. Returns null on no match, or
+// { ambiguous: true, count } when a prefix matches multiple distinct entries.
+// Completeness (the .hf-complete sentinel) is left to importFromCache so the
+// caller can surface an "incomplete cache entry" error distinctly from a miss.
+export function findGlobalBySha(shaPrefix) {
+  const p = String(shaPrefix || "")
+    .toLowerCase()
+    .trim();
+  if (!p) return null;
+  const matches = readGlobalManifest().filter(
+    (r) => r.reusable && typeof r.sha === "string" && r.sha.startsWith(p),
+  );
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    const exact = matches.find((r) => r.sha === p);
+    if (exact) return exact;
+    return { ambiguous: true, count: matches.length };
+  }
+  return matches[0];
 }
 
 function validateCacheHit(match) {

--- a/skills/media-use/scripts/lib/candidates.mjs
+++ b/skills/media-use/scripts/lib/candidates.mjs
@@ -1,0 +1,90 @@
+// Reuse candidates: a side-effect-free view of assets already available to this
+// project (its own manifest) and across every project (the global ~/.media
+// cache), so the calling agent can judge semantic fit itself. No download, no
+// provider, no mutation. The ranker only *surfaces* — it orders by lexical
+// overlap but never filters a candidate out on zero overlap (that would
+// pre-empt the agent's judgment); the agent does the semantic call.
+
+import { readManifest } from "./manifest.mjs";
+import { readGlobalManifest } from "./cache.mjs";
+import { tokenOverlap, typesMatch } from "./match.mjs";
+
+export const CANDIDATE_CAP = 8;
+
+function shape(record, scope, intent) {
+  const description = record.description || record.provenance?.prompt || "";
+  const prompt = record.provenance?.prompt || null;
+  return {
+    id: record.id,
+    type: record.type,
+    scope,
+    description,
+    prompt,
+    provider: record.provenance?.provider || null,
+    duration: record.duration ?? null,
+    width: record.width ?? null,
+    height: record.height ?? null,
+    // Only global records carry a content sha — it is the stable reuse handle
+    // for `resolve --reuse <sha>`. Project assets are reused by referencing
+    // their path directly, so they need no handle.
+    sha: scope === "global" ? record.sha || null : null,
+    path: scope === "project" ? record.path : null,
+    score: intent ? tokenOverlap(intent, `${description} ${prompt || ""}`) : 0,
+  };
+}
+
+// Rank one scope: type-matched (icon<->image aware), newest-first within equal
+// overlap, ordered by overlap desc. Returns the full ranked list (uncapped).
+function rankScope(records, scope, type, intent) {
+  return records
+    .filter((r) => typesMatch(r.type, type))
+    .reverse() // manifest is append-order (oldest first); newest-first at equal score
+    .map((r) => shape(r, scope, intent))
+    .sort((a, b) => b.score - a.score); // Array.sort is stable → recency preserved
+}
+
+// List reuse candidates for `type`, capped per scope. Returns:
+//   candidates: capped project candidates followed by capped global candidates
+//   truncated:  true if either scope had more than `cap`
+//   total:      { project, global } counts before the cap (machine-readable)
+//   similar:    count of candidates with lexical overlap > 0 (drives the nudge)
+export function listCandidates({ projectDir, type, intent = "", cap = CANDIDATE_CAP }) {
+  const project = rankScope(readManifest(projectDir), "project", type, intent);
+  const global = rankScope(readGlobalManifest(), "global", type, intent);
+  const candidates = [...project.slice(0, cap), ...global.slice(0, cap)];
+  return {
+    candidates,
+    truncated: project.length > cap || global.length > cap,
+    total: { project: project.length, global: global.length },
+    similar: [...project, ...global].filter((c) => c.score > 0).length,
+  };
+}
+
+function meta(c) {
+  const parts = [];
+  if (c.duration != null) parts.push(`${c.duration}s`);
+  if (c.width && c.height) parts.push(`${c.width}x${c.height}`);
+  if (c.provider) parts.push(c.provider);
+  return parts.join(", ");
+}
+
+// Human-readable listing. The agent can read this directly; --json is for
+// programmatic use. Reuse handle differs by scope: path for project, sha for
+// global.
+export function formatCandidates(candidates, { truncated, total } = {}) {
+  if (candidates.length === 0) return "no reuse candidates found (project or global cache)";
+  const lines = [`${candidates.length} reuse candidate${candidates.length === 1 ? "" : "s"}:`, ""];
+  for (const c of candidates) {
+    const handle = c.scope === "global" ? `--reuse ${String(c.sha).slice(0, 16)}` : c.path;
+    const m = meta(c);
+    lines.push(`  [${c.scope}] ${c.description}${m ? ` (${m})` : ""}`);
+    lines.push(`          ${handle}`);
+  }
+  if (truncated && total) {
+    lines.push("");
+    lines.push(
+      `  (showing top ${CANDIDATE_CAP} per scope; ${total.project} project / ${total.global} global total — refine --intent to narrow)`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/skills/media-use/scripts/lib/candidates.test.mjs
+++ b/skills/media-use/scripts/lib/candidates.test.mjs
@@ -1,0 +1,155 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { listCandidates, formatCandidates, CANDIDATE_CAP } from "./candidates.mjs";
+import { findGlobalBySha } from "./cache.mjs";
+
+// candidates + findGlobalBySha are offline (no heygen), so we can override HOME
+// to a temp dir and seed a fake global ~/.media manifest deterministically.
+function sandbox() {
+  const root = mkdtempSync(join(tmpdir(), "mu-cand-"));
+  const project = join(root, "proj");
+  const home = join(root, "home");
+  process.env.HOME = home;
+  return { root, project, home };
+}
+function seedManifest(dir, records) {
+  const md = join(dir, ".media");
+  mkdirSync(md, { recursive: true });
+  writeFileSync(md + "/manifest.jsonl", records.map((r) => JSON.stringify(r)).join("\n") + "\n");
+}
+function proj(id, type, description, prompt) {
+  return { id, type, path: `.media/audio/bgm/${id}.wav`, description, provenance: { prompt } };
+}
+function glob(id, type, description, prompt, sha) {
+  return {
+    id,
+    type,
+    sha,
+    reusable: true,
+    cached_path: `/x/${sha}/${id}.wav`,
+    description,
+    provenance: { prompt, provider: "heygen.audio.sounds" },
+  };
+}
+
+test("ranks project + global by overlap, tags scope", () => {
+  const { root, project, home } = sandbox();
+  try {
+    seedManifest(project, [proj("bgm_001", "bgm", "calm ambient piano", "calm ambient piano")]);
+    seedManifest(home, [
+      glob("bgm_009", "bgm", "energetic tech launch", "energetic tech launch", "a".repeat(64)),
+      glob("bgm_010", "bgm", "sad corporate piano", "sad corporate piano", "b".repeat(64)),
+    ]);
+    const { candidates } = listCandidates({
+      projectDir: project,
+      type: "bgm",
+      intent: "tech launch",
+    });
+    assert.equal(candidates[0].scope, "project"); // project listed first
+    const g = candidates.filter((c) => c.scope === "global");
+    assert.equal(g[0].description, "energetic tech launch"); // higher overlap ranks first
+    assert.ok(g[0].score >= g[1].score);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("zero-overlap intent still lists candidates (no hard filter)", () => {
+  const { root, project, home } = sandbox();
+  try {
+    seedManifest(project, []);
+    seedManifest(home, [glob("bgm_009", "bgm", "driving synth", "driving synth", "c".repeat(64))]);
+    const { candidates, similar } = listCandidates({
+      projectDir: project,
+      type: "bgm",
+      intent: "totally unrelated words xyz",
+    });
+    assert.equal(candidates.length, 1, "listed despite zero overlap");
+    assert.equal(candidates[0].score, 0);
+    assert.equal(similar, 0, "similar counts only overlap>0");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("caps per scope and reports truncation + totals", () => {
+  const { root, project, home } = sandbox();
+  try {
+    const many = Array.from({ length: CANDIDATE_CAP + 3 }, (_, i) =>
+      glob(`bgm_${i}`, "bgm", `track ${i}`, `track ${i}`, String(i).padStart(64, "0")),
+    );
+    seedManifest(project, []);
+    seedManifest(home, many);
+    const { candidates, truncated, total } = listCandidates({ projectDir: project, type: "bgm" });
+    assert.equal(candidates.length, CANDIDATE_CAP);
+    assert.equal(truncated, true);
+    assert.equal(total.global, CANDIDATE_CAP + 3);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("honors icon<->image adjacency", () => {
+  const { root, project, home } = sandbox();
+  try {
+    seedManifest(project, []);
+    seedManifest(home, [glob("image_1", "image", "rocket logo", "rocket logo", "d".repeat(64))]);
+    const { candidates } = listCandidates({ projectDir: project, type: "icon", intent: "rocket" });
+    assert.equal(candidates.length, 1, "image asset surfaces for icon request");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("sha only on global, path only on project", () => {
+  const { root, project, home } = sandbox();
+  try {
+    seedManifest(project, [proj("bgm_001", "bgm", "x", "x")]);
+    seedManifest(home, [glob("bgm_009", "bgm", "y", "y", "e".repeat(64))]);
+    const { candidates } = listCandidates({ projectDir: project, type: "bgm" });
+    const p = candidates.find((c) => c.scope === "project");
+    const g = candidates.find((c) => c.scope === "global");
+    assert.ok(p.path && !p.sha);
+    assert.ok(g.sha && !g.path);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("findGlobalBySha resolves unique prefix, flags ambiguity, misses cleanly", () => {
+  const { root, project, home } = sandbox();
+  try {
+    seedManifest(project, []);
+    seedManifest(home, [
+      glob("bgm_1", "bgm", "a", "a", "abc" + "0".repeat(61)),
+      glob("bgm_2", "bgm", "b", "b", "abd" + "0".repeat(61)),
+      glob("bgm_3", "bgm", "c", "c", "fff" + "0".repeat(61)),
+    ]);
+    assert.equal(findGlobalBySha("fff").id, "bgm_3", "unique prefix resolves");
+    assert.deepEqual(
+      { ambiguous: findGlobalBySha("ab").ambiguous, count: findGlobalBySha("ab").count },
+      { ambiguous: true, count: 2 },
+      "ambiguous prefix flagged",
+    );
+    assert.equal(findGlobalBySha("zzz"), null, "miss returns null");
+    assert.equal(findGlobalBySha(""), null, "empty returns null");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("formatCandidates shows reuse handles by scope; empty message", () => {
+  const { candidates } = {
+    candidates: [
+      { scope: "project", description: "p", path: ".media/audio/bgm/bgm_001.wav" },
+      { scope: "global", description: "g", sha: "f".repeat(64) },
+    ],
+  };
+  const out = formatCandidates(candidates, {});
+  assert.match(out, /\.media\/audio\/bgm\/bgm_001\.wav/);
+  assert.match(out, /--reuse ffffffffffffffff/);
+  assert.match(formatCandidates([], {}), /no reuse candidates/);
+});

--- a/skills/media-use/scripts/lib/manifest.mjs
+++ b/skills/media-use/scripts/lib/manifest.mjs
@@ -64,11 +64,25 @@ export function appendRecord(projectDir, record) {
   appendFileSync(p, line);
 }
 
+// Match prompts forgivingly. Agents rarely re-emit a byte-identical intent, so
+// keying cache lookups on exact equality meant "Calm piano" and "calm  piano"
+// re-searched and re-downloaded. Normalize (trim, lowercase, collapse internal
+// whitespace) on both sides; the raw prompt is still stored for audit.
+export function normalizePrompt(prompt) {
+  return String(prompt ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
 export function findByPrompt(projectDir, prompt, type) {
+  const key = normalizePrompt(prompt);
+  if (!key) return null;
   const records = readManifest(projectDir);
   return (
-    records.find((r) => r.provenance?.prompt === prompt && (type == null || r.type === type)) ||
-    null
+    records.find(
+      (r) => normalizePrompt(r.provenance?.prompt) === key && (type == null || r.type === type),
+    ) || null
   );
 }
 

--- a/skills/media-use/scripts/lib/manifest.test.mjs
+++ b/skills/media-use/scripts/lib/manifest.test.mjs
@@ -8,6 +8,7 @@ import {
   findByPrompt,
   findByEntity,
   nextId,
+  normalizePrompt,
   manifestPath,
   mediaDir,
   typeDirPath,
@@ -114,6 +115,20 @@ function runTests() {
     cleanup();
   });
 
+  test("findByPrompt matches across case and whitespace variants", () => {
+    setup();
+    appendRecord(tmp, makeRecord({ provenance: { provider: "x", prompt: "calm ambient piano" } }));
+    assert.ok(findByPrompt(tmp, "Calm Ambient Piano", "bgm"), "case-insensitive");
+    assert.ok(findByPrompt(tmp, "  calm   ambient  piano ", "bgm"), "whitespace-insensitive");
+    assert.equal(findByPrompt(tmp, "calm ambient guitar", "bgm"), null, "still a real miss");
+    cleanup();
+  });
+
+  test("normalizePrompt trims, lowercases, collapses whitespace", () => {
+    assert.equal(normalizePrompt("  Upbeat   Tech  Launch "), "upbeat tech launch");
+    assert.equal(normalizePrompt(null), "");
+  });
+
   test("findByEntity matches case-insensitively", () => {
     setup();
     appendRecord(tmp, makeRecord({ entity: "GitHub", type: "icon" }));
@@ -203,6 +218,10 @@ function runTests() {
     assert.ok(found);
     assert.equal(found.reusable, true);
     assert.equal(found.sha, sha);
+
+    // cross-project reuse must survive trivial prompt variation, not just
+    // byte-identical intents (the whole point of normalizePrompt).
+    assert.ok(cacheGet("  Cache   Test ", "bgm"), "cacheGet is case/whitespace-insensitive");
     cleanup();
   });
 

--- a/skills/media-use/scripts/lib/match.mjs
+++ b/skills/media-use/scripts/lib/match.mjs
@@ -1,0 +1,46 @@
+// Shared lexical-matching helpers used by both the assets/ scan (adopt.mjs) and
+// the reuse-candidate ranker (candidates.mjs), and the type-equivalence check
+// used by resolve.mjs and candidates.mjs. Kept in one place so the icon<->image
+// equivalence and the token rules can't drift between the "do" path (resolve)
+// and the "look" path (candidates).
+
+// Common filler words that should never, on their own, make two strings match.
+const MATCH_STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "this",
+  "that",
+  "your",
+  "our",
+]);
+
+// Split into lowercased word tokens of length >= 3, minus stopwords.
+export function matchTokens(text) {
+  return new Set(
+    String(text)
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 3 && !MATCH_STOPWORDS.has(t)),
+  );
+}
+
+// Count of shared meaningful word tokens between two strings. 0 = no lexical
+// overlap (the candidate ranker still surfaces these, ordered after overlaps).
+export function tokenOverlap(a, b) {
+  const ta = matchTokens(a);
+  const tb = matchTokens(b);
+  let n = 0;
+  for (const t of ta) if (tb.has(t)) n++;
+  return n;
+}
+
+// icon and image are interchangeable: both live in images/, and figma-imported
+// brand marks are recorded as type image while agents ask for logos as icon.
+export function typesMatch(a, b) {
+  if (a === b) return true;
+  const visual = new Set(["icon", "image"]);
+  return visual.has(a) && visual.has(b);
+}

--- a/skills/media-use/scripts/resolve.mjs
+++ b/skills/media-use/scripts/resolve.mjs
@@ -10,6 +10,9 @@ import { runCapability, listTypes } from "./lib/registry.mjs";
 import { freezeUrl, freezeLocalFile, isDirectMediaUrl } from "./lib/freeze.mjs";
 import { findExistingAsset } from "./lib/adopt.mjs";
 import { track } from "./lib/telemetry.mjs";
+import { typesMatch } from "./lib/match.mjs";
+import { listCandidates, formatCandidates, CANDIDATE_CAP } from "./lib/candidates.mjs";
+import { findGlobalBySha } from "./lib/cache.mjs";
 
 const { values: args } = parseArgs({
   options: {
@@ -18,6 +21,9 @@ const { values: args } = parseArgs({
     entity: { type: "string", short: "e" },
     project: { type: "string", short: "p", default: "." },
     adopt: { type: "boolean", default: false },
+    candidates: { type: "boolean", default: false },
+    "dry-run": { type: "boolean", default: false },
+    reuse: { type: "string" },
     from: { type: "string" },
     "local-only": { type: "boolean", default: false },
     provider: { type: "string" },
@@ -41,6 +47,10 @@ Options:
   --entity, -e    Entity name for cache matching (optional)
   --project, -p   Project directory (default: .)
   --adopt         Adopt all existing assets/ files into the manifest
+  --candidates    List reusable assets (project + global cache) for --type; no
+                  download, no mutation. Read them and decide reuse yourself.
+  --reuse <sha>   Import a specific global-cache asset (by content sha/prefix,
+                  from --candidates) into this project
   --provider      Force one generator (e.g. codex, mflux, kokoro, heygen)
   --json          Output JSON instead of one-line result
   --help, -h      Show this help`);
@@ -59,6 +69,21 @@ if (args.adopt) {
     console.log(`adopted ${adopted.length} asset${adopted.length === 1 ? "" : "s"} from assets/`);
     for (const r of adopted) console.log(`  ${r.id} → ${r.path} (${r.type})`);
   }
+  process.exit(0);
+}
+
+// Candidates: side-effect-free listing of reusable assets (project + global
+// cache) for --type. No download, no provider, no mutation. The agent reads
+// these and decides semantic fit itself.
+if (args.candidates || args["dry-run"]) {
+  await showCandidates();
+  process.exit(0);
+}
+
+// Reuse: import a specific global-cache asset (by content sha/prefix, taken
+// from --candidates) into this project.
+if (args.reuse) {
+  await reuseGlobal(args.reuse);
   process.exit(0);
 }
 
@@ -154,6 +179,22 @@ async function run() {
   // leaving the project + global cache and any local provider.
   const localOnly = args["local-only"];
   const ctx = { entity, projectDir, localOnly, provider: args.provider };
+
+  // Adherence nudge (offline, no auto-reuse): the exact-cache floor missed and
+  // we're about to fetch/generate. If lexically-similar assets already exist,
+  // point the agent at --candidates so it can reuse instead of fetching. Only a
+  // fuzzy match ever reaches the agent this way — never auto-applied. Goes to
+  // stderr so it reaches --json callers without corrupting stdout. Best-effort.
+  try {
+    const { similar } = listCandidates({ projectDir, type, intent, cap: CANDIDATE_CAP });
+    if (similar > 0) {
+      console.error(
+        `media-use: ${similar} similar cached asset${similar === 1 ? "" : "s"} already exist — run \`resolve --candidates --type ${type} --intent "${intent}"\` to review and reuse instead of fetching.`,
+      );
+    }
+  } catch {
+    // hint is best-effort; never block a resolve
+  }
 
   // 3. provider search — registry tries providers in order (heygen-CLI first)
   let searchResult = null;
@@ -284,10 +325,65 @@ async function ingest(src) {
   await result(record, "ingested");
 }
 
-function typesMatch(a, b) {
-  if (a === b) return true;
-  const visual = new Set(["icon", "image"]);
-  return visual.has(a) && visual.has(b);
+async function showCandidates() {
+  const projectDir = resolve(args.project);
+  const type = args.type;
+  if (!type || !listTypes().includes(type)) {
+    console.error(`error: --candidates requires --type (one of: ${listTypes().join(", ")})`);
+    process.exit(2);
+  }
+  const intent = args.intent || "";
+  const { candidates, truncated, total, similar } = listCandidates({
+    projectDir,
+    type,
+    intent,
+    cap: CANDIDATE_CAP,
+  });
+  await track("media_use_candidates", {
+    type,
+    project_n: total.project,
+    global_n: total.global,
+    local_only: !!args["local-only"],
+  });
+  if (args.json) {
+    console.log(JSON.stringify({ ok: true, candidates, truncated, total, similar }));
+  } else {
+    console.log(formatCandidates(candidates, { truncated, total }));
+  }
+}
+
+async function reuseGlobal(shaArg) {
+  const projectDir = resolve(args.project);
+  const type = args.type;
+  if (!type || !listTypes().includes(type)) {
+    console.error(`error: --reuse requires --type (one of: ${listTypes().join(", ")})`);
+    process.exit(2);
+  }
+  const rec = findGlobalBySha(shaArg);
+  if (rec && rec.ambiguous) {
+    console.error(
+      `error: sha prefix "${shaArg}" is ambiguous (${rec.count} matches) — use more characters`,
+    );
+    process.exit(2);
+  }
+  if (!rec) {
+    console.error(`error: no reusable global asset matches sha "${shaArg}"`);
+    process.exit(1);
+  }
+  const id = nextId(projectDir, type);
+  const ext = extname(rec.cached_path || "") || defaultExt(type);
+  const localPath = `.media/${typeSubdir(type)}/${id}${ext}`;
+  const imported = importFromCache(rec, projectDir, id, localPath);
+  if (!imported) {
+    console.error(`error: cache entry for "${shaArg}" is incomplete or missing on disk`);
+    process.exit(1);
+  }
+  // Distinguish an explicit agent reuse from an automatic normalize-exact hit.
+  imported.source = "reused-explicit";
+  imported.provenance = { ...imported.provenance, reused_by: "agent" };
+  appendRecord(projectDir, imported);
+  regenerateIndex(projectDir);
+  await result(imported, "reused-explicit");
 }
 
 async function result(record, source) {
@@ -313,7 +409,7 @@ function formatMeta(record, source) {
   if (record.duration != null) parts.push(`${record.duration}s`);
   if (record.width && record.height) parts.push(`${record.width}×${record.height}`);
   if (record.transparent) parts.push("transparent");
-  if (source === "reused") parts.push("reused");
+  if (source === "reused" || source === "reused-explicit") parts.push("reused");
   if (source === "generated") parts.push("generated");
   return parts.join(", ");
 }


### PR DESCRIPTION
## What

Makes media-use's asset reuse smart by handing the semantic judgment to the coding agent (the ICP) instead of a string heuristic — while keeping the deterministic normalize-exact match as an automatic dedup floor. **No LLM/embedding call enters `resolve`; it stays offline-capable.**

Stacked on #2028 (the normalize + precise-scan bug fixes, whose `matchTokens` this builds on). Review/merge #2028 first.

## The idea

The "let an LLM match" instinct is a trap inside `resolve` (no LLM provider, must stay offline, fuzzy in-tool matching silently returns wrong assets). But the LLM is already there — it's the agent calling `resolve`. So media-use's job becomes *showing the agent what exists* and letting it decide. The gap it closes: the agent could see the project's assets but was blind to the global `~/.media` cache (only Studio could browse that).

## Changes

- **`lib/match.mjs`** — shared `matchTokens` + `typesMatch` (extracted from `adopt.mjs`/`resolve.mjs` so the icon↔image equivalence and token rules can't drift between the do-path and the look-path) + a `tokenOverlap` ranker.
- **`resolve --candidates`** — side-effect-free listing of reusable assets across the project manifest **and** the global cache, ranked by lexical overlap, capped per scope, `--json` or human table. Never hard-filters on zero overlap (that would pre-empt the agent's judgment).
- **`resolve --reuse <sha>`** — import a specific global-cache asset by content sha/prefix (from `--candidates`) via `importFromCache`; marked `source=reused-explicit` / `provenance.reused_by=agent`.
- **Adherence nudge** — on a resolve that misses the exact floor and is about to fetch, a one-line **stderr** hint fires when similar cached assets exist (safe under `--json`, never auto-reuses). This is what makes reuse actually fire instead of relying on the agent remembering.
- **`cache.mjs`** — export `readGlobalManifest`; add `findGlobalBySha` (prefix resolution with ambiguity/miss handling).
- **Telemetry** — `media_use_candidates` event + `reused-explicit` source (type/scope/counts only; no intent text or paths).
- **SKILL.md** — "Reuse before you resolve" guidance + trust guardrail (prefer-fresh-when-unsure, entity-exact for brand, cross-project asset+metadata bleed).

## Guardrail (the important part)

A **fuzzy** match is never auto-applied. The floor (steps 1 & 3) only auto-reuses an exact-normalized match; all semantic reuse is an explicit agent act (`--reuse`). This is the structural defense against silently shipping the wrong asset — the failure mode #2028 hardened at the substring level.

## Tests / verification

- `lib/candidates.test.mjs` (7): ranking, no-hard-filter on zero overlap, cap/truncation + totals, icon↔image adjacency, sha-only-on-global, `findGlobalBySha` prefix/ambiguity/miss, formatter handles by scope. Adopt refactor covered by existing `lib/adopt.test.mjs`.
- Full media-use suite green (resolve 13, manifest 21, adopt 7, candidates 7, all `node:test` libs 0 fail). oxlint + oxfmt clean.
- **Verified e2e against the live catalog:** project A resolve → auto-promote → project B `--candidates` surfaces it globally with a sha handle (score 5) → `--reuse` imports it (`reused-explicit`, `imported_from`, file in project) → adherence hint fires on a subsequent miss.

## Open (design) questions carried from the plan
- The adherence nudge is adopted here (not deferred) — it's what makes the agent actually consult candidates.
- Candidate cap = 8/scope with machine-readable `truncated`/`total` in `--json`.