### PR TITLE
fix(studio): support drag on FlatSlider, not just click-to-set

### DIFF
--- a/packages/studio/src/components/editor/propertyPanelFlatPrimitives.test.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatPrimitives.test.tsx
@@ -280,6 +280,82 @@ describe("FlatSlider", () => {
     expect(onCommit).toHaveBeenCalledWith(10);
     act(() => root.unmount());
   });
+
+  it("commits continuously while dragging, not just on the initial pointerdown", () => {
+    const onCommit = vi.fn();
+    const { host, root } = renderInto(
+      <FlatSlider
+        label="Opacity"
+        value={50}
+        min={0}
+        max={100}
+        tier="explicitCustom"
+        displayValue="50%"
+        onCommit={onCommit}
+      />,
+    );
+    const track = host.querySelector<HTMLElement>('[data-flat-slider-track="true"]');
+    if (!track) throw new Error("expected a track element");
+    Object.defineProperty(track, "getBoundingClientRect", {
+      value: () => ({ left: 0, width: 200, top: 0, height: 20, right: 200, bottom: 20 }),
+    });
+    act(() => {
+      track.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, clientX: 20, pointerId: 1 }),
+      );
+    });
+    expect(onCommit).toHaveBeenLastCalledWith(10);
+    act(() => {
+      track.dispatchEvent(
+        new PointerEvent("pointermove", { bubbles: true, clientX: 160, pointerId: 1 }),
+      );
+    });
+    expect(onCommit).toHaveBeenLastCalledWith(80);
+    act(() => {
+      track.dispatchEvent(
+        new PointerEvent("pointermove", { bubbles: true, clientX: 100, pointerId: 1 }),
+      );
+    });
+    expect(onCommit).toHaveBeenLastCalledWith(50);
+    act(() => {
+      track.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+    act(() => root.unmount());
+  });
+
+  it("ignores pointermove once a drag has ended (pointer capture released)", () => {
+    const onCommit = vi.fn();
+    const { host, root } = renderInto(
+      <FlatSlider
+        label="Opacity"
+        value={50}
+        min={0}
+        max={100}
+        tier="explicitCustom"
+        displayValue="50%"
+        onCommit={onCommit}
+      />,
+    );
+    const track = host.querySelector<HTMLElement>('[data-flat-slider-track="true"]');
+    if (!track) throw new Error("expected a track element");
+    Object.defineProperty(track, "getBoundingClientRect", {
+      value: () => ({ left: 0, width: 200, top: 0, height: 20, right: 200, bottom: 20 }),
+    });
+    act(() => {
+      track.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, clientX: 20, pointerId: 1 }),
+      );
+      track.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+    onCommit.mockClear();
+    act(() => {
+      track.dispatchEvent(
+        new PointerEvent("pointermove", { bubbles: true, clientX: 160, pointerId: 1 }),
+      );
+    });
+    expect(onCommit).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
 });
 
 describe("FlatSlider — Grade extensions", () => {

--- a/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
@@ -262,7 +262,17 @@ export function FlatSlider({
         className={`relative h-5 flex-1 ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}
         onPointerDown={(e) => {
           if (disabled) return;
+          e.currentTarget.setPointerCapture(e.pointerId);
           commitFromClientX(e.clientX, e.currentTarget.getBoundingClientRect());
+        }}
+        onPointerMove={(e) => {
+          if (disabled || !e.currentTarget.hasPointerCapture(e.pointerId)) return;
+          commitFromClientX(e.clientX, e.currentTarget.getBoundingClientRect());
+        }}
+        onPointerUp={(e) => {
+          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.currentTarget.releasePointerCapture(e.pointerId);
+          }
         }}
       >
         <div className="absolute inset-x-0 top-1/2 h-0.5 -translate-y-1/2 rounded-full bg-panel-hover">


### PR DESCRIPTION
## What

Thirteenth PR in the flat inspector stack (see #2120 for the foundation and full stack list). Adds real drag support to `FlatSlider` — dragging the track/knob now moves the value continuously with the cursor, matching how a native `<input type="range">` behaves.

Stack: #2120 → ... → #2142 → #2186 (this).

## Why

Reported directly after using the redesigned inspector live — only `onPointerDown` was ever wired on the slider's track, so a click set the value once but dragging did nothing further; the value stayed pinned to wherever the mouse first went down.

## How

- Added `onPointerMove`/`onPointerUp` alongside the existing `onPointerDown`, using the standard Pointer Capture API: `setPointerCapture` on pointerdown so the element keeps receiving move events even if the cursor leaves its bounds mid-drag, `onPointerMove` recomputes and commits the value from the current `clientX` while capture is held, and `onPointerUp` releases capture.
- Confirmed this is genuinely missing (not a legacy-panel bug too) — the legacy `SliderControl` uses a native `<input type="range">`, which gets drag for free from the browser; `FlatSlider` is a custom-drawn track/knob div with no such built-in behavior, so this needed explicit wiring.

## Test plan

- New tests drive a full pointerdown→pointermove→pointermove→pointerup sequence and assert the committed value follows each intermediate position, plus a test confirming a stray pointermove after pointerup (capture released) is correctly ignored.
- **Verified live with real, trusted mouse input** (not synthetic DOM events — Chromium silently no-ops `setPointerCapture` for untrusted/script-dispatched pointer events, which is worth knowing if this needs re-testing later): drove an actual mouse-down + mouse-move sequence via CDP-level input and confirmed the slider's value tracked the drag's live position, not just the initial click.
- Full monorepo suite green (1584 tests, 0 failures); `oxlint`/`oxfmt`/`fallow` clean.
- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable — internal Studio UI behind an off-by-default flag)