### PR TITLE
fix(motion-graphics): build at the CLI root target

### DIFF
--- a/skills/motion-graphics/SKILL.md
+++ b/skills/motion-graphics/SKILL.md
@@ -33,7 +33,7 @@ A short design-led motion graphic. **Asset-first**: decide the asset strategy an
 | plan     | subagent — **decide search?** + classify + asset strategy             | `shot-plan.json` (draft: category, `asset_needs` queries, brief) | `agents/director.md` (Part 1) |
 | source ◇ | Bash — media-use resolve (**skip if `asset_needs` is empty**)         | `assets/` + `assets/index.md`                                    | `phases/source/guide.md`      |
 | design   | subagent — shot design around resolved assets                         | `shot-plan.json` (final: block(s) + layout + motion + positions) | `agents/director.md` (Part 2) |
-| build    | subagent — reuse-first composition                                    | `compositions/index.html`                                        | `agents/builder.md`           |
+| build    | subagent — reuse-first composition                                    | `index.html`                                                     | `agents/builder.md`           |
 | render   | Bash — `hyperframes render` (MP4, or `--format webm/mov` for overlay) | `renders/video.mp4`                                              | Step 5                        |
 | verify   | Bash — `lint` / `inspect` -> repair subagent on failure               | (fixes in place)                                                 | `agents/finalize.md`          |
 
