### PR TITLE
fix(cli): add --no-clipboard throws 'Unknown flag: --clipboard' [P2]

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -238,9 +238,15 @@ export default defineCommand({
       type: "string",
       description: "Project directory (defaults to the current working directory)",
     },
-    "no-clipboard": {
+    clipboard: {
+      // Declared as the positive `clipboard` (default on) so citty's built-in
+      // `--no-<name>` negation handles `--no-clipboard`. Declaring the arg
+      // literally as `"no-clipboard"` made citty parse `--no-clipboard` as the
+      // negation of a (nonexistent) `clipboard` arg, so assertKnownFlags threw
+      // "Unknown flag: --clipboard" even though --help advertised it.
       type: "boolean",
-      description: "Skip copying the include snippet to the clipboard",
+      default: true,
+      description: "Copy the include snippet to the clipboard (use --no-clipboard to skip)",
     },
     json: {
       type: "boolean",
@@ -250,7 +256,7 @@ export default defineCommand({
   async run({ args }) {
     const projectDir = resolve(args.dir ?? process.cwd());
     const json = args.json === true;
-    const skipClipboard = args["no-clipboard"] === true;
+    const skipClipboard = args.clipboard === false;
     const hasConfigBefore = existsSync(projectConfigPath(projectDir));
 
     // Try single item first. If it fails, check if the name matches a tag.


### PR DESCRIPTION
## Bug
`hyperframes add <name> --no-clipboard` errored `Error: Unknown flag: --clipboard` (from `assertKnownFlags`), even though `--help` lists `--no-clipboard` as valid. Reported via CLI feedback (2026-07-08).

## Cause
The arg was declared literally as `"no-clipboard"`. citty treats `--no-<name>` as the **negation** of a boolean `<name>` arg, so `--no-clipboard` parsed as negating a nonexistent `clipboard` arg → unknown flag.

## Fix
Declare the positive `clipboard` (`type: boolean, default: true`) and read `args.clipboard === false`. citty's native `--no-<name>` negation then handles `--no-clipboard`. `--help` still shows both spellings.

## Verified
`hyperframes add data-chart --no-clipboard` → `✓ Added data-chart` (previously errored on the flag).