### PR TITLE
fix(render): scale timeout for long video encodes

### DIFF
--- a/packages/producer/src/services/render/stages/encodeStage.test.ts
+++ b/packages/producer/src/services/render/stages/encodeStage.test.ts
@@ -154,6 +154,24 @@ describe("gif encode args", () => {
 });
 
 describe("runEncodeStage config plumbing", () => {
+  it("scales the encode timeout for long compositions", async () => {
+    const { runEncodeStage } = await import("./encodeStage.js");
+
+    await runEncodeStage(
+      makeInput({
+        job: {
+          ...makeInput().job,
+          duration: 754.8,
+        },
+        engineConfig: { ffmpegEncodeTimeout: 600_000 },
+      }),
+    );
+
+    expect(encodeFramesFromDirMock.mock.calls[0]?.[5]).toEqual({
+      ffmpegEncodeTimeout: 3_019_200,
+    });
+  });
+
   it("prefers engine config supplied by the orchestrator", async () => {
     const { runEncodeStage } = await import("./encodeStage.js");
     const orchestratorEngineConfig = { ffmpegEncodeTimeout: 54_321 };

--- a/packages/producer/src/services/render/stages/encodeStage.ts
+++ b/packages/producer/src/services/render/stages/encodeStage.ts
@@ -277,6 +277,16 @@ export async function runEncodeStage(input: EncodeStageInput): Promise<EncodeSta
   // ── Stage 5: Encode ───────────────────────────────────────────────
   updateJobStatus(job, "encoding", "Encoding video", 75, onProgress);
 
+  // ffmpegEncodeTimeout is a total wall-clock cap, not an inactivity timeout.
+  // A fixed ten-minute cap reliably kills long high-quality disk-frame encodes
+  // that are still making progress. Preserve larger operator overrides while
+  // guaranteeing four seconds of encode budget per second of source video.
+  const scaledEncodeTimeout = Math.ceil((job.duration ?? 0) * 4_000);
+  const videoEngineCfg =
+    scaledEncodeTimeout > engineCfg.ffmpegEncodeTimeout
+      ? { ...engineCfg, ffmpegEncodeTimeout: scaledEncodeTimeout }
+      : engineCfg;
+
   const frameExt = needsAlpha ? "png" : "jpg";
   const framePattern = `frame_%06d.${frameExt}`;
   const encoderOpts = {
@@ -305,7 +315,7 @@ export async function runEncodeStage(input: EncodeStageInput): Promise<EncodeSta
         encoderOpts,
         chunkedEncodeSize,
         abortSignal,
-        engineCfg,
+        videoEngineCfg,
       )
     : await encodeFramesFromDir(
         framesDir,
@@ -313,7 +323,7 @@ export async function runEncodeStage(input: EncodeStageInput): Promise<EncodeSta
         videoOnlyPath,
         encoderOpts,
         abortSignal,
-        engineCfg,
+        videoEngineCfg,
       );
   assertNotAborted();
 


### PR DESCRIPTION
## What
Scale the video encode timeout to at least four times the composition duration while preserving larger operator overrides.

## Why
The existing 600-second total wall-clock timeout kills long disk-frame encodes that are still making progress. Two Windows reports reproduced this on 353-second and 755-second compositions; both completed after manually increasing `FFMPEG_ENCODE_TIMEOUT_MS`.

## How
Derive a video-only engine config in the encode stage with `max(configured timeout, duration × 4 seconds)`. GIF behavior and short-render config identity remain unchanged.

## Test plan
- `bun test packages/producer/src/services/render/stages/encodeStage.test.ts --timeout 30000`
- `bun run --filter @hyperframes/producer typecheck`
- pre-commit lint, format, tracked-artifact, fallow, and typecheck hooks