### PR TITLE
feat(engine,producer,cli): capture failing dB/frame index on drawElement verify fallback

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -2064,6 +2064,8 @@ function trackRenderMetrics(
     deVerifyInitMs: perf?.drawElement?.verifyInitMs,
     deSelfVerifyFallback: perf?.drawElement?.selfVerifyFallback,
     deFallbackReason: perf?.drawElement?.fallbackReason,
+    deFallbackFailedDb: perf?.drawElement?.fallbackFailedDb,
+    deFallbackFrameIndex: perf?.drawElement?.fallbackFrameIndex,
     deBlankSuspects: perf?.drawElement?.blankSuspects,
     deBlankDeterministicAccepts: perf?.drawElement?.blankDeterministicAccepts,
     deBlankRecaptures: perf?.drawElement?.blankRecaptures,

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -2066,6 +2066,7 @@ function trackRenderMetrics(
     deFallbackReason: perf?.drawElement?.fallbackReason,
     deFallbackFailedDb: perf?.drawElement?.fallbackFailedDb,
     deFallbackFrameIndex: perf?.drawElement?.fallbackFrameIndex,
+    deFallbackThresholdDb: perf?.drawElement?.fallbackThresholdDb,
     deBlankSuspects: perf?.drawElement?.blankSuspects,
     deBlankDeterministicAccepts: perf?.drawElement?.blankDeterministicAccepts,
     deBlankRecaptures: perf?.drawElement?.blankRecaptures,

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -252,6 +252,30 @@ describe("render telemetry events", () => {
     );
   });
 
+  it("carries the failing dB and frame index on render_error for a psnr fallback that failed hard afterward", () => {
+    trackRenderError({
+      fps: 30,
+      quality: "standard",
+      docker: false,
+      errorMessage: "worker crashed after a psnr fallback",
+      captureDeParallelRouter: "reverted",
+      captureDeSelfVerifyFallback: true,
+      captureDeFallbackReason: "psnr",
+      captureDeFallbackFailedDb: 28.4,
+      captureDeFallbackFrameIndex: 649,
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "render_error",
+      expect.objectContaining({
+        de_fallback_reason: "psnr",
+        de_fallback_failed_db: 28.4,
+        de_fallback_frame_index: 649,
+      }),
+      undefined,
+    );
+  });
+
   it("prefers the explicit perfSummary-sourced de_worker_inversion over the capture-observability fallback on render_complete", () => {
     trackRenderComplete({
       durationMs: 1000,
@@ -268,6 +292,30 @@ describe("render telemetry events", () => {
     expect(trackEvent).toHaveBeenCalledWith(
       "render_complete",
       expect.objectContaining({ de_worker_inversion: "inverted" }),
+      undefined,
+    );
+  });
+
+  it("carries the perfSummary-sourced failing dB and frame index on render_complete", () => {
+    trackRenderComplete({
+      durationMs: 1000,
+      fps: 30,
+      quality: "standard",
+      docker: false,
+      gpu: false,
+      deParallelRouter: "reverted",
+      deFallbackReason: "psnr",
+      deFallbackFailedDb: 28.4,
+      deFallbackFrameIndex: 649,
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "render_complete",
+      expect.objectContaining({
+        de_fallback_reason: "psnr",
+        de_fallback_failed_db: 28.4,
+        de_fallback_frame_index: 649,
+      }),
       undefined,
     );
   });

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -252,7 +252,7 @@ describe("render telemetry events", () => {
     );
   });
 
-  it("carries the failing dB and frame index on render_error for a psnr fallback that failed hard afterward", () => {
+  it("carries the failing dB, frame index, and threshold on render_error for a psnr fallback that failed hard afterward", () => {
     trackRenderError({
       fps: 30,
       quality: "standard",
@@ -263,6 +263,7 @@ describe("render telemetry events", () => {
       captureDeFallbackReason: "psnr",
       captureDeFallbackFailedDb: 28.4,
       captureDeFallbackFrameIndex: 649,
+      captureDeFallbackThresholdDb: 32,
     });
 
     expect(trackEvent).toHaveBeenCalledWith(
@@ -271,6 +272,7 @@ describe("render telemetry events", () => {
         de_fallback_reason: "psnr",
         de_fallback_failed_db: 28.4,
         de_fallback_frame_index: 649,
+        de_fallback_threshold_db: 32,
       }),
       undefined,
     );
@@ -296,7 +298,7 @@ describe("render telemetry events", () => {
     );
   });
 
-  it("carries the perfSummary-sourced failing dB and frame index on render_complete", () => {
+  it("carries the perfSummary-sourced failing dB, frame index, and threshold on render_complete", () => {
     trackRenderComplete({
       durationMs: 1000,
       fps: 30,
@@ -307,6 +309,7 @@ describe("render telemetry events", () => {
       deFallbackReason: "psnr",
       deFallbackFailedDb: 28.4,
       deFallbackFrameIndex: 649,
+      deFallbackThresholdDb: 32,
     });
 
     expect(trackEvent).toHaveBeenCalledWith(
@@ -315,6 +318,7 @@ describe("render telemetry events", () => {
         de_fallback_reason: "psnr",
         de_fallback_failed_db: 28.4,
         de_fallback_frame_index: 649,
+        de_fallback_threshold_db: 32,
       }),
       undefined,
     );

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -54,6 +54,8 @@ export interface RenderObservabilityTelemetryPayload {
   captureDePreRouterWorkers?: number;
   captureDeSelfVerifyFallback?: boolean;
   captureDeFallbackReason?: string;
+  captureDeFallbackFailedDb?: number;
+  captureDeFallbackFrameIndex?: number;
   /** Non-DE parallel-streaming router outcome ("screenshot" | "beginframe" —
    * routed; "eligible_off" — would route but the kill switch is off). */
   captureParallelStream?: string;
@@ -108,6 +110,8 @@ function renderObservabilityEventProperties(props: RenderObservabilityTelemetryP
     de_pre_router_workers: props.captureDePreRouterWorkers,
     de_self_verify_fallback: props.captureDeSelfVerifyFallback,
     de_fallback_reason: props.captureDeFallbackReason,
+    de_fallback_failed_db: props.captureDeFallbackFailedDb,
+    de_fallback_frame_index: props.captureDeFallbackFrameIndex,
     capture_parallel_stream: props.captureParallelStream,
     observability_extract_video_count: props.observabilityExtractVideoCount,
     observability_extracted_video_count: props.observabilityExtractedVideoCount,
@@ -173,6 +177,8 @@ export function trackRenderComplete(
     deVerifyInitMs?: number;
     deSelfVerifyFallback?: boolean;
     deFallbackReason?: string;
+    deFallbackFailedDb?: number;
+    deFallbackFrameIndex?: number;
     deBlankSuspects?: number;
     deBlankDeterministicAccepts?: number;
     deBlankRecaptures?: number;
@@ -260,6 +266,8 @@ export function trackRenderComplete(
       de_verify_init_ms: props.deVerifyInitMs,
       de_self_verify_fallback: props.deSelfVerifyFallback,
       de_fallback_reason: props.deFallbackReason,
+      de_fallback_failed_db: props.deFallbackFailedDb,
+      de_fallback_frame_index: props.deFallbackFrameIndex,
       de_blank_suspects: props.deBlankSuspects,
       de_blank_deterministic_accepts: props.deBlankDeterministicAccepts,
       de_blank_recaptures: props.deBlankRecaptures,

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -56,6 +56,7 @@ export interface RenderObservabilityTelemetryPayload {
   captureDeFallbackReason?: string;
   captureDeFallbackFailedDb?: number;
   captureDeFallbackFrameIndex?: number;
+  captureDeFallbackThresholdDb?: number;
   /** Non-DE parallel-streaming router outcome ("screenshot" | "beginframe" —
    * routed; "eligible_off" — would route but the kill switch is off). */
   captureParallelStream?: string;
@@ -112,6 +113,7 @@ function renderObservabilityEventProperties(props: RenderObservabilityTelemetryP
     de_fallback_reason: props.captureDeFallbackReason,
     de_fallback_failed_db: props.captureDeFallbackFailedDb,
     de_fallback_frame_index: props.captureDeFallbackFrameIndex,
+    de_fallback_threshold_db: props.captureDeFallbackThresholdDb,
     capture_parallel_stream: props.captureParallelStream,
     observability_extract_video_count: props.observabilityExtractVideoCount,
     observability_extracted_video_count: props.observabilityExtractedVideoCount,
@@ -179,6 +181,7 @@ export function trackRenderComplete(
     deFallbackReason?: string;
     deFallbackFailedDb?: number;
     deFallbackFrameIndex?: number;
+    deFallbackThresholdDb?: number;
     deBlankSuspects?: number;
     deBlankDeterministicAccepts?: number;
     deBlankRecaptures?: number;
@@ -268,6 +271,7 @@ export function trackRenderComplete(
       de_fallback_reason: props.deFallbackReason,
       de_fallback_failed_db: props.deFallbackFailedDb,
       de_fallback_frame_index: props.deFallbackFrameIndex,
+      de_fallback_threshold_db: props.deFallbackThresholdDb,
       de_blank_suspects: props.deBlankSuspects,
       de_blank_deterministic_accepts: props.deBlankDeterministicAccepts,
       de_blank_recaptures: props.deBlankRecaptures,

--- a/packages/cli/src/telemetry/renderObservability.test.ts
+++ b/packages/cli/src/telemetry/renderObservability.test.ts
@@ -81,6 +81,27 @@ describe("renderObservabilityTelemetryPayload — DE inversion/router cohort (fa
     const payload = renderObservabilityTelemetryPayload(makeSummary({}));
     expect(payload.captureDeFallbackReason).toBeUndefined();
   });
+
+  it("carries the failing dB and frame index for a psnr fallback, still visible on a hard failure", () => {
+    const payload = renderObservabilityTelemetryPayload(
+      makeSummary({
+        deParallelRouter: "routed",
+        deFallbackReason: "psnr",
+        deFallbackFailedDb: 28.4,
+        deFallbackFrameIndex: 649,
+      }),
+    );
+    expect(payload.captureDeFallbackFailedDb).toBe(28.4);
+    expect(payload.captureDeFallbackFrameIndex).toBe(649);
+  });
+
+  it("leaves failedDb undefined for a blank/oom/capture_error fallback (no PSNR score exists)", () => {
+    const payload = renderObservabilityTelemetryPayload(
+      makeSummary({ deFallbackReason: "oom", deFallbackFrameIndex: undefined }),
+    );
+    expect(payload.captureDeFallbackFailedDb).toBeUndefined();
+    expect(payload.captureDeFallbackFrameIndex).toBeUndefined();
+  });
 });
 
 describe("renderObservabilityTelemetryPayload — non-DE parallel-stream router", () => {

--- a/packages/cli/src/telemetry/renderObservability.test.ts
+++ b/packages/cli/src/telemetry/renderObservability.test.ts
@@ -82,25 +82,28 @@ describe("renderObservabilityTelemetryPayload — DE inversion/router cohort (fa
     expect(payload.captureDeFallbackReason).toBeUndefined();
   });
 
-  it("carries the failing dB and frame index for a psnr fallback, still visible on a hard failure", () => {
+  it("carries the failing dB, frame index, and threshold for a psnr fallback, still visible on a hard failure", () => {
     const payload = renderObservabilityTelemetryPayload(
       makeSummary({
         deParallelRouter: "routed",
         deFallbackReason: "psnr",
         deFallbackFailedDb: 28.4,
         deFallbackFrameIndex: 649,
+        deFallbackThresholdDb: 32,
       }),
     );
     expect(payload.captureDeFallbackFailedDb).toBe(28.4);
     expect(payload.captureDeFallbackFrameIndex).toBe(649);
+    expect(payload.captureDeFallbackThresholdDb).toBe(32);
   });
 
-  it("leaves failedDb undefined for a blank/oom/capture_error fallback (no PSNR score exists)", () => {
+  it("leaves failedDb/thresholdDb undefined for a blank/oom/capture_error fallback (no PSNR score exists)", () => {
     const payload = renderObservabilityTelemetryPayload(
       makeSummary({ deFallbackReason: "oom", deFallbackFrameIndex: undefined }),
     );
     expect(payload.captureDeFallbackFailedDb).toBeUndefined();
     expect(payload.captureDeFallbackFrameIndex).toBeUndefined();
+    expect(payload.captureDeFallbackThresholdDb).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/telemetry/renderObservability.ts
+++ b/packages/cli/src/telemetry/renderObservability.ts
@@ -46,6 +46,8 @@ export function renderObservabilityTelemetryPayload(
     captureDePreRouterWorkers: capture.dePreRouterWorkers,
     captureDeSelfVerifyFallback: capture.deSelfVerifyFallback,
     captureDeFallbackReason: capture.deFallbackReason,
+    captureDeFallbackFailedDb: capture.deFallbackFailedDb,
+    captureDeFallbackFrameIndex: capture.deFallbackFrameIndex,
     captureParallelStream: capture.captureParallelStream,
     observabilityExtractVideoCount: extraction?.videoCount,
     observabilityExtractedVideoCount: extraction?.extractedVideoCount,

--- a/packages/cli/src/telemetry/renderObservability.ts
+++ b/packages/cli/src/telemetry/renderObservability.ts
@@ -48,6 +48,7 @@ export function renderObservabilityTelemetryPayload(
     captureDeFallbackReason: capture.deFallbackReason,
     captureDeFallbackFailedDb: capture.deFallbackFailedDb,
     captureDeFallbackFrameIndex: capture.deFallbackFrameIndex,
+    captureDeFallbackThresholdDb: capture.deFallbackThresholdDb,
     captureParallelStream: capture.captureParallelStream,
     observabilityExtractVideoCount: extraction?.videoCount,
     observabilityExtractedVideoCount: extraction?.extractedVideoCount,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -91,6 +91,8 @@ export {
   captureFramesBatchPipelined,
   DrawElementVerificationError,
   isDrawElementVerificationError,
+  getDrawElementVerificationDetails,
+  type DrawElementVerificationDetails,
   recaptureDrawElementFrameForVerify,
   completeDeferredDrawElementInit,
   writeCapturedFrame,

--- a/packages/engine/src/services/frameCapture.test.ts
+++ b/packages/engine/src/services/frameCapture.test.ts
@@ -229,12 +229,14 @@ describe("navigation diagnostics", () => {
 describe("DrawElementVerificationError details", () => {
   it("carries frameIndex/failedDb/verifyThresholdDb when provided", () => {
     const err = new DrawElementVerificationError("drawElement self-verify failed at frame 649", {
+      kind: "psnr",
       frameIndex: 649,
       failedDb: 28.4,
       verifyThresholdDb: 32,
     });
     expect(isDrawElementVerificationError(err)).toBe(true);
     expect(getDrawElementVerificationDetails(err)).toEqual({
+      kind: "psnr",
       frameIndex: 649,
       failedDb: 28.4,
       verifyThresholdDb: 32,
@@ -242,8 +244,11 @@ describe("DrawElementVerificationError details", () => {
   });
 
   it("omits fields that weren't supplied (blank-frame throws have no dB)", () => {
-    const err = new DrawElementVerificationError("blank drawElement frame 12", { frameIndex: 12 });
-    expect(getDrawElementVerificationDetails(err)).toEqual({ frameIndex: 12 });
+    const err = new DrawElementVerificationError("blank drawElement frame 12", {
+      kind: "blank",
+      frameIndex: 12,
+    });
+    expect(getDrawElementVerificationDetails(err)).toEqual({ kind: "blank", frameIndex: 12 });
   });
 
   it("returns undefined for a non-verification error", () => {
@@ -252,11 +257,49 @@ describe("DrawElementVerificationError details", () => {
 
   it("finds details through a wrapping cause chain (producer's CaptureStageError)", () => {
     const inner = new DrawElementVerificationError("psnr breach", {
+      kind: "psnr",
       frameIndex: 5,
       failedDb: 12.1,
     });
     const wrapper = new Error("capture stage failed", { cause: inner });
     expect(isDrawElementVerificationError(wrapper)).toBe(true);
-    expect(getDrawElementVerificationDetails(wrapper)).toEqual({ frameIndex: 5, failedDb: 12.1 });
+    expect(getDrawElementVerificationDetails(wrapper)).toEqual({
+      kind: "psnr",
+      frameIndex: 5,
+      failedDb: 12.1,
+    });
+  });
+
+  it("carries kind='blank'/'psnr' as a structural field, not derived from message text", () => {
+    const blankErr = new DrawElementVerificationError("blank drawElement frame 12", {
+      kind: "blank",
+      frameIndex: 12,
+    });
+    const psnrErr = new DrawElementVerificationError(
+      "drawElement self-verify failed at frame 649",
+      { kind: "psnr", frameIndex: 649, failedDb: 28.4, verifyThresholdDb: 32 },
+    );
+    expect(getDrawElementVerificationDetails(blankErr)?.kind).toBe("blank");
+    expect(getDrawElementVerificationDetails(psnrErr)?.kind).toBe("psnr");
+  });
+
+  it("kind survives even when the message text disagrees with (or omits) the word psnr/blank", () => {
+    // A reworded message that says neither "blank" nor "psnr" — a regex over
+    // message text would have no signal here; the structural kind must still
+    // report correctly.
+    const reworded = new DrawElementVerificationError("frame 12 failed verification", {
+      kind: "blank",
+      frameIndex: 12,
+    });
+    expect(getDrawElementVerificationDetails(reworded)?.kind).toBe("blank");
+
+    // Adversarial: a psnr failure whose message happens to mention "blank"
+    // (e.g. quoting a neighboring log line) — the structural kind must not
+    // flip just because the substring "blank" appears in the text.
+    const adversarial = new DrawElementVerificationError(
+      "drawElement self-verify failed at frame 5 (previous frame was blank-guard-accepted)",
+      { kind: "psnr", frameIndex: 5, failedDb: 12.1, verifyThresholdDb: 32 },
+    );
+    expect(getDrawElementVerificationDetails(adversarial)?.kind).toBe("psnr");
   });
 });

--- a/packages/engine/src/services/frameCapture.test.ts
+++ b/packages/engine/src/services/frameCapture.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from "vitest";
 import {
+  DrawElementVerificationError,
   formatHttpErrorDiagnostic,
   formatConsoleDiagnostic,
   formatNavigationFailureDiagnostic,
   formatNavigationStartDiagnostic,
   formatRequestFailureDiagnostic,
+  getDrawElementVerificationDetails,
   isFontResourceError,
+  isDrawElementVerificationError,
   sanitizeDiagnosticUrl,
 } from "./frameCapture.js";
 
@@ -220,5 +223,40 @@ describe("navigation diagnostics", () => {
         statusText: "Forbidden",
       }),
     ).toBe("[Browser:HTTP403] GET https://cdn.example.com/frame.png resource=image Forbidden");
+  });
+});
+
+describe("DrawElementVerificationError details", () => {
+  it("carries frameIndex/failedDb/verifyThresholdDb when provided", () => {
+    const err = new DrawElementVerificationError("drawElement self-verify failed at frame 649", {
+      frameIndex: 649,
+      failedDb: 28.4,
+      verifyThresholdDb: 32,
+    });
+    expect(isDrawElementVerificationError(err)).toBe(true);
+    expect(getDrawElementVerificationDetails(err)).toEqual({
+      frameIndex: 649,
+      failedDb: 28.4,
+      verifyThresholdDb: 32,
+    });
+  });
+
+  it("omits fields that weren't supplied (blank-frame throws have no dB)", () => {
+    const err = new DrawElementVerificationError("blank drawElement frame 12", { frameIndex: 12 });
+    expect(getDrawElementVerificationDetails(err)).toEqual({ frameIndex: 12 });
+  });
+
+  it("returns undefined for a non-verification error", () => {
+    expect(getDrawElementVerificationDetails(new Error("boring"))).toBeUndefined();
+  });
+
+  it("finds details through a wrapping cause chain (producer's CaptureStageError)", () => {
+    const inner = new DrawElementVerificationError("psnr breach", {
+      frameIndex: 5,
+      failedDb: 12.1,
+    });
+    const wrapper = new Error("capture stage failed", { cause: inner });
+    expect(isDrawElementVerificationError(wrapper)).toBe(true);
+    expect(getDrawElementVerificationDetails(wrapper)).toEqual({ frameIndex: 5, failedDb: 12.1 });
   });
 });

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -203,32 +203,38 @@ export interface CaptureSession {
  */
 /**
  * Structured detail carried alongside the human-readable message — lets
- * telemetry report the actual failing dB / frame index instead of the
- * orchestrator having to regex them back out of formatted text. All optional:
- * a blank-frame trip has no PSNR score, so `failedDb`/`verifyThresholdDb`
- * are omitted for that throw site.
+ * telemetry report the actual failure kind / failing dB / frame index
+ * instead of the orchestrator having to regex them back out of formatted
+ * text (a message-text dependency is exactly the failure mode this shape
+ * exists to close — review finding: message wording, translation, or a
+ * cross-module/serialized error must never be able to flip the reported
+ * kind). All fields but `kind` are optional: a blank-frame trip has no PSNR
+ * score, so `failedDb`/`verifyThresholdDb` are omitted for that throw site.
  */
 export interface DrawElementVerificationDetails {
+  kind: "blank" | "psnr";
   frameIndex?: number;
   failedDb?: number;
   verifyThresholdDb?: number;
 }
 
 export class DrawElementVerificationError extends Error {
+  readonly kind: "blank" | "psnr";
   readonly frameIndex?: number;
   readonly failedDb?: number;
   readonly verifyThresholdDb?: number;
 
-  constructor(message: string, details?: DrawElementVerificationDetails) {
+  constructor(message: string, details: DrawElementVerificationDetails) {
     super(message);
     this.name = "DrawElementVerificationError";
     // Discriminant property, assigned dynamically: isDrawElementVerificationError
     // reads it structurally so detection survives duplicated module instances
     // across package boundaries (where instanceof fails).
     (this as unknown as { deVerificationFailure: boolean }).deVerificationFailure = true;
-    this.frameIndex = details?.frameIndex;
-    this.failedDb = details?.failedDb;
-    this.verifyThresholdDb = details?.verifyThresholdDb;
+    this.kind = details.kind;
+    this.frameIndex = details.frameIndex;
+    this.failedDb = details.failedDb;
+    this.verifyThresholdDb = details.verifyThresholdDb;
   }
 }
 
@@ -255,7 +261,14 @@ export function getDrawElementVerificationDetails(
   for (let depth = 0; depth < 5 && typeof e === "object" && e !== null; depth++) {
     const rec = e as { deVerificationFailure?: boolean } & Partial<DrawElementVerificationDetails>;
     if (rec.deVerificationFailure === true) {
-      const details: DrawElementVerificationDetails = {};
+      // Every construction path sets `kind` (required on the constructor), so
+      // this only defends against a malformed cross-module-instance shape —
+      // treat anything other than exactly "blank" as "psnr", the same
+      // fallback polarity the old message regex had, but driven by a
+      // structural field instead of parsing text.
+      const details: DrawElementVerificationDetails = {
+        kind: rec.kind === "blank" ? "blank" : "psnr",
+      };
       if (typeof rec.frameIndex === "number") details.frameIndex = rec.frameIndex;
       if (typeof rec.failedDb === "number") details.failedDb = rec.failedDb;
       if (typeof rec.verifyThresholdDb === "number")

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -201,14 +201,34 @@ export interface CaptureSession {
  * forceScreenshot. Discriminant-based guard (not instanceof) so it survives
  * duplicated module instances across package boundaries.
  */
+/**
+ * Structured detail carried alongside the human-readable message — lets
+ * telemetry report the actual failing dB / frame index instead of the
+ * orchestrator having to regex them back out of formatted text. All optional:
+ * a blank-frame trip has no PSNR score, so `failedDb`/`verifyThresholdDb`
+ * are omitted for that throw site.
+ */
+export interface DrawElementVerificationDetails {
+  frameIndex?: number;
+  failedDb?: number;
+  verifyThresholdDb?: number;
+}
+
 export class DrawElementVerificationError extends Error {
-  constructor(message: string) {
+  readonly frameIndex?: number;
+  readonly failedDb?: number;
+  readonly verifyThresholdDb?: number;
+
+  constructor(message: string, details?: DrawElementVerificationDetails) {
     super(message);
     this.name = "DrawElementVerificationError";
     // Discriminant property, assigned dynamically: isDrawElementVerificationError
     // reads it structurally so detection survives duplicated module instances
     // across package boundaries (where instanceof fails).
     (this as unknown as { deVerificationFailure: boolean }).deVerificationFailure = true;
+    this.frameIndex = details?.frameIndex;
+    this.failedDb = details?.failedDb;
+    this.verifyThresholdDb = details?.verifyThresholdDb;
   }
 }
 
@@ -220,6 +240,31 @@ export function isDrawElementVerificationError(err: unknown): boolean {
     e = (e as { cause?: unknown }).cause;
   }
   return false;
+}
+
+/**
+ * Extracts the structured details off a (possibly cause-wrapped) verification
+ * error — same chain-walk as isDrawElementVerificationError, structural
+ * (not instanceof) for the same duplicated-module-instance reason. Returns
+ * undefined when the error isn't a verification failure at all.
+ */
+export function getDrawElementVerificationDetails(
+  err: unknown,
+): DrawElementVerificationDetails | undefined {
+  let e: unknown = err;
+  for (let depth = 0; depth < 5 && typeof e === "object" && e !== null; depth++) {
+    const rec = e as { deVerificationFailure?: boolean } & Partial<DrawElementVerificationDetails>;
+    if (rec.deVerificationFailure === true) {
+      const details: DrawElementVerificationDetails = {};
+      if (typeof rec.frameIndex === "number") details.frameIndex = rec.frameIndex;
+      if (typeof rec.failedDb === "number") details.failedDb = rec.failedDb;
+      if (typeof rec.verifyThresholdDb === "number")
+        details.verifyThresholdDb = rec.verifyThresholdDb;
+      return details;
+    }
+    e = (e as { cause?: unknown }).cause;
+  }
+  return undefined;
 }
 
 /** Wait for inline CSS background images introduced by the latest seek. */

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -60,6 +60,10 @@ export interface RenderCaptureObservability {
    * telemetry from one that never attempted any fallback.
    */
   deFallbackReason?: string;
+  /** The failing PSNR (dB) when `deFallbackReason === "psnr"`; undefined for blank/oom/capture_error (no score exists). */
+  deFallbackFailedDb?: number;
+  /** Frame index the verification failure was detected at; set for both "psnr" and "blank" fallback reasons. */
+  deFallbackFrameIndex?: number;
   /** Auto-parallel inversion outcome: "inverted" (fired, held) | "reverted" (fired, self-verify retry rolled back). */
   deWorkerInversion?: "inverted" | "reverted";
   /** Worker count the resolver would have used absent the inversion; undefined if it never fired. */

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -64,6 +64,8 @@ export interface RenderCaptureObservability {
   deFallbackFailedDb?: number;
   /** Frame index the verification failure was detected at; set for both "psnr" and "blank" fallback reasons. */
   deFallbackFrameIndex?: number;
+  /** The HF_DE_VERIFY_MIN_DB threshold the failing dB breached; only set alongside deFallbackFailedDb (psnr reason). */
+  deFallbackThresholdDb?: number;
   /** Auto-parallel inversion outcome: "inverted" (fired, held) | "reverted" (fired, self-verify retry rolled back). */
   deWorkerInversion?: "inverted" | "reverted";
   /** Worker count the resolver would have used absent the inversion; undefined if it never fired. */

--- a/packages/producer/src/services/render/perfSummary.test.ts
+++ b/packages/producer/src/services/render/perfSummary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { roundDb } from "./perfSummary.js";
+
+describe("roundDb", () => {
+  it("rounds to 1 decimal", () => {
+    expect(roundDb(28.4373)).toBe(28.4);
+    expect(roundDb(28.45)).toBe(28.5);
+  });
+
+  it("clamps at 999 (an Infinity PSNR must never ship literally to telemetry)", () => {
+    expect(roundDb(Infinity)).toBe(999);
+    expect(roundDb(50000)).toBe(999);
+  });
+
+  it("passes undefined through unchanged", () => {
+    expect(roundDb(undefined)).toBeUndefined();
+  });
+
+  it("is idempotent — rounding an already-rounded value is a no-op", () => {
+    expect(roundDb(roundDb(28.4373))).toBe(28.4);
+  });
+});

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -72,6 +72,10 @@ export interface DrawElementPerfInput {
   preRouterWorkers?: number;
   selfVerifyFallback: boolean;
   fallbackReason?: string;
+  /** The failing PSNR (dB) when `fallbackReason === "psnr"`; undefined for blank/oom/capture_error. */
+  fallbackFailedDb?: number;
+  /** Frame index the verification failure was detected at; set for both "psnr" and "blank". */
+  fallbackFrameIndex?: number;
   drainStats?: {
     verifyChecked: number;
     verifyMinDb?: number;
@@ -112,6 +116,11 @@ function aggregateDrawElement(
     verifyInitMs: perfs.reduce((sum, p) => sum + (p.deVerifyInitMs ?? 0), 0),
     selfVerifyFallback: de.selfVerifyFallback,
     fallbackReason: de.fallbackReason,
+    fallbackFailedDb:
+      de.fallbackFailedDb === undefined
+        ? undefined
+        : Math.round(Math.min(de.fallbackFailedDb, 999) * 10) / 10,
+    fallbackFrameIndex: de.fallbackFrameIndex,
     blankSuspects: drain?.blankSuspects ?? 0,
     blankDeterministicAccepts: drain?.blankDeterministicAccepts ?? 0,
     blankRecaptures: drain?.blankRecaptures ?? 0,

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -59,6 +59,19 @@ export function pushWorkerDedupPerfs(
  * render-level drawElement outcome. mode/gateReason |-join distinct values
  * across workers (bounded cardinality); counters SUM.
  */
+/**
+ * Round a dB value to 1 decimal and clamp at 999 (an `Infinity` PSNR — a
+ * bit-exact frame match — must not ship literally to telemetry). Single
+ * source of truth for every dB field crossing into `RenderPerfSummary` or
+ * `RenderCaptureObservability` — both must agree byte-for-byte so PostHog
+ * consumers joining `render_complete` against the crash-survival
+ * `render_error` mirror never see the same underlying score reported at two
+ * different precisions (review finding).
+ */
+export function roundDb(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : Math.round(Math.min(value, 999) * 10) / 10;
+}
+
 /** Orchestrator-supplied render-level drawElement outcome (one shape, used by
  * both the aggregate function and buildRenderPerfSummary's input). */
 export interface DrawElementPerfInput {
@@ -76,6 +89,8 @@ export interface DrawElementPerfInput {
   fallbackFailedDb?: number;
   /** Frame index the verification failure was detected at; set for both "psnr" and "blank". */
   fallbackFrameIndex?: number;
+  /** The HF_DE_VERIFY_MIN_DB threshold the failing dB breached; only set alongside fallbackFailedDb. */
+  fallbackThresholdDb?: number;
   drainStats?: {
     verifyChecked: number;
     verifyMinDb?: number;
@@ -109,18 +124,13 @@ function aggregateDrawElement(
     workerEncode: perfs.some((p) => p.deWorkerEncode),
     verifyArmed: perfs.reduce((sum, p) => sum + (p.deVerifyArmed ?? 0), 0),
     verifyChecked: drain?.verifyChecked ?? 0,
-    verifyMinDb:
-      drain?.verifyMinDb === undefined
-        ? undefined
-        : Math.round(Math.min(drain.verifyMinDb, 999) * 10) / 10,
+    verifyMinDb: roundDb(drain?.verifyMinDb),
     verifyInitMs: perfs.reduce((sum, p) => sum + (p.deVerifyInitMs ?? 0), 0),
     selfVerifyFallback: de.selfVerifyFallback,
     fallbackReason: de.fallbackReason,
-    fallbackFailedDb:
-      de.fallbackFailedDb === undefined
-        ? undefined
-        : Math.round(Math.min(de.fallbackFailedDb, 999) * 10) / 10,
+    fallbackFailedDb: roundDb(de.fallbackFailedDb),
     fallbackFrameIndex: de.fallbackFrameIndex,
+    fallbackThresholdDb: roundDb(de.fallbackThresholdDb),
     blankSuspects: drain?.blankSuspects ?? 0,
     blankDeterministicAccepts: drain?.blankDeterministicAccepts ?? 0,
     blankRecaptures: drain?.blankRecaptures ?? 0,

--- a/packages/producer/src/services/render/stages/captureStreamingStage.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.ts
@@ -289,6 +289,7 @@ function createDrainFrameGuard(args: {
         } catch (err) {
           throw new DrawElementVerificationError(
             `blank drawElement frame ${idx}: ${buf.length}B < floor ${Math.round(floor)}B and recapture failed (${err instanceof Error ? err.message : String(err)})`,
+            { frameIndex: idx },
           );
         }
         if (retryBuf.equals(buf)) {
@@ -306,6 +307,7 @@ function createDrainFrameGuard(args: {
         } else if (retryBuf.length < floor) {
           throw new DrawElementVerificationError(
             `blank drawElement frame ${idx}: ${buf.length}B (retry ${retryBuf.length}B) < floor ${Math.round(floor)}B`,
+            { frameIndex: idx },
           );
         } else {
           buf = retryBuf;
@@ -339,6 +341,7 @@ function createDrainFrameGuard(args: {
         }
         throw new DrawElementVerificationError(
           `drawElement self-verify failed at frame ${idx}: ${db.toFixed(1)}dB < ${verifyMinDb}dB vs pre-injection screenshot${dumpDir ? ` (pair: ${dumpDir})` : ""}`,
+          { frameIndex: idx, failedDb: db, verifyThresholdDb: verifyMinDb },
         );
       }
       stats.verifyChecked += 1;

--- a/packages/producer/src/services/render/stages/captureStreamingStage.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.ts
@@ -289,7 +289,7 @@ function createDrainFrameGuard(args: {
         } catch (err) {
           throw new DrawElementVerificationError(
             `blank drawElement frame ${idx}: ${buf.length}B < floor ${Math.round(floor)}B and recapture failed (${err instanceof Error ? err.message : String(err)})`,
-            { frameIndex: idx },
+            { kind: "blank", frameIndex: idx },
           );
         }
         if (retryBuf.equals(buf)) {
@@ -307,7 +307,7 @@ function createDrainFrameGuard(args: {
         } else if (retryBuf.length < floor) {
           throw new DrawElementVerificationError(
             `blank drawElement frame ${idx}: ${buf.length}B (retry ${retryBuf.length}B) < floor ${Math.round(floor)}B`,
-            { frameIndex: idx },
+            { kind: "blank", frameIndex: idx },
           );
         } else {
           buf = retryBuf;
@@ -341,7 +341,7 @@ function createDrainFrameGuard(args: {
         }
         throw new DrawElementVerificationError(
           `drawElement self-verify failed at frame ${idx}: ${db.toFixed(1)}dB < ${verifyMinDb}dB vs pre-injection screenshot${dumpDir ? ` (pair: ${dumpDir})` : ""}`,
-          { frameIndex: idx, failedDb: db, verifyThresholdDb: verifyMinDb },
+          { kind: "psnr", frameIndex: idx, failedDb: db, verifyThresholdDb: verifyMinDb },
         );
       }
       stats.verifyChecked += 1;

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -76,6 +76,7 @@ import {
   isMemoryExhaustionError,
   isTransientBrowserError,
   isDrawElementVerificationError,
+  getDrawElementVerificationDetails,
 } from "@hyperframes/engine";
 import { join, dirname, resolve } from "path";
 import { totalmem } from "node:os";
@@ -449,6 +450,10 @@ export interface RenderPerfSummary {
     selfVerifyFallback: boolean;
     /** What tripped the fallback retry: psnr | blank | oom | capture_error. */
     fallbackReason?: string;
+    /** The failing PSNR (dB) when `fallbackReason === "psnr"`; undefined for blank/oom/capture_error (no score exists). */
+    fallbackFailedDb?: number;
+    /** Frame index the verification failure was detected at; set for both "psnr" and "blank" fallback reasons. */
+    fallbackFrameIndex?: number;
     /** Blank-guard counters. */
     blankSuspects: number;
     blankDeterministicAccepts: number;
@@ -1737,6 +1742,11 @@ export async function executeRenderJob(
     let captureParallelStreamForced = false;
     let deSelfVerifyFallback = false;
     let deFallbackReason: string | undefined;
+    // Structured detail behind deFallbackReason's "blank"/"psnr" bucket — the
+    // failing dB and frame index otherwise only exist as text inside the
+    // thrown error's message, unavailable to telemetry.
+    let deFallbackFailedDb: number | undefined;
+    let deFallbackFrameIndex: number | undefined;
     let deDrainStats: import("./render/stages/captureStreamingStage.js").DeDrainStats | undefined;
     updateCaptureObservability({ forceScreenshot: captureForceScreenshot });
     observability.checkpoint("compile", "composition metadata resolved", {
@@ -2718,6 +2728,11 @@ export async function executeRenderJob(
             : isMemoryExhaustion
               ? "oom"
               : "capture_error";
+          if (isVerifyError) {
+            const verifyDetails = getDrawElementVerificationDetails(err);
+            deFallbackFailedDb = verifyDetails?.failedDb;
+            deFallbackFrameIndex = verifyDetails?.frameIndex;
+          }
           log.warn(
             isVerifyError
               ? "[Render] drawElement self-verification failed; re-rendering via screenshot"
@@ -2735,6 +2750,8 @@ export async function executeRenderJob(
             forceScreenshot: true,
             deSelfVerifyFallback,
             deFallbackReason,
+            deFallbackFailedDb,
+            deFallbackFrameIndex,
           });
           probeSession = null;
           // Must clear BEFORE resolveParallelRouterRetryPlan recomputes
@@ -3023,6 +3040,8 @@ export async function executeRenderJob(
         preRouterWorkers: deParallelRouter ? preRoutingWorkerCount : undefined,
         selfVerifyFallback: deSelfVerifyFallback,
         fallbackReason: deFallbackReason,
+        fallbackFailedDb: deFallbackFailedDb,
+        fallbackFrameIndex: deFallbackFrameIndex,
         drainStats: deDrainStats,
       },
       hdrDiagnostics,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -2729,15 +2729,17 @@ export async function executeRenderJob(
             throw err;
           const isMemoryExhaustion = !isVerifyError && isMemoryExhaustionError(err);
           deSelfVerifyFallback = isVerifyError;
+          // `kind` is a structural field on the error (DrawElementVerificationDetails),
+          // never derived from message text — a reworded message, a translated
+          // string, or a cross-module/serialized error must never be able to
+          // flip "blank" into "psnr" or vice versa (review finding).
+          const verifyDetails = isVerifyError ? getDrawElementVerificationDetails(err) : undefined;
           deFallbackReason = isVerifyError
-            ? /blank/i.test(err instanceof Error ? err.message : "")
-              ? "blank"
-              : "psnr"
+            ? (verifyDetails?.kind ?? "psnr")
             : isMemoryExhaustion
               ? "oom"
               : "capture_error";
           if (isVerifyError) {
-            const verifyDetails = getDrawElementVerificationDetails(err);
             deFallbackFailedDb = roundDb(verifyDetails?.failedDb);
             deFallbackFrameIndex = verifyDetails?.frameIndex;
             deFallbackThresholdDb = roundDb(verifyDetails?.verifyThresholdDb);

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -103,6 +103,7 @@ import { resolveEffectiveHdrMode } from "./render/hdrMode.js";
 import {
   buildRenderPerfSummary,
   pushWorkerDedupPerfs,
+  roundDb,
   worstSubTimelineWaitOutcome,
 } from "./render/perfSummary.js";
 import { getCaptureStageBrowserConsole } from "./render/captureStageError.js";
@@ -454,6 +455,8 @@ export interface RenderPerfSummary {
     fallbackFailedDb?: number;
     /** Frame index the verification failure was detected at; set for both "psnr" and "blank" fallback reasons. */
     fallbackFrameIndex?: number;
+    /** The HF_DE_VERIFY_MIN_DB threshold the failing dB breached; only set alongside fallbackFailedDb (psnr reason). */
+    fallbackThresholdDb?: number;
     /** Blank-guard counters. */
     blankSuspects: number;
     blankDeterministicAccepts: number;
@@ -1744,9 +1747,14 @@ export async function executeRenderJob(
     let deFallbackReason: string | undefined;
     // Structured detail behind deFallbackReason's "blank"/"psnr" bucket — the
     // failing dB and frame index otherwise only exist as text inside the
-    // thrown error's message, unavailable to telemetry.
+    // thrown error's message, unavailable to telemetry. Rounded once here
+    // (roundDb) so both downstream consumers — the render_complete
+    // perfSummary path and the crash-survival RenderCaptureObservability
+    // mirror — report the identical dB, not two different precisions for
+    // the same underlying score (review finding).
     let deFallbackFailedDb: number | undefined;
     let deFallbackFrameIndex: number | undefined;
+    let deFallbackThresholdDb: number | undefined;
     let deDrainStats: import("./render/stages/captureStreamingStage.js").DeDrainStats | undefined;
     updateCaptureObservability({ forceScreenshot: captureForceScreenshot });
     observability.checkpoint("compile", "composition metadata resolved", {
@@ -2730,8 +2738,9 @@ export async function executeRenderJob(
               : "capture_error";
           if (isVerifyError) {
             const verifyDetails = getDrawElementVerificationDetails(err);
-            deFallbackFailedDb = verifyDetails?.failedDb;
+            deFallbackFailedDb = roundDb(verifyDetails?.failedDb);
             deFallbackFrameIndex = verifyDetails?.frameIndex;
+            deFallbackThresholdDb = roundDb(verifyDetails?.verifyThresholdDb);
           }
           log.warn(
             isVerifyError
@@ -2752,6 +2761,7 @@ export async function executeRenderJob(
             deFallbackReason,
             deFallbackFailedDb,
             deFallbackFrameIndex,
+            deFallbackThresholdDb,
           });
           probeSession = null;
           // Must clear BEFORE resolveParallelRouterRetryPlan recomputes
@@ -3042,6 +3052,7 @@ export async function executeRenderJob(
         fallbackReason: deFallbackReason,
         fallbackFailedDb: deFallbackFailedDb,
         fallbackFrameIndex: deFallbackFrameIndex,
+        fallbackThresholdDb: deFallbackThresholdDb,
         drainStats: deDrainStats,
       },
       hdrDiagnostics,


### PR DESCRIPTION
## What

`DrawElementVerificationError` now carries structured `frameIndex`/`failedDb`/`verifyThresholdDb` fields instead of only a formatted message string. Two new telemetry properties flow from them: `de_fallback_failed_db` and `de_fallback_frame_index`, on both `render_complete` (perfSummary path) and the crash-survival `RenderCaptureObservability` mirror (so a hard failure that happens right after a fallback attempt — before perfSummary is ever built — still reports the failing dB/frame).

- New `getDrawElementVerificationDetails(err)` helper in `frameCapture.ts` (engine), same chain-walk pattern as the existing `isDrawElementVerificationError`, so it survives duplicated module instances and `CaptureStageError` wrapping.
- All 3 throw sites in `captureStreamingStage.ts` (2 blank-frame, 1 PSNR) now pass the detail through.
- `renderOrchestrator.ts`'s catch block extracts details via the helper instead of regexing the error message, threads two new locals (`deFallbackFailedDb`/`deFallbackFrameIndex`) through both `DrawElementPerfInput` (perfSummary.ts) and `RenderCaptureObservability` (observability.ts).
- `render.ts` + `telemetry/events.ts` map both fields through to PostHog on `render_complete` and `render_error`.

## Why

Working the current DE parallel-router soak (v0.7.52+, `de_parallel_router` telemetry), `de_fallback_reason` already discriminates `psnr | blank | oom | capture_error`, but a `psnr` revert carries no score — the failing dB only ever existed as text inside the thrown error's message, which the orchestrator never captured. Can't currently tell "32.1dB just under the 32dB threshold, maybe tune it" from "12dB real corruption, investigate the bug" — that distinction should drive whether the next step on the soak is a threshold tweak or a fix.

## How

Structural discriminant fields on the error class (mirrors the existing `deVerificationFailure` boolean pattern) rather than re-parsing the message — `getDrawElementVerificationDetails` walks the same `.cause` chain as `isDrawElementVerificationError` since `CaptureStageError` wraps the original error before the orchestrator sees it. `failedDb` gets the same rounding/clamp treatment as the existing `verifyMinDb` field for consistency (round to 1 decimal, clamp at 999).

## Test plan

- [x] Unit tests added: `frameCapture.test.ts` (engine) — the new class fields + extraction helper, including a cause-chain-wrapped case; `renderObservability.test.ts` — the crash-survival mirror carries both fields for a psnr fallback and leaves them undefined for blank/oom/capture_error; `events.test.ts` — both `render_error` and `render_complete` emit the new PostHog properties
- [x] Full typecheck clean on engine/producer/cli
- [x] `renderOrchestrator.test.ts` (141/141), `captureStreamingStage.test.ts` (6/6, bun test), `frameCapture.test.ts` (23/23), `events.test.ts` + `renderObservability.test.ts` (49/49) all pass
- [x] Confirmed 5 unrelated pre-existing test failures (macOS resource-fork/tmpdir flakiness in `lintProject.test.ts` and `render.test.ts`) reproduce identically on a clean `origin/main` checkout — not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)