### PR TITLE
fix(render): avoid Windows output path limit for work dirs

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -27,6 +27,7 @@ import {
   isRecoverableParallelCaptureError,
   MAX_TRANSIENT_CAPTURE_RETRIES,
   resolveCaptureForceScreenshotForPageSideCompositing,
+  resolveRenderWorkDirPrefix,
   shouldDiscardProbeSessionForPageSideCompositing,
   resolveInversionRetryPlan,
   resolveParallelRouterRetryPlan,
@@ -56,6 +57,16 @@ import {
   writeCompiledArtifacts,
 } from "./render/shared.js";
 import { formatCaptureFrameName, toExternalAssetKey } from "../utils/paths.js";
+
+describe("resolveRenderWorkDirPrefix", () => {
+  it("uses a short system temp prefix on Windows instead of the output path", () => {
+    const outputPath = win32.join("C:\\deep", "nested".repeat(30), "renders", "final.mp4");
+
+    expect(resolveRenderWorkDirPrefix(outputPath, "long-render-job-id", "win32", "C:/Temp")).toBe(
+      join("C:/Temp", "hf-render-"),
+    );
+  });
+});
 
 describe("extractStandaloneEntryFromIndex", () => {
   it("reuses the index wrapper and keeps only the requested composition host", () => {

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -43,6 +43,7 @@ import {
   copyFileSync,
   appendFileSync,
 } from "fs";
+import { tmpdir } from "node:os";
 import { parseHTML } from "linkedom";
 import { type CanvasResolution, type Fps, type FpsInput, toFps } from "@hyperframes/core";
 import {
@@ -724,6 +725,16 @@ export function buildMissingFrameRetryBatches(
 
 export function getNextRetryWorkerCount(currentWorkers: number): number {
   return Math.max(1, Math.floor(currentWorkers / 2));
+}
+
+export function resolveRenderWorkDirPrefix(
+  outputPath: string,
+  jobId: string,
+  platform: NodeJS.Platform = process.platform,
+  systemTempDir: string = tmpdir(),
+): string {
+  if (platform === "win32") return join(systemTempDir, "hf-render-");
+  return join(dirname(outputPath), `work-${jobId}-`);
 }
 
 /**
@@ -1514,7 +1525,7 @@ export async function executeRenderJob(
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
   const workDir = job.config.debug
     ? join(debugDir, job.id)
-    : mkdtempSync(join(outputDir, `work-${job.id}-`));
+    : mkdtempSync(resolveRenderWorkDirPrefix(outputPath, job.id));
   const pipelineStart = Date.now();
   const baseLog = job.config.logger ?? defaultLogger;
   const logPath = job.config.debug ? join(workDir, "render.log") : null;


### PR DESCRIPTION
## Summary

Windows renders can now write to deeply nested output paths without failing before compilation with `mkdtemp ENOENT`. Non-debug Windows jobs use a short system-temp work directory, preserving path budget for compiled assets and extracted frames; other platforms retain output-adjacent work directories.

The regression test simulates a destination beyond the traditional Windows path budget and pins the short temp-root policy. Source report: https://heygen.slack.com/archives/C0BGC335AQY/p1784119211373089

## Test plan

- `bun x vitest run src/services/renderOrchestrator.test.ts` — 142/142 passed
- `bun run typecheck`
- `bunx oxlint src/services/renderOrchestrator.ts src/services/renderOrchestrator.test.ts`
- `bunx oxfmt --check src/services/renderOrchestrator.ts src/services/renderOrchestrator.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
