### PR TITLE
fix(skills): ignore no-SFX storyboard sentinel

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,8 +6,8 @@
       "files": 144
     },
     "faceless-explainer": {
-      "hash": "b57c98179677e7a0",
-      "files": 18
+      "hash": "80c894bdf031f0de",
+      "files": 19
     },
     "figma": {
       "hash": "0e6e96f5a76ff824",
@@ -58,11 +58,11 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "2132f6f9bd474f52",
+      "hash": "a1deb2657635c2e2",
       "files": 22
     },
     "product-launch-video": {
-      "hash": "b1b41c74a52e28f1",
+      "hash": "ff5f0a06e2977634",
       "files": 21
     },
     "remotion-to-hyperframes": {

--- a/skills/faceless-explainer/scripts/audio.mjs
+++ b/skills/faceless-explainer/scripts/audio.mjs
@@ -180,7 +180,7 @@ function runFetchSfx(argv) {
     const names = (f.extra?.sfx ?? "")
       .split(",")
       .map((s) => s.trim())
-      .filter(Boolean);
+      .filter((s) => s && s.toLowerCase() !== "none");
     if (names.length && f.number != null) lines.push({ id: pad2(f.number), sfx: names });
   }
 

--- a/skills/faceless-explainer/scripts/audio.test.mjs
+++ b/skills/faceless-explainer/scripts/audio.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SKILLS = resolve(HERE, "..", "..");
+const ADAPTERS = ["faceless-explainer", "product-launch-video", "pr-to-video"];
+
+test("fetch-sfx ignores the none sentinel across shared adapters", async (t) => {
+  for (const skill of ADAPTERS) {
+    await t.test(skill, () => {
+      const project = mkdtempSync(join(tmpdir(), "hyperframes-sfx-none-"));
+      try {
+        writeFileSync(
+          join(project, "STORYBOARD.md"),
+          [
+            "---",
+            "format: portrait",
+            "message: SFX sentinel regression",
+            "---",
+            "",
+            "## Frame 1 — Silent beat",
+            "- duration: 1s",
+            "- sfx: none",
+            "",
+            "## Frame 2 — Audible beat",
+            "- duration: 1s",
+            "- sfx: whoosh, NONE",
+            "",
+          ].join("\n"),
+        );
+        const engine = join(project, "fake-engine.mjs");
+        writeFileSync(
+          engine,
+          [
+            'import { readFileSync, writeFileSync } from "node:fs";',
+            "const arg = (name) => process.argv[process.argv.indexOf(name) + 1];",
+            'const request = JSON.parse(readFileSync(arg("--request"), "utf8"));',
+            "const sfx = (request.lines ?? []).flatMap((line) =>",
+            "  (line.sfx ?? []).map((name) => ({ id: line.id, file: `assets/sfx/${name}.mp3` })),",
+            ");",
+            'writeFileSync(arg("--out"), JSON.stringify({ voices: [], bgm: null, sfx }));',
+          ].join("\n"),
+        );
+
+        const adapter = join(SKILLS, skill, "scripts", "audio.mjs");
+        const result = spawnSync(
+          process.execPath,
+          [
+            adapter,
+            "fetch-sfx",
+            "--storyboard",
+            join(project, "STORYBOARD.md"),
+            "--hyperframes",
+            project,
+          ],
+          {
+            encoding: "utf8",
+            env: { ...process.env, HF_MEDIA_ENGINE: engine },
+          },
+        );
+        assert.equal(result.status, 0, result.stderr);
+
+        const request = JSON.parse(readFileSync(join(project, "audio_request.json"), "utf8"));
+        assert.deepEqual(request.lines, [{ id: "02", sfx: ["whoosh"] }]);
+        const meta = JSON.parse(readFileSync(join(project, "audio_meta.json"), "utf8"));
+        assert.deepEqual(meta.sfx, [
+          {
+            frame: 2,
+            file: "assets/sfx/whoosh.mp3",
+            offset_s: 0,
+            duration_s: 1,
+            volume: 0.35,
+          },
+        ]);
+      } finally {
+        rmSync(project, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/skills/pr-to-video/scripts/audio.mjs
+++ b/skills/pr-to-video/scripts/audio.mjs
@@ -180,7 +180,7 @@ function runFetchSfx(argv) {
     const names = (f.extra?.sfx ?? "")
       .split(",")
       .map((s) => s.trim())
-      .filter(Boolean);
+      .filter((s) => s && s.toLowerCase() !== "none");
     if (names.length && f.number != null) lines.push({ id: pad2(f.number), sfx: names });
   }
 

--- a/skills/product-launch-video/scripts/audio.mjs
+++ b/skills/product-launch-video/scripts/audio.mjs
@@ -178,7 +178,7 @@ function runFetchSfx(argv) {
     const names = (f.extra?.sfx ?? "")
       .split(",")
       .map((s) => s.trim())
-      .filter(Boolean);
+      .filter((s) => s && s.toLowerCase() !== "none");
     if (names.length && f.number != null) lines.push({ id: pad2(f.number), sfx: names });
   }
 


### PR DESCRIPTION
## What

Storyboards can now use `sfx: none` to explicitly request silence without triggering an SFX lookup or creating a fake `none.mp3` metadata entry.

## Why

The faceless-explainer workflow treated every non-empty `sfx:` value as a catalog query. A literal no-SFX sentinel therefore polluted `audio_meta.json` and could overwrite otherwise-valid audio metadata with a nonexistent asset.

## How

The three shared audio adapters now ignore the case-insensitive `none` sentinel while retaining adjacent real cues. One integration regression test exercises both silent and mixed-cue frames across faceless-explainer, product-launch-video, and pr-to-video.

## Test plan

- [x] `node --test skills/faceless-explainer/scripts/audio.test.mjs` (4/4)
- [x] `bunx oxlint` on the affected adapters and test
- [x] `bunx oxfmt --check` on the affected adapters and test
- [x] `bun run --cwd packages/cli gen:skills-manifest --check`
- [x] `git diff --check`
- [ ] Documentation updated (not applicable)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
