### PR TITLE
fix(render): scope strict lint to composition

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -807,7 +807,8 @@ export default defineCommand({
 
     // ── Pre-render lint ──────────────────────────────────────────────────
     {
-      const lintResult = await lintProject(project.dir);
+      const explicitEntry = args.composition && args.composition !== "." ? entryFile : undefined;
+      const lintResult = await lintProject(project.dir, explicitEntry);
       if (!quiet && (lintResult.totalErrors > 0 || lintResult.totalWarnings > 0)) {
         console.log("");
         for (const line of formatLintFindings(lintResult, { errorsFirst: true })) console.log(line);

--- a/packages/cli/src/utils/lintProject.test.ts
+++ b/packages/cli/src/utils/lintProject.test.ts
@@ -876,6 +876,20 @@ describe("texture_mask_asset_not_found", () => {
 });
 
 describe("multiple_root_compositions", () => {
+  it("scopes lint to an explicit render composition entry", async () => {
+    const project = makeProject(validHtml());
+    const standalone = join(project, "standalone.html");
+    writeFileSync(standalone, validHtml("standalone"));
+
+    const { totalErrors, results } = await lintProject(project, standalone);
+
+    expect(totalErrors).toBe(0);
+    expect(results.map((result) => result.file)).toEqual(["standalone.html"]);
+    expect(
+      results[0]?.result.findings.find((finding) => finding.code === "multiple_root_compositions"),
+    ).toBeUndefined();
+  });
+
   it("fires when two HTML files have data-composition-id", async () => {
     const project = makeProject(validHtml());
     writeFileSync(

--- a/packages/cli/src/utils/lintProject.test.ts
+++ b/packages/cli/src/utils/lintProject.test.ts
@@ -890,6 +890,29 @@ describe("multiple_root_compositions", () => {
     ).toBeUndefined();
   });
 
+  it("reports findings from an explicit render composition entry", async () => {
+    const project = makeProject(validHtml());
+    const standalone = join(project, "standalone.html");
+    writeFileSync(standalone, htmlWithMissingMediaId());
+
+    const { totalErrors, results } = await lintProject(project, standalone);
+
+    expect(totalErrors).toBeGreaterThan(0);
+    expect(results[0]?.result.findings.some((finding) => finding.code === "media_missing_id")).toBe(
+      true,
+    );
+  });
+
+  it("rejects an explicit render composition entry outside the project", async () => {
+    const project = makeProject(validHtml());
+    const outsideDir = tmpProject("outside-entry");
+    dirs.push(outsideDir);
+    const outsideEntry = join(outsideDir, "standalone.html");
+    writeFileSync(outsideEntry, validHtml("standalone"));
+
+    await expect(lintProject(project, outsideEntry)).rejects.toThrow(/outside.*project/i);
+  });
+
   it("fires when two HTML files have data-composition-id", async () => {
     const project = makeProject(validHtml());
     writeFileSync(

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -180,8 +180,13 @@ function resolveCssAssetCandidates(
   return resolveLocalAssetCandidates(projectDir, url);
 }
 
-export async function lintProject(projectDir: string): Promise<ProjectLintResult> {
-  const indexPath = resolve(projectDir, "index.html");
+export async function lintProject(
+  projectDir: string,
+  entryFile?: string,
+): Promise<ProjectLintResult> {
+  const indexPath = entryFile ? resolve(entryFile) : resolve(projectDir, "index.html");
+  const rootFile = relative(resolve(projectDir), indexPath).replace(/\\/g, "/") || "index.html";
+  const rootCompSrcPath = rootFile === "index.html" ? undefined : rootFile;
   const results: Array<{ file: string; result: HyperframeLintResult }> = [];
   let totalErrors = 0;
   let totalWarnings = 0;
@@ -190,16 +195,16 @@ export async function lintProject(projectDir: string): Promise<ProjectLintResult
   const rootHtml = readFileSync(indexPath, "utf-8");
   const rootResult = await lintHyperframeHtml(rootHtml, {
     filePath: indexPath,
-    externalStyles: collectExternalStyles(projectDir, rootHtml),
+    externalStyles: collectExternalStyles(projectDir, rootHtml, rootCompSrcPath),
   });
-  results.push({ file: "index.html", result: rootResult });
+  results.push({ file: rootFile, result: rootResult });
   totalErrors += rootResult.errorCount;
   totalWarnings += rootResult.warningCount;
   totalInfos += rootResult.infoCount;
 
-  const allHtmlSources: HtmlSource[] = [{ html: rootHtml }];
+  const allHtmlSources: HtmlSource[] = [{ html: rootHtml, compSrcPath: rootCompSrcPath }];
   const compositionsDir = resolve(projectDir, "compositions");
-  if (existsSync(compositionsDir)) {
+  if (!entryFile && existsSync(compositionsDir)) {
     const collectHtmlFiles = (dir: string, rel: string): string[] => {
       const out: string[] = [];
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -239,7 +244,7 @@ export async function lintProject(projectDir: string): Promise<ProjectLintResult
     ...lintAudioSrcNotFound(projectDir, allHtmlSources),
     ...lintMissingLocalAsset(projectDir, allHtmlSources),
     ...lintTextureMaskAssetNotFound(projectDir, allHtmlSources),
-    ...lintMultipleRootCompositions(projectDir),
+    ...(!entryFile ? lintMultipleRootCompositions(projectDir) : []),
     ...lintDuplicateAudioTracks(allHtmlSources),
     ...lintMissingOrEmptySubComposition(projectDir, rootHtml),
   ];

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -185,6 +185,9 @@ export async function lintProject(
   entryFile?: string,
 ): Promise<ProjectLintResult> {
   const indexPath = entryFile ? resolve(entryFile) : resolve(projectDir, "index.html");
+  if (entryFile && !isWithinProjectRoot(projectDir, indexPath)) {
+    throw new Error(`Explicit lint entry is outside the project directory: ${entryFile}`);
+  }
   const rootFile = relative(resolve(projectDir), indexPath).replace(/\\/g, "/") || "index.html";
   const rootCompSrcPath = rootFile === "index.html" ? undefined : rootFile;
   const results: Array<{ file: string; result: HyperframeLintResult }> = [];


### PR DESCRIPTION
## What

Scope pre-render lint to the file selected by `render --composition`.

## Why

On CLI 0.7.53, `render --composition standalone.html --strict` still linted sibling root HTML files, emitted `multiple_root_compositions`, and aborted. Users had to copy the same entry and assets into an isolated temporary project even though the command explicitly selected one composition.

## How

- Allow `lintProject` to accept an explicit entry file.
- Treat that file as the root lint source and resolve its local assets relative to its location.
- Skip unrelated `compositions/` discovery and the project-wide multiple-root rule only for explicit-entry lint.
- Pass the resolved entry from the render command when `--composition` is set.
- Preserve existing whole-project behavior when rendering `index.html`.

## Test plan

- Reproduced published 0.7.53 strict abort with two valid root compositions
- `bunx vitest run packages/cli/src/utils/lintProject.test.ts packages/cli/src/commands/render.test.ts` (125 passed)
- `bun run --filter @hyperframes/cli typecheck`
- `npx oxfmt --check packages/lint/src/project.ts packages/cli/src/commands/render.ts packages/cli/src/utils/lintProject.test.ts`
- `npx oxlint packages/lint/src/project.ts packages/cli/src/commands/render.ts packages/cli/src/utils/lintProject.test.ts`