### PR TITLE
test(cli): stabilize flaky install-lock wait-notice test with fake timers

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -411,6 +411,12 @@ describe("findBrowser — cache resolution", () => {
   });
 
   it("withInstallLock reports progress while waiting instead of staying silent", async () => {
+    // Fake timers freeze Date.now() so the lock mtime stays non-stale across
+    // the dynamic import that follows — without them, a slow import beat could
+    // push wall-clock past staleMs before `withInstallLock` even starts polling,
+    // firing the immediate-stale short-circuit and skipping the wait-notice
+    // branch this test exists to observe.
+    vi.useFakeTimers();
     const paths = installFsMocks({
       existing: new Set([CACHE_ROOT, HF_LOCK]),
       initialMtimeMs: Date.now(),
@@ -418,8 +424,17 @@ describe("findBrowser — cache resolution", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const { withInstallLock } = await import("./manager.js");
-    await withInstallLock(async () => "done", { ...TEST_LOCK_TIMINGS, waitNoticeMs: 20 });
+    const acquisition = withInstallLock(async () => "done", {
+      ...TEST_LOCK_TIMINGS,
+      waitNoticeMs: 20,
+    });
 
+    // Advance past waitNoticeMs (fires the "Waiting for…" warn), then past
+    // staleMs (lets `reclaimStaleInstallLock` clear the held lock so the
+    // acquisition resolves).
+    await vi.advanceTimersByTimeAsync(TEST_LOCK_TIMINGS.staleMs + TEST_LOCK_TIMINGS.pollMs * 5);
+
+    await expect(acquisition).resolves.toBe("done");
     expect(paths.has(HF_LOCK)).toBe(false);
     expect(
       warnSpy.mock.calls.some(([msg]) =>


### PR DESCRIPTION
## What

Adopts the fake-timer pattern (already used in the sibling "recovers when a crashed reclaimer leaves both lock directories" test) for `withInstallLock reports progress while waiting instead of staying silent` (`packages/cli/src/browser/manager.test.ts:413`). Test-only change; no production-code diff.

## Why

The test seeds `initialMtimeMs: Date.now()` inside `installFsMocks(...)`, then does `await import("./manager.js")` (a `vi.resetModules()`'d dynamic import per `beforeEach`) before calling `withInstallLock`. Under real timers, if the dynamic-import beat exceeds `staleMs=50ms` — plausible on a busy shared runner with vitest resetting modules between tests — the new `isDirLockStale(INSTALL_LOCK_DIR, staleMs)` short-circuit added in #2328 (`manager.ts:154`) fires on iteration 1, the loop breaks before `waitedMs` reaches `waitNoticeMs=20`, no `"Waiting for another hyperframes process"` warn ever emits, and the assertion at `manager.test.ts:428` (`expected false to be true`) fails.

Observed on `main` (post-#2328): reruns of the `Test` lane fire the same failure at `line=428,column=7 ::AssertionError: expected false to be true`. Two separate CI runs on unrelated PRs (`#2359`, `#2360`) both hit it — one on the first attempt and again on the retry — so retries alone don't clear it under current CI load. My own review of #2328 (`https://github.com/heygen-com/hyperframes/pull/2328#pullrequestreview-*`) called out exactly this flake mechanism and suggested this fix.

## How

Under fake timers, `Date.now()` is frozen at `useFakeTimers()` time, so the mtime seed stays non-stale across the dynamic import regardless of real wall-clock latency. `vi.advanceTimersByTimeAsync(TEST_LOCK_TIMINGS.staleMs + TEST_LOCK_TIMINGS.pollMs * 5)` then drives the loop past both `waitNoticeMs` (fires the warn the test observes) and the stale deadline (lets `reclaimStaleInstallLock` clear the held lock so the acquisition resolves).

`afterEach(() => vi.useRealTimers())` already exists at `describe("findBrowser — cache resolution")`'s teardown, so no per-test cleanup is needed.

## Test plan

- Local `vitest run src/browser/manager.test.ts`: 27/27 pass in 487ms.
- Both blocked PRs (`#2359`, `#2360`) should turn the Test lane green after their next CI runs.

- [x] Unit tests added/updated

— Via
