### PR TITLE
fix(engine): fail-fast the sub-composition timeline wait when a script 404s

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -23,6 +23,7 @@
  */
 import { join, sep } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CHROME_VERSION } from "./manager.js";
 
 // Use `path.join` so the fake paths line up with whatever separator Node's
 // real `path.join` produces in `manager.ts` on the host running the test
@@ -107,7 +108,12 @@ function installFsMocks({ existing, dirs }: FsMockOptions) {
 
 function installPuppeteerBrowsersMock(
   opts: {
-    installedInHfCache?: Array<{ browser: string; executablePath: string; path?: string }>;
+    installedInHfCache?: Array<{
+      browser: string;
+      executablePath: string;
+      path?: string;
+      buildId?: string;
+    }>;
     installedInHfCacheError?: Error;
     installResult?: { executablePath: string };
     installImpl?: () => Promise<{ executablePath: string }>;
@@ -167,13 +173,34 @@ describe("findBrowser — cache resolution", () => {
     // last-resort fallback.
     installFsMocks({ existing: new Set([HF_CACHE, HF_BINARY]) });
     installPuppeteerBrowsersMock({
-      installedInHfCache: [{ browser: "chrome-headless-shell", executablePath: HF_BINARY }],
+      installedInHfCache: [
+        { browser: "chrome-headless-shell", executablePath: HF_BINARY, buildId: CHROME_VERSION },
+      ],
     });
 
     const { findBrowser } = await import("./manager.js");
     const result = await findBrowser();
 
     expect(result).toEqual({ executablePath: HF_BINARY, source: "cache" });
+  });
+
+  it("does not resolve to a hyperframes-cache build from an older CHROME_VERSION pin", async () => {
+    // A build downloaded by a prior hyperframes version (this pin has moved
+    // 131 -> 151 -> 152 across releases) must not satisfy resolution, or an
+    // upgrade silently keeps running a stale build forever instead of ever
+    // fetching the version the new release actually needs (HF#2060 review).
+    installFsMocks({ existing: new Set([HF_CACHE, HF_BINARY, SYSTEM_CHROME]) });
+    installPuppeteerBrowsersMock({
+      installedInHfCache: [
+        { browser: "chrome-headless-shell", executablePath: HF_BINARY, buildId: "131.0.6778.85" },
+      ],
+    });
+
+    const { findBrowser } = await import("./manager.js");
+    const result = await findBrowser();
+
+    expect(result?.executablePath).not.toBe(HF_BINARY);
+    expect(result).toEqual({ executablePath: SYSTEM_CHROME, source: "system" });
   });
 
   it("re-downloads when the hyperframes cache manifest points at a missing binary", async () => {
@@ -191,7 +218,12 @@ describe("findBrowser — cache resolution", () => {
     const paths = installFsMocks({ existing: new Set([HF_CACHE, staleInstallDir]) });
     installPuppeteerBrowsersMock({
       installedInHfCache: [
-        { browser: "chrome-headless-shell", executablePath: HF_BINARY, path: staleInstallDir },
+        {
+          browser: "chrome-headless-shell",
+          executablePath: HF_BINARY,
+          path: staleInstallDir,
+          buildId: CHROME_VERSION,
+        },
       ],
       installResult: { executablePath: redownloadedBinary },
     });

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -228,7 +228,14 @@ async function findFromHyperframesCache(): Promise<CacheLookupResult> {
     );
     installed = [];
   }
-  const match = installed.find((b) => b.browser === Browser.CHROMEHEADLESSSHELL);
+  // Match on buildId too, not just browser type — an install left over from
+  // an older hyperframes version (this pin has moved 131 → 151 → 152 across
+  // releases) must NOT satisfy resolution, or an upgrade silently keeps
+  // running whatever build happened to be cached instead of ever fetching
+  // the version this release actually needs (HF#2060 review).
+  const match = installed.find(
+    (b) => b.browser === Browser.CHROMEHEADLESSSHELL && b.buildId === CHROME_VERSION,
+  );
   if (match && existsSync(match.executablePath)) {
     return { result: { executablePath: match.executablePath, source: "cache" } };
   }

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1708,6 +1708,7 @@ function trackRenderMetrics(
     speedRatio,
     captureAvgMs: perf?.captureAvgMs,
     captureP50Ms: perf?.captureP50Ms,
+    subTimelineWait: perf?.subTimelineWait,
     videoCount: perf?.videoCount,
     capturePeakMs: perf?.capturePeakMs,
     tmpPeakBytes: perf?.tmpPeakBytes,

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -148,6 +148,7 @@ export function trackRenderComplete(
     captureAvgMs?: number;
     /** Warmup-robust per-frame capture median (basis for speedup estimates). */
     captureP50Ms?: number;
+    subTimelineWait?: string;
     /** <video> element count (speedup segmentation: injection comps read lower). */
     videoCount?: number;
     capturePeakMs?: number;
@@ -221,6 +222,7 @@ export function trackRenderComplete(
       speed_ratio: props.speedRatio,
       capture_avg_ms: props.captureAvgMs,
       capture_p50_ms: props.captureP50Ms,
+      sub_timeline_wait: props.subTimelineWait,
       video_count: props.videoCount,
       capture_peak_ms: props.capturePeakMs,
       peak_memory_mb: props.peakMemoryMb,

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -1,8 +1,11 @@
 import { redactTelemetryString, type OutputResolutionIssueKind } from "@hyperframes/core";
+import type { SubTimelineWaitOutcome } from "@hyperframes/engine";
 import { trackEvent } from "./client.js";
 import { readConfig } from "./config.js";
 
 export interface RenderObservabilityTelemetryPayload {
+  /** Worst sub-composition timeline wait outcome across sessions. */
+  subTimelineWait?: SubTimelineWaitOutcome;
   observabilityRenderJobId?: string;
   observabilityCompositionHash?: string;
   observabilityEventCount?: number;
@@ -47,6 +50,7 @@ export interface RenderObservabilityTelemetryPayload {
 
 function renderObservabilityEventProperties(props: RenderObservabilityTelemetryPayload) {
   return {
+    sub_timeline_wait: props.subTimelineWait,
     observability_render_job_id: props.observabilityRenderJobId,
     observability_composition_hash: props.observabilityCompositionHash,
     observability_event_count: props.observabilityEventCount,
@@ -148,7 +152,6 @@ export function trackRenderComplete(
     captureAvgMs?: number;
     /** Warmup-robust per-frame capture median (basis for speedup estimates). */
     captureP50Ms?: number;
-    subTimelineWait?: string;
     /** <video> element count (speedup segmentation: injection comps read lower). */
     videoCount?: number;
     capturePeakMs?: number;
@@ -222,7 +225,6 @@ export function trackRenderComplete(
       speed_ratio: props.speedRatio,
       capture_avg_ms: props.captureAvgMs,
       capture_p50_ms: props.captureP50Ms,
-      sub_timeline_wait: props.subTimelineWait,
       video_count: props.videoCount,
       capture_peak_ms: props.capturePeakMs,
       peak_memory_mb: props.peakMemoryMb,

--- a/packages/cli/src/telemetry/renderObservability.ts
+++ b/packages/cli/src/telemetry/renderObservability.ts
@@ -58,7 +58,10 @@ export function renderObservabilityTelemetryPayload(
 export function renderJobObservabilityTelemetryPayload(
   job: RenderJob | undefined,
 ): RenderObservabilityTelemetryPayload {
-  return renderObservabilityTelemetryPayload(
-    job?.errorDetails?.observability ?? job?.perfSummary?.observability,
-  );
+  return {
+    ...renderObservabilityTelemetryPayload(
+      job?.errorDetails?.observability ?? job?.perfSummary?.observability,
+    ),
+    subTimelineWait: job?.errorDetails?.subTimelineWait ?? job?.perfSummary?.subTimelineWait,
+  };
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -40,6 +40,7 @@ export type {
   CaptureResult,
   CaptureBufferResult,
   CapturePerfSummary,
+  SubTimelineWaitOutcome,
 } from "./types.js";
 
 // ── Configuration ──────────────────────────────────────────────────────────────

--- a/packages/engine/src/services/frameCapture-subTimelinePoll.test.ts
+++ b/packages/engine/src/services/frameCapture-subTimelinePoll.test.ts
@@ -1,0 +1,66 @@
+/**
+ * pollSubCompositionTimelines fail-fast contract: a script resource that
+ * failed to load can never register its `window.__timelines[id]`, so the
+ * poll must cut to the short grace window instead of burning the full
+ * playerReadyTimeout (measured wild: a 705-render spike at the 45s setup
+ * bucket over 30 days — ~1% of local renders).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { Page } from "puppeteer-core";
+import { pollSubCompositionTimelines } from "./frameCapture.js";
+
+function makeMockPage(evaluateResults: (expr: string) => unknown): Page {
+  return {
+    evaluate: vi.fn(async (expr: string) => evaluateResults(expr)),
+  } as unknown as Page;
+}
+
+describe("pollSubCompositionTimelines fail-fast", () => {
+  it("returns ready and forces a timeline rebind when timelines register", async () => {
+    const page = makeMockPage(() => true);
+    const outcome = await pollSubCompositionTimelines(page, 1_000, 10);
+    expect(outcome).toBe("ready");
+    // Second evaluate is the __hfForceTimelineRebind call.
+    expect((page.evaluate as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+  });
+
+  it("bails after the grace window when a script resource failed to load", async () => {
+    const page = makeMockPage((expr) =>
+      expr.includes("__hfForceTimelineRebind") ? undefined : false,
+    );
+    const started = Date.now();
+    const outcome = await pollSubCompositionTimelines(
+      page,
+      60_000, // full timeout must NOT be waited
+      10,
+      () => ["http://localhost/animations.js"],
+      50, // grace
+    );
+    expect(outcome).toBe("script_failure");
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  it("waits the full timeout when timelines are missing but no script failed", async () => {
+    const page = makeMockPage(() => false);
+    const outcome = await pollSubCompositionTimelines(page, 120, 10, () => []);
+    expect(outcome).toBe("timeout");
+  });
+
+  it("keeps waiting through the grace window when failures appear but timelines register late", async () => {
+    let calls = 0;
+    const page = makeMockPage((expr) => {
+      if (expr.includes("__hfForceTimelineRebind")) return undefined;
+      calls++;
+      return calls >= 3; // registers on the 3rd poll tick, inside the grace window
+    });
+    const outcome = await pollSubCompositionTimelines(
+      page,
+      60_000,
+      10,
+      () => ["http://localhost/late.js"],
+      10_000, // generous grace — registration lands first
+    );
+    expect(outcome).toBe("ready");
+  });
+});

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -1214,18 +1214,24 @@ export async function pollSubCompositionTimelines(
     })()`);
     return "ready";
   }
-  if (!scriptFailureBail) {
-    const missing = await page.evaluate(`(function() {
-      var hosts = document.querySelectorAll("[data-composition-id]");
-      var timelines = window.__timelines || {};
-      var m = [];
-      for (var i = 0; i < hosts.length; i++) {
-        if (hosts[i].hasAttribute("data-no-timeline")) continue;
-        var id = hosts[i].getAttribute("data-composition-id");
-        if (id && !timelines[id]) m.push(id);
-      }
-      return m.join(", ");
-    })()`);
+  // Enumerate the still-unregistered composition ids regardless of bail
+  // reason — a script-failure bail used to skip this entirely, so a render
+  // with multiple sub-compositions only named the failed script URL(s), not
+  // which composition(s) it was still waiting on (review).
+  const missing = await page.evaluate(`(function() {
+    var hosts = document.querySelectorAll("[data-composition-id]");
+    var timelines = window.__timelines || {};
+    var m = [];
+    for (var i = 0; i < hosts.length; i++) {
+      if (hosts[i].hasAttribute("data-no-timeline")) continue;
+      var id = hosts[i].getAttribute("data-composition-id");
+      if (id && !timelines[id]) m.push(id);
+    }
+    return m.join(", ");
+  })()`);
+  if (scriptFailureBail) {
+    console.warn(`[FrameCapture] Composition(s) still waiting on the failed script: ${missing}.`);
+  } else {
     console.warn(
       `[FrameCapture] Sub-composition timelines not registered after ${timeoutMs}ms: ${missing}. ` +
         `Compositions that load data asynchronously (e.g. fetch) must register window.__timelines[id] after setup completes. ` +

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -95,6 +95,16 @@ export interface CaptureSession {
   pageReleased?: boolean;
   browserReleased?: boolean;
   browserConsoleBuffer: string[];
+  /**
+   * Script resources that failed to load (request failure or HTTP >= 400).
+   * pollSubCompositionTimelines fail-fasts on these: a comp whose timeline
+   * script 404'd can never register window.__timelines[id], so waiting the
+   * full playerReadyTimeout (45s) buys nothing (~1% of wild local renders
+   * were hitting that wall — a 705-render spike at the 45s setup bucket).
+   */
+  scriptLoadFailures: string[];
+  /** Outcome of the sub-composition timeline wait: ready | timeout | script_failure. */
+  subTimelineWaitOutcome?: "ready" | "timeout" | "script_failure";
   initTelemetry?: {
     initDurationMs: number;
     tweenCount: number;
@@ -929,6 +939,7 @@ export async function createCaptureSession(
     onBeforeCapture,
     isInitialized: false,
     browserConsoleBuffer: [],
+    scriptLoadFailures: [],
     capturePerf: {
       frames: 0,
       seekMs: 0,
@@ -999,21 +1010,6 @@ export function formatConsoleDiagnostic(
         : "[Browser]";
 
   return { text: `${prefix} ${text}`, suppressHostLog: false };
-}
-
-async function pollPageExpression(
-  page: Page,
-  expression: string,
-  timeoutMs: number,
-  intervalMs: number = 100,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const ready = Boolean(await page.evaluate(expression));
-    if (ready) return true;
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
-  }
-  return Boolean(await page.evaluate(expression));
 }
 
 const HF_READY_DIAGNOSTIC_EXPR = `(function() {
@@ -1151,11 +1147,19 @@ async function pollHfReady(page: Page, timeoutMs: number, intervalMs: number = 1
   );
 }
 
-async function pollSubCompositionTimelines(
+export async function pollSubCompositionTimelines(
   page: Page,
   timeoutMs: number,
   intervalMs: number = 150,
-): Promise<void> {
+  // Fail-fast hook: when a SCRIPT resource failed to load (404 / request
+  // failure), the timeline registration it carried can never arrive — the
+  // full-timeout wait buys nothing (measured: a 705-render spike at the 45s
+  // setup bucket in 30 days of wild local renders, ~1% of renders, each also
+  // shipping silently-broken animations). Once failures are present the poll
+  // is cut to `scriptFailureGraceMs` from its start.
+  getScriptLoadFailures?: () => readonly string[],
+  scriptFailureGraceMs: number = 2_000,
+): Promise<"ready" | "timeout" | "script_failure"> {
   // Hosts may opt out of the timeline wait with `data-no-timeline` —
   // compositions driven purely by CSS animations / rAF (the render-compat
   // contract) never register window.__timelines[id], and without the opt-out
@@ -1172,7 +1176,28 @@ async function pollSubCompositionTimelines(
     }
     return true;
   })()`;
-  const ready = await pollPageExpression(page, expression, timeoutMs, intervalMs);
+  const start = Date.now();
+  const deadline = start + timeoutMs;
+  let ready = false;
+  let scriptFailureBail = false;
+  for (;;) {
+    ready = Boolean(await page.evaluate(expression));
+    if (ready) break;
+    const now = Date.now();
+    if (now >= deadline) break;
+    const failures = getScriptLoadFailures?.() ?? [];
+    if (failures.length > 0 && now - start >= scriptFailureGraceMs) {
+      scriptFailureBail = true;
+      console.warn(
+        `[FrameCapture] Sub-composition timeline wait cut short after ${now - start}ms: ` +
+          `script resource(s) failed to load (${failures.join(", ")}) — ` +
+          `the timeline registration they carry can never arrive. ` +
+          `Fix the script reference; the render proceeds without those animations.`,
+      );
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
   // Always force a timeline rebind once sub-composition timelines are
   // confirmed present. The previous implementation only called rebind
   // when the timeline count grew during the poll, which missed the case
@@ -1186,8 +1211,9 @@ async function pollSubCompositionTimelines(
         window.__hfForceTimelineRebind();
       }
     })()`);
+    return "ready";
   }
-  if (!ready) {
+  if (!scriptFailureBail) {
     const missing = await page.evaluate(`(function() {
       var hosts = document.querySelectorAll("[data-composition-id]");
       var timelines = window.__timelines || {};
@@ -1205,6 +1231,7 @@ async function pollSubCompositionTimelines(
         `Compositions intentionally driven without GSAP timelines (CSS animations / rAF) can mark the host with data-no-timeline to skip this wait.`,
     );
   }
+  return scriptFailureBail ? "script_failure" : "timeout";
 }
 
 async function pollVideosReady(
@@ -1411,6 +1438,9 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   });
 
   page.on("requestfailed", (request) => {
+    if (request.resourceType() === "script") {
+      session.scriptLoadFailures.push(request.url());
+    }
     appendBrowserDiagnostic(
       session,
       formatRequestFailureDiagnostic({
@@ -1427,6 +1457,9 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     if (status < 400) return;
 
     const request = response.request();
+    if (request.resourceType() === "script") {
+      session.scriptLoadFailures.push(response.url());
+    }
     appendBrowserDiagnostic(
       session,
       formatHttpErrorDiagnostic({
@@ -1491,8 +1524,13 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     await pollHfReady(page, pageReadyTimeout);
     logInitPhase("pollHfReady complete");
 
-    await pollSubCompositionTimelines(page, pageReadyTimeout);
-    logInitPhase("pollSubCompositionTimelines complete");
+    session.subTimelineWaitOutcome = await pollSubCompositionTimelines(
+      page,
+      pageReadyTimeout,
+      undefined,
+      () => session.scriptLoadFailures,
+    );
+    logInitPhase(`pollSubCompositionTimelines complete (${session.subTimelineWaitOutcome})`);
 
     await applyVideoMetadataHints(page, session.options.videoMetadataHints);
     logInitPhase("applyVideoMetadataHints complete");
@@ -1626,8 +1664,13 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     throw err;
   }
 
-  await pollSubCompositionTimelines(page, pageReadyTimeout);
-  logInitPhase("pollSubCompositionTimelines complete");
+  session.subTimelineWaitOutcome = await pollSubCompositionTimelines(
+    page,
+    pageReadyTimeout,
+    undefined,
+    () => session.scriptLoadFailures,
+  );
+  logInitPhase(`pollSubCompositionTimelines complete (${session.subTimelineWaitOutcome})`);
 
   await applyVideoMetadataHints(page, session.options.videoMetadataHints);
   logInitPhase("applyVideoMetadataHints complete");
@@ -3086,6 +3129,7 @@ export function getCapturePerfSummary(session: CaptureSession): CapturePerfSumma
     avgBeforeCaptureMs: Math.round(session.capturePerf.beforeCaptureMs / frames),
     avgScreenshotMs: Math.round(session.capturePerf.screenshotMs / frames),
     p50TotalMs: medianOf(session.capturePerf.frameMs),
+    subTimelineWaitOutcome: session.subTimelineWaitOutcome,
     staticDedupReused: session.staticDedupCount ?? 0,
     staticDedupEnabled: session.staticDedupEnabled ?? false,
     // armed ⟺ a non-empty static set survived verification; predicted === its size.

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -50,6 +50,7 @@ import type {
   CaptureResult,
   CaptureBufferResult,
   CapturePerfSummary,
+  SubTimelineWaitOutcome,
 } from "../types.js";
 
 export type { CaptureOptions, CaptureResult, CaptureBufferResult, CapturePerfSummary };
@@ -104,7 +105,7 @@ export interface CaptureSession {
    */
   scriptLoadFailures: string[];
   /** Outcome of the sub-composition timeline wait: ready | timeout | script_failure. */
-  subTimelineWaitOutcome?: "ready" | "timeout" | "script_failure";
+  subTimelineWaitOutcome?: SubTimelineWaitOutcome;
   initTelemetry?: {
     initDurationMs: number;
     tweenCount: number;
@@ -1159,7 +1160,7 @@ export async function pollSubCompositionTimelines(
   // is cut to `scriptFailureGraceMs` from its start.
   getScriptLoadFailures?: () => readonly string[],
   scriptFailureGraceMs: number = 2_000,
-): Promise<"ready" | "timeout" | "script_failure"> {
+): Promise<SubTimelineWaitOutcome> {
   // Hosts may opt out of the timeline wait with `data-no-timeline` —
   // compositions driven purely by CSS animations / rAF (the render-compat
   // contract) never register window.__timelines[id], and without the opt-out
@@ -1408,6 +1409,16 @@ async function waitForOptionalTailwindReady(page: Page, timeoutMs: number): Prom
   }
 }
 
+// A 4xx `response` and a `requestfailed` can both fire for the same script
+// (e.g. a `requestfailed` following the 4xx), and repeated <script> tags for
+// the same URL duplicate it further — dedupe so the fail-fast warning names
+// each failed URL once.
+function recordScriptLoadFailure(session: CaptureSession, url: string): void {
+  if (!session.scriptLoadFailures.includes(url)) {
+    session.scriptLoadFailures.push(url);
+  }
+}
+
 // fallow-ignore-next-line unit-size
 export async function initializeSession(session: CaptureSession): Promise<void> {
   const { page, serverUrl } = session;
@@ -1439,7 +1450,7 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
 
   page.on("requestfailed", (request) => {
     if (request.resourceType() === "script") {
-      session.scriptLoadFailures.push(request.url());
+      recordScriptLoadFailure(session, request.url());
     }
     appendBrowserDiagnostic(
       session,
@@ -1458,7 +1469,7 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
 
     const request = response.request();
     if (request.resourceType() === "script") {
-      session.scriptLoadFailures.push(response.url());
+      recordScriptLoadFailure(session, response.url());
     }
     appendBrowserDiagnostic(
       session,

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -6,6 +6,13 @@
  */
 import type { Fps } from "@hyperframes/core";
 
+/**
+ * Outcome of waiting for a sub-composition's GSAP timelines to register.
+ * Threaded string-typed through `CapturePerfSummary` / `RenderPerfSummary` /
+ * telemetry so a single alias keeps the values in sync end-to-end.
+ */
+export type SubTimelineWaitOutcome = "ready" | "timeout" | "script_failure";
+
 // ── Seek Protocol ──────────────────────────────────────────────────────────────
 
 /**
@@ -183,8 +190,8 @@ export interface CapturePerfSummary {
    * averages). Basis for in-the-wild speedup estimates. 0 when no frames.
    */
   p50TotalMs: number;
-  /** Sub-composition timeline wait outcome: ready | timeout | script_failure (absent pre-init). */
-  subTimelineWaitOutcome?: string;
+  /** Sub-composition timeline wait outcome (absent pre-init). */
+  subTimelineWaitOutcome?: SubTimelineWaitOutcome;
   /**
    * Frames served from the static-dedup cache instead of a real seek+screenshot
    * (opt-out HF_STATIC_DEDUP=false). 0 when dedup was off or never armed. NOT counted

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -183,6 +183,8 @@ export interface CapturePerfSummary {
    * averages). Basis for in-the-wild speedup estimates. 0 when no frames.
    */
   p50TotalMs: number;
+  /** Sub-composition timeline wait outcome: ready | timeout | script_failure (absent pre-init). */
+  subTimelineWaitOutcome?: string;
   /**
    * Frames served from the static-dedup cache instead of a real seek+screenshot
    * (opt-out HF_STATIC_DEDUP=false). 0 when dedup was off or never armed. NOT counted

--- a/packages/producer/src/services/render/cleanup.ts
+++ b/packages/producer/src/services/render/cleanup.ts
@@ -5,7 +5,11 @@
 
 import { rmSync } from "node:fs";
 import { freemem } from "node:os";
-import { type CaptureSession, closeCaptureSession } from "@hyperframes/engine";
+import {
+  type CaptureSession,
+  type SubTimelineWaitOutcome,
+  closeCaptureSession,
+} from "@hyperframes/engine";
 import type { FileServerHandle } from "../fileServer.js";
 import { defaultLogger, type ProducerLogger } from "../../logger.js";
 import type { HdrDiagnostics, RenderJob } from "../renderOrchestrator.js";
@@ -82,6 +86,7 @@ export function buildRenderErrorDetails(input: {
   perfStages: Record<string, number>;
   hdrDiagnostics: HdrDiagnostics;
   observability?: RenderObservabilitySummary;
+  subTimelineWait?: SubTimelineWaitOutcome;
 }): NonNullable<RenderJob["errorDetails"]> {
   const errorMessage = normalizeErrorMessage(input.error);
   const errorStack = input.error instanceof Error ? input.error.stack : undefined;
@@ -99,5 +104,6 @@ export function buildRenderErrorDetails(input: {
         ? { ...input.hdrDiagnostics }
         : undefined,
     observability: input.observability,
+    subTimelineWait: input.subTimelineWait,
   };
 }

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -189,6 +189,16 @@ export function buildRenderPerfSummary(input: {
               input.totalFrames,
           )
         : undefined,
+    subTimelineWait: (() => {
+      const outcomes = input.dedupPerfs
+        .map((p) => p.subTimelineWaitOutcome)
+        .filter((o): o is string => !!o);
+      if (outcomes.length === 0) return undefined;
+      // Worst outcome wins: script_failure > timeout > ready.
+      if (outcomes.includes("script_failure")) return "script_failure";
+      if (outcomes.includes("timeout")) return "timeout";
+      return "ready";
+    })(),
     captureP50Ms: (() => {
       // Per-frame median from the engine's samples; when parallel workers
       // report separately, take the busiest session's median.

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -4,7 +4,7 @@
  */
 
 import { fpsToNumber } from "@hyperframes/core";
-import type { CapturePerfSummary } from "@hyperframes/engine";
+import type { CapturePerfSummary, SubTimelineWaitOutcome } from "@hyperframes/engine";
 import type { CaptureCalibrationSample, CaptureCostEstimate } from "./captureCost.js";
 import type {
   CaptureAttemptSummary,
@@ -14,6 +14,25 @@ import type {
 } from "../renderOrchestrator.js";
 import { type HdrPerfCollector, finalizeHdrPerf } from "./hdrPerf.js";
 import type { RenderObservabilitySummary } from "./observability.js";
+
+/**
+ * Worst sub-composition timeline wait outcome across sessions: script_failure
+ * > timeout > ready. Shared by the success-path perf summary and the error
+ * path (a fail-fast can still be followed by an unrelated downstream
+ * failure, e.g. in `pollVideosReady` or encode — that render fires
+ * `render_error`, not `render_complete`, and should carry this too).
+ */
+export function worstSubTimelineWaitOutcome(
+  perfs: CapturePerfSummary[],
+): SubTimelineWaitOutcome | undefined {
+  const outcomes = perfs
+    .map((p) => p.subTimelineWaitOutcome)
+    .filter((o): o is SubTimelineWaitOutcome => !!o);
+  if (outcomes.length === 0) return undefined;
+  if (outcomes.includes("script_failure")) return "script_failure";
+  if (outcomes.includes("timeout")) return "timeout";
+  return "ready";
+}
 
 /**
  * Append each parallel worker's static-dedup perf into the render-level sink
@@ -189,16 +208,7 @@ export function buildRenderPerfSummary(input: {
               input.totalFrames,
           )
         : undefined,
-    subTimelineWait: (() => {
-      const outcomes = input.dedupPerfs
-        .map((p) => p.subTimelineWaitOutcome)
-        .filter((o): o is string => !!o);
-      if (outcomes.length === 0) return undefined;
-      // Worst outcome wins: script_failure > timeout > ready.
-      if (outcomes.includes("script_failure")) return "script_failure";
-      if (outcomes.includes("timeout")) return "timeout";
-      return "ready";
-    })(),
+    subTimelineWait: worstSubTimelineWaitOutcome(input.dedupPerfs),
     captureP50Ms: (() => {
       // Per-frame median from the engine's samples; when parallel workers
       // report separately, take the busiest session's median.

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -322,6 +322,8 @@ export interface RenderPerfSummary {
    * captured the most frames when parallel workers report separately.
    */
   captureP50Ms?: number;
+  /** Worst sub-composition timeline wait outcome across sessions: ready | timeout | script_failure. */
+  subTimelineWait?: string;
   capturePeakMs?: number;
   captureCalibration?: {
     sampledFrames: number[];

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -67,6 +67,7 @@ import {
   LOW_MEMORY_TOTAL_MB_THRESHOLD,
   assertConfiguredFfmpegBinariesExist,
   type CapturePerfSummary,
+  type SubTimelineWaitOutcome,
   resolveBrowserGpuMode,
   resolveHeadlessShellPath,
   scaleProtocolTimeoutForComposition,
@@ -90,7 +91,11 @@ import { buildRenderErrorDetails, cleanupRenderResources, safeCleanup } from "./
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
 import { formatCaptureFrameName } from "../utils/paths.js";
 import { resolveEffectiveHdrMode } from "./render/hdrMode.js";
-import { buildRenderPerfSummary, pushWorkerDedupPerfs } from "./render/perfSummary.js";
+import {
+  buildRenderPerfSummary,
+  pushWorkerDedupPerfs,
+  worstSubTimelineWaitOutcome,
+} from "./render/perfSummary.js";
 import { getCaptureStageBrowserConsole } from "./render/captureStageError.js";
 import { resolveVideoCaptureBeyondViewport } from "./render/captureBeyondViewport.js";
 import {
@@ -322,8 +327,8 @@ export interface RenderPerfSummary {
    * captured the most frames when parallel workers report separately.
    */
   captureP50Ms?: number;
-  /** Worst sub-composition timeline wait outcome across sessions: ready | timeout | script_failure. */
-  subTimelineWait?: string;
+  /** Worst sub-composition timeline wait outcome across sessions. */
+  subTimelineWait?: SubTimelineWaitOutcome;
   capturePeakMs?: number;
   captureCalibration?: {
     sampledFrames: number[];
@@ -457,6 +462,8 @@ export interface RenderJob {
     perfStages?: Record<string, number>;
     hdrDiagnostics?: HdrDiagnostics;
     observability?: RenderObservabilitySummary;
+    /** Worst sub-composition timeline wait outcome across sessions captured before the failure. */
+    subTimelineWait?: SubTimelineWaitOutcome;
   };
 }
 
@@ -1189,6 +1196,11 @@ export async function executeRenderJob(
   // can read it — the catch records transient-retry burn on renders that still
   // failed, which is the more actionable signal for tuning the retry cap.
   const captureAttempts: CaptureAttemptSummary[] = [];
+  // Static-dedup perf, appended per sequential session / per parallel worker
+  // by the capture stage. Also function-scoped so the catch block can read
+  // the sub-timeline-wait outcome for a render that fails downstream of a
+  // fail-fast (aggregated into the success-path perf summary below too).
+  const dedupPerfs: CapturePerfSummary[] = [];
   const recordTransientRetryObservability = (): void => {
     const count = captureAttempts.filter((a) => a.reason === "transient-retry").length;
     if (count > 0) updateCaptureObservability({ transientRetries: count });
@@ -1824,11 +1836,6 @@ export async function executeRenderJob(
       }
     }
 
-    // `captureAttempts` is declared at function scope above (shared with the
-    // catch block). Static-dedup perf, appended per sequential session / per
-    // parallel worker by the capture stage, aggregated into the perf summary below.
-    const dedupPerfs: CapturePerfSummary[] = [];
-
     // png-sequence is "no container" — outputPath is treated as a directory and
     // the encode/mux/faststart stages are skipped entirely. The empty extension
     // keeps `videoOnlyPath` (which is constructed below) sensible even though
@@ -2434,6 +2441,7 @@ export async function executeRenderJob(
       perfStages,
       hdrDiagnostics,
       observability: observabilitySummary,
+      subTimelineWait: worstSubTimelineWaitOutcome(dedupPerfs),
     });
 
     log.info("[Render] Failure summary", {


### PR DESCRIPTION
## Why

`pollSubCompositionTimelines` waits for every `[data-composition-id]` host to register `window.__timelines[id]`. When the script carrying that registration **fails to load** (404 / request failure), the registration can never arrive — but the poll still burned the full `playerReadyTimeout` (**45 seconds**), then warned and shipped a silently animation-less render. The engine was logging the exact load failure and waiting anyway.

**Wild scale** (30 days, local renders, n=89,786): the capture-setup histogram decays smoothly — 402/503/364/282/191 per 5s bucket — then **spikes to 705 at the 45s bucket**. A textbook timeout wall: ~1,000 renders/month across **402 distinct users**, ≈15 user-hours of pure waiting, each render also delivering broken animations with only a console warn.

Found while benchmarking comp `0768f038`: its "45s init" was 99% this one poll phase (139ms → 45,203ms) — its `animations.js` was unreachable.

## What

- **Sessions record failed script resources** (`requestfailed` + HTTP ≥ 400 responses with `resourceType === "script"` — extending the diagnostic listeners that already existed) in `session.scriptLoadFailures`.
- **The poll fail-fasts**: once any script has failed, the wait cuts to a **2s grace** with a loud warning naming the URL(s). Late-registering fetch-async comps are untouched — no script failure means the full 45s still applies, and a registration landing inside the grace window still wins (unit-tested).
- **Outcome telemetry**: `sub_timeline_wait` (`"ready" | "timeout" | "script_failure"`) on `render_complete`, threaded session → `CapturePerfSummary` → `RenderPerfSummary` (worst across sessions) → CLI. The wild rate becomes a direct filter instead of setup-histogram forensics.

## Validation

- **Discovery comp e2e**: total render **~72s → 23.1s** — poll cut at 2.1s, warning names the script, render completes; healthy comp reports `ready`. Telemetry smoke: `subTimelineWait: "script_failure"` / `"ready"` respectively.
- Canary suite 7/7, PSNRs identical to baseline.
- 4 new unit tests on the poll contract (ready / fail-fast / full-timeout-when-healthy / late-registration-inside-grace).
- Engine suite: 907 passed; the 14 failures are **pre-existing on main at v0.7.42** (18 fail on a clean checkout — stash A/B verified; `parseVideoElements`/color-grading, untouched by this diff).
- tsc/oxlint/oxfmt clean. The now-orphaned `pollPageExpression` helper was removed.

## Corpus note

258/1,762 corpus comps (14%) reference local scripts missing from the corpus fetch — historical eval **init** timings on those comps measured this timeout, not the engine. Capture-stage ratios remain valid (both paths paid it equally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
