### PR TITLE
fix(lint): recognize gsap.fromTo initial state in overlay-visibility check

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -214,6 +214,48 @@ describe("GSAP rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does not error when a full-frame overlay uses a GSAP fromTo entrance at frame zero", async () => {
+    const html = `
+<html><body data-composition-id="c1" data-width="1920" data-height="1080">
+  <div id="tr-flash-1" style="position:fixed;inset:0;background:#fff;pointer-events:none;z-index:990"></div>
+  <section class="clip" data-start="0" data-duration="8"><h1>Scene 1</h1></section>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#tr-flash-1", { opacity: 0 }, { opacity: 1, duration: 0.3 }, 0);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_fullscreen_overlay_starts_visible",
+    );
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not error when a full-frame overlay's GSAP fromTo entrance at frame zero is later hidden again", async () => {
+    const html = `
+<html><body data-composition-id="c1" data-width="1920" data-height="1080">
+  <div id="tr-flash-1" style="position:fixed;inset:0;background:#fff;pointer-events:none;z-index:990"></div>
+  <section class="clip" data-start="0" data-duration="8"><h1>Scene 1</h1></section>
+  <section class="clip" data-start="8" data-duration="8"><h1>Scene 2</h1></section>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#tr-flash-1", { opacity: 0 }, { opacity: 1, duration: 0.3 }, 0);
+    tl.to("#tr-flash-1", { opacity: 0, duration: 0.18 }, 8.00);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_fullscreen_overlay_starts_visible",
+    );
+    expect(finding).toBeUndefined();
+  });
+
   it("reports one full-frame transition flash finding when multiple scripts touch it", async () => {
     const html = `
 <html><body data-composition-id="c1" data-width="1920" data-height="1080">

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -42,6 +42,10 @@ type GsapWindow = {
   end: number;
   properties: string[];
   propertyValues: Record<string, string | number>;
+  // fromTo()'s first ("from") vars object — the true state at the tween's start,
+  // as opposed to propertyValues which is always the destination (toVars). Only
+  // set for method === "fromTo"; other methods have no separate from-state.
+  fromPropertyValues?: Record<string, string | number>;
   overwriteAuto: boolean;
   method: string;
   raw: string;
@@ -141,6 +145,7 @@ async function extractGsapWindows(script: string): Promise<GsapWindow[]> {
       end: animation.position + effectiveDuration,
       properties: Object.keys(animation.properties),
       propertyValues: animation.properties,
+      fromPropertyValues: animation.fromProperties,
       overwriteAuto: unwrapRaw(animation.extras?.overwrite) === "auto",
       method: animation.method,
       raw: synthesizeWindowRaw(parsed.timelineVar, animation),
@@ -207,6 +212,16 @@ function isVisibleGsapState(values: Record<string, string | number>): boolean {
   if (display && display !== "none") return true;
 
   return false;
+}
+
+// The property values a window's element actually holds at the window's own
+// start (position). For fromTo() this is the authored fromVars, not the
+// destination toVars captured in propertyValues — a fade-in via
+// `fromTo(el, {opacity:0}, {opacity:1}, 0)` genuinely starts hidden even
+// though propertyValues (the toVars) says opacity: 1.
+function windowStartStateValues(win: GsapWindow): Record<string, string | number> {
+  if (win.method === "fromTo") return win.fromPropertyValues ?? win.propertyValues;
+  return win.propertyValues;
 }
 
 function makesOverlayVisible(win: GsapWindow): boolean {
@@ -680,7 +695,8 @@ export const gsapRules: LintRule<LintContext>[] = [
           .sort((a, b) => a.position - b.position);
         const startsHiddenAtZero = visibilityWindows.some(
           (win) =>
-            win.position <= SCENE_BOUNDARY_EPSILON_SECONDS && isHiddenGsapState(win.propertyValues),
+            win.position <= SCENE_BOUNDARY_EPSILON_SECONDS &&
+            isHiddenGsapState(windowStartStateValues(win)),
         );
         if (startsHiddenAtZero) continue;
         const firstVisible = visibilityWindows.find((win) => makesOverlayVisible(win));


### PR DESCRIPTION
## What

`gsap_fullscreen_overlay_starts_visible` false-positives on a full-frame overlay that fades in via `gsap.fromTo(el, {opacity:0}, {opacity:1}, 0)` at t=0, when that element is later hidden again (e.g. an outro fade or a hard-kill `tl.set`). The overlay genuinely starts hidden, but the rule flags it as starting visible and asks the author to redundantly add `opacity: 0` in CSS on top of the fromTo call.

## Why

`GsapWindow.propertyValues` is populated from `animation.properties`, which for a `fromTo(el, fromVars, toVars, pos)` call only reflects `toVars` — the destination state, not the starting state. The rule's `startsHiddenAtZero` check inspected `propertyValues` at position 0, so for a fade-in fromTo it saw the destination (`opacity: 1`) instead of the true t=0 state (`opacity: 0`), and never recognized it as "starts hidden." The parser already parses `fromVars` separately into `animation.fromProperties`, but `GsapWindow` had no field for it and nothing read it.

The misfire was conditional: a bare fromTo fade-in with nothing else hiding the element later didn't trigger the rule (a separate guard suppressed it), but it did trigger once the element was hidden again later in the timeline.

## How

- Added a `fromPropertyValues` field to `GsapWindow`, populated from `animation.fromProperties` in `extractGsapWindows`.
- Added a `windowStartStateValues` helper that returns `fromPropertyValues` for `fromTo` windows (falling back to `propertyValues` if absent) and `propertyValues` otherwise.
- Updated `startsHiddenAtZero` to check the window's true start state instead of always checking the destination.
- Checked the sibling `makesOverlayVisible`/`isSceneBoundaryExit` checks for the same blind spot — they intentionally use the destination state (correct for "does this tween end in a visible/hidden state"), so no change was needed there.

## Test plan

- [x] Unit tests added: a bare `fromTo` fade-in at t=0 (no finding), and the regression case — `fromTo` fade-in at t=0 plus a later hide (previously flagged, now correctly not flagged).
- [x] `bun run test` in `packages/lint` — all 349 tests pass, no regressions.
- [x] `bun run typecheck` in `packages/lint` — clean.
- [x] `oxlint` / `oxfmt --check` on changed files — clean.