### PR TITLE
fix(runtime): preserve fragment variable defaults

### DIFF
--- a/packages/core/src/runtime/compositionLoader.test.ts
+++ b/packages/core/src/runtime/compositionLoader.test.ts
@@ -974,6 +974,41 @@ describe("loadExternalCompositions", () => {
       expect(byComp["card-2"]).toEqual({ title: "Default Title" });
     });
 
+    it("merges defaults declared on a template composition root", async () => {
+      const host = document.createElement("div");
+      host.setAttribute("data-composition-src", "https://example.com/card.html");
+      host.setAttribute("data-composition-id", "card-template");
+      host.setAttribute("data-variable-values", '{"title":"Host title"}');
+      document.body.appendChild(host);
+
+      const compositionHtml = `
+        <html>
+          <body>
+            <template id="card-template-template">
+              <div
+                data-composition-id="card-template"
+                data-composition-variables='[
+                  {"id":"title","type":"string","label":"Title","default":"Default title"},
+                  {"id":"theme","type":"string","label":"Theme","default":"dark"}
+                ]'
+              ><p>card</p></div>
+            </template>
+          </body>
+        </html>
+      `;
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(compositionHtml, { status: 200 }),
+      );
+
+      await loadExternalCompositions({ ...defaultParams });
+
+      const byComp = (window as WindowWithScopedVars).__hfVariablesByComp ?? {};
+      expect(byComp["card-template"]).toEqual({
+        title: "Host title",
+        theme: "dark",
+      });
+    });
+
     it("skips registration when neither declared defaults nor host overrides exist", async () => {
       const host = document.createElement("div");
       host.setAttribute("data-composition-src", "https://example.com/card.html");

--- a/packages/core/src/runtime/compositionLoader.ts
+++ b/packages/core/src/runtime/compositionLoader.ts
@@ -375,12 +375,9 @@ async function mountCompositionContent(params: {
   /** Extra <link> elements from the parsed document <head> (font stylesheets, preconnects). */
   headLinks?: HTMLLinkElement[];
   /**
-   * Defaults extracted from the sub-composition's own
-   * `<html data-composition-variables="...">` attribute. Layered under the
-   * host element's `data-variable-values` to produce the per-instance
-   * variables visible inside the sub-comp's scoped `getVariables()`.
-   * Populated only by `loadExternalCompositions`; inline templates have no
-   * separate document root so no declared defaults are passed.
+   * Defaults extracted from the sub-composition document carrier. Defaults
+   * declared on an inner fragment root are merged below after `innerRoot` is
+   * resolved. Host `data-variable-values` override both layers.
    */
   declaredVariableDefaults?: Record<string, unknown>;
   onDiagnostic?: (payload: {
@@ -406,6 +403,10 @@ async function mountCompositionContent(params: {
   const runtimeScopeCompositionId =
     params.runtimeCompositionId || authoredScopeCompositionId || null;
   const authoredRootId = innerRoot?.getAttribute("id")?.trim() || null;
+  const declaredVariableDefaults = {
+    ...params.declaredVariableDefaults,
+    ...readDeclaredDefaults(innerRoot),
+  };
   const runtimeScopeSelector = runtimeScopeCompositionId
     ? `[data-composition-id="${CSS.escape(runtimeScopeCompositionId)}"]`
     : undefined;
@@ -536,7 +537,11 @@ async function mountCompositionContent(params: {
   // `window.__hfVariablesByComp[compId]`, so this table must be populated
   // before the wrapped IIFE evaluates.
   if (runtimeScopeCompositionId) {
-    stashInstanceVariables(params, contentNode, runtimeScopeCompositionId);
+    stashInstanceVariables(
+      { host: params.host, declaredVariableDefaults },
+      contentNode,
+      runtimeScopeCompositionId,
+    );
   }
 
   for (const scriptPayload of scriptPayloads) {
@@ -734,10 +739,6 @@ export async function loadExternalCompositions(
           headStyles,
           headScripts,
           headLinks,
-          // TODO(template-var-carriers): reads `<html>` only. A template/fragment
-          // sub-comp that declares on its `[data-composition-id]` root div (the
-          // dual-carrier contract from #2081) loses its defaults on this lazy
-          // external-load path — see inlineSubCompositions for the fixed path.
           declaredVariableDefaults: readDeclaredDefaults(doc.documentElement),
           onDiagnostic: params.onDiagnostic,
         });


### PR DESCRIPTION
## What changed

- Merge variable defaults from an external composition document and its inner fragment root.
- Apply the same root-default behavior to local template mounts.
- Add a regression covering host overrides layered over template-root defaults.

## Why

The lazy composition loader only forwarded defaults from `<html data-composition-variables>`. Template and fragment compositions put their schema on the inner `[data-composition-id]` root, so their defaults disappeared in Studio preview even though the compiler path preserved them. Scripts using scoped `getVariables()` therefore saw only host overrides and lost every unoverridden default.

## Validation

- `bunx oxlint packages/core/src/runtime/compositionLoader.ts packages/core/src/runtime/compositionLoader.test.ts`
- `bun run --filter @hyperframes/core test -- compositionLoader.test.ts`
- `bun run --filter @hyperframes/core typecheck`
- pre-commit hooks (lint, format, typecheck, fallow)
- `git diff --check`