### PR TITLE
feat(producer): calibration-aware heartbeat + worker-death terminal-error contract

### DIFF
--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   calculateOptimalWorkers,
   distributeFrames,
+  expectedFramesForTask,
   formatWorkerFailure,
   selectWorkerDiagnostics,
   shouldDisableBrowserPoolForParallelWorker,
   shouldVerifyWorkerGpu,
+  synthesizeSilentWorkerExitError,
   resolveParallelDeVerifySamples,
 } from "./parallelCoordinator.js";
 import type { EngineConfig } from "../config.js";
@@ -160,6 +162,91 @@ describe("worker failure diagnostics", () => {
     ).toBe(
       "Worker 1: Navigation timeout of 60000 ms exceeded; diagnostics: [FrameCapture:ERROR] page.goto failed mode=screenshot timeoutMs=60000",
     );
+  });
+
+  // Field signal ts=1784042064: a Windows render hard-exited during video
+  // frame extraction without emitting a terminal error string; the parent
+  // treated the result as success because `error` was falsy. The synthesized
+  // string surfaces the shortfall so downstream telemetry can classify the
+  // failure instead of it disappearing silently.
+  it("synthesizes a terminal error when a worker exits with no error string", () => {
+    const message = formatWorkerFailure({
+      workerId: 3,
+      framesCaptured: 12,
+      startFrame: 0,
+      endFrame: 60,
+      durationMs: 180_000,
+    });
+    expect(message).toContain("Worker 3: worker 3 exited without terminal error string");
+    expect(message).toContain("framesCaptured=12");
+    expect(message).toContain("expected=60");
+    expect(message).toContain("range=[0, 60)");
+    expect(message).toContain("ts=1784042064");
+    expect(message).toContain("--workers=1");
+  });
+
+  it("prefers an explicit error string over the synthesized silent-exit message", () => {
+    const message = formatWorkerFailure({
+      workerId: 3,
+      framesCaptured: 12,
+      startFrame: 0,
+      endFrame: 60,
+      durationMs: 180_000,
+      error: "Target closed",
+    });
+    expect(message).toBe("Worker 3: Target closed");
+    expect(message).not.toContain("ts=1784042064");
+    expect(message).not.toContain("exited without terminal error string");
+  });
+
+  it("treats an empty error string as a silent exit for the message contract", () => {
+    const message = formatWorkerFailure({
+      workerId: 3,
+      framesCaptured: 12,
+      startFrame: 0,
+      endFrame: 60,
+      durationMs: 180_000,
+      error: "",
+    });
+    expect(message).toContain("exited without terminal error string");
+    expect(message).toContain("ts=1784042064");
+  });
+});
+
+describe("expectedFramesForTask", () => {
+  it("returns the range length for contiguous tasks", () => {
+    expect(expectedFramesForTask({ startFrame: 0, endFrame: 30 })).toBe(30);
+    expect(expectedFramesForTask({ startFrame: 10, endFrame: 25 })).toBe(15);
+  });
+
+  it("divides by stride for interleaved tasks", () => {
+    // Worker 0 in a 3-way interleave over 30 frames captures 0, 3, 6, ..., 27 → 10 frames.
+    expect(expectedFramesForTask({ startFrame: 0, endFrame: 30, frameStride: 3 })).toBe(10);
+  });
+
+  it("rounds up so the last-stride-remainder frame is expected", () => {
+    // Worker 0 in a 3-way interleave over 31 frames captures 0, 3, ..., 30 → 11 frames.
+    expect(expectedFramesForTask({ startFrame: 0, endFrame: 31, frameStride: 3 })).toBe(11);
+  });
+
+  it("returns zero for empty ranges", () => {
+    expect(expectedFramesForTask({ startFrame: 10, endFrame: 10 })).toBe(0);
+    expect(expectedFramesForTask({ startFrame: 30, endFrame: 10 })).toBe(0);
+  });
+});
+
+describe("synthesizeSilentWorkerExitError", () => {
+  it("names the field signal and reruns hint so operators can classify the failure", () => {
+    const message = synthesizeSilentWorkerExitError(
+      { workerId: 7, framesCaptured: 40, startFrame: 60, endFrame: 120 },
+      60,
+    );
+    expect(message).toContain("worker 7 exited without terminal error string");
+    expect(message).toContain("framesCaptured=40");
+    expect(message).toContain("expected=60");
+    expect(message).toContain("range=[60, 120)");
+    expect(message).toContain("Field signal ts=1784042064");
+    expect(message).toContain("--workers=1");
   });
 });
 

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -147,8 +147,49 @@ function compactDiagnosticLine(line: string): string {
   return line.replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Expected frame count for a worker task, honoring its stride. Contiguous
+ * tasks (stride 1) expect `endFrame - startFrame`; interleaved tasks
+ * (stride > 1) expect `ceil((endFrame - startFrame) / stride)`, matching
+ * the loop shape in `captureFrameRange`.
+ */
+export function expectedFramesForTask(task: {
+  startFrame: number;
+  endFrame: number;
+  frameStride?: number;
+}): number {
+  const stride = task.frameStride ?? 1;
+  return Math.max(0, Math.ceil((task.endFrame - task.startFrame) / stride));
+}
+
+/**
+ * Synthetic terminal-error message for a worker whose exit didn't produce
+ * an explicit error string but under-captured its expected frame range.
+ * Field signal ts=1784042064: a 1292s Windows render hard-exited during
+ * capture with no final error string, leaving the operator with no
+ * actionable trace. This message surfaces the shortfall + reruns hint
+ * so downstream telemetry (and operators grepping logs) can classify the
+ * failure instead of it disappearing silently.
+ */
+export function synthesizeSilentWorkerExitError(
+  result: Pick<WorkerResult, "workerId" | "framesCaptured" | "startFrame" | "endFrame">,
+  expectedFrames: number,
+): string {
+  return (
+    `worker ${result.workerId} exited without terminal error string ` +
+    `(framesCaptured=${result.framesCaptured}, expected=${expectedFrames}, ` +
+    `range=[${result.startFrame}, ${result.endFrame})). ` +
+    `Field signal ts=1784042064 — this class of failure has been reported; ` +
+    `consider re-run with --workers=1 to isolate.`
+  );
+}
+
 export function formatWorkerFailure(result: WorkerResult): string {
-  const base = `Worker ${result.workerId}: ${result.error ?? "unknown error"}`;
+  const errorText =
+    result.error && result.error.length > 0
+      ? result.error
+      : synthesizeSilentWorkerExitError(result, expectedFramesForTask(result));
+  const base = `Worker ${result.workerId}: ${errorText}`;
   if (!result.diagnostics || result.diagnostics.length === 0) return base;
 
   const diagnostics = result.diagnostics.map(compactDiagnosticLine).join(" | ");
@@ -540,6 +581,17 @@ export async function executeParallelCapture(
       ),
     ),
   );
