### PR TITLE
fix(media-use): format resolver diagnostics

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "a842eab0c9d3a0c0",
+      "hash": "11f3025c7c97dd8f",
       "files": 124
     },
     "motion-graphics": {

--- a/skills/media-use/scripts/resolve.mjs
+++ b/skills/media-use/scripts/resolve.mjs
@@ -35,10 +35,7 @@ import {
   flushHeygenFailureTracking,
   versionLessThan,
 } from "./lib/heygen-cli.mjs";
-import {
-  BundledSfxAssetsError,
-  inspectBundledSfxAssets,
-} from "./lib/bundled-sfx-provider.mjs";
+import { BundledSfxAssetsError, inspectBundledSfxAssets } from "./lib/bundled-sfx-provider.mjs";
 
 const INGEST_TYPES = [...listTypes(), "video"];
 
@@ -387,10 +384,10 @@ async function run() {
       providerFailure instanceof BundledSfxAssetsError
         ? providerFailure.message
         : type === "brand"
-        ? "no brand spec found — add a frame.md or design.md (colors/font/logo) to this project. Run the HyperFrames design flow to create one; brand tokens are read locally for deterministic rendering."
-        : args.provider
-          ? `provider "${args.provider}" could not resolve ${type}: "${intent}"${localOnly ? " (--local-only skips network providers; drop it or the --provider override)" : ""}`
-          : `no provider could resolve ${type}: "${intent}"`;
+          ? "no brand spec found — add a frame.md or design.md (colors/font/logo) to this project. Run the HyperFrames design flow to create one; brand tokens are read locally for deterministic rendering."
+          : args.provider
+            ? `provider "${args.provider}" could not resolve ${type}: "${intent}"${localOnly ? " (--local-only skips network providers; drop it or the --provider override)" : ""}`
+            : `no provider could resolve ${type}: "${intent}"`;
     if (args.json) {
       console.log(
         JSON.stringify({


### PR DESCRIPTION
## What

Restores green format preflights on `main` without reverting the bundled-SFX diagnostics from #2460.

## Why

#2460 introduced an unformatted `skills/media-use/scripts/resolve.mjs`. The first completed CI run at that commit ([run 29382994067](https://github.com/heygen-com/hyperframes/actions/runs/29382994067), 2026-07-15 01:59 UTC) failed `bun run format:check`; later main runs inherited the same deterministic failure, and relevant regression/Windows workflows failed their shared format preflight.

## How

Applies the repository formatter to the affected resolver and regenerates the required media-use manifest hash. Runtime behavior is unchanged.

## Test plan

- [x] `bun run format:check` — 3,118 files clean
- [x] `bun run test:skills` — 263 tests passed
- [x] `bun packages/cli/scripts/gen-skills-manifest.ts --check` — manifest in sync
- [x] `bunx oxlint skills/media-use/scripts/resolve.mjs` — clean
- [ ] Documentation updated (not applicable)