### PR TITLE
fix(cli): preserve per-input transcripts

### DIFF
--- a/packages/cli/src/commands/transcribe.test.ts
+++ b/packages/cli/src/commands/transcribe.test.ts
@@ -125,6 +125,53 @@ Render video. Built for agents.
     exitSpy.mockRestore();
   });
 
+  it("preserves per-input transcripts across consecutive imports", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-transcribe-test-"));
+    dirs.push(dir);
+    const first = join(dir, "first.srt");
+    const second = join(dir, "second.srt");
+    writeFileSync(first, "1\n00:00:00,000 --> 00:00:01,000\nFIRST\n");
+    writeFileSync(second, "1\n00:00:00,000 --> 00:00:01,000\nSECOND\n");
+
+    await transcribeCmd.run!({ args: { input: first, dir, json: true } } as never);
+    await transcribeCmd.run!({ args: { input: second, dir, json: true } } as never);
+
+    expect(readFileSync(join(dir, "first.transcript.json"), "utf-8")).toContain("FIRST");
+    expect(readFileSync(join(dir, "second.transcript.json"), "utf-8")).toContain("SECOND");
+    expect(readFileSync(join(dir, "transcript.json"), "utf-8")).toContain("SECOND");
+  });
+
+  it("passes distinct per-input paths to the ASR engine", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-transcribe-test-"));
+    dirs.push(dir);
+    const first = join(dir, "first.wav");
+    const second = join(dir, "second.wav");
+    writeFileSync(first, "not-real-audio");
+    writeFileSync(second, "not-real-audio");
+    transcribeMock.mockImplementation(
+      async (input: string, _dir: string, opts: { transcriptPath: string }) => {
+        const text = input === first ? "FIRST" : "SECOND";
+        writeFileSync(opts.transcriptPath, JSON.stringify([{ text, start: 0, end: 1 }], null, 2));
+        return {
+          transcriptPath: opts.transcriptPath,
+          wordCount: 1,
+          durationSeconds: 1,
+          speechOnsetSeconds: null,
+        };
+      },
+    );
+
+    await transcribeCmd.run!({
+      args: { input: first, dir, engine: "whisper", json: true },
+    } as never);
+    await transcribeCmd.run!({
+      args: { input: second, dir, engine: "whisper", json: true },
+    } as never);
+
+    expect(readFileSync(join(dir, "first.transcript.json"), "utf-8")).toContain("FIRST");
+    expect(readFileSync(join(dir, "second.transcript.json"), "utf-8")).toContain("SECOND");
+  });
+
   it("--preserve-cues keeps single-word cues separate when exporting from JSON", async () => {
     const dir = mkdtempSync(join(tmpdir(), "hf-transcribe-test-"));
     dirs.push(dir);

--- a/packages/cli/src/commands/transcribe.test.ts
+++ b/packages/cli/src/commands/transcribe.test.ts
@@ -136,8 +136,8 @@ Render video. Built for agents.
     await transcribeCmd.run!({ args: { input: first, dir, json: true } } as never);
     await transcribeCmd.run!({ args: { input: second, dir, json: true } } as never);
 
-    expect(readFileSync(join(dir, "first.transcript.json"), "utf-8")).toContain("FIRST");
-    expect(readFileSync(join(dir, "second.transcript.json"), "utf-8")).toContain("SECOND");
+    expect(readFileSync(join(dir, "first.srt.transcript.json"), "utf-8")).toContain("FIRST");
+    expect(readFileSync(join(dir, "second.srt.transcript.json"), "utf-8")).toContain("SECOND");
     expect(readFileSync(join(dir, "transcript.json"), "utf-8")).toContain("SECOND");
   });
 
@@ -168,8 +168,35 @@ Render video. Built for agents.
       args: { input: second, dir, engine: "whisper", json: true },
     } as never);
 
