### PR TITLE
fix(render): reject incomplete captured frames

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -230,7 +230,7 @@ describe("executeDiskCaptureWithAdaptiveRetry — transient Target-closed single
 
   const writeAllFrames = (framesDir: string, totalFrames: number): void => {
     for (let i = 0; i < totalFrames; i++) {
-      writeFileSync(join(framesDir, formatCaptureFrameName(i, "jpg")), "x");
+      writeFileSync(join(framesDir, formatCaptureFrameName(i, "jpg")), "captured-frame");
     }
   };
 
@@ -1432,13 +1432,28 @@ describe("adaptive missing-frame retry helpers", () => {
   it("finds contiguous missing frame ranges from captured disk frames", () => {
     const framesDir = makeFramesDir();
     for (const frameIndex of [0, 1, 4]) {
-      writeFileSync(join(framesDir, `frame_${String(frameIndex).padStart(6, "0")}.jpg`), "x");
+      writeFileSync(
+        join(framesDir, `frame_${String(frameIndex).padStart(6, "0")}.jpg`),
+        "captured-frame",
+      );
     }
 
     expect(findMissingFrameRanges(6, framesDir, "jpg")).toEqual([
       { startFrame: 2, endFrame: 4 },
       { startFrame: 5, endFrame: 6 },
     ]);
+  });
+
+  it("retries a worker placeholder instead of accepting a truncated sequence", () => {
+    const framesDir = makeFramesDir();
+    for (let frameIndex = 0; frameIndex < 4; frameIndex++) {
+      writeFileSync(
+        join(framesDir, `frame_${String(frameIndex).padStart(6, "0")}.jpg`),
+        frameIndex === 2 ? "x" : "captured-frame",
+      );
+    }
+
+    expect(findMissingFrameRanges(4, framesDir, "jpg")).toEqual([{ startFrame: 2, endFrame: 3 }]);
   });
 
   it("builds retry batches that cap active workers per attempt", () => {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -603,7 +603,12 @@ export function findMissingFrameRanges(
 
   for (let frameIndex = 0; frameIndex < totalFrames; frameIndex++) {
     const framePath = join(framesDir, formatCaptureFrameName(frameIndex, frameExt));
-    const missing = !existsSync(framePath);
+    // A capture worker can leave a zero/one-byte placeholder behind when it
+    // exits between creating the destination and writing the image. FFmpeg's
+    // image2 demuxer treats that as end-of-sequence but still exits 0, which
+    // used to let a truncated video be reported as successful. Real JPEG and
+    // PNG captures are necessarily larger than their 8-byte file signatures.
+    const missing = !existsSync(framePath) || statSync(framePath).size <= 8;
     if (missing && rangeStart === null) {
       rangeStart = frameIndex;
     } else if (!missing && rangeStart !== null) {


### PR DESCRIPTION
## What

Treat tiny capture-worker frame placeholders as missing frames before encoding.

## Why

A Windows multi-worker render reported success even though its video stopped at frame 2,855 while audio continued to the full 229.5 seconds. Locally, an image sequence containing a one-byte worker placeholder reproduced the integrity failure: FFmpeg stopped at the placeholder, emitted only the prefix, and still exited with status 0. The existing capture continuity check only tested file existence, so it accepted the placeholder as a completed frame.

## How

- Require captured JPEG/PNG frame files to be larger than the 8-byte image-signature floor when scanning continuity.
- Let the existing adaptive missing-frame path retry or fail the affected range instead of encoding a truncated prefix.
- Add a regression test for a one-byte placeholder inside an otherwise contiguous sequence.

## Test plan

- Reproduced FFmpeg exit-0 truncation locally with a one-byte frame placeholder.
- `bunx vitest run src/services/renderOrchestrator.test.ts` (140 passed)
- `bun run test:unit`
- `bun run typecheck`
- `bunx oxfmt --check src/services/renderOrchestrator.ts src/services/renderOrchestrator.test.ts`
- `bunx oxlint src/services/renderOrchestrator.ts src/services/renderOrchestrator.test.ts`