### PR TITLE
fix(cli): restore tts --text-file compatibility

### DIFF
--- a/packages/cli/src/commands/tts.test.ts
+++ b/packages/cli/src/commands/tts.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertKnownFlags } from "../utils/reject-unknown-flags.js";
+
+const synthesizeMock = vi.fn().mockResolvedValue({
+  durationSeconds: 1,
+  langApplied: true,
+  outputPath: "/tmp/speech.wav",
+});
+vi.mock("../tts/synthesize.js", () => ({ synthesize: synthesizeMock }));
+
+import ttsCommand from "./tts.js";
+
+describe("tts command", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hf-tts-command-test-"));
+    synthesizeMock.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("accepts --text-file as a compatibility alias for file input", async () => {
+    const input = join(dir, "script.txt");
+    writeFileSync(input, "Legacy file input\n");
+
+    expect(() =>
+      assertKnownFlags(ttsCommand as never, ["--text-file", input, "--json"]),
+    ).not.toThrow();
+    await ttsCommand.run!({ args: { "text-file": input, json: true } } as never);
+
+    expect(synthesizeMock).toHaveBeenCalledWith(
+      "Legacy file input",
+      expect.stringMatching(/speech\.wav$/),
+      expect.objectContaining({ lang: "en-us" }),
+    );
+  });
+});

--- a/packages/cli/src/commands/tts.ts
+++ b/packages/cli/src/commands/tts.ts
@@ -46,6 +46,10 @@ export default defineCommand({
       description: "Text to speak, or path to a .txt file",
       required: false,
     },
+    "text-file": {
+      type: "string",
+      description: "Read text from a .txt file (compatibility alias)",
+    },
     output: {
       type: "string",
       description: "Output file path (default: speech.wav in current directory)",
@@ -85,13 +89,14 @@ export default defineCommand({
     }
 
     // ── Resolve input text ────────────────────────────────────────────
-    if (!args.input) {
+    const input = args["text-file"] ?? args.input;
+    if (!input) {
       console.error(c.error("Provide text to speak, or use --list to see available voices."));
       process.exit(1);
     }
 
     let text: string;
-    const maybeFile = resolve(args.input);
+    const maybeFile = resolve(input);
 
     if (existsSync(maybeFile) && extname(maybeFile).toLowerCase() === ".txt") {
       text = readFileSync(maybeFile, "utf-8").trim();
@@ -100,7 +105,7 @@ export default defineCommand({
         process.exit(1);
       }
     } else {
-      text = args.input;
+      text = input;
     }
 
     if (!text.trim()) {


### PR DESCRIPTION
## Summary

`hyperframes tts --text-file script.txt` works again for existing skills and documentation instead of exiting with `Unknown flag: --text-file`. The compatibility flag feeds the same file-reading path as the current positional input, without changing positional usage. Regression coverage exercises both strict flag validation and the text passed into synthesis.

## Test plan

- Reproduced on 0.7.47: `hyperframes tts --text-file script.txt --json` exits 1 with `Unknown flag: --text-file`
- Verified `hyperframes tts --help` exposes `--text-file`
- `bun run build`
- `bun run --filter @hyperframes/cli test` — 1,430/1,430
- CLI typecheck, oxlint, and oxfmt checks

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
