### PR TITLE
fix(registry): remove invalid media from caption components

### DIFF
--- a/packages/cli/src/registry/registryComponents.test.ts
+++ b/packages/cli/src/registry/registryComponents.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { lintHyperframeHtml } from "@hyperframes/lint";
@@ -13,28 +13,57 @@ interface RegistryManifest {
   files: Array<{ path: string; type: string }>;
 }
 
+async function invalidInstallableMedia(entryName: string): Promise<string[]> {
+  const itemDir = join(componentsDir, entryName);
+  const manifest = JSON.parse(
+    readFileSync(join(itemDir, "registry-item.json"), "utf8"),
+  ) as RegistryManifest;
+  const invalidMedia: string[] = [];
+
+  for (const file of manifest.files) {
+    if (file.type !== "hyperframes:snippet" || !file.path.endsWith(".html")) continue;
+    const result = await lintHyperframeHtml(readFileSync(join(itemDir, file.path), "utf8"), {
+      isSubComposition: true,
+    });
+    for (const finding of result.findings) {
+      if (finding.code !== "media_in_subcomposition" && finding.code !== "media_missing_src") {
+        continue;
+      }
+      invalidMedia.push(`${entryName}/${file.path}: ${finding.code}`);
+    }
+  }
+
+  return invalidMedia;
+}
+
+async function invalidDemoMedia(entryName: string): Promise<string[]> {
+  const demoPath = join(componentsDir, entryName, "demo.html");
+  if (!existsSync(demoPath)) return [];
+
+  const result = await lintHyperframeHtml(readFileSync(demoPath, "utf8"));
+  return result.findings
+    .filter((finding) => finding.code === "media_missing_src")
+    .map((finding) => `${entryName}/demo.html: ${finding.code}`);
+}
+
 describe("registry components", () => {
   it("ships installable snippets without invalid nested media", async () => {
     const invalidMedia: string[] = [];
 
     for (const entry of readdirSync(componentsDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
+      invalidMedia.push(...(await invalidInstallableMedia(entry.name)));
+    }
 
-      const itemDir = join(componentsDir, entry.name);
-      const manifest = JSON.parse(
-        readFileSync(join(itemDir, "registry-item.json"), "utf8"),
-      ) as RegistryManifest;
+    expect(invalidMedia).toEqual([]);
+  });
 
-      for (const file of manifest.files) {
-        if (file.type !== "hyperframes:snippet" || !file.path.endsWith(".html")) continue;
-        const result = await lintHyperframeHtml(readFileSync(join(itemDir, file.path), "utf8"));
-        for (const finding of result.findings) {
-          if (finding.code !== "media_in_subcomposition" && finding.code !== "media_missing_src") {
-            continue;
-          }
-          invalidMedia.push(`${entry.name}/${file.path}: ${finding.code}`);
-        }
-      }
+  it("ships demos without source-less media", async () => {
+    const invalidMedia: string[] = [];
+
+    for (const entry of readdirSync(componentsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      invalidMedia.push(...(await invalidDemoMedia(entry.name)));
     }
 
     expect(invalidMedia).toEqual([]);

--- a/packages/cli/src/registry/registryComponents.test.ts
+++ b/packages/cli/src/registry/registryComponents.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { lintHyperframeHtml } from "@hyperframes/lint";
+import { describe, expect, it } from "vitest";
+
+const componentsDir = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../registry/components",
+);
+
+interface RegistryManifest {
+  files: Array<{ path: string; type: string }>;
+}
+
+describe("registry components", () => {
+  it("ships installable snippets without invalid nested media", async () => {
+    const invalidMedia: string[] = [];
+
+    for (const entry of readdirSync(componentsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const itemDir = join(componentsDir, entry.name);
+      const manifest = JSON.parse(
+        readFileSync(join(itemDir, "registry-item.json"), "utf8"),
+      ) as RegistryManifest;
+
+      for (const file of manifest.files) {
+        if (file.type !== "hyperframes:snippet" || !file.path.endsWith(".html")) continue;
+        const result = await lintHyperframeHtml(readFileSync(join(itemDir, file.path), "utf8"));
+        for (const finding of result.findings) {
+          if (finding.code !== "media_in_subcomposition" && finding.code !== "media_missing_src") {
+            continue;
+          }
+          invalidMedia.push(`${entry.name}/${file.path}: ${finding.code}`);
+        }
+      }
+    }
+
+    expect(invalidMedia).toEqual([]);
+  });
+});

--- a/registry/components/caption-clip-wipe/caption-clip-wipe.html
+++ b/registry/components/caption-clip-wipe/caption-clip-wipe.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #wp-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .wp-overlay {
         position: absolute;
         inset: 0;
@@ -92,15 +84,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="wp-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="wp-overlay"></div>
       <div id="wp-container"></div>
     </div>

--- a/registry/components/caption-clip-wipe/demo.html
+++ b/registry/components/caption-clip-wipe/demo.html
@@ -32,14 +32,6 @@
         overflow: hidden;
         background: #0a0a0a;
       }
-      #wp-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .wp-overlay {
         position: absolute;
         inset: 0;
@@ -90,15 +82,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="wp-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="wp-overlay"></div>
       <div id="wp-container"></div>
     </div>

--- a/registry/components/caption-editorial-emphasis/caption-editorial-emphasis.html
+++ b/registry/components/caption-editorial-emphasis/caption-editorial-emphasis.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -132,17 +123,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-editorial-emphasis/demo.html
+++ b/registry/components/caption-editorial-emphasis/demo.html
@@ -36,15 +36,6 @@
         background: #000;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -130,17 +121,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-emoji-pop/caption-emoji-pop.html
+++ b/registry/components/caption-emoji-pop/caption-emoji-pop.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -128,16 +119,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-emoji-pop/demo.html
+++ b/registry/components/caption-emoji-pop/demo.html
@@ -36,15 +36,6 @@
         background: #000000;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -126,16 +117,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-glitch-rgb/caption-glitch-rgb.html
+++ b/registry/components/caption-glitch-rgb/caption-glitch-rgb.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #gl-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .gl-overlay {
         position: absolute;
         inset: 0;
@@ -112,15 +104,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="gl-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="gl-overlay"></div>
       <div class="gl-scanlines"></div>
       <div id="gl-container"></div>

--- a/registry/components/caption-glitch-rgb/demo.html
+++ b/registry/components/caption-glitch-rgb/demo.html
@@ -32,14 +32,6 @@
         overflow: hidden;
         background: #0a0a0a;
       }
-      #gl-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .gl-overlay {
         position: absolute;
         inset: 0;
@@ -110,15 +102,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="gl-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="gl-overlay"></div>
       <div class="gl-scanlines"></div>
       <div id="gl-container"></div>

--- a/registry/components/caption-gradient-fill/caption-gradient-fill.html
+++ b/registry/components/caption-gradient-fill/caption-gradient-fill.html
@@ -80,15 +80,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="gr-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div id="gr-container"></div>
     </div>
 

--- a/registry/components/caption-gradient-fill/demo.html
+++ b/registry/components/caption-gradient-fill/demo.html
@@ -78,15 +78,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="gr-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div id="gr-container"></div>
     </div>
 

--- a/registry/components/caption-kinetic-slam/caption-kinetic-slam.html
+++ b/registry/components/caption-kinetic-slam/caption-kinetic-slam.html
@@ -30,14 +30,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #kt-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .kt-overlay {
         position: absolute;
         inset: 0;
@@ -79,15 +71,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="kt-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="kt-overlay"></div>
       <div id="kt-container"></div>
     </div>

--- a/registry/components/caption-kinetic-slam/demo.html
+++ b/registry/components/caption-kinetic-slam/demo.html
@@ -29,14 +29,6 @@
         overflow: hidden;
         background: #0a0a0a;
       }
-      #kt-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .kt-overlay {
         position: absolute;
         inset: 0;
@@ -77,15 +69,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="kt-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="kt-overlay"></div>
       <div id="kt-container"></div>
     </div>

--- a/registry/components/caption-matrix-decode/caption-matrix-decode.html
+++ b/registry/components/caption-matrix-decode/caption-matrix-decode.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #sc-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .sc-overlay {
         position: absolute;
         inset: 0;
@@ -100,15 +92,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="sc-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="sc-overlay"></div>
       <div id="sc-container"></div>
     </div>

--- a/registry/components/caption-matrix-decode/demo.html
+++ b/registry/components/caption-matrix-decode/demo.html
@@ -32,14 +32,6 @@
         overflow: hidden;
         background: #000;
       }
-      #sc-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .sc-overlay {
         position: absolute;
         inset: 0;
@@ -98,15 +90,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="sc-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="sc-overlay"></div>
       <div id="sc-container"></div>
     </div>

--- a/registry/components/caption-neon-accent/caption-neon-accent.html
+++ b/registry/components/caption-neon-accent/caption-neon-accent.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -128,16 +119,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-neon-accent/demo.html
+++ b/registry/components/caption-neon-accent/demo.html
@@ -36,15 +36,6 @@
         background: #000000;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -126,16 +117,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-neon-glow/caption-neon-glow.html
+++ b/registry/components/caption-neon-glow/caption-neon-glow.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #ne-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .ne-overlay {
         position: absolute;
         inset: 0;
@@ -91,15 +83,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="ne-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="ne-overlay"></div>
       <div id="ne-container"></div>
     </div>

--- a/registry/components/caption-neon-glow/demo.html
+++ b/registry/components/caption-neon-glow/demo.html
@@ -32,14 +32,6 @@
         overflow: hidden;
         background: #000;
       }
-      #ne-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .ne-overlay {
         position: absolute;
         inset: 0;
@@ -89,15 +81,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="ne-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="ne-overlay"></div>
       <div id="ne-container"></div>
     </div>

--- a/registry/components/caption-parallax-layers/caption-parallax-layers.html
+++ b/registry/components/caption-parallax-layers/caption-parallax-layers.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       /* Behind captions: big red 3D text */
       .behind-caption-layer {
         position: absolute;
@@ -156,17 +147,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="behind-caption-layer" aria-hidden="true">
         <div id="behind-stage" class="behind-safe-zone"></div>
       </div>

--- a/registry/components/caption-parallax-layers/demo.html
+++ b/registry/components/caption-parallax-layers/demo.html
@@ -36,15 +36,6 @@
         background: #000;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       /* Behind captions: big red 3D text */
       .behind-caption-layer {
         position: absolute;
@@ -154,17 +145,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="behind-caption-layer" aria-hidden="true">
         <div id="behind-stage" class="behind-safe-zone"></div>
       </div>

--- a/registry/components/caption-particle-burst/caption-particle-burst.html
+++ b/registry/components/caption-particle-burst/caption-particle-burst.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #bs-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .bs-overlay {
         position: absolute;
         inset: 0;
@@ -102,15 +94,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bs-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="bs-overlay"></div>
       <div id="bs-container"></div>
     </div>

--- a/registry/components/caption-particle-burst/demo.html
+++ b/registry/components/caption-particle-burst/demo.html
@@ -32,14 +32,6 @@
         overflow: hidden;
         background: #0a0a0a;
       }
-      #bs-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .bs-overlay {
         position: absolute;
         inset: 0;
@@ -100,15 +92,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bs-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="bs-overlay"></div>
       <div id="bs-container"></div>
     </div>

--- a/registry/components/caption-pill-karaoke/caption-pill-karaoke.html
+++ b/registry/components/caption-pill-karaoke/caption-pill-karaoke.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -134,16 +125,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-pill-karaoke/demo.html
+++ b/registry/components/caption-pill-karaoke/demo.html
@@ -36,15 +36,6 @@
         background: #000000;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -132,16 +123,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-texture/caption-texture.html
+++ b/registry/components/caption-texture/caption-texture.html
@@ -40,14 +40,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #lv-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .lv-overlay {
         position: absolute;
         inset: 0;
@@ -105,15 +97,6 @@
       data-height="1080"
       data-composition-variables='{"texture":{"type":"string","default":"lava"}}'
     >
-      <video
-        id="lv-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="lv-overlay"></div>
       <div id="lv-container"></div>
     </div>

--- a/registry/components/caption-texture/demo.html
+++ b/registry/components/caption-texture/demo.html
@@ -40,14 +40,6 @@
         overflow: hidden;
         background: #0a0805;
       }
-      #lv-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .lv-overlay {
         position: absolute;
         inset: 0;
@@ -104,15 +96,6 @@
       data-height="1080"
       data-composition-variables='{"texture":{"type":"string","default":"lava"}}'
     >
-      <video
-        id="lv-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="lv-overlay"></div>
       <div id="lv-container"></div>
     </div>

--- a/registry/components/caption-weight-shift/caption-weight-shift.html
+++ b/registry/components/caption-weight-shift/caption-weight-shift.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -120,16 +111,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-weight-shift/demo.html
+++ b/registry/components/caption-weight-shift/demo.html
@@ -36,15 +36,6 @@
         background: #000000;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -118,16 +109,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>


### PR DESCRIPTION
## Summary
- remove demo-only empty video elements and their dead CSS from all 14 affected installable caption components and matching demos
- keep caption components as media-free overlays so they can be mounted as subcompositions without media placement or missing-src errors
- add a registry-wide regression that lints every installable HTML snippet for invalid nested or source-less media

## Verification
- reproduced media_missing_src against the shipped caption-editorial-emphasis registry HTML
- registry-wide red test identified 14 affected components before the fix
- registryComponents.test.ts and registryBlocks.test.ts pass
- CLI typecheck passes
- oxlint and oxfmt checks pass for the new regression test
- tracked-artifact and diff checks pass

## Review notes
This intentionally fixes the class rather than only caption-editorial-emphasis. Demo files receive the same removal because the empty videos had no source and did not contribute pixels; their visual backgrounds remain authored on the composition root.