### PR TITLE
fix(cli): flag text with an effectively transparent fill in check

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -796,6 +796,43 @@
     };
   }
 
+  // Text whose glyphs paint with an effectively transparent fill renders
+  // invisibly even though the element, its box, opacity and color all read as
+  // present — so geometry/occlusion/contrast audits miss it (contrast reads
+  // `color`, not the fill that actually paints). `-webkit-text-fill-color`
+  // overrides `color` for the glyph fill AND inherits, so a parent's
+  // `transparent` fill silently blanks descendant text that has its own opaque
+  // `color`. Its computed value already resolves to `color` when unset, so it
+  // is the effective fill directly. Gradient/clipped text (`background-clip:
+  // text`) legitimately uses a transparent fill — the clipped background paints
+  // the glyphs — so exclude it.
+  function invisibleTextIssue(element, time) {
+    const textRect = textRectFor(element);
+    if (!textRect) return null;
+    const text = textContentFor(element);
+    if (!text) return null;
+    const cs = getComputedStyle(element);
+    const fill = cs.getPropertyValue("-webkit-text-fill-color") || cs.color;
+    if (colorAlpha(fill) > 0.05) return null;
+    const clip =
+      cs.getPropertyValue("-webkit-background-clip") ||
+      cs.getPropertyValue("background-clip") ||
+      "";
+    if (/text/i.test(clip)) return null;
+    return {
+      code: "text_not_painted",
+      severity: "error",
+      time,
+      selector: selectorFor(element),
+      text,
+      message:
+        "Text paints with an effectively transparent fill (-webkit-text-fill-color / color), so its glyphs are invisible.",
+      rect: textRect,
+      fixHint:
+        "Set an explicit, opaque `color` on the text — and an explicit `-webkit-text-fill-color` if an ancestor makes the fill transparent. If the transparency is intentional gradient text, add `background-clip: text`.",
+    };
+  }
+
   function candidateAnchor(element) {
     const dataAttributes = {};
     for (const attribute of Array.from(element.attributes)) {
@@ -881,6 +918,8 @@
       issues.push(...textOverflowIssues(element, root, rootRect, time, tolerance));
       const occluded = occludedTextIssue(element, time);
       if (occluded) issues.push(occluded);
+      const invisible = invisibleTextIssue(element, time);
+      if (invisible) issues.push(invisible);
     }
 
     issues.push(...containerOverflowIssues(root, time, tolerance));

--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -812,12 +812,12 @@
     const text = textContentFor(element);
     if (!text) return null;
     const cs = getComputedStyle(element);
-    const fill = cs.getPropertyValue("-webkit-text-fill-color") || cs.color;
+    // Vendor computed-style props are read by property (camelCase), matching
+    // the rest of this script; `webkitTextFillColor` computes to `color` when
+    // unset, so it is the effective fill directly.
+    const fill = cs.webkitTextFillColor || cs.color;
     if (colorAlpha(fill) > 0.05) return null;
-    const clip =
-      cs.getPropertyValue("-webkit-background-clip") ||
-      cs.getPropertyValue("background-clip") ||
-      "";
+    const clip = cs.webkitBackgroundClip || cs.backgroundClip || "";
     if (/text/i.test(clip)) return null;
     return {
       code: "text_not_painted",

--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -803,9 +803,10 @@
   // overrides `color` for the glyph fill AND inherits, so a parent's
   // `transparent` fill silently blanks descendant text that has its own opaque
   // `color`. Its computed value already resolves to `color` when unset, so it
-  // is the effective fill directly. Gradient/clipped text (`background-clip:
-  // text`) legitimately uses a transparent fill — the clipped background paints
-  // the glyphs — so exclude it.
+  // is the effective fill directly. Clipped text (`background-clip: text`)
+  // legitimately uses a transparent fill — BUT only when a background actually
+  // paints the glyphs; a `background-clip: text` with no gradient/image and no
+  // opaque background-color paints nothing, so it stays reportable.
   function invisibleTextIssue(element, time) {
     const textRect = textRectFor(element);
     if (!textRect) return null;
@@ -818,7 +819,14 @@
     const fill = cs.webkitTextFillColor || cs.color;
     if (colorAlpha(fill) > 0.05) return null;
     const clip = cs.webkitBackgroundClip || cs.backgroundClip || "";
-    if (/text/i.test(clip)) return null;
+    if (/text/i.test(clip)) {
+      const bgImage = cs.backgroundImage || "none";
+      const paintsGlyphs =
+        bgImage !== "none" || colorAlpha(cs.backgroundColor || "rgba(0, 0, 0, 0)") > 0.05;
+      // A usable clipped background fills the glyphs — legitimate gradient/solid
+      // clipped text. If nothing paints, fall through and report it.
+      if (paintsGlyphs) return null;
+    }
     return {
       code: "text_not_painted",
       severity: "error",

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -346,6 +346,56 @@ it("uses the bridge opacity floor across the ancestor chain", () => {
   expect(candidates.some((candidate) => candidate.selector === "#stacked-copy")).toBe(true);
 });
 
+describe("layout-audit.browser invisible text", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+    delete (window as unknown as { __hyperframesLayoutAudit?: unknown }).__hyperframesLayoutAudit;
+    clearGeometryCollector();
+  });
+
+  function invisibleTextScene(headlineStyle: Partial<CSSStyleDeclaration>): AuditIssue[] {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="headline">Headline copy</div>
+      </div>
+    `;
+    installGeometry(
+      {
+        root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+        headline: rect({ left: 40, top: 150, width: 300, height: 56 }),
+        text: rect({ left: 40, top: 150, width: 300, height: 56 }),
+      },
+      { headline: headlineStyle },
+    );
+    installAuditScript();
+    return runAudit();
+  }
+
+  it("flags text whose -webkit-text-fill-color is transparent", () => {
+    const issues = invisibleTextScene({
+      color: "rgb(255, 255, 255)",
+      webkitTextFillColor: "rgba(0, 0, 0, 0)",
+    } as unknown as Partial<CSSStyleDeclaration>);
+    const invisible = issues.find((issue) => issue.code === "text_not_painted");
+    expect(invisible).toMatchObject({ selector: "#headline", severity: "error" });
+  });
+
+  it("does not flag text with an opaque color and default fill", () => {
+    const issues = invisibleTextScene({ color: "rgb(255, 255, 255)" });
+    expect(issues.some((issue) => issue.code === "text_not_painted")).toBe(false);
+  });
+
+  it("does not flag gradient text (transparent fill clipped to the glyphs)", () => {
+    const issues = invisibleTextScene({
+      color: "rgb(255, 255, 255)",
+      webkitTextFillColor: "rgba(0, 0, 0, 0)",
+      webkitBackgroundClip: "text",
+    } as unknown as Partial<CSSStyleDeclaration>);
+    expect(issues.some((issue) => issue.code === "text_not_painted")).toBe(false);
+  });
+});
+
 describe("layout-audit.browser content overlap", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -354,10 +354,16 @@ describe("layout-audit.browser invisible text", () => {
     clearGeometryCollector();
   });
 
-  function invisibleTextScene(headlineStyle: Partial<CSSStyleDeclaration>): AuditIssue[] {
+  // The mock resolves computed style per element, so setting `webkitTextFillColor`
+  // on the headline models exactly what the browser computes there — whether the
+  // value was authored on the element or inherited from an ancestor.
+  function invisibleTextScene(
+    headlineStyle: Partial<CSSStyleDeclaration>,
+    text = "Headline copy",
+  ): AuditIssue[] {
     document.body.innerHTML = `
       <div id="root" data-composition-id="main" data-width="640" data-height="360">
-        <div id="headline">Headline copy</div>
+        <div id="headline">${text}</div>
       </div>
     `;
     installGeometry(
@@ -372,27 +378,79 @@ describe("layout-audit.browser invisible text", () => {
     return runAudit();
   }
 
-  it("flags text whose -webkit-text-fill-color is transparent", () => {
-    const issues = invisibleTextScene({
-      color: "rgb(255, 255, 255)",
-      webkitTextFillColor: "rgba(0, 0, 0, 0)",
-    } as unknown as Partial<CSSStyleDeclaration>);
-    const invisible = issues.find((issue) => issue.code === "text_not_painted");
-    expect(invisible).toMatchObject({ selector: "#headline", severity: "error" });
+  const flagged = (issues: AuditIssue[]) =>
+    issues.some((issue) => issue.code === "text_not_painted");
+  const style = (s: Record<string, string>) => s as unknown as Partial<CSSStyleDeclaration>;
+
+  it("flags a directly transparent -webkit-text-fill-color", () => {
+    const issues = invisibleTextScene(
+      style({ color: "rgb(255, 255, 255)", webkitTextFillColor: "rgba(0, 0, 0, 0)" }),
+    );
+    expect(issues.find((i) => i.code === "text_not_painted")).toMatchObject({
+      selector: "#headline",
+      severity: "error",
+    });
   });
 
-  it("does not flag text with an opaque color and default fill", () => {
-    const issues = invisibleTextScene({ color: "rgb(255, 255, 255)" });
-    expect(issues.some((issue) => issue.code === "text_not_painted")).toBe(false);
+  it("flags an inherited transparent fill overriding the child's opaque color", () => {
+    // getComputedStyle on the child resolves the inherited fill to transparent
+    // (browsers always return the rgba() form), even though the child sets its
+    // own opaque `color`.
+    expect(
+      flagged(
+        invisibleTextScene(
+          style({ color: "rgb(255, 255, 255)", webkitTextFillColor: "rgba(0, 0, 0, 0)" }),
+        ),
+      ),
+    ).toBe(true);
   });
 
-  it("does not flag gradient text (transparent fill clipped to the glyphs)", () => {
-    const issues = invisibleTextScene({
-      color: "rgb(255, 255, 255)",
-      webkitTextFillColor: "rgba(0, 0, 0, 0)",
-      webkitBackgroundClip: "text",
-    } as unknown as Partial<CSSStyleDeclaration>);
-    expect(issues.some((issue) => issue.code === "text_not_painted")).toBe(false);
+  it("flags color:transparent when no explicit fill is set (color fallback)", () => {
+    // -webkit-text-fill-color unset → resolves to `color`; a transparent color
+    // must still be caught via the `|| cs.color` fallback.
+    expect(flagged(invisibleTextScene(style({ color: "rgba(0, 0, 0, 0)" })))).toBe(true);
+  });
+
+  it("does not flag opaque text with a default fill", () => {
+    expect(flagged(invisibleTextScene(style({ color: "rgb(255, 255, 255)" })))).toBe(false);
+  });
+
+  it("does not flag gradient text (transparent fill clipped over a real background)", () => {
+    expect(
+      flagged(
+        invisibleTextScene(
+          style({
+            color: "rgb(255, 255, 255)",
+            webkitTextFillColor: "rgba(0, 0, 0, 0)",
+            webkitBackgroundClip: "text",
+            backgroundImage: "linear-gradient(90deg, rgb(255, 0, 0), rgb(0, 0, 255))",
+          }),
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("still flags background-clip:text when no background actually paints the glyphs", () => {
+    // A clipped-to-text fill with no gradient/image and a transparent background
+    // paints nothing — a broken gradient must remain reportable.
+    expect(
+      flagged(
+        invisibleTextScene(
+          style({
+            webkitTextFillColor: "rgba(0, 0, 0, 0)",
+            webkitBackgroundClip: "text",
+            backgroundImage: "none",
+            backgroundColor: "rgba(0, 0, 0, 0)",
+          }),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag an element with a transparent fill but no text content", () => {
+    expect(
+      flagged(invisibleTextScene(style({ webkitTextFillColor: "rgba(0, 0, 0, 0)" }), "")),
+    ).toBe(false);
   });
 });
 

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -946,6 +946,7 @@ const LAYOUT_ISSUE_CODES: readonly LayoutIssueCode[] = [
   "container_overflow",
   "content_overlap",
   "text_occluded",
+  "text_not_painted",
   "caption_zone_collision",
   "frame_out_of_frame",
   "motion_appears_late",

--- a/packages/cli/src/utils/layoutAudit.ts
+++ b/packages/cli/src/utils/layoutAudit.ts
@@ -16,6 +16,7 @@ export type LayoutIssueCode =
   | "container_overflow"
   | "content_overlap"
   | "text_occluded"
+  | "text_not_painted"
   | "caption_zone_collision"
   | "frame_out_of_frame"
   // Frozen-sweep guard (#U10) — a whole-run meta-finding, not a per-sample


### PR DESCRIPTION
## What

Adds an invisible-text detector to `check`'s layout audit: any text element whose **effective glyph fill** is transparent is flagged `text_not_painted` (error). The effective fill is the computed `-webkit-text-fill-color`, which already resolves to `color` when unset — so it's the value that actually paints. Gradient/clipped text (`background-clip: text`) legitimately uses a transparent fill and is excluded.

## Why

Wild report (5th in the inherited-color snapshot glyph-loss cluster, CLI 0.7.53, macOS): `hyperframes snapshot` omitted **all** text while `check` passed; explicit `color` + `-webkit-text-fill-color` on the text classes fixed it. The reporter explicitly noted "the check did not catch the missing rendered glyphs."

Root cause of the check gap: `-webkit-text-fill-color` overrides `color` for the glyph fill **and inherits**, so a parent's `transparent` fill silently blanks descendant text that has its own opaque `color`. Every audit missed it — geometry/occlusion see a present box; the **contrast** check reads `color` (not the fill that paints), so `color: white` + transparent-fill text scored as high-contrast and passed. The text renders invisibly with no signal.

This is distinct from the remote-font localization fix (#2264): that was font *family* falling back to a system sans; this is any-font text painting *invisibly* due to fill.

## Validation

Reproduced deterministically with fixtures + `check --json`:

| Fixture | Before | After |
|---|---|---|
| Parent `-webkit-text-fill-color: transparent`, child opaque `color` (invisible text) | `ok: true`, 0 findings | `ok: false`, `text_not_painted` ✓ |
| Gradient text (`background-clip: text` + transparent fill) | — | no `text_not_painted` (excluded) ✓ |
| Body-inherited `color`, no explicit color (visible) | — | clean ✓ |
| Sub-composition inherited `color` (visible) | — | clean ✓ |
| Real registry examples (kinetic-type, swiss-grid, nyt-graph) | — | 0 `text_not_painted` (no false positives) ✓ |

`checkBrowser` test suite green; lint/format/build clean.

## Notes

Scoped to the check-side detection gap the report called out. The separate question of *why snapshot's capture differs from render's* for a given composition wasn't reproducible across five fixtures (snapshot renders inherited-color and gradient text correctly), consistent with the reporter's own note that the final render was clean — so the actionable, verifiable defect here is that `check` now catches invisible text before it ships.