### PR TITLE
feat(studio): fold variables into the design panel + summonable manager

### DIFF
--- a/packages/studio/src/components/DesignPanelPromoteProvider.tsx
+++ b/packages/studio/src/components/DesignPanelPromoteProvider.tsx
@@ -38,7 +38,12 @@ export function DesignPanelPromoteProvider({
     activeCompPath: targetPath,
   });
   return (
-    <VariablePromoteProvider session={handle.session} selection={selection} persist={persist}>
+    <VariablePromoteProvider
+      session={handle.session}
+      selection={selection}
+      persist={persist}
+      targetPath={targetPath}
+    >
       {children}
     </VariablePromoteProvider>
   );

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -14,7 +14,10 @@ import { BlockParamsPanel } from "./editor/BlockParamsPanel";
 import { RenderQueue } from "./renders/RenderQueue";
 import { SlideshowPanel } from "./panels/SlideshowPanel";
 import type { SceneInfo } from "./panels/SlideshowPanel";
-import { VariablesPanel } from "./panels/VariablesPanel";
+import {
+  VariablesManagerSlideOver,
+  VariablesManagerTrigger,
+} from "./panels/VariablesManagerSlideOver";
 import { PanelTabButton } from "./PanelTabButton";
 import { usePreviewVariablesStore } from "../hooks/previewVariablesStore";
 import type { RenderJob } from "./renders/useRenderQueue";
