### PR TITLE
feat(cli): correlate render feedback submissions

### DIFF
--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -162,12 +162,12 @@ export default defineCommand({
 
     // The standalone command runs separately from `render`, so it has no real
     // elapsed time to report. Omit it rather than recording a fake duration.
-    trackRenderFeedback({ rating, comment, doctorSummary });
+    const feedbackId = trackRenderFeedback({ rating, comment, doctorSummary });
 
     await flush();
     // Ack first so the user isn't kept waiting on the best-effort forward (which
     // is bounded to a few seconds and never surfaces an error either way).
-    console.log(c.dim("Thanks for the feedback!"));
+    console.log(c.dim(`Thanks for the feedback! (Feedback ID: ${feedbackId})`));
     await submitFeedback({ rating, comment, cliVersion: VERSION, env: doctorSummary });
 
     if (args["file-issue"] === true) {

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -140,6 +140,30 @@ describe("trackRenderFeedback", () => {
       expect.objectContaining({ render_duration_ms: 6000 }),
     );
   });
+
+  it("uses an injected feedback id for deterministic correlation", () => {
+    expect(trackRenderFeedback({ rating: 5, feedbackId: "feedback-test-123" })).toBe(
+      "feedback-test-123",
+    );
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "survey sent",
+      expect.objectContaining({ feedback_id: "feedback-test-123" }),
+    );
+  });
+
+  it("generates a submission-scoped UUID when no id is injected", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "generated-feedback-id" as `${string}-${string}-${string}-${string}-${string}`,
+    );
+
+    expect(trackRenderFeedback({ rating: 4 })).toBe("generated-feedback-id");
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "survey sent",
+      expect.objectContaining({ feedback_id: "generated-feedback-id" }),
+    );
+  });
 });
 
 describe("trackCliError", () => {

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -529,14 +529,18 @@ export function trackRenderFeedback(props: {
   renderDurationMs?: number;
   comment?: string;
   doctorSummary?: string;
-}): void {
+  feedbackId?: string;
+}): string {
+  const feedbackId = props.feedbackId ?? globalThis.crypto.randomUUID();
   trackEvent("survey sent", {
     $survey_id: "render_satisfaction",
     $survey_response: props.rating,
+    feedback_id: feedbackId,
     ...(props.comment ? { $survey_response_2: props.comment } : {}),
     ...(props.renderDurationMs !== undefined ? { render_duration_ms: props.renderDurationMs } : {}),
     ...(props.doctorSummary ? { doctor_summary: props.doctorSummary } : {}),
   });
+  return feedbackId;
 }
 
 export function trackCommandResult(props: {


### PR DESCRIPTION
## Summary

Correlate each CLI feedback submission with a short-lived submission ID.

- `survey sent` events now carry a UUID generated per submission.
- Explicit `hyperframes feedback` reports the ID after telemetry flush so it can be used when asking for support.
- Interactive post-render surveys keep their existing quiet thank-you output.
- Telemetry opt-out and fail-silent behavior are unchanged.

## Verification

- Added deterministic injected-ID and generated-UUID coverage.
- `packages/cli` typecheck passes.
- Targeted telemetry tests pass.
- Existing generated producer outputs were preserved and are intentionally not part of this PR.
