### PR TITLE
test(aws-lambda): fix flaky CDK-synth test timeout (30s → 120s)

### DIFF
--- a/packages/aws-lambda/src/cdk/HyperframesRenderStack.contract.test.ts
+++ b/packages/aws-lambda/src/cdk/HyperframesRenderStack.contract.test.ts
@@ -17,11 +17,12 @@ import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { HyperframesRenderStack } from "./HyperframesRenderStack.js";
 
-// CDK synth is slow on cold start (~5-8s on the slowest CI runner). The
-// default bun:test 5s timeout trips the first `it()` that calls it. Cache
-// the default-args synth in `beforeAll` so each test is pure assertions.
-// Tests that need non-default props still synth on demand and bump their
-// own per-test timeout.
+// CDK synth is sub-second locally, but jsii cold-start on a contended CI runner
+// can spike it far past the default bun:test 5s timeout (observed >30s, which
+// tripped the old 30s cap). The default-args synth is cached in `beforeAll` so
+// each test is pure assertions; synth calls carry a generous 120s ceiling —
+// enough to ride out CI variance while still surfacing a genuine hang. Tests
+// that need non-default props synth on demand under the same ceiling.
 let DEFAULT_TEMPLATE: Template;
 
 function synthFixture(): Template {
@@ -37,7 +38,7 @@ function synthFixture(): Template {
 describe("HyperframesRenderStack — contract", () => {
   beforeAll(() => {
     DEFAULT_TEMPLATE = synthFixture();
-  }, 30000);
+  }, 120000);
 
   it("provisions exactly one Lambda function on the Node.js 22 runtime, x86_64, 10 GiB /tmp", () => {
     const t = DEFAULT_TEMPLATE;
@@ -117,7 +118,7 @@ describe("HyperframesRenderStack — contract", () => {
     t.hasResourceProperties("AWS::Lambda::Function", {
       ReservedConcurrentExecutions: 4,
     });
-  }, 30000);
+  }, 120000);
 
   it("uses the projectName prefix on function + state-machine names", () => {
     const zipDir = mkdtempSync(join(tmpdir(), "hf-cdk-test-"));
@@ -133,5 +134,5 @@ describe("HyperframesRenderStack — contract", () => {
     t.hasResourceProperties("AWS::StepFunctions::StateMachine", {
       StateMachineName: "demo-render",
     });
-  }, 30000);
+  }, 120000);
 });

--- a/packages/aws-lambda/src/cdk/HyperframesRenderStack.snapshot.test.ts
+++ b/packages/aws-lambda/src/cdk/HyperframesRenderStack.snapshot.test.ts
@@ -27,11 +27,11 @@ import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { HyperframesRenderStack } from "./HyperframesRenderStack.js";
 
-// CDK synth + Template.fromStack is slow on cold start in CI (~5-8s on
-// the first call). The default bun:test 5s timeout trips it on the
-// first `it()` that calls `synth()`. Run synth once in `beforeAll`
-// and reuse the result — each test is a few µs of pure assertions
-// against the already-synthed template.
+// CDK synth + Template.fromStack is sub-second locally but jsii cold-start on a
+// contended CI runner can spike far past the default bun:test 5s timeout
+// (observed >30s). Run synth once in `beforeAll` under a generous 120s ceiling
+// and reuse the result — each test is a few µs of pure assertions against the
+// already-synthed template.
 let SYNTHED: ReturnType<typeof doSynth>;
 
 const EXPECTED_RESOURCE_COUNTS: Record<string, number> = {
@@ -105,7 +105,7 @@ describe("HyperframesRenderStack — snapshot", () => {
   // 30s is plenty: cold synth on the slowest CI runner has measured ~8s.
   beforeAll(() => {
     SYNTHED = doSynth();
-  }, 30000);
+  }, 120000);
 
   it("emits the expected set of AWS resource types in the expected counts", () => {
     const { template } = SYNTHED;


### PR DESCRIPTION
## What

Raise the CDK-synth timeout on the `HyperframesRenderStack` contract + snapshot tests from 30s to a 120s ceiling.

## Why

The `HyperframesRenderStack — contract` `beforeAll` synth **timed out at 30s** on a contended CI runner, going red on unrelated PRs. Synth is **sub-second locally** (measured ~0.5s for both files); the 30s cap just wasn't enough headroom for jsii cold-start variance on a loaded runner.

## How

- Bump the four `synth()` timeouts (3 in `.contract.test.ts`, 1 in `.snapshot.test.ts`) 30000 → 120000.
- Refresh the rationale comments to describe the CI-variance reality. 120s still surfaces a genuine hang; it only absorbs cold-start spikes.

## Test plan

- [x] `bun test` on both CDK test files: 9 pass, 0 fail (~0.5s locally).