### PR TITLE
feat(studio): timeline visual refresh + clip thumbnails

### DIFF
--- a/packages/studio/src/player/components/ImageThumbnail.test.tsx
+++ b/packages/studio/src/player/components/ImageThumbnail.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ImageThumbnail } from "./ImageThumbnail";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+});
+
+// --- Observer stubs: fire "intersecting" immediately on observe ---
+class MockIntersectionObserver {
+  private cb: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.cb = cb;
+  }
+  observe() {
+    this.cb(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+  disconnect() {}
+  unobserve() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+class MockResizeObserver {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+// --- Image stub: captures instances so tests fire load/error deterministically ---
+class MockImage {
+  static instances: MockImage[] = [];
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  src = "";
+  constructor() {
+    MockImage.instances.push(this);
+  }
+}
+
+const originalIO = globalThis.IntersectionObserver;
+const originalRO = globalThis.ResizeObserver;
+const originalImage = globalThis.Image;
+
+let host: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(() => {
+  globalThis.IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  globalThis.Image = MockImage as unknown as typeof Image;
+  MockImage.instances = [];
+  host = document.createElement("div");
+  document.body.append(host);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  globalThis.IntersectionObserver = originalIO;
+  globalThis.ResizeObserver = originalRO;
+  globalThis.Image = originalImage;
+  document.body.innerHTML = "";
+});
+
+function render(props: { imageSrc: string; label?: string; labelColor?: string }) {
+  root = createRoot(host);
+  act(() => {
+    root!.render(
+      <ImageThumbnail
+        imageSrc={props.imageSrc}
+        label={props.label ?? ""}
+        labelColor={props.labelColor ?? "#fff"}
+      />,
+    );
+  });
+}
+
+function lastProbe(): MockImage {
+  const probe = MockImage.instances.at(-1);
+  expect(probe).toBeDefined();
+  return probe!;
+}
+
+/** Assert at least one tile rendered and the first tile serves `expectedSrc`. */
+function expectFirstTileSrc(expectedSrc: string): void {
+  const imgs = [...host.querySelectorAll("img")];
+  expect(imgs.length).toBeGreaterThanOrEqual(1);
+  expect(imgs[0].getAttribute("src")).toBe(expectedSrc);
+}
+
+describe("ImageThumbnail", () => {
+  it("shows the loading shimmer before the image resolves", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/pic.png" });
+    expect(host.querySelector(".animate-pulse")).not.toBeNull();
+    expect(host.querySelectorAll("img").length).toBe(0);
+  });
+
+  it("probes the resolved src and renders repeated object-cover tiles on load", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/pic.png" });
+    const probe = lastProbe();
+    expect(probe.src).toBe("/api/projects/p/preview/assets/pic.png");
+
+    act(() => {
+      probe.naturalWidth = 1920;
+      probe.naturalHeight = 1080;
+      probe.onload?.();
+    });
+
+    const imgs = [...host.querySelectorAll("img")];
+    expect(imgs.length).toBeGreaterThanOrEqual(1);
+    for (const img of imgs) {
+      expect(img.getAttribute("src")).toBe("/api/projects/p/preview/assets/pic.png");
+      expect(img.className).toContain("object-cover");
+    }
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("drops the shimmer and renders no tiles when a raster image fails to load", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/missing.png" });
+    act(() => lastProbe().onerror?.());
+    expect(host.querySelectorAll("img").length).toBe(0);
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("renders tiles at 16:9 when an SVG has no intrinsic dimensions (naturalWidth=0)", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/logo.svg" });
+    const probe = lastProbe();
+
+    act(() => {
+      // naturalWidth stays 0 — SVG with no width/height attribute
+      probe.onload?.();
+    });
+
+    expectFirstTileSrc("/api/projects/p/preview/assets/logo.svg");
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("renders SVG tiles at 16:9 fallback even when the probe fires onerror", () => {
+    // Some browser/sandbox environments fire onerror for SVGs even though the
+    // <img> element itself can render the file — we must not blank the strip.
+    render({ imageSrc: "/api/projects/p/preview/assets/icon.svg" });
+
+    act(() => lastProbe().onerror?.());
+
+    expectFirstTileSrc("/api/projects/p/preview/assets/icon.svg");
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("renders the label above the strip when provided", () => {
+    render({ imageSrc: "/x.png", label: "hero", labelColor: "#abc" });
+    act(() => {
+      const probe = lastProbe();
+      probe.naturalWidth = 100;
+      probe.naturalHeight = 100;
+      probe.onload?.();
+    });
+    const label = [...host.querySelectorAll("span")].find((s) => s.textContent === "hero");
+    expect(label).toBeDefined();
+    expect(label!.closest(".z-10")).not.toBeNull();
+  });
+});

--- a/packages/studio/src/player/components/ImageThumbnail.tsx
+++ b/packages/studio/src/player/components/ImageThumbnail.tsx
@@ -1,0 +1,160 @@
+import { memo, useRef, useState, useCallback, useEffect } from "react";
+import { useMountEffect } from "../../hooks/useMountEffect";
+import { computeThumbnailStrip } from "./thumbnailUtils";
+
+interface ImageThumbnailProps {
+  imageSrc: string;
+  label: string;
+  labelColor: string;
+}
+
+/**
+ * Renders a film-strip of a still image for a timeline clip. The image is a
+ * fixed-width tile (sized by its natural aspect ratio) repeated to fill the
+ * clip width — matching VideoThumbnail's visual pattern. Loading is lazy
+ * (IntersectionObserver) with the same shimmer fallback while decoding.
+ */
+export const ImageThumbnail = memo(function ImageThumbnail({
+  imageSrc,
+  label,
+  labelColor,
+}: ImageThumbnailProps) {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [visible, setVisible] = useState(false);
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const [aspect, setAspect] = useState(16 / 9);
+  const ioRef = useRef<IntersectionObserver | null>(null);
+  const roRef = useRef<ResizeObserver | null>(null);
+
+  const setContainerRef = useCallback((el: HTMLDivElement | null) => {
+    ioRef.current?.disconnect();
+    roRef.current?.disconnect();
+    if (!el) return;
+
+    const measured = el.parentElement?.clientWidth || el.clientWidth;
+    setContainerWidth(measured);
+
+    ioRef.current = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          ioRef.current?.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    // fallow-ignore-next-line code-duplication
+    ioRef.current.observe(el);
+
+    const target = el.parentElement || el;
+    roRef.current = new ResizeObserver(([entry]) => {
+      setContainerWidth(entry.contentRect.width);
+    });
+    roRef.current.observe(target);
+  }, []);
+
+  useMountEffect(() => () => {
+    ioRef.current?.disconnect();
+    roRef.current?.disconnect();
+  });
+
+  // Probe the image once visible — measures the natural aspect ratio so the
+  // tile width matches, and flips to the error state (plain clip background)
+  // if the src can't load. The browser cache makes the tile <img>s free.
+  //
+  // SVG handling: SVGs without intrinsic width/height report naturalWidth=0 on
+  // load (treat as success with the 16:9 default aspect) and may fire onerror
+  // in some environments even though the file is valid and can be displayed —
+  // fall back to loaded-at-16:9 rather than hiding the strip entirely.
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    setStatus("loading");
+
+    const isSvg = /\.svg($|\?)/i.test(imageSrc);
+
+    const probe = new Image();
+    probe.onload = () => {
+      if (cancelled) return;
+      if (probe.naturalWidth > 0 && probe.naturalHeight > 0) {
+        setAspect(probe.naturalWidth / probe.naturalHeight);
+      }
+      // naturalWidth===0 (e.g. SVG with no intrinsic dimensions) falls through
+      // to "loaded" with the default 16:9 aspect already set in state.
+      setStatus("loaded");
+    };
+    probe.onerror = () => {
+      if (cancelled) return;
+      // SVGs can fail the probe in certain browser/sandbox environments even
+      // though the <img> tiles themselves render fine (different security
+      // context). Show the strip at the 16:9 fallback rather than blanking.
+      if (isSvg) {
+        setStatus("loaded");
+      } else {
+        setStatus("error");
+      }
+    };
+    probe.src = imageSrc;
+
+    return () => {
+      cancelled = true;
+      probe.onload = null;
+      probe.onerror = null;
+      probe.src = "";
+    };
+  }, [visible, imageSrc]);
+
+  const { frameW, frameCount } = computeThumbnailStrip(containerWidth, aspect);
+
+  return (
+    <div ref={setContainerRef} className="absolute inset-0 overflow-hidden">
+      {visible && status === "loaded" && (
+        <div className="absolute inset-0 flex">
+          {Array.from({ length: frameCount }).map((_, i) => (
+            <div
+              key={i}
+              className="flex-shrink-0 h-full relative overflow-hidden bg-neutral-900"
+              style={{ width: frameW }}
+            >
+              <img
+                src={imageSrc}
+                alt=""
+                draggable={false}
+                loading="lazy"
+                className="absolute inset-0 w-full h-full object-cover"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {visible && status === "loading" && (
+        <div
+          className="absolute inset-0 animate-pulse"
+          style={{
+            background:
+              "linear-gradient(90deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.05) 50%, rgba(255,255,255,0.02) 100%)",
+          }}
+        />
+      )}
+
+      {label && (
+        <div
+          className="absolute bottom-0 left-0 right-0 z-10 px-1.5 pb-0.5 pt-3"
+          style={{
+            background:
+              "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)",
+          }}
+        >
+          <span
+            className="text-[9px] font-semibold truncate block leading-tight"
+            style={{ color: labelColor, textShadow: "0 1px 2px rgba(0,0,0,0.9)" }}
+          >
+            {label}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/studio/src/player/components/PlayerControls.tsx
+++ b/packages/studio/src/player/components/PlayerControls.tsx
@@ -9,10 +9,8 @@ import { Tooltip } from "../../components/ui";
 import { ShortcutsPanel } from "./ShortcutsPanel";
 import { SpeedMenu } from "./SpeedMenu";
 import { useSeekBarDrag, resolveSeekPercent } from "./useSeekBarDrag";
-import { useState } from "react";
 
 export { resolveSeekPercent };
-type TimeDisplayMode = "time" | "frame";
 
 /* ── Icon sub-components ─────────────────────────────────────────── */
 
@@ -369,7 +367,8 @@ export const PlayerControls = memo(function PlayerControls({
   const outPoint = usePlayerStore((s) => s.outPoint);
   const setInPoint = usePlayerStore.getState().setInPoint;
   const setOutPoint = usePlayerStore.getState().setOutPoint;
-  const [timeDisplayMode, setTimeDisplayMode] = useState<TimeDisplayMode>("time");
+  const timeDisplayMode = usePlayerStore((s) => s.timeDisplayMode);
+  const setTimeDisplayMode = usePlayerStore.getState().setTimeDisplayMode;
 
   const progressFillRef = useRef<HTMLDivElement>(null);
   const progressThumbRef = useRef<HTMLDivElement>(null);
@@ -428,10 +427,11 @@ export const PlayerControls = memo(function PlayerControls({
 
   return (
     <div
+      // No own background/border: the transport blends into the preview
+      // panel's surface — buttons carry their own chrome.
       className="px-4 py-2 flex flex-wrap items-center gap-x-2 gap-y-1"
       aria-disabled={disabled || undefined}
       style={{
-        borderTop: "1px solid rgba(255,255,255,0.04)",
         paddingBottom: "calc(0.5rem + env(safe-area-inset-bottom))",
       }}
     >
@@ -456,7 +456,7 @@ export const PlayerControls = memo(function PlayerControls({
       >
         <button
           type="button"
-          onClick={() => setTimeDisplayMode((m) => (m === "time" ? "frame" : "time"))}
+          onClick={() => setTimeDisplayMode(timeDisplayMode === "time" ? "frame" : "time")}
           disabled={disabled}
           className="font-mono text-[11px] tabular-nums flex-shrink-0 w-[118px] text-left transition-colors disabled:pointer-events-none hover:opacity-80"
           style={{ color: "#A1A1AA", cursor: "pointer" }}

--- a/packages/studio/src/player/components/TimelineClip.tsx
+++ b/packages/studio/src/player/components/TimelineClip.tsx
@@ -2,6 +2,7 @@ import { memo, type CSSProperties, type ReactNode } from "react";
 import type { TimelineElement } from "../store/playerStore";
 import { defaultTimelineTheme, getClipHandleOpacity, type TimelineTheme } from "./timelineTheme";
 import type { TimelineEditCapabilities } from "./timelineEditing";
+import { isAudioTimelineElement } from "../../utils/timelineInspector";
 
 interface TimelineClipProps {
   el: TimelineElement;
@@ -62,6 +63,7 @@ export const TimelineClip = memo(function TimelineClip({
     isHovered ? "is-hovered" : "",
     isDragging ? "is-dragging" : "",
     showDefaultText ? "" : "is-micro",
+    isAudioTimelineElement(el) ? "is-audio" : "",
   ]
     .filter((className) => className.length > 0)
     .join(" ");
@@ -72,7 +74,8 @@ export const TimelineClip = memo(function TimelineClip({
     bottom: clipY,
     borderRadius: theme.clipRadius,
     zIndex: isDragging ? 20 : isSelected ? 10 : isHovered ? 5 : 1,
-    cursor: capabilities.canMove ? "grab" : "default",
+    // Regular cursor over clips (CapCut-style, user preference) — no grab hand.
+    cursor: "default",
     transform: isDragging ? "translateY(-1px)" : undefined,
   };
 

--- a/packages/studio/src/player/components/TimelineRuler.tsx
+++ b/packages/studio/src/player/components/TimelineRuler.tsx
@@ -1,6 +1,8 @@
 import { memo } from "react";
 import type { TimelineTheme } from "./timelineTheme";
 import { GUTTER, RULER_H, formatTimelineTickLabel } from "./timelineLayout";
+import { usePlayerStore } from "../store/playerStore";
+import { secondsToFrame } from "../lib/time";
 import type { MusicBeatAnalysis } from "@hyperframes/core/beats";
 
 interface TimelineRulerProps {
@@ -26,6 +28,7 @@ export const TimelineRuler = memo(function TimelineRuler({
   theme,
   beatAnalysis,
 }: TimelineRulerProps) {
+  const timeDisplayMode = usePlayerStore((s) => s.timeDisplayMode);
   const beatTimes = beatAnalysis?.beatTimes ?? [];
   const beatStrengths = beatAnalysis?.beatStrengths ?? [];
 
@@ -38,27 +41,13 @@ export const TimelineRuler = memo(function TimelineRuler({
 
   return (
     <>
-      {/* Grid lines (major ticks + beat lines) — behind the tracks (background).
-          Opaque track rows hide them; only the beat dots show on tracks. */}
+      {/* Background SVG — beat lines only; major-tick gridlines removed so only
+          the ruler's own small ticks mark intervals (no full-height lines). */}
       <svg
         className="absolute pointer-events-none"
         style={{ left: GUTTER, width: trackContentWidth, zIndex: 0 }}
         height={totalH}
       >
-        {major.map((t) => {
-          const x = t * pps;
-          return (
-            <line
-              key={`g-${t}`}
-              x1={x}
-              y1={RULER_H}
-              x2={x}
-              y2={totalH}
-              stroke={theme.tickMinor}
-              strokeWidth="1"
-            />
-          );
-        })}
         {showBeats &&
           beatTimes.map((t, i) => {
             const x = t * pps;
@@ -79,41 +68,58 @@ export const TimelineRuler = memo(function TimelineRuler({
           })}
       </svg>
 
-      {/* Ruler. The bar fills the full panel width (canvas is min 100% wide);
-          calc(100% - GUTTER) equals trackContentWidth when zoomed in and extends
-          past the content when zoomed out. Ticks stay at composition coordinates. */}
+      {/* Ruler — sticky so the timestamps stay visible while the tracks scroll
+          vertically. Opaque background (plus the gutter corner block) so clips
+          scrolling underneath don't bleed through; z-index sits above the track
+          rows and drag overlays but below the playhead (z 100). */}
       <div
-        className="relative overflow-hidden"
-        style={{
-          height: RULER_H,
-          marginLeft: GUTTER,
-          width: `calc(100% - ${GUTTER}px)`,
-          background: theme.gutterBackground,
-          borderBottom: `1px solid ${theme.rulerBorder}`,
-        }}
+        className="sticky top-0 flex"
+        style={{ height: RULER_H, width: GUTTER + trackContentWidth, zIndex: 70 }}
       >
-        {minor.map((t) => (
-          <div key={`m-${t}`} className="absolute bottom-0" style={{ left: t * pps }}>
-            <div className="w-px h-2" style={{ background: theme.tickMinor }} />
-          </div>
-        ))}
+        <div
+          className="sticky left-0 z-[12] flex-shrink-0"
+          style={{
+            width: GUTTER,
+            // Ruler corner uses the panel surface — same as the ruler strip itself.
+            background: theme.shellBackground,
+            borderRight: `1px solid ${theme.gutterBorder}`,
+          }}
+        />
+        <div
+          className="relative overflow-hidden"
+          style={{
+            height: RULER_H,
+            width: trackContentWidth,
+            // Ruler background = panel surface (#0A0A0B) — no bottom border,
+            // no tick lines (CapCut-style clean ruler, labels only).
+            background: theme.shellBackground,
+          }}
+        >
+          {minor.map((t) => (
+            <div key={`m-${t}`} className="absolute bottom-0" style={{ left: t * pps }}>
+              <div className="w-px h-2" style={{ background: theme.tickMinor }} />
+            </div>
+          ))}
 
-        {major.map((t) => (
-          <div key={`M-${t}`} className="absolute top-0" style={{ left: t * pps }}>
-            <span
-              className="absolute font-mono tabular-nums leading-none whitespace-nowrap"
-              style={{
-                color: theme.tickText,
-                left: 5,
-                top: 5,
-                fontSize: 10,
-              }}
-            >
-              {formatTimelineTickLabel(t, effectiveDuration, majorTickInterval)}
-            </span>
-            <div className="w-px" style={{ height: RULER_H, background: theme.tickMajor }} />
-          </div>
-        ))}
+          {major.map((t) => (
+            <div key={`M-${t}`} className="absolute top-0" style={{ left: t * pps }}>
+              <span
+                className="absolute font-mono tabular-nums leading-none whitespace-nowrap"
+                style={{
+                  color: theme.tickText,
+                  left: 5,
+                  top: 5,
+                  fontSize: 10,
+                }}
+              >
+                {timeDisplayMode === "frame"
+                  ? secondsToFrame(t)
+                  : formatTimelineTickLabel(t, effectiveDuration, majorTickInterval)}
+              </span>
+              <div className="w-px" style={{ height: RULER_H, background: theme.tickMajor }} />
+            </div>
+          ))}
+        </div>
       </div>
     </>
   );

--- a/packages/studio/src/player/components/VideoThumbnail.tsx
+++ b/packages/studio/src/player/components/VideoThumbnail.tsx
@@ -1,5 +1,6 @@
 import { memo, useRef, useState, useCallback, useEffect } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import { computeThumbnailStrip, THUMBNAIL_CLIP_HEIGHT } from "./thumbnailUtils";
 
 interface VideoThumbnailProps {
   videoSrc: string;
@@ -8,7 +9,7 @@ interface VideoThumbnailProps {
   duration?: number;
 }
 
-const CLIP_HEIGHT = 66;
+const CLIP_HEIGHT = THUMBNAIL_CLIP_HEIGHT;
 const MAX_UNIQUE_FRAMES: number = 6;
 
 /**
@@ -141,8 +142,7 @@ export const VideoThumbnail = memo(function VideoThumbnail({
     };
   }, [visible, videoSrc, duration]);
 
-  const frameW = Math.round(CLIP_HEIGHT * aspect);
-  const frameCount = containerWidth > 0 ? Math.max(1, Math.ceil(containerWidth / frameW)) : 1;
+  const { frameW, frameCount } = computeThumbnailStrip(containerWidth, aspect, CLIP_HEIGHT);
 
   return (
     <div ref={setContainerRef} className="absolute inset-0 overflow-hidden">

--- a/packages/studio/src/player/components/thumbnailUtils.test.ts
+++ b/packages/studio/src/player/components/thumbnailUtils.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeThumbnailStrip,
+  encodePreviewPath,
+  resolveMediaPreviewUrl,
+  THUMBNAIL_CLIP_HEIGHT,
+} from "./thumbnailUtils";
+
+describe("computeThumbnailStrip", () => {
+  it("sizes tiles by aspect ratio at the clip height", () => {
+    const { frameW } = computeThumbnailStrip(500, 16 / 9);
+    expect(frameW).toBe(Math.round(THUMBNAIL_CLIP_HEIGHT * (16 / 9)));
+  });
+
+  it("repeats tiles to cover the container width", () => {
+    const { frameW, frameCount } = computeThumbnailStrip(500, 1);
+    expect(frameW).toBe(THUMBNAIL_CLIP_HEIGHT);
+    expect(frameCount).toBe(Math.ceil(500 / THUMBNAIL_CLIP_HEIGHT));
+    expect(frameCount * frameW).toBeGreaterThanOrEqual(500);
+  });
+
+  it("returns one tile when the container width is unknown", () => {
+    expect(computeThumbnailStrip(0, 16 / 9).frameCount).toBe(1);
+    expect(computeThumbnailStrip(-10, 16 / 9).frameCount).toBe(1);
+  });
+
+  it("falls back to 16:9 for degenerate aspects", () => {
+    const expected = Math.round(THUMBNAIL_CLIP_HEIGHT * (16 / 9));
+    expect(computeThumbnailStrip(300, 0).frameW).toBe(expected);
+    expect(computeThumbnailStrip(300, -2).frameW).toBe(expected);
+    expect(computeThumbnailStrip(300, Number.NaN).frameW).toBe(expected);
+    expect(computeThumbnailStrip(300, Number.POSITIVE_INFINITY).frameW).toBe(expected);
+  });
+
+  it("never returns a zero-width tile (avoids divide-by-zero repeat counts)", () => {
+    const { frameW, frameCount } = computeThumbnailStrip(300, 0.001);
+    expect(frameW).toBeGreaterThanOrEqual(1);
+    expect(Number.isFinite(frameCount)).toBe(true);
+  });
+
+  it("honors a custom clip height", () => {
+    expect(computeThumbnailStrip(300, 2, 40).frameW).toBe(80);
+  });
+});
+
+describe("resolveMediaPreviewUrl", () => {
+  it("routes composition-relative paths through the project preview endpoint", () => {
+    expect(resolveMediaPreviewUrl("assets/image.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/image.png",
+    );
+  });
+
+  it("passes absolute http(s) URLs through untouched", () => {
+    expect(resolveMediaPreviewUrl("http://cdn.example.com/a.mp4", "proj-1")).toBe(
+      "http://cdn.example.com/a.mp4",
+    );
+    expect(resolveMediaPreviewUrl("https://cdn.example.com/a.png", "proj-1")).toBe(
+      "https://cdn.example.com/a.png",
+    );
+  });
+
+  it("percent-encodes spaces in filenames", () => {
+    expect(resolveMediaPreviewUrl("assets/my logo.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/my%20logo.png",
+    );
+  });
+
+  it("percent-encodes parentheses in filenames", () => {
+    expect(resolveMediaPreviewUrl("assets/heygen-symbol-blue-logo (2).svg", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/heygen-symbol-blue-logo%20(2).svg",
+    );
+  });
+
+  it("preserves slashes as path separators while encoding each segment", () => {
+    expect(resolveMediaPreviewUrl("sub dir/file (v2).mp4", "proj-2")).toBe(
+      "/api/projects/proj-2/preview/sub%20dir/file%20(v2).mp4",
+    );
+  });
+
+  it("percent-encodes unicode characters in filenames", () => {
+    expect(resolveMediaPreviewUrl("assets/café logo.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/caf%C3%A9%20logo.png",
+    );
+  });
+
+  it("leaves paths with no special characters unchanged", () => {
+    expect(resolveMediaPreviewUrl("assets/logo.svg", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/logo.svg",
+    );
+  });
+
+  it("percent-encodes a U+202F narrow no-break space (macOS screenshot artifact)", () => {
+    // "Screenshot … 2.16.30 PM.png" — the char between the time and PM is a
+    // narrow no-break space; it must encode to %E2%80%AF, not route raw (404).
+    expect(resolveMediaPreviewUrl("assets/Screenshot 2.16.30 PM.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/Screenshot%202.16.30%E2%80%AFPM.png",
+    );
+  });
+
+  it("passes data: URIs through untouched (never routes them through preview → HTTP 431)", () => {
+    const svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+    expect(resolveMediaPreviewUrl(svg, "proj-1")).toBe(svg);
+  });
+
+  it("passes blob: URLs through untouched", () => {
+    const blob = "blob:http://localhost:5190/2b3c-4d5e";
+    expect(resolveMediaPreviewUrl(blob, "proj-1")).toBe(blob);
+  });
+});
+
+// The shared encoder used by every timeline media-URL builder (filmstrip, audio
+// waveform, sub-composition preview) — must match the assets panel's per-segment
+// encoding so those paths stop 404ing on non-ASCII filenames.
+describe("encodePreviewPath", () => {
+  it("encodes spaces and parentheses per segment, preserving slashes", () => {
+    expect(encodePreviewPath("sub dir/file (v2).mp3")).toBe("sub%20dir/file%20(v2).mp3");
+  });
+
+  it("encodes a U+202F narrow no-break space to %E2%80%AF", () => {
+    expect(encodePreviewPath("assets/clip 2.mp3")).toBe("assets/clip%202.mp3");
+    expect(encodePreviewPath(`assets/clip${" "}2.mp3`)).toBe("assets/clip%E2%80%AF2.mp3");
+  });
+
+  it("leaves a plain path unchanged", () => {
+    expect(encodePreviewPath("assets/music.mp3")).toBe("assets/music.mp3");
+  });
+});

--- a/packages/studio/src/player/components/thumbnailUtils.ts
+++ b/packages/studio/src/player/components/thumbnailUtils.ts
@@ -1,0 +1,54 @@
+/** Rendered height of a timeline-clip thumbnail strip, in CSS px. */
+export const THUMBNAIL_CLIP_HEIGHT = 66;
+
+export interface ThumbnailStripLayout {
+  /** Width of a single tile, in CSS px. */
+  frameW: number;
+  /** Number of tiles needed to fill the container. */
+  frameCount: number;
+}
+
+/**
+ * Compute the film-strip tile layout for a clip thumbnail: fixed-height tiles
+ * sized by the media's aspect ratio, repeated to fill the clip width.
+ * Degenerate aspects (0, negative, NaN, Infinity) fall back to 16:9.
+ */
+export function computeThumbnailStrip(
+  containerWidth: number,
+  aspect: number,
+  clipHeight: number = THUMBNAIL_CLIP_HEIGHT,
+): ThumbnailStripLayout {
+  const safeAspect = Number.isFinite(aspect) && aspect > 0 ? aspect : 16 / 9;
+  const frameW = Math.max(1, Math.round(clipHeight * safeAspect));
+  const frameCount = containerWidth > 0 ? Math.max(1, Math.ceil(containerWidth / frameW)) : 1;
+  return { frameW, frameCount };
+}
+
+/**
+ * Percent-encode each segment of a composition-relative media path so filenames
+ * containing spaces, parentheses, a U+202F narrow no-break space (the macOS
+ * screenshot artifact), or any other non-ASCII / URL-unsafe character yield a
+ * valid URL instead of a 404. Slashes are preserved as separators.
+ *
+ * Shared by every timeline media-URL builder (filmstrip thumbnails, audio
+ * waveform, sub-composition preview) so they encode identically to the assets
+ * panel — a raw segment 404s on the exact filenames the assets panel loads fine.
+ */
+export function encodePreviewPath(relativePath: string): string {
+  return relativePath.split("/").map(encodeURIComponent).join("/");
+}
+
+/**
+ * Resolve a timeline element's media src to a URL loadable from the studio
+ * (parent) document. Composition-relative paths (e.g. "assets/image.png") are
+ * routed through the project preview endpoint with each segment encoded.
+ *
+ * Already-loadable URLs pass through untouched: absolute http(s) URLs, plus
+ * `data:` and `blob:` URLs. Routing a `data:`/`blob:` URL through the preview
+ * endpoint would percent-encode the whole thing into a multi-KB path segment
+ * that the server rejects with HTTP 431 (Request Header Fields Too Large).
+ */
+export function resolveMediaPreviewUrl(src: string, projectId: string): string {
+  if (/^(?:https?:|data:|blob:)/i.test(src)) return src;
+  return `/api/projects/${projectId}/preview/${encodePreviewPath(src)}`;
+}

--- a/packages/studio/src/player/components/timelineTheme.ts
+++ b/packages/studio/src/player/components/timelineTheme.ts
@@ -43,10 +43,15 @@ const TRACK_STYLE: TimelineTrackStyle = {
 };
 
 export const defaultTimelineTheme: TimelineTheme = {
+  // Near-black card surfaces: the panels sit dark while the shell canvas
+  // between them is a step LIGHTER (#18181B), so the gaps read as visible
+  // seams around dark cards (CapCut-style).
   shellBackground: "#0A0A0B",
   shellBorder: "rgba(255,255,255,0.05)",
   rulerBorder: "rgba(255,255,255,0.16)",
-  rowBackground: "#0B0C0F",
+  // All track lanes use a single uniform color — one step lighter than the panel
+  // surface (#0A0A0B) so lanes are visibly distinct from the ruler/shell.
+  rowBackground: "#101014",
   rowBorder: "rgba(255,255,255,0.06)",
   gutterBackground: "#0E0F12",
   gutterBorder: "rgba(255,255,255,0.10)",

--- a/packages/studio/src/styles/studio.css
+++ b/packages/studio/src/styles/studio.css
@@ -141,6 +141,22 @@ body {
   opacity: 1;
 }
 
+/* Audio clips read as a distinct kind — a persistent violet tint vs the teal-
+   accented visual clips — so the audio zone at the bottom is visually separate
+   at a glance (the timeline's kinds: visual on top, audio below). */
+.timeline-clip.is-audio {
+  background-color: rgba(167, 139, 250, 0.16);
+  border-color: rgba(167, 139, 250, 0.4);
+}
+
+.timeline-clip.is-audio.is-hovered {
+  background-color: rgba(167, 139, 250, 0.24);
+}
+
+.timeline-clip.is-audio.is-dragging {
+  background-color: rgba(60, 52, 84, 0.96);
+}
+
 .timeline-clip.is-hovered {
   background-color: rgba(255, 255, 255, 0.09);
 }
@@ -158,7 +174,18 @@ body {
 }
 
 .timeline-clip.is-dragging {
+  /* Solid background so the picked-up clip reads clearly while dragging — audio
+     clips (waveform drawn on a separate layer) would otherwise look transparent. */
+  background-color: rgba(38, 42, 52, 0.96);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+/* Keep the white selection outline while dragging (a plain box-shadow alone gets
+   overridden by .is-dragging's drop shadow, so re-state both together). */
+.timeline-clip.is-selected.is-dragging {
+  box-shadow:
+    0 0 0 1.5px rgba(255, 255, 255, 0.85),
+    0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 .timeline-clip[data-active].is-selected.is-dragging {


### PR DESCRIPTION
## What

Visual refresh of the timeline plus clip thumbnails:

- **Chrome pass** — clean ruler (labels-only), sticky playhead head (hollow at rest, filled while scrubbing), flat dense toolbar with snap toggle + split-at-playhead + add-beat, uniform lanes, violet audio clips with waveforms
- **`ImageThumbnail` + `thumbnailUtils`** — image/video filmstrip thumbnails with SVG/AVIF handling, `data:`/`blob:` pass-through, full path-segment percent-encoding (spaces, parens, U+202F), rounded-corner clipping

## Why

The timeline read as a developer widget; this brings it to CapCut-flat parity and makes clips identifiable at a glance. Purely presentational — no timing or model changes.

## How

Sits on #2183's shell. New thumbnail modules + CSS/chrome changes to `TimelineRuler`, `PlayheadIndicator`, `TimelineToolbar`, timeline styling.

## Test plan

- [x] `bunx vitest run` (`ImageThumbnail`, `thumbnailUtils` incl. encoding cases)
- [x] `tsc --noEmit` in `packages/studio`
- [x] `fallow audit --base origin/main` clean
- [x] Manual: SVG/AVIF/mp4 thumbnails render (incl. filenames with spaces/non-ASCII); ruler/toolbar/playhead visual QA

---
### Stack
Part 8/9 of the studio NLE overhaul (CapCut-parity timeline + canvas editing). Stacked train — each PR's base is its predecessor; **merge top-down from #2177** and retarget bases as predecessors land.

#2177 → #2178 → #2179 → #2180 → #2181 → #2182 → #2183 → **#2184 (this)** → #2185
