### PR TITLE
fix(cli): reject missing init example values

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -43,6 +43,19 @@ function expectScaffoldedScripts(target: string): void {
 }
 
 describe("hyperframes init flag rename", () => {
+  it("rejects a following flag when --example has no value", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-init-test-"));
+    const target = join(dir, "proj");
+    try {
+      const res = runInit([target, "--example", "--non-interactive"]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("--example requires a value");
+      expect(existsSync(target)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("--example blank scaffolds a bundled project with npm scripts", () => {
     const dir = mkdtempSync(join(tmpdir(), "hf-init-test-"));
     const target = join(dir, "proj");

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -719,6 +719,10 @@ export default defineCommand({
       process.exit(1);
     }
     const exampleFlag = args.example;
+    if (exampleFlag?.startsWith("-")) {
+      console.error(c.error(`--example requires a value; received flag "${exampleFlag}" instead.`));
+      process.exit(1);
+    }
     const videoFlag = args.video;
     const audioFlag = args.audio;
     const skipTranscribe = args["skip-transcribe"] === true;


### PR DESCRIPTION
## Summary
- reject flag-shaped values consumed by `init --example`
- emit a clear missing-value diagnostic before scaffolding
- add an end-to-end regression test for `--example --non-interactive`

## Test plan
- `bun test packages/cli/src/commands/init.test.ts` (21/21)
- `bunx oxfmt --check packages/cli/src/commands/init.ts packages/cli/src/commands/init.test.ts`
- `bunx oxlint packages/cli/src/commands/init.ts packages/cli/src/commands/init.test.ts`
- `bun run --cwd packages/cli typecheck`