### PR TITLE
fix(example): make play-mode pass lint

### DIFF
--- a/packages/lint/src/project.test.ts
+++ b/packages/lint/src/project.test.ts
@@ -235,3 +235,13 @@ describe("template shell style sources", () => {
     expect(findings.some((finding) => finding.code === "texture_mask_asset_not_found")).toBe(true);
   });
 });
+
+describe("shipped example projects", () => {
+  it("keeps play-mode free of blocking lint errors", async () => {
+    const playModeDir = join(import.meta.dirname, "../../../registry/examples/play-mode");
+
+    const { totalErrors } = await lintProject(playModeDir);
+
+    expect(totalErrors).toBe(0);
+  });
+});

--- a/packages/lint/src/rules/captions.test.ts
+++ b/packages/lint/src/rules/captions.test.ts
@@ -142,6 +142,38 @@ describe("caption rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("accepts formatter-normalized transcript objects with unquoted keys", async () => {
+    const html = `<html><body>
+      <div data-composition-id="captions" data-width="1920" data-height="1080">
+        <div class="caption-group"></div>
+        <script>
+          const TRANSCRIPT = [
+            { text: "don't", start: 0, end: 0.5 },
+            { text: "stop", start: 0.5, end: 1 },
+          ];
+        </script>
+      </div>
+    </body></html>`;
+
+    const result = await lintHyperframeHtml(html);
+
+    expect(result.findings.some((f) => f.code === "caption_transcript_parse_error")).toBe(false);
+  });
+
+  it("still rejects transcript syntax unsupported by the Studio parser", async () => {
+    const html = `<html><body>
+      <div data-composition-id="captions" data-width="1920" data-height="1080">
+        <div class="caption-group"></div>
+        <style>.caption-group { position: absolute; }</style>
+        <script>const TRANSCRIPT = [{ ...word }];</script>
+      </div>
+    </body></html>`;
+
+    const result = await lintHyperframeHtml(html);
+
+    expect(result.findings.some((f) => f.code === "caption_transcript_parse_error")).toBe(true);
+  });
+
   it("warns when caption container uses position: relative", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/rules/captions.ts
+++ b/packages/lint/src/rules/captions.ts
@@ -28,6 +28,22 @@ function extractArrayLiteral(src: string, varMatch: RegExpExecArray): string | n
   return null;
 }
 
+/** Match the Studio caption parser's supported JavaScript-array normalization. */
+function parseTranscriptArrayLiteral(arrayLiteral: string): unknown {
+  try {
+    return JSON.parse(arrayLiteral);
+  } catch {
+    let normalized = arrayLiteral;
+    normalized = normalized.replace(/'((?:[^'\\]|\\.)*)'/g, (_match, inner: string) => {
+      const escaped = inner.replace(/\\'/g, "'").replace(/"/g, '\\"');
+      return `"${escaped}"`;
+    });
+    normalized = normalized.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":');
+    normalized = normalized.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(normalized);
+  }
+}
+
 export const captionRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
   // caption_exit_missing_hard_kill
   ({ scripts, styles, options, rootCompositionId }) => {
@@ -130,17 +146,15 @@ export const captionRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> 
       const transcriptJson = varStart ? extractArrayLiteral(allScript, varStart) : null;
       if (transcriptJson) {
         try {
-          JSON.parse(transcriptJson);
+          parseTranscriptArrayLiteral(transcriptJson);
         } catch {
           findings.push({
             code: "caption_transcript_parse_error",
             severity: "error",
-            message:
-              "Inline TRANSCRIPT array is not valid JSON. The studio caption editor may fail " +
-              "to parse it. Common cause: unquoted property keys with apostrophes in text.",
+            message: "Inline TRANSCRIPT array cannot be parsed by the Studio caption editor.",
             fixHint:
-              'Use JSON-quoted keys: { "text": "don\'t", "start": 0, "end": 1 } instead of ' +
-              '{ text: "don\'t", start: 0, end: 1 }.',
+              'Use plain word objects such as { text: "don\'t", start: 0, end: 1 } with ' +
+              "string text and numeric start/end values.",
           });
         }
       }

--- a/registry/examples/play-mode/compositions/stats.html
+++ b/registry/examples/play-mode/compositions/stats.html
@@ -7,7 +7,7 @@
   >
     <div id="stats-container">
       <!-- Moment 1: 47% NEED MOTION GRAPHICS -->
-      <div id="moment-1" class="moment" style="opacity: 0; transform: scale(0) rotate(8deg)">
+      <div id="moment-1" class="moment" style="opacity: 0">
         <div class="sticker-stack">
           <div class="sticker-bg blue-bg"></div>
           <div class="sticker-content white-bg blue-border">
@@ -22,12 +22,12 @@
         ></div>
         <div
           class="shape pill lime-bg"
-          style="bottom: -30px; right: -50px; width: 120px; height: 40px; transform: rotate(-15deg)"
+          style="bottom: -30px; right: -50px; width: 120px; height: 40px"
         ></div>
       </div>
 
       <!-- Moment 2: 62% STRUGGLE WITH STATIC CONTENT -->
-      <div id="moment-2" class="moment" style="opacity: 0; transform: scale(0) rotate(-5deg)">
+      <div id="moment-2" class="moment" style="opacity: 0">
         <div class="sticker-stack">
           <div class="sticker-bg white-bg"></div>
           <div class="sticker-content blue-bg white-border">
@@ -53,7 +53,7 @@
       </div>
 
       <!-- Moment 3: 75% LACK EDITING SKILLS -->
-      <div id="moment-3" class="moment" style="opacity: 0; transform: scale(0) rotate(3deg)">
+      <div id="moment-3" class="moment" style="opacity: 0">
         <div class="sticker-stack">
           <div class="sticker-bg pink-bg"></div>
           <div class="sticker-content white-bg pink-border">
@@ -64,13 +64,7 @@
         <!-- Decorative shapes -->
         <div
           class="shape pill blue-bg"
-          style="
-            top: -30px;
-            left: 50%;
-            transform: translateX(-50%) rotate(5deg);
-            width: 150px;
-            height: 45px;
-          "
+          style="top: -30px; left: 50%; width: 150px; height: 45px"
         ></div>
         <div
           class="shape circle yellow-bg"
@@ -120,7 +114,6 @@
       [data-composition-id="stats"] #moment-3 {
         bottom: 100px; /* Below A-roll when centered */
         left: 50%;
-        transform: translateX(-50%);
         width: 800px;
       }
 
