### PR TITLE
fix(engine): support current FFmpeg filter scripts

### DIFF
--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 // The mix filter graph is written to a temp file and passed via
-// -filter_complex_script (not inlined via -filter_complex) so the command
+// a file-valued filter option (not inlined via -filter_complex) so the command
 // line doesn't scale with track count — production code deletes that file
 // the moment the (real) ffmpeg process exits. The mock captures each call's
 // filter content synchronously, while the file still exists, into an
@@ -15,7 +15,9 @@ const { runFfmpegMock, capturedFilterScripts } = vi.hoisted(() => {
   return {
     capturedFilterScripts,
     runFfmpegMock: vi.fn(async (args: string[]) => {
-      const idx = args.indexOf("-filter_complex_script");
+      const legacyIdx = args.indexOf("-filter_complex_script");
+      const currentIdx = args.indexOf("-/filter_complex");
+      const idx = legacyIdx >= 0 ? legacyIdx : currentIdx;
       if (idx >= 0) {
         const { readFileSync } = await import("node:fs");
         capturedFilterScripts.push(readFileSync(args[idx + 1], "utf8"));
@@ -346,6 +348,57 @@ describe("processCompositionAudio", () => {
     const filter = capturedFilterScripts.at(-1);
     expect(filter).toContain(`amix=inputs=${trackCount}`);
     expect((filter?.match(/atrim=/g) ?? []).length).toBe(trackCount);
+  });
+
+  it("retries with the current file-valued filter option when a nightly removes the legacy alias", async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), "hf-audio-base-"));
+    const workDir = mkdtempSync(join(tmpdir(), "hf-audio-work-"));
+    tempDirs.push(baseDir, workDir);
+
+    writeFileSync(join(baseDir, "voice.wav"), "stub");
+
+    runFfmpegMock
+      .mockImplementationOnce(async () => {
+        capturedFilterScripts.push("");
+        return { success: true, durationMs: 1, stderr: "", exitCode: 0 };
+      })
+      .mockImplementationOnce(async () => {
+        capturedFilterScripts.push("");
+        return {
+          success: false,
+          durationMs: 1,
+          stderr: "Unrecognized option 'filter_complex_script'.\nError splitting the argument list",
+          exitCode: 8,
+        };
+      });
+
+    const result = await processCompositionAudio(
+      [
+        {
+          id: "voice",
+          src: "voice.wav",
+          start: 0,
+          end: 2,
+          mediaStart: 0,
+          layer: 0,
+          volume: 1,
+          type: "audio",
+        },
+      ],
+      baseDir,
+      workDir,
+      join(baseDir, "out.m4a"),
+      2,
+    );
+
+    expect(result.success).toBe(true);
+    expect(runFfmpegMock).toHaveBeenCalledTimes(3);
+    const legacyArgs = runFfmpegMock.mock.calls[1]?.[0] as string[];
+    const currentArgs = runFfmpegMock.mock.calls[2]?.[0] as string[];
+    expect(legacyArgs).toContain("-filter_complex_script");
+    expect(currentArgs).toContain("-/filter_complex");
+    expect(currentArgs).not.toContain("-filter_complex_script");
+    expect(capturedFilterScripts[2]).toContain("amix=inputs=1");
   });
 
   it("prepares percent-encoded non-Latin audio srcs from decoded filesystem paths", async () => {

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -32,6 +32,13 @@ function escapeExpressionCommas(expression: string): string {
   return expression.replace(/\\/g, "\\\\").replace(/,/g, "\\,");
 }
 
+function legacyFilterScriptOptionIsUnsupported(stderr: string): boolean {
+  return (
+    /filter_complex_script/i.test(stderr) &&
+    /(?:unrecognized option|option (?:was )?not found)/i.test(stderr)
+  );
+}
+
 /**
  * Upper bound on volume-automation keyframes folded into the FFmpeg `volume`
  * expression. The expression nests one `if(lt(...))` per keyframe, and
@@ -406,10 +413,14 @@ async function mixAudioTracks(
   // argument scale linearly with track count until it exceeds the OS
   // command-line length limit — spawn ENAMETOOLONG, seen in practice at 146
   // tracks — even though every individual filter segment is short. FFmpeg's
-  // own `-filter_complex_script <file>` reads the same graph from disk
-  // instead, sidestepping the argv limit for the one component of this
-  // command line that actually grows with the composition.
-  const runMix = (ignoreAutomation: boolean) => {
+  // file-valued filter options read the same graph from disk instead,
+  // sidestepping the argv limit for the one component of this command line
+  // that actually grows with the composition. FFmpeg deprecated
+  // `-filter_complex_script` in favour of `-/filter_complex`, then removed the
+  // alias from nightly builds; older stable builds do not understand the new
+  // spelling. Prefer the legacy spelling for broad compatibility and retry
+  // only when FFmpeg explicitly says that option is unavailable.
+  const runMix = async (ignoreAutomation: boolean) => {
     const inputs: string[] = [];
     tracks.forEach((track) => inputs.push("-i", track.srcPath));
     const scriptDir = mkdtempSync(join(outputDir, ".filter-complex-"));
@@ -435,9 +446,17 @@ async function mixAudioTracks(
       "-y",
       outputPath,
     ];
-    return runFfmpeg(args, { signal, timeout: ffmpegProcessTimeout }).finally(() =>
-      rmSync(scriptDir, { recursive: true, force: true }),
-    );
+    try {
+      const legacyResult = await runFfmpeg(args, { signal, timeout: ffmpegProcessTimeout });
+      if (legacyResult.success || !legacyFilterScriptOptionIsUnsupported(legacyResult.stderr)) {
+        return legacyResult;
+      }
+      const currentArgs = [...args];
+      currentArgs[currentArgs.indexOf("-filter_complex_script")] = "-/filter_complex";
+      return await runFfmpeg(currentArgs, { signal, timeout: ffmpegProcessTimeout });
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
   };
 
   let result = await runMix(false);


### PR DESCRIPTION
## What

Audio mixing now works on current FFmpeg nightlies without giving up compatibility with older stable installations or reintroducing Windows command-line overflow for large track counts.

## Why

FFmpeg removed the deprecated `-filter_complex_script` alias from nightly builds. HyperFrames therefore emitted a video-only fallback even though the same filter graph is valid through FFmpeg's replacement `-/filter_complex <file>` syntax. Older FFmpeg builds do not recognize that replacement, so switching unconditionally would break existing users.

## How

The mixer keeps the legacy file-valued option as its first attempt and retries with `-/filter_complex` only when stderr explicitly reports that `filter_complex_script` is unavailable. Both paths use the same temporary graph file, keeping 100+ track graphs off argv, and cleanup still runs after either attempt.

## Test plan

- [x] Reproduced `Unrecognized option 'filter_complex_script'` on FFmpeg nightly `N-125551`
- [x] Verified `-/filter_complex` succeeds on the identical nightly graph
- [x] Verified local FFmpeg 4.2 rejects `-/filter_complex`, exercising the backward-compatibility requirement
- [x] `bun run --cwd packages/engine test -- audioMixer.test.ts` (12/12)
- [x] `bun run --cwd packages/engine typecheck`
- [x] `bunx oxlint` and `bunx oxfmt --check` on changed files
- [x] Pre-commit hooks, including typecheck and tracked-artifact checks

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
