### PR TITLE
fix(cli): list check in root help

### DIFF
--- a/packages/cli/src/cli.commands.test.ts
+++ b/packages/cli/src/cli.commands.test.ts
@@ -27,6 +27,13 @@ describe("CLI command registration", () => {
     );
   });
 
+  it("shows check in root help when deprecated commands recommend it", () => {
+    const loaders = commandLoaderBlock();
+
+    expect(loaders).toMatch(/\bcheck:\s*\(\)\s*=>\s*import\("\.\/commands\/check\.js"\)/);
+    expect(helpSource).toContain('["check", "Run all composition quality checks"]');
+  });
+
   // A command actively reconciling skills (`skills check`/`skills update`)
   // must not also nudge the user to go reconcile skills — that nudge is
   // either redundant (it just ran) or misleading (a stale cached count from

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -32,6 +32,7 @@ const GROUPS: Group[] = [
   {
     title: "Project",
     commands: [
+      ["check", "Run all composition quality checks"],
       ["lint", "Validate a composition for common mistakes"],
       [
         "validate",


### PR DESCRIPTION
## What

Add `check` to the Project section of root CLI help.

## Why

CLI 0.7.54 deprecates `validate` and `inspect` in favor of `hyperframes check`, but `hyperframes --help` did not list the replacement command even though it was registered and usable. That made the deprecation guidance look invalid.

## How

- List `check` alongside the other project-quality commands.
- Add a command-registration regression test requiring registered `check` to appear in root help.

## Test plan

- `bunx vitest run src/cli.commands.test.ts`
- `bun run test` (128 files, 1,637 tests passed)
- `bun run typecheck`
- `bunx oxfmt --check src/help.ts src/cli.commands.test.ts`
- `bunx oxlint src/help.ts src/cli.commands.test.ts`