### PR TITLE
fix(producer): tolerate rounded frame-boundary durations

### DIFF
--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -279,6 +279,30 @@ describe("runProbeStage — forceScreenshot threading", () => {
   });
 });
 
+describe("runProbeStage — decimal duration frame count", () => {
+  it("does not add a frame for a six-decimal duration rounded from an exact frame boundary", async () => {
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 32.866667;
+    input.compiled.staticDuration = 32.866667;
+
+    const result = await runProbeStage(input);
+
+    expect(result.totalFrames).toBe(986);
+  });
+
+  it("still ceilings a duration that genuinely extends into the next frame", async () => {
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 32.867;
+    input.compiled.staticDuration = 32.867;
+
+    const result = await runProbeStage(input);
+
+    expect(result.totalFrames).toBe(987);
+  });
+});
+
 describe("runProbeStage — transient browser error retry (#1687)", () => {
   it("retries once on a transient 'Navigating frame was detached' error and succeeds", async () => {
     resetRetryMocks();

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -83,6 +83,16 @@ export interface ProbeStageInput {
   deviceScaleFactor: number;
 }
 
+const FRAME_BOUNDARY_EPSILON = 1e-3;
+
+function durationToFrameCount(duration: number, fps: number): number {
+  const rawFrameCount = duration * fps;
+  const nearestFrame = Math.round(rawFrameCount);
+  return Math.abs(rawFrameCount - nearestFrame) <= FRAME_BOUNDARY_EPSILON
+    ? nearestFrame
+    : Math.ceil(rawFrameCount);
+}
+
 export interface ProbeStageResult {
   /** May be reassigned from `recompileWithResolutions`. */
   compiled: CompiledComposition;
@@ -536,7 +546,7 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
   const browserProbeMs = Date.now() - probeStart;
 
   const duration = composition.duration;
-  const totalFrames = Math.ceil(duration * fpsToNumber(job.config.fps));
+  const totalFrames = durationToFrameCount(duration, fpsToNumber(job.config.fps));
 
   if (duration <= 0) {
     // Gather diagnostics to help users understand why the render would produce a black video.


### PR DESCRIPTION
## What
- avoid an extra output frame when a decimal duration is a serialized approximation of an exact frame boundary
- retain ceiling behavior for durations that genuinely extend into the next frame

## Why
At 30fps, a static duration of `32.866667` represents 986 frames after six-decimal serialization. Multiplication yields `986.00001`, so the producer probe stage's raw `Math.ceil` scheduled 987 frames and required a post-render one-frame trim.

## How
Convert duration to frame count by snapping values within 0.001 frame of an integer boundary, otherwise ceiling as before. This tolerance is wider than six-decimal metadata error even at high frame rates, while remaining far below a visible frame interval.

## Test plan
- added a regression test that first failed with 987 and now returns 986 for `32.866667` at 30fps
- added a guard test confirming `32.867` still ceilings to 987
- `bun test packages/producer/src/services/render/stages/probeStage.test.ts`
- `bun run --filter @hyperframes/producer typecheck`
- `bunx oxlint packages/producer/src/services/render/stages/probeStage.ts packages/producer/src/services/render/stages/probeStage.test.ts`
- pre-commit lint, format, fallow, and typecheck hooks passed