### PR TITLE
fix(cli): surface HYPERFRAMES_BROWSER_PATH hint on Windows chrome-headless-shell launch crashes

### DIFF
--- a/packages/cli/src/browser/windowsCrash.test.ts
+++ b/packages/cli/src/browser/windowsCrash.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { isWindowsChromeCrashError, windowsChromeCrashRemediation } from "./windowsCrash.js";
+
+describe("isWindowsChromeCrashError", () => {
+  it("matches Puppeteer launch-failure wrapper + decimal exit code", () => {
+    expect(
+      isWindowsChromeCrashError(
+        "Failed to launch the browser process! Code: 3221225595, with no stderr.",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches Puppeteer launch-failure wrapper + hex exit code", () => {
+    expect(
+      isWindowsChromeCrashError("Failed to launch the browser process (exited with 0xC0000409)"),
+    ).toBe(true);
+  });
+
+  it("matches Puppeteer launch-failure wrapper + named Windows status symbol", () => {
+    expect(
+      isWindowsChromeCrashError(
+        "Failed to launch the browser process — STATUS_STACK_BUFFER_OVERRUN",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a launch failure without the crash-code signal", () => {
+    // Linux shared-library launch failures land in the sibling
+    // chromeLaunchRemediation path, not this one.
+    expect(
+      isWindowsChromeCrashError(
+        "Failed to launch the browser process (libnss3.so: cannot open shared object file)",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match the crash code alone without the launch-failure wrapper", () => {
+    expect(isWindowsChromeCrashError("some other Windows process exited with 3221225595")).toBe(
+      false,
+    );
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isWindowsChromeCrashError("Composition HTML is empty")).toBe(false);
+  });
+});
+
+describe("windowsChromeCrashRemediation", () => {
+  it("returns undefined off Windows even for a matching error", () => {
+    if (process.platform === "win32") return;
+    expect(
+      windowsChromeCrashRemediation("Failed to launch the browser process! Code: 3221225595"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for non-launch errors on any platform", () => {
+    expect(windowsChromeCrashRemediation("Composition HTML is empty")).toBeUndefined();
+  });
+
+  it("returns undefined for a launch failure without the crash code on any platform", () => {
+    expect(
+      windowsChromeCrashRemediation(
+        "Failed to launch the browser process (libnss3.so cannot open)",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/cli/src/browser/windowsCrash.ts
+++ b/packages/cli/src/browser/windowsCrash.ts
@@ -1,0 +1,50 @@
+/**
+ * Detection + remediation for Windows chrome-headless-shell launch crashes.
+ *
+ * Field feedback (#hyperframes-cli-feedback ts=1784116246, win32/x64,
+ * HyperFrames CLI 0.7.58) hit the exact error
+ * `Failed to launch the browser process ... Code: 3221225595` with no stderr.
+ * Exit code 3221225595 == 0xC0000409 == STATUS_STACK_BUFFER_OVERRUN — a Windows
+ * stack-corruption fatal reported against the pinned chrome-headless-shell
+ * binary on some Win10/Win11 hosts (typically pre-24H2 or particular AV/EDR
+ * combinations). The reporter recovered by pointing `HYPERFRAMES_BROWSER_PATH`
+ * at their system Chrome; the render then used the screenshot fallback and
+ * produced a complete MP4.
+ *
+ * The generic "Try --docker" hint the CLI already emits doesn't name that env
+ * var, so the workaround is undiscoverable unaided. Sibling failure mode to
+ * the download-time hint added in #2443 and the closed-with-invite #2078
+ * (SIGTRAP at launch on macOS arm64); same `HYPERFRAMES_BROWSER_PATH`
+ * remediation, different trigger + platform.
+ *
+ * The match is gated on both the Puppeteer launch-failure wrapper text AND the
+ * specific crash-code signal (decimal, hex, or symbol name) so unrelated
+ * Windows launch failures — which need different remediation — don't
+ * mis-fire this hint.
+ */
+
+const STATUS_STACK_BUFFER_OVERRUN_DEC = "3221225595";
+const STATUS_STACK_BUFFER_OVERRUN_HEX = /0x[cC]0000409/;
+const STATUS_STACK_BUFFER_OVERRUN_NAME = /STATUS_STACK_BUFFER_OVERRUN/i;
+
+export function isWindowsChromeCrashError(errorMessage: string): boolean {
+  if (!/Failed to launch the browser process/i.test(errorMessage)) return false;
+  return (
+    errorMessage.includes(STATUS_STACK_BUFFER_OVERRUN_DEC) ||
+    STATUS_STACK_BUFFER_OVERRUN_HEX.test(errorMessage) ||
+    STATUS_STACK_BUFFER_OVERRUN_NAME.test(errorMessage)
+  );
+}
+
+export function windowsChromeCrashRemediation(errorMessage: string): string | undefined {
+  if (process.platform !== "win32") return undefined;
+  if (!isWindowsChromeCrashError(errorMessage)) return undefined;
+  return [
+    "chrome-headless-shell crashed at launch (Windows STATUS_STACK_BUFFER_OVERRUN, exit 0xC0000409 / 3221225595).",
+    "The pinned Chromium build is not stable on this Windows host; point hyperframes at your installed Chrome instead:",
+    "",
+    '  set HYPERFRAMES_BROWSER_PATH="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"',
+    "",
+    "Then re-run your command. Any Chrome build works for the screenshot capture path; install a real chrome-headless-shell later if you need the perf-optimized BeginFrame path.",
+  ].join("\n");
+}

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1446,7 +1446,7 @@ function handleRenderError(
       message,
       windowsRemediation,
     );
-    process.exit(1);
+    failCommand();
   }
   errorBox("Render failed", message, hint);
   failCommand();

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -79,6 +79,7 @@ import { runEnvironmentChecks } from "../browser/preflight.js";
 import { detectH264EncoderMode } from "../browser/ffmpeg.js";
 import { chromeLaunchRemediation } from "../browser/linuxDeps.js";
 import { macosOldChromeCrashRemediation } from "../browser/macosOldChromeCrash.js";
+import { windowsChromeCrashRemediation } from "../browser/windowsCrash.js";
 import { killOrphanedProcesses } from "../utils/orphanCleanup.js";
 import {
   markRenderSucceeded,
@@ -1432,6 +1433,20 @@ function handleRenderError(
   if (macosRemediation) {
     errorBox("Render failed — Chrome could not launch", message, macosRemediation);
     failCommand();
+  }
+  // Windows chrome-headless-shell can crash at launch with
+  // STATUS_STACK_BUFFER_OVERRUN (exit 0xC0000409 / 3221225595). Same
+  // HYPERFRAMES_BROWSER_PATH remediation as the download-time hint (#2443)
+  // and the closed-with-invite arm64 macOS sibling (#2078). Field feedback
+  // ts=1784116246.
+  const windowsRemediation = windowsChromeCrashRemediation(message);
+  if (windowsRemediation) {
+    errorBox(
+      "Render failed — chrome-headless-shell crashed at launch",
+      message,
+      windowsRemediation,
+    );
+    process.exit(1);
   }
   errorBox("Render failed", message, hint);
   failCommand();


### PR DESCRIPTION
## What

Add a Windows-scoped launch-crash remediation to `handleRenderError` in `packages/cli/src/commands/render.ts`. When the pinned `chrome-headless-shell` binary fails to launch with `STATUS_STACK_BUFFER_OVERRUN` (exit `0xC0000409` / `3221225595`), surface a scoped `errorBox` that names `HYPERFRAMES_BROWSER_PATH` with an actionable per-platform example — same remediation as the download-time hint (#2443) and the closed-with-invite arm64 macOS sibling (#2078), different trigger + platform.

## Why

Field feedback in `#hyperframes-cli-feedback` — message ts `1784116246`, `win32/x64`, HyperFrames CLI `0.7.58` — hit the exact error `Failed to launch the browser process ... Code: 3221225595` with no stderr. Exit code `3221225595` == `0xC0000409` == `STATUS_STACK_BUFFER_OVERRUN`, a Windows stack-corruption fatal reported against the pinned `chrome-headless-shell` binary on some Win10/Win11 hosts (typically pre-24H2 or particular AV/EDR combinations). The reporter recovered by pointing `HYPERFRAMES_BROWSER_PATH` at their system Google Chrome; the render then used the screenshot fallback and produced a complete MP4.

The CLI's generic post-render hint (`Try --docker`, etc.) doesn't name that env var, so the workaround is undiscoverable unaided. Same discoverability issue #2443 solved for the download-time failure mode; this is its launch-time sibling on Windows.

#2078 is the arm64-macOS sibling, closed 2026-07-14 with an explicit invitation: *"Please reopen or resubmit against current main if the need is still concrete."* This report is that fresh concrete case — distinct platform (win32/x64 vs darwin/arm64), distinct exit code (`0xC0000409` vs SIGTRAP/EXC_BREAKPOINT), same remediation surface.

## How

- New `packages/cli/src/browser/windowsCrash.ts` — exports `isWindowsChromeCrashError(errorMessage)` and `windowsChromeCrashRemediation(errorMessage)`. The detector requires BOTH the Puppeteer wrapper text (`Failed to launch the browser process`) AND the specific crash-code signal (decimal `3221225595`, hex `0xC0000409`, or symbol name `STATUS_STACK_BUFFER_OVERRUN`) so unrelated Windows launch failures — which need different remediation — don't mis-fire this hint. `windowsChromeCrashRemediation` returns `undefined` off Windows.
- `render.ts` `handleRenderError` invokes `windowsChromeCrashRemediation(message)` immediately after the existing `chromeLaunchRemediation` (Linux) check. Neither matching → fall through to the generic `errorBox("Render failed", ...)`. Linux path is untouched; the download-time wrap in `manager.ts` (#2443) is untouched.
- Naming: kept `linuxDeps.ts` for the Linux launch-side; new file for Windows-side to preserve single-responsibility. Bikeshed name in a follow-up if a third platform arrives.

Net diff: +132 / -0 across 3 files.

## Test plan

- [x] Unit tests added — `packages/cli/src/browser/windowsCrash.test.ts` (9 vitest cases):
  - positive matches on all three code forms (decimal / hex / symbol name)
  - negative on Linux-shared-lib launch failures (those hit `chromeLaunchRemediation`)
  - negative on the crash code alone without the launch-failure wrapper
  - off-platform (non-win32) short-circuits and non-launch short-circuits
- [x] `bunx vitest run src/browser/windowsCrash.test.ts` — 9 passed
- [x] `bunx oxlint packages/cli/src/browser/windowsCrash{,\.test}.ts packages/cli/src/commands/render.ts` — 0 warnings 0 errors
- [x] `bunx oxfmt` — clean on all three files
- [ ] Manual testing performed — n/a, the crash requires a specific Windows host that reproduced it (would need to be reproduced on the reporter's environment)
- [ ] Documentation updated — n/a; the hint IS the documentation

## Enterprise release / feature flag holdout

<!-- pr-check:enterprise-ff:start -->
- [ ] N/A — this PR doesn't touch enterprise-relevant surfaces
- [x] Ships to all users on merge without feature-flag holdout
<!-- pr-check:enterprise-ff:end -->

## UX/Screenshot recording

<!-- pr-check:ui-impact -->
- [x] <!-- pr-opt:no-ui-impact --> No UI impact — CLI error-message content only

— Via