### PR TITLE
fix(cli): require explicit non-interactive init source

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -43,6 +43,19 @@ function expectScaffoldedScripts(target: string): void {
 }
 
 describe("hyperframes init flag rename", () => {
+  it("requires an explicit source in non-interactive mode", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-init-test-"));
+    const target = join(dir, "proj");
+    try {
+      const res = runInit([target, "--non-interactive"]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("Non-interactive init requires --example, --video, or --audio");
+      expect(existsSync(target)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a following flag when --example has no value", () => {
     const dir = mkdtempSync(join(tmpdir(), "hf-init-test-"));
     const target = join(dir, "proj");

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,10 +14,13 @@ export const examples: Example[] = [
   ["Start from an existing video file", "hyperframes init my-video --video clip.mp4"],
   ["Start from an audio file", "hyperframes init my-video --audio track.mp3"],
   ["Scaffold with Tailwind CSS", "hyperframes init my-video --example blank --tailwind"],
-  ["Non-interactive mode (for CI or AI agents)", "hyperframes init my-video --non-interactive"],
+  [
+    "Non-interactive mode (for CI or AI agents)",
+    "hyperframes init my-video --example blank --non-interactive",
+  ],
   [
     "Opt out of the GitHub skills check (CI/tests only)",
-    "HYPERFRAMES_SKIP_SKILLS=1 hyperframes init my-video --non-interactive",
+    "HYPERFRAMES_SKIP_SKILLS=1 hyperframes init my-video --example blank --non-interactive",
   ],
 ];
 import {
@@ -771,6 +774,16 @@ export default defineCommand({
     // Non-interactive mode — all inputs from flags, defaults where missing
     // -----------------------------------------------------------------------
     if (!interactive) {
+      if (!exampleFlag && !videoFlag && !audioFlag) {
+        console.error(
+          c.error(
+            "Non-interactive init requires --example, --video, or --audio. " +
+              "For an empty starter project, pass --example blank explicitly.",
+          ),
+        );
+        process.exit(1);
+      }
+
       const templateId = exampleFlag ?? "blank";
       const name = args.name ?? "my-video";
       const destDir = resolve(name);


### PR DESCRIPTION
## Summary
- fail non-interactive `init` when no `--example`, `--video`, or `--audio` source is provided
- prevent silent scaffolding of an empty 10-second black composition that passes `check`
- update CLI examples to pass `--example blank` explicitly
- add regression coverage that asserts failure leaves no project directory

## Reproduction

`HYPERFRAMES_SKIP_SKILLS=1 npx --yes hyperframes@0.7.56 init demo --non-interactive` exits 0, creates a blank 10-second composition, and `check --json` reports zero findings.

## Verification
- regression test failed before fix and passes after fix
- `bunx vitest run packages/cli/src/commands/init.test.ts` (22/22)
- `bun run --filter @hyperframes/cli typecheck`
- targeted oxfmt and oxlint clean
- branch CLI exits 1 with the actionable source requirement and creates no project
- pre-commit gates passed

Human review required; do not self-merge.
