### PR TITLE
feat(studio): pure timeline drag math — collision, snapping, multi-drag preview

### DIFF
--- a/packages/studio/src/player/components/timelineCollision.test.ts
+++ b/packages/studio/src/player/components/timelineCollision.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineElement } from "../store/playerStore";
+import {
+  clampTrackToZone,
+  isInsertAllowedForZone,
+  isLaneFree,
+  resolveInsertRow,
+  resolvePlacement,
+  resolveZoneDropPlacement,
+  timeRangesOverlap,
+} from "./timelineCollision";
+
+function el(id: string, track: number, start: number, duration: number): TimelineElement {
+  return { id, tag: "video", start, duration, track };
+}
+
+describe("timeRangesOverlap", () => {
+  it("detects overlap and treats touching edges as free (half-open)", () => {
+    expect(timeRangesOverlap(0, 2, 1, 3)).toBe(true);
+    expect(timeRangesOverlap(0, 2, 2, 4)).toBe(false); // touching at 2
+    expect(timeRangesOverlap(2, 4, 0, 2)).toBe(false);
+  });
+});
+
+describe("isLaneFree", () => {
+  const els = [el("a", 0, 0, 5), el("b", 1, 2, 3)];
+
+  it("is free when nothing overlaps on the track", () => {
+    expect(isLaneFree(els, 2, 0, 5, null)).toBe(true);
+    expect(isLaneFree(els, 0, 6, 8, null)).toBe(true); // same track, no time overlap
+  });
+
+  it("is occupied when a clip overlaps on the same track", () => {
+    expect(isLaneFree(els, 0, 1, 3, null)).toBe(false);
+  });
+
+  it("ignores the excluded (dragged) clip", () => {
+    expect(isLaneFree(els, 0, 1, 3, "a")).toBe(true);
+  });
+});
+
+describe("resolvePlacement", () => {
+  const trackOrder = [0, 1, 2, 3];
+
+  it("keeps the desired lane when it is free", () => {
+    const els = [el("a", 2, 0, 4)];
+    expect(
+      resolvePlacement({
+        elements: els,
+        desiredTrack: 1,
+        start: 0,
+        duration: 4,
+        trackOrder,
+        excludeKey: null,
+      }),
+    ).toEqual({
+      track: 1,
+      needsInsert: false,
+    });
+  });
+
+  it("pushes up to the nearest free lane above when the target is occupied", () => {
+    // desired = 2 occupied; 1 free above → land on 1
+    const els = [el("blocker", 2, 0, 4)];
+    expect(
+      resolvePlacement({
+        elements: els,
+        desiredTrack: 2,
+        start: 1,
+        duration: 2,
+        trackOrder,
+        excludeKey: null,
+      }),
+    ).toEqual({ track: 1, needsInsert: false });
+  });
+
+  it("prefers up even when a lane below is also free", () => {
+    // desired 2 occupied; both 1 (up) and 3 (down) free → up wins
+    const els = [el("blocker", 2, 0, 5)];
+    expect(
+      resolvePlacement({
+        elements: els,
+        desiredTrack: 2,
+        start: 0,
+        duration: 3,
+        trackOrder,
+        excludeKey: null,
+      }),
+    ).toEqual({ track: 1, needsInsert: false });
+  });
+
+  it("falls to a lane below when every lane above is occupied", () => {
+    // desired 1 occupied; 0 occupied above; 2 free below → land on 2
+    const els = [el("x", 0, 0, 5), el("y", 1, 0, 5)];
+    expect(
+      resolvePlacement({
+        elements: els,
+        desiredTrack: 1,
+        start: 1,
+        duration: 2,
+        trackOrder,
+        excludeKey: null,
+      }),
+    ).toEqual({ track: 2, needsInsert: false });
+  });
+
+  it("signals needsInsert when no lane is free", () => {
+    const els = [el("a", 0, 0, 9), el("b", 1, 0, 9), el("c", 2, 0, 9), el("d", 3, 0, 9)];
+    expect(
+      resolvePlacement({
+        elements: els,
+        desiredTrack: 2,
+        start: 1,
+        duration: 2,
+        trackOrder,
+        excludeKey: null,
+      }),
+    ).toEqual({ track: 2, needsInsert: true });
+  });
+
+  it("placeholder-scenario excludes the dragged clip so it does not collide with itself", () => {
+    const els = [el("self", 1, 0, 5)];
+    expect(
+      resolvePlacement({
+        elements: els,
+        desiredTrack: 1,
+        start: 0,
+        duration: 5,
+        trackOrder,
+        excludeKey: "self",
+      }),
+    ).toEqual({ track: 1, needsInsert: false });
+  });
+});
+
+describe("resolveInsertRow", () => {
+  const n = 3; // three lanes: rows 0,1,2
+
+  it("targets the lane (null) when over its middle band", () => {
+    expect(resolveInsertRow(1.5, n, 0.22)).toBe(null); // dead center of lane 1
+  });
+
+  it("inserts at the top boundary of a lane when near its top edge", () => {
+    expect(resolveInsertRow(1.1, n, 0.22)).toBe(1); // just into lane 1 → boundary above it
+  });
+
+  it("inserts at the bottom boundary of a lane when near its bottom edge", () => {
+    expect(resolveInsertRow(1.9, n, 0.22)).toBe(2); // near bottom of lane 1 → boundary below
+  });
+
+  it("inserts above the top lane when the pointer is above everything", () => {
+    expect(resolveInsertRow(-0.5, n, 0.22)).toBe(0);
+  });
+
+  it("inserts below the bottom lane when the pointer is past the last lane", () => {
+    expect(resolveInsertRow(3.4, n, 0.22)).toBe(3);
+  });
+});
+
+describe("clampTrackToZone", () => {
+  // trackOrder [0,1,2,3]: rows 0,1 = visual; rows 2,3 = audio (audioRow = 2).
+  const order = [0, 1, 2, 3];
+
+  it("is a no-op when there is no audio zone", () => {
+    expect(clampTrackToZone(3, order, -1, false)).toBe(3);
+  });
+
+  it("keeps a visual clip in the visual zone", () => {
+    expect(clampTrackToZone(1, order, 2, false)).toBe(1); // already visual
+    expect(clampTrackToZone(3, order, 2, false)).toBe(1); // in audio → last visual lane
+  });
+
+  it("keeps an audio clip in the audio zone", () => {
+    expect(clampTrackToZone(2, order, 2, true)).toBe(2); // already audio
+    expect(clampTrackToZone(0, order, 2, true)).toBe(2); // in visual → first audio lane
+  });
+});
+
+describe("isInsertAllowedForZone", () => {
+  // audioRow = 2
+  it("allows any insert when there is no audio zone", () => {
+    expect(isInsertAllowedForZone(0, -1, false)).toBe(true);
+    expect(isInsertAllowedForZone(3, -1, true)).toBe(true);
+  });
+
+  it("allows a visual insert only at/above the audio zone top", () => {
+    expect(isInsertAllowedForZone(0, 2, false)).toBe(true);
+    expect(isInsertAllowedForZone(2, 2, false)).toBe(true); // bottom of the visual zone
+    expect(isInsertAllowedForZone(3, 2, false)).toBe(false); // inside the audio zone
+  });
+
+  it("allows an audio insert only at/below the audio zone top (audio clips make audio tracks)", () => {
+    expect(isInsertAllowedForZone(2, 2, true)).toBe(true);
+    expect(isInsertAllowedForZone(4, 2, true)).toBe(true); // below the bottom
+    expect(isInsertAllowedForZone(1, 2, true)).toBe(false); // inside the visual zone
+  });
+});
+
+describe("resolveZoneDropPlacement (the whole drop decision, no same-track overlap)", () => {
+  // order [0,1,2] visual + [3] audio. audioRow = 3.
+  const order = [0, 1, 2, 3];
+  const audioTracks = new Set([3]);
+  const base = {
+    order,
+    audioTracks,
+    deliberateInsertRow: null as number | null,
+    start: 2,
+    duration: 2,
+    dragKey: "x",
+    isAudio: false,
+  };
+
+  it("lands on the aimed track when it is free at that time", () => {
+    expect(
+      resolveZoneDropPlacement({ ...base, elements: [el("a", 1, 10, 3)], desiredTrack: 1 }),
+    ).toEqual({ track: 1, insertRow: null });
+  });
+
+  it("relocates UP to the nearest free track when the aimed spot overlaps a clip", () => {
+    expect(
+      resolveZoneDropPlacement({ ...base, elements: [el("a", 1, 0, 5)], desiredTrack: 1 }),
+    ).toEqual({ track: 0, insertRow: null });
+  });
+
+  it("relocates DOWN when the tracks above are also occupied", () => {
+    expect(
+      resolveZoneDropPlacement({
+        ...base,
+        elements: [el("a", 0, 0, 5), el("b", 1, 0, 5)],
+        desiredTrack: 1,
+      }),
+    ).toEqual({ track: 2, insertRow: null });
+  });
+
+  it("auto-creates a new track when EVERY lane in the zone is occupied at that time", () => {
+    expect(
+      resolveZoneDropPlacement({
+        ...base,
+        elements: [el("a", 0, 0, 5), el("b", 1, 0, 5), el("c", 2, 0, 5)],
+        desiredTrack: 1,
+      }),
+    ).toEqual({ track: 1, insertRow: 2 });
+  });
+
+  it("shares a track for sequential (non-overlapping) clips", () => {
+    expect(
+      resolveZoneDropPlacement({
+        ...base,
+        elements: [el("a", 1, 0, 2)],
+        desiredTrack: 1,
+        start: 2,
+      }),
+    ).toEqual({ track: 1, insertRow: null });
+  });
+
+  it("clamps a visual clip OUT of the audio zone before placing", () => {
+    expect(resolveZoneDropPlacement({ ...base, elements: [], desiredTrack: 3 })).toEqual({
+      track: 2,
+      insertRow: null,
+    });
+  });
+
+  it("clamps an audio clip INTO the audio zone before placing", () => {
+    expect(
+      resolveZoneDropPlacement({ ...base, elements: [], desiredTrack: 0, isAudio: true }),
+    ).toEqual({ track: 3, insertRow: null });
+  });
+
+  it("honors a deliberate boundary insert in the clip's own zone", () => {
+    expect(
+      resolveZoneDropPlacement({ ...base, elements: [], desiredTrack: 1, deliberateInsertRow: 1 }),
+    ).toEqual({ track: 1, insertRow: 1 });
+  });
+
+  it("ignores a deliberate insert that lands in the WRONG zone (visual into audio)", () => {
+    expect(
+      resolveZoneDropPlacement({ ...base, elements: [], desiredTrack: 1, deliberateInsertRow: 4 }),
+    ).toEqual({ track: 1, insertRow: null });
+  });
+
+  it("lets an AUDIO clip create a new audio track via a boundary insert", () => {
+    expect(
+      resolveZoneDropPlacement({
+        ...base,
+        elements: [],
+        desiredTrack: 3,
+        isAudio: true,
+        deliberateInsertRow: 4,
+      }),
+    ).toEqual({ track: 3, insertRow: 4 });
+  });
+});

