### PR TITLE
fix(studio): preserve zero gesture bases

### DIFF
--- a/packages/studio/src/hooks/useGestureRecording.test.ts
+++ b/packages/studio/src/hooks/useGestureRecording.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { readBasePosition } from "./useGestureRecording";
+
+describe("readBasePosition", () => {
+  it("preserves zero opacity and scale from the GSAP runtime", () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const element = document.createElement("div");
+    const values: Record<string, number> = {
+      opacity: 0,
+      scaleX: 0,
+      x: 0,
+      y: 0,
+    };
+    Object.assign(iframe.contentWindow!, {
+      gsap: {
+        getProperty: (_element: Element, property: string) => values[property],
+      },
+    });
+
+    expect(readBasePosition(element, iframe)).toMatchObject({
+      baseOpacity: 0,
+      baseScale: 0,
+      baseX: 0,
+      baseY: 0,
+    });
+  });
+
+  it("falls back only for non-finite GSAP values", () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const element = document.createElement("div");
+    Object.assign(iframe.contentWindow!, {
+      gsap: {
+        getProperty: (_element: Element, property: string) =>
+          property === "opacity" ? Number.NaN : Number.POSITIVE_INFINITY,
+      },
+    });
+
+    expect(readBasePosition(element, iframe)).toMatchObject({
+      baseOpacity: 1,
+      baseScale: 1,
+      baseX: 0,
+      baseY: 0,
+    });
+  });
+});

--- a/packages/studio/src/hooks/useGestureRecording.ts
+++ b/packages/studio/src/hooks/useGestureRecording.ts
@@ -42,7 +42,12 @@ interface GsapRuntime {
 // Extracted helpers — pure functions, no refs, no React.
 // ---------------------------------------------------------------------------
 
-function readBasePosition(element: HTMLElement, iframeEl: HTMLIFrameElement): BasePosition {
+function finiteNumberOr(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function readBasePosition(element: HTMLElement, iframeEl: HTMLIFrameElement): BasePosition {
   let baseOpacity = 1;
   let baseScale = 1;
   let baseX = 0;
@@ -55,10 +60,10 @@ function readBasePosition(element: HTMLElement, iframeEl: HTMLIFrameElement): Ba
       }
     ).gsap;
     if (gsap?.getProperty) {
-      baseOpacity = Number(gsap.getProperty(element, "opacity")) || 1;
-      baseScale = Number(gsap.getProperty(element, "scaleX")) || 1;
-      baseX = Number(gsap.getProperty(element, "x")) || 0;
-      baseY = Number(gsap.getProperty(element, "y")) || 0;
+      baseOpacity = finiteNumberOr(gsap.getProperty(element, "opacity"), 1);
+      baseScale = finiteNumberOr(gsap.getProperty(element, "scaleX"), 1);
+      baseX = finiteNumberOr(gsap.getProperty(element, "x"), 0);
+      baseY = finiteNumberOr(gsap.getProperty(element, "y"), 0);
     }
   } catch {
     /* cross-origin guard */


### PR DESCRIPTION
## Summary
- preserve valid zero opacity and scale values when recording gestures
- fall back only when GSAP returns a non-finite value
- add regression coverage for hidden and zero-scale elements

## Why
The previous `|| 1` fallback treated valid `0` values as missing, so recording a gesture on a hidden or collapsed element changed its base opacity or scale to `1`.

## Validation
- `bunx oxfmt packages/studio/src/hooks/useGestureRecording.ts packages/studio/src/hooks/useGestureRecording.test.ts`
- `bunx oxlint packages/studio/src/hooks/useGestureRecording.ts packages/studio/src/hooks/useGestureRecording.test.ts`
- `bun run --filter @hyperframes/studio test -- useGestureRecording.test.ts`
- `bun run --filter @hyperframes/studio typecheck`