### PR TITLE
fix(studio): mute composition hover previews

### DIFF
--- a/packages/studio/src/components/sidebar/CompositionsTab.test.ts
+++ b/packages/studio/src/components/sidebar/CompositionsTab.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { resolveCompositionPreviewScale, resolveThumbnailSeekTime } from "./CompositionsTab";
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveCompositionPreviewScale,
+  resolveThumbnailSeekTime,
+  syncIframePlayback,
+} from "./CompositionsTab";
 
 describe("resolveCompositionPreviewScale", () => {
   it("scales a 16:9 stage to fit the composition card", () => {
@@ -48,5 +52,21 @@ describe("resolveThumbnailSeekTime", () => {
   it("falls back to the default 3s frame when duration is unknown", () => {
     expect(resolveThumbnailSeekTime(null)).toBe(3);
     expect(resolveThumbnailSeekTime(Number.NaN)).toBe(3);
+  });
+});
+
+describe("syncIframePlayback", () => {
+  it("mutes a composition-card preview before playing it", () => {
+    const player = {
+      muted: false,
+      play: vi.fn(),
+    };
+    const iframe = {
+      contentWindow: { __player: player },
+    } as unknown as HTMLIFrameElement;
+
+    expect(syncIframePlayback(iframe, true)).toBe(true);
+    expect(player.muted).toBe(true);
+    expect(player.play).toHaveBeenCalledOnce();
   });
 });

--- a/packages/studio/src/components/sidebar/CompositionsTab.test.ts
+++ b/packages/studio/src/components/sidebar/CompositionsTab.test.ts
@@ -57,16 +57,22 @@ describe("resolveThumbnailSeekTime", () => {
 
 describe("syncIframePlayback", () => {
   it("mutes a composition-card preview before playing it", () => {
+    const calls: string[] = [];
+    const postMessage = vi.fn(() => calls.push("mute"));
     const player = {
-      muted: false,
-      play: vi.fn(),
+      play: vi.fn(() => calls.push("play")),
     };
     const iframe = {
-      contentWindow: { __player: player },
+      contentWindow: { __player: player, postMessage },
+      getRootNode: () => ({}),
     } as unknown as HTMLIFrameElement;
 
     expect(syncIframePlayback(iframe, true)).toBe(true);
-    expect(player.muted).toBe(true);
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "set-muted", muted: true }),
+      "*",
+    );
+    expect(calls).toEqual(["mute", "play"]);
     expect(player.play).toHaveBeenCalledOnce();
   });
 });

--- a/packages/studio/src/components/sidebar/CompositionsTab.tsx
+++ b/packages/studio/src/components/sidebar/CompositionsTab.tsx
@@ -18,6 +18,7 @@ const THUMBNAIL_PLAYBACK_SYNC_ATTEMPTS = 10;
 
 type PreviewWindow = Window & {
   __player?: {
+    muted?: boolean;
     play?: () => void;
     pause?: () => void;
     seek?: (time: number) => void;
@@ -87,12 +88,13 @@ function resolveIframeDuration(iframe: HTMLIFrameElement | null): number | null 
   }
 }
 
-function syncIframePlayback(iframe: HTMLIFrameElement | null, shouldPlay: boolean): boolean {
+export function syncIframePlayback(iframe: HTMLIFrameElement | null, shouldPlay: boolean): boolean {
   try {
     const player = (iframe?.contentWindow as PreviewWindow | null)?.__player;
     if (!player) return false;
 
     if (shouldPlay) {
+      player.muted = true;
       player.play?.();
       return true;
     }

--- a/packages/studio/src/components/sidebar/CompositionsTab.tsx
+++ b/packages/studio/src/components/sidebar/CompositionsTab.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { setPreviewMediaMuted } from "../../player/lib/timelineIframeHelpers";
 
 interface CompositionsTabProps {
   projectId: string;
@@ -18,7 +19,6 @@ const THUMBNAIL_PLAYBACK_SYNC_ATTEMPTS = 10;
 
 type PreviewWindow = Window & {
   __player?: {
-    muted?: boolean;
     play?: () => void;
     pause?: () => void;
     seek?: (time: number) => void;
@@ -94,7 +94,7 @@ export function syncIframePlayback(iframe: HTMLIFrameElement | null, shouldPlay:
     if (!player) return false;
 
     if (shouldPlay) {
-      player.muted = true;
+      setPreviewMediaMuted(iframe, true);
       player.play?.();
       return true;
     }


### PR DESCRIPTION
## Summary

Studio composition cards can no longer start a second audible stream while the main preview is playing. Hover previews are muted before playback begins, preserving the main player as the only audible preview source.

The regression test reproduces the prior overlap by starting an initially unmuted card player and verifies muting occurs before playback. Source report: https://heygen.slack.com/archives/C0BGC335AQY/p1784118425210739

## Test plan

- `bun run --cwd packages/studio test -- CompositionsTab.test.ts`
- `bun run --cwd packages/studio typecheck`
- `bunx oxlint packages/studio/src/components/sidebar/CompositionsTab.tsx packages/studio/src/components/sidebar/CompositionsTab.test.ts`
- `bunx oxfmt --check packages/studio/src/components/sidebar/CompositionsTab.tsx packages/studio/src/components/sidebar/CompositionsTab.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