--- a/packages/studio/src/player/components/timelineCollision.ts
+++ b/packages/studio/src/player/components/timelineCollision.ts
@@ -1,0 +1,203 @@
+import type { TimelineElement } from "../store/playerStore";
+
+/**
+ * Keep a landing track inside the dragged clip's kind-zone: visual clips stay in
+ * the rows ABOVE the first audio lane; audio clips stay AT/BELOW it. Prevents a
+ * clip from appearing to land in the wrong zone mid-drag (which normalizeToZones
+ * would then snap back). `audioRow` = index in `trackOrder` of the first audio
+ * lane, or -1 when there is no audio zone yet (then it's a no-op).
+ */
+export function clampTrackToZone(
+  targetTrack: number,
+  trackOrder: number[],
+  audioRow: number,
+  isAudio: boolean,
+): number {
+  if (audioRow < 0) return targetTrack;
+  const row = trackOrder.indexOf(targetTrack);
+  if (row < 0) return targetTrack;
+  if (isAudio) return row >= audioRow ? targetTrack : (trackOrder[audioRow] ?? targetTrack);
+  return row < audioRow ? targetTrack : (trackOrder[audioRow - 1] ?? targetTrack);
+}
+
+/**
+ * Whether a new-track insert at boundary `insertRow` is allowed for a clip of the
+ * given kind. Visual clips may only insert visual lanes (boundary at/above the top
+ * of the audio zone); audio clips may only insert audio lanes (boundary at/below
+ * it) — so audio clips CAN create a new audio track, and neither kind inserts into
+ * the other's zone. `audioRow` = first audio lane row, or -1 (no audio zone) → any.
+ */
+export function isInsertAllowedForZone(
+  insertRow: number,
+  audioRow: number,
+  isAudio: boolean,
+): boolean {
+  if (audioRow < 0) return true;
+  return isAudio ? insertRow >= audioRow : insertRow <= audioRow;
+}
+
+/**
+ * The full drop-placement decision for a dragged clip — one pure, testable unit.
+ * Enforces: NO time-overlap on a single track; a clip stays in its kind-zone;
+ * a new track is created only when needed. Order of resolution:
+ *   1. Deliberate boundary insert (pointer near a lane edge), if it's in the
+ *      clip's own zone → create a new track there.
+ *   2. Otherwise land on a lane: clamp the aimed track to the clip's zone, take it
+ *      if free at [start, start+duration), else the nearest FREE lane in the zone
+ *      (prefer up), else auto-create a new track right below the aimed lane.
+ * `audioTracks` = the set of track indices that currently hold audio (so the fn
+ * needs no element-kind import). Returns the landing `track` and, when a new track
+ * should be created, the `insertRow` boundary (else null).
+ */
+export function resolveZoneDropPlacement(input: {
+  order: number[];
+  audioTracks: ReadonlySet<number>;
+  elements: TimelineElement[];
+  desiredTrack: number;
+  deliberateInsertRow: number | null;
+  start: number;
+  duration: number;
+  dragKey: string;
+  isAudio: boolean;
+}): { track: number; insertRow: number | null } {
+  const { order, audioTracks, elements, desiredTrack, deliberateInsertRow } = input;
+  const { start, duration, dragKey, isAudio } = input;
+  const audioRow = order.findIndex((t) => audioTracks.has(t));
+
+  if (
+    deliberateInsertRow !== null &&
+    isInsertAllowedForZone(deliberateInsertRow, audioRow, isAudio)
+  ) {
+    return { track: desiredTrack, insertRow: deliberateInsertRow };
+  }
+
+  const desired = clampTrackToZone(desiredTrack, order, audioRow, isAudio);
+  const zoneTracks = order.filter((t) => audioTracks.has(t) === isAudio);
+  const placement = resolvePlacement({
+    elements,
+    desiredTrack: desired,
+    start,
+    duration,
+    trackOrder: zoneTracks,
+    excludeKey: dragKey,
+  });
+  if (placement.needsInsert) {
+    const desiredRow = order.indexOf(desired);
+    return { track: desired, insertRow: desiredRow >= 0 ? desiredRow + 1 : order.length };
+  }
+  return { track: placement.track, insertRow: null };
+}
+
+/**
+ * Fraction of a track height near a lane boundary that switches a vertical drag
+ * from "target this lane" into "insert a new track at this boundary". Tuned by
+ * feel — bigger = easier to hit boundaries (harder to land on a lane).
+ */
+const INSERT_BAND = 0.32;
+
+/**
+ * Decide whether a vertical drag is inserting a new track at a lane boundary.
+ * `rowFloat` is the pointer's position in track-height units from the top of the
+ * first lane (0 = top of lane 0). Returns the boundary row to insert at
+ * (0 = above the top lane, `trackCount` = below the bottom), or null when the
+ * pointer is over a lane's middle band (a normal move/target).
+ */
+export function resolveInsertRow(
+  rowFloat: number,
+  trackCount: number,
+  band: number = INSERT_BAND,
+): number | null {
+  if (trackCount === 0) return 0;
+  if (rowFloat <= 0) return 0;
+  if (rowFloat >= trackCount) return trackCount;
+  const lane = Math.floor(rowFloat);
+  const frac = rowFloat - lane;
+  if (frac < band) return lane;
+  if (frac > 1 - band) return lane + 1;
+  return null;
+}
+
+/** Half-open overlap test: [aStart, aEnd) intersects [bStart, bEnd). */
+export function timeRangesOverlap(
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+/**
+ * True when no clip on `track` overlaps [start, end) — excluding the clip
+ * identified by `excludeKey` (the one being dragged).
+ */
+export function isLaneFree(
+  elements: TimelineElement[],
+  track: number,
+  start: number,
+  end: number,
+  excludeKey: string | null,
+): boolean {
+  return !elements.some(
+    (el) =>
+      (el.key ?? el.id) !== excludeKey &&
+      el.track === track &&
+      timeRangesOverlap(start, end, el.start, el.start + el.duration),
+  );
+}
+
+export interface PlacementInput {
+  elements: TimelineElement[];
+  desiredTrack: number;
+  start: number;
+  duration: number;
+  trackOrder: number[];
+  excludeKey: string | null;
+}
+
+export interface PlacementResult {
+  /** The lane the clip should land on. */
+  track: number;
+  /**
+   * True when no existing lane was free and the caller should insert a new
+   * track instead of landing on `track` (which is then the desired lane as a
+   * last-resort fallback). Consumed in later stages (2b/2c); stage 2a ignores it.
+   */
+  needsInsert: boolean;
+}
+
+/**
+ * Resolve where a dragged clip should land, avoiding overlap. If the desired
+ * lane is free, keep it. Otherwise search the nearest free lane, **preferring
+ * up** (all lanes above, nearest first), then down. If none is free, signal an
+ * insert and fall back to the desired lane.
+ */
+export function resolvePlacement({
+  elements,
+  desiredTrack,
+  start,
+  duration,
+  trackOrder,
+  excludeKey,
+}: PlacementInput): PlacementResult {
+  const end = start + duration;
+  if (isLaneFree(elements, desiredTrack, start, end, excludeKey)) {
+    return { track: desiredTrack, needsInsert: false };
+  }
+  const idx = trackOrder.indexOf(desiredTrack);
+  if (idx === -1) return { track: desiredTrack, needsInsert: false };
+
+  // Prefer up: nearest lane above first, then the rest above.
+  for (let up = idx - 1; up >= 0; up--) {
+    if (isLaneFree(elements, trackOrder[up], start, end, excludeKey)) {
+      return { track: trackOrder[up], needsInsert: false };
+    }
+  }
+  // Then down: nearest lane below first.
+  for (let down = idx + 1; down < trackOrder.length; down++) {
+    if (isLaneFree(elements, trackOrder[down], start, end, excludeKey)) {
+      return { track: trackOrder[down], needsInsert: false };
+    }
+  }
+  return { track: desiredTrack, needsInsert: true };
+}

--- a/packages/studio/src/player/components/timelineMultiDragPreview.test.ts
+++ b/packages/studio/src/player/components/timelineMultiDragPreview.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampGroupMoveDelta,
+  isMultiDragActive,
+  isMultiDragPassenger,
+  multiDragDeltaSeconds,
+  multiDragPassengerOffsetPx,
+  type MultiDragPreviewInput,
+} from "./timelineMultiDragPreview";
+
+const base = (over: Partial<MultiDragPreviewInput> = {}): MultiDragPreviewInput => ({
+  dragStarted: true,
+  draggedKey: "a",
+  draggedOriginStart: 2,
+  draggedPreviewStart: 5,
+  selectedKeys: new Set(["a", "b", "c"]),
+  ...over,
+});
+
+describe("isMultiDragActive", () => {
+  it("is active when a started drag's clip is part of a 2+ selection", () => {
+    expect(isMultiDragActive(base())).toBe(true);
+  });
+
+  it("is inactive before the drag starts", () => {
+    expect(isMultiDragActive(base({ dragStarted: false }))).toBe(false);
+  });
+
+  it("is inactive for a single-clip selection (single-drag behavior)", () => {
+    expect(isMultiDragActive(base({ selectedKeys: new Set(["a"]) }))).toBe(false);
+  });
+
+  it("is inactive when the dragged clip is not itself selected", () => {
+    expect(isMultiDragActive(base({ draggedKey: "z" }))).toBe(false);
+  });
+});
+
+describe("multiDragDeltaSeconds (the one formation delta)", () => {
+  it("is the grabbed clip's preview − origin start when active", () => {
+    // The preview start is already group-clamped upstream, so this delta is the
+    // clamped delta every member (ghost + passengers) moves by.
+    expect(multiDragDeltaSeconds(base())).toBe(3);
+  });
+
+  it("supports a leftward (negative) delta", () => {
+    expect(multiDragDeltaSeconds(base({ draggedPreviewStart: 0.5 }))).toBeCloseTo(-1.5);
+  });
+
+  it("is zero when no multi-drag is active", () => {
+    expect(multiDragDeltaSeconds(base({ selectedKeys: new Set(["a"]) }))).toBe(0);
+  });
+});
+
+describe("isMultiDragPassenger", () => {
+  it("marks a selected non-dragged clip as a passenger", () => {
+    expect(isMultiDragPassenger("b", base())).toBe(true);
+    expect(isMultiDragPassenger("c", base())).toBe(true);
+  });
+
+  it("never marks the dragged clip itself (it is the free ghost)", () => {
+    expect(isMultiDragPassenger("a", base())).toBe(false);
+  });
+
+  it("never marks an unselected clip", () => {
+    expect(isMultiDragPassenger("d", base())).toBe(false);
+  });
+
+  it("marks nothing when the drag is a single-drag", () => {
+    const single = base({ selectedKeys: new Set(["a"]) });
+    expect(isMultiDragPassenger("b", single)).toBe(false);
+  });
+});
+
+describe("multiDragPassengerOffsetPx (rigid: every passenger shares the delta)", () => {
+  it("converts the one formation delta to pixels for every passenger", () => {
+    // Both passengers move by the SAME 3s × 100pps = 300px — spacing locked.
+    expect(multiDragPassengerOffsetPx("b", 100, base())).toBe(300);
+    expect(multiDragPassengerOffsetPx("c", 100, base())).toBe(300);
+  });
+
+  it("is zero for the dragged clip and for non-passengers", () => {
+    expect(multiDragPassengerOffsetPx("a", 100, base())).toBe(0);
+    expect(multiDragPassengerOffsetPx("d", 100, base())).toBe(0);
+  });
+
+  it("is zero for a non-finite pps", () => {
+    expect(multiDragPassengerOffsetPx("b", Number.NaN, base())).toBe(0);
+  });
+
+  it("follows a leftward delta", () => {
+    expect(multiDragPassengerOffsetPx("c", 50, base({ draggedPreviewStart: 0 }))).toBe(-100);
+  });
+});
+
+describe("clampGroupMoveDelta (rigid group move)", () => {
+  it("passes a rightward delta through unchanged (no right wall)", () => {
+    expect(clampGroupMoveDelta(3, [2, 5, 9])).toBe(3);
+    expect(clampGroupMoveDelta(1000, [0, 4])).toBe(1000);
+  });
+
+  it("passes a leftward delta through when no member would cross 0", () => {
+    // Leftmost member at 5, moving left by 3 → 2 ≥ 0, so unclamped.
+    expect(clampGroupMoveDelta(-3, [5, 8, 12])).toBe(-3);
+  });
+
+  it("clamps a leftward delta so the leftmost member stops exactly at 0", () => {
+    // Leftmost at 2 → the furthest left the group can move is -2 (that member → 0).
+    // A pointer asking for -5 is clamped to -2: the grabbed clip stops with the
+    // formation instead of out-running it.
+    expect(clampGroupMoveDelta(-5, [2, 6, 10])).toBe(-2);
+  });
+
+  it("is bounded by the MOST-constrained (leftmost) member, not the grabbed one", () => {
+    // Grabbed clip is at 10; a passenger at 1 is the constraint. Max left = -1.
+    expect(clampGroupMoveDelta(-8, [10, 1, 4])).toBe(-1);
+  });
+
+  it("already-at-0 member forbids any leftward move", () => {
+    expect(clampGroupMoveDelta(-4, [0, 3, 7])).toBe(0);
+    // rightward still allowed
+    expect(clampGroupMoveDelta(2, [0, 3, 7])).toBe(2);
+  });
+
+  it("returns the raw delta for an empty formation", () => {
+    expect(clampGroupMoveDelta(-9, [])).toBe(-9);
+  });
+});

