### PR TITLE
feat(studio): clip thumbnail modules

### DIFF
--- a/packages/studio/src/components/nle/AssetPreviewOverlay.tsx
+++ b/packages/studio/src/components/nle/AssetPreviewOverlay.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useCallback } from "react";
 import { VIDEO_EXT, IMAGE_EXT } from "../../utils/mediaTypes";
 import { useAssetPreviewStore } from "../../utils/assetPreviewStore";
+import { resolveMediaPreviewUrl } from "../../player/components/thumbnailUtils";
 
 function basename(path: string): string {
   return path.split("/").pop() ?? path;
@@ -95,8 +96,7 @@ export function AssetPreviewOverlay() {
 
   if (!previewAsset || !previewProjectId) return null;
 
-  const encodedAsset = previewAsset.split("/").map(encodeURIComponent).join("/");
-  const serveUrl = `/api/projects/${previewProjectId}/preview/${encodedAsset}`;
+  const serveUrl = resolveMediaPreviewUrl(previewAsset, previewProjectId);
   const name = basename(previewAsset);
 
   return (

--- a/packages/studio/src/components/nle/useCompositionStack.ts
+++ b/packages/studio/src/components/nle/useCompositionStack.ts
@@ -2,6 +2,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { usePlayerStore } from "../../player";
 import type { CompositionLevel } from "./CompositionBreadcrumb";
+import { encodePreviewPath } from "../../player/components/thumbnailUtils";
 
 interface UseCompositionStackOptions {
   projectId: string;
@@ -84,7 +85,7 @@ export function useCompositionStack({
             .split("/")
             .pop()
             ?.replace(/\.html$/, "") || resolvedPath;
-        const previewUrl = `/api/projects/${projectId}/preview/comp/${resolvedPath}`;
+        const previewUrl = `/api/projects/${projectId}/preview/comp/${encodePreviewPath(resolvedPath)}`;
         return [...prev, { id: resolvedPath, label, previewUrl }];
       });
     },
@@ -100,7 +101,7 @@ export function useCompositionStack({
       updateCompositionStack((prev) => (prev.length > 1 ? [prev[0]] : prev));
     } else if (activeCompositionPath && activeCompositionPath.startsWith("compositions/")) {
       const label = activeCompositionPath.replace(/^compositions\//, "").replace(/\.html$/, "");
-      const previewUrl = `/api/projects/${projectId}/preview/comp/${activeCompositionPath}`;
+      const previewUrl = `/api/projects/${projectId}/preview/comp/${encodePreviewPath(activeCompositionPath)}`;
       usePlayerStore.getState().setElements([]);
       updateCompositionStack((prev) => {
         if (prev[prev.length - 1]?.id === activeCompositionPath) return prev;

--- a/packages/studio/src/components/sidebar/AssetCard.tsx
+++ b/packages/studio/src/components/sidebar/AssetCard.tsx
@@ -11,6 +11,7 @@ import { usePlayerStore } from "../../player/store/playerStore";
 import { useAssetPreviewStore } from "../../utils/assetPreviewStore";
 import { findClipForAsset, isPointerClick } from "../../utils/assetClickBehavior";
 import { basename, ext, truncateMiddle, formatDuration } from "./assetHelpers";
+import { resolveMediaPreviewUrl } from "../../player/components/thumbnailUtils";
 
 /** Drag payload writer shared by the asset tile and the font row: copy effect
  *  plus the timeline-asset MIME and a plain-text path fallback. */
@@ -40,25 +41,32 @@ function useProbedDuration(src: string, skip: boolean): number | null | undefine
   useEffect(() => {
     if (skip) return;
     let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    // The in-flight probe element, so unmount cleanup can abort its network
+    // fetch (clearing `src`) instead of leaving it to finish in the background.
+    let liveVid: HTMLVideoElement | null = null;
+
+    function teardown(vid: HTMLVideoElement) {
+      vid.onloadedmetadata = null;
+      vid.onerror = null;
+      vid.src = "";
+    }
 
     function probe(attempt: number) {
       if (cancelled) return;
       const vid = document.createElement("video");
+      liveVid = vid;
       vid.preload = "metadata";
       vid.muted = true;
       vid.onloadedmetadata = () => {
         const d = Number.isFinite(vid.duration) && vid.duration > 0 ? vid.duration : null;
+        teardown(vid);
         if (!cancelled) setDuration(d);
-        vid.onloadedmetadata = null;
-        vid.onerror = null;
-        vid.src = "";
       };
       vid.onerror = () => {
-        vid.onloadedmetadata = null;
-        vid.onerror = null;
-        vid.src = "";
+        teardown(vid);
         if (!cancelled) {
-          if (attempt < 1) setTimeout(() => probe(attempt + 1), 50);
+          if (attempt < 1) retryTimer = setTimeout(() => probe(attempt + 1), 50);
           else setDuration(null);
         }
       };
@@ -68,6 +76,8 @@ function useProbedDuration(src: string, skip: boolean): number | null | undefine
     probe(0);
     return () => {
       cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (liveVid) teardown(liveVid);
     };
   }, [src, skip]);
   return duration;
@@ -111,7 +121,7 @@ export function AssetCard({
   const fullName = asset.split("/").pop() ?? asset;
   const name = basename(asset);
   const extension = ext(asset);
-  const serveUrl = `/api/projects/${projectId}/preview/${asset}`;
+  const serveUrl = resolveMediaPreviewUrl(asset, projectId);
   const isVideo = VIDEO_EXT.test(asset);
   const isImage = IMAGE_EXT.test(asset);
   const probedDuration = useProbedDuration(serveUrl, !isVideo || duration != null);

--- a/packages/studio/src/components/sidebar/AudioRow.tsx
+++ b/packages/studio/src/components/sidebar/AudioRow.tsx
@@ -5,6 +5,7 @@ import { TIMELINE_ASSET_MIME } from "../../utils/timelineAssetDrop";
 import { usePlayerStore } from "../../player/store/playerStore";
 import { useAssetPreviewStore } from "../../utils/assetPreviewStore";
 import { findClipForAsset, isPointerClick } from "../../utils/assetClickBehavior";
+import { resolveMediaPreviewUrl } from "../../player/components/thumbnailUtils";
 
 export function AudioRow({
   projectId,
@@ -37,7 +38,7 @@ export function AudioRow({
   const animRef = useRef<number>(0);
   const name = basename(asset);
   const subtype = getAudioSubtype(asset);
-  const serveUrl = `/api/projects/${projectId}/preview/${asset}`;
+  const serveUrl = resolveMediaPreviewUrl(asset, projectId);
 
   // CapCut-style click behavior: drag-threshold gate.
   const pointerDownRef = useRef<{ x: number; y: number } | null>(null);

--- a/packages/studio/src/player/components/ImageThumbnail.test.tsx
+++ b/packages/studio/src/player/components/ImageThumbnail.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ImageThumbnail } from "./ImageThumbnail";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+});
+
+// --- Observer stubs: fire "intersecting" immediately on observe ---
+class MockIntersectionObserver {
+  private cb: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.cb = cb;
+  }
+  observe() {
+    this.cb(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+  disconnect() {}
+  unobserve() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+class MockResizeObserver {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+// --- Image stub: captures instances so tests fire load/error deterministically ---
+class MockImage {
+  static instances: MockImage[] = [];
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  src = "";
+  constructor() {
+    MockImage.instances.push(this);
+  }
+}
+
+const originalIO = globalThis.IntersectionObserver;
+const originalRO = globalThis.ResizeObserver;
+const originalImage = globalThis.Image;
+
+let host: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(() => {
+  globalThis.IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  globalThis.Image = MockImage as unknown as typeof Image;
+  MockImage.instances = [];
+  host = document.createElement("div");
+  document.body.append(host);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  globalThis.IntersectionObserver = originalIO;
+  globalThis.ResizeObserver = originalRO;
+  globalThis.Image = originalImage;
+  document.body.innerHTML = "";
+});
+
+function render(props: { imageSrc: string; label?: string; labelColor?: string }) {
+  root = createRoot(host);
+  act(() => {
+    root!.render(
+      <ImageThumbnail
+        imageSrc={props.imageSrc}
+        label={props.label ?? ""}
+        labelColor={props.labelColor ?? "#fff"}
+      />,
+    );
+  });
+}
+
+function lastProbe(): MockImage {
+  const probe = MockImage.instances.at(-1);
+  expect(probe).toBeDefined();
+  return probe!;
+}
+
+/** Assert at least one tile rendered and the first tile serves `expectedSrc`. */
+function expectFirstTileSrc(expectedSrc: string): void {
+  const imgs = [...host.querySelectorAll("img")];
+  expect(imgs.length).toBeGreaterThanOrEqual(1);
+  expect(imgs[0].getAttribute("src")).toBe(expectedSrc);
+}
+
+describe("ImageThumbnail", () => {
+  it("shows the loading shimmer before the image resolves", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/pic.png" });
+    expect(host.querySelector(".animate-pulse")).not.toBeNull();
+    expect(host.querySelectorAll("img").length).toBe(0);
+  });
+
+  it("probes the resolved src and renders repeated object-cover tiles on load", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/pic.png" });
+    const probe = lastProbe();
+    expect(probe.src).toBe("/api/projects/p/preview/assets/pic.png");
+
+    act(() => {
+      probe.naturalWidth = 1920;
+      probe.naturalHeight = 1080;
+      probe.onload?.();
+    });
+
+    const imgs = [...host.querySelectorAll("img")];
+    expect(imgs.length).toBeGreaterThanOrEqual(1);
+    for (const img of imgs) {
+      expect(img.getAttribute("src")).toBe("/api/projects/p/preview/assets/pic.png");
+      expect(img.className).toContain("object-cover");
+    }
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("drops the shimmer and renders no tiles when a raster image fails to load", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/missing.png" });
+    act(() => lastProbe().onerror?.());
+    expect(host.querySelectorAll("img").length).toBe(0);
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("renders tiles at 16:9 when an SVG has no intrinsic dimensions (naturalWidth=0)", () => {
+    render({ imageSrc: "/api/projects/p/preview/assets/logo.svg" });
+    const probe = lastProbe();
+
+    act(() => {
+      // naturalWidth stays 0 — SVG with no width/height attribute
+      probe.onload?.();
+    });
+
+    expectFirstTileSrc("/api/projects/p/preview/assets/logo.svg");
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("renders SVG tiles at 16:9 fallback even when the probe fires onerror", () => {
+    // Some browser/sandbox environments fire onerror for SVGs even though the
+    // <img> element itself can render the file — we must not blank the strip.
+    render({ imageSrc: "/api/projects/p/preview/assets/icon.svg" });
+
+    act(() => lastProbe().onerror?.());
+
+    expectFirstTileSrc("/api/projects/p/preview/assets/icon.svg");
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("renders the label above the strip when provided", () => {
+    render({ imageSrc: "/x.png", label: "hero", labelColor: "#abc" });
+    act(() => {
+      const probe = lastProbe();
+      probe.naturalWidth = 100;
+      probe.naturalHeight = 100;
+      probe.onload?.();
+    });
+    const label = [...host.querySelectorAll("span")].find((s) => s.textContent === "hero");
+    expect(label).toBeDefined();
+    expect(label!.closest(".z-10")).not.toBeNull();
+  });
+});

--- a/packages/studio/src/player/components/ImageThumbnail.tsx
+++ b/packages/studio/src/player/components/ImageThumbnail.tsx
@@ -1,0 +1,160 @@
+import { memo, useRef, useState, useCallback, useEffect } from "react";
+import { useMountEffect } from "../../hooks/useMountEffect";
+import { computeThumbnailStrip } from "./thumbnailUtils";
+
+interface ImageThumbnailProps {
+  imageSrc: string;
+  label: string;
+  labelColor: string;
+}
+
+/**
+ * Renders a film-strip of a still image for a timeline clip. The image is a
+ * fixed-width tile (sized by its natural aspect ratio) repeated to fill the
+ * clip width — matching VideoThumbnail's visual pattern. Loading is lazy
+ * (IntersectionObserver) with the same shimmer fallback while decoding.
+ */
+export const ImageThumbnail = memo(function ImageThumbnail({
+  imageSrc,
+  label,
+  labelColor,
+}: ImageThumbnailProps) {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [visible, setVisible] = useState(false);
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const [aspect, setAspect] = useState(16 / 9);
+  const ioRef = useRef<IntersectionObserver | null>(null);
+  const roRef = useRef<ResizeObserver | null>(null);
+
+  const setContainerRef = useCallback((el: HTMLDivElement | null) => {
+    ioRef.current?.disconnect();
+    roRef.current?.disconnect();
+    if (!el) return;
+
+    const measured = el.parentElement?.clientWidth || el.clientWidth;
+    setContainerWidth(measured);
+
+    ioRef.current = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          ioRef.current?.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    // fallow-ignore-next-line code-duplication
+    ioRef.current.observe(el);
+
+    const target = el.parentElement || el;
+    roRef.current = new ResizeObserver(([entry]) => {
+      setContainerWidth(entry.contentRect.width);
+    });
+    roRef.current.observe(target);
+  }, []);
+
+  useMountEffect(() => () => {
+    ioRef.current?.disconnect();
+    roRef.current?.disconnect();
+  });
+
+  // Probe the image once visible — measures the natural aspect ratio so the
+  // tile width matches, and flips to the error state (plain clip background)
+  // if the src can't load. The browser cache makes the tile <img>s free.
+  //
+  // SVG handling: SVGs without intrinsic width/height report naturalWidth=0 on
+  // load (treat as success with the 16:9 default aspect) and may fire onerror
+  // in some environments even though the file is valid and can be displayed —
+  // fall back to loaded-at-16:9 rather than hiding the strip entirely.
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    setStatus("loading");
+
+    const isSvg = /\.svg($|\?)/i.test(imageSrc);
+
+    const probe = new Image();
+    probe.onload = () => {
+      if (cancelled) return;
+      if (probe.naturalWidth > 0 && probe.naturalHeight > 0) {
+        setAspect(probe.naturalWidth / probe.naturalHeight);
+      }
+      // naturalWidth===0 (e.g. SVG with no intrinsic dimensions) falls through
+      // to "loaded" with the default 16:9 aspect already set in state.
+      setStatus("loaded");
+    };
+    probe.onerror = () => {
+      if (cancelled) return;
+      // SVGs can fail the probe in certain browser/sandbox environments even
+      // though the <img> tiles themselves render fine (different security
+      // context). Show the strip at the 16:9 fallback rather than blanking.
+      if (isSvg) {
+        setStatus("loaded");
+      } else {
+        setStatus("error");
+      }
+    };
+    probe.src = imageSrc;
+
+    return () => {
+      cancelled = true;
+      probe.onload = null;
+      probe.onerror = null;
+      probe.src = "";
+    };
+  }, [visible, imageSrc]);
+
+  const { frameW, frameCount } = computeThumbnailStrip(containerWidth, aspect);
+
+  return (
+    <div ref={setContainerRef} className="absolute inset-0 overflow-hidden">
+      {visible && status === "loaded" && (
+        <div className="absolute inset-0 flex">
+          {Array.from({ length: frameCount }).map((_, i) => (
+            <div
+              key={i}
+              className="flex-shrink-0 h-full relative overflow-hidden bg-neutral-900"
+              style={{ width: frameW }}
+            >
+              <img
+                src={imageSrc}
+                alt=""
+                draggable={false}
+                loading="lazy"
+                className="absolute inset-0 w-full h-full object-cover"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {visible && status === "loading" && (
+        <div
+          className="absolute inset-0 animate-pulse"
+          style={{
+            background:
+              "linear-gradient(90deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.05) 50%, rgba(255,255,255,0.02) 100%)",
+          }}
+        />
+      )}
+
+      {label && (
+        <div
+          className="absolute bottom-0 left-0 right-0 z-10 px-1.5 pb-0.5 pt-3"
+          style={{
+            background:
+              "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)",
+          }}
+        >
+          <span
+            className="text-[9px] font-semibold truncate block leading-tight"
+            style={{ color: labelColor, textShadow: "0 1px 2px rgba(0,0,0,0.9)" }}
+          >
+            {label}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/studio/src/player/components/VideoThumbnail.test.tsx
+++ b/packages/studio/src/player/components/VideoThumbnail.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VideoThumbnail } from "./VideoThumbnail";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+});
+
+// Fire "intersecting" immediately on observe so the extraction effect runs.
+class MockIntersectionObserver {
+  private cb: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.cb = cb;
+  }
+  observe() {
+    this.cb(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+  disconnect() {}
+  unobserve() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+class MockResizeObserver {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+const originalIO = globalThis.IntersectionObserver;
+const originalRO = globalThis.ResizeObserver;
+
+let host: HTMLDivElement;
+let root: Root | null = null;
+let createdVideos: HTMLVideoElement[];
+
+beforeEach(() => {
+  globalThis.IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+  createdVideos = [];
+  const origCreate = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    const el = origCreate(tag);
+    if (tag === "video") createdVideos.push(el as HTMLVideoElement);
+    return el;
+  });
+
+  // happy-dom's <video>/<canvas> don't decode media; stub the seam the
+  // extractor depends on so the effect can run deterministically.
+  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+    drawImage: () => {},
+  } as unknown as CanvasRenderingContext2D);
+
+  host = document.createElement("div");
+  document.body.append(host);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  vi.restoreAllMocks();
+  globalThis.IntersectionObserver = originalIO;
+  globalThis.ResizeObserver = originalRO;
+  document.body.innerHTML = "";
+});
+
+function render(videoSrc: string) {
+  root = createRoot(host);
+  act(() => {
+    root!.render(React.createElement(VideoThumbnail, { videoSrc, label: "", labelColor: "#fff" }));
+  });
+}
+
+function lastVideo(): HTMLVideoElement {
+  const v = createdVideos.at(-1);
+  expect(v).toBeDefined();
+  return v!;
+}
+
+describe("VideoThumbnail — tainted-canvas fallback", () => {
+  it("stops the extractor and drops the shimmer when toDataURL throws a SecurityError", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockImplementation(() => {
+      throw new DOMException("Tainted canvases may not be exported.", "SecurityError");
+    });
+
+    render("https://cdn.example.com/no-cors.mp4");
+
+    // The effect ran once visible → a hidden <video> was created.
+    const video = lastVideo();
+
+    act(() => {
+      video.dispatchEvent(new Event("loadedmetadata"));
+    });
+    act(() => {
+      video.dispatchEvent(new Event("seeked"));
+    });
+
+    // No frame captured, and crucially the shimmer is gone (not spinning
+    // forever) — the clip falls back to its plain background.
+    expect(host.querySelectorAll("img").length).toBe(0);
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("drops the shimmer when a no-CORS load fires the video error event (0 frames) (#2214)", () => {
+    render("https://cdn.example.com/no-cors.mp4");
+    // Before the load resolves, the shimmer placeholder is up.
+    expect(host.querySelector(".animate-pulse")).not.toBeNull();
+
+    const video = lastVideo();
+    // crossOrigin="anonymous" against a CORS-less server fails the load outright —
+    // the error listener fires instead of loadedmetadata/seeked, so no frame is
+    // ever captured. The shimmer must stop rather than spin forever.
+    act(() => {
+      video.dispatchEvent(new Event("error"));
+    });
+
+    expect(host.querySelectorAll("img").length).toBe(0);
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("keeps streaming frames while the shimmer is up until a frame arrives", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue(
+      "data:image/jpeg;base64,AAAA",
+    );
+
+    render("/api/projects/p/preview/assets/clip.mp4");
+    // Before any seek resolves, the shimmer placeholder is shown.
+    expect(host.querySelector(".animate-pulse")).not.toBeNull();
+
+    const video = lastVideo();
+    act(() => {
+      video.dispatchEvent(new Event("loadedmetadata"));
+    });
+    act(() => {
+      video.dispatchEvent(new Event("seeked"));
+    });
+
+    // A frame was captured, so tiles render and the shimmer clears.
+    expect(host.querySelectorAll("img").length).toBeGreaterThanOrEqual(1);
+    expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+});

--- a/packages/studio/src/player/components/VideoThumbnail.tsx
+++ b/packages/studio/src/player/components/VideoThumbnail.tsx
@@ -1,5 +1,6 @@
 import { memo, useRef, useState, useCallback, useEffect } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import { computeThumbnailStrip, THUMBNAIL_CLIP_HEIGHT } from "./thumbnailUtils";
 
 interface VideoThumbnailProps {
   videoSrc: string;
@@ -8,7 +9,7 @@ interface VideoThumbnailProps {
   duration?: number;
 }
 
-const CLIP_HEIGHT = 66;
+const CLIP_HEIGHT = THUMBNAIL_CLIP_HEIGHT;
 const MAX_UNIQUE_FRAMES: number = 6;
 
 /**
@@ -25,6 +26,7 @@ export const VideoThumbnail = memo(function VideoThumbnail({
   const [containerWidth, setContainerWidth] = useState(0);
   const [visible, setVisible] = useState(false);
   const [frames, setFrames] = useState<string[]>([]);
+  const [failed, setFailed] = useState(false);
   const [aspect, setAspect] = useState(16 / 9);
   const ioRef = useRef<IntersectionObserver | null>(null);
   const roRef = useRef<ResizeObserver | null>(null);
@@ -117,8 +119,22 @@ export const VideoThumbnail = memo(function VideoThumbnail({
 
     video.addEventListener("seeked", () => {
       if (cancelled) return;
-      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-      const dataUrl = canvas.toDataURL("image/jpeg", 0.6);
+      let dataUrl: string;
+      try {
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        dataUrl = canvas.toDataURL("image/jpeg", 0.6);
+      } catch {
+        // An external http(s) video served without CORS headers taints the
+        // canvas, so toDataURL throws a SecurityError. Stop the extractor
+        // cleanly and fall back to the no-thumbnail rendering (plain clip
+        // background), matching ImageThumbnail's error path — otherwise the
+        // shimmer placeholder would spin forever.
+        cancelled = true;
+        setFailed(true);
+        video.src = "";
+        video.load();
+        return;
+      }
       // Stream each frame immediately
       setFrames((prev) => [...prev, dataUrl]);
       idx++;
@@ -126,7 +142,12 @@ export const VideoThumbnail = memo(function VideoThumbnail({
     });
 
     video.addEventListener("error", () => {
-      /* keep whatever frames we have */
+      // A no-CORS load fails outright (crossOrigin="anonymous" rejects a video
+      // served without CORS headers), firing this instead of the taint path in
+      // "seeked" — so 0 frames are ever extracted. Keep whatever frames we have,
+      // but mark failed so the shimmer placeholder stops spinning forever and we
+      // fall back to the plain clip background (#2214).
+      setFailed(true);
     });
 
     video.src = videoSrc;
@@ -136,13 +157,13 @@ export const VideoThumbnail = memo(function VideoThumbnail({
       cancelled = true;
       extractingRef.current = false;
       setFrames([]);
+      setFailed(false);
       video.src = "";
       video.load();
     };
   }, [visible, videoSrc, duration]);
 
-  const frameW = Math.round(CLIP_HEIGHT * aspect);
-  const frameCount = containerWidth > 0 ? Math.max(1, Math.ceil(containerWidth / frameW)) : 1;
+  const { frameW, frameCount } = computeThumbnailStrip(containerWidth, aspect, CLIP_HEIGHT);
 
   return (
     <div ref={setContainerRef} className="absolute inset-0 overflow-hidden">
@@ -168,7 +189,7 @@ export const VideoThumbnail = memo(function VideoThumbnail({
         </div>
       )}
 
-      {visible && frames.length === 0 && (
+      {visible && frames.length === 0 && !failed && (
         <div
           className="absolute inset-0 animate-pulse"
           style={{

--- a/packages/studio/src/player/components/thumbnailUtils.test.ts
+++ b/packages/studio/src/player/components/thumbnailUtils.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeThumbnailStrip,
+  encodePreviewPath,
+  resolveMediaPreviewUrl,
+  THUMBNAIL_CLIP_HEIGHT,
+} from "./thumbnailUtils";
+
+describe("computeThumbnailStrip", () => {
+  it("sizes tiles by aspect ratio at the clip height", () => {
+    const { frameW } = computeThumbnailStrip(500, 16 / 9);
+    expect(frameW).toBe(Math.round(THUMBNAIL_CLIP_HEIGHT * (16 / 9)));
+  });
+
+  it("repeats tiles to cover the container width", () => {
+    const { frameW, frameCount } = computeThumbnailStrip(500, 1);
+    expect(frameW).toBe(THUMBNAIL_CLIP_HEIGHT);
+    expect(frameCount).toBe(Math.ceil(500 / THUMBNAIL_CLIP_HEIGHT));
+    expect(frameCount * frameW).toBeGreaterThanOrEqual(500);
+  });
+
+  it("returns one tile when the container width is unknown", () => {
+    expect(computeThumbnailStrip(0, 16 / 9).frameCount).toBe(1);
+    expect(computeThumbnailStrip(-10, 16 / 9).frameCount).toBe(1);
+  });
+
+  it("falls back to 16:9 for degenerate aspects", () => {
+    const expected = Math.round(THUMBNAIL_CLIP_HEIGHT * (16 / 9));
+    expect(computeThumbnailStrip(300, 0).frameW).toBe(expected);
+    expect(computeThumbnailStrip(300, -2).frameW).toBe(expected);
+    expect(computeThumbnailStrip(300, Number.NaN).frameW).toBe(expected);
+    expect(computeThumbnailStrip(300, Number.POSITIVE_INFINITY).frameW).toBe(expected);
+  });
+
+  it("never returns a zero-width tile (avoids divide-by-zero repeat counts)", () => {
+    const { frameW, frameCount } = computeThumbnailStrip(300, 0.001);
+    expect(frameW).toBeGreaterThanOrEqual(1);
+    expect(Number.isFinite(frameCount)).toBe(true);
+  });
+
+  it("honors a custom clip height", () => {
+    expect(computeThumbnailStrip(300, 2, 40).frameW).toBe(80);
+  });
+});
+
+describe("resolveMediaPreviewUrl", () => {
+  it("routes composition-relative paths through the project preview endpoint", () => {
+    expect(resolveMediaPreviewUrl("assets/image.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/image.png",
+    );
+  });
+
+  it("passes absolute http(s) URLs through untouched", () => {
+    expect(resolveMediaPreviewUrl("http://cdn.example.com/a.mp4", "proj-1")).toBe(
+      "http://cdn.example.com/a.mp4",
+    );
+    expect(resolveMediaPreviewUrl("https://cdn.example.com/a.png", "proj-1")).toBe(
+      "https://cdn.example.com/a.png",
+    );
+  });
+
+  it("percent-encodes spaces in filenames", () => {
+    expect(resolveMediaPreviewUrl("assets/my logo.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/my%20logo.png",
+    );
+  });
+
+  it("percent-encodes parentheses in filenames", () => {
+    expect(resolveMediaPreviewUrl("assets/heygen-symbol-blue-logo (2).svg", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/heygen-symbol-blue-logo%20(2).svg",
+    );
+  });
+
+  it("preserves slashes as path separators while encoding each segment", () => {
+    expect(resolveMediaPreviewUrl("sub dir/file (v2).mp4", "proj-2")).toBe(
+      "/api/projects/proj-2/preview/sub%20dir/file%20(v2).mp4",
+    );
+  });
+
+  it("percent-encodes unicode characters in filenames", () => {
+    expect(resolveMediaPreviewUrl("assets/café logo.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/caf%C3%A9%20logo.png",
+    );
+  });
+
+  it("leaves paths with no special characters unchanged", () => {
+    expect(resolveMediaPreviewUrl("assets/logo.svg", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/logo.svg",
+    );
+  });
+
+  it("percent-encodes a U+202F narrow no-break space (macOS screenshot artifact)", () => {
+    // "Screenshot … 2.16.30 PM.png" — the char between the time and PM is a
+    // narrow no-break space; it must encode to %E2%80%AF, not route raw (404).
+    expect(resolveMediaPreviewUrl("assets/Screenshot 2.16.30 PM.png", "proj-1")).toBe(
+      "/api/projects/proj-1/preview/assets/Screenshot%202.16.30%E2%80%AFPM.png",
+    );
+  });
+
+  it("passes data: URIs through untouched (never routes them through preview → HTTP 431)", () => {
+    const svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+    expect(resolveMediaPreviewUrl(svg, "proj-1")).toBe(svg);
+  });
+
+  it("passes blob: URLs through untouched", () => {
+    const blob = "blob:http://localhost:5190/2b3c-4d5e";
+    expect(resolveMediaPreviewUrl(blob, "proj-1")).toBe(blob);
+  });
+});
+
+// The shared encoder used by every timeline media-URL builder (filmstrip, audio
+// waveform, sub-composition preview) — must match the assets panel's per-segment
+// encoding so those paths stop 404ing on non-ASCII filenames.
+describe("encodePreviewPath", () => {
+  it("encodes spaces and parentheses per segment, preserving slashes", () => {
+    expect(encodePreviewPath("sub dir/file (v2).mp3")).toBe("sub%20dir/file%20(v2).mp3");
+  });
+
+  it("encodes a U+202F narrow no-break space to %E2%80%AF", () => {
+    expect(encodePreviewPath("assets/clip 2.mp3")).toBe("assets/clip%202.mp3");
+    expect(encodePreviewPath(`assets/clip${" "}2.mp3`)).toBe("assets/clip%E2%80%AF2.mp3");
+  });
+
+  it("leaves a plain path unchanged", () => {
+    expect(encodePreviewPath("assets/music.mp3")).toBe("assets/music.mp3");
+  });
+});

--- a/packages/studio/src/player/components/thumbnailUtils.ts
+++ b/packages/studio/src/player/components/thumbnailUtils.ts
@@ -1,0 +1,54 @@
+/** Rendered height of a timeline-clip thumbnail strip, in CSS px. */
+export const THUMBNAIL_CLIP_HEIGHT = 66;
+
+export interface ThumbnailStripLayout {
+  /** Width of a single tile, in CSS px. */
+  frameW: number;
+  /** Number of tiles needed to fill the container. */
+  frameCount: number;
+}
+
+/**
+ * Compute the film-strip tile layout for a clip thumbnail: fixed-height tiles
+ * sized by the media's aspect ratio, repeated to fill the clip width.
+ * Degenerate aspects (0, negative, NaN, Infinity) fall back to 16:9.
+ */
+export function computeThumbnailStrip(
+  containerWidth: number,
+  aspect: number,
+  clipHeight: number = THUMBNAIL_CLIP_HEIGHT,
+): ThumbnailStripLayout {
+  const safeAspect = Number.isFinite(aspect) && aspect > 0 ? aspect : 16 / 9;
+  const frameW = Math.max(1, Math.round(clipHeight * safeAspect));
+  const frameCount = containerWidth > 0 ? Math.max(1, Math.ceil(containerWidth / frameW)) : 1;
+  return { frameW, frameCount };
+}
+
+/**
+ * Percent-encode each segment of a composition-relative media path so filenames
+ * containing spaces, parentheses, a U+202F narrow no-break space (the macOS
+ * screenshot artifact), or any other non-ASCII / URL-unsafe character yield a
+ * valid URL instead of a 404. Slashes are preserved as separators.
+ *
+ * Shared by every timeline media-URL builder (filmstrip thumbnails, audio
+ * waveform, sub-composition preview) so they encode identically to the assets
+ * panel — a raw segment 404s on the exact filenames the assets panel loads fine.
+ */
+export function encodePreviewPath(relativePath: string): string {
+  return relativePath.split("/").map(encodeURIComponent).join("/");
+}
+
+/**
+ * Resolve a timeline element's media src to a URL loadable from the studio
+ * (parent) document. Composition-relative paths (e.g. "assets/image.png") are
+ * routed through the project preview endpoint with each segment encoded.
+ *
+ * Already-loadable URLs pass through untouched: absolute http(s) URLs, plus
+ * `data:` and `blob:` URLs. Routing a `data:`/`blob:` URL through the preview
+ * endpoint would percent-encode the whole thing into a multi-KB path segment
+ * that the server rejects with HTTP 431 (Request Header Fields Too Large).
+ */
+export function resolveMediaPreviewUrl(src: string, projectId: string): string {
+  if (/^(?:https?:|data:|blob:)/i.test(src)) return src;
+  return `/api/projects/${projectId}/preview/${encodePreviewPath(src)}`;
+}


### PR DESCRIPTION
## What

ImageThumbnail (+tests) and thumbnailUtils (+tests) — frame decode with SVG/AVIF format fallbacks and rounded-corner clipping — plus VideoThumbnail updates.

## Why

the decode layer for timeline clip thumbnails, ahead of the visual refresh that renders them.

## How

new modules + one modified file; purely presentational.

## Test plan

bunx vitest run on both test files; tsc --noEmit; fallow audit clean.

---
**Stack position 23/25** — studio NLE overhaul (CapCut-parity timeline + canvas). Graphite manages bases; merge from #2192 upward. Temporary `TEMP(studio-dnd)` fallow entries (unwired-component windows) are all removed by #2213 (app-shell swap), whose tree is byte-identical to the fully-verified integration branch.