### PR TITLE
fix(media-use): preserve bundled SFX durations

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "7a51f53cf615fe97",
+      "hash": "d6639c5194baae03",
       "files": 124
     },
     "motion-graphics": {

--- a/skills/media-use/audio/assets/sfx/manifest.json
+++ b/skills/media-use/audio/assets/sfx/manifest.json
@@ -1,57 +1,57 @@
 {
   "chime": {
     "file": "chime.mp3",
-    "duration": 2.5,
+    "duration": 2.544,
     "description": "Soft melodic chime — gentle positive beat: success/confirmation or a lighthearted transition. Sync to the visual moment."
   },
   "click-soft": {
     "file": "click-soft.mp3",
-    "duration": 0.37,
+    "duration": 0.365688,
     "description": "Quiet short click — low-key UI tap / soft selection. Short accent, sync exactly to the on-screen action."
   },
   "click": {
     "file": "click.mp3",
-    "duration": 0.37,
+    "duration": 0.365688,
     "description": "Crisp UI click — button press, toggle, selection. Short accent, sync exactly to the on-screen action."
   },
   "error": {
     "file": "error.mp3",
-    "duration": 1.62,
+    "duration": 1.619594,
     "description": "Negative / error tone — failure state, a 'wrong' beat, or a glitchy interruption."
   },
   "glitch-1": {
     "file": "glitch-1.mp3",
-    "duration": 2.64,
+    "duration": 2.638344,
     "description": "Punchy digital glitch — hard-cut accent or sudden reveal. Trigger on the hit; let the decay bleed into the next shot (J-cut)."
   },
   "glitch-2": {
     "file": "glitch-2.mp3",
-    "duration": 3.5,
+    "duration": 3.504,
     "description": "Harsh, longer glitch — chaotic / jarring transition or a distorted reveal."
   },
   "glitch-3": {
     "file": "glitch-3.mp3",
-    "duration": 3.1,
+    "duration": 3.096,
     "description": "Low-key glitch texture — subtle digital shift, minimal transition that sits under other audio."
   },
   "impact-bass-1": {
     "file": "impact-bass-1.mp3",
-    "duration": 2.12,
+    "duration": 2.115906,
     "description": "Bass impact hit — logo/hero snap, headline slam. Trigger on the visual landing; decay carries into the next shot (J-cut)."
   },
   "impact-bass-2": {
     "file": "impact-bass-2.mp3",
-    "duration": 2.59,
+    "duration": 2.592,
     "description": "Bass impact with a short swell — brief anticipation then a deep hit. Place so the peak lands on the reveal."
   },
   "key-press": {
     "file": "key-press.mp3",
-    "duration": 0.4,
+    "duration": 0.432,
     "description": "Single key press — one keystroke / terminal-input beat. Short accent, sync to the typed character."
   },
   "notification": {
     "file": "notification.mp3",
-    "duration": 2.46,
+    "duration": 2.4555,
     "description": "Notification chime — alert, message-in, toast/badge appears. Sync to the element entering."
   },
   "ping": {
@@ -66,32 +66,32 @@
   },
   "riser": {
     "file": "riser.mp3",
-    "duration": 10.03,
+    "duration": 10.032,
     "description": "Long cinematic riser (~10s build, peak at the end). Trigger at (climax_time − 10.03s) so it crests exactly on the reveal."
   },
   "sparkle": {
     "file": "sparkle.mp3",
-    "duration": 1.8,
+    "duration": 1.802438,
     "description": "Bright sparkle / shimmer — magical reveal or 'shine' highlight on a hero element. Sync to the highlight."
   },
   "typing": {
     "file": "typing.mp3",
-    "duration": 1.5,
+    "duration": 1.541224,
     "description": "Typing burst (~1.5s of keys) — keyboard / code typing reveal, text-being-typed beat. Start as the text begins typing."
   },
   "whoosh-cinematic": {
     "file": "whoosh-cinematic.mp3",
-    "duration": 5.54,
+    "duration": 5.544,
     "description": "Cinematic whoosh build (~5.5s) — sweeping scene transition. Align so the swell peaks on the cut."
   },
   "whoosh-short": {
     "file": "whoosh-short.mp3",
-    "duration": 0.57,
+    "duration": 0.574688,
     "description": "Short whoosh — quick swipe/slide accent, fast element move, snappy transition. Sync to the motion."
   },
   "whoosh": {
     "file": "whoosh.mp3",
-    "duration": 0.57,
+    "duration": 0.574688,
     "description": "Punchy whoosh/impact — fast reveal or hard transition accent. Sync to the motion."
   }
 }

--- a/skills/media-use/scripts/lib/bundled-sfx-provider.test.mjs
+++ b/skills/media-use/scripts/lib/bundled-sfx-provider.test.mjs
@@ -1,9 +1,45 @@
 import { strict as assert } from "node:assert";
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { test } from "node:test";
 import { extensionForBundledSfxFile } from "./bundled-sfx-provider.mjs";
+
+const SFX_DIR = join(import.meta.dirname, "..", "..", "audio", "assets", "sfx");
+const HAS_FFPROBE = spawnSync("ffprobe", ["-version"], { stdio: "ignore" }).status === 0;
+
+function frozenDuration(filePath) {
+  return Number(
+    execFileSync(
+      "ffprobe",
+      ["-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", filePath],
+      { encoding: "utf8" },
+    ).trim(),
+  );
+}
 
 test("derives bundled SFX extension from the manifest filename", () => {
   assert.equal(extensionForBundledSfxFile("impact.wav"), ".wav");
   assert.equal(extensionForBundledSfxFile("whoosh.ogg"), ".ogg");
   assert.equal(extensionForBundledSfxFile("extensionless"), ".mp3");
 });
+
+test(
+  "bundled SFX manifest covers every frozen asset with its exact duration",
+  { skip: !HAS_FFPROBE },
+  () => {
+    const manifest = JSON.parse(readFileSync(join(SFX_DIR, "manifest.json"), "utf8"));
+    const frozenFiles = readdirSync(SFX_DIR)
+      .filter((file) => file.endsWith(".mp3"))
+      .sort();
+    const manifestFiles = Object.values(manifest)
+      .map((entry) => entry.file)
+      .sort();
+
+    assert.deepEqual(manifestFiles, frozenFiles);
+    for (const [key, entry] of Object.entries(manifest)) {
+      const actual = frozenDuration(join(SFX_DIR, entry.file));
+      assert.equal(entry.duration, actual, `${key} duration must match ${entry.file}`);
+    }
+  },
+);

--- a/skills/media-use/scripts/resolve.mjs
+++ b/skills/media-use/scripts/resolve.mjs
@@ -405,15 +405,19 @@ async function run() {
     process.exit(1);
   }
 
+  const resolvedDuration =
+    searchResult.metadata?.duration == null
+      ? null
+      : searchResult.metadata?.provider === "bundled.sfx"
+        ? searchResult.metadata.duration
+        : Math.round(searchResult.metadata.duration * 10) / 10;
   const record = {
     id,
     type,
     path: localPath,
     source: searchResult.source || "search",
     description: searchResult.metadata?.description || intent,
-    ...(searchResult.metadata?.duration != null && {
-      duration: Math.round(searchResult.metadata.duration * 10) / 10, // round to 0.1s like probe (voice bypassed it)
-    }),
+    ...(resolvedDuration != null && { duration: resolvedDuration }),
     ...(searchResult.metadata?.width != null && { width: searchResult.metadata.width }),
     ...(searchResult.metadata?.height != null && { height: searchResult.metadata.height }),
     ...(searchResult.metadata?.transparent != null && {

--- a/skills/media-use/scripts/resolve.test.mjs
+++ b/skills/media-use/scripts/resolve.test.mjs
@@ -25,6 +25,7 @@ const RESOLVE_CLI = join(import.meta.dirname, "resolve.mjs");
 // The "Test: skills" CI job has no ffmpeg on PATH (by design). The smart-grade
 // test shells to ffmpeg, so it's skipped there and runs where ffmpeg exists.
 const HAS_FFMPEG = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0;
+const HAS_FFPROBE = spawnSync("ffprobe", ["-version"], { stdio: "ignore" }).status === 0;
 // The core-conformance test imports core's TypeScript via tsx. The dependency-free
 // "Test: skills" CI job has neither tsx nor installed deps, so skip it there; it
 // runs wherever the workspace is installed (locally, the main Test job).
@@ -142,6 +143,37 @@ test("bundled SFX resolve without HeyGen on PATH", () => {
   assert.equal(parsed.provenance.provider, "bundled.sfx");
   assert.match(parsed.advisory?.message ?? "", /Install: curl -fsSL/);
   assert.ok(existsSync(join(tmp, parsed.path)));
+  cleanup();
+});
+
+test("bundled SFX resolve ends exactly at the frozen media boundary", () => {
+  if (!HAS_FFPROBE) return;
+  setup();
+  const result = spawnResolve([
+    "--type",
+    "sfx",
+    "--intent",
+    "whoosh",
+    "--project",
+    tmp,
+    "--local-only",
+    "--provider",
+    "bundled.sfx",
+    "--json",
+  ]);
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  const frozenPath = join(tmp, parsed.path);
+  const actual = Number(
+    execFileSync(
+      "ffprobe",
+      ["-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", frozenPath],
+      { encoding: "utf8" },
+    ).trim(),
+  );
+
+  assert.equal(parsed.duration, actual);
+  assert.equal(0 + parsed.duration, actual, "the following clip may start at the media boundary");
   cleanup();
 });
 


### PR DESCRIPTION
## Summary
- preserve exact bundled SFX durations when freezing media-use resolver records
- align every bundled SFX manifest duration with the frozen MP3 reported by ffprobe
- enforce full manifest-to-library coverage and exact duration integrity
- regress the real resolve boundary so a following audio clip can start at the frozen file endpoint

## Root cause
The bundled manifest stored rounded durations, and the generic resolver rounded provider metadata again to tenths of a second. A 0.574688-second frozen effect was therefore recorded as 0.6 seconds, creating a false same-track overlap when the next clip began at the actual media boundary.

## TDD evidence
The new tests were run against the previous implementation first:
- manifest integrity failed at `chime.mp3`: `2.5 !== 2.544`
- bundled resolve boundary failed: `0.6 !== 0.574688`

## Verification
- `bun run test:skills` — 247 passed
- `node --test skills/media-use/scripts/lib/bundled-sfx-provider.test.mjs` — 2 passed
- `node skills/media-use/scripts/resolve.test.mjs` — 37 passed
- `bun run lint:skills` — 20 skill files clean
- `bunx oxfmt --check` on all changed media-use files
- `git diff --check`

Human review required; do not self-merge.