### PR TITLE
feat(sdk): attachSync mirrors composition edits onto a live document

### DIFF
--- a/packages/sdk-playground/src/main.ts
+++ b/packages/sdk-playground/src/main.ts
@@ -85,6 +85,10 @@ class PlaygroundPreview implements PreviewAdapter {
       this.handlers = this.handlers.filter((h) => h !== handler);
     };
   }
+
+  attachSync(_comp: Composition): () => void {
+    return () => {};
+  }
 }
 
 // ── Preview iframe ────────────────────────────────────────────────────────────

--- a/packages/sdk/src/adapters/headless.ts
+++ b/packages/sdk/src/adapters/headless.ts
@@ -1,4 +1,5 @@
 import type { PreviewAdapter, ElementAtPointResult, DraftProps } from "./types.js";
+import type { Composition } from "../types.js";
 
 /** Null PreviewAdapter for headless use (agents, CI, server-side rendering). */
 class HeadlessPreviewAdapter implements PreviewAdapter {
@@ -15,6 +16,10 @@ class HeadlessPreviewAdapter implements PreviewAdapter {
   select(_ids: string[], _opts?: { additive?: boolean }): void {}
 
   on(_event: "selection", _handler: (ids: string[]) => void): () => void {
+    return () => {};
+  }
+
+  attachSync(_comp: Composition): () => void {
     return () => {};
   }
 }

--- a/packages/sdk/src/adapters/iframe.sync.test.ts
+++ b/packages/sdk/src/adapters/iframe.sync.test.ts
@@ -108,4 +108,47 @@ describe("IframePreviewAdapter.attachSync", () => {
       ),
     ).toBe("#f00");
   });
+
+  it("does NOT mirror a /script/gsap patch onto the live <script> tag", async () => {
+    const html = `<!DOCTYPE html>
+<html><body>
+  <div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px" data-duration="5">
+    <div data-hf-id="hf-box" style="opacity:0"></div>
+  </div>
+  <script>var tl = gsap.timeline({ paused: true });
+window.__timelines = { t: tl };</script>
+</body></html>`;
+    const iframe = mountIframe(html);
+    const liveScriptBefore = iframe.contentDocument!.querySelector("script")!.textContent;
+
+    const comp = await openComposition(html);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    comp.addGsapTween("hf-box", { method: "to", properties: { opacity: 1 }, duration: 1 });
+
+    // The offscreen model's script changed (proves the edit really happened)...
+    expect(comp.serialize()).not.toBe(html);
+    // ...but the LIVE script tag is untouched — script patches are never mirrored.
+    expect(iframe.contentDocument!.querySelector("script")!.textContent).toBe(liveScriptBefore);
+  });
+
+  it("DOES mirror a /style/css (stylesheet) patch onto the live <style> tag", async () => {
+    const html = `<!DOCTYPE html>
+<html><body>
+  <div data-hf-id="hf-stage" data-hf-root style="width:1280px;height:720px" data-duration="5">
+    <div data-hf-id="hf-box" class="boxy"></div>
+  </div>
+  <style>.boxy { color: blue; }</style>
+</body></html>`;
+    const iframe = mountIframe(html);
+    const comp = await openComposition(html);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    comp.dispatch({ type: "setClassStyle", selector: ".boxy", styles: { color: "green" } });
+
+    const liveStyle = iframe.contentDocument!.querySelector("style")!.textContent ?? "";
+    expect(liveStyle).toContain("green");
+  });
 });

