### PR TITLE
test(ci): stabilize Windows suites after Studio cutover

### DIFF
--- a/packages/cli/src/utils/checkBrowser.test.ts
+++ b/packages/cli/src/utils/checkBrowser.test.ts
@@ -9,11 +9,15 @@ import { captureOverviewShot, runBrowserCheck } from "./checkBrowser.js";
 import type { ProjectDir } from "./project.js";
 
 const mocks = vi.hoisted(() => ({
+  bundleWithLocalizedFonts: vi.fn(async () => "<html></html>"),
   serverClose: vi.fn(async () => undefined),
 }));
 
-vi.mock("@hyperframes/core/compiler", () => ({
-  bundleToSingleHtml: vi.fn(async () => "<html></html>"),
+vi.mock("./bundleWithLocalizedFonts.js", () => ({
+  // Keep browser-check unit tests focused on the page driver and audit pipeline.
+  // The real helper cold-loads the producer/font graph, which is covered by its
+  // own tests and can exhaust this suite's timeout under Windows CI contention.
+  bundleWithLocalizedFonts: mocks.bundleWithLocalizedFonts,
 }));
 
 vi.mock("../capture/captureCompositionFrame.js", async (importOriginal) => ({
@@ -47,6 +51,7 @@ const PROJECT: ProjectDir = {
 };
 
 afterEach(() => {
+  vi.clearAllMocks();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   document.body.innerHTML = "";
@@ -100,6 +105,7 @@ it("carries raw browser geometry through the page driver and pipeline", async ()
     runAuditGrid,
   );
 
+  expect(mocks.bundleWithLocalizedFonts).toHaveBeenCalledWith(PROJECT.dir);
   expect(result.layoutIssues).toEqual([
     expect.objectContaining({
       code: "frame_out_of_frame",

--- a/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
@@ -437,12 +437,19 @@ describe("anonymous timeline identity", () => {
 });
 
 describe("mergeTimelineElementsPreservingDowngrades", () => {
-  it("preserves missing current elements when a shorter manifest arrives", () => {
+  it("preserves missing sub-composition elements when a shorter manifest arrives", () => {
     expect(
       mergeTimelineElementsPreservingDowngrades(
         [
           { id: "hero", tag: "div", start: 0, duration: 4, track: 0 },
-          { id: "cta", tag: "div", start: 4, duration: 2, track: 1 },
+          {
+            id: "cta",
+            tag: "div",
+            start: 4,
+            duration: 2,
+            track: 1,
+            compositionSrc: "scenes/cta.html",
+          },
         ],
         [{ id: "hero", tag: "div", start: 0, duration: 4, track: 0 }],
         8,
@@ -450,8 +457,29 @@ describe("mergeTimelineElementsPreservingDowngrades", () => {
       ),
     ).toEqual([
       { id: "hero", tag: "div", start: 0, duration: 4, track: 0 },
-      { id: "cta", tag: "div", start: 4, duration: 2, track: 1 },
+      {
+        id: "cta",
+        tag: "div",
+        start: 4,
+        duration: 2,
+        track: 1,
+        compositionSrc: "scenes/cta.html",
+      },
     ]);
+  });
+
+  it("drops missing top-level elements so undo does not leave ghost clips", () => {
+    expect(
+      mergeTimelineElementsPreservingDowngrades(
+        [
+          { id: "hero", tag: "div", start: 0, duration: 4, track: 0 },
+          { id: "split-clone", tag: "div", start: 4, duration: 2, track: 1 },
+        ],
+        [{ id: "hero", tag: "div", start: 0, duration: 4, track: 0 }],
+        8,
+        8,
+      ),
+    ).toEqual([{ id: "hero", tag: "div", start: 0, duration: 4, track: 0 }]);
   });
 
   it("accepts longer-duration or same-size updates as authoritative", () => {
@@ -477,6 +505,7 @@ describe("mergeTimelineElementsPreservingDowngrades", () => {
             start: 0,
             duration: 3,
             track: 0,
+            compositionSrc: "scenes/cards.html",
           },
           {
             id: "Card",
@@ -486,6 +515,7 @@ describe("mergeTimelineElementsPreservingDowngrades", () => {
             start: 3,
             duration: 3,
             track: 1,
+            compositionSrc: "scenes/cards.html",
           },
         ],
         [
@@ -497,6 +527,7 @@ describe("mergeTimelineElementsPreservingDowngrades", () => {
             start: 0,
             duration: 3,
             track: 0,
+            compositionSrc: "scenes/cards.html",
           },
         ],
         8,
@@ -511,6 +542,7 @@ describe("mergeTimelineElementsPreservingDowngrades", () => {
         start: 0,
         duration: 3,
         track: 0,
+        compositionSrc: "scenes/cards.html",
       },
       {
         id: "Card",
@@ -520,6 +552,7 @@ describe("mergeTimelineElementsPreservingDowngrades", () => {
         start: 3,
         duration: 3,
         track: 1,
+        compositionSrc: "scenes/cards.html",
       },
     ]);
   });


### PR DESCRIPTION
## Root causes

Two consecutive `main` Windows runs timed out in the first `checkBrowser.test.ts` case ([29227777037](https://github.com/heygen-com/hyperframes/actions/runs/29227777037), [29220733386](https://github.com/heygen-com/hyperframes/actions/runs/29220733386)). The test mocked `@hyperframes/core/compiler`, but production reaches bundling through `bundleWithLocalizedFonts`, so the first case cold-loaded the unrelated producer/font graph under the full Windows monorepo workload and exhausted Vitest's 20s ceiling.

After the Studio/Ular cutover merged, both Linux and Windows then consistently failed two `useTimelinePlayer` assertions. #2291 intentionally narrowed downgrade preservation to enriched sub-composition children so undoing a split can remove a top-level clone instead of leaving a ghost clip; the old tests still expected every missing top-level element to be preserved.

## Fix

- Mock the browser-check unit's actual `bundleWithLocalizedFonts` boundary and assert the project directory crosses that seam. The real helper remains covered by its own integration test.
- Align the timeline merge regressions with the new policy: sub-composition children (including anonymous same-label clips) remain preserved, while a dedicated regression proves a missing top-level split clone is dropped.

No production timeout or behavior was loosened.

## Verification

- `bun run build` ✅
- CLI browser/font suites: 12 passed ✅
- Studio timeline-player suite: 28 passed ✅
- CLI + Studio typecheck ✅
- Changed-file format + lint: 0 warnings/errors ✅
- 10 repeated isolated `checkBrowser.test.ts` runs: 10/10 passed, 1.79–2.35s wall time ✅
- First PR Windows rerun: CLI 1,649 tests passed with the original timeout gone; the run then isolated only the two stale Studio assertions corrected by the second commit. Render-on-Windows passed end to end. A fresh full CI/Windows run is attached to the updated head.
