### PR TITLE
fix(product-launch): preserve brand font and accent roles

### DIFF
--- a/skills/product-launch-video/scripts/build-frame.mjs
+++ b/skills/product-launch-video/scripts/build-frame.mjs
@@ -32,6 +32,7 @@ import { fileURLToPath } from "node:url";
 import {
   brandRolesFromStats,
   chroma,
+  isIconFont,
   lum,
   parseColors,
   parseFonts,
@@ -163,10 +164,6 @@ let brandFontWeights = []; // weights the brand text font actually ships (tokens
 let brandColorStats = []; // rich per-color usage stats (areaBg / interactiveBg / textCount …)
 // Icon/glyph fonts capture surfaces as "fonts" — they are never the brand text face
 // (webflow-icons, Font Awesome, icomoon …) and must not become display/body or contribute weights.
-const isIconFont = (name) =>
-  /(?:^|[\s_-])icons?(?:[\s_-]|$)|icomoon|font\s*-?awesome|glyphicons?|material\s*icons|feather\s*icons/i.test(
-    String(name),
-  );
 if (existsSync(tokensPath)) {
   try {
     const t = JSON.parse(readFileSync(tokensPath, "utf8"));

--- a/skills/product-launch-video/scripts/lib/tokens.mjs
+++ b/skills/product-launch-video/scripts/lib/tokens.mjs
@@ -48,6 +48,12 @@ export const UA_DEFAULT_COLORS = new Set(
   ["#0000EE", "#0000FF", "#0000CC", "#1A0DAB", "#551A8B", "#EE0000"].map((c) => c.toUpperCase()),
 );
 
+export function isIconFont(name) {
+  return /(?:^|[\s_-])icons?(?:[\s_-]|$)|icomoon|font\s*-?awesome|glyphicons?|material\s*icons|feather\s*icons|(?:icon|glyph).*font|font.*(?:icon|glyph)|font$/i.test(
+    String(name),
+  );
+}
+
 // Semantic STATUS roles (green "positive", red "negative"/"error", amber "warning" …). Their HUE
 // carries the meaning, so they are never a brand ACCENT — a status red is frequently the most
 // chromatic color in a palette (e.g. #dc2626 chroma 182 beats a deep-blue accent #1E40AF chroma
@@ -127,15 +133,7 @@ export function brandRolesFromStats(stats, colorsInOrder) {
       .find((s) => Math.abs((lum(s.hex) ?? 0) - cl) > 64)?.hex ??
     (cl > 128 ? "#000000" : "#FFFFFF");
   const accent2 =
-    v
-      .filter(
-        (s) =>
-          ![canvas, ink, accent].includes(s.hex) &&
-          (s.interactiveBg || 0) > 0 &&
-          chroma(s.hex) > 40 &&
-          !UA_DEFAULT_COLORS.has(s.hex.toUpperCase()),
-      )
-      .sort((a, b) => (b.interactiveBg || 0) - (a.interactiveBg || 0))[0]?.hex ?? accent;
+    pickAccent(v, colorsInOrder ?? v.map((s) => s.hex), [canvas, ink, accent]) ?? accent;
   return { ink, canvas, accent, accent2 };
 }
 

--- a/skills/product-launch-video/scripts/lib/tokens.test.mjs
+++ b/skills/product-launch-video/scripts/lib/tokens.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { brandRolesFromStats, isIconFont } from "./tokens.mjs";
+
+test("recognizes brand-specific icon font names", () => {
+  assert.equal(isIconFont("vidaXLfont"), true);
+  assert.equal(isIconFont("BrandGlyphFont"), true);
+  assert.equal(isIconFont("Poppins"), false);
+});
+
+test("preserves a prominent second accent used outside interactive backgrounds", () => {
+  const colors = ["#FFFFFF", "#2D1238", "#F3E62B", "#111111"];
+  const stats = [
+    { hex: "#FFFFFF", areaBg: 1000, maxArea: 1000 },
+    { hex: "#2D1238", textCount: 4, interactiveBg: 3 },
+    { hex: "#F3E62B", textCount: 3, interactiveBg: 0 },
+    { hex: "#111111", textCount: 20 },
+  ];
+
+  assert.deepEqual(brandRolesFromStats(stats, colors), {
+    canvas: "#FFFFFF",
+    ink: "#111111",
+    accent: "#F3E62B",
+    accent2: "#2D1238",
+  });
+});


### PR DESCRIPTION
## What

Keep product-launch brand remixing from selecting custom icon fonts as display/body typography and from collapsing a legitimate two-accent palette into one hue.

## Why

Two independent product-launch runs required manual `frame.md` repairs: custom glyph fonts such as `vidaXLfont` replaced text fonts, while a secondary brand accent used in text/icons was discarded because it had no `interactiveBg` count.

## How

- Centralize and broaden icon-font detection to cover custom `*font` glyph families.
- Select the secondary accent with the same prominence-aware picker used for the primary, excluding canvas, ink, and the chosen primary.
- Add regression cases for custom icon-font names and a plum/lemon palette where the second accent is not an interactive background.

## Test plan

- `node --test skills/product-launch-video/scripts/lib/tokens.test.mjs`
- `bun run test:skills` (216 passed)
- `bunx oxfmt --check skills/product-launch-video/scripts/build-frame.mjs skills/product-launch-video/scripts/lib/tokens.mjs skills/product-launch-video/scripts/lib/tokens.test.mjs`
- `bunx oxlint skills/product-launch-video/scripts/build-frame.mjs skills/product-launch-video/scripts/lib/tokens.mjs skills/product-launch-video/scripts/lib/tokens.test.mjs`
- `bun run lint:skills`