### PR TITLE
fix(render): ignore favicon probe noise

### DIFF
--- a/packages/producer/src/services/render/stages/probeFailures.test.ts
+++ b/packages/producer/src/services/render/stages/probeFailures.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { isActionableProbeFailure } from "./probeFailures.js";
+
+describe("isActionableProbeFailure", () => {
+  it("ignores favicon 404 noise without hiding real asset failures", () => {
+    expect(
+      isActionableProbeFailure(
+        "[Browser:HTTP404] GET http://127.0.0.1:4173/favicon.ico resource=image",
+      ),
+    ).toBe(false);
+    expect(
+      isActionableProbeFailure(
+        "[Browser:HTTP404] GET http://127.0.0.1:4173/assets/missing.png resource=image",
+      ),
+    ).toBe(true);
+    expect(
+      isActionableProbeFailure(
+        "[Browser:REQUESTFAILED] GET http://127.0.0.1:4173/assets/app.js resource=script error=net::ERR_FAILED",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/producer/src/services/render/stages/probeFailures.ts
+++ b/packages/producer/src/services/render/stages/probeFailures.ts
@@ -1,0 +1,6 @@
+const NETWORK_FAILURE_PATTERN = /404|ERR_NAME_NOT_RESOLVED|ERR_CONNECTION_REFUSED|net::ERR_/i;
+const FAVICON_PATTERN = /(?:^|[/?])favicon(?:\.[a-z0-9]+)?(?:[?#\s]|$)/i;
+
+export function isActionableProbeFailure(line: string): boolean {
+  return NETWORK_FAILURE_PATTERN.test(line) && !FAVICON_PATTERN.test(line);
+}

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -59,6 +59,7 @@ import {
   type CompositionMetadata,
 } from "../shared.js";
 import type { RenderJob } from "../../renderOrchestrator.js";
+import { isActionableProbeFailure } from "./probeFailures.js";
 
 export interface ProbeStageInput {
   projectDir: string;
@@ -643,9 +644,7 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
   // These don't block the render but indicate missing images, fonts, or
   // scripts that may produce unexpected visual artifacts.
   if (probeSession) {
-    const failedRequests = probeSession.browserConsoleBuffer.filter((line) =>
-      /404|ERR_NAME_NOT_RESOLVED|ERR_CONNECTION_REFUSED|net::ERR_/i.test(line),
-    );
+    const failedRequests = probeSession.browserConsoleBuffer.filter(isActionableProbeFailure);
     if (failedRequests.length > 0) {
       log.warn("Browser encountered network failures during page load:", {
         failures: failedRequests.slice(0, 10),


### PR DESCRIPTION
## What

Ignore favicon 404s when the render probe summarizes browser asset-load failures, while preserving real missing assets and network failures.

## Why

Browsers may request `/favicon.ico` automatically. The file server and validator already treat that miss as benign, but the probe warning path promoted every buffered 404 to `[Render] Asset load failure`, adding noise to otherwise clean renders.

## Verification

- failing-then-passing focused test covers favicon 404 vs real image 404 and script `net::ERR_FAILED`
- `bun test packages/producer/src/services/render/stages/probeFailures.test.ts`
- `oxfmt --check` on changed files
- `git diff --check`
- pre-commit lint/format/fallow/tracked-artifact checks passed; monorepo typecheck could not resolve workspace packages in the isolated worktree node_modules setup