### PR TITLE
fix(check): resolve color-mix() colors in contrast audit instead of false-failing

### DIFF
--- a/packages/cli/src/commands/contrast-audit.browser.js
+++ b/packages/cli/src/commands/contrast-audit.browser.js
@@ -58,28 +58,29 @@ window.__contrastAuditPrepare = function () {
   }
 
   function parseColor(c) {
-    var m = c.match(/rgba?\(([^)]+)\)/);
-    if (!m) return [0, 0, 0, 1];
-    var p = m[1].split(",").map(function (s) {
-      return parseFloat(s.trim());
-    });
-    return [p[0], p[1], p[2], p[3] != null ? p[3] : 1];
-  }
-
-  // Like parseColor, but returns null instead of defaulting to black when the
-  // value isn't a solid rgb()/rgba() color — e.g. SVG paint keywords such as
-  // "none"/"context-fill", or a gradient/pattern reference like
-  // 'url("#grad")'. Callers should fall back to another source of truth
-  // rather than trust a fabricated black.
-  function tryParseSolidColor(c) {
-    var m = c.match(/rgba?\(([^)]+)\)/);
-    if (!m) return null;
+    var m = (c || "").match(/^rgba?\(([^)]+)\)$/i);
+    if (!m) {
+      var mix = (c || "").match(
+        /^color-mix\(\s*in\s+srgb\s*,\s*(rgba?\([^)]+\))\s+(\d+(?:\.\d+)?|\.\d+)%\s*,\s*(rgba?\([^)]+\))\s+(\d+(?:\.\d+)?|\.\d+)%\s*\)$/i,
+      );
+      if (!mix) return null;
+      var first = parseColor(mix[1]);
+      var second = parseColor(mix[3]);
+      var firstWeight = parseFloat(mix[2]);
+      var secondWeight = parseFloat(mix[4]);
+      var weightTotal = firstWeight + secondWeight;
+      if (!first || !second || !isFinite(weightTotal) || weightTotal <= 0) return null;
+      return first.map(function (channel, index) {
+        return (channel * firstWeight + second[index] * secondWeight) / weightTotal;
+      });
+    }
     var p = m[1].split(",").map(function (s) {
       return parseFloat(s.trim());
     });
     if (
+      (p.length !== 3 && p.length !== 4) ||
       p.some(function (v) {
-        return isNaN(v);
+        return !isFinite(v);
       })
     )
       return null;
@@ -218,10 +219,11 @@ window.__contrastAuditPrepare = function () {
     // `color` rather than crashing parseColor or reporting a fabricated
     // black.
     var isSvgText = isSvgTextElement(el);
-    var fg = isSvgText ? tryParseSolidColor(cs.fill) || parseColor(cs.color) : parseColor(cs.color);
+    var fg = isSvgText ? parseColor(cs.fill) || parseColor(cs.color) : parseColor(cs.color);
+    if (!fg) continue;
     if (fg[3] <= 0.01) continue;
     var strokeWidth = parseFloat(cs.webkitTextStrokeWidth || "0");
-    var stroke = strokeWidth > 0 ? tryParseSolidColor(cs.webkitTextStrokeColor || "") : null;
+    var stroke = strokeWidth > 0 ? parseColor(cs.webkitTextStrokeColor || "") : null;
     if (stroke && stroke[3] <= 0.01) stroke = null;
 
     var fontSize = parseFloat(cs.fontSize);

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -1133,6 +1133,50 @@ describe("contrast-audit.browser background sampling", () => {
     expect(result[0]).toMatchObject({ selector: "#label", wcagAA: true, bg: "rgb(10,10,10)" });
   });
 
+  it("resolves color-mix() foregrounds before computing contrast", async () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <span id="label">Mixed color</span>
+      </div>
+    `;
+
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          display: "block",
+          visibility: "visible",
+          opacity: "1",
+          color: "color-mix(in srgb, rgb(37, 99, 235) 20%, rgb(255, 255, 255) 80%)",
+          fontSize: "20px",
+          fontWeight: "400",
+          clipPath: "none",
+        }) as unknown as CSSStyleDeclaration,
+    );
+    vi.spyOn(document.getElementById("label")!, "getBoundingClientRect").mockReturnValue(
+      rect({ left: 50, top: 50, width: 120, height: 30 }),
+    );
+    (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint = () =>
+      null;
+
+    installContrastScript(
+      pixelsWithRegion(
+        rect({ left: 0, top: 0, width: 640, height: 360 }),
+        [10, 10, 10],
+        [10, 10, 10],
+      ),
+    );
+
+    const result = await runContrastAudit();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      selector: "#label",
+      fg: "rgb(211,224,251)",
+      bg: "rgb(10,10,10)",
+      ratio: 14.92,
+      wcagAA: true,
+    });
+  });
+
   it("accepts outlined text when its stroke has adequate background contrast", async () => {
     document.body.innerHTML = `
       <div id="root" data-composition-id="main" data-width="640" data-height="360">


### PR DESCRIPTION
## What

The browser contrast audit in `hyperframes check` now resolves CSS `color-mix(in srgb, ...)` colors before computing WCAG contrast ratios, and skips elements whose colors it cannot resolve instead of reporting a fabricated ratio.

## Why

Any composition using `color-mix()` in a text or SVG color false-fails the contrast gate today: the parser only recognizes `rgb()`/`rgba()` strings, so `color-mix()` values fell through to a default black parse, producing a bogus ~1.23:1 ratio regardless of the actual rendered colors. `color-mix()` is increasingly common in tokenized compositions (mixing an accent into a surface), so this false positive blocks legitimate compositions from passing check.

## How

- `parseColor()` in `contrast-audit.browser.js` recognizes `color-mix(in srgb, <color> P1%, <color> P2%)` and linearly interpolates the parsed endpoint channels by their percentages.
- Any color that still cannot be parsed returns `null`, and both call sites (foreground/SVG fill and stroke) skip that element rather than auditing it against a fabricated ratio. The audit never emits a ratio it did not actually compute.
- The duplicate `tryParseSolidColor` helper was folded into the single `parseColor`.

## Test plan

- New regression test in `layout-audit.browser.test.ts`: a `color-mix(in srgb, rgb(37, 99, 235) 20%, rgb(255, 255, 255) 80%)` foreground on a dark background asserts the correct ~14.92:1 ratio. This test fails against the previous parser.
- Full test file passes: 65/65. oxlint and oxfmt clean on both changed files.