### PR TITLE
fix(lint): ignore embedded caption rail entrypoint

### DIFF
--- a/packages/cli/src/utils/lintProject.test.ts
+++ b/packages/cli/src/utils/lintProject.test.ts
@@ -951,6 +951,19 @@ describe("multiple_root_compositions", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("ignores root-level rail.html generated for embedded-caption compositing", async () => {
+    const project = makeProject(validHtml());
+    writeFileSync(
+      join(project, "rail.html"),
+      '<div data-composition-id="rail" data-width="1080" data-height="1920" data-duration="10"></div>',
+    );
+    const { results } = await lintProject(project);
+    const finding = results[0]?.result.findings.find(
+      (f) => f.code === "multiple_root_compositions",
+    );
+    expect(finding).toBeUndefined();
+  });
+
   it("ignores macOS AppleDouble HTML metadata files", async () => {
     const project = makeProject(validHtml());
     writeFileSync(join(project, "._index.html"), validHtml());

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -462,7 +462,7 @@ function lintMultipleRootCompositions(projectDir: string): HyperframeLintFinding
     );
     const rootCompositions: string[] = [];
     for (const file of rootHtmlFiles) {
-      if (file === "caption-skin.html") continue;
+      if (file === "caption-skin.html" || file === "rail.html") continue;
       const content = readFileSync(join(projectDir, file), "utf-8");
       if (/data-composition-id/i.test(content)) {
         rootCompositions.push(file);


### PR DESCRIPTION
## Summary
- ignore the root-level `rail.html` helper emitted by the embedded-captions theme workflow when detecting multiple root compositions
- retain the existing `caption-skin.html` exception
- add a regression test covering `index.html` plus the generated rail entrypoint

## Reproduction
An embedded-captions Standard theme writes both `index.html` and `rail.html` at the project root. `hyperframes check` treated both as standalone compositions and emitted `multiple_root_compositions`, even though `render-and-composite.sh` renders each in an isolated shadow project.

## Verification
- `bun run --filter @hyperframes/lint test` (362 tests)
- `bun run --filter @hyperframes/cli test -- --run src/utils/lintProject.test.ts` (76 tests)
- lint and CLI typechecks
- oxlint and oxfmt checks
- pre-commit hooks