### PR TITLE
fix(producer): fail renders when audio mixing fails

### DIFF
--- a/packages/producer/src/services/distributed/plan.test.ts
+++ b/packages/producer/src/services/distributed/plan.test.ts
@@ -74,9 +74,9 @@ describe("distributed warning policy", () => {
     expect(job.warnings.map((warning) => warning.code)).toEqual(["audio_processing_failed"]);
   });
 
-  it("records distributed audio degradation in best-effort mode", () => {
+  it("rejects distributed audio degradation in best-effort mode", () => {
     const job = createJob("best-effort");
-    expect(() => applyDistributedAudioWarningPolicy(job, "mix failed")).not.toThrow();
+    expect(() => applyDistributedAudioWarningPolicy(job, "mix failed")).toThrow(RenderQualityError);
     expect(job.warnings.map((warning) => warning.code)).toEqual(["audio_processing_failed"]);
   });
 });

--- a/packages/producer/src/services/render/renderEventPublisher.test.ts
+++ b/packages/producer/src/services/render/renderEventPublisher.test.ts
@@ -128,7 +128,7 @@ describe("updateJobStatus", () => {
     expect(job.warnings).toHaveLength(1);
   });
 
-  it("preserves best-effort behavior when strictness is omitted", () => {
+  it("blocks audio processing failures when strictness is omitted", () => {
     const job = createRenderJob({ fps: 30, quality: "high" });
     const log = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
     expect(() =>
@@ -143,7 +143,7 @@ describe("updateJobStatus", () => {
         ],
         log,
       ),
-    ).not.toThrow();
+    ).toThrow(RenderQualityError);
     expect(job.config.strictness).toBe("best-effort");
     expect(job.warnings).toHaveLength(1);
   });

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -557,7 +557,10 @@ export function applyRenderWarningPolicy(
     strictness,
     warningCodes: job.warnings.map((warning) => warning.code),
   });
-  if (strictness === "strict") {
+  const hasAudioProcessingFailure = job.warnings.some(
+    (warning) => warning.code === "audio_processing_failed",
+  );
+  if (strictness === "strict" || hasAudioProcessingFailure) {
     throw new RenderQualityError(job.warnings);
   }
 }


### PR DESCRIPTION
## Summary

When audio mixing fails, renders now stop instead of exiting successfully with a video-only artifact. The invariant applies to both local and distributed best-effort renders, while unrelated correctness warnings retain their existing completed-with-warnings behavior.

## Test plan

- `bunx vitest run packages/producer/src/services/render/renderEventPublisher.test.ts`
- `bun test packages/producer/src/services/distributed/plan.test.ts`
- `bunx oxlint packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/render/renderEventPublisher.test.ts packages/producer/src/services/distributed/plan.test.ts`
- `bunx oxfmt --check packages/producer/src/services/renderOrchestrator.ts packages/producer/src/services/render/renderEventPublisher.test.ts packages/producer/src/services/distributed/plan.test.ts`
- `bun run --cwd packages/producer typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
