### PR TITLE
fix(render): recover explicit parallel capture timeouts

### DIFF
--- a/packages/producer/src/services/render/stages/captureStage.test.ts
+++ b/packages/producer/src/services/render/stages/captureStage.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { shouldAllowAdaptiveCaptureRetry } from "./captureStage.js";
+
+describe("shouldAllowAdaptiveCaptureRetry", () => {
+  it("keeps timeout recovery enabled when the initial worker count was explicit", () => {
+    expect(shouldAllowAdaptiveCaptureRetry(6, true)).toBe(true);
+  });
+
+  it("does not retry an already sequential capture", () => {
+    expect(shouldAllowAdaptiveCaptureRetry(1, true)).toBe(false);
+  });
+});

--- a/packages/producer/src/services/render/stages/captureStage.ts
+++ b/packages/producer/src/services/render/stages/captureStage.ts
@@ -133,6 +133,19 @@ export interface CaptureStageResult {
   captureBeyondViewport?: boolean;
 }
 
+/**
+ * An explicit worker count selects the initial concurrency; it must not disable
+ * recovery after a worker times out. The adaptive loop only retries missing
+ * frames, requires forward progress, and halves workers until sequential, so it
+ * remains bounded while preserving already-captured work.
+ */
+export function shouldAllowAdaptiveCaptureRetry(
+  workerCount: number,
+  _explicitlyConfigured: boolean,
+): boolean {
+  return workerCount > 1;
+}
+
 export async function runCaptureStage(input: CaptureStageInput): Promise<CaptureStageResult> {
   const {
     fileServer,
@@ -200,7 +213,7 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
       framesDir,
       totalFrames,
       initialWorkerCount: workerCount,
-      allowRetry: job.config.workers === undefined,
+      allowRetry: shouldAllowAdaptiveCaptureRetry(workerCount, job.config.workers !== undefined),
       frameExt: needsAlpha ? "png" : "jpg",
       captureOptions: buildCaptureOptions(),
       createBeforeCaptureHook: createRenderVideoFrameInjector,


### PR DESCRIPTION
## What

Keep adaptive missing-frame recovery enabled when a user explicitly selects a parallel worker count. The explicit value remains the initial concurrency, but a recoverable timeout can now halve workers and retry only missing frames down to the sequential path.

## Why

A Windows render with explicit 6 workers and then 3 workers twice reached 4084/4085 completed worker frames before one worker hit `Runtime.callFunctionOn timed out`; both runs exited without an MP4. `captureStage` disabled the existing bounded retry loop whenever `--workers` was explicit, forcing the user to manually rerun with `--workers 1`.

## Reproduction

- Confirmed locally that an induced parallel protocol/navigation timeout exits without output and only recommends `--workers 1`.
- Traced the reporter signature to `allowRetry: job.config.workers === undefined`: explicit parallel counts bypassed recovery despite thousands of successfully captured frames.

## Safety

The existing adaptive loop remains bounded: it retries only missing frames, requires forward progress for protocol timeouts, halves worker count each attempt, and stops at one worker. Zero-progress structural failures still fail immediately.

## Tests

- Added coverage that explicit parallel worker counts keep recovery enabled and sequential captures do not retry.
- Producer render orchestrator + capture-stage tests: 143 passed.
- Producer TypeScript typecheck.
- Targeted oxlint, oxfmt, and `git diff --check`.
- Pre-commit tracked-artifacts, lint, format, fallow, and typecheck hooks passed.