### PR TITLE
fix(runtime): sync clip visibility every tick, not just while playing

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -742,6 +742,50 @@ describe("initSandboxRuntimeModular", () => {
     expect(sceneB.style.visibility).toBe("visible");
   });
 
+  it("hides sibling scenes outside their time window on initial load, before any explicit seek (paused)", () => {
+    // Regression: a freshly mounted composition sits paused at t=0 until the
+    // Studio player (or a "play" command) explicitly seeks it. The transport
+    // tick loop still runs every frame while paused — it must re-derive clip
+    // visibility from the current time on its own, not only when something
+    // calls player.seek()/player.play() first. Before the fix,
+    // syncTimedElementVisibility was only reached from inside the
+    // clock.isPlaying() branch of the tick, so a paused composition never hid
+    // a later sibling scene outside its own window — every "cut"-transition
+    // scene (no incoming/outgoing GSAP opacity tween of its own) stayed at
+    // the CSS default visibility:visible and permanently painted over any
+    // earlier scene lower in the same stacking context.
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "8");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const sceneA = document.createElement("div");
+    sceneA.id = "scene-a";
+    sceneA.setAttribute("data-start", "0");
+    sceneA.setAttribute("data-duration", "4");
+    root.appendChild(sceneA);
+
+    const sceneB = document.createElement("div");
+    sceneB.id = "scene-b";
+    sceneB.setAttribute("data-start", "4");
+    sceneB.setAttribute("data-duration", "4");
+    root.appendChild(sceneB);
+
+    window.__timelines = { main: createMockTimeline(8) };
+
+    initSandboxRuntimeModular();
+
+    // No player.seek()/player.play() call — this is the composition's state
+    // exactly as a browser would paint it right after the iframe loads.
+    expect(window.__player).toBeDefined();
+    expect(sceneA.style.visibility).toBe("visible");
+    expect(sceneB.style.visibility).toBe("hidden");
+  });
+
   it("hides GSAP tween targets inside a hidden timed clip (issue #1387)", () => {
     withStudioIframe(() => {
       const root = document.createElement("div");

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2860,6 +2860,16 @@ export function initSandboxRuntimeModular(): void {
       // affected — the seek runs whenever the clock is playing.
       if (clock.isPlaying() || !hasActiveStudioManualEditGesture()) {
         seekTimelineAndAdapters(t);
+        // Clip visibility must track the playhead every tick, paused or not —
+        // GSAP tween values update via seekTimelineAndAdapters above regardless
+        // of play state, but the separate [data-start] visibility/display gate
+        // (syncTimedElementVisibility) was only reached through
+        // syncMediaForCurrentState below, which is gated on clock.isPlaying().
+        // A composition loaded paused (the common case: initial mount, or any
+        // seek that doesn't also start playback) therefore never hid clips
+        // outside their time window, leaving every later-DOM-order scene at its
+        // default visibility:visible and permanently stacked over earlier ones.
+        syncTimedElementVisibility(t);
       }
 
       // Looping is handled at the player layer (<hyperframes-player>),


### PR DESCRIPTION
## What

The Studio live-preview player never hides a scene outside its own time
window while paused — including on initial load, before anything has
called `player.seek()`/`player.play()`. Any composition with more than one
scene mounted as absolutely-positioned siblings (the common shape for a
multi-frame video: `.scene` divs stacked in DOM order) shows the wrong
content, or nothing recognizable, until the user presses play.

Symptom, concretely: a 6-scene composition loaded fresh renders as a blank
background — every scene past the first sits at the browser's default
`visibility: visible` and paints over the earlier ones in DOM order, with
only the true "current" scene's text hidden underneath.

## Root cause

`transportTick`'s per-frame loop always re-seeks GSAP/adapters
(`seekTimelineAndAdapters`) regardless of play state, but only calls
`syncMediaForCurrentState()` — the function that also runs
`syncTimedElementVisibility()`, the thing that sets `style.visibility` on
every `[data-start]` element based on the current time — **inside an
`if (clock.isPlaying())` guard**:

```ts
if (clock.isPlaying()) {
  syncMediaForCurrentState();
}
```

So while paused, GSAP tween values update every tick (correct), but the
separate DOM-level clip-visibility gate never re-runs. A composition that
loads paused (the default) never gets its initial visibility computed at
all — every timed element just keeps the CSS default (`visibility: visible`)
until playback starts once.

Confirmed by hand before touching any code: calling the existing internal
debug hook `window.__hfForceTimelineRebind()` (which does call
`syncTimedElementVisibility` directly) on an affected page immediately fixes
the stacking, with zero other changes — isolating the bug to exactly this
one missing call.

## Fix

Call `syncTimedElementVisibility(t)` unconditionally every tick, right next
to the existing unconditional `seekTimelineAndAdapters(t)` call (same guard:
skip only during an active Studio manual-edit drag, matching the existing
rationale for that guard). Visibility now tracks the playhead whether the
clock is playing or paused, same as the tween values already did.

## Test plan

- [x] Added a regression test in `packages/core/src/runtime/init.test.ts`:
      mounts two sibling timed scenes, calls `initSandboxRuntimeModular()`,
      and asserts correct visibility **without ever calling
      `player.seek()`/`player.play()`** — i.e. exactly the state a browser
      paints right after the iframe loads. Verified this test fails without
      the fix (`AssertionError: expected '' to be 'visible'` — the runtime
      never touched `style.visibility` at all) and passes with it.
- [x] Full `packages/core` runtime suite: 715 tests passed, no regressions.