### PR TITLE
fix(cli): bundle zip extraction fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "prettier": "^3.8.1",
         "puppeteer-core": "^25.2.1",
         "sharp": "^0.34.5",
+        "yauzl": "^3.4.0",
       },
       "devDependencies": {
         "@clack/prompts": "^1.1.0",
@@ -1268,8 +1269,6 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
-    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
-
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
@@ -1491,8 +1490,6 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
-
-    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -2152,7 +2149,7 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+    "yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,8 @@
     "postcss": "^8.5.8",
     "prettier": "^3.8.1",
     "puppeteer-core": "^25.2.1",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "yauzl": "^3.4.0"
   },
   "devDependencies": {
     "@clack/prompts": "^1.1.0",

--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -710,9 +710,9 @@ describe("installWithCorruptArchiveRecovery", () => {
 //
 // `@puppeteer/browsers` 3.0.2 dropped `extract-zip` as a dependency and now
 // extracts with `modern-tar` by default (`yauzl` lingers only as an optional
-// peer fallback — no longer a runtime dependency), which is the fix. This test
-// fails if a dependency change ever drags the pin back below 3.x — i.e.
-// reintroduces the broken extractor as a hard dependency.
+// peer fallback), which avoids the old hard dependency. HyperFrames supplies a
+// safe yauzl 3.x directly so ZIP extraction still works on Linux hosts without
+// a system `unzip`. These tests keep both sides of that contract intact.
 describe("@puppeteer/browsers pin (HF#2103 extractor-hang regression guard)", () => {
   it("stays on the major (>= 3) that dropped extract-zip and no longer depends on yauzl", async () => {
     const { createRequire } = await import("node:module");
@@ -730,5 +730,17 @@ describe("@puppeteer/browsers pin (HF#2103 extractor-hang regression guard)", ()
     const deps = pkg.dependencies ?? {};
     expect(deps["extract-zip"]).toBeUndefined();
     expect(deps["yauzl"]).toBeUndefined();
+  });
+
+  it("bundles a safe yauzl fallback for hosts without a system unzip", async () => {
+    const { createRequire } = await import("node:module");
+    const require = createRequire(import.meta.url);
+    const cliPkg = require("../../package.json") as {
+      dependencies?: Record<string, string>;
+    };
+    const yauzlPkg = require("yauzl/package.json") as { version: string };
+
+    expect(cliPkg.dependencies?.["yauzl"]).toBeDefined();
+    expect(Number.parseInt(yauzlPkg.version.split(".")[0] ?? "0", 10)).toBeGreaterThanOrEqual(3);
   });
 });


### PR DESCRIPTION
## Summary

- bundle `yauzl` as a direct CLI dependency so managed browser ZIP extraction works without a system `unzip`
- ensure the fallback is available from npx/global install trees rather than relying on a consumer project's dependencies
- add a regression assertion for the packaged extractor dependency

## Root cause

`@puppeteer/browsers` treats `yauzl` as an optional peer. In an npx-cached installation, a copy installed in the user's project cannot be resolved from the CLI package tree, leaving neither an in-process ZIP extractor nor a system archiver available.

## Verification

- `bun run --cwd packages/cli test -- src/browser/manager.test.ts` (28 passed)
- CLI typecheck
- formatting and lint checks
- `bun install --frozen-lockfile`
- extracted a ZIP through `@puppeteer/browsers` with `PATH` containing Node only and no system `unzip`
