### PR TITLE
fix(lint): ignore !important in font families

### DIFF
--- a/packages/lint/src/rules/fonts.test.ts
+++ b/packages/lint/src/rules/fonts.test.ts
@@ -178,6 +178,14 @@ describe("font rules", () => {
       expect(findings).toHaveLength(0);
     });
 
+    it("does not treat !important as part of a generic font family", async () => {
+      const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+        <style>body { font-family: 'Inter', cursive !important; }</style>
+      </div>`;
+      const findings = await findByCode(html, "font_family_without_font_face");
+      expect(findings).toHaveLength(0);
+    });
+
     it("reports multiple missing families in one finding", async () => {
       const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
         <style>

--- a/packages/lint/src/rules/fonts.ts
+++ b/packages/lint/src/rules/fonts.ts
@@ -65,6 +65,7 @@ function extractFontFaceFamilies(styles: Array<{ content: string }>): Set<string
 function normalizeUsedFontName(part: string): string | null {
   const name = part
     .trim()
+    .replace(/\s*!important\s*$/i, "")
     .replace(/^['"]|['"]$/g, "")
     .trim()
     .toLowerCase();


### PR DESCRIPTION
## Summary

CSS declarations ending in `!important` no longer produce false `font_family_without_font_face` errors for generic fallback families. The linter now removes the priority token before normalizing each font-family entry.

## Test plan

- `bun test packages/lint/src/rules/fonts.test.ts` — 34 passed
- `bunx oxfmt --check packages/lint/src/rules/fonts.ts packages/lint/src/rules/fonts.test.ts`
- `bunx oxlint packages/lint/src/rules/fonts.ts packages/lint/src/rules/fonts.test.ts`
- `git diff --check`

The broader package test/typecheck commands are unavailable in this checkout because its shared install lacks `jsdom` and Node type declarations; the focused Bun suite exercises the real linter path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with_Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
