### PR TITLE
fix(lint): exempt caption cues from track density

### DIFF
--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -173,6 +173,22 @@ describe("composition rules", () => {
       expect(finding).toBeUndefined();
     });
 
+    it("does not count transcript caption cues as dense track elements", async () => {
+      const html = `<!DOCTYPE html>
+<html><body>
+  <div data-composition-id="main" data-width="1080" data-height="1920" data-start="0">
+    <div class="caption-group clip" data-start="0" data-duration="1" data-track-index="2">一</div>
+    <div class="caption-line clip" data-start="1" data-duration="1" data-track-index="2">二</div>
+    <div class="caption_block clip" data-start="2" data-duration="1" data-track-index="2">三</div>
+    <div class="cg-4 clip" data-start="3" data-duration="1" data-track-index="2">四</div>
+  </div>
+</body></html>`;
+
+      const result = await lintHyperframeHtml(html, { filePath: "/project/index.html" });
+      const finding = result.findings.find((f) => f.code === "timeline_track_too_dense");
+      expect(finding).toBeUndefined();
+    });
+
     it("does not count root composition or mounted sub-compositions as dense elements", async () => {
       const html = `<!DOCTYPE html>
 <html><body>

--- a/packages/lint/src/rules/composition.ts
+++ b/packages/lint/src/rules/composition.ts
@@ -15,6 +15,8 @@ import { COMPOSITION_VARIABLE_TYPES } from "@hyperframes/parsers/composition";
 const MAX_COMPOSITION_LINES = 300;
 const MAX_TIMED_ELEMENTS_PER_TRACK = 3;
 const TRACK_DENSITY_EXEMPT_TAGS = new Set(["audio", "script", "style", "video"]);
+const CAPTION_CUE_TOKEN =
+  /^(?:caption(?:[-_](?:group|word|line|block|cue|text))?|subtitle(?:[-_](?:group|line|cue|text))?|cg-.+)$/i;
 
 // `parseFloat("0.1") + parseFloat("0.2") = 0.30000000000000004`. Sub-second
 // authored adjacencies survive parse + add as a value a few ulps above the
@@ -34,6 +36,15 @@ function countPhysicalLines(source: string): number {
 
 function countStructuralLines(source: string): number {
   return countPhysicalLines(source.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "<style></style>"));
+}
+
+function isCaptionCue(tag: OpenTag): boolean {
+  const classTokens = (readAttr(tag.raw, "class") || "").split(/\s+/).filter(Boolean);
+  const id = readAttr(tag.raw, "id");
+  return (
+    classTokens.some((token) => CAPTION_CUE_TOKEN.test(token)) ||
+    Boolean(id && CAPTION_CUE_TOKEN.test(id))
+  );
 }
 
 export function isRegistrySourceFile(filePath?: string): boolean {
@@ -294,6 +305,7 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
     const trackCounts = new Map<string, number>();
     for (const tag of tags) {
       if (TRACK_DENSITY_EXEMPT_TAGS.has(tag.name)) continue;
+      if (isCaptionCue(tag)) continue;
       if (isCompositionRootOrMount(tag.raw)) continue;
       if (!readAttr(tag.raw, "data-start")) continue;
 

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "a842eab0c9d3a0c0",
+      "hash": "11f3025c7c97dd8f",
       "files": 124
     },
     "motion-graphics": {

--- a/skills/media-use/scripts/resolve.mjs
+++ b/skills/media-use/scripts/resolve.mjs
@@ -35,10 +35,7 @@ import {
   flushHeygenFailureTracking,
   versionLessThan,
 } from "./lib/heygen-cli.mjs";
-import {
-  BundledSfxAssetsError,
-  inspectBundledSfxAssets,
-} from "./lib/bundled-sfx-provider.mjs";
+import { BundledSfxAssetsError, inspectBundledSfxAssets } from "./lib/bundled-sfx-provider.mjs";
 
 const INGEST_TYPES = [...listTypes(), "video"];
 
@@ -387,10 +384,10 @@ async function run() {
       providerFailure instanceof BundledSfxAssetsError
         ? providerFailure.message
         : type === "brand"
-        ? "no brand spec found — add a frame.md or design.md (colors/font/logo) to this project. Run the HyperFrames design flow to create one; brand tokens are read locally for deterministic rendering."
-        : args.provider
-          ? `provider "${args.provider}" could not resolve ${type}: "${intent}"${localOnly ? " (--local-only skips network providers; drop it or the --provider override)" : ""}`
-          : `no provider could resolve ${type}: "${intent}"`;
+          ? "no brand spec found — add a frame.md or design.md (colors/font/logo) to this project. Run the HyperFrames design flow to create one; brand tokens are read locally for deterministic rendering."
+          : args.provider
+            ? `provider "${args.provider}" could not resolve ${type}: "${intent}"${localOnly ? " (--local-only skips network providers; drop it or the --provider override)" : ""}`
+            : `no provider could resolve ${type}: "${intent}"`;
     if (args.json) {
       console.log(
         JSON.stringify({


### PR DESCRIPTION
## What

- exclude caption/subtitle cue elements from `timeline_track_too_dense` counts
- preserve the density warning for ordinary timed scene elements
- add regression coverage for common caption cue class/id forms

## Why

A field report used 26 verbatim transcript cues. Splitting them across one, two, or four tracks still warned because the rule treats every timed DOM element as scene complexity and caps each track at three elements. Transcript captions inherently contain many short cues, so the suggested split cannot satisfy the rule and produces a permanent false positive.

Source: https://heygen.slack.com/archives/C0BGC335AQY/p1784081830116249

## How

Recognize the caption naming forms already used throughout the linter (`caption-*`, `caption_*`, `subtitle-*`, and `cg-*`) and skip those timed cues before accumulating density counts. Media, composition mounts, and ordinary scene elements keep their existing behavior.

The separate single-sample contrast warning from the same report is intentionally not changed because the affected composition fixture was not available for a load-bearing reproduction.

## Test plan

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (not applicable)
- [x] Focused composition rule test: 117 passed
- [x] Full `@hyperframes/lint` suite: 376 passed
- [x] `@hyperframes/lint` typecheck passed
- [x] Core + Studio pre-commit typechecks passed
- [x] oxlint + oxfmt passed
- [x] fallow audit passed when run directly (the worktree hook could not create its nested temporary worktree)