### PR TITLE
fix(core): make timing masks safe for source loaders

### DIFF
--- a/packages/core/src/compiler/timingCompiler.test.ts
+++ b/packages/core/src/compiler/timingCompiler.test.ts
@@ -168,6 +168,22 @@ describe("compileTimingAttrs", () => {
     expect(compiled).toContain('id="hf-video-0"');
     expect(compiled).toContain('data-end="2"');
   });
+
+  it("preserves inert regions when compiled output is compiled again", () => {
+    const html = [
+      '<style>.hero::after { content: "$& $$ $` $\' <video>"; }</style>',
+      '<script>const markup = "$& $$ $` $\' <audio>";</script>',
+      '<video class="hero" src="a.mp4" data-start="0" data-duration="2">',
+    ].join("\n");
+
+    const first = compileTimingAttrs(html).html;
+    const second = compileTimingAttrs(first).html;
+
+    expect(second).toContain('<style>.hero::after { content: "$& $$ $` $\' <video>"; }</style>');
+    expect(second).toContain('<script>const markup = "$& $$ $` $\' <audio>";</script>');
+    expect(second).toContain('data-end="2"');
+    expect(second).not.toContain("HFMASK");
+  });
 });
 
 describe("injectDurations", () => {


### PR DESCRIPTION
## What

Make timing compilation mask non-HTML source regions before rewriting timing attributes.

## Why

Source-loader scripts and embedded text can contain attribute-like strings that must never be mutated as markup.

## How

Restrict timing rewrites to real element tags and add adversarial source-loader fixtures.

## Test plan

- [x] core timingCompiler unit tests; strict core typecheck
- [x] Stack-wide lint, format, build, typecheck, and relevant integration gates