### PR TITLE
refactor(producer): unify render requests

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -87,6 +87,25 @@ vi.mock("../utils/producer.js", () => ({
       producerState.resolveConfigCalls.push(overrides);
       return { ...overrides, resolved: true };
     }),
+    createRenderRequest: vi.fn(
+      (input: {
+        projectDir: string;
+        outputPath: string;
+        engineConfig: unknown;
+        options: object;
+      }) => ({
+        version: 1,
+        projectDir: input.projectDir,
+        outputPath: input.outputPath,
+        options: { ...input.options, engineConfig: input.engineConfig },
+      }),
+    ),
+    renderConfigFromRequest: vi.fn(
+      (request: { options: Record<string, unknown> }, runtime: { logger?: unknown }) => {
+        const { engineConfig, ...options } = request.options;
+        return { ...options, producerConfig: engineConfig, logger: runtime.logger };
+      },
+    ),
     createRenderJob: vi.fn((config: Record<string, unknown>) => {
       producerState.createdJobs.push(config);
       return { config, progress: 100, outcome: "completed", warnings: [] };

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1494,6 +1494,8 @@ async function renderDocker(
       bestEffort: options.bestEffort,
       experimentalFastCapture: options.experimentalFastCapture,
       pageNavigationTimeoutMs: options.pageNavigationTimeoutMs,
+      protocolTimeoutMs: options.protocolTimeout,
+      playerReadyTimeoutMs: options.playerReadyTimeout,
     },
   });
 
@@ -1629,34 +1631,39 @@ export async function renderLocal(
     producer.createConsoleLogger?.(options.debug ? "debug" : "info") ?? createNoopProducerLogger(),
   );
 
-  const job = producer.createRenderJob({
-    fps: options.fps,
-    quality: options.quality,
-    format: options.format,
-    gifLoop: options.gifLoop,
-    workers: options.workers,
-    useGpu: options.gpu,
-    logger,
-    producerConfig: producer.resolveConfig({
-      browserGpuMode: options.browserGpuMode ?? "software",
-      ...(options.pageNavigationTimeoutMs != null
-        ? { pageNavigationTimeout: options.pageNavigationTimeoutMs }
-        : {}),
-      ...(options.protocolTimeout != null && { protocolTimeout: options.protocolTimeout }),
-      ...(options.playerReadyTimeout != null && { playerReadyTimeout: options.playerReadyTimeout }),
-      ...(options.vp9CpuUsed != null ? { vp9CpuUsed: options.vp9CpuUsed } : {}),
-    }),
-    hdrMode: options.hdrMode,
-    crf: options.crf,
-    videoBitrate: options.videoBitrate,
-    videoFrameFormat: options.videoFrameFormat,
-    variables: options.variables,
-    entryFile: options.entryFile,
-    outputResolution: options.outputResolution,
-    outputResolutionAspectAgnostic: options.outputResolutionAspectAgnostic,
-    debug: options.debug,
-    strictness: options.bestEffort === false ? "strict" : "best-effort",
+  const engineConfig = producer.resolveConfig({
+    browserGpuMode: options.browserGpuMode ?? "software",
+    ...(options.pageNavigationTimeoutMs != null
+      ? { pageNavigationTimeout: options.pageNavigationTimeoutMs }
+      : {}),
+    ...(options.protocolTimeout != null && { protocolTimeout: options.protocolTimeout }),
+    ...(options.playerReadyTimeout != null && { playerReadyTimeout: options.playerReadyTimeout }),
+    ...(options.vp9CpuUsed != null ? { vp9CpuUsed: options.vp9CpuUsed } : {}),
   });
+  const request = producer.createRenderRequest({
+    projectDir,
+    outputPath,
+    engineConfig,
+    options: {
+      fps: options.fps,
+      quality: options.quality,
+      format: options.format,
+      gifLoop: options.gifLoop,
+      workers: options.workers,
+      useGpu: options.gpu,
+      hdrMode: options.hdrMode,
+      crf: options.crf,
+      videoBitrate: options.videoBitrate,
+      videoFrameFormat: options.videoFrameFormat,
+      variables: options.variables,
+      entryFile: options.entryFile,
+      outputResolution: options.outputResolution,
+      outputResolutionAspectAgnostic: options.outputResolutionAspectAgnostic,
+      debug: options.debug,
+      strictness: options.bestEffort === false ? "strict" : "best-effort",
+    },
+  });
+  const job = producer.createRenderJob(producer.renderConfigFromRequest(request, { logger }));
 
   const onProgress = options.quiet
     ? undefined

--- a/packages/cli/src/utils/dockerRunArgs.test.ts
+++ b/packages/cli/src/utils/dockerRunArgs.test.ts
@@ -344,6 +344,22 @@ describe("buildDockerRunArgs", () => {
     expect(args).not.toContain("--browser-timeout");
   });
 
+  it("forwards protocol and player-ready timeouts without unit conversion", () => {
+    const args = buildDockerRunArgs({
+      ...FIXED_INPUT,
+      options: {
+        ...BASE,
+        protocolTimeoutMs: 240_000,
+        playerReadyTimeoutMs: 90_000,
+      },
+    });
+
+    expect(args).toContain("--protocol-timeout");
+    expect(args[args.indexOf("--protocol-timeout") + 1]).toBe("240000");
+    expect(args).toContain("--player-ready-timeout");
+    expect(args[args.indexOf("--player-ready-timeout") + 1]).toBe("90000");
+  });
+
   it("forwards rational --fps verbatim (NTSC 30000/1001)", () => {
     // Regression for the fps fraction-syntax feature: the rational form must
     // survive the host → container hop as a single `30000/1001` argument so

--- a/packages/cli/src/utils/dockerRunArgs.ts
+++ b/packages/cli/src/utils/dockerRunArgs.ts
@@ -66,6 +66,10 @@ export interface DockerRenderOptions {
    * `--browser-timeout` flag).
    */
   pageNavigationTimeoutMs?: number;
+  /** CDP protocol timeout in milliseconds. */
+  protocolTimeoutMs?: number;
+  /** Player readiness timeout in milliseconds. */
+  playerReadyTimeoutMs?: number;
 }
 
 /**
@@ -153,6 +157,12 @@ export function buildDockerRunArgs(input: DockerRunArgsInput): string[] {
     ...(options.experimentalFastCapture ? ["--experimental-fast-capture"] : []),
     ...(options.pageNavigationTimeoutMs != null
       ? ["--browser-timeout", String(options.pageNavigationTimeoutMs / 1000)]
+      : []),
+    ...(options.protocolTimeoutMs != null
+      ? ["--protocol-timeout", String(options.protocolTimeoutMs)]
+      : []),
+    ...(options.playerReadyTimeoutMs != null
+      ? ["--player-ready-timeout", String(options.playerReadyTimeoutMs)]
       : []),
   ];
 }

--- a/packages/engine/src/config.ts
+++ b/packages/engine/src/config.ts
@@ -344,7 +344,6 @@ const BOOLEAN_ENGINE_CONFIG_FIELDS = [
 ] as const;
 
 const POSITIVE_NUMBER_ENGINE_CONFIG_FIELDS = [
-  "coresPerWorker",
   "browserTimeout",
   "protocolTimeout",
   "chunkSizeFrames",
@@ -394,6 +393,13 @@ function assertEngineConfigNumber(
   }
 }
 
+function assertPositiveEngineConfigNumber(config: Record<string, unknown>, field: string): void {
+  const value = config[field];
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`Engine config ${field} must be a finite number > 0`);
+  }
+}
+
 function assertEngineConfigEnum(
   config: Record<string, unknown>,
   field: string,
@@ -435,7 +441,7 @@ function validateEngineConfigParallelism(config: Record<string, unknown>): void 
   ) {
     throw new Error("Engine config concurrency must be a positive integer or auto");
   }
-  assertEngineConfigNumber(config, "coresPerWorker", 0);
+  assertPositiveEngineConfigNumber(config, "coresPerWorker");
   for (const field of ["minParallelFrames", "largeRenderThreshold"] as const) {
     assertEngineConfigNumber(config, field, 0, true);
   }

--- a/packages/engine/src/config.ts
+++ b/packages/engine/src/config.ts
@@ -317,6 +317,206 @@ export const DEFAULT_CONFIG: EngineConfig = {
   debug: false,
 };
 
+const OPTIONAL_ENGINE_CONFIG_FIELDS = [
+  "chromePath",
+  "expectedChromiumMajor",
+  "pageSideCompositingAutoDisabled",
+  "forceScreenshotExplicitlyOptedOut",
+  "streamingEncodeAutoDisabledOnWin32Compound",
+  "runtimeManifestPath",
+  "extractCacheDir",
+] as const;
+
+const BOOLEAN_ENGINE_CONFIG_FIELDS = [
+  "disableGpu",
+  "enableBrowserPool",
+  "forceScreenshot",
+  "staticFrameDedup",
+  "useDrawElement",
+  "enableDrawElementWorkerEncode",
+  "lowMemoryMode",
+  "enablePageSideCompositing",
+  "enableChunkedEncode",
+  "enableStreamingEncode",
+  "hdrAutoDetect",
+  "verifyRuntime",
+  "debug",
+] as const;
+
+const POSITIVE_NUMBER_ENGINE_CONFIG_FIELDS = [
+  "coresPerWorker",
+  "browserTimeout",
+  "protocolTimeout",
+  "chunkSizeFrames",
+  "ffmpegEncodeTimeout",
+  "ffmpegProcessTimeout",
+  "ffmpegStreamingTimeout",
+  "frameDataUriCacheLimit",
+  "frameDataUriCacheBytesLimitMb",
+  "playerReadyTimeout",
+  "renderReadyTimeout",
+  "pageNavigationTimeout",
+  "extractCacheMaxBytes",
+] as const;
+
+const ENUM_ENGINE_CONFIG_FIELDS = {
+  fps: [24, 30, 60],
+  quality: ["draft", "standard", "high"],
+  format: ["jpeg", "png"],
+  browserGpuMode: ["software", "hardware", "auto"],
+} as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(value))
+  );
+}
+
+function assertEngineConfigNumber(
+  config: Record<string, unknown>,
+  field: string,
+  min: number,
+  integer = false,
+): void {
+  const value = config[field];
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value < min ||
+    (integer && !Number.isInteger(value))
+  ) {
+    throw new Error(
+      `Engine config ${field} must be a ${integer ? "finite integer" : "finite number"} >= ${min}`,
+    );
+  }
+}
+
+function assertEngineConfigEnum(
+  config: Record<string, unknown>,
+  field: string,
+  values: readonly unknown[],
+): void {
+  if (!values.includes(config[field])) throw new Error(`Engine config ${field} is invalid`);
+}
+
+function validateRequiredEngineConfigFields(config: Record<string, unknown>): void {
+  const requiredFields = Object.keys(DEFAULT_CONFIG);
+  for (const field of requiredFields) {
+    if (!Object.hasOwn(config, field)) {
+      throw new Error(`Engine config snapshot is missing required field ${field}`);
+    }
+  }
+  const allowedFields = new Set([...requiredFields, ...OPTIONAL_ENGINE_CONFIG_FIELDS]);
+  for (const field of Object.keys(config)) {
+    if (!allowedFields.has(field))
+      throw new Error(`Engine config snapshot has unknown field ${field}`);
+  }
+}
+
+function validateEngineConfigScalars(config: Record<string, unknown>): void {
+  for (const [field, values] of Object.entries(ENUM_ENGINE_CONFIG_FIELDS)) {
+    assertEngineConfigEnum(config, field, values);
+  }
+  assertEngineConfigNumber(config, "jpegQuality", 0);
+  if (typeof config.jpegQuality === "number" && config.jpegQuality > 100) {
+    throw new Error("Engine config jpegQuality must be <= 100");
+  }
+}
+
+function validateEngineConfigParallelism(config: Record<string, unknown>): void {
+  if (
+    config.concurrency !== "auto" &&
+    (typeof config.concurrency !== "number" ||
+      !Number.isInteger(config.concurrency) ||
+      config.concurrency < 1)
+  ) {
+    throw new Error("Engine config concurrency must be a positive integer or auto");
+  }
+  assertEngineConfigNumber(config, "coresPerWorker", 0);
+  for (const field of ["minParallelFrames", "largeRenderThreshold"] as const) {
+    assertEngineConfigNumber(config, field, 0, true);
+  }
+}
+
+function validateEngineConfigVp9(config: Record<string, unknown>): void {
+  if (
+    typeof config.vp9CpuUsed !== "number" ||
+    !Number.isInteger(config.vp9CpuUsed) ||
+    config.vp9CpuUsed < -8 ||
+    config.vp9CpuUsed > 8
+  ) {
+    throw new Error("Engine config vp9CpuUsed must be an integer in [-8, 8]");
+  }
+}
+
+function validateEngineConfigRuntime(config: Record<string, unknown>): void {
+  for (const field of BOOLEAN_ENGINE_CONFIG_FIELDS) {
+    if (typeof config[field] !== "boolean")
+      throw new Error(`Engine config ${field} must be a boolean`);
+  }
+  for (const field of POSITIVE_NUMBER_ENGINE_CONFIG_FIELDS) {
+    assertEngineConfigNumber(config, field, 1, field === "frameDataUriCacheLimit");
+  }
+  assertEngineConfigNumber(config, "streamingEncodeMaxDurationSeconds", 0);
+  assertEngineConfigNumber(config, "audioGain", 0);
+}
+
+function validateEngineConfigHdr(config: Record<string, unknown>): void {
+  const { hdr } = config;
+  if (
+    hdr !== false &&
+    (!isPlainObject(hdr) ||
+      Object.keys(hdr).length !== 1 ||
+      (hdr.transfer !== "hlg" && hdr.transfer !== "pq"))
+  ) {
+    throw new Error("Engine config hdr must be false or an hlg/pq transfer object");
+  }
+}
+
+function validateOptionalEngineConfigFields(config: Record<string, unknown>): void {
+  for (const field of ["chromePath", "runtimeManifestPath", "extractCacheDir"] as const) {
+    if (
+      config[field] !== undefined &&
+      (typeof config[field] !== "string" || config[field].length === 0)
+    ) {
+      throw new Error(`Engine config ${field} must be a non-empty string`);
+    }
+  }
+  if (config.expectedChromiumMajor !== undefined) {
+    assertEngineConfigNumber(config, "expectedChromiumMajor", 1, true);
+  }
+  for (const field of [
+    "pageSideCompositingAutoDisabled",
+    "forceScreenshotExplicitlyOptedOut",
+    "streamingEncodeAutoDisabledOnWin32Compound",
+  ] as const) {
+    if (config[field] !== undefined && typeof config[field] !== "boolean") {
+      throw new Error(`Engine config ${field} must be a boolean`);
+    }
+  }
+}
+
+/**
+ * Validate a complete EngineConfig crossing a JSON wire boundary.
+ *
+ * `resolveConfig()` intentionally accepts partial programmatic overrides, but
+ * a serialized render request stores a resolved snapshot. Accepting a partial
+ * snapshot would skip the orchestrator's `resolveConfig()` fallback entirely.
+ */
+export function validateEngineConfigSnapshot(value: unknown): asserts value is EngineConfig {
+  if (!isPlainObject(value)) throw new Error("Engine config snapshot must be a plain object");
+  validateRequiredEngineConfigFields(value);
+  validateEngineConfigScalars(value);
+  validateEngineConfigParallelism(value);
+  validateEngineConfigVp9(value);
+  validateEngineConfigRuntime(value);
+  validateEngineConfigHdr(value);
+  validateOptionalEngineConfigFields(value);
+}
+
 /**
  * Reference canvas area for the baseline `protocolTimeout`: 1080p. A single CDP
  * call (`Runtime.callFunctionOn` seek+paint, or `Page.captureScreenshot`)

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -48,6 +48,7 @@ export type {
 // ── Configuration ──────────────────────────────────────────────────────────────
 export {
   resolveConfig,
+  validateEngineConfigSnapshot,
   DEFAULT_CONFIG,
   scaleProtocolTimeoutForComposition,
   shouldClampToScreenshotForConcreteGpu,

--- a/packages/producer/src/index.ts
+++ b/packages/producer/src/index.ts
@@ -24,6 +24,19 @@ export {
   type ProgressCallback,
 } from "./services/renderOrchestrator.js";
 export {
+  RENDER_REQUEST_VERSION,
+  createRenderRequest,
+  distributedConfigFromRequest,
+  parseRenderRequest,
+  renderConfigFromRequest,
+  renderRequestFromDistributedConfig,
+  serializeRenderRequest,
+  type CreateRenderRequestInput,
+  type DistributedRenderOptions,
+  type RenderRequest,
+  type RenderRequestOptions,
+} from "./renderRequest.js";
+export {
   type BrowserDiagnosticSummary,
   type RenderCaptureObservability,
   type RenderObservabilitySummary,

--- a/packages/producer/src/renderRequest.test.ts
+++ b/packages/producer/src/renderRequest.test.ts
@@ -25,6 +25,7 @@ function request() {
       fps: { num: 30, den: 1 },
       quality: "high",
       format: "mp4",
+      gifLoop: 0,
       workers: 3,
       useGpu: true,
       strictness: "best-effort",
@@ -72,9 +73,12 @@ describe("RenderRequest", () => {
       height: 1080,
       format: "mp4",
       chunkSize: 120,
+      strictness: "best-effort",
+      outputResolutionAspectAgnostic: true,
       variables: value.options.variables,
-      producerConfig: { protocolTimeout: 123_456 },
+      engineConfig: { protocolTimeout: 123_456 },
     });
+    expect(distributed).not.toHaveProperty("producerConfig");
   });
 
   it("round-trips distributed adapter fields back into the shared request", () => {
@@ -90,6 +94,12 @@ describe("RenderRequest", () => {
       fps: value.options.fps,
       quality: value.options.quality,
       format: value.options.format,
+      crf: value.options.crf,
+      videoFrameFormat: value.options.videoFrameFormat,
+      outputResolution: value.options.outputResolution,
+      outputResolutionAspectAgnostic: value.options.outputResolutionAspectAgnostic,
+      hdrMode: value.options.hdrMode,
+      strictness: value.options.strictness,
       entryFile: value.options.entryFile,
       variables: value.options.variables,
       distributed: value.options.distributed,
@@ -113,5 +123,51 @@ describe("RenderRequest", () => {
     const value = request();
     value.options.fps = { num: 30_000, den: 1_001 };
     expect(() => distributedConfigFromRequest(value)).toThrow("does not support fps");
+  });
+
+  it("rejects JSON-unsafe request values before serialization", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    for (const variables of [
+      { missing: undefined },
+      { callback: () => undefined },
+      { identifier: 1n },
+      { ratio: Number.NaN },
+      { when: new Date(0) },
+      cyclic,
+    ]) {
+      expect(() =>
+        createRenderRequest({
+          projectDir: "/project",
+          outputPath: "/output/video.mp4",
+          options: { fps: { num: 30, den: 1 }, quality: "standard", format: "mp4", variables },
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("rejects malformed optional and distributed fields", () => {
+    const value = request();
+    expect(() =>
+      parseRenderRequest({ ...value, options: { ...value.options, workers: "many" } }),
+    ).toThrow("workers");
+    expect(() =>
+      parseRenderRequest({
+        ...value,
+        options: { ...value.options, distributed: { ...value.options.distributed, width: "wide" } },
+      }),
+    ).toThrow("distributed.width");
+  });
+
+  it("validates the reverse distributed adapter at the wire boundary", () => {
+    const distributed = distributedConfigFromRequest(request());
+    distributed.width = 1921;
+    expect(() =>
+      renderRequestFromDistributedConfig({
+        projectDir: "/project",
+        outputPath: "/output/video.mp4",
+        config: distributed,
+      }),
+    ).toThrow("must be even");
   });
 });

--- a/packages/producer/src/renderRequest.test.ts
+++ b/packages/producer/src/renderRequest.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { DEFAULT_CONFIG } from "@hyperframes/engine";
+import { DEFAULT_CONFIG, resolveConfig } from "@hyperframes/engine";
 import {
   createRenderRequest,
   distributedConfigFromRequest,
@@ -8,6 +8,7 @@ import {
   renderRequestFromDistributedConfig,
   serializeRenderRequest,
 } from "./renderRequest.js";
+import { InvalidConfigError } from "./services/distributed/renderConfigValidation.js";
 
 const originalForceScreenshot = process.env.PRODUCER_FORCE_SCREENSHOT;
 
@@ -200,6 +201,52 @@ describe("RenderRequest", () => {
           config: distributed,
         }),
       ).toThrow("Engine config");
+    }
+  });
+
+  it("accepts fractional coresPerWorker snapshots from the canonical resolver", () => {
+    const engineConfig = resolveConfig({ coresPerWorker: 0.5 });
+    const value = createRenderRequest({
+      projectDir: "/project",
+      outputPath: "/output/video.mp4",
+      engineConfig,
+      options: {
+        fps: { num: 30, den: 1 },
+        quality: "standard",
+        format: "mp4",
+        distributed: { width: 1920, height: 1080, cfr: true },
+      },
+    });
+
+    expect(value.options.engineConfig.coresPerWorker).toBe(0.5);
+    expect(parseRenderRequest(serializeRenderRequest(value))).toEqual(value);
+
+    const distributed = distributedConfigFromRequest(value);
+    (distributed as { engineConfig: unknown }).engineConfig = engineConfig;
+    expect(
+      renderRequestFromDistributedConfig({
+        projectDir: value.projectDir,
+        outputPath: value.outputPath,
+        config: distributed,
+      }).options.engineConfig.coresPerWorker,
+    ).toBe(0.5);
+  });
+
+  it("preserves the distributed InvalidConfigError contract for engine snapshots", () => {
+    const value = request();
+    const distributed = distributedConfigFromRequest(value);
+    (distributed as { engineConfig: unknown }).engineConfig = {};
+
+    try {
+      renderRequestFromDistributedConfig({
+        projectDir: value.projectDir,
+        outputPath: value.outputPath,
+        config: distributed,
+      });
+      throw new Error("expected distributed validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidConfigError);
+      expect((error as InvalidConfigError).field).toBe("config.engineConfig");
     }
   });
 

--- a/packages/producer/src/renderRequest.test.ts
+++ b/packages/producer/src/renderRequest.test.ts
@@ -146,6 +146,21 @@ describe("RenderRequest", () => {
     }
   });
 
+  it("omits absent optional options while preserving JSON validation for payloads", () => {
+    const value = createRenderRequest({
+      projectDir: "/project",
+      outputPath: "/output/video.mp4",
+      options: {
+        fps: { num: 30, den: 1 },
+        quality: "standard",
+        format: "mp4",
+        gifLoop: undefined,
+      },
+    });
+
+    expect(value.options).not.toHaveProperty("gifLoop");
+  });
+
   it("rejects malformed optional and distributed fields", () => {
     const value = request();
     expect(() =>

--- a/packages/producer/src/renderRequest.test.ts
+++ b/packages/producer/src/renderRequest.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "@hyperframes/engine";
+import {
+  createRenderRequest,
+  distributedConfigFromRequest,
+  parseRenderRequest,
+  renderConfigFromRequest,
+  renderRequestFromDistributedConfig,
+  serializeRenderRequest,
+} from "./renderRequest.js";
+
+const originalForceScreenshot = process.env.PRODUCER_FORCE_SCREENSHOT;
+
+afterEach(() => {
+  if (originalForceScreenshot === undefined) delete process.env.PRODUCER_FORCE_SCREENSHOT;
+  else process.env.PRODUCER_FORCE_SCREENSHOT = originalForceScreenshot;
+});
+
+function request() {
+  return createRenderRequest({
+    projectDir: "/project",
+    outputPath: "/output/video.mp4",
+    engineConfig: { ...DEFAULT_CONFIG, protocolTimeout: 123_456 },
+    options: {
+      fps: { num: 30, den: 1 },
+      quality: "high",
+      format: "mp4",
+      workers: 3,
+      useGpu: true,
+      strictness: "best-effort",
+      entryFile: "compositions/main.html",
+      crf: 18,
+      videoFrameFormat: "png",
+      hdrMode: "force-sdr",
+      variables: { title: "Hello", nested: { count: 2 } },
+      outputResolution: "landscape-4k",
+      outputResolutionAspectAgnostic: true,
+      distributed: {
+        width: 1920,
+        height: 1080,
+        codec: "h264",
+        chunkSize: 120,
+        maxParallelChunks: 8,
+        cfr: true,
+      },
+    },
+  });
+}
+
+describe("RenderRequest", () => {
+  it("round-trips through JSON without dropping nested options", () => {
+    const value = request();
+    expect(parseRenderRequest(serializeRenderRequest(value))).toEqual(value);
+  });
+
+  it("adapts the same request to local and distributed execution", () => {
+    const value = request();
+    const local = renderConfigFromRequest(value);
+    const distributed = distributedConfigFromRequest(value);
+
+    expect(local).toMatchObject({
+      fps: { num: 30, den: 1 },
+      quality: "high",
+      format: "mp4",
+      variables: value.options.variables,
+      outputResolutionAspectAgnostic: true,
+      producerConfig: { protocolTimeout: 123_456 },
+    });
+    expect(distributed).toMatchObject({
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      format: "mp4",
+      chunkSize: 120,
+      variables: value.options.variables,
+      producerConfig: { protocolTimeout: 123_456 },
+    });
+  });
+
+  it("round-trips distributed adapter fields back into the shared request", () => {
+    const value = request();
+    const distributed = distributedConfigFromRequest(value);
+    const reconstructed = renderRequestFromDistributedConfig({
+      projectDir: value.projectDir,
+      outputPath: value.outputPath,
+      config: distributed,
+    });
+
+    expect(reconstructed.options).toMatchObject({
+      fps: value.options.fps,
+      quality: value.options.quality,
+      format: value.options.format,
+      entryFile: value.options.entryFile,
+      variables: value.options.variables,
+      distributed: value.options.distributed,
+    });
+  });
+
+  it("snapshots environment-derived engine options once at the boundary", () => {
+    process.env.PRODUCER_FORCE_SCREENSHOT = "true";
+    const value = createRenderRequest({
+      projectDir: "/project",
+      outputPath: "/output/video.mp4",
+      options: { fps: { num: 30, den: 1 }, quality: "standard", format: "mp4" },
+    });
+    process.env.PRODUCER_FORCE_SCREENSHOT = "false";
+
+    expect(value.options.engineConfig.forceScreenshot).toBe(true);
+    expect(renderConfigFromRequest(value).producerConfig?.forceScreenshot).toBe(true);
+  });
+
+  it("rejects unsupported distributed fps before an adapter launch", () => {
+    const value = request();
+    value.options.fps = { num: 30_000, den: 1_001 };
+    expect(() => distributedConfigFromRequest(value)).toThrow("does not support fps");
+  });
+});

--- a/packages/producer/src/renderRequest.test.ts
+++ b/packages/producer/src/renderRequest.test.ts
@@ -174,6 +174,35 @@ describe("RenderRequest", () => {
     ).toThrow("distributed.width");
   });
 
+  it("requires complete and valid engine config snapshots on both wire paths", () => {
+    const value = request();
+    for (const engineConfig of [
+      {},
+      { ...value.options.engineConfig, protocolTimeout: "forever" },
+      { ...value.options.engineConfig, browserGpuMode: "turbo" },
+    ]) {
+      expect(() =>
+        parseRenderRequest({ ...value, options: { ...value.options, engineConfig } }),
+      ).toThrow("Engine config");
+    }
+
+    for (const engineConfig of [
+      {},
+      { ...value.options.engineConfig, protocolTimeout: "forever" },
+      { ...value.options.engineConfig, browserGpuMode: "turbo" },
+    ]) {
+      const distributed = distributedConfigFromRequest(value);
+      (distributed as { engineConfig: unknown }).engineConfig = engineConfig;
+      expect(() =>
+        renderRequestFromDistributedConfig({
+          projectDir: value.projectDir,
+          outputPath: value.outputPath,
+          config: distributed,
+        }),
+      ).toThrow("Engine config");
+    }
+  });
+
   it("validates the reverse distributed adapter at the wire boundary", () => {
     const distributed = distributedConfigFromRequest(request());
     distributed.width = 1921;

--- a/packages/producer/src/renderRequest.ts
+++ b/packages/producer/src/renderRequest.ts
@@ -1,9 +1,18 @@
-import { resolveConfig, type EngineConfig, type VideoFrameFormat } from "@hyperframes/engine";
-import type { CanvasResolution, Fps } from "@hyperframes/core";
+import {
+  isVideoFrameFormat,
+  resolveConfig,
+  type EngineConfig,
+  type VideoFrameFormat,
+} from "@hyperframes/engine";
+import { VALID_CANVAS_RESOLUTIONS, type CanvasResolution, type Fps } from "@hyperframes/core";
 import type { ProducerLogger } from "./logger.js";
 import type { RenderConfig } from "./services/renderOrchestrator.js";
 import type { DistributedRenderConfig } from "./services/distributed/plan.js";
-import type { SerializableDistributedRenderConfig } from "./services/distributed/renderConfigValidation.js";
+import {
+  validateDistributedRenderConfig,
+  validateJsonSafeValue,
+  type SerializableDistributedRenderConfig,
+} from "./services/distributed/renderConfigValidation.js";
 
 export const RENDER_REQUEST_VERSION = 1 as const;
 
@@ -59,20 +68,121 @@ export interface CreateRenderRequestInput {
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 function assertPositiveFps(options: Record<string, unknown>): void {
   const fps = options.fps;
   if (
     !isPlainObject(fps) ||
+    typeof fps.num !== "number" ||
+    typeof fps.den !== "number" ||
     !Number.isInteger(fps.num) ||
     !Number.isInteger(fps.den) ||
-    (fps.num as number) <= 0 ||
-    (fps.den as number) <= 0
+    fps.num <= 0 ||
+    fps.den <= 0
   ) {
     throw new Error("Render request fps must be a positive rational");
   }
+}
+
+function assertOptionalBoolean(options: Record<string, unknown>, field: string): void {
+  if (options[field] !== undefined && typeof options[field] !== "boolean") {
+    throw new Error(`Render request ${field} must be a boolean`);
+  }
+}
+
+function assertOptionalInteger(options: Record<string, unknown>, field: string, min = 0): void {
+  const value = options[field];
+  if (
+    value !== undefined &&
+    (typeof value !== "number" || !Number.isInteger(value) || value < min)
+  ) {
+    throw new Error(`Render request ${field} must be an integer >= ${min}`);
+  }
+}
+
+function assertOptionalString(options: Record<string, unknown>, field: string): void {
+  if (options[field] !== undefined && typeof options[field] !== "string") {
+    throw new Error(`Render request ${field} must be a string`);
+  }
+}
+
+function assertOptionalEnum(
+  options: Record<string, unknown>,
+  field: string,
+  allowed: readonly string[],
+): void {
+  const value = options[field];
+  if (value !== undefined && (typeof value !== "string" || !allowed.includes(value))) {
+    throw new Error(`Render request ${field} is invalid`);
+  }
+}
+
+function isCanvasResolution(value: unknown): value is CanvasResolution {
+  return (
+    typeof value === "string" && VALID_CANVAS_RESOLUTIONS.some((resolution) => resolution === value)
+  );
+}
+
+function assertDistributedOptions(value: unknown): void {
+  if (!isPlainObject(value)) throw new Error("Render request distributed must be an object");
+  for (const field of ["width", "height"] as const) {
+    if (typeof value[field] !== "number" || !Number.isInteger(value[field]) || value[field] <= 0) {
+      throw new Error(`Render request distributed.${field} must be a positive integer`);
+    }
+  }
+  assertOptionalEnum(value, "codec", ["h264", "h265"]);
+  for (const field of [
+    "chunkSize",
+    "maxParallelChunks",
+    "targetChunkFrames",
+    "planDirSizeLimitBytes",
+  ] as const) {
+    assertOptionalInteger(value, field, 1);
+  }
+  assertOptionalEnum(value, "runtimeCap", [
+    "lambda",
+    "temporal",
+    "cloud-run-job",
+    "k8s-job",
+    "none",
+  ]);
+  for (const field of ["rejectOnSystemFonts", "failClosedFontFetch", "cfr"] as const) {
+    assertOptionalBoolean(value, field);
+  }
+}
+
+function assertRequestOptionScalars(options: Record<string, unknown>): void {
+  assertOptionalInteger(options, "gifLoop");
+  assertOptionalInteger(options, "workers", 1);
+  assertOptionalInteger(options, "crf");
+  for (const field of ["useGpu", "debug", "outputResolutionAspectAgnostic"] as const) {
+    assertOptionalBoolean(options, field);
+  }
+  for (const field of ["entryFile", "videoBitrate"] as const) {
+    assertOptionalString(options, field);
+  }
+  assertOptionalEnum(options, "strictness", ["strict", "best-effort"]);
+  assertOptionalEnum(options, "hdrMode", ["auto", "force-hdr", "force-sdr"]);
+  if (options.videoFrameFormat !== undefined && !isVideoFrameFormat(options.videoFrameFormat)) {
+    throw new Error("Render request videoFrameFormat is invalid");
+  }
+  if (options.outputResolution !== undefined && !isCanvasResolution(options.outputResolution)) {
+    throw new Error("Render request outputResolution is invalid");
+  }
+}
+
+function assertRequestOptionObjects(options: Record<string, unknown>): void {
+  if (!isPlainObject(options.engineConfig)) {
+    throw new Error("Render request must contain a resolved engineConfig snapshot");
+  }
+  if (options.variables !== undefined && !isPlainObject(options.variables)) {
+    throw new Error("Render request variables must be a JSON object");
+  }
+  if (options.distributed !== undefined) assertDistributedOptions(options.distributed);
 }
 
 function assertRequestOptions(options: unknown): asserts options is RenderRequestOptions {
@@ -84,12 +194,8 @@ function assertRequestOptions(options: unknown): asserts options is RenderReques
   if (!["mp4", "webm", "mov", "png-sequence", "gif"].includes(String(options.format))) {
     throw new Error("Render request format is invalid");
   }
-  if (!isPlainObject(options.engineConfig)) {
-    throw new Error("Render request must contain a resolved engineConfig snapshot");
-  }
-  if (options.variables !== undefined && !isPlainObject(options.variables)) {
-    throw new Error("Render request variables must be a JSON object");
-  }
+  assertRequestOptionScalars(options);
+  assertRequestOptionObjects(options);
 }
 
 function assertNonEmptyPath(value: unknown, field: "projectDir" | "outputPath"): void {
@@ -106,6 +212,7 @@ function assertRenderRequest(value: unknown): asserts value is RenderRequest {
   assertNonEmptyPath(value.projectDir, "projectDir");
   assertNonEmptyPath(value.outputPath, "outputPath");
   assertRequestOptions(value.options);
+  validateJsonSafeValue(value, "renderRequest");
 }
 
 export function parseRenderRequest(serialized: string | unknown): RenderRequest {
@@ -129,9 +236,9 @@ export function createRenderRequest(input: CreateRenderRequestInput): RenderRequ
       engineConfig: input.engineConfig ?? resolveConfig(input.engineOverrides),
     },
   } satisfies RenderRequest;
-  // A JSON round-trip both proves serializability and detaches caller-owned
-  // variables/config objects before asynchronous adapters receive them.
-  return parseRenderRequest(JSON.stringify(request));
+  // Validate before serialization so JSON never silently drops or normalizes
+  // caller data at this boundary, then detach it for asynchronous adapters.
+  return parseRenderRequest(serializeRenderRequest(request));
 }
 
 export function renderConfigFromRequest(
@@ -173,6 +280,7 @@ export function distributedConfigFromRequest(
     bitrate: options.videoBitrate,
     videoFrameFormat: options.videoFrameFormat,
     outputResolution: options.outputResolution,
+    outputResolutionAspectAgnostic: options.outputResolutionAspectAgnostic,
     chunkSize: distributed.chunkSize,
     maxParallelChunks: distributed.maxParallelChunks,
     targetChunkFrames: distributed.targetChunkFrames,
@@ -182,13 +290,20 @@ export function distributedConfigFromRequest(
     hdrMode: options.hdrMode === "auto" ? "auto" : "force-sdr",
     cfr: distributed.cfr,
     logger: runtime.logger,
-    producerConfig: options.engineConfig,
     engineConfig: options.engineConfig,
     entryFile: options.entryFile,
+    strictness: options.strictness,
     abortSignal: runtime.abortSignal,
     planDirSizeLimitBytes: distributed.planDirSizeLimitBytes,
     variables: options.variables,
   };
+}
+
+function optionalProperty<Key extends string, Value>(
+  key: Key,
+  value: Value | undefined,
+): Partial<Record<Key, Value>> {
+  return value === undefined ? {} : ({ [key]: value } as Partial<Record<Key, Value>>);
 }
 
 export function renderRequestFromDistributedConfig(input: {
@@ -197,34 +312,39 @@ export function renderRequestFromDistributedConfig(input: {
   config: SerializableDistributedRenderConfig;
 }): RenderRequest {
   const { config } = input;
+  validateDistributedRenderConfig(config);
+  const distributed = {
+    width: config.width,
+    height: config.height,
+    ...optionalProperty("codec", config.codec),
+    ...optionalProperty("chunkSize", config.chunkSize),
+    ...optionalProperty("maxParallelChunks", config.maxParallelChunks),
+    ...optionalProperty("targetChunkFrames", config.targetChunkFrames),
+    ...optionalProperty("runtimeCap", config.runtimeCap),
+    ...optionalProperty("rejectOnSystemFonts", config.rejectOnSystemFonts),
+    ...optionalProperty("failClosedFontFetch", config.failClosedFontFetch),
+    ...optionalProperty("cfr", config.cfr),
+    ...optionalProperty("planDirSizeLimitBytes", config.planDirSizeLimitBytes),
+  } satisfies DistributedRenderOptions;
+  const options = {
+    fps: { num: config.fps, den: 1 },
+    quality: config.quality ?? "standard",
+    format: config.format,
+    distributed,
+    ...optionalProperty("crf", config.crf),
+    ...optionalProperty("videoBitrate", config.bitrate),
+    ...optionalProperty("videoFrameFormat", config.videoFrameFormat),
+    ...optionalProperty("outputResolution", config.outputResolution),
+    ...optionalProperty("outputResolutionAspectAgnostic", config.outputResolutionAspectAgnostic),
+    ...optionalProperty("hdrMode", config.hdrMode),
+    ...optionalProperty("strictness", config.strictness),
+    ...optionalProperty("entryFile", config.entryFile),
+    ...optionalProperty("variables", config.variables),
+  } satisfies CreateRenderRequestInput["options"];
   return createRenderRequest({
     projectDir: input.projectDir,
     outputPath: input.outputPath,
     engineConfig: config.engineConfig ?? resolveConfig(),
-    options: {
-      fps: { num: config.fps, den: 1 },
-      quality: config.quality ?? "standard",
-      format: config.format,
-      crf: config.crf,
-      videoBitrate: config.bitrate,
-      videoFrameFormat: config.videoFrameFormat,
-      outputResolution: config.outputResolution,
-      hdrMode: config.hdrMode ?? "force-sdr",
-      entryFile: config.entryFile,
-      variables: config.variables,
-      distributed: {
-        width: config.width,
-        height: config.height,
-        codec: config.codec,
-        chunkSize: config.chunkSize,
-        maxParallelChunks: config.maxParallelChunks,
-        targetChunkFrames: config.targetChunkFrames,
-        runtimeCap: config.runtimeCap,
-        rejectOnSystemFonts: config.rejectOnSystemFonts,
-        failClosedFontFetch: config.failClosedFontFetch,
-        cfr: config.cfr,
-        planDirSizeLimitBytes: config.planDirSizeLimitBytes,
-      },
-    },
+    options,
   });
 }

--- a/packages/producer/src/renderRequest.ts
+++ b/packages/producer/src/renderRequest.ts
@@ -1,0 +1,230 @@
+import { resolveConfig, type EngineConfig, type VideoFrameFormat } from "@hyperframes/engine";
+import type { CanvasResolution, Fps } from "@hyperframes/core";
+import type { ProducerLogger } from "./logger.js";
+import type { RenderConfig } from "./services/renderOrchestrator.js";
+import type { DistributedRenderConfig } from "./services/distributed/plan.js";
+import type { SerializableDistributedRenderConfig } from "./services/distributed/renderConfigValidation.js";
+
+export const RENDER_REQUEST_VERSION = 1 as const;
+
+export interface DistributedRenderOptions {
+  width: number;
+  height: number;
+  codec?: "h264" | "h265";
+  chunkSize?: number;
+  maxParallelChunks?: number;
+  targetChunkFrames?: number;
+  runtimeCap?: DistributedRenderConfig["runtimeCap"];
+  rejectOnSystemFonts?: boolean;
+  failClosedFontFetch?: boolean;
+  cfr?: boolean;
+  planDirSizeLimitBytes?: number;
+}
+
+/** JSON-safe render intent shared by local, Docker, server and cloud adapters. */
+export interface RenderRequestOptions {
+  fps: Fps;
+  quality: "draft" | "standard" | "high";
+  format: NonNullable<RenderConfig["format"]>;
+  gifLoop?: number;
+  workers?: number;
+  useGpu?: boolean;
+  debug?: boolean;
+  strictness?: RenderConfig["strictness"];
+  entryFile?: string;
+  crf?: number;
+  videoBitrate?: string;
+  videoFrameFormat?: VideoFrameFormat;
+  hdrMode?: RenderConfig["hdrMode"];
+  variables?: Record<string, unknown>;
+  outputResolution?: CanvasResolution;
+  outputResolutionAspectAgnostic?: boolean;
+  engineConfig: EngineConfig;
+  distributed?: DistributedRenderOptions;
+}
+
+export interface RenderRequest {
+  version: typeof RENDER_REQUEST_VERSION;
+  projectDir: string;
+  outputPath: string;
+  options: RenderRequestOptions;
+}
+
+export interface CreateRenderRequestInput {
+  projectDir: string;
+  outputPath: string;
+  options: Omit<RenderRequestOptions, "engineConfig">;
+  engineConfig?: EngineConfig;
+  engineOverrides?: Partial<EngineConfig>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertPositiveFps(options: Record<string, unknown>): void {
+  const fps = options.fps;
+  if (
+    !isPlainObject(fps) ||
+    !Number.isInteger(fps.num) ||
+    !Number.isInteger(fps.den) ||
+    (fps.num as number) <= 0 ||
+    (fps.den as number) <= 0
+  ) {
+    throw new Error("Render request fps must be a positive rational");
+  }
+}
+
+function assertRequestOptions(options: unknown): asserts options is RenderRequestOptions {
+  if (!isPlainObject(options)) throw new Error("Render request options must be an object");
+  assertPositiveFps(options);
+  if (!["draft", "standard", "high"].includes(String(options.quality))) {
+    throw new Error("Render request quality is invalid");
+  }
+  if (!["mp4", "webm", "mov", "png-sequence", "gif"].includes(String(options.format))) {
+    throw new Error("Render request format is invalid");
+  }
+  if (!isPlainObject(options.engineConfig)) {
+    throw new Error("Render request must contain a resolved engineConfig snapshot");
+  }
+  if (options.variables !== undefined && !isPlainObject(options.variables)) {
+    throw new Error("Render request variables must be a JSON object");
+  }
+}
+
+function assertNonEmptyPath(value: unknown, field: "projectDir" | "outputPath"): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Render request ${field} must be a non-empty string`);
+  }
+}
+
+function assertRenderRequest(value: unknown): asserts value is RenderRequest {
+  if (!isPlainObject(value) || value.version !== RENDER_REQUEST_VERSION) {
+    const version = isPlainObject(value) ? value.version : undefined;
+    throw new Error(`Unsupported render request version: ${String(version)}`);
+  }
+  assertNonEmptyPath(value.projectDir, "projectDir");
+  assertNonEmptyPath(value.outputPath, "outputPath");
+  assertRequestOptions(value.options);
+}
+
+export function parseRenderRequest(serialized: string | unknown): RenderRequest {
+  const value = typeof serialized === "string" ? JSON.parse(serialized) : serialized;
+  assertRenderRequest(value);
+  return value;
+}
+
+export function serializeRenderRequest(request: RenderRequest): string {
+  assertRenderRequest(request);
+  return JSON.stringify(request);
+}
+
+export function createRenderRequest(input: CreateRenderRequestInput): RenderRequest {
+  const request = {
+    version: RENDER_REQUEST_VERSION,
+    projectDir: input.projectDir,
+    outputPath: input.outputPath,
+    options: {
+      ...input.options,
+      engineConfig: input.engineConfig ?? resolveConfig(input.engineOverrides),
+    },
+  } satisfies RenderRequest;
+  // A JSON round-trip both proves serializability and detaches caller-owned
+  // variables/config objects before asynchronous adapters receive them.
+  return parseRenderRequest(JSON.stringify(request));
+}
+
+export function renderConfigFromRequest(
+  request: RenderRequest,
+  runtime: { logger?: ProducerLogger } = {},
+): RenderConfig {
+  const { engineConfig, distributed: _distributed, ...options } = request.options;
+  return {
+    ...options,
+    producerConfig: engineConfig,
+    logger: runtime.logger,
+  };
+}
+
+function distributedFps(fps: Fps): 24 | 30 | 60 {
+  if (fps.den === 1 && (fps.num === 24 || fps.num === 30 || fps.num === 60)) return fps.num;
+  throw new Error(`Distributed render does not support fps ${fps.num}/${fps.den}`);
+}
+
+export function distributedConfigFromRequest(
+  request: RenderRequest,
+  runtime: { logger?: ProducerLogger; abortSignal?: AbortSignal } = {},
+): DistributedRenderConfig {
+  const options = request.options;
+  const distributed = options.distributed;
+  if (!distributed) throw new Error("Render request is missing distributed options");
+  if (options.format === "gif") throw new Error("Distributed render does not support gif");
+  if (options.hdrMode === "force-hdr") {
+    throw new Error("Distributed render does not support force-hdr");
+  }
+  return {
+    fps: distributedFps(options.fps),
+    width: distributed.width,
+    height: distributed.height,
+    format: options.format,
+    codec: distributed.codec,
+    quality: options.quality,
+    crf: options.crf,
+    bitrate: options.videoBitrate,
+    videoFrameFormat: options.videoFrameFormat,
+    outputResolution: options.outputResolution,
+    chunkSize: distributed.chunkSize,
+    maxParallelChunks: distributed.maxParallelChunks,
+    targetChunkFrames: distributed.targetChunkFrames,
+    runtimeCap: distributed.runtimeCap,
+    rejectOnSystemFonts: distributed.rejectOnSystemFonts,
+    failClosedFontFetch: distributed.failClosedFontFetch,
+    hdrMode: options.hdrMode === "auto" ? "auto" : "force-sdr",
+    cfr: distributed.cfr,
+    logger: runtime.logger,
+    producerConfig: options.engineConfig,
+    engineConfig: options.engineConfig,
+    entryFile: options.entryFile,
+    abortSignal: runtime.abortSignal,
+    planDirSizeLimitBytes: distributed.planDirSizeLimitBytes,
+    variables: options.variables,
+  };
+}
+
+export function renderRequestFromDistributedConfig(input: {
+  projectDir: string;
+  outputPath: string;
+  config: SerializableDistributedRenderConfig;
+}): RenderRequest {
+  const { config } = input;
+  return createRenderRequest({
+    projectDir: input.projectDir,
+    outputPath: input.outputPath,
+    engineConfig: config.engineConfig ?? resolveConfig(),
+    options: {
+      fps: { num: config.fps, den: 1 },
+      quality: config.quality ?? "standard",
+      format: config.format,
+      crf: config.crf,
+      videoBitrate: config.bitrate,
+      videoFrameFormat: config.videoFrameFormat,
+      outputResolution: config.outputResolution,
+      hdrMode: config.hdrMode ?? "force-sdr",
+      entryFile: config.entryFile,
+      variables: config.variables,
+      distributed: {
+        width: config.width,
+        height: config.height,
+        codec: config.codec,
+        chunkSize: config.chunkSize,
+        maxParallelChunks: config.maxParallelChunks,
+        targetChunkFrames: config.targetChunkFrames,
+        runtimeCap: config.runtimeCap,
+        rejectOnSystemFonts: config.rejectOnSystemFonts,
+        failClosedFontFetch: config.failClosedFontFetch,
+        cfr: config.cfr,
+        planDirSizeLimitBytes: config.planDirSizeLimitBytes,
+      },
+    },
+  });
+}

--- a/packages/producer/src/renderRequest.ts
+++ b/packages/producer/src/renderRequest.ts
@@ -204,6 +204,10 @@ function assertNonEmptyPath(value: unknown, field: "projectDir" | "outputPath"):
   }
 }
 
+function omitUndefinedProperties<T extends object>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T;
+}
+
 function assertRenderRequest(value: unknown): asserts value is RenderRequest {
   if (!isPlainObject(value) || value.version !== RENDER_REQUEST_VERSION) {
     const version = isPlainObject(value) ? value.version : undefined;
@@ -232,7 +236,7 @@ export function createRenderRequest(input: CreateRenderRequestInput): RenderRequ
     projectDir: input.projectDir,
     outputPath: input.outputPath,
     options: {
-      ...input.options,
+      ...omitUndefinedProperties(input.options),
       engineConfig: input.engineConfig ?? resolveConfig(input.engineOverrides),
     },
   } satisfies RenderRequest;

--- a/packages/producer/src/renderRequest.ts
+++ b/packages/producer/src/renderRequest.ts
@@ -1,6 +1,7 @@
 import {
   isVideoFrameFormat,
   resolveConfig,
+  validateEngineConfigSnapshot,
   type EngineConfig,
   type VideoFrameFormat,
 } from "@hyperframes/engine";
@@ -176,9 +177,7 @@ function assertRequestOptionScalars(options: Record<string, unknown>): void {
 }
 
 function assertRequestOptionObjects(options: Record<string, unknown>): void {
-  if (!isPlainObject(options.engineConfig)) {
-    throw new Error("Render request must contain a resolved engineConfig snapshot");
-  }
+  validateEngineConfigSnapshot(options.engineConfig);
   if (options.variables !== undefined && !isPlainObject(options.variables)) {
     throw new Error("Render request variables must be a JSON object");
   }

--- a/packages/producer/src/server.ts
+++ b/packages/producer/src/server.ts
@@ -49,6 +49,7 @@ import {
   isAspectAgnosticResolutionAlias,
   type CanvasResolution,
 } from "@hyperframes/core";
+import { createRenderRequest, renderConfigFromRequest } from "./renderRequest.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -221,22 +222,26 @@ function parseRenderOverrides(body: Record<string, unknown>): {
  * the sync (`render`) and streaming (`render-stream`) handlers so the field
  * set — including `variables` and `outputResolution` — stays in one place.
  */
-function buildRenderJobConfig(input: RenderInput, log: ProducerLogger) {
-  return {
-    fps: input.fps,
-    quality: input.quality,
-    format: input.format,
-    workers: input.workers,
-    useGpu: input.useGpu,
-    debug: input.debug,
-    strictness: input.strictness,
-    entryFile: input.entryFile,
-    variables: input.variables,
-    outputResolution: input.outputResolution,
-    outputResolutionAspectAgnostic: input.outputResolutionAspectAgnostic,
-    videoFrameFormat: input.videoFrameFormat,
-    logger: log,
-  };
+function buildRenderJobConfig(input: RenderInput, outputPath: string, log: ProducerLogger) {
+  const request = createRenderRequest({
+    projectDir: input.projectDir,
+    outputPath,
+    options: {
+      fps: input.fps,
+      quality: input.quality,
+      format: input.format ?? "mp4",
+      workers: input.workers,
+      useGpu: input.useGpu,
+      debug: input.debug,
+      strictness: input.strictness,
+      entryFile: input.entryFile,
+      variables: input.variables,
+      outputResolution: input.outputResolution,
+      outputResolutionAspectAgnostic: input.outputResolutionAspectAgnostic,
+      videoFrameFormat: input.videoFrameFormat,
+    },
+  });
+  return renderConfigFromRequest(request, { logger: log });
 }
 
 /**
@@ -642,7 +647,7 @@ export function createRenderHandlers(options: HandlerOptions = {}): RenderHandle
       quality: input.quality,
     });
 
-    const job = createRenderJob(buildRenderJobConfig(input, log));
+    const job = createRenderJob(buildRenderJobConfig(input, absoluteOutputPath, log));
 
     try {
       await executeRenderJob(
@@ -718,7 +723,7 @@ export function createRenderHandlers(options: HandlerOptions = {}): RenderHandle
 
       log.info("render-stream started", { requestId, projectDir: input.projectDir });
 
-      const job = createRenderJob(buildRenderJobConfig(input, log));
+      const job = createRenderJob(buildRenderJobConfig(input, absoluteOutputPath, log));
       const abortController = new AbortController();
       const onRequestAbort = () =>
         abortController.abort(new RenderCancelledError("request_aborted"));

--- a/packages/producer/src/services/distributed/plan.ts
+++ b/packages/producer/src/services/distributed/plan.ts
@@ -206,6 +206,8 @@ export interface DistributedRenderConfig {
   cfr?: boolean;
 
   logger?: ProducerLogger;
+  /** JSON-safe engine snapshot carried across cloud/process boundaries. */
+  engineConfig?: EngineConfig;
   /** Optional engine config override (env vars are not read when provided). */
   producerConfig?: EngineConfig;
   /** Entry HTML file relative to `projectDir`. Defaults to `"index.html"`. */
@@ -755,7 +757,7 @@ export async function plan(
     }
   };
   const cfg: EngineConfig = {
-    ...(config.producerConfig ?? resolveConfig()),
+    ...(config.producerConfig ?? config.engineConfig ?? resolveConfig()),
     browserGpuMode: "software",
     forceScreenshot: false,
   };
@@ -775,7 +777,7 @@ export async function plan(
     strictness: config.strictness,
     entryFile: config.entryFile ?? "index.html",
     logger: config.logger,
-    producerConfig: config.producerConfig,
+    producerConfig: cfg,
   });
   const entryFile = config.entryFile ?? "index.html";
   const htmlPath = join(projectDir, entryFile);

--- a/packages/producer/src/services/distributed/renderConfigValidation.ts
+++ b/packages/producer/src/services/distributed/renderConfigValidation.ts
@@ -229,7 +229,12 @@ export function validateVariablesPayload(value: unknown): void {
       `must be a plain JSON object (got ${describeValue(value)})`,
     );
   }
-  walkVariables(value, "config.variables", new WeakSet());
+  validateJsonSafeValue(value, "config.variables");
+}
+
+/** Validate any JSON-boundary value without silently normalizing it. */
+export function validateJsonSafeValue(value: unknown, field: string): void {
+  walkVariables(value, field, new WeakSet());
 }
 
 /** Per-typeof rejection messages for JSON-unsafe leaves. */

--- a/packages/producer/src/services/distributed/renderConfigValidation.ts
+++ b/packages/producer/src/services/distributed/renderConfigValidation.ts
@@ -208,7 +208,14 @@ export function validateDistributedRenderConfig(
     validateVariablesPayload(config.variables);
   }
   if (config.engineConfig !== undefined) {
-    validateEngineConfigSnapshot(config.engineConfig);
+    try {
+      validateEngineConfigSnapshot(config.engineConfig);
+    } catch (error) {
+      throw new InvalidConfigError(
+        "config.engineConfig",
+        error instanceof Error ? error.message : "must be a valid engine config snapshot",
+      );
+    }
   }
 
   return config;

--- a/packages/producer/src/services/distributed/renderConfigValidation.ts
+++ b/packages/producer/src/services/distributed/renderConfigValidation.ts
@@ -203,6 +203,9 @@ export function validateDistributedRenderConfig(
   if (config.variables !== undefined) {
     validateVariablesPayload(config.variables);
   }
+  if (config.engineConfig !== undefined) {
+    walkVariables(config.engineConfig, "config.engineConfig", new WeakSet());
+  }
 
   return config;
 }

--- a/packages/producer/src/services/distributed/renderConfigValidation.ts
+++ b/packages/producer/src/services/distributed/renderConfigValidation.ts
@@ -17,7 +17,11 @@
  * needs the actual planner.
  */
 
-import { VIDEO_FRAME_FORMATS, isVideoFrameFormat } from "@hyperframes/engine";
+import {
+  VIDEO_FRAME_FORMATS,
+  isVideoFrameFormat,
+  validateEngineConfigSnapshot,
+} from "@hyperframes/engine";
 import { type DistributedFormat } from "./shared.js";
 import { type DistributedRenderConfig } from "./plan.js";
 
@@ -204,7 +208,7 @@ export function validateDistributedRenderConfig(
     validateVariablesPayload(config.variables);
   }
   if (config.engineConfig !== undefined) {
-    walkVariables(config.engineConfig, "config.engineConfig", new WeakSet());
+    validateEngineConfigSnapshot(config.engineConfig);
   }
 
   return config;


### PR DESCRIPTION
## What

Define one serializable RenderRequest and normalize environment input at the boundary.

## Why

CLI, Docker, server, and distributed adapters copied option bags and silently dropped fields.

## How

Add a shared request schema, explicit adapters, round-trip validation, and thread it through local/server/distributed entry points.

## Test plan

- [x] render request round-trip, server parsing, CLI Docker, and distributed validation tests
- [x] Stack-wide lint, format, build, typecheck, and relevant integration gates