### PR TITLE
fix(studio): widen FlatSlider's click/drag hit area vertically

### DIFF
--- a/packages/studio/src/components/editor/propertyPanelFlatPrimitives.test.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatPrimitives.test.tsx
@@ -253,6 +253,33 @@ describe("FlatSlider", () => {
     expect(onCommit).toHaveBeenCalledWith(50);
     act(() => root.unmount());
   });
+
+  it("widens the click/drag hit area vertically beyond the thin visible line", () => {
+    const onCommit = vi.fn();
+    const { host, root } = renderInto(
+      <FlatSlider
+        label="Opacity"
+        value={50}
+        min={0}
+        max={100}
+        tier="explicitCustom"
+        displayValue="50%"
+        onCommit={onCommit}
+      />,
+    );
+    const track = host.querySelector<HTMLElement>('[data-flat-slider-track="true"]');
+    if (!track) throw new Error("expected a track element");
+    Object.defineProperty(track, "getBoundingClientRect", {
+      value: () => ({ left: 0, width: 200, top: 0, height: 20, right: 200, bottom: 20 }),
+    });
+    act(() => {
+      track.dispatchEvent(
+        new MouseEvent("pointerdown", { bubbles: true, clientX: 20, clientY: 18 }),
+      );
+    });
+    expect(onCommit).toHaveBeenCalledWith(10);
+    act(() => root.unmount());
+  });
 });
 
 describe("FlatSlider — Grade extensions", () => {

--- a/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
@@ -259,27 +259,27 @@ export function FlatSlider({
         aria-label={label}
         aria-valuenow={value}
         aria-disabled={disabled}
-        className={`relative h-0.5 flex-1 rounded-full bg-panel-hover ${
-          disabled ? "cursor-not-allowed" : "cursor-pointer"
-        }`}
+        className={`relative h-5 flex-1 ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}
         onPointerDown={(e) => {
           if (disabled) return;
           commitFromClientX(e.clientX, e.currentTarget.getBoundingClientRect());
         }}
       >
-        {centerTick && (
-          <div
-            data-flat-slider-center-tick="true"
-            className="absolute left-1/2 top-[-1px] h-1 w-px -translate-x-1/2 bg-panel-text-5"
-          />
-        )}
-        {tier === "explicitCustom" && (
-          <div
-            data-flat-slider-fill="true"
-            className="absolute inset-y-0 left-0 rounded-full bg-panel-text-5"
-            style={{ width: `${clampedPct}%` }}
-          />
-        )}
+        <div className="absolute inset-x-0 top-1/2 h-0.5 -translate-y-1/2 rounded-full bg-panel-hover">
+          {centerTick && (
+            <div
+              data-flat-slider-center-tick="true"
+              className="absolute left-1/2 top-[-1px] h-1 w-px -translate-x-1/2 bg-panel-text-5"
+            />
+          )}
+          {tier === "explicitCustom" && (
+            <div
+              data-flat-slider-fill="true"
+              className="absolute inset-y-0 left-0 rounded-full bg-panel-text-5"
+              style={{ width: `${clampedPct}%` }}
+            />
+          )}
+        </div>
         <div
           data-flat-slider-knob="true"
           className={`absolute top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full ${


### PR DESCRIPTION
## What

Twelfth PR in the flat inspector stack (see #2120 for the foundation and full stack list). Widens `FlatSlider`'s click/drag hit area from 2px (matching the thin visible line) to 20px, without changing anything about how the slider looks.

Stack: #2120 → ... → #2136 → #2142 (this).

## Why

Requested directly after using the redesigned inspector live — the slider's clickable/draggable region was exactly as tall as its thin visual line, making it easy to miss.

## How

- The visible 2px line is now a decorative child, vertically centered inside a taller (20px) wrapping element.
- The wrapping element carries the `role`, `aria-*` attributes, `onPointerDown` handler, and cursor styling that used to live on the thin line itself.
- The click-ratio math only reads `left`/`width` from the target element's bounding rect (never `height`), so click-position accuracy is completely unaffected by the height change.
- Knob and center-tick positioning (`top-1/2 -translate-y-1/2`) already centered relative to the parent's height, so they needed no changes to stay correctly aligned.

## Test plan

- Existing click-accuracy test passes unmodified (same rect-mocking technique, still asserts exact committed values).
- New test asserts a pointerdown near the *edge* of the widened hit box (not the center) still commits the correct value — this is the specific behavior being fixed.
- **Verified live in the browser**: measured the actual rendered hit area (20px) vs. visible line (2px), then dispatched real pointer events at both the top and bottom edges of the widened area and confirmed the committed value changed correctly each time (previously, only the 2px center would have registered).
- Full monorepo suite green (1582 tests, 0 failures); `oxlint`/`oxfmt`/`fallow` clean.
- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable — internal Studio UI behind an off-by-default flag)