### PR TITLE
fix(cli): skip contrast for intentionally covered text

### DIFF
--- a/packages/cli/src/commands/contrast-audit.browser.js
+++ b/packages/cli/src/commands/contrast-audit.browser.js
@@ -131,6 +131,12 @@ window.__contrastAuditPrepare = function () {
     return !paintsAnyProbePoint(el, rect);
   }
 
+  function isIntentionallyOccluded(el, rect) {
+    if (typeof document.elementFromPoint !== "function") return false;
+    if (!el.closest || !el.closest("[data-layout-allow-occlusion]")) return false;
+    return !paintsAnyProbePoint(el, rect);
+  }
+
   var out = [];
   var restores = [];
   // Registered BEFORE the walk starts (not after it finishes) and pushed to
@@ -200,6 +206,10 @@ window.__contrastAuditPrepare = function () {
     if (rect.width < 8 || rect.height < 8) continue;
     if (rect.right <= 0 || rect.bottom <= 0) continue;
     if (isClippedAway(el, rect)) continue;
+    // The layout audit's explicit occlusion opt-out means this text is allowed
+    // to sit behind another scene. Skip contrast only while every probe point
+    // is actually covered; the same copy is audited normally when visible.
+    if (isIntentionallyOccluded(el, rect)) continue;
 
     // For SVG text, `fill` is the paint that's actually rendered; `color` is
     // frequently just the inherited/initial value and unrelated to what's on

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -635,6 +635,68 @@ describe("contrast-audit.browser clip-path visibility", () => {
     expect(selectors).not.toContain("#rail-label");
   });
 
+  it("excludes intentionally occluded text from contrast reports", async () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="headline" data-layout-allow-occlusion>Covered copy</div>
+        <div id="cover"></div>
+      </div>
+    `;
+
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          display: "block",
+          visibility: "visible",
+          opacity: "1",
+          color: "rgb(255, 255, 255)",
+          fontSize: "32px",
+          fontWeight: "400",
+          clipPath: "none",
+        }) as unknown as CSSStyleDeclaration,
+    );
+    vi.spyOn(document.getElementById("headline")!, "getBoundingClientRect").mockReturnValue(
+      rect({ left: 100, top: 100, width: 400, height: 40 }),
+    );
+    (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint = () =>
+      document.getElementById("cover");
+
+    installContrastScript();
+
+    expect(await runContrastAudit()).toEqual([]);
+  });
+
+  it("still audits visible text that allows occlusion", async () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="headline" data-layout-allow-occlusion>Visible copy</div>
+      </div>
+    `;
+
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          display: "block",
+          visibility: "visible",
+          opacity: "1",
+          color: "rgb(255, 255, 255)",
+          fontSize: "32px",
+          fontWeight: "400",
+          clipPath: "none",
+        }) as unknown as CSSStyleDeclaration,
+    );
+    vi.spyOn(document.getElementById("headline")!, "getBoundingClientRect").mockReturnValue(
+      rect({ left: 100, top: 100, width: 400, height: 40 }),
+    );
+    (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint = () =>
+      document.getElementById("headline");
+
+    installContrastScript();
+
+    const entries = await runContrastAudit();
+    expect(entries.map((entry) => entry.selector)).toContain("#headline");
+  });
+
   it("excludes text that has left the canvas from contrast reports", async () => {
     document.body.innerHTML = `
       <div id="root" data-composition-id="main" data-width="640" data-height="360">


### PR DESCRIPTION
## Summary

- Skip contrast candidates that explicitly allow occlusion while they are fully covered.
- Continue auditing the same text whenever any probe point is visible.
- Add regression coverage for both covered and visible states.

## Root Cause

### Contrast ignored the layout occlusion contract

**Error:** Fully covered copy marked `data-layout-allow-occlusion` produced repeated `contrast_aa_failure` findings.

**Mechanism:** The layout audit honors the explicit occlusion opt-out, but the contrast candidate walk only excluded `data-layout-ignore`, clipped-away, off-canvas, and hidden text. It therefore sampled the covering scene as the hidden text's background and reported meaningless low ratios.

**Fix:** Reuse the existing hit-test probe grid when an element or ancestor carries `data-layout-allow-occlusion`. Skip the candidate only when every probe point is covered; visible text still enters the contrast audit.

## Changes

- `packages/cli/src/commands/contrast-audit.browser.js`: exclude fully covered intentional-occlusion candidates.
- `packages/cli/src/commands/layout-audit.browser.test.ts`: cover fully occluded and still-visible opt-out states.

## Test Plan

- [x] Exact 0.7.56 reproduction: layout passed while contrast emitted five false failures for fully covered text.
- [x] Focused browser audit tests: 49 passed.
- [x] Lint and format hooks passed.
- [x] Workspace typecheck hook passed after generating the expected runtime artifact.

## Confidence Score: 9/10

The fix is limited to the explicit `data-layout-allow-occlusion` contract and regression-tests both branches. CI remains the final cross-platform validation.

Source report: https://heygen.slack.com/archives/C0BGC335AQY/p1783980684706089
