### PR TITLE
fix(media-use): explain the codex alias-vs-PATH gotcha in the unavailable message

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "ffd883ca5d722a3b",
+      "hash": "b982d0f7c710bf23",
       "files": 101
     },
     "motion-graphics": {

--- a/skills/media-use/scripts/lib/codex-provider.mjs
+++ b/skills/media-use/scripts/lib/codex-provider.mjs
@@ -62,7 +62,10 @@ function codexUnavailableReason() {
     const which = process.platform === "win32" ? "where" : "which";
     execFileSync(which, ["codex"], { stdio: ["ignore", "ignore", "ignore"], timeout: 5000 });
   } catch {
-    return "codex CLI not on PATH";
+    // A shell alias (e.g. `codex → /Applications/Codex.app/...`) is NOT enough:
+    // aliases live only in the interactive shell, so a spawned subprocess's PATH
+    // lookup can't see them. Symlink the real binary onto PATH.
+    return 'codex CLI not reachable on PATH (a shell alias won\'t work — spawned processes can\'t see aliases; symlink the real binary onto PATH, e.g. ln -s "$(readlink -f "$(command -v codex)")" ~/.local/bin/codex)';
   }
   // Auth marker: presence of the credentials file, NOT `codex login status`.
   // That command prints "Logged in using ChatGPT" only to a human stream


### PR DESCRIPTION
## What

When `codex` is set up as a **shell alias** (e.g. `codex → /Applications/Codex.app/Contents/Resources/codex`), media-use's `which codex` preflight fails — aliases live only in the interactive shell, and a spawned subprocess's PATH lookup can't see them. The old message was the bare `codex CLI not on PATH`, which reads as *"the binary is missing"* and sends people hunting for a broken install.

## Fix

Spell out the real cause and the one-line remedy in the message (and a code comment):

> `codex CLI not reachable on PATH (a shell alias won't work — spawned processes can't see aliases; symlink the real binary onto PATH, e.g. ln -s "$(readlink -f "$(command -v codex)")" ~/.local/bin/codex)`

No behavior change — same failure path, clearer guidance so an agent (or human) fixes it in seconds instead of misdiagnosing a missing binary. Real case: hit during a media-use codex image-gen run; the symlink resolved it immediately.

Follow-up to #2033 (which fixed the codex *auth* gate). Regenerates `skills-manifest.json` for the media-use hash.