### PR TITLE
fix(render): require HDR transfer metadata

### DIFF
--- a/packages/engine/src/utils/hdr.test.ts
+++ b/packages/engine/src/utils/hdr.test.ts
@@ -19,10 +19,10 @@ describe("isHdrColorSpace", () => {
     ).toBe(false);
   });
 
-  it("detects bt2020 primaries", () => {
+  it("does not treat SDR transfer in a BT.2020 gamut as HDR", () => {
     expect(
       isHdrColorSpace({ colorTransfer: "bt709", colorPrimaries: "bt2020", colorSpace: "bt709" }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("detects smpte2084 (PQ)", () => {

--- a/packages/engine/src/utils/hdr.ts
+++ b/packages/engine/src/utils/hdr.ts
@@ -15,12 +15,10 @@ export type HdrTransfer = "hlg" | "pq";
  */
 export function isHdrColorSpace(cs: VideoColorSpace | null): boolean {
   if (!cs) return false;
-  return (
-    cs.colorPrimaries.includes("bt2020") ||
-    cs.colorSpace.includes("bt2020") ||
-    cs.colorTransfer === "smpte2084" ||
-    cs.colorTransfer === "arib-std-b67"
-  );
+  // BT.2020 describes a color gamut/matrix, not a dynamic range. SDR media
+  // can legitimately carry BT.2020 primaries with a BT.709 transfer. Only
+  // the transfer function distinguishes HDR here: PQ (SMPTE 2084) or HLG.
+  return cs.colorTransfer === "smpte2084" || cs.colorTransfer === "arib-std-b67";
 }
 
 /**


### PR DESCRIPTION
## Summary
- classify HDR from PQ/HLG transfer metadata instead of BT.2020 gamut metadata alone
- keep SDR BT.2020 sources on the normal SDR capture path
- add a regression test for BT.2020 primaries with a BT.709 transfer

## Test plan
- `bun test packages/engine/src/utils/hdr.test.ts` (19/19)
- `bunx oxfmt --check packages/engine/src/utils/hdr.ts packages/engine/src/utils/hdr.test.ts`
- `bunx oxlint packages/engine/src/utils/hdr.ts packages/engine/src/utils/hdr.test.ts`

Note: package-level typecheck is blocked in this fresh worktree by unresolved existing workspace package/type dependencies; targeted tests and changed-file static checks pass.