### PR TITLE
fix(cli): avoid Python whisper CLI collision

### DIFF
--- a/packages/cli/src/whisper/manager-resolution.test.ts
+++ b/packages/cli/src/whisper/manager-resolution.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFileSync: vi.fn((_command: string, args: string[]) => {
+      if (args[0] === "whisper") return "/fake/python-whisper\n";
+      throw new Error(`${args[0]} not found`);
+    }),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, existsSync: vi.fn(() => false) };
+});
+
+describe("findWhisper", () => {
+  it("does not treat the OpenAI Python whisper command as whisper.cpp", async () => {
+    const { findWhisper } = await import("./manager.js");
+
+    expect(findWhisper()).toBeUndefined();
+  });
+});

--- a/packages/cli/src/whisper/manager.ts
+++ b/packages/cli/src/whisper/manager.ts
@@ -67,10 +67,9 @@ function findFromEnv(): WhisperResult | undefined {
 }
 
 function findFromSystem(): WhisperResult | undefined {
-  for (const name of ["whisper-cli", "whisper"]) {
-    const path = whichBinary(name);
-    if (path) return { executablePath: path, source: "system" };
-  }
+  // `whisper` is the OpenAI Python CLI; only whisper.cpp's binary accepts our flags.
+  const path = whichBinary("whisper-cli");
+  if (path) return { executablePath: path, source: "system" };
 
   // Check brew paths directly on macOS
   if (platform() === "darwin") {


### PR DESCRIPTION
## Root cause

`hyperframes transcribe` searched for both `whisper-cli` and `whisper`, but the latter is OpenAI Python Whisper. The transcriber then sent whisper.cpp-only flags such as `--output-json-full`, so machines with Python Whisper installed selected an incompatible executable.

## Fix

Resolve only the whisper.cpp `whisper-cli` binary from PATH. Keep the existing explicit environment and bundled-binary resolution paths unchanged.

## Regression coverage

Adds a resolver test proving a system `whisper` command alone is not accepted as whisper.cpp.

## Validation

- `bun run build`
- CLI suite: 130 files, 1,647 tests passed
- focused Whisper suite: 13 tests passed
- CLI typecheck
- changed-file lint, format, fallow, and pre-commit hooks
- independent code review completed

## Reviewer action

Confirm that intentionally dropping the ambiguous Python `whisper` PATH fallback matches the CLI contract; explicit `HYPERFRAMES_WHISPER_PATH` remains available for custom binaries.