### PR TITLE
fix(render): extend high-quality encode timeout

### DIFF
--- a/packages/producer/src/services/render/stages/encodeStage.test.ts
+++ b/packages/producer/src/services/render/stages/encodeStage.test.ts
@@ -154,6 +154,26 @@ describe("gif encode args", () => {
 });
 
 describe("runEncodeStage config plumbing", () => {
+  it("gives high-quality encodes enough budget for slow Windows libx264", async () => {
+    const { runEncodeStage } = await import("./encodeStage.js");
+    const input = makeInput();
+
+    await runEncodeStage(
+      makeInput({
+        job: {
+          ...input.job,
+          config: { ...input.job.config, quality: "high" },
+          duration: 172.56,
+        },
+        engineConfig: { ffmpegEncodeTimeout: 600_000 },
+      }),
+    );
+
+    expect(encodeFramesFromDirMock.mock.calls[0]?.[5]).toEqual({
+      ffmpegEncodeTimeout: 4_141_440,
+    });
+  });
+
   it("scales the encode timeout for long compositions", async () => {
     const { runEncodeStage } = await import("./encodeStage.js");
 

--- a/packages/producer/src/services/render/stages/encodeStage.ts
+++ b/packages/producer/src/services/render/stages/encodeStage.ts
@@ -278,10 +278,13 @@ export async function runEncodeStage(input: EncodeStageInput): Promise<EncodeSta
   updateJobStatus(job, "encoding", "Encoding video", 75, onProgress);
 
   // ffmpegEncodeTimeout is a total wall-clock cap, not an inactivity timeout.
-  // A fixed ten-minute cap reliably kills long high-quality disk-frame encodes
-  // that are still making progress. Preserve larger operator overrides while
-  // guaranteeing four seconds of encode budget per second of source video.
-  const scaledEncodeTimeout = Math.ceil((job.duration ?? 0) * 4_000);
+  // A fixed ten-minute cap reliably kills long disk-frame encodes that are
+  // still making progress. High-quality libx264 can be substantially slower
+  // than standard presets on CPU-only Windows hosts, so give that preset the
+  // same conservative budget operators previously had to set by hand while
+  // retaining the established 4x budget for draft/standard renders.
+  const encodeBudgetPerSourceSecond = job.config.quality === "high" ? 24_000 : 4_000;
+  const scaledEncodeTimeout = Math.ceil((job.duration ?? 0) * encodeBudgetPerSourceSecond);
   const videoEngineCfg =
     scaledEncodeTimeout > engineCfg.ffmpegEncodeTimeout
       ? { ...engineCfg, ffmpegEncodeTimeout: scaledEncodeTimeout }


### PR DESCRIPTION
## Summary

- Reserve a 24× source-duration wall-clock budget for high-quality disk-frame encodes.
- Keep the existing 4× budget for draft and standard renders.
- Preserve larger operator-provided FFMPEG_ENCODE_TIMEOUT_MS overrides.

## Root cause

PR #2244 made the encode timeout scale to 4× source duration. A 5,177-frame 30 fps Windows high-quality render is 172.56 seconds long, so that policy computes 690,240 ms—the exact reported timeout after all frames had already been captured. High-quality libx264 encoding can exceed 4× realtime on constrained hosts, discarding the completed capture.

## Tests

- Exact 172.56-second high-quality regression: red at 690,240 ms; green at 4,141,440 ms.
- Focused encode-stage tests: 8 passed.
- Producer unit suite: 295 tests passed, plus all classified producer lanes.
- Producer typecheck passed.
- Formatting, lint, diff check, and pre-commit checks passed.

Human review is required; this PR is not self-approved or merged.