### PR TITLE
chore(cli): R1 follow-ups — add-flag test, webm-alpha telemetry, subcomp-media comment [P2]

### DIFF
--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -20,6 +20,7 @@ const {
   trackFigmaImport,
   trackRenderFeedback,
   trackRenderPreflightRejected,
+  trackWebmAlphaDropped,
   trackAuthLoginStarted,
   trackAuthLoginCompleted,
   trackAuthLoginFailed,
@@ -196,6 +197,18 @@ describe("trackCommandFailure", () => {
         error_message: "No words found in transcript.",
       }),
     );
+  });
+});
+
+describe("trackWebmAlphaDropped", () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+  });
+
+  it("emits a minimal dropped-alpha event", () => {
+    trackWebmAlphaDropped();
+
+    expect(trackEvent).toHaveBeenCalledWith("webm_alpha_dropped", {});
   });
 });
 

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -488,6 +488,12 @@ export function trackTranscribeUnavailable(props: { optional: boolean }): void {
   trackEvent("transcribe_unavailable", { optional: props.optional });
 }
 
+// Track dropped WebM alpha as an environment signal, so fleet telemetry can
+// reveal ffmpeg/libvpx-vp9 builds and OS combinations that need MOV fallback.
+export function trackWebmAlphaDropped(): void {
+  trackEvent("webm_alpha_dropped", {});
+}
+
 // A skills install was skipped because a required prerequisite binary is
 // absent from PATH (e.g. git on a fresh Windows box). Best-effort callers
 // (init) skip cleanly rather than crash, so the skip is otherwise invisible;

--- a/packages/cli/src/utils/reject-unknown-flags.test.ts
+++ b/packages/cli/src/utils/reject-unknown-flags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ArgsDef, CommandDef } from "citty";
+import addCmd from "../commands/add.js";
 import { assertKnownFlags } from "./reject-unknown-flags.js";
 
 const cmd = {
@@ -37,6 +38,10 @@ describe("assertKnownFlags", () => {
 
   it("accepts --no-<boolean> negation", () => {
     expect(ok(["--no-docker"])).not.toThrow();
+  });
+
+  it("accepts add command --no-clipboard negation", () => {
+    expect(() => assertKnownFlags(addCmd, ["shader-wipe", "--no-clipboard"])).not.toThrow();
   });
 
   it("accepts global flags and stops at --", () => {

--- a/packages/cli/src/utils/reject-unknown-flags.ts
+++ b/packages/cli/src/utils/reject-unknown-flags.ts
@@ -53,7 +53,7 @@ function unknownFlagIn(tok: string, known: Set<string>): string | null {
  * + the global set). Only dash-prefixed tokens are inspected, so positionals and
  * flag values pass through untouched. Stops at `--`.
  */
-export function assertKnownFlags(cmd: CommandDef<ArgsDef>, rawArgs: string[]): void {
+export function assertKnownFlags<T extends ArgsDef>(cmd: CommandDef<T>, rawArgs: string[]): void {
   if (!Array.isArray(rawArgs)) return;
   // citty types `args` as Resolvable<ArgsDef> (it may be a fn/promise); every
   // hyperframes command uses a static object, so treat anything else as "no

--- a/packages/cli/src/utils/webmAlphaCheck.test.ts
+++ b/packages/cli/src/utils/webmAlphaCheck.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, it } from "vitest";
-import { webmAlphaAdvisory } from "./webmAlphaCheck.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileSync = vi.fn();
+const findFFprobe = vi.fn();
+const trackWebmAlphaDropped = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSync(...args),
+}));
+
+vi.mock("../browser/ffmpeg.js", () => ({
+  findFFprobe: () => findFFprobe(),
+}));
+
+vi.mock("../telemetry/events.js", () => ({
+  trackWebmAlphaDropped: () => trackWebmAlphaDropped(),
+}));
+
+const { webmAlphaAdvisory, warnIfWebmAlphaDropped } = await import("./webmAlphaCheck.js");
+
+beforeEach(() => {
+  execFileSync.mockReset();
+  findFFprobe.mockReset();
+  trackWebmAlphaDropped.mockReset();
+});
 
 describe("webmAlphaAdvisory", () => {
   it("warns when a probed webm lacks the ALPHA_MODE sidecar tag", () => {
@@ -25,5 +48,29 @@ describe("webmAlphaAdvisory", () => {
   it("stays silent for non-webm formats (mp4 opaque; mov carries alpha natively)", () => {
     expect(webmAlphaAdvisory("mp4", { probed: true, alphaMode: false })).toBeUndefined();
     expect(webmAlphaAdvisory("mov", { probed: true, alphaMode: false })).toBeUndefined();
+  });
+});
+
+describe("warnIfWebmAlphaDropped", () => {
+  it("tracks telemetry when a completed WebM lost alpha", () => {
+    findFFprobe.mockReturnValue("/usr/bin/ffprobe");
+    execFileSync.mockReturnValue(JSON.stringify({ streams: [{ codec_name: "vp9", tags: {} }] }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      warnIfWebmAlphaDropped("out.webm", "webm", false);
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(trackWebmAlphaDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not track telemetry when quiet or not rendering WebM", () => {
+    warnIfWebmAlphaDropped("out.webm", "webm", true);
+    warnIfWebmAlphaDropped("out.mp4", "mp4", false);
+
+    expect(trackWebmAlphaDropped).not.toHaveBeenCalled();
+    expect(findFFprobe).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/utils/webmAlphaCheck.ts
+++ b/packages/cli/src/utils/webmAlphaCheck.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { findFFprobe } from "../browser/ffmpeg.js";
+import { trackWebmAlphaDropped } from "../telemetry/events.js";
 import { c } from "../ui/colors.js";
 
 /**
@@ -96,6 +97,7 @@ export function warnIfWebmAlphaDropped(outputPath: string, format: string, quiet
   if (quiet || format !== "webm") return;
   const advisory = webmAlphaAdvisory(format, probeWebmAlpha(outputPath));
   if (!advisory) return;
+  trackWebmAlphaDropped();
   console.warn(`\n${c.warn("⚠")}  ${c.bold("Transparency not preserved")}`);
   console.warn(`   ${c.dim(advisory)}\n`);
 }

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -1920,6 +1920,11 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
       if (!id) return;
 
       const src = htmlEl.src || htmlEl.getAttribute("src") || "";
+      // These parseFloat calls assume the runtime start resolver has already
+      // numericized data-start before this browser evaluate() runs. If a
+      // dynamic-src regression lets a nonnumeric data-start reach here,
+      // parseFloat silently yields NaN and drops timing. See #2062 and
+      // packages/core/src/runtime/startResolver.ts for the invariant.
       const start = parseFloat(htmlEl.getAttribute("data-start") || "0");
       const end = parseFloat(htmlEl.getAttribute("data-end") || "0");
       const duration = parseFloat(htmlEl.getAttribute("data-duration") || "0");


### PR DESCRIPTION
- #2067: packages/cli/src/utils/reject-unknown-flags.test.ts adds coverage for add --no-clipboard flag negation.
- #2044: packages/cli/src/telemetry/events.ts and packages/cli/src/utils/webmAlphaCheck.ts emit telemetry when WebM alpha is dropped.
- #2062: packages/producer/src/services/htmlCompiler.ts documents the numeric data-start invariant for browser media discovery.
