### PR TITLE
fix(engine): ignore benign media request aborts

### DIFF
--- a/packages/engine/src/services/frameCapture.test.ts
+++ b/packages/engine/src/services/frameCapture.test.ts
@@ -7,6 +7,7 @@ import {
   formatRequestFailureDiagnostic,
   isFontResourceError,
   sanitizeDiagnosticUrl,
+  shouldIgnoreRequestFailureDiagnostic,
 } from "./frameCapture.js";
 
 describe("isFontResourceError", () => {
@@ -220,5 +221,36 @@ describe("navigation diagnostics", () => {
         statusText: "Forbidden",
       }),
     ).toBe("[Browser:HTTP403] GET https://cdn.example.com/frame.png resource=image Forbidden");
+  });
+
+  it("ignores benign media aborts without hiding real request failures", () => {
+    expect(
+      shouldIgnoreRequestFailureDiagnostic({
+        resourceType: "media",
+        url: "http://127.0.0.1:4173/assets/video.mp4",
+        failureText: "net::ERR_ABORTED",
+      }),
+    ).toBe(true);
+    expect(
+      shouldIgnoreRequestFailureDiagnostic({
+        resourceType: "other",
+        url: "http://127.0.0.1:4173/assets/audio.oga?cache=1",
+        failureText: "net::ERR_ABORTED",
+      }),
+    ).toBe(true);
+    expect(
+      shouldIgnoreRequestFailureDiagnostic({
+        resourceType: "media",
+        url: "http://127.0.0.1:4173/assets/video.mp4",
+        failureText: "net::ERR_FAILED",
+      }),
+    ).toBe(false);
+    expect(
+      shouldIgnoreRequestFailureDiagnostic({
+        resourceType: "script",
+        url: "http://127.0.0.1:4173/assets/app.js",
+        failureText: "net::ERR_ABORTED",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -341,6 +341,27 @@ export function formatRequestFailureDiagnostic(input: {
   );
 }
 
+/**
+ * Chromium reports media loads that it intentionally cancels during probing as
+ * request failures. They are expected when the probe discovers or seeks local
+ * audio/video and do not indicate a missing asset.
+ */
+export function shouldIgnoreRequestFailureDiagnostic(input: {
+  resourceType: string;
+  url: string;
+  failureText: string;
+}): boolean {
+  if (input.failureText !== "net::ERR_ABORTED") return false;
+  if (input.resourceType === "media") return true;
+  try {
+    return /\.(?:aac|flac|m4a|mp3|mp4|mov|oga|ogg|ogv|wav|webm)$/i.test(
+      new URL(input.url).pathname,
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function formatHttpErrorDiagnostic(input: {
   method: string;
   resourceType: string;
@@ -1581,16 +1602,20 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
   });
 
   page.on("requestfailed", (request) => {
-    if (request.resourceType() === "script") {
+    const resourceType = request.resourceType();
+    const url = request.url();
+    const failureText = request.failure()?.errorText ?? "unknown";
+    if (resourceType === "script") {
       recordScriptLoadFailure(session, request.url());
     }
+    if (shouldIgnoreRequestFailureDiagnostic({ resourceType, url, failureText })) return;
     appendBrowserDiagnostic(
       session,
       formatRequestFailureDiagnostic({
         method: request.method(),
-        resourceType: request.resourceType(),
-        url: request.url(),
-        failureText: request.failure()?.errorText ?? "unknown",
+        resourceType,
+        url,
+        failureText,
       }),
     );
   });


### PR DESCRIPTION
## Summary
- suppress Chromium `net::ERR_ABORTED` diagnostics for media requests cancelled during probe/seek
- preserve real media failures and all non-media request failures
- cover Puppeteer media classification plus extension fallback, including `.oga`

## Root cause
The capture session appended every `requestfailed` event to its browser diagnostic buffer. Chromium commonly aborts media requests while the probe discovers or seeks audio/video, and producer probe treated any buffered `net::ERR_*` line as an asset-load warning even when the final media rendered correctly.

## Regression coverage
- red/green unit test for benign media aborts and real failures
- `@hyperframes/engine` targeted test: 20/20
- `@hyperframes/engine` typecheck
- producer probe-stage test: 18/18
- producer full unit lanes: 295 Vitest + all Bun lanes passed
- format, lint, diff check, pre-commit fallow/typecheck passed
- full engine suite: 887 passed; 3 pre-existing LFS HDR-fixture failures in this smudge-disabled worktree

## Review
Independent review caught missing `.oga` fallback coverage; fixed and re-reviewed with no remaining findings.


Reviewer action: verify benign abort suppression does not hide real media/network failures, then approve if CI is green.