### PR TITLE
fix(cli): localize remote fonts in snapshot/check capture to match render

### DIFF
--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -193,11 +193,13 @@ async function captureSnapshots(
     zoomScale?: number;
   },
 ): Promise<string[]> {
-  const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
+  const { bundleWithLocalizedFonts } = await import("../utils/bundleWithLocalizedFonts.js");
 
   const numFrames = opts.frames ?? 5;
 
-  const html = await bundleToSingleHtml(projectDir);
+  // Localize fonts (embed remote @font-face as data URIs, matching the render
+  // path) so snapshots render the real font instead of a fallback sans.
+  const html = await bundleWithLocalizedFonts(projectDir);
   const server = await serveStaticProjectHtml(projectDir, html);
 
   const savedPaths: string[] = [];

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@hyperframes/core/compiler", () => ({
+  bundleToSingleHtml: vi.fn(async () => "<html><body>bundled</body></html>"),
+}));
+
+const injectMock = vi.fn(async (html: string) => html.replace("bundled", "bundled+fonts"));
+vi.mock("@hyperframes/producer", () => ({
+  injectDeterministicFontFaces: (html: string) => injectMock(html),
+}));
+
+import { bundleWithLocalizedFonts } from "./bundleWithLocalizedFonts.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("bundleWithLocalizedFonts", () => {
+  it("localizes fonts on top of the plain bundle", async () => {
+    const html = await bundleWithLocalizedFonts("/project");
+    expect(injectMock).toHaveBeenCalledOnce();
+    expect(html).toBe("<html><body>bundled+fonts</body></html>");
+  });
+
+  it("falls open to the plain bundle when font localization throws", async () => {
+    injectMock.mockRejectedValueOnce(new Error("offline / fetch layer unavailable"));
+    const html = await bundleWithLocalizedFonts("/project");
+    // Never worse than a plain bundleToSingleHtml — the remote <link> still
+    // loads at capture time as before.
+    expect(html).toBe("<html><body>bundled</body></html>");
+  });
+});

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
@@ -4,13 +4,18 @@ vi.mock("@hyperframes/core/compiler", () => ({
   bundleToSingleHtml: vi.fn(async () => "<html><body>bundled</body></html>"),
 }));
 
-import { bundleWithLocalizedFonts } from "./bundleWithLocalizedFonts.js";
+import {
+  __resetFontLocalizationWarningsForTests,
+  bundleWithLocalizedFonts,
+  localizeWithProducer,
+} from "./bundleWithLocalizedFonts.js";
 
 afterEach(() => {
+  __resetFontLocalizationWarningsForTests();
   vi.clearAllMocks();
 });
 
