### PR TITLE
fix(cli): discover project-local ffmpeg binaries

### DIFF
--- a/packages/cli/src/browser/ffmpeg.test.ts
+++ b/packages/cli/src/browser/ffmpeg.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
   Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
   vi.clearAllMocks();
   delete process.env.HYPERFRAMES_FFMPEG_PATH;
+  delete process.env.HYPERFRAMES_FFPROBE_PATH;
 });
 
 describe("findFFmpeg", () => {
@@ -52,6 +53,19 @@ describe("findFFmpeg", () => {
 
     const { findFFmpeg } = await import("./ffmpeg.js");
     expect(findFFmpeg()).toBeUndefined();
+  });
+
+  it("finds project-local FFmpeg binaries when they are not on PATH", async () => {
+    mockExec.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    const localFFmpeg = resolve(".hyperframes", "bin", "ffmpeg");
+    const localFFprobe = resolve(".hyperframes", "bin", "ffprobe");
+    mockExists.mockImplementation((path) => path === localFFmpeg || path === localFFprobe);
+
+    const { findFFmpeg, findFFprobe } = await import("./ffmpeg.js");
+    expect(findFFmpeg()).toBe(localFFmpeg);
+    expect(findFFprobe()).toBe(localFFprobe);
   });
 });
 

--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -99,7 +99,9 @@ function findConfiguredBinary(
 ): string | undefined {
   const configured = process.env[envName]?.trim();
   if (configured) return existsSync(configured) ? resolve(configured) : undefined;
-  return findOnPath(binaryName) ?? findInProjectLocalBin(binaryName) ?? findInCommonDirs(binaryName);
+  return (
+    findOnPath(binaryName) ?? findInProjectLocalBin(binaryName) ?? findInCommonDirs(binaryName)
+  );
 }
 
 export function findFFmpeg(): string | undefined {

--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -87,13 +87,19 @@ function findInCommonDirs(name: "ffmpeg" | "ffprobe"): string | undefined {
   return undefined;
 }
 
+function findInProjectLocalBin(name: "ffmpeg" | "ffprobe"): string | undefined {
+  const extension = process.platform === "win32" ? ".exe" : "";
+  const candidate = resolve(".hyperframes", "bin", `${name}${extension}`);
+  return existsSync(candidate) ? candidate : undefined;
+}
+
 function findConfiguredBinary(
   envName: string,
   binaryName: "ffmpeg" | "ffprobe",
 ): string | undefined {
   const configured = process.env[envName]?.trim();
   if (configured) return existsSync(configured) ? resolve(configured) : undefined;
-  return findOnPath(binaryName) ?? findInCommonDirs(binaryName);
+  return findOnPath(binaryName) ?? findInProjectLocalBin(binaryName) ?? findInCommonDirs(binaryName);
 }
 
 export function findFFmpeg(): string | undefined {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "a842eab0c9d3a0c0",
+      "hash": "11f3025c7c97dd8f",
       "files": 124
     },
     "motion-graphics": {

--- a/skills/media-use/scripts/resolve.mjs
+++ b/skills/media-use/scripts/resolve.mjs
@@ -35,10 +35,7 @@ import {
   flushHeygenFailureTracking,
   versionLessThan,
 } from "./lib/heygen-cli.mjs";
-import {
-  BundledSfxAssetsError,
-  inspectBundledSfxAssets,
-} from "./lib/bundled-sfx-provider.mjs";
+import { BundledSfxAssetsError, inspectBundledSfxAssets } from "./lib/bundled-sfx-provider.mjs";
 
 const INGEST_TYPES = [...listTypes(), "video"];
 
@@ -387,10 +384,10 @@ async function run() {
       providerFailure instanceof BundledSfxAssetsError
         ? providerFailure.message
         : type === "brand"
-        ? "no brand spec found — add a frame.md or design.md (colors/font/logo) to this project. Run the HyperFrames design flow to create one; brand tokens are read locally for deterministic rendering."
-        : args.provider
-          ? `provider "${args.provider}" could not resolve ${type}: "${intent}"${localOnly ? " (--local-only skips network providers; drop it or the --provider override)" : ""}`
-          : `no provider could resolve ${type}: "${intent}"`;
+          ? "no brand spec found — add a frame.md or design.md (colors/font/logo) to this project. Run the HyperFrames design flow to create one; brand tokens are read locally for deterministic rendering."
+          : args.provider
+            ? `provider "${args.provider}" could not resolve ${type}: "${intent}"${localOnly ? " (--local-only skips network providers; drop it or the --provider override)" : ""}`
+            : `no provider could resolve ${type}: "${intent}"`;
     if (args.json) {
       console.log(
         JSON.stringify({


### PR DESCRIPTION
## Summary

Projects that already contain FFmpeg and FFprobe in `.hyperframes/bin` no longer fail preflight when that directory is missing from the invoking shell's `PATH`. Discovery now falls back to the project-local binaries after explicit environment overrides and `PATH`, while retaining the existing common-system-directory fallback.

## Test plan

- `vitest run packages/cli/src/browser/ffmpeg.test.ts` — 7 passed
- `git diff --check`
- Full CLI typecheck was not rerun in this isolated worktree because dependency installation exhausted the workspace disk; CI remains the authoritative full-package check.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
