### PR TITLE
fix(ci): keep contact sheet test lightweight

### DIFF
--- a/packages/cli/src/capture/contactSheet.test.ts
+++ b/packages/cli/src/capture/contactSheet.test.ts
@@ -39,6 +39,7 @@ describe("createContactSheet", () => {
 
       await createContactSheet([a, b], out, {
         cols: 2,
+        cellWidth: 16,
         labelMode: "custom",
         labels: ["A", "B"],
         maxImages: 2,


### PR DESCRIPTION
## What

Keep the contact-sheet PNG unit test lightweight by setting its cell width to match the 16px fixture width.

## Why

The Windows test job on main timed out in `packages/cli/src/capture/contactSheet.test.ts`; no assertion failed.

The test creates 16×9 fixtures but exercised the production default `cellWidth: 600`, making Sharp upscale both inputs 37.5×, render SVG labels, composite, and PNG-encode a production-sized sheet while CLI test files run in parallel. This test already took 5.845s in its original green Windows PR run. The CLI suite has since grown from 114 to 142 files, and on the current Windows runner image the test exceeded Vitest's 20s timeout.

Failing job: https://github.com/heygen-com/hyperframes/actions/runs/29432470663/job/87410880478

## How

Set `cellWidth: 16` in the unit test. The behavior under test is unchanged—a `.png` output path must produce PNG—without doing irrelevant production-sized image work.

## Test plan

- [x] Unit tests added/updated
- [x] `bun run build`
- [x] `bun run --cwd packages/cli test` — 1,835 passed, 2 skipped
- [x] `bunx oxlint packages/cli/src/capture/contactSheet.test.ts`
- [x] `bunx oxfmt --check packages/cli/src/capture/contactSheet.test.ts`
- [ ] Documentation updated (not applicable)