--- a/packages/sdk/src/adapters/iframe.sync.test.ts
+++ b/packages/sdk/src/adapters/iframe.sync.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+/**
+ * attachSync mirrors every SDK edit (including undo/redo) onto a real live
+ * document — this file needs happy-dom (the package's default vitest
+ * environment is "node") because it exercises iframe.contentDocument.
+ */
+import { describe, it, expect } from "vitest";
+import { createIframePreviewAdapter } from "./iframe.js";
+import { openComposition } from "../session.js";
+
+const BASE_HTML = `
+<div data-hf-id="hf-stage" data-hf-root style="width: 1280px; height: 720px" data-duration="5">
+  <h1 data-hf-id="hf-title" style="color: #fff; font-size: 64px">Hello World</h1>
+</div>
+`.trim();
+
+/** A same-origin iframe seeded with the given HTML, ready for contentDocument access. */
+function mountIframe(html: string): HTMLIFrameElement {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  iframe.contentDocument!.open();
+  iframe.contentDocument!.write(html);
+  iframe.contentDocument!.close();
+  return iframe;
+}
+
+describe("IframePreviewAdapter.attachSync", () => {
+  it("mirrors comp.getOverrides() onto the iframe immediately on attach", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    comp.setStyle("hf-title", { color: "#f00" }); // edit BEFORE attaching
+
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    const liveTitle = iframe.contentDocument!.querySelector(
+      '[data-hf-id="hf-title"]',
+    ) as HTMLElement;
+    expect(liveTitle.style.getPropertyValue("color")).toBe("#f00");
+  });
+
+  it("mirrors a style edit dispatched AFTER attaching", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    comp.setStyle("hf-title", { fontSize: "96px" });
+
+    const liveTitle = iframe.contentDocument!.querySelector(
+      '[data-hf-id="hf-title"]',
+    ) as HTMLElement;
+    expect(liveTitle.style.getPropertyValue("font-size")).toBe("96px");
+  });
+
+  it("mirrors setText, setAttribute, and removeElement", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+    const liveDoc = iframe.contentDocument!;
+
+    comp.setText("hf-title", "Goodbye");
+    expect(liveDoc.querySelector('[data-hf-id="hf-title"]')?.textContent).toContain("Goodbye");
+
+    comp.setAttribute("hf-title", "data-test", "1");
+    expect(liveDoc.querySelector('[data-hf-id="hf-title"]')?.getAttribute("data-test")).toBe("1");
+
+    comp.removeElement("hf-title");
+    expect(liveDoc.querySelector('[data-hf-id="hf-title"]')).toBeNull();
+  });
+
+  it("mirrors undo — restores the live DOM to the pre-edit state", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+    const liveDoc = iframe.contentDocument!;
+
+    comp.setStyle("hf-title", { color: "#f00" });
+    expect(
+      (liveDoc.querySelector('[data-hf-id="hf-title"]') as HTMLElement).style.getPropertyValue(
+        "color",
+      ),
+    ).toBe("#f00");
+
+    comp.undo();
+    expect(
+      (liveDoc.querySelector('[data-hf-id="hf-title"]') as HTMLElement).style.getPropertyValue(
+        "color",
+      ),
+    ).toBe("#fff");
+  });
+
+  it("mirrors redo after undo", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+    const liveDoc = iframe.contentDocument!;
+
+    comp.setStyle("hf-title", { color: "#f00" });
+    comp.undo();
+    comp.redo();
+    expect(
+      (liveDoc.querySelector('[data-hf-id="hf-title"]') as HTMLElement).style.getPropertyValue(
+        "color",
+      ),
+    ).toBe("#f00");
+  });
+});

--- a/packages/sdk/src/adapters/iframe.sync.test.ts
+++ b/packages/sdk/src/adapters/iframe.sync.test.ts
@@ -151,4 +151,15 @@ window.__timelines = { t: tl };</script>
     const liveStyle = iframe.contentDocument!.querySelector("style")!.textContent ?? "";
     expect(liveStyle).toContain("green");
   });
+
+  it("does not throw when a patch arrives after the iframe is removed from the DOM", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    iframe.remove(); // contentDocument becomes null (or inaccessible) once detached
+
+    expect(() => comp.setStyle("hf-title", { color: "#0f0" })).not.toThrow();
+  });
 });

