### PR TITLE
docs(media-use): drop the HeyGen generative use-cases table

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "f8765298f9681d93",
+      "hash": "688ce2db33d293bc",
       "files": 124
     },
     "motion-graphics": {

--- a/skills/media-use/references/operations.md
+++ b/skills/media-use/references/operations.md
@@ -251,30 +251,7 @@ Common optional fields: `title`, `resolution` (`4k`/`1080p`/`720p`),
 CLI self-documents the full, current body with
 `heygen video create --request-schema` (a discriminated union keyed on `type`),
 so read the schema rather than trusting a stale field list. For a still you'll
-reuse across many scripts, create a **Photo Avatar** once instead (below). Ledger
-the result with `resolve --from <downloaded.mp4> --type video`. Docs:
+reuse across many scripts, create a reusable **Photo Avatar** once instead
+(`heygen avatar create`). Ledger the result with
+`resolve --from <downloaded.mp4> --type video`. Docs:
 <https://developers.heygen.com/image-to-video>.
-
-### Other HeyGen generative use cases
-
-All reachable through the installed `heygen` CLI (verified v0.3.0): either
-`video create -d '{...}'` body variants (keyed on `type`) or the dedicated
-subcommands. There is no capability gap that would need the raw API, and every
-command prints its exact input with `--request-schema`, so this table is a
-pointer, not a spec. Reach for these when a composition needs a real presenter, a
-dub, or a designed clip that LTX/avatar don't cover:
-
-| Use case                      | Reach it via                               | What it does                                                                          | Docs                                 |
-| ----------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------ |
-| Photo Avatar / talking photo  | `avatar create` + `avatar looks`           | Create a reusable avatar from one still, then drive it via `video create` type avatar | `photo-avatar`                       |
-| Digital Twin (video avatar)   | `video create` (`type:"avatar"`)           | Lifelike avatar trained from real footage; speaks any script                          | `generate-avatar-video`              |
-| Cinematic avatar (prompt-gen) | `video create` (`type:"cinematic_avatar"`) | Prompt + 1-3 avatar/reference assets → generated clip (Seedance); no script/voice     | `avatar-v`                           |
-| Video translation             | `heygen video-translate`                   | Translate + voice-clone + lip-sync a video across 30+ languages                       | `docs/video-translate`               |
-| Lipsync / dub                 | `heygen lipsync`                           | Replace or dub audio on an existing video with fresh lip-sync                         | `lipsync-speed`, `lipsync-precision` |
-| Short clips from long video   | `heygen ai-clipping`                       | Turn long-form footage into ready-to-share short clips with captions                  | `ai-clipping`                        |
-| Voice design / clone          | `heygen voice`                             | Describe or clone a voice, then use its id as `voice_id`                              | `docs/voices/design-voices`          |
-
-Doc slugs are under `https://developers.heygen.com/`. Prefer HyperFrames'
-own compositions for motion graphics / data-viz / title cards (that's what this
-repo is for); the HeyGen generative endpoints are for presenter footage, dubs,
-and image-driven talking clips that HTML compositions can't produce.


### PR DESCRIPTION
## What

Remove the "Other HeyGen generative use cases" table (photo avatar, digital twin, cinematic, translate, lipsync, ai-clipping, voice) from `skills/media-use/references/operations.md`. Keep the image-to-video recipe.

## Why

The table drifted toward the API-reference surface that media-use's OP1 decision says the skill shouldn't carry ("guides, not wraps"). Every `heygen` command already self-documents its input via `--request-schema`, so a hand-maintained capability table is redundant and rots. Follow-up to #2356.

## How

- Delete the section (intro paragraph + table + closing note).
- Fix the now-dangling "(below)" pointer in the image-to-video note, which referenced the removed Photo Avatar row → now points at `heygen avatar create`.
- Regenerate `skills-manifest.json`.

## Test plan

- [x] Documentation updated (docs/skills only, no runtime code)
- [x] `skills-manifest.json` regenerated and `--check` passes
- [ ] Unit tests — n/a