### PR TITLE
fix(website-to-video): correct local render dimensions guidance

### DIFF
--- a/packages/cli/src/commands/websiteToVideoSkillContent.test.ts
+++ b/packages/cli/src/commands/websiteToVideoSkillContent.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..", "..", "..");
+const VALIDATION_GUIDE = readFileSync(
+  join(REPO_ROOT, "skills", "website-to-video", "references", "step-6-validate.md"),
+  "utf8",
+);
+
+describe("website-to-video validation guide", () => {
+  it("does not pass cloud-only dimension flags to local render", () => {
+    const localRenderExample = VALIDATION_GUIDE.match(
+      /node \/<repo-root>\/packages\/cli\/dist\/cli\.js render[\s\S]*?```/,
+    )?.[0];
+
+    expect(localRenderExample).toBeDefined();
+    expect(localRenderExample).not.toContain("--width");
+    expect(localRenderExample).not.toContain("--height");
+    expect(localRenderExample).toContain("--quality draft");
+  });
+});

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -78,7 +78,7 @@
       "files": 27
     },
     "website-to-video": {
-      "hash": "e8143700c50b7469",
+      "hash": "623619275f0fa75b",
       "files": 32
     }
   }

--- a/skills/website-to-video/references/step-6-validate.md
+++ b/skills/website-to-video/references/step-6-validate.md
@@ -230,13 +230,16 @@ Open the Studio URL in a browser via Playwright (or another browser tool you hav
 [ ] Audio audible and not clipped/peaked
 ```
 
-### Path 2: Render a low-res MP4 and read it frame-by-frame
+### Path 2: Render a draft MP4 and read it frame-by-frame
 
-When Playwright isn't available, render at 540p (fast — ~30s for a 30s video) and read the MP4:
+When Playwright isn't available, render at draft quality and read the MP4. Local
+`hyperframes render` takes its canvas dimensions from the composition's
+`data-width` / `data-height`; `--width` and `--height` are cloud-render flags and
+are not supported by the local command.
 
 ```bash
 node /<repo-root>/packages/cli/dist/cli.js render <project-dir> \
-  --width 960 --height 540 --quality medium
+  --quality draft
 ```
 
 Then sample the resulting MP4 at minimum 5fps (use `ffmpeg -i <mp4> -r 5 frames/frame-%04d.png` if needed). Read those frames sequentially. For each SFX moment in STORYBOARD.md, find the corresponding frame and confirm the visual matches.


### PR DESCRIPTION
## What
- replace the unsupported local `render --width/--height` example with a draft-quality render
- explain that local canvas dimensions come from composition metadata
- add a content regression test for the documented local render command

## Why
CLI feedback reported that v0.7.52 rejected the documented `--width`/`--height` flags. Those flags belong to cloud rendering; local `hyperframes render` does not expose them.

## How
The validation fallback now uses `--quality draft` at the composition's authored dimensions. A focused test extracts the local render example and prevents cloud-only dimension flags from returning.

## Test plan
- `bun run --cwd packages/cli test src/commands/websiteToVideoSkillContent.test.ts`
- pre-commit lint, format, skills-manifest, fallow, and typecheck hooks