### PR TITLE
fix: discard the warmup capture frame in the parallel coordinator

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run studio",
-    "build": "bun run --filter '@hyperframes/{parsers,lint,studio-server}' build && bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions,aws-lambda,gcp-cloud-run,sdk}' build && bun run --filter @hyperframes/cli build && bun run --filter @hyperframes/sdk-playground build",
+    "build": "bun run --filter '@hyperframes/{parsers,lint,studio-server}' build && bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions}' build && bun run --filter '@hyperframes/{aws-lambda,gcp-cloud-run,sdk}' build && bun run --filter @hyperframes/cli build && bun run --filter @hyperframes/sdk-playground build",
     "build:producer": "bun run --filter @hyperframes/producer build",
     "studio": "bun run --filter @hyperframes/studio dev",
     "build:hyperframes-runtime": "bun run --filter @hyperframes/core build:hyperframes-runtime",

--- a/packages/engine/src/services/frameCapture-discardWarmup.test.ts
+++ b/packages/engine/src/services/frameCapture-discardWarmup.test.ts
@@ -19,11 +19,14 @@
  * `innerCapture` for exactly this reason). We don't need a real Chrome.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { existsSync, readdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { discardWarmupCapture, type CaptureSession } from "./frameCapture.js";
+import { captureFrameToBuffer, discardWarmupCapture, type CaptureSession } from "./frameCapture.js";
+import { pageScreenshotCapture } from "./screenshotService.js";
+
+vi.mock("./screenshotService.js");
 
 function makeFakeSession(): CaptureSession {
   // The discardWarmupCapture wrapper only reads `capturePerf`,
@@ -44,6 +47,7 @@ function makeFakeSession(): CaptureSession {
       beforeCaptureMs: 50,
       screenshotMs: 200,
       totalMs: 350,
+      frameMs: [40, 50],
     },
     captureMode: "screenshot",
     beginFrameTimeTicks: 0,
@@ -58,6 +62,20 @@ function cleanupSession(session: CaptureSession): void {
 }
 
 describe("discardWarmupCapture", () => {
+  it("settles and retains screenshots after a single seek", async () => {
+    const session = makeFakeSession();
+    const evaluate = vi.fn(async () => false);
+    session.page = { evaluate } as unknown as CaptureSession["page"];
+    vi.mocked(pageScreenshotCapture)
+      .mockResolvedValueOnce(Buffer.from("warmup"))
+      .mockResolvedValueOnce(Buffer.from("retained"));
+    const result = await captureFrameToBuffer(session, 36, 1.2, true);
+    expect(evaluate.mock.calls.filter((call) => call.length === 2)).toHaveLength(1);
+    expect(pageScreenshotCapture).toHaveBeenCalledTimes(2);
+    expect(result.buffer.toString()).toBe("retained");
+    cleanupSession(session);
+  });
+
   it("rejects BeginFrame sessions before issuing a duplicate compositor tick", async () => {
     const session = makeFakeSession();
     session.captureMode = "beginframe";
@@ -111,7 +129,7 @@ describe("discardWarmupCapture", () => {
 
   it("restores perf counters after the inner capture mutates them", async () => {
     const session = makeFakeSession();
-    const before = { ...session.capturePerf };
+    const before = { ...session.capturePerf, frameMs: [...session.capturePerf.frameMs] };
     try {
       await discardWarmupCapture(session, 0, 0, async (s) => {
         s.capturePerf.frames += 1;
@@ -119,6 +137,7 @@ describe("discardWarmupCapture", () => {
         s.capturePerf.beforeCaptureMs += 5;
         s.capturePerf.screenshotMs += 33;
         s.capturePerf.totalMs += 50;
+        s.capturePerf.frameMs.push(999);
         return { buffer: Buffer.alloc(0), quantizedTime: 0, captureTimeMs: 50 };
       });
       expect(session.capturePerf).toEqual(before);

--- a/packages/engine/src/services/frameCapture-discardWarmup.test.ts
+++ b/packages/engine/src/services/frameCapture-discardWarmup.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for `discardWarmupCapture` — the helper distributed chunk workers
- * run before their first real capture to prime `lastFrameCache`.
+ * Tests for `discardWarmupCapture` — the helper screenshot-mode parallel
+ * workers run before their first real capture to settle their first seek.
  *
  * The helper is a thin wrapper around the inner `captureFrameCore`
  * machinery, so its testable contract is post-conditional rather than
@@ -45,7 +45,7 @@ function makeFakeSession(): CaptureSession {
       screenshotMs: 200,
       totalMs: 350,
     },
-    captureMode: "beginframe",
+    captureMode: "screenshot",
     beginFrameTimeTicks: 0,
     beginFrameIntervalMs: 33,
     beginFrameHasDamageCount: 4,
@@ -53,7 +53,28 @@ function makeFakeSession(): CaptureSession {
   } as unknown as CaptureSession;
 }
 
+function cleanupSession(session: CaptureSession): void {
+  rmSync(session.outputDir, { recursive: true, force: true });
+}
+
 describe("discardWarmupCapture", () => {
+  it("rejects BeginFrame sessions before issuing a duplicate compositor tick", async () => {
+    const session = makeFakeSession();
+    session.captureMode = "beginframe";
+    let called = false;
+    try {
+      await expect(
+        discardWarmupCapture(session, 36, 1.2, async () => {
+          called = true;
+          return { buffer: Buffer.alloc(0), quantizedTime: 1.2, captureTimeMs: 0 };
+        }),
+      ).rejects.toThrow("screenshot capture mode");
+      expect(called).toBe(false);
+    } finally {
+      cleanupSession(session);
+    }
+  });
+
   it("calls the inner capture exactly once with (frameIndex=0, time=0) by default", async () => {
     const session = makeFakeSession();
     try {
@@ -70,7 +91,7 @@ describe("discardWarmupCapture", () => {
       expect(receivedFrameIndex).toBe(0);
       expect(receivedTime).toBe(0);
     } finally {
-      rmSync(session.outputDir, { recursive: true, force: true });
+      cleanupSession(session);
     }
   });
 
@@ -84,7 +105,7 @@ describe("discardWarmupCapture", () => {
       });
       expect(received).toEqual({ fi: 240, t: 8 });
     } finally {
-      rmSync(session.outputDir, { recursive: true, force: true });
+      cleanupSession(session);
     }
   });
 
@@ -102,7 +123,7 @@ describe("discardWarmupCapture", () => {
       });
       expect(session.capturePerf).toEqual(before);
     } finally {
-      rmSync(session.outputDir, { recursive: true, force: true });
+      cleanupSession(session);
     }
   });
 
@@ -119,7 +140,7 @@ describe("discardWarmupCapture", () => {
       expect(session.beginFrameHasDamageCount).toBe(hasBefore);
       expect(session.beginFrameNoDamageCount).toBe(noBefore);
     } finally {
-      rmSync(session.outputDir, { recursive: true, force: true });
+      cleanupSession(session);
     }
   });
 
@@ -146,7 +167,7 @@ describe("discardWarmupCapture", () => {
       expect(session.beginFrameHasDamageCount).toBe(hasBefore);
       expect(session.beginFrameNoDamageCount).toBe(noBefore);
     } finally {
-      rmSync(session.outputDir, { recursive: true, force: true });
+      cleanupSession(session);
     }
   });
 
@@ -163,7 +184,7 @@ describe("discardWarmupCapture", () => {
       const after = readdirSync(session.outputDir);
       expect(after).toEqual(before);
     } finally {
-      rmSync(session.outputDir, { recursive: true, force: true });
+      cleanupSession(session);
     }
   });
 
@@ -177,7 +198,7 @@ describe("discardWarmupCapture", () => {
       }));
       expect(result).toBeUndefined();
     } finally {
-      rmSync(session.outputDir, { recursive: true, force: true });
+      cleanupSession(session);
     }
   });
 });