-describe("bundleWithLocalizedFonts", () => {
+describe("bundleWithLocalizedFonts (call-site integration)", () => {
   it("runs the injected font localizer over the plain bundle", async () => {
     const localize = vi.fn(async (html: string) => html.replace("bundled", "bundled+fonts"));
     const html = await bundleWithLocalizedFonts("/project", localize);
@@ -19,11 +24,45 @@ describe("bundleWithLocalizedFonts", () => {
     expect(html).toBe("<html><body>bundled+fonts</body></html>");
   });
 
-  it("returns the localizer's output verbatim (localization is the last step)", async () => {
-    const html = await bundleWithLocalizedFonts(
-      "/project",
-      async () => "<html>embedded-face</html>",
-    );
-    expect(html).toBe("<html>embedded-face</html>");
+  it("returns the localizer output verbatim (localization is the last step)", async () => {
+    const html = await bundleWithLocalizedFonts("/project", async () => "<html>embedded</html>");
+    expect(html).toBe("<html>embedded</html>");
+  });
+});
+
+describe("localizeWithProducer", () => {
+  it("embeds fonts when the injector is available", async () => {
+    const inject = vi.fn(async (html: string) => `${html}<!--fonts-->`);
+    const warn = vi.fn();
+    const out = await localizeWithProducer("<html></html>", async () => inject, warn);
+    expect(out).toBe("<html></html><!--fonts-->");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("fails open silently when producer is unavailable (module absent → null)", async () => {
+    const warn = vi.fn();
+    const out = await localizeWithProducer("<html>plain</html>", async () => null, warn);
+    // Never worse than a plain bundle; benign absence is not a warning.
+    expect(out).toBe("<html>plain</html>");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("fails open WITH a diagnostic when the injector itself throws", async () => {
+    const warn = vi.fn();
+    const boom: () => Promise<never> = () => Promise.reject(new Error("fetch layer down"));
+    const out = await localizeWithProducer("<html>plain</html>", async () => boom, warn);
+    expect(out).toBe("<html>plain</html>");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain("fetch layer down");
+  });
+
+  it("dedups repeated identical injector failures across re-bundles", async () => {
+    const warn = vi.fn();
+    const boom: () => Promise<never> = () => Promise.reject(new Error("same failure"));
+    for (let i = 0; i < 5; i++) {
+      await localizeWithProducer("<html></html>", async () => boom, warn);
+    }
+    // snapshot/check re-bundle per grid point; the warning must fire once.
+    expect(warn).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
@@ -4,11 +4,6 @@ vi.mock("@hyperframes/core/compiler", () => ({
   bundleToSingleHtml: vi.fn(async () => "<html><body>bundled</body></html>"),
 }));
 
-const injectMock = vi.fn(async (html: string) => html.replace("bundled", "bundled+fonts"));
-vi.mock("@hyperframes/producer", () => ({
-  injectDeterministicFontFaces: (html: string) => injectMock(html),
-}));
-
 import { bundleWithLocalizedFonts } from "./bundleWithLocalizedFonts.js";
 
 afterEach(() => {
@@ -16,17 +11,19 @@ afterEach(() => {
 });
 
 describe("bundleWithLocalizedFonts", () => {
-  it("localizes fonts on top of the plain bundle", async () => {
-    const html = await bundleWithLocalizedFonts("/project");
-    expect(injectMock).toHaveBeenCalledOnce();
+  it("runs the injected font localizer over the plain bundle", async () => {
+    const localize = vi.fn(async (html: string) => html.replace("bundled", "bundled+fonts"));
+    const html = await bundleWithLocalizedFonts("/project", localize);
+    expect(localize).toHaveBeenCalledOnce();
+    expect(localize).toHaveBeenCalledWith("<html><body>bundled</body></html>");
     expect(html).toBe("<html><body>bundled+fonts</body></html>");
   });
 
-  it("falls open to the plain bundle when font localization throws", async () => {
-    injectMock.mockRejectedValueOnce(new Error("offline / fetch layer unavailable"));
-    const html = await bundleWithLocalizedFonts("/project");
-    // Never worse than a plain bundleToSingleHtml — the remote <link> still
-    // loads at capture time as before.
-    expect(html).toBe("<html><body>bundled</body></html>");
+  it("returns the localizer's output verbatim (localization is the last step)", async () => {
+    const html = await bundleWithLocalizedFonts(
+      "/project",
+      async () => "<html>embedded-face</html>",
+    );
+    expect(html).toBe("<html>embedded-face</html>");
   });
 });

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.ts
@@ -1,0 +1,31 @@
+/**
+ * Bundle a project to a single HTML string AND localize its fonts — fetch and
+ * embed `@font-face` rules for every requested family (including families
+ * declared only via a remote `<link>`, e.g. Google Fonts) as data URIs.
+ *
+ * Why the audit/snapshot paths need this: core's `bundleToSingleHtml` inlines
+ * only LOCAL stylesheets and leaves remote font `<link>`s as-is, so a snapshot
+ * depends on loading the remote font at capture time. The render pipeline
+ * instead localizes fonts in its compile stage, which is why a render embeds
+ * (say) League Gothic correctly while a snapshot of the same composition can
+ * fall back to an un-styled system sans when the remote font loses the race
+ * against the capture. Running the SAME localization the render path uses makes
+ * snapshot/check captures font-faithful and deterministic — no network race.
+ *
+ * Fail-open: if a family can't be fetched (offline, unknown font), the
+ * underlying injector leaves the HTML unchanged, so this never makes a bundle
+ * worse than plain `bundleToSingleHtml`.
+ */
+export async function bundleWithLocalizedFonts(projectDir: string): Promise<string> {
+  const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
+  const html = await bundleToSingleHtml(projectDir);
+  try {
+    const { injectDeterministicFontFaces } = await import("@hyperframes/producer");
+    return await injectDeterministicFontFaces(html);
+  } catch {
+    // Producer/font localization unavailable (or a fetch layer threw) — fall
+    // back to the plain bundle. Fonts declared via remote <link> still load at
+    // capture time as before; we just lose the deterministic embed.
+    return html;
+  }
+}

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.ts
@@ -1,3 +1,6 @@
+import { normalizeErrorMessage } from "./errorMessage.js";
+import { c } from "../ui/colors.js";
+
 /**
  * Bundle a project to a single HTML string AND localize its fonts — fetch and
  * embed `@font-face` rules for every requested family (including families
@@ -11,15 +14,11 @@
  * fall back to an un-styled system sans when the remote font loses the race
  * against the capture. Running the SAME localization the render path uses makes
  * snapshot/check captures font-faithful and deterministic — no network race.
- *
- * Fail-open: if a family can't be fetched (offline, unknown font), the
- * underlying injector leaves the HTML unchanged, so this never makes a bundle
- * worse than plain `bundleToSingleHtml`.
  */
 export async function bundleWithLocalizedFonts(
   projectDir: string,
   // Injectable for tests. Production callers omit it and get the producer
-  // font-localization pass, resolved lazily at runtime (see localizeWithProducer).
+  // font-localization pass (see localizeWithProducer).
   localizeFonts: (html: string) => Promise<string> = localizeWithProducer,
 ): Promise<string> {
   const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
@@ -27,26 +26,71 @@ export async function bundleWithLocalizedFonts(
   return localizeFonts(html);
 }
 
+type FontInjector = (html: string) => Promise<string>;
+
 /**
- * Run the render pipeline's `injectDeterministicFontFaces` pass, resolving
+ * Load the render pipeline's `injectDeterministicFontFaces`, resolving
  * `@hyperframes/producer` at RUNTIME only. The specifier is kept out of the
  * bundler's/test-runner's static module graph (`@vite-ignore` + a variable
- * specifier) on purpose: the CLI test job doesn't build producer, so a static
- * `import("@hyperframes/producer")` would fail Vitest's transform-time
- * resolution. At runtime — the built CLI, or an installed package — producer is
- * a real dependency and resolves via node_modules.
+ * specifier) on purpose: the CLI test job builds with `--filter
+ * '!@hyperframes/producer'`, so a static `import("@hyperframes/producer")`
+ * would fail Vitest's transform-time resolution. At runtime — the built CLI or
+ * an installed package — producer is a real dependency and resolves via
+ * node_modules.
  *
- * Fail-open: if producer can't be resolved or a fetch layer throws, return the
- * HTML unchanged so a bundle is never worse than plain `bundleToSingleHtml`.
+ * Returns `null` (not a throw) when the module simply isn't available in this
+ * environment, so the caller can treat "producer absent" — a benign, expected
+ * condition — differently from "the injector itself failed".
  */
-async function localizeWithProducer(html: string): Promise<string> {
+async function loadFontInjector(): Promise<FontInjector | null> {
   try {
     const producerSpecifier = "@hyperframes/producer";
-    const { injectDeterministicFontFaces } = (await import(
-      /* @vite-ignore */ producerSpecifier
-    )) as typeof import("@hyperframes/producer");
-    return await injectDeterministicFontFaces(html);
+    const mod = (await import(/* @vite-ignore */ producerSpecifier)) as {
+      injectDeterministicFontFaces?: FontInjector;
+    };
+    return mod.injectDeterministicFontFaces ?? null;
   } catch {
+    return null;
+  }
+}
+
+const warnedFontLocalizationFailures = new Set<string>();
+
+/** Reset the dedup latch — tests only. */
+export function __resetFontLocalizationWarningsForTests(): void {
+  warnedFontLocalizationFailures.clear();
+}
+
+/**
+ * Localize fonts via the producer injector, distinguishing two failure modes:
+ *
+ *  - **Module unavailable** (`loadInjector` yields `null`): benign — producer
+ *    isn't in this environment. Return the HTML unchanged, silently; fonts
+ *    declared via a remote `<link>` still load at capture time as before.
+ *  - **Injector threw** (a fetch layer failed, a family errored past the
+ *    injector's own per-family handling): unexpected — surface it ONCE per
+ *    distinct message (snapshot/check re-bundle per grid point, so an
+ *    un-deduped warning would spam), then fail open to the plain bundle.
+ *
+ * Per-family resolution failures inside a successful pass are already reported
+ * by the injector itself (producer's `warnUnresolvedFonts`); this layer only
+ * owns the module-vs-execution distinction and the dedup.
+ */
+export async function localizeWithProducer(
+  html: string,
+  loadInjector: () => Promise<FontInjector | null> = loadFontInjector,
+  warn: (message: string) => void = (m) => console.warn(`   ${c.warn("⚠")} ${m}`),
+): Promise<string> {
+  const inject = await loadInjector();
+  if (!inject) return html;
+  try {
+    return await inject(html);
+  } catch (err) {
+    const message = `Font localization failed; capturing with remote/fallback fonts instead: ${normalizeErrorMessage(err)}`;
+    if (!warnedFontLocalizationFailures.has(message)) {
+      warnedFontLocalizationFailures.add(message);
+      warn(message);
+    }
     return html;
   }
 }

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.ts
@@ -16,16 +16,37 @@
  * underlying injector leaves the HTML unchanged, so this never makes a bundle
  * worse than plain `bundleToSingleHtml`.
  */
-export async function bundleWithLocalizedFonts(projectDir: string): Promise<string> {
+export async function bundleWithLocalizedFonts(
+  projectDir: string,
+  // Injectable for tests. Production callers omit it and get the producer
+  // font-localization pass, resolved lazily at runtime (see localizeWithProducer).
+  localizeFonts: (html: string) => Promise<string> = localizeWithProducer,
+): Promise<string> {
   const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
   const html = await bundleToSingleHtml(projectDir);
+  return localizeFonts(html);
+}
+
+/**
+ * Run the render pipeline's `injectDeterministicFontFaces` pass, resolving
+ * `@hyperframes/producer` at RUNTIME only. The specifier is kept out of the
+ * bundler's/test-runner's static module graph (`@vite-ignore` + a variable
+ * specifier) on purpose: the CLI test job doesn't build producer, so a static
+ * `import("@hyperframes/producer")` would fail Vitest's transform-time
+ * resolution. At runtime — the built CLI, or an installed package — producer is
+ * a real dependency and resolves via node_modules.
+ *
+ * Fail-open: if producer can't be resolved or a fetch layer throws, return the
+ * HTML unchanged so a bundle is never worse than plain `bundleToSingleHtml`.
+ */
+async function localizeWithProducer(html: string): Promise<string> {
   try {
-    const { injectDeterministicFontFaces } = await import("@hyperframes/producer");
+    const producerSpecifier = "@hyperframes/producer";
+    const { injectDeterministicFontFaces } = (await import(
+      /* @vite-ignore */ producerSpecifier
+    )) as typeof import("@hyperframes/producer");
     return await injectDeterministicFontFaces(html);
   } catch {
-    // Producer/font localization unavailable (or a fetch layer threw) — fall
-    // back to the plain bundle. Fonts declared via remote <link> still load at
-    // capture time as before; we just lose the deterministic embed.
     return html;
   }
 }

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -88,8 +88,8 @@ export async function runBrowserCheck(
   motion: MotionSpecResolution,
   runGrid: RunAuditGrid,
 ): Promise<CheckBrowserResult> {
-  const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
-  const html = await bundleToSingleHtml(project.dir);
+  const { bundleWithLocalizedFonts } = await import("./bundleWithLocalizedFonts.js");
+  const html = await bundleWithLocalizedFonts(project.dir);
   const server = await serveStaticProjectHtml(project.dir, html, "Failed to bind check server");
   const drafts: RuntimeDraft[] = [];
   let currentTime = 0;
@@ -145,8 +145,8 @@ export async function captureFindingCrops(
   requests: CheckFindingCropRequest[],
 ): Promise<string[]> {
   if (requests.length === 0) return [];
-  const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
-  const html = await bundleToSingleHtml(project.dir);
+  const { bundleWithLocalizedFonts } = await import("./bundleWithLocalizedFonts.js");
+  const html = await bundleWithLocalizedFonts(project.dir);
   const server = await serveStaticProjectHtml(project.dir, html, "Failed to bind check server");
   let chromeBrowser: import("puppeteer-core").Browser | undefined;
   const written: string[] = [];

--- a/packages/producer/src/index.ts
+++ b/packages/producer/src/index.ts
@@ -86,6 +86,15 @@ export {
 
 // ── Utilities ───────────────────────────────────────────────────────────────
 export { normalizeErrorMessage } from "./utils/errorMessage.js";
+// Font localization: fetch + embed @font-face rules for requested families
+// (including those declared only via a remote <link>) so a bundled composition
+// renders with the real font instead of a fallback, regardless of network
+// timing. The render pipeline runs this in its compile stage; the CLI audit
+// paths (snapshot/check) reuse it so their captures match the render.
+export {
+  injectDeterministicFontFaces,
+  type InjectDeterministicFontFacesOptions,
+} from "./services/deterministicFonts.js";
 export { quantizeTimeToFrame } from "./utils/parityContract.js";
 export { resolveRenderPaths, type RenderPaths } from "./utils/paths.js";
 


### PR DESCRIPTION
## What

Snapshot and check now localize fonts before capture — fetch and embed an `@font-face` (data URI) for every requested family, including families declared only via a remote `<link>` (e.g. Google Fonts) — reusing the exact `injectDeterministicFontFaces` pass the render pipeline already runs. New shared helper `bundleWithLocalizedFonts(projectDir)` wraps `bundleToSingleHtml` + the injector; snapshot.ts and both bundling sites in checkBrowser.ts use it.

## Why

Wild report (CLI 0.7.53, macOS): `hyperframes snapshot` rendered League Gothic as an un-condensed fallback sans, while the actual render/draft-render embedded the font correctly.

Root cause (structural, not timing): the **render** path localizes fonts in its compile stage (`deterministicFonts.ts` — fetches from Google Fonts, embeds as data URIs). The **snapshot/check** path uses core's `bundleToSingleHtml`, which inlines only *local* CSS (`htmlBundler.ts`) and leaves remote font `<link>`s as-is — so a snapshot depends on loading the remote font at capture time. When that remote load loses the race against the capture (slow CDN / memory pressure / cold cache), Chrome paints the fallback family. This fix removes the remote dependency entirely, matching render.

Fail-open: if a family can't be fetched (offline, unknown font) the injector leaves the HTML unchanged, so a bundle is never worse than plain `bundleToSingleHtml`.

## Validation

- **Deterministic**: ran `bundleWithLocalizedFonts` on a composition that declares League Gothic *only* via a Google Fonts `<link>` — the bundled HTML now contains a `data-hyperframes-deterministic-fonts` `<style>` with an embedded `@font-face` data URI for League Gothic (previously only the remote `<link>` was present). RESULT: PASS.
- **End-to-end**: `hyperframes snapshot` of that composition renders condensed League Gothic correctly (visually confirmed), Fonts: 2 loaded.
- Unit test for the helper's happy path + fail-open contract; existing `snapshot`, `captureCompositionFrame`, and `checkBrowser` suites green; full monorepo build clean.

## Notes

Applied to the two reported paths (snapshot, check). Other audit bundling sites (compare, layout, motionShot, grade-compare, validate) still use plain `bundleToSingleHtml`; extending them to the shared helper is a straightforward follow-up if desired — kept this PR scoped to the reported paths.