### PR TITLE
feat(lint): warn on repeated tl.fromTo() on one selector without a tl.set baseline [P2]

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -978,6 +978,91 @@ describe("GSAP rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("warns when repeated tl.fromTo calls target one selector without a tl.set baseline", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080" data-start="0">
+    <div id="overlay"><div class="cell"></div></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#overlay .cell", { opacity: 0, zIndex: 999 }, { opacity: 1, duration: 0.25 }, 1);
+    tl.fromTo("#overlay .cell", { opacity: 0, scale: 0.9 }, { opacity: 1, scale: 1, duration: 0.25 }, 3);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_repeated_fromto_without_baseline");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("warning");
+    expect(finding?.selector).toBe("#overlay .cell");
+  });
+
+  it("does not warn when repeated tl.fromTo calls have an earlier tl.set baseline", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080" data-start="0">
+    <div id="overlay"><div class="cell"></div></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.set("#overlay .cell", { opacity: 0, scale: 1 }, 0);
+    tl.fromTo("#overlay .cell", { opacity: 0, zIndex: 999 }, { opacity: 1, duration: 0.25 }, 1);
+    tl.fromTo("#overlay .cell", { opacity: 0, scale: 0.9 }, { opacity: 1, scale: 1, duration: 0.25 }, 3);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_repeated_fromto_without_baseline");
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not warn for a single tl.fromTo call on a selector", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080" data-start="0">
+    <div id="overlay"><div class="cell"></div></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#overlay .cell", { opacity: 0, y: 20 }, { opacity: 1, y: 0, duration: 0.25 }, 1);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_repeated_fromto_without_baseline");
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not warn when tl.fromTo calls target different selectors", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080" data-start="0">
+    <div id="overlay">
+      <div class="cell-a"></div>
+      <div class="cell-b"></div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#overlay .cell-a", { opacity: 0, zIndex: 999 }, { opacity: 1, duration: 0.25 }, 1);
+    tl.fromTo("#overlay .cell-b", { opacity: 0, scale: 0.9 }, { opacity: 1, scale: 1, duration: 0.25 }, 3);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_repeated_fromto_without_baseline");
+    expect(finding).toBeUndefined();
+  });
+
   it("warns when an opacity exit ends at a clip start boundary without a hard kill", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -618,6 +618,57 @@ export const gsapRules: LintRule<LintContext>[] = [
         }
       }
 
+      // gsap_repeated_fromto_without_baseline
+      const fromToWindowsBySelector = new Map<string, GsapWindow[]>();
+      for (const win of gsapWindows) {
+        if (win.method !== "fromTo") continue;
+        if (win.targetSelector === UNRESOLVED_TARGET) continue;
+        const windows = fromToWindowsBySelector.get(win.targetSelector) ?? [];
+        windows.push(win);
+        fromToWindowsBySelector.set(win.targetSelector, windows);
+      }
+
+      const repeatedFromToSelectors = [...fromToWindowsBySelector.values()].filter(
+        (windows) => windows.length >= 2,
+      );
+      const standaloneSetSelectors =
+        repeatedFromToSelectors.length > 0
+          ? new Set(
+              extractStandaloneGsapTransformCalls(stripJsComments(script.content))
+                .filter((call) => call.method === "set")
+                .map((call) => call.selector),
+            )
+          : new Set<string>();
+
+      for (const fromToWindows of repeatedFromToSelectors) {
+        const selector = fromToWindows[0]?.targetSelector;
+        if (!selector) continue;
+        const firstFromToPosition = Math.min(...fromToWindows.map((win) => win.position));
+        const hasTimelineBaseline = gsapWindows.some(
+          (candidate) =>
+            candidate.method === "set" &&
+            candidate.targetSelector === selector &&
+            candidate.position <= firstFromToPosition,
+        );
+        if (hasTimelineBaseline || standaloneSetSelectors.has(selector)) continue;
+
+        findings.push({
+          code: "gsap_repeated_fromto_without_baseline",
+          severity: "warning",
+          message:
+            `${fromToWindows.length} tl.fromTo() calls target "${selector}" with no earlier tl.set() baseline. ` +
+            `The last-authored fromTo "from" values become the element's resting state for any seek before ` +
+            `the first tween actually runs, because GSAP applies fromTo from-values at authoring time ` +
+            `(immediateRender), not at tween position.`,
+          selector,
+          fixHint:
+            `Add \`tl.set("${selector}", { ...safe resting values... }, 0)\` as an explicit baseline before ` +
+            `the first fromTo, so pre-first-tween seeks have a defined, deterministic resting state instead ` +
+            `of inheriting whichever fromTo call happened to author last.`,
+          snippet: truncateSnippet(fromToWindows.map((win) => win.raw).join("\n")),
+        });
+      }
+
       // gsap_exit_missing_hard_kill
       if (clipStartBoundaries.length > 0) {
         for (const win of gsapWindows) {


### PR DESCRIPTION
## Bug

`tl.fromTo(SELECTOR, { from }, { to }, laterTime)` applies its `from` values
to the DOM at authoring time (GSAP's immediateRender), regardless of the
tween's timeline position. When the same string-literal selector gets 2+
`tl.fromTo()` calls with no earlier `tl.set()` baseline, the last-authored
`from` becomes the element's resting state for any seek before the first
tween actually runs, e.g. a z-index:999 overlay rendered solid black across
~40% of the timeline. `hyperframes lint`/`validate`/`inspect` all pass clean
today for this pattern.

## Fix

New warning-severity rule: `gsap_repeated_fromto_without_baseline`, extending
the existing GSAP static analysis in `packages/lint/src/rules/gsap.ts`.

Per script/timeline: groups `fromTo` GSAP windows by target selector; for any
selector with 2+ `fromTo` calls, checks for a `tl.set`/`gsap.set` baseline on
that exact selector (before or at the first `fromTo`). If no baseline exists,
fires one finding per offending selector with a `fixHint` suggesting
`tl.set(selector, { ...safe resting values... }, 0)`.

## False-positive guards

This repo has a real history of GSAP false positives, so the rule is
conservative:

- Byte-identical string-literal selector matching only, no normalization or
  token/substring matching.
- Selectors the parser can't statically resolve (dynamic/variable selectors)
  never fire.
- A single `fromTo` call on a selector never fires.
- Two `fromTo` calls on different selectors never fire together.
- Any `tl.set`/`gsap.set` on the exact same literal selector suppresses the
  finding.

## Tests

Added 4 tests to `packages/lint/src/rules/gsap.test.ts`:
- warns when repeated `tl.fromTo` calls target one selector without a
  `tl.set` baseline
- does not warn when repeated `tl.fromTo` calls have an earlier `tl.set`
  baseline
- does not warn for a single `tl.fromTo` call on a selector
- does not warn when `tl.fromTo` calls target different selectors

`bunx vitest run packages/lint/src/rules/gsap.test.ts`: 86 passed.
`bunx oxlint` / `bunx oxfmt --check`: clean.