+
+  // A worker may return without an error string yet with framesCaptured
+  // below the task's expected count — that's the silent-exit shape field
+  // signal ts=1784042064 called out. Synthesize a terminal error string
+  // in-place so the filter below treats it as a failure (and so the
+  // caller's failure message actually names what went wrong).
+  for (const r of results) {
+    if (!r.error && r.framesCaptured < expectedFramesForTask(r)) {
+      r.error = synthesizeSilentWorkerExitError(r, expectedFramesForTask(r));
+    }
+  }
 
   const errors = results.filter((r) => r.error);
   if (errors.length > 0) {

--- a/packages/producer/src/services/render/observability.test.ts
+++ b/packages/producer/src/services/render/observability.test.ts
@@ -209,6 +209,98 @@ describe("RenderObservabilityRecorder", () => {
     vi.useRealTimers();
   });
 
+  // Field signal ts=1784019503: a healthy ~64s browser calibration
+  // pre-capture emitted heartbeats saying "stage still running /
+  // framesCompleted: 0" and read as broken to downstream consumers. The
+  // calibration call sites now pass `heartbeatMessage: "browser calibrating
+  // (frames not started)"` so operator-facing logs and metrics can
+  // distinguish healthy calibration waits from actual zero-frame stalls
+  // once capture is meant to be underway.
+  it("uses a custom heartbeat message during calibration stages", async () => {
+    vi.useFakeTimers();
+    const log = makeLog();
+    const recorder = new RenderObservabilityRecorder({
+      pipelineStartMs: Date.now(),
+      log,
+      renderJobId: "render-calibrating",
+    });
+    let resolveStage: (() => void) | undefined;
+    const stage = observeRenderStage(
+      recorder,
+      "capture_calibration",
+      { stagePhase: "calibrating", framesCompleted: 0, totalFrames: 900 },
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStage = resolve;
+        }),
+      { heartbeatMessage: "browser calibrating (frames not started)" },
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const heartbeatCalls = log.info.mock.calls.filter(
+      ([message, meta]) =>
+        message === "[Render:trace]" &&
+        meta?.phase === "capture_calibration" &&
+        meta?.status === "checkpoint",
+    );
+    expect(heartbeatCalls).toHaveLength(1);
+    expect(heartbeatCalls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        message: "browser calibrating (frames not started)",
+        stagePhase: "calibrating",
+        framesCompleted: 0,
+        heartbeatIndex: 1,
+      }),
+    );
+    // No "stage still running" for this stage — the calibration override
+    // must fully replace the default, not sit alongside it.
+    expect(
+      log.info.mock.calls.some(
+        ([message, meta]) =>
+          message === "[Render:trace]" && meta?.message === "stage still running",
+      ),
+    ).toBe(false);
+
+    resolveStage?.();
+    await stage;
+    vi.useRealTimers();
+  });
+
+  it("keeps the default heartbeat message when no override is passed", async () => {
+    vi.useFakeTimers();
+    const log = makeLog();
+    const recorder = new RenderObservabilityRecorder({
+      pipelineStartMs: Date.now(),
+      log,
+      renderJobId: "render-default",
+    });
+    let resolveStage: (() => void) | undefined;
+    const stage = observeRenderStage(
+      recorder,
+      "capture_streaming",
+      { stagePhase: "capturing", framesCompleted: 42, totalFrames: 900 },
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStage = resolve;
+        }),
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const heartbeatCalls = log.info.mock.calls.filter(
+      ([message, meta]) => message === "[Render:trace]" && meta?.message === "stage still running",
+    );
+    expect(heartbeatCalls).toHaveLength(1);
+    expect(heartbeatCalls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        stagePhase: "capturing",
+        framesCompleted: 42,
+      }),
+    );
+    resolveStage?.();
+    await stage;
+    vi.useRealTimers();
+  });
+
   it("clears pending heartbeats when a stage rejects", async () => {
     vi.useFakeTimers();
     const log = makeLog();

--- a/packages/producer/src/services/render/observability.ts
+++ b/packages/producer/src/services/render/observability.ts
@@ -164,6 +164,12 @@ const ALLOWED_STRING_DATA_KEYS = new Set([
   "renderJobId",
   "requestedHdrMode",
   "requestedWorkers",
+  // "calibrating" during pre-capture browser warm-up / calibration stages;
+  // "capturing" during capture_disk / capture_streaming / capture_hdr_*
+  // stages. Distinguishes healthy 0-frame heartbeats (browser starting up)
+  // from actual zero-frame stalls once capture is meant to be underway.
+  // Field signal ts=1784019503.
+  "stagePhase",
 ]);
 const RESERVED_LOG_KEYS = new Set([
   "data",
@@ -416,12 +422,40 @@ function heartbeatTargetMs(index: number): number {
   return HEARTBEAT_RAMP_END_MS + overflow * HEARTBEAT_REPEAT_MS;
 }
 
+/**
+ * Options for `observeRenderStage` heartbeat behavior.
+ *
+ * The default heartbeat message is "stage still running", chosen for the
+ * capture stages where a live frame count in the observation data already
+ * communicates progress. Stages that run BEFORE any frame count is
+ * meaningful — the ~64s browser calibration path in particular — inherit
+ * that default and confusingly report "stage still running / framesCompleted:
+ * 0" to downstream consumers. Field signal ts=1784019503 captured exactly
+ * that read-as-broken shape on a healthy 64s calibration.
+ *
+ * `heartbeatMessage` lets the calibration call sites override the message
+ * to "browser calibrating" so operator-facing logs and downstream metrics
+ * can distinguish healthy pre-capture waits from actual zero-frame stalls
+ * mid-capture. The `data` payload also flows through (callers pass a
+ * `stagePhase: "calibrating" | "capturing"` field) so structured consumers
+ * don't have to string-match on the message.
+ */
+export interface ObserveRenderStageOptions {
+  /**
+   * Message to attach to each heartbeat checkpoint for this stage.
+   * Defaults to "stage still running".
+   */
+  heartbeatMessage?: string;
+}
+
 export async function observeRenderStage<T>(
   recorder: RenderObservabilityRecorder,
   phase: string,
   data: RenderObservationData | undefined,
   fn: () => Promise<T>,
+  options: ObserveRenderStageOptions = {},
 ): Promise<T> {
+  const heartbeatMessage = options.heartbeatMessage ?? "stage still running";
   const startedAt = recorder.stageStart(phase, data);
   let heartbeatCount = 0;
   let lastFiredAtMs = 0;
@@ -431,7 +465,7 @@ export async function observeRenderStage<T>(
     heartbeatTimer = setTimeout(() => {
       lastFiredAtMs = targetMs;
       heartbeatCount += 1;
-      recorder.checkpoint(phase, "stage still running", {
+      recorder.checkpoint(phase, heartbeatMessage, {
         ...data,
         heartbeatIndex: heartbeatCount,
         stageElapsedMs: Date.now() - startedAt,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -1862,7 +1862,7 @@ export async function executeRenderJob(
     const probeResult = await observeRenderStage(
       observability,
       "browser_probe",
-      { forceScreenshot: captureForceScreenshot },
+      { forceScreenshot: captureForceScreenshot, stagePhase: "calibrating" },
       () =>
         runProbeStage({
           projectDir,
@@ -1879,6 +1879,10 @@ export async function executeRenderJob(
           needsAlpha,
           deviceScaleFactor,
         }),
+      // Browser probe is pre-capture; report `browser calibrating` so a
+      // slow probe (~64s SwiftShader warm-up on Windows was the reported
+      // shape) doesn't read as a zero-frame stall. Field signal ts=1784019503.
+      { heartbeatMessage: "browser calibrating (frames not started)" },
     );
     compiled = probeResult.compiled;
     compositionHash = computeCompositionObservabilityHash(compiled.html);
@@ -2277,9 +2281,15 @@ export async function executeRenderJob(
     // captureStageObservationData can close over it for the calibration
     // stage itself — reads as undefined until resolveRenderWorkerCount runs.
     let workerCount: number;
+    // Default `stagePhase` — spread FIRST so a caller can override via
+    // `extra` (the calibration call site passes `stagePhase: "calibrating"`
+    // to distinguish healthy pre-capture waits from actual zero-frame stalls
+    // during capture; heartbeats in `capture_calibration` otherwise emit
+    // `framesCompleted: 0` and read as broken). Field signal ts=1784019503.
     const captureStageObservationData = (
       extra: RenderObservationData = {},
     ): RenderObservationData => ({
+      stagePhase: "capturing",
       ...extra,
       get workerCount() {
         return workerCount;
@@ -2329,7 +2339,14 @@ export async function executeRenderJob(
       const outcome = await observeRenderStage(
         observability,
         "capture_calibration",
-        captureStageObservationData({ forceScreenshot: captureForceScreenshot }),
+        captureStageObservationData({
+          forceScreenshot: captureForceScreenshot,
+          // Override the default `capturing` — calibration writes probe
+          // frames only, not `job.framesRendered`, so heartbeats reporting
+          // `framesCompleted: 0` misread as broken. Field signal
+          // ts=1784019503.
+          stagePhase: "calibrating",
+        }),
         () =>
           runCaptureCalibration({
             cfg,
@@ -2344,6 +2361,7 @@ export async function executeRenderJob(
             createRenderVideoFrameInjector,
             assertNotAborted,
           }),
+        { heartbeatMessage: "browser calibrating (frames not started)" },
       );
       captureCalibration = outcome.calibration;
       captureForceScreenshot = outcome.forceScreenshot;


### PR DESCRIPTION
## Description
Two additive parallel-capture observability improvements that make healthy runs distinguishable from broken ones in the render trace:

**Fix 1 — Calibration-aware heartbeat label.** `observeRenderStage` now accepts an optional `heartbeatMessage` override, and the `browser_probe` + `capture_calibration` call sites pass `"browser calibrating (frames not started)"` so their heartbeats no longer share the `"stage still running"` phrasing with post-capture stages. A new `stagePhase: "calibrating" | "capturing"` field flows through the observation data (added to `ALLOWED_STRING_DATA_KEYS`, defaulted inside `captureStageObservationData`, overridden at the calibration call site) so structured consumers can classify the heartbeat without string-matching the message.

**Fix 2 — Worker-death terminal-error contract.** `formatWorkerFailure` now synthesizes a terminal error string when `result.error` is falsy (undefined or empty), naming the framesCaptured shortfall, the expected count, the range, the field-signal reference, and the `--workers=1` isolation hint. `executeParallelCapture` now also detects under-captured but no-error results — a worker returning success with `framesCaptured < expected` gets an error string written to `result.error` in place, so the downstream `results.filter((r) => r.error)` doesn't silently accept it. Two exports added to support both branches: `expectedFramesForTask(task)` (stride-aware) and `synthesizeSilentWorkerExitError(result, expected)`.

Both changes are additive — the existing "stage still running" message is preserved everywhere else, and workers that already surface a bare error still get their explicit message untouched (the synthesized string only fills in when `result.error` is falsy).

## Context
Two field signals define the observability failure surface. Both concern healthy or broken runs that the current instrumentation cannot tell apart:

- `ts=1784019503` (`#hyperframes-cli-feedback`): parallel-capture heartbeat/observability during startup underinstruments healthy runs. On a ~64s browser calibration (SwiftShader warm-up class), the heartbeat emitted at 30s and 60s carried `framesCompleted: 0` — read as a broken zero-frame stall — while calibration probe frames were legitimately being written to disk. The stage phase is `capture_calibration` (which uses `captureStageObservationData` — that helper's `framesCompleted` getter returns `job.framesRendered ?? 0`, and calibration doesn't touch `job.framesRendered` because it writes probe frames only). **Directly covered here** — the calibration call sites now override the heartbeat message and pass `stagePhase: "calibrating"` in the data, so consumers can distinguish healthy pre-capture waits from mid-capture zero-frame stalls.

- `ts=1784042064` (`#hyperframes-cli-feedback`): a 1292s Windows render hard-exited during video frame extraction after `heartbeatIndex: 3` (~180s) with no final error string. The parallel-worker path in `parallelCoordinator.ts` treats a `WorkerResult` with `error === undefined` as success and never surfaces the failure — the parent's `executeParallelCapture` filters `results.filter((r) => r.error)` so a silent no-error result gets dropped from the aggregated failure message entirely. **Directly covered here** — under-captured no-error results now get a synthesized error string in place, and `formatWorkerFailure` also fills in a synthesized message when it's asked to format a result whose error field is missing or empty. Both paths cite the field signal + `--workers=1` isolation hint so operators grepping logs can classify the failure.

The heartbeat message + `stagePhase` field are backward-compatible additions — no consumer that reads `message === "stage still running"` regresses (the default is unchanged), and `RenderObservationData` remains a `Record<string, RenderObservationValue>`. The worker-death contract keeps the current happy-path behavior for workers that emit real error strings; the synthesized message only fills gaps where the current code emits `"unknown error"` (in `formatWorkerFailure`) or silently passes the result through (in `executeParallelCapture`).

## Testing
- `packages/producer/src/services/render/observability.test.ts` — 11 pass, 0 fail. Two new cases:
  - `uses a custom heartbeat message during calibration stages` — verifies the custom message replaces `"stage still running"` (no both-emission), that `stagePhase: "calibrating"` and `framesCompleted: 0` flow through the heartbeat data, and that `heartbeatIndex: 1` still increments as expected.
  - `keeps the default heartbeat message when no override is passed` — verifies `"stage still running"` is unchanged when the fifth arg is omitted, and that `stagePhase: "capturing"` flows through when the caller sets it.
- `packages/engine/src/services/parallelCoordinator.test.ts` — 34 pass, 0 fail. Six new cases across three describes:
  - `synthesizes a terminal error when a worker exits with no error string` — verifies the synthesized message names the worker, the shortfall (12 captured / 60 expected), the range `[0, 60)`, the field signal `ts=1784042064`, and the `--workers=1` hint.
  - `prefers an explicit error string over the synthesized silent-exit message` — verifies real errors (e.g. `Target closed`) are unchanged and the field-signal reference does NOT appear.
  - `treats an empty error string as a silent exit for the message contract` — closes the "empty-string is falsy but not undefined" gap.
  - `expectedFramesForTask` — contiguous range, stride-3 interleaved (30 → 10 frames), remainder round-up (31 → 11), empty range → 0, reversed range → 0.
  - `synthesizeSilentWorkerExitError` — direct-call test verifying every field lands in the message.
- `bun run typecheck` — clean on both `@hyperframes/producer` and `@hyperframes/engine`.
- `oxfmt --write` — clean on all 5 touched files.
- Pre-existing `ffprobe.test.ts` failures (3 cases about HDR PNG cICP metadata) are unrelated to this PR — they touch `packages/engine/src/utils/ffprobe.ts` and predate `via/overlay-count-lint`.

## Enterprise release / feature flag holdout
<!-- pr-check:enterprise-ff:start -->
- [x] No enterprise release / feature flag holdout required — observability-only additions (log message text + one new optional string data field + a synthesized error string). No user-visible surface, no runtime behavior change on healthy paths.
- [ ] Enterprise release / feature flag holdout required — coordinated with enterprise team.
<!-- pr-check:enterprise-ff:end -->

## UX/Screenshot recording
<!-- pr-check:ui-impact -->
- [x] <!-- pr-opt:no-ui-impact --> No UI impact — heartbeat log text + structured trace data + operator-facing error message only.
<!-- pr-check:ui-impact-end -->

**Stack:** PR #6 of 9. Base: `via/overlay-count-lint` (#2508).

— Via

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
