### PR TITLE
fix(studio): reserve a gutter for the promote-to-variable badge

### DIFF
--- a/packages/studio/src/components/editor/PromotableControl.tsx
+++ b/packages/studio/src/components/editor/PromotableControl.tsx
@@ -76,12 +76,20 @@ export function PromotableControl({
       : { bound: false },
   );
 
+  // The badge is absolutely positioned over the wrapped control, so its own
+  // width doesn't push anything — without a matching right-padding reserve on
+  // the wrapper, a control whose value renders flush to the row's right edge
+  // (e.g. flat Font/Color rows) sits directly underneath it instead of beside it.
+  const gutterClass = bound ? "pr-16" : canPromote ? "pr-9" : "";
+
   return (
-    <div className={`relative ${bound ? "rounded-lg ring-1 ring-studio-accent/40" : ""}`}>
+    <div
+      className={`relative ${gutterClass} ${bound ? "rounded-lg ring-1 ring-studio-accent/40" : ""}`}
+    >
       {rendered}
       {bound && (
         <span
-          className="pointer-events-none absolute right-1.5 top-0 z-10 inline-flex max-w-[60%] items-center gap-1 truncate rounded bg-studio-accent/20 px-1 py-px font-mono text-[8px] font-medium text-studio-accent"
+          className="pointer-events-none absolute right-1.5 top-0 z-10 inline-flex max-w-[100px] items-center gap-1 truncate rounded bg-studio-accent/20 px-1 py-px font-mono text-[8px] font-medium text-studio-accent"
           title={`Bound to variable "${promote.boundId}"`}
         >
           ◆ {promote.boundId}

--- a/packages/studio/src/components/editor/PromotableControl.tsx
+++ b/packages/studio/src/components/editor/PromotableControl.tsx
@@ -76,20 +76,14 @@ export function PromotableControl({
       : { bound: false },
   );
 
-  // The badge is absolutely positioned over the wrapped control, so its own
-  // width doesn't push anything — without a matching right-padding reserve on
-  // the wrapper, a control whose value renders flush to the row's right edge
-  // (e.g. flat Font/Color rows) sits directly underneath it instead of beside it.
-  const gutterClass = bound ? "pr-16" : canPromote ? "pr-9" : "";
-
   return (
-    <div
-      className={`relative ${gutterClass} ${bound ? "rounded-lg ring-1 ring-studio-accent/40" : ""}`}
-    >
+    <div className={`relative ${bound ? "rounded-lg ring-1 ring-studio-accent/40" : ""}`}>
       {rendered}
       {bound && (
         <span
-          className="pointer-events-none absolute right-1.5 top-0 z-10 inline-flex max-w-[100px] items-center gap-1 truncate rounded bg-studio-accent/20 px-1 py-px font-mono text-[8px] font-medium text-studio-accent"
+          // Sits above the row (not on top of top-0) so it clears a value that
+          // renders flush to the row's right edge, e.g. flat Font/Color rows.
+          className="pointer-events-none absolute -top-2 right-1.5 z-10 inline-flex max-w-[60%] items-center gap-1 truncate rounded bg-studio-accent/20 px-1 py-px font-mono text-[8px] font-medium text-studio-accent"
           title={`Bound to variable "${promote.boundId}"`}
         >
           ◆ {promote.boundId}
@@ -103,7 +97,7 @@ export function PromotableControl({
             e.stopPropagation();
             promote.promote();
           }}
-          className="absolute right-1.5 top-0 z-10 inline-flex items-center gap-1 rounded bg-neutral-800/80 px-1 py-px font-mono text-[8px] font-medium text-neutral-400 opacity-70 transition-colors hover:bg-studio-accent/20 hover:text-studio-accent hover:opacity-100"
+          className="absolute -top-2 right-1.5 z-10 inline-flex items-center gap-1 rounded bg-neutral-800/80 px-1 py-px font-mono text-[8px] font-medium text-neutral-400 opacity-70 transition-colors hover:bg-studio-accent/20 hover:text-studio-accent hover:opacity-100"
         >
           ◇ var
         </button>

--- a/packages/studio/src/components/editor/propertyPanelFlatTextSection.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatTextSection.tsx
@@ -267,7 +267,7 @@ export function FlatTextSection({
 
   if (textFields.length > 1) {
     return (
-      <div className="space-y-1.5">
+      <div className="space-y-2.5">
         <FlatTextLayerList
           fields={textFields}
           activeFieldKey={activeField.key}
@@ -295,7 +295,7 @@ export function FlatTextSection({
   }
 
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2.5">
       <FlatTextFieldEditor
         field={activeField}
         styles={styles}


### PR DESCRIPTION
## Summary
- The flat inspector's promote-to-variable badge (`◇ var` / `◆ {id}`) is absolutely positioned over the wrapped control. On rows where the value renders flush to the right edge (Content, Font, Color in the Text section), the badge sat directly on top of the value instead of beside it.
- Fixed by moving the badge to sit just above the row (`-top-2`) instead of on top of it, and widened the Text section's row gap (6px → 10px) so the badge has clear space from the row above it.

## Test plan
- [x] `bunx vitest run` — full studio suite (231 files / 2643 passed)
- [x] `tsc --noEmit`, `oxlint`, `oxfmt --check` clean on touched files
- [x] Verified live in Studio: Content/Font/Color rows now show the badge clearing the value with visible spacing, both when promotable and when bound to a variable
