### PR TITLE
fix(render): fall back when libx264 is unavailable

### DIFF
--- a/packages/cli/src/browser/ffmpeg.test.ts
+++ b/packages/cli/src/browser/ffmpeg.test.ts
@@ -1,12 +1,13 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("node:child_process", () => ({ execSync: vi.fn() }));
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn(), execSync: vi.fn() }));
 vi.mock("node:fs", () => ({ existsSync: vi.fn() }));
 
 const mockExec = vi.mocked(execSync);
+const mockExecFile = vi.mocked(execFileSync);
 const mockExists = vi.mocked(existsSync);
 
 // The common-dir fallback list is platform-gated (empty on win32), so pin the
@@ -51,5 +52,30 @@ describe("findFFmpeg", () => {
 
     const { findFFmpeg } = await import("./ffmpeg.js");
     expect(findFFmpeg()).toBeUndefined();
+  });
+});
+
+describe("resolveH264EncoderMode", () => {
+  it("falls back to VideoToolbox when libx264 is absent", async () => {
+    const { resolveH264EncoderMode } = await import("./ffmpeg.js");
+    const encoders = `
+ V....D h264_videotoolbox    VideoToolbox H.264 Encoder
+`;
+
+    expect(resolveH264EncoderMode(encoders, false)).toBe("gpu");
+  });
+
+  it("inspects the configured FFmpeg binary", async () => {
+    mockExecFile.mockReturnValue(
+      " V....D h264_videotoolbox    VideoToolbox H.264 Encoder\n" as never,
+    );
+    const { detectH264EncoderMode } = await import("./ffmpeg.js");
+
+    expect(detectH264EncoderMode("/custom/ffmpeg", false)).toBe("gpu");
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "/custom/ffmpeg",
+      ["-hide_banner", "-encoders"],
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
   });
 });

--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -1,11 +1,39 @@
 // fallow-ignore-file code-duplication
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { detectLinuxDistro, ffmpegInstallCommand } from "./linuxDeps.js";
 
 export const FFMPEG_PATH_ENV = "HYPERFRAMES_FFMPEG_PATH";
 export const FFPROBE_PATH_ENV = "HYPERFRAMES_FFPROBE_PATH";
+
+export type H264EncoderMode = "software" | "gpu";
+
+/**
+ * Select the H.264 encoder class supported by an FFmpeg build.
+ *
+ * Some macOS FFmpeg distributions expose VideoToolbox but omit libx264. The
+ * default CPU render path must not pass libx264-only options such as `-preset`
+ * to those builds.
+ */
+export function resolveH264EncoderMode(
+  ffmpegEncodersOutput: string,
+  gpuRequested: boolean,
+): H264EncoderMode {
+  if (gpuRequested) return "gpu";
+  if (/\blibx264\b/.test(ffmpegEncodersOutput)) return "software";
+  if (/\bh264_(?:videotoolbox|nvenc|vaapi|qsv|amf)\b/.test(ffmpegEncodersOutput)) return "gpu";
+  throw new Error("This FFmpeg build has neither libx264 nor a supported H.264 hardware encoder.");
+}
+
+export function detectH264EncoderMode(ffmpegPath: string, gpuRequested: boolean): H264EncoderMode {
+  const encoders = execFileSync(ffmpegPath, ["-hide_banner", "-encoders"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 5000,
+  });
+  return resolveH264EncoderMode(encoders, gpuRequested);
+}
 
 function chooseBestPathCandidate(
   name: "ffmpeg" | "ffprobe",

--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -69,6 +69,8 @@ const preflightState = vi.hoisted(() => ({
   },
 }));
 
