### PR TITLE
chore: release v0.7.43

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,58 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.43"
+  description="Released - 2026-07-08"
+  tags={["Release", "Cli,engine", "Engine,cli", "CLI"]}
+>
+Chrome/drawElement fast-capture reliability fixes, a new GSAP lint rule catching text-reflow layout thrash, and creation-skill briefs that lead with mode and value instead of generic scaffolding.
+
+## Features
+
+- **Skills:** Mode-first briefs, value-first storyboards, and destination defaults across creation workflows ([17b852784](https://github.com/heygen-com/hyperframes/commit/17b852784bf3922a42b3aa9801db647423073a13), [#2058](https://github.com/heygen-com/hyperframes/pull/2058))
+- **Media Use:** Resolve official brand logos via a four-tier cascade ([4d3cdc3e4](https://github.com/heygen-com/hyperframes/commit/4d3cdc3e4bb952a926b466561ed9c96540e10f20), [#2061](https://github.com/heygen-com/hyperframes/pull/2061))
+- **Lint:** Flag text-reflow props in gsap_non_transform_motion ([082280e8d](https://github.com/heygen-com/hyperframes/commit/082280e8de2cc68e0943b4cae755b465aa41547f))
+
+## Fixes
+
+- **Cli,engine:** Close review gaps in Chrome resolution fix ([5f9ee0b67](https://github.com/heygen-com/hyperframes/commit/5f9ee0b67829ac1430ae04be6011edb355ef4ac5))
+- **Engine,cli:** Resolve drawElement to a Chrome build that actually has it ([8854bad8f](https://github.com/heygen-com/hyperframes/commit/8854bad8f96623584199f913a0e06c867b4b6fe1))
+- **CLI:** Report unknown-flag errors + cover nested subcommands (HF#2033) [P2] ([38b27c4d8](https://github.com/heygen-com/hyperframes/commit/38b27c4d820d3e49b2a5a14ef00629fff7ea59a7), [#2072](https://github.com/heygen-com/hyperframes/pull/2072))
+- **Producer:** Scope per-instance variables for repeated sub-composition mounts ([5ebc5bb10](https://github.com/heygen-com/hyperframes/commit/5ebc5bb10f4895375a5fa5e4976f80cf920a773e), [#2070](https://github.com/heygen-com/hyperframes/pull/2070))
+- **CLI:** Contrast audit reads an element's own opaque background ([701ae9e9b](https://github.com/heygen-com/hyperframes/commit/701ae9e9b90d93667503f75e4107c3c96dbaf6c9), [#1975](https://github.com/heygen-com/hyperframes/pull/1975))
+- **CLI:** Add --no-clipboard no longer throws "Unknown flag: --clipboard" ([e01831822](https://github.com/heygen-com/hyperframes/commit/e0183182253c34631bee2388c7df4abe28cacc7d), [#2067](https://github.com/heygen-com/hyperframes/pull/2067))
+- **CLI:** Warn when a WebM render silently drops its alpha channel [P2] ([f5f94a949](https://github.com/heygen-com/hyperframes/commit/f5f94a949524c804b1961da2471689c8ce6e60c0), [#2044](https://github.com/heygen-com/hyperframes/pull/2044))
+- **Engine:** Resolve relative data-start references for audio tracks ([6f8bf5f36](https://github.com/heygen-com/hyperframes/commit/6f8bf5f364e5044a383f603b451fca2e00c15c6c), [#2062](https://github.com/heygen-com/hyperframes/pull/2062))
+- **Engine:** Inject sub-composition variables on the render path ([41ad5b469](https://github.com/heygen-com/hyperframes/commit/41ad5b46906689fd800132bb869306026e29517e), [#2066](https://github.com/heygen-com/hyperframes/pull/2066))
+- **Cli,skills:** Install workflow skills on demand instead of re-pulling the full set ([81884a749](https://github.com/heygen-com/hyperframes/commit/81884a74956fbf7d2666795422f325d78266e1aa), [#2012](https://github.com/heygen-com/hyperframes/pull/2012))
+- **Core:** Address PR feedback — ReDoS-safe slug trim, getVariables cleanups ([d9368ec05](https://github.com/heygen-com/hyperframes/commit/d9368ec051a151dc377ec2daa98d7372ab4a1e86))
+- **Core,producer:** Composition CSS variables reach the render path at eval time ([e2c88ef68](https://github.com/heygen-com/hyperframes/commit/e2c88ef689a11fb293934907d36c93584c57d083))
+- **Core,cli,lint:** Close the figma brand-token loop — runtime CSS variables, --name, snippet lint ([def276524](https://github.com/heygen-com/hyperframes/commit/def276524bc786625fce17f130e5b350996f1f4f))
+- **Media Use:** Explain the codex alias-vs-PATH gotcha in the unavailable message ([80271863d](https://github.com/heygen-com/hyperframes/commit/80271863d34523e956e15f514ddfe85e75fa533a), [#2042](https://github.com/heygen-com/hyperframes/pull/2042))
+- **CLI:** Pin arm64 render Chromium to Playwright headless-shell (#2039) ([cebce603d](https://github.com/heygen-com/hyperframes/commit/cebce603dfa5f24d65d82b98dc1698f7ea1fd48d), [#2040](https://github.com/heygen-com/hyperframes/pull/2040))
+- **Producer:** Suppress GSAP call side effects during render seeks ([5b9b71df2](https://github.com/heygen-com/hyperframes/commit/5b9b71df258f239a841542c92dd799126655eb05), [#2037](https://github.com/heygen-com/hyperframes/pull/2037))
+- **Ci:** Format migrated comps with oxfmt, sync skills manifest ([b95f2ca25](https://github.com/heygen-com/hyperframes/commit/b95f2ca25e46ac12468ca11efcaf51068de607ae))
+- **Lint:** Catch fromTo from-object layout/reflow props in gsap_non_transform_motion ([189d8582f](https://github.com/heygen-com/hyperframes/commit/189d8582f46d74083982a0408fd0f9d973aebf56))
+- **Lint,skills:** Make the reflow-prop fix faithful, not a lossy scale swap ([6e21072f4](https://github.com/heygen-com/hyperframes/commit/6e21072f442791339f9af904d34fe4bd129e4d1f))
+
+## Docs & Examples
+
+- **CLI:** Fix render examples that pass a file as the project dir [P2] ([ab129023d](https://github.com/heygen-com/hyperframes/commit/ab129023de03f4d98f3bb4ad01c2aeb60da21e50), [#1974](https://github.com/heygen-com/hyperframes/pull/1974))
+- Add modal deployment template to deploy guide ([bb423dd21](https://github.com/heygen-com/hyperframes/commit/bb423dd217f92767962a39a25b14d42b0b612dee), [#2069](https://github.com/heygen-com/hyperframes/pull/2069))
+- **Skills:** Teach transforms-over-layout-props up front ([58f7dc1c7](https://github.com/heygen-com/hyperframes/commit/58f7dc1c724b0ef432f1e92b1eab2c2ae5d3d0e1))
+
+## Catalog
+
+- **Lint:** Add gsap_non_transform_motion rule, migrate registry comps to transforms ([619a603ea](https://github.com/heygen-com/hyperframes/commit/619a603eabd7d0e3b7ee7b32297e6667acd7ecc5))
+
+## Internal
+
+- **Skills,lint:** Migrate kinetic-letter-in off letterSpacing; document rule design ([1c0eef835](https://github.com/heygen-com/hyperframes/commit/1c0eef835f3c30ccae4908b26498e2f7f462c64a))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.42...v0.7.43).
+</Update>
+
+<Update
   label="HyperFrames v0.7.42"
   description="Released - 2026-07-07"
   tags={["Release", "Producer,cli", "CLI", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.43.md
+++ b/releases/v0.7.43.md
@@ -1,0 +1,51 @@
+# HyperFrames v0.7.43
+
+Released on 2026-07-08.
+
+Chrome/drawElement fast-capture reliability fixes, a new GSAP lint rule catching text-reflow layout thrash, and creation-skill briefs that lead with mode and value instead of generic scaffolding.
+
+## Features
+
+- **Skills:** Mode-first briefs, value-first storyboards, and destination defaults across creation workflows ([17b852784](https://github.com/heygen-com/hyperframes/commit/17b852784bf3922a42b3aa9801db647423073a13), [#2058](https://github.com/heygen-com/hyperframes/pull/2058))
+- **Media Use:** Resolve official brand logos via a four-tier cascade ([4d3cdc3e4](https://github.com/heygen-com/hyperframes/commit/4d3cdc3e4bb952a926b466561ed9c96540e10f20), [#2061](https://github.com/heygen-com/hyperframes/pull/2061))
+- **Lint:** Flag text-reflow props in gsap_non_transform_motion ([082280e8d](https://github.com/heygen-com/hyperframes/commit/082280e8de2cc68e0943b4cae755b465aa41547f))
+
+## Fixes
+
+- **Cli,engine:** Close review gaps in Chrome resolution fix ([5f9ee0b67](https://github.com/heygen-com/hyperframes/commit/5f9ee0b67829ac1430ae04be6011edb355ef4ac5))
+- **Engine,cli:** Resolve drawElement to a Chrome build that actually has it ([8854bad8f](https://github.com/heygen-com/hyperframes/commit/8854bad8f96623584199f913a0e06c867b4b6fe1))
+- **CLI:** Report unknown-flag errors + cover nested subcommands (HF#2033) [P2] ([38b27c4d8](https://github.com/heygen-com/hyperframes/commit/38b27c4d820d3e49b2a5a14ef00629fff7ea59a7), [#2072](https://github.com/heygen-com/hyperframes/pull/2072))
+- **Producer:** Scope per-instance variables for repeated sub-composition mounts ([5ebc5bb10](https://github.com/heygen-com/hyperframes/commit/5ebc5bb10f4895375a5fa5e4976f80cf920a773e), [#2070](https://github.com/heygen-com/hyperframes/pull/2070))
+- **CLI:** Contrast audit reads an element's own opaque background ([701ae9e9b](https://github.com/heygen-com/hyperframes/commit/701ae9e9b90d93667503f75e4107c3c96dbaf6c9), [#1975](https://github.com/heygen-com/hyperframes/pull/1975))
+- **CLI:** Add --no-clipboard no longer throws "Unknown flag: --clipboard" ([e01831822](https://github.com/heygen-com/hyperframes/commit/e0183182253c34631bee2388c7df4abe28cacc7d), [#2067](https://github.com/heygen-com/hyperframes/pull/2067))
+- **CLI:** Warn when a WebM render silently drops its alpha channel [P2] ([f5f94a949](https://github.com/heygen-com/hyperframes/commit/f5f94a949524c804b1961da2471689c8ce6e60c0), [#2044](https://github.com/heygen-com/hyperframes/pull/2044))
+- **Engine:** Resolve relative data-start references for audio tracks ([6f8bf5f36](https://github.com/heygen-com/hyperframes/commit/6f8bf5f364e5044a383f603b451fca2e00c15c6c), [#2062](https://github.com/heygen-com/hyperframes/pull/2062))
+- **Engine:** Inject sub-composition variables on the render path ([41ad5b469](https://github.com/heygen-com/hyperframes/commit/41ad5b46906689fd800132bb869306026e29517e), [#2066](https://github.com/heygen-com/hyperframes/pull/2066))
+- **Cli,skills:** Install workflow skills on demand instead of re-pulling the full set ([81884a749](https://github.com/heygen-com/hyperframes/commit/81884a74956fbf7d2666795422f325d78266e1aa), [#2012](https://github.com/heygen-com/hyperframes/pull/2012))
+- **Core:** Address PR feedback — ReDoS-safe slug trim, getVariables cleanups ([d9368ec05](https://github.com/heygen-com/hyperframes/commit/d9368ec051a151dc377ec2daa98d7372ab4a1e86))
+- **Core,producer:** Composition CSS variables reach the render path at eval time ([e2c88ef68](https://github.com/heygen-com/hyperframes/commit/e2c88ef689a11fb293934907d36c93584c57d083))
+- **Core,cli,lint:** Close the figma brand-token loop — runtime CSS variables, --name, snippet lint ([def276524](https://github.com/heygen-com/hyperframes/commit/def276524bc786625fce17f130e5b350996f1f4f))
+- **Media Use:** Explain the codex alias-vs-PATH gotcha in the unavailable message ([80271863d](https://github.com/heygen-com/hyperframes/commit/80271863d34523e956e15f514ddfe85e75fa533a), [#2042](https://github.com/heygen-com/hyperframes/pull/2042))
+- **CLI:** Pin arm64 render Chromium to Playwright headless-shell (#2039) ([cebce603d](https://github.com/heygen-com/hyperframes/commit/cebce603dfa5f24d65d82b98dc1698f7ea1fd48d), [#2040](https://github.com/heygen-com/hyperframes/pull/2040))
+- **Producer:** Suppress GSAP call side effects during render seeks ([5b9b71df2](https://github.com/heygen-com/hyperframes/commit/5b9b71df258f239a841542c92dd799126655eb05), [#2037](https://github.com/heygen-com/hyperframes/pull/2037))
+- **Ci:** Format migrated comps with oxfmt, sync skills manifest ([b95f2ca25](https://github.com/heygen-com/hyperframes/commit/b95f2ca25e46ac12468ca11efcaf51068de607ae))
+- **Lint:** Catch fromTo from-object layout/reflow props in gsap_non_transform_motion ([189d8582f](https://github.com/heygen-com/hyperframes/commit/189d8582f46d74083982a0408fd0f9d973aebf56))
+- **Lint,skills:** Make the reflow-prop fix faithful, not a lossy scale swap ([6e21072f4](https://github.com/heygen-com/hyperframes/commit/6e21072f442791339f9af904d34fe4bd129e4d1f))
+
+## Docs & Examples
+
+- **CLI:** Fix render examples that pass a file as the project dir [P2] ([ab129023d](https://github.com/heygen-com/hyperframes/commit/ab129023de03f4d98f3bb4ad01c2aeb60da21e50), [#1974](https://github.com/heygen-com/hyperframes/pull/1974))
+- Add modal deployment template to deploy guide ([bb423dd21](https://github.com/heygen-com/hyperframes/commit/bb423dd217f92767962a39a25b14d42b0b612dee), [#2069](https://github.com/heygen-com/hyperframes/pull/2069))
+- **Skills:** Teach transforms-over-layout-props up front ([58f7dc1c7](https://github.com/heygen-com/hyperframes/commit/58f7dc1c724b0ef432f1e92b1eab2c2ae5d3d0e1))
+
+## Catalog
+
+- **Lint:** Add gsap_non_transform_motion rule, migrate registry comps to transforms ([619a603ea](https://github.com/heygen-com/hyperframes/commit/619a603eabd7d0e3b7ee7b32297e6667acd7ecc5))
+
+## Internal
+
+- **Skills,lint:** Migrate kinetic-letter-in off letterSpacing; document rule design ([1c0eef835](https://github.com/heygen-com/hyperframes/commit/1c0eef835f3c30ccae4908b26498e2f7f462c64a))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.42...v0.7.43


### PR DESCRIPTION
## Summary

Chrome/drawElement fast-capture reliability fixes, a new GSAP lint rule catching text-reflow layout thrash, and creation-skill briefs that lead with mode and value instead of generic scaffolding.

See [releases/v0.7.43.md](https://github.com/heygen-com/hyperframes/blob/release/v0.7.43/releases/v0.7.43.md) for full notes.

Full changelog: https://github.com/heygen-com/hyperframes/compare/v0.7.42...v0.7.43

🤖 Generated with [Claude Code](https://claude.com/claude-code)