--- a/packages/studio/src/player/components/timelineMultiDragPreview.ts
+++ b/packages/studio/src/player/components/timelineMultiDragPreview.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure geometry for the LIVE multi-selection drag preview.
+ *
+ * Visual model (matches main): while a selected clip is dragged, ALL selected
+ * clips move together LIVE as one rigid formation following the cursor. The
+ * GRABBED clip is drawn as the free-floating ghost; every OTHER selected member
+ * ("passenger") slides by the SAME time delta via a cheap compositor
+ * `translateX` (no re-layout). Passengers do NOT stay still, and they do NOT lag
+ * behind individually — the whole formation moves by one delta, spacing locked.
+ *
+ * That single delta is the GRABBED clip's `draggedPreviewStart − draggedOriginStart`.
+ * The preview start is ALREADY group-clamped upstream (updateDraggedClipPreview
+ * runs clampGroupMoveDelta before setting it), so this delta is the clamped delta:
+ * the instant any member would cross 0 the grabbed clip stops and every passenger
+ * stops with it — the formation never deforms. On DROP the commit shifts every
+ * selected clip by this same delta (see timelineClipDragCommit / useTimelineClipDrag).
+ *
+ * Track changes apply to the grabbed clip only (mirroring the commit); passengers
+ * keep their lanes, so only their x moves.
+ */
+
+export interface MultiDragPreviewInput {
+  /** The drag is live (past the movement threshold). */
+  dragStarted: boolean;
+  /** Key of the clip under the pointer. */
+  draggedKey: string;
+  /** The dragged clip's committed start (pre-drag). */
+  draggedOriginStart: number;
+  /** The dragged clip's live preview start (already group-clamped upstream). */
+  draggedPreviewStart: number;
+  /** The current multi-selection (store.selectedElementIds). */
+  selectedKeys: ReadonlySet<string>;
+}
+
+/**
+ * Whether a live multi-selection drag is in effect: the drag started, and the
+ * dragged clip is itself part of a 2+ multi-selection. Below this, single-drag
+ * behavior is unchanged and there are no passengers.
+ */
+export function isMultiDragActive(input: MultiDragPreviewInput): boolean {
+  return (
+    input.dragStarted && input.selectedKeys.size > 1 && input.selectedKeys.has(input.draggedKey)
+  );
+}
+
+/**
+ * The single time delta the WHOLE formation shifts by — the grabbed clip's
+ * preview start minus its origin start. Because the preview start is already
+ * group-clamped, this is the clamped delta every member (ghost + passengers)
+ * moves by. Zero when the clip hasn't moved (or no multi-drag).
+ */
+export function multiDragDeltaSeconds(input: MultiDragPreviewInput): number {
+  if (!isMultiDragActive(input)) return 0;
+  return input.draggedPreviewStart - input.draggedOriginStart;
+}
+
+/**
+ * Whether a specific rendered clip is a passenger — a selected clip that is NOT
+ * the dragged clip and NOT the same clip key. Passengers get the translateX
+ * treatment; the dragged clip is drawn as the free-floating ghost instead.
+ */
+export function isMultiDragPassenger(clipKey: string, input: MultiDragPreviewInput): boolean {
+  return (
+    isMultiDragActive(input) && clipKey !== input.draggedKey && input.selectedKeys.has(clipKey)
+  );
+}
+
+/**
+ * The passenger's rendered x offset in PIXELS (delta seconds × pixels/second),
+ * to apply as `transform: translateX(...px)`. Every passenger uses the SAME
+ * formation delta, so the group moves rigidly. Returns 0 for non-passengers so
+ * callers can compute unconditionally and only branch on the elevated styling.
+ */
+export function multiDragPassengerOffsetPx(
+  clipKey: string,
+  pixelsPerSecond: number,
+  input: MultiDragPreviewInput,
+): number {
+  if (!isMultiDragPassenger(clipKey, input)) return 0;
+  const pps = Number.isFinite(pixelsPerSecond) ? pixelsPerSecond : 0;
+  return multiDragDeltaSeconds(input) * pps;
+}
+
+/**
+ * Clamp a group move so the WHOLE selection moves as ONE rigid formation.
+ *
+ * The grabbed clip proposes a raw delta (its desired preview start minus its
+ * origin start, after its own snapping). Applied naively, a passenger could be
+ * pushed below 0 (or past any other member bound), and the commit's per-clip
+ * `Math.max(0, …)` would then deform the formation — the grabbed clip out-runs
+ * the group while a passenger sticks at the wall. This ports main's model
+ * (useTimelineClipGroupDrag / clampTimelineGroupMoveDelta): the applied delta is
+ * bounded by the MOST-CONSTRAINED member, so the grabbed clip STOPS the instant
+ * any member hits 0 and the formation never deforms.
+ *
+ * `memberStarts` are the pre-drag starts of every selected clip (the grabbed clip
+ * included). Only the lower bound (start ≥ 0) constrains a move; the timeline has
+ * no fixed right wall (the composition grows on commit).
+ */
+export function clampGroupMoveDelta(rawDelta: number, memberStarts: readonly number[]): number {
+  if (memberStarts.length === 0) return rawDelta;
+  // Leftmost member sets the floor: delta ≥ -min(start) keeps every start ≥ 0.
+  const minStart = Math.min(...memberStarts);
+  const minDelta = minStart === 0 ? 0 : -minStart; // avoid -0
+  return rawDelta < minDelta ? minDelta : rawDelta;
+}

