### PR TITLE
fix(producer): skip slow TTC recompression

### DIFF
--- a/packages/producer/src/services/deterministicFonts-systemCapture.test.ts
+++ b/packages/producer/src/services/deterministicFonts-systemCapture.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { injectDeterministicFontFaces } from "./deterministicFonts.js";
+import { fontFormatHint, injectDeterministicFontFaces } from "./deterministicFonts.js";
 
 // A font family that is NOT in FONT_ALIASES but exists on macOS as
 // /System/Library/Fonts/Supplemental/Impact.ttf. When Google Fonts
@@ -36,6 +36,11 @@ function makeHttp400Fetch(): typeof fetch {
 }
 
 describe("system font capture — allowSystemFontCapture option", () => {
+  it("uses the CSS collection hint for raw TTC data URIs", () => {
+    expect(fontFormatHint("data:font/collection;base64,AA==")).toBe("collection");
+    expect(fontFormatHint("data:font/woff2;base64,AA==")).toBe("woff2");
+  });
+
   it("does not attempt system font capture when allowSystemFontCapture is false", async () => {
     const html = makeHtml("NotARealFontFamilyForTest");
     const result = await injectDeterministicFontFaces(html, {

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -432,6 +432,10 @@ function extractRequestedFontFamilies(html: string): Map<string, string> {
   return requested;
 }
 
+export function fontFormatHint(src: string): "collection" | "woff2" {
+  return src.startsWith("data:font/collection;") ? "collection" : "woff2";
+}
+
 function buildFontFaceRule(
   familyName: string,
   src: string,
@@ -442,7 +446,7 @@ function buildFontFaceRule(
   return [
     "@font-face {",
     `  font-family: "${familyName}";`,
-    `  src: url("${src}") format("woff2");`,
+    `  src: url("${src}") format("${fontFormatHint(src)}");`,
     `  font-style: ${style};`,
     `  font-weight: ${weight};`,
     "  font-display: block;",

--- a/packages/producer/src/services/fontCompression.test.ts
+++ b/packages/producer/src/services/fontCompression.test.ts
@@ -72,9 +72,17 @@ describe("fontToDataUri", () => {
     expect(uri).toMatch(/^data:font\/otf;base64,/);
   });
 
-  it("falls back with correct MIME type for ttc", async () => {
-    const garbage = Buffer.from("not a font");
-    const uri = await fontToDataUri(garbage, "ttc");
-    expect(uri).toMatch(/^data:font\/collection;base64,/);
+  it("embeds ttc collections raw without attempting slow woff2 compression", async () => {
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      const raw = Buffer.from("ttc-bytes");
+      const uri = await fontToDataUri(raw, "ttc");
+      expect(uri).toBe(`data:font/collection;base64,${raw.toString("base64")}`);
+      expect(warnings).toHaveLength(0);
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });

--- a/packages/producer/src/services/fontCompression.ts
+++ b/packages/producer/src/services/fontCompression.ts
@@ -22,6 +22,9 @@ export async function fontToDataUri(input: Buffer, originalFormat: string): Prom
   if (originalFormat === "woff2") {
     return `data:font/woff2;base64,${input.toString("base64")}`;
   }
+  if (originalFormat === "ttc") {
+    return `data:font/collection;base64,${input.toString("base64")}`;
+  }
   try {
     const compressed = await compressToWoff2(input);
     return `data:font/woff2;base64,${compressed.toString("base64")}`;


### PR DESCRIPTION
## What

Skip wawoff2 recompression for TTC font collections and embed them as raw font/collection data URIs with the matching CSS format(collection) hint.

## Why

A reported 120-second talking-head package spent about six extra minutes compiling a TTC font. Reproduction with a 19 MB Noto Sans CJK collection took 57.73 seconds and about 320 MB RSS in fontToDataUri alone. Chromium also rejects a raw collection when it is mislabeled as format(woff2).

## How

- Return TTC buffers directly as font/collection instead of attempting whole-collection WOFF2 compression.
- Select format(collection) for collection data URIs while preserving format(woff2) everywhere else.
- Add regression coverage for the no-compression path and CSS format selection.

The same real TTC now embeds in 0.07 seconds with the correct data URI prefix.

## Test plan

- [x] 37 focused deterministic-font and compression tests pass
- [x] Producer typecheck
- [x] Formatting check on the four changed files
- [x] Pre-commit lint, format, fallow, tracked-artifact, and typecheck hooks
- [x] Real 19 MB NotoSansCJK-Regular.ttc benchmark: 57.73s before, 0.07s after
- [x] Chromium validation: raw font/collection with format(collection) loads; format(woff2) does not
- [x] Independent review: no findings
