### PR TITLE
fix(render): discover runtime-inserted media before extraction

### DIFF
--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -286,6 +286,37 @@ describe("runProbeStage — forceScreenshot threading", () => {
     expect(capturedCfgs.length).toBeGreaterThan(0);
   });
 
+  it("launches a probe when a static-duration composition inserts audio at runtime", async () => {
+    capturedCfgs.length = 0;
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 5;
+    input.compiled.html = `<script>
+      const audio = document.createElement("audio");
+      audio.src = "music.mp3";
+      document.body.appendChild(audio);
+    </script>`;
+
+    await runProbeStage(input);
+
+    expect(capturedCfgs.length).toBeGreaterThan(0);
+  });
+
+  it("launches a probe when a static-duration composition uses the Audio constructor", async () => {
+    capturedCfgs.length = 0;
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 5;
+    input.compiled.html = `<script>
+      const audio = new Audio("music.mp3");
+      document.body.appendChild(audio);
+    </script>`;
+
+    await runProbeStage(input);
+
+    expect(capturedCfgs.length).toBeGreaterThan(0);
+  });
+
   it("launches a probe when script-inserted markup contains timed video", async () => {
     capturedCfgs.length = 0;
     const { runProbeStage } = await import("./probeStage.js");

--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -334,6 +334,23 @@ describe("runProbeStage — forceScreenshot threading", () => {
     expect(capturedCfgs.length).toBeGreaterThan(0);
   });
 
+  it("launches a probe when script-inserted markup contains timed audio", async () => {
+    capturedCfgs.length = 0;
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 5;
+    input.compiled.html = `<script>
+      document.body.insertAdjacentHTML(
+        "beforeend",
+        '<audio id="music" src="music.mp3" data-start="0" data-duration="5"></audio>',
+      );
+    </script>`;
+
+    await runProbeStage(input);
+
+    expect(capturedCfgs.length).toBeGreaterThan(0);
+  });
+
   it("launches a probe for a static-duration composition with variable-bound audio", async () => {
     capturedCfgs.length = 0;
     const { runProbeStage } = await import("./probeStage.js");

--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -267,6 +267,42 @@ describe("hasVariableBoundMedia", () => {
 });
 
 describe("runProbeStage — forceScreenshot threading", () => {
+  it("launches a probe when a static-duration composition inserts video at runtime", async () => {
+    capturedCfgs.length = 0;
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 5;
+    input.compiled.html = `<script>
+      const video = document.createElement("video");
+      video.id = "gameplay";
+      video.src = "gameplay.mp4";
+      video.dataset.start = "0";
+      video.dataset.duration = "5";
+      document.body.appendChild(video);
+    </script>`;
+
+    await runProbeStage(input);
+
+    expect(capturedCfgs.length).toBeGreaterThan(0);
+  });
+
+  it("launches a probe when script-inserted markup contains timed video", async () => {
+    capturedCfgs.length = 0;
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 5;
+    input.compiled.html = `<script>
+      document.body.insertAdjacentHTML(
+        "beforeend",
+        '<video id="gameplay" src="gameplay.mp4" data-start="0" data-duration="5"></video>',
+      );
+    </script>`;
+
+    await runProbeStage(input);
+
+    expect(capturedCfgs.length).toBeGreaterThan(0);
+  });
+
   it("launches a probe for a static-duration composition with variable-bound audio", async () => {
     capturedCfgs.length = 0;
     const { runProbeStage } = await import("./probeStage.js");

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -176,7 +176,8 @@ function hasRuntimeInsertedMedia(html: string): boolean {
     .join("\n");
   return (
     /\bcreateElement\s*\(\s*["'`](?:video|audio)["'`]\s*\)/i.test(scriptBodies) ||
-    /<(?:video|audio)\b/i.test(scriptBodies)
+    /\bnew\s+Audio\s*\(/.test(scriptBodies) ||
+    /<(?:video|audio)\b[^>]*>/i.test(scriptBodies)
   );
 }
 

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -164,6 +164,22 @@ export function hasVariableBoundMedia(
   });
 }
 
+/**
+ * Runtime-created media does not exist when the static compiler scans the HTML.
+ * Launch a browser probe so discoverMediaFromBrowser can reconcile it before
+ * extraction, even when the root duration is already known.
+ */
+function hasRuntimeInsertedMedia(html: string): boolean {
+  const { document } = parseHTML(html);
+  const scriptBodies = [...document.querySelectorAll("script")]
+    .map((script) => script.textContent ?? "")
+    .join("\n");
+  return (
+    /\bcreateElement\s*\(\s*["'`](?:video|audio)["'`]\s*\)/i.test(scriptBodies) ||
+    /<(?:video|audio)\b/i.test(scriptBodies)
+  );
+}
+
 export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageResult> {
   const {
     projectDir,
@@ -196,12 +212,14 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
     composition.audios.length,
   );
   const hasVariableMedia = hasVariableBoundMedia(compiled.html, job.config.variables);
+  const hasInsertedMedia = hasRuntimeInsertedMedia(compiled.html);
   const needsBrowser =
     composition.duration <= 0 ||
     compiled.unresolvedCompositions.length > 0 ||
     hasAutoStart ||
     hasScriptedAudio ||
-    hasVariableMedia;
+    hasVariableMedia ||
+    hasInsertedMedia;
 
   if (needsBrowser) {
     const reasons = [];
@@ -210,6 +228,7 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
       reasons.push(`${compiled.unresolvedCompositions.length} unresolved composition(s)`);
     if (hasAutoStart) reasons.push("auto-start video(s)");
     if (hasScriptedAudio) reasons.push("scripted audio volume");
+    if (hasInsertedMedia) reasons.push("runtime-inserted media");
     if (hasVariableMedia) reasons.push("variable-bound media source(s)");
 
     log.info("Launching browser for composition probe...", {

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -167,7 +167,8 @@ export function hasVariableBoundMedia(
 /**
  * Runtime-created media does not exist when the static compiler scans the HTML.
  * Launch a browser probe so discoverMediaFromBrowser can reconcile it before
- * extraction, even when the root duration is already known.
+ * extraction, even when the root duration is already known. External script
+ * sources have no inline text to inspect and remain a known heuristic gap.
  */
 function hasRuntimeInsertedMedia(html: string): boolean {
   const { document } = parseHTML(html);
@@ -176,7 +177,7 @@ function hasRuntimeInsertedMedia(html: string): boolean {
     .join("\n");
   return (
     /\bcreateElement\s*\(\s*["'`](?:video|audio)["'`]\s*\)/i.test(scriptBodies) ||
-    /\bnew\s+Audio\s*\(/.test(scriptBodies) ||
+    /\bnew\s+(?:Audio|Video)\s*\(/i.test(scriptBodies) ||
     /<(?:video|audio)\b[^>]*>/i.test(scriptBodies)
   );
 }


### PR DESCRIPTION
## Summary

Runtime-created `<video>` and `<audio>` elements are now discovered before frame extraction, so compositions that preview correctly no longer compile with `videoCount: 0` or produce nearly frozen media. Static-duration compositions now launch the existing browser probe when their scripts create media elements or insert media markup; ordinary static compositions keep the fast no-probe path.

Regression coverage pins both `document.createElement("video")` and script-inserted `<video>` markup.

Source feedback: https://heygen.slack.com/archives/C0BGC335AQY/p1784105345085129

## Test plan

- `bun test packages/producer/src/services/render/stages/probeStage.test.ts` (26 pass)
- `bun run --cwd packages/producer typecheck`
- `bun run --cwd packages/producer test:unit:bun`
- `bunx oxfmt --check packages/producer/src/services/render/stages/probeStage.ts packages/producer/src/services/render/stages/probeStage.test.ts`
- `bunx fallow audit --base origin/main --fail-on-issues`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
