### PR TITLE
fix(engine): honor explicit render worker counts

### DIFF
--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -76,6 +76,17 @@ describe("calculateOptimalWorkers", () => {
 
     expect(workers).toBe(4);
   });
+
+  it.each([12, 16])(
+    "honors an explicit %i-worker request above the auto safe maximum",
+    (requested) => {
+      expect(calculateOptimalWorkers(900, requested, { concurrency: "auto" })).toBe(requested);
+    },
+  );
+
+  it("caps explicit worker requests at the documented 24-worker ceiling", () => {
+    expect(calculateOptimalWorkers(900, 25, { concurrency: "auto" })).toBe(24);
+  });
 });
 
 describe("shouldDisableBrowserPoolForParallelWorker", () => {

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -160,6 +160,10 @@ export function calculateOptimalWorkers(
   requested?: number,
   config?: WorkerSizingConfig,
 ): number {
+  if (requested !== undefined) {
+    return Math.max(MIN_WORKERS, Math.min(ABSOLUTE_MAX_WORKERS, requested));
+  }
+
   // Resolve effective values: config overrides → DEFAULT_CONFIG fallback.
   const effectiveMaxWorkers = (() => {
     const concurrency = config?.concurrency ?? DEFAULT_CONFIG.concurrency;
@@ -173,10 +177,6 @@ export function calculateOptimalWorkers(
   const effectiveLargeRenderThreshold =
     config?.largeRenderThreshold ?? DEFAULT_CONFIG.largeRenderThreshold;
   const captureCostMultiplier = Math.max(1, config?.captureCostMultiplier ?? 1);
-
-  if (requested !== undefined) {
-    return Math.max(MIN_WORKERS, Math.min(effectiveMaxWorkers, requested));
-  }
 
   if (totalFrames < MIN_FRAMES_PER_WORKER * 2) return 1;
 


### PR DESCRIPTION
## Summary
- keep automatic worker sizing under the host-safe cap
- honor explicit worker requests independently up to the existing 24-worker ceiling
- cover explicit 12/16 requests and requests above the ceiling

## Test plan
- `bun run --cwd packages/engine test src/services/parallelCoordinator.test.ts`
- `bunx vitest run src/services/renderOrchestrator.test.ts` from `packages/producer`
- `bun run --cwd packages/cli test src/commands/render.test.ts`
- `bun run --cwd packages/engine typecheck`
- `bun run --cwd packages/producer typecheck`
- `bun run --cwd packages/cli typecheck`
- changed-file lint and format checks
