### PR TITLE
fix(lint): honor data-no-timeline on root compositions

### DIFF
--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -227,6 +227,15 @@ describe("core rules", () => {
     expect(finding).toBeDefined();
   });
 
+  it("allows a timeline-free root that explicitly declares data-no-timeline", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-no-timeline data-width="1920" data-height="1080" data-duration="5"></div>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    expect(result.findings.find((f) => f.code === "missing_timeline_registry")).toBeUndefined();
+  });
+
   it("does not flag missing_timeline_registry on a sub-composition (inherits from host)", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/rules/core.ts
+++ b/packages/lint/src/rules/core.ts
@@ -264,11 +264,12 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
   },
 
   // missing_timeline_registry + timeline_registry_missing_init
-  ({ source, rawSource, options }) => {
+  ({ source, rawSource, rootTag, options }) => {
     // Sub-compositions inherit window.__timelines from the host composition
     if (options.isSubComposition || rawSource.trimStart().toLowerCase().startsWith("<template")) {
       return [];
     }
+    if (/(?:^|\s)data-no-timeline(?=[\s=/]|$)/i.test(rootTag?.attrs || "")) return [];
     const findings: HyperframeLintFinding[] = [];
     if (
       !TIMELINE_REGISTRY_INIT_PATTERN.test(source) &&


### PR DESCRIPTION
## What

Allow root compositions that explicitly declare `data-no-timeline` to omit `window.__timelines` without triggering the hard `missing_timeline_registry` error.

## Why

The composition lint contract already documents `data-no-timeline` as the opt-out for deterministic CSS/WAAPI compositions, but the core registry rule ignored it and forced authors to add a token GSAP timeline. This contradicted the dedicated `missing_data_no_timeline` rule and produced a false error on valid CSS-only projects.

## How

- Read the root composition's authored attributes in the core registry rule.
- Skip only the generic registry requirement when the exact `data-no-timeline` attribute is present.
- Preserve the dedicated GSAP safety rule: an actual unregistered `gsap.timeline()` is still an error.
- Add a regression test for a timeline-free root composition.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

Validation performed:
- `bun run --filter @hyperframes/lint test` (359 passed)
- `bun run --filter @hyperframes/lint typecheck`
- `bunx oxfmt --check packages/lint/src/rules/core.ts packages/lint/src/rules/core.test.ts`
- `bunx oxlint packages/lint/src/rules/core.ts packages/lint/src/rules/core.test.ts`
- pre-commit lint, format, fallow, and repository typecheck hooks
