### PR TITLE
fix(cli): ignore incompatible Python whisper command

### DIFF
--- a/packages/cli/src/whisper/manager.test.ts
+++ b/packages/cli/src/whisper/manager.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { WhisperUnavailableError, isWhisperUnavailable } from "./manager.js";
+import {
+  WHISPER_CPP_SYSTEM_BINARY_NAMES,
+  WhisperUnavailableError,
+  isWhisperUnavailable,
+} from "./manager.js";
+
+describe("system executable discovery", () => {
+  it("does not accept the unrelated Python whisper CLI", () => {
+    expect(WHISPER_CPP_SYSTEM_BINARY_NAMES).toEqual(["whisper-cli"]);
+    expect(WHISPER_CPP_SYSTEM_BINARY_NAMES).not.toContain("whisper");
+  });
+});
 
 describe("isWhisperUnavailable", () => {
   it("recognizes WhisperUnavailableError instances", () => {

--- a/packages/cli/src/whisper/manager.ts
+++ b/packages/cli/src/whisper/manager.ts
@@ -16,6 +16,11 @@ export interface WhisperResult {
   source: WhisperSource;
 }
 
+// Only whisper.cpp's current executable is compatible with the CLI arguments
+// used below. The unrelated Python `whisper` package installs a binary named
+// `whisper` with a different interface, so it must never satisfy discovery.
+export const WHISPER_CPP_SYSTEM_BINARY_NAMES = ["whisper-cli"] as const;
+
 // A missing/uninstallable whisper-cpp is an environment prerequisite gap (no
 // binary, no Homebrew, no compiler toolchain), not a transcription bug. Callers
 // that treat captions as optional (init, skill pipelines) skip on this and keep
@@ -67,7 +72,7 @@ function findFromEnv(): WhisperResult | undefined {
 }
 
 function findFromSystem(): WhisperResult | undefined {
-  for (const name of ["whisper-cli", "whisper"]) {
+  for (const name of WHISPER_CPP_SYSTEM_BINARY_NAMES) {
     const path = whichBinary(name);
     if (path) return { executablePath: path, source: "system" };
   }


### PR DESCRIPTION
## Summary
- discover only the whisper.cpp `whisper-cli` executable on PATH
- stop treating the unrelated Python package’s `whisper` command as compatible
- retain `HYPERFRAMES_WHISPER_PATH` as the explicit override
- add regression coverage for the allowed system binary names

## Verification
- `bun run --cwd packages/cli test --run src/whisper/manager.test.ts` (4 tests passed)
- `bunx oxfmt --check packages/cli/src/whisper/manager.ts packages/cli/src/whisper/manager.test.ts`
- `git diff --check`