### PR TITLE
test(engine): make FFmpeg path assertion cross-platform

### DIFF
--- a/packages/engine/src/utils/runFfmpeg.test.ts
+++ b/packages/engine/src/utils/runFfmpeg.test.ts
@@ -70,7 +70,7 @@ describe("formatFfmpegError", () => {
       const message = formatFfmpegError(exitCode, "");
 
       expect(message).toContain("0xC0000135 (STATUS_DLL_NOT_FOUND)");
-      expect(message).toContain("/tools/ffmpeg.exe");
+      expect(message).toContain(resolve("/tools/ffmpeg.exe"));
       expect(message).toContain("working 64-bit Windows FFmpeg build");
     },
   );


### PR DESCRIPTION
## Summary

PR #2430 merged before Windows render verification completed. Its new FFmpeg diagnostic test expected the POSIX path `/tools/ffmpeg.exe`, while the Windows runner correctly rendered `D:\tools\ffmpeg.exe`, causing both DLL-not-found exit-code cases to fail. The assertion now compares against Node's platform-resolved path; production behavior is unchanged.

## Test plan

- `bun run --cwd packages/engine test -- src/utils/runFfmpeg.test.ts`
- `bunx oxfmt --check packages/engine/src/utils/runFfmpeg.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