+const ffmpegEncoderState = vi.hoisted(() => ({ mode: "software" as "software" | "gpu" }));
+
 vi.mock("../utils/producer.js", () => ({
   loadProducer: vi.fn(async () => ({
     resolveConfig: vi.fn((overrides: Record<string, unknown>) => {
@@ -117,6 +119,7 @@ vi.mock("../telemetry/events.js", () => ({
 }));
 
 vi.mock("../browser/ffmpeg.js", () => ({
+  detectH264EncoderMode: vi.fn(() => ffmpegEncoderState.mode),
   findFFmpeg: vi.fn(() => "/usr/bin/ffmpeg"),
   getFFmpegInstallHint: vi.fn(() => "brew install ffmpeg"),
 }));
@@ -170,6 +173,7 @@ describe("renderLocal browser GPU config", () => {
     configState.writeConfigCalls = [];
     trackingState.shouldTrack = true;
     trackingState.renderObservations = [];
+    ffmpegEncoderState.mode = "software";
     resetTrialState();
     savedEnv.clear();
     savedEnv.set("HYPERFRAMES_FFMPEG_PATH", process.env.HYPERFRAMES_FFMPEG_PATH);
@@ -318,6 +322,22 @@ describe("renderLocal browser GPU config", () => {
     expect(process.env.HYPERFRAMES_FFMPEG_PATH).toBe("/usr/bin/ffmpeg");
     expect(process.env.HYPERFRAMES_FFPROBE_PATH).toBe("/usr/bin/ffprobe");
     expect(process.env.PRODUCER_HEADLESS_SHELL_PATH).toBe("/mock/chrome");
+  });
+
+  it("falls back to hardware encoding when FFmpeg omits libx264", async () => {
+    ffmpegEncoderState.mode = "gpu";
+
+    await renderLocal("/tmp/project", "/tmp/out.mp4", {
+      fps: { num: 30, den: 1 },
+      quality: "high",
+      format: "mp4",
+      gpu: false,
+      browserGpuMode: "software",
+      hdrMode: "force-sdr",
+      quiet: true,
+    });
+
+    expect(producerState.createdJobs[0]?.useGpu).toBe(true);
   });
 
   it("resolves browser GPU from CLI flags, Docker mode, and env fallback", () => {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -76,6 +76,7 @@ import { isDevMode } from "../utils/env.js";
 import { buildDockerRunArgs, resolveDockerPlatform } from "../utils/dockerRunArgs.js";
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
 import { runEnvironmentChecks } from "../browser/preflight.js";
+import { detectH264EncoderMode } from "../browser/ffmpeg.js";
 import { chromeLaunchRemediation } from "../browser/linuxDeps.js";
 import type { ProducerLogger, RenderJob } from "@hyperframes/producer";
 import {
@@ -1449,6 +1450,18 @@ export async function renderLocal(
   if (preflight.ffprobePath) process.env.HYPERFRAMES_FFPROBE_PATH = preflight.ffprobePath;
   if (preflight.browser?.executablePath && !process.env.PRODUCER_HEADLESS_SHELL_PATH) {
     process.env.PRODUCER_HEADLESS_SHELL_PATH = preflight.browser.executablePath;
+  }
+
+  if (!options.gpu && options.format === "mp4" && preflight.ffmpegPath) {
+    const encoderMode = detectH264EncoderMode(preflight.ffmpegPath, false);
+    if (encoderMode === "gpu") {
+      console.warn(
+        c.warn(
+          "  FFmpeg does not include libx264; falling back to the available H.264 hardware encoder.",
+        ),
+      );
+      options = { ...options, gpu: true };
+    }
   }
 
   const producer = await loadProducer();


### PR DESCRIPTION
## Summary
- inspect the selected FFmpeg build before local MP4 rendering
- automatically enable the supported H.264 hardware path when `libx264` is absent
- preserve the software path when `libx264` is available and surface a clear warning on fallback

## Regression
A macOS FFmpeg 8.1.2 build exposing `h264_videotoolbox` but not `libx264` failed the default high-quality render with `Unrecognized option 'preset'`; `--gpu` succeeded. The new tests model that capability list and assert the render job switches to hardware encoding.

## Verification
- `bun --cwd packages/cli vitest run src/browser/ffmpeg.test.ts src/commands/render.test.ts` (58 passed)
- `cd packages/cli && bun run typecheck`
- pre-commit lint/format/fallow/typecheck hooks passed

Source: https://heygen.slack.com/archives/C0BGC335AQY/p1783985360149839