### PR TITLE
fix(telemetry): expose stalled render stages

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -41,6 +41,7 @@ const trackingState = vi.hoisted(() => ({
   // `.ts` source under vitest — mocked here so the CLI-trial tests can
   // control it directly instead of inheriting that environment quirk.
   shouldTrack: true,
+  renderObservations: [] as Array<Record<string, unknown>>,
 }));
 
 const preflightState = vi.hoisted(() => ({
@@ -110,6 +111,9 @@ vi.mock("../telemetry/client.js", () => ({
 vi.mock("../telemetry/events.js", () => ({
   trackRenderComplete: vi.fn(),
   trackRenderError: vi.fn(),
+  trackRenderObservation: vi.fn((props: Record<string, unknown>) => {
+    trackingState.renderObservations.push(props);
+  }),
 }));
 
 vi.mock("../browser/ffmpeg.js", () => ({
@@ -154,6 +158,7 @@ describe("renderLocal browser GPU config", () => {
     configState.failWrites = 0;
     configState.writeConfigCalls = [];
     trackingState.shouldTrack = true;
+    trackingState.renderObservations = [];
     resetTrialState();
     savedEnv.clear();
     savedEnv.set("HYPERFRAMES_FFMPEG_PATH", process.env.HYPERFRAMES_FFMPEG_PATH);
@@ -198,6 +203,59 @@ describe("renderLocal browser GPU config", () => {
       resolved: true,
     });
   }, 15_000);
+
+  it("forwards render stage start and end lifecycle events to telemetry", async () => {
+    producerState.executeImpl = async (job) => {
+      const logger = (job.config as { logger: { info: (message: string, meta: object) => void } })
+        .logger;
+      logger.info("[Render:trace]", {
+        renderJobId: "render-lifecycle",
+        phase: "capture_streaming",
+        status: "start",
+        elapsedMs: 100,
+        workerCount: 1,
+        captureMode: "screenshot",
+        captureOperation: "captureScreenshot",
+        framesCompleted: 12,
+        totalFrames: 900,
+      });
+      logger.info("[Render:trace]", {
+        renderJobId: "render-lifecycle",
+        phase: "capture_streaming",
+        status: "end",
+        elapsedMs: 250,
+        durationMs: 150,
+      });
+    };
+
+    await renderLocal("/tmp/project", "/tmp/out.mp4", {
+      fps: { num: 30, den: 1 },
+      quality: "standard",
+      format: "mp4",
+      gpu: false,
+      browserGpuMode: "software",
+      hdrMode: "auto",
+      quiet: true,
+      skipFeedback: true,
+    });
+
+    expect(trackingState.renderObservations).toEqual([
+      expect.objectContaining({
+        renderJobId: "render-lifecycle",
+        phase: "capture_streaming",
+        status: "start",
+        captureOperation: "captureScreenshot",
+        framesCompleted: 12,
+        totalFrames: 900,
+      }),
+      expect.objectContaining({
+        renderJobId: "render-lifecycle",
+        phase: "capture_streaming",
+        status: "end",
+        durationMs: 150,
+      }),
+    ]);
+  });
 
   it("forwards browserGpuMode='auto' into producer config (probe-then-choose)", async () => {
     await renderLocal("/tmp/project", "/tmp/out.mp4", {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1572,7 +1572,9 @@ function metaBoolean(meta: Record<string, unknown> | undefined, key: string): bo
 function trackRenderTraceFromLog(message: string, meta: Record<string, unknown> | undefined): void {
   if (message !== "[Render:trace]") return;
   const status = metaString(meta, "status");
-  if (status !== "checkpoint" && status !== "error") return;
+  if (status !== "start" && status !== "end" && status !== "checkpoint" && status !== "error") {
+    return;
+  }
   trackRenderObservation({
     source: "cli",
     renderJobId: metaString(meta, "renderJobId"),
@@ -1589,6 +1591,11 @@ function trackRenderTraceFromLog(message: string, meta: Record<string, unknown> 
     usePageSideCompositing: metaBoolean(meta, "usePageSideCompositing"),
     hasHdrContent: metaBoolean(meta, "hasHdrContent"),
     captureMode: metaString(meta, "captureMode"),
+    captureOperation: metaString(meta, "captureOperation"),
+    framesCompleted: metaNumber(meta, "framesCompleted"),
+    totalFrames: metaNumber(meta, "totalFrames"),
+    heartbeatIndex: metaNumber(meta, "heartbeatIndex"),
+    stageElapsedMs: metaNumber(meta, "stageElapsedMs"),
     videoCount: metaNumber(meta, "videoCount"),
     extractedVideoCount: metaNumber(meta, "extractedVideoCount"),
     totalFramesExtracted: metaNumber(meta, "totalFramesExtracted"),

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -316,6 +316,12 @@ describe("render telemetry events", () => {
       phase: "capture_hdr_layered",
       status: "error",
       compositionHash: "abc123",
+      captureMode: "screenshot",
+      captureOperation: "captureScreenshot",
+      framesCompleted: 12,
+      totalFrames: 900,
+      heartbeatIndex: 1,
+      stageElapsedMs: 30_000,
       message: "Navigation failed for C:\\Users\\Alice\\project\\video.mov?not-a-query",
     });
 
@@ -324,6 +330,12 @@ describe("render telemetry events", () => {
       expect.objectContaining({
         render_job_id: "render-123",
         composition_hash: "abc123",
+        capture_mode: "screenshot",
+        capture_operation: "captureScreenshot",
+        frames_completed: 12,
+        total_frames: 900,
+        heartbeat_index: 1,
+        stage_elapsed_ms: 30_000,
         message: "Navigation failed for [path]",
       }),
     );

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -347,6 +347,11 @@ export function trackRenderObservation(props: {
   usePageSideCompositing?: boolean;
   hasHdrContent?: boolean;
   captureMode?: string;
+  captureOperation?: string;
+  framesCompleted?: number;
+  totalFrames?: number;
+  heartbeatIndex?: number;
+  stageElapsedMs?: number;
   videoCount?: number;
   extractedVideoCount?: number;
   totalFramesExtracted?: number;
@@ -373,6 +378,11 @@ export function trackRenderObservation(props: {
     use_page_side_compositing: props.usePageSideCompositing,
     has_hdr_content: props.hasHdrContent,
     capture_mode: props.captureMode,
+    capture_operation: props.captureOperation,
+    frames_completed: props.framesCompleted,
+    total_frames: props.totalFrames,
+    heartbeat_index: props.heartbeatIndex,
+    stage_elapsed_ms: props.stageElapsedMs,
     video_count: props.videoCount,
     extracted_video_count: props.extractedVideoCount,
     total_frames_extracted: props.totalFramesExtracted,

--- a/packages/producer/src/services/render/observability.test.ts
+++ b/packages/producer/src/services/render/observability.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { CaptureStageError, getCaptureStageBrowserConsole } from "./captureStageError.js";
 import {
   computeCompositionObservabilityHash,
+  observeRenderStage,
   RenderObservabilityRecorder,
   sanitizeObservationMessage,
   summarizeBrowserDiagnostics,
@@ -95,6 +96,94 @@ describe("CaptureStageError", () => {
 });
 
 describe("RenderObservabilityRecorder", () => {
+  it("emits capped heartbeats while a stage is still running and stops after settlement", async () => {
+    vi.useFakeTimers();
+    const log = makeLog();
+    const recorder = new RenderObservabilityRecorder({
+      pipelineStartMs: Date.now(),
+      log,
+      renderJobId: "render-hang",
+    });
+    let resolveStage: (() => void) | undefined;
+    let framesCompleted = 0;
+    const stage = observeRenderStage(
+      recorder,
+      "capture_streaming",
+      {
+        workerCount: 1,
+        captureMode: "screenshot",
+        captureOperation: "captureScreenshot",
+        totalFrames: 900,
+        get framesCompleted() {
+          return framesCompleted;
+        },
+      },
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStage = resolve;
+        }),
+    );
+
+    framesCompleted = 12;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(log.info).toHaveBeenCalledWith(
+      "[Render:trace]",
+      expect.objectContaining({
+        phase: "capture_streaming",
+        status: "checkpoint",
+        message: "stage still running",
+        heartbeatIndex: 1,
+        stageElapsedMs: 30_000,
+        captureMode: "screenshot",
+        captureOperation: "captureScreenshot",
+        framesCompleted: 12,
+        totalFrames: 900,
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(90_000);
+    const heartbeatCalls = log.info.mock.calls.filter(
+      ([message, meta]) => message === "[Render:trace]" && meta?.message === "stage still running",
+    );
+    expect(heartbeatCalls).toHaveLength(3);
+
+    resolveStage?.();
+    await stage;
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(
+      log.info.mock.calls.filter(
+        ([message, meta]) =>
+          message === "[Render:trace]" && meta?.message === "stage still running",
+      ),
+    ).toHaveLength(3);
+    vi.useRealTimers();
+  });
+
+  it("clears pending heartbeats when a stage rejects", async () => {
+    vi.useFakeTimers();
+    const log = makeLog();
+    const recorder = new RenderObservabilityRecorder({
+      pipelineStartMs: Date.now(),
+      log,
+      renderJobId: "render-error",
+    });
+
+    await expect(
+      observeRenderStage(recorder, "capture_disk", { workerCount: 2 }, async () => {
+        throw new Error("capture failed");
+      }),
+    ).rejects.toThrow("capture failed");
+    await vi.advanceTimersByTimeAsync(240_000);
+
+    expect(
+      log.info.mock.calls.some(
+        ([message, meta]) =>
+          message === "[Render:trace]" && meta?.message === "stage still running",
+      ),
+    ).toBe(false);
+    vi.useRealTimers();
+  });
+
   // fallow-ignore-next-line complexity
   it("records bounded phase events and summarizes browser diagnostics", () => {
     const log = makeLog();

--- a/packages/producer/src/services/render/observability.test.ts
+++ b/packages/producer/src/services/render/observability.test.ts
@@ -150,6 +150,7 @@ describe("RenderObservabilityRecorder", () => {
     resolveStage?.();
     await stage;
     const endCall = log.info.mock.calls.find(
+      // fallow-ignore-next-line complexity
       ([message, meta]) =>
         message === "[Render:trace]" &&
         meta?.phase === "capture_streaming" &&
@@ -171,6 +172,40 @@ describe("RenderObservabilityRecorder", () => {
           message === "[Render:trace]" && meta?.message === "stage still running",
       ),
     ).toHaveLength(3);
+    vi.useRealTimers();
+  });
+
+  it("keeps emitting heartbeats every 120s once the initial ramp is exhausted", async () => {
+    vi.useFakeTimers();
+    const log = makeLog();
+    const recorder = new RenderObservabilityRecorder({
+      pipelineStartMs: Date.now(),
+      log,
+      renderJobId: "render-long-hang",
+    });
+    let resolveStage: (() => void) | undefined;
+    const stage = observeRenderStage(
+      recorder,
+      "capture_streaming",
+      { captureMode: "screenshot" },
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStage = resolve;
+        }),
+    );
+
+    // Ramp: 30s, 60s, 120s → 3 heartbeats. Then steady 120s cadence: 240s, 360s.
+    await vi.advanceTimersByTimeAsync(360_000);
+    const heartbeatCalls = log.info.mock.calls.filter(
+      ([message, meta]) => message === "[Render:trace]" && meta?.message === "stage still running",
+    );
+    expect(heartbeatCalls.map(([, meta]) => meta?.heartbeatIndex)).toEqual([1, 2, 3, 4, 5]);
+    expect(heartbeatCalls.map(([, meta]) => meta?.stageElapsedMs)).toEqual([
+      30_000, 60_000, 120_000, 240_000, 360_000,
+    ]);
+
+    resolveStage?.();
+    await stage;
     vi.useRealTimers();
   });
 
@@ -200,6 +235,7 @@ describe("RenderObservabilityRecorder", () => {
       ),
     ).rejects.toThrow("capture failed");
     const errorCall = log.info.mock.calls.find(
+      // fallow-ignore-next-line complexity
       ([message, meta]) =>
         message === "[Render:trace]" && meta?.phase === "capture_disk" && meta?.status === "error",
     );

--- a/packages/producer/src/services/render/observability.test.ts
+++ b/packages/producer/src/services/render/observability.test.ts
@@ -149,6 +149,21 @@ describe("RenderObservabilityRecorder", () => {
 
     resolveStage?.();
     await stage;
+    const endCall = log.info.mock.calls.find(
+      ([message, meta]) =>
+        message === "[Render:trace]" &&
+        meta?.phase === "capture_streaming" &&
+        meta?.status === "end",
+    );
+    expect(endCall?.[1]).toEqual(
+      expect.objectContaining({
+        framesCompleted: 12,
+        totalFrames: 900,
+        captureMode: "screenshot",
+        captureOperation: "captureScreenshot",
+        workerCount: 1,
+      }),
+    );
     await vi.advanceTimersByTimeAsync(240_000);
     expect(
       log.info.mock.calls.filter(
@@ -169,10 +184,34 @@ describe("RenderObservabilityRecorder", () => {
     });
 
     await expect(
-      observeRenderStage(recorder, "capture_disk", { workerCount: 2 }, async () => {
-        throw new Error("capture failed");
-      }),
+      observeRenderStage(
+        recorder,
+        "capture_disk",
+        {
+          workerCount: 2,
+          totalFrames: 42,
+          framesCompleted: 7,
+          captureMode: "screenshot",
+          captureOperation: "captureScreenshot",
+        },
+        async () => {
+          throw new Error("capture failed");
+        },
+      ),
     ).rejects.toThrow("capture failed");
+    const errorCall = log.info.mock.calls.find(
+      ([message, meta]) =>
+        message === "[Render:trace]" && meta?.phase === "capture_disk" && meta?.status === "error",
+    );
+    expect(errorCall?.[1]).toEqual(
+      expect.objectContaining({
+        framesCompleted: 7,
+        totalFrames: 42,
+        captureMode: "screenshot",
+        captureOperation: "captureScreenshot",
+        workerCount: 2,
+      }),
+    );
     await vi.advanceTimersByTimeAsync(240_000);
 
     expect(

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -118,6 +118,7 @@ const MAX_EVENTS = 160;
 const ALLOWED_STRING_DATA_KEYS = new Set([
   "browserGpuMode",
   "captureMode",
+  "captureOperation",
   "compositionHash",
   "effectiveHdr",
   "format",
@@ -370,11 +371,27 @@ export async function observeRenderStage<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   const startedAt = recorder.stageStart(phase, data);
+  const heartbeatTimers = [30_000, 60_000, 120_000].map((delayMs, index) => {
+    const timer = setTimeout(() => {
+      recorder.checkpoint(phase, "stage still running", {
+        ...data,
+        heartbeatIndex: index + 1,
+        stageElapsedMs: Date.now() - startedAt,
+      });
+    }, delayMs);
+    timer.unref?.();
+    return timer;
+  });
+  const clearHeartbeats = () => {
+    for (const timer of heartbeatTimers) clearTimeout(timer);
+  };
   try {
     const result = await fn();
+    clearHeartbeats();
     recorder.stageEnd(phase, startedAt);
     return result;
   } catch (error) {
+    clearHeartbeats();
     recorder.stageError(phase, startedAt, error);
     throw error;
   }

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -388,11 +388,11 @@ export async function observeRenderStage<T>(
   try {
     const result = await fn();
     clearHeartbeats();
-    recorder.stageEnd(phase, startedAt);
+    recorder.stageEnd(phase, startedAt, data);
     return result;
   } catch (error) {
     clearHeartbeats();
-    recorder.stageError(phase, startedAt, error);
+    recorder.stageError(phase, startedAt, error, data);
     throw error;
   }
 }

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -364,6 +364,20 @@ export class RenderObservabilityRecorder {
   }
 }
 
+/** Heartbeat ramp before falling back to a steady repeat cadence. */
+const HEARTBEAT_RAMP_MS = [30_000, 60_000, 120_000];
+const HEARTBEAT_REPEAT_MS = 120_000;
+const HEARTBEAT_RAMP_END_MS =
+  HEARTBEAT_RAMP_MS[HEARTBEAT_RAMP_MS.length - 1] ?? HEARTBEAT_REPEAT_MS;
+
+/** Target elapsed-ms for the Nth heartbeat (0-indexed): ramp, then steady repeat so long stalls keep emitting breadcrumbs instead of going dark after the ramp. */
+function heartbeatTargetMs(index: number): number {
+  const rampTarget = HEARTBEAT_RAMP_MS[index];
+  if (rampTarget !== undefined) return rampTarget;
+  const overflow = index - HEARTBEAT_RAMP_MS.length + 1;
+  return HEARTBEAT_RAMP_END_MS + overflow * HEARTBEAT_REPEAT_MS;
+}
+
 export async function observeRenderStage<T>(
   recorder: RenderObservabilityRecorder,
   phase: string,
@@ -371,19 +385,26 @@ export async function observeRenderStage<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   const startedAt = recorder.stageStart(phase, data);
-  const heartbeatTimers = [30_000, 60_000, 120_000].map((delayMs, index) => {
-    const timer = setTimeout(() => {
+  let heartbeatCount = 0;
+  let lastFiredAtMs = 0;
+  let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
+  const scheduleNextHeartbeat = () => {
+    const targetMs = heartbeatTargetMs(heartbeatCount);
+    heartbeatTimer = setTimeout(() => {
+      lastFiredAtMs = targetMs;
+      heartbeatCount += 1;
       recorder.checkpoint(phase, "stage still running", {
         ...data,
-        heartbeatIndex: index + 1,
+        heartbeatIndex: heartbeatCount,
         stageElapsedMs: Date.now() - startedAt,
       });
-    }, delayMs);
-    timer.unref?.();
-    return timer;
-  });
+      scheduleNextHeartbeat();
+    }, targetMs - lastFiredAtMs);
+    heartbeatTimer.unref?.();
+  };
+  scheduleNextHeartbeat();
   const clearHeartbeats = () => {
-    for (const timer of heartbeatTimers) clearTimeout(timer);
+    clearTimeout(heartbeatTimer);
   };
   try {
     const result = await fn();

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -30,6 +30,7 @@ import {
   shouldDiscardProbeSessionForPageSideCompositing,
   resolveInversionRetryPlan,
   resolveParallelRouterRetryPlan,
+  resetCaptureAttemptProgress,
   shouldRetryViaPinnedFallback,
   shouldPreferParallelDrawElement,
   shouldPreferSingleWorkerDrawElement,
@@ -115,6 +116,14 @@ describe("extractStandaloneEntryFromIndex", () => {
 });
 
 describe("captureAttemptMadeProgress", () => {
+  it("resets completed frames before a fallback attempt starts", () => {
+    const job = { framesRendered: 900 };
+
+    resetCaptureAttemptProgress(job);
+
+    expect(job.framesRendered).toBe(0);
+  });
+
   it("retries when the attempt captured at least one frame toward its target", () => {
     // targeted 100 frames, 40 still missing -> 60 captured -> worth retrying the rest
     expect(captureAttemptMadeProgress(100, 40)).toBe(true);

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1950,7 +1950,7 @@ export async function executeRenderJob(
       const outcome = await observeRenderStage(
         observability,
         "capture_calibration",
-        { forceScreenshot: captureForceScreenshot },
+        captureStageObservationData({ forceScreenshot: captureForceScreenshot }),
         () =>
           runCaptureCalibration({
             cfg,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -110,6 +110,7 @@ import {
   observeRenderStage,
   type RenderCaptureObservability,
   type RenderExtractionObservability,
+  type RenderObservationData,
   type RenderObservabilitySummary,
 } from "./render/observability.js";
 import { type HdrPerfCollector, type HdrPerfSummary } from "./render/hdrPerf.js";
@@ -658,6 +659,10 @@ export function captureAttemptMadeProgress(
   remainingFrameCount: number,
 ): boolean {
   return remainingFrameCount < attemptTargetFrameCount;
+}
+
+export function resetCaptureAttemptProgress(job: { framesRendered?: number }): void {
+  job.framesRendered = 0;
 }
 
 export function isRecoverableParallelCaptureError(error: unknown): boolean {
@@ -2229,7 +2234,47 @@ export async function executeRenderJob(
     const effectiveQuality = job.config.crf ?? preset.quality;
     const effectiveBitrate = job.config.crf != null ? undefined : job.config.videoBitrate;
 
-    job.framesRendered = 0;
+    resetCaptureAttemptProgress(job);
+    const captureStageObservationData = (
+      extra: RenderObservationData = {},
+    ): RenderObservationData => ({
+      ...extra,
+      get workerCount() {
+        return workerCount;
+      },
+      get forceScreenshot() {
+        return captureForceScreenshot;
+      },
+      get totalFrames() {
+        return totalFrames;
+      },
+      get framesCompleted() {
+        return job.framesRendered ?? 0;
+      },
+      get captureMode() {
+        return (
+          probeSession?.captureMode ??
+          (captureForceScreenshot
+            ? "screenshot"
+            : cfg.useDrawElement
+              ? "drawelement"
+              : "beginframe")
+        );
+      },
+      get captureOperation() {
+        if ((job.framesRendered ?? 0) >= totalFrames) return "encode";
+        const mode =
+          probeSession?.captureMode ??
+          (captureForceScreenshot
+            ? "screenshot"
+            : cfg.useDrawElement
+              ? "drawelement"
+              : "beginframe");
+        if (mode === "screenshot") return "captureScreenshot";
+        if (mode === "drawelement") return "drawElement";
+        return "beginFrame";
+      },
+    });
 
     // ── Z-ordered multi-layer compositing ─────────────────────────────────
     // Per frame: query all elements' z-order, group into layers (DOM or HDR),
@@ -2248,7 +2293,7 @@ export async function executeRenderJob(
       const hdrRes = await observeRenderStage(
         observability,
         "capture_hdr_layered",
-        { workerCount, forceScreenshot: captureForceScreenshot, hasHdrContent },
+        captureStageObservationData({ hasHdrContent }),
         () =>
           runCaptureHdrStage({
             job,
@@ -2297,11 +2342,12 @@ export async function executeRenderJob(
       let streamingHandled = false;
       if (useStreamingEncode) {
         const captureFrameStart = Date.now();
-        const invokeStreaming = () =>
-          observeRenderStage(
+        const invokeStreaming = () => {
+          resetCaptureAttemptProgress(job);
+          return observeRenderStage(
             observability,
             "capture_streaming",
-            { workerCount, forceScreenshot: captureForceScreenshot },
+            captureStageObservationData(),
             () =>
               runCaptureStreamingStage({
                 fileServer: activeFileServer,
@@ -2339,6 +2385,7 @@ export async function executeRenderJob(
                 dedupPerfs,
               }),
           );
+        };
         let streamingRes;
         try {
           streamingRes = await invokeStreaming();
@@ -2510,11 +2557,12 @@ export async function executeRenderJob(
 
       if (!streamingHandled) {
         // ── Disk-based capture (original flow) ────────────────────────────
+        resetCaptureAttemptProgress(job);
         const captureFrameStart = Date.now();
         const captureRes = await observeRenderStage(
           observability,
           "capture_disk",
-          { workerCount, forceScreenshot: captureForceScreenshot, needsAlpha },
+          captureStageObservationData({ needsAlpha }),
           () =>
             runCaptureStage({
               fileServer: activeFileServer,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1939,6 +1939,51 @@ export async function executeRenderJob(
         process.env.HF_DE_PARALLEL_STREAM === "true",
       routerEnabled: deParallelRouterEnabled,
     });
+    // Declared ahead of resolution (assigned below, after calibration) so
+    // captureStageObservationData can close over it for the calibration
+    // stage itself — reads as undefined until resolveRenderWorkerCount runs.
+    let workerCount: number;
+    const captureStageObservationData = (
+      extra: RenderObservationData = {},
+    ): RenderObservationData => ({
+      ...extra,
+      get workerCount() {
+        return workerCount;
+      },
+      get forceScreenshot() {
+        return captureForceScreenshot;
+      },
+      get totalFrames() {
+        return totalFrames;
+      },
+      get framesCompleted() {
+        return job.framesRendered ?? 0;
+      },
+      get captureMode() {
+        return (
+          probeSession?.captureMode ??
+          (captureForceScreenshot
+            ? "screenshot"
+            : cfg.useDrawElement
+              ? "drawelement"
+              : "beginframe")
+        );
+      },
+      get captureOperation() {
+        if ((job.framesRendered ?? 0) >= totalFrames) return "encode";
+        const mode =
+          probeSession?.captureMode ??
+          (captureForceScreenshot
+            ? "screenshot"
+            : cfg.useDrawElement
+              ? "drawelement"
+              : "beginframe");
+        if (mode === "screenshot") return "captureScreenshot";
+        if (mode === "drawelement") return "drawElement";
+        return "beginFrame";
+      },
+    });
+
     if (
       job.config.workers === undefined &&
       totalFrames >= 60 &&
@@ -1991,7 +2036,7 @@ export async function executeRenderJob(
 
     // Low-memory safe-mode's single-worker pin lives inside
     // resolveRenderWorkerCount so its "why workers=N" logging stays coherent.
-    let workerCount = resolveRenderWorkerCount(
+    workerCount = resolveRenderWorkerCount(
       totalFrames,
       job.config.workers,
       cfg,
@@ -2235,46 +2280,6 @@ export async function executeRenderJob(
     const effectiveBitrate = job.config.crf != null ? undefined : job.config.videoBitrate;
 
     resetCaptureAttemptProgress(job);
-    const captureStageObservationData = (
-      extra: RenderObservationData = {},
-    ): RenderObservationData => ({
-      ...extra,
-      get workerCount() {
-        return workerCount;
-      },
-      get forceScreenshot() {
-        return captureForceScreenshot;
-      },
-      get totalFrames() {
-        return totalFrames;
-      },
-      get framesCompleted() {
-        return job.framesRendered ?? 0;
-      },
-      get captureMode() {
-        return (
-          probeSession?.captureMode ??
-          (captureForceScreenshot
-            ? "screenshot"
-            : cfg.useDrawElement
-              ? "drawelement"
-              : "beginframe")
-        );
-      },
-      get captureOperation() {
-        if ((job.framesRendered ?? 0) >= totalFrames) return "encode";
-        const mode =
-          probeSession?.captureMode ??
-          (captureForceScreenshot
-            ? "screenshot"
-            : cfg.useDrawElement
-              ? "drawelement"
-              : "beginframe");
-        if (mode === "screenshot") return "captureScreenshot";
-        if (mode === "drawelement") return "drawElement";
-        return "beginFrame";
-      },
-    });
 
     // ── Z-ordered multi-layer compositing ─────────────────────────────────
     // Per frame: query all elements' z-order, group into layers (DOM or HDR),
@@ -2603,7 +2608,12 @@ export async function executeRenderJob(
         const encodeRes = await observeRenderStage(
           observability,
           "encode",
-          { hasAudio, isPngSequence, isGif, chunkedEncode: enableChunkedEncode },
+          captureStageObservationData({
+            hasAudio,
+            isPngSequence,
+            isGif,
+            chunkedEncode: enableChunkedEncode,
+          }),
           () =>
             runEncodeStage({
               job,
@@ -2651,17 +2661,21 @@ export async function executeRenderJob(
     // directory deliverable, and gif is written directly to outputPath by the
     // two-pass palette encoder.
     if (!isPngSequence && !isGif) {
-      const assembleRes = await observeRenderStage(observability, "assemble", { hasAudio }, () =>
-        runAssembleStage({
-          job,
-          videoOnlyPath,
-          audioOutputPath,
-          outputPath,
-          hasAudio,
-          abortSignal,
-          assertNotAborted,
-          onProgress,
-        }),
+      const assembleRes = await observeRenderStage(
+        observability,
+        "assemble",
+        captureStageObservationData({ hasAudio }),
+        () =>
+          runAssembleStage({
+            job,
+            videoOnlyPath,
+            audioOutputPath,
+            outputPath,
+            hasAudio,
+            abortSignal,
+            assertNotAborted,
+            onProgress,
+          }),
       );
       perfStages.assembleMs = assembleRes.assembleMs;
     } else {


### PR DESCRIPTION
## Summary

Stalled renders now leave enough live telemetry to identify where they stopped instead of ending at `capture_strategy` with only exit 130. The CLI forwards every render-stage lifecycle event, while slow stages emit capped heartbeats at 30s, 60s, and 120s with live capture mode, operation, worker count, and frame progress. Retry attempts reset their progress first, so fallback heartbeats cannot falsely report that encoding has begun.

This closes the gap confirmed in PostHog for four `Page.captureScreenshot` hangs: future SIGINT exits can retain the active stage and whether the render was in `captureScreenshot`, `beginFrame`, `drawElement`, or encoder work, without recording paths, URLs, or composition content.

## Test plan

- `bunx vitest run` across producer observability/orchestrator and CLI render/telemetry suites — 223 passed
- Producer and CLI typechecks
- oxfmt and oxlint on all changed files
- Full workspace build
- Independent design and code review; stale fallback progress finding addressed with regression coverage
