### PR TITLE
fix(skills): require actionable CLI feedback repros

### DIFF
--- a/packages/cli/src/commands/coreSkillContent.test.ts
+++ b/packages/cli/src/commands/coreSkillContent.test.ts
@@ -23,4 +23,16 @@ describe("hyperframes-core contract docs", () => {
     expect(brief).toContain("`hyperframes check`");
     expect(brief).not.toContain("`lint` / `validate` / `inspect`");
   });
+
+  it("requires actionable reproduction packets in CLI defect feedback", () => {
+    const skill = read("skills", "hyperframes-cli", "SKILL.md");
+    const renderReference = read("skills", "hyperframes-cli", "references", "preview-render.md");
+
+    expect(skill).toContain("reproduction packet");
+    expect(renderReference).toContain("REPRO COMMAND:");
+    expect(renderReference).toContain("EXPECTED / ACTUAL:");
+    expect(renderReference).toContain("EXACT ERROR:");
+    expect(renderReference).toContain("OUTCOME:");
+    expect(renderReference).toContain("WORKAROUND:");
+  });
 });

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 102
     },
     "hyperframes-cli": {
-      "hash": "1065ea34fecfda50",
+      "hash": "05f7c65e6f9db100",
       "files": 11
     },
     "hyperframes-core": {

--- a/skills/hyperframes-cli/SKILL.md
+++ b/skills/hyperframes-cli/SKILL.md
@@ -104,7 +104,7 @@ After verifying a successful render, send one feedback report unless telemetry i
 npx hyperframes feedback --rating <0-10> --comment "<specific result or friction>"
 ```
 
-Use `--file-issue` only with consent: it publishes a minimal reproduction to a public URL. The bug report format and privacy warning live in `references/preview-render.md`.
+Keep clean-run feedback concise. For any bug or friction, capture a **reproduction packet** before submitting; do not send only a symptom summary. Include the rerunnable command and working directory, expected versus actual behavior, exact error, whether output completed/fell back/failed, workaround, and repro-project status. If the issue did not reproduce again, say so and still include the last failing command and logs. Use `--file-issue` only with consent: it publishes a minimal reproduction to a public URL. The required packet format and privacy warning live in `references/preview-render.md`.
 
 ## Read the matching reference before running a command
 

--- a/skills/hyperframes-cli/references/preview-render.md
+++ b/skills/hyperframes-cli/references/preview-render.md
@@ -153,7 +153,17 @@ npx hyperframes feedback --rating 10                              # clean run, n
 npx hyperframes feedback --rating 6 --comment "bg <video> renders grey in multi-scene; worked around with --format png-sequence"
 ```
 
-`--rating` is an integer from 0-10 (required); `--comment` is free text — use it for any bug, workaround, missing feature, or confusing behaviour. Feedback is anonymous and attaches a `doctorSummary` (OS/Node/CPU/mem/ffmpeg) automatically, so don't repeat env in the comment. For a **bug**, a paraphrase can't be reproduced — give the maintainer: the **exact error string verbatim** and whether the render still produced output / silently fell back (`re-rendering via screenshot`) / hard-exited (`Killed: 9`, `Target closed`); the **isolated trigger** ("only at 4K", "only with a `<video>`", "only when the text uses `font-family: 苹方`"); the **exact command + `HF_*`/`PRODUCER_*` env**; and the **frame/timestamp + visual defect** vs. expected.
+`--rating` is an integer from 0-10 (required); `--comment` is free text. Feedback is anonymous and attaches a `doctorSummary` (OS/Node/CPU/mem/ffmpeg) automatically, so don't repeat those fields. A clean run needs only a short result. Before sending any bug, workaround, or confusing behavior, collect this compact reproduction packet:
+
+```text
+REPRO COMMAND: cd <project path> && <HF_*/PRODUCER_* env> npx hyperframes <exact command>
+EXPECTED / ACTUAL: <expected behavior> / <observed behavior and isolated trigger>
+EXACT ERROR: <verbatim error or warning; include frame/timestamp for visual defects>
+OUTCOME: <output correct | output corrupt | fallback succeeded | hard exit | command hung>
+WORKAROUND: <exact workaround, or none>
+```
+
+Preserve paths containing spaces, flags, and relevant `HF_*` / `PRODUCER_*` variables; redact secrets and credentials. If the failure no longer reproduces, include the last failing command and log excerpt. Share a project link only when one is already available and safe to share.
 
 Hit a reproducible bug? Add `--file-issue` (optionally `--dir <project>` and `--yes` for non-interactive shells) to also publish a minimal repro to a public URL and open a pre-filled GitHub `bug` issue draft for a maintainer to file. This publishes the project publicly, so it is opt-in and consent-gated; the issue is never auto-submitted.
 


### PR DESCRIPTION
## Summary

CLI defect feedback from agents now arrives with a rerunnable reproduction packet instead of a symptom-only summary. Clean-run reports stay concise; bug and friction reports capture the exact command and working directory, expected versus actual behavior, verbatim error, output outcome, and workaround.

Project sharing remains optional. The skill asks for a link only when one is already available and safe to share.

A source-contract regression test keeps that reporting format in the shipped skill, and the published skills manifest is refreshed for update detection.

## Test plan

- `bunx vitest run packages/cli/src/commands/coreSkillContent.test.ts packages/cli/src/utils/skillsManifest.test.ts` — 59 passed
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli gen:skills-manifest --check`
- `bunx oxfmt --check packages/cli/src/commands/coreSkillContent.test.ts skills/hyperframes-cli/SKILL.md skills/hyperframes-cli/references/preview-render.md skills-manifest.json`
- `bunx oxlint packages/cli/src/commands/coreSkillContent.test.ts`
