### PR TITLE
fix(media-use): tag avatar-video heygen recipes with X-HeyGen-Client-Source

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "ea061d942d97f2c2",
+      "hash": "7a51f53cf615fe97",
       "files": 124
     },
     "motion-graphics": {

--- a/skills/media-use/references/operations.md
+++ b/skills/media-use/references/operations.md
@@ -209,13 +209,18 @@ avatar upsell (decision X3).
   raw API. For a talking-head / avatar video, `heygen video create` (avatar
   engine IV by default) beats a generative clip when you want a real presenter.
   Browser OAuth uses the web-plan/free avatar-video allowance where eligible;
-  API keys follow the normal API billing path:
+  API keys follow the normal API billing path. Always pass
+  `--headers "X-HeyGen-Client-Source: media-use"` on any generating `heygen`
+  command (`video create`, `avatar create`, `video-translate`) — it's the
+  allowlisted attribution header (persistent flag, works on every subcommand) that
+  tags the usage as media-use in billing/resource meta so it shows up in the API
+  dashboards. Read-only discovery (`avatar list`, `voice list`) doesn't need it.
 
   ```bash
   # discover an avatar + a starfish voice, then create + wait
   heygen avatar list --ownership public --limit 5
   heygen voice list --engine starfish --limit 5
-  heygen video create --wait -d '{
+  heygen video create --headers "X-HeyGen-Client-Source: media-use" --wait -d '{
     "type": "avatar",
     "avatar_id": "<avatar-id>",
     "script": "Your narration here.",
@@ -236,7 +241,7 @@ public URL or an uploaded `asset_id`, and drive speech with a `script`+`voice_id
 or a pre-recorded `audio_url`:
 
 ```bash
-heygen video create --wait -d '{
+heygen video create --headers "X-HeyGen-Client-Source: media-use" --wait -d '{
   "type": "image",
   "image": { "type": "url", "url": "https://example.com/person.jpg" },
   "script": "Your narration here.",


### PR DESCRIPTION
## What
Add `--headers "X-HeyGen-Client-Source: media-use"` to the generating `heygen video create` recipes in `skills/media-use/references/operations.md` (avatar video + image-to-video), plus a note requiring it on any generating `heygen` command.

## Why
media-use's avatar-video path is agent-driven — the skill instructs the agent to run `heygen video create` directly (no wrapper script). Those recipes went out **untagged**, so media-use avatar / image-to-video usage landed in `master_video_table` as generic `cli:<agent>` traffic with no `client_source` — i.e. not attributable to media-use, and invisible to a media-use dashboard slice. This closes that gap so avatar-video free usage is measured alongside TTS (#2365) and the CLI (#2368).

## How
- `--headers "X-HeyGen-Client-Source: media-use"` on both `heygen video create` recipes. It's the CLI's allowlisted attribution header and a persistent flag, so it works on every subcommand and can't override the reserved `X-HeyGen-Source` free-gate header.
- Prose note generalizes it to `video create` / `avatar create` / `video-translate`; read-only discovery (`avatar list`, `voice list`) is explicitly exempt.

## Test plan
- Docs/recipe change only — no code. Verified both generating recipes now carry the header and code fences stay balanced.

## Pairs with
Backend persistence #41968 (allowlist already includes the values); once merged, tagged avatar videos carry `client_source=media-use` in `master_video_table.metadata`, queryable via `mvt.metadata:client_source` in API Dashboard V3.