### PR TITLE
fix(cli): keep snapshot fonts aligned with render

### DIFF
--- a/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.test.ts
@@ -1,7 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const producerMocks = vi.hoisted(() => ({
+  loadProducer: vi.fn(async () => ({
+    injectDeterministicFontFaces: async (html: string) => `${html}<!--bundled-producer-->`,
+  })),
+}));
+
 vi.mock("@hyperframes/core/compiler", () => ({
   bundleToSingleHtml: vi.fn(async () => "<html><body>bundled</body></html>"),
+}));
+
+vi.mock("./producer.js", () => ({
+  loadProducer: producerMocks.loadProducer,
 }));
 
 import {
@@ -31,6 +41,12 @@ describe("bundleWithLocalizedFonts (call-site integration)", () => {
 });
 
 describe("localizeWithProducer", () => {
+  it("loads the injector through the producer module bundled with the CLI", async () => {
+    const out = await localizeWithProducer("<html></html>");
+    expect(producerMocks.loadProducer).toHaveBeenCalledOnce();
+    expect(out).toBe("<html></html><!--bundled-producer-->");
+  });
+
   it("embeds fonts when the injector is available", async () => {
     const inject = vi.fn(async (html: string) => `${html}<!--fonts-->`);
     const warn = vi.fn();

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.ts
@@ -29,14 +29,11 @@ export async function bundleWithLocalizedFonts(
 type FontInjector = (html: string) => Promise<string>;
 
 /**
- * Load the render pipeline's `injectDeterministicFontFaces`, resolving
- * `@hyperframes/producer` at RUNTIME only. The specifier is kept out of the
- * bundler's/test-runner's static module graph (`@vite-ignore` + a variable
- * specifier) on purpose: the CLI test job builds with `--filter
- * '!@hyperframes/producer'`, so a static `import("@hyperframes/producer")`
- * would fail Vitest's transform-time resolution. At runtime — the built CLI or
- * an installed package — producer is a real dependency and resolves via
- * node_modules.
+ * Load the render pipeline's `injectDeterministicFontFaces` through the CLI's
+ * canonical producer loader. That loader uses a literal dynamic import, which
+ * lets tsup see and inline producer into the published CLI bundle. A variable
+ * bare-package import is invisible to tsup and silently fails after `npm
+ * install`, because producer is intentionally only a workspace devDependency.
  *
  * Returns `null` (not a throw) when the module simply isn't available in this
  * environment, so the caller can treat "producer absent" — a benign, expected
@@ -44,8 +41,8 @@ type FontInjector = (html: string) => Promise<string>;
  */
 async function loadFontInjector(): Promise<FontInjector | null> {
   try {
-    const producerSpecifier = "@hyperframes/producer";
-    const mod = (await import(/* @vite-ignore */ producerSpecifier)) as {
+    const { loadProducer } = await import("./producer.js");
+    const mod = (await loadProducer()) as {
       injectDeterministicFontFaces?: FontInjector;
     };
     return mod.injectDeterministicFontFaces ?? null;


### PR DESCRIPTION
## What

Ensure snapshot/check font localization loads through the producer module that is bundled into the published CLI.

## Why

The prior variable `@hyperframes/producer` import was invisible to tsup and producer is not a runtime dependency. In a packed install it silently returned the unlocalized HTML, so preview/check could measure a host font while render used the deterministic alias (for example Segoe UI rendered with Roboto metrics). This could change line wrapping only in the final video.

Source: https://heygen.slack.com/archives/C0BGC335AQY/p1784060694374839

## How

Reuse the CLI canonical `loadProducer()` bridge, whose literal dynamic import is bundled by tsup. Add a regression test proving the default font-localization path resolves through that bundled bridge.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)

Verification:
- `bun run --cwd packages/cli test` — 1,759 passed, 2 skipped
- `bun run --cwd packages/cli typecheck`
- pre-commit lint, format, fallow, typecheck
- packed CLI tarball built successfully; bundled `dist/cli.js` contains `injectDeterministicFontFaces` and no runtime variable producer import