### PR TITLE
fix(runtime): preserve template head stylesheets

### DIFF
--- a/packages/core/src/runtime/compositionLoader.test.ts
+++ b/packages/core/src/runtime/compositionLoader.test.ts
@@ -89,6 +89,34 @@ describe("loadExternalCompositions", () => {
     expect(injectedStyles.length).toBeGreaterThan(0);
   });
 
+  it("preserves head stylesheets when an external composition uses a template", async () => {
+    const host = document.createElement("div");
+    host.setAttribute("data-composition-src", "https://example.com/compositions/scene.html");
+    host.setAttribute("data-composition-id", "scene");
+    document.body.appendChild(host);
+
+    const compositionHtml = `
+      <html>
+        <head><link rel="stylesheet" href="./scene.css"></head>
+        <body>
+          <template id="scene-template">
+            <div data-composition-id="scene"><p>Styled scene</p></div>
+          </template>
+        </body>
+      </html>
+    `;
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(compositionHtml, { status: 200 }));
+
+    await loadExternalCompositions({ ...defaultParams });
+
+    expect(
+      document.head.querySelector(
+        'link[rel="stylesheet"][href="https://example.com/compositions/scene.css"]',
+      ),
+    ).not.toBeNull();
+  });
+
   it("calls onDiagnostic when fetch fails", async () => {
     const host = document.createElement("div");
     host.setAttribute("data-composition-src", "https://example.com/broken.html");

--- a/packages/core/src/runtime/compositionLoader.ts
+++ b/packages/core/src/runtime/compositionLoader.ts
@@ -390,10 +390,13 @@ async function mountCompositionContent(params: {
 
   if (params.headLinks) {
     for (const link of params.headLinks) {
-      const href = link.getAttribute("href") || "";
+      const rawHref = link.getAttribute("href") || "";
+      const href = params.compositionUrl ? new URL(rawHref, params.compositionUrl).href : rawHref;
       if (!href) continue;
       if (document.head.querySelector(`link[href="${CSS.escape(href)}"]`)) continue;
-      document.head.appendChild(link.cloneNode(true));
+      const clonedLink = link.cloneNode(true) as HTMLLinkElement;
+      clonedLink.href = href;
+      document.head.appendChild(clonedLink);
     }
   }
 
@@ -677,13 +680,11 @@ export async function loadExternalCompositions(
         const headScripts = !template
           ? Array.from(doc.head.querySelectorAll<HTMLScriptElement>("script"))
           : undefined;
-        const headLinks = !template
-          ? Array.from(
-              doc.head.querySelectorAll<HTMLLinkElement>(
-                'link[rel="stylesheet"], link[rel="preconnect"]',
-              ),
-            )
-          : undefined;
+        const headLinks = Array.from(
+          doc.head.querySelectorAll<HTMLLinkElement>(
+            'link[rel="stylesheet"], link[rel="preconnect"]',
+          ),
+        );
         await mountCompositionContent({
           host,
           authoredCompositionId,


### PR DESCRIPTION
## Summary
- preserve stylesheet and preconnect links from fetched sub-composition documents even when they use a `<template>`
- resolve relative link URLs against the sub-composition document URL before mounting
- add regression coverage for a templated external composition with a relative stylesheet

## Reproduction
Confirmed from [CLI feedback](https://heygen.slack.com/archives/C0BGC335AQY/p1783988265686079): the runtime only collected head links when no template was present, so the stylesheet disappeared during mounting. The new test fails on `main` and passes with this change.

## Tests
- `bunx vitest run src/runtime/compositionLoader.test.ts` (47/47)
- `bun run build:hyperframes-runtime && bun run typecheck`
- `bunx oxfmt --check` on changed files
- `bunx oxlint` on changed files

No self-approval or merge requested; human review required.