### PR TITLE
feat(cli): preview --browser-no-gpu for gpu-unstable hosts

### DIFF
--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -50,6 +50,7 @@ interface BrowserLaunchOptions {
   browserPath?: string;
   userDataDir?: string;
   remoteDebuggingPort?: number;
+  browserNoGpu?: boolean;
 }
 
 interface StudioLaunchOptions extends BrowserLaunchOptions {
@@ -141,6 +142,12 @@ export default defineCommand({
     "remote-debugging-port": {
       type: "string",
       description: "Chromium remote debugging port (requires --browser-path and --user-data-dir)",
+    },
+    "browser-no-gpu": {
+      type: "boolean",
+      default: false,
+      description:
+        "Launch the opened browser with --disable-gpu (requires --browser-path). For hosts where hardware acceleration crashes the graphics driver (e.g. NVIDIA Xid resets); with the system default browser use --no-open instead.",
     },
   },
   async run({ args }) {
@@ -239,6 +246,14 @@ export default defineCommand({
 
     const noOpen = !args.open;
     const browserPath = args["browser-path"] as string | undefined;
+    const browserNoGpu = !!args["browser-no-gpu"];
+    if (browserNoGpu && !browserPath) {
+      clack.log.error(
+        "--browser-no-gpu requires --browser-path (the system default browser cannot receive Chromium flags — use --no-open on GPU-unstable hosts)",
+      );
+      process.exitCode = 1;
+      return;
+    }
     const userDataDir = args["user-data-dir"] as string | undefined;
     let remoteDebuggingPort: number | undefined;
     try {
@@ -258,6 +273,7 @@ export default defineCommand({
         browserPath,
         userDataDir,
         remoteDebuggingPort,
+        browserNoGpu,
       });
     }
 
@@ -269,6 +285,7 @@ export default defineCommand({
         browserPath,
         userDataDir,
         remoteDebuggingPort,
+        browserNoGpu,
       });
     }
 
@@ -280,6 +297,7 @@ export default defineCommand({
       browserPath,
       userDataDir,
       remoteDebuggingPort,
+      browserNoGpu,
     });
   },
 });
@@ -641,6 +659,7 @@ function openStudioBrowser(url: string, projectName: string, options?: BrowserLa
     browserPath: options?.browserPath,
     userDataDir: options?.userDataDir,
     remoteDebuggingPort: options?.remoteDebuggingPort,
+    disableGpu: options?.browserNoGpu,
   });
 }
 

--- a/packages/cli/src/utils/openBrowser.test.ts
+++ b/packages/cli/src/utils/openBrowser.test.ts
@@ -158,3 +158,16 @@ describe("validateRemoteDebuggingPortDeps", () => {
     ).toBe("--remote-debugging-port requires --browser-path");
   });
 });
+
+describe("buildBrowserArgs --disable-gpu", () => {
+  it("appends --disable-gpu before the url when disableGpu is set", () => {
+    expect(buildBrowserArgs("http://localhost:3002", { disableGpu: true })).toEqual([
+      "--disable-gpu",
+      "http://localhost:3002",
+    ]);
+  });
+
+  it("omits --disable-gpu by default", () => {
+    expect(buildBrowserArgs("http://localhost:3002", {})).toEqual(["http://localhost:3002"]);
+  });
+});

--- a/packages/cli/src/utils/openBrowser.ts
+++ b/packages/cli/src/utils/openBrowser.ts
@@ -4,6 +4,14 @@ export interface OpenBrowserOptions {
   browserPath?: string;
   userDataDir?: string;
   remoteDebuggingPort?: number;
+  /**
+   * Launch the browser with --disable-gpu. For hosts where hardware
+   * acceleration crashes the graphics driver (wild report: auto-opened
+   * preview triggered NVIDIA Xid 32 resets on NixOS). Only effective with
+   * `browserPath` — the `open`-package fallback launches the system default
+   * browser with no way to pass Chromium flags.
+   */
+  disableGpu?: boolean;
 }
 
 export function parseRemoteDebuggingPort(value: string | undefined): number | undefined {
@@ -51,6 +59,9 @@ export function buildBrowserArgs(url: string, options: OpenBrowserOptions): stri
   // the CLI validation layer requires both flags together.
   if (options.remoteDebuggingPort !== undefined && options.userDataDir) {
     args.push(`--remote-debugging-port=${options.remoteDebuggingPort}`);
+  }
+  if (options.disableGpu) {
+    args.push("--disable-gpu");
   }
   args.push(url);
   return args;


### PR DESCRIPTION
## What

Adds `hyperframes preview --browser-no-gpu` (requires `--browser-path`): launches the opened browser with `--disable-gpu`. Threaded through `openBrowser`'s `disableGpu` option and all three preview launch modes (dev, local-studio, embedded).

## Why

Wild report: on NixOS, `preview`'s auto-opened hardware-accelerated Chrome triggered NVIDIA Xid 32 driver crashes. Preview has no way to avoid launching a hardware-accelerated browser on a GPU-unstable host; this gives an explicit opt-out.

## Validation

New unit tests in `openBrowser.test.ts` (`buildBrowserArgs` appends/omits `--disable-gpu` correctly) — 25 tests total, all green. Validation error added when `--browser-no-gpu` is passed without `--browser-path` (the system default browser can't receive Chromium flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
