### PR TITLE
fix(core): reproduce figma's vertical text trim via text-box-trim

### DIFF
--- a/packages/core/src/figma/nodeToHtml.test.ts
+++ b/packages/core/src/figma/nodeToHtml.test.ts
@@ -102,6 +102,45 @@ describe("nodeToHtml", () => {
     expect(out.html).not.toContain('id="3d-object-headphones"');
   });
 
+  it("emits text-box-trim for vertically trimmed text (box height < line-height)", () => {
+    const out = nodeToHtml(
+      frame([
+        {
+          id: "1:2",
+          name: "Headline",
+          type: "TEXT",
+          absoluteBoundingBox: BOX(140, 260, 304, 51),
+          fills: [SOLID_BLUE],
+          characters: "Unlocked",
+          style: { fontFamily: "Inter", fontWeight: 700, fontSize: 70, lineHeightPx: 66.5 },
+        },
+      ]),
+      { resolved: [], unresolved: [] },
+    );
+    // figma's trimmed bounds (51px box for a 66.5px line) place cap height at
+    // the box top; browsers overflow the glyphs below without text-box-trim
+    expect(out.html).toContain("text-box-trim: trim-both");
+    expect(out.html).toContain("text-box-edge: cap alphabetic");
+  });
+
+  it("does not trim text whose box matches its line-height", () => {
+    const out = nodeToHtml(
+      frame([
+        {
+          id: "1:2",
+          name: "Body",
+          type: "TEXT",
+          absoluteBoundingBox: BOX(140, 260, 304, 39),
+          fills: [SOLID_BLUE],
+          characters: "Subtitle",
+          style: { fontFamily: "Inter", fontWeight: 400, fontSize: 32, lineHeightPx: 38.4 },
+        },
+      ]),
+      { resolved: [], unresolved: [] },
+    );
+    expect(out.html).not.toContain("text-box-trim");
+  });
+
   it("emits var() with literal fallback for resolved bindings", () => {
     const out = nodeToHtml(
       frame([

--- a/packages/core/src/figma/nodeToHtml.ts
+++ b/packages/core/src/figma/nodeToHtml.ts
@@ -152,6 +152,23 @@ function textCss(node: FigmaNodeDocument, styles: string[]): void {
   if (typeof s.lineHeightPx === "number") styles.push(`line-height: ${round(s.lineHeightPx)}px`);
   if (typeof s.letterSpacing === "number" && s.letterSpacing !== 0)
     styles.push(`letter-spacing: ${round(s.letterSpacing)}px`);
+  if (isVerticallyTrimmed(node, s.lineHeightPx)) {
+    styles.push("text-box-trim: trim-both", "text-box-edge: cap alphabetic");
+  }
+}
+
+/**
+ * Vertical trim: a figma text box SHORTER than its line-height is
+ * cap-height-trimmed bounds. Browsers place glyphs with half-leading and
+ * overflow the short box downward (~6px low on a 70px font, measured
+ * against figma's own render). text-box-trim reproduces figma's trim in
+ * the render engine (Chrome). Single-line text only.
+ */
+function isVerticallyTrimmed(node: FigmaNodeDocument, lineHeightPx: unknown): boolean {
+  if (typeof lineHeightPx !== "number") return false;
+  const box = boxOf(node);
+  if (box === null || box.height >= lineHeightPx - 1) return false;
+  return typeof node.characters === "string" && !node.characters.includes("\n");
 }
 
 interface RenderContext {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -10,7 +10,7 @@
       "files": 18
     },
     "figma": {
-      "hash": "431580ce359639f5",
+      "hash": "c2929c6cc7ca35b3",
       "files": 2
     },
     "general-video": {

--- a/skills/figma/SKILL.md
+++ b/skills/figma/SKILL.md
@@ -78,6 +78,7 @@ hyperframes figma component '<url-or-fileKey:nodeId>'
 
 Node tree → editable HTML at exact figma geometry, packaged as a registry item under `compositions/components/<name>/`. Vectors/boolean-ops auto-rasterize via Phase-1 export. Binding pass (spec §7.1, exact-ID only — never value matching):
 
+- **Static fidelity self-check (mandatory for hero content)**: after importing, render the fragment and compare against figma's own pixels — `figma asset <same node> --format png` is the ground truth. Text is the known drift axis: a figma text box shorter than its line-height is vertically-trimmed bounds (the mapper emits `text-box-trim` for these; measured drift without it was ~6px on a 70px font). If the comparison shows drift the mapper doesn't cover, report it — don't hand-tweak the fragment silently.
 - Fill bound to an **imported** token → `var(--slug, #literal)` — brand refresh propagates.
 - Bound to an **unknown** token → literal + `data-figma-unresolved` flag. The command tells you; offer the user: run `tokens` on the source (or library) file, then re-import the component to link them. Ask **once** per unknown library which file it is — never guess, never match by hex.
 


### PR DESCRIPTION
Follow-up to #2063, found by a user report ("the Unlocked text is slightly off center") and root-caused with glyph-centroid measurement against Figma's own render.

## The defect

A Figma text node whose box is **shorter than its line-height** carries vertically-trimmed (cap-to-baseline) bounds — e.g. a 51px box for a 70px font with 66.5px line-height. The mapper positioned the box at those bounds but let the browser lay glyphs with normal half-leading, so the glyphs overflowed the short box downward: measured **+9.1px** glyph-centroid offset inside the pill vs Figma's own **+3.4px** — the text sat ~6px too low.

## The fix

When `box.height < lineHeightPx - 1` on single-line text, emit `text-box-trim: trim-both; text-box-edge: cap alphabetic` — Chrome (the render engine) reproduces Figma's trim exactly. Verified with a minimal repro (trimmed vs untrimmed box side by side) and re-measured on the real import: post-fix centroid agrees with Figma within **0.4px**, and the motion verifier's min window score improved 20.3 → 25.3dB (the mispositioned text had been dragging motion-delta windows too). Boxes matching their line-height are untouched.

## Systemic guard

The `/figma` skill's component step now includes a mandatory static fidelity self-check for hero content: compare the imported fragment against `figma asset <same node> --format png` (Figma's own pixels), and report mapper gaps instead of hand-tweaking fragments.

Tests: trimmed-text emits trim, line-height-matching text doesn't; core figma suite 106/106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)