### PR TITLE
fix(cli): sample motion assertion deadlines

### DIFF
--- a/packages/cli/src/commands/layout.ts
+++ b/packages/cli/src/commands/layout.ts
@@ -26,7 +26,12 @@ import {
   evaluateMotion,
   type MotionFrame,
 } from "../utils/motionAudit.js";
-import { findMotionSpec, readMotionSpec, type MotionSpec } from "../utils/motionSpec.js";
+import {
+  buildMotionSampleTimes,
+  findMotionSpec,
+  readMotionSpec,
+  type MotionSpec,
+} from "../utils/motionSpec.js";
 import {
   AUDIT_SEEK_OPTIONS,
   installPageFunctionGuard,
@@ -40,9 +45,6 @@ const __dirname = dirname(__filename);
 const LAYOUT_SEEK_OPTIONS: SeekCompositionTimelineOptions = AUDIT_SEEK_OPTIONS;
 // All new envelope fields are optional (?); additive changes don't bump this.
 const INSPECT_SCHEMA_VERSION = 1;
-// Motion verification (#1437): dense sampling grid for the seeked-timeline checks.
-const MOTION_FPS = 20;
-const MOTION_MAX_SAMPLES = 300;
 
 export const examples: Example[] = [
   ["Inspect visual layout across the current composition", "hyperframes layout"],
@@ -66,13 +68,6 @@ interface LayoutAuditResult {
   transitionSamplesDropped: number;
   rawIssues: LayoutIssue[];
   motionSamples: number;
-}
-
-function buildMotionSampleTimes(duration: number): number[] {
-  if (!Number.isFinite(duration) || duration <= 0) return [];
-  const count = Math.min(MOTION_MAX_SAMPLES, Math.max(2, Math.ceil(duration * MOTION_FPS) + 1));
-  const step = duration / (count - 1);
-  return Array.from({ length: count }, (_, index) => Math.round(index * step * 1000) / 1000);
 }
 
 async function getCompositionDuration(page: import("puppeteer-core").Page): Promise<number> {
@@ -367,7 +362,7 @@ async function runMotionPass(
   spec: MotionSpec,
   duration: number,
 ): Promise<{ issues: LayoutIssue[]; sampleCount: number }> {
-  const times = buildMotionSampleTimes(spec.duration ?? duration);
+  const times = buildMotionSampleTimes(spec.duration ?? duration, spec.assertions);
   if (times.length === 0) return { issues: [], sampleCount: 0 };
 
   const { selectors, livenessScopes } = collectSamplingTargets(spec.assertions);

--- a/packages/cli/src/utils/checkPipeline.ts
+++ b/packages/cli/src/utils/checkPipeline.ts
@@ -20,7 +20,7 @@ import {
   type Canvas,
   type MotionFrame,
 } from "./motionAudit.js";
-import { findMotionSpec, readMotionSpec } from "./motionSpec.js";
+import { buildMotionSampleTimes, findMotionSpec, readMotionSpec } from "./motionSpec.js";
 import { normalizeErrorMessage } from "./errorMessage.js";
 import {
   parseColorRGBA,
@@ -65,8 +65,6 @@ export type {
   MotionSpecResolution,
 } from "./checkTypes.js";
 
-const MOTION_FPS = 20;
-const MOTION_MAX_SAMPLES = 300;
 const ZERO_BBOX: CheckBbox = { x: 0, y: 0, width: 0, height: 0 };
 // Ignore normal in/out slide travel; only substantive frame breaches are actionable.
 const FRAME_BREACH_FLOOR_PX = 120;
@@ -91,13 +89,6 @@ export function selectContrastTimes(grid: number[]): number[] {
     const selected = Math.floor((index * (grid.length - 1)) / 4);
     return grid[selected] ?? grid[0] ?? 0;
   });
-}
-
-function buildMotionSampleTimes(duration: number): number[] {
-  if (!Number.isFinite(duration) || duration <= 0) return [];
-  const count = Math.min(MOTION_MAX_SAMPLES, Math.max(2, Math.ceil(duration * MOTION_FPS) + 1));
-  const step = duration / (count - 1);
-  return Array.from({ length: count }, (_, index) => Math.round(index * step * 1000) / 1000);
 }
 
 interface SampleGrid {
@@ -177,7 +168,9 @@ async function planMotionSampling(
   const targets = collectSamplingTargets(motion.spec.assertions);
   const preflightIssues = await driver.findAmbiguousSelectors(targets.selectors);
   const times =
-    preflightIssues.length === 0 ? buildMotionSampleTimes(motion.spec.duration ?? duration) : [];
+    preflightIssues.length === 0
+      ? buildMotionSampleTimes(motion.spec.duration ?? duration, motion.spec.assertions)
+      : [];
   return { times, ...targets, preflightIssues };
 }
 

--- a/packages/cli/src/utils/motionSpec.test.ts
+++ b/packages/cli/src/utils/motionSpec.test.ts
@@ -2,7 +2,13 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { findMotionSpec, parseMotionSpec, readMotionSpec, type MotionSpec } from "./motionSpec.js";
+import {
+  buildMotionSampleTimes,
+  findMotionSpec,
+  parseMotionSpec,
+  readMotionSpec,
+  type MotionSpec,
+} from "./motionSpec.js";
 
 const RFC_SPEC = {
   duration: 6,
@@ -20,6 +26,14 @@ function expectOk(result: ReturnType<typeof parseMotionSpec>): MotionSpec {
 }
 
 describe("parseMotionSpec", () => {
+  it("samples an appearsBy deadline exactly when the uniform grid skips it", () => {
+    const assertions: MotionSpec["assertions"] = [
+      { kind: "appearsBy", selector: "#headline", bySec: 0.5 },
+    ];
+
+    expect(buildMotionSampleTimes(15, assertions)).toContain(0.5);
+  });
+
   it("parses the RFC four-assertion spec", () => {
     const spec = expectOk(parseMotionSpec(RFC_SPEC));
     expect(spec.duration).toBe(6);

--- a/packages/cli/src/utils/motionSpec.ts
+++ b/packages/cli/src/utils/motionSpec.ts
@@ -18,6 +18,24 @@ export interface MotionSpec {
   assertions: MotionAssertion[];
 }
 
+const MOTION_FPS = 20;
+const MOTION_MAX_SAMPLES = 300;
+
+export function buildMotionSampleTimes(
+  duration: number,
+  assertions: MotionAssertion[] = [],
+): number[] {
+  if (!Number.isFinite(duration) || duration <= 0) return [];
+  const count = Math.min(MOTION_MAX_SAMPLES, Math.max(2, Math.ceil(duration * MOTION_FPS) + 1));
+  const step = duration / (count - 1);
+  const grid = Array.from({ length: count }, (_, index) => Math.round(index * step * 1000) / 1000);
+  const deadlines = assertions.flatMap((assertion) => {
+    if (assertion.kind !== "appearsBy") return [];
+    return assertion.bySec <= duration ? [assertion.bySec] : [];
+  });
+  return [...new Set([...grid, ...deadlines])].sort((a, b) => a - b);
+}
+
 export type MotionSpecParse = { ok: true; spec: MotionSpec } | { ok: false; errors: string[] };
 
 function isObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- include exact `appearsBy` deadlines in motion sampling
- share the sampling helper between `check` and deprecated `layout` paths
- preserve the bounded uniform grid and add regression coverage

## Testing
- `bunx vitest run packages/cli/src/utils/motionSpec.test.ts packages/cli/src/utils/motionAudit.test.ts packages/cli/src/commands/check.test.ts packages/cli/src/commands/layout.test.ts` (77 passed)
- `bunx oxlint` on changed files
- `bunx oxfmt --check` on changed files
- `git diff --check`
- pre-commit typecheck and tracked-artifact checks passed