### PR TITLE
chore: release v0.7.58

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperframes",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
   "author": {
     "name": "HeyGen",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,39 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.58"
+  description="Released - 2026-07-14"
+  tags={["Release", "Feedback", "Producer", "Pr To Video"]}
+>
+HyperFrames now uses a 0–10 recommendation scale for feedback, keeps canvas z-order actions synchronized with timeline lanes, and makes the core workflow set easier to install from the skills picker. Rendering is more reliable across variable-bound and root-absolute media, explicit worker counts, Windows FFmpeg failures, and final artifact publication, while CLI snapshot, frame, layout, and contrast diagnostics are more consistent.
+
+## Features
+
+- **Feedback:** Adopt 0–10 recommendation scale ([990f5c314](https://github.com/heygen-com/hyperframes/commit/990f5c314513a379ccceef050da31a633101c9d1), [#2438](https://github.com/heygen-com/hyperframes/pull/2438))
+- **Studio:** Mirror canvas z-order actions into timeline lanes (track order = default paint order) ([89db71889](https://github.com/heygen-com/hyperframes/commit/89db7188994b6d808382cb311dd4d3677a89078d), [#2380](https://github.com/heygen-com/hyperframes/pull/2380))
+- **Skills:** Group core skills in the skills add picker ([4a4903b49](https://github.com/heygen-com/hyperframes/commit/4a4903b49a8e1c8cf5ffa91add6c1d9032e79317), [#2412](https://github.com/heygen-com/hyperframes/pull/2412))
+
+## Fixes
+
+- **CLI:** Resolve color-mix() colors in contrast audit instead of false-failing ([6c2513d5c](https://github.com/heygen-com/hyperframes/commit/6c2513d5c80fea57d6686ccddf560e2e8c213afb), [#2445](https://github.com/heygen-com/hyperframes/pull/2445))
+- **Producer:** Probe variable-bound media sources ([d2c8c2d80](https://github.com/heygen-com/hyperframes/commit/d2c8c2d8087814f35a3059069efc8c3a7a91cad8), [#2444](https://github.com/heygen-com/hyperframes/pull/2444))
+- **Pr To Video:** Use display names, not GitHub logins, in credits narration ([4cba58f5a](https://github.com/heygen-com/hyperframes/commit/4cba58f5a3a269b438d88aa9be406f7961c2fa25), [#2385](https://github.com/heygen-com/hyperframes/pull/2385))
+- **Engine:** Honor explicit render worker counts ([e05debe1a](https://github.com/heygen-com/hyperframes/commit/e05debe1afadb802590ee8a58c55f7494a9229f1), [#2439](https://github.com/heygen-com/hyperframes/pull/2439))
+- **Render:** Diagnose unlaunchable Windows FFmpeg ([3d7e26aab](https://github.com/heygen-com/hyperframes/commit/3d7e26aabfa34d1a96cc66b7b59cd646711bf216), [#2430](https://github.com/heygen-com/hyperframes/pull/2430))
+- **Render:** Publish artifacts atomically ([fb0d82350](https://github.com/heygen-com/hyperframes/commit/fb0d8235008632439967117d4e7f798cfb07e592), [#2154](https://github.com/heygen-com/hyperframes/pull/2154))
+- **CLI:** Consolidate snapshot and frame diagnostics ([6933e8acd](https://github.com/heygen-com/hyperframes/commit/6933e8acda57268da9a40e0adf3d99c85059d2b5), [#2402](https://github.com/heygen-com/hyperframes/pull/2402))
+- **CLI:** Consolidate layout and contrast audit correctness ([b98463ae3](https://github.com/heygen-com/hyperframes/commit/b98463ae3ae7e278f410ebcae20ce2c3fc82218b), [#2401](https://github.com/heygen-com/hyperframes/pull/2401))
+- **Engine:** Resolve root-absolute media from project ([6fc92308d](https://github.com/heygen-com/hyperframes/commit/6fc92308d638a75d753cf160f656e7ec3f9066ea), [#2399](https://github.com/heygen-com/hyperframes/pull/2399))
+- **Engine:** Skip unnecessary dimension pad ([0dfc85b68](https://github.com/heygen-com/hyperframes/commit/0dfc85b680aaff20d89dcab4f9d937b8139eb9f5), [#2398](https://github.com/heygen-com/hyperframes/pull/2398))
+
+## Internal
+
+- **Engine:** Make FFmpeg path assertion platform-safe ([d7204ac47](https://github.com/heygen-com/hyperframes/commit/d7204ac47fceff0551de64312ed6affc41892ddc), [#2433](https://github.com/heygen-com/hyperframes/pull/2433))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.57...v0.7.58).
+</Update>
+
+<Update
   label="HyperFrames v0.7.57"
   description="Released - 2026-07-14"
   tags={["Release", "Producer", "Release", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.58.md
+++ b/releases/v0.7.58.md
@@ -1,0 +1,32 @@
+# HyperFrames v0.7.58
+
+Released on 2026-07-14.
+
+HyperFrames now uses a 0–10 recommendation scale for feedback, keeps canvas z-order actions synchronized with timeline lanes, and makes the core workflow set easier to install from the skills picker. Rendering is more reliable across variable-bound and root-absolute media, explicit worker counts, Windows FFmpeg failures, and final artifact publication, while CLI snapshot, frame, layout, and contrast diagnostics are more consistent.
+
+## Features
+
+- **Feedback:** Adopt 0–10 recommendation scale ([990f5c314](https://github.com/heygen-com/hyperframes/commit/990f5c314513a379ccceef050da31a633101c9d1), [#2438](https://github.com/heygen-com/hyperframes/pull/2438))
+- **Studio:** Mirror canvas z-order actions into timeline lanes (track order = default paint order) ([89db71889](https://github.com/heygen-com/hyperframes/commit/89db7188994b6d808382cb311dd4d3677a89078d), [#2380](https://github.com/heygen-com/hyperframes/pull/2380))
+- **Skills:** Group core skills in the skills add picker ([4a4903b49](https://github.com/heygen-com/hyperframes/commit/4a4903b49a8e1c8cf5ffa91add6c1d9032e79317), [#2412](https://github.com/heygen-com/hyperframes/pull/2412))
+
+## Fixes
+
+- **CLI:** Resolve color-mix() colors in contrast audit instead of false-failing ([6c2513d5c](https://github.com/heygen-com/hyperframes/commit/6c2513d5c80fea57d6686ccddf560e2e8c213afb), [#2445](https://github.com/heygen-com/hyperframes/pull/2445))
+- **Producer:** Probe variable-bound media sources ([d2c8c2d80](https://github.com/heygen-com/hyperframes/commit/d2c8c2d8087814f35a3059069efc8c3a7a91cad8), [#2444](https://github.com/heygen-com/hyperframes/pull/2444))
+- **Pr To Video:** Use display names, not GitHub logins, in credits narration ([4cba58f5a](https://github.com/heygen-com/hyperframes/commit/4cba58f5a3a269b438d88aa9be406f7961c2fa25), [#2385](https://github.com/heygen-com/hyperframes/pull/2385))
+- **Engine:** Honor explicit render worker counts ([e05debe1a](https://github.com/heygen-com/hyperframes/commit/e05debe1afadb802590ee8a58c55f7494a9229f1), [#2439](https://github.com/heygen-com/hyperframes/pull/2439))
+- **Render:** Diagnose unlaunchable Windows FFmpeg ([3d7e26aab](https://github.com/heygen-com/hyperframes/commit/3d7e26aabfa34d1a96cc66b7b59cd646711bf216), [#2430](https://github.com/heygen-com/hyperframes/pull/2430))
+- **Render:** Publish artifacts atomically ([fb0d82350](https://github.com/heygen-com/hyperframes/commit/fb0d8235008632439967117d4e7f798cfb07e592), [#2154](https://github.com/heygen-com/hyperframes/pull/2154))
+- **CLI:** Consolidate snapshot and frame diagnostics ([6933e8acd](https://github.com/heygen-com/hyperframes/commit/6933e8acda57268da9a40e0adf3d99c85059d2b5), [#2402](https://github.com/heygen-com/hyperframes/pull/2402))
+- **CLI:** Consolidate layout and contrast audit correctness ([b98463ae3](https://github.com/heygen-com/hyperframes/commit/b98463ae3ae7e278f410ebcae20ce2c3fc82218b), [#2401](https://github.com/heygen-com/hyperframes/pull/2401))
+- **Engine:** Resolve root-absolute media from project ([6fc92308d](https://github.com/heygen-com/hyperframes/commit/6fc92308d638a75d753cf160f656e7ec3f9066ea), [#2399](https://github.com/heygen-com/hyperframes/pull/2399))
+- **Engine:** Skip unnecessary dimension pad ([0dfc85b68](https://github.com/heygen-com/hyperframes/commit/0dfc85b680aaff20d89dcab4f9d937b8139eb9f5), [#2398](https://github.com/heygen-com/hyperframes/pull/2398))
+
+## Internal
+
+- **Engine:** Make FFmpeg path assertion platform-safe ([d7204ac47](https://github.com/heygen-com/hyperframes/commit/d7204ac47fceff0551de64312ed6affc41892ddc), [#2433](https://github.com/heygen-com/hyperframes/pull/2433))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.57...v0.7.58


### PR DESCRIPTION
## Summary

- publish HyperFrames v0.7.58 as the next stable release
- include the 0–10 feedback scale, timeline z-order synchronization, core-skills marketplace grouping, and rendering/CLI reliability fixes
- bump all public packages and plugin manifests to 0.7.58
- add reviewed GitHub and docs changelog entries

## Release process

Merging this release PR triggers the canonical publish workflow, which validates the stable channel, builds and verifies packed manifests, publishes npm packages under the latest dist-tag, tags the merge commit, and creates the GitHub release.

## Verification

- bun run test:scripts
- bun run build
- bun run verify:packed-manifests
- bun --cwd packages/cli test src/utils/submitFeedback.test.ts src/telemetry/events.test.ts (41 passed)
- VERSION=0.7.58 DIST_TAG=latest EVENT_NAME=pull_request PR_HEAD_REF=release/v0.7.58 bun run validate:release-channel

Full changelog: https://github.com/heygen-com/hyperframes/compare/v0.7.57...release/v0.7.58