### PR TITLE
fix(browser): recover abandoned install locks

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -62,13 +62,14 @@ interface FsMockOptions {
   /** map of dir path -> entries returned by readdirSync */
   dirs?: Record<string, string[]>;
   touchError?: Error;
+  initialMtimeMs?: number;
 }
 
-function installFsMocks({ existing, dirs, touchError }: FsMockOptions) {
+function installFsMocks({ existing, dirs, touchError, initialMtimeMs = 0 }: FsMockOptions) {
   // Mutable, and returned, so tests can pre-seed a "lock already held" path or
   // assert the lock dir doesn't leak after ensureBrowser resolves.
   const paths = new Set(existing);
-  const mtimes = new Map([...existing].map((p) => [p, 0]));
+  const mtimes = new Map([...existing].map((p) => [p, initialMtimeMs]));
   vi.doMock("node:fs", () => ({
     existsSync: (p: string) => paths.has(p),
     readdirSync: (p: string) => {
@@ -174,6 +175,7 @@ describe("findBrowser — cache resolution", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
     Object.defineProperty(process, "arch", { value: origArch, configurable: true });
     vi.restoreAllMocks();
@@ -347,6 +349,23 @@ describe("findBrowser — cache resolution", () => {
     expect(paths.has(HF_LOCK)).toBe(false);
   });
 
+  it("withInstallLock recovers when a crashed reclaimer leaves both lock directories", async () => {
+    vi.useFakeTimers();
+    const paths = installFsMocks({
+      existing: new Set([CACHE_ROOT, HF_LOCK, HF_RECLAIM_LOCK]),
+    });
+
+    const { withInstallLock } = await import("./manager.js");
+    const acquisition = withInstallLock(async () => "done", TEST_LOCK_TIMINGS);
+    await vi.advanceTimersByTimeAsync(TEST_LOCK_TIMINGS.pollMs * 2);
+
+    await expect(Promise.race([acquisition, Promise.resolve("still waiting")])).resolves.toBe(
+      "done",
+    );
+    expect(paths.has(HF_LOCK)).toBe(false);
+    expect(paths.has(HF_RECLAIM_LOCK)).toBe(false);
+  });
+
   it("withInstallLock does not reclaim another waiter's fresh lock after this waiter timed out", async () => {
     // Regression guard for the timeout-reclaim race: if multiple waiters cross
     // the stale-lock deadline together, waiter A can reclaim the stale lock and
@@ -392,7 +411,10 @@ describe("findBrowser — cache resolution", () => {
   });
 
   it("withInstallLock reports progress while waiting instead of staying silent", async () => {
-    const paths = installFsMocks({ existing: new Set([CACHE_ROOT, HF_LOCK]) });
+    const paths = installFsMocks({
+      existing: new Set([CACHE_ROOT, HF_LOCK]),
+      initialMtimeMs: Date.now(),
+    });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const { withInstallLock } = await import("./manager.js");

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -77,6 +77,15 @@ function tryAcquireDirLock(lockDir: string): boolean {
   }
 }
 
+function isDirLockStale(lockDir: string, timeoutMs: number): boolean {
+  try {
+    return Date.now() - statSync(lockDir).mtimeMs > timeoutMs;
+  } catch (err) {
+    if (isErrno(err, "ENOENT")) return false;
+    throw err;
+  }
+}
+
 function reclaimStaleInstallLock(timeoutMs: number): void {
   if (!tryAcquireDirLock(INSTALL_RECLAIM_LOCK_DIR)) return;
   try {
@@ -88,6 +97,16 @@ function reclaimStaleInstallLock(timeoutMs: number): void {
     if (!isErrno(err, "ENOENT")) throw err;
   } finally {
     rmSync(INSTALL_RECLAIM_LOCK_DIR, { recursive: true, force: true });
+  }
+}
+
+function reclaimAbandonedReclaimLock(timeoutMs: number): void {
+  try {
+    if (isDirLockStale(INSTALL_RECLAIM_LOCK_DIR, timeoutMs)) {
+      rmSync(INSTALL_RECLAIM_LOCK_DIR, { recursive: true, force: true });
+    }
+  } catch (err) {
+    if (!isErrno(err, "ENOENT")) throw err;
   }
 }
 
@@ -113,6 +132,11 @@ export async function withInstallLock<T>(
   let lastNoticeMs = 0;
   for (;;) {
     if (existsSync(INSTALL_RECLAIM_LOCK_DIR)) {
+      // A process can die after acquiring the reclaim gate but before its
+      // synchronous cleanup runs. Without aging out that gate, every future
+      // installer sleeps here forever and never reaches the install-lock
+      // timeout/reclaim path below.
+      reclaimAbandonedReclaimLock(timings.staleMs);
       await sleep(timings.pollMs);
       continue;
     }
@@ -127,7 +151,7 @@ export async function withInstallLock<T>(
         `[browser] Waiting for another hyperframes process to finish installing chrome-headless-shell (${Math.round(waitedMs / 1000)}s elapsed)...`,
       );
     }
-    if (Date.now() > deadline) {
+    if (isDirLockStale(INSTALL_LOCK_DIR, timings.staleMs) || Date.now() > deadline) {
       // The reclaim gate matters when multiple waiters cross the timeout at
       // once: without it, waiter A can delete the stale lock and acquire a
       // fresh one, then waiter B (whose old deadline also expired) can delete


### PR DESCRIPTION
## What

Recover Chrome installation when a crashed process leaves a stale .chrome.install.reclaim.lock, including the reported case where both install lock directories remain.

## Why

On Windows, a timed-out render could leave both browser lock directories behind. Every later render waited forever at browser setup because the reclaim gate was never aged out. HYPERFRAMES_BROWSER_PATH bypassed the stale cache, but the default managed-browser path remained blocked.

## How

- Detect and remove an abandoned reclaim gate after the configured stale interval.
- Reclaim an already-stale install lock immediately instead of waiting through a fresh timeout.
- Preserve the existing reclaim gate that prevents concurrent waiters from deleting a newly acquired lock.
- Add a fake-timer regression test covering both stale lock directories left by a crashed reclaimer.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)

Verification:
- Reproduced with published 0.7.55 under an isolated HOME containing both stale lock directories; render remained blocked at browser setup until host timeout.
- packages/cli manager suite: 27 passed.
- packages/cli full suite: 129 files and 1650 tests passed.
- packages/cli typecheck passed.
- Lint and formatting passed.
- Built the fixed local CLI and rendered a 48-frame MP4 under the same pre-aged two-lock setup; render exited 0 and produced the output.