--- a/packages/studio/src/player/components/timelineSnapping.test.ts
+++ b/packages/studio/src/player/components/timelineSnapping.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  TIMELINE_SNAP_PX,
+  collectTimelineSnapTargets,
+  snapMoveToTargets,
+  snapTimelineTime,
+} from "./timelineSnapping";
+
+describe("collectTimelineSnapTargets", () => {
+  const elements = [
+    { start: 2, duration: 3, key: "a", id: "a" },
+    { start: 10, duration: 1.5, key: "b", id: "b" },
+  ];
+
+  it("collects clip starts and ends, playhead, and beats with types", () => {
+    const targets = collectTimelineSnapTargets({
+      elements,
+      playheadTime: 7.25,
+      beatTimes: [0.5, 1.0],
+    });
+    expect(targets).toContainEqual({ time: 2, type: "clip-edge" });
+    expect(targets).toContainEqual({ time: 5, type: "clip-edge" });
+    expect(targets).toContainEqual({ time: 10, type: "clip-edge" });
+    expect(targets).toContainEqual({ time: 11.5, type: "clip-edge" });
+    expect(targets).toContainEqual({ time: 7.25, type: "playhead" });
+    expect(targets).toContainEqual({ time: 0.5, type: "beat" });
+  });
+
+  it("excludes the dragged element's own edges", () => {
+    const targets = collectTimelineSnapTargets({
+      elements,
+      playheadTime: null,
+      beatTimes: [],
+      excludeElementKey: "a",
+    });
+    expect(targets.some((t) => t.time === 2)).toBe(false);
+    expect(targets.some((t) => t.time === 5)).toBe(false);
+    expect(targets).toContainEqual({ time: 10, type: "clip-edge" });
+  });
+
+  it("omits playhead when null and dedupes identical times preferring playhead > clip-edge > beat", () => {
+    const targets = collectTimelineSnapTargets({
+      elements: [{ start: 1, duration: 1, key: "x", id: "x" }],
+      playheadTime: 2,
+      beatTimes: [2],
+    });
+    const atTwo = targets.filter((t) => t.time === 2);
+    expect(atTwo).toEqual([{ time: 2, type: "playhead" }]);
+  });
+});
+
+describe("snapTimelineTime", () => {
+  const targets = [
+    { time: 5, type: "clip-edge" as const },
+    { time: 5.3, type: "playhead" as const },
+  ];
+
+  it("snaps to the nearest target within threshold", () => {
+    expect(snapTimelineTime(5.05, targets, 0.1)).toEqual({
+      time: 5,
+      target: { time: 5, type: "clip-edge" },
+    });
+  });
+
+  it("returns input unchanged when nothing is within threshold", () => {
+    expect(snapTimelineTime(6, targets, 0.1)).toEqual({ time: 6, target: null });
+  });
+});
+
+describe("snapMoveToTargets", () => {
+  // pps=100 → threshold = TIMELINE_SNAP_PX/100 = 0.08s
+  const targets = [{ time: 5, type: "playhead" as const }];
+
+  it("snaps the start edge when it is the closer edge", () => {
+    const r = snapMoveToTargets(5.05, 2, targets, 100, 60);
+    expect(r).toEqual({ start: 5, snapTime: 5, snapType: "playhead" });
+  });
+
+  it("snaps the end edge, shifting start so the end lands on the target", () => {
+    const r = snapMoveToTargets(3.03, 2, targets, 100, 60);
+    expect(r.start).toBeCloseTo(3, 5);
+    expect(r.snapTime).toBe(5);
+    expect(r.snapType).toBe("playhead");
+  });
+
+  it("drops the snap when clamping to timeline bounds pulls it off target", () => {
+    // duration 2, timeline 6 → maxStart 4; target at 5.05 wants start 5.05 → clamped to 4
+    const r = snapMoveToTargets(5.0, 2, [{ time: 5.05, type: "beat" }], 100, 6);
+    expect(r.snapTime).toBeNull();
+  });
+
+  it("threshold scales with pixels-per-second", () => {
+    // pps=10 → threshold 0.8s: 5.5 snaps; pps=1000 → threshold 0.008s: it does not
+    expect(snapMoveToTargets(5.5, 2, targets, 10, 60).snapTime).toBe(5);
+    expect(snapMoveToTargets(5.5, 2, targets, 1000, 60).snapTime).toBeNull();
+  });
+
+  it("TIMELINE_SNAP_PX matches the historical beat-snap threshold", () => {
+    expect(TIMELINE_SNAP_PX).toBe(8);
+  });
+});

