### PR TITLE
fix(transcribe): default output to project directory

### DIFF
--- a/packages/cli/src/commands/transcribe.test.ts
+++ b/packages/cli/src/commands/transcribe.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { writeFileSync, readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { writeFileSync, readFileSync, mkdtempSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { WhisperUnavailableError } from "../whisper/manager.js";
@@ -97,6 +97,21 @@ Render video. Built for agents.
       wordCount: 2,
       outputPath,
     });
+  });
+
+  it("writes transcript.json to the current project directory by default", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-transcribe-test-"));
+    dirs.push(projectDir);
+    const assetDir = join(projectDir, "assets", "audio");
+    mkdirSync(assetDir, { recursive: true });
+    const input = join(assetDir, "sample.srt");
+    writeFileSync(input, "1\n00:00:00,000 --> 00:00:01,000\nHello\n");
+    vi.spyOn(process, "cwd").mockReturnValue(projectDir);
+
+    await transcribeCmd.run!({ args: { input, json: true } } as never);
+
+    expect(existsSync(join(projectDir, "transcript.json"))).toBe(true);
+    expect(existsSync(join(assetDir, "transcript.json"))).toBe(false);
   });
 
   it("--preserve-cues keeps single-word cues separate when exporting from JSON", async () => {

--- a/packages/cli/src/commands/transcribe.ts
+++ b/packages/cli/src/commands/transcribe.ts
@@ -95,15 +95,12 @@ export default defineCommand({
       process.exit(1);
     }
 
-    // Default to the directory containing the input file so transcript.json
-    // lands next to narration.wav regardless of where the command is run from.
-    // Explicit --dir overrides this (e.g. for import mode targeting a project dir).
-    const dir = resolve(args.dir ?? dirname(inputPath));
     const ext = extname(inputPath).toLowerCase();
 
     // ── Import mode: convert existing transcript ──────────────────────────
     const isImport = ext === ".json" || ext === ".srt" || ext === ".vtt";
     const to = parseExportFormat(args.to, args.json);
+    const dir = resolve(args.dir ?? (to ? dirname(inputPath) : process.cwd()));
 
     if (to) {
       if (!isImport) {


### PR DESCRIPTION
## Summary
- make `transcribe` honor its documented current-directory default
- keep explicit `--dir` behavior unchanged
- preserve input-adjacent defaults for `--to srt|vtt` exports
- avoid writing `transcript.json` into `assets/audio` when input media lives there

Source feedback: https://heygen.slack.com/archives/C0BGC335AQY/p1783984033363839

## Tests
- `bun run --filter @hyperframes/cli test -- src/commands/transcribe.test.ts`
- `bunx oxfmt --check packages/cli/src/commands/transcribe.ts packages/cli/src/commands/transcribe.test.ts`
- `bunx oxlint packages/cli/src/commands/transcribe.ts packages/cli/src/commands/transcribe.test.ts`
- `bun run --filter @hyperframes/cli typecheck`