### PR TITLE
fix(studio): give flat-inspector value fields a resting-state input affordance

### DIFF
--- a/packages/studio/src/components/editor/propertyPanelFlatColorGradingSection.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatColorGradingSection.tsx
@@ -377,7 +377,7 @@ export function FlatColorGradingSection({
                   track("select", "Custom LUT");
                   applyLut(src || null, src && lut?.src === src ? lut.intensity : 1);
                 }}
-                className="bg-transparent font-mono text-[10px] text-panel-text-3 outline-none"
+                className="border-b border-panel-border-input/50 bg-transparent font-mono text-[10px] text-panel-text-3 outline-none hover:border-panel-border-input"
               >
                 <option value="">None</option>
                 {lutAssets.map((asset) => (
@@ -545,7 +545,7 @@ export function FlatColorGradingSection({
                 onSetApplyScope(e.target.value as "source-file" | "project");
               }}
               disabled={applyBusy}
-              className="bg-transparent font-mono text-[11px] text-panel-text-0 outline-none disabled:opacity-50"
+              className="border-b border-panel-border-input/50 bg-transparent font-mono text-[11px] text-panel-text-0 outline-none hover:border-panel-border-input disabled:opacity-50"
             >
               <option value="source-file">Current file media</option>
               <option value="project">All project media</option>

--- a/packages/studio/src/components/editor/propertyPanelFlatMotionSection.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatMotionSection.tsx
@@ -85,7 +85,7 @@ export function FlatTimingRow({
   const cell = (label: string, value: string, onCommit: (next: string) => void) => (
     <div className="grid gap-px">
       <span className="text-[9px] text-panel-text-4">{label}</span>
-      <span className="border-b border-transparent font-mono text-[11px] text-panel-text-0 hover:border-panel-border-input">
+      <span className="border-b border-panel-border-input/50 font-mono text-[11px] text-panel-text-0 hover:border-panel-border-input">
         <CommitField
           value={value}
           onCommit={(next) => {

--- a/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
@@ -43,8 +43,8 @@ export function FlatRow({
           data-flat-row-value="true"
           className={`min-w-0 border-b pb-px font-mono text-[11px] ${VALUE_TIER_VALUE_CLASS[tier]} ${
             tier === "explicitCustom"
-              ? "border-transparent group-hover:border-panel-accent/35"
-              : "border-transparent group-hover:border-panel-border-input"
+              ? "border-panel-accent/30 group-hover:border-panel-accent/70"
+              : "border-panel-border-input/50 group-hover:border-panel-border-input"
           }`}
         >
           <CommitField

--- a/packages/studio/src/components/editor/propertyPanelFlatSelectRow.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatSelectRow.tsx
@@ -53,7 +53,13 @@ export function FlatSelectRow({
     <div className="group flex min-h-[30px] items-center justify-between">
       <span className={`text-[11px] ${VALUE_TIER_LABEL_CLASS[tier]}`}>{label}</span>
       <span className="flex items-center gap-2">
-        <label className="flex items-center gap-1.5">
+        <label
+          className={`flex items-center gap-1.5 border-b pb-px ${
+            tier === "explicitCustom"
+              ? "border-panel-accent/30 group-hover:border-panel-accent/70"
+              : "border-panel-border-input/50 group-hover:border-panel-border-input"
+          }`}
+        >
           <select
             value={value}
             disabled={disabled}

--- a/packages/studio/src/components/editor/propertyPanelFlatTextSection.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatTextSection.tsx
@@ -111,7 +111,7 @@ function FlatTextFieldEditor({
         >
           Weight
         </span>
-        <label className="flex items-center gap-1.5">
+        <label className="flex items-center gap-1.5 border-b border-panel-border-input/50 pb-px hover:border-panel-border-input">
           <select
             value={weight}
             onChange={(e) => {


### PR DESCRIPTION
## Summary
- Every editable value in the flat inspector (FlatRow's CommitField, Motion Timing's Start/End/Duration cells, and every raw `<select>` — Style/Text dropdowns, Grade's Custom LUT and Copy-grade-to scope) only showed its underline/border on hover. At rest a value looked like plain static text, indistinguishable from a label — testers reported not being able to tell which fields were editable.
- Give each a dim-but-visible resting border (`border-panel-border-input/50`, or `border-panel-accent/30` for the explicitCustom tier) that brightens on hover/focus, instead of a fully transparent one. Purely visual, no behavior change.

## Test plan
- [x] Full studio suite (2641 tests) green
- [x] Typecheck/oxlint/oxfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)