### PR TITLE
fix(cli): fold canvas pixel hashes into the frozen-sweep fingerprint

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -895,6 +895,31 @@
   // actually moved anything and the whole audit run is unreliable. Deliberately
   // a single opaque string (not a structured array) since Node only ever needs
   // equality, not per-element diffing.
+  // Pixel-only canvas motion (a 2D/WebGL canvas repainting without any element
+  // moving) is invisible to a geometry+opacity fingerprint and false-positived
+  // sweep_static (wild report: 4K WebGL comp needed a transparent moving DOM
+  // sentinel to pass). Downsample each visible canvas to 8x8 and fold its
+  // pixels into the fingerprint. Tainted/zero-sized/unreadable canvases hash
+  // to a constant — no worse than today, never a new false NEGATIVE for
+  // DOM-motion comps.
+  function canvasPixelHash(canvas) {
+    try {
+      if (!canvas.width || !canvas.height) return "x";
+      const off = document.createElement("canvas");
+      off.width = 8;
+      off.height = 8;
+      const ctx = off.getContext("2d");
+      if (!ctx) return "x";
+      ctx.drawImage(canvas, 0, 0, 8, 8);
+      const data = ctx.getImageData(0, 0, 8, 8).data;
+      let hash = 0;
+      for (let i = 0; i < data.length; i++) hash = (hash * 31 + data[i]) >>> 0;
+      return String(hash);
+    } catch {
+      return "x";
+    }
+  }
+
   window.__hyperframesLayoutGeometry = function collectLayoutGeometry() {
     const root =
       document.querySelector("[data-composition-id][data-width][data-height]") ||
@@ -903,12 +928,15 @@
     const elements = Array.from(root.querySelectorAll("*")).filter((element) =>
       isVisibleElement(element),
     );
-    return elements
-      .map((element) => {
-        const rect = toRect(element.getBoundingClientRect());
-        const opacity = round(opacityChain(element));
-        return `${rect.left},${rect.top},${rect.width},${rect.height},${opacity}`;
-      })
-      .join("|");
+    const parts = elements.map((element) => {
+      const rect = toRect(element.getBoundingClientRect());
+      const opacity = round(opacityChain(element));
+      return `${rect.left},${rect.top},${rect.width},${rect.height},${opacity}`;
+    });
+    for (const canvas of root.querySelectorAll("canvas")) {
+      if (!isVisibleElement(canvas)) continue;
+      parts.push(`c:${canvasPixelHash(canvas)}`);
+    }
+    return parts.join("|");
   };
 })();


### PR DESCRIPTION
## What

Folds a canvas-pixel hash into the frozen-sweep audit fingerprint (`__hyperframesLayoutGeometry` in `layout-audit.browser.js`). Each visible `<canvas>` is downsampled to 8x8 and its pixels hashed into the per-sample signature; tainted/zero-sized/unreadable canvases hash to a constant.

## Why

Wild report: `strict check` reported `sweep_static` for a seek-correct, pixel-only canvas animation (native 4K WebGL PNG-sequence render) — a transparent moving DOM sentinel was needed to make it pass. The frozen-sweep guard's fingerprint was geometry+opacity of DOM elements only, blind to a canvas repainting without any element moving.

## Validation

Built a minimal pure-canvas-motion fixture (zero DOM motion, only a canvas repaint) and confirmed: WITHOUT the fix, `check` reports `sweep_static` (bug reproduced); WITH the fix, it doesn't. Also confirmed no new false positive on a DOM-motion fixture. CLI build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
