### PR TITLE
fix(cli): preserve snapshot alpha and create shot dirs

### DIFF
--- a/packages/cli/src/capture/captureCompositionFrame.test.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.test.ts
@@ -293,7 +293,11 @@ describe("captureRegionCrop", () => {
     const buffer = await captureRegionCrop(page, region, 3);
 
     expect(setViewport).toHaveBeenNthCalledWith(1, { ...original, deviceScaleFactor: 3 });
-    expect(screenshot).toHaveBeenCalledWith({ clip: region, type: "png" });
+    expect(screenshot).toHaveBeenCalledWith({
+      clip: region,
+      type: "png",
+      omitBackground: true,
+    });
     expect(setViewport).toHaveBeenNthCalledWith(2, original);
     expect(buffer).toBeInstanceOf(Buffer);
     expect(Array.from(buffer)).toEqual([1, 2, 3]);

--- a/packages/cli/src/capture/captureCompositionFrame.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.ts
@@ -421,7 +421,7 @@ export interface CropCapturePage {
     height: number;
     deviceScaleFactor?: number;
   }): Promise<void>;
-  screenshot(options: { clip: CropRegion; type: "png" }): Promise<Uint8Array>;
+  screenshot(options: { clip: CropRegion; type: "png"; omitBackground: true }): Promise<Uint8Array>;
 }
 
 /**
@@ -440,7 +440,7 @@ export async function captureRegionCrop(
   const original = page.viewport();
   if (original) await page.setViewport({ ...original, deviceScaleFactor: scale });
   try {
-    const shot = await page.screenshot({ clip: region, type: "png" });
+    const shot = await page.screenshot({ clip: region, type: "png", omitBackground: true });
     return Buffer.isBuffer(shot) ? shot : Buffer.from(shot);
   } finally {
     if (original) await page.setViewport(original);

--- a/packages/cli/src/commands/keyframes.test.ts
+++ b/packages/cli/src/commands/keyframes.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
 import { ensureDOMParser } from "../utils/dom.js";
 import { collectShotSelectors, resolveScope, surfaceComposition } from "./keyframes.js";
+import { ensureShotOutputDir } from "./motionShot.js";
 
 beforeAll(() => ensureDOMParser());
 
@@ -23,6 +24,15 @@ describe("keyframes direct composition scope", () => {
 
     expect(scope.projectDir).toBe(projectDir);
     expect(scope.entryFile).toBe("compositions/scene.html");
+  });
+});
+
+describe("keyframes shot output", () => {
+  it("creates a missing parent directory before writing --shot", () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-keyframes-shot-dir-"));
+    const outputDir = join(projectDir, "nested", "proofs");
+    ensureShotOutputDir(join(outputDir, "shot.png"));
+    expect(existsSync(outputDir)).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/motionShot.ts
+++ b/packages/cli/src/commands/motionShot.ts
@@ -10,7 +10,8 @@
 // exactly what it's editing. All geometry + SVG live in ./motionShotLayout.ts
 // (pure, tested); this file only drives the browser and SAMPLES.
 
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import {
   buildOnionSvg,
   ghostAlphas,
@@ -23,6 +24,10 @@ import {
 export interface ShotRequest {
   /** CSS selector of the moving element to sample (e.g. "#dot"). */
   selector: string;
+}
+
+export function ensureShotOutputDir(outPath: string): void {
+  mkdirSync(dirname(outPath), { recursive: true });
 }
 
 /** Returned by the in-browser selector resolver: which animated selectors a
@@ -611,6 +616,7 @@ export async function captureMotionPathShot(
   outPath: string,
   opts: ShotOptions = {},
 ): Promise<string> {
+  ensureShotOutputDir(outPath);
   let requests = requestsIn;
   const samples = Math.max(1, Math.min(60, opts.samples ?? 9));
   const layout = opts.layout ?? "path";

--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { computeSnapshotTimes, parseZoomScale, tailFrameTime } from "./snapshot.js";
+import { readFileSync } from "node:fs";
 
 // --zoom's crop-region math (selector bbox + padding + clamp, exact region
 // form, no-match error) is owned by and tested in
@@ -18,6 +19,15 @@ describe("tailFrameTime", () => {
 
   it("never goes negative", () => {
     expect(tailFrameTime(0)).toBe(0);
+  });
+});
+
+describe("transparent snapshot capture", () => {
+  it("asks Chrome to retain the alpha channel in review PNGs", () => {
+    const source = readFileSync(new URL("./snapshot.ts", import.meta.url), "utf8");
+    expect(source).toContain(
+      'page.screenshot({ path: framePath, type: "png", omitBackground: true })',
+    );
   });
 });
 

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -465,7 +465,7 @@ async function captureSnapshots(
           );
           writeFileSync(framePath, buffer);
         } else {
-          await page.screenshot({ path: framePath, type: "png" });
+          await page.screenshot({ path: framePath, type: "png", omitBackground: true });
         }
         const rel = relative(projectDir, framePath);
         savedPaths.push(rel.startsWith("..") || isAbsolute(rel) ? framePath : rel);


### PR DESCRIPTION
## What
- preserve transparency in full-frame and zoomed snapshot PNGs
- create missing parent directories for `keyframes --shot` output paths

## Why
Transparent standalone overlays rendered correctly to VP9 alpha, but their snapshot review PNGs were forced to opaque RGB. The same workflow also failed with ENOENT when `--shot` targeted a file inside a directory that did not already exist. Both behaviors reproduce on CLI 0.7.52.

## How
- pass Puppeteer `omitBackground: true` for snapshot screenshots and cropped snapshot captures
- recursively create the shot output parent before browser capture
- add regression coverage for both behaviors

## Test plan
- `bun run --filter @hyperframes/cli test -- --run src/commands/snapshot.test.ts src/commands/keyframes.test.ts src/capture/captureCompositionFrame.test.ts`
- `bun run --filter @hyperframes/cli typecheck`
- `bunx oxlint` on the six changed files
- built the CLI and verified a transparent repro emits RGBA snapshot PNGs and writes a nested `--shot` path without pre-creating the directory