### PR TITLE
feat(cli): tag HeyGen API calls with X-HeyGen-Client-Source

### DIFF
--- a/packages/cli/src/auth/client.test.ts
+++ b/packages/cli/src/auth/client.test.ts
@@ -3,6 +3,8 @@ import {
   AuthClient,
   HEYGEN_CLI_SOURCE,
   HEYGEN_CLI_SOURCE_HEADER,
+  HEYGEN_CLIENT_SOURCE,
+  HEYGEN_CLIENT_SOURCE_HEADER,
   apiBaseUrl,
   buildAuthHeaders,
 } from "./client.js";
@@ -81,12 +83,14 @@ describe("auth/client", () => {
     expect(buildAuthHeaders(cred)).toEqual({
       authorization: "Bearer at_123",
       [HEYGEN_CLI_SOURCE_HEADER]: HEYGEN_CLI_SOURCE,
+      [HEYGEN_CLIENT_SOURCE_HEADER]: HEYGEN_CLIENT_SOURCE,
     });
   });
 
-  it("buildAuthHeaders uses x-api-key for api_key, without the cli-source header", () => {
+  it("buildAuthHeaders uses x-api-key for api_key, without the cli-source header but with the tool tag", () => {
     expect(buildAuthHeaders(apiKeyCred())).toEqual({
       "x-api-key": "hg_x",
+      [HEYGEN_CLIENT_SOURCE_HEADER]: HEYGEN_CLIENT_SOURCE,
     });
   });
 

--- a/packages/cli/src/auth/client.ts
+++ b/packages/cli/src/auth/client.ts
@@ -23,6 +23,12 @@ import type { OAuthTokens } from "./store.js";
 const DEFAULT_BASE_URL = "https://api.heygen.com";
 export const HEYGEN_CLI_SOURCE_HEADER = "X-HeyGen-Source";
 export const HEYGEN_CLI_SOURCE = "cli";
+// Tool-attribution header identifying this CLI as the request origin. Sent on
+// every HeyGen call (both auth types) so the backend can isolate hyperframes CLI
+// usage in billing meta. Distinct from HEYGEN_CLI_SOURCE_HEADER above, which is
+// the OAuth-only cli-source header that gates the free allowance.
+export const HEYGEN_CLIENT_SOURCE_HEADER = "X-HeyGen-Client-Source";
+export const HEYGEN_CLIENT_SOURCE = "hyperframes";
 
 export function apiBaseUrl(): string {
   const override = process.env["HEYGEN_API_URL"];
@@ -182,12 +188,14 @@ export function buildAuthHeaders(credential: ResolvedCredential): Record<string,
     return {
       authorization: `Bearer ${credential.access_token}`,
       [HEYGEN_CLI_SOURCE_HEADER]: HEYGEN_CLI_SOURCE,
+      [HEYGEN_CLIENT_SOURCE_HEADER]: HEYGEN_CLIENT_SOURCE,
     };
   }
   // API-key traffic keeps the normal billing path; the backend ignores the
   // cli-source header for it, so we don't send it (avoids a contradictory
-  // "cli-source claim on an API-key request").
-  return { "x-api-key": credential.key };
+  // "cli-source claim on an API-key request"). The tool-attribution header IS
+  // sent here — an API-key hyperframes call is still hyperframes usage.
+  return { "x-api-key": credential.key, [HEYGEN_CLIENT_SOURCE_HEADER]: HEYGEN_CLIENT_SOURCE };
 }
 
 async function safeText(res: Response): Promise<string> {


### PR DESCRIPTION
## What
The hyperframes CLI now sends `X-HeyGen-Client-Source: hyperframes` on every HeyGen API request, from the single `buildAuthHeaders()` chokepoint (both OAuth and API-key auth).

## Why
The CLI's HeyGen traffic is currently indistinguishable from any other first-party client, so CLI usage can't be attributed. This is the CLI analog of the media-use tagging in #2365 — it declares the CLI as the request origin so the backend can isolate hyperframes CLI usage in billing meta.

## How
- New `HEYGEN_CLIENT_SOURCE_HEADER` / `HEYGEN_CLIENT_SOURCE = "hyperframes"` constants.
- Added to both branches of `buildAuthHeaders()` — this is the single point all core CLI + cloud HeyGen calls route through, so one edit covers them.
- Unconditional of auth type (an API-key CLI call is still hyperframes usage). The OAuth-only `X-HeyGen-Source: cli` free-gate header is unchanged.
- Note: `hyperframes` (a tool) goes in `client_source`, not `client_origin` — that field is reserved for the driving agent (`claude_code`/`codex`/…) and its allowlist would drop a non-agent value.

## Test plan
- `client.test.ts`: both `buildAuthHeaders` branches now assert `X-HeyGen-Client-Source: hyperframes`. `vitest run src/auth/client.test.ts` → 17/17 pass.
- oxlint + oxfmt + fallow + typecheck clean (pre-commit).

## Pairs with
Backend persistence in heygen-com/experiment-framework#41968 — its `_KNOWN_CLIENT_SOURCES` allowlist already includes `hyperframes`, so no additional backend change is needed for this PR.