### PR TITLE
fix(lint): respect timed clip visibility for overlays

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -214,6 +214,27 @@ describe("GSAP rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("does not treat a later timed full-frame clip as visible before its window", async () => {
+    const html = `
+<html><body data-composition-id="c1" data-width="1920" data-height="1080">
+  <style>.scene { position: fixed; inset: 0; background: #123; }</style>
+  <section id="scene-1" class="scene clip" data-start="0" data-duration="8"><h1>Scene 1</h1></section>
+  <section id="scene-2" class="scene clip" data-start="8" data-duration="8"><h1>Scene 2</h1></section>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.from("#scene-2", { opacity: 0, duration: 0.18 }, 8.00);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_fullscreen_overlay_starts_visible",
+    );
+    expect(finding).toBeUndefined();
+  });
+
   it("reports one full-frame transition flash finding when multiple scripts touch it", async () => {
     const html = `
 <html><body data-composition-id="c1" data-width="1920" data-height="1080">

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -677,6 +677,9 @@ export const gsapRules: LintRule<LintContext>[] = [
 
       // gsap_fullscreen_overlay_starts_visible
       for (const tag of tags) {
+        // Timed clips are hidden by the runtime outside their data-start/data-duration
+        // window, so they cannot cover frames before a later GSAP reveal.
+        if (getClipTagClasses(tag)) continue;
         const selectors = tagSimpleSelectors(tag);
         if (selectors.length === 0) continue;
         const overlayKey = readAttr(tag.raw, "id") || String(tag.index);


### PR DESCRIPTION
## Summary

Full-frame scene clips no longer fail `gsap_fullscreen_overlay_starts_visible` merely because their reveal begins after time zero. The runtime already hides timed `.clip` elements outside their `data-start`/`data-duration` window, so the rule now remains focused on unmanaged overlays that can actually cover earlier frames while preserving the existing transition-flash protections.

A regression test pins a later full-frame clip whose GSAP reveal begins at its own clip boundary.

## Test plan

- `bun test packages/lint/src/rules/gsap.test.ts` — 91 passed
- `bun run --cwd packages/lint test` — 377 passed
- `bun run --cwd packages/lint typecheck`
- `bunx oxfmt --check packages/lint/src/rules/gsap.ts packages/lint/src/rules/gsap.test.ts`
- `bunx oxlint packages/lint/src/rules/gsap.ts packages/lint/src/rules/gsap.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
