### PR TITLE
fix(cli): serve local assets with query strings

### DIFF
--- a/packages/cli/src/utils/staticProjectServer.test.ts
+++ b/packages/cli/src/utils/staticProjectServer.test.ts
@@ -43,6 +43,14 @@ describe("serveStaticProjectHtml range support", () => {
     expect(await res.text()).toBe("abcdef");
   });
 
+  it("serves an asset when its URL has a query string", async () => {
+    const { url } = await serveWith(Buffer.from("versioned", "utf-8"));
+
+    const res = await fetch(`${url}tone.wav?v=123&cache=1`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("versioned");
+  });
+
   it("streams a small slice out of a large file without buffering the whole thing", async () => {
     // 8MB file, ask for 4 bytes deep inside it. The handler must createReadStream
     // the [start,end] window only, not readFileSync the whole 8MB and slice.

--- a/packages/cli/src/utils/staticProjectServer.ts
+++ b/packages/cli/src/utils/staticProjectServer.ts
@@ -79,13 +79,14 @@ export async function serveStaticProjectHtml(
   // fallow-ignore-next-line complexity
   const server = createServer((req, res) => {
     const url = req.url ?? "/";
-    if (url === "/" || url === "/index.html") {
+    const pathname = new URL(url, "http://127.0.0.1").pathname;
+    if (pathname === "/" || pathname === "/index.html") {
       res.writeHead(200, { "Content-Type": "text/html" });
       res.end(html);
       return;
     }
 
-    const requestPath = decodeURIComponent(url).replace(/^\//, "");
+    const requestPath = decodeURIComponent(pathname).replace(/^\//, "");
     for (const root of roots) {
       const filePath = resolve(root, requestPath);
       const rel = relative(root, filePath);


### PR DESCRIPTION
## Summary
- resolve runtime-check requests by URL pathname instead of the full request target
- preserve query-string cache busting for local images and other assets
- cover the failure with a static-server regression test

## Root cause
The local check/snapshot server decoded `req.url` directly and used it as a filesystem path. A request such as `assets/image.png?v=1` therefore looked for a literal filename containing `?v=1` and returned 404.

## Validation
- `bun test packages/cli/src/utils/staticProjectServer.test.ts` (8 passed)
- `bun run --cwd packages/cli typecheck`
- `bunx oxfmt --check packages/cli/src/utils/staticProjectServer.ts packages/cli/src/utils/staticProjectServer.test.ts`