### PR TITLE
fix(engine): densify drawelement self-verify with parallel worker count

### DIFF
--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -3125,7 +3125,9 @@ async function captureDeVerificationFrames(
   page: Page,
   logInitPhase: (phase: string) => void,
 ): Promise<void> {
-  const kRaw = Number(process.env.HF_DE_VERIFY ?? "4");
+  // Explicit HF_DE_VERIFY wins; otherwise the session's own sample count
+  // (raised by the parallel coordinator for multi-worker DE), then default 4.
+  const kRaw = Number(process.env.HF_DE_VERIFY ?? session.options.deVerifySamples ?? "4");
   const k = Number.isFinite(kRaw) ? Math.max(0, Math.min(8, Math.floor(kRaw))) : 4;
   if (k === 0 || process.env.HF_FORCE_DRAWELEMENT === "1") return;
   if (session.options.format === "png") return; // worker-encode drain (the consumer) is jpeg-only

--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -6,6 +6,7 @@ import {
   selectWorkerDiagnostics,
   shouldDisableBrowserPoolForParallelWorker,
   shouldVerifyWorkerGpu,
+  resolveParallelDeVerifySamples,
 } from "./parallelCoordinator.js";
 import type { EngineConfig } from "../config.js";
 
@@ -174,5 +175,26 @@ describe("shouldVerifyWorkerGpu", () => {
   it("returns false when config is undefined", () => {
     expect(shouldVerifyWorkerGpu(0, undefined)).toBe(false);
     expect(shouldVerifyWorkerGpu(3, undefined)).toBe(false);
+  });
+});
+
+describe("resolveParallelDeVerifySamples", () => {
+  it("densifies with worker count: 4 base + 2 per extra worker", () => {
+    expect(resolveParallelDeVerifySamples(undefined, 2)).toBe(6);
+    expect(resolveParallelDeVerifySamples(undefined, 3)).toBe(8);
+  });
+
+  it("clamps at the verify path's max of 8", () => {
+    expect(resolveParallelDeVerifySamples(undefined, 5)).toBe(8);
+    expect(resolveParallelDeVerifySamples(undefined, 16)).toBe(8);
+  });
+
+  it("leaves single-worker capture on the session default", () => {
+    expect(resolveParallelDeVerifySamples(undefined, 1)).toBeUndefined();
+    expect(resolveParallelDeVerifySamples(undefined, 0)).toBeUndefined();
+  });
+
+  it("passes a caller-set value through untouched", () => {
+    expect(resolveParallelDeVerifySamples(2, 3)).toBe(2);
   });
 });

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -459,6 +459,24 @@ async function executeWorkerTask(
   }
 }
 
+/**
+ * drawElement self-verify sample count for multi-worker capture. Each worker
+ * arms the same shared sample grid but drains only ~1/N of it, and N
+ * concurrent hardware-GPU browsers are exactly where compositor-tile damage
+ * shows up (wild 0.7.52 black-slab report) — so density rises with worker
+ * count: 4 base + 2 per extra worker, clamped to the verify path's max of 8.
+ * A caller-set value passes through untouched, and explicit HF_DE_VERIFY
+ * still overrides inside the session.
+ */
+export function resolveParallelDeVerifySamples(
+  callerValue: number | undefined,
+  workerCount: number,
+): number | undefined {
+  if (callerValue !== undefined) return callerValue;
+  if (workerCount <= 1) return undefined;
+  return Math.min(8, 4 + 2 * (workerCount - 1));
+}
+
 export async function executeParallelCapture(
   serverUrl: string,
   workDir: string,
@@ -499,12 +517,20 @@ export async function executeParallelCapture(
   };
 
   const parallel = tasks.length > 1;
+  const deVerifySamples = resolveParallelDeVerifySamples(
+    captureOptions.deVerifySamples,
+    tasks.length,
+  );
+  const workerCaptureOptions: CaptureOptions =
+    deVerifySamples === captureOptions.deVerifySamples
+      ? captureOptions
+      : { ...captureOptions, deVerifySamples };
   const results = await Promise.all(
     tasks.map((task) =>
       executeWorkerTask(
         task,
         serverUrl,
-        captureOptions,
+        workerCaptureOptions,
         createBeforeCaptureHook,
         signal,
         onFrameCaptured,

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -158,6 +158,16 @@ export interface CaptureOptions {
    * warmup loop).
    */
   lockWarmupTicks?: boolean;
+  /**
+   * drawElement self-verify ground-truth sample count for this session.
+   * Overrides the HF_DE_VERIFY default (4). The parallel coordinator raises
+   * it for multi-worker drawElement capture — N concurrent hardware-GPU
+   * browsers widen the damage surface (compositor tile eviction under
+   * GPU/memory pressure), and each worker only drains ~1/N of the shared
+   * sample grid, thinning effective coverage exactly when risk peaks.
+   * Clamped to 0..8 like the env knob; HF_DE_VERIFY, when set, still wins.
+   */
+  deVerifySamples?: number;
 }
 
 export interface CaptureVideoMetadataHint {


### PR DESCRIPTION
## What

Densifies the drawElement self-verify sample grid with parallel worker count. `resolveParallelDeVerifySamples()`: 4 base samples + 2 per extra worker, clamped to 8 (the verify path's max). A caller-set value passes through untouched.

## Why

Each parallel worker arms the same shared sample grid but drains only ~1/N of it — N concurrent hardware-GPU browsers are exactly where compositor-tile damage shows up (the same wild black-slab report driving PR2249). Thinner effective per-worker coverage exactly when risk is highest.

## Validation

4 new unit tests (`resolveParallelDeVerifySamples`) covering densification, the 8-sample clamp, single-worker no-op, and caller-value passthrough. Full engine test suite (47 tests) green. Live canary render (12s/360-frame comp, 3 workers) shows the grid land at 8 samples `[45, 90, 135, 180, 225, 270, 315, 342]` — correctly densified from the base 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