--- a/packages/studio/src/player/components/timelineSnapping.ts
+++ b/packages/studio/src/player/components/timelineSnapping.ts
@@ -1,0 +1,103 @@
+import type { TimelineElement } from "../store/playerStore";
+
+export type TimelineSnapType = "beat" | "playhead" | "clip-edge";
+
+export interface TimelineSnapTarget {
+  time: number;
+  type: TimelineSnapType;
+}
+
+/** Pixel radius within which a time snaps to a target (matches historical beat snap). */
+export const TIMELINE_SNAP_PX = 8;
+
+const TYPE_PRIORITY: Record<TimelineSnapType, number> = {
+  playhead: 0,
+  "clip-edge": 1,
+  beat: 2,
+};
+
+export function collectTimelineSnapTargets(input: {
+  elements: ReadonlyArray<Pick<TimelineElement, "start" | "duration" | "key" | "id">>;
+  playheadTime: number | null;
+  beatTimes: readonly number[];
+  excludeElementKey?: string | null;
+}): TimelineSnapTarget[] {
+  const byTime = new Map<number, TimelineSnapTarget>();
+  const add = (time: number, type: TimelineSnapType) => {
+    if (!Number.isFinite(time) || time < 0) return;
+    const rounded = Math.round(time * 1000) / 1000;
+    const existing = byTime.get(rounded);
+    if (!existing || TYPE_PRIORITY[type] < TYPE_PRIORITY[existing.type]) {
+      byTime.set(rounded, { time: rounded, type });
+    }
+  };
+
+  for (const beat of input.beatTimes) add(beat, "beat");
+  for (const el of input.elements) {
+    if (input.excludeElementKey != null && (el.key ?? el.id) === input.excludeElementKey) continue;
+    add(el.start, "clip-edge");
+    add(el.start + el.duration, "clip-edge");
+  }
+  if (input.playheadTime != null) add(input.playheadTime, "playhead");
+
+  return Array.from(byTime.values()).sort((a, b) => a.time - b.time);
+}
+
+export function snapTimelineTime(
+  time: number,
+  targets: readonly TimelineSnapTarget[],
+  thresholdSecs: number,
+): { time: number; target: TimelineSnapTarget | null } {
+  let best: TimelineSnapTarget | null = null;
+  let bestDist = thresholdSecs;
+  for (const target of targets) {
+    const d = Math.abs(target.time - time);
+    if (
+      d < bestDist ||
+      (d === bestDist && best && TYPE_PRIORITY[target.type] < TYPE_PRIORITY[best.type])
+    ) {
+      bestDist = d;
+      best = target;
+    }
+  }
+  return best ? { time: best.time, target: best } : { time, target: null };
+}
+
+/**
+ * Snap a moved clip so whichever edge (start or end) is nearest a target lands
+ * on it, keeping duration fixed. Mirrors the historical beat-snap semantics:
+ * clamp to [0, timelineDuration - duration]; if clamping pulls the clip off the
+ * target, drop the highlight.
+ */
+export function snapMoveToTargets(
+  start: number,
+  duration: number,
+  targets: readonly TimelineSnapTarget[],
+  pixelsPerSecond: number,
+  timelineDuration: number,
+): { start: number; snapTime: number | null; snapType: TimelineSnapType | null } {
+  if (targets.length === 0) return { start, snapTime: null, snapType: null };
+  const thresholdSecs = TIMELINE_SNAP_PX / Math.max(pixelsPerSecond, 1);
+  const startSnap = snapTimelineTime(start, targets, thresholdSecs);
+  const endSnap = snapTimelineTime(start + duration, targets, thresholdSecs);
+  const startMoved = startSnap.target !== null;
+  const endMoved = endSnap.target !== null;
+
+  let candidate = start;
+  let target: TimelineSnapTarget | null = null;
+  if (
+    startMoved &&
+    (!endMoved || Math.abs(startSnap.time - start) <= Math.abs(endSnap.time - (start + duration)))
+  ) {
+    candidate = startSnap.time;
+    target = startSnap.target;
+  } else if (endMoved) {
+    candidate = endSnap.time - duration;
+    target = endSnap.target;
+  }
+
+  const maxStart = Math.max(0, timelineDuration - duration);
+  const clamped = Math.max(0, Math.min(maxStart, Math.round(candidate * 1000) / 1000));
+  if (target && Math.abs(clamped - candidate) > 1e-6) target = null;
+  return { start: clamped, snapTime: target?.time ?? null, snapType: target?.type ?? null };
+}


