### PR TITLE
fix(cli): stream non-TTY render progress

### DIFF
--- a/packages/cli/src/ui/progress.test.ts
+++ b/packages/cli/src/ui/progress.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { renderProgress } from "./progress.js";
+
+const originalWrite = process.stdout.write.bind(process.stdout);
+const originalIsTTY = process.stdout.isTTY;
+
+afterEach(() => {
+  process.stdout.write = originalWrite;
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: originalIsTTY,
+    configurable: true,
+  });
+});
+
+describe("renderProgress", () => {
+  it("emits line-delimited updates when stdout is not a TTY", () => {
+    let output = "";
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    renderProgress(42, "Capturing frames");
+
+    expect(output).toMatch(/Capturing frames\n$/);
+    expect(output).not.toContain("\r");
+  });
+});

--- a/packages/cli/src/ui/progress.ts
+++ b/packages/cli/src/ui/progress.ts
@@ -12,6 +12,8 @@ export function renderProgress(percent: number, stage: string, row?: number): vo
 
   if (row !== undefined && stdout.isTTY) {
     stdout.write(`\x1b[${row};1H\x1b[2K${line}`);
+  } else if (!stdout.isTTY) {
+    stdout.write(`${line}\n`);
   } else {
     stdout.write(`\r\x1b[2K${line}`);
   }


### PR DESCRIPTION
## Problem

Render progress redraws used carriage returns without newlines even when stdout was not a TTY. Line-buffered adapters therefore withheld all progress until the process completed.

## Fix

- keep cursor redraws for interactive TTY output
- emit newline-delimited progress records for non-TTY stdout
- add a regression test that captures non-TTY output and rejects carriage-return redraws

## Verification

- focused CLI regression test passes
- CLI typecheck passes after generating the runtime artifact
- pre-commit lint, format, typecheck, and Fallow gates pass