### PR TITLE
chore: release v0.7.44

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,33 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.44"
+  description="Released - 2026-07-08"
+  tags={["Release", "Engine,producer", "Producer", "CLI"]}
+>
+Opt-in verified interleaved parallel drawElement streaming, plus fail-fast sub-composition timeline waits and Chrome-cache resolution fixes carried over from PR review.
+
+## Features
+
+- **Engine,producer:** Verified interleaved parallel drawElement streaming (opt-in) ([b3493a7b6](https://github.com/heygen-com/hyperframes/commit/b3493a7b61cd3d07e7ce5de690c3cae7859e91be))
+
+## Fixes
+
+- **Engine,producer:** Fix quadratic dedup rescan, correct race justification ([381887541](https://github.com/heygen-com/hyperframes/commit/381887541f9513661666877f67335cc489ab5273))
+- **Engine,producer:** Close review gaps in parallel drawElement streaming ([2dbe958a4](https://github.com/heygen-com/hyperframes/commit/2dbe958a49baa08319d091d36795edd51afc3988))
+- **CLI:** Check buildId when resolving the managed Chrome cache ([df1d20b76](https://github.com/heygen-com/hyperframes/commit/df1d20b7659df7858e1c8324e84cb88fa8124af0))
+- **Engine:** Log composition-id attribution on script-failure bail too ([8fee20a52](https://github.com/heygen-com/hyperframes/commit/8fee20a52543dc961983d5e31d3b44125c944416))
+- **Engine,producer,cli:** Close review gaps in sub-timeline fail-fast ([8ba3c3391](https://github.com/heygen-com/hyperframes/commit/8ba3c339156c9d96dd08407019b550191851e5e5))
+- **Engine:** Fail-fast the sub-composition timeline wait when a script 404s ([54359f3d6](https://github.com/heygen-com/hyperframes/commit/54359f3d6ad45a99c359c8d92a59795fbdc60052))
+
+## Docs & Examples
+
+- **Producer:** Disambiguate compositor frame scheduling from the beginframe capture mode ([81a4f0436](https://github.com/heygen-com/hyperframes/commit/81a4f04360cf71ce67daa8eefe55d998eb375ab1))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.43...v0.7.44).
+</Update>
+
+<Update
   label="HyperFrames v0.7.43"
   description="Released - 2026-07-08"
   tags={["Release", "Cli,engine", "Engine,cli", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.44.md
+++ b/releases/v0.7.44.md
@@ -1,0 +1,26 @@
+# HyperFrames v0.7.44
+
+Released on 2026-07-08.
+
+Opt-in verified interleaved parallel drawElement streaming, plus fail-fast sub-composition timeline waits and Chrome-cache resolution fixes carried over from PR review.
+
+## Features
+
+- **Engine,producer:** Verified interleaved parallel drawElement streaming (opt-in) ([b3493a7b6](https://github.com/heygen-com/hyperframes/commit/b3493a7b61cd3d07e7ce5de690c3cae7859e91be))
+
+## Fixes
+
+- **Engine,producer:** Fix quadratic dedup rescan, correct race justification ([381887541](https://github.com/heygen-com/hyperframes/commit/381887541f9513661666877f67335cc489ab5273))
+- **Engine,producer:** Close review gaps in parallel drawElement streaming ([2dbe958a4](https://github.com/heygen-com/hyperframes/commit/2dbe958a49baa08319d091d36795edd51afc3988))
+- **CLI:** Check buildId when resolving the managed Chrome cache ([df1d20b76](https://github.com/heygen-com/hyperframes/commit/df1d20b7659df7858e1c8324e84cb88fa8124af0))
+- **Engine:** Log composition-id attribution on script-failure bail too ([8fee20a52](https://github.com/heygen-com/hyperframes/commit/8fee20a52543dc961983d5e31d3b44125c944416))
+- **Engine,producer,cli:** Close review gaps in sub-timeline fail-fast ([8ba3c3391](https://github.com/heygen-com/hyperframes/commit/8ba3c339156c9d96dd08407019b550191851e5e5))
+- **Engine:** Fail-fast the sub-composition timeline wait when a script 404s ([54359f3d6](https://github.com/heygen-com/hyperframes/commit/54359f3d6ad45a99c359c8d92a59795fbdc60052))
+
+## Docs & Examples
+
+- **Producer:** Disambiguate compositor frame scheduling from the beginframe capture mode ([81a4f0436](https://github.com/heygen-com/hyperframes/commit/81a4f04360cf71ce67daa8eefe55d998eb375ab1))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.43...v0.7.44


### PR DESCRIPTION
## Summary

Opt-in verified interleaved parallel drawElement streaming, plus fail-fast sub-composition timeline waits and Chrome-cache resolution fixes carried over from PR review.

See [releases/v0.7.44.md](https://github.com/heygen-com/hyperframes/blob/release/v0.7.44/releases/v0.7.44.md) for full notes.

Full changelog: https://github.com/heygen-com/hyperframes/compare/v0.7.43...v0.7.44

🤖 Generated with [Claude Code](https://claude.com/claude-code)