### PR TITLE
fix(cli): grant s3 encryption actions in lambda policies user output

### DIFF
--- a/packages/cli/src/commands/lambda/policies.test.ts
+++ b/packages/cli/src/commands/lambda/policies.test.ts
@@ -32,6 +32,10 @@ describe("policies — required actions", () => {
       "lambda:CreateFunction",
       "states:StartExecution",
       "s3:PutObject",
+      // SAM's --resolve-s3 managed bucket is encrypted; the deploy user must
+      // be able to set/read that encryption or the first deploy rolls back.
+      "s3:PutEncryptionConfiguration",
+      "s3:GetEncryptionConfiguration",
       "iam:CreateRole",
       "logs:CreateLogGroup",
       "cloudwatch:PutMetricAlarm",

--- a/packages/cli/src/commands/lambda/policies.ts
+++ b/packages/cli/src/commands/lambda/policies.ts
@@ -123,12 +123,18 @@ const REQUIRED_ACTIONS = {
     "s3:GetBucketPolicy",
     "s3:GetBucketTagging",
     "s3:GetBucketVersioning",
+    // SAM's `--resolve-s3` managed bucket (aws-sam-cli-managed-default) sets
+    // default SSE encryption; CloudFormation reads it on update/drift. Without
+    // Get/PutEncryptionConfiguration the first `lambda deploy` 403s creating
+    // that bucket and the managed stack rolls back.
+    "s3:GetEncryptionConfiguration",
     "s3:GetLifecycleConfiguration",
     "s3:ListAllMyBuckets",
     "s3:ListBucket",
     "s3:PutBucketPolicy",
     "s3:PutBucketTagging",
     "s3:PutBucketVersioning",
+    "s3:PutEncryptionConfiguration",
     "s3:PutLifecycleConfiguration",
     "s3:PutPublicAccessBlock",
   ],

--- a/packages/cli/src/commands/lambda/sam.ts
+++ b/packages/cli/src/commands/lambda/sam.ts
@@ -106,7 +106,14 @@ export function samDeploy(opts: DeployOptions): void {
   const samDir = join(opts.repoRoot, "examples", "aws-lambda");
   const result = spawnSync("sam", args, { cwd: samDir, stdio: opts.stdio ?? "inherit" });
   if (result.status !== 0) {
-    throw new Error(`[lambda] sam deploy exited with code ${result.status ?? "unknown"}`);
+    throw new Error(
+      `[lambda] sam deploy exited with code ${result.status ?? "unknown"}\n` +
+        `If a prior attempt left a stack in ROLLBACK_COMPLETE, CloudFormation can't reuse it. ` +
+        `Delete it before retrying:\n` +
+        `  aws cloudformation delete-stack --stack-name aws-sam-cli-managed-default --region ${opts.region}\n` +
+        `  aws cloudformation delete-stack --stack-name ${opts.stackName} --region ${opts.region}\n` +
+        `(the first is SAM's managed artifacts stack from --resolve-s3; the second is the render stack).`,
+    );
   }
 }
 


### PR DESCRIPTION
## What

Add `s3:GetEncryptionConfiguration` and `s3:PutEncryptionConfiguration` to the `s3Bucket` action set emitted by `hyperframes lambda policies user` / `role` (`packages/cli/src/commands/lambda/policies.ts`). Also add a recovery hint to the `sam deploy` failure path in `sam.ts`.

Fixes #2137.

## Why

`hyperframes lambda deploy` runs `sam deploy --resolve-s3`. SAM's managed artifacts bucket (`aws-sam-cli-managed-default` → `SamCliSourceBucket`) is created with default SSE encryption (`BucketEncryption`, `SSEAlgorithm: aws:kms` — see SAM CLI `samcli/lib/bootstrap/bootstrap.py`). CloudFormation, acting with the deploy user's own credentials (no `--role-arn` is passed), must call `s3:PutEncryptionConfiguration` to set that.

The generated policy granted `CreateBucket`, `PutPublicAccessBlock`, `PutBucketVersioning`, and `PutBucketPolicy` — every other property the managed bucket sets — but **not** encryption. So a user provisioned exactly per `lambda policies user` gets a single 403 on `s3:PutEncryptionConfiguration`, the managed-resources stack rolls back, and the first deploy exits 1. This matches the CloudFormation error in the issue verbatim.

`GetEncryptionConfiguration` is paired with `Put` because CloudFormation's S3 handler reads encryption state on update/drift, consistent with the existing `Get`/`Put` pairs already in the list (`GetBucketVersioning`/`PutBucketVersioning`, `GetBucketPolicy`/`PutBucketPolicy`).

Secondary: the reporter noted that after the rollback, the dead stack is stuck in `ROLLBACK_COMPLETE` and must be deleted before a retry succeeds — so the `sam deploy` failure now prints the `delete-stack` commands for both the managed and render stacks.

## How

- `policies.ts`: two actions added to `s3Bucket`, in alphabetical position, with a comment explaining the SAM dependency.
- `sam.ts`: `samDeploy` non-zero-exit error now includes the `ROLLBACK_COMPLETE` recovery hint.
- These flow through `allRequiredActions()`, so `policies validate` and `policies role` pick them up automatically.

Out of scope (left as follow-ups from the issue): a `--skip-sam`/adopt-existing-stack mode for `deploy`, and a `render` fallback that reads stack outputs directly when `.hyperframes/lambda-stack-<region>.json` is absent. Those are features with design tradeoffs, not part of this permission gap.

## Test plan

- [x] Unit tests added/updated — `policies.test.ts` now asserts both encryption actions are in the required set; full suite passes (16/16).
- [x] Lint (oxlint), format (oxfmt), and typecheck (`@hyperframes/cli`) pass locally; pre-commit hooks (incl. fallow audit gate) green.
- [ ] Manual AWS deploy not run here (needs a live account); the fix is verified by matching the exact CloudFormation 403 in the issue against SAM's managed-bucket template and the generated action list.