### PR TITLE
fix(release): make packed-consumer verify self-contained for unpublished versions

### DIFF
--- a/scripts/verify-packed-manifests.mjs
+++ b/scripts/verify-packed-manifests.mjs
@@ -310,15 +310,27 @@ function writeConsumerFixture(packDir, packedWorkspaces) {
   const fixtureDir = join(packDir, "consumer");
   mkdirSync(fixtureDir);
   const rootPackage = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
-  const dependencies = Object.fromEntries(
+  const workspaceFileDeps = Object.fromEntries(
     packedWorkspaces.map(({ filename, packedPackage }) => [packedPackage.name, `file:${filename}`]),
   );
+  const dependencies = { ...workspaceFileDeps };
   dependencies.typescript = rootPackage.devDependencies.typescript;
   dependencies["@types/node"] = rootPackage.devDependencies["@types/node"];
   writeFileSync(
     join(fixtureDir, "package.json"),
     JSON.stringify(
-      { name: "packed-consumer", private: true, type: "module", dependencies },
+      {
+        name: "packed-consumer",
+        private: true,
+        type: "module",
+        dependencies,
+        // Each packed tarball pins its inter-@hyperframes deps to the exact
+        // release version. On a release bump that version is not on the registry
+        // yet, so a plain install fails to resolve those transitive deps. Force
+        // every @hyperframes/* to the sibling local tarball so the check is
+        // self-contained pre-publish (matches how the packages install together).
+        overrides: { ...workspaceFileDeps },
+      },
       null,
       2,
     ),


### PR DESCRIPTION
## What
`verify:packed-manifests`'s consumer fixture (added in #2149) installs each package as a `file:` tarball, but each tarball pins its inter-`@hyperframes` deps to the exact release version. On a release bump the new version isn't on the npm registry yet, so `bun install` resolves those transitive deps from the registry and fails with `No version matching <v>`.

## Why
This passed until now only because the check had only ever run at an already-published version (e.g. a normal PR at `0.7.56`). The **first real release to run it (v0.7.57) fails**, and since `publish.yml` runs the same step before publishing with no `continue-on-error`, it would block the actual publish too. Affects every future release.

## How
Add an `overrides` map to the consumer fixture pinning every `@hyperframes/*` to its sibling local tarball, so transitive deps resolve locally instead of from the registry. Makes the check self-contained pre-publish; behavior at published versions is unchanged.

## Test plan
- Reproduced the failure on a local 0.7.57 bump; with this change `bun run verify:packed-manifests` passes ("Resolved 90 packed exports and loaded public SDK adapters. Verified clean packed consumer install, type resolution, and CLI startup.").
- The v0.7.57 release PR (#2393) is the real end-to-end exercise once this lands and it rebases.

Not covered: pinning bun's version in CI (separate concern).