### PR TITLE
fix(cli): make skills update work with npm 11

### DIFF
--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -124,6 +124,8 @@ const GLOBAL_ARGS_TAIL = [
   "--yes",
 ] as const;
 
+const SKILLS_NPX_ARGS = ["--yes", "--package=skills", "skills"] as const;
+
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", {
     value: platform,
@@ -213,7 +215,7 @@ describe("hyperframes skills", () => {
       "npx",
       ["--version"],
       [
-        "skills",
+        ...SKILLS_NPX_ARGS,
         "add",
         "https://github.com/heygen-com/hyperframes",
         "--skill",
@@ -226,7 +228,7 @@ describe("hyperframes skills", () => {
       "npx",
       ["--version"],
       [
-        "skills",
+        ...SKILLS_NPX_ARGS,
         "add",
         "https://github.com/heygen-com/hyperframes",
         "--skill",
@@ -243,7 +245,7 @@ describe("hyperframes skills", () => {
         "/s",
         "/c",
         "npx.cmd",
-        "skills",
+        ...SKILLS_NPX_ARGS,
         "add",
         "https://github.com/heygen-com/hyperframes",
         "--skill",
@@ -355,9 +357,13 @@ describe("hyperframes skills", () => {
     expect(state.spawnCalls[0]?.args).toContain("add");
     const removeCall = state.spawnCalls.find((s) => s.args.includes("remove"));
     expect(removeCall, "expected a `skills remove` spawn").toBeDefined();
-    expect(removeCall!.args).toContain("graphic-overlays");
-    expect(removeCall!.args).toContain("--yes");
-    expect(removeCall!.args).toContain("-g"); // attributed from the global lock → remove globally
+    expect(removeCall!.args).toEqual([
+      ...SKILLS_NPX_ARGS,
+      "remove",
+      "graphic-overlays",
+      "-g", // attributed from the global lock → remove globally
+      "--yes",
+    ]);
     expect(process.exitCode).toBe(0);
   });
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -109,6 +109,10 @@ const GLOBAL_INSTALL_ARGS_TAIL = [
   "--yes",
 ];
 
+// npm 11 does not reliably infer/install a package from `npx <bin> ...`.
+// Select the package explicitly so both add and remove resolve the skills CLI.
+const SKILLS_NPX_ARGS = ["--yes", "--package=skills", "skills"];
+
 /** All skills, or an explicit list of skill names to install. */
 type SkillSelection = "*" | readonly string[];
 
@@ -125,7 +129,13 @@ function runSkillsAdd(
   opts: { cwd?: string } = {},
 ): Promise<void> {
   return spawnNpx(
-    ["skills", "add", source, ...skillSelectionArgs(selection), ...GLOBAL_INSTALL_ARGS_TAIL],
+    [
+      ...SKILLS_NPX_ARGS,
+      "add",
+      source,
+      ...skillSelectionArgs(selection),
+      ...GLOBAL_INSTALL_ARGS_TAIL,
+    ],
     opts,
   );
 }
@@ -148,7 +158,7 @@ function runSkillsRemove(names: string[], opts: { global: boolean }): Promise<vo
   // lock entry non-interactively. `-g` targets the global install; without it,
   // the project (cwd) install — we pass whichever scope detection attributed
   // these names from, so we never reach into a scope we didn't inspect.
-  return spawnNpx(["skills", "remove", ...safe, ...(opts.global ? ["-g"] : []), "--yes"]);
+  return spawnNpx([...SKILLS_NPX_ARGS, "remove", ...safe, ...(opts.global ? ["-g"] : []), "--yes"]);
 }
 
 // Use the full GitHub URL (not the `owner/repo` slug) as the clone source. The


### PR DESCRIPTION
## Summary

`hyperframes skills update` can install and remove skills again under npm 11. npm 11 no longer reliably infers the package behind nested `npx skills` calls, which previously ended with `skills: not found`; explicitly selecting the `skills` package preserves the existing command behavior across Linux, macOS, and Windows.

## Test plan

- `bun run --cwd packages/cli test src/commands/skills.test.ts` — 33 passed
- `bun run --cwd packages/cli test` — 1,747 passed, 2 skipped
- `bun run --cwd packages/cli typecheck`
- `bun run build`
- Isolated Node 26.5.0 / npm 11.18.0 smoke: built CLI installed `general-video` plus its core skills and exited 0

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
