### PR TITLE
feat(studio): asset preview overlay, preview store, and clip-drag types (unwired)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -55,6 +55,11 @@
     "packages/studio/src/hooks/gsapRuntimePreview.ts",
     // TEMP(studio-dnd): shipped unwired ahead of the NLE integration;
     // consumers land in studio-dnd/pr07-nle-integration-wiring, which removes this block.
+    "packages/studio/src/components/nle/AssetPreviewOverlay.tsx",
+    "packages/studio/src/player/components/timelineClipDragTypes.ts",
+    "packages/studio/src/utils/assetPreviewStore.ts",
+    // TEMP(studio-dnd): shipped unwired ahead of the NLE integration;
+    // consumers land in studio-dnd/pr07-nle-integration-wiring, which removes this block.
     "packages/studio/src/components/editor/CanvasContextMenu.tsx",
   ],
   "ignorePatterns": [

--- a/packages/studio/src/components/nle/AssetPreviewOverlay.tsx
+++ b/packages/studio/src/components/nle/AssetPreviewOverlay.tsx
@@ -1,0 +1,147 @@
+/**
+ * CapCut-style asset preview overlay rendered inside PreviewPane.
+ *
+ * Shown when the user clicks an asset card that has NOT yet been added to the
+ * timeline. Displays the media (image / video / audio) without modifying the
+ * composition — no undo entry, no file mutation.
+ *
+ * Dismiss: X button, Escape key, or click on the scrim.
+ * Switching to another not-added asset replaces the current preview.
+ */
+import { useEffect, useCallback } from "react";
+import { VIDEO_EXT, IMAGE_EXT } from "../../utils/mediaTypes";
+import { useAssetPreviewStore } from "../../utils/assetPreviewStore";
+
+function basename(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
+type AssetKind = "image" | "video" | "audio";
+
+function resolveAssetKind(path: string): AssetKind {
+  if (VIDEO_EXT.test(path)) return "video";
+  if (IMAGE_EXT.test(path)) return "image";
+  return "audio";
+}
+
+/** The media element for a previewed asset, chosen by kind. */
+function AssetPreviewMedia({
+  kind,
+  serveUrl,
+  name,
+}: {
+  kind: AssetKind;
+  serveUrl: string;
+  name: string;
+}) {
+  if (kind === "image") {
+    return (
+      <img
+        src={serveUrl}
+        alt={name}
+        className="max-w-full max-h-[70vh] rounded-md object-contain shadow-2xl"
+      />
+    );
+  }
+  if (kind === "video") {
+    return (
+      <video
+        src={serveUrl}
+        controls
+        autoPlay
+        muted
+        playsInline
+        className="max-w-full max-h-[70vh] rounded-md shadow-2xl"
+      />
+    );
+  }
+  return (
+    <div className="flex flex-col items-center gap-4 px-6 py-8 rounded-xl bg-neutral-900 border border-neutral-800">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        className="text-neutral-500"
+      >
+        <path d="M9 18V5l12-2v13" strokeLinecap="round" strokeLinejoin="round" />
+        <circle cx="6" cy="18" r="3" />
+        <circle cx="18" cy="16" r="3" />
+      </svg>
+      <audio src={serveUrl} controls className="w-64" />
+    </div>
+  );
+}
+
+export function AssetPreviewOverlay() {
+  const previewAsset = useAssetPreviewStore((s) => s.previewAsset);
+  const previewProjectId = useAssetPreviewStore((s) => s.previewProjectId);
+  const clearPreviewAsset = useAssetPreviewStore((s) => s.clearPreviewAsset);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") clearPreviewAsset();
+    },
+    [clearPreviewAsset],
+  );
+
+  useEffect(() => {
+    if (!previewAsset) return;
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [previewAsset, handleKeyDown]);
+
+  if (!previewAsset || !previewProjectId) return null;
+
+  const encodedAsset = previewAsset.split("/").map(encodeURIComponent).join("/");
+  const serveUrl = `/api/projects/${previewProjectId}/preview/${encodedAsset}`;
+  const name = basename(previewAsset);
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex flex-col items-center justify-center bg-black/80"
+      onClick={clearPreviewAsset}
+      role="dialog"
+      aria-label={`Preview: ${name}`}
+      aria-modal="true"
+    >
+      {/* Close button */}
+      <button
+        className="absolute top-3 right-3 w-7 h-7 rounded-full bg-neutral-800 hover:bg-neutral-700 text-neutral-300 hover:text-white flex items-center justify-center transition-colors z-10"
+        onClick={(e) => {
+          e.stopPropagation();
+          clearPreviewAsset();
+        }}
+        aria-label="Close preview"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          fill="none"
+          strokeLinecap="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+
+      {/* Media */}
+      <div
+        className="flex flex-col items-center gap-3 max-w-[90%] max-h-[85%]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <AssetPreviewMedia kind={resolveAssetKind(previewAsset)} serveUrl={serveUrl} name={name} />
+
+        {/* Filename label */}
+        <span className="text-[12px] text-neutral-400 truncate max-w-full px-2 text-center">
+          {name}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/studio/src/player/components/timelineClipDragTypes.ts
+++ b/packages/studio/src/player/components/timelineClipDragTypes.ts
@@ -1,0 +1,54 @@
+import type { TimelineElement } from "../store/playerStore";
+import type { TimelineSnapType } from "./timelineSnapping";
+import type { BlockedTimelineEditIntent } from "./timelineEditing";
+
+/* ── Shared clip-drag state types ───────────────────────────────── */
+export interface DraggedClipState {
+  element: TimelineElement;
+  originClientX: number;
+  originClientY: number;
+  originScrollLeft: number;
+  originScrollTop: number;
+  pointerClientX: number;
+  pointerClientY: number;
+  pointerOffsetX: number;
+  pointerOffsetY: number;
+  previewStart: number;
+  previewTrack: number;
+  /**
+   * When non-null, the drop inserts a NEW track at this visual row boundary
+   * (0 = above the top lane, trackOrder.length = below the bottom) instead of
+   * landing on previewTrack. Drives the insertion-line indicator.
+   */
+  insertRow: number | null;
+  /** Snap target the clip will land on, for the guide highlight. */
+  snapTime: number | null;
+  snapType: TimelineSnapType | null;
+  started: boolean;
+}
+
+export interface ResizingClipState {
+  element: TimelineElement;
+  edge: "start" | "end";
+  originClientX: number;
+  /**
+   * scrollLeft at gesture start. Edge auto-scroll moves the content under a
+   * stationary pointer, so the trim math folds (current − origin) scrollLeft
+   * into the pointer x — mirroring resolveTimelineMove's scroll compensation.
+   * Optional so pre-existing constructors/tests stay valid; when absent the
+   * first preview update captures the current scrollLeft.
+   */
+  originScrollLeft?: number;
+  previewStart: number;
+  previewDuration: number;
+  previewPlaybackStart?: number;
+  started: boolean;
+}
+
+export interface BlockedClipState {
+  element: TimelineElement;
+  intent: BlockedTimelineEditIntent;
+  originClientX: number;
+  originClientY: number;
+  started: boolean;
+}

--- a/packages/studio/src/utils/assetPreviewStore.ts
+++ b/packages/studio/src/utils/assetPreviewStore.ts
@@ -1,0 +1,31 @@
+/**
+ * Tiny Zustand slice that carries the "asset preview overlay" state.
+ *
+ * When a user clicks an asset card that has NOT yet been added to the
+ * timeline the overlay fires up: a dark scrim + centered media element
+ * (img / video / audio) + filename label rendered inside PreviewPane.
+ *
+ * State lives here so AssetsTab (sidebar) and PreviewPane (preview column)
+ * can communicate without prop-drilling through the multi-layer EditorShell
+ * tree. The store is project-scoped: clearing it on project change keeps
+ * stale previews from bleeding across projects.
+ */
+import { create } from "zustand";
+
+interface AssetPreviewState {
+  /** Project-relative asset path currently being previewed, or null. */
+  previewAsset: string | null;
+  /** projectId for which the preview was opened (used to build the serve URL). */
+  previewProjectId: string | null;
+  /** Open a media preview for the given asset. */
+  setPreviewAsset: (asset: string, projectId: string) => void;
+  /** Close the preview overlay. */
+  clearPreviewAsset: () => void;
+}
+
+export const useAssetPreviewStore = create<AssetPreviewState>((set) => ({
+  previewAsset: null,
+  previewProjectId: null,
+  setPreviewAsset: (asset, projectId) => set({ previewAsset: asset, previewProjectId: projectId }),
+  clearPreviewAsset: () => set({ previewAsset: null, previewProjectId: null }),
+}));


### PR DESCRIPTION
## What

The NLE shell layer, shipped **unwired**:

- **`AssetPreviewOverlay`** + **`assetPreviewStore`** — CapCut-style view-only media preview over the canvas (image/video/audio; Escape/scrim to close), backed by a small zustand slice
- **`timelineClipDragTypes`** — shared drag-state types for the clip-drag engine

## Why

Standalone, reviewable components; #2183 mounts them. Keeping them out of the integration diff keeps that PR to glue and deletes.

## How

New files only, tsc-clean against current main. Nothing imports them yet, so `.fallowrc.jsonc` gains `TEMP(studio-dnd)` entry registrations; **#2183 removes every one of them** when the components become reachable.

Note: the larger extracted shell files (`NLEContext`, `PreviewPane`, `TimelineOverlays`, `useTimelinePlayerLoop`, `timelineClipChildren`) intentionally ride in #2183 instead — they duplicate blocks of their still-alive originals (`NLELayout`, `Timeline`, `useTimelinePlayer`), so they can only land in the diff that deletes/rewrites those originals.

## Test plan

- [x] `tsc --noEmit` in `packages/studio`
- [x] `bunx vitest run` (studio suite unchanged)
- [x] `fallow audit --base origin/main` clean

---
### Stack
Part 6/9 of the studio NLE overhaul (CapCut-parity timeline + canvas editing). Stacked train — each PR's base is its predecessor; **merge top-down from #2177** and retarget bases as predecessors land.

#2177 → #2178 → #2179 → #2180 → #2181 → **#2182 (this)** → #2183 → #2184 → #2185