@@ -504,12 +507,10 @@ export function StudioRightPanel({
                 active={rightPanelTab === "slideshow"}
                 onClick={() => setRightPanelTab("slideshow")}
               />
-              <PanelTabButton
-                label="Variables"
-                tooltip="Template variables — declare, preview with values"
-                active={rightPanelTab === "variables"}
-                onClick={() => setRightPanelTab("variables")}
-              />
+              {/* Variables is no longer a tab: creation/default-editing is inline
+                  in the Design panel (promote pill + bound chip); this opens the
+                  on-demand manager for the full list. */}
+              <VariablesManagerTrigger />
             </div>
             <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
               {rightPanelTab === "block-params" && activeBlockParams ? (
@@ -525,13 +526,6 @@ export function StudioRightPanel({
                   scenes={slideshowScenes}
                   onPersist={onPersistSlideshow}
                   onPersistNotes={onPersistSlideshowNotes}
-                />
-              ) : rightPanelTab === "variables" ? (
-                <VariablesPanel
-                  sdkSession={sdkSession}
-                  reloadPreview={reloadPreview}
-                  domEditSaveTimestampRef={domEditSaveTimestampRef}
-                  recordEdit={recordEdit}
                 />
               ) : layersPaneOpen && designPaneOpen ? (
                 <div ref={splitContainerRef} className="flex h-full min-h-0 min-w-0 flex-col">
@@ -585,6 +579,12 @@ export function StudioRightPanel({
           </>
         )}
       </div>
+      <VariablesManagerSlideOver
+        sdkSession={sdkSession}
+        reloadPreview={reloadPreview}
+        domEditSaveTimestampRef={domEditSaveTimestampRef}
+        recordEdit={recordEdit}
+      />
     </>
   );
 }

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -581,6 +581,8 @@ export function StudioRightPanel({
       </div>
       <VariablesManagerSlideOver
         sdkSession={sdkSession}
+        projectId={projectId}
+        activeCompPath={activeCompPath}
         reloadPreview={reloadPreview}
         domEditSaveTimestampRef={domEditSaveTimestampRef}
         recordEdit={recordEdit}

--- a/packages/studio/src/components/editor/PromotableControl.tsx
+++ b/packages/studio/src/components/editor/PromotableControl.tsx
@@ -87,7 +87,10 @@ export function PromotableControl({
           title={`Bound to variable "${promote.boundId}" — open the Variables manager`}
           onClick={(e) => {
             e.stopPropagation();
-            openVariablesManager(true);
+            // Open the manager against the SAME file this control's variable
+            // lives in (a sub-comp file when the selection is inside an inlined
+            // sub-composition), so it isn't managing the host by mistake.
+            openVariablesManager(true, promote.targetPath);
           }}
           className="absolute right-1.5 top-0 z-10 inline-flex max-w-[60%] items-center gap-1 truncate rounded bg-studio-accent/20 px-1 py-px font-mono text-[8px] font-medium text-studio-accent transition-colors hover:bg-studio-accent/30"
         >

--- a/packages/studio/src/components/editor/PromotableControl.tsx
+++ b/packages/studio/src/components/editor/PromotableControl.tsx
@@ -14,6 +14,7 @@ import {
   useVariablePromoteChannel,
   type PromoteChannel,
 } from "../../contexts/VariablePromoteContext";
+import { useVariablesManagerStore } from "../../hooks/variablesManagerStore";
 
 interface RenderArgs {
   /** When bound, the variable's default to display; otherwise undefined. */
@@ -38,6 +39,7 @@ export function PromotableControl({
   children: (args: RenderArgs) => React.ReactNode;
 }) {
   const promote = useVariablePromoteChannel(channel);
+  const openVariablesManager = useVariablesManagerStore((s) => s.setOpen);
 
   // A binding attribute (`data-var-*` / `var(--id)`) pointing at a declaration
   // that no longer exists renders as a plain unbound control — a silent
@@ -80,12 +82,17 @@ export function PromotableControl({
     <div className={`relative ${bound ? "rounded-lg ring-1 ring-studio-accent/40" : ""}`}>
       {rendered}
       {bound && (
-        <span
-          className="pointer-events-none absolute right-1.5 top-0 z-10 inline-flex max-w-[60%] items-center gap-1 truncate rounded bg-studio-accent/20 px-1 py-px font-mono text-[8px] font-medium text-studio-accent"
-          title={`Bound to variable "${promote.boundId}"`}
+        <button
+          type="button"
+          title={`Bound to variable "${promote.boundId}" — open the Variables manager`}
+          onClick={(e) => {
+            e.stopPropagation();
+            openVariablesManager(true);
+          }}
+          className="absolute right-1.5 top-0 z-10 inline-flex max-w-[60%] items-center gap-1 truncate rounded bg-studio-accent/20 px-1 py-px font-mono text-[8px] font-medium text-studio-accent transition-colors hover:bg-studio-accent/30"
         >
           ◆ {promote.boundId}
-        </span>
+        </button>
       )}
       {canPromote && (
         <button

--- a/packages/studio/src/components/panels/VariablesManagerSlideOver.test.ts
+++ b/packages/studio/src/components/panels/VariablesManagerSlideOver.test.ts
@@ -1,0 +1,32 @@
+/**
+ * resolveManagerOverridePath: decides whether the Variables manager opens a
+ * dedicated session for a targeted sub-composition file (bound-chip open) or
+ * reuses the host session (header trigger / same-file target).
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveManagerOverridePath } from "./VariablesManagerSlideOver";
+
+describe("resolveManagerOverridePath", () => {
+  it("returns null when the manager is closed", () => {
+    expect(resolveManagerOverridePath(false, "frames/card.html", "index.html")).toBeNull();
+  });
+
+  it("returns null when there is no target (header trigger)", () => {
+    expect(resolveManagerOverridePath(true, null, "index.html")).toBeNull();
+  });
+
+  it("returns null when the target is the active composition", () => {
+    expect(resolveManagerOverridePath(true, "index.html", "index.html")).toBeNull();
+  });
+
+  it("returns the target file when it differs from the active composition", () => {
+    expect(resolveManagerOverridePath(true, "frames/card.html", "index.html")).toBe(
+      "frames/card.html",
+    );
+  });
+
+  it("overrides even when there is no active composition (master view)", () => {
+    expect(resolveManagerOverridePath(true, "frames/card.html", null)).toBe("frames/card.html");
+  });
+});

--- a/packages/studio/src/components/panels/VariablesManagerSlideOver.tsx
+++ b/packages/studio/src/components/panels/VariablesManagerSlideOver.tsx
@@ -1,0 +1,107 @@
+import { useEffect, type MutableRefObject } from "react";
+import type { Composition } from "@hyperframes/sdk";
+import type { EditHistoryKind } from "../../utils/editHistory";
+import { useVariablesManagerStore } from "../../hooks/variablesManagerStore";
+import { usePreviewVariablesStore } from "../../hooks/previewVariablesStore";
+import { VariablesPanel } from "./VariablesPanel";
+
+/**
+ * Inspector-header button that opens the Variables manager. Not a tab — it also
+ * carries the global "previewing N overrides" signal (accent styling) so that
+ * state stays visible while the manager is closed.
+ */
+export function VariablesManagerTrigger() {
+  const setOpen = useVariablesManagerStore((s) => s.setOpen);
+  const overrideCount = usePreviewVariablesStore((s) =>
+    s.values ? Object.keys(s.values).length : 0,
+  );
+  return (
+    <button
+      type="button"
+      title="Manage template variables — declare, preview with values, dev handoff"
+      onClick={() => setOpen(true)}
+      className={`ml-auto flex h-6 items-center gap-1 rounded-md border px-2 text-[10px] font-medium transition-colors ${
+        overrideCount > 0
+          ? "border-studio-accent/40 bg-studio-accent/15 text-studio-accent"
+          : "border-neutral-800 text-neutral-400 hover:border-neutral-700 hover:text-neutral-200"
+      }`}
+    >
+      ◆ Variables
+      {overrideCount > 0 && <span>· {overrideCount}</span>}
+    </button>
+  );
+}
+
+/**
+ * Summonable overlay that hosts the full Variables manager (VariablesPanel).
+ *
+ * Replaces the dedicated Variables tab: the same declare / edit / remove /
+ * preview-override / handoff / other-composition surface, now opened on demand
+ * from the Design panel instead of occupying a permanent tab. Per-element
+ * creation and default-editing stay inline in the Design panel; this overlay is
+ * the list-oriented "manage everything" view. Closes on backdrop click or Esc.
+ */
+export function VariablesManagerSlideOver({
+  sdkSession,
+  reloadPreview,
+  domEditSaveTimestampRef,
+  recordEdit,
+}: {
+  sdkSession: Composition | null;
+  reloadPreview: () => void;
+  domEditSaveTimestampRef: MutableRefObject<number>;
+  recordEdit: (entry: {
+    label: string;
+    kind: EditHistoryKind;
+    files: Record<string, { before: string; after: string }>;
+  }) => Promise<void>;
+}) {
+  const open = useVariablesManagerStore((s) => s.open);
+  const setOpen = useVariablesManagerStore((s) => s.setOpen);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, setOpen]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex justify-end"
+      role="dialog"
+      aria-label="Variables manager"
+    >
+      <button
+        type="button"
+        aria-label="Close variables manager"
+        className="absolute inset-0 bg-black/40"
+        onClick={() => setOpen(false)}
+      />
+      <div className="relative flex h-full w-[360px] max-w-[90vw] flex-col border-l border-neutral-800 bg-neutral-900 shadow-2xl">
+        <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
+          <span className="text-[11px] font-semibold text-neutral-200">Variables manager</span>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="h-6 rounded px-2 text-[11px] text-neutral-400 hover:text-neutral-200"
+          >
+            Close
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <VariablesPanel
+            sdkSession={sdkSession}
+            reloadPreview={reloadPreview}
+            domEditSaveTimestampRef={domEditSaveTimestampRef}
+            recordEdit={recordEdit}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/studio/src/components/panels/VariablesManagerSlideOver.tsx
+++ b/packages/studio/src/components/panels/VariablesManagerSlideOver.tsx
@@ -3,6 +3,7 @@ import type { Composition } from "@hyperframes/sdk";
 import type { EditHistoryKind } from "../../utils/editHistory";
 import { useVariablesManagerStore } from "../../hooks/variablesManagerStore";
 import { usePreviewVariablesStore } from "../../hooks/previewVariablesStore";
+import { useSdkSession } from "../../hooks/useSdkSession";
 import { VariablesPanel } from "./VariablesPanel";
 
 /**
@@ -41,13 +42,62 @@ export function VariablesManagerTrigger() {
  * creation and default-editing stay inline in the Design panel; this overlay is
  * the list-oriented "manage everything" view. Closes on backdrop click or Esc.
  */
+/** Close the manager on Escape while it is open. */
+function useEscapeToClose(open: boolean, setOpen: (open: boolean) => void): void {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, setOpen]);
+}
+
+/**
+ * The file the manager should open a dedicated session for, or null to reuse the
+ * host session. Non-null only when the manager is open AND targets a file other
+ * than the active composition (a bound-chip open on a sub-composition element).
+ */
+export function resolveManagerOverridePath(
+  open: boolean,
+  targetPath: string | null,
+  activeCompPath: string | null,
+): string | null {
+  if (!open || !targetPath || targetPath === activeCompPath) return null;
+  return targetPath;
+}
+
+/**
+ * The session + path the manager panel edits. When opened from a bound chip on a
+ * sub-composition element the manager must target that element's OWN file — the
+ * host session manages the wrong composition — so a dedicated session is opened
+ * for the target (only while overriding). Otherwise the host session is reused.
+ */
+function useManagerPanelSession(
+  hostSession: Composition | null,
+  projectId: string | null,
+  activeCompPath: string | null,
+  ref: MutableRefObject<number>,
+  open: boolean,
+  targetPath: string | null,
+): { overridePath: string | null; panelSession: Composition | null } {
+  const overridePath = resolveManagerOverridePath(open, targetPath, activeCompPath);
+  const overrideHandle = useSdkSession(projectId, overridePath, ref);
+  return { overridePath, panelSession: overridePath ? overrideHandle.session : hostSession };
+}
+
 export function VariablesManagerSlideOver({
   sdkSession,
+  projectId,
+  activeCompPath,
   reloadPreview,
   domEditSaveTimestampRef,
   recordEdit,
 }: {
   sdkSession: Composition | null;
+  projectId: string | null;
+  activeCompPath: string | null;
   reloadPreview: () => void;
   domEditSaveTimestampRef: MutableRefObject<number>;
   recordEdit: (entry: {
@@ -57,18 +107,21 @@ export function VariablesManagerSlideOver({
   }) => Promise<void>;
 }) {
   const open = useVariablesManagerStore((s) => s.open);
+  const targetPath = useVariablesManagerStore((s) => s.targetPath);
   const setOpen = useVariablesManagerStore((s) => s.setOpen);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, setOpen]);
+  useEscapeToClose(open, setOpen);
+  const { overridePath, panelSession } = useManagerPanelSession(
+    sdkSession,
+    projectId,
+    activeCompPath,
+    domEditSaveTimestampRef,
+    open,
+    targetPath,
+  );
 
   if (!open) return null;
+
+  const usingOverride = overridePath !== null;
 
   return (
     <div
@@ -84,7 +137,14 @@ export function VariablesManagerSlideOver({
       />
       <div className="relative flex h-full w-[360px] max-w-[90vw] flex-col border-l border-neutral-800 bg-neutral-900 shadow-2xl">
         <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
-          <span className="text-[11px] font-semibold text-neutral-200">Variables manager</span>
+          <div className="flex min-w-0 flex-col">
+            <span className="text-[11px] font-semibold text-neutral-200">Variables manager</span>
+            {usingOverride && (
+              <span className="truncate font-mono text-[9px] text-neutral-500" title={overridePath}>
+                {overridePath}
+              </span>
+            )}
+          </div>
           <button
             type="button"
             onClick={() => setOpen(false)}
@@ -95,7 +155,8 @@ export function VariablesManagerSlideOver({
         </div>
         <div className="min-h-0 flex-1 overflow-hidden">
           <VariablesPanel
-            sdkSession={sdkSession}
+            sdkSession={panelSession}
+            compPathOverride={usingOverride ? overridePath : null}
             reloadPreview={reloadPreview}
             domEditSaveTimestampRef={domEditSaveTimestampRef}
             recordEdit={recordEdit}

--- a/packages/studio/src/components/panels/VariablesPanel.tsx
+++ b/packages/studio/src/components/panels/VariablesPanel.tsx
@@ -32,6 +32,14 @@ function shellSingleQuote(value: string): string {
 
 interface VariablesPanelProps {
   sdkSession: Composition | null;
+  /**
+   * Override the composition this panel manages as its PRIMARY comp, instead of
+   * the shell's `activeCompPath`. Set when the Variables manager is opened
+   * against a specific sub-composition file (a bound-chip click), so the panel's
+   * declarations, persist target, handoff, and "other compositions" exclusion
+   * all key off that file rather than the host.
+   */
+  compPathOverride?: string | null;
   reloadPreview: () => void;
   domEditSaveTimestampRef: MutableRefObject<number>;
   recordEdit: (entry: {
@@ -247,11 +255,15 @@ const EMPTY_STATE = (
 // fallow-ignore-next-line complexity
 export const VariablesPanel = memo(function VariablesPanel({
   sdkSession,
+  compPathOverride,
   reloadPreview,
   domEditSaveTimestampRef,
   recordEdit,
 }: VariablesPanelProps) {
-  const { activeCompPath, showToast } = useStudioShellContext();
+  const { activeCompPath: shellActiveCompPath, showToast } = useStudioShellContext();
+  // The manager can target a specific sub-composition file (bound-chip open);
+  // everywhere else this is just the shell's active composition.
+  const activeCompPath = compPathOverride ?? shellActiveCompPath;
   const { refreshKey } = useStudioPlaybackContext();
   const { readProjectFile, writeProjectFile, fileTree } = useFileManagerContext();
   const { domEditSelection } = useDomEditContext();

--- a/packages/studio/src/contexts/VariablePromoteContext.tsx
+++ b/packages/studio/src/contexts/VariablePromoteContext.tsx
@@ -36,6 +36,13 @@ export interface ChannelPromote {
   promote: () => void;
   /** Update the bound variable's default value in place. */
   setDefault: (value: string) => void;
+  /**
+   * Composition file this channel's variables live in — the selection's own
+   * sourceFile (a sub-comp when the element is inside an inlined sub-composition),
+   * else the active composition. The bound chip passes this to the Variables
+   * manager so it opens against the same file promotion writes to.
+   */
+  targetPath: string;
 }
 
 interface VariablePromoteContextValue {
@@ -44,6 +51,7 @@ interface VariablePromoteContextValue {
   actions: BindAction[];
   declarations: CompositionVariable[];
   persist: (label: string, mutate: (session: Composition) => void) => Promise<boolean>;
+  targetPath: string;
 }
 
 const VariablePromoteContext = createContext<VariablePromoteContextValue | null>(null);
@@ -58,11 +66,13 @@ export function VariablePromoteProvider({
   session,
   selection,
   persist,
+  targetPath,
   children,
 }: {
   session: Composition | null;
   selection: DomEditSelection | null;
   persist: (label: string, mutate: (session: Composition) => void) => Promise<boolean>;
+  targetPath: string;
   children: React.ReactNode;
 }) {
   // Re-derive actions/bindings after each persisted schema edit.
@@ -85,8 +95,8 @@ export function VariablePromoteProvider({
   }, [session, revision]);
 
   const value = useMemo<VariablePromoteContextValue>(
-    () => ({ session, selection, actions, declarations, persist }),
-    [session, selection, actions, declarations, persist],
+    () => ({ session, selection, actions, declarations, persist, targetPath }),
+    [session, selection, actions, declarations, persist, targetPath],
   );
 
   return (
@@ -105,7 +115,7 @@ export function useVariablePromoteChannel(channel: PromoteChannel): ChannelPromo
 
   return useMemo(() => {
     if (!ctx || !ctx.session || !ctx.selection?.hfId) return null;
-    const { session, selection, actions, declarations, persist } = ctx;
+    const { session, selection, actions, declarations, persist, targetPath } = ctx;
     const hfId = selection.hfId!;
     const action = matchAction(actions, channel);
     const boundId = readBinding(session, hfId, channel);
@@ -116,6 +126,7 @@ export function useVariablePromoteChannel(channel: PromoteChannel): ChannelPromo
       action,
       boundId,
       declaration,
+      targetPath,
       promote: () => {
         if (!action) return;
         // Right-click promote auto-names, so always mint a fresh id — unlike the

--- a/packages/studio/src/hooks/useDomSelection.ts
+++ b/packages/studio/src/hooks/useDomSelection.ts
@@ -207,11 +207,9 @@ export function useDomSelection({
       if (nextSelection) {
         if (options?.revealPanel !== false) {
           setRightCollapsed(false);
-          // Keep the Variables tab in place — selecting elements is part of
-          // the bind flow there; yanking to Design would lose the context.
-          if (rightPanelTabRef.current !== "variables") {
-            setRightPanelTab("design");
-          }
+          // Reveal the Design panel to inspect/promote the selection. The
+          // Variables manager (if open) is an overlay, so it stays put on top.
+          setRightPanelTab("design");
         }
         const nextSelectedTimelineId =
           findMatchingTimelineElementId(nextSelection, timelineElements) ??

--- a/packages/studio/src/hooks/useStudioContextValue.ts
+++ b/packages/studio/src/hooks/useStudioContextValue.ts
@@ -97,12 +97,7 @@ export function useInspectorState(
         STUDIO_INSPECTOR_PANELS_ENABLED && !rightCollapsed && inspectorPanelActive,
       // Keep the selection box + motion path drawn even when the Inspector is
       // collapsed — closing the panel shouldn't visually deselect the element.
-      // The Variables tab also works against the canvas selection (bind card),
-      // so the selection outline stays visible there too.
-      shouldShowSelectedDomBounds:
-        (inspectorPanelActive || rightPanelTab === "variables") &&
-        !isPlaying &&
-        !isGestureRecording,
+      shouldShowSelectedDomBounds: inspectorPanelActive && !isPlaying && !isGestureRecording,
     };
   }, [rightPanelTab, rightInspectorPanes, rightCollapsed, isPlaying, isGestureRecording]);
 }

--- a/packages/studio/src/hooks/variablesManagerStore.ts
+++ b/packages/studio/src/hooks/variablesManagerStore.ts
@@ -12,10 +12,19 @@ import { create } from "zustand";
  */
 interface VariablesManagerState {
   open: boolean;
-  setOpen: (open: boolean) => void;
+  /**
+   * Composition file the manager should manage as its PRIMARY composition. A
+   * bound-chip click passes the promoted element's own file (a sub-comp when the
+   * selection lives inside an inlined sub-composition) so the manager edits the
+   * same file promotion wrote to — not the host. `null` targets the active/master
+   * composition (the header trigger's behavior).
+   */
+  targetPath: string | null;
+  setOpen: (open: boolean, targetPath?: string | null) => void;
 }
 
 export const useVariablesManagerStore = create<VariablesManagerState>((set) => ({
   open: false,
-  setOpen: (open) => set({ open }),
+  targetPath: null,
+  setOpen: (open, targetPath = null) => set({ open, targetPath }),
 }));

--- a/packages/studio/src/hooks/variablesManagerStore.ts
+++ b/packages/studio/src/hooks/variablesManagerStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+/**
+ * Open/closed state for the summonable Variables manager slide-over.
+ *
+ * The manager replaces the old dedicated Variables tab: variable creation and
+ * default-editing happen inline in the Design panel (promote pill + bound chip),
+ * while the full list — declare, edit, remove, preview overrides, dev handoff,
+ * and other-composition variables — lives in this on-demand overlay. It is a
+ * global store because the trigger (a control's ◆ chip, deep in the Design
+ * panel) and the overlay (mounted at the right panel) live in different subtrees.
+ */
+interface VariablesManagerState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export const useVariablesManagerStore = create<VariablesManagerState>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+}));

--- a/packages/studio/src/utils/studioHelpers.ts
+++ b/packages/studio/src/utils/studioHelpers.ts
@@ -13,13 +13,7 @@ export interface AppToast {
   tone: "error" | "info";
 }
 
-export type RightPanelTab =
-  | "layers"
-  | "design"
-  | "renders"
-  | "block-params"
-  | "slideshow"
-  | "variables";
+export type RightPanelTab = "layers" | "design" | "renders" | "block-params" | "slideshow";
 export type RightInspectorPane = "layers" | "design";
 
 export interface RightInspectorPanes {

--- a/packages/studio/src/utils/studioUrlState.test.ts
+++ b/packages/studio/src/utils/studioUrlState.test.ts
@@ -33,13 +33,16 @@ describe("resolveMasterCompositionPath", () => {
 });
 
 describe("normalizeStudioUrlPanelTab", () => {
-  it("accepts slideshow and variables as valid tabs", () => {
+  it("accepts slideshow as a valid tab", () => {
     expect(normalizeStudioUrlPanelTab("slideshow", { inspectorPanelsEnabled: true })).toBe(
       "slideshow",
     );
-    expect(normalizeStudioUrlPanelTab("variables", { inspectorPanelsEnabled: true })).toBe(
-      "variables",
-    );
+  });
+
+  it("rejects the retired 'variables' tab (now an on-demand manager, not a tab)", () => {
+    expect(
+      normalizeStudioUrlPanelTab("variables" as never, { inspectorPanelsEnabled: true }),
+    ).toBeNull();
   });
 });
 

--- a/packages/studio/src/utils/studioUrlState.ts
+++ b/packages/studio/src/utils/studioUrlState.ts
@@ -19,7 +19,11 @@ export interface StudioUrlState {
   selection: StudioUrlSelectionState | null;
 }
 
-const VALID_TABS: RightPanelTab[] = ["layers", "design", "renders", "slideshow", "variables"];
+// "variables" is intentionally absent: variables are no longer a tab — they're
+// managed inline in the Design panel + an on-demand slide-over (see
+// useVariablesManagerStore), so a persisted ?tab=variables deep link falls back
+// to the default rather than selecting a tab that no longer exists.
+const VALID_TABS: RightPanelTab[] = ["layers", "design", "renders", "slideshow"];
 
 /**
  * The composition a schema-level panel (Variables / Slideshow) targets on the


### PR DESCRIPTION
## What

Retires the dedicated **Variables tab** and folds variable management into the Design panel, per Miguel's feedback ("variables doesn't need a new tab… can we modify them directly in the design panel"). Stacked on #2084.

## Design rationale (adversarially reviewed)

Before building, I ran two design subagents — one attacking the "just fold it in" proposal, one steelmanning it. They converged on:
1. **Drop the tab** — creation + default-editing already live in the Design panel (the `◇ var` promote pill / `◆ {id}` bound chip), so the tab was a redundant second home.
2. **The one real trap** is losing *bind-to-existing* (define-once, bind-many). This PR avoids it by construction: the manager hosts the **existing `VariablesPanel` unchanged**, which still contains the "Bind selected" card.
3. **Keep the "previewing N overrides" signal always visible** — the trigger button carries it while the manager is closed.

## How

- **`◆ Variables` trigger** in the inspector header (`VariablesManagerTrigger`) opens an on-demand slide-over; accent-styled + count when preview overrides are active.
- **`VariablesManagerSlideOver`** — right-anchored overlay hosting `VariablesPanel` verbatim (declare / edit / remove / preview / handoff / other-comps / bind-to-existing). Closes on backdrop click or Esc.
- **Bound `◆` chip** in the Design panel is now clickable → opens the manager (manage-where-you-see-it).
- Tab removed from `StudioRightPanel`, `RightPanelTab`, and `VALID_TABS`; `?tab=variables` deep links fall back to the default. Selection-outline logic that special-cased the old tab is simplified (the manager overlays the Design panel, so bounds already show).

## Follow-up (deferred, not a regression)

Per-control **"New variable / Bind to existing…"** on the `◇` pill (bind-to-existing from the control itself) — the capability is preserved today via the manager's bind card; this would add locality. Left for a follow-up.

## Testing

Full studio suite green (1423). Typecheck + lint + fallow + filesize gates pass. ⚠️ Live browser UX (slide-over layout, chip-opens-manager, override-signal accent) wants a human pass — agent-browser canvas-selection driving is unreliable in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
