### PR TITLE
fix(check): ignore registry component templates

### DIFF
--- a/packages/cli/src/utils/lintProject.test.ts
+++ b/packages/cli/src/utils/lintProject.test.ts
@@ -217,6 +217,21 @@ describe("lintProject", () => {
     expect(results).toHaveLength(1);
   });
 
+  it("ignores registry component templates under compositions/components", async () => {
+    const project = makeProject(validHtml());
+    const componentsDir = join(project, "compositions", "components", "unused-widget");
+    mkdirSync(componentsDir, { recursive: true });
+    writeFileSync(
+      join(componentsDir, "template.html"),
+      `<template><div data-duration="1">unused registry template</div></template>`,
+    );
+
+    const { results, totalErrors } = await lintProject(project);
+
+    expect(results.map((result) => result.file)).toEqual(["index.html"]);
+    expect(totalErrors).toBe(0);
+  });
+
   it("ignores non-HTML files in compositions/", async () => {
     const project = makeProject(validHtml(), {
       "captions.html": validHtml("captions"),

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -212,8 +212,13 @@ export async function lintProject(
       const out: string[] = [];
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const relPath = rel ? `${rel}/${entry.name}` : entry.name;
-        if (entry.isDirectory()) out.push(...collectHtmlFiles(join(dir, entry.name), relPath));
-        else if (entry.isFile() && entry.name.endsWith(".html") && !entry.name.startsWith("._")) {
+        if (entry.isDirectory()) {
+          // Registry components are source snippets, not independently mounted
+          // sub-compositions. Linting every installed template here makes an
+          // unused component fail the assembled project check.
+          if (!rel && entry.name === "components") continue;
+          out.push(...collectHtmlFiles(join(dir, entry.name), relPath));
+        } else if (entry.isFile() && entry.name.endsWith(".html") && !entry.name.startsWith("._")) {
           out.push(relPath);
         }
       }


### PR DESCRIPTION
## What

Stop project-wide `hyperframes check` lint discovery from treating installed registry component templates under `compositions/components/` as standalone sub-compositions.

## Why

Unused registry component templates were scanned and could fail an otherwise valid assembled deliverable. Reproduced on CLI 0.7.58: a project with one unused template reported `filesScanned: 2` and emitted composition-root findings from the component file.


## How

- Skip the reserved `compositions/components` source-snippet directory during recursive sub-composition discovery.
- Preserve recursive linting for actual sub-compositions such as `compositions/frames`.
- Add a regression test proving an unused component template is excluded.

## Test plan

- RED: new regression test included `compositions/components/unused-widget/template.html` in lint results.
- GREEN: targeted regression test passes.
- `bun test packages/cli/src/utils/lintProject.test.ts` — 76 passed.
- `bunx oxlint packages/lint/src/project.ts packages/cli/src/utils/lintProject.test.ts` — clean.
- `bunx oxfmt --check ...` — clean.
- `bun run --filter @hyperframes/lint typecheck` — pass.
- `bun run --filter @hyperframes/cli typecheck` — pass after generating the normal runtime-inline artifact.
- Pre-commit lint/format/typecheck/tracked-artifact hooks — pass.