### PR TITLE
chore: release v0.7.60

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,62 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.60"
+  description="Released - 2026-07-16"
+  tags={["Release", "Renderer", "Engine", "Studio"]}
+>
+Rendering is more deterministic across software-GPU, Windows, and long-running worker paths: SwiftShader no longer leaks stale compositor layers into captured frames, video clips can intentionally hold their final frame through a longer composition slot, and capture failures now surface with clearer diagnostics. This release also strengthens Studio file concurrency and SDK/runtime synchronization so edits and previews stay aligned with the underlying project state.
+
+## Features
+
+- **Engine:** Opt-in per-frame timing on fast-capture fallback path ([e6cdf4abb](https://github.com/heygen-com/hyperframes/commit/e6cdf4abb174ea9792a79df83cba3646f140f48e))
+- **Engine:** Software-GPU parity diff helper for solid-black capture-shape bugs ([97e094621](https://github.com/heygen-com/hyperframes/commit/97e094621f889c472f5acce760cb3e074f78a67f))
+- **Producer:** Calibration-aware heartbeat + worker-death terminal-error contract ([971bcf39a](https://github.com/heygen-com/hyperframes/commit/971bcf39aeb72deda8eb4d161c1c1016eee28f87))
+- **Lint:** Flag high overlay-element counts (heavy-capture risk) ([75de927fb](https://github.com/heygen-com/hyperframes/commit/75de927fb52f1e17832ac4d05acc7772ab71dd59))
+- **Producer:** Parity telemetry gate for per-clip frame-count invariant ([69b393865](https://github.com/heygen-com/hyperframes/commit/69b393865ae75fff35fd0d105c6ef8ed0bff4303))
+- **Engine:** Surface escape hatches in page.goto Nav timeout errors ([58cff5f6d](https://github.com/heygen-com/hyperframes/commit/58cff5f6d5dc8a136617df1a1b1712b142ec0986))
+- **Engine:** Auto-disable streaming-encode on Windows software-GPU compound ([cbf2a2ec6](https://github.com/heygen-com/hyperframes/commit/cbf2a2ec69f12f4b5aad384d538d354321ce64cf))
+- **Engine:** Surface protocolTimeout env + flag in Puppeteer timeout errors ([6944a1c2d](https://github.com/heygen-com/hyperframes/commit/6944a1c2d0430c8d42c6c5e1408d640b9674a2c8))
+- **Core:** ApplyPositionEdits gains force option and undo reset path ([049f72d4d](https://github.com/heygen-com/hyperframes/commit/049f72d4d9e11e86854f0512499aa65a8f5dc012))
+- **Sdk:** GetVariableValue(\{ base: true \}) reads pre-override declared defaults ([db5e06221](https://github.com/heygen-com/hyperframes/commit/db5e062211fbad324b67bcc672d4e92cc4e2d351))
+
+## Fixes
+
+- **Renderer:** Prevent stale SwiftShader layers ([54a3ef200](https://github.com/heygen-com/hyperframes/commit/54a3ef2000da635b93c03a41c129a78f0276bf38))
+- **Engine:** Emit SystemMemory cgroup notice to stderr, not stdout ([b179c9536](https://github.com/heygen-com/hyperframes/commit/b179c95362645c3ca06fa869d698429e2e3d1e61), [#2520](https://github.com/heygen-com/hyperframes/pull/2520))
+- **Studio:** Give flat-inspector value fields a resting-state input affordance ([2b51c5263](https://github.com/heygen-com/hyperframes/commit/2b51c5263414ee9faafbb453f5a9a3ee13af3e43))
+- **Studio:** Make setRightPanelTab itself flat-aware, not just the direct tab click ([fb24ecac2](https://github.com/heygen-com/hyperframes/commit/fb24ecac22a766f8a405923551ca51b850487cfc))
+- **Video:** Hold final frame through composition ([2e8f871bc](https://github.com/heygen-com/hyperframes/commit/2e8f871bc86d29ec3369f0eb11f0183b2001a07a))
+- **Studio:** Show Layers full-height in the flat inspector, not split with Design ([79b688f20](https://github.com/heygen-com/hyperframes/commit/79b688f204d00e85d4dd111e1e35c8d4dc5703ba))
+- **Core:** Guard undefined NodeList index in applyPositionEdits loops ([4ac7b4fa8](https://github.com/heygen-com/hyperframes/commit/4ac7b4fa8200ea4250b0370cc5b53ac1002d1efb))
+- **Producer:** Propagate --exclude-tags to Dockerfile.test ENTRYPOINT ([1c46eadce](https://github.com/heygen-com/hyperframes/commit/1c46eadceb6b2434a1e245a190057e43035caa98))
+- **Skills:** Require actionable CLI feedback repros ([3a71a03de](https://github.com/heygen-com/hyperframes/commit/3a71a03de5037592b3de5f6edafcd76a6415f31a), [#2498](https://github.com/heygen-com/hyperframes/pull/2498))
+- **Studio:** Enforce optimistic file concurrency ([2417293da](https://github.com/heygen-com/hyperframes/commit/2417293dabad96bc464495027a751b8aedb6441a), [#2156](https://github.com/heygen-com/hyperframes/pull/2156))
+- **Sdk:** AttachSync re-syncs the override snapshot on iframe load ([4682da14f](https://github.com/heygen-com/hyperframes/commit/4682da14f19061aeac25b723e1cbb6a98f5d86ad))
+- **CLI:** Align video output boundaries ([35e623b4f](https://github.com/heygen-com/hyperframes/commit/35e623b4f3502a88945750955000f59526a62ed3), [#2490](https://github.com/heygen-com/hyperframes/pull/2490))
+- **Skills:** Preserve caption skin contrast states ([f45f76247](https://github.com/heygen-com/hyperframes/commit/f45f762473735befc8cce3407f7dabb6ce8bb4ac), [#2486](https://github.com/heygen-com/hyperframes/pull/2486))
+- **CLI:** Preserve snapshot timestamp precision ([9e53c0f9b](https://github.com/heygen-com/hyperframes/commit/9e53c0f9b1da2d11a400d264ffcc41157302925c), [#2494](https://github.com/heygen-com/hyperframes/pull/2494))
+- **Runtime:** Resume readiness after deferred GSAP batching ([b874c4440](https://github.com/heygen-com/hyperframes/commit/b874c4440f9fcd4afeeb3a8e616d036d633cba28), [#2491](https://github.com/heygen-com/hyperframes/pull/2491))
+- **Engine:** Fail partial audio track preparation ([968c90397](https://github.com/heygen-com/hyperframes/commit/968c90397b3e7852367fa3741c9fc44c3472814d), [#2488](https://github.com/heygen-com/hyperframes/pull/2488))
+- **Render:** Ignore favicon probe noise ([850f57ea0](https://github.com/heygen-com/hyperframes/commit/850f57ea04450e21775f9dbd2c39bd45ddf9aa7a), [#2487](https://github.com/heygen-com/hyperframes/pull/2487))
+- **Producer:** Bridge stall-timeout env var rename, disambiguate abort from stall on sequential path ([b70d849a4](https://github.com/heygen-com/hyperframes/commit/b70d849a4728ee08d070ac49cd6e6af4b23f4a2e))
+- **Producer:** Extend DE stall watchdog to the single-worker streaming path ([650977d1d](https://github.com/heygen-com/hyperframes/commit/650977d1d8a695203047c3020c8a61465ed55bb8))
+
+## Docs & Examples
+
+- **Renderer:** Link SwiftShader workaround tracker ([9c25e27da](https://github.com/heygen-com/hyperframes/commit/9c25e27da64e65e789471e866ec5763097f8053e))
+
+## Internal
+
+- **Producer:** Use intrinsic duration in style fixtures ([4cbde3830](https://github.com/heygen-com/hyperframes/commit/4cbde38301c8453d78ac703ef62519bd0b4227eb))
+- **Producer:** Update remaining video slot goldens ([1284703ad](https://github.com/heygen-com/hyperframes/commit/1284703adbe6444a2dc3e873c5a6bdd89b0356d3))
+- **Producer:** Update video slot regression golden ([31cc2fe87](https://github.com/heygen-com/hyperframes/commit/31cc2fe875f56d2c79de918f3af0a19042bbd5f1))
+- **Producer:** Reproducer fixture for both-escape-hatches-fail case ([e5c4e1970](https://github.com/heygen-com/hyperframes/commit/e5c4e1970cf6cd2b15a54460cd5dd23c50058225))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.59...v0.7.60).
+</Update>
+
+<Update
   label="HyperFrames v0.7.59"
   description="Released - 2026-07-15"
   tags={["Release", "Ci", "Registry,skills", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.60.md
+++ b/releases/v0.7.60.md
@@ -1,0 +1,55 @@
+# HyperFrames v0.7.60
+
+Released on 2026-07-16.
+
+Rendering is more deterministic across software-GPU, Windows, and long-running worker paths: SwiftShader no longer leaks stale compositor layers into captured frames, video clips can intentionally hold their final frame through a longer composition slot, and capture failures now surface with clearer diagnostics. This release also strengthens Studio file concurrency and SDK/runtime synchronization so edits and previews stay aligned with the underlying project state.
+
+## Features
+
+- **Engine:** Opt-in per-frame timing on fast-capture fallback path ([e6cdf4abb](https://github.com/heygen-com/hyperframes/commit/e6cdf4abb174ea9792a79df83cba3646f140f48e))
+- **Engine:** Software-GPU parity diff helper for solid-black capture-shape bugs ([97e094621](https://github.com/heygen-com/hyperframes/commit/97e094621f889c472f5acce760cb3e074f78a67f))
+- **Producer:** Calibration-aware heartbeat + worker-death terminal-error contract ([971bcf39a](https://github.com/heygen-com/hyperframes/commit/971bcf39aeb72deda8eb4d161c1c1016eee28f87))
+- **Lint:** Flag high overlay-element counts (heavy-capture risk) ([75de927fb](https://github.com/heygen-com/hyperframes/commit/75de927fb52f1e17832ac4d05acc7772ab71dd59))
+- **Producer:** Parity telemetry gate for per-clip frame-count invariant ([69b393865](https://github.com/heygen-com/hyperframes/commit/69b393865ae75fff35fd0d105c6ef8ed0bff4303))
+- **Engine:** Surface escape hatches in page.goto Nav timeout errors ([58cff5f6d](https://github.com/heygen-com/hyperframes/commit/58cff5f6d5dc8a136617df1a1b1712b142ec0986))
+- **Engine:** Auto-disable streaming-encode on Windows software-GPU compound ([cbf2a2ec6](https://github.com/heygen-com/hyperframes/commit/cbf2a2ec69f12f4b5aad384d538d354321ce64cf))
+- **Engine:** Surface protocolTimeout env + flag in Puppeteer timeout errors ([6944a1c2d](https://github.com/heygen-com/hyperframes/commit/6944a1c2d0430c8d42c6c5e1408d640b9674a2c8))
+- **Core:** ApplyPositionEdits gains force option and undo reset path ([049f72d4d](https://github.com/heygen-com/hyperframes/commit/049f72d4d9e11e86854f0512499aa65a8f5dc012))
+- **Sdk:** GetVariableValue({ base: true }) reads pre-override declared defaults ([db5e06221](https://github.com/heygen-com/hyperframes/commit/db5e062211fbad324b67bcc672d4e92cc4e2d351))
+
+## Fixes
+
+- **Renderer:** Prevent stale SwiftShader layers ([54a3ef200](https://github.com/heygen-com/hyperframes/commit/54a3ef2000da635b93c03a41c129a78f0276bf38))
+- **Engine:** Emit SystemMemory cgroup notice to stderr, not stdout ([b179c9536](https://github.com/heygen-com/hyperframes/commit/b179c95362645c3ca06fa869d698429e2e3d1e61), [#2520](https://github.com/heygen-com/hyperframes/pull/2520))
+- **Studio:** Give flat-inspector value fields a resting-state input affordance ([2b51c5263](https://github.com/heygen-com/hyperframes/commit/2b51c5263414ee9faafbb453f5a9a3ee13af3e43))
+- **Studio:** Make setRightPanelTab itself flat-aware, not just the direct tab click ([fb24ecac2](https://github.com/heygen-com/hyperframes/commit/fb24ecac22a766f8a405923551ca51b850487cfc))
+- **Video:** Hold final frame through composition ([2e8f871bc](https://github.com/heygen-com/hyperframes/commit/2e8f871bc86d29ec3369f0eb11f0183b2001a07a))
+- **Studio:** Show Layers full-height in the flat inspector, not split with Design ([79b688f20](https://github.com/heygen-com/hyperframes/commit/79b688f204d00e85d4dd111e1e35c8d4dc5703ba))
+- **Core:** Guard undefined NodeList index in applyPositionEdits loops ([4ac7b4fa8](https://github.com/heygen-com/hyperframes/commit/4ac7b4fa8200ea4250b0370cc5b53ac1002d1efb))
+- **Producer:** Propagate --exclude-tags to Dockerfile.test ENTRYPOINT ([1c46eadce](https://github.com/heygen-com/hyperframes/commit/1c46eadceb6b2434a1e245a190057e43035caa98))
+- **Skills:** Require actionable CLI feedback repros ([3a71a03de](https://github.com/heygen-com/hyperframes/commit/3a71a03de5037592b3de5f6edafcd76a6415f31a), [#2498](https://github.com/heygen-com/hyperframes/pull/2498))
+- **Studio:** Enforce optimistic file concurrency ([2417293da](https://github.com/heygen-com/hyperframes/commit/2417293dabad96bc464495027a751b8aedb6441a), [#2156](https://github.com/heygen-com/hyperframes/pull/2156))
+- **Sdk:** AttachSync re-syncs the override snapshot on iframe load ([4682da14f](https://github.com/heygen-com/hyperframes/commit/4682da14f19061aeac25b723e1cbb6a98f5d86ad))
+- **CLI:** Align video output boundaries ([35e623b4f](https://github.com/heygen-com/hyperframes/commit/35e623b4f3502a88945750955000f59526a62ed3), [#2490](https://github.com/heygen-com/hyperframes/pull/2490))
+- **Skills:** Preserve caption skin contrast states ([f45f76247](https://github.com/heygen-com/hyperframes/commit/f45f762473735befc8cce3407f7dabb6ce8bb4ac), [#2486](https://github.com/heygen-com/hyperframes/pull/2486))
+- **CLI:** Preserve snapshot timestamp precision ([9e53c0f9b](https://github.com/heygen-com/hyperframes/commit/9e53c0f9b1da2d11a400d264ffcc41157302925c), [#2494](https://github.com/heygen-com/hyperframes/pull/2494))
+- **Runtime:** Resume readiness after deferred GSAP batching ([b874c4440](https://github.com/heygen-com/hyperframes/commit/b874c4440f9fcd4afeeb3a8e616d036d633cba28), [#2491](https://github.com/heygen-com/hyperframes/pull/2491))
+- **Engine:** Fail partial audio track preparation ([968c90397](https://github.com/heygen-com/hyperframes/commit/968c90397b3e7852367fa3741c9fc44c3472814d), [#2488](https://github.com/heygen-com/hyperframes/pull/2488))
+- **Render:** Ignore favicon probe noise ([850f57ea0](https://github.com/heygen-com/hyperframes/commit/850f57ea04450e21775f9dbd2c39bd45ddf9aa7a), [#2487](https://github.com/heygen-com/hyperframes/pull/2487))
+- **Producer:** Bridge stall-timeout env var rename, disambiguate abort from stall on sequential path ([b70d849a4](https://github.com/heygen-com/hyperframes/commit/b70d849a4728ee08d070ac49cd6e6af4b23f4a2e))
+- **Producer:** Extend DE stall watchdog to the single-worker streaming path ([650977d1d](https://github.com/heygen-com/hyperframes/commit/650977d1d8a695203047c3020c8a61465ed55bb8))
+
+## Docs & Examples
+
+- **Renderer:** Link SwiftShader workaround tracker ([9c25e27da](https://github.com/heygen-com/hyperframes/commit/9c25e27da64e65e789471e866ec5763097f8053e))
+
+## Internal
+
+- **Producer:** Use intrinsic duration in style fixtures ([4cbde3830](https://github.com/heygen-com/hyperframes/commit/4cbde38301c8453d78ac703ef62519bd0b4227eb))
+- **Producer:** Update remaining video slot goldens ([1284703ad](https://github.com/heygen-com/hyperframes/commit/1284703adbe6444a2dc3e873c5a6bdd89b0356d3))
+- **Producer:** Update video slot regression golden ([31cc2fe87](https://github.com/heygen-com/hyperframes/commit/31cc2fe875f56d2c79de918f3af0a19042bbd5f1))
+- **Producer:** Reproducer fixture for both-escape-hatches-fail case ([e5c4e1970](https://github.com/heygen-com/hyperframes/commit/e5c4e1970cf6cd2b15a54460cd5dd23c50058225))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.59...v0.7.60


### PR DESCRIPTION
## What

Publishes HyperFrames `0.7.60` as the next stable release.

## Why

This release carries the merged renderer fix that prevents stale SwiftShader compositor layers from flashing in rendered frames, plus the other user-facing fixes merged since `0.7.59`.

## How

- bumps every publishable HyperFrames package and plugin manifest to `0.7.60`
- adds reviewed release notes and the matching docs changelog entry
- uses the standard `release/v*` merge workflow, which creates `v0.7.60`, publishes npm packages under `latest`, and creates the GitHub release

## Verification

- `bun run release:prepare 0.7.60`
- release pre-commit tracked-artifact and format checks passed
- source fix: #2521