### PR DESCRIPTION
## What

Three new pure modules, each with its test suite:

- **`timelineCollision`** — zone-aware placement: `clampTrackToZone`, `resolveInsertRow`, `resolvePlacement`, lane/overlap predicates. No two clips may overlap in time on one lane; a colliding drop relocates to the nearest free lane or inserts a new one.
- **`timelineSnapping`** — snap-target collection (clip edges, playhead, beats) and pixel-threshold time snapping, zoom-scaled.
- **`timelineMultiDragPreview`** — group-drag passenger offsets and clamped group deltas (rigid formation moves).

## Why

This is the math core of the NLE clip-drag engine. It has **no DOM, no React, no store writes** — reviewable as plain functions with their tests, before the integration PR wires them into the drag gesture.

## How

New files only; imports are limited to types from the existing `playerStore`. Nothing on main imports these yet — the integration PR (#2183) becomes the first runtime consumer.

## Test plan

- [x] `bunx vitest run` on the three test suites
- [x] `tsc --noEmit` in `packages/studio`
- [x] `fallow audit --base origin/main` clean (every export is consumed by same-PR tests)

---
### Stack
Part 2/9 of the studio NLE overhaul (CapCut-parity timeline + canvas editing). Stacked train — each PR's base is its predecessor; **merge top-down from #2177** and retarget bases as predecessors land.

#2177 → **#2178 (this)** → #2179 → #2180 → #2181 → #2182 → #2183 → #2184 → #2185
