### PR TITLE
fix(product-launch): preserve hoisted media offsets

### DIFF
--- a/skills/product-launch-video/scripts/assemble-index.mjs
+++ b/skills/product-launch-video/scripts/assemble-index.mjs
@@ -177,7 +177,14 @@ function escapeHtmlAttr(value) {
 
 function approvedVideoAttrs(attrs) {
   const forwarded = [];
-  for (const name of ["id", "src", "poster", "preload", "aria-label"]) {
+  for (const name of [
+    "id",
+    "src",
+    "poster",
+    "preload",
+    "aria-label",
+    "data-media-start",
+  ]) {
     const value = attrValueFrom(attrs, name);
     if (value !== null) forwarded.push(`${name}="${escapeHtmlAttr(value)}"`);
   }

--- a/skills/product-launch-video/scripts/media-contract.test.mjs
+++ b/skills/product-launch-video/scripts/media-contract.test.mjs
@@ -26,7 +26,7 @@ test("assemble hoists an approved timed frame video to the host root", () => {
   );
   writeFileSync(
     framePath,
-    `<html><body><div id="root" data-composition-id="frame-1" data-width="1920" data-height="1080"><video data-frame-video="approved" src="https://cdn.example/clip.mp4" poster="poster.png" preload="auto" muted playsinline loop style="background:url(https://evil.example/x)" nonce="unsafe" onerror="alert(1)" srcdoc="<script>alert(2)</script>" data-start="0.25" data-duration="1.5" data-track-index="7"></video></div><script>window.__timelines = {}; window.__timelines["frame-1"] = gsap.timeline();</script></body></html>`,
+    `<html><body><div id="root" data-composition-id="frame-1" data-width="1920" data-height="1080"><video data-frame-video="approved" src="https://cdn.example/clip.mp4" poster="poster.png" preload="auto" muted playsinline loop style="background:url(https://evil.example/x)" nonce="unsafe" onerror="alert(1)" srcdoc="<script>alert(2)</script>" data-start="0.25" data-duration="1.5" data-media-start="12.75" data-track-index="7"></video></div><script>window.__timelines = {}; window.__timelines["frame-1"] = gsap.timeline();</script></body></html>`,
   );
 
   const result = spawnSync(
@@ -39,6 +39,7 @@ test("assemble hoists an approved timed frame video to the host root", () => {
   const frame = readFileSync(framePath, "utf8");
   assert.match(index, /data-start="0\.25"/);
   assert.match(index, /data-duration="1\.5"/);
+  assert.match(index, /data-media-start="12\.75"/);
   assert.match(index, /data-track-index="1007"/);
   assert.match(index, /src="https:\/\/cdn\.example\/clip\.mp4"/);
   assert.match(index, /poster="poster\.png"/);


### PR DESCRIPTION
## Summary
- preserve `data-media-start` when the product-launch assembler hoists approved frame videos to the host root
- add regression coverage for trimmed source-video windows

## Reproduction
A frame video with `data-media-start="12.75"` lost that attribute during assembly, causing the hoisted host-root video to play from the source beginning. The new test failed before this change and passes afterward.

## Validation
- `node --test skills/product-launch-video/scripts/media-contract.test.mjs`
- `bun run lint:skills`
- `bun run test:skills` (229 passed)
- `git diff --check`