### PR TITLE
fix(cli): preserve snapshot times and clarify occlusion opt-out

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -1000,7 +1000,7 @@
       rect: textRect,
       coveredFraction,
       fixHint:
-        "Give the text its own zone, raise its stacking order above the covering element, or mark intentional layering with data-layout-allow-occlusion.",
+        "Give the text its own zone or raise its stacking order above the covering element. Add data-layout-allow-occlusion to the covered text or one of its ancestors, not the covering element, when the occlusion is intentional.",
     };
   }
 

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -1325,7 +1325,13 @@ describe("layout-audit.browser occlusion", () => {
 
   it("still treats opaque pixels in an image as text occlusion", () => {
     const occluded = auditImageOcclusionScene(255).find((issue) => issue.code === "text_occluded");
-    expect(occluded).toMatchObject({ selector: "#headline", containerSelector: "#overlay" });
+    expect(occluded).toMatchObject({
+      selector: "#headline",
+      containerSelector: "#overlay",
+      fixHint: expect.stringContaining(
+        "Add data-layout-allow-occlusion to the covered text or one of its ancestors, not the covering element",
+      ),
+    });
   });
 
   it("does not treat object-fit letterboxing as image occlusion", () => {

--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import {
   computeSnapshotTimes,
+  parseSnapshotAtTimestamps,
   parseZoomScale,
   requireSnapshotFfmpeg,
   tailFrameTime,
@@ -86,6 +87,34 @@ describe("computeSnapshotTimes (FINDING [7]: tail is always captured)", () => {
       includeEnd: false,
     });
     expect(times).toEqual([exactTransition]);
+  });
+});
+
+describe("parseSnapshotAtTimestamps", () => {
+  it("preserves every repeated --at value", () => {
+    expect(
+      parseSnapshotAtTimestamps("0.8", [
+        "node",
+        "hyperframes",
+        "snapshot",
+        "--at",
+        "0.2",
+        "--at",
+        "0.8",
+      ]),
+    ).toEqual([0.2, 0.8]);
+  });
+
+  it("flattens comma-separated timestamps mixed with repeated --at flags", () => {
+    expect(
+      parseSnapshotAtTimestamps("0.8,1.0", ["snapshot", "--at=0.2,0.4", "--at", "0.8,1.0"]),
+    ).toEqual([0.2, 0.4, 0.8, 1]);
+  });
+
+  it("keeps the existing comma-only behavior", () => {
+    expect(parseSnapshotAtTimestamps("0.2,0.8", ["snapshot", "--at", "0.2,0.8"])).toEqual([
+      0.2, 0.8,
+    ]);
   });
 });
 

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -130,6 +130,38 @@ export function parseZoomScale(value: unknown): number {
 }
 
 /**
+ * Preserve every raw `--at` occurrence before citty collapses repeated string
+ * flags to the final value. Each occurrence may still contain the documented
+ * comma-separated form.
+ */
+export function parseSnapshotAtTimestamps(
+  parsedAt: unknown,
+  argv: readonly string[],
+): number[] | undefined {
+  const rawValues: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--at") {
+      const value = argv[index + 1];
+      if (value !== undefined) {
+        rawValues.push(value);
+        index += 1;
+      }
+    } else if (arg?.startsWith("--at=")) {
+      rawValues.push(arg.slice("--at=".length));
+    }
+  }
+
+  const values = rawValues.length > 0 ? rawValues : parsedAt == null ? [] : [String(parsedAt)];
+  if (values.length === 0) return undefined;
+
+  return values
+    .flatMap((value) => value.split(","))
+    .map((value) => parseFloat(value.trim()))
+    .filter((value) => !isNaN(value));
+}
+
+/**
  * Seeking the timeline to EXACTLY `data-duration` renders blank — the runtime
  * treats t >= clip-end as past-end and unmounts the clip (verified on a V4 3D
  * artifact: t=8.0 of an 8s clip was pure white, t=7.76 showed the final hero).
@@ -529,7 +561,8 @@ export default defineCommand({
     },
     at: {
       type: "string",
-      description: "Comma-separated timestamps in seconds (e.g., --at 3.0,10.5,18.0)",
+      description:
+        "Timestamps in seconds; repeat --at or use commas (e.g., --at 3.0 --at 10.5,18.0)",
     },
     timeout: {
       type: "string",
@@ -567,12 +600,7 @@ export default defineCommand({
     const project = resolveProject(args.dir);
     const frames = parseInt(args.frames as string, 10) || 5;
     const timeout = parseInt(args.timeout as string, 10) || 5000;
-    const atTimestamps = args.at
-      ? String(args.at)
-          .split(",")
-          .map((s) => parseFloat(s.trim()))
-          .filter((n) => !isNaN(n))
-      : undefined;
+    const atTimestamps = parseSnapshotAtTimestamps(args.at, process.argv);
     // Gemini frame analysis runs by default (silently skipped if
     // GEMINI_API_KEY is not set). `--describe "custom question"` overrides
     // the default prompt with a targeted question. `--describe false` opts

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 99
     },
     "hyperframes-cli": {
-      "hash": "5e1e197baf9b6653",
+      "hash": "9679c27a66180aeb",
       "files": 8
     },
     "hyperframes-core": {

--- a/skills/hyperframes-cli/references/lint-validate-inspect.md
+++ b/skills/hyperframes-cli/references/lint-validate-inspect.md
@@ -62,7 +62,7 @@ Every finding carries a selector, the element's `data-*` identity, the compositi
 
 - `data-layout-allow-overflow` — overflow is intentional (entrance/exit travel).
 - `data-layout-allow-overlap` — deliberate text layering (e.g. a demo cursor label over a heading).
-- `data-layout-allow-occlusion` — an element is meant to cover text.
+- `data-layout-allow-occlusion` — place on covered text (or one of its ancestors) when the occlusion is intentional; do not place it on the covering element.
 - `data-layout-ignore` — decorative element that should never be audited.
 
 **Opt-in pipeline gates** (used by orchestrators; off by default):


### PR DESCRIPTION
## Summary

Repeated `snapshot --at` flags previously discarded every timestamp except the last one. Repeated flags, comma-separated lists, and mixed forms now combine in order so every requested frame is captured.

`text_occluded` also suggested the intentional-occlusion opt-out without identifying its target, while the skill reference implied it belonged on the covering element. Both now state that `data-layout-allow-occlusion` belongs on the covered text or one of its ancestors, never the covering element.

## Test plan

- `bun run --cwd packages/cli test` — 1,750 passed, 2 skipped
- `bun run --cwd packages/cli typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- Built CLI: `snapshot ... --at 0.2 --at 0.8 --no-end` captured both requested PNGs

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