--- a/packages/engine/src/services/frameCapture-discardWarmup.test.ts
+++ b/packages/engine/src/services/frameCapture-discardWarmup.test.ts
@@ -165,7 +165,7 @@ describe("discardWarmupCapture", () => {
 
   it("restores state even when the inner capture throws", async () => {
     const session = makeFakeSession();
-    const perfBefore = { ...session.capturePerf };
+    const perfBefore = { ...session.capturePerf, frameMs: [...session.capturePerf.frameMs] };
     const hasBefore = session.beginFrameHasDamageCount;
     const noBefore = session.beginFrameNoDamageCount;
     try {
@@ -173,6 +173,7 @@ describe("discardWarmupCapture", () => {
       try {
         await discardWarmupCapture(session, 0, 0, async (s) => {
           s.capturePerf.frames += 5;
+          s.capturePerf.frameMs.push(999);
           s.beginFrameNoDamageCount += 2;
           throw new Error("simulated capture failure");
         });

--- a/packages/engine/src/services/frameCapture-discardWarmup.test.ts
+++ b/packages/engine/src/services/frameCapture-discardWarmup.test.ts
@@ -24,7 +24,7 @@ import { existsSync, readdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { captureFrameToBuffer, discardWarmupCapture, type CaptureSession } from "./frameCapture.js";
-import { pageScreenshotCapture } from "./screenshotService.js";
+import { beginFrameCapture, pageScreenshotCapture } from "./screenshotService.js";
 
 vi.mock("./screenshotService.js");
 
@@ -73,6 +73,27 @@ describe("discardWarmupCapture", () => {
     expect(evaluate.mock.calls.filter((call) => call.length === 2)).toHaveLength(1);
     expect(pageScreenshotCapture).toHaveBeenCalledTimes(2);
     expect(result.buffer.toString()).toBe("retained");
+    cleanupSession(session);
+  });
+
+  it("ignores settlePaint in BeginFrame mode so no extra screenshot interleaves the tick", async () => {
+    // The parallelCoordinator only requests settlement for screenshot workers,
+    // but captureFrameCore must enforce the mode itself: a throwaway
+    // Page.captureScreenshot interleaved with HeadlessExperimental.beginFrame
+    // is the duplicate-compositor-tick hazard class discardWarmupCapture guards.
+    const session = makeFakeSession();
+    session.captureMode = "beginframe";
+    const evaluate = vi.fn(async () => false);
+    session.page = { evaluate } as unknown as CaptureSession["page"];
+    vi.mocked(pageScreenshotCapture).mockClear();
+    vi.mocked(beginFrameCapture).mockResolvedValue({
+      buffer: Buffer.from("beginframe"),
+      hasDamage: true,
+    });
+    const result = await captureFrameToBuffer(session, 36, 1.2, true);
+    expect(pageScreenshotCapture).not.toHaveBeenCalled();
+    expect(beginFrameCapture).toHaveBeenCalledTimes(1);
+    expect(result.buffer.toString()).toBe("beginframe");
     cleanupSession(session);
   });
 

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -3233,14 +3233,15 @@ export type DiscardWarmupInnerCapture = (
  * side-effects (perf counters, BeginFrame damage tallies) so downstream
  * captures see state identical to a fresh session.
  *
- * Distributed chunk workers need this because Chrome's BeginFrame screenshot
- * pipeline maintains a per-process `lastFrameCache`: when a captured frame's
- * `hasDamage` reports `false`, the screenshot path returns the previously
- * captured buffer. For chunk N (N > 0) the worker has no prior frame in its
- * cache, so the very first capture's `hasDamage` reporting diverges from
- * what an in-process render at the same absolute frame index would see (the
- * in-process renderer always has frame N-1 cached). One discard capture
- * before the first real capture primes the cache.
+ * Screenshot-mode parallel workers use this to settle the paint scheduled by
+ * their first non-zero `__hf.seek()`: the throwaway Page.captureScreenshot
+ * produces a frame, allowing rAF/compositor work to land before the real
+ * capture reads the pixels.
+ *
+ * This helper is intentionally forbidden for BeginFrame and drawElement
+ * sessions. Repeating a BeginFrame timestamp stalls Chrome's compositor, and
+ * priming with an earlier frame makes the subsequent real capture move time
+ * backwards, which stalls for the same reason (see producer renderChunk).
  *
  * The function intentionally restores perf state so the warmup capture does
  * NOT bias `getCapturePerfSummary()`'s per-frame averages.
@@ -3261,6 +3262,9 @@ export async function discardWarmupCapture(
   time: number = 0,
   innerCapture: DiscardWarmupInnerCapture = captureFrameCore,
 ): Promise<void> {
+  if (session.captureMode !== "screenshot") {
+    throw new Error("discardWarmupCapture requires screenshot capture mode");
+  }
   // Snapshot the side-effect counters captureFrameCore mutates. We use a
   // shallow `{...}` for capturePerf because all five fields are primitive
   // numbers — no nested state to deep-copy.

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -2751,6 +2751,7 @@ async function captureFrameCore(
   session: CaptureSession,
   frameIndex: number,
   time: number,
+  settlePaint: boolean = false,
 ): Promise<{ buffer: Buffer; quantizedTime: number; captureTimeMs: number }> {
   const { page, options } = session;
   const startTime = Date.now();
@@ -2787,6 +2788,7 @@ async function captureFrameCore(
     );
 
     const screenshotStart = Date.now();
+    if (settlePaint) await pageScreenshotCapture(page, options);
     let screenshotBuffer: Buffer;
 
     if (session.captureMode === "beginframe") {
@@ -2920,11 +2922,13 @@ export async function captureFrame(
   session: CaptureSession,
   frameIndex: number,
   time: number,
+  settlePaint: boolean = false,
 ): Promise<CaptureResult> {
   const { buffer, quantizedTime, captureTimeMs } = await captureFrameCore(
     session,
     frameIndex,
     time,
+    settlePaint,
   );
   const framePath = writeCapturedFrame(session, frameIndex, buffer);
   return { frameIndex, time: quantizedTime, path: framePath, captureTimeMs };
@@ -2957,8 +2961,9 @@ export async function captureFrameToBuffer(
   session: CaptureSession,
   frameIndex: number,
   time: number,
+  settlePaint: boolean = false,
 ): Promise<CaptureBufferResult> {
-  const { buffer, captureTimeMs } = await captureFrameCore(session, frameIndex, time);
+  const { buffer, captureTimeMs } = await captureFrameCore(session, frameIndex, time, settlePaint);
 
   return { buffer, captureTimeMs };
 }
@@ -3265,10 +3270,7 @@ export async function discardWarmupCapture(
   if (session.captureMode !== "screenshot") {
     throw new Error("discardWarmupCapture requires screenshot capture mode");
   }
-  // Snapshot the side-effect counters captureFrameCore mutates. We use a
-  // shallow `{...}` for capturePerf because all five fields are primitive
-  // numbers — no nested state to deep-copy.
-  const perfBefore = { ...session.capturePerf };
+  const perfBefore = { ...session.capturePerf, frameMs: [...session.capturePerf.frameMs] };
   const hasDamageBefore = session.beginFrameHasDamageCount;
   const noDamageBefore = session.beginFrameNoDamageCount;
   const dedupCountBefore = session.staticDedupCount;

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -2788,7 +2788,17 @@ async function captureFrameCore(
     );
 
     const screenshotStart = Date.now();
-    if (settlePaint) await pageScreenshotCapture(page, options);
+    // Paint-settlement barrier (fresh non-zero screenshot workers): the seek
+    // above may have scheduled rAF/compositor work that has not painted yet.
+    // One throwaway Page.captureScreenshot lets that work land so the retained
+    // screenshot below reads settled pixels — same seek, no second
+    // prepareFrameForCapture. Screenshot mode only, enforced here and not just
+    // at the call site: interleaving an extra captureScreenshot with
+    // BeginFrame/drawElement capture risks the duplicate-compositor-tick
+    // stalls documented on discardWarmupCapture.
+    if (settlePaint && session.captureMode === "screenshot") {
+      await pageScreenshotCapture(page, options);
+    }
     let screenshotBuffer: Buffer;
 
     if (session.captureMode === "beginframe") {

--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -27,10 +27,12 @@ import type { EngineConfig } from "../config.js";
 
 const { executeWorkerTask } = __testing;
 
-function makeWorkerSession() {
+function makeWorkerSession(
+  captureMode: "screenshot" | "beginframe" | "drawelement" = "screenshot",
+) {
   return {
     browserConsoleBuffer: [],
-    captureMode: "screenshot",
+    captureMode,
     workerEncodeEnabled: false,
   };
 }
@@ -61,7 +63,7 @@ beforeEach(() => {
 });
 
 describe("executeWorkerTask", () => {
-  it("warms a non-zero worker after initialization and before its first frame", async () => {
+  it("settles a non-zero screenshot worker at its first absolute frame", async () => {
     const callOrder: string[] = [];
     frameCaptureMocks.initializeSession.mockImplementation(async () => {
       callOrder.push("initialize");
@@ -76,17 +78,30 @@ describe("executeWorkerTask", () => {
     const result = await runWorker(1, 36);
 
     expect(result.error).toBeUndefined();
-    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledOnce();
+    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledWith(expect.anything(), 36, 1.2);
     expect(callOrder).toEqual(["initialize", "warmup", "capture:36", "capture:37"]);
   });
 
-  it("warms every worker without changing its reported frame count", async () => {
+  it("does not warm worker zero because its initial state is already painted", async () => {
     const results = await Promise.all([runWorker(0, 0), runWorker(1, 36)]);
 
-    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledTimes(2);
+    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledTimes(1);
     expect(results.map((result) => result.framesCaptured)).toEqual([2, 2]);
     expect(frameCaptureMocks.captureFrame).toHaveBeenCalledTimes(4);
   });
+
+  it.each(["beginframe", "drawelement"] as const)(
+    "does not issue a duplicate warmup capture in %s mode",
+    async (captureMode) => {
+      frameCaptureMocks.createCaptureSession.mockResolvedValue(makeWorkerSession(captureMode));
+
+      const result = await runWorker(1, 36);
+
+      expect(result.error).toBeUndefined();
+      expect(frameCaptureMocks.discardWarmupCapture).not.toHaveBeenCalled();
+      expect(frameCaptureMocks.captureFrame).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("returns a worker error and closes the session when warmup fails", async () => {
     const session = makeWorkerSession();
@@ -108,7 +123,7 @@ describe("executeWorkerTask", () => {
       controller.abort();
     });
 
-    const result = await runWorker(0, 0, controller.signal);
+    const result = await runWorker(1, 36, controller.signal);
 
     expect(result).toMatchObject({ error: "Parallel worker cancelled", framesCaptured: 0 });
     expect(frameCaptureMocks.captureFrame).not.toHaveBeenCalled();

--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -1,5 +1,20 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const frameCaptureMocks = vi.hoisted(() => ({
+  createCaptureSession: vi.fn(),
+  initializeSession: vi.fn(),
+  discardWarmupCapture: vi.fn(),
+  closeCaptureSession: vi.fn(),
+  captureFrame: vi.fn(),
+  captureFrameToBufferPipelined: vi.fn(),
+  captureFrameToBuffer: vi.fn(),
+  getCapturePerfSummary: vi.fn(),
+}));
+
+vi.mock("./frameCapture.js", () => frameCaptureMocks);
+
 import {
+  __testing,
   calculateOptimalWorkers,
   distributeFrames,
   formatWorkerFailure,
@@ -9,6 +24,97 @@ import {
   resolveParallelDeVerifySamples,
 } from "./parallelCoordinator.js";
 import type { EngineConfig } from "../config.js";
+
+const { executeWorkerTask } = __testing;
+
+function makeWorkerSession() {
+  return {
+    browserConsoleBuffer: [],
+    captureMode: "screenshot",
+    workerEncodeEnabled: false,
+  };
+}
+
+const captureOptions = {
+  width: 1280,
+  height: 720,
+  fps: { num: 30, den: 1 },
+};
+
+function runWorker(workerId: number, startFrame: number, signal?: AbortSignal) {
+  return executeWorkerTask(
+    { workerId, startFrame, endFrame: startFrame + 2, outputDir: "/tmp" },
+    "http://127.0.0.1:4173",
+    captureOptions,
+    () => null,
+    signal,
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  frameCaptureMocks.createCaptureSession.mockImplementation(async () => makeWorkerSession());
+  frameCaptureMocks.initializeSession.mockResolvedValue(undefined);
+  frameCaptureMocks.discardWarmupCapture.mockResolvedValue(undefined);
+  frameCaptureMocks.closeCaptureSession.mockResolvedValue(undefined);
+  frameCaptureMocks.captureFrame.mockResolvedValue(undefined);
+});
+
+describe("executeWorkerTask", () => {
+  it("warms a non-zero worker after initialization and before its first frame", async () => {
+    const callOrder: string[] = [];
+    frameCaptureMocks.initializeSession.mockImplementation(async () => {
+      callOrder.push("initialize");
+    });
+    frameCaptureMocks.discardWarmupCapture.mockImplementation(async () => {
+      callOrder.push("warmup");
+    });
+    frameCaptureMocks.captureFrame.mockImplementation(async (_session, frameIndex) => {
+      callOrder.push(`capture:${frameIndex}`);
+    });
+
+    const result = await runWorker(1, 36);
+
+    expect(result.error).toBeUndefined();
+    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledOnce();
+    expect(callOrder).toEqual(["initialize", "warmup", "capture:36", "capture:37"]);
+  });
+
+  it("warms every worker without changing its reported frame count", async () => {
+    const results = await Promise.all([runWorker(0, 0), runWorker(1, 36)]);
+
+    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledTimes(2);
+    expect(results.map((result) => result.framesCaptured)).toEqual([2, 2]);
+    expect(frameCaptureMocks.captureFrame).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns a worker error and closes the session when warmup fails", async () => {
+    const session = makeWorkerSession();
+    frameCaptureMocks.createCaptureSession.mockResolvedValue(session);
+    frameCaptureMocks.discardWarmupCapture.mockRejectedValue(new Error("warmup failed"));
+
+    const result = await runWorker(1, 36);
+
+    expect(result).toMatchObject({ error: "warmup failed", framesCaptured: 0 });
+    expect(frameCaptureMocks.captureFrame).not.toHaveBeenCalled();
+    expect(frameCaptureMocks.closeCaptureSession).toHaveBeenCalledWith(session);
+  });
+
+  it("returns a cancellation error and closes the session when aborted during warmup", async () => {
+    const controller = new AbortController();
+    const session = makeWorkerSession();
+    frameCaptureMocks.createCaptureSession.mockResolvedValue(session);
+    frameCaptureMocks.discardWarmupCapture.mockImplementation(async () => {
+      controller.abort();
+    });
+
+    const result = await runWorker(0, 0, controller.signal);
+
+    expect(result).toMatchObject({ error: "Parallel worker cancelled", framesCaptured: 0 });
+    expect(frameCaptureMocks.captureFrame).not.toHaveBeenCalled();
+    expect(frameCaptureMocks.closeCaptureSession).toHaveBeenCalledWith(session);
+  });
+});
 
 describe("distributeFrames", () => {
   it("distributes frames evenly across workers", () => {

--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, it, expect, vi } from "vitest";
 const frameCaptureMocks = vi.hoisted(() => ({
   createCaptureSession: vi.fn(),
   initializeSession: vi.fn(),
-  discardWarmupCapture: vi.fn(),
   closeCaptureSession: vi.fn(),
   captureFrame: vi.fn(),
   captureFrameToBufferPipelined: vi.fn(),
@@ -57,7 +56,6 @@ beforeEach(() => {
   vi.resetAllMocks();
   frameCaptureMocks.createCaptureSession.mockImplementation(async () => makeWorkerSession());
   frameCaptureMocks.initializeSession.mockResolvedValue(undefined);
-  frameCaptureMocks.discardWarmupCapture.mockResolvedValue(undefined);
   frameCaptureMocks.closeCaptureSession.mockResolvedValue(undefined);
   frameCaptureMocks.captureFrame.mockResolvedValue(undefined);
 });
@@ -68,26 +66,23 @@ describe("executeWorkerTask", () => {
     frameCaptureMocks.initializeSession.mockImplementation(async () => {
       callOrder.push("initialize");
     });
-    frameCaptureMocks.discardWarmupCapture.mockImplementation(async () => {
-      callOrder.push("warmup");
-    });
-    frameCaptureMocks.captureFrame.mockImplementation(async (_session, frameIndex) => {
-      callOrder.push(`capture:${frameIndex}`);
-    });
+    frameCaptureMocks.captureFrame.mockImplementation(
+      async (_session, frameIndex, _time, settle) => {
+        callOrder.push(`capture:${frameIndex}:${settle}`);
+      },
+    );
 
-    const result = await runWorker(1, 36);
+    await runWorker(1, 36);
 
-    expect(result.error).toBeUndefined();
-    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledWith(expect.anything(), 36, 1.2);
-    expect(callOrder).toEqual(["initialize", "warmup", "capture:36", "capture:37"]);
+    expect(callOrder).toEqual(["initialize", "capture:36:true", "capture:37:false"]);
   });
 
   it("does not warm worker zero because its initial state is already painted", async () => {
-    const results = await Promise.all([runWorker(0, 0), runWorker(1, 36)]);
+    const result = await runWorker(0, 0);
 
-    expect(frameCaptureMocks.discardWarmupCapture).toHaveBeenCalledTimes(1);
-    expect(results.map((result) => result.framesCaptured)).toEqual([2, 2]);
-    expect(frameCaptureMocks.captureFrame).toHaveBeenCalledTimes(4);
+    expect(result.framesCaptured).toBe(2);
+    const settles = frameCaptureMocks.captureFrame.mock.calls.map((call) => call[3]);
+    expect(settles).toEqual([false, false]);
   });
 
   it.each(["beginframe", "drawelement"] as const)(
@@ -98,35 +93,20 @@ describe("executeWorkerTask", () => {
       const result = await runWorker(1, 36);
 
       expect(result.error).toBeUndefined();
-      expect(frameCaptureMocks.discardWarmupCapture).not.toHaveBeenCalled();
-      expect(frameCaptureMocks.captureFrame).toHaveBeenCalledTimes(2);
+      const settles = frameCaptureMocks.captureFrame.mock.calls.map((call) => call[3]);
+      expect(settles).toEqual([false, false]);
     },
   );
 
-  it("returns a worker error and closes the session when warmup fails", async () => {
+  it("returns a worker error and closes the session when the paint barrier fails", async () => {
     const session = makeWorkerSession();
     frameCaptureMocks.createCaptureSession.mockResolvedValue(session);
-    frameCaptureMocks.discardWarmupCapture.mockRejectedValue(new Error("warmup failed"));
+    frameCaptureMocks.captureFrame.mockRejectedValue(new Error("warmup failed"));
 
     const result = await runWorker(1, 36);
 
     expect(result).toMatchObject({ error: "warmup failed", framesCaptured: 0 });
-    expect(frameCaptureMocks.captureFrame).not.toHaveBeenCalled();
-    expect(frameCaptureMocks.closeCaptureSession).toHaveBeenCalledWith(session);
-  });
-
-  it("returns a cancellation error and closes the session when aborted during warmup", async () => {
-    const controller = new AbortController();
-    const session = makeWorkerSession();
-    frameCaptureMocks.createCaptureSession.mockResolvedValue(session);
-    frameCaptureMocks.discardWarmupCapture.mockImplementation(async () => {
-      controller.abort();
-    });
-
-    const result = await runWorker(1, 36, controller.signal);
-
-    expect(result).toMatchObject({ error: "Parallel worker cancelled", framesCaptured: 0 });
-    expect(frameCaptureMocks.captureFrame).not.toHaveBeenCalled();
+    expect(frameCaptureMocks.captureFrame).toHaveBeenCalledWith(session, 36, 1.2, true);
     expect(frameCaptureMocks.closeCaptureSession).toHaveBeenCalledWith(session);
   });
 });

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -13,7 +13,6 @@ import { join } from "path";
 import {
   createCaptureSession,
   initializeSession,
-  discardWarmupCapture,
   closeCaptureSession,
   captureFrame,
   captureFrameToBufferPipelined,
@@ -295,6 +294,7 @@ async function captureFrameRange(
   let framesCaptured = 0;
   const outputOffset = task.outputFrameOffset ?? 0;
   const stride = task.frameStride ?? 1;
+  const settleFirstPaint = session.captureMode === "screenshot" && task.startFrame !== 0;
   // Depth-2 pipelined drawElement produce (HF_DE_PARALLEL_STREAM spike): frame
   // k's in-page worker encode overlaps frame k+stride's produce phase — the
   // same shape as the sequential worker-encode loop. Only engaged when the
@@ -360,12 +360,13 @@ async function captureFrameRange(
     if (signal?.aborted) throw new Error("Parallel worker cancelled");
     const time = (i * captureOptions.fps.den) / captureOptions.fps.num;
     const fileFrameIdx = i - outputOffset;
+    const settlePaint = settleFirstPaint && i === task.startFrame;
 
     if (onFrameBuffer) {
-      const { buffer } = await captureFrameToBuffer(session, fileFrameIdx, time);
+      const { buffer } = await captureFrameToBuffer(session, fileFrameIdx, time, settlePaint);
       await onFrameBuffer(i, buffer, session);
     } else {
-      await captureFrame(session, fileFrameIdx, time);
+      await captureFrame(session, fileFrameIdx, time, settlePaint);
     }
     framesCaptured++;
     if (onFrameCaptured) onFrameCaptured(task.workerId, i);
@@ -419,7 +420,6 @@ async function executeWorkerTask(
       await assertSwiftShader(session.page, readWebGlVendorInfoFromCanvas);
     }
     await initializeSession(session);
-    await settleFirstScreenshotFrame(session, task, captureOptions);
     if (process.env.HF_DE_PAR_DEBUG === "1") {
       console.log(
         `[par:w${task.workerId}] init done (mode=${session.captureMode} workerEncode=${session.workerEncodeEnabled === true})`,
@@ -459,26 +459,6 @@ async function executeWorkerTask(
   } finally {
     if (session) await closeCaptureSession(session).catch(() => {});
   }
-}
-
-async function settleFirstScreenshotFrame(
-  session: CaptureSession,
-  task: WorkerTask,
-  captureOptions: CaptureOptions,
-): Promise<void> {
-  // Screenshot capture is driven by Page.captureScreenshot rather than
-  // HeadlessExperimental.beginFrame. On a fresh non-zero worker, the first
-  // screenshot can race the paint scheduled by __hf.seek(startTime); issue
-  // one throwaway screenshot at that exact frame so the real capture sees
-  // the settled state. Worker 0 already starts from the initially-painted
-  // frame, and BeginFrame/drawElement sessions must never be double-captured
-  // at the same compositor tick (Chrome stalls on duplicate timestamps).
-  if (session.captureMode !== "screenshot" || task.startFrame === 0) return;
-
-  const outputOffset = task.outputFrameOffset ?? 0;
-  const firstFrameIndex = task.startFrame - outputOffset;
-  const firstTime = (task.startFrame * captureOptions.fps.den) / captureOptions.fps.num;
-  await discardWarmupCapture(session, firstFrameIndex, firstTime);
 }
 
 export const __testing = { executeWorkerTask };

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -419,7 +419,7 @@ async function executeWorkerTask(
       await assertSwiftShader(session.page, readWebGlVendorInfoFromCanvas);
     }
     await initializeSession(session);
-    await discardWarmupCapture(session);
+    await settleFirstScreenshotFrame(session, task, captureOptions);
     if (process.env.HF_DE_PAR_DEBUG === "1") {
       console.log(
         `[par:w${task.workerId}] init done (mode=${session.captureMode} workerEncode=${session.workerEncodeEnabled === true})`,
@@ -459,6 +459,26 @@ async function executeWorkerTask(
   } finally {
     if (session) await closeCaptureSession(session).catch(() => {});
   }
+}
+
+async function settleFirstScreenshotFrame(
+  session: CaptureSession,
+  task: WorkerTask,
+  captureOptions: CaptureOptions,
+): Promise<void> {
+  // Screenshot capture is driven by Page.captureScreenshot rather than
+  // HeadlessExperimental.beginFrame. On a fresh non-zero worker, the first
+  // screenshot can race the paint scheduled by __hf.seek(startTime); issue
+  // one throwaway screenshot at that exact frame so the real capture sees
+  // the settled state. Worker 0 already starts from the initially-painted
+  // frame, and BeginFrame/drawElement sessions must never be double-captured
+  // at the same compositor tick (Chrome stalls on duplicate timestamps).
+  if (session.captureMode !== "screenshot" || task.startFrame === 0) return;
+
+  const outputOffset = task.outputFrameOffset ?? 0;
+  const firstFrameIndex = task.startFrame - outputOffset;
+  const firstTime = (task.startFrame * captureOptions.fps.den) / captureOptions.fps.num;
+  await discardWarmupCapture(session, firstFrameIndex, firstTime);
 }
 
 export const __testing = { executeWorkerTask };

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -13,6 +13,7 @@ import { join } from "path";
 import {
   createCaptureSession,
   initializeSession,
+  discardWarmupCapture,
   closeCaptureSession,
   captureFrame,
   captureFrameToBufferPipelined,
@@ -418,6 +419,7 @@ async function executeWorkerTask(
       await assertSwiftShader(session.page, readWebGlVendorInfoFromCanvas);
     }
     await initializeSession(session);
+    await discardWarmupCapture(session);
     if (process.env.HF_DE_PAR_DEBUG === "1") {
       console.log(
         `[par:w${task.workerId}] init done (mode=${session.captureMode} workerEncode=${session.workerEncodeEnabled === true})`,
@@ -458,6 +460,8 @@ async function executeWorkerTask(
     if (session) await closeCaptureSession(session).catch(() => {});
   }
 }
+
+export const __testing = { executeWorkerTask };
 
 /**
  * drawElement self-verify sample count for multi-worker capture. Each worker

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -374,6 +374,13 @@ async function captureFrameRange(
   return framesCaptured;
 }
 
+function logParDebug(workerId: number, message: string): void {
+  if (process.env.HF_DE_PAR_DEBUG === "1") console.log(`[par:w${workerId}] ${message}`);
+}
+
+// Inherited coordinator complexity (session lifecycle + success/error/finally
+// result shapes), re-flagged by the settle-paint edits shifting lines.
+// fallow-ignore-next-line complexity
 async function executeWorkerTask(
   task: WorkerTask,
   serverUrl: string,
@@ -412,19 +419,16 @@ async function executeWorkerTask(
       createBeforeCaptureHook(),
       workerConfig,
     );
-    if (process.env.HF_DE_PAR_DEBUG === "1") {
-      console.log(`[par:w${task.workerId}] session created`);
-    }
+    logParDebug(task.workerId, "session created");
     // Worker-0-only SwiftShader assertion — see `shouldVerifyWorkerGpu` and #955.
     if (shouldVerifyWorkerGpu(task.workerId, workerConfig)) {
       await assertSwiftShader(session.page, readWebGlVendorInfoFromCanvas);
     }
     await initializeSession(session);
-    if (process.env.HF_DE_PAR_DEBUG === "1") {
-      console.log(
-        `[par:w${task.workerId}] init done (mode=${session.captureMode} workerEncode=${session.workerEncodeEnabled === true})`,
-      );
-    }
+    logParDebug(
+      task.workerId,
+      `init done (mode=${session.captureMode} workerEncode=${session.workerEncodeEnabled === true})`,
+    );
     framesCaptured = await captureFrameRange(
       session,
       task,

--- a/packages/producer/tests/webm-transparency/meta.json
+++ b/packages/producer/tests/webm-transparency/meta.json
@@ -9,6 +9,6 @@
   "renderConfig": {
     "fps": 30,
     "format": "webm",
-    "workers": 1
+    "workers": 4
   }
 }


### PR DESCRIPTION
## What
Settles the first seek of each fresh non-zero screenshot worker in parallel capture, so no stale/transparent frame is emitted at a worker chunk boundary.

## Why
A non-zero parallel worker's first pixel read can race the paint scheduled by its first `__hf.seek()`, so the first frame of a worker chunk could come back stale or fully transparent. Issue #2477 reported a transparent frame at each chunk boundary.

## How
`captureFrameCore` accepts a `settlePaint` flag: after the single `prepareFrameForCapture` seek, it takes one throwaway `Page.captureScreenshot` so the scheduled rAF/compositor work lands, then takes the retained screenshot — no second seek, so the emitted pixels observe the settled paint. `captureFrameRange` requests settlement only for the first frame of a fresh non-zero screenshot worker. Worker 0 and BeginFrame/drawElement sessions are excluded — enforced both at the coordinator and inside `captureFrameCore` itself — so no duplicate or backward compositor timestamps are introduced (the deadlock class removed in `24f64f02c` stays out).

`discardWarmupCapture` (no longer on the coordinator path, still an exported helper) now snapshots `capturePerf` with a by-value copy of the mutable `frameMs` array and restores it in a `finally`, so a discarded warmup sample can no longer leak into `getCapturePerfSummary().p50TotalMs` on either the success or the failure path. The stale "all fields are primitive" comment is gone.

The root `bun run build` was also made deterministic (the aws-lambda / gcp-cloud-run builds raced producer's concurrent rebuild because workspace dependency cycles disable bun's topological ordering) — surfaced while validating this change on a low-core machine.

## Test plan
- [x] Unit tests added/updated

`frameCapture-discardWarmup.test.ts`: pins the settlement shape (exactly one seek, throwaway + retained screenshot, retained buffer emitted), pins that a BeginFrame session ignores `settlePaint`, and pins full `capturePerf` restoration — including `frameMs` by value — on both the success and throw paths. `parallelCoordinator.test.ts`: settle flag on the first frame of non-zero screenshot workers only, worker-0 and BeginFrame/drawElement exclusions, frame accounting, failure and abort handling, session cleanup. Focused suites: 41 passed. `oxfmt`, `oxlint`, `fallow`, and engine typecheck are clean.

Related to #2477 — kept open pending reporter validation; exact closure is not demonstrated without the reporter's artifact/environment.