### PR TITLE
fix(cli): keep slow browser installs from losing their lock [P0]

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -97,6 +97,14 @@ function installFsMocks({ existing, dirs }: FsMockOptions) {
       }
       return { mtimeMs: mtimes.get(p) ?? 0 };
     },
+    utimesSync: (p: string, _atime: Date, mtime: Date) => {
+      if (!paths.has(p)) {
+        const err = new Error(`ENOENT: no such file or directory, utimes '${p}'`);
+        (err as NodeJS.ErrnoException).code = "ENOENT";
+        throw err;
+      }
+      mtimes.set(p, mtime.getTime());
+    },
   }));
   vi.doMock("node:os", () => ({
     homedir: () => FAKE_HOME,
@@ -359,6 +367,65 @@ describe("findBrowser — cache resolution", () => {
     await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
     expect(paths.has(HF_LOCK)).toBe(false);
     expect(paths.has(HF_RECLAIM_LOCK)).toBe(false);
+  });
+
+  it("withInstallLock does not let a second caller run concurrently with a slow-but-alive holder", async () => {
+    // Bug: the timeout-reclaim check only ever looked at the lock dir's
+    // mtime, which used to be set once at acquire time and never touched
+    // again. A real (non-crashed) download+extract that runs *longer* than
+    // timeoutMs — plausible on a slow/throttled connection downloading the
+    // ~115-160MB chrome-headless-shell archive — looks indistinguishable
+    // from a crashed holder, so a concurrent waiter reclaims the lock and
+    // starts its own install while the first is still running. That
+    // recreates the exact concurrent-extraction race #1866 added this lock
+    // to prevent (feedback: a 100%-download loop on a Linux daemon, and a
+    // fleet of processes racing the same shared cache path).
+    const paths = installFsMocks({ existing: new Set([CACHE_ROOT]) });
+
+    const { withInstallLock } = await import("./manager.js");
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    const trackConcurrency = async (label: string, durationMs: number) => {
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((resolve) => setTimeout(resolve, durationMs));
+      concurrent -= 1;
+      return label;
+    };
+
+    // timeoutMs=10 is far shorter than the first caller's 40ms "install" —
+    // without a heartbeat keeping the lock's mtime fresh, the second caller
+    // would reclaim it well before the first finishes.
+    const first = withInstallLock(() => trackConcurrency("first", 40), 10, 5, 5);
+    await new Promise((resolve) => setTimeout(resolve, 2)); // let `first` acquire the lock
+    const second = withInstallLock(() => trackConcurrency("second", 5), 10, 5, 5);
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
+    expect(maxConcurrent).toBe(1);
+    expect(paths.has(HF_LOCK)).toBe(false);
+  });
+
+  it("withInstallLock reports progress while waiting instead of staying silent", async () => {
+    // Feedback: ~16 concurrent processes racing the same shared install lock
+    // saw completely silent output for ~10 minutes while waiting — indistin-
+    // guishable from a genuine hang. The lock itself was working correctly
+    // (no corruption), but nothing told the user a wait was in progress.
+    const paths = installFsMocks({ existing: new Set([CACHE_ROOT, HF_LOCK]) });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { withInstallLock } = await import("./manager.js");
+    // The lock in `paths` is never released by anyone else, so this caller
+    // waits out its own timeout (10ms) and reclaims it — but only after
+    // polling long enough to cross at least one wait-notice interval (5ms).
+    await withInstallLock(async () => "done", 10, 5, 1_000, 5);
+
+    expect(paths.has(HF_LOCK)).toBe(false);
+    expect(
+      warnSpy.mock.calls.some(([msg]) =>
+        String(msg).includes("Waiting for another hyperframes process"),
+      ),
+    ).toBe(true);
   });
 
   it("warns and falls through when the hyperframes cache cannot be read", async () => {

--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -50,6 +50,12 @@ const HF_BINARY = join(
   "chrome-headless-shell",
 );
 const SYSTEM_CHROME = "/usr/bin/google-chrome";
+const TEST_LOCK_TIMINGS = {
+  staleMs: 10,
+  pollMs: 5,
+  heartbeatMs: 5,
+  waitNoticeMs: 1_000,
+};
 
 interface FsMockOptions {
   existing: ReadonlySet<string>;
@@ -330,17 +336,10 @@ describe("findBrowser — cache resolution", () => {
   });
 
   it("withInstallLock reclaims a lock held past the timeout instead of hanging forever", async () => {
-    // A crashed/killed process could leave the lock directory behind
-    // permanently. Reclaiming after a timeout (rather than hanging or
-    // refusing forever) is the behavior that makes the lock safe to add at
-    // all — otherwise one bad exit wedges every future render. Exercises
-    // withInstallLock directly with tiny real timeouts (it takes an
-    // injectable timeoutMs/pollMs for exactly this) rather than mocking
-    // Date.now()/setTimeout through the full ensureBrowser call graph.
     const paths = installFsMocks({ existing: new Set([CACHE_ROOT, HF_LOCK]) });
 
     const { withInstallLock } = await import("./manager.js");
-    const result = await withInstallLock(async () => "done", 10, 5);
+    const result = await withInstallLock(async () => "done", TEST_LOCK_TIMINGS);
 
     expect(result).toBe("done");
     expect(paths.has(HF_LOCK)).toBe(false);
@@ -354,15 +353,12 @@ describe("findBrowser — cache resolution", () => {
     const paths = installFsMocks({ existing: new Set([CACHE_ROOT, HF_LOCK]) });
 
     const { withInstallLock } = await import("./manager.js");
-    const first = withInstallLock(
-      async () => {
-        await new Promise((resolve) => setTimeout(resolve, 30));
-        return "first";
-      },
-      10,
-      5,
-    );
-    const second = withInstallLock(async () => "second", 10, 5);
+    const reclaimOnlyTimings = { ...TEST_LOCK_TIMINGS, heartbeatMs: 1_000 };
+    const first = withInstallLock(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      return "first";
+    }, reclaimOnlyTimings);
+    const second = withInstallLock(async () => "second", reclaimOnlyTimings);
 
     await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
     expect(paths.has(HF_LOCK)).toBe(false);
@@ -370,16 +366,6 @@ describe("findBrowser — cache resolution", () => {
   });
 
   it("withInstallLock does not let a second caller run concurrently with a slow-but-alive holder", async () => {
-    // Bug: the timeout-reclaim check only ever looked at the lock dir's
-    // mtime, which used to be set once at acquire time and never touched
-    // again. A real (non-crashed) download+extract that runs *longer* than
-    // timeoutMs — plausible on a slow/throttled connection downloading the
-    // ~115-160MB chrome-headless-shell archive — looks indistinguishable
-    // from a crashed holder, so a concurrent waiter reclaims the lock and
-    // starts its own install while the first is still running. That
-    // recreates the exact concurrent-extraction race #1866 added this lock
-    // to prevent (feedback: a 100%-download loop on a Linux daemon, and a
-    // fleet of processes racing the same shared cache path).
     const paths = installFsMocks({ existing: new Set([CACHE_ROOT]) });
 
     const { withInstallLock } = await import("./manager.js");
@@ -394,12 +380,9 @@ describe("findBrowser — cache resolution", () => {
       return label;
     };
 
-    // timeoutMs=10 is far shorter than the first caller's 40ms "install" —
-    // without a heartbeat keeping the lock's mtime fresh, the second caller
-    // would reclaim it well before the first finishes.
-    const first = withInstallLock(() => trackConcurrency("first", 40), 10, 5, 5);
+    const first = withInstallLock(() => trackConcurrency("first", 40), TEST_LOCK_TIMINGS);
     await new Promise((resolve) => setTimeout(resolve, 2)); // let `first` acquire the lock
-    const second = withInstallLock(() => trackConcurrency("second", 5), 10, 5, 5);
+    const second = withInstallLock(() => trackConcurrency("second", 5), TEST_LOCK_TIMINGS);
 
     await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
     expect(maxConcurrent).toBe(1);
@@ -407,18 +390,11 @@ describe("findBrowser — cache resolution", () => {
   });
 
   it("withInstallLock reports progress while waiting instead of staying silent", async () => {
-    // Feedback: ~16 concurrent processes racing the same shared install lock
-    // saw completely silent output for ~10 minutes while waiting — indistin-
-    // guishable from a genuine hang. The lock itself was working correctly
-    // (no corruption), but nothing told the user a wait was in progress.
     const paths = installFsMocks({ existing: new Set([CACHE_ROOT, HF_LOCK]) });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const { withInstallLock } = await import("./manager.js");
-    // The lock in `paths` is never released by anyone else, so this caller
-    // waits out its own timeout (10ms) and reclaims it — but only after
-    // polling long enough to cross at least one wait-notice interval (5ms).
-    await withInstallLock(async () => "done", 10, 5, 1_000, 5);
+    await withInstallLock(async () => "done", { ...TEST_LOCK_TIMINGS, waitNoticeMs: 5 });
 
     expect(paths.has(HF_LOCK)).toBe(false);
     expect(

--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -51,9 +51,9 @@ const HF_BINARY = join(
 );
 const SYSTEM_CHROME = "/usr/bin/google-chrome";
 const TEST_LOCK_TIMINGS = {
-  staleMs: 10,
+  staleMs: 50,
   pollMs: 5,
-  heartbeatMs: 5,
+  heartbeatMs: 10,
   waitNoticeMs: 1_000,
 };
 
@@ -61,9 +61,10 @@ interface FsMockOptions {
   existing: ReadonlySet<string>;
   /** map of dir path -> entries returned by readdirSync */
   dirs?: Record<string, string[]>;
+  touchError?: Error;
 }
 
-function installFsMocks({ existing, dirs }: FsMockOptions) {
+function installFsMocks({ existing, dirs, touchError }: FsMockOptions) {
   // Mutable, and returned, so tests can pre-seed a "lock already held" path or
   // assert the lock dir doesn't leak after ensureBrowser resolves.
   const paths = new Set(existing);
@@ -104,6 +105,7 @@ function installFsMocks({ existing, dirs }: FsMockOptions) {
       return { mtimeMs: mtimes.get(p) ?? 0 };
     },
     utimesSync: (p: string, _atime: Date, mtime: Date) => {
+      if (touchError) throw touchError;
       if (!paths.has(p)) {
         const err = new Error(`ENOENT: no such file or directory, utimes '${p}'`);
         (err as NodeJS.ErrnoException).code = "ENOENT";
@@ -380,9 +382,9 @@ describe("findBrowser — cache resolution", () => {
       return label;
     };
 
-    const first = withInstallLock(() => trackConcurrency("first", 40), TEST_LOCK_TIMINGS);
-    await new Promise((resolve) => setTimeout(resolve, 2)); // let `first` acquire the lock
-    const second = withInstallLock(() => trackConcurrency("second", 5), TEST_LOCK_TIMINGS);
+    const first = withInstallLock(() => trackConcurrency("first", 120), TEST_LOCK_TIMINGS);
+    await new Promise((resolve) => setTimeout(resolve, 5)); // let `first` acquire the lock
+    const second = withInstallLock(() => trackConcurrency("second", 10), TEST_LOCK_TIMINGS);
 
     await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
     expect(maxConcurrent).toBe(1);
@@ -394,7 +396,7 @@ describe("findBrowser — cache resolution", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const { withInstallLock } = await import("./manager.js");
-    await withInstallLock(async () => "done", { ...TEST_LOCK_TIMINGS, waitNoticeMs: 5 });
+    await withInstallLock(async () => "done", { ...TEST_LOCK_TIMINGS, waitNoticeMs: 20 });
 
     expect(paths.has(HF_LOCK)).toBe(false);
     expect(
@@ -402,6 +404,21 @@ describe("findBrowser — cache resolution", () => {
         String(msg).includes("Waiting for another hyperframes process"),
       ),
     ).toBe(true);
+  });
+
+  it("keeps the holder running when a heartbeat cannot touch the lock", async () => {
+    installFsMocks({
+      existing: new Set([CACHE_ROOT]),
+      touchError: Object.assign(new Error("EACCES"), { code: "EACCES" }),
+    });
+
+    const { withInstallLock } = await import("./manager.js");
+    await expect(
+      withInstallLock(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        return "done";
+      }, TEST_LOCK_TIMINGS),
+    ).resolves.toBe("done");
   });
 
   it("warns and falls through when the hyperframes cache cannot be read", async () => {

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -1,6 +1,6 @@
 // fallow-ignore-file code-duplication
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync, utimesSync } from "node:fs";
 import { basename } from "node:path";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -44,6 +44,22 @@ const INSTALL_LOCK_DIR = join(CACHE_ROOT_DIR, ".chrome.install.lock");
 const INSTALL_RECLAIM_LOCK_DIR = join(CACHE_ROOT_DIR, ".chrome.install.reclaim.lock");
 const INSTALL_LOCK_TIMEOUT_MS = 120_000; // generous: a real download+extract can take a while
 const INSTALL_LOCK_POLL_MS = 200;
+// The reclaim check above only looks at the lock dir's mtime, which used to be
+// set once at acquire time and never touched again. On a slow or throttled
+// connection a real (non-crashed) download+extract of the ~115-160MB archive
+// can easily exceed INSTALL_LOCK_TIMEOUT_MS, so a concurrent waiter would
+// reclaim the "stale" lock out from under the still-running holder and start
+// a second install into the same target directory — recreating the exact
+// concurrent-extraction race #1866 added this lock to prevent, just gated by
+// a timer instead of by "no cache miss yet". Touching the lock's mtime while
+// the holder is actively running keeps it looking fresh so only a genuinely
+// dead holder (crashed/killed, no more heartbeats) is ever reclaimed.
+const INSTALL_LOCK_HEARTBEAT_MS = 15_000;
+// While a caller is blocked waiting on someone else's lock, print an
+// occasional notice so a long wait (e.g. 16 processes racing the same
+// download in a fleet/batch run) reads as "waiting", not "hung" — reported as
+// a silent ~10 minute stall with no output at all.
+const INSTALL_LOCK_WAIT_NOTICE_MS = 10_000;
 
 function isErrno(err: unknown, code: string): boolean {
   return (err as NodeJS.ErrnoException).code === code;
@@ -80,19 +96,36 @@ function reclaimStaleInstallLock(timeoutMs: number): void {
   }
 }
 
-// timeoutMs/pollMs are parameters (not just the module constants) so tests can
-// exercise the reclaim-on-timeout branch with real but tiny waits instead of
-// mocking Date.now()/setTimeout through the full ensureBrowser call graph.
+/** Refresh the lock dir's mtime so an active holder is never mistaken for a
+ * crashed one just because its install is taking a while. Best-effort: if the
+ * lock dir is somehow already gone, there's nothing to touch. */
+function touchInstallLock(): void {
+  try {
+    const now = new Date();
+    utimesSync(INSTALL_LOCK_DIR, now, now);
+  } catch (err) {
+    if (!isErrno(err, "ENOENT")) throw err;
+  }
+}
+
+// timeoutMs/pollMs/heartbeatMs are parameters (not just the module constants)
+// so tests can exercise the reclaim-on-timeout and heartbeat-keeps-it-alive
+// branches with real but tiny waits instead of mocking Date.now()/setTimeout
+// through the full ensureBrowser call graph.
 export async function withInstallLock<T>(
   fn: () => Promise<T>,
   timeoutMs = INSTALL_LOCK_TIMEOUT_MS,
   pollMs = INSTALL_LOCK_POLL_MS,
+  heartbeatMs = INSTALL_LOCK_HEARTBEAT_MS,
+  waitNoticeMs = INSTALL_LOCK_WAIT_NOTICE_MS,
 ): Promise<T> {
   // recursive:false below needs the parent to already exist (unlike `mkdir -p`).
   // Keep lock dirs outside CACHE_DIR so force-clearing the Chrome cache cannot
   // delete another installer's in-flight lock.
   if (!existsSync(CACHE_ROOT_DIR)) mkdirSync(CACHE_ROOT_DIR, { recursive: true });
   let deadline = Date.now() + timeoutMs;
+  const waitStart = Date.now();
+  let lastNoticeMs = 0;
   for (;;) {
     if (existsSync(INSTALL_RECLAIM_LOCK_DIR)) {
       await sleep(pollMs);
@@ -101,6 +134,16 @@ export async function withInstallLock<T>(
     if (tryAcquireDirLock(INSTALL_LOCK_DIR)) {
       rmSync(INSTALL_RECLAIM_LOCK_DIR, { recursive: true, force: true });
       break;
+    }
+    // Contended: someone else holds the lock. Report progress periodically so
+    // a long wait (a fleet of processes racing the same first-run download)
+    // reads as "waiting on another install", not a silent hang.
+    const waitedMs = Date.now() - waitStart;
+    if (waitedMs - lastNoticeMs >= waitNoticeMs) {
+      lastNoticeMs = waitedMs;
+      console.warn(
+        `[browser] Waiting for another hyperframes process to finish installing chrome-headless-shell (${Math.round(waitedMs / 1000)}s elapsed)...`,
+      );
     }
     if (Date.now() > deadline) {
       // The reclaim gate matters when multiple waiters cross the timeout at
@@ -114,9 +157,15 @@ export async function withInstallLock<T>(
     }
     await sleep(pollMs);
   }
+  // Keep the lock's mtime fresh for as long as fn() is actually running, so
+  // reclaimStaleInstallLock only ever reclaims a holder that's stopped
+  // heartbeating (crashed/killed) — not one that's simply slow.
+  const heartbeat = setInterval(touchInstallLock, heartbeatMs);
+  if (typeof heartbeat.unref === "function") heartbeat.unref();
   try {
     return await fn();
   } finally {
+    clearInterval(heartbeat);
     rmSync(INSTALL_LOCK_DIR, { recursive: true, force: true });
   }
 }

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -42,24 +42,19 @@ const PUPPETEER_CACHE_DIR = join(homedir(), ".cache", "puppeteer", "chrome-headl
 // doubles as a zero-dependency cross-process mutex — no lockfile library needed.
 const INSTALL_LOCK_DIR = join(CACHE_ROOT_DIR, ".chrome.install.lock");
 const INSTALL_RECLAIM_LOCK_DIR = join(CACHE_ROOT_DIR, ".chrome.install.reclaim.lock");
-const INSTALL_LOCK_TIMEOUT_MS = 120_000; // generous: a real download+extract can take a while
-const INSTALL_LOCK_POLL_MS = 200;
-// The reclaim check above only looks at the lock dir's mtime, which used to be
-// set once at acquire time and never touched again. On a slow or throttled
-// connection a real (non-crashed) download+extract of the ~115-160MB archive
-// can easily exceed INSTALL_LOCK_TIMEOUT_MS, so a concurrent waiter would
-// reclaim the "stale" lock out from under the still-running holder and start
-// a second install into the same target directory — recreating the exact
-// concurrent-extraction race #1866 added this lock to prevent, just gated by
-// a timer instead of by "no cache miss yet". Touching the lock's mtime while
-// the holder is actively running keeps it looking fresh so only a genuinely
-// dead holder (crashed/killed, no more heartbeats) is ever reclaimed.
-const INSTALL_LOCK_HEARTBEAT_MS = 15_000;
-// While a caller is blocked waiting on someone else's lock, print an
-// occasional notice so a long wait (e.g. 16 processes racing the same
-// download in a fleet/batch run) reads as "waiting", not "hung" — reported as
-// a silent ~10 minute stall with no output at all.
-const INSTALL_LOCK_WAIT_NOTICE_MS = 10_000;
+const INSTALL_LOCK_TIMINGS = {
+  staleMs: 120_000,
+  pollMs: 200,
+  heartbeatMs: 15_000,
+  waitNoticeMs: 10_000,
+};
+
+interface InstallLockTimings {
+  staleMs: number;
+  pollMs: number;
+  heartbeatMs: number;
+  waitNoticeMs: number;
+}
 
 function isErrno(err: unknown, code: string): boolean {
   return (err as NodeJS.ErrnoException).code === code;
@@ -96,9 +91,6 @@ function reclaimStaleInstallLock(timeoutMs: number): void {
   }
 }
 
-/** Refresh the lock dir's mtime so an active holder is never mistaken for a
- * crashed one just because its install is taking a while. Best-effort: if the
- * lock dir is somehow already gone, there's nothing to touch. */
 function touchInstallLock(): void {
   try {
     const now = new Date();
@@ -108,38 +100,28 @@ function touchInstallLock(): void {
   }
 }
 
-// timeoutMs/pollMs/heartbeatMs are parameters (not just the module constants)
-// so tests can exercise the reclaim-on-timeout and heartbeat-keeps-it-alive
-// branches with real but tiny waits instead of mocking Date.now()/setTimeout
-// through the full ensureBrowser call graph.
 export async function withInstallLock<T>(
   fn: () => Promise<T>,
-  timeoutMs = INSTALL_LOCK_TIMEOUT_MS,
-  pollMs = INSTALL_LOCK_POLL_MS,
-  heartbeatMs = INSTALL_LOCK_HEARTBEAT_MS,
-  waitNoticeMs = INSTALL_LOCK_WAIT_NOTICE_MS,
+  timings: InstallLockTimings = INSTALL_LOCK_TIMINGS,
 ): Promise<T> {
   // recursive:false below needs the parent to already exist (unlike `mkdir -p`).
   // Keep lock dirs outside CACHE_DIR so force-clearing the Chrome cache cannot
   // delete another installer's in-flight lock.
   if (!existsSync(CACHE_ROOT_DIR)) mkdirSync(CACHE_ROOT_DIR, { recursive: true });
-  let deadline = Date.now() + timeoutMs;
+  let deadline = Date.now() + timings.staleMs;
   const waitStart = Date.now();
   let lastNoticeMs = 0;
   for (;;) {
     if (existsSync(INSTALL_RECLAIM_LOCK_DIR)) {
-      await sleep(pollMs);
+      await sleep(timings.pollMs);
       continue;
     }
     if (tryAcquireDirLock(INSTALL_LOCK_DIR)) {
       rmSync(INSTALL_RECLAIM_LOCK_DIR, { recursive: true, force: true });
       break;
     }
-    // Contended: someone else holds the lock. Report progress periodically so
-    // a long wait (a fleet of processes racing the same first-run download)
-    // reads as "waiting on another install", not a silent hang.
     const waitedMs = Date.now() - waitStart;
-    if (waitedMs - lastNoticeMs >= waitNoticeMs) {
+    if (waitedMs - lastNoticeMs >= timings.waitNoticeMs) {
       lastNoticeMs = waitedMs;
       console.warn(
         `[browser] Waiting for another hyperframes process to finish installing chrome-headless-shell (${Math.round(waitedMs / 1000)}s elapsed)...`,
@@ -151,16 +133,13 @@ export async function withInstallLock<T>(
       // fresh one, then waiter B (whose old deadline also expired) can delete
       // A's fresh lock. The gate serializes reclaimers, and the mtime re-check
       // after the gate prevents deleting a fresh lock another waiter just won.
-      reclaimStaleInstallLock(timeoutMs);
-      deadline = Date.now() + timeoutMs;
+      reclaimStaleInstallLock(timings.staleMs);
+      deadline = Date.now() + timings.staleMs;
       continue;
     }
-    await sleep(pollMs);
+    await sleep(timings.pollMs);
   }
-  // Keep the lock's mtime fresh for as long as fn() is actually running, so
-  // reclaimStaleInstallLock only ever reclaims a holder that's stopped
-  // heartbeating (crashed/killed) — not one that's simply slow.
-  const heartbeat = setInterval(touchInstallLock, heartbeatMs);
+  const heartbeat = setInterval(touchInstallLock, timings.heartbeatMs);
   if (typeof heartbeat.unref === "function") heartbeat.unref();
   try {
     return await fn();

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -95,8 +95,8 @@ function touchInstallLock(): void {
   try {
     const now = new Date();
     utimesSync(INSTALL_LOCK_DIR, now, now);
-  } catch (err) {
-    if (!isErrno(err, "ENOENT")) throw err;
+  } catch {
+    // ponytail: heartbeat is best-effort; stale-lock reclaim remains the fallback.
   }
 }
 


### PR DESCRIPTION
## Summary

A slow Chrome download or extraction can now hold the cross-process install lock past two minutes without another HyperFrames process misclassifying it as stale and starting a concurrent install into the same cache. Active installers heartbeat the lock until completion, while waiting callers print progress every 10 seconds instead of appearing hung. Crashed holders remain reclaimable through the existing stale-lock timeout.

## Test plan

- Regression test fails before the fix with `expected maxConcurrent to be 1`, received `2`, and passes after the heartbeat is added.
- `bun run build`
- `bun run typecheck` in `packages/cli`
- `bun run test` in `packages/cli` — 1,428 tests passed
- `bunx oxlint packages/cli/src/browser/manager.ts packages/cli/src/browser/manager.test.ts`
- `bunx oxfmt --check packages/cli/src/browser/manager.ts packages/cli/src/browser/manager.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
