### PR TITLE
fix(cli): inject deterministic fonts in snapshots

### DIFF
--- a/packages/cli/src/commands/snapshot-fonts.test.ts
+++ b/packages/cli/src/commands/snapshot-fonts.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  bundleToSingleHtml: vi.fn(async () => "<html><head></head><body>bundled</body></html>"),
+  injectDeterministicFontFaces: vi.fn(async (html: string) => `${html}\n<!-- fonts -->`),
+}));
+
+vi.mock("@hyperframes/core/compiler", () => ({
+  bundleToSingleHtml: mocks.bundleToSingleHtml,
+}));
+vi.mock("@hyperframes/producer", () => ({
+  injectDeterministicFontFaces: mocks.injectDeterministicFontFaces,
+}));
+
+import { prepareSnapshotHtml } from "./snapshot.js";
+
+describe("prepareSnapshotHtml", () => {
+  it("injects the same deterministic font faces used by render", async () => {
+    const html = await prepareSnapshotHtml("/project");
+
+    expect(mocks.bundleToSingleHtml).toHaveBeenCalledWith("/project");
+    expect(mocks.injectDeterministicFontFaces).toHaveBeenCalledWith(
+      "<html><head></head><body>bundled</body></html>",
+    );
+    expect(html).toContain("<!-- fonts -->");
+  });
+});

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -180,6 +180,15 @@ export function computeSnapshotTimes(
  * Render key frames from a composition as PNG screenshots.
  * The agent can Read these to verify its output visually.
  */
+export async function prepareSnapshotHtml(projectDir: string): Promise<string> {
+  const [{ bundleToSingleHtml }, { injectDeterministicFontFaces }] = await Promise.all([
+    import("@hyperframes/core/compiler"),
+    import("@hyperframes/producer"),
+  ]);
+  const bundledHtml = await bundleToSingleHtml(projectDir);
+  return injectDeterministicFontFaces(bundledHtml);
+}
+
 async function captureSnapshots(
   projectDir: string,
   opts: {
@@ -193,11 +202,9 @@ async function captureSnapshots(
     zoomScale?: number;
   },
 ): Promise<string[]> {
-  const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
-
   const numFrames = opts.frames ?? 5;
 
-  const html = await bundleToSingleHtml(projectDir);
+  const html = await prepareSnapshotHtml(projectDir);
   const server = await serveStaticProjectHtml(projectDir, html);
 
   const savedPaths: string[] = [];

--- a/packages/producer/src/index.ts
+++ b/packages/producer/src/index.ts
@@ -35,6 +35,7 @@ export {
   localizeRemoteImageSources,
   localizeRemoteFontFaces,
 } from "./services/htmlCompiler.js";
+export { injectDeterministicFontFaces } from "./services/deterministicFonts.js";
 
 // ── Frame capture (lower-level) ─────────────────────────────────────────────
 export {


### PR DESCRIPTION
## Summary
- run snapshot HTML through the same deterministic font-face injection used by render
- export the producer font injection helper for CLI snapshot use
- add a regression test covering bundled-font injection

## Reproduction
On CLI 0.7.55, `hyperframes snapshot` rendered League Gothic and Oswald with system fallback while `hyperframes render` used the bundled deterministic fonts. The snapshot path bundled HTML but skipped `injectDeterministicFontFaces`.

## Verification
- 13 snapshot-focused tests pass
- CLI typecheck passes
- formatting passes
- end-to-end League Gothic snapshot reports `Fonts: 1 loaded` and logs deterministic `@font-face` injection