### PR TITLE
fix(studio): retire legacy Style and Grade sections from flat inspector

### DIFF
--- a/packages/studio/src/components/editor/PropertyPanel.test.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.test.tsx
@@ -692,6 +692,45 @@ describe("PropertyPanel — Grade group (flag on)", () => {
     },
     RENDER_TIMEOUT_MS,
   );
+
+  it(
+    "does not render the legacy Style/Grade Section duplicates for a style-and-grade-editable element",
+    async () => {
+      // A <video> with no text fields is both style-editable (inherited
+      // capabilities.canEditStyles: true) and grade-editable (tag === "video"),
+      // so both the flat Style and Grade groups render — the exact shape that
+      // used to also mount the legacy ColorGradingSection + StyleSections below
+      // them (the hybrid-duplication bug this task retires).
+      const { host, root } = await renderPanel(true, {
+        ...baseElement(),
+        tagName: "video",
+        textFields: [],
+      });
+      expect(host.textContent).toContain("Style");
+      expect(host.textContent).toContain("Grade");
+      // The legacy `Section` primitive (propertyPanelStyleSections.tsx /
+      // propertyPanelColorGradingSection.tsx) renders a `<section
+      // data-panel-section="<slugified-title>">` for each of its sections. A
+      // bare textContent check can't tell a legacy Section title apart from a
+      // flat row label with the same word — "Fill" is both the legacy Fill
+      // `Section` title AND a row label inside FlatStyleSection, which is
+      // supposed to still be there — so assert on the legacy Section's actual
+      // DOM shape instead of a substring match.
+      for (const slug of [
+        "radius",
+        "stroke",
+        "effects",
+        "clip",
+        "transparency",
+        "fill",
+        "color-grading",
+      ]) {
+        expect(host.querySelector(`[data-panel-section="${slug}"]`)).toBeNull();
+      }
+      act(() => root.unmount());
+    },
+    RENDER_TIMEOUT_MS,
+  );
 });
 
 describe("PropertyPanel — Media group (Plan 4)", () => {

--- a/packages/studio/src/components/editor/PropertyPanelFlat.tsx
+++ b/packages/studio/src/components/editor/PropertyPanelFlat.tsx
@@ -14,9 +14,8 @@ import { FlatMotionSection } from "./propertyPanelFlatMotionSection";
 import { FlatMediaSection } from "./propertyPanelFlatMediaSection";
 import { deriveElementTiming } from "./propertyPanelFlatTimingDerivation";
 import { createGsapLivePreview } from "./gsapLivePreview";
-import { formatTextFieldPreview, StyleSections } from "./propertyPanelSections";
+import { formatTextFieldPreview } from "./propertyPanelSections";
 import { STUDIO_GSAP_PANEL_ENABLED } from "./manualEditingAvailability";
-import { ColorGradingSection } from "./propertyPanelColorGradingSection";
 import { useColorGradingController } from "./useColorGradingController";
 import { usePersistedPinnedGroups } from "../../hooks/usePersistedPinnedGroups";
 import {
@@ -55,8 +54,7 @@ const EMPTY_GSAP_EFFECT_HANDLERS = {
  * (same one-directional-import precedent as FlatTextSection). Rendered only
  * when STUDIO_FLAT_INSPECTOR_ENABLED is on; owns the one-open/pin group state.
  *
- * The Text/Style/Layout/Motion/Media groups share the one-open accordion. The
- * legacy Color-Grading section renders unchanged below the flat groups.
+ * The Text/Style/Layout/Motion/Media/Grade groups share the one-open accordion.
  */
 // fallow-ignore-next-line complexity
 export function PropertyPanelFlat({
@@ -502,37 +500,6 @@ export function PropertyPanelFlat({
             {g.content}
           </FlatGroup>
         ))}
-        {sections.colorGrading && (
-          <ColorGradingSection
-            key={[
-              element.id ?? "",
-              element.hfId ?? "",
-              element.selector ?? "",
-              String(element.selectorIndex ?? ""),
-            ].join("|")}
-            projectId={projectId}
-            element={element}
-            assets={assets}
-            previewIframeRef={previewIframeRef}
-            onImportAssets={onImportAssets}
-            onSetAttributeLive={onSetAttributeLive}
-            onApplyScope={onApplyColorGradingScope}
-          />
-        )}
-        {showEditableSections && (
-          <StyleSections
-            projectId={projectId}
-            element={element}
-            styles={styles}
-            assets={assets}
-            onSetStyle={onSetStyle}
-            onImportAssets={onImportAssets}
-            gsapBorderRadius={gsapBorderRadius}
-            // Flex now lives in the flat Layout group (LayoutFlexBlock); suppress
-            // the legacy StyleSections Flex `Section` so it renders exactly once.
-            hideFlex
-          />
-        )}
       </div>
       <PropertyPanelFlatFooter
         onAskAgent={onAskAgent}


### PR DESCRIPTION
## What

Seventh PR in the flat inspector stack (see #2120 for the foundation and full stack list). Removes the legacy `ColorGradingSection`/`StyleSections` render call sites from `PropertyPanelFlat.tsx` — with the flag on, these were rendering a second time below their flat equivalents (Color grading, Radius, Stroke, Effects, Clip, Transparency, Fill all doubled).

Stack: #2120 → #2121 → #2122 → #2123 → #2124 → #2125 → #2126 (this).

## Why

This was flagged as an Important (non-blocking) finding in the final whole-branch review, then confirmed live during manual testing of #2125 — every Style/Grade control was visibly duplicated. Flat coverage was already confirmed complete for both groups, so the legacy twins were pure redundant duplication, not a fallback for missing functionality.

## How

- Removed the `<ColorGradingSection>` and `<StyleSections hideFlex>` blocks (and their now-dead imports) from `PropertyPanelFlat.tsx` only.
- The legacy components themselves (`propertyPanelColorGradingSection.tsx`, `propertyPanelStyleSections.tsx`) are untouched — the non-flat legacy `PropertyPanel.tsx` still uses them when the feature flag is off.
- As a side effect, `useColorGradingController` now runs exactly once per render instead of twice (the second invocation was inside the now-removed legacy `ColorGradingSection` instance) — resolving another Important finding from the whole-branch review.

## Test plan

- New test asserting the legacy sections' specific DOM shape (`data-panel-section` attribute) is absent with the flag on, scoped carefully to avoid a false failure against the flat Style group's own "Fill" row label (which is supposed to still render).
- Confirmed the flag-off (legacy) panel's own tests are untouched — this PR only affects the flat path.
- Full monorepo suite green (1563 tests, 0 failures); `oxlint`/`oxfmt`/`fallow` clean.
- [x] Unit tests added/updated
- [x] Manual testing performed (this is what surfaced the bug)
- [ ] Documentation updated (not applicable — internal Studio UI behind an off-by-default flag)