@@ -285,6 +278,18 @@
         const t2 = getWordTime("Sixty-two") || 4.659;
         const t3 = getWordTime("three") || 8.88;
 
+        // Keep all transform state in GSAP so later scale/y tweens compose
+        // with the authored rotation and centering instead of replacing it.
+        tl.set("#moment-1", { scale: 0, rotation: 8, transformOrigin: "center center" }, 0);
+        tl.set("#moment-2", { scale: 0, rotation: -5, transformOrigin: "center center" }, 0);
+        tl.set(
+          "#moment-3",
+          { scale: 0, rotation: 3, xPercent: -50, transformOrigin: "center center" },
+          0,
+        );
+        tl.set("#moment-1 .pill", { rotation: -15 }, 0);
+        tl.set("#moment-3 .pill", { xPercent: -50, rotation: 5 }, 0);
+
         // Moment 1 Animation (approx 5s)
         tl.to(
           "#moment-1",
@@ -293,7 +298,6 @@
             scale: 1,
             duration: 0.8,
             ease: "elastic.out(1, 0.6)",
-            onStart: () => gsap.set("#moment-1", { transformOrigin: "center center" }),
           },
           t1,
         );
@@ -318,7 +322,6 @@
             scale: 1,
             duration: 0.8,
             ease: "elastic.out(1, 0.6)",
-            onStart: () => gsap.set("#moment-2", { transformOrigin: "center center" }),
           },
           t2,
         );
@@ -343,7 +346,6 @@
             scale: 1,
             duration: 0.8,
             ease: "elastic.out(1, 0.6)",
-            onStart: () => gsap.set("#moment-3", { transformOrigin: "center center" }),
           },
           t3,
         );


### PR DESCRIPTION
## What

- move play-mode stats transform baselines from CSS into its paused GSAP timeline
- align transcript lint parsing with the JavaScript object syntax already supported by Studio
- add regression coverage that lints the shipped play-mode project and requires zero blocking errors

## Why

A fresh `hyperframes@0.7.54 init --example play-mode` scaffold fails its own lint gate with five errors: four CSS/GSAP transform conflicts and one transcript parse error. The transcript error also conflicts with the formatter, which removes unnecessary property-key quotes, and with Studio, which already accepts unquoted JavaScript keys.

## How

The stats composition now initializes scale, rotation, centering, and transform origins through deterministic `tl.set` calls before its existing tweens. Caption lint uses the same conservative normalization as the Studio parser for single quotes, unquoted keys, and trailing commas while still rejecting unsupported syntax.

## Test plan

- `bun run --filter @hyperframes/lint test` (364 passed)
- `bun run --filter @hyperframes/lint typecheck`
- `bun run --filter @hyperframes/lint build`
- `bunx oxfmt --check` on all changed files
- `bunx oxlint` on changed TypeScript files
- full pre-commit hooks, including repository typecheck and tracked-artifact checks