@@ -122,7 +122,7 @@ Dispatch a subagent (prompt = `agents/director.md` Part 2 + dispatch context inc
 
 ### Step 4 — Build (subagent: Builder, reuse-first)
 
-Dispatch a subagent. prompt = full `agents/builder.md` + dispatch context (`shot-plan.json`, `catalog-map.md`, the category's `module.md`, `references/motion-vocabulary.md`, `references/builder-contract.md`). **Reuse-first**: `npx hyperframes add <block>` + customize in place; hand-author only gaps + the asset-fusion affordance. Output `compositions/index.html` honoring the HF contract (paused GSAP timeline on `window.__timelines`, `class="clip"` + stable ids, `tl.seek(0)`, deterministic).
+Dispatch a subagent. prompt = full `agents/builder.md` + dispatch context (`shot-plan.json`, `catalog-map.md`, the category's `module.md`, `references/motion-vocabulary.md`, `references/builder-contract.md`). **Reuse-first**: `npx hyperframes add <block>` + customize in place; hand-author only gaps + the asset-fusion affordance. Output `index.html` at the project root so the default `hyperframes check .` and `hyperframes render .` commands target the finished film. Honor the HF contract (paused GSAP timeline on `window.__timelines`, `class="clip"` + stable ids, `tl.seek(0)`, deterministic).
 
 ### Step 5 — Render (Bash)
 
@@ -151,13 +151,13 @@ Flags live in the `hyperframes-cli` skill (`references/preview-render.md`).
 
 ## Resume table
 
-| State                                                    | Continue from            |
-| -------------------------------------------------------- | ------------------------ |
-| no `shot-plan.json`                                      | Step 1 (plan)            |
-| `shot-plan.json` has `asset_needs`, no `assets/`         | Step 2 (source)          |
-| `shot-plan.json` final, no `compositions/index.html`     | Step 3/4 (design+build)  |
-| `compositions/index.html` exists, no `renders/video.mp4` | Step 5 (render) + Step 6 |
-| `renders/video.mp4` exists                               | Report + stop            |
+| State                                            | Continue from            |
+| ------------------------------------------------ | ------------------------ |
+| no `shot-plan.json`                              | Step 1 (plan)            |
+| `shot-plan.json` has `asset_needs`, no `assets/` | Step 2 (source)          |
+| `shot-plan.json` final, no `index.html`          | Step 3/4 (design+build)  |
+| `index.html` exists, no `renders/video.mp4`      | Step 5 (render) + Step 6 |
+| `renders/video.mp4` exists                       | Report + stop            |
 
 ## Design notes (maintainers — execution does not read this)
 
@@ -170,7 +170,7 @@ Flags live in the `hyperframes-cli` skill (`references/preview-render.md`).
     hyperframes.json  context.log
     shot-plan.json            # the IR (Director output)
     assets/  assets/index.md  # media-use output (if sourced)
-    compositions/index.html   # Builder output
+    index.html                # Builder output and default CLI target
     renders/video.mp4
   ```
 - **Registration:** in `hyperframes` router — add the "design-led short motion graphic" intent + Workflow description; carve the motion-graphics triggers out of `/general-video`; add reverse Do-NOT-use edges. See `motion-graphics-genre.md` §5-7.

--- a/skills/motion-graphics/agents/builder.md
+++ b/skills/motion-graphics/agents/builder.md
@@ -1,6 +1,6 @@
 # Motion-Graphics Builder
 
-Turn `shot-plan.json` into one renderable HyperFrames composition (`compositions/index.html`). Everything stays in the HF ecosystem — HTML is the source of truth; a single **paused** GSAP timeline carries all motion; the engine seeks it. Category-specific build rules live in `categories/<id>/module.md`; this file is the shared contract.
+Turn `shot-plan.json` into one renderable HyperFrames composition (`index.html` at the project root). The CLI's default `check .` and `render .` targets resolve this root file, so do not leave the finished film only under `compositions/`. Everything stays in the HF ecosystem — HTML is the source of truth; a single **paused** GSAP timeline carries all motion; the engine seeks it. Category-specific build rules live in `categories/<id>/module.md`; this file is the shared contract.
 
 ## Reuse-first (the default)
 

--- a/skills/motion-graphics/agents/finalize.md
+++ b/skills/motion-graphics/agents/finalize.md
@@ -9,7 +9,7 @@ Snapshot visual QA + one in-place fix pass + render. Dispatched only when Step 6
 ## Flow
 
 1. **Snapshots** — `npx hyperframes check . --at <beat times> --snapshots`; eyeball for: overflow / off-canvas, text collisions, empty frames, wrong content, motion that doesn't read.
-2. **One in-place repair pass** — `Edit` `compositions/index.html` for the visible issues. **Never change a fixed `data-duration`** (timing is set upstream; changing it breaks assembly). Re-run `lint`/`inspect`.
+2. **One in-place repair pass** — `Edit` the project-root `index.html` for the visible issues. **Never change a fixed `data-duration`** (timing is set upstream; changing it breaks assembly). Re-run `check`.
 3. **Render** — `(cd "$PROJECT_DIR" && npx hyperframes render . --skill=motion-graphics -q <quality> -o ./renders/video.mp4)` (add `--format webm` for an alpha overlay export). Verify the mp4 exists + duration matches.
 
 ## STOP / escalate

--- a/skills/motion-graphics/skill.test.mjs
+++ b/skills/motion-graphics/skill.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("motion-graphics builds the composition at the CLI default target", async () => {
+  const [skill, builder, finalize] = await Promise.all([
+    read("./SKILL.md"),
+    read("./agents/builder.md"),
+    read("./agents/finalize.md"),
+  ]);
+
+  for (const content of [skill, builder, finalize]) {
+    assert.doesNotMatch(content, /compositions\/index\.html/);
+  }
+  assert.match(skill, /Output `index\.html`/);
+  assert.match(builder, /renderable HyperFrames composition \(`index\.html` at the project root\)/);
+});


### PR DESCRIPTION
## Summary
- make the motion-graphics builder write the finished film to project-root `index.html`
- align resume/finalize guidance with the CLI default `check .` and `render .` target
- add a regression test that prevents reintroducing `compositions/index.html` as the standalone output

## Reproduction
With a blank scaffold at root `index.html` and the intended film at `compositions/index.html`, `npx hyperframes@0.7.55 check . --json` scanned both files but ran runtime/layout against the root scaffold. This matches the 4/5 field report.

## Verification
- `node --test skills/motion-graphics/skill.test.mjs`
- `bun run test:skills` (226 passed)
- `bun run lint:skills`
- `git diff --check`