### PR TITLE
fix(packages): declare Apache-2.0 license

### DIFF
--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/aws-lambda",
   "version": "0.7.70",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/core",
   "version": "0.7.70",
   "description": "",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/engine",
   "version": "0.7.70",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/gcp-cloud-run",
   "version": "0.7.70",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hyperframes/lint",
   "version": "0.7.70",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hyperframes/parsers",
   "version": "0.7.70",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/player",
   "version": "0.7.70",
   "description": "Embeddable web component for HyperFrames compositions",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/producer",
   "version": "0.7.70",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/sdk",
   "version": "0.7.70",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/shader-transitions",
   "version": "0.7.70",
   "description": "WebGL shader transitions for HyperFrames compositions",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hyperframes/studio-server",
   "version": "0.7.70",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/studio",
   "version": "0.7.70",
   "description": "",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",


### PR DESCRIPTION
## Summary

Add explicit `Apache-2.0` license metadata to every publishable `@hyperframes/*` workspace package. This keeps npm and downstream compliance tooling from classifying the packages as proprietary when the repository is Apache-2.0 licensed.

Private workspace packages are intentionally unchanged.

Closes #2334.

## Validation

- `bun run build`
- `bun run verify:packed-manifests`
- `oxfmt --check .`
- `git diff --check`

The packed-manifest check verified all 13 public packages, 101 packed exports, 96 executable Node exports, a clean consumer install, TypeScript/Vite resolution, and CLI startup.