### PR TITLE
fix(cli): correct strict warning hint

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -130,14 +130,25 @@ describe("renderLocal browser GPU config", () => {
   // suites). Importing once in `beforeAll` keeps every test fast and isolated.
   let renderLocal: typeof import("./render.js").renderLocal;
   let resolveBrowserGpuForCli: typeof import("./render.js").resolveBrowserGpuForCli;
+  let renderLintContinuationHint: typeof import("./render.js").renderLintContinuationHint;
   let resetTrialState: typeof import("./render.js").__resetDeParallelRouterTrialStateForTests;
 
   beforeAll(async () => {
     ({
       renderLocal,
       resolveBrowserGpuForCli,
+      renderLintContinuationHint,
       __resetDeParallelRouterTrialStateForTests: resetTrialState,
     } = await import("./render.js"));
+  });
+
+  it("points strict warning-only renders to --strict-all", () => {
+    expect(renderLintContinuationHint(true)).toContain("--strict-all");
+    expect(renderLintContinuationHint(true)).not.toContain("Use --strict to block");
+  });
+
+  it("points non-strict renders to --strict for lint errors", () => {
+    expect(renderLintContinuationHint(false)).toContain("Use --strict to block errors");
   });
 
   function setEnv(key: string, value: string) {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -825,7 +825,7 @@ export default defineCommand({
           console.log("");
           process.exit(1);
         }
-        console.log(c.dim("  Continuing render despite lint issues. Use --strict to block."));
+        console.log(c.dim(renderLintContinuationHint(strictErrors)));
         console.log("");
       }
     }
@@ -1002,6 +1002,12 @@ export default defineCommand({
 export interface SingleRenderResult {
   durationMs?: number;
   renderTimeMs: number;
+}
+
+export function renderLintContinuationHint(strictErrors: boolean): string {
+  return strictErrors
+    ? "  Continuing render despite lint warnings. Use --strict-all to block warnings."
+    : "  Continuing render despite lint issues. Use --strict to block errors.";
 }
 
 interface RenderOptions {


### PR DESCRIPTION
Warning-only renders no longer tell users to add `--strict` when that flag is already active. The continuation hint now points strict users to `--strict-all`, while non-strict users still see the error-blocking `--strict` guidance.

Tested with the full CLI render suite (51/51), CLI typecheck, oxfmt, oxlint, and CLI build.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
