### PR TITLE
fix(producer): suppress GSAP call side effects during render seeks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@ packages/producer/tests/**/*.mp4 filter=lfs diff=lfs merge=lfs -text
 packages/producer/tests/**/*.mov filter=lfs diff=lfs merge=lfs -text
 packages/producer/tests/**/*.webm filter=lfs diff=lfs merge=lfs -text
 packages/producer/tests/**/*.png filter=lfs diff=lfs merge=lfs -text
+packages/producer/tests/**/output/compiled.html filter=lfs diff=lfs merge=lfs -text
 
 # ONNX models must ALWAYS use LFS regardless of location: a 31 MB ppmattingv2
 # model was once committed raw into skills/ then deleted — but a raw commit

--- a/packages/core/src/runtime/adapters/gsap.ts
+++ b/packages/core/src/runtime/adapters/gsap.ts
@@ -13,13 +13,14 @@ export function createGsapAdapter(deps: GsapAdapterDeps): RuntimeDeterministicAd
       if (!timeline) return;
       timeline.pause();
       const safeTime = Math.max(0, Number(ctx.time) || 0);
+      const suppressEvents = ctx.suppressEvents === true;
       if (typeof timeline.totalTime === "function") {
         // GSAP 3.x skips rendering when the new totalTime equals _tTime.
         // Nudge first to force a dirty state, then seek to the exact time.
         timeline.totalTime(safeTime + 0.001, true);
-        timeline.totalTime(safeTime, false);
+        timeline.totalTime(safeTime, suppressEvents);
       } else {
-        timeline.seek(safeTime, false);
+        timeline.seek(safeTime, suppressEvents);
       }
     },
     pause: () => {

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1031,6 +1031,33 @@ describe("initSandboxRuntimeModular", () => {
     expect(hookHost.style.visibility).toBe("visible");
   });
 
+  it("does not seek the root GSAP timeline twice during renderSeek", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "10");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const seekCalls: number[] = [];
+    const rootTimeline = createMockTimeline(10);
+    const originalTotalTime = rootTimeline.totalTime;
+    rootTimeline.totalTime = (time: number, suppressEvents?: boolean) => {
+      seekCalls.push(time);
+      return originalTotalTime?.(time, suppressEvents);
+    };
+
+    window.__timelines = { main: rootTimeline };
+    initSandboxRuntimeModular();
+    seekCalls.length = 0;
+
+    window.__player?.renderSeek(2);
+
+    expect(seekCalls).toEqual([2]);
+  });
+
   it("shows pip video at global start time even when host composition starts late", () => {
     // Regression: resolveStartForElement used to add the host composition's start on top of
     // the video's own data-start, causing double-offset. A pip video with data-start="45.40"

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1031,7 +1031,7 @@ describe("initSandboxRuntimeModular", () => {
     expect(hookHost.style.visibility).toBe("visible");
   });
 
-  it("does not seek the root GSAP timeline twice during renderSeek", () => {
+  it("keeps the root GSAP render nudge for normal frames but not silent probes", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");
     root.setAttribute("data-root", "true");
@@ -1041,11 +1041,11 @@ describe("initSandboxRuntimeModular", () => {
     root.setAttribute("data-height", "1080");
     document.body.appendChild(root);
 
-    const seekCalls: number[] = [];
+    const seekCalls: Array<{ time: number; suppressEvents?: boolean }> = [];
     const rootTimeline = createMockTimeline(10);
     const originalTotalTime = rootTimeline.totalTime;
     rootTimeline.totalTime = (time: number, suppressEvents?: boolean) => {
-      seekCalls.push(time);
+      seekCalls.push({ time, suppressEvents });
       return originalTotalTime?.(time, suppressEvents);
     };
 
@@ -1055,7 +1055,52 @@ describe("initSandboxRuntimeModular", () => {
 
     window.__player?.renderSeek(2);
 
-    expect(seekCalls).toEqual([2]);
+    expect(seekCalls).toEqual([
+      { time: 2, suppressEvents: false },
+      { time: 2.001, suppressEvents: true },
+      { time: 2, suppressEvents: true },
+    ]);
+
+    seekCalls.length = 0;
+    window.__player?.renderSeek(3, { suppressEvents: true });
+
+    expect(seekCalls).toEqual([{ time: 3, suppressEvents: true }]);
+  });
+
+  it("does not nudge root GSAP timelines that contain zero-duration callbacks", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "10");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const seekCalls: Array<{ time: number; suppressEvents?: boolean }> = [];
+    const rootTimeline = createMockTimeline(10);
+    const originalTotalTime = rootTimeline.totalTime;
+    rootTimeline.totalTime = (time: number, suppressEvents?: boolean) => {
+      seekCalls.push({ time, suppressEvents });
+      return originalTotalTime?.(time, suppressEvents);
+    };
+    Object.assign(rootTimeline, {
+      getChildren: () => [
+        {
+          vars: { onComplete: () => {} },
+          duration: () => 0,
+          totalDuration: () => 0,
+        },
+      ],
+    });
+
+    window.__timelines = { main: rootTimeline };
+    initSandboxRuntimeModular();
+    seekCalls.length = 0;
+
+    window.__player?.renderSeek(2);
+
+    expect(seekCalls).toEqual([{ time: 2, suppressEvents: false }]);
   });
 
   it("shows pip video at global start time even when host composition starts late", () => {

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2421,6 +2421,70 @@ export function initSandboxRuntimeModular(): void {
     }
   };
 
+  const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null;
+
+  const gsapCallbackTweenCache = new WeakMap<RuntimeTimelineLike, boolean>();
+  const GSAP_CALLBACK_NAMES = [
+    "onStart",
+    "onUpdate",
+    "onComplete",
+    "onReverseComplete",
+    "onRepeat",
+  ];
+
+  const readGsapDuration = (child: Record<string, unknown>, property: string): number | null => {
+    const getter = child[property];
+    if (typeof getter !== "function") return null;
+    try {
+      const value = Number(getter.call(child));
+      return Number.isFinite(value) ? value : null;
+    } catch (err) {
+      swallow("runtime.init.gsapCallbackDuration", err);
+      return null;
+    }
+  };
+
+  const hasZeroDurationCallbackTween = (timeline: RuntimeTimelineLike): boolean => {
+    const cached = gsapCallbackTweenCache.get(timeline);
+    if (cached != null) return cached;
+
+    if (!("getChildren" in timeline) || typeof timeline.getChildren !== "function") {
+      return false;
+    }
+
+    let children: unknown;
+    try {
+      children = timeline.getChildren(true, true, true);
+    } catch (err) {
+      swallow("runtime.init.gsapCallbackChildren", err);
+      gsapCallbackTweenCache.set(timeline, false);
+      return false;
+    }
+    if (!Array.isArray(children)) {
+      gsapCallbackTweenCache.set(timeline, false);
+      return false;
+    }
+
+    for (const child of children) {
+      if (!isObjectRecord(child) || !isObjectRecord(child.vars)) continue;
+      const hasCallback = GSAP_CALLBACK_NAMES.some(
+        (name) => typeof child.vars[name] === "function",
+      );
+      if (!hasCallback) continue;
+
+      const totalDuration = readGsapDuration(child, "totalDuration");
+      const duration = totalDuration ?? readGsapDuration(child, "duration");
+      if (duration != null && duration <= 0.000001) {
+        gsapCallbackTweenCache.set(timeline, true);
+        return true;
+      }
+    }
+
+    gsapCallbackTweenCache.set(timeline, false);
+    return false;
+  };
+
   const seekTimelineAndAdapters = (
     t: number,
     opts?: { activateChildren?: boolean; suppressEvents?: boolean },
@@ -2461,6 +2525,13 @@ export function initSandboxRuntimeModular(): void {
       try {
         if (typeof tl.totalTime === "function") {
           tl.totalTime(tlSeekTime, suppressEvents);
+          if (!suppressEvents && !hasZeroDurationCallbackTween(tl)) {
+            // Preserve GSAP's forced-render nudge for root timelines without
+            // firing callbacks a second time. The first seek is the only
+            // eventful one; the follow-up nudges only refresh computed styles.
+            tl.totalTime(tlSeekTime + 0.001, true);
+            tl.totalTime(tlSeekTime, true);
+          }
         } else {
           tl.seek(tlSeekTime, suppressEvents);
         }

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -34,7 +34,12 @@ import { TransportClock } from "./clock";
 import { WebAudioTransport } from "./webAudioTransport";
 import { quantizeTimeToFrame } from "../inline-scripts/parityContract";
 import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../studio-api/helpers/draftMarkers";
-import type { RuntimeDeterministicAdapter, RuntimeJson, RuntimeTimelineLike } from "./types";
+import type {
+  RuntimeDeterministicAdapter,
+  RuntimeJson,
+  RuntimeSeekOptions,
+  RuntimeTimelineLike,
+} from "./types";
 import type { PlayerAPI } from "../core.types";
 import { swallow } from "./diagnostics";
 
@@ -205,7 +210,7 @@ export function initSandboxRuntimeModular(): void {
     getTime: () => number;
     getDuration: () => number;
     isPlaying: () => boolean;
-    renderSeek: (timeSeconds: number) => void;
+    renderSeek: (timeSeconds: number, options?: RuntimeSeekOptions) => void;
   }): PlayerAPI => {
     const defaultStageZoom: ReturnType<PlayerAPI["getStageZoom"]> = {
       scale: 1,
@@ -1901,7 +1906,7 @@ export function initSandboxRuntimeModular(): void {
       }
       if (method === "discover") {
         try {
-          adapter.seek({ time: timeSeconds });
+          adapter.seek({ time: timeSeconds, suppressEvents: true });
         } catch (err) {
           // ignore seek bootstrap failures
           swallow("runtime.init.site9", err);
@@ -2064,10 +2069,14 @@ export function initSandboxRuntimeModular(): void {
       syncMediaForCurrentState();
     },
     onStatePost: postState,
-    onDeterministicSeek: (timeSeconds) => {
+    onDeterministicSeek: (timeSeconds, options) => {
       for (const adapter of state.deterministicAdapters) {
+        if (adapter.name === "gsap" && state.capturedTimeline) continue;
         try {
-          adapter.seek({ time: Number(timeSeconds) || 0 });
+          adapter.seek({
+            time: Number(timeSeconds) || 0,
+            suppressEvents: options?.suppressEvents,
+          });
         } catch (err) {
           // ignore adapter failure
           swallow("runtime.init.site11", err);
@@ -2351,20 +2360,22 @@ export function initSandboxRuntimeModular(): void {
     timeline: RuntimeTimelineLike,
     timeSeconds: number,
     swallowLabel: string,
+    options?: RuntimeSeekOptions,
   ) => {
     try {
+      const suppressEvents = options?.suppressEvents === true;
       timeline.pause();
       if (typeof timeline.totalTime === "function") {
-        timeline.totalTime(timeSeconds, false);
+        timeline.totalTime(timeSeconds, suppressEvents);
       } else {
-        timeline.seek(timeSeconds, false);
+        timeline.seek(timeSeconds, suppressEvents);
       }
     } catch (err) {
       swallow(swallowLabel, err);
     }
   };
 
-  const seekStandaloneRegisteredTimelines = (timeSeconds: number) => {
+  const seekStandaloneRegisteredTimelines = (timeSeconds: number, options?: RuntimeSeekOptions) => {
     const timelines = (window.__timelines ?? {}) as Record<string, RuntimeTimelineLike | undefined>;
     const rootCompositionId =
       resolveRootCompositionElement()?.getAttribute("data-composition-id") ?? null;
@@ -2386,7 +2397,7 @@ export function initSandboxRuntimeModular(): void {
           ? Math.min(duration, timeSeconds - start)
           : timeSeconds - start,
       );
-      seekRuntimeTimeline(timeline, localTime, "runtime.init.transport.childTimeline");
+      seekRuntimeTimeline(timeline, localTime, "runtime.init.transport.childTimeline", options);
     }
   };
 
@@ -2410,8 +2421,12 @@ export function initSandboxRuntimeModular(): void {
     }
   };
 
-  const seekTimelineAndAdapters = (t: number, opts?: { activateChildren?: boolean }) => {
+  const seekTimelineAndAdapters = (
+    t: number,
+    opts?: { activateChildren?: boolean; suppressEvents?: boolean },
+  ) => {
     const tl = state.capturedTimeline;
+    const suppressEvents = opts?.suppressEvents === true;
     if (tl) {
       // When rendering frame-by-frame (activateChildren=true), ensure all
       // sibling timelines are unpaused before seeking the root. GSAP
@@ -2445,9 +2460,9 @@ export function initSandboxRuntimeModular(): void {
       }
       try {
         if (typeof tl.totalTime === "function") {
-          tl.totalTime(tlSeekTime, false);
+          tl.totalTime(tlSeekTime, suppressEvents);
         } else {
-          tl.seek(tlSeekTime, false);
+          tl.seek(tlSeekTime, suppressEvents);
         }
       } catch (err) {
         swallow("runtime.init.transport.seek", err);
@@ -2460,11 +2475,12 @@ export function initSandboxRuntimeModular(): void {
       // Play/pause propagation for siblings happens in the player.play()
       // and player.pause() overrides via the adapter layer.
     } else {
-      seekStandaloneRegisteredTimelines(t);
+      seekStandaloneRegisteredTimelines(t, opts);
     }
     for (const adapter of state.deterministicAdapters) {
+      if (adapter.name === "gsap" && tl) continue;
       try {
-        adapter.seek({ time: t });
+        adapter.seek({ time: t, suppressEvents });
       } catch (err) {
         swallow("runtime.init.transport.adapter", err);
       }
@@ -2791,7 +2807,7 @@ export function initSandboxRuntimeModular(): void {
     postState(true);
   };
 
-  player.renderSeek = (timeSeconds: number) => {
+  player.renderSeek = (timeSeconds: number, options?: RuntimeSeekOptions) => {
     const quantized = quantizeTimeToFrame(
       Math.max(0, Number(timeSeconds) || 0),
       state.canonicalFps,
@@ -2801,7 +2817,10 @@ export function initSandboxRuntimeModular(): void {
     state.currentTime = clock.now();
     state.isPlaying = false;
     state.mediaForceSyncNextTick = true;
-    seekTimelineAndAdapters(state.currentTime, { activateChildren: true });
+    seekTimelineAndAdapters(state.currentTime, {
+      activateChildren: true,
+      suppressEvents: options?.suppressEvents,
+    });
     syncMediaForCurrentState();
     colorGrading.redraw();
     postState(true);

--- a/packages/core/src/runtime/player.test.ts
+++ b/packages/core/src/runtime/player.test.ts
@@ -466,6 +466,20 @@ describe("createRuntimePlayer", () => {
       expect(deps.onRenderFrameSeek).toHaveBeenCalled();
     });
 
+    it("can suppress timeline events during administrative render seeks", () => {
+      const timeline = createMockTimeline({ duration: 10 });
+      const deps = createMockDeps(timeline);
+      const player = createRuntimePlayer(deps);
+      const renderSeek = player.renderSeek as (
+        time: number,
+        options?: { suppressEvents?: boolean },
+      ) => void;
+
+      renderSeek(5, { suppressEvents: true });
+
+      expect(timeline.totalTime).toHaveBeenCalledWith(5, true);
+    });
+
     it("renderSeek rearms paused siblings and keeps them active for export frames", () => {
       const { master, scene1, scene2, scene5 } = createNestedTimelineHarness();
       const deps = createMockDeps(master);

--- a/packages/core/src/runtime/player.ts
+++ b/packages/core/src/runtime/player.ts
@@ -1,4 +1,4 @@
-import type { RuntimePlayer, RuntimeTimelineLike } from "./types";
+import type { RuntimePlayer, RuntimeSeekOptions, RuntimeTimelineLike } from "./types";
 import { quantizeTimeToFrame } from "../inline-scripts/parityContract";
 import { swallow } from "./diagnostics";
 
@@ -41,7 +41,7 @@ type PlayerDeps = {
   getCanonicalFps: () => number;
   onSyncMedia: (timeSeconds: number, playing: boolean) => void;
   onStatePost: (force: boolean) => void;
-  onDeterministicSeek: (timeSeconds: number) => void;
+  onDeterministicSeek: (timeSeconds: number, options?: RuntimeSeekOptions) => void;
   onDeterministicPause: () => void;
   onDeterministicPlay: () => void;
   onRenderFrameSeek: (timeSeconds: number) => void;
@@ -79,13 +79,15 @@ function seekTimelineDeterministically(
   timeline: RuntimeTimelineLike,
   timeSeconds: number,
   canonicalFps: number,
+  options?: RuntimeSeekOptions,
 ): number {
   const quantized = quantizeTimeToFrame(timeSeconds, canonicalFps);
+  const suppressEvents = options?.suppressEvents === true;
   safeVoid(timeline, "pause");
   if (typeof timeline.totalTime === "function") {
-    timeline.totalTime(quantized, false);
+    timeline.totalTime(quantized, suppressEvents);
   } else {
-    if (typeof timeline.seek === "function") timeline.seek(quantized, false);
+    if (typeof timeline.seek === "function") timeline.seek(quantized, suppressEvents);
   }
   return quantized;
 }
@@ -95,6 +97,7 @@ function seekMasterAndSiblingTimelinesDeterministically(
   master: RuntimeTimelineLike,
   timeSeconds: number,
   canonicalFps: number,
+  options?: RuntimeSeekOptions,
 ): number {
   const rearmedSiblings: RuntimeTimelineLike[] = [];
   forEachSiblingTimeline(registry, master, (tl) => {
@@ -102,7 +105,7 @@ function seekMasterAndSiblingTimelinesDeterministically(
     rearmedSiblings.push(tl);
   });
   try {
-    return seekTimelineDeterministically(master, timeSeconds, canonicalFps);
+    return seekTimelineDeterministically(master, timeSeconds, canonicalFps, options);
   } finally {
     for (const tl of rearmedSiblings) {
       try {
@@ -206,7 +209,7 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
       deps.onRenderFrameSeek(quantized);
       deps.onStatePost(true);
     },
-    renderSeek: (timeSeconds: number) => {
+    renderSeek: (timeSeconds: number, options?: RuntimeSeekOptions) => {
       const timeline = deps.getTimeline();
       const canonicalFps = deps.getCanonicalFps();
       // When a composition has no GSAP timeline (pure CSS / WAAPI / Lottie /
@@ -219,10 +222,10 @@ export function createRuntimePlayer(deps: PlayerDeps): RuntimePlayer {
             // If nested siblings stay paused, GSAP collapses the root back to the
             // authored master duration and later frames clamp incorrectly.
             activateSiblingTimelines(deps.getTimelineRegistry?.(), timeline);
-            return seekTimelineDeterministically(timeline, timeSeconds, canonicalFps);
+            return seekTimelineDeterministically(timeline, timeSeconds, canonicalFps, options);
           })()
         : quantizeTimeToFrame(Math.max(0, Number(timeSeconds) || 0), canonicalFps);
-      deps.onDeterministicSeek(quantized);
+      deps.onDeterministicSeek(quantized, options);
       deps.setIsPlaying(false);
       deps.onSyncMedia(quantized, false);
       deps.onRenderFrameSeek(quantized);

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -212,12 +212,16 @@ export type RuntimePlayer = {
   play: () => void;
   pause: () => void;
   seek: (timeSeconds: number, options?: { keepPlaying?: boolean }) => void;
-  renderSeek: (timeSeconds: number) => void;
+  renderSeek: (timeSeconds: number, options?: RuntimeSeekOptions) => void;
   getTime: () => number;
   getDuration: () => number;
   isPlaying: () => boolean;
   setPlaybackRate: (rate: number) => void;
   getPlaybackRate: () => number;
+};
+
+export type RuntimeSeekOptions = {
+  suppressEvents?: boolean;
 };
 
 export type RuntimeTimelineLike = {
@@ -236,7 +240,7 @@ export type RuntimeTimelineLike = {
 export type RuntimeDeterministicAdapter = {
   name: string;
   discover: () => void;
-  seek: (ctx: { time: number }) => void;
+  seek: (ctx: { time: number; suppressEvents?: boolean }) => void;
   pause: () => void;
   play?: () => void;
   revert?: () => void;

--- a/packages/core/src/runtime/window.d.ts
+++ b/packages/core/src/runtime/window.d.ts
@@ -1,4 +1,4 @@
-import type { RuntimeTimelineMessage, RuntimeTimelineLike } from "./types";
+import type { RuntimeSeekOptions, RuntimeTimelineMessage, RuntimeTimelineLike } from "./types";
 import type { RuntimeColorGradingApi } from "./colorGrading";
 import type { HyperframePickerApi } from "../inline-scripts/pickerApi";
 import type { PlayerAPI } from "../core.types";
@@ -35,6 +35,8 @@ declare global {
     __hf?: {
       colorGrading?: RuntimeColorGradingApi;
       onSwallowed?: (label: string, err: unknown) => void;
+      seek?: (timeSeconds: number, options?: RuntimeSeekOptions) => void;
+      duration?: number;
     };
     __playerReady?: boolean;
     __renderReady?: boolean;

--- a/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
+++ b/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
@@ -147,4 +147,40 @@ describe("verifyStaticFramesSafe catches drift the old fixed-point density would
     expect(result?.budgetExhausted).toBe(false);
     expect(result?.badFrame).toBe(changeAt);
   });
+
+  it("uses silent verification seeks and restores the playhead to frame zero", async () => {
+    const seekCalls: Array<{ t: number; options?: { suppressEvents?: boolean } }> = [];
+    const page = {
+      evaluate: vi.fn(async (fn: (tt: number) => void, t: number) => {
+        const globalWithWindow = globalThis as typeof globalThis & { window?: unknown };
+        const previousWindow = globalWithWindow.window;
+        globalWithWindow.window = {
+          __hf: {
+            seek: (seekTime: number, options?: { suppressEvents?: boolean }) => {
+              seekCalls.push({ t: seekTime, options });
+            },
+          },
+        };
+        try {
+          fn(t);
+        } finally {
+          if (previousWindow === undefined) delete globalWithWindow.window;
+          else globalWithWindow.window = previousWindow;
+        }
+      }),
+    };
+    vi.mocked(pageScreenshotCapture).mockImplementation(async () => Buffer.from("same"));
+
+    const result = await verifyStaticFramesSafe(
+      { options: {} } as unknown as CaptureSession,
+      page as unknown as Parameters<typeof verifyStaticFramesSafe>[1],
+      new Set([1, 2]),
+      fps,
+      3,
+    );
+
+    expect(result).toBeNull();
+    expect(seekCalls.map((call) => Math.round(call.t * fps))).toEqual([0, 1, 2, 0]);
+    expect(seekCalls.every((call) => call.options?.suppressEvents === true)).toBe(true);
+  });
 });

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -2067,12 +2067,19 @@ export async function verifyStaticFramesSafe(
     if (last && f === last.b + 1) last.b = f;
     else runs.push({ a: f, b: f });
   }
-  const seekCapture = async (frameIdx: number): Promise<Buffer> => {
+  const seekToFrame = async (frameIdx: number): Promise<void> => {
     const t = quantizeTimeToFrame(frameIdx / fps, fps);
     await page.evaluate((tt: number) => {
-      const hf = (window as unknown as { __hf?: { seek?: (t: number) => void } }).__hf;
-      if (hf && typeof hf.seek === "function") hf.seek(tt);
+      const hf = (
+        window as unknown as {
+          __hf?: { seek?: (t: number, options?: { suppressEvents?: boolean }) => void };
+        }
+      ).__hf;
+      if (hf && typeof hf.seek === "function") hf.seek(tt, { suppressEvents: true });
     }, t);
+  };
+  const seekCapture = async (frameIdx: number): Promise<Buffer> => {
+    await seekToFrame(frameIdx);
     return pageScreenshotCapture(page, session.options);
   };
   // Verify EVERY run in order (no longest-first truncation that would leave runs armed
@@ -2093,23 +2100,27 @@ export async function verifyStaticFramesSafe(
     400,
     Math.ceil(frames.length / STATIC_VERIFY_REFERENCE_STRIDE) * 3 + runs.length,
   );
-  let spent = 0;
-  for (const { a, b } of runs) {
-    const anchor = a - 1;
-    if (anchor < 0) continue;
-    const anchorBuf = await seekCapture(anchor);
-    spent++;
-    for (const f of computeStaticVerificationPoints(a, b, sampleCount)) {
-      const cur = await seekCapture(f);
+  try {
+    let spent = 0;
+    for (const { a, b } of runs) {
+      const anchor = a - 1;
+      if (anchor < 0) continue;
+      const anchorBuf = await seekCapture(anchor);
       spent++;
-      if (!anchorBuf.equals(cur)) return { badFrame: f, budgetExhausted: false };
+      for (const f of computeStaticVerificationPoints(a, b, sampleCount)) {
+        const cur = await seekCapture(f);
+        spent++;
+        if (!anchorBuf.equals(cur)) return { badFrame: f, budgetExhausted: false };
+      }
+      // Budget exhausted → can't fully verify → disarm, distinct from real drift so a
+      // `verification_budget` spike in telemetry reads as "this composition has a lot
+      // of static material to verify," not "compositions are non-static."
+      if (spent > hardCap) return { badFrame: a, budgetExhausted: true };
     }
-    // Budget exhausted → can't fully verify → disarm, distinct from real drift so a
-    // `verification_budget` spike in telemetry reads as "this composition has a lot
-    // of static material to verify," not "compositions are non-static."
-    if (spent > hardCap) return { badFrame: a, budgetExhausted: true };
+    return null;
+  } finally {
+    await seekToFrame(0).catch(() => {});
   }
-  return null;
 }
 
 /**
@@ -2985,8 +2996,12 @@ async function captureDeVerificationFrames(
   const fractions = Array.from({ length: k }, (_, i) => (i + 1) / (k + 1));
   const seekTo = async (t: number): Promise<void> => {
     await page.evaluate((tt: number) => {
-      const hf = (window as unknown as { __hf?: { seek?: (x: number) => void } }).__hf;
-      if (hf && typeof hf.seek === "function") hf.seek(tt);
+      const hf = (
+        window as unknown as {
+          __hf?: { seek?: (x: number, options?: { suppressEvents?: boolean }) => void };
+        }
+      ).__hf;
+      if (hf && typeof hf.seek === "function") hf.seek(tt, { suppressEvents: true });
     }, t);
   };
   await seekTo(quantizeTimeToFrame(0, fps));

--- a/packages/parsers/src/types.ts
+++ b/packages/parsers/src/types.ts
@@ -363,7 +363,7 @@ export interface PlayerAPI {
   ensureTimeline(): void;
   enableRenderMode(): void;
   disableRenderMode(): void;
-  renderSeek(time: number): void;
+  renderSeek(time: number, options?: { suppressEvents?: boolean }): void;
   getElementVisibility(elementId: string): { visible: boolean; opacity?: number };
   getVisibleElements(): Array<{ id: string; tagName: string; start: number; end: number }>;
   getRenderState(): {

--- a/packages/producer/src/services/fileServer.test.ts
+++ b/packages/producer/src/services/fileServer.test.ts
@@ -643,6 +643,49 @@ describe("HF_EARLY_STUB + HF_BRIDGE_SCRIPT integration", () => {
     expect(sandbox.window.__hf?.duration).toBe(30);
   });
 
+  it("forwards suppressEvents from __hf.seek to renderSeek", () => {
+    const renderSeekCalls: Array<[number, { suppressEvents?: boolean } | undefined]> = [];
+    const sandbox: {
+      window: Record<string, unknown> & {
+        __hf?: {
+          seek?: (t: number, options?: { suppressEvents?: boolean }) => void;
+          duration?: number;
+        };
+        __player?: {
+          renderSeek: (t: number, options?: { suppressEvents?: boolean }) => void;
+          getDuration: () => number;
+        };
+        setInterval: typeof setInterval;
+        clearInterval: typeof clearInterval;
+      };
+      document: { querySelector: () => null };
+    } = {
+      window: {
+        setInterval: globalThis.setInterval,
+        clearInterval: globalThis.clearInterval,
+      },
+      document: { querySelector: () => null },
+    };
+    sandbox.window.window = sandbox.window;
+    sandbox.window.document = sandbox.document;
+    sandbox.window.__renderReady = true;
+    sandbox.window.__player = {
+      renderSeek: (time, options) => {
+        renderSeekCalls.push([time, options]);
+      },
+      getDuration: () => 10,
+    };
+
+    new Function("window", "document", `with (window) {\n${HF_BRIDGE_SCRIPT}\n}`)(
+      sandbox.window,
+      sandbox.document,
+    );
+
+    sandbox.window.__hf?.seek?.(5, { suppressEvents: true });
+
+    expect(renderSeekCalls).toEqual([[5, { suppressEvents: true }]]);
+  });
+
   it("keeps render-time timeline seeks synchronous during large renders", () => {
     const sandbox: {
       window: Record<string, unknown> & {

--- a/packages/producer/src/services/fileServer.ts
+++ b/packages/producer/src/services/fileServer.ts
@@ -636,8 +636,8 @@ const HF_BRIDGE_SCRIPT = `(function() {
         return d > 0 ? d : getDeclaredDuration();
       },
     });
-    hf.seek = function(t) {
-      p.renderSeek(t);
+    hf.seek = function(t, options) {
+      p.renderSeek(t, options);
       var nextTimeMs = (Math.max(0, Number(t) || 0)) * 1000;
       if (window.__HF_VIRTUAL_TIME__ && typeof window.__HF_VIRTUAL_TIME__.seekToTime === "function") {
         window.__HF_VIRTUAL_TIME__.seekToTime(nextTimeMs);

--- a/packages/producer/tests/gsap-call-render-seek/meta.json
+++ b/packages/producer/tests/gsap-call-render-seek/meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "gsap-call-render-seek",
+  "description": "Regression guard for GSAP .call() side effects during producer render seeks. Administrative/static-dedup seeks must not fire callbacks or leave the page playhead poisoned before real frame capture.",
+  "tags": ["regression", "render-compat", "gsap"],
+  "minPsnr": 30,
+  "maxFrameFailures": 0,
+  "minAudioCorrelation": 0,
+  "maxAudioLagWindows": 1,
+  "renderConfig": {
+    "fps": 30,
+    "workers": 1
+  }
+}

--- a/packages/producer/tests/gsap-call-render-seek/output/compiled.html
+++ b/packages/producer/tests/gsap-call-render-seek/output/compiled.html
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d350fb3d1c2e01ed5c21a811d79cee3bfb61a0f713326ba2fb729ab43115d92
+size 2563366

--- a/packages/producer/tests/gsap-call-render-seek/output/output.mp4
+++ b/packages/producer/tests/gsap-call-render-seek/output/output.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e8fd9d5f29443375a919d0229751f29c3b3e7da758d3bdec3e21f4546b25455
+size 123087

--- a/packages/producer/tests/gsap-call-render-seek/src/index.html
+++ b/packages/producer/tests/gsap-call-render-seek/src/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=1920, height=1080">
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+  <style>
+    html,
+    body {
+      margin: 0;
+      width: 1920px;
+      height: 1080px;
+      overflow: hidden;
+      background: #06070a;
+      color: #f6f0e8;
+      font-family: sans-serif;
+    }
+
+    #main {
+      position: relative;
+      width: 1920px;
+      height: 1080px;
+      overflow: hidden;
+      background:
+        linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px) 0 0 / 120px 120px,
+        linear-gradient(0deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px) 0 0 / 120px 120px,
+        radial-gradient(circle at 50% 45%, #191b26 0, #06070a 62%);
+    }
+
+    .clip {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+    }
+
+    .counter {
+      font-size: 360px;
+      line-height: 0.9;
+      font-weight: 700;
+      font-variant-numeric: tabular-nums;
+      letter-spacing: 0;
+      text-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+    }
+
+    .label {
+      position: absolute;
+      top: 108px;
+      left: 128px;
+      font-size: 34px;
+      line-height: 1;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: #9fd8ff;
+    }
+
+    .rail {
+      position: absolute;
+      left: 320px;
+      right: 320px;
+      bottom: 160px;
+      height: 22px;
+      border: 1px solid rgba(246, 240, 232, 0.32);
+      background: rgba(246, 240, 232, 0.08);
+    }
+
+    .fill {
+      width: 0;
+      height: 100%;
+      background: linear-gradient(90deg, #9fd8ff, #f8d87a);
+    }
+  </style>
+</head>
+<body>
+  <div
+    id="main"
+    data-composition-id="gsap-call-render-seek"
+    data-width="1920"
+    data-height="1080"
+    data-start="0"
+    data-duration="6"
+  >
+    <div id="counter-scene" class="clip" data-start="0" data-duration="6">
+      <div class="label">GSAP call render seek</div>
+      <div id="counter" class="counter">0</div>
+      <div class="rail"><div id="fill" class="fill"></div></div>
+    </div>
+  </div>
+
+  <script>
+    window.__timelines = window.__timelines || {};
+
+    var counter = 0;
+    var counterEl = document.getElementById("counter");
+
+    function bump() {
+      counter += 1;
+      counterEl.textContent = String(counter);
+    }
+
+    var tl = gsap.timeline({ paused: true });
+    tl.to("#fill", { width: "100%", duration: 6, ease: "none" }, 0);
+    tl.call(bump, null, 1);
+    tl.call(bump, null, 2);
+    tl.call(bump, null, 3);
+    tl.call(bump, null, 4);
+
+    window.__timelines["gsap-call-render-seek"] = tl;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Problem

Issue #2036 was a producer-only GSAP side-effect bug: render-internal seeks were firing authored `.call()` callbacks before real capture, so a counter that should render as `0 → 1 → 2 → 3 → 4 → 4` came out of published `hyperframes@0.7.41` as `0 → 3 → 4 → 5 → 6 → 4`.

The preview looked correct because the corruption came from producer probes, not the authored timeline: calibration, static-dedup, drawElement verification, and one duplicate root GSAP seek all drove timeline state with callback events enabled.

CI also caught the subtle half of the fix: simply removing the duplicate root seek prevents `.call()` inflation, but it also removes GSAP's forced-render refresh for ordinary root timelines. That drifted an existing `style-4-prod` caption checkpoint in regression shard 5.

## Fix

- Thread `suppressEvents` through `window.__hf.seek`, `renderSeek`, deterministic adapters, and the GSAP adapter so render/admin probes can seek silently.
- Make producer verification seeks silent and restore the page to frame 0 afterwards, so real capture starts from a known timeline state.
- Treat the captured root GSAP timeline as the single source of truth: skip the deterministic GSAP adapter for it, do one eventful root seek for the frame, then preserve GSAP's forced-render nudge with suppressed events.
- Guard that suppressed nudge for zero-duration callback tweens (`tl.call` and callback-only tweens), so callback side effects are not re-armed while normal tween timelines keep their previous visual refresh behavior.
- Add the producer golden fixture `gsap-call-render-seek`, including LFS-backed compiled/output baselines, to lock the bug down end-to-end.

Closes heygen-com/hyperframes#2036

## Tests

- `bun run build`
- `bunx oxlint <changed source/test files>`
- `bunx oxfmt --check <changed source/test files>`
- Core runtime tests: `init.test.ts` 44/44, `player.test.ts` 40/40
- Focused bridge/capture tests from the first fix: producer file server 47/47, engine static-dedup 12/12
- `hyperframes lint` / `hyperframes validate` on `gsap-call-render-seek`: 0 errors, 0 warnings, no console errors
- Devbox EC2 Docker baseline flow: reproduced the published bad sequence, generated the fixed baseline, then verified `gsap-call-render-seek` with 100/100 visual checkpoints
- Devbox EC2 Docker CI-follow-up proof: `style-4-prod` + `gsap-call-render-seek` both passed; the shard-5 checkpoint at 11.876s is clean again
