### PR TITLE
fix(cli): stop advertising missing init examples

### DIFF
--- a/packages/cli/src/docs/examples.md
+++ b/packages/cli/src/docs/examples.md
@@ -1,18 +1,18 @@
-# Templates
+# Examples
 
-Built-in templates available via `npx hyperframes init --example <name>`.
+Examples available via `npx hyperframes init --example <name>`.
+
+The following example is bundled with the CLI and is always available:
 
 ## blank
 
 Empty 1920x1080 composition with GSAP timeline wired up. Start from scratch.
 
-## title-card
+## Registry examples
 
-Animated title and subtitle with GSAP fade-in/out. Good for intro cards.
-
-## video-edit
-
-Video element with trimming, audio, and track controls. Starting point for video editing.
+Additional examples are fetched from the current registry. Run `npx hyperframes init`
+interactively to browse them, or use `npx hyperframes catalog` to inspect the registry
+before passing a name to `--example`.
 
 ## Custom Templates
 

--- a/packages/cli/src/docs/examples.test.ts
+++ b/packages/cli/src/docs/examples.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("examples documentation", () => {
+  it("only advertises bundled examples as always available to init", () => {
+    const markdown = readFileSync(fileURLToPath(new URL("./examples.md", import.meta.url)), "utf8");
+    const alwaysAvailableSection = markdown.split("## Registry examples")[0];
+    const documented = [...alwaysAvailableSection.matchAll(/^## ([\w-]+)$/gm)].map(
+      ([, name]) => name,
+    );
+    const generators = readFileSync(
+      fileURLToPath(new URL("../templates/generators.ts", import.meta.url)),
+      "utf8",
+    );
+    const bundledSection = generators.match(
+      /export const BUNDLED_TEMPLATES:[\s\S]*?= \[([\s\S]*?)\n\];/,
+    )?.[1];
+    const bundled = [...(bundledSection ?? "").matchAll(/\bid: "([\w-]+)"/g)].map(
+      ([, name]) => name,
+    );
+
+    expect(documented).toEqual(bundled);
+  });
+});


### PR DESCRIPTION
## Summary
- document only the bundled `blank` example as always available
- direct users to interactive init/catalog for dynamic registry examples
- add a regression test that keeps always-available docs aligned with bundled templates

## Reproduction
`npx hyperframes@0.7.56 init ... --example title-card --non-interactive` fails because `title-card` is not in the registry, despite the installed examples docs advertising it.

## Test plan
- `bun test packages/cli/src/docs/examples.test.ts`
- `bunx prettier --check packages/cli/src/docs/examples.md packages/cli/src/docs/examples.test.ts`
- `git diff --check`

Human review required; do not self-merge.