### PR TITLE
fix(cli): declare Apache-2.0 license

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/cli",
   "version": "0.7.56",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/scripts/verify-packed-manifests.mjs
+++ b/scripts/verify-packed-manifests.mjs
@@ -262,6 +262,18 @@ function readPackedPackage(filename) {
   return JSON.parse(packedPackageJson);
 }
 
+export function verifyCliLicense(workspace, sourcePackage, packedPackage) {
+  if (workspace !== "packages/cli") return;
+
+  const expectedLicense = "Apache-2.0";
+  if (sourcePackage.license !== expectedLicense) {
+    throw new Error(`${workspace} must declare license ${expectedLicense}`);
+  }
+  if (packedPackage.license !== sourcePackage.license) {
+    throw new Error(`${workspace} packed manifest must preserve license ${expectedLicense}`);
+  }
+}
+
 function assertNoWorkspaceRefs(workspace, packedPackage) {
   const packedRefs = listWorkspaceRefs(packedPackage);
   if (packedRefs.length === 0) return;
@@ -271,10 +283,11 @@ function assertNoWorkspaceRefs(workspace, packedPackage) {
   );
 }
 
-function verifyPackedWorkspace(workspace, filename) {
+function verifyPackedWorkspace(workspace, sourcePackage, filename) {
   const packedPackage = readPackedPackage(filename);
   const packedFiles = listPackedFiles(filename);
 
+  verifyCliLicense(workspace, sourcePackage, packedPackage);
   assertNoWorkspaceRefs(workspace, packedPackage);
   verifyPackedEntrypoints(workspace, packedPackage, packedFiles);
   verifyPackedJavaScriptImports(workspace, filename, packedFiles);
@@ -395,7 +408,7 @@ function packAndVerifyWorkspace(workspace, packDir) {
 
   assertPublishedExportsMatchSource(workspace, sourcePackageJson);
   const filename = packWorkspace(workspace, packDir);
-  verifyPackedWorkspace(workspace, filename);
+  verifyPackedWorkspace(workspace, sourcePackageJson, filename);
   const packedPackage = readPackedPackage(filename);
   console.log(`Verified ${workspace}: packed manifest is publish-safe.`);
   return { workspace, filename, packedPackage };

--- a/scripts/verify-packed-manifests.test.mjs
+++ b/scripts/verify-packed-manifests.test.mjs
@@ -8,9 +8,24 @@ import {
   listPackedExportContracts,
   listPackedJavaScriptImportIssues,
   packageExportSpecifier,
+  verifyCliLicense,
 } from "./verify-packed-manifests.mjs";
 
 describe("packed manifest verifier", () => {
+  it("requires the CLI package and tarball to declare Apache-2.0", () => {
+    assert.throws(
+      () => verifyCliLicense("packages/cli", {}, {}),
+      /packages\/cli must declare license Apache-2\.0/,
+    );
+    assert.throws(
+      () => verifyCliLicense("packages/cli", { license: "Apache-2.0" }, { license: "UNLICENSED" }),
+      /packages\/cli packed manifest must preserve license Apache-2\.0/,
+    );
+    assert.doesNotThrow(() =>
+      verifyCliLicense("packages/cli", { license: "Apache-2.0" }, { license: "Apache-2.0" }),
+    );
+  });
+
   it("derives consumer specifiers from the packed export map", () => {
     assert.equal(packageExportSpecifier("@hyperframes/sdk", "."), "@hyperframes/sdk");
     assert.equal(


### PR DESCRIPTION
## Summary

- declare the CLI package license as Apache-2.0 using its SPDX identifier
- verify the source and packed CLI manifests preserve the same license metadata
- add regression coverage to the packed-manifest release gate

## Validation

- `node --test scripts/verify-packed-manifests.test.mjs` (7 passed)
- `bun run test:scripts` (67 passed)
- `npm pack` tarball inspection confirmed `license: Apache-2.0`
- changed-file formatting and lint checks passed

Closes #2334