### PR TITLE
docs(cli): sync SRT upload docs from EF

### DIFF
--- a/packages/cli/src/cloud/_gen/client.ts
+++ b/packages/cli/src/cloud/_gen/client.ts
@@ -204,7 +204,7 @@ export class HyperframesCloudClient {
   /**
    * Upload Asset
    *
-   * Uploads a file (image, video, audio, or PDF) and returns an asset_id for use in other endpoints. Max 32 MB. Supported types: png, jpeg, mp4, webm, mp3, wav, pdf.
+   * Uploads a file (image, video, audio, PDF, or SRT subtitle) and returns an asset_id for use in other endpoints. Max 32 MB. Supported types: png, jpeg, mp4, webm, mp3, wav, pdf, srt.
    */
   async uploadAsset(args: {
     file: Blob | Buffer | Uint8Array;

--- a/packages/cli/src/cloud/generatedClient.contract.test.ts
+++ b/packages/cli/src/cloud/generatedClient.contract.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const generatedClientSource = readFileSync(new URL("./_gen/client.ts", import.meta.url), "utf8");
+
+describe("generated cloud client source contract", () => {
+  it("documents SRT subtitles on the uploadAsset endpoint", () => {
+    const uploadAssetDocs = generatedClientSource.match(
+      /\/\*\*\s*\*\s*Upload Asset[\s\S]*?\*\/\s+async uploadAsset/,
+    )?.[0];
+
+    expect(uploadAssetDocs).toContain("SRT subtitle");
+    expect(uploadAssetDocs).toMatch(/Supported types:[^\n]*\bsrt\b/);
+  });
+});


### PR DESCRIPTION
## What changed

- Sync the generated HyperFrames cloud client documentation with Experiment Framework commit `a71c71b8` so `/v3/assets` advertises SRT subtitle uploads and the `.srt` type.
- Add a focused source-contract regression test that pins the SRT documentation to the `uploadAsset` endpoint.

This documents existing upload support; it does not change upload runtime behavior.

## Root cause

The Experiment Framework codegen job generated this update successfully, but its `GIT_PAT` could check out HyperFrames without creating a branch: GitHub returned 404 from the first `POST /repos/heygen-com/hyperframes/git/refs` write. This PR clears the pending generated-client drift from #2355. The workflow secret still needs repository contents-write and pull-request permissions before automatic syncs can resume.

## Verification

- Regenerated from Experiment Framework `a71c71b8`; `client.ts` and `types.ts` match the generator output.
- Captured the regression test failing before the generated documentation update and passing afterward.
- `bun run --cwd packages/cli test` — 130 files, 1660 tests passed.
- CLI typecheck, focused format/lint, tracked-artifact check, workspace-contract check, and `git diff --check` pass.

Refs #2355
