### PR TITLE
fix(engine): await dynamic CSS backgrounds before capture

### DIFF
--- a/packages/engine/src/services/frameCapture-cssBackgroundReady.test.ts
+++ b/packages/engine/src/services/frameCapture-cssBackgroundReady.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { Page } from "puppeteer-core";
+import { decodeDynamicCssBackgroundImages } from "./frameCapture.js";
+
+function makeMockPage(
+  getBackgroundImage: () => string,
+  decoded: string[],
+  decodeImage?: (src: string) => Promise<void>,
+): Page {
+  return {
+    evaluate: async (fn: () => unknown) => {
+      const previousDocument = globalThis.document;
+      const previousImage = globalThis.Image;
+      const previousWindow = globalThis.window;
+
+      const element = {
+        style: {
+          get backgroundImage() {
+            return getBackgroundImage();
+          },
+        },
+      };
+
+      class MockImage {
+        src = "";
+
+        async decode(): Promise<void> {
+          decoded.push(this.src);
+          await decodeImage?.(this.src);
+        }
+      }
+
+      Object.assign(globalThis, {
+        document: {
+          querySelectorAll: () => [element],
+        },
+        Image: MockImage,
+        window: previousWindow ?? {},
+      });
+
+      try {
+        return await fn();
+      } finally {
+        Object.assign(globalThis, {
+          document: previousDocument,
+          Image: previousImage,
+          window: previousWindow,
+        });
+      }
+    },
+  } as unknown as Page;
+}
+
+afterEach(() => {
+  delete (globalThis as { __hf_css_background_decoded?: Set<string> }).__hf_css_background_decoded;
+});
+
+describe("decodeDynamicCssBackgroundImages", () => {
+  it("decodes each newly assigned inline background URL before capture", async () => {
+    let backgroundImage = 'url("/assets/row-0.jpg")';
+    const decoded: string[] = [];
+    const page = makeMockPage(() => backgroundImage, decoded);
+
+    await decodeDynamicCssBackgroundImages(page);
+    await decodeDynamicCssBackgroundImages(page);
+
+    backgroundImage = 'url("/assets/row-1.jpg")';
+    await decodeDynamicCssBackgroundImages(page);
+
+    expect(decoded).toEqual(["/assets/row-0.jpg", "/assets/row-1.jpg"]);
+  });
+
+  it("decodes every URL in a layered inline background", async () => {
+    const decoded: string[] = [];
+    const page = makeMockPage(
+      () => "linear-gradient(#000, #fff), url(\"/assets/plate.png\"), url('/assets/grain.webp')",
+      decoded,
+    );
+
+    await decodeDynamicCssBackgroundImages(page);
+
+    expect(decoded).toEqual(["/assets/plate.png", "/assets/grain.webp"]);
+  });
+
+  it("retries a URL after a transient decode failure", async () => {
+    const decoded: string[] = [];
+    let attempts = 0;
+    const page = makeMockPage(
+      () => 'url("/assets/late.jpg")',
+      decoded,
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("not ready");
+      },
+    );
+
+    await decodeDynamicCssBackgroundImages(page);
+    await decodeDynamicCssBackgroundImages(page);
+
+    expect(decoded).toEqual(["/assets/late.jpg", "/assets/late.jpg"]);
+  });
+});

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -219,6 +219,41 @@ export function isDrawElementVerificationError(err: unknown): boolean {
   return false;
 }
 
+/** Wait for inline CSS background images introduced by the latest seek. */
+export async function decodeDynamicCssBackgroundImages(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const root = globalThis as typeof globalThis & {
+      __hf_css_background_decoded?: Set<string>;
+    };
+    const decoded = (root.__hf_css_background_decoded ??= new Set<string>());
+    const urls: string[] = [];
+    const urlPattern = /url\(\s*(?:"((?:\\.|[^"])*)"|'((?:\\.|[^'])*)'|([^)'"\s][^)]*?))\s*\)/g;
+
+    for (const element of document.querySelectorAll<HTMLElement>('[style*="background"]')) {
+      const backgroundImage = element.style.backgroundImage;
+      if (!backgroundImage || backgroundImage === "none") continue;
+
+      for (const match of backgroundImage.matchAll(urlPattern)) {
+        const url = match[1] ?? match[2] ?? match[3]?.trim();
+        if (url && !decoded.has(url)) urls.push(url);
+      }
+    }
+
+    await Promise.all(
+      [...new Set(urls)].map(async (url) => {
+        const image = new Image();
+        image.src = url;
+        try {
+          await image.decode();
+          decoded.add(url);
+        } catch {
+          // Keep existing capture behavior for missing assets; request diagnostics report them.
+        }
+      }),
+    );
+  });
+}
+
 // Circular buffer for browser console messages dumped on render failure diagnostics.
 // Complex compositions produce 100+ messages; 50 was too small to capture relevant errors.
 const BROWSER_CONSOLE_BUFFER_SIZE = 200;
@@ -1873,6 +1908,8 @@ async function prepareFrameForCapture(
     return !!(window as unknown as { __hf_page_composite_pending?: boolean })
       .__hf_page_composite_pending;
   }, quantizedTime);
+
+  await decodeDynamicCssBackgroundImages(page);
 
   const seekMs = Date.now() - seekStart;
 


### PR DESCRIPTION
## Summary
- wait for newly assigned inline CSS background images to decode after each deterministic seek
- cache successfully decoded URLs per page so steady-state frames avoid repeated decode work
- retry transient decode failures on later frames

## Reproduction
Feedback source: https://heygen.slack.com/archives/C0BGC335AQY/p1783954331452369

A deterministic delayed-image fixture reproduced the race on published 0.7.56: the first two frames after every row switch captured transparent pixels. With this patch, all 90 frames used the expected row, including boundary frames 16, 31, 46, 61, and 76.

## Tests
- `bun run typecheck` in `packages/engine`
- `bunx vitest run src/services/frameCapture-*.test.ts` (96 tests)
- full repository build
- pre-commit lint, format, fallow, tracked-artifact, and typecheck hooks
- 90-frame delayed-response PNG-sequence before/after audit