### PR TITLE
chore: release v0.7.42

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,31 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.42"
+  description="Released - 2026-07-07"
+  tags={["Release", "Producer,cli", "CLI", "Engine"]}
+>
+This release switches drawElement fast capture to single-worker streaming after benchmarks showed multi-page parallelism losing to priority inversion, and makes Windows rendering reliable by copying extracted frames when symlinks hit EPERM. It also hardens the CLI: render fps defaults to the composition's `data-fps`, corrupt browser downloads self-heal, and upgrade notices match the detected install method.
+
+## Features
+
+- **Producer,cli:** DrawElement priority inversion — single-worker streaming over auto-parallel ([924727a0b](https://github.com/heygen-com/hyperframes/commit/924727a0b462b63c28c68a5fdf971ba7a6b1a369), [#2026](https://github.com/heygen-com/hyperframes/pull/2026))
+
+## Fixes
+
+- **CLI:** Upgrade and update notice use the detected install method ([4b3c73d94](https://github.com/heygen-com/hyperframes/commit/4b3c73d941f208834d913876b94757a767218c70))
+- **Engine:** Resolve relative data-start references in video-frame extraction ([4a36655b2](https://github.com/heygen-com/hyperframes/commit/4a36655b2bd966ed81afcdcd2afb3bb201810b09))
+- **Media Use:** Create the output dir before ElevenLabs TTS writes ([42a209545](https://github.com/heygen-com/hyperframes/commit/42a209545b55c62d0647e7770523e1ce47c2de67))
+- **Producer:** Fall back to copying extracted frames when symlink hits EPERM ([00b96d2ea](https://github.com/heygen-com/hyperframes/commit/00b96d2eaab071e65a02452b0416088866a2c451))
+- **Producer:** Copy extracted frames on Windows to avoid symlink EPERM ([1aa39d465](https://github.com/heygen-com/hyperframes/commit/1aa39d46538544c71ca98dfa3bff059a48ceaec9))
+- **CLI:** Default render fps to the composition's data-fps ([de27b4668](https://github.com/heygen-com/hyperframes/commit/de27b466808d1e1f020d06701c8ed1196a4d3029))
+- **CLI:** Re-download the browser when the cached archive is corrupt ([92f3116de](https://github.com/heygen-com/hyperframes/commit/92f3116dee8d10090d1e6d18647b9445ee965a01))
+- **CLI:** Lint sets process.exitCode instead of process.exit() to flush stdout ([4834de37f](https://github.com/heygen-com/hyperframes/commit/4834de37f4c94f05fc8ab3098d5f12e6486b18de))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.41...v0.7.42).
+</Update>
+
+<Update
   label="HyperFrames v0.7.41"
   description="Released - 2026-07-07"
   tags={["Release", "Media Use", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.42.md
+++ b/releases/v0.7.42.md
@@ -1,0 +1,24 @@
+# HyperFrames v0.7.42
+
+Released on 2026-07-07.
+
+This release switches drawElement fast capture to single-worker streaming after benchmarks showed multi-page parallelism losing to priority inversion, and makes Windows rendering reliable by copying extracted frames when symlinks hit EPERM. It also hardens the CLI: render fps defaults to the composition's `data-fps`, corrupt browser downloads self-heal, and upgrade notices match the detected install method.
+
+## Features
+
+- **Producer,cli:** DrawElement priority inversion — single-worker streaming over auto-parallel ([924727a0b](https://github.com/heygen-com/hyperframes/commit/924727a0b462b63c28c68a5fdf971ba7a6b1a369), [#2026](https://github.com/heygen-com/hyperframes/pull/2026))
+
+## Fixes
+
+- **CLI:** Upgrade and update notice use the detected install method ([4b3c73d94](https://github.com/heygen-com/hyperframes/commit/4b3c73d941f208834d913876b94757a767218c70))
+- **Engine:** Resolve relative data-start references in video-frame extraction ([4a36655b2](https://github.com/heygen-com/hyperframes/commit/4a36655b2bd966ed81afcdcd2afb3bb201810b09))
+- **Media Use:** Create the output dir before ElevenLabs TTS writes ([42a209545](https://github.com/heygen-com/hyperframes/commit/42a209545b55c62d0647e7770523e1ce47c2de67))
+- **Producer:** Fall back to copying extracted frames when symlink hits EPERM ([00b96d2ea](https://github.com/heygen-com/hyperframes/commit/00b96d2eaab071e65a02452b0416088866a2c451))
+- **Producer:** Copy extracted frames on Windows to avoid symlink EPERM ([1aa39d465](https://github.com/heygen-com/hyperframes/commit/1aa39d46538544c71ca98dfa3bff059a48ceaec9))
+- **CLI:** Default render fps to the composition's data-fps ([de27b4668](https://github.com/heygen-com/hyperframes/commit/de27b466808d1e1f020d06701c8ed1196a4d3029))
+- **CLI:** Re-download the browser when the cached archive is corrupt ([92f3116de](https://github.com/heygen-com/hyperframes/commit/92f3116dee8d10090d1e6d18647b9445ee965a01))
+- **CLI:** Lint sets process.exitCode instead of process.exit() to flush stdout ([4834de37f](https://github.com/heygen-com/hyperframes/commit/4834de37f4c94f05fc8ab3098d5f12e6486b18de))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.41...v0.7.42


### PR DESCRIPTION
## HyperFrames v0.7.42

This release switches drawElement fast capture to single-worker streaming after benchmarks showed multi-page parallelism losing to priority inversion, and makes Windows rendering reliable by copying extracted frames when symlinks hit EPERM. It also hardens the CLI: render fps defaults to the composition's `data-fps`, corrupt browser downloads self-heal, and upgrade notices match the detected install method.

Full notes: `releases/v0.7.42.md`
Compare: https://github.com/heygen-com/hyperframes/compare/v0.7.41...release/v0.7.42

On merge, the publish workflow tags `v0.7.42` and publishes all packages to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)