### PR TITLE
fix(check): preserve external module scripts

### DIFF
--- a/packages/cli/src/utils/compositionServer.ts
+++ b/packages/cli/src/utils/compositionServer.ts
@@ -62,6 +62,7 @@ export function injectRuntime(html: string): string {
 
 const ASSET_CONTENT_TYPES: Record<string, string> = {
   js: "application/javascript",
+  mjs: "application/javascript",
   css: "text/css",
   json: "application/json",
   png: "image/png",

--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -405,6 +405,22 @@ describe("bundleToSingleHtml", () => {
     expect(bundled).not.toContain('src="vendor/effect-plugin.js"');
   });
 
+  it("preserves local module scripts and their import base URL", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html><html><body>
+        <div data-composition-id="main" data-start="0" data-duration="1"></div>
+        <script type="module" src="./module.js"></script>
+      </body></html>`,
+      "module.js": `import { value } from "./value.js"; window.result = value;`,
+      "value.js": `export const value = "loaded";`,
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    expect(bundled).toMatch(/<script\b[^>]*\btype="module"[^>]*\bsrc="\.\/module\.js"/);
+    expect(bundled).not.toContain('import { value } from "./value.js"');
+  });
+
   it("preserves local sub-composition script order before inline scene scripts", async () => {
     const dir = makeTempProject({
       "index.html": `<!doctype html>

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -843,6 +843,10 @@ export async function bundleToSingleHtml(
   for (const el of [...document.querySelectorAll("script[src]")]) {
     const src = el.getAttribute("src");
     if (!src || !isRelativeUrl(src)) continue;
+    // Module scripts can contain static imports whose resolution is relative
+    // to the script URL. Folding their source into a classic inline script
+    // both drops module semantics and changes the import base URL.
+    if ((el.getAttribute("type") || "").trim().toLowerCase() === "module") continue;
     const jsPath = resolveEntryPath(src);
     const js = jsPath ? safeReadFile(jsPath) : null;
     if (js == null) continue;

--- a/packages/engine/src/services/fileServer.ts
+++ b/packages/engine/src/services/fileServer.ts
@@ -16,6 +16,7 @@ const MIME_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
   ".css": "text/css; charset=utf-8",
   ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
   ".json": "application/json; charset=utf-8",
   ".png": "image/png",
   ".jpg": "image/jpeg",

--- a/packages/producer/src/services/fileServer.test.ts
+++ b/packages/producer/src/services/fileServer.test.ts
@@ -315,6 +315,24 @@ describe("parseRangeHeader", () => {
 });
 
 describe("createFileServer", () => {
+  it("serves ES modules with a JavaScript MIME type", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-file-server-mjs-"));
+    try {
+      writeEmptyIndex(projectDir);
+      writeFileSync(join(projectDir, "scene.mjs"), "export const scene = true;");
+      const server = await createFileServer({ projectDir, preHeadScripts: [], headScripts: [] });
+      try {
+        const response = await fetch(`${server.url}/scene.mjs`);
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("application/javascript; charset=utf-8");
+      } finally {
+        server.close();
+      }
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
   async function expectInjectedRenderFps(
     fps: Parameters<typeof createFileServer>[0]["fps"],
     expected: {

--- a/packages/producer/src/services/fileServer.ts
+++ b/packages/producer/src/services/fileServer.ts
@@ -79,6 +79,7 @@ const MIME_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
   ".css": "text/css; charset=utf-8",
   ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
   ".json": "application/json; charset=utf-8",
   ".cube": "text/plain; charset=utf-8",
   ".png": "image/png",


### PR DESCRIPTION
## What

Preserve local external `type="module"` scripts when bundling a composition for check/render.

## Why

The bundler inlined every local script into a classic script tag. Module imports then failed during `check` with `Cannot use import statement outside a module`, even though the author explicitly used `type="module"`.

## How

Skip classic-script coalescing for local module scripts so the static project server retains module semantics and the script-relative import base URL.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)

- `bun test packages/core/src/compiler/htmlBundler.test.ts`
- `bunx oxlint packages/core/src/compiler/htmlBundler.ts packages/core/src/compiler/htmlBundler.test.ts`
- Reproduced failure with an external module importing a sibling file on 0.7.54; source CLI now passes `check --snapshots` with 0 runtime errors.
