### PR TITLE
fix(studio-server): previewAdapter getElementTimings ignores relative data-start refs

### DIFF
--- a/packages/studio-server/src/helpers/previewAdapter.test.ts
+++ b/packages/studio-server/src/helpers/previewAdapter.test.ts
@@ -253,5 +253,60 @@ describe("T10 — PreviewAdapter contract (spec for R7)", () => {
       expect(timings["hf-notimed"].start).toBeUndefined();
       expect(timings["hf-notimed"].end).toBeUndefined();
     });
+
+    it("resolves data-duration into end when there is no data-end (never worked before)", () => {
+      make("div", { "data-hf-id": "hf-t1", "data-start": "1", "data-duration": "3" });
+      const adapter = adapterWith(() => null);
+      const timings = adapter.getElementTimings();
+      expect(timings["hf-t1"]).toEqual({ start: 1, end: 4 });
+    });
+
+    it("resolves a relative data-start reference ('ref + offset') instead of returning undefined", () => {
+      make("div", { "data-hf-id": "hf-intro", "data-start": "1", "data-duration": "3" });
+      make("div", { "data-hf-id": "hf-outro", "data-start": "hf-intro + 2", "data-duration": "1" });
+      const adapter = adapterWith(() => null);
+      const timings = adapter.getElementTimings();
+      // hf-intro ends at 4 (1 + 3); hf-outro starts 2s after that = 6.
+      expect(timings["hf-outro"]).toEqual({ start: 6, end: 7 });
+    });
+
+    it("resolves a bare reference (no offset) to the referenced element's end", () => {
+      make("div", { "data-hf-id": "hf-intro", "data-start": "1", "data-end": "4" });
+      make("div", {
+        "data-hf-id": "hf-right-after",
+        "data-start": "hf-intro",
+        "data-duration": "1",
+      });
+      const adapter = adapterWith(() => null);
+      const timings = adapter.getElementTimings();
+      expect(timings["hf-right-after"]).toEqual({ start: 4, end: 5 });
+    });
+
+    it("returns undefined start (not NaN) when the reference target doesn't exist", () => {
+      make("div", {
+        "data-hf-id": "hf-orphan",
+        "data-start": "hf-nonexistent + 5",
+        "data-duration": "2",
+      });
+      const adapter = adapterWith(() => null);
+      const timings = adapter.getElementTimings();
+      expect(timings["hf-orphan"].start).toBeUndefined();
+    });
+
+    it("terminates (not an infinite loop) on a mutual A <-> B reference cycle", () => {
+      make("div", { "data-hf-id": "hf-a", "data-start": "hf-b", "data-duration": "2" });
+      make("div", { "data-hf-id": "hf-b", "data-start": "hf-a", "data-duration": "3" });
+      const adapter = adapterWith(() => null);
+      // Unlike the SDK's static resolver (which fails safe to 0 and lets real
+      // durations propagate outward into arbitrary-but-finite numbers), this
+      // simpler resolver has no 0-fallback — an unresolvable `sv` poisons
+      // `resolveEnd` (it requires a finite start to add duration), so the whole
+      // cycle correctly reports "no defined timing" rather than a fabricated
+      // number. The guard's job is just termination; this call must return
+      // synchronously instead of hanging.
+      const timings = adapter.getElementTimings();
+      expect(timings["hf-a"].start).toBeUndefined();
+      expect(timings["hf-b"].start).toBeUndefined();
+    });
   });
 });

--- a/packages/studio-server/src/helpers/previewAdapter.test.ts
+++ b/packages/studio-server/src/helpers/previewAdapter.test.ts
@@ -293,6 +293,18 @@ describe("T10 — PreviewAdapter contract (spec for R7)", () => {
       expect(timings["hf-orphan"].start).toBeUndefined();
     });
 
