### PR TITLE
fix(parsers): read fragment composition metadata

### DIFF
--- a/packages/parsers/src/htmlParser.test.ts
+++ b/packages/parsers/src/htmlParser.test.ts
@@ -748,6 +748,35 @@ describe("extractCompositionMetadata", () => {
     expect(meta.variables[1].type).toBe("number");
   });
 
+  it("extracts metadata from a composition root inside a template", () => {
+    const variables = JSON.stringify([
+      { id: "headline", type: "string", label: "Headline", default: "Launch" },
+    ]);
+    const html = `<!DOCTYPE html>
+<html>
+<body>
+  <template id="scene-template">
+    <section
+      data-composition-id="scene"
+      data-composition-duration="6.5"
+      data-composition-variables='${variables}'
+    ></section>
+  </template>
+</body>
+</html>`;
+
+    const meta = extractCompositionMetadata(html);
+
+    expect(meta.compositionId).toBe("scene");
+    expect(meta.compositionDuration).toBe(6.5);
+    expect(meta.variables).toHaveLength(1);
+    expect(meta.variables[0]).toMatchObject({
+      id: "headline",
+      type: "string",
+      default: "Launch",
+    });
+  });
+
   // T9 — CompositionVariable font/image parse (WS-B R1 implemented).
 
   it("parses a font variable (type: font) with name and source", () => {

--- a/packages/parsers/src/htmlParser.ts
+++ b/packages/parsers/src/htmlParser.ts
@@ -782,6 +782,17 @@ export interface CompositionMetadata {
   variables: CompositionVariable[];
 }
 
+function findCompositionMetadataCarrier(doc: Document): Element {
+  const htmlEl = doc.documentElement;
+  if (htmlEl.hasAttribute("data-composition-id")) return htmlEl;
+
+  let carrier: Element | null = null;
+  walkCompositionDescendants(doc, (el) => {
+    if (!carrier && el.hasAttribute("data-composition-id")) carrier = el;
+  });
+  return carrier ?? htmlEl;
+}
+
 export function extractCompositionMetadata(html: string): CompositionMetadata {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, "text/html");
@@ -792,15 +803,12 @@ export function extractCompositionMetadata(html: string): CompositionMetadata {
     );
   }
 
-  const compositionId = htmlEl.getAttribute("data-composition-id");
-  const durationStr = htmlEl.getAttribute("data-composition-duration");
+  const metadataCarrier = findCompositionMetadataCarrier(doc);
+  const compositionId = metadataCarrier.getAttribute("data-composition-id");
+  const durationStr = metadataCarrier.getAttribute("data-composition-duration");
   const compositionDuration = durationStr ? parseFloat(durationStr) : null;
 
-  // TODO(template-var-carriers): reads `<html>` only. A template/fragment comp
-  // that declares variables on its `[data-composition-id]` root div (the
-  // dual-carrier contract from #2081) reports no variables when its metadata is
-  // extracted standalone (e.g. CLI --variables validation of a sub-comp file).
-  const variables = parseCompositionVariables(htmlEl);
+  const variables = parseCompositionVariables(metadataCarrier);
 
   return {
     compositionId,


### PR DESCRIPTION
## What changed

- Resolve composition metadata from the first composition carrier when the synthetic `<html>` element has no composition attributes.
- Traverse composition templates so fragment roots inside `<template>` are supported.
- Add a regression test covering id, duration, and variables on a template root.

## Why

Template and fragment sub-compositions follow the dual-carrier contract introduced in #2081: their metadata may live on the inner `[data-composition-id]` root rather than `<html>`. `extractCompositionMetadata()` only read `<html>`, so CLI variable validation saw an empty schema for otherwise valid sub-composition files.

## Validation

- `bunx oxlint packages/parsers/src/htmlParser.ts packages/parsers/src/htmlParser.test.ts`
- `bun run --filter @hyperframes/parsers test -- htmlParser.test.ts`
- `bun run --filter @hyperframes/parsers typecheck`
- pre-commit hooks (lint, format, typecheck, fallow)
- `git diff --check`