### PR TITLE
fix(engine): emit SystemMemory cgroup notice to stderr, not stdout

### DIFF
--- a/packages/engine/src/services/systemMemory.test.ts
+++ b/packages/engine/src/services/systemMemory.test.ts
@@ -252,6 +252,27 @@ describe("getSystemTotalMb", () => {
     );
   });
 
+  it("logs the cgroup-limit notice to stderr, not stdout (keeps --json output clean)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await withSystemMemoryMocks(
+      {
+        files: {
+          [CGROUP_V2_MEMORY_MAX_PATH]: `${4096 * BYTES_PER_MIB}`,
+        },
+      },
+      ({ getSystemTotalMb }) => {
+        expect(getSystemTotalMb()).toBe(4096);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toContain("[SystemMemory] cgroup memory limit detected");
+        // stdout must stay clean so `check --json` output is machine-parseable.
+        expect(info).not.toHaveBeenCalled();
+        expect(log).not.toHaveBeenCalled();
+      },
+    );
+  });
+
   it("stays silent when cgroup files are absent", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     await withSystemMemoryMocks({}, ({ getSystemTotalMb }) => {

--- a/packages/engine/src/services/systemMemory.ts
+++ b/packages/engine/src/services/systemMemory.ts
@@ -93,7 +93,10 @@ function getCgroupLimitMb(): number | null {
 
   _cachedCgroupLimitMb = parseCgroupLimitMb(v2Content, v1Content);
   if (_cachedCgroupLimitMb !== null) {
-    console.info(
+    // stderr, not stdout: this is a diagnostic notice, and commands like `check --json`
+    // write their machine-readable payload to stdout. A banner on stdout corrupts that
+    // payload for any JSON consumer (it broke the Video Agent's hyperframes check parse).
+    console.warn(
       `[SystemMemory] cgroup memory limit detected: ${_cachedCgroupLimitMb} MiB — ` +
         `it governs memory-adaptive render behaviour instead of host RAM.`,
     );


### PR DESCRIPTION
## What

Emit the `[SystemMemory] cgroup memory limit detected: ...` notice with `console.warn` (stderr) instead of `console.info` (stdout) in `packages/engine/src/services/systemMemory.ts`.

## Why

The `check --json` command writes its machine-readable envelope to stdout via `console.log`. This SystemMemory notice was also going to stdout (`console.info`), so on any host with a cgroup memory limit it prepended a non-JSON line ahead of the `--json` payload and broke consumers that parse stdout as JSON. Standard CLI practice: stdout carries the data payload, diagnostics go to stderr. The sibling "unable to read cgroup" warning already uses `console.warn` (stderr); this aligns the detected-limit notice with it.

## How

One-line change: `console.info(...)` → `console.warn(...)` for the detected-limit notice. Message text and all memory-adaptive behaviour are unchanged — only the stream moves from stdout to stderr. `dist/` is gitignored, so there is no built artifact to update.

## Test plan

Added a regression test in `packages/engine/src/services/systemMemory.test.ts` asserting the detected-limit notice is emitted on `console.warn` and NOT on `console.info`/`console.log`, so `check --json` stdout stays machine-parseable.

- `bunx vitest run src/services/systemMemory.test.ts` → 27 passed (vitest labels the notice output as stderr)
- `oxfmt` + `oxlint` on both changed files → clean

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)