### PR TITLE
fix(cli): preflight browser archive extraction

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -88,6 +88,36 @@ describe("parseToolVersion", () => {
   });
 });
 
+describe("checkArchiveExtractor", () => {
+  it("reports a missing unzip dependency on non-Windows hosts", async () => {
+    const doctor = await import("./doctor.js");
+    expect(doctor).toHaveProperty("checkArchiveExtractor");
+    const result = doctor.checkArchiveExtractor("linux", () => false);
+
+    expect(result).toEqual({
+      ok: false,
+      detail: "Not found",
+      hint: "Install unzip so HyperFrames can extract its managed Chrome download.",
+    });
+  });
+
+  it("accepts unzip on non-Windows hosts", async () => {
+    const { checkArchiveExtractor } = await import("./doctor.js");
+    expect(checkArchiveExtractor("darwin", (command) => command === "unzip")).toEqual({
+      ok: true,
+      detail: "unzip",
+    });
+  });
+
+  it("uses the built-in Windows extraction path", async () => {
+    const { checkArchiveExtractor } = await import("./doctor.js");
+    expect(checkArchiveExtractor("win32", () => false)).toEqual({
+      ok: true,
+      detail: "Built into Windows",
+    });
+  });
+});
+
 describe("buildDoctorReport", () => {
   it("emits the locked schema shape", () => {
     const report = buildDoctorReport(OUTCOMES_ALL_OK);

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,6 @@
 // fallow-ignore-file complexity
 import { defineCommand } from "citty";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { platform } from "node:os";
 import type { Example } from "./_examples.js";
 import { c } from "../ui/colors.js";
@@ -133,6 +133,37 @@ function checkDisk(): CheckResult {
   return { ok: true, detail: `${freeGb} GB free` };
 }
 
+function commandExists(command: string): boolean {
+  try {
+    execFileSync("which", [command], { stdio: "ignore", timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Puppeteer's managed Chrome download delegates ZIP extraction to `unzip` on
+ * macOS and Linux. Windows has built-in tar/PowerShell extraction paths, so it
+ * does not need this Unix dependency.
+ */
+export function checkArchiveExtractor(
+  hostPlatform = platform(),
+  exists: (command: string) => boolean = commandExists,
+): CheckResult {
+  if (hostPlatform === "win32") {
+    return { ok: true, detail: "Built into Windows" };
+  }
+  if (exists("unzip")) {
+    return { ok: true, detail: "unzip" };
+  }
+  return {
+    ok: false,
+    detail: "Not found",
+    hint: "Install unzip so HyperFrames can extract its managed Chrome download.",
+  };
+}
+
 function checkEnvironment(): CheckResult {
   const sys = getSystemMeta();
   const parts: string[] = [];
@@ -238,6 +269,7 @@ export default defineCommand({
       { name: "CPU", run: checkCPU },
       { name: "Memory", run: checkMemory },
       { name: "Disk", run: checkDisk },
+      { name: "Archive extractor", run: checkArchiveExtractor },
     ];
 
     // /dev/shm is only relevant on Linux (especially Docker)


### PR DESCRIPTION
## What

`hyperframes doctor` now checks for the archive extractor required before downloading managed Chrome on macOS and Linux.

## Why

Fresh Linux hosts without `unzip` previously passed setup preflight, then failed later during render with `no zip archiver is available`. The new check surfaces that missing dependency before the browser download begins and gives an actionable install hint. Windows remains green because Puppeteer uses built-in tar/PowerShell extraction there.

Source feedback: https://heygen.slack.com/archives/C0BGC335AQY/p1784094494115199

## How

Added a platform-aware archive-extractor check to the existing doctor report. Non-Windows hosts require `unzip`; Windows reports its built-in extraction path. Dependency detection uses `execFileSync` with a fixed command and no shell interpolation.

## Test plan

- [x] Unit tests cover missing/present `unzip` and the Windows path (20 doctor tests passing)
- [x] CLI TypeScript check, lint, formatting, Fallow, and build pass
- [x] Built `doctor --json` reports `Archive extractor: unzip` on this Linux host
- [ ] Documentation updated (not applicable)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
