### PR TITLE
fix(lint): ignore macOS AppleDouble HTML files

### DIFF
--- a/packages/cli/src/utils/lintProject.test.ts
+++ b/packages/cli/src/utils/lintProject.test.ts
@@ -914,6 +914,19 @@ describe("multiple_root_compositions", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("ignores macOS AppleDouble HTML metadata files", async () => {
+    const project = makeProject(validHtml());
+    writeFileSync(join(project, "._index.html"), validHtml());
+    mkdirSync(join(project, "compositions"), { recursive: true });
+    writeFileSync(join(project, "compositions", "._scene.html"), validHtml("scene"));
+    const { results } = await lintProject(project);
+    const finding = results[0]?.result.findings.find(
+      (f) => f.code === "multiple_root_compositions",
+    );
+    expect(finding).toBeUndefined();
+    expect(results.some((result) => result.file.includes("._"))).toBe(false);
+  });
+
   it("ignores HTML files without data-composition-id", async () => {
     const project = makeProject(validHtml());
     writeFileSync(join(project, "readme.html"), "<html><body>Not a composition</body></html>");

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -200,7 +200,9 @@ export async function lintProject(projectDir: string): Promise<ProjectLintResult
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const relPath = rel ? `${rel}/${entry.name}` : entry.name;
         if (entry.isDirectory()) out.push(...collectHtmlFiles(join(dir, entry.name), relPath));
-        else if (entry.isFile() && entry.name.endsWith(".html")) out.push(relPath);
+        else if (entry.isFile() && entry.name.endsWith(".html") && !entry.name.startsWith("._")) {
+          out.push(relPath);
+        }
       }
       return out;
     };
@@ -442,7 +444,9 @@ function lintTextureMaskAssetNotFound(
 function lintMultipleRootCompositions(projectDir: string): HyperframeLintFinding[] {
   const findings: HyperframeLintFinding[] = [];
   try {
-    const rootHtmlFiles = readdirSync(projectDir).filter((f) => f.endsWith(".html"));
+    const rootHtmlFiles = readdirSync(projectDir).filter(
+      (file) => file.endsWith(".html") && !file.startsWith("._"),
+    );
     const rootCompositions: string[] = [];
     for (const file of rootHtmlFiles) {
       if (file === "caption-skin.html") continue;


### PR DESCRIPTION
## Summary
- ignore macOS `._*` AppleDouble metadata files during recursive composition discovery
- exclude AppleDouble HTML files from the multiple-root-composition check
- add regression coverage for root and nested metadata files

## Reproduction
Copying a project through a macOS external drive can create `._index.html` and `compositions/._scene.html`. Before this change, lint parsed those resource-fork metadata files and emitted false errors such as `multiple_root_compositions`.

## Verification
- `bun test packages/cli/src/utils/lintProject.test.ts` (72 passed)
- `bunx oxlint packages/lint/src/project.ts packages/cli/src/utils/lintProject.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/lint typecheck`
- pre-commit lint, format, typecheck, and fallow hooks passed