### PR TITLE
fix(transcribe): avoid Python whisper CLI

### DIFF
--- a/packages/cli/src/whisper/manager.test.ts
+++ b/packages/cli/src/whisper/manager.test.ts
@@ -1,5 +1,35 @@
-import { describe, it, expect } from "vitest";
-import { WhisperUnavailableError, isWhisperUnavailable } from "./manager.js";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { findWhisper, WhisperUnavailableError, isWhisperUnavailable } from "./manager.js";
+
+const originalPath = process.env["PATH"];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  process.env["PATH"] = originalPath;
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+describe("findWhisper", () => {
+  it.runIf(process.platform !== "win32")(
+    "does not mistake Python openai-whisper for whisper.cpp",
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), "hyperframes-whisper-path-"));
+      tempDirs.push(dir);
+      const pythonWhisper = join(dir, "whisper");
+      writeFileSync(pythonWhisper, "#!/bin/sh\necho 'OpenAI Whisper Python CLI'\n");
+      chmodSync(pythonWhisper, 0o755);
+      process.env["PATH"] = `${dir}:/usr/bin:/bin`;
+
+      const result = findWhisper();
+
+      expect(result?.executablePath).not.toBe(pythonWhisper);
+    },
+  );
+});
 
 describe("isWhisperUnavailable", () => {
   it("recognizes WhisperUnavailableError instances", () => {

--- a/packages/cli/src/whisper/manager.ts
+++ b/packages/cli/src/whisper/manager.ts
@@ -67,10 +67,11 @@ function findFromEnv(): WhisperResult | undefined {
 }
 
 function findFromSystem(): WhisperResult | undefined {
-  for (const name of ["whisper-cli", "whisper"]) {
-    const path = whichBinary(name);
-    if (path) return { executablePath: path, source: "system" };
-  }
+  // `whisper` is also the executable installed by Python's openai-whisper
+  // package. It accepts a different flag set from whisper.cpp, so treating it
+  // as a compatible fallback causes transcription to fail after discovery.
+  const path = whichBinary("whisper-cli");
+  if (path) return { executablePath: path, source: "system" };
 
   // Check brew paths directly on macOS
   if (platform() === "darwin") {


### PR DESCRIPTION
## What

Only discover `whisper-cli` when looking for a system whisper.cpp binary.

## Why

The Python OpenAI Whisper package also installs a `whisper` executable. HyperFrames treated that unrelated CLI as whisper.cpp and passed incompatible flags, causing transcription to fail before fallback.

## How

Remove the ambiguous `whisper` executable fallback and add a regression test that places a fake Python-style `whisper` on PATH.

## Test plan

- `bun run --filter @hyperframes/cli test` (128 files, 1637 tests)
- `bun run --filter @hyperframes/cli typecheck`
- `bunx oxfmt --check packages/cli/src/whisper/manager.ts packages/cli/src/whisper/manager.test.ts`
- `bunx oxlint packages/cli/src/whisper/manager.ts packages/cli/src/whisper/manager.test.ts`
- `git diff --check`