### PR TITLE
fix(registry): remove invalid editorial video placeholder

### DIFF
--- a/packages/lint/src/rules/media.test.ts
+++ b/packages/lint/src/rules/media.test.ts
@@ -1,7 +1,23 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { lintHyperframeHtml } from "../hyperframeLinter.js";
 
 describe("media rules", () => {
+  it("keeps the editorial emphasis registry component free of invalid placeholder media", async () => {
+    const component = readFileSync(
+      resolve(
+        process.cwd(),
+        "../../registry/components/caption-editorial-emphasis/caption-editorial-emphasis.html",
+      ),
+      "utf8",
+    );
+
+    const result = await lintHyperframeHtml(component);
+
+    expect(result.findings.find((finding) => finding.code === "media_missing_src")).toBeUndefined();
+  });
+
   it("reports error for duplicate media ids", async () => {
     const html = `
 <html><body>

--- a/registry/components/caption-editorial-emphasis/caption-editorial-emphasis.html
+++ b/registry/components/caption-editorial-emphasis/caption-editorial-emphasis.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -132,17 +123,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-editorial-emphasis/demo.html
+++ b/registry/components/caption-editorial-emphasis/demo.html
@@ -36,15 +36,6 @@
         background: #000;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -130,17 +121,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>


### PR DESCRIPTION
## What
- remove the source-less background video placeholder from `caption-editorial-emphasis`
- remove the same unused placeholder from its demo
- lint the actual shipped registry component in a regression test

## Why
`hyperframes add caption-editorial-emphasis` installed a component containing a timed `<video>` with no `src`. CLI 0.7.52 correctly raised `media_missing_src`, so the component could not be reused directly and had to be removed from the final composition.

## How
The placeholder had no source and no runtime references, so the component now remains a transparent, host-agnostic caption overlay. The test reads the real registry artifact and asserts it has no `media_missing_src` finding.

## Test plan
- reproduced via `hyperframes add caption-editorial-emphasis` followed by lint of the installed artifact
- watched the new regression test fail with `media_missing_src` before the change
- `bun run --filter @hyperframes/lint test -- --run src/rules/media.test.ts` (22 passed)
- `bunx oxlint packages/lint/src/rules/media.test.ts`
- `bun run --filter @hyperframes/lint typecheck`
- pre-commit lint, format, fallow, and typecheck hooks passed