-    expect(readFileSync(join(dir, "first.transcript.json"), "utf-8")).toContain("FIRST");
-    expect(readFileSync(join(dir, "second.transcript.json"), "utf-8")).toContain("SECOND");
+    expect(readFileSync(join(dir, "first.wav.transcript.json"), "utf-8")).toContain("FIRST");
+    expect(readFileSync(join(dir, "second.wav.transcript.json"), "utf-8")).toContain("SECOND");
+  });
+
+  it("preserves transcripts for same-stem inputs with different extensions", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-transcribe-test-"));
+    dirs.push(dir);
+    const wav = join(dir, "sample.wav");
+    const mp3 = join(dir, "sample.mp3");
+    writeFileSync(wav, "not-real-audio");
+    writeFileSync(mp3, "not-real-audio");
+    transcribeMock.mockImplementation(
+      async (input: string, _dir: string, opts: { transcriptPath: string }) => {
+        const text = input === wav ? "WAV" : "MP3";
+        writeFileSync(opts.transcriptPath, JSON.stringify([{ text, start: 0, end: 1 }], null, 2));
+        return {
+          transcriptPath: opts.transcriptPath,
+          wordCount: 1,
+          durationSeconds: 1,
+          speechOnsetSeconds: null,
+        };
+      },
+    );
+
+    await transcribeCmd.run!({ args: { input: wav, dir, engine: "whisper", json: true } } as never);
+    await transcribeCmd.run!({ args: { input: mp3, dir, engine: "whisper", json: true } } as never);
+
+    expect(readFileSync(join(dir, "sample.wav.transcript.json"), "utf-8")).toContain("WAV");
+    expect(readFileSync(join(dir, "sample.mp3.transcript.json"), "utf-8")).toContain("MP3");
   });
 
   it("--preserve-cues keeps single-word cues separate when exporting from JSON", async () => {

--- a/packages/cli/src/commands/transcribe.ts
+++ b/packages/cli/src/commands/transcribe.ts
@@ -19,7 +19,7 @@ export const examples: Example[] = [
     "hyperframes transcribe transcript.json --to vtt --preserve-cues",
   ],
 ];
-import { resolve, join, extname, dirname } from "node:path";
+import { resolve, join, extname, dirname, basename } from "node:path";
 import * as clack from "@clack/prompts";
 import { c } from "../ui/colors.js";
 import { DEFAULT_MODEL, isWhisperUnavailable } from "../whisper/manager.js";
@@ -203,14 +203,24 @@ function exitNoWords(json: boolean): never {
   failWith("No words found in transcript.", json);
 }
 
+function transcriptPathForInput(inputPath: string, dir: string): string {
+  const stem = basename(inputPath, extname(inputPath));
+  return join(dir, `${stem}.transcript.json`);
+}
+
+function writeLegacyTranscriptAlias(dir: string, words: unknown): void {
+  writeFileSync(join(dir, "transcript.json"), JSON.stringify(words, null, 2));
+}
+
 async function importTranscript(inputPath: string, dir: string, json: boolean): Promise<void> {
   const { loadTranscript, patchCaptionHtml } = await import("../whisper/normalize.js");
   const { words, format } = loadTranscript(inputPath);
 
   if (words.length === 0) exitNoWords(json);
 
-  const outPath = join(dir, "transcript.json");
+  const outPath = transcriptPathForInput(inputPath, dir);
   writeFileSync(outPath, JSON.stringify(words, null, 2));
+  writeLegacyTranscriptAlias(dir, words);
   patchCaptionHtml(dir, words);
 
   if (json) {
@@ -219,7 +229,7 @@ async function importTranscript(inputPath: string, dir: string, json: boolean): 
     );
   } else {
     console.log(
-      `${c.success("◇")}  Imported ${c.accent(String(words.length))} words from ${c.accent(format)} format → ${c.accent("transcript.json")}`,
+      `${c.success("◇")}  Imported ${c.accent(String(words.length))} words from ${c.accent(format)} format → ${c.accent(basename(outPath))}`,
     );
   }
 }
