### PR TITLE
fix(snapshot): preserve exact requested times

### DIFF
--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -62,6 +62,16 @@ describe("computeSnapshotTimes (FINDING [7]: tail is always captured)", () => {
     expect(times).toEqual([1, 2]);
     expect(appendedTail).toBe(false);
   });
+
+  it("preserves exact explicit transition timestamps", () => {
+    const exactTransition = 3.3666666666666667;
+    const { times } = computeSnapshotTimes(8, {
+      frames: 5,
+      at: [exactTransition],
+      includeEnd: false,
+    });
+    expect(times).toEqual([exactTransition]);
+  });
 });
 
 describe("parseZoomScale (--zoom-scale)", () => {

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -159,7 +159,11 @@ export function computeSnapshotTimes(
   const round = (t: number) => Math.round(t * 1000) / 1000;
 
   if (opts.at?.length) {
-    const times = opts.at.map(round);
+    // `--at` is an evidence contract: callers may pass exact fractional-frame
+    // boundaries (for example 101 / 30). Do not normalize their requested
+    // positions; rounding to milliseconds can move a transition sample to the
+    // other side of the boundary.
+    const times = [...opts.at];
     // Only append if the user didn't already sample at/near the readable tail.
     const hasTail = times.some((t) => Math.abs(t - tail) < 0.05 || t >= duration);
     if (includeEnd && duration > 0 && !hasTail) {


### PR DESCRIPTION
## What

Explicit `snapshot --at` timestamps now reach the timeline seek unchanged, so before/midpoint/after evidence can target exact fractional-frame transition boundaries.

## Why

Snapshot rounded every requested time to three decimal places. For values such as `101 / 30`, that moves the sample relative to the requested boundary and can capture the wrong side of a deterministic transition.

## How

Only caller-supplied `--at` values retain full precision. Automatically generated default and readable-tail samples remain normalized, and existing tail de-duplication behavior is unchanged.

## Test plan

- [x] Added a regression test for an exact `3.3666666666666667s` transition timestamp
- [x] `bun run --cwd packages/cli test -- snapshot.test.ts` (13/13)
- [x] `bun run --cwd packages/cli typecheck`
- [x] `bunx oxlint` and `bunx oxfmt --check` on changed files
- [x] Pre-commit hooks, including typecheck and tracked-artifact checks

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
