### PR TITLE
fix(render): stream long low-memory captures

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -392,6 +392,7 @@ describe("shouldUseStreamingEncode", () => {
   const streamingEnabledConfig = {
     enableStreamingEncode: true,
     streamingEncodeMaxDurationSeconds: 240,
+    lowMemoryMode: false,
   };
 
   it("enables streaming for default single-worker video renders", () => {
@@ -433,6 +434,12 @@ describe("shouldUseStreamingEncode", () => {
         120.001,
       ),
     ).toBe(false);
+  });
+
+  it("keeps long single-worker renders streaming in low-memory mode", () => {
+    expect(
+      shouldUseStreamingEncode({ ...streamingEnabledConfig, lowMemoryMode: true }, "mp4", 1, 411),
+    ).toBe(true);
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -966,7 +966,8 @@ function replaceBodyWithRenderClone(body: HTMLElement, renderClone: Element): vo
 }
 
 export function shouldUseStreamingEncode(
-  cfg: Pick<EngineConfig, "enableStreamingEncode" | "streamingEncodeMaxDurationSeconds">,
+  cfg: Pick<EngineConfig, "enableStreamingEncode" | "streamingEncodeMaxDurationSeconds"> &
+    Partial<Pick<EngineConfig, "lowMemoryMode">>,
   outputFormat: NonNullable<RenderConfig["format"]>,
   workerCount: number,
   // Composition timeline duration in seconds.
@@ -980,7 +981,11 @@ export function shouldUseStreamingEncode(
   if (outputFormat === "png-sequence") return false;
   if (outputFormat === "gif") return false;
   if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return false;
-  if (durationSeconds > cfg.streamingEncodeMaxDurationSeconds) return false;
+  // Low-memory mode already pins capture to one worker. Keep those renders on
+  // the streaming path regardless of duration so captured frames are drained
+  // directly into FFmpeg instead of accumulating hundreds of gigabytes of
+  // data URIs / disk frames until Chrome OOMs.
+  if (!cfg.lowMemoryMode && durationSeconds > cfg.streamingEncodeMaxDurationSeconds) return false;
   // HF_DE_PARALLEL_STREAM (manual opt-in) / forceParallelStream (router):
   // allow multi-worker streaming for the interleaved drawElement produce
   // path. Contiguous-chunk parallel streaming stalls (worker k+1's first


### PR DESCRIPTION
## What
Keep single-worker video renders on streaming encode in low-memory mode even when their duration exceeds the normal streaming cap.

## Why
A 411-second render on an 8GB Windows host silently switched to disk capture because of the 240-second cap, then Chrome OOM-crashed at 56%. Raising the cap and bounding the frame data-URI cache completed the render. Low-memory mode should prefer bounded streaming memory over accumulating the full capture.

## How
Teach `shouldUseStreamingEncode` to bypass only the duration clamp when `lowMemoryMode` is active. Format, validity, enablement, and worker-count gates remain unchanged.

## Test plan
- `bunx vitest run packages/producer/src/services/renderOrchestrator.test.ts -t shouldUseStreamingEncode`
- `bun run --filter @hyperframes/producer typecheck`
- pre-commit lint, format, tracked-artifact, fallow, and typecheck hooks