### PR TITLE
fix(audits): avoid caption false positives

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -215,10 +215,10 @@
     const text = textContentFor(element, directOnly);
     if (!text) return false;
     if (directOnly) return true;
-    for (const child of Array.from(element.children)) {
-      if (isVisibleElement(child) && textContentFor(child)) return false;
-    }
-    return true;
+    // Aggregate text may come exclusively from descendants (including hidden
+    // captions). The container itself does not paint that text and must not be
+    // audited as though it did.
+    return textContentFor(element, true).length > 0;
   }
 
   function textClientRects(element, directOnly) {

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -870,6 +870,28 @@ describe("layout-audit.browser occlusion", () => {
     expect(issues.some((issue) => issue.code === "text_occluded")).toBe(false);
   });
 
+  it("does not treat a visible container as painted text when its only text child is hidden", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+        <div id="caption-container"><span id="caption">Hidden caption</span></div>
+        <div id="overlay"></div>
+      </div>
+    `;
+    installOcclusionGeometry({
+      styleOverrides: {
+        caption: { opacity: "0" },
+        overlay: { backgroundColor: "rgb(10, 10, 10)" },
+      },
+      headlineTextRect: rect({ left: 200, top: 500, width: 600, height: 80 }),
+      topmostId: "overlay",
+      textRectElementId: "caption-container",
+    });
+    installAuditScript();
+
+    const issues = runAudit();
+    expect(issues.some((issue) => issue.code === "text_occluded")).toBe(false);
+  });
+
   it("carries the fully-covered fraction when the occluder hits every probe point", () => {
     const occluded = auditOcclusionScene({
       overlayStyle: { backgroundColor: "rgb(10, 10, 10)" },
@@ -979,6 +1001,7 @@ function installOcclusionGeometry(options: {
   styleOverrides: Record<string, Partial<Record<string, string>>>;
   headlineTextRect: DOMRect;
   topmostId: string;
+  textRectElementId?: string;
 }): void {
   const baseStyle: Record<string, string> = {
     display: "block",
@@ -1025,7 +1048,7 @@ function installOcclusionGeometry(options: {
         selected = node;
       },
       getClientRects() {
-        return (selected as Element | null)?.id === "headline"
+        return (selected as Element | null)?.id === (options.textRectElementId ?? "headline")
           ? ([options.headlineTextRect] as unknown as DOMRectList)
           : ([] as unknown as DOMRectList);
       },

--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -978,6 +978,29 @@ describe("GSAP rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does NOT report overlapping_gsap_tweens for distinct loop-built DOM targets", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="caption-card-0"></div>
+    <div id="caption-card-1"></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    for (let i = 0; i < 2; i++) {
+      const card = document.getElementById("caption-card-" + i);
+      tl.to(card, { opacity: 1, duration: 1 }, i * 0.5);
+    }
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "overlapping_gsap_tweens");
+    expect(finding).toBeUndefined();
+  });
+
   it("warns when an opacity exit ends at a clip start boundary without a hard kill", async () => {
     const html = `
 <html><body>

--- a/packages/parsers/src/gsapInline.ts
+++ b/packages/parsers/src/gsapInline.ts
@@ -340,7 +340,11 @@ function expandBody(
 ): Node[] {
   const block = substituteParams(cloneNode({ type: "BlockStatement", body: bodyStmts }), bindings);
   tagTimelineCalls(block.body, prov, ctx);
-  return expandStatements(block.body, { ...ctx, depth: ctx.depth + 1 });
+  block.body = expandStatements(block.body, { ...ctx, depth: ctx.depth + 1 });
+  // Keep each synthetic expansion in its own lexical scope. Flattening repeated
+  // loop/helper bodies into Program scope makes same-named local DOM bindings
+  // overwrite one another during selector analysis.
+  return [block];
 }
 
 function inlineHelper(call: Node, ctx: ExpandCtx): Node[] {

--- a/packages/parsers/src/gsapParserAcorn.computed.test.ts
+++ b/packages/parsers/src/gsapParserAcorn.computed.test.ts
@@ -65,6 +65,21 @@ describe("parseGsapScriptAcorn — computed timelines", () => {
     expect(animations.map((a) => a.provenance?.kind)).toEqual(["loop", "loop", "loop"]);
   });
 
+  it("keeps DOM target bindings distinct across bounded loop iterations", () => {
+    const { animations } = parseGsapScriptAcorn(`
+      const tl = gsap.timeline();
+      for (let i = 0; i < 2; i++) {
+        const card = document.getElementById("caption-card-" + i);
+        tl.to(card, { opacity: 1, duration: 1 }, i * 0.5);
+      }
+    `);
+
+    expect(animations.map((animation) => animation.targetSelector)).toEqual([
+      "#caption-card-0",
+      "#caption-card-1",
+    ]);
+  });
+
   it("leaves a literal-position composition unchanged (regression)", () => {
     const { animations } = parseGsapScriptAcorn(`
       const tl = gsap.timeline();

--- a/packages/parsers/src/gsapParserAcorn.ts
+++ b/packages/parsers/src/gsapParserAcorn.ts
@@ -39,6 +39,7 @@ const QUERY_METHODS = new Set(["querySelector", "querySelectorAll"]);
 const ITERATION_METHODS = new Set(["forEach", "map"]);
 const SCOPE_NODE_TYPES = new Set([
   "Program",
+  "BlockStatement",
   "FunctionDeclaration",
   "FunctionExpression",
   "ArrowFunctionExpression",


### PR DESCRIPTION
## Summary

- preserve lexical scopes while expanding computed GSAP loops so iteration-local DOM targets remain distinct
- stop promoting text from hidden descendant captions to a visible parent during layout occlusion audits
- add parser lint and browser-audit regression coverage for both reported false positives

## Reproduction

Confirmed against HyperFrames 0.7.54 and 0.7.55:

- loop-local `getElementById("caption-card-" + i)` targets were collapsed to the first selector and triggered `overlapping_gsap_tweens`
- a visible caption container whose only text child had opacity 0 was reported as `text_occluded`

## Verification

- parsers: 27 files passed; 812 tests passed
- lint: 13 files passed; 363 tests passed
- CLI layout/check: 2 files passed; 78 tests passed
- parser lint and CLI typechecks passed
- both original source-level repro projects now return zero findings