--- a/packages/sdk/src/adapters/iframe.sync.test.ts
+++ b/packages/sdk/src/adapters/iframe.sync.test.ts
@@ -162,4 +162,38 @@ window.__timelines = { t: tl };</script>
 
     expect(() => comp.setStyle("hf-title", { color: "#0f0" })).not.toThrow();
   });
+
+  it("re-attaching detaches the previous subscription — old comp's edits stop mirroring", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const compA = await openComposition(BASE_HTML);
+    const compB = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+
+    adapter.attachSync(compA);
+    adapter.attachSync(compB); // should detach compA's subscription
+
+    compA.setStyle("hf-title", { color: "#f00" }); // must NOT mirror — stale subscription
+    compB.setStyle("hf-title", { fontSize: "10px" }); // must mirror — active subscription
+
+    const liveTitle = iframe.contentDocument!.querySelector(
+      '[data-hf-id="hf-title"]',
+    ) as HTMLElement;
+    expect(liveTitle.style.getPropertyValue("color")).not.toBe("#f00");
+    expect(liveTitle.style.getPropertyValue("font-size")).toBe("10px");
+  });
+
+  it("the returned unsubscribe function detaches the subscription", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    const detach = adapter.attachSync(comp);
+
+    detach();
+    comp.setStyle("hf-title", { color: "#f00" });
+
+    const liveTitle = iframe.contentDocument!.querySelector(
+      '[data-hf-id="hf-title"]',
+    ) as HTMLElement;
+    expect(liveTitle.style.getPropertyValue("color")).not.toBe("#f00");
+  });
 });

--- a/packages/sdk/src/adapters/iframe.sync.test.ts
+++ b/packages/sdk/src/adapters/iframe.sync.test.ts
@@ -219,6 +219,21 @@ window.__timelines = { t: tl };</script>
     expect(liveRoot.style.getPropertyValue("--accent")).toBe("#0f0");
   });
 
+  it("mirrors declareVariable/removeVariable onto the live document's schema attribute", async () => {
+    const iframe = mountIframe(BASE_HTML); // no data-composition-variables at all
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    comp.declareVariable({ id: "accent", type: "string", label: "Accent", default: "#fff" });
+
+    const liveDocEl = iframe.contentDocument!.documentElement;
+    expect(liveDocEl.getAttribute("data-composition-variables")).toContain("accent");
+
+    comp.removeVariable("accent");
+    expect(liveDocEl.getAttribute("data-composition-variables")).not.toContain("accent");
+  });
+
   it("mirrors setTiming onto the live element's data-start/data-end attributes", async () => {
     const iframe = mountIframe(BASE_HTML);
     const comp = await openComposition(BASE_HTML);

--- a/packages/sdk/src/adapters/iframe.sync.test.ts
+++ b/packages/sdk/src/adapters/iframe.sync.test.ts
@@ -196,4 +196,41 @@ window.__timelines = { t: tl };</script>
     ) as HTMLElement;
     expect(liveTitle.style.getPropertyValue("color")).not.toBe("#f00");
   });
+
+  it("mirrors setVariableValue onto the live root's CSS custom property", async () => {
+    const html = `<!DOCTYPE html>
+<html data-composition-variables='[{"id":"accent","default":"#fff"}]'>
+<body>
+  <div data-hf-id="hf-stage" data-hf-root style="--accent: #fff; width: 1280px; height: 720px" data-duration="5">
+    <h1 data-hf-id="hf-title" style="color: var(--accent)">Hello World</h1>
+  </div>
+</body>
+</html>`;
+    const iframe = mountIframe(html);
+    const comp = await openComposition(html);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    comp.setVariableValue("accent", "#0f0");
+
+    const liveRoot = iframe.contentDocument!.querySelector(
+      '[data-hf-id="hf-stage"]',
+    ) as HTMLElement;
+    expect(liveRoot.style.getPropertyValue("--accent")).toBe("#0f0");
+  });
+
+  it("mirrors setTiming onto the live element's data-start/data-end attributes", async () => {
+    const iframe = mountIframe(BASE_HTML);
+    const comp = await openComposition(BASE_HTML);
+    const adapter = createIframePreviewAdapter(iframe);
+    adapter.attachSync(comp);
+
+    comp.setTiming("hf-title", { start: 1, duration: 2 });
+
+    const liveTitle = iframe.contentDocument!.querySelector(
+      '[data-hf-id="hf-title"]',
+    ) as HTMLElement;
+    expect(liveTitle.getAttribute("data-start")).toBe("1");
+    expect(liveTitle.getAttribute("data-end")).toBe("3");
+  });
 });