@@ -300,16 +310,19 @@ async function transcribeAudio(
   const label = useParakeet ? "Parakeet" : model;
   const spin = opts.json ? null : clack.spinner();
   spin?.start(`Transcribing with ${c.accent(label)}...`);
+  const transcriptPath = transcriptPathForInput(inputPath, dir);
 
   try {
     const result = useParakeet
       ? transcribeWithParakeet(inputPath, dir, {
           language: opts.language,
+          transcriptPath,
           onProgress: spin ? (msg) => spin.message(msg) : undefined,
         })
       : await transcribe(inputPath, dir, {
           model,
           language: opts.language,
+          transcriptPath,
           onProgress: spin ? (msg) => spin.message(msg) : undefined,
           timeoutMs: opts.timeoutMs,
         });
@@ -328,6 +341,7 @@ async function transcribeAudio(
     }
 
     writeFileSync(result.transcriptPath, JSON.stringify(words, null, 2));
+    writeLegacyTranscriptAlias(dir, words);
     patchCaptionHtml(dir, words);
 
     if (opts.json) {

--- a/packages/cli/src/commands/transcribe.ts
+++ b/packages/cli/src/commands/transcribe.ts
@@ -204,8 +204,7 @@ function exitNoWords(json: boolean): never {
 }
 
 function transcriptPathForInput(inputPath: string, dir: string): string {
-  const stem = basename(inputPath, extname(inputPath));
-  return join(dir, `${stem}.transcript.json`);
+  return join(dir, `${basename(inputPath)}.transcript.json`);
 }
 
 function writeLegacyTranscriptAlias(dir: string, words: unknown): void {

--- a/packages/cli/src/whisper/parakeet.ts
+++ b/packages/cli/src/whisper/parakeet.ts
@@ -106,6 +106,7 @@ export function mergeTokensToWords(parakeet: ParakeetJson): Word[] {
 interface ParakeetOptions {
   language?: string;
   model?: string;
+  transcriptPath?: string;
   onProgress?: (message: string) => void;
 }
 
@@ -141,7 +142,7 @@ export function transcribeWithParakeet(
     if (!existsSync(produced)) throw new Error("Parakeet did not produce output.");
     const words = mergeTokensToWords(JSON.parse(readFileSync(produced, "utf-8")) as ParakeetJson);
 
-    const transcriptPath = join(dir, "transcript.json");
+    const transcriptPath = options?.transcriptPath ?? join(dir, "transcript.json");
     writeFileSync(transcriptPath, JSON.stringify(words, null, 2));
     const durationSeconds = words.length > 0 ? words[words.length - 1]!.end : 0;
     return { transcriptPath, wordCount: words.length, durationSeconds, speechOnsetSeconds: null };

--- a/packages/cli/src/whisper/transcribe.ts
+++ b/packages/cli/src/whisper/transcribe.ts
@@ -1,7 +1,7 @@
 // fallow-ignore-file complexity
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, mkdirSync, unlinkSync } from "node:fs";
-import { join, extname } from "node:path";
+import { dirname, join, extname } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { findFFmpeg, findFFprobe, getFFmpegInstallHint } from "../browser/ffmpeg.js";
@@ -260,6 +260,7 @@ const VIDEO_EXTENSIONS = new Set([".mp4", ".webm", ".mov", ".mkv", ".avi"]);
 export interface TranscribeOptions {
   model?: string;
   language?: string;
+  transcriptPath?: string;
   onProgress?: (message: string) => void;
   /**
    * Explicit whisper spawn timeout in ms. Overrides the duration+model auto-
@@ -452,8 +453,11 @@ export async function transcribe(
 
   // 5. Run whisper
   options?.onProgress?.("Transcribing...");
-  const outputBase = join(outputDir, "transcript");
-  mkdirSync(outputDir, { recursive: true });
+  const transcriptPath = options?.transcriptPath ?? join(outputDir, "transcript.json");
+  const outputBase = transcriptPath.endsWith(".json")
+    ? transcriptPath.slice(0, -".json".length)
+    : transcriptPath;
+  mkdirSync(dirname(transcriptPath), { recursive: true });
 
   const whisperArgs = [
     "--model",
@@ -492,12 +496,12 @@ export async function transcribe(
   }
 
   // 6. Read and validate output
-  const transcriptPath = `${outputBase}.json`;
-  if (!existsSync(transcriptPath)) {
+  const producedTranscriptPath = `${outputBase}.json`;
+  if (!existsSync(producedTranscriptPath)) {
     throw new Error("Whisper did not produce output. Check the input file.");
   }
 
-  const transcript = JSON.parse(readFileSync(transcriptPath, "utf-8"));
+  const transcript = JSON.parse(readFileSync(producedTranscriptPath, "utf-8"));
   const segments = transcript.transcription ?? [];
 
   let wordCount = 0;
@@ -524,7 +528,7 @@ export async function transcribe(
   }
 
   return {
-    transcriptPath,
+    transcriptPath: producedTranscriptPath,
     wordCount,
     durationSeconds: maxEnd / 1000,
     speechOnsetSeconds,


### PR DESCRIPTION
## Summary

- save each transcription to a deterministic `<input-basename>.transcript.json` file
- include the source extension so same-stem inputs such as `foo.wav` and `foo.mp3` remain distinct
- keep `transcript.json` as a backward-compatible alias to the latest result
- pass the distinct output path through both Whisper and Parakeet

## Root cause

Every `transcribe` invocation wrote to the same `media/transcript.json` path. Consecutive runs for different inputs in one project silently replaced the earlier transcript.

## Verification

- red-first regression reproduced two inputs overwriting the same file
- red-first same-stem regression reproduced `foo.wav` and `foo.mp3` colliding
- `bunx vitest run src/commands/transcribe.test.ts src/whisper/transcribe.test.ts src/whisper/parakeet.test.ts` — 30 passed
- focused `oxfmt --check` — passed
- focused `oxlint` — 0 warnings / 0 errors
- `git diff --check` — passed
- package-wide typecheck was attempted but the isolated worktree cannot resolve pre-existing workspace packages and AWS dependencies