### PR TITLE
fix(engine): decode-accurate seek for single-keyframe/long-GOP clips [P1] (needs perf review)

### DIFF
--- a/packages/engine/src/services/videoFrameExtractor.test.ts
+++ b/packages/engine/src/services/videoFrameExtractor.test.ts
@@ -21,6 +21,7 @@ import {
   createFrameLookupTable,
   resolveProjectRelativeSrc,
   resolveFrameFormat,
+  buildVideoFrameExtractionArgs,
   codecMayHaveAlpha,
   decoderForCodec,
   getFrameAtTime,
@@ -113,6 +114,48 @@ describe("resolveFrameFormat", () => {
   it("forces png when alpha is present or the codec can carry alpha", () => {
     expect(resolveFrameFormat(metadata({ hasAlpha: true }), "jpg")).toBe("png");
     expect(resolveFrameFormat(metadata({ videoCodec: "vp9" }), "jpg")).toBe("png");
+  });
+});
+
+describe("buildVideoFrameExtractionArgs", () => {
+  function metadata(overrides: Partial<VideoMetadata> = {}): VideoMetadata {
+    return {
+      durationSeconds: 4,
+      width: 320,
+      height: 240,
+      fps: 30,
+      hasAudio: false,
+      videoCodec: "h264",
+      colorSpace: {
+        colorTransfer: "bt709",
+        colorPrimaries: "bt709",
+        colorSpace: "bt709",
+      },
+      isVFR: false,
+      hasAlpha: false,
+      ...overrides,
+    };
+  }
+
+  it("places seek after input so long-GOP clips decode to the requested frame", () => {
+    const args = buildVideoFrameExtractionArgs({
+      videoPath: "/videos/single-keyframe.mp4",
+      startTime: 1.25,
+      duration: 2,
+      fps: 30,
+      outputPattern: "/frames/frame_%05d.jpg",
+      format: "jpg",
+      quality: 95,
+      metadata: metadata(),
+    });
+
+    const inputIndex = args.indexOf("-i");
+    const seekIndex = args.indexOf("-ss");
+
+    expect(inputIndex).toBeGreaterThanOrEqual(0);
+    expect(seekIndex).toBeGreaterThan(inputIndex);
+    expect(args.slice(inputIndex, inputIndex + 2)).toEqual(["-i", "/videos/single-keyframe.mp4"]);
+    expect(args.slice(seekIndex, seekIndex + 2)).toEqual(["-ss", "1.25"]);
   });
 });
 

--- a/packages/engine/src/services/videoFrameExtractor.ts
+++ b/packages/engine/src/services/videoFrameExtractor.ts
@@ -277,56 +277,17 @@ export async function extractVideoFramesRange(
   const framePattern = `${FRAME_FILENAME_PREFIX}%05d.${format}`;
   const outputPattern = join(videoOutputDir, framePattern);
 
-  // When extracting from HDR source, tone-map to SDR in FFmpeg rather than
-  // letting Chrome's uncontrollable tone-mapper handle it (which washes out).
-  // macOS: VideoToolbox hardware decoder does HDR→SDR natively on Apple Silicon.
-  // Linux: zscale filter (when available) or colorspace filter as fallback.
-  const isHdr = isHdrColorSpaceUtil(metadata.colorSpace);
-  const isMacOS = process.platform === "darwin";
-
-  const args: string[] = [];
-  if (isHdr && isMacOS) {
-    args.push("-hwaccel", "videotoolbox");
-  }
-  // Always force the alpha-aware decoder on codecs that can carry alpha. The
-  // alternative — gating on `metadata.hasAlpha` — relies on tag detection that
-  // has at least three known failure modes: case-sensitivity across ffmpeg
-  // versions (`alpha_mode` vs `ALPHA_MODE`), missing tags from older muxers,
-  // and mp4-as-webm rewraps that drop the sidecar. A wrong negative there
-  // silently strips alpha during decode and the bug doesn't surface until
-  // the rendered video is missing layers. Codec-based default has no such
-  // ambiguity: libvpx-vp9 reads the alpha sidecar when present and decodes
-  // normally when it isn't.
-  if (codecMayHaveAlpha(metadata.videoCodec)) {
-    args.push("-c:v", decoderForCodec(metadata.videoCodec));
-  }
-  args.push("-ss", String(startTime), "-i", videoPath, "-t", String(duration));
-
-  const vfFilters: string[] = [];
-  if (isHdr && isMacOS) {
-    // VideoToolbox tone-maps during decode; force output to bt709 SDR format
-    vfFilters.push("format=nv12");
-  }
-  if (!metadata.isVFR) {
-    vfFilters.push(`fps=${fps}`);
-  }
-  if (options.sdrToHdrTransfer) {
-    // Ordering intent: fps sampling runs BEFORE the colorspace remap so only
-    // kept frames are converted. The remap is pointwise per-frame, so the
-    // output is identical either way for the SDR (BT.709, 8-bit) inputs this
-    // flag is set for. If format=nv12 (macOS HDR-source decode) ever combines
-    // with this flag, revisit: nv12 subsampling before a BT.2020 remap is an
-    // untested interaction (today the flags are mutually exclusive — the
-    // remap only applies to SDR sources, nv12 only to HDR sources).
-    vfFilters.push(SDR_TO_HDR_COLORSPACE_FILTER);
-  }
-  if (vfFilters.length > 0) args.push("-vf", vfFilters.join(","));
-  if (metadata.isVFR) args.push("-fps_mode", "cfr", "-r", String(fps));
-
-  args.push("-q:v", format === "jpg" ? String(Math.ceil((100 - quality) / 3)) : "0");
-  // Render-scoped temp frames are read once; level 1 measured 3-5x faster for ~14% larger files.
-  if (format === "png") args.push("-compression_level", "1");
-  args.push("-y", outputPattern);
+  const args = buildVideoFrameExtractionArgs({
+    videoPath,
+    startTime,
+    duration,
+    fps,
+    outputPattern,
+    format,
+    quality,
+    metadata,
+    sdrToHdrTransfer: options.sdrToHdrTransfer,
+  });
 
   return new Promise((resolve, reject) => {
     const ffmpeg = spawn(getFfmpegBinary(), args);
@@ -445,6 +406,62 @@ export function resolveFrameFormat(
   if (metadata.hasAlpha || codecMayHaveAlpha(metadata.videoCodec)) return "png";
   if (requested === "png" || requested === "jpg") return requested;
   return "jpg";
+}
+
+export interface VideoFrameExtractionArgsInput {
+  videoPath: string;
+  startTime: number;
+  duration: number;
+  fps: number;
+  outputPattern: string;
+  format: CacheFrameFormat;
+  quality: number;
+  metadata: VideoMetadata;
+  sdrToHdrTransfer?: HdrTransfer;
+}
+
+export function buildVideoFrameExtractionArgs(input: VideoFrameExtractionArgsInput): string[] {
+  const {
+    videoPath,
+    startTime,
+    duration,
+    fps,
+    outputPattern,
+    format,
+    quality,
+    metadata,
+    sdrToHdrTransfer,
+  } = input;
+  const isHdr = isHdrColorSpaceUtil(metadata.colorSpace);
+  const isMacOS = process.platform === "darwin";
+
+  const args: string[] = [];
+  if (isHdr && isMacOS) {
+    args.push("-hwaccel", "videotoolbox");
+  }
+  if (codecMayHaveAlpha(metadata.videoCodec)) {
+    args.push("-c:v", decoderForCodec(metadata.videoCodec));
+  }
+  args.push("-i", videoPath, "-ss", String(startTime), "-t", String(duration));
+
+  const vfFilters: string[] = [];
+  if (isHdr && isMacOS) {
+    vfFilters.push("format=nv12");
+  }
+  if (!metadata.isVFR) {
+    vfFilters.push(`fps=${fps}`);
+  }
+  if (sdrToHdrTransfer) {
+    vfFilters.push(SDR_TO_HDR_COLORSPACE_FILTER);
+  }
+  if (vfFilters.length > 0) args.push("-vf", vfFilters.join(","));
+  if (metadata.isVFR) args.push("-fps_mode", "cfr", "-r", String(fps));
+
+  args.push("-q:v", format === "jpg" ? String(Math.ceil((100 - quality) / 3)) : "0");
+  if (format === "png") args.push("-compression_level", "1");
+  args.push("-y", outputPattern);
+
+  return args;
 }
 
 type PreparedExtraction = {

--- a/packages/producer/src/services/render/stages/captureHdrResources.ts
+++ b/packages/producer/src/services/render/stages/captureHdrResources.ts
@@ -192,10 +192,10 @@ export async function extractHdrVideoFrames(args: {
     const dims = prep.hdrExtractionDims.get(videoId) ?? { width, height };
     const rawPath = join(frameDir, "frames.rgb48le");
     const ffmpegArgs = [
-      "-ss",
-      String(video.mediaStart),
       "-i",
       srcPath,
+      "-ss",
+      String(video.mediaStart),
       "-t",
       String(duration),
       "-r",


### PR DESCRIPTION
## Bug
A source clip with a single keyframe / very long GOP rendered solid black for its whole window (`video_extract` succeeded, frames pure black); re-encoding with `-g 12` fixed it. Reported darwin/arm64 0.7.42.

## Fix
The extractor built ffmpeg args with `-ss` **before** `-i` (input/fast seek), which on a sparse-keyframe source can land short of decodable frame data. Switched to `-ss` **after** `-i` (output/decode-accurate seek) so ffmpeg decodes from the real preceding keyframe. Same pattern was duplicated in the HDR raw-frame path (`captureHdrResources.ts`) — both fixed via one shared `buildVideoFrameExtractionArgs`. Regression test pins `-ss` after `-i`. 68 engine tests pass.

## ⚠️ Why this is a DRAFT — please gate on these
1. **Not reproduced on this ffmpeg/arm64**: sampled frames were already non-black before AND after, so the fix rests on the code path + the reporter's `-g 12` workaround, not an end-to-end repro. Needs on-hardware (the reporter's env) confirmation.
2. **Perf**: output-seek re-decodes from the preceding keyframe — negligible for play-from-start clips (`mediaStart≈0`) but adds cost for clips with a large source in-point. A **hybrid coarse-input + fine-output seek** (`-ss <coarse> -i … -ss <fine>`) would keep the speed and the accuracy; worth considering before merge.

Do not merge without (1) and a perf check.