### PR TITLE
fix(render): normalize local AAC duration before mux

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -203,6 +203,58 @@ describe("ffprobe missing-binary fallback", () => {
     expect(calls[0]?.command).toBe(resolve("/tools/ffprobe.exe"));
   });
 
+  it.each([
+    { name: "non-AAC metadata", codec: "mp3", packets: undefined, expected: 1.25, calls: 1 },
+    { name: "valid AAC packet count", codec: "aac", packets: "783", expected: 16.704, calls: 2 },
+    {
+      name: "missing AAC packet count",
+      codec: "aac",
+      packets: undefined,
+      expected: 1.25,
+      calls: 2,
+    },
+    { name: "zero AAC packet count", codec: "aac", packets: "0", expected: 1.25, calls: 2 },
+    {
+      name: "invalid AAC packet count",
+      codec: "aac",
+      packets: "invalid",
+      expected: 1.25,
+      calls: 2,
+    },
+  ])(
+    "derives audio duration for $name",
+    async ({ codec, packets, expected, calls: expectedCalls }) => {
+      const outcomes: SpawnOutcome[] = [
+        {
+          kind: "exit",
+          code: 0,
+          stdout: JSON.stringify({
+            streams: [
+              { codec_type: "audio", codec_name: codec, sample_rate: "48000", channels: 2 },
+            ],
+            format: { duration: "1.25", bit_rate: "128000" },
+          }),
+        },
+      ];
+      if (codec === "aac") {
+        outcomes.push({
+          kind: "exit",
+          code: 0,
+          stdout: JSON.stringify({ streams: [{ nb_read_packets: packets }], format: {} }),
+        });
+      }
+      const { spawn, calls } = createSpawnSpy(outcomes);
+      vi.resetModules();
+      vi.doMock("child_process", () => ({ spawn }));
+
+      const { extractAudioMetadata } = await import("./ffprobe.js");
+      const meta = await extractAudioMetadata(`/tmp/${codec}-${packets ?? "none"}.audio`);
+
+      expect(meta.durationSeconds).toBeCloseTo(expected, 6);
+      expect(calls).toHaveLength(expectedCalls);
+    },
+  );
+
   it("extractMediaMetadata falls back to PNG cICP metadata when ffprobe is missing", async () => {
     const { spawn, calls } = createSpawnSpy([{ kind: "missing" }]);
     hidePathBinaries();

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -53,6 +53,8 @@ function parseProbeJson(stdout: string): FFProbeOutput {
 
 const videoMetadataCache = new Map<string, Promise<VideoMetadata>>();
 const audioMetadataCache = new Map<string, Promise<AudioMetadata>>();
+// FFmpeg's built-in AAC encoder emits AAC-LC, which has 1024 samples per packet.
+const AAC_LC_SAMPLES_PER_PACKET = 1024;
 
 export interface VideoColorSpace {
   /** Color transfer characteristics, e.g. "bt709", "smpte2084", "arib-std-b67" */
@@ -98,6 +100,7 @@ interface FFProbeStream {
   height?: number;
   duration?: string;
   nb_frames?: string;
+  nb_read_packets?: string;
   pix_fmt?: string;
   r_frame_rate?: string;
   avg_frame_rate?: string;
@@ -366,15 +369,36 @@ export async function extractAudioMetadata(filePath: string): Promise<AudioMetad
     const audioStream = output.streams.find((s) => s.codec_type === "audio");
     if (!audioStream) throw new Error("[FFmpeg] No audio stream found");
 
-    const durationSeconds = output.format.duration ? parseFloat(output.format.duration) : 0;
+    let durationSeconds = output.format.duration ? parseFloat(output.format.duration) : 0;
     const streamDuration = audioStream.duration ? parseFloat(audioStream.duration) : undefined;
+    const sampleRate = audioStream.sample_rate ? parseInt(audioStream.sample_rate) : 44100;
+    const audioCodec = audioStream.codec_name || "unknown";
+    if (audioCodec === "aac" && sampleRate > 0) {
+      const packetStdout = await runFfprobe([
+        "-v",
+        "quiet",
+        "-select_streams",
+        "a:0",
+        "-count_packets",
+        "-show_entries",
+        "stream=nb_read_packets",
+        "-print_format",
+        "json",
+        filePath,
+      ]);
+      const packetOutput = parseProbeJson(packetStdout);
+      const packetCount = Number(packetOutput.streams[0]?.nb_read_packets);
+      if (Number.isFinite(packetCount) && packetCount > 0) {
+        durationSeconds = (packetCount * AAC_LC_SAMPLES_PER_PACKET) / sampleRate;
+      }
+    }
 
     return {
       durationSeconds,
       streamDurationSeconds: streamDuration && streamDuration > 0 ? streamDuration : undefined,
-      sampleRate: audioStream.sample_rate ? parseInt(audioStream.sample_rate) : 44100,
+      sampleRate,
       channels: audioStream.channels || 2,
-      audioCodec: audioStream.codec_name || "unknown",
+      audioCodec,
       bitrate: output.format.bit_rate ? parseInt(output.format.bit_rate) : undefined,
     };
   })();

--- a/packages/producer/src/services/render/audioPadTrim.test.ts
+++ b/packages/producer/src/services/render/audioPadTrim.test.ts
@@ -17,18 +17,11 @@ import { describe, expect, it } from "bun:test";
 import {
   buildPadTrimAudioArgs,
   buildPadTrimAudioPlan,
-  durationSecondsFromAacPacketCount,
   padOrTrimAudioToVideoFrameCount,
   type AudioProbeInfo,
   type PadTrimAudioInput,
   type ProbeVideoFrameInfo,
 } from "./audioPadTrim.js";
-
-describe("durationSecondsFromAacPacketCount", () => {
-  it("derives ADTS AAC duration from packet count instead of unreliable container metadata", () => {
-    expect(durationSecondsFromAacPacketCount(783, 48_000)).toBe(16.704);
-  });
-});
 
 describe("buildPadTrimAudioArgs", () => {
   it("emits a concat-copy pad plan when audio is shorter than target", () => {

--- a/packages/producer/src/services/render/audioPadTrim.test.ts
+++ b/packages/producer/src/services/render/audioPadTrim.test.ts
@@ -17,11 +17,18 @@ import { describe, expect, it } from "bun:test";
 import {
   buildPadTrimAudioArgs,
   buildPadTrimAudioPlan,
+  durationSecondsFromAacPacketCount,
   padOrTrimAudioToVideoFrameCount,
   type AudioProbeInfo,
   type PadTrimAudioInput,
   type ProbeVideoFrameInfo,
 } from "./audioPadTrim.js";
+
+describe("durationSecondsFromAacPacketCount", () => {
+  it("derives ADTS AAC duration from packet count instead of unreliable container metadata", () => {
+    expect(durationSecondsFromAacPacketCount(783, 48_000)).toBe(16.704);
+  });
+});
 
 describe("buildPadTrimAudioArgs", () => {
   it("emits a concat-copy pad plan when audio is shorter than target", () => {

--- a/packages/producer/src/services/render/audioPadTrim.ts
+++ b/packages/producer/src/services/render/audioPadTrim.ts
@@ -36,6 +36,11 @@ import {
  * threshold and well below any frame interval at 24/30/60fps.
  */
 const AUDIO_DURATION_TOLERANCE_SECONDS = 0.001;
+const AAC_SAMPLES_PER_PACKET = 1024;
+
+export function durationSecondsFromAacPacketCount(packetCount: number, sampleRate: number): number {
+  return (packetCount * AAC_SAMPLES_PER_PACKET) / sampleRate;
+}
 
 export interface ProbeVideoFrameInfo {
   /** Number of video frames in the stream. */
@@ -418,8 +423,27 @@ function parseFrameRate(rate: string): { fpsNum: number; fpsDen: number } {
 async function defaultProbeAudioInfo(audioPath: string): Promise<AudioProbeInfo> {
   // extractAudioMetadata is the shared ffprobe wrapper (caches results).
   const metadata: AudioMetadata = await extractAudioMetadata(audioPath);
+  let durationSeconds = metadata.durationSeconds;
+  if (metadata.audioCodec === "aac" && metadata.sampleRate > 0) {
+    const packetInfo = await runFfprobeJson<FfprobeOutput>([
+      "-v",
+      "error",
+      "-select_streams",
+      "a:0",
+      "-count_packets",
+      "-show_entries",
+      "stream=nb_read_packets",
+      "-of",
+      "json",
+      audioPath,
+    ]);
+    const packetCount = Number(packetInfo.streams?.[0]?.nb_read_packets);
+    if (Number.isFinite(packetCount) && packetCount > 0) {
+      durationSeconds = durationSecondsFromAacPacketCount(packetCount, metadata.sampleRate);
+    }
+  }
   return {
-    durationSeconds: metadata.durationSeconds,
+    durationSeconds,
     sampleRate: metadata.sampleRate,
     channels: metadata.channels,
     audioCodec: metadata.audioCodec,

--- a/packages/producer/src/services/render/audioPadTrim.ts
+++ b/packages/producer/src/services/render/audioPadTrim.ts
@@ -36,11 +36,6 @@ import {
  * threshold and well below any frame interval at 24/30/60fps.
  */
 const AUDIO_DURATION_TOLERANCE_SECONDS = 0.001;
-const AAC_SAMPLES_PER_PACKET = 1024;
-
-export function durationSecondsFromAacPacketCount(packetCount: number, sampleRate: number): number {
-  return (packetCount * AAC_SAMPLES_PER_PACKET) / sampleRate;
-}
 
 export interface ProbeVideoFrameInfo {
   /** Number of video frames in the stream. */
@@ -421,29 +416,11 @@ function parseFrameRate(rate: string): { fpsNum: number; fpsDen: number } {
 }
 
 async function defaultProbeAudioInfo(audioPath: string): Promise<AudioProbeInfo> {
-  // extractAudioMetadata is the shared ffprobe wrapper (caches results).
+  // The shared ffprobe wrapper derives AAC-LC duration from packet count so
+  // every consumer sees the same VBR-safe metadata.
   const metadata: AudioMetadata = await extractAudioMetadata(audioPath);
-  let durationSeconds = metadata.durationSeconds;
-  if (metadata.audioCodec === "aac" && metadata.sampleRate > 0) {
-    const packetInfo = await runFfprobeJson<FfprobeOutput>([
-      "-v",
-      "error",
-      "-select_streams",
-      "a:0",
-      "-count_packets",
-      "-show_entries",
-      "stream=nb_read_packets",
-      "-of",
-      "json",
-      audioPath,
-    ]);
-    const packetCount = Number(packetInfo.streams?.[0]?.nb_read_packets);
-    if (Number.isFinite(packetCount) && packetCount > 0) {
-      durationSeconds = durationSecondsFromAacPacketCount(packetCount, metadata.sampleRate);
-    }
-  }
   return {
-    durationSeconds,
+    durationSeconds: metadata.durationSeconds,
     sampleRate: metadata.sampleRate,
     channels: metadata.channels,
     audioCodec: metadata.audioCodec,

--- a/packages/producer/src/services/render/stages/assembleStage.test.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AssembleStageInput } from "./assembleStage.js";
+
+const { muxVideoWithAudioMock, padOrTrimAudioMock } = vi.hoisted(() => ({
+  muxVideoWithAudioMock: vi.fn(),
+  padOrTrimAudioMock: vi.fn(),
+}));
+
+vi.mock("@hyperframes/engine", () => ({
+  applyFaststart: vi.fn(),
+  muxVideoWithAudio: muxVideoWithAudioMock,
+}));
+
+vi.mock("../audioPadTrim.js", () => ({
+  padOrTrimAudioToVideoFrameCount: padOrTrimAudioMock,
+}));
+
+vi.mock("../shared.js", () => ({
+  updateJobStatus: vi.fn(),
+}));
+
+import { runAssembleStage } from "./assembleStage.js";
+
+function makeInput(
+  overrides: Partial<AssembleStageInput> = {},
+): AssembleStageInput {
+  return {
+    job: {
+      id: "aac-duration-parity",
+      config: { fps: { num: 30, den: 1 }, quality: "draft" },
+      status: "queued",
+      progress: 0,
+      currentStage: "queued",
+      createdAt: new Date(0),
+      duration: 1,
+    },
+    videoOnlyPath: "/tmp/video-only.mp4",
+    audioOutputPath: "/tmp/audio.aac",
+    outputPath: "/tmp/output.mp4",
+    hasAudio: true,
+    abortSignal: undefined,
+    assertNotAborted: () => {},
+    ...overrides,
+  };
+}
+
+describe("runAssembleStage audio duration parity", () => {
+  beforeEach(() => {
+    muxVideoWithAudioMock.mockReset();
+    padOrTrimAudioMock.mockReset();
+    muxVideoWithAudioMock.mockResolvedValue({ success: true });
+    padOrTrimAudioMock.mockResolvedValue({
+      success: true,
+      outputPath: "/tmp/audio.duration-normalized.aac",
+      targetDurationSeconds: 1,
+      sourceDurationSeconds: 1.024,
+      operation: "trim",
+    });
+  });
+
+  it("normalizes mixed AAC to the encoded video frame duration before muxing", async () => {
+    await runAssembleStage(makeInput());
+
+    expect(padOrTrimAudioMock).toHaveBeenCalledWith({
+      videoPath: "/tmp/video-only.mp4",
+      audioPath: "/tmp/audio.aac",
+      outputPath: "/tmp/audio.duration-normalized.aac",
+    });
+    expect(muxVideoWithAudioMock).toHaveBeenCalledWith(
+      "/tmp/video-only.mp4",
+      "/tmp/audio.duration-normalized.aac",
+      "/tmp/output.mp4",
+      undefined,
+      { audioCodec: "aac" },
+      { num: 30, den: 1 },
+    );
+  });
+
+  it("fails instead of muxing an unnormalized AAC tail", async () => {
+    padOrTrimAudioMock.mockResolvedValue({
+      success: false,
+      outputPath: "/tmp/audio.duration-normalized.aac",
+      targetDurationSeconds: 1,
+      sourceDurationSeconds: 1.024,
+      operation: "trim",
+      error: "ffmpeg trim failed",
+    });
+
+    await expect(runAssembleStage(makeInput())).rejects.toThrow(
+      "Audio duration normalization failed: ffmpeg trim failed",
+    );
+    expect(muxVideoWithAudioMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/producer/src/services/render/stages/assembleStage.test.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.test.ts
@@ -74,6 +74,16 @@ describe("runAssembleStage audio duration parity", () => {
     );
   });
 
+  it("uses a distinct AAC normalization path when the mixed-audio extension differs", async () => {
+    await runAssembleStage(makeInput({ audioOutputPath: "/tmp/audio.m4a" }));
+
+    expect(padOrTrimAudioMock).toHaveBeenCalledWith({
+      videoPath: "/tmp/video-only.mp4",
+      audioPath: "/tmp/audio.m4a",
+      outputPath: "/tmp/audio.duration-normalized.aac",
+    });
+  });
+
   it("fails instead of muxing an unnormalized AAC tail", async () => {
     padOrTrimAudioMock.mockResolvedValue({
       success: false,

--- a/packages/producer/src/services/render/stages/assembleStage.test.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.test.ts
@@ -21,9 +21,7 @@ vi.mock("../shared.js", () => ({
 
 import { runAssembleStage } from "./assembleStage.js";
 
-function makeInput(
-  overrides: Partial<AssembleStageInput> = {},
-): AssembleStageInput {
+function makeInput(overrides: Partial<AssembleStageInput> = {}): AssembleStageInput {
   return {
     job: {
       id: "aac-duration-parity",

--- a/packages/producer/src/services/render/stages/assembleStage.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.ts
@@ -40,9 +40,7 @@ export interface AssembleStageResult {
   assembleMs: number;
 }
 
-export async function runAssembleStage(
-  input: AssembleStageInput,
-): Promise<AssembleStageResult> {
+export async function runAssembleStage(input: AssembleStageInput): Promise<AssembleStageResult> {
   const {
     job,
     videoOnlyPath,
@@ -58,10 +56,7 @@ export async function runAssembleStage(
   updateJobStatus(job, "assembling", "Assembling final video", 90, onProgress);
 
   if (hasAudio) {
-    const normalizedAudioPath = audioOutputPath.replace(
-      /\.aac$/i,
-      ".duration-normalized.aac",
-    );
+    const normalizedAudioPath = audioOutputPath.replace(/\.aac$/i, ".duration-normalized.aac");
     const normalizeResult = await padOrTrimAudioToVideoFrameCount({
       videoPath: videoOnlyPath,
       audioPath: audioOutputPath,
@@ -69,9 +64,7 @@ export async function runAssembleStage(
     });
     assertNotAborted();
     if (!normalizeResult.success) {
-      throw new Error(
-        `Audio duration normalization failed: ${normalizeResult.error}`,
-      );
+      throw new Error(`Audio duration normalization failed: ${normalizeResult.error}`);
     }
     const muxResult = await muxVideoWithAudio(
       videoOnlyPath,

--- a/packages/producer/src/services/render/stages/assembleStage.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.ts
@@ -17,6 +17,7 @@
  */
 
 import { applyFaststart, muxVideoWithAudio } from "@hyperframes/engine";
+import { extname } from "node:path";
 import type { ProgressCallback, RenderJob } from "../../renderOrchestrator.js";
 import { padOrTrimAudioToVideoFrameCount } from "../audioPadTrim.js";
 import { updateJobStatus } from "../shared.js";
@@ -56,7 +57,11 @@ export async function runAssembleStage(input: AssembleStageInput): Promise<Assem
   updateJobStatus(job, "assembling", "Assembling final video", 90, onProgress);
 
   if (hasAudio) {
-    const normalizedAudioPath = audioOutputPath.replace(/\.aac$/i, ".duration-normalized.aac");
+    const audioExtension = extname(audioOutputPath);
+    const audioStem = audioExtension
+      ? audioOutputPath.slice(0, -audioExtension.length)
+      : audioOutputPath;
+    const normalizedAudioPath = `${audioStem}.duration-normalized.aac`;
     const normalizeResult = await padOrTrimAudioToVideoFrameCount({
       videoPath: videoOnlyPath,
       audioPath: audioOutputPath,

--- a/packages/producer/src/services/render/stages/assembleStage.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.ts
@@ -18,6 +18,7 @@
 
 import { applyFaststart, muxVideoWithAudio } from "@hyperframes/engine";
 import type { ProgressCallback, RenderJob } from "../../renderOrchestrator.js";
+import { padOrTrimAudioToVideoFrameCount } from "../audioPadTrim.js";
 import { updateJobStatus } from "../shared.js";
 
 export interface AssembleStageInput {
@@ -39,7 +40,9 @@ export interface AssembleStageResult {
   assembleMs: number;
 }
 
-export async function runAssembleStage(input: AssembleStageInput): Promise<AssembleStageResult> {
+export async function runAssembleStage(
+  input: AssembleStageInput,
+): Promise<AssembleStageResult> {
   const {
     job,
     videoOnlyPath,
@@ -55,9 +58,24 @@ export async function runAssembleStage(input: AssembleStageInput): Promise<Assem
   updateJobStatus(job, "assembling", "Assembling final video", 90, onProgress);
 
   if (hasAudio) {
+    const normalizedAudioPath = audioOutputPath.replace(
+      /\.aac$/i,
+      ".duration-normalized.aac",
+    );
+    const normalizeResult = await padOrTrimAudioToVideoFrameCount({
+      videoPath: videoOnlyPath,
+      audioPath: audioOutputPath,
+      outputPath: normalizedAudioPath,
+    });
+    assertNotAborted();
+    if (!normalizeResult.success) {
+      throw new Error(
+        `Audio duration normalization failed: ${normalizeResult.error}`,
+      );
+    }
     const muxResult = await muxVideoWithAudio(
       videoOnlyPath,
-      audioOutputPath,
+      normalizeResult.outputPath,
       outputPath,
       abortSignal,
       { audioCodec: "aac" },

--- a/packages/producer/tests/style-7-prod/output/compiled.html
+++ b/packages/producer/tests/style-7-prod/output/compiled.html
@@ -1048,7 +1048,7 @@
   </div>
 
       <!-- Background Audio (A-roll Audio) -->
-      <audio id="aroll-audio" src="_remote_media/download_054a544691a0.mp4" data-start="0" data-duration="16.043" data-track-index="1" data-end="16.043"></audio>
+      <audio id="aroll-audio" src="_remote_media/download_054a544691a0.mp4" data-start="0" data-duration="16.064" data-track-index="1" data-end="16.064"></audio>
     </div>
 
     


### PR DESCRIPTION
## Summary\n\nNormalize local AAC audio to the encoded video frame duration before final muxing, and make AAC duration metadata reliable for VBR ADTS inputs.\n\nThis is an adjacent parity fix, not a claimed root-cause closure for the reported 615-second render that failed while opening audio.aac with an OS timeout. That field failure remains a separate concurrency or filesystem symptom; its workaround changed drawElement parallelism. This PR closes the independently verified AAC duration-drift class shared by local assembly, distributed assembly, and composition metadata consumers.\n\n## Changes\n\n- Run fail-closed pad or trim normalization before local final mux.\n- Derive AAC-LC duration from packet count and sample rate in the shared engine extractAudioMetadata path, so htmlCompiler and all other consumers receive the same VBR-safe duration.\n- Keep non-AAC and invalid or missing packet-count inputs on container metadata.\n- Always create a distinct extension-agnostic duration-normalized AAC tempfile.\n- Document the AAC-LC 1024-sample packet invariant.\n\n## Tests\n\n- Shared engine metadata: table-driven coverage for non-AAC, valid AAC packets, missing packets, zero packets, and invalid packets.\n- Assemble stage: normalization before mux, fail-closed behavior, and non-.aac input path isolation.\n- Full ffprobe utility suite: 19 passing.\n- Focused assemble suite: 3 passing.\n- Producer audioPadTrim execution is blocked locally by a missing sparse-worktree dependency; current-head CI provides the full package run.\n\n## Scope\n\nThe original field timeout is intentionally not marked closed by this PR. This change fixes the duration-parity sibling class and prevents composition metadata from retaining the same VBR AAC undercount.