### PR TITLE
test(engine): isolate peer abort regression

### DIFF
--- a/packages/engine/src/services/parallelCoordinator-peerAbort.test.ts
+++ b/packages/engine/src/services/parallelCoordinator-peerAbort.test.ts
@@ -14,28 +14,29 @@ describe("executeParallelCapture peer abort", () => {
     const root = mkdtempSync(join(tmpdir(), "hf-peer-abort-"));
     const captureFrame = vi.fn().mockResolvedValue(undefined);
     const closeCaptureSession = vi.fn().mockResolvedValue(undefined);
-    vi.doMock("./frameCapture.js", async (importOriginal) => {
-      const original = await importOriginal<typeof import("./frameCapture.js")>();
-      return {
-        ...original,
-        createCaptureSession: vi.fn(async (_url: string, outputDir: string) => {
-          const workerId = outputDir.endsWith("worker-0") ? 0 : 1;
-          return {
-            workerId,
-            browserConsoleBuffer: workerId === 0 ? ["[Browser:ERROR] bad source"] : [],
-          } as unknown as CaptureSession & { workerId: number };
-        }),
-        initializeSession: vi.fn(async (session: CaptureSession & { workerId: number }) => {
-          if (session.workerId === 0) {
-            throw new Error("Composition has zero duration. Runtime ready: true");
-          }
-          await Promise.resolve();
-        }),
-        captureFrame,
-        closeCaptureSession,
-        getCapturePerfSummary: vi.fn(() => ({ frames: 0 })),
-      };
-    });
+    // Keep this regression isolated from frameCapture's very large module graph.
+    // Importing the real module here made the test exceed Vitest's 5s budget
+    // only when every workspace suite competed for CPU during the CI matrix.
+    vi.doMock("./frameCapture.js", () => ({
+      createCaptureSession: vi.fn(async (_url: string, outputDir: string) => {
+        const workerId = outputDir.endsWith("worker-0") ? 0 : 1;
+        return {
+          workerId,
+          browserConsoleBuffer: workerId === 0 ? ["[Browser:ERROR] bad source"] : [],
+        } as unknown as CaptureSession & { workerId: number };
+      }),
+      initializeSession: vi.fn(async (session: CaptureSession & { workerId: number }) => {
+        if (session.workerId === 0) {
+          throw new Error("Composition has zero duration. Runtime ready: true");
+        }
+        await Promise.resolve();
+      }),
+      captureFrame,
+      captureFrameToBuffer: vi.fn(),
+      captureFrameToBufferPipelined: vi.fn(),
+      closeCaptureSession,
+      getCapturePerfSummary: vi.fn(() => ({ frames: 0 })),
+    }));
 
     try {
       const { executeParallelCapture } = await import("./parallelCoordinator.js");


### PR DESCRIPTION
## What

Isolate the engine peer-abort regression test from unrelated production dependency loading.

## Why

The test used importOriginal for a large module graph, causing full-matrix timeouts that obscured the cancellation behavior it was meant to protect.

## How

Replace the partial importOriginal mock with a complete minimal dependency mock and keep the assertion focused on aborting peer workers after the first fatal classified failure.

## Test plan

- [x] Focused peer-abort regression
- [x] Complete Engine suite and non-Producer package matrix