### PR TITLE
docs(snapshot): use supported output flag

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -74,7 +74,7 @@
       "files": 2
     },
     "talking-head-recut": {
-      "hash": "d5c51342625c9952",
+      "hash": "50d66642a86ab532",
       "files": 27
     },
     "website-to-video": {

--- a/skills/talking-head-recut/SKILL.md
+++ b/skills/talking-head-recut/SKILL.md
@@ -1170,7 +1170,8 @@ For a sanity check before the full render, capture a single frame at a
 specific timestamp:
 
 ```bash
-npx hyperframes snapshot public --at 5    # → public/snapshots/frame-00-at-5s.png (a single --at ignores --out)
+npx hyperframes snapshot public --at 5 --output public/review-frames
+# → public/review-frames/frame-00-at-5s.png (`-o` is the short form of `--output`)
 ```
 
 ### 11. Report Results


### PR DESCRIPTION
## What
Update the talking-head snapshot example to use the supported `--output` flag and document its `-o` short form.

## Why
The skill said a single `--at` ignored `--out`, but HyperFrames 0.7.53 has no `--out` flag and rejects it. Users were led to believe snapshot output-directory control was unavailable.

## How
Replace the misleading comment with a working command that writes to `public/review-frames`.

## Test plan
- reproduced `Unknown flag: --out` on published 0.7.53
- verified `snapshot --help` advertises `-o, --output`
- `tsx scripts/lint-skills.ts` (20 skill files, no issues)
- `git diff --check`