### PR TITLE
fix(skills): group character-timed CJK captions readably

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,8 +6,8 @@
       "files": 144
     },
     "faceless-explainer": {
-      "hash": "e486bec3499bd84d",
-      "files": 19
+      "hash": "35dccc45ccd48e7f",
+      "files": 20
     },
     "figma": {
       "hash": "0e6e96f5a76ff824",
@@ -58,11 +58,11 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "739774abd773a3d3",
+      "hash": "930c87fe32f3f90c",
       "files": 28
     },
     "product-launch-video": {
-      "hash": "86fcf6421ab9aa8f",
+      "hash": "e37cd96b5dea54f7",
       "files": 23
     },
     "remotion-to-hyperframes": {

--- a/skills/faceless-explainer/scripts/captions.mjs
+++ b/skills/faceless-explainer/scripts/captions.mjs
@@ -47,10 +47,26 @@ const r3 = (x) => Number(x.toFixed(3));
 // ── grouping params ───────────────────────────────────────────────────────────
 const SILENCE_GAP = 0.18; // s of silence between words → split
 const TAIL_PAD = 0.12; // s the group lingers after its last word
-const SENT_END = /[.?!,;:—]$/;
+const SENT_END = /[.?!,;:—。！？；：，、]$/;
 const DENSITY_WINDOW = 1.0; // s window for words/sec density
-function wordCap(density) {
-  return density > 3.5 ? 2 : density > 2.5 ? 3 : 4;
+const CJK_TEXT = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/;
+function wordCap(density, text) {
+  const cap = density > 3.5 ? 2 : density > 2.5 ? 3 : 4;
+  // CJK ASR providers commonly emit one timing token per character. Treat two
+  // characters as roughly one display word so dense Mandarin/Japanese/Korean
+  // streams do not collapse into unreadable 1–2 character captions.
+  return CJK_TEXT.test(text) ? cap * 2 : cap;
+}
+function joinCaptionWords(words) {
+  return words.reduce(
+    (text, word, index) =>
+      text +
+      (index > 0 && !(CJK_TEXT.test(words[index - 1].text) && CJK_TEXT.test(word.text))
+        ? " "
+        : "") +
+      word.text,
+    "",
+  );
 }
 
 function runBuild(argv) {
@@ -129,7 +145,7 @@ function runBuild(argv) {
     const full = cur && cur.words.length >= cur.cap;
     if (!cur || crossFrame || gap || full) {
       if (cur) groups.push(cur);
-      cur = { frame: w.frame, cap: wordCap(densityAt(i)), words: [] };
+      cur = { frame: w.frame, cap: wordCap(densityAt(i), w.text), words: [] };
     }
     cur.words.push(w);
     if (SENT_END.test(w.text)) {
@@ -151,7 +167,7 @@ function runBuild(argv) {
       frame: g.frame,
       start: r3(first.start),
       end,
-      text: g.words.map((w) => w.text).join(" "),
+      text: joinCaptionWords(g.words),
       words: g.words.map((w, wi) => ({
         id: `caption-word-${gi}-${wi}`,
         text: w.text,
@@ -478,7 +494,7 @@ function buildCaptionsHtml(groups, total, W, H) {
         g.words.forEach(function (w) {
           var s = document.createElement("span");
           s.className = "caption-word";
-          s.textContent = w.text + " ";
+          s.textContent = w.text + (/[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/.test(w.text) ? "" : " ");
           el.appendChild(s);
         });
         cap.appendChild(el);

--- a/skills/faceless-explainer/scripts/captions.test.mjs
+++ b/skills/faceless-explainer/scripts/captions.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "captions.mjs");
+
+test("groups character-level Mandarin timings into readable captions", () => {
+  const dir = mkdtempSync(join(tmpdir(), "hf-cjk-captions-"));
+  writeFileSync(
+    join(dir, "STORYBOARD.md"),
+    `---
+format: 1920x1080
+---
+
+## Frame 1 — CJK grouping
+- duration: 2s
+- scene: Chinese caption grouping repro
+`,
+  );
+  const characters = [..."检索增强生成系统优化"];
+  writeFileSync(
+    join(dir, "audio_meta.json"),
+    JSON.stringify({
+      voices: [
+        {
+          frame: 1,
+          words: characters.map((text, index) => ({
+            text,
+            start: index / 10,
+            end: index / 10 + 0.09,
+          })),
+        },
+      ],
+    }),
+  );
+
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        scriptPath,
+        "build",
+        "--storyboard",
+        join(dir, "STORYBOARD.md"),
+        "--audio-meta",
+        join(dir, "audio_meta.json"),
+        "--hyperframes",
+        dir,
+      ],
+      { stdio: "pipe" },
+    );
+    const output = JSON.parse(readFileSync(join(dir, "caption_groups.json"), "utf8"));
+    assert.deepEqual(
+      output.groups.map((group) => group.text),
+      ["检索增强", "生成系统", "优化"],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/skills/pr-to-video/scripts/captions.mjs
+++ b/skills/pr-to-video/scripts/captions.mjs
@@ -47,10 +47,26 @@ const r3 = (x) => Number(x.toFixed(3));
 // ── grouping params ───────────────────────────────────────────────────────────
 const SILENCE_GAP = 0.18; // s of silence between words → split
 const TAIL_PAD = 0.12; // s the group lingers after its last word
-const SENT_END = /[.?!,;:—]$/;
+const SENT_END = /[.?!,;:—。！？；：，、]$/;
 const DENSITY_WINDOW = 1.0; // s window for words/sec density
-function wordCap(density) {
-  return density > 3.5 ? 2 : density > 2.5 ? 3 : 4;
+const CJK_TEXT = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/;
+function wordCap(density, text) {
+  const cap = density > 3.5 ? 2 : density > 2.5 ? 3 : 4;
+  // CJK ASR providers commonly emit one timing token per character. Treat two
+  // characters as roughly one display word so dense Mandarin/Japanese/Korean
+  // streams do not collapse into unreadable 1–2 character captions.
+  return CJK_TEXT.test(text) ? cap * 2 : cap;
+}
+function joinCaptionWords(words) {
+  return words.reduce(
+    (text, word, index) =>
+      text +
+      (index > 0 && !(CJK_TEXT.test(words[index - 1].text) && CJK_TEXT.test(word.text))
+        ? " "
+        : "") +
+      word.text,
+    "",
+  );
 }
 
 function runBuild(argv) {
@@ -129,7 +145,7 @@ function runBuild(argv) {
     const full = cur && cur.words.length >= cur.cap;
     if (!cur || crossFrame || gap || full) {
       if (cur) groups.push(cur);
-      cur = { frame: w.frame, cap: wordCap(densityAt(i)), words: [] };
+      cur = { frame: w.frame, cap: wordCap(densityAt(i), w.text), words: [] };
     }
     cur.words.push(w);
     if (SENT_END.test(w.text)) {
@@ -151,7 +167,7 @@ function runBuild(argv) {
       frame: g.frame,
       start: r3(first.start),
       end,
-      text: g.words.map((w) => w.text).join(" "),
+      text: joinCaptionWords(g.words),
       words: g.words.map((w, wi) => ({
         id: `caption-word-${gi}-${wi}`,
         text: w.text,
@@ -478,7 +494,7 @@ function buildCaptionsHtml(groups, total, W, H) {
         g.words.forEach(function (w) {
           var s = document.createElement("span");
           s.className = "caption-word";
-          s.textContent = w.text + " ";
+          s.textContent = w.text + (/[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/.test(w.text) ? "" : " ");
           el.appendChild(s);
         });
         cap.appendChild(el);

--- a/skills/product-launch-video/scripts/captions.mjs
+++ b/skills/product-launch-video/scripts/captions.mjs
@@ -47,10 +47,26 @@ const r3 = (x) => Number(x.toFixed(3));
 // ── grouping params ───────────────────────────────────────────────────────────
 const SILENCE_GAP = 0.18; // s of silence between words → split
 const TAIL_PAD = 0.12; // s the group lingers after its last word
-const SENT_END = /[.?!,;:—]$/;
+const SENT_END = /[.?!,;:—。！？；：，、]$/;
 const DENSITY_WINDOW = 1.0; // s window for words/sec density
-function wordCap(density) {
-  return density > 3.5 ? 2 : density > 2.5 ? 3 : 4;
+const CJK_TEXT = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/;
+function wordCap(density, text) {
+  const cap = density > 3.5 ? 2 : density > 2.5 ? 3 : 4;
+  // CJK ASR providers commonly emit one timing token per character. Treat two
+  // characters as roughly one display word so dense Mandarin/Japanese/Korean
+  // streams do not collapse into unreadable 1–2 character captions.
+  return CJK_TEXT.test(text) ? cap * 2 : cap;
+}
+function joinCaptionWords(words) {
+  return words.reduce(
+    (text, word, index) =>
+      text +
+      (index > 0 && !(CJK_TEXT.test(words[index - 1].text) && CJK_TEXT.test(word.text))
+        ? " "
+        : "") +
+      word.text,
+    "",
+  );
 }
 
 function runBuild(argv) {
@@ -129,7 +145,7 @@ function runBuild(argv) {
     const full = cur && cur.words.length >= cur.cap;
     if (!cur || crossFrame || gap || full) {
       if (cur) groups.push(cur);
-      cur = { frame: w.frame, cap: wordCap(densityAt(i)), words: [] };
+      cur = { frame: w.frame, cap: wordCap(densityAt(i), w.text), words: [] };
     }
     cur.words.push(w);
     if (SENT_END.test(w.text)) {
@@ -151,7 +167,7 @@ function runBuild(argv) {
       frame: g.frame,
       start: r3(first.start),
       end,
-      text: g.words.map((w) => w.text).join(" "),
+      text: joinCaptionWords(g.words),
       words: g.words.map((w, wi) => ({
         id: `caption-word-${gi}-${wi}`,
         text: w.text,
@@ -478,7 +494,7 @@ function buildCaptionsHtml(groups, total, W, H) {
         g.words.forEach(function (w) {
           var s = document.createElement("span");
           s.className = "caption-word";
-          s.textContent = w.text + " ";
+          s.textContent = w.text + (/[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/.test(w.text) ? "" : " ");
           el.appendChild(s);
         });
         cap.appendChild(el);


### PR DESCRIPTION
## Summary
- scale caption density caps for character-level CJK timing tokens
- omit artificial spaces between adjacent CJK characters
- recognize CJK sentence punctuation
- keep the shared caption builders aligned across faceless-explainer, product-launch-video, and pr-to-video

## Current reproduction
A 10-character Mandarin timing stream (`检索增强生成系统优化`) produces five mostly two-character captions on current main:

```json
["检 索", "增 强", "生 成", "系 统", "优 化"]
```

The field report saw the same behavior at production scale: 57 mostly two-character groups, manually regrouped into 26 readable phrases.

Refreshes the exact closed backlog fix from #2318 after the requested new field reproduction made it current again. GitHub would not reopen the closed PR after its branch was refreshed, so this PR carries the same scope rebased on current `main`.

## Verification
- red current-main repro captured above
- focused Node regression: 1/1 passing and now yields `检索增强`, `生成系统`, `优化`
- all three shared caption builders are byte-identical
- `oxfmt --check` on all changed files
- skills manifest regenerated
- diff whitespace check