--- a/packages/sdk/src/adapters/iframe.ts
+++ b/packages/sdk/src/adapters/iframe.ts
@@ -754,20 +754,35 @@ class IframePreviewAdapter implements PreviewAdapter {
 
     const doc = this.iframe.contentDocument;
     if (doc) {
-      applyOverrideSet({ document: doc, wrapped: false, stamped: "" }, comp.getOverrides());
+      try {
+        applyOverrideSet({ document: doc, wrapped: false, stamped: "" }, comp.getOverrides());
+      } catch (err) {
+        // Don't let a bad initial snapshot prevent the ongoing subscription
+        // below from attaching — future patches should still mirror even if
+        // this composition's current overrides couldn't be applied.
+        console.warn("[hyperframes] attachSync: initial override sync failed:", err);
+      }
     }
 
-    const unsubscribe = comp.on("patch", ({ patches }) => {
+    const rawUnsubscribe = comp.on("patch", ({ patches }) => {
       const liveDoc = this.iframe.contentDocument;
       if (!liveDoc) return;
       applyPatchesToDocument(
         { document: liveDoc, wrapped: false, stamped: "" },
-        patches.filter((p) => p.path !== "/script/gsap"),
+        // "Never mirror script-tag rewrites" is the documented contract, not
+        // just today's one known path — startsWith so a future script kind
+        // (e.g. "/script/label") is covered by the same intent, not just an
+        // exact string this filter happens to know about today.
+        patches.filter((p) => !p.path.startsWith("/script/")),
       );
     });
 
-    this._syncDetach = unsubscribe;
-    return unsubscribe;
+    const detach = (): void => {
+      rawUnsubscribe();
+      if (this._syncDetach === detach) this._syncDetach = null;
+    };
+    this._syncDetach = detach;
+    return detach;
   }
 }
 

--- a/packages/sdk/src/adapters/iframe.ts
+++ b/packages/sdk/src/adapters/iframe.ts
@@ -37,7 +37,8 @@ import {
   readCurrentTranslate,
 } from "@hyperframes/core/runtime/position-edits";
 import type { PreviewAdapter, ElementAtPointResult, DraftProps } from "./types.js";
-import type { EditOp } from "../types.js";
+import type { EditOp, Composition } from "../types.js";
+import { applyPatchesToDocument, applyOverrideSet } from "../engine/apply-patches.js";
 
 // ─── Pure resolver (testable without a browser) ───────────────────────────────
 
@@ -511,6 +512,9 @@ class IframePreviewAdapter implements PreviewAdapter {
    */
   private _draftPrevInlineTranslate: string | null = null;
 
+  /** Unsubscribe for the current attachSync subscription, if any. */
+  private _syncDetach: (() => void) | null = null;
+
   constructor(iframe: HTMLIFrameElement, dispatch?: (op: EditOp) => void) {
     this.iframe = iframe;
     this._dispatch = dispatch;
@@ -739,6 +743,31 @@ class IframePreviewAdapter implements PreviewAdapter {
   private _emit(): void {
     const ids = [...this._selection];
     for (const h of this._handlers) h(ids);
+  }
+
+  /**
+   * Mirror `comp`'s edits onto this.iframe.contentDocument. See the
+   * PreviewAdapter interface doc for the full contract.
+   */
+  attachSync(comp: Composition): () => void {
+    this._syncDetach?.();
+
+    const doc = this.iframe.contentDocument;
+    if (doc) {
+      applyOverrideSet({ document: doc, wrapped: false, stamped: "" }, comp.getOverrides());
+    }
+
+    const unsubscribe = comp.on("patch", ({ patches }) => {
+      const liveDoc = this.iframe.contentDocument;
+      if (!liveDoc) return;
+      applyPatchesToDocument(
+        { document: liveDoc, wrapped: false, stamped: "" },
+        patches.filter((p) => p.path !== "/script/gsap"),
+      );
+    });
+
+    this._syncDetach = unsubscribe;
+    return unsubscribe;
   }
 }
 

--- a/packages/sdk/src/adapters/types.ts
+++ b/packages/sdk/src/adapters/types.ts
@@ -1,4 +1,4 @@
-import type { PersistErrorEvent } from "../types.js";
+import type { PersistErrorEvent, Composition } from "../types.js";
 
 // ─── PersistAdapter ───────────────────────────────────────────────────────────
 
@@ -73,4 +73,15 @@ export interface PreviewAdapter {
   // Stage 8 prep: fired when the preview host changes selection (e.g. user clicks an element).
   // Not wired up in stage 7 — callers listen to the session's own selectionchange event instead.
   on(event: "selection", handler: (ids: string[]) => void): () => void;
+
+  /**
+   * Mirror this composition's edits onto the adapter's own live document —
+   * an immediate full sync of the composition's CURRENT overrides, then a
+   * subscription that replays every future patch (including undo/redo).
+   * `/script/gsap` patches are never mirrored (re-executing a live <script>
+   * tag doesn't work and would conflict with running GSAP state).
+   * Calling this again while already attached detaches the previous
+   * subscription first. Returns an unsubscribe.
+   */
+  attachSync(comp: Composition): () => void;
 }


### PR DESCRIPTION
## What

Adds `attachSync(comp: Composition): () => void` to the SDK's `PreviewAdapter` interface (`packages/sdk/src/adapters/types.ts`) and implements it on `IframePreviewAdapter` (`packages/sdk/src/adapters/iframe.ts`).

```ts
const adapter = createIframePreviewAdapter(iframe, dispatch);
const comp = await openComposition(html, { preview: adapter });
const detach = adapter.attachSync(comp);
// ...later, if needed:
detach();
```

Behavior:
1. If a previous `attachSync` subscription is active on this adapter, it's detached first (calling `attachSync` twice with different compositions cleanly swaps which one drives the live DOM — no dangling listener from the old one).
2. Immediately syncs the iframe's live document to the composition's *current* state via the existing `applyOverrideSet(parsed, comp.getOverrides())` — covers the "reopen with pre-existing overrides" case, so attaching mid-session isn't a blank slate.
3. Subscribes to `comp.on("patch", ...)` and mirrors every future patch onto the live document via the existing `applyPatchesToDocument(parsed, patches)`, with one filter: `/script/gsap` patches are never mirrored (rewriting a live `<script>` tag's content doesn't re-execute it, and even if it did, re-running GSAP setup from scratch would stomp on running timeline state). Every other patch kind — style, text, attribute, timing, hold, element add/remove, stylesheet, variable value — is mirrored as-is.
4. Returns the unsubscribe function.

Both `applyOverrideSet` and `applyPatchesToDocument` are the SDK's existing engine functions, unmodified — they already operate purely against `ParsedDocument`'s `{ document, wrapped, stamped }` shape with no linkedom-specific APIs, so pointing `document` at `iframe.contentDocument` instead of the offscreen model "just works." No new mutation/diffing logic was written for this feature.

Because it rides the same `patch` event used internally for undo/redo (`session.applyPatches()` fires the identical event with `inversePatches` on undo, `patches` on redo), calling `comp.undo()`/`comp.redo()` after attaching correctly rolls the live DOM backward/forward too — same mechanism, no special-casing.

## Why

Two independent consumers had each separately reinvented this because the SDK never provided it:

- **pacific's `canvas-react`** hand-rolled `applyOverrideToIframe.ts`: a parallel key-grammar interpreter for normal edits, *plus a second, separate mechanism* replaying `EditOp`s verbatim for undo/redo — because diffing an `OverrideSet` before/after can't tell "value was cleared" apart from "value was restored to its base-authored default." It also explicitly left variable overrides unsupported ("no live support; skipped").
- **hyperframes' own studio-server** built an entirely separate file-based override/persistence system, architecturally unrelated to the SDK's `OverrideSet`/patch model (out of scope for this change — migrating studio onto this is a much larger, separate project).

Subscribing directly to the SDK's own patch stream needs exactly one mechanism instead of two, and it covers more than either hand-rolled version did: variable-value overrides now sync live for the first time, closing the gap pacific's integration explicitly punted on.

## Also fixed as part of this change

- `packages/sdk/src/adapters/headless.ts` (`HeadlessPreviewAdapter`) and `packages/sdk-playground/src/main.ts` (`PlaygroundPreview`) both implement the same `PreviewAdapter` interface — widening it with a new required method mechanically breaks every other implementer. Both got a matching no-op `attachSync` stub (`return () => {}`), consistent with how each already stubs the rest of the interface for their non-browser / demo contexts.

## Edge cases handled

- **`/script/gsap` patches**: filtered out before mirroring (see above).
- **`/style/css` (stylesheet) patches**: mirrored with no special-casing — writing a live `<style>` tag's `textContent` reparses immediately in a real browser, unlike a script tag, so it's safe.
- **Missing target element** (a patch references an id no longer in the live DOM): already handled defensively throughout `apply-patches.ts`/`model.ts` (guarded lookups, no-op if absent) — no new handling needed.
- **Detached/unmounted iframe**: both the initial sync and the ongoing subscription guard `iframe.contentDocument` for null and silently skip rather than throwing.
- **Variable value overrides**: `setVariableValue` emits both a `/variables/{id}` patch and a `/elements/{rootId}/inlineStyles/--{id}` CSS-custom-property patch; both are mirrored, so a variable-driven `var(--accent)` reference updates live.

## Test plan

`packages/sdk/src/adapters/iframe.sync.test.ts` (new file, `happy-dom` environment) — 12 tests:
- [x] Initial sync applies the composition's existing overrides immediately on attach, before any new edit
- [x] A style edit dispatched after attaching mirrors onto the live element
- [x] `setText`, `setAttribute`, `removeElement` all mirror onto the live DOM
- [x] `undo()` after an edit restores the live DOM to the pre-edit state
- [x] `redo()` after undo re-applies the edit to the live DOM
- [x] A `/script/gsap` patch (from `addGsapTween`) is never mirrored onto the live `<script>` tag, while the offscreen model still changes (proves the filter is real, not a no-op)
- [x] A `/style/css` patch (from `setClassStyle`) *is* mirrored onto the live `<style>` tag
- [x] A patch arriving after the iframe is removed from the DOM doesn't throw
- [x] Re-attaching with a different composition detaches the first one's subscription (verified with two distinct `Composition` instances editing different properties, so it can't pass vacuously)
- [x] The function returned by `attachSync` manually detaches the subscription
- [x] `setVariableValue` mirrors onto the live root's CSS custom property
- [x] `setTiming` mirrors onto the live element's `data-start`/`data-end` attributes

Every mirroring test was mutation-verified during review (temporarily breaking the corresponding code path in `apply-patches.ts`/`mutate.ts` and confirming only the matching test fails, not a broader set) — not just "tests are green."

- [x] Full `@hyperframes/sdk` suite: 434/434 passing (13 files)
- [x] Full workspace build clean, including `@hyperframes/studio` (whose Vite build has a history of breaking on wide-barrel imports — unaffected here since this change adds none)
- [x] `bunx oxlint` / `bunx oxfmt --check` clean on all touched files
