### PR TITLE
feat(producer): stream parallel screenshot/beginframe capture to the encoder

### DIFF
--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -361,6 +361,22 @@ describe("render telemetry events", () => {
       }),
     );
   });
+
+  it("carries capture_parallel_stream on render_error via the shared payload", () => {
+    trackRenderError({
+      fps: 30,
+      quality: "standard",
+      docker: false,
+      errorMessage: "worker crashed",
+      captureParallelStream: "beginframe",
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "render_error",
+      expect.objectContaining({ capture_parallel_stream: "beginframe" }),
+      undefined,
+    );
+  });
 });
 
 describe("trackRenderFeedback", () => {

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -53,7 +53,8 @@ export interface RenderObservabilityTelemetryPayload {
   captureDePreRouterWorkers?: number;
   captureDeSelfVerifyFallback?: boolean;
   captureDeFallbackReason?: string;
-  /** Non-DE parallel-streaming router outcome ("screenshot" | "beginframe"). */
+  /** Non-DE parallel-streaming router outcome ("screenshot" | "beginframe" —
+   * routed; "eligible_off" — would route but the kill switch is off). */
   captureParallelStream?: string;
   observabilityExtractVideoCount?: number;
   observabilityExtractedVideoCount?: number;

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -53,6 +53,8 @@ export interface RenderObservabilityTelemetryPayload {
   captureDePreRouterWorkers?: number;
   captureDeSelfVerifyFallback?: boolean;
   captureDeFallbackReason?: string;
+  /** Non-DE parallel-streaming router outcome ("screenshot" | "beginframe"). */
+  captureParallelStream?: string;
   observabilityExtractVideoCount?: number;
   observabilityExtractedVideoCount?: number;
   observabilityExtractTotalFrames?: number;
@@ -104,6 +106,7 @@ function renderObservabilityEventProperties(props: RenderObservabilityTelemetryP
     de_pre_router_workers: props.captureDePreRouterWorkers,
     de_self_verify_fallback: props.captureDeSelfVerifyFallback,
     de_fallback_reason: props.captureDeFallbackReason,
+    capture_parallel_stream: props.captureParallelStream,
     observability_extract_video_count: props.observabilityExtractVideoCount,
     observability_extracted_video_count: props.observabilityExtractedVideoCount,
     observability_extract_total_frames: props.observabilityExtractTotalFrames,

--- a/packages/cli/src/telemetry/renderObservability.test.ts
+++ b/packages/cli/src/telemetry/renderObservability.test.ts
@@ -91,6 +91,13 @@ describe("renderObservabilityTelemetryPayload — non-DE parallel-stream router"
     expect(payload.captureParallelStream).toBe("beginframe");
   });
 
+  it("maps the passive eligible_off cohort-sizing signal", () => {
+    const payload = renderObservabilityTelemetryPayload(
+      makeSummary({ captureParallelStream: "eligible_off" }),
+    );
+    expect(payload.captureParallelStream).toBe("eligible_off");
+  });
+
   it("stays undefined when the router never fired", () => {
     const payload = renderObservabilityTelemetryPayload(makeSummary({}));
     expect(payload.captureParallelStream).toBeUndefined();

--- a/packages/cli/src/telemetry/renderObservability.test.ts
+++ b/packages/cli/src/telemetry/renderObservability.test.ts
@@ -82,3 +82,17 @@ describe("renderObservabilityTelemetryPayload — DE inversion/router cohort (fa
     expect(payload.captureDeFallbackReason).toBeUndefined();
   });
 });
+
+describe("renderObservabilityTelemetryPayload — non-DE parallel-stream router", () => {
+  it("maps the router outcome", () => {
+    const payload = renderObservabilityTelemetryPayload(
+      makeSummary({ captureParallelStream: "beginframe" }),
+    );
+    expect(payload.captureParallelStream).toBe("beginframe");
+  });
+
+  it("stays undefined when the router never fired", () => {
+    const payload = renderObservabilityTelemetryPayload(makeSummary({}));
+    expect(payload.captureParallelStream).toBeUndefined();
+  });
+});

--- a/packages/cli/src/telemetry/renderObservability.ts
+++ b/packages/cli/src/telemetry/renderObservability.ts
@@ -46,6 +46,7 @@ export function renderObservabilityTelemetryPayload(
     captureDePreRouterWorkers: capture.dePreRouterWorkers,
     captureDeSelfVerifyFallback: capture.deSelfVerifyFallback,
     captureDeFallbackReason: capture.deFallbackReason,
+    captureParallelStream: capture.captureParallelStream,
     observabilityExtractVideoCount: extraction?.videoCount,
     observabilityExtractedVideoCount: extraction?.extractedVideoCount,
     observabilityExtractTotalFrames: extraction?.totalFramesExtracted,

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -68,6 +68,13 @@ export interface RenderCaptureObservability {
   deParallelRouter?: "routed" | "reverted";
   /** Worker count the resolver would have used absent the router; undefined if it never fired. */
   dePreRouterWorkers?: number;
+  /**
+   * Non-DE parallel-streaming router outcome (HF_CAPTURE_PARALLEL_STREAM):
+   * set when a multi-worker screenshot/BeginFrame render was routed through
+   * the interleaved streaming encoder instead of the parallel disk path.
+   * The value is the capture mode that streamed. Absent = not routed.
+   */
+  captureParallelStream?: "screenshot" | "beginframe";
   protocolTimeoutMs?: number;
   pageNavigationTimeoutMs?: number;
   playerReadyTimeoutMs?: number;

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -70,11 +70,14 @@ export interface RenderCaptureObservability {
   dePreRouterWorkers?: number;
   /**
    * Non-DE parallel-streaming router outcome (HF_CAPTURE_PARALLEL_STREAM):
-   * set when a multi-worker screenshot/BeginFrame render was routed through
-   * the interleaved streaming encoder instead of the parallel disk path.
-   * The value is the capture mode that streamed. Absent = not routed.
+   * "screenshot" | "beginframe" — the render passed every gate AND the kill
+   * switch was on, so it was routed through the interleaved streaming encoder
+   * (the value is the capture mode that streamed); "eligible_off" — the render
+   * passed every gate EXCEPT the kill switch (passive cohort-sizing signal for
+   * the default-off soak: how many renders WOULD route if enabled). Absent =
+   * ineligible regardless of the switch.
    */
-  captureParallelStream?: "screenshot" | "beginframe";
+  captureParallelStream?: "screenshot" | "beginframe" | "eligible_off";
   protocolTimeoutMs?: number;
   pageNavigationTimeoutMs?: number;
   playerReadyTimeoutMs?: number;

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -34,6 +34,7 @@ import {
   shouldRetryViaPinnedFallback,
   shouldPreferParallelDrawElement,
   shouldPreferSingleWorkerDrawElement,
+  shouldStreamParallelCapture,
   shouldUseStreamingEncode,
 } from "./renderOrchestrator.js";
 import { ensureFrameWritten } from "./render/stages/captureHdrFrameShared.js";
@@ -2047,5 +2048,45 @@ describe("shouldRetryViaPinnedFallback (widen the self-verify retry to generic c
         deParallelRouter: undefined,
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldStreamParallelCapture (non-DE parallel streaming router)", () => {
+  const eligible = {
+    routerEnabled: true,
+    workerCount: 3,
+    useDrawElement: false,
+    outputFormat: "mp4" as const,
+    streamingOk: true,
+    layeredOrEffectRoute: false,
+  };
+
+  it("routes an eligible multi-worker non-drawElement render", () => {
+    expect(shouldStreamParallelCapture(eligible)).toBe(true);
+  });
+
+  it("is disabled by default (kill switch off is the shipped default)", () => {
+    expect(shouldStreamParallelCapture({ ...eligible, routerEnabled: false })).toBe(false);
+  });
+
+  it("never fires for single-worker renders (those already stream)", () => {
+    expect(shouldStreamParallelCapture({ ...eligible, workerCount: 1 })).toBe(false);
+  });
+
+  it("never fires when drawElement will capture (the DE routers own that path)", () => {
+    expect(shouldStreamParallelCapture({ ...eligible, useDrawElement: true })).toBe(false);
+  });
+
+  it("only applies to mp4", () => {
+    expect(shouldStreamParallelCapture({ ...eligible, outputFormat: "webm" })).toBe(false);
+    expect(shouldStreamParallelCapture({ ...eligible, outputFormat: "png-sequence" })).toBe(false);
+  });
+
+  it("respects the streaming-encode config/duration gates", () => {
+    expect(shouldStreamParallelCapture({ ...eligible, streamingOk: false })).toBe(false);
+  });
+
+  it("skips HDR-layered and shader-transition routes", () => {
+    expect(shouldStreamParallelCapture({ ...eligible, layeredOrEffectRoute: true })).toBe(false);
   });
 });

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1299,6 +1299,54 @@ export function shouldRetryViaPinnedFallback(args: {
   return args.deWorkerInversion === "inverted" || args.deParallelRouter === "routed";
 }
 
+/**
+ * Parallel-streaming router for NON-drawElement capture (screenshot on
+ * macOS/Windows/forced-screenshot, BeginFrame on Linux): should this
+ * multi-worker render stream captured frame buffers straight into the single
+ * ffmpeg stdin encoder (interleaved distribution + ordered reorder-buffer
+ * writer — the PR #2056 machinery) instead of the parallel disk path (workers
+ * write JPEGs, a separate sequential encode pass reads them back)?
+ *
+ * Measured motivation (2026-07-10, macOS SS W3): the disk path's encode is a
+ * purely additive tail (~27% of wall clock on a 3,600-frame comp). Streaming
+ * overlapped it for 1.29x on a uniform-cost comp and was a wash (not a
+ * regression) on a 39%-static bimodal comp — the interleaved writer's
+ * near-lockstep coupling eats the encode win when frame costs are bimodal.
+ * v1 accepts the wash; static-aware routing is a documented follow-up.
+ *
+ * Unlike the DE router this deliberately does NOT require auto-resolved
+ * workers: streaming doesn't change the worker count, so an explicit
+ * `--workers 3` should benefit too. It requires !useDrawElement
+ * (post-resolveConfig — always true on Linux): DE parallel renders belong to
+ * the DE parallel router (HF_DE_PARALLEL_ROUTER) with its self-verify
+ * machinery; both DE predicates independently require useDrawElement, making
+ * the two routers mutually exclusive by construction.
+ */
+export function shouldStreamParallelCapture(args: {
+  /** HF_CAPTURE_PARALLEL_STREAM === "true" — kill switch, default OFF. */
+  routerEnabled: boolean;
+  workerCount: number;
+  /** cfg.useDrawElement AFTER resolveConfig clamps. */
+  useDrawElement: boolean;
+  outputFormat: NonNullable<RenderConfig["format"]>;
+  /** shouldUseStreamingEncode(cfg, format, 1, duration) at the call site —
+   * carries the enableStreamingEncode/format/duration-cap gates. */
+  streamingOk: boolean;
+  /** HDR layered composite or shader transitions — bespoke pipelines
+   * (including page-side compositing, which only engages when
+   * hasShaderTransitions) that never stream. */
+  layeredOrEffectRoute: boolean;
+}): boolean {
+  return (
+    args.routerEnabled &&
+    args.workerCount > 1 &&
+    !args.useDrawElement &&
+    args.outputFormat === "mp4" &&
+    args.streamingOk &&
+    !args.layeredOrEffectRoute
+  );
+}
+
 export function resolveCaptureForceScreenshotForPageSideCompositing(args: {
   forceScreenshot: boolean;
   usePageSideCompositing: boolean;

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1647,6 +1647,10 @@ export async function executeRenderJob(
     // render already executing in the same process. Threading this as a
     // local instead closes that cross-talk, not just the sequential leak.
     let deParallelStreamForced = false;
+    // Per-render (not process-global) signal that the NON-DE parallel-stream
+    // router fired — same threading discipline as deParallelStreamForced
+    // (see that flag's comment for why this must never be an env mutation).
+    let captureParallelStreamForced = false;
     let deSelfVerifyFallback = false;
     let deFallbackReason: string | undefined;
     let deDrainStats: import("./render/stages/captureStreamingStage.js").DeDrainStats | undefined;
@@ -2238,6 +2242,39 @@ export async function executeRenderJob(
       deParallelRouter: deParallelRouter ?? "none",
     });
 
+    // Non-DE parallel-streaming router — see shouldStreamParallelCapture.
+    // Mutually exclusive with the DE inversion/router above by construction
+    // (both DE predicates require useDrawElement; this requires its negation).
+    const captureParallelStreamEligible = shouldStreamParallelCapture({
+      routerEnabled: process.env.HF_CAPTURE_PARALLEL_STREAM === "true",
+      workerCount,
+      useDrawElement: cfg.useDrawElement,
+      outputFormat,
+      streamingOk: shouldUseStreamingEncode(cfg, outputFormat, 1, job.duration),
+      layeredOrEffectRoute: hasHdrContent || compiled.hasShaderTransitions,
+    });
+    if (captureParallelStreamEligible) {
+      captureParallelStreamForced = true;
+      // Which mode will stream: the engine picks beginframe only on Linux with
+      // headless-shell and no forced screenshot (frameCapture.ts preMode);
+      // everything else is screenshot. Recorded for telemetry cohorting.
+      const captureParallelStream =
+        process.platform === "linux" && !captureForceScreenshot ? "beginframe" : "screenshot";
+      log.info(
+        `[Render] Parallel ${captureParallelStream} capture will stream to the encoder ` +
+          `(interleaved, ${workerCount} workers) instead of the disk path. ` +
+          "Set HF_CAPTURE_PARALLEL_STREAM=false to disable.",
+      );
+      updateCaptureObservability({ captureParallelStream });
+      // NOTE: no string data on the checkpoint — RenderObservationData string
+      // values are dropped unless the key is in observability.ts's
+      // ALLOWED_STRING_DATA_KEYS allow-list. The message carries the detail.
+      observability.checkpoint(
+        "worker_resolution",
+        `parallel ${captureParallelStream} capture routed to streaming`,
+      );
+    }
+
     if (workerCount > 1 && probeSession) {
       lastBrowserConsole = probeSession.browserConsoleBuffer;
       await closeCaptureSession(probeSession);
@@ -2254,7 +2291,7 @@ export async function executeRenderJob(
       outputFormat,
       workerCount,
       job.duration,
-      deParallelStreamForced,
+      deParallelStreamForced || captureParallelStreamForced,
     );
     log.info("streaming-encode gate", {
       enabled: useStreamingEncode,
@@ -2498,7 +2535,7 @@ export async function executeRenderJob(
                 workerCount,
                 probeSession,
                 outputFormat,
-                forceParallelStream: deParallelStreamForced,
+                forceParallelStream: deParallelStreamForced || captureParallelStreamForced,
                 streamingEncoderOptions: {
                   fps: job.config.fps,
                   width,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -2245,13 +2245,17 @@ export async function executeRenderJob(
     // Non-DE parallel-streaming router — see shouldStreamParallelCapture.
     // Mutually exclusive with the DE inversion/router above by construction
     // (both DE predicates require useDrawElement; this requires its negation).
-    const captureParallelStreamEligible = shouldStreamParallelCapture({
-      routerEnabled: process.env.HF_CAPTURE_PARALLEL_STREAM === "true",
+    const captureParallelStreamRouterEnabled = process.env.HF_CAPTURE_PARALLEL_STREAM === "true";
+    const captureParallelStreamArgs = {
       workerCount,
       useDrawElement: cfg.useDrawElement,
       outputFormat,
       streamingOk: shouldUseStreamingEncode(cfg, outputFormat, 1, job.duration),
       layeredOrEffectRoute: hasHdrContent || compiled.hasShaderTransitions,
+    };
+    const captureParallelStreamEligible = shouldStreamParallelCapture({
+      routerEnabled: captureParallelStreamRouterEnabled,
+      ...captureParallelStreamArgs,
     });
     if (captureParallelStreamEligible) {
       captureParallelStreamForced = true;
@@ -2273,6 +2277,13 @@ export async function executeRenderJob(
         "worker_resolution",
         `parallel ${captureParallelStream} capture routed to streaming`,
       );
+    } else if (shouldStreamParallelCapture({ routerEnabled: true, ...captureParallelStreamArgs })) {
+      // The kill switch is the ONLY failed gate: emit a passive cohort-sizing
+      // signal (capture_parallel_stream = "eligible_off") so the default-off
+      // soak can measure how many fleet renders WOULD route before anyone
+      // enables the flag. Observability-only — no behavior change, no log
+      // noise on the default path.
+      updateCaptureObservability({ captureParallelStream: "eligible_off" });
     }
 
     if (workerCount > 1 && probeSession) {


### PR DESCRIPTION
## Summary

Routes multi-worker NON-drawElement renders (screenshot on macOS/Windows, BeginFrame on Linux/Docker) through the existing interleaved parallel-streaming encoder (PR #2056 machinery) instead of the parallel disk path, behind default-off `HF_CAPTURE_PARALLEL_STREAM`. Zero engine/stage changes — one orchestrator predicate (`shouldStreamParallelCapture`) + per-render flag threading (`captureParallelStreamForced`, following the existing `deParallelStreamForced` pattern — no `process.env` mutation) + telemetry (`capture_parallel_stream` on both `render_complete` and `render_error`).

Motivation: on the disk path, encode is a purely additive tail after capture completes. On Linux the whole fleet is drawElement-ineligible (SwiftShader, no hardware GPU), so this is the only parallel-encode speedup lever available there.

**Soak signal while default-off:** renders that pass every gate *except* the kill switch emit `capture_parallel_stream: "eligible_off"` (observability-only, no log line, no behavior change). This sizes the eligible cohort fleet-wide before anyone enables the flag; `"screenshot"` / `"beginframe"` values mean the render actually routed.

Benchmarked end-to-end on native Linux (AMD EPYC 9R14, 8 vCPU, chrome-headless-shell 152.0.7928.2, software/SwiftShader rendering) — 3 reps per cell, arms interleaved, hygiene between runs, every arm verified from logs (not flags).

## Numbers (Linux, native)

### Task 2 — pre-implementation baseline (escape-hatch `HF_DE_PARALLEL_STREAM=true`)

Per-cell medians (ms) and streaming-vs-disk speedup:

| comp | capmode | W1 median | W3-disk median | W3-stream median | stream speedup vs disk |
|---|---|---|---|---|---|
| uniform | bf | 156,276 | 120,559 | 110,076 | **1.095×** |
| uniform | ss | 274,064 | 163,759 | 148,678 | **1.101×** |
| static  | bf | 146,092 | 94,166  | 86,595  | **1.087×** |
| static  | ss | 166,228 | 116,166 | 118,937 | **0.977×** (2.4% slower) |

Go/no-go gate: **GO** — all 36 rows (2 comps × 2 capmodes × 3 arms × 3 reps) verified `ok` from logs (zero `NO_STREAMING`/`DISK_FALLBACK`/`NOT_BEGINFRAME`/`NOT_SCREENSHOT`/`DE_ENGAGED`); this is the first time the streaming plumbing has been confirmed working end-to-end under BeginFrame in production (previously only code-verified).

### Task 6 — post-implementation validation (production router `HF_CAPTURE_PARALLEL_STREAM=true`)

**Router smoke**: log line + `captureParallelStream` observability field present when enabled; with no env var set the render uses the disk path and reports `eligible_off` (multi-worker eligible renders) or no field at all (ineligible, e.g. single-worker) — all three directions verified end-to-end.

**Criterion 1 — router-mode `w3stream` within ±10% of Task 2's flag-mode `w3stream`** (proves the new gate reuses the identical mechanism, not a divergent path):

| cell | baseline (flag) | router | delta | verdict |
|---|---|---|---|---|
| uniform/bf | 110,076 | 109,747 | −0.30% | **PASS** |
| uniform/ss | 148,678 | 148,689 | +0.01% | **PASS** |
| static/bf  | 86,595  | 86,725  | +0.15% | **PASS** |
| static/ss  | 118,937 | 117,391 | −1.30% | **PASS** |

**Criterion 2 — uniform comp: `w3stream` ≥1.10× faster than `w3disk`:**

| cell | w3disk | w3stream | speedup | verdict |
|---|---|---|---|---|
| uniform/bf | 120,302 | 109,747 | 1.096× | **FAIL** (just under bar — see note below) |
| uniform/ss | 163,868 | 148,689 | 1.102× | **PASS** |

**Criterion 3 — static comp: `w3stream` no more than 1.10× slower than `w3disk`:**

| cell | w3disk | w3stream | ratio | verdict |
|---|---|---|---|---|
| static/bf | 93,207  | 86,725  | 0.930× (faster) | **PASS** |
| static/ss | 115,977 | 117,391 | 1.012×           | **PASS** |

**Criterion 4 — PSNR parity** (re-run on router-mode outputs):

| comparison | uniform/bf | uniform/ss | static/bf | static/ss |
|---|---|---|---|---|
| disk vs stream | 51.60 dB | 51.78 dB | 59.42 dB | 56.53 dB |

| comparison (BF only, interleaved-determinism) | uniform | static |
|---|---|---|
| W1 vs W3-stream | 46.46 dB | 47.98 dB |

All ≥45dB — **PASS** across all 6 comparisons.

### On the uniform/bf 1.096× shortfall (criterion 2)

Not a wiring defect. Stage decomposition from the disk path (`captureMs`/`encodeMs` from `perfSummary.stages`): `uniform/bf` disk-path capture takes ~79.2s, encode ~40.4s, giving a theoretical streaming ceiling of `disk_total/captureMs ≈ 1.52×` (if encode fully hid behind capture). The observed 1.096× captures only ~18% of that ceiling because this benchmark machine is an 8-core box running 3 concurrent SwiftShader (software-GL) capture workers — capture is already CPU-bound, leaving little idle capacity for the also-CPU-bound libx264 encode to overlap into. The 1.10× bar was calibrated to the original macOS spike's hardware-GPU numbers (1.29× observed there, where capture uses the GPU and leaves CPU free for encode); this machine's ceiling is comparable-or-larger (1.33–1.52× across cells) but a much smaller fraction gets captured due to CPU contention. `uniform/ss` clears the bar on the same hardware. Recorded in full in the benchmark notes; not chased with implementation changes per the plan's own "valid negative result" guidance.

## Test plan

- [x] predicate unit matrix (7 tests) in `renderOrchestrator.test.ts` — 122/122 passing
- [x] telemetry payload + event tests (`capture_parallel_stream` on `render_complete` AND `render_error`, including the `eligible_off` value) — 34/34 passing
- [x] Linux end-to-end: router smoke (log line + observability field present when enabled, absent when not), full 36-cell benchmark matrix in router mode (all verified `ok`), PSNR parity disk-vs-stream and w1-vs-w3stream all ≥45dB
- [x] default-off verified end-to-end, all three directions: flag off + eligible render → `eligible_off` field, disk path unchanged; flag on → routed (`beginframe`); ineligible render (W1) → field absent
- [x] `bunx tsc --noEmit` clean on both `packages/producer` and `packages/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)