### PR TITLE
fix(render): retry transient network changes

### DIFF
--- a/packages/engine/src/services/frameCapture-transientErrors.test.ts
+++ b/packages/engine/src/services/frameCapture-transientErrors.test.ts
@@ -14,6 +14,7 @@ describe("isTransientBrowserError", () => {
     "Cannot find context with specified id",
     "Failed to launch the browser process! TROUBLESHOOTING: https://pptr.dev/troubleshooting",
     "connect ECONNREFUSED 127.0.0.1:9222",
+    "net::ERR_NETWORK_CHANGED at http://127.0.0.1:4173/index.html",
     "Navigation timeout of 60000 ms exceeded",
     // pollHfReady timed out before window.__renderReady flipped true — the
     // classic symptom of a slow/contended host (e.g. several renders running

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -3266,6 +3266,11 @@ const TRANSIENT_BROWSER_ERROR_PATTERNS = [
   /Failed to launch the browser process/i,
   /Navigation timeout of \d+ ms exceeded/i,
   /ECONNREFUSED/i,
+  // Chromium can briefly invalidate even a localhost connection when Windows
+  // reports an adapter/route change. A fresh capture session succeeds once the
+  // network stack settles, so treat this like the other bounded navigation
+  // retries instead of failing the render immediately.
+  /net::ERR_NETWORK_CHANGED/i,
   // pollHfReady's own timeout — thrown when window.__renderReady never flips
   // true within playerReadyTimeout. "Runtime ready: false" means init simply
   // didn't finish in time (commonly a slow/contended host, e.g. several


### PR DESCRIPTION
## What

Classify Chromium `net::ERR_NETWORK_CHANGED` navigation failures as transient capture errors.

## Why

A Windows render failed mid-capture while navigating the local HyperFrames server with `net::ERR_NETWORK_CHANGED`; an immediate retry succeeded. The bounded browser retry classifier did not recognize this Chromium network-stack transition, so otherwise recoverable captures could fail on the first occurrence.

## How

Add the error signature to the existing transient-browser classifier, which routes it through the already bounded fresh-session retry path. Add a regression case with the localhost URL form reported by Chromium.

## Test plan

- `bunx vitest run src/services/frameCapture-transientErrors.test.ts` (42 passed)
- `bun run typecheck`
- `bunx oxfmt --check src/services/frameCapture.ts src/services/frameCapture-transientErrors.test.ts`
- `bunx oxlint src/services/frameCapture.ts src/services/frameCapture-transientErrors.test.ts`
- Full engine suite: 942 passed; 2 unrelated VFR extraction tests failed because the host FFmpeg 4.2.2 does not support `-fps_mode`.