### PR TITLE
fix(cli): report unknown-flag errors + cover nested subcommands (HF#2033) [P2]

### DIFF
--- a/packages/cli/src/utils/command-failure-tracking.test.ts
+++ b/packages/cli/src/utils/command-failure-tracking.test.ts
@@ -59,6 +59,46 @@ describe("trackCommandFailures", () => {
     const cmd = await wrapped();
     await expect((cmd.run as () => Promise<unknown>)()).rejects.toBe(boom);
   });
+
+  it("REPORTS an unknown-flag rejection to onFailure (HF#2033: assertion inside the try)", async () => {
+    // The flag assertion used to run before the try/catch, so an unknown-flag
+    // throw skipped telemetry. It must now be reported like any other failure.
+    const onFailure = vi.fn();
+    const cmd = {
+      meta: { name: "render" },
+      args: { output: { type: "string", alias: "o" } },
+      run: vi.fn(() => Promise.resolve()),
+    } as unknown as CommandDef;
+    const wrapped = trackCommandFailures(() => Promise.resolve(cmd), onFailure);
+
+    const resolved = await wrapped();
+    await expect(
+      (resolved.run as (ctx: unknown) => Promise<unknown>)({ rawArgs: ["--nope", "x"] }),
+    ).rejects.toThrow(/unknown flag/i);
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(cmd.run).not.toHaveBeenCalled(); // body never ran — flag rejected first
+  });
+
+  it("recursively wraps nested subcommands so their failures report too (HF#2033)", async () => {
+    // cli.ts wraps only top-level loaders; a group's leaves (cloud/*, auth/*, …)
+    // were never wrapped, silently dropping unknown-flag + failure telemetry.
+    const onFailure = vi.fn();
+    const boom = new Error("nested boom");
+    const group: CommandDef = {
+      meta: { name: "cloud" },
+      subCommands: {
+        render: defineRun(() => Promise.reject(boom)),
+      },
+    };
+    const wrapped = trackCommandFailures(() => Promise.resolve(group), onFailure);
+
+    const resolvedGroup = await wrapped();
+    const subLoader = (resolvedGroup.subCommands as Record<string, () => Promise<CommandDef>>)
+      .render;
+    const leaf = await subLoader();
+    await expect((leaf.run as () => Promise<unknown>)()).rejects.toBe(boom);
+    expect(onFailure).toHaveBeenCalledWith(boom);
+  });
 });
 
 describe("reportCommandFailure", () => {

--- a/packages/cli/src/utils/command-failure-tracking.test.ts
+++ b/packages/cli/src/utils/command-failure-tracking.test.ts
@@ -95,6 +95,7 @@ describe("trackCommandFailures", () => {
     const resolvedGroup = await wrapped();
     const subLoader = (resolvedGroup.subCommands as Record<string, () => Promise<CommandDef>>)
       .render;
+    if (!subLoader) throw new Error("expected a wrapped 'render' subcommand loader");
     const leaf = await subLoader();
     await expect((leaf.run as () => Promise<unknown>)()).rejects.toBe(boom);
     expect(onFailure).toHaveBeenCalledWith(boom);

--- a/packages/cli/src/utils/command-failure-tracking.ts
+++ b/packages/cli/src/utils/command-failure-tracking.ts
@@ -23,31 +23,62 @@ export function trackCommandFailures(
   load: () => Promise<AnyCommandDef>,
   onFailure: (err: unknown) => void | Promise<void>,
 ): () => Promise<AnyCommandDef> {
-  return () =>
-    load().then((cmd) => {
-      const run = cmd.run;
-      if (typeof run !== "function") return cmd;
-      return {
-        ...cmd,
-        run: async (ctx: Parameters<typeof run>[0]) => {
-          // Reject unknown flags before the command runs: citty silently ignores
-          // them otherwise, dropping the value (e.g. `render --out x` fell back
-          // to the default output path). A leaf command with a `run` is the right
-          // place — nested command groups delegate to their own subcommands.
-          assertKnownFlags(cmd, ctx?.rawArgs ?? []);
-          try {
-            return await run(ctx);
-          } catch (err) {
-            try {
-              await onFailure(err);
-            } catch {
-              // Telemetry must never mask the real command failure.
-            }
-            throw err;
-          }
-        },
-      };
-    });
+  return () => load().then((cmd) => wrapCommand(cmd, onFailure));
+}
+
+/**
+ * Wrap a resolved command's `run` (assert-flags + report-failure) AND
+ * recursively wrap every entry in its `subCommands`. Two HF#2033 fixes live
+ * here:
+ *   1. `assertKnownFlags` runs INSIDE the try, so an unknown-flag throw is
+ *      routed through `onFailure` (telemetry) like any other failure — it
+ *      used to throw before the try and lose the event entirely.
+ *   2. Recursion covers nested command groups (`cloud/*`, `auth/*`, `figma/*`,
+ *      `lambda/*`, `capture/*`, `skills`). cli.ts only wraps the top-level
+ *      loaders, so before this a `hyperframes cloud render --badflag` silently
+ *      ignored the flag and reported nothing — citty dispatches to the leaf,
+ *      whose `run` was never wrapped.
+ */
+function wrapCommand(
+  cmd: AnyCommandDef,
+  onFailure: (err: unknown) => void | Promise<void>,
+): AnyCommandDef {
+  const run = cmd.run;
+  // Nothing to wrap (no run, no nested subcommands) — preserve identity.
+  if (typeof run !== "function" && !cmd.subCommands) return cmd;
+
+  const wrapped: AnyCommandDef = { ...cmd };
+  if (typeof run === "function") {
+    wrapped.run = async (ctx: Parameters<typeof run>[0]) => {
+      try {
+        // Reject unknown flags before the command body: citty silently ignores
+        // them otherwise, dropping the value (e.g. `render --out x` fell back to
+        // the default output path). Inside the try so the rejection is reported.
+        assertKnownFlags(cmd, ctx?.rawArgs ?? []);
+        return await run(ctx);
+      } catch (err) {
+        try {
+          await onFailure(err);
+        } catch {
+          // Telemetry must never mask the real command failure.
+        }
+        throw err;
+      }
+    };
+  }
+  if (cmd.subCommands) {
+    const wrappedSubs: Record<string, () => Promise<AnyCommandDef>> = {};
+    for (const [name, sub] of Object.entries(cmd.subCommands)) {
+      // citty subCommands are Resolvable<CommandDef>: a def, a promise, or a
+      // (possibly async) loader. Normalize to a loader that resolves then wraps.
+      wrappedSubs[name] = () =>
+        Promise.resolve(typeof sub === "function" ? (sub as () => unknown)() : sub).then((c) =>
+          wrapCommand(c as AnyCommandDef, onFailure),
+        );
+    }
+    wrapped.subCommands = wrappedSubs;
+  }
+  return wrapped;
 }
 
 /**


### PR DESCRIPTION
Addresses the two OPEN items from Rames' HF#2033 review (the load-bearing hardening behind the flag-hygiene arc, e.g. #2067).

## 1. Unknown-flag errors weren't reported to telemetry
`assertKnownFlags` ran **before** the `try/catch` in the command wrapper, so an unknown-flag throw bypassed `reportCommandFailure` — no signal on how often users hit bad flags. Moved the assertion **inside** the try so it's reported like any other failure.

## 2. Nested command groups weren't covered
`cli.ts` wraps only the **top-level** command loaders. citty dispatches `hyperframes cloud render --badflag` to the `render` **leaf**, whose `run` was never wrapped — so nested groups (`cloud/*`, `auth/*`, `figma/*`, `lambda/*`, `capture/*`, `skills`) **silently ignored unknown flags** and reported nothing. `trackCommandFailures` now recurses through `cmd.subCommands` (normalizing citty's `Resolvable` entries to loaders) and wraps every leaf. Object identity is preserved for bare no-run/no-subcommand defs.

## Verified E2E
- `auth status --badflag` → **`Error: Unknown flag: --badflag`** (previously silently ignored)
- `auth --help` still dispatches correctly (no regression)
- top-level `lint --badflag` still rejected

## Tests
+2: an unknown-flag rejection is routed through `onFailure`; a nested subcommand's failure reaches `onFailure`. 15 tracker+reject tests pass.