### PR TITLE
fix(cli): honor PRODUCER_HEADLESS_SHELL_PATH in findFromEnv

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -171,6 +171,7 @@ describe("findBrowser — cache resolution", () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     Object.defineProperty(process, "arch", { value: "x64", configurable: true });
     delete process.env["HYPERFRAMES_BROWSER_PATH"];
+    delete process.env["PRODUCER_HEADLESS_SHELL_PATH"];
     installChildProcessMocks();
   });
 
@@ -593,6 +594,54 @@ describe("findBrowser — cache resolution", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  // Sibling env-var alias for the CLI resolver. The engine layer already
+  // honors `PRODUCER_HEADLESS_SHELL_PATH` (see
+  // `packages/engine/src/services/browserManager.ts`), and docs
+  // (skills/hyperframes-animation/adapters/typegpu.md,
+  // packages/gcp-cloud-run/Dockerfile, examples/k8s-jobs/Dockerfile.example)
+  // all instruct users to set that name. Before this alias, `hyperframes
+  // check`/`snapshot`/`compare` — which all route through `openSettledCompositionPage`
+  // → `ensureBrowser` → `findFromEnv` — silently ignored a documented escape
+  // hatch that `render` had honored, so a user with a broken pinned build
+  // (win32/x64 STATUS_STACK_BUFFER_OVERRUN 3221225595, #hyperframes-cli-feedback
+  // ts=1784095034) could render successfully but check would still crash on
+  // the cached headless-shell. The alias closes that direction of the
+  // symmetry (the engine side is being closed by #2459).
+  it("resolves via PRODUCER_HEADLESS_SHELL_PATH when HYPERFRAMES_BROWSER_PATH is unset", async () => {
+    const directShell = "/opt/chrome-headless-shell/chrome-headless-shell";
+    installFsMocks({ existing: new Set([directShell]) });
+    installPuppeteerBrowsersMock();
+    process.env["PRODUCER_HEADLESS_SHELL_PATH"] = directShell;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { findBrowser, _resetSystemFallbackWarnForTests } = await import("./manager.js");
+    _resetSystemFallbackWarnForTests();
+    const result = await findBrowser();
+
+    expect(result?.executablePath).toBe(directShell);
+    expect(result?.source).toBe("env");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("prefers HYPERFRAMES_BROWSER_PATH over PRODUCER_HEADLESS_SHELL_PATH when both are set", async () => {
+    // Tiebreak matches `render.ts` — the CLI-native name canonicalizes; the
+    // engine name is a compatibility alias. If both are set the caller almost
+    // certainly meant the CLI-native one.
+    const hfPath = "/opt/hf/chrome-headless-shell";
+    const producerPath = "/opt/producer/chrome-headless-shell";
+    installFsMocks({ existing: new Set([hfPath, producerPath]) });
+    installPuppeteerBrowsersMock();
+    process.env["HYPERFRAMES_BROWSER_PATH"] = hfPath;
+    process.env["PRODUCER_HEADLESS_SHELL_PATH"] = producerPath;
+
+    const { findBrowser, _resetSystemFallbackWarnForTests } = await import("./manager.js");
+    _resetSystemFallbackWarnForTests();
+    const result = await findBrowser();
+
+    expect(result?.executablePath).toBe(hfPath);
+    expect(result?.source).toBe("env");
+  });
+
   it("does NOT warn on macOS when falling back to system Chrome", async () => {
     // macOS Chrome still works fine for the screenshot path and the perf
     // claims around BeginFrame are Linux-only — keep the warning Linux-scoped
@@ -716,6 +765,7 @@ describe("downloadBrowser — install failure surfaces HYPERFRAMES_BROWSER_PATH 
   beforeEach(() => {
     vi.resetModules();
     delete process.env["HYPERFRAMES_BROWSER_PATH"];
+    delete process.env["PRODUCER_HEADLESS_SHELL_PATH"];
     installChildProcessMocks();
   });
 

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -250,8 +250,26 @@ function whichBinary(name: string): string | undefined {
   }
 }
 
+// Env-var aliases for a caller-supplied browser executable path. The CLI-native
+// name `HYPERFRAMES_BROWSER_PATH` is the canonical spelling (documented via the
+// download-failure hint added in #2443). `PRODUCER_HEADLESS_SHELL_PATH` is the
+// engine-side name that per-worker render launches already honor (see
+// `packages/engine/src/services/browserManager.ts` and `render.ts` which even
+// propagates the CLI-resolved executable into it). Docs in
+// `skills/hyperframes-animation/adapters/typegpu.md`,
+// `packages/gcp-cloud-run/Dockerfile`, and `examples/k8s-jobs/Dockerfile.example`
+// all instruct users to set `PRODUCER_HEADLESS_SHELL_PATH`, so field reports
+// (e.g. `#hyperframes-cli-feedback` ts=1784095034 on win32/x64) hit the case
+// where `render` completes via that env var while `check`, `snapshot`, and
+// `compare` all ignore it and crash on the cached headless-shell instead.
+// Alias them here so every consumer of `openSettledCompositionPage` (which
+// calls `ensureBrowser` → `findFromEnv`) picks up the same escape hatch.
+// Tiebreak: HYPERFRAMES_BROWSER_PATH wins when both are set, matching the
+// CLI-native canonicalization in `render.ts` (which only sets
+// `PRODUCER_HEADLESS_SHELL_PATH` if not already present).
 function findFromEnv(): BrowserResult | undefined {
-  const envPath = process.env["HYPERFRAMES_BROWSER_PATH"];
+  const envPath =
+    process.env["HYPERFRAMES_BROWSER_PATH"] ?? process.env["PRODUCER_HEADLESS_SHELL_PATH"];
   if (envPath && existsSync(envPath)) {
     return { executablePath: envPath, source: "env" };
   }


### PR DESCRIPTION
## What

Add `PRODUCER_HEADLESS_SHELL_PATH` as an alias for `HYPERFRAMES_BROWSER_PATH` in the CLI's browser resolver (`findFromEnv`). Both env vars now route to the same env-based override for the CLI's `ensureBrowser` path (consumed by `check`, `snapshot`, `compare`, `grade-compare`, and every other call site that goes through `openSettledCompositionPage`).

## Why

Field report: [#hyperframes-cli-feedback ts=1784095034](https://heygen.slack.com/archives/C0BGC335AQY/p1784095034851009) (win32/x64, CLI 0.7.58). Cached `chrome-headless-shell 152.0.7928.2` crashed with `Failed to launch the browser process: Code: 3221225595` (`STATUS_STACK_BUFFER_OVERRUN`). Setting `PRODUCER_HEADLESS_SHELL_PATH` to system Chrome unblocked `hyperframes render`, but `hyperframes check` continued to crash on the broken cached shell.

Root cause: the engine layer (`packages/engine/src/services/browserManager.ts`) reads `PRODUCER_HEADLESS_SHELL_PATH` directly for per-worker render launches, and `render.ts:1479` even propagates the CLI-resolved executable path into it as a courtesy. But the CLI resolver in `packages/cli/src/browser/manager.ts` — used by `check` / `snapshot` / `compare` / `grade-compare` via `ensureBrowser` — only knew the CLI-native name `HYPERFRAMES_BROWSER_PATH`. So a user with a broken pinned build could render but not check, even after finding the documented escape hatch.

Docs and deployment manifests all instruct users to set `PRODUCER_HEADLESS_SHELL_PATH`:
- `skills/hyperframes-animation/adapters/typegpu.md`
- `packages/gcp-cloud-run/Dockerfile`
- `examples/k8s-jobs/Dockerfile.example`

So the escape hatch is documentation-blessed but was silently half-implemented on the CLI side.

## How

Read both env vars in `findFromEnv()`:

```ts
const envPath =
  process.env["HYPERFRAMES_BROWSER_PATH"] ?? process.env["PRODUCER_HEADLESS_SHELL_PATH"];
```

Tiebreak: `HYPERFRAMES_BROWSER_PATH` wins when both are set. This matches the precedent in `packages/cli/src/commands/render.ts:1479-1481` — the CLI-native name is canonical; the engine name is the compatibility alias, so if a caller sets both they almost certainly meant the CLI-native one.

Test isolation: the two `beforeEach` blocks that clear `HYPERFRAMES_BROWSER_PATH` now also clear `PRODUCER_HEADLESS_SHELL_PATH` so a stray env var from a prior test cannot leak into a subsequent case.

This is the CLI side of the alias symmetry [#2459](https://github.com/heygen-com/hyperframes/pull/2459) is closing on the engine (engine gaining `HYPERFRAMES_BROWSER_PATH` honoring). The two together make the alias coherent both directions.

Sibling to [#2443](https://github.com/heygen-com/hyperframes/pull/2443) (which surfaces `HYPERFRAMES_BROWSER_PATH` on download failures — the same env-var name is now honored by both the CLI resolver and the failure-hint machinery). Not the same class as [#2040](https://github.com/heygen-com/hyperframes/pull/2040) (arm64 pin), [#2078](https://github.com/heygen-com/hyperframes/pull/2078) (SIGTRAP at launch), or [#2082](https://github.com/heygen-com/hyperframes/pull/2082) (launch crash rewrap) — those are download / launch fixes; this is the env-var alias gap.

## Test plan

- [x] Unit tests added: two new regression cases in `packages/cli/src/browser/manager.test.ts`
  - `resolves via PRODUCER_HEADLESS_SHELL_PATH when HYPERFRAMES_BROWSER_PATH is unset` — proves the alias routes through `findFromEnv` with `source: "env"`.
  - `prefers HYPERFRAMES_BROWSER_PATH over PRODUCER_HEADLESS_SHELL_PATH when both are set` — pins the tiebreak direction so nothing silently flips it later.
- [x] Existing HYPERFRAMES_BROWSER_PATH tests still pass (32/32 in the manager suite).
- [ ] Manual testing performed — not by me; would need a Windows box with a broken cached headless-shell to reproduce the original scenario, but the tests cover the resolver behavior deterministically.
- [ ] Documentation updated — deferred: no doc changes needed since the existing docs already reference `PRODUCER_HEADLESS_SHELL_PATH` (the alias makes the docs true where before they were half-true).

<!-- pr-source:cron-authored -->

— Via