### PR TITLE
fix(cli): actionable remediation for chrome-headless-shell SIGTRAP on arm64 macOS [P2]

### DIFF
--- a/packages/cli/src/browser/macosChromeCrash.test.ts
+++ b/packages/cli/src/browser/macosChromeCrash.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { macosChromeCrashRemediation } from "./macosChromeCrash.js";
+
+describe("macosChromeCrashRemediation", () => {
+  it.each([
+    ["darwin", "arm64"],
+    ["darwin", "x64"],
+    ["linux", "arm64"],
+  ] as const)("returns undefined for unrelated errors on %s/%s", (platform, arch) => {
+    expect(macosChromeCrashRemediation("Composition has zero duration", platform, arch)).toBe(
+      undefined,
+    );
+  });
+
+  it("returns undefined on Intel macOS for browser crash messages", () => {
+    expect(macosChromeCrashRemediation("Page crashed!", "darwin", "x64")).toBe(undefined);
+  });
+
+  it("returns undefined on non-macOS platforms for browser crash messages", () => {
+    expect(macosChromeCrashRemediation("Target closed", "linux", "arm64")).toBe(undefined);
+    expect(macosChromeCrashRemediation("Target closed", "win32", "arm64")).toBe(undefined);
+  });
+
+  it.each(["Target closed", "Page crashed!"])(
+    "returns Docker guidance on Apple Silicon macOS for %s",
+    (message) => {
+      const remediation = macosChromeCrashRemediation(message, "darwin", "arm64");
+
+      expect(remediation).toBeDefined();
+      expect(remediation).toContain("known chrome-headless-shell crash pattern");
+      expect(remediation).toContain("HYPERFRAMES_DOCKER_PLATFORM=linux/amd64");
+      expect(remediation).toContain("--docker");
+      expect(remediation).toContain("native macOS browser");
+      expect(remediation).toContain("HYPERFRAMES_BROWSER_PATH");
+    },
+  );
+});

--- a/packages/cli/src/browser/macosChromeCrash.ts
+++ b/packages/cli/src/browser/macosChromeCrash.ts
@@ -1,0 +1,20 @@
+import { isTransientBrowserError } from "@hyperframes/engine";
+
+export function macosChromeCrashRemediation(
+  errorMessage: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): string | undefined {
+  if (platform !== "darwin" || arch !== "arm64") return undefined;
+  if (!isTransientBrowserError(errorMessage)) return undefined;
+
+  const lines: string[] = [];
+  lines.push("This matches a known chrome-headless-shell crash pattern on Apple Silicon macOS.");
+  lines.push(
+    "Re-run with Docker to render inside a Linux container instead of the native macOS browser:",
+  );
+  lines.push("  HYPERFRAMES_DOCKER_PLATFORM=linux/amd64 npx hyperframes render --docker");
+  lines.push("Or point HyperFrames at a different local Chrome or Chromium build:");
+  lines.push("  HYPERFRAMES_BROWSER_PATH=/path/to/chrome npx hyperframes render");
+  return lines.join("\n");
+}

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -75,6 +75,7 @@ import { buildDockerRunArgs, resolveDockerPlatform } from "../utils/dockerRunArg
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
 import { runEnvironmentChecks } from "../browser/preflight.js";
 import { chromeLaunchRemediation } from "../browser/linuxDeps.js";
+import { macosChromeCrashRemediation } from "../browser/macosChromeCrash.js";
 import type { ProducerLogger, RenderJob } from "@hyperframes/producer";
 import {
   MAX_VP9_CPU_USED,
@@ -1634,6 +1635,11 @@ function handleRenderError(
   const remediation = chromeLaunchRemediation(message);
   if (remediation) {
     errorBox("Render failed — Chrome could not launch", message, remediation);
+    process.exit(1);
+  }
+  const macosRemediation = macosChromeCrashRemediation(message);
+  if (macosRemediation) {
+    errorBox("Render failed — Chrome could not launch", message, macosRemediation);
     process.exit(1);
   }
   errorBox("Render failed", message, hint);


### PR DESCRIPTION
## Bug
On arm64 macOS the bundled chrome-headless-shell can crash with SIGTRAP (EXC_BREAKPOINT) at launch; the render then fails with no guidance. Reported darwin/arm64 macOS 26 (0.7.42); confirmed on an arm64 macOS 26.5.1 machine with **21 chrome-headless-shell trap crash reports** in DiagnosticReports.

## Why not bump the pinned version
Crashes were observed against builds **newer** than the current pin (`CHROME_VERSION`), so a bump is an unverified gamble with a repo-wide blast radius. Chose the lower-risk actionable-error path.

## Fix
`macosChromeCrashRemediation()` (darwin+arm64-gated; reuses `isTransientBrowserError` from the engine, no duplicated regex) wired into `handleRenderError` after the Linux `chromeLaunchRemediation` check. Surfaces `--docker` / `HYPERFRAMES_DOCKER_PLATFORM=linux/amd64` + `HYPERFRAMES_BROWSER_PATH`. `CHROME_VERSION` + Linux path untouched.

## Tests
+7 (platform/arch gating + message). Full build + typecheck + oxfmt/oxlint clean.