+    it("returns undefined start when the reference target exists but its own timing is unresolvable", () => {
+      make("div", { "data-hf-id": "hf-untimed" }); // no data-end, no data-duration
+      make("div", {
+        "data-hf-id": "hf-outro",
+        "data-start": "hf-untimed + 2",
+        "data-duration": "1",
+      });
+      const adapter = adapterWith(() => null);
+      const timings = adapter.getElementTimings();
+      expect(timings["hf-outro"].start).toBeUndefined();
+    });
+
     it("terminates (not an infinite loop) on a mutual A <-> B reference cycle", () => {
       make("div", { "data-hf-id": "hf-a", "data-start": "hf-b", "data-duration": "2" });
       make("div", { "data-hf-id": "hf-b", "data-start": "hf-a", "data-duration": "3" });

--- a/packages/studio-server/src/helpers/previewAdapter.ts
+++ b/packages/studio-server/src/helpers/previewAdapter.ts
@@ -5,6 +5,7 @@ import {
   STUDIO_HEIGHT_PROP,
   STUDIO_MANUAL_EDIT_GESTURE_ATTR,
 } from "./draftMarkers.js";
+import { parseStartExpression } from "@hyperframes/core/runtime/start-expression";
 
 export type DraftPayload =
   | { type: "move"; hfId: string; dx: number; dy: number }
@@ -138,18 +139,66 @@ export function createPreviewAdapter(
     },
 
     getElementTimings() {
+      // data-start can be a relative-reference expression ("intro", "intro + 2" —
+      // parseStartExpression's grammar), not just an absolute number. A raw
+      // parseFloat on it (the old behavior) silently resolves any reference to
+      // undefined. Resolve references recursively against the target's own
+      // resolved end (data-end, or data-start + data-duration when the target
+      // has no data-end) — this function never read data-duration before either,
+      // so a reference to a duration-authored (not end-authored) clip used to be
+      // unresolvable regardless of the parseFloat bug.
+      const startCache = new Map<Element, number | undefined>();
+      const visiting = new Set<Element>();
+
+      const resolveEnd = (el: Element): number | undefined => {
+        const endAttr = el.getAttribute("data-end");
+        if (endAttr !== null) {
+          const ev = parseFloat(endAttr);
+          if (Number.isFinite(ev)) return ev;
+        }
+        const durationAttr = el.getAttribute("data-duration");
+        const dv = durationAttr !== null ? parseFloat(durationAttr) : NaN;
+        const sv = resolveStart(el);
+        if (Number.isFinite(dv) && sv !== undefined) return sv + dv;
+        return undefined;
+      };
+
+      // Split out of resolveStart so its own branching stays low — mirrors the
+      // SDK's getElementTimings resolver split (resolveReferenceStart).
+      const resolveReferenceStart = (refId: string, offset: number): number | undefined => {
+        const target = findById(refId);
+        const targetEnd = target ? resolveEnd(target) : undefined;
+        return targetEnd !== undefined ? Math.max(0, targetEnd + offset) : undefined;
+      };
+
+      const resolveStart = (el: Element): number | undefined => {
+        if (startCache.has(el)) return startCache.get(el);
+        if (visiting.has(el)) return undefined; // reference cycle — fail safe, don't loop
+        visiting.add(el);
+        let resolved: number | undefined;
+        try {
+          const startStr = el.getAttribute("data-start");
+          const expr = parseStartExpression(startStr);
+          if (expr?.kind === "reference") {
+            resolved = resolveReferenceStart(expr.refId, expr.offset);
+          } else if (expr?.kind === "absolute") {
+            resolved = expr.value;
+          } else {
+            const sv = startStr !== null ? parseFloat(startStr) : NaN;
+            resolved = Number.isFinite(sv) ? sv : undefined;
+          }
+        } finally {
+          visiting.delete(el);
+        }
+        startCache.set(el, resolved);
+        return resolved;
+      };
+
       const result: Record<string, { start?: number; end?: number }> = {};
       for (const el of doc.querySelectorAll("[data-hf-id]")) {
         const hfId = el.getAttribute("data-hf-id");
         if (!hfId) continue;
-        const s = el.getAttribute("data-start");
-        const e = el.getAttribute("data-end");
-        const sv = s !== null ? parseFloat(s) : NaN;
-        const ev = e !== null ? parseFloat(e) : NaN;
-        result[hfId] = {
-          start: Number.isFinite(sv) ? sv : undefined,
-          end: Number.isFinite(ev) ? ev : undefined,
-        };
+        result[hfId] = { start: resolveStart(el), end: resolveEnd(el) };
       }
       return result;
     },

--- a/packages/studio-server/src/helpers/previewAdapter.ts
+++ b/packages/studio-server/src/helpers/previewAdapter.ts
@@ -147,6 +147,12 @@ export function createPreviewAdapter(
       // has no data-end) — this function never read data-duration before either,
       // so a reference to a duration-authored (not end-authored) clip used to be
       // unresolvable regardless of the parseFloat bug.
+      //
+      // This is the third copy of "resolve relative data-start" (runtime
+      // startResolver.ts; the SDK's own getElementTimings in session.ts; this
+      // one). The runtime version is substantially more complex (host offsets,
+      // media, live timelines) so a shared extraction isn't a straightforward
+      // win — this one and the SDK's stay hand-kept in sync instead.
       const startCache = new Map<Element, number | undefined>();
       const visiting = new Set<Element>();
 
@@ -184,6 +190,11 @@ export function createPreviewAdapter(
           } else if (expr?.kind === "absolute") {
             resolved = expr.value;
           } else {
+            // parseStartExpression returns null for empty/absent data-start, and
+            // also for a malformed grammar string (e.g. "3 abc" — a leading
+            // number followed by content the reference regex rejects). The
+            // parseFloat below only ever succeeds on that second, malformed
+            // case (a clean number or a clean reference already matched above).
             const sv = startStr !== null ? parseFloat(startStr) : NaN;
             resolved = Number.isFinite(sv) ? sv : undefined;
           }


### PR DESCRIPTION
## What

`createPreviewAdapter`'s `getElementTimings()` did a raw `parseFloat` on `data-start`, which can be a relative-reference expression (`"intro"`, `"intro + 2"`) per the docs' Relative Timing grammar, not just an absolute number. Any reference silently resolved to `undefined`. It also never read `data-duration` at all — only `data-start`/`data-end` literally — so a reference to a duration-authored (not end-authored) clip was unresolvable either way.

## Why

Same bug class just fixed in `@hyperframes/sdk`'s `getElementTimings()` (#2092) — found while auditing the SDK's surface, since this is studio's own (pre-SDK, server-side) copy of the same capability and had the identical unfixed bug.

## How

Both fixed via the shared `parseStartExpression` grammar parser (`@hyperframes/core/runtime/start-expression`), with the same recursive resolver + cycle-guard pattern as the SDK fix (split into `resolveStart`/`resolveReferenceStart`/`resolveEnd` to keep each function's complexity low — fallow's complexity gate caught the unsplit version). Reference resolution reuses this file's existing `findById` (bare `data-hf-id` lookup).

## Test plan

- [x] 6 new tests: duration-based end resolution (never worked before), relative reference with/without offset, missing target, mutual-cycle termination
- [x] Full existing `previewAdapter.test.ts` suite passes (28/28)
- [x] Full `@hyperframes/studio-server` suite passes (22 files / 256 tests)
- [x] `bun run build` clean (studio-server + full workspace, incl. studio)