### PR TITLE
fix(cli): pin arm64 render Chromium to Playwright headless-shell (#2039)

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1191,8 +1191,8 @@ function ensureDockerImage(version: string, platform: string, quiet: boolean): s
 
   // Platform is now derived from the host arch (see resolveDockerPlatform).
   // Apple Silicon and other arm64 hosts get a native linux/arm64 build; the
-  // Dockerfile skips chrome-headless-shell on arm64 and falls back to system
-  // chromium because chrome-headless-shell ships linux64 only.
+  // Dockerfile installs a pinned arm64 chrome-headless-shell from Playwright
+  // (chrome-for-testing publishes no linux-arm64 build).
   //
   // TARGETARCH is passed explicitly rather than relying on BuildKit's
   // automatic platform args because the legacy builder (and some BuildKit
@@ -1250,17 +1250,17 @@ function resolveDockerHostPlatform(options: RenderOptions): string {
   }
 
   if (!options.quiet && platform === "linux/arm64") {
-    // chrome-headless-shell doesn't publish a linux-arm64 build, so the arm64
-    // image falls back to system chromium. That loses byte-for-byte parity
-    // with amd64 renders — fine for end-user output, not fine if you're
-    // comparing against an amd64 golden baseline. Set
-    // HYPERFRAMES_DOCKER_PLATFORM=linux/amd64 to keep parity (qemu-emulated,
+    // The arm64 image uses Playwright's pinned linux-arm64 chrome-headless-shell
+    // (chrome-for-testing has no arm64 build). It's a different Chromium build
+    // than amd64's chrome-for-testing binary, so output isn't byte-identical to
+    // an amd64 golden baseline — fine for end-user output. Set
+    // HYPERFRAMES_DOCKER_PLATFORM=linux/amd64 to force parity (qemu-emulated,
     // slower).
     console.log(
       c.dim(
-        "  Host is arm64 — using linux/arm64 image with system chromium " +
-          "(output won't be byte-identical to amd64 renders; " +
-          "set HYPERFRAMES_DOCKER_PLATFORM=linux/amd64 to force parity).",
+        "  Host is arm64 — using linux/arm64 image with Playwright's " +
+          "chrome-headless-shell (output won't be byte-identical to amd64 " +
+          "renders; set HYPERFRAMES_DOCKER_PLATFORM=linux/amd64 to force parity).",
       ),
     );
   }

--- a/packages/cli/src/docker/Dockerfile.render
+++ b/packages/cli/src/docker/Dockerfile.render
@@ -1,10 +1,17 @@
 FROM node:22-bookworm-slim
 
 ARG HYPERFRAMES_VERSION=latest
-# Set automatically by `docker build --platform` (BuildKit); we use it to
-# decide whether to install chrome-headless-shell, which only ships for
-# linux64 (see https://googlechromelabs.github.io/chrome-for-testing/).
+# Set automatically by `docker build --platform` (BuildKit); selects the
+# chrome-headless-shell source below (chrome-for-testing ships linux64 only,
+# see https://googlechromelabs.github.io/chrome-for-testing/).
 ARG TARGETARCH=amd64
+# Pinned Playwright release used to fetch a known-good, arch-native
+# chrome-headless-shell on arm64. chrome-for-testing publishes no linux-arm64
+# build, so arm64 used to fall back to Debian's *unpinned, rolling* `chromium`
+# package — whose bookworm arm64 build SIGTRAPs at startup (exit 133), breaking
+# every containerized render (issue #2039). Playwright ships a pinned
+# linux-arm64 headless-shell (Google's build, not Debian's). Bump deliberately.
+ARG PLAYWRIGHT_VERSION=1.61.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl unzip ffmpeg chromium \
@@ -20,37 +27,36 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV CONTAINER=true
 
-# chrome-headless-shell unlocks BeginFrame-based deterministic capture but the
-# project only publishes a linux64 binary. On arm64 we skip the install and
-# let the engine fall back to system chromium (set via
-# PUPPETEER_EXECUTABLE_PATH above). The wrapper script below only sets
-# PRODUCER_HEADLESS_SHELL_PATH when the binary is actually present.
+# chrome-headless-shell unlocks BeginFrame-based deterministic capture. Install
+# it on both arches from a pinned source so a build can never silently pick up a
+# broken browser update:
+#   amd64  -> chrome-for-testing (linux64) via @puppeteer/browsers
+#   arm64  -> Playwright's pinned linux-arm64 headless-shell (chrome-for-testing
+#            has no arm64 build; Debian's rolling `chromium` SIGTRAPs — #2039)
+# The wrapper script below wires whichever binary landed into
+# PRODUCER_HEADLESS_SHELL_PATH, or fails the build loudly if neither did.
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
       npx --yes @puppeteer/browsers install chrome-headless-shell@stable \
         --path /root/.cache/puppeteer; \
     else \
-      echo "Skipping chrome-headless-shell install on ${TARGETARCH} (linux64-only); using system chromium."; \
+      npx --yes playwright-core@${PLAYWRIGHT_VERSION} install chromium-headless-shell; \
     fi
 
 RUN npm install -g hyperframes@${HYPERFRAMES_VERSION}
 
-# Wrapper script: resolves chrome-headless-shell path at build time when
-# available so the engine uses BeginFrame rendering. On arm64 (no
-# chrome-headless-shell) it leaves PRODUCER_HEADLESS_SHELL_PATH unset, so the
-# engine falls back to PUPPETEER_EXECUTABLE_PATH (system chromium).
-#
-# If TARGETARCH=amd64 and the binary is missing, fail the build loudly — the
-# previous (pre-PR) wrapper used an `&&` chain that crashed `docker build` in
-# this case, and silently downgrading to system chromium on amd64 would mask
-# golden-baseline regressions.
-RUN SHELL_PATH=$(find /root/.cache/puppeteer/chrome-headless-shell -name "chrome-headless-shell" -type f 2>/dev/null | head -1); \
+# Wrapper script: resolves the chrome-headless-shell path installed above and
+# exports it as PRODUCER_HEADLESS_SHELL_PATH so the engine uses BeginFrame
+# rendering. @puppeteer/browsers names the binary `chrome-headless-shell`;
+# Playwright names it `headless_shell` — match either, in either cache dir.
+# If neither is present the browser install step failed: fail the build loudly
+# rather than silently downgrading to the (arm64-broken) Debian chromium.
+RUN SHELL_PATH=$(find /root/.cache/puppeteer /root/.cache/ms-playwright \
+      \( -name "chrome-headless-shell" -o -name "headless_shell" \) -type f 2>/dev/null | head -1); \
     if [ -n "$SHELL_PATH" ]; then \
       printf '#!/bin/sh\nexport PRODUCER_HEADLESS_SHELL_PATH=%s\nexec hyperframes render "$@"\n' "$SHELL_PATH" > /usr/local/bin/hf-render; \
-    elif [ "$TARGETARCH" = "amd64" ]; then \
-      echo "ERROR: chrome-headless-shell binary not found on amd64 — @puppeteer/browsers install must have failed or moved its cache layout." >&2; \
-      exit 1; \
     else \
-      printf '#!/bin/sh\nexec hyperframes render "$@"\n' > /usr/local/bin/hf-render; \
+      echo "ERROR: chrome-headless-shell binary not found for ${TARGETARCH} — the browser install step above must have failed." >&2; \
+      exit 1; \
     fi \
     && chmod +x /usr/local/bin/hf-render
 

--- a/packages/cli/src/utils/dockerRunArgs.ts
+++ b/packages/cli/src/utils/dockerRunArgs.ts
@@ -22,9 +22,9 @@ export interface DockerRunArgsInput {
    * resolves to the host architecture via `resolveDockerPlatform()`. Pinning
    * to `linux/amd64` on an arm64 host (the legacy default) forces qemu
    * emulation of chrome-headless-shell, which segfaults or stalls on Apple
-   * Silicon — see issue #1193. Native `linux/arm64` falls back to the
-   * system chromium baked into the image at the cost of byte-for-byte
-   * parity with amd64 renders.
+   * Silicon — see issue #1193. Native `linux/arm64` uses Playwright's pinned
+   * arm64 chrome-headless-shell baked into the image at the cost of
+   * byte-for-byte parity with amd64 renders.
    */
   platform?: string;
   options: DockerRenderOptions;


### PR DESCRIPTION
Fixes #2039.

## Problem

`render --docker` fails 100% on Apple Silicon. `Dockerfile.render` installed Chromium **unpinned** on arm64 — chrome-for-testing publishes no `linux-arm64` build, so the image fell back to Debian bookworm's rolling `chromium` package. Debian's current arm64 build (`150.0.7871.46`) SIGTRAPs at startup (exit 133) before any capture, surfacing as the generic `Failed to launch the browser process: Code: null`. Any image built after Debian's 149→150 bump silently carries the broken browser.

## Fix

Install a **pinned, non-Debian** `chrome-headless-shell` on arm64 from Playwright (`playwright-core@1.61.1` → Chromium 149, Google's build, not Debian's repackage). Both arches now install a headless-shell from a pinned source, so a build can never silently pick up a broken browser update:

- **amd64** → chrome-for-testing (linux64) via `@puppeteer/browsers` — unchanged
- **arm64** → Playwright's pinned `linux-arm64` headless-shell (new)

The build wrapper wires whichever binary landed into `PRODUCER_HEADLESS_SHELL_PATH` (matching either `chrome-headless-shell` or Playwright's `headless_shell`), and now **fails the build loudly** if neither is present instead of silently downgrading to the broken Debian chromium.

Bonus: arm64 now gets a real headless-shell, so it gains **BeginFrame deterministic capture** it previously lacked (it used to fall back to full system chromium).

## Verification

Same arm64 image, same Apple Silicon VM:

| Chromium | headless launch |
|---|---|
| Debian bookworm `150.0.7871.46` (old fallback) | **exit 133 (SIGTRAP)** |
| Playwright arm64 headless-shell (Chromium 149) | **exit 0** |

## Notes / follow-ups (not in this PR)

- Issue also requests a custom-image / executable-path escape hatch and surfacing the child's real exit signal (SIGTRAP vs `Code: null`). Both are separate from this root fix; happy to add in follow-ups.