### PR TITLE
fix(cli): respect pointer-transparent text in occlusion checks

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -717,13 +717,36 @@
     return !!ctx && ctx === preserve3dContext(b);
   }
 
+  // elementFromPoint intentionally skips pointer-events:none content, even
+  // though that content still paints. Caption rails commonly disable pointer
+  // events while sitting above a background video, so probe the text with hit
+  // testing temporarily enabled and restore its authored inline style.
+  function paintedElementFromPoint(element, x, y) {
+    if (getComputedStyle(element).pointerEvents !== "none") {
+      return document.elementFromPoint(x, y);
+    }
+    const property = "pointer-events";
+    const previousValue = element.style.getPropertyValue(property);
+    const previousPriority = element.style.getPropertyPriority(property);
+    element.style.setProperty(property, "auto", "important");
+    try {
+      return document.elementFromPoint(x, y);
+    } finally {
+      if (previousValue) {
+        element.style.setProperty(property, previousValue, previousPriority);
+      } else {
+        element.style.removeProperty(property);
+      }
+    }
+  }
+
   // The opaque element painted over (x, y), or null when the topmost element
   // there is related to the text, non-opaque, sharing a 3D context with it, or
   // part of a transient crossfade overlap.
   // fallow-ignore-next-line complexity
   function occluderAt(element, x, y) {
     if (typeof document.elementFromPoint !== "function") return null;
-    const hit = document.elementFromPoint(x, y);
+    const hit = paintedElementFromPoint(element, x, y);
     if (!isForeignElement(element, hit)) return null;
     if (sharedPreserve3d(element, hit)) return null;
     if (!isOpaqueOccluder(hit)) return null;

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -853,6 +853,19 @@ describe("layout-audit.browser occlusion", () => {
     expect(issues.some((issue) => issue.code === "text_occluded")).toBe(false);
   });
 
+  it("ignores a video beneath pointer-transparent text that is painted on top", () => {
+    const issues = auditOcclusionScene({
+      headlineAttrs: 'style="pointer-events: none"',
+      overlayTag: "video",
+      overlayStyle: {},
+      topmostId: "overlay",
+      topmostWhenHeadlineHitTestableId: "headline",
+    });
+
+    expect(issues.some((issue) => issue.code === "text_occluded")).toBe(false);
+    expect(document.getElementById("headline")?.style.pointerEvents).toBe("none");
+  });
+
   it("ignores low-opacity overlays such as scrims and grain", () => {
     const issues = auditOcclusionScene({
       overlayStyle: { backgroundColor: "rgb(10, 10, 10)", opacity: "0.3" },
@@ -957,19 +970,24 @@ function auditCoverageScene(options: {
 
 function auditOcclusionScene(options: {
   headlineAttrs?: string;
+  overlayTag?: "div" | "video";
   overlayStyle: Partial<Record<string, string>>;
   topmostId: string;
+  topmostWhenHeadlineHitTestableId?: string;
 }): ReturnType<typeof runAudit> {
+  const overlay =
+    options.overlayTag === "video" ? '<video id="overlay"></video>' : '<div id="overlay"></div>';
   document.body.innerHTML = `
     <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
       <div id="headline" ${options.headlineAttrs ?? ""}>Headline copy</div>
-      <div id="overlay"></div>
+      ${overlay}
     </div>
   `;
   installOcclusionGeometry({
     styleOverrides: { overlay: options.overlayStyle },
     headlineTextRect: rect({ left: 200, top: 500, width: 600, height: 80 }),
     topmostId: options.topmostId,
+    topmostWhenHeadlineHitTestableId: options.topmostWhenHeadlineHitTestableId,
   });
   installAuditScript();
   return runAudit();
@@ -979,6 +997,7 @@ function installOcclusionGeometry(options: {
   styleOverrides: Record<string, Partial<Record<string, string>>>;
   headlineTextRect: DOMRect;
   topmostId: string;
+  topmostWhenHeadlineHitTestableId?: string;
 }): void {
   const baseStyle: Record<string, string> = {
     display: "block",
@@ -1008,6 +1027,7 @@ function installOcclusionGeometry(options: {
     const id = (element as Element).id;
     return {
       ...baseStyle,
+      pointerEvents: (element as HTMLElement).style.pointerEvents || "auto",
       ...(options.styleOverrides[id] ?? {}),
     } as unknown as CSSStyleDeclaration;
   });
@@ -1033,8 +1053,13 @@ function installOcclusionGeometry(options: {
     } as unknown as Range;
   });
 
-  (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint = () =>
-    document.getElementById(options.topmostId);
+  (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint = () => {
+    const headline = document.getElementById("headline");
+    if (headline?.style.pointerEvents === "auto" && options.topmostWhenHeadlineHitTestableId) {
+      return document.getElementById(options.topmostWhenHeadlineHitTestableId);
+    }
+    return document.getElementById(options.topmostId);
+  };
 }
 
 function installAuditScript(): void {


### PR DESCRIPTION
## What

`hyperframes check` no longer reports captions as hidden by a background video when the captions are visibly painted above it with `pointer-events: none`.

## Why

The occlusion audit relied on `document.elementFromPoint()`, which intentionally skips pointer-transparent content. Caption rails commonly disable pointer events, so the audit saw the video underneath and produced a blocking `text_occluded` false positive despite correct z-index and verified rendered output.

## How

During each occlusion probe, pointer-transparent text is made hit-testable just long enough to query the true paint order. Its authored inline value and priority are restored immediately afterward. A regression test covers a video beneath pointer-transparent text and verifies that the original style survives the audit.

## Test plan

- [x] Added a regression test and observed it fail before the fix
- [x] `bun run --cwd packages/cli test -- src/commands/layout-audit.browser.test.ts` (39 passed)
- [x] `bun run --cwd packages/cli test` (1,650 passed)
- [x] CLI typecheck, lint, formatting, and commit hooks passed
- [x] Reproduced with a real video/caption fixture on 0.7.56, then verified the local CLI returns zero layout findings

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
