### PR TITLE
fix(lint): decode entity-encoded variable values

### DIFF
--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -823,6 +823,15 @@ describe("composition rules", () => {
       expect(finding).toBeUndefined();
     });
 
+    it("does not warn for Studio-serialized entity-encoded JSON", async () => {
+      const html = `<html><body>
+<div data-composition-src="card.html" data-variable-values="{&quot;title&quot;:&quot;R&amp;D&quot;,&quot;count&quot;:3}"></div>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "invalid_variable_values_json");
+      expect(finding).toBeUndefined();
+    });
+
     it("does not warn when data-variable-values is absent", async () => {
       const html = `<html><body>
 <div data-composition-src="card.html"></div>

--- a/packages/lint/src/utils.ts
+++ b/packages/lint/src/utils.ts
@@ -194,7 +194,18 @@ export function readJsonAttr(tagSource: string, attr: string): string | null {
     new RegExp(`(?<![\\w-])${escaped}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, "i"),
   );
   if (!match) return null;
-  return match[1] ?? match[2] ?? null;
+  const value = match[1] ?? match[2] ?? null;
+  if (value == null) return null;
+
+  // Studio serializes edited attributes with double quotes and escapes JSON's
+  // inner quotes as HTML entities. Decode the attribute value the same way a
+  // browser does before handing it to JSON.parse.
+  return value
+    .replace(/&quot;|&#34;|&#x22;/gi, '"')
+    .replace(/&apos;|&#39;|&#x27;/gi, "'")
+    .replace(/&lt;|&#60;|&#x3c;/gi, "<")
+    .replace(/&gt;|&#62;|&#x3e;/gi, ">")
+    .replace(/&amp;|&#38;|&#x26;/gi, "&");
 }
 
 export function collectCompositionIds(tags: OpenTag[]): Set<string> {


### PR DESCRIPTION
## What

Decode HTML entities in `data-variable-values` before validating the attribute as JSON.

## Why

Studio serializes edited JSON attributes with double-quoted HTML attributes and entity-encoded inner quotes. That markup is valid HTML and browsers expose decoded JSON, but StaticGuard lint parsed the raw `&quot;` text and reported `invalid_variable_values_json`.

## How

- Decode standard named and numeric entities in JSON attribute values.
- Add a regression test covering Studio-style serialization, including an encoded ampersand in a string value.

## Test plan

- `bun run --filter @hyperframes/lint test` (363 tests passed)
- `bun run --filter @hyperframes/lint typecheck`
- `bunx oxfmt --check packages/lint/src/utils.ts packages/lint/src/rules/composition.test.ts`
- `bunx oxlint packages/lint/src/utils.ts packages/lint/src/rules/composition.test.ts`
- `git diff --check`

Note: the repository-wide pre-commit typecheck currently cannot resolve the ungenerated Producer `runtime-inline` module in a fresh worktree; package-scoped lint typecheck passes.