### PR TITLE
fix(producer): audioPadTrim FFmpeg-8.x-compatible apad invocation

### DIFF
--- a/packages/producer/src/services/render/audioPadTrim.test.ts
+++ b/packages/producer/src/services/render/audioPadTrim.test.ts
@@ -44,17 +44,28 @@ describe("buildPadTrimAudioArgs", () => {
     const concatArgs = plan.steps[1]!.args;
     expect(plan.steps[1]!.kind).toBe("pad-concat");
     expect(concatArgs).toContain("concat");
-    expect(concatArgs[concatArgs.indexOf("-i") + 1]).toBe("pipe:0");
+    // The concat script is passed via a real file (NOT `pipe:0`). Feeding
+    // it through stdin makes FFmpeg's URL joiner prepend `pipe:` to bare
+    // absolute paths in the script — the demuxer then tries to open e.g.
+    // `pipe:/tmp/foo.aac` and fails with "Impossible to open pipe:/…".
+    // Materializing to a file matches `assemble.ts`'s concat convention.
+    expect(plan.steps[1]!.concatListPath).toBe("/tmp/out.aac.concat-list.txt");
+    expect(concatArgs[concatArgs.indexOf("-i") + 1]).toBe("/tmp/out.aac.concat-list.txt");
     expect(concatArgs[concatArgs.indexOf("-c:a") + 1]).toBe("copy");
     expect(concatArgs[concatArgs.length - 1]).toBe("/tmp/out.aac");
     // Concat script MUST use bare paths, NOT `file://` URLs. FFmpeg 8.x
     // on Windows can't open `file:///C:/…` URLs from the concat demuxer
     // (field-signal ts=1784169914 / 1784177061 / 1784177375). Regression
-    // pin: the `file://` scheme prefix must never appear in the stdin.
-    expect(plan.steps[1]!.stdin).toContain("file '/tmp/in.aac'");
-    expect(plan.steps[1]!.stdin).toContain("file '/tmp/out.aac.pad-silence.aac'");
-    expect(plan.steps[1]!.stdin).not.toContain("file://");
-    expect(plan.cleanupPaths).toEqual(["/tmp/out.aac.pad-silence.aac"]);
+    // pin: the `file://` scheme prefix must never appear in the concat
+    // list content.
+    expect(plan.steps[1]!.concatListContent).toContain("file '/tmp/in.aac'");
+    expect(plan.steps[1]!.concatListContent).toContain("file '/tmp/out.aac.pad-silence.aac'");
+    expect(plan.steps[1]!.concatListContent).not.toContain("file://");
+    // Cleanup includes BOTH the silence tail and the concat list script.
+    expect(plan.cleanupPaths).toEqual([
+      "/tmp/out.aac.pad-silence.aac",
+      "/tmp/out.aac.concat-list.txt",
+    ]);
 
     const reencodedSourceStep = plan.steps.find(
       (step) =>
@@ -112,7 +123,7 @@ describe("buildPadTrimAudioArgs", () => {
     expect(trimNeeded.operation).toBe("trim");
   });
 
-  it("does not emit `file://` URLs in the pad-concat stdin (FFmpeg 8.x Windows compat)", () => {
+  it("does not emit `file://` URLs in the pad-concat script (FFmpeg 8.x Windows compat)", () => {
     // Regression pin for field-signal reports ts=1784169914 / 1784177061 /
     // ts=1784177375 (win32/x64, CLI 0.7.59, ffmpeg 8.1.1-full_build). The
     // concat demuxer's file open on Windows in FFmpeg 8.x rejects
@@ -128,13 +139,32 @@ describe("buildPadTrimAudioArgs", () => {
     expect(winPlan.operation).toBe("pad");
     const concatStep = winPlan.steps.find((s) => s.kind === "pad-concat");
     expect(concatStep).toBeDefined();
-    expect(concatStep!.stdin).toBeDefined();
-    expect(concatStep!.stdin).not.toContain("file://");
-    expect(concatStep!.stdin).not.toContain("file:\\\\");
+    expect(concatStep!.concatListContent).toBeDefined();
+    expect(concatStep!.concatListContent).not.toContain("file://");
+    expect(concatStep!.concatListContent).not.toContain("file:\\\\");
     // Bare Windows paths appear as-is in the concat directives.
-    expect(concatStep!.stdin).toContain(
+    expect(concatStep!.concatListContent).toContain(
       "file 'C:\\Users\\alice\\AppData\\Local\\Temp\\hf-render-abc\\audio.aac'",
     );
+  });
+
+  it("materializes the pad-concat script to a real file (not `pipe:0`)", () => {
+    // Regression pin for the Linux CI failure that surfaced when the
+    // fix originally dropped `file://` while still feeding the concat
+    // script via `pipe:0`. FFmpeg's URL joiner resolves bare absolute
+    // paths against the base `pipe:` URL, producing `pipe:/tmp/foo.aac`
+    // which the demuxer then tries to open as a pipe. Materializing to
+    // a real file makes the demuxer treat absolute paths as absolute.
+    const plan = buildPadTrimAudioPlan("/tmp/in.aac", "/tmp/out.aac", 4.0, 5.0);
+    const concatStep = plan.steps.find((s) => s.kind === "pad-concat");
+    expect(concatStep).toBeDefined();
+    // The concat script must NOT be piped in via stdin.
+    expect(concatStep!.args).not.toContain("pipe:0");
+    // The `-i` arg points at the materialized concat list file.
+    const iIdx = concatStep!.args.indexOf("-i");
+    expect(concatStep!.args[iIdx + 1]).toBe(concatStep!.concatListPath);
+    // The concat list file is cleaned up alongside the silence tail.
+    expect(plan.cleanupPaths).toContain(concatStep!.concatListPath!);
   });
 });
 

--- a/packages/producer/src/services/render/audioPadTrim.test.ts
+++ b/packages/producer/src/services/render/audioPadTrim.test.ts
@@ -47,8 +47,13 @@ describe("buildPadTrimAudioArgs", () => {
     expect(concatArgs[concatArgs.indexOf("-i") + 1]).toBe("pipe:0");
     expect(concatArgs[concatArgs.indexOf("-c:a") + 1]).toBe("copy");
     expect(concatArgs[concatArgs.length - 1]).toBe("/tmp/out.aac");
-    expect(plan.steps[1]!.stdin).toContain("file 'file:///tmp/in.aac'");
-    expect(plan.steps[1]!.stdin).toContain("file 'file:///tmp/out.aac.pad-silence.aac'");
+    // Concat script MUST use bare paths, NOT `file://` URLs. FFmpeg 8.x
+    // on Windows can't open `file:///C:/…` URLs from the concat demuxer
+    // (field-signal ts=1784169914 / 1784177061 / 1784177375). Regression
+    // pin: the `file://` scheme prefix must never appear in the stdin.
+    expect(plan.steps[1]!.stdin).toContain("file '/tmp/in.aac'");
+    expect(plan.steps[1]!.stdin).toContain("file '/tmp/out.aac.pad-silence.aac'");
+    expect(plan.steps[1]!.stdin).not.toContain("file://");
     expect(plan.cleanupPaths).toEqual(["/tmp/out.aac.pad-silence.aac"]);
 
     const reencodedSourceStep = plan.steps.find(
@@ -105,6 +110,31 @@ describe("buildPadTrimAudioArgs", () => {
     expect(padNeeded.operation).toBe("pad");
     const trimNeeded = buildPadTrimAudioArgs("/tmp/a.aac", "/tmp/o.aac", 5.002, 5.0);
     expect(trimNeeded.operation).toBe("trim");
+  });
+
+  it("does not emit `file://` URLs in the pad-concat stdin (FFmpeg 8.x Windows compat)", () => {
+    // Regression pin for field-signal reports ts=1784169914 / 1784177061 /
+    // ts=1784177375 (win32/x64, CLI 0.7.59, ffmpeg 8.1.1-full_build). The
+    // concat demuxer's file open on Windows in FFmpeg 8.x rejects
+    // `file:///C:/…` URLs with "Impossible to open …". The concat script
+    // MUST use bare paths. Match sibling `assemble.ts` /
+    // `chunkEncoder.ts` conventions.
+    const winPlan = buildPadTrimAudioPlan(
+      "C:\\Users\\alice\\AppData\\Local\\Temp\\hf-render-abc\\audio.aac",
+      "C:\\Users\\alice\\AppData\\Local\\Temp\\hf-render-abc\\audio-padded.aac",
+      4.0,
+      5.0,
+    );
+    expect(winPlan.operation).toBe("pad");
+    const concatStep = winPlan.steps.find((s) => s.kind === "pad-concat");
+    expect(concatStep).toBeDefined();
+    expect(concatStep!.stdin).toBeDefined();
+    expect(concatStep!.stdin).not.toContain("file://");
+    expect(concatStep!.stdin).not.toContain("file:\\\\");
+    // Bare Windows paths appear as-is in the concat directives.
+    expect(concatStep!.stdin).toContain(
+      "file 'C:\\Users\\alice\\AppData\\Local\\Temp\\hf-render-abc\\audio.aac'",
+    );
   });
 });
 

--- a/packages/producer/src/services/render/audioPadTrim.ts
+++ b/packages/producer/src/services/render/audioPadTrim.ts
@@ -20,7 +20,6 @@
 
 import { spawn } from "node:child_process";
 import { rmSync } from "node:fs";
-import { pathToFileURL } from "node:url";
 import {
   extractAudioMetadata,
   formatFfmpegError,
@@ -231,8 +230,17 @@ function channelLayoutForChannels(channels: number | undefined): string {
 }
 
 function concatFileLine(path: string): string {
-  const normalized = pathToFileURL(path).href;
-  return `file '${normalized.replace(/'/g, "'\\''")}'`;
+  // Bare paths in concat directives — NOT `file://` URLs. FFmpeg 8.x on
+  // Windows fails to open URL-form paths from the concat demuxer with
+  // "Impossible to open file:///C:/…" (its file protocol strips the
+  // `file:` prefix leaving `///C:/…`, which Windows path parsing then
+  // rejects). Field-signal reports (ts=1784169914 / 1784177061 /
+  // 1784177375, all win32/x64 CLI 0.7.59; the last isolated the module's
+  // arg shape vs a working manual `apad=whole_dur` command). Bare paths
+  // also match the convention already used by the sibling concat
+  // scripts in `assemble.ts` and `chunkEncoder.ts`. The single-quote
+  // escaping (`'\''`) is the concat demuxer's own escape rule.
+  return `file '${path.replace(/'/g, "'\\''")}'`;
 }
 
 /**

--- a/packages/producer/src/services/render/audioPadTrim.ts
+++ b/packages/producer/src/services/render/audioPadTrim.ts
@@ -19,11 +19,10 @@
  */
 
 import { spawn } from "node:child_process";
-import { rmSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import {
   extractAudioMetadata,
   formatFfmpegError,
-  getFfmpegBinary,
   getFfprobeBinary,
   runFfmpeg,
   type AudioMetadata,
@@ -69,10 +68,7 @@ export interface PadTrimAudioInput {
    */
   probeVideoFrameInfo?: (videoPath: string) => Promise<ProbeVideoFrameInfo>;
   probeAudioInfo?: (audioPath: string) => Promise<AudioProbeInfo>;
-  runFfmpeg?: (
-    args: string[],
-    options?: { stdin?: string },
-  ) => Promise<{ success: boolean; error?: string }>;
+  runFfmpeg?: (args: string[]) => Promise<{ success: boolean; error?: string }>;
 }
 
 export type PadTrimOperation = "pad" | "trim" | "copy";
@@ -95,7 +91,16 @@ export type PadTrimAudioStepKind = "copy" | "trim" | "pad-silence" | "pad-concat
 export interface PadTrimAudioStep {
   kind: PadTrimAudioStepKind;
   args: string[];
-  stdin?: string;
+  /**
+   * Concat-demuxer script materialization. When both fields are set, the
+   * runner writes `concatListContent` to `concatListPath` synchronously
+   * before spawning ffmpeg, and the step's `args` reference that path via
+   * `-i concatListPath`. Feeding the concat script through a real file
+   * (instead of `pipe:0`) is what makes bare-path directives work on both
+   * Linux and Windows — see `concatFileLine` for the platform history.
+   */
+  concatListPath?: string;
+  concatListContent?: string;
 }
 
 export interface PadTrimAudioPlan {
@@ -137,6 +142,7 @@ export function buildPadTrimAudioPlan(
   if (delta > 0) {
     const padDur = formatSeconds(delta);
     const silencePath = `${outputPath}.pad-silence.aac`;
+    const concatListPath = `${outputPath}.concat-list.txt`;
     return {
       operation: "pad",
       steps: [
@@ -164,19 +170,18 @@ export function buildPadTrimAudioPlan(
             "concat",
             "-safe",
             "0",
-            "-protocol_whitelist",
-            "file,pipe,crypto,data",
             "-i",
-            "pipe:0",
+            concatListPath,
             "-c:a",
             "copy",
             "-y",
             outputPath,
           ],
-          stdin: `${concatFileLine(audioPath)}\n${concatFileLine(silencePath)}\n`,
+          concatListPath,
+          concatListContent: `${concatFileLine(audioPath)}\n${concatFileLine(silencePath)}\n`,
         },
       ],
-      cleanupPaths: [silencePath],
+      cleanupPaths: [silencePath, concatListPath],
     };
   }
   // Trim. `-t` truncates AAC without re-encoding because AAC frames are
@@ -230,16 +235,26 @@ function channelLayoutForChannels(channels: number | undefined): string {
 }
 
 function concatFileLine(path: string): string {
-  // Bare paths in concat directives — NOT `file://` URLs. FFmpeg 8.x on
-  // Windows fails to open URL-form paths from the concat demuxer with
-  // "Impossible to open file:///C:/…" (its file protocol strips the
-  // `file:` prefix leaving `///C:/…`, which Windows path parsing then
-  // rejects). Field-signal reports (ts=1784169914 / 1784177061 /
-  // 1784177375, all win32/x64 CLI 0.7.59; the last isolated the module's
-  // arg shape vs a working manual `apad=whole_dur` command). Bare paths
-  // also match the convention already used by the sibling concat
-  // scripts in `assemble.ts` and `chunkEncoder.ts`. The single-quote
-  // escaping (`'\''`) is the concat demuxer's own escape rule.
+  // Bare paths in concat directives — NOT `file://` URLs. Two failure
+  // modes on the round trip to a working shape:
+  //   1. `file:///C:/…` — FFmpeg 8.x on Windows fails to open URL-form
+  //      paths from the concat demuxer with "Impossible to open
+  //      file:///C:/…" (its `file:` protocol strips the scheme leaving
+  //      `///C:/…`, which Windows path parsing then rejects). Field-
+  //      signal reports ts=1784169914 / 1784177061 / 1784177375 (all
+  //      win32/x64 CLI 0.7.59; the last isolated the module's arg shape
+  //      vs a working manual `apad=whole_dur` command).
+  //   2. Bare `/tmp/…` when the concat script was fed via `pipe:0` —
+  //      FFmpeg's URL joiner resolves absolute POSIX paths against the
+  //      base `pipe:` URL, producing `pipe:/tmp/…` which the demuxer
+  //      then tries to open as a pipe. Broke Linux CI (regression shard
+  //      + producer integration) once the `file://` prefix was dropped.
+  // Fix: emit bare paths AND materialize the concat script into a real
+  // file (see `concatListPath`/`concatListContent` on the pad-concat
+  // step), matching sibling `assemble.ts`'s concat convention. A real
+  // file's directory becomes the base URL, and absolute paths in the
+  // script resolve as-is on both platforms. The single-quote escaping
+  // (`'\''`) is the concat demuxer's own escape rule.
   return `file '${path.replace(/'/g, "'\\''")}'`;
 }
 
@@ -308,7 +323,14 @@ export async function padOrTrimAudioToVideoFrameCount(
 
   try {
     for (const step of plan.steps) {
-      const ffmpegResult = await runner(step.args, { stdin: step.stdin });
+      // Materialize the concat-demuxer script to a real file when the step
+      // needs one. Doing this here (instead of piping via `pipe:0` in the
+      // runner) is what makes the demuxer's URL resolution treat
+      // absolute paths as absolute — see `concatFileLine` for context.
+      if (step.concatListPath !== undefined && step.concatListContent !== undefined) {
+        writeFileSync(step.concatListPath, step.concatListContent, "utf-8");
+      }
+      const ffmpegResult = await runner(step.args);
       if (!ffmpegResult.success) {
         return {
           success: false,
@@ -435,52 +457,13 @@ async function defaultProbeAudioInfo(audioPath: string): Promise<AudioProbeInfo>
   };
 }
 
-async function defaultRunFfmpeg(
-  args: string[],
-  options?: { stdin?: string },
-): Promise<{ success: boolean; error?: string }> {
-  if (options?.stdin !== undefined) return runFfmpegWithStdin(args, options.stdin);
-
+async function defaultRunFfmpeg(args: string[]): Promise<{ success: boolean; error?: string }> {
   const result = await runFfmpeg(args);
   if (result.success) return { success: true };
   return {
     success: false,
     error: `[audioPadTrim] ${formatFfmpegError(result.exitCode, result.stderr)}`,
   };
-}
-
-async function runFfmpegWithStdin(
-  args: string[],
-  stdin: string,
-): Promise<{ success: boolean; error?: string }> {
-  return new Promise((resolve) => {
-    const proc = spawn(getFfmpegBinary(), args);
-    let stderr = "";
-
-    proc.stderr.on("data", (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    proc.on("error", (err) => {
-      resolve({
-        success: false,
-        error: `[audioPadTrim] ${err instanceof Error ? err.message : String(err)}`,
-      });
-    });
-
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve({ success: true });
-        return;
-      }
-      resolve({
-        success: false,
-        error: `[audioPadTrim] ${formatFfmpegError(code, stderr)}`,
-      });
-    });
-
-    proc.stdin.end(stdin);
-  });
 }
 
 // ── ffprobe JSON runner (shared between fast/slow video probe paths) ─────


### PR DESCRIPTION
## What

Change `audioPadTrim`'s pad-concat step to use bare file paths in the concat script instead of `file://` URLs. One-line change to `concatFileLine` in `packages/producer/src/services/render/audioPadTrim.ts`; drops the `pathToFileURL` import; updates the arg-shape unit tests + adds a Windows-path regression pin.

## Why

Four field-signal reports over ~24h — all on Windows, CLI 0.7.59:

- `ts=1784169914` (:warning: 7/10, win32/x64, Baoyu) — 60s render, native audio assembly failed; workaround = video-only render + external ffmpeg mux.
- `ts=1784177061` (:red_circle: 5/10, win32/x64, andre 22cores) — 345.87s composition, 9 WAV audio elements, same error shape.
- `ts=1784177375` (:red_circle: 3/10, win32/x64, ffmpeg 8.1.1-full_build gyan.dev) — **KEY DIAGNOSTIC.** 13 mono 44.1kHz mp3 tracks. Reporter isolated the failure: "Same project rendered fine in July with an older ffmpeg. Manual `ffmpeg -i track.mp3 -af apad=whole_dur=16 -t 16 -c:a aac out.aac` works with the same binary, so the tool's audioPadTrim invocation appears incompatible with ffmpeg 8.x."
- `ts=1784177375` (follow-up from same reporter).

Error signature in all four:
\`\`\`
[audioPadTrim] FFmpeg exited with code 4294967294
Impossible to open file:///…/Temp/hf-render-*/audio.aac
\`\`\`
`4294967294` = `-2` unsigned = FFmpeg's `AVERROR(ENOENT)`. The `"Impossible to open …"` string is the concat demuxer's message for a file it couldn't open.

## How

**Ground-truth audit findings:**

1. `packages/producer/src/services/render/audioPadTrim.ts` (line 233-236, pre-fix) built each concat directive as:
   \`\`\`ts
   function concatFileLine(path: string): string {
     const normalized = pathToFileURL(path).href;
     return \`file '\${normalized.replace(/'/g, "'\\\\''")}'\`;
   }
   \`\`\`
   On Windows, `pathToFileURL("C:\\…\\audio.aac").href` produces `file:///C:/…/audio.aac`. FFmpeg's `file:` protocol handler (`libavformat/file.c`) strips the `file:` prefix, leaving `///C:/…/audio.aac`. FFmpeg 8.x on Windows rejects this triple-slash form.

2. **The sibling concat scripts in this repo do NOT use URLs.** `packages/producer/src/services/distributed/assemble.ts` (line 184), `packages/engine/src/services/chunkEncoder.ts` (line 680), and the smoke test `packages/producer/tests/distributed/_smoke/webm-concat-copy.test.ts` all use bare paths with only single-quote escaping (`file '${path.replace(/'/g, "'\\\\''")}'`) — those work on Windows today. `audioPadTrim.ts` was the outlier.

3. **Regression provenance.** The original implementation (commit `62317f7f3`, 2026-05-13) used `apad=pad_dur=Δ` — the same filter family as the reporter's proven-working manual command. PR #1615 (commit `0473254bd`, 2026-06-20, "fix(engine): preserve AAC start time during MP4 mux") refactored the pad path to the concat-copy approach and introduced the `pathToFileURL` conversion. That refactor is the direct source of the Windows-8.x incompatibility.

4. **Manual command vs. module command diff:**
   - Reporter's working command: `ffmpeg -i track.mp3 -af apad=whole_dur=16 -t 16 -c:a aac out.aac` — filter-based padding, no concat demuxer.
   - Module's failing command (step 2, pad-concat): `ffmpeg -f concat -safe 0 -protocol_whitelist file,pipe,crypto,data -i pipe:0 -c:a copy -y outputPath` with stdin `file 'file:///C:/…/audio.aac'\nfile 'file:///C:/…/silence.aac'\n`.
   - The concat approach is intentional (avoids re-encoding the pre-mixed AAC — that was the point of PR #1615's refactor). Fix is to keep the concat approach but switch to bare paths so it survives FFmpeg 8.x on Windows.

**The fix** (`packages/producer/src/services/render/audioPadTrim.ts`, `concatFileLine`):

\`\`\`diff
 function concatFileLine(path: string): string {
-  const normalized = pathToFileURL(path).href;
-  return \`file '\${normalized.replace(/'/g, "'\\\\''")}'\`;
+  // Bare paths in concat directives — NOT \`file://\` URLs. FFmpeg 8.x on
+  // Windows fails to open URL-form paths from the concat demuxer with
+  // "Impossible to open file:///C:/…" (its file protocol strips the
+  // \`file:\` prefix leaving \`///C:/…\`, which Windows path parsing then
+  // rejects). …
+  return \`file '\${path.replace(/'/g, "'\\\\''")}'\`;
 }
\`\`\`

Also drops the now-unused `pathToFileURL` import.

## Test plan

- [x] `bun test packages/producer/src/services/render/audioPadTrim.test.ts` — 17/17 pass (16 pre-existing + 1 new regression pin asserting the pad-concat stdin never contains `file://` for a Windows-shaped input path).
- [x] `node scripts/run-test-lane.mjs unit bun` (producer) — 365 pass / 0 fail.
- [x] `bun x vitest run src/services/render/stages/assembleStage.test.ts` — 3/3 pass (audioPadTrim consumer, mocks the module).
- [x] `bun run --filter @hyperframes/producer typecheck` — clean.
- [x] `oxlint` + `oxfmt --check` on the two changed files — clean.
- [ ] **End-to-end verification on Windows + FFmpeg 8.x** — I don't have a Windows box with FFmpeg 8.x to reproduce the pre-fix failure and verify the post-fix success. Reviewer with access, please:
  1. Reproduce with `main`: render a composition on Windows that triggers the pad branch (audio shorter than video by >1ms) with `ffmpeg 8.1.1` on PATH → expect the "Impossible to open file:///…/audio.aac" error.
  2. Repeat with this branch → expect the render to complete with the concat-copy pad step succeeding.

## Enterprise release / feature flag holdout

<!-- pr-check:enterprise-ff:start -->
- [x] N/A — no user-facing behavior change beyond the bug fix
- [ ] Feature-flagged and held out from enterprise until validated
<!-- pr-check:enterprise-ff:end -->

## UX/Screenshot recording

<!-- pr-check:ui-impact -->
- [x] <!-- pr-opt:no-ui-impact --> No UI impact — this is a producer-side FFmpeg arg shape fix, backend-only.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Via