### PR TITLE
fix(lint): tolerate float noise at audio boundaries

### DIFF
--- a/packages/cli/src/utils/lintProject.test.ts
+++ b/packages/cli/src/utils/lintProject.test.ts
@@ -1006,6 +1006,20 @@ describe("duplicate_audio_track", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does NOT fire when floating-point arithmetic makes adjacent audio boundaries differ", async () => {
+    const html = `<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080" data-duration="1">
+    <audio id="a" src="a.wav" data-track-index="0" data-start="0.1" data-duration="0.2">
+    <audio id="b" src="b.wav" data-track-index="0" data-start="0.3" data-duration="0.2">
+  </div>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines["main"] = gsap.timeline({ paused: true });</script>
+</body></html>`;
+    const project = makeProject(html);
+    const { results } = await lintProject(project);
+    const finding = results[0]?.result.findings.find((f) => f.code === "duplicate_audio_track");
+    expect(finding).toBeUndefined();
+  });
+
   it("does NOT fire for audio on different tracks", async () => {
     const html = `<html><body>
   <div data-composition-id="main" data-width="1920" data-height="1080" data-duration="20">

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -484,6 +484,7 @@ function lintMultipleRootCompositions(projectDir: string): HyperframeLintFinding
 }
 
 function lintDuplicateAudioTracks(htmlSources: HtmlSource[]): HyperframeLintFinding[] {
+  const timingEpsilon = 0.0001;
   const findings: HyperframeLintFinding[] = [];
   function extractAttr(tag: string, name: string): string | null {
     const re = new RegExp(`\\b${name}\\s*=\\s*["']([^"']+)["']`, "i");
@@ -521,7 +522,7 @@ function lintDuplicateAudioTracks(htmlSources: HtmlSource[]): HyperframeLintFind
       const a = tracks[i]!;
       const b = tracks[j]!;
       if (a.trackIndex !== b.trackIndex) continue;
-      if (a.start < b.end && b.start < a.end) {
+      if (a.start < b.end - timingEpsilon && b.start < a.end - timingEpsilon) {
         findings.push({
           code: "duplicate_audio_track",
           severity: "warning",


### PR DESCRIPTION
## Summary
- tolerate sub-millisecond floating-point noise when comparing adjacent audio windows
- keep reporting genuine same-track overlaps
- add regression coverage for `0.1 + 0.2` ending next to `0.3`

## Reproduction
HyperFrames 0.7.55 reports `duplicate_audio_track` for adjacent clips whose computed boundary is `0.30000000000000004` vs authored `0.3`. The warning text rounds both to `0.3s`.

## Verification
- `bunx vitest run packages/cli/src/utils/lintProject.test.ts` (76 passed)
- `bun run --cwd packages/lint typecheck`
- `bunx oxfmt --check packages/lint/src/project.ts packages/cli/src/utils/lintProject.test.ts`
- pre-commit format/lint/fallow/typecheck hooks passed

Human review required; do not self-merge.