### PR TITLE
fix(cli): transcribe --model large-v3 crashes on unknown DTW preset

### DIFF
--- a/packages/cli/src/whisper/transcribe.test.ts
+++ b/packages/cli/src/whisper/transcribe.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { dtwPresetForModel } from "./transcribe.js";
+
+describe("dtwPresetForModel", () => {
+  // The large family is the regression: model files are hyphenated but
+  // whisper.cpp's --dtw preset is dotted, so `--dtw large-v3` used to abort
+  // with "unknown DTW preset 'large-v3'".
+  test.each([
+    ["large-v3", "large.v3"],
+    ["large-v2", "large.v2"],
+    ["large-v1", "large.v1"],
+    ["large-v3-turbo", "large.v3.turbo"],
+  ])("maps hyphenated large model %s to dotted preset %s", (model, preset) => {
+    expect(dtwPresetForModel(model)).toBe(preset);
+  });
+
+  // tiny/base/small/medium (+.en) already match their preset — must be unchanged.
+  test.each(["tiny", "base.en", "small.en", "medium.en", "small"])(
+    "leaves preset-identical model %s unchanged",
+    (model) => {
+      expect(dtwPresetForModel(model)).toBe(model);
+    },
+  );
+});

--- a/packages/cli/src/whisper/transcribe.ts
+++ b/packages/cli/src/whisper/transcribe.ts
@@ -206,6 +206,21 @@ function prepareAudio(audioPath: string): string {
 }
 
 /**
+ * Map a ggml model file-stem to whisper.cpp's `--dtw` alignment-heads preset.
+ *
+ * The two mostly coincide, so the stem was long passed straight to `--dtw` — but
+ * they diverge for the large family: the model files are hyphenated
+ * (`ggml-large-v3.bin`) while the DTW presets are dotted (`large.v3`,
+ * `large.v3.turbo`). `--dtw large-v3` makes whisper-cli abort with
+ * "unknown DTW preset 'large-v3'", surfacing as "Transcription failed". The
+ * tiny/base/small/medium (+`.en`) families have no hyphen, so `-`→`.` is a no-op
+ * for them and correct for the large family.
+ */
+export function dtwPresetForModel(model: string): string {
+  return model.replace(/-/g, ".");
+}
+
+/**
  * Transcribe an audio or video file and save transcript.json to the output directory.
  */
 // fallow-ignore-next-line complexity
@@ -281,7 +296,7 @@ export async function transcribe(
     "--output-file",
     outputBase,
     "--dtw",
-    effectiveModel,
+    dtwPresetForModel(effectiveModel),
     "--suppress-nst",
   ];
   if (detectedLanguage) {


### PR DESCRIPTION
## Problem
`hyperframes transcribe audio.mp3 --model large-v3` (and `large-v2`/`large-v1`) fails with:

```
error: unknown DTW preset 'large-v3'
→ Transcription failed
```

## Root cause
`packages/cli/src/whisper/transcribe.ts` passed the **ggml model file-stem** straight to whisper.cpp's `--dtw` flag. But those are two different namespaces:

- model files are **hyphenated**: `ggml-large-v3.bin`
- `--dtw` alignment-heads presets are **dotted**: `large.v3`, `large.v3.turbo`

They coincide for `tiny` / `base` / `small` / `medium` (+`.en`) — the models most people use — which is why it went unnoticed. They diverge for the `large-v*` family, so `--dtw large-v3` hits whisper-cli's unknown-preset guard and aborts.

## Fix
A small exported `dtwPresetForModel(model)` that maps the file-stem to the preset (`-` → `.`): a no-op for the tiny/base/small/medium families, correct for `large-v1/v2/v3` and `large-v3-turbo`. Used only for the `--dtw` arg; `--model` still gets the file path.

Also fixes **media-use** transcription — its whisper fallback shells to `hyperframes transcribe`, so it inherited the same crash for large models.

## Test
`packages/cli/src/whisper/transcribe.test.ts` — table-driven cases for the large family (hyphen→dot) and the preset-identical families (unchanged). `vitest run` 9/9.

Verified: cli `tsc --noEmit` exit 0, oxlint/oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5k87mPZ4d6yiFwcWSb8Vv