### PR TITLE
fix(render): check disk space on write volumes

### DIFF
--- a/packages/cli/src/browser/preflight.test.ts
+++ b/packages/cli/src/browser/preflight.test.ts
@@ -1,6 +1,6 @@
 // fallow-ignore-file code-duplication
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { parseToolVersion, runEnvironmentChecks } from "./preflight.js";
+import { checkDisk, parseToolVersion, runEnvironmentChecks } from "./preflight.js";
 import * as manager from "./manager.js";
 import * as linuxDeps from "./linuxDeps.js";
 
@@ -185,5 +185,17 @@ describe("parseToolVersion", () => {
     expect(parseToolVersion("ffprobe version 7.1.1-essentials_build-www.gyan.dev Copyright")).toBe(
       "ffprobe 7.1.1-essentials_build-www.gyan.dev",
     );
+  });
+});
+
+describe("checkDisk", () => {
+  it("checks the requested render volume", () => {
+    const freeDiskMb = vi.fn(() => 512);
+
+    expect(checkDisk("/external/render-output", freeDiskMb)).toMatchObject({
+      ok: false,
+      detail: "0.5 GB free at /external/render-output",
+    });
+    expect(freeDiskMb).toHaveBeenCalledWith("/external/render-output");
   });
 });

--- a/packages/cli/src/browser/preflight.ts
+++ b/packages/cli/src/browser/preflight.ts
@@ -38,6 +38,7 @@ export interface EnvironmentCheckResult {
 
 export interface EnvironmentCheckOptions {
   projectDir?: string;
+  diskPaths?: string[];
   browserPath?: string;
   includeBrowser?: boolean;
   includeDisk?: boolean;
@@ -205,8 +206,11 @@ async function checkChrome(browserPath?: string): Promise<EnvironmentCheckOutcom
   };
 }
 
-function checkDisk(projectDir = "."): EnvironmentCheckOutcome {
-  const freeMb = getFreeDiskMb(projectDir);
+export function checkDisk(
+  path = ".",
+  freeDiskMb: (path: string) => number | null = getFreeDiskMb,
+): EnvironmentCheckOutcome {
+  const freeMb = freeDiskMb(path);
   if (freeMb === null) {
     return { name: "Disk", ok: true, level: "ok", detail: "Unable to check" };
   }
@@ -217,11 +221,11 @@ function checkDisk(projectDir = "."): EnvironmentCheckOutcome {
       ok: false,
       level: "error",
       title: "Low disk space",
-      detail: `${freeGb} GB free`,
+      detail: `${freeGb} GB free at ${path}`,
       hint: "Renders produce large temp files. Free disk space before rendering.",
     };
   }
-  return { name: "Disk", ok: true, level: "ok", detail: `${freeGb} GB free` };
+  return { name: "Disk", ok: true, level: "ok", detail: `${freeGb} GB free at ${path}` };
 }
 
 function checkWindowsUncPath(projectDir = process.cwd()): EnvironmentCheckOutcome | undefined {
@@ -260,7 +264,8 @@ export async function runEnvironmentChecks(
   }
 
   if (options.includeDisk) {
-    outcomes.push(checkDisk(options.projectDir));
+    const diskPaths = [...new Set(options.diskPaths ?? [options.projectDir ?? "."])];
+    outcomes.push(...diskPaths.map((path) => checkDisk(path)));
   }
 
   if (options.includeWindowsUnc) {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1423,6 +1423,7 @@ export async function renderLocal(
 ): Promise<SingleRenderResult> {
   const preflight = await runEnvironmentChecks({
     projectDir,
+    diskPaths: [tmpdir(), dirname(outputPath)],
     browserPath: options.browserPath,
     includeBrowser: true,
     includeDisk: true,


### PR DESCRIPTION
## What

Make local render disk preflight validate the temp/intermediate volume and final output volume instead of the project source volume.

## Why

A render with `TMPDIR` and `--output` on a roomy external drive was blocked because preflight only measured the low-space project volume, even though that volume was not receiving the large render artifacts.

## How

- Add explicit disk paths to environment-check options.
- Check both `os.tmpdir()` and `dirname(outputPath)` for local renders.
- Include the checked path in low-space diagnostics.
- Add a regression test proving the requested render volume is measured.

## Test plan

- `bunx vitest run packages/cli/src/browser/preflight.test.ts` (11 passed)
- `bun run --filter @hyperframes/cli typecheck`
- `bunx oxfmt --check packages/cli/src/browser/preflight.ts packages/cli/src/browser/preflight.test.ts packages/cli/src/commands/render.ts`
- `bunx oxlint packages/cli/src/browser/preflight.ts packages/cli/src/browser/preflight.test.ts packages/cli/src/commands/render.ts`