### PR TITLE
fix(producer): dedupe local font embedding by resolved path

### DIFF
--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseHTML } from "linkedom";
+import { defaultLogger } from "../logger.js";
 import {
   collectExternalAssets,
   compileForRender,
@@ -855,6 +856,40 @@ describe("system-primary font normalization", () => {
     const rootStyle = document.querySelector('[data-composition-id="root"]')?.getAttribute("style");
     expect(rootStyle).toContain("--inline-system-font: Inter, system-ui, sans-serif");
     expect(rootStyle).toContain("font-family: Inter, sans-serif");
+  });
+});
+
+describe("local font embedding", () => {
+  it("embeds one font file once when sub-compositions use equivalent relative paths", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-local-font-dedupe-"));
+    const assetsDir = join(projectDir, "assets");
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(join(assetsDir, "shared.woff2"), "fake-woff2");
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!DOCTYPE html>
+<html><head><style>
+  @font-face { font-family: "A"; src: url("assets/shared.woff2"); }
+  @font-face { font-family: "B"; src: url("./assets/shared.woff2"); }
+  @font-face { font-family: "C"; src: url("assets/../assets/shared.woff2"); }
+</style></head><body>
+  <div data-composition-id="root" data-width="640" data-height="360" data-duration="1">Text</div>
+</body></html>`,
+    );
+
+    const originalInfo = defaultLogger.info;
+    const embeddedMessages: string[] = [];
+    defaultLogger.info = (message) => {
+      if (message.includes("Embedded local font file")) embeddedMessages.push(message);
+    };
+
+    try {
+      await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+    } finally {
+      defaultLogger.info = originalInfo;
+    }
+
+    expect(embeddedMessages).toHaveLength(1);
   });
 });
 

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -1605,7 +1605,8 @@ async function embedLocalFontFaces(html: string, projectDir: string): Promise<st
   const styleBlockRe = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
   const fontFaceRe = /@font-face\s*\{([^}]*)\}/gi;
   let result = html;
-  const embedded = new Set<string>();
+  const embeddedPaths = new Set<string>();
+  const dataUriByAbsolutePath = new Map<string, string>();
 
   let styleMatch: RegExpExecArray | null;
   while ((styleMatch = styleBlockRe.exec(html)) !== null) {
@@ -1618,19 +1619,23 @@ async function embedLocalFontFaces(html: string, projectDir: string): Promise<st
       let urlMatch: RegExpExecArray | null;
       while ((urlMatch = urlRe.exec(block)) !== null) {
         const localPath = urlMatch[1];
-        if (!localPath || embedded.has(localPath)) continue;
+        if (!localPath || embeddedPaths.has(localPath)) continue;
         const absPath = localPath.startsWith("/") ? localPath : resolve(projectDir, localPath);
         if (!isPathInside(absPath, projectDir)) continue;
         if (!existsSync(absPath)) continue;
         const ext = absPath.match(/\.(woff2?|ttf|otf|ttc)$/i)?.[1]?.toLowerCase() ?? "ttf";
         try {
-          const buffer = readFileSync(absPath);
-          const dataUri = await toDataUri(buffer, ext);
+          let dataUri = dataUriByAbsolutePath.get(absPath);
+          if (!dataUri) {
+            const buffer = readFileSync(absPath);
+            dataUri = await toDataUri(buffer, ext);
+            dataUriByAbsolutePath.set(absPath, dataUri);
+            defaultLogger.info(
+              `[Compiler] Embedded local font file: ${localPath} (${(buffer.length / 1024).toFixed(0)} KB → data URI)`,
+            );
+          }
           result = result.replaceAll(localPath, dataUri);
-          embedded.add(localPath);
-          defaultLogger.info(
-            `[Compiler] Embedded local font file: ${localPath} (${(buffer.length / 1024).toFixed(0)} KB → data URI)`,
-          );
+          embeddedPaths.add(localPath);
         } catch {
           // File read or compression failed — keep the original path
         }


### PR DESCRIPTION
## Summary
- cache embedded local fonts by resolved absolute path
- reuse one data URI across equivalent sub-composition-relative aliases
- add regression coverage for repeated references to one font file

## Reproduction
A composition with three `@font-face` URLs (`assets/shared.woff2`, `./assets/shared.woff2`, and `assets/../assets/shared.woff2`) triggered three embed operations before this change. With large TTC assets across sub-compositions, that repeated read/compression caused multi-minute compile stalls.

## Verification
- `bun test packages/producer/src/services/htmlCompiler.test.ts` (103 pass)
- `bun run --cwd packages/producer typecheck`
- `bunx oxfmt --check packages/producer/src/services/htmlCompiler.ts packages/producer/src/services/htmlCompiler.test.ts`
- pre-commit hooks passed (lint, format, fallow, typecheck)