### PR TITLE
fix(cli): catch transient contrast and counter overflow

### DIFF
--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -311,9 +311,9 @@ function runtimeError(): CheckFinding {
 }
 
 describe("contrast sample selection", () => {
-  it("chooses five evenly distributed grid points including both ends", () => {
+  it("checks every point in the default nine-sample layout grid", () => {
     expect(selectContrastTimes([0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5])).toEqual([
-      0.5, 2.5, 4.5, 6.5, 8.5,
+      0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5,
     ]);
     expect(selectContrastTimes([1, 2, 3])).toEqual([1, 2, 3]);
   });
@@ -950,15 +950,19 @@ describe("check pipeline", () => {
     });
     const { report } = await runScenario(captured, { snapshots: true }, { writeSnapshot: writer });
 
-    expect(report.snapshots.times).toEqual([0.5, 2.5, 4.5, 6.5, 8.5]);
+    expect(report.snapshots.times).toEqual([0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5]);
     expect(report.snapshots.files).toEqual([
       "snapshots/frame-00-at-0.5s.png",
-      "snapshots/frame-01-at-2.5s.png",
-      "snapshots/frame-02-at-4.5s.png",
-      "snapshots/frame-03-at-6.5s.png",
-      "snapshots/frame-04-at-8.5s.png",
+      "snapshots/frame-01-at-1.5s.png",
+      "snapshots/frame-02-at-2.5s.png",
+      "snapshots/frame-03-at-3.5s.png",
+      "snapshots/frame-04-at-4.5s.png",
+      "snapshots/frame-05-at-5.5s.png",
+      "snapshots/frame-06-at-6.5s.png",
+      "snapshots/frame-07-at-7.5s.png",
+      "snapshots/frame-08-at-8.5s.png",
     ]);
-    expect(writer).toHaveBeenCalledTimes(5);
+    expect(writer).toHaveBeenCalledTimes(9);
 
     const absentWriter = vi.fn(async () => "unused.png");
     await runScenario(fakeDriver(), { snapshots: false }, { writeSnapshot: absentWriter });

--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -419,6 +419,34 @@
     };
   }
 
+  function visibleNowrapOverflowIssue(element, time, tolerance) {
+    const style = getComputedStyle(element);
+    if (clipsOverflow(style) || style.whiteSpace !== "nowrap") return null;
+    const overflowX = element.scrollWidth - element.clientWidth;
+    if (overflowX <= tolerance) return null;
+    const rect = toRect(element.getBoundingClientRect());
+    const overflow = { right: round(overflowX) };
+    return {
+      code: "text_box_overflow",
+      severity: "error",
+      time,
+      selector: selectorFor(element),
+      containerSelector: selectorFor(element),
+      text: textContentFor(element),
+      message: "Non-wrapping text extends outside its authored width.",
+      rect: textRectFor(element) || rect,
+      containerRect: rect,
+      overflow,
+      fixHint: textOverflowFixHint(
+        textRectFor(element) || rect,
+        rect,
+        overflow,
+        parsePx(style.fontSize),
+        "the text box",
+      ),
+    };
+  }
+
   // An ancestor (up to and including `stopAt`) that clips its overflow makes any
   // text spilling past it invisible — that clipping IS the layout mechanism
   // (odometer/ticker reels, masked windows), not a defect to report.
@@ -878,6 +906,8 @@
       if (!hasOwnTextCandidate(element)) continue;
       const clipped = clippedTextIssue(element, time, tolerance);
       if (clipped) issues.push(clipped);
+      const visibleNowrapOverflow = visibleNowrapOverflowIssue(element, time, tolerance);
+      if (visibleNowrapOverflow) issues.push(visibleNowrapOverflow);
       issues.push(...textOverflowIssues(element, root, rootRect, time, tolerance));
       const occluded = occludedTextIssue(element, time);
       if (occluded) issues.push(occluded);

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -145,6 +145,34 @@ describe("layout-audit.browser", () => {
     expect(runAudit().some((issue) => issue.code === "text_box_overflow")).toBe(true);
   });
 
+  it("flags nowrap text that outgrows its own authored width", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="headline">99999999999999</div>
+      </div>
+    `;
+    installGeometry(
+      {
+        root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+        headline: rect({ left: 40, top: 80, width: 220, height: 64 }),
+        text: rect({ left: 40, top: 80, width: 436, height: 64 }),
+      },
+      { headline: { width: "220px", whiteSpace: "nowrap" } },
+    );
+    const headline = document.getElementById("headline")!;
+    Object.defineProperty(headline, "clientWidth", { value: 220 });
+    Object.defineProperty(headline, "scrollWidth", { value: 436 });
+    installAuditScript();
+
+    expect(runAudit()).toContainEqual(
+      expect.objectContaining({
+        code: "text_box_overflow",
+        selector: "#headline",
+        containerSelector: "#headline",
+      }),
+    );
+  });
+
   it("keeps auditing visible descendants beyond the second element", () => {
     document.body.innerHTML = `
       <div id="root" data-composition-id="main" data-width="640" data-height="360">

--- a/packages/cli/src/utils/checkPipeline.ts
+++ b/packages/cli/src/utils/checkPipeline.ts
@@ -84,11 +84,11 @@ export const DEFAULT_CHECK_OPTIONS: CheckOptions = {
   snapshots: false,
 };
 
-/** Pick at most five evenly-strided points from the already-merged layout grid. */
+/** Check every point in the default layout grid; cap unusually dense grids at nine. */
 export function selectContrastTimes(grid: number[]): number[] {
-  if (grid.length <= 5) return [...grid];
-  return Array.from({ length: 5 }, (_, index) => {
-    const selected = Math.floor((index * (grid.length - 1)) / 4);
+  if (grid.length <= 9) return [...grid];
+  return Array.from({ length: 9 }, (_, index) => {
+    const selected = Math.floor((index * (grid.length - 1)) / 8);
     return grid[selected] ?? grid[0] ?? 0;
   });
 }


### PR DESCRIPTION
## What
- run contrast checks at every point in the default nine-sample layout grid (still capped at nine for denser custom grids)
- flag visible `white-space: nowrap` text when `scrollWidth` exceeds its authored `clientWidth`
- add regression coverage for both sampling and dynamic numeric overflow

## Why
A 39–46s low-contrast scene in a 70s composition fell between the five contrast samples even though the nine-point layout grid sampled it. A GSAP count-up ending at 14 digits also grew to ~436px inside a 220px visible box without a layout finding because overflow was visible rather than clipped.

## Reproduction
Confirmed on 0.7.55 with a 70s fixture: contrast sampled 35.0s then 50.556s and missed the coral scene; the counter glyph rect exceeded its fixed box with no warning.

## Verification
- 70 targeted CLI tests pass
- CLI typecheck passes
- E2E source CLI check samples 42.778s, emits `contrast_aa_failure`, and emits `text_box_overflow`
- formatting and `git diff --check` pass