### PR TITLE
fix(lint): skip installed component snippets

### DIFF
--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -217,6 +217,9 @@ export async function lintProject(projectDir: string): Promise<ProjectLintResult
       const html = readFileSync(filePath, "utf-8");
       const compSrcPath = `compositions/${file}`;
       allHtmlSources.push({ html, compSrcPath });
+      // Registry components are pasteable snippets installed under this
+      // reserved directory, not independently renderable compositions.
+      if (file === "components" || file.startsWith("components/")) continue;
       // Mountable fragments (figma component imports, registry snippets) are
       // not standalone compositions — composition-root rules don't apply.
       // Anchored to the file's ROOT element so a real composition that merely

--- a/packages/lint/src/snippetFragment.test.ts
+++ b/packages/lint/src/snippetFragment.test.ts
@@ -26,6 +26,21 @@ async function lintWithFragment(name: string, html: string) {
 }
 
 describe("snippet fragment exemption", () => {
+  it("skips registry snippets installed under compositions/components", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-component-lint-"));
+    dirs.push(dir);
+    writeFileSync(join(dir, "index.html"), INDEX);
+    mkdirSync(join(dir, "compositions", "components"), { recursive: true });
+    writeFileSync(
+      join(dir, "compositions", "components", "grain-overlay.html"),
+      '<div id="grain-overlay"><div class="grain-texture"></div></div>',
+    );
+
+    const result = await lintProject(dir);
+
+    expect(result.results.map((entry) => entry.file)).toEqual(["index.html"]);
+  });
+
   it("skips composition-root rules for files whose ROOT carries data-hf-snippet", async () => {
     const findings = await lintWithFragment(
       "frag.html",


### PR DESCRIPTION
## What

Exclude the reserved `compositions/components/` snippet directory from standalone composition linting.

## Why

`hyperframes add grain-overlay` installs pasteable component HTML under that directory. Project lint then treated the snippet as a renderable composition and emitted false `root_missing_composition_id` and `root_missing_dimensions` errors.

## How

Keep component HTML in the project-wide source set, but skip standalone composition-root rules for files under `compositions/components/`.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)

- Reproduced with `hyperframes@0.7.54 init` + `add grain-overlay` + `lint`
- `bun test packages/lint/src/snippetFragment.test.ts packages/lint/src/project.test.ts`
- `bunx oxlint packages/lint/src/project.ts packages/lint/src/snippetFragment.test.ts`
