### PR TITLE
fix(skills,cli): close four reproduced contract gaps from the CLI feedback digest

### DIFF
--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -184,11 +184,19 @@ describe("hyperframes skills", () => {
     vi.resetModules();
     // vi.resetModules re-imports skills.js but the manifest mock's vi.fn
     // instances persist — restore their default behavior for each test.
-    const { checkSkills, presentSkills } = await import("../utils/skillsManifest.js");
+    // pruneOrphanedLockEntries is reset explicitly too: relying on afterEach's
+    // vi.restoreAllMocks() to clear vi.fn() call state is vitest-3-specific
+    // (vitest 4 restores spies only), and call-count assertions like the
+    // twice-in-a-row convergence test would then see counts accumulated from
+    // earlier tests.
+    const { checkSkills, presentSkills, pruneOrphanedLockEntries } =
+      await import("../utils/skillsManifest.js");
     vi.mocked(checkSkills).mockReset();
     vi.mocked(checkSkills).mockImplementation(async () => DEFAULT_CHECK as never);
     vi.mocked(presentSkills).mockReset();
     vi.mocked(presentSkills).mockImplementation((names: readonly string[]) => [...names]);
+    vi.mocked(pruneOrphanedLockEntries).mockReset();
+    vi.mocked(pruneOrphanedLockEntries).mockImplementation(() => []);
     // Each test asserts on process.exitCode; isolate it from the runner's own.
     prevExitCode = process.exitCode;
     process.exitCode = 0;
@@ -653,11 +661,16 @@ describe("hyperframes skills update <names>", () => {
     state.spawnExitCode = 0;
     state.gitMissing = false;
     vi.resetModules();
-    const { checkSkills, presentSkills } = await import("../utils/skillsManifest.js");
+    // Same explicit resets as the describe above (incl. the vitest-4-proofing
+    // note on pruneOrphanedLockEntries).
+    const { checkSkills, presentSkills, pruneOrphanedLockEntries } =
+      await import("../utils/skillsManifest.js");
     vi.mocked(checkSkills).mockReset();
     vi.mocked(checkSkills).mockImplementation(async () => DEFAULT_CHECK as never);
     vi.mocked(presentSkills).mockReset();
     vi.mocked(presentSkills).mockImplementation((names: readonly string[]) => [...names]);
+    vi.mocked(pruneOrphanedLockEntries).mockReset();
+    vi.mocked(pruneOrphanedLockEntries).mockImplementation(() => []);
     prevExitCode = process.exitCode;
     process.exitCode = 0;
   });

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -112,6 +112,15 @@ vi.mock("../utils/skillsMirror.js", () => ({
   mirrorGlobalSkills: vi.fn(() => ({ source: null, mirrored: [] })),
 }));
 
+// The reconcile commands drop the background nudge's cached verdict on
+// success (the stale-24h-cache fix). Stub it so these tests never touch the
+// dev machine's real ~/.hyperframes config; the invalidation behavior itself
+// is unit-tested in skillsUpdateCheck.test.ts.
+const invalidateSkillsCache = vi.fn();
+vi.mock("../utils/skillsUpdateCheck.js", () => ({
+  invalidateSkillsCache: (...args: unknown[]) => invalidateSkillsCache(...args),
+}));
+
 // The global install command this CLI runs (after `skills add <url>` and the
 // per-name `--skill` selection).
 const GLOBAL_ARGS_TAIL = [
@@ -133,7 +142,7 @@ function setPlatform(platform: NodeJS.Platform): void {
 
 /** Invoke a `skills <name>` subcommand from a freshly-imported module. */
 async function runSkillsSub(
-  name: "update",
+  name: "update" | "check",
   args: Record<string, unknown> = {},
   positionals: string[] = [],
 ): Promise<void> {
@@ -569,6 +578,65 @@ describe("hyperframes skills", () => {
 
     expect(state.spawnCalls).toHaveLength(0);
     expect(process.exitCode).toBe(1);
+  });
+
+  // The stale-24h-cache regression: the skills commands are excluded from the
+  // background nudge pipeline (cli.ts), so unless they drop the cached verdict
+  // themselves, a successful install keeps the pre-install "N out of date or
+  // missing" nag alive on every other command for up to 24h.
+  describe("nudge-cache invalidation", () => {
+    it("skills update drops the cached nudge verdict on success", async () => {
+      setPlatform("linux");
+      invalidateSkillsCache.mockClear();
+
+      await runSkillsUpdate();
+
+      expect(process.exitCode).toBe(0);
+      expect(invalidateSkillsCache).toHaveBeenCalled();
+    });
+
+    it("skills update keeps the cached verdict when the install fails", async () => {
+      setPlatform("linux");
+      invalidateSkillsCache.mockClear();
+      state.spawnExitCode = 1; // `skills add` exits non-zero → strict throw
+
+      await runSkillsUpdate();
+
+      expect(process.exitCode).toBe(1);
+      expect(invalidateSkillsCache).not.toHaveBeenCalled();
+    });
+
+    it("skills update keeps the cached verdict on the offline (presence-only) path", async () => {
+      setPlatform("linux");
+      invalidateSkillsCache.mockClear();
+      const { checkSkills } = await import("../utils/skillsManifest.js");
+      vi.mocked(checkSkills).mockRejectedValue(new Error("offline"));
+
+      await runSkillsUpdate();
+
+      // Presence-only run never learned anything about freshness — the cached
+      // verdict is still the best information available.
+      expect(invalidateSkillsCache).not.toHaveBeenCalled();
+    });
+
+    it("bare `skills` (full install) drops the cached nudge verdict", async () => {
+      setPlatform("linux");
+      invalidateSkillsCache.mockClear();
+
+      const { default: skillsCmd } = await import("./skills.js");
+      await skillsCmd.run?.({ args: {}, rawArgs: [], cmd: skillsCmd } as never);
+
+      expect(invalidateSkillsCache).toHaveBeenCalled();
+    });
+
+    it("skills check drops the cached verdict — the fresh result supersedes it", async () => {
+      setPlatform("linux");
+      invalidateSkillsCache.mockClear();
+
+      await runSkillsSub("check", { json: true });
+
+      expect(invalidateSkillsCache).toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -16,6 +16,7 @@ import {
   type SkillsCheckResult,
 } from "../utils/skillsManifest.js";
 import { mirrorGlobalSkills } from "../utils/skillsMirror.js";
+import { invalidateSkillsCache } from "../utils/skillsUpdateCheck.js";
 import { trackSkillsInstallSkipped } from "../telemetry/events.js";
 import type { Example } from "./_examples.js";
 
@@ -368,6 +369,13 @@ export async function updateSkills(
     await installSkills(result.installed, { cwd: opts.cwd, strict });
     verifyInstalled(result.installed, { strict, cwd: opts.cwd });
   }
+  // The install (or the fresh canonical check confirming everything current)
+  // supersedes whatever the background nudge cached before it — drop the
+  // cached verdict so the next command re-checks instead of nagging from the
+  // pre-install snapshot for up to 24h. Deliberately NOT done on the offline
+  // (presence-only) path above: that run never learned anything about
+  // freshness, so the cached verdict is the best information we still have.
+  invalidateSkillsCache();
   return result;
 }
 
@@ -554,6 +562,11 @@ const checkCommand = defineCommand({
 
     if (args.json) console.log(JSON.stringify(withMeta(result), null, 2));
     else renderCheck(result);
+
+    // This check just displayed a fresh verdict, superseding whatever the
+    // background nudge cached — invalidate so the next command's nudge agrees
+    // with what the user was just shown instead of a pre-check snapshot.
+    invalidateSkillsCache();
 
     // Exit non-zero when installed skills are stale, so agents and CI can gate:
     //   hyperframes skills check || npx hyperframes skills update
@@ -748,6 +761,11 @@ export default defineCommand({
     // citty runs this parent handler even when a subcommand matches; guard on
     // the positional so bare `hyperframes skills` installs, while
     // `hyperframes skills check|update` does not also re-install.
-    if (!args._?.[0]) await installSkills("*");
+    if (!args._?.[0]) {
+      await installSkills("*");
+      // Same as updateSkills: a full install supersedes the background
+      // nudge's cached pre-install verdict.
+      invalidateSkillsCache();
+    }
   },
 });

--- a/packages/cli/src/utils/skillsUpdateCheck.test.ts
+++ b/packages/cli/src/utils/skillsUpdateCheck.test.ts
@@ -11,6 +11,7 @@ let config: FakeConfig;
 
 vi.mock("../telemetry/config.js", () => ({
   readConfig: () => ({ ...config }),
+  readConfigFresh: () => ({ ...config }),
   writeConfig: (next: FakeConfig) => {
     config = { ...next };
   },
@@ -107,5 +108,72 @@ describe("skillsUpdateCheck", () => {
       skillsRemovedCount: 1,
     });
     expect(text).toContain("1 HyperFrames skill out of date or missing");
+  });
+
+  // Regression: the stale-24h-cache bug. A successful `skills update`/install
+  // never wrote the cache, and the skills commands are excluded from the nudge
+  // pipeline entirely — so the pre-install "20 out of date or missing" verdict
+  // kept printing on every other command until the TTL expired.
+  // invalidateSkillsCache() is the fix: reconcile commands drop the cached
+  // verdict so the next command re-checks for real.
+  describe("invalidateSkillsCache", () => {
+    const PRE_INSTALL_CACHE = {
+      lastSkillsCheck: new Date().toISOString(), // fresh — inside the 24h TTL
+      skillsUpdateAvailable: true,
+      skillsOutdatedCount: 12,
+      skillsMissingCount: 8,
+      skillsRemovedCount: 0,
+    };
+
+    it("a fresh cache short-circuits the background check with the stale verdict (the bug's precondition)", async () => {
+      config = { ...PRE_INSTALL_CACHE };
+      const { checkSkillsForUpdate } = await import("./skillsUpdateCheck.js");
+
+      const meta = await checkSkillsForUpdate();
+
+      expect(mockCheckSkills).not.toHaveBeenCalled();
+      expect(meta).toEqual({ updateAvailable: true, outdated: 12, missing: 8, removed: 0 });
+    });
+
+    it("drops the cached verdict so the next background check re-runs for real", async () => {
+      config = { ...PRE_INSTALL_CACHE };
+      mockCheckSkills.mockResolvedValue({
+        location: "/home/user/.claude/skills",
+        updateAvailable: false,
+        summary: { current: 20, outdated: 0, missing: 0, coreMissing: 0, removed: 0 },
+      });
+
+      const { checkSkillsForUpdate, invalidateSkillsCache } =
+        await import("./skillsUpdateCheck.js");
+      invalidateSkillsCache();
+
+      // All five cached fields are gone — timestamp AND counts.
+      expect(config["lastSkillsCheck"]).toBeUndefined();
+      expect(config["skillsUpdateAvailable"]).toBeUndefined();
+      expect(config["skillsOutdatedCount"]).toBeUndefined();
+      expect(config["skillsMissingCount"]).toBeUndefined();
+      expect(config["skillsRemovedCount"]).toBeUndefined();
+
+      const meta = await checkSkillsForUpdate();
+      expect(mockCheckSkills).toHaveBeenCalledWith({ canonical: true });
+      expect(meta).toEqual({ updateAvailable: false, outdated: 0, missing: 0, removed: 0 });
+    });
+
+    it("counts are cleared, not just the timestamp — an offline machine goes quiet instead of resurrecting stale counts", async () => {
+      config = { ...PRE_INSTALL_CACHE };
+      mockCheckSkills.mockRejectedValue(new Error("offline"));
+
+      const { checkSkillsForUpdate, invalidateSkillsCache, printSkillsUpdateNotice } =
+        await import("./skillsUpdateCheck.js");
+      invalidateSkillsCache();
+
+      // Refresh fails (offline) → falls back to cached meta, which is now empty.
+      const meta = await checkSkillsForUpdate();
+      expect(meta).toEqual({ updateAvailable: false, outdated: 0, missing: 0, removed: 0 });
+
+      const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      printSkillsUpdateNotice();
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/src/utils/skillsUpdateCheck.ts
+++ b/packages/cli/src/utils/skillsUpdateCheck.ts
@@ -6,7 +6,7 @@
 // check on their own, but they DO run render/lint/validate — so we piggyback
 // the reminder on the commands they already run.
 
-import { readConfig, writeConfig } from "../telemetry/config.js";
+import { readConfig, readConfigFresh, writeConfig } from "../telemetry/config.js";
 import { checkSkills } from "./skillsManifest.js";
 import { updateNoticesSuppressed } from "./updateCheck.js";
 
@@ -64,6 +64,40 @@ async function refreshSkillsCache(): Promise<SkillsUpdateMeta> {
     missing: result.summary.coreMissing,
     removed: result.summary.removed,
   };
+}
+
+/**
+ * Drop the cached verdict (counts + timestamp) so the next command's
+ * background check re-runs instead of nagging from a pre-reconcile snapshot.
+ *
+ * Called after a `skills` install/update/check has reconciled or re-measured
+ * the install. Those commands are excluded from the nudge pipeline entirely
+ * (see cli.ts), so nothing else refreshes the cache when they run — without
+ * this, the last background verdict (taken BEFORE the install) keeps printing
+ * "N skills out of date or missing" on every other command for up to 24h
+ * after a successful install/update.
+ *
+ * Counts are cleared along with the timestamp — not left behind — so an
+ * offline machine (where the next refresh fails and falls back to the cached
+ * meta) goes quiet rather than resurrecting the stale pre-install counts.
+ *
+ * Best-effort: a config write failure must never fail the skills command
+ * that just succeeded.
+ */
+export function invalidateSkillsCache(): void {
+  try {
+    // Fresh read narrows the lost-update window against a concurrently
+    // running CLI process that wrote other config fields in the meantime.
+    const config = readConfigFresh();
+    delete config.lastSkillsCheck;
+    delete config.skillsUpdateAvailable;
+    delete config.skillsOutdatedCount;
+    delete config.skillsMissingCount;
+    delete config.skillsRemovedCount;
+    writeConfig(config);
+  } catch {
+    // best-effort — never break the command that just reconciled skills
+  }
 }
 
 /**

--- a/packages/producer/src/index.ts
+++ b/packages/producer/src/index.ts
@@ -50,6 +50,10 @@ export {
   captureFrameToBuffer,
   getCompositionDuration,
   getCapturePerfSummary,
+  // Transient-vs-genuine init failure classifier — re-exported so standalone
+  // skill helpers (animation-map, contrast-report) can reuse the render
+  // pipeline's canonical retry gating instead of re-deriving it.
+  isTransientBrowserError,
   prepareCaptureSessionForReuse,
   type CaptureOptions,
   type CaptureSession,

--- a/packages/producer/src/services/frameCapture.ts
+++ b/packages/producer/src/services/frameCapture.ts
@@ -10,6 +10,7 @@ export {
   captureFrameToBuffer,
   getCompositionDuration,
   getCapturePerfSummary,
+  isTransientBrowserError,
   prepareCaptureSessionForReuse,
   type CaptureOptions,
   type CaptureResult,

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 102
     },
     "hyperframes-cli": {
-      "hash": "7029ae6357bf9892",
+      "hash": "bc0feefa2255c5e1",
       "files": 11
     },
     "hyperframes-core": {
@@ -62,7 +62,7 @@
       "files": 28
     },
     "product-launch-video": {
-      "hash": "85be1aea92554840",
+      "hash": "19bbd309a4a2791a",
       "files": 23
     },
     "remotion-to-hyperframes": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,8 +6,8 @@
       "files": 144
     },
     "faceless-explainer": {
-      "hash": "b6b0dbe5be873138",
-      "files": 18
+      "hash": "e486bec3499bd84d",
+      "files": 19
     },
     "figma": {
       "hash": "0e6e96f5a76ff824",
@@ -22,7 +22,7 @@
       "files": 6
     },
     "hyperframes-animation": {
-      "hash": "f83c266fac8bed56",
+      "hash": "6652e2ad567a12dd",
       "files": 102
     },
     "hyperframes-cli": {
@@ -34,7 +34,7 @@
       "files": 17
     },
     "hyperframes-creative": {
-      "hash": "340c65604d083536",
+      "hash": "b9e2cbfa49e6ed6c",
       "files": 78
     },
     "hyperframes-keyframes": {
@@ -58,7 +58,7 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "d6d76c4d99d03256",
+      "hash": "739774abd773a3d3",
       "files": 28
     },
     "product-launch-video": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,8 +46,8 @@
       "files": 10
     },
     "media-use": {
-      "hash": "5bb2cf3a97d0b09c",
-      "files": 130
+      "hash": "a8f18a3bac060654",
+      "files": 131
     },
     "motion-graphics": {
       "hash": "1aee662a16dedc08",

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -22,7 +22,7 @@
       "files": 6
     },
     "hyperframes-animation": {
-      "hash": "6652e2ad567a12dd",
+      "hash": "78f333feba8bd836",
       "files": 102
     },
     "hyperframes-cli": {
@@ -46,8 +46,8 @@
       "files": 10
     },
     "media-use": {
-      "hash": "a8f18a3bac060654",
-      "files": 131
+      "hash": "316e9a260f56b9df",
+      "files": 133
     },
     "motion-graphics": {
       "hash": "1aee662a16dedc08",
@@ -62,7 +62,7 @@
       "files": 28
     },
     "product-launch-video": {
-      "hash": "19bbd309a4a2791a",
+      "hash": "86fcf6421ab9aa8f",
       "files": 23
     },
     "remotion-to-hyperframes": {

--- a/skills/faceless-explainer/SKILL.md
+++ b/skills/faceless-explainer/SKILL.md
@@ -107,7 +107,9 @@ The audio script handles narration, word timings, BGM lookup from HeyGen's music
 
 If there is no narration and no `SCRIPT.md`, skip voice generation. BGM may still run if the storyboard has a music mood.
 
-**Gate:** audio job has started, or the project is marked silent.
+**The canonical fully-silent marker** (shared across the workflows that reuse this audio model): `music: none` in the STORYBOARD.md top YAML block **and** no `SCRIPT.md`. That combination marks the project silent — no narration, no BGM, no SFX. `audio.mjs` recognizes it and generates nothing (it removes any stale `audio_meta.json`; an absent `audio_meta.json` is what assemble treats as silent), so this step is a clean skip. `music: none` with narration keeps TTS and turns only BGM off. Use exactly this spelling — don't improvise other markers.
+
+**Gate:** audio job has started, or the project is marked silent (`music: none` + no `SCRIPT.md`).
 
 ---
 

--- a/skills/faceless-explainer/references/story-design.md
+++ b/skills/faceless-explainer/references/story-design.md
@@ -210,6 +210,13 @@ Treat `user_script.txt` as source material. Rewrite, reorder, merge, or omit to 
 
 Do not rewrite the user's words. Segment the script into frame-sized chunks at sentence or paragraph boundaries (you may split a long sentence at a natural clause boundary, but do not change words). Final duration follows the provided script.
 
+## Music & silence
+
+The storyboard's top YAML block carries a `music:` field — the BGM mood the audio step retrieves against (e.g. `music: confident minimal tech underscore`). Omitting it falls back to `message:` → `arc:` → a neutral default, so BGM plays unless turned off explicitly.
+
+- **`music: none`** — BGM off (narration, if any, still runs).
+- **`music: none` + no `SCRIPT.md`** — the canonical **fully-silent marker**: no narration, no BGM, no SFX. `audio.mjs` generates nothing and the audio step is a clean skip. Use exactly this spelling when the user asks for a silent / music-free video.
+
 ## Frame template
 
 Use the exact fields required by the core storyboard format. This is the narrative shape each frame should satisfy:

--- a/skills/faceless-explainer/scripts/audio.mjs
+++ b/skills/faceless-explainer/scripts/audio.mjs
@@ -23,7 +23,7 @@
 //   node audio.mjs fetch-sfx --storyboard ./STORYBOARD.md --hyperframes .
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseStoryboard } from "./lib/storyboard.mjs";
@@ -138,6 +138,22 @@ function runGenerate(argv) {
         text: l.text,
       }))
     : [];
+  // The canonical fully-silent marker (SKILL.md Step 3.1): `music: none` in
+  // the storyboard's top YAML block turns BGM off; combined with no SCRIPT.md
+  // the project is fully silent — generate nothing and remove any stale meta
+  // from a previous run (assemble treats an absent audio_meta.json as silent).
+  const bgmOff =
+    String(g.extra?.music ?? "")
+      .trim()
+      .toLowerCase() === "none";
+  if (bgmOff && !lines.length) {
+    rmSync(outPath, { force: true });
+    rmSync(neutralPath(outPath), { force: true });
+    console.log(
+      "✓ audio generate: project marked silent (music: none, no SCRIPT.md) — nothing to generate",
+    );
+    return;
+  }
   if (!lines.length) console.error("· no SCRIPT.md — silent film (BGM only)");
 
   // BGM mood: storyboard `music:` → message → arc → default. `mode: retrieve` is
@@ -147,7 +163,9 @@ function runGenerate(argv) {
     provider: "auto",
     speed,
     lines,
-    bgm: { mode: "retrieve", query, blob: g.message || "", arc: g.arc || "" },
+    bgm: bgmOff
+      ? { mode: "none" }
+      : { mode: "retrieve", query, blob: g.message || "", arc: g.arc || "" },
   };
   if (userVoice) request.voice = userVoice;
 

--- a/skills/faceless-explainer/scripts/audio.test.mjs
+++ b/skills/faceless-explainer/scripts/audio.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const script = new URL("./audio.mjs", import.meta.url).pathname;
+
+// The header of this adapter declares it "intentionally identical across the
+// reusing skills" — pin that contract so a fix landing in one copy can't
+// silently miss the other (the fully-silent marker bug did exactly that).
+test("audio.mjs is byte-identical to pr-to-video's copy (the stated contract)", () => {
+  const here = readFileSync(script, "utf8");
+  const sibling = readFileSync(
+    new URL("../../pr-to-video/scripts/audio.mjs", import.meta.url),
+    "utf8",
+  );
+  assert.equal(here, sibling);
+});
+
+// ── the canonical fully-silent marker (SKILL.md Step 3.1) ────────────────────
+// Same contract as product-launch (see its audio.test.mjs): `music: none` in
+// the storyboard's top YAML block + no SCRIPT.md ⇒ generate nothing; with
+// narration ⇒ TTS runs, BGM off.
+
+function runAudioRaw({ storyboard, scriptMd = null, preexistingMeta = null }) {
+  const dir = mkdtempSync(join(tmpdir(), "faceless-audio-"));
+  const engine = join(dir, "engine.mjs");
+  writeFileSync(join(dir, "STORYBOARD.md"), storyboard);
+  if (scriptMd != null) writeFileSync(join(dir, "SCRIPT.md"), scriptMd);
+  if (preexistingMeta != null) writeFileSync(join(dir, "audio_meta.json"), preexistingMeta);
+  writeFileSync(
+    engine,
+    `import { readFileSync, writeFileSync } from "node:fs";
+const argv = process.argv.slice(2);
+const flag = (name) => argv[argv.indexOf(name) + 1];
+const request = JSON.parse(readFileSync(flag("--request"), "utf8"));
+writeFileSync(new URL("request.json", import.meta.url), JSON.stringify(request));
+writeFileSync(flag("--out"), JSON.stringify({ voices: [], bgm: null, sfx: [] }));
+`,
+  );
+  const result = spawnSync(
+    process.execPath,
+    [script, "--hyperframes", dir, "--storyboard", join(dir, "STORYBOARD.md")],
+    { encoding: "utf8", env: { ...process.env, HF_MEDIA_ENGINE: engine } },
+  );
+  return { dir, result };
+}
+
+test("music: none + no SCRIPT.md = fully silent: no engine run, no audio_meta.json", () => {
+  const { dir, result } = runAudioRaw({ storyboard: "---\nmessage: Test\nmusic: none\n---\n" });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /marked silent/);
+  assert.equal(existsSync(join(dir, "request.json")), false);
+  assert.equal(existsSync(join(dir, "audio_meta.json")), false);
+});
+
+test("fully-silent run removes stale audio_meta.json from a previous non-silent run", () => {
+  const { dir, result } = runAudioRaw({
+    storyboard: "---\nmessage: Test\nmusic: none\n---\n",
+    preexistingMeta: JSON.stringify({ bgm: { path: "old.mp3" }, voices: [], sfx: [] }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(existsSync(join(dir, "audio_meta.json")), false);
+});
+
+test("music: none with narration keeps TTS but turns BGM off (not fully silent)", () => {
+  const { dir, result } = runAudioRaw({
+    storyboard: "---\nmessage: Test\nmusic: none\n---\n",
+    scriptMd: "## Hook (Frame 1)\n\n    Spoken line for frame one.\n",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const request = JSON.parse(readFileSync(join(dir, "request.json"), "utf8"));
+  assert.equal(request.bgm.mode, "none");
+  assert.equal(request.lines.length, 1);
+});
+
+test("a storyboard music mood still retrieves BGM (marker is exact, not fuzzy)", () => {
+  const { dir, result } = runAudioRaw({
+    storyboard: "---\nmessage: Test\nmusic: upbeat synthwave with heavy drums\n---\n",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const request = JSON.parse(readFileSync(join(dir, "request.json"), "utf8"));
+  assert.equal(request.bgm.mode, "retrieve");
+  assert.equal(request.bgm.query, "upbeat synthwave with heavy drums");
+});

--- a/skills/hyperframes-animation/scripts/animation-map.mjs
+++ b/skills/hyperframes-animation/scripts/animation-map.mjs
@@ -21,6 +21,7 @@ import {
   bundleCompositionForCapture,
   hyperframesPackageSpec,
   importPackagesOrBootstrap,
+  initializeSessionWithRetry,
 } from "./package-loader.mjs";
 
 const packages = await importPackagesOrBootstrap(
@@ -32,13 +33,8 @@ const packages = await importPackagesOrBootstrap(
     ],
   },
 );
-const {
-  createFileServer,
-  createCaptureSession,
-  initializeSession,
-  closeCaptureSession,
-  getCompositionDuration,
-} = packages["@hyperframes/producer"];
+const { createFileServer, createCaptureSession, closeCaptureSession, getCompositionDuration } =
+  packages["@hyperframes/producer"];
 const { parseFps } = packages["@hyperframes/core"];
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
@@ -71,13 +67,22 @@ try {
     compiledDir: bundle.compiledDir,
     port: 0,
   });
-  session = await createCaptureSession(
-    server.url,
-    OUT_DIR,
-    { width: WIDTH, height: HEIGHT, fps: FPS, format: "png" },
-    null,
+  // Canonical transient-init retry/cleanup (mirrors the render pipeline's
+  // probeStage): a valid modular project's sub-composition timelines register
+  // asynchronously, so the first attempt can time out as transient
+  // "zero duration / Runtime ready: false" — retry once with a fresh browser
+  // instead of false-failing the project.
+  session = await initializeSessionWithRetry(
+    packages["@hyperframes/producer"],
+    () =>
+      createCaptureSession(
+        server.url,
+        OUT_DIR,
+        { width: WIDTH, height: HEIGHT, fps: FPS, format: "png" },
+        null,
+      ),
+    { log: (message) => console.error(`animation-map: ${message}`) },
   );
-  await initializeSession(session);
 
   const duration = await getCompositionDuration(session);
   const tweens = await enumerateTweens(session);

--- a/skills/hyperframes-animation/scripts/animation-map.test.mjs
+++ b/skills/hyperframes-animation/scripts/animation-map.test.mjs
@@ -116,3 +116,154 @@ describe("HyperFrames skill helpers", () => {
       }
     });
 });
+
+// ── Transient-init retry (the zero-duration false-fail fix) ─────────────────
+// A valid modular project's sub-composition timelines register asynchronously;
+// the first initializeSession can time out with the transient "zero duration /
+// Runtime ready: false" diagnostic. The render pipeline closes the crashed
+// session and retries once with a fresh browser (probeStage) — the standalone
+// helpers must do the same instead of reporting the project as zero-duration.
+
+/** Write a fake node_modules with the given producer index.mjs source. */
+function writeFakeEnv(root, producerIndexSource) {
+  const packageDir = join(root, "node_modules", "@hyperframes", "producer");
+  const corePackageDir = join(root, "node_modules", "@hyperframes", "core");
+  const sharpPackageDir = join(root, "node_modules", "sharp");
+  const compositionDir = join(root, "composition");
+  mkdirSync(packageDir, { recursive: true });
+  mkdirSync(corePackageDir, { recursive: true });
+  mkdirSync(sharpPackageDir, { recursive: true });
+  mkdirSync(compositionDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({ name: "@hyperframes/producer", type: "module", exports: "./index.mjs" }),
+  );
+  writeFileSync(join(packageDir, "index.mjs"), producerIndexSource);
+  writeFileSync(
+    join(corePackageDir, "package.json"),
+    JSON.stringify({
+      name: "@hyperframes/core",
+      type: "module",
+      exports: { ".": "./index.mjs", "./compiler": "./compiler.mjs" },
+    }),
+  );
+  writeFileSync(
+    join(corePackageDir, "index.mjs"),
+    "export function parseFps(input) { return { ok: true, value: { num: Number(input), den: 1 } }; }",
+  );
+  writeFileSync(
+    join(corePackageDir, "compiler.mjs"),
+    'export async function bundleToSingleHtml() { return "<!doctype html><main>x</main>"; }',
+  );
+  writeFileSync(
+    join(sharpPackageDir, "package.json"),
+    JSON.stringify({ name: "sharp", type: "module", exports: "./index.mjs" }),
+  );
+  writeFileSync(join(sharpPackageDir, "index.mjs"), "export default function sharp() {}\n");
+  return compositionDir;
+}
+
+function runHelper(helper, root, compositionDir) {
+  const result = spawnSync(process.execPath, [helper, compositionDir, "--out", join(root, "out")], {
+    encoding: "utf8",
+    env: { ...process.env, HYPERFRAMES_SKILL_NODE_MODULES: join(root, "node_modules") },
+  });
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+const FAKE_PRODUCER_COMMON = [
+  'export async function createFileServer() { return { url: "http://test", close() {} }; }',
+  'export async function createCaptureSession() { console.error("SESSION_CREATED"); return {}; }',
+  'export async function closeCaptureSession() { console.error("SESSION_CLOSED"); }',
+  "export async function getCompositionDuration() { return 0; }",
+].join("\n");
+
+describe("transient-init retry", () => {
+  for (const helper of HELPERS) {
+    it(`${helper.split("/").at(-1)} retries a transient zero-duration init once with a fresh session`, () => {
+      const root = mkdtempSync(join(tmpdir(), "hyperframes-skill-retry-test-"));
+      try {
+        const compositionDir = writeFakeEnv(
+          root,
+          [
+            FAKE_PRODUCER_COMMON,
+            "let initCalls = 0;",
+            "export async function initializeSession() {",
+            "  initCalls++;",
+            "  if (initCalls === 1) {",
+            // The transient shape: readiness deadline hit before async
+            // sub-composition timelines landed (Runtime ready: false).
+            '    throw new Error("Composition has zero duration after initialization.\\nRuntime ready: false");',
+            "  }",
+            '  throw new Error("INIT_ATTEMPT_2_REACHED");',
+            "}",
+          ].join("\n"),
+        );
+
+        const output = runHelper(helper, root, compositionDir);
+
+        // Retried: fresh session created for attempt 2, crashed one closed.
+        assert.match(output, /retrying with a fresh browser session/);
+        assert.equal((output.match(/SESSION_CREATED/g) ?? []).length, 2);
+        assert.equal((output.match(/SESSION_CLOSED/g) ?? []).length, 2);
+        // ...and the retry genuinely re-ran init (bounded: no third attempt).
+        assert.match(output, /INIT_ATTEMPT_2_REACHED/);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it(`${helper.split("/").at(-1)} does NOT retry a genuine authoring failure (Runtime ready: true)`, () => {
+      const root = mkdtempSync(join(tmpdir(), "hyperframes-skill-retry-test-"));
+      try {
+        const compositionDir = writeFakeEnv(
+          root,
+          [
+            FAKE_PRODUCER_COMMON,
+            "export async function initializeSession() {",
+            // The fast-fail shape: runtime IS ready, there is genuinely no
+            // timeline/duration — an authoring bug retries can't fix.
+            '  throw new Error("Composition has zero duration after initialization.\\nRuntime ready: true");',
+            "}",
+          ].join("\n"),
+        );
+
+        const output = runHelper(helper, root, compositionDir);
+
+        assert.doesNotMatch(output, /retrying with a fresh browser session/);
+        assert.equal((output.match(/SESSION_CREATED/g) ?? []).length, 1);
+        assert.match(output, /Composition has zero duration/);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("prefers the producer's own isTransientBrowserError classifier when exported", () => {
+    const root = mkdtempSync(join(tmpdir(), "hyperframes-skill-retry-test-"));
+    try {
+      const compositionDir = writeFakeEnv(
+        root,
+        [
+          FAKE_PRODUCER_COMMON,
+          // A message the frozen fallback patterns would NOT match — only the
+          // producer-provided classifier can mark it transient.
+          "export function isTransientBrowserError(err) { return String(err && err.message).includes('CUSTOM_TRANSIENT'); }",
+          "let initCalls = 0;",
+          "export async function initializeSession() {",
+          "  initCalls++;",
+          '  if (initCalls === 1) throw new Error("CUSTOM_TRANSIENT flake");',
+          '  throw new Error("INIT_ATTEMPT_2_REACHED");',
+          "}",
+        ].join("\n"),
+      );
+
+      const output = runHelper(HELPERS[0], root, compositionDir);
+
+      assert.match(output, /retrying with a fresh browser session/);
+      assert.match(output, /INIT_ATTEMPT_2_REACHED/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/skills/hyperframes-animation/scripts/animation-map.test.mjs
+++ b/skills/hyperframes-animation/scripts/animation-map.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -115,6 +115,25 @@ describe("HyperFrames skill helpers", () => {
         rmSync(root, { recursive: true, force: true });
       }
     });
+});
+
+// The two package-loader.mjs copies are intentionally byte-identical (each
+// skill ships standalone, so neither can import the other's) and now carry
+// shared logic (initializeSessionWithRetry + FALLBACK_TRANSIENT_PATTERNS)
+// that a future fix could land in one copy and silently miss in the other —
+// the exact drift class the audio.mjs identity pin was born to catch.
+describe("package-loader parity", () => {
+  it("package-loader.mjs is byte-identical to hyperframes-creative's copy (the stated contract)", () => {
+    const here = readFileSync(
+      join(REPO_ROOT, "skills", "hyperframes-animation", "scripts", "package-loader.mjs"),
+      "utf8",
+    );
+    const sibling = readFileSync(
+      join(REPO_ROOT, "skills", "hyperframes-creative", "scripts", "package-loader.mjs"),
+      "utf8",
+    );
+    assert.equal(here, sibling);
+  });
 });
 
 // ── Transient-init retry (the zero-duration false-fail fix) ─────────────────

--- a/skills/hyperframes-animation/scripts/package-loader.mjs
+++ b/skills/hyperframes-animation/scripts/package-loader.mjs
@@ -73,6 +73,71 @@ export async function bundleCompositionForCapture(compiler, projectDir) {
   }
 }
 
+// ── Transient-init retry ─────────────────────────────────────────────────────
+// Frozen snapshot of the engine's TRANSIENT_BROWSER_ERROR_PATTERNS (see
+// packages/engine frameCapture.ts), used only when the imported
+// @hyperframes/producer predates the isTransientBrowserError re-export. The
+// last pattern is the load-bearing one for modular projects: sub-composition
+// timelines register asynchronously, so a first init attempt can time out as
+// "zero duration / Runtime ready: false" on a valid project.
+const FALLBACK_TRANSIENT_PATTERNS = [
+  /Navigating frame was detached/i,
+  /Target closed/i,
+  /Session closed/i,
+  /browser has disconnected/i,
+  /Page crashed/i,
+  /Execution context was destroyed/i,
+  /Cannot find context with specified id/i,
+  /Failed to launch the browser process/i,
+  /Navigation timeout of \d+ ms exceeded/i,
+  /ECONNREFUSED/i,
+  /net::ERR_NETWORK_CHANGED/i,
+  /Composition has zero duration[\s\S]*Runtime ready: false/,
+];
+
+/**
+ * Create + initialize a capture session with the canonical transient-init
+ * retry/cleanup the render pipeline uses (see probeStage in
+ * @hyperframes/producer): on a transient failure, close the crashed session
+ * and retry ONCE with a fresh browser. Without this, a standalone helper
+ * false-fails valid modular projects whose sub-composition timelines land a
+ * beat after the first readiness deadline ("zero duration" with
+ * "Runtime ready: false").
+ *
+ * `producer` is the imported @hyperframes/producer namespace;
+ * `createSession` is a factory returning a fresh (uninitialized) session.
+ * Non-transient init failures (e.g. the "Runtime ready: true" zero-duration
+ * fast-fail — a genuine authoring bug) still throw on the first attempt.
+ */
+export async function initializeSessionWithRetry(producer, createSession, options = {}) {
+  const maxAttempts = options.maxAttempts ?? 2;
+  const log = options.log ?? ((message) => console.error(message));
+  const isTransient =
+    typeof producer.isTransientBrowserError === "function"
+      ? producer.isTransientBrowserError
+      : (err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          return FALLBACK_TRANSIENT_PATTERNS.some((pattern) => pattern.test(message));
+        };
+
+  for (let attempt = 1; ; attempt++) {
+    const session = await createSession();
+    try {
+      await producer.initializeSession(session);
+      return session;
+    } catch (error) {
+      await producer.closeCaptureSession(session).catch(() => {});
+      if (attempt >= maxAttempts || !isTransient(error)) throw error;
+      log(
+        `transient browser-init failure (attempt ${attempt}/${maxAttempts}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      log("retrying with a fresh browser session...");
+    }
+  }
+}
+
 export function hyperframesPackageSpec(packageName) {
   const override = process.env[VERSION_OVERRIDE_ENV]?.trim();
   if (override) return `${packageName}@${override}`;

--- a/skills/hyperframes-cli/references/cloud.md
+++ b/skills/hyperframes-cli/references/cloud.md
@@ -22,6 +22,10 @@ Cloud rendering needs a HeyGen credential, stored at `~/.heygen/credentials` (`0
 npx hyperframes auth login              # OAuth 2.0 + PKCE, opens the browser
 npx hyperframes auth login --api-key    # CI/headless: hidden prompt, or pipe: echo "$HEYGEN_API_KEY" | ... --api-key
 npx hyperframes auth status             # active credential source, identity, billing snapshot
+                                        #   exit 0 = signed in and verified; exit 1 = not signed in,
+                                        #   or the credential was rejected — signed-out exit 1 is the
+                                        #   normal offline state (scripts: `auth status || echo offline`),
+                                        #   not a command failure
 npx hyperframes auth refresh            # force-refresh an OAuth token before a long job
 npx hyperframes auth logout             # clear the stored credential
 ```

--- a/skills/hyperframes-creative/scripts/contrast-report.mjs
+++ b/skills/hyperframes-creative/scripts/contrast-report.mjs
@@ -49,6 +49,7 @@ import {
   bundleCompositionForCapture,
   hyperframesPackageSpec,
   importPackagesOrBootstrap,
+  initializeSessionWithRetry,
 } from "./package-loader.mjs";
 
 // Bundle first so mounted sub-compositions are inlined before the producer's
@@ -68,7 +69,6 @@ const { parseFps } = packages["@hyperframes/core"];
 const {
   createFileServer,
   createCaptureSession,
-  initializeSession,
   closeCaptureSession,
   captureFrameToBuffer,
   getCompositionDuration,
@@ -101,13 +101,20 @@ try {
     compiledDir: bundle.compiledDir,
     port: 0,
   });
-  session = await createCaptureSession(
-    server.url,
-    OUT_DIR,
-    { width: WIDTH, height: HEIGHT, fps: FPS, format: "png" },
-    null,
+  // Canonical transient-init retry/cleanup (mirrors the render pipeline's
+  // probeStage) — same reasoning as animation-map.mjs: don't false-fail a
+  // valid modular project whose sub-composition timelines land a beat late.
+  session = await initializeSessionWithRetry(
+    packages["@hyperframes/producer"],
+    () =>
+      createCaptureSession(
+        server.url,
+        OUT_DIR,
+        { width: WIDTH, height: HEIGHT, fps: FPS, format: "png" },
+        null,
+      ),
+    { log: (message) => console.error(`contrast-report: ${message}`) },
   );
-  await initializeSession(session);
 
   const duration = await getCompositionDuration(session);
   const times = Array.from(

--- a/skills/hyperframes-creative/scripts/package-loader.mjs
+++ b/skills/hyperframes-creative/scripts/package-loader.mjs
@@ -73,6 +73,71 @@ export async function bundleCompositionForCapture(compiler, projectDir) {
   }
 }
 
+// ── Transient-init retry ─────────────────────────────────────────────────────
+// Frozen snapshot of the engine's TRANSIENT_BROWSER_ERROR_PATTERNS (see
+// packages/engine frameCapture.ts), used only when the imported
+// @hyperframes/producer predates the isTransientBrowserError re-export. The
+// last pattern is the load-bearing one for modular projects: sub-composition
+// timelines register asynchronously, so a first init attempt can time out as
+// "zero duration / Runtime ready: false" on a valid project.
+const FALLBACK_TRANSIENT_PATTERNS = [
+  /Navigating frame was detached/i,
+  /Target closed/i,
+  /Session closed/i,
+  /browser has disconnected/i,
+  /Page crashed/i,
+  /Execution context was destroyed/i,
+  /Cannot find context with specified id/i,
+  /Failed to launch the browser process/i,
+  /Navigation timeout of \d+ ms exceeded/i,
+  /ECONNREFUSED/i,
+  /net::ERR_NETWORK_CHANGED/i,
+  /Composition has zero duration[\s\S]*Runtime ready: false/,
+];
+
+/**
+ * Create + initialize a capture session with the canonical transient-init
+ * retry/cleanup the render pipeline uses (see probeStage in
+ * @hyperframes/producer): on a transient failure, close the crashed session
+ * and retry ONCE with a fresh browser. Without this, a standalone helper
+ * false-fails valid modular projects whose sub-composition timelines land a
+ * beat after the first readiness deadline ("zero duration" with
+ * "Runtime ready: false").
+ *
+ * `producer` is the imported @hyperframes/producer namespace;
+ * `createSession` is a factory returning a fresh (uninitialized) session.
+ * Non-transient init failures (e.g. the "Runtime ready: true" zero-duration
+ * fast-fail — a genuine authoring bug) still throw on the first attempt.
+ */
+export async function initializeSessionWithRetry(producer, createSession, options = {}) {
+  const maxAttempts = options.maxAttempts ?? 2;
+  const log = options.log ?? ((message) => console.error(message));
+  const isTransient =
+    typeof producer.isTransientBrowserError === "function"
+      ? producer.isTransientBrowserError
+      : (err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          return FALLBACK_TRANSIENT_PATTERNS.some((pattern) => pattern.test(message));
+        };
+
+  for (let attempt = 1; ; attempt++) {
+    const session = await createSession();
+    try {
+      await producer.initializeSession(session);
+      return session;
+    } catch (error) {
+      await producer.closeCaptureSession(session).catch(() => {});
+      if (attempt >= maxAttempts || !isTransient(error)) throw error;
+      log(
+        `transient browser-init failure (attempt ${attempt}/${maxAttempts}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      log("retrying with a fresh browser session...");
+    }
+  }
+}
+
 export function hyperframesPackageSpec(packageName) {
   const override = process.env[VERSION_OVERRIDE_ENV]?.trim();
   if (override) return `${packageName}@${override}`;

--- a/skills/media-use/SKILL.md
+++ b/skills/media-use/SKILL.md
@@ -401,15 +401,15 @@ tools are OPT-IN alternatives where they exist; install one to unlock its free,
 private, on-device path instead of or ahead of HeyGen for that type. Only
 `ffmpeg`/`ffprobe` are strictly required for the tool to run at all.
 
-| Tool               | Serves                                                                          | Install                                                                                                         |
-| ------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `ffmpeg`/`ffprobe` | adopt probing, smart-grade signalstats, cut, duck bake, loudnorm                | system package (`brew install ffmpeg`)                                                                          |
-| `heygen`           | catalog (bgm/sfx/image/icon) + TTS (voice) + avatar video — the free-usage path | `curl -fsSL https://static.heygen.ai/cli/install.sh \| bash` then `heygen auth login --oauth` (needs >= v0.3.0) |
-| `mflux-generate`   | local image gen (FLUX), best-for-RAM                                            | `uv venv ~/.venvs/mflux && VIRTUAL_ENV=~/.venvs/mflux uv pip install mflux==0.9.6`                              |
-| `codex`            | image gen upsell (ChatGPT sub)                                                  | Codex CLI, logged in via ChatGPT (owns its own auth)                                                            |
-| `parakeet-mlx`     | local transcription (default ASR, best)                                         | `uv venv ~/.venvs/parakeet && VIRTUAL_ENV=~/.venvs/parakeet uv pip install parakeet-mlx`                        |
-| `ltx-2-mlx`        | local video gen                                                                 | `git clone https://github.com/dgrauet/ltx-2-mlx && cd ltx-2-mlx && uv sync --all-extras`                        |
-| `npx hyperframes`  | Kokoro TTS (voice), whisper.cpp (transcribe fallback), remove-background        | bundled with the hyperframes CLI                                                                                |
+| Tool               | Serves                                                                          | Install                                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `ffmpeg`/`ffprobe` | adopt probing, smart-grade signalstats, cut, duck bake, loudnorm                | system package (`brew install ffmpeg`)                                                                                           |
+| `heygen`           | catalog (bgm/sfx/image/icon) + TTS (voice) + avatar video — the free-usage path | `curl -fsSL https://static.heygen.ai/cli/install.sh \| bash` then `heygen auth login --oauth` (needs >= v0.3.0)                  |
+| `mflux-generate`   | local image gen (FLUX), best-for-RAM                                            | `uv venv ~/.venvs/mflux && VIRTUAL_ENV=~/.venvs/mflux uv pip install mflux==0.9.6`                                               |
+| `codex`            | image gen upsell (ChatGPT sub)                                                  | Codex CLI, logged in via ChatGPT (owns its own auth)                                                                             |
+| `parakeet-mlx`     | local transcription (default ASR, best)                                         | `uv venv ~/.venvs/parakeet && VIRTUAL_ENV=~/.venvs/parakeet uv pip install parakeet-mlx`                                         |
+| `ltx-2-mlx`        | local video gen                                                                 | `git clone https://github.com/dgrauet/ltx-2-mlx && cd ltx-2-mlx && uv sync --all-extras`                                         |
+| `npx hyperframes`  | Kokoro TTS (voice), whisper.cpp (transcribe fallback), remove-background        | via the hyperframes CLI; whisper.cpp is built on first use (Homebrew on macOS, else git+cmake), models download from HuggingFace |
 
 The RAM-graded local-model shortlist + exact per-tier install/invoke lives in
 `scripts/lib/local-models.mjs` (the agent can read `describeModelLadder(cap, specs)`

--- a/skills/media-use/audio/references/requirements.md
+++ b/skills/media-use/audio/references/requirements.md
@@ -23,7 +23,7 @@ Each command downloads its own model on first run and caches it under `~/.cache/
 - **TTS (Kokoro)** — Kokoro-82M (~311 MB) + voices (~27 MB) in `tts/`. Requires Python 3.8+ with `kokoro-onnx` and `soundfile` (`pip install kokoro-onnx soundfile`). Non-English text also needs `espeak-ng` system-wide.
 - **BGM (Lyria)** — needs `$GEMINI_API_KEY` or `$GOOGLE_API_KEY` + `pip install google-genai`. No local model cache.
 - **BGM (MusicGen)** — `pip install transformers torch soundfile`. `facebook/musicgen-small` (~300 MB) cached under `~/.cache/huggingface/` on first run.
-- **Transcribe** — Whisper model size depending on choice (75 MB – 3.1 GB) in `whisper/`. Bundles `whisper.cpp`.
+- **Transcribe** — Whisper model size depending on choice (75 MB – 3.1 GB) in `whisper/`, downloaded from HuggingFace on first use. `whisper.cpp` itself is NOT bundled: the CLI resolves it from PATH, installs via Homebrew (macOS), or builds it from source with git+cmake on first use (`$HYPERFRAMES_WHISPER_PATH` overrides).
 - **Remove-background** — `u2net_human_seg` (~168 MB ONNX) in `background-removal/models/`. Peak inference RAM ~1.5 GB.
 
 Run `npx hyperframes doctor` if a command fails because of a missing dependency.

--- a/skills/media-use/scripts/lib/npx-sync.mjs
+++ b/skills/media-use/scripts/lib/npx-sync.mjs
@@ -1,0 +1,31 @@
+import { existsSync } from "node:fs";
+import { resolveSpawnCommand } from "../../audio/scripts/lib/tts.mjs";
+
+// Sync-spawn analog of the audio engine's spawnP, for execFileSync call sites
+// that must hard-fail (rather than fall through to another provider) when npx
+// cannot be resolved. On Windows a bare "npx" is npx.cmd, which
+// execFileSync/spawnSync cannot exec (spawnSync npx ENOENT) —
+// resolveSpawnCommand reroutes it through node + npx-cli.js, no shell:true.
+//
+// `platform`/`env`/`pathExists` params (defaulting to the real values) exist
+// so tests can exercise the win32 branch without mocking node:child_process
+// (its ESM exports are non-configurable) — same idiom as spawnP and
+// localTtsGenerate.
+export function resolveNpxInvocation(
+  argv,
+  opts,
+  platform = process.platform,
+  env = process.env,
+  pathExists = existsSync,
+) {
+  const resolved = resolveSpawnCommand("npx", argv, opts, platform, env, pathExists);
+  if (!resolved) {
+    // npx-on-win32 with no resolvable npx-cli.js — same terminal condition
+    // spawnP warns about, surfaced as a throw for callers with no fallback.
+    throw new Error(
+      "cannot run npx on Windows: npm's npx-cli.js was not found " +
+        "(install npm with Node, or run via npx/npm run so npm_execpath is set)",
+    );
+  }
+  return resolved;
+}

--- a/skills/media-use/scripts/lib/npx-sync.test.mjs
+++ b/skills/media-use/scripts/lib/npx-sync.test.mjs
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveNpxInvocation } from "./npx-sync.mjs";
+
+// Coverage parity with tts-local-provider.test.mjs, for the whisper.cpp
+// fallback's call-site shape (transcribe.mjs runWhisper): the same three
+// branches, but with the hard-fail contract — no fallback provider exists,
+// so an unresolvable npx must throw actionably instead of returning null.
+
+const envWithNpxCli = {
+  npm_execpath: "C:/Program Files/nodejs/node_modules/npm/bin/npm-cli.js",
+  npm_node_execpath: "C:/Program Files/nodejs/node.exe",
+};
+const npxCliPath = "C:/Program Files/nodejs/node_modules/npm/bin/npx-cli.js";
+const pathExists = (path) => path === npxCliPath;
+
+const WHISPER_ARGV = ["hyperframes", "transcribe", "C:\\media\\input.wav", "--dir", "C:\\work"];
+const WHISPER_OPTS = { stdio: ["ignore", "pipe", "pipe"], timeout: 1_800_000 };
+
+test("win32: routes the whisper fallback through node + npx-cli, never bare npx", () => {
+  const resolved = resolveNpxInvocation(
+    WHISPER_ARGV,
+    WHISPER_OPTS,
+    "win32",
+    envWithNpxCli,
+    pathExists,
+  );
+
+  assert.equal(resolved.cmd, envWithNpxCli.npm_node_execpath);
+  assert.equal(resolved.args[0], npxCliPath);
+  assert.deepEqual(resolved.args.slice(1, 3), ["hyperframes", "transcribe"]);
+  // execFileSync options survive the rerouting (the timeout bounds the
+  // whisper build/model download; the pipes surface its errors).
+  assert.deepEqual(resolved.opts.stdio, ["ignore", "pipe", "pipe"]);
+  assert.equal(resolved.opts.timeout, 1_800_000);
+});
+
+test("win32 without a resolvable npx-cli: throws the actionable install hint", () => {
+  assert.throws(
+    () => resolveNpxInvocation(WHISPER_ARGV, WHISPER_OPTS, "win32", {}, () => false),
+    /npx-cli\.js was not found/,
+  );
+});
+
+test("non-win32: spawns plain npx unchanged", () => {
+  const resolved = resolveNpxInvocation(WHISPER_ARGV, WHISPER_OPTS, "darwin", {}, () => false);
+
+  assert.equal(resolved.cmd, "npx");
+  assert.deepEqual(resolved.args, WHISPER_ARGV);
+});

--- a/skills/media-use/scripts/lib/tts-local-provider.mjs
+++ b/skills/media-use/scripts/lib/tts-local-provider.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolveSpawnCommand } from "../../audio/scripts/lib/tts.mjs";
 
 // Local voiceover via the packaged Kokoro-82M TTS (the `hyperframes tts` CLI),
 // the free/private default now that HeyGen TTS costs wallet credits. Kokoro runs
@@ -26,17 +27,44 @@ function probeDurationSeconds(file) {
   }
 }
 
-export async function localTtsGenerate(intent, ctx) {
+// `platform`/`execFn`/`env`/`pathExists` params (defaulting to the real
+// values) exist so tests can exercise the win32 branch without mocking
+// node:child_process (its ESM exports are non-configurable) — same idiom as
+// spawnP in ../../audio/scripts/lib/tts.mjs.
+export async function localTtsGenerate(
+  intent,
+  ctx,
+  platform = process.platform,
+  execFn = execFileSync,
+  env = process.env,
+  pathExists = existsSync,
+) {
   const outPath = join(tmpdir(), `media-use-kokoro-${process.pid}-${Date.now()}.wav`);
   const argv = ["hyperframes", "tts", intent, "--output", outPath];
   if (ctx?.voice) argv.push("--voice", ctx.voice);
   if (ctx?.lang && ctx.lang !== "en") argv.push("--lang", ctx.lang);
+  // On Windows a bare "npx" is npx.cmd, which execFileSync cannot exec
+  // (spawnSync npx ENOENT) — resolveSpawnCommand reroutes it through
+  // node + npx-cli.js, same as the audio engine's TTS spawns.
+  const resolved = resolveSpawnCommand(
+    "npx",
+    argv,
+    { encoding: "utf8", timeout: 300000, stdio: ["ignore", "pipe", "pipe"] },
+    platform,
+    env,
+    pathExists,
+  );
+  if (!resolved) {
+    // npx-on-win32 with no resolvable npx-cli.js — same terminal condition
+    // spawnP warns about. Fall through to the next provider rather than crash.
+    console.error(
+      "media-use: local voice not enabled (kokoro). Cannot run npx on Windows: " +
+        "npm's npx-cli.js was not found (install npm with Node, or run via npx/npm run so npm_execpath is set).",
+    );
+    return null;
+  }
   try {
-    execFileSync("npx", argv, {
-      encoding: "utf8",
-      timeout: 300000,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    execFn(resolved.cmd, resolved.args, resolved.opts);
   } catch (err) {
     // `hyperframes tts` prints its "kokoro-onnx not installed" hint to stdout
     // (clack UI), so read both streams and surface the actionable enable-command

--- a/skills/media-use/scripts/lib/tts-local-provider.test.mjs
+++ b/skills/media-use/scripts/lib/tts-local-provider.test.mjs
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { localTtsGenerate } from "./tts-local-provider.mjs";
+
+// Regression: on Windows, a bare "npx" is npx.cmd, which execFileSync cannot
+// exec — the Kokoro delegation failed with `spawnSync npx ENOENT` instead of
+// synthesizing (or cleanly falling through to the next provider). The spawn
+// must route through node + npx-cli.js on win32, same as the audio engine's
+// TTS spawns (see ../../audio/scripts/lib/tts.spawn.test.mjs).
+
+const envWithNpxCli = {
+  npm_execpath: "C:/Program Files/nodejs/node_modules/npm/bin/npm-cli.js",
+  npm_node_execpath: "C:/Program Files/nodejs/node.exe",
+};
+const npxCliPath = "C:/Program Files/nodejs/node_modules/npm/bin/npx-cli.js";
+const pathExists = (path) => path === npxCliPath;
+
+test("win32: routes the hyperframes tts call through node + npx-cli, never bare npx", async () => {
+  const captured = [];
+  const fakeExec = (cmd, args, opts) => {
+    captured.push({ cmd, args, opts });
+    // Synthesize nothing — the provider then returns null via the
+    // missing-output check, which is fine: we only assert the spawn shape.
+  };
+
+  await localTtsGenerate(
+    "hello there",
+    { voice: "am_michael" },
+    "win32",
+    fakeExec,
+    envWithNpxCli,
+    pathExists,
+  );
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].cmd, envWithNpxCli.npm_node_execpath);
+  assert.equal(captured[0].args[0], npxCliPath);
+  assert.deepEqual(captured[0].args.slice(1, 4), ["hyperframes", "tts", "hello there"]);
+  assert.ok(captured[0].args.includes("--voice"));
+  // execFileSync options survive the rerouting (pipes are what let the caller
+  // read the "kokoro-onnx not installed" hint back out).
+  assert.deepEqual(captured[0].opts.stdio, ["ignore", "pipe", "pipe"]);
+});
+
+test("win32 without a resolvable npx-cli: falls through to the next provider (null), no spawn", async () => {
+  const captured = [];
+  const fakeExec = (...call) => captured.push(call);
+
+  const result = await localTtsGenerate(
+    "hello",
+    {},
+    "win32",
+    fakeExec,
+    {}, // no npm_execpath, and pathExists finds nothing
+    () => false,
+  );
+
+  assert.equal(result, null);
+  assert.equal(captured.length, 0);
+});
+
+test("non-win32: spawns plain npx unchanged", async () => {
+  const captured = [];
+  const fakeExec = (cmd, args) => captured.push({ cmd, args });
+
+  await localTtsGenerate("hola", { lang: "es" }, "darwin", fakeExec, {}, () => false);
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].cmd, "npx");
+  assert.deepEqual(captured[0].args.slice(0, 3), ["hyperframes", "tts", "hola"]);
+  assert.ok(captured[0].args.includes("--lang"));
+});

--- a/skills/media-use/scripts/transcribe.mjs
+++ b/skills/media-use/scripts/transcribe.mjs
@@ -15,6 +15,7 @@ import { basename, extname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { mergeTokensToWords } from "./lib/parakeet-words.mjs";
 import { track } from "./lib/telemetry.mjs";
+import { resolveSpawnCommand } from "../audio/scripts/lib/tts.mjs";
 
 // The DEFAULT local transcription path. Prefers NVIDIA Parakeet-TDT via
 // parakeet-mlx, which beats whisper.cpp on the Open ASR Leaderboard (~6.05% vs
@@ -24,8 +25,9 @@ import { track } from "./lib/telemetry.mjs";
 // captions / the audio engine.
 //
 // Parakeet v3 covers English + 25 European languages. For other languages, or
-// when parakeet-mlx is not installed, it falls back to the packaged whisper.cpp
-// (`hyperframes transcribe`, 99 languages). `--engine` forces one.
+// when parakeet-mlx is not installed, it falls back to whisper.cpp via
+// `hyperframes transcribe` (99 languages; the CLI resolves/builds whisper.cpp
+// on first use — it is not bundled). `--engine` forces one.
 
 const { values: args } = parseArgs({
   options: {
@@ -120,14 +122,26 @@ function runParakeet(runner) {
   }
 }
 
-// whisper.cpp via the packaged CLI: writes transcript.json into --dir; relocate to --out.
+// whisper.cpp via the hyperframes CLI (fetched/built on first use — see
+// SKILL.md): writes transcript.json into --dir; relocate to --out.
 function runWhisper() {
   const workDir = mkdtempSync(join(tmpdir(), "media-use-whisper-"));
   try {
-    execFileSync("npx", ["hyperframes", "transcribe", inputPath, "--dir", workDir], {
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 1_800_000,
-    });
+    // On Windows a bare "npx" is npx.cmd, which execFileSync cannot exec
+    // (spawnSync npx ENOENT) — resolveSpawnCommand reroutes it through
+    // node + npx-cli.js, same as the audio engine's TTS spawns.
+    const resolved = resolveSpawnCommand(
+      "npx",
+      ["hyperframes", "transcribe", inputPath, "--dir", workDir],
+      { stdio: ["ignore", "pipe", "pipe"], timeout: 1_800_000 },
+    );
+    if (!resolved) {
+      throw new Error(
+        "cannot run npx on Windows: npm's npx-cli.js was not found " +
+          "(install npm with Node, or run via npx/npm run so npm_execpath is set)",
+      );
+    }
+    execFileSync(resolved.cmd, resolved.args, resolved.opts);
     const produced = join(workDir, "transcript.json");
     if (!existsSync(produced)) throw new Error("whisper produced no transcript.json");
     const tmp = `${outPath}.tmp-${process.pid}`;

--- a/skills/media-use/scripts/transcribe.mjs
+++ b/skills/media-use/scripts/transcribe.mjs
@@ -15,7 +15,7 @@ import { basename, extname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { mergeTokensToWords } from "./lib/parakeet-words.mjs";
 import { track } from "./lib/telemetry.mjs";
-import { resolveSpawnCommand } from "../audio/scripts/lib/tts.mjs";
+import { resolveNpxInvocation } from "./lib/npx-sync.mjs";
 
 // The DEFAULT local transcription path. Prefers NVIDIA Parakeet-TDT via
 // parakeet-mlx, which beats whisper.cpp on the Open ASR Leaderboard (~6.05% vs
@@ -128,19 +128,13 @@ function runWhisper() {
   const workDir = mkdtempSync(join(tmpdir(), "media-use-whisper-"));
   try {
     // On Windows a bare "npx" is npx.cmd, which execFileSync cannot exec
-    // (spawnSync npx ENOENT) — resolveSpawnCommand reroutes it through
-    // node + npx-cli.js, same as the audio engine's TTS spawns.
-    const resolved = resolveSpawnCommand(
-      "npx",
+    // (spawnSync npx ENOENT) — resolveNpxInvocation reroutes it through
+    // node + npx-cli.js (and throws actionably when it can't), same
+    // mechanism as the audio engine's TTS spawns.
+    const resolved = resolveNpxInvocation(
       ["hyperframes", "transcribe", inputPath, "--dir", workDir],
       { stdio: ["ignore", "pipe", "pipe"], timeout: 1_800_000 },
     );
-    if (!resolved) {
-      throw new Error(
-        "cannot run npx on Windows: npm's npx-cli.js was not found " +
-          "(install npm with Node, or run via npx/npm run so npm_execpath is set)",
-      );
-    }
     execFileSync(resolved.cmd, resolved.args, resolved.opts);
     const produced = join(workDir, "transcript.json");
     if (!existsSync(produced)) throw new Error("whisper produced no transcript.json");

--- a/skills/pr-to-video/SKILL.md
+++ b/skills/pr-to-video/SKILL.md
@@ -135,7 +135,9 @@ The audio script handles narration, word timings, BGM lookup from HeyGen's music
 
 If there is no narration and no `SCRIPT.md`, skip voice generation. BGM may still run if the storyboard has a music mood.
 
-**Gate:** audio job has started, or the project is marked silent.
+**The canonical fully-silent marker** (shared across the workflows that reuse this audio model): `music: none` in the STORYBOARD.md top YAML block **and** no `SCRIPT.md`. That combination marks the project silent — no narration, no BGM, no SFX. `audio.mjs` recognizes it and generates nothing (it removes any stale `audio_meta.json`; an absent `audio_meta.json` is what assemble treats as silent), so this step is a clean skip. `music: none` with narration keeps TTS and turns only BGM off. Use exactly this spelling — don't improvise other markers.
+
+**Gate:** audio job has started, or the project is marked silent (`music: none` + no `SCRIPT.md`).
 
 ---
 

--- a/skills/pr-to-video/references/story-design.md
+++ b/skills/pr-to-video/references/story-design.md
@@ -185,6 +185,13 @@ Estimate while writing: `duration ≈ ceil(word_count / 2.2)`. 29 words → 13s 
 
 **Write each line as discrete cues, not one run-on breath.** Step 5 reveals each on-screen piece _when the voiceover names it_ (the anti-PowerPoint mechanism). A line with clear phrase boundaries — "Three retries — then it backs off — then it gives up clean" — hands the shot its reveal cadence for free; a single long clause leaves the frame nothing to pace to.
 
+## Music & silence
+
+The storyboard's top YAML block carries a `music:` field — the BGM mood the audio step retrieves against (e.g. `music: confident minimal tech underscore`). Omitting it falls back to `message:` → `arc:` → a neutral default, so BGM plays unless turned off explicitly.
+
+- **`music: none`** — BGM off (narration, if any, still runs).
+- **`music: none` + no `SCRIPT.md`** — the canonical **fully-silent marker**: no narration, no BGM, no SFX. `audio.mjs` generates nothing and the audio step is a clean skip. Use exactly this spelling when the user asks for a silent / music-free video.
+
 ## Frame template
 
 ```md

--- a/skills/pr-to-video/scripts/audio.mjs
+++ b/skills/pr-to-video/scripts/audio.mjs
@@ -23,7 +23,7 @@
 //   node audio.mjs fetch-sfx --storyboard ./STORYBOARD.md --hyperframes .
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseStoryboard } from "./lib/storyboard.mjs";
@@ -138,6 +138,22 @@ function runGenerate(argv) {
         text: l.text,
       }))
     : [];
+  // The canonical fully-silent marker (SKILL.md Step 3.1): `music: none` in
+  // the storyboard's top YAML block turns BGM off; combined with no SCRIPT.md
+  // the project is fully silent — generate nothing and remove any stale meta
+  // from a previous run (assemble treats an absent audio_meta.json as silent).
+  const bgmOff =
+    String(g.extra?.music ?? "")
+      .trim()
+      .toLowerCase() === "none";
+  if (bgmOff && !lines.length) {
+    rmSync(outPath, { force: true });
+    rmSync(neutralPath(outPath), { force: true });
+    console.log(
+      "✓ audio generate: project marked silent (music: none, no SCRIPT.md) — nothing to generate",
+    );
+    return;
+  }
   if (!lines.length) console.error("· no SCRIPT.md — silent film (BGM only)");
 
   // BGM mood: storyboard `music:` → message → arc → default. `mode: retrieve` is
@@ -147,7 +163,9 @@ function runGenerate(argv) {
     provider: "auto",
     speed,
     lines,
-    bgm: { mode: "retrieve", query, blob: g.message || "", arc: g.arc || "" },
+    bgm: bgmOff
+      ? { mode: "none" }
+      : { mode: "retrieve", query, blob: g.message || "", arc: g.arc || "" },
   };
   if (userVoice) request.voice = userVoice;
 

--- a/skills/product-launch-video/SKILL.md
+++ b/skills/product-launch-video/SKILL.md
@@ -35,7 +35,7 @@ After init, let `<PROJECT_ROOT>` be `videos/<project>` and run every subsequent 
 
 **Write `BRIEF.md` immediately after init** (never before — `init` refuses a non-empty directory): the intent layer's locked brief, shape per `../hyperframes-core/references/brief-format.md`. Resolve `<MEDIA_DIR>` as the installed `/media-use` skill directory. Then record each preference-backed answer with `node <MEDIA_DIR>/scripts/prefs.mjs record --hyperframes .` (`brief-format.md` names the subset). If the intent layer adopted a recipe, run `node <MEDIA_DIR>/scripts/recipe.mjs use --hyperframes . --name <name>`; it copies its `frame.md` into the project (Step 2 is then skipped) and returns the skeletons Step 3 drafts from. A recipe fills answers, not approvals; the review gates still run.
 
-**Show sign-in status before proceeding past Setup** — run `npx hyperframes auth status` and relay its output verbatim. It reports whether voice/BGM will use HeyGen or local engines and, when signed out, how to sign in. Apply one branch:
+**Show sign-in status before proceeding past Setup** — run `npx hyperframes auth status` and relay its output verbatim. It reports whether voice/BGM will use HeyGen or local engines and, when signed out, how to sign in. Note the exit code contract: `auth status` **exits 1 when not signed in** (and when the stored credential is rejected) — that non-zero exit is the normal signed-out state, not a command failure, so don't treat it as an error, don't retry it, and don't chain it with `&&`/`set -e` in a way that would abort the workflow. Apply one branch:
 
 - **Collaborative:** wait for the user to sign in or explicitly choose `offline` / `go`.
 - **Autonomous:** state the status and continue through the available local engines.
@@ -104,11 +104,13 @@ Start audio after Step 3 approval. Run it in the background, then continue to St
 
 `node <SKILL_DIR>/scripts/audio.mjs --script ./SCRIPT.md --storyboard ./STORYBOARD.md --hyperframes . --out ./audio_meta.json --provider <provider> --voice <voice-id> &`
 
-The audio script handles narration, word timings, BGM lookup from HeyGen's music library, and timing metadata. BGM mood comes from the storyboard's `music:` field. This uses the HeyGen Audio API for retrieval, not generation, and uses the same `~/.heygen` credential as TTS. For provider details, read `../media-use/audio/references/tts.md`.
+The audio script handles narration, word timings, BGM lookup from HeyGen's music library, and timing metadata. BGM mood comes from the storyboard's `music:` field; **`music: none` turns BGM off**. This uses the HeyGen Audio API for retrieval, not generation, and uses the same `~/.heygen` credential as TTS. For provider details, read `../media-use/audio/references/tts.md`.
 
 If there is no narration and no `SCRIPT.md`, skip voice generation. BGM may still run if the storyboard has a music mood.
 
-**Gate:** audio job has started, or the project is marked silent.
+**The canonical fully-silent marker:** `music: none` in the STORYBOARD.md top YAML block **and** no `SCRIPT.md`. That combination marks the project silent — no narration, no BGM, no SFX. `audio.mjs` recognizes it and generates nothing (it removes any stale `audio_meta.json`; an absent `audio_meta.json` is what assemble treats as silent), so Step 3.1 is a clean skip. Use it when the user asks for a silent / music-free video — don't improvise other spellings.
+
+**Gate:** audio job has started, or the project is marked silent (`music: none` + no `SCRIPT.md`).
 
 ---
 

--- a/skills/product-launch-video/references/story-design.md
+++ b/skills/product-launch-video/references/story-design.md
@@ -332,6 +332,13 @@ The five registry types:
 
 Pick a small set and repeat them: default to `crossfade` (or `blur-crossfade` when the backgrounds clash), and reach for `zoom-through` at section boundaries. Frame 1's `transition_in` is a placeholder.
 
+## Music & silence
+
+The storyboard's top YAML block carries a `music:` field — the BGM mood the audio step retrieves against (e.g. `music: confident minimal tech underscore`). Omitting it falls back to `message:` → `arc:` → a neutral default, so BGM plays unless turned off explicitly.
+
+- **`music: none`** — BGM off (narration, if any, still runs).
+- **`music: none` + no `SCRIPT.md`** — the canonical **fully-silent marker**: no narration, no BGM, no SFX. `audio.mjs` generates nothing and Step 3.1 is a clean skip. Use exactly this spelling when the user asks for a silent / music-free video.
+
 ## Frame template
 
 Use the exact fields required by the core storyboard format. The narrative shape each frame satisfies:

--- a/skills/product-launch-video/scripts/audio.mjs
+++ b/skills/product-launch-video/scripts/audio.mjs
@@ -21,7 +21,7 @@
 //   node audio.mjs fetch-sfx --storyboard ./STORYBOARD.md --hyperframes .
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseStoryboard } from "./lib/storyboard.mjs";
@@ -137,6 +137,22 @@ function runGenerate(argv) {
         text: l.text,
       }))
     : [];
+  // The canonical fully-silent marker (SKILL.md Step 3.1): `music: none` in
+  // the storyboard's top YAML block turns BGM off; combined with no SCRIPT.md
+  // the project is fully silent — generate nothing and remove any stale meta
+  // from a previous run (assemble treats an absent audio_meta.json as silent).
+  const bgmOff =
+    String(g.extra?.music ?? "")
+      .trim()
+      .toLowerCase() === "none";
+  if (bgmOff && !lines.length) {
+    rmSync(outPath, { force: true });
+    rmSync(neutralPath(outPath), { force: true });
+    console.log(
+      "✓ audio generate: project marked silent (music: none, no SCRIPT.md) — nothing to generate",
+    );
+    return;
+  }
   if (!lines.length) console.error("· no SCRIPT.md — silent film (BGM only)");
 
   // BGM mood: storyboard `music:` → message → arc → default. `mode: retrieve` is
@@ -146,7 +162,9 @@ function runGenerate(argv) {
     provider,
     speed,
     lines,
-    bgm: { mode: "retrieve", query, blob: g.message || "", arc: g.arc || "" },
+    bgm: bgmOff
+      ? { mode: "none" }
+      : { mode: "retrieve", query, blob: g.message || "", arc: g.arc || "" },
   };
   if (userVoice) request.voice = userVoice;
 

--- a/skills/product-launch-video/scripts/audio.test.mjs
+++ b/skills/product-launch-video/scripts/audio.test.mjs
@@ -108,6 +108,19 @@ test("music: none with narration keeps TTS but turns BGM off (not fully silent)"
   assert.equal(request.lines.length, 1);
 });
 
+test('a quoted music: "none" is still the silent marker (frontmatter stripQuotes)', () => {
+  // YAML authors quote scalars freely; the vendored storyboard parser strips
+  // matching quotes at parse time (storyboard.mjs stripQuotes), so the marker
+  // must not depend on the unquoted spelling.
+  const { dir, result } = runAudioRaw({
+    storyboard: '---\nmessage: Test\nmusic: "none"\n---\n',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /marked silent/);
+  assert.equal(existsSync(join(dir, "audio_meta.json")), false);
+});
+
 test("a storyboard music mood still retrieves BGM (marker is exact, not fuzzy)", () => {
   const { dir, result } = runAudioRaw({
     storyboard: "---\nmessage: Test\nmusic: upbeat synthwave with heavy drums\n---\n",

--- a/skills/product-launch-video/scripts/audio.test.mjs
+++ b/skills/product-launch-video/scripts/audio.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -43,4 +43,78 @@ test("--provider takes precedence over HF_TTS_PROVIDER", () => {
     runAudio({ args: ["--provider", "kokoro"], env: { HF_TTS_PROVIDER: "elevenlabs" } }).provider,
     "kokoro",
   );
+});
+
+// ── the canonical fully-silent marker (SKILL.md Step 3.1) ────────────────────
+// `music: none` in the storyboard's top YAML block + no SCRIPT.md marks the
+// project fully silent: generate must produce nothing (an absent
+// audio_meta.json is what assemble treats as silent) and clear stale meta.
+
+/** Like runAudio, but with a caller-controlled storyboard and no request assertion. */
+function runAudioRaw({ storyboard, scriptMd = null, preexistingMeta = null }) {
+  const dir = mkdtempSync(join(tmpdir(), "product-launch-audio-"));
+  const engine = join(dir, "engine.mjs");
+  writeFileSync(join(dir, "STORYBOARD.md"), storyboard);
+  if (scriptMd != null) writeFileSync(join(dir, "SCRIPT.md"), scriptMd);
+  if (preexistingMeta != null) writeFileSync(join(dir, "audio_meta.json"), preexistingMeta);
+  writeFileSync(
+    engine,
+    `import { readFileSync, writeFileSync } from "node:fs";
+const argv = process.argv.slice(2);
+const flag = (name) => argv[argv.indexOf(name) + 1];
+const request = JSON.parse(readFileSync(flag("--request"), "utf8"));
+writeFileSync(new URL("request.json", import.meta.url), JSON.stringify(request));
+writeFileSync(flag("--out"), JSON.stringify({ voices: [], bgm: null, sfx: [] }));
+`,
+  );
+  const result = spawnSync(
+    process.execPath,
+    [script, "--hyperframes", dir, "--storyboard", join(dir, "STORYBOARD.md")],
+    { encoding: "utf8", env: { ...process.env, HF_MEDIA_ENGINE: engine } },
+  );
+  return { dir, result };
+}
+
+test("music: none + no SCRIPT.md = fully silent: no engine run, no audio_meta.json", () => {
+  const { dir, result } = runAudioRaw({ storyboard: "---\nmessage: Test\nmusic: none\n---\n" });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /marked silent/);
+  // The engine was never invoked...
+  assert.equal(existsSync(join(dir, "request.json")), false);
+  // ...and no meta exists (absence ⇒ assemble treats the film as silent).
+  assert.equal(existsSync(join(dir, "audio_meta.json")), false);
+});
+
+test("fully-silent run removes stale audio_meta.json from a previous non-silent run", () => {
+  const { dir, result } = runAudioRaw({
+    storyboard: "---\nmessage: Test\nmusic: none\n---\n",
+    preexistingMeta: JSON.stringify({ bgm: { path: "old.mp3" }, voices: [], sfx: [] }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(existsSync(join(dir, "audio_meta.json")), false);
+});
+
+test("music: none with narration keeps TTS but turns BGM off (not fully silent)", () => {
+  const { dir, result } = runAudioRaw({
+    storyboard: "---\nmessage: Test\nmusic: none\n---\n",
+    scriptMd: "## Hook (Frame 1)\n\n    Spoken line for frame one.\n",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const request = JSON.parse(readFileSync(join(dir, "request.json"), "utf8"));
+  assert.equal(request.bgm.mode, "none");
+  assert.equal(request.lines.length, 1);
+});
+
+test("a storyboard music mood still retrieves BGM (marker is exact, not fuzzy)", () => {
+  const { dir, result } = runAudioRaw({
+    storyboard: "---\nmessage: Test\nmusic: upbeat synthwave with heavy drums\n---\n",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const request = JSON.parse(readFileSync(join(dir, "request.json"), "utf8"));
+  assert.equal(request.bgm.mode, "retrieve");
+  assert.equal(request.bgm.query, "upbeat synthwave with heavy drums");
 });


### PR DESCRIPTION
Fixes the four reproduced contract gaps assigned to skills owners in the 07-15 12:00 PM PT CLI feedback digest, plus two follow-ups found while fixing them. One commit per item.

## 1. Stale 24h skills cache (`fix(cli)`, ee7ef4549)

**Bug:** after a successful `skills update`/install/check, the passive nudge kept reporting the pre-install "N skills out of date or missing" for up to 24h.

**Root cause:** the nudge's 24h config cache is only ever written by the background check on *non-skills* commands, and the `skills` command family is excluded from that pipeline (by design — see `cli.ts`). So no reconcile command ever refreshed or invalidated the cached verdict; it survived untouched until the TTL expired.

**Fix:** `invalidateSkillsCache()` — successful `skills update`, bare `skills` install, and `skills check` drop the cached verdict (counts + timestamp) so the next command's background check re-runs for real. Counts are cleared with the timestamp so an offline machine goes quiet instead of resurrecting stale counts; the offline presence-only update path deliberately keeps the cache (that run learns nothing about freshness).

## 2. Windows media-use Whisper fallback ENOENT (`fix(skills)`, 41b62f965)

**Bug:** the whisper.cpp transcribe fallback (and the Kokoro local-TTS delegation, same defect) spawned a bare `npx` via `execFileSync` — on Windows npx is `npx.cmd`, which spawn cannot exec → `spawnSync npx ENOENT`.

**Fix:** both sites route through the skill's existing `resolveSpawnCommand` (win32 → `node <npx-cli.js>`, no `shell:true`), the same mechanism the audio engine's TTS spawns already use and test. Also corrects the "bundled with the hyperframes CLI" wording about whisper.cpp — it's resolved from PATH / brew-installed / built from source on first use, with models downloaded from HuggingFace; nothing whisper ships in the package.

## 3. product-launch fully-silent marker + auth exit-code docs (`feat(skills)`, fcbfb95ff)

**Gap:** Step 3.1's gate said "or the project is marked silent" but no skill defined how to mark one (and `audio.mjs` unconditionally retrieved BGM); `auth status`'s exit-1-when-signed-out contract lived only in a source doc comment.

**Fix:** the canonical marker is **`music: none` in the STORYBOARD.md top YAML block + no `SCRIPT.md`**. `audio.mjs` honors it: fully silent → generate nothing and remove stale `audio_meta.json` (absence ⇒ assemble treats the film as silent); `music: none` with narration → TTS runs, BGM off (`mode: "none"`). Documented in SKILL.md Step 3.1, story-design.md, and the exit-code contract in the Step 0 auth note + `hyperframes-cli` cloud.md.

## 4. animation-map zero-duration false fail (`fix(skills)`, 34613df47)

**Bug:** the standalone `animation-map.mjs` called `initializeSession` exactly once. A valid modular project (sub-composition timelines register asynchronously) can hit the readiness deadline with the transient "zero duration / Runtime ready: false" diagnostic — which the render pipeline's probeStage classifies transient and retries with a fresh browser session, but the standalone script reported as a hard failure.

**Fix:** `initializeSessionWithRetry` in the shared `package-loader.mjs` (both byte-identical copies kept in lockstep): close the crashed session, retry once, gated by the engine's canonical `isTransientBrowserError` — now re-exported from `@hyperframes/producer`, with a frozen fallback pattern list when an older published producer lacks the export. `contrast-report.mjs` had the identical defect and now uses the same helper. The "Runtime ready: true" fast-fail (genuine authoring bug) still fails immediately, no retry.

## Follow-up A: same silent-marker gap in the sibling workflows (`feat(skills)`, 9901b8f6b)

faceless-explainer and pr-to-video reuse product-launch's audio model: same undefined "marked silent" gate, same unconditional BGM retrieve in their (intentionally identical) `audio.mjs` copies. Ported the `music: none` handling into both copies, documented the marker in their SKILL.md + story-design.md, and turned the copies' "intentionally identical" header claim into a byte-identity pin test so the next fix can't silently miss one of them.

## Follow-up B: vitest-4-proof the converge test (`test(cli)`, 1e195caa6)

`skills.test.ts › "running update twice in a row converges"` relies on `vi.restoreAllMocks()` clearing `vi.fn()` call state — true in the pinned vitest 3.2.4, but vitest 4 restores spies only, so `toHaveBeenCalledTimes(1)` would see counts accumulated from earlier tests. `pruneOrphanedLockEntries` is now reset explicitly in `beforeEach` like the other manifest mocks. Verified 38/38 under both vitest 3.2.4 and vitest 4.1.10.

## Testing

- 25 new tests: 8 (cache invalidation, incl. the exact stale-verdict repro) + 3 (win32 npx routing / clean degrade / non-win32 unchanged) + 4 (product-launch silent marker) + 5 (transient retry / non-transient no-retry / classifier preference) + 5 (sibling silent marker + byte-identity pin)
- `oxlint` / `oxfmt` clean on all changed files; `tsc --noEmit` clean for producer and cli
- `skills.test.ts` passes 38/38 under both the pinned vitest 3.2.4 and vitest 4.1.10