### PR TITLE
fix(cli): allow zero layout tolerance

### DIFF
--- a/packages/cli/src/commands/layout.test.ts
+++ b/packages/cli/src/commands/layout.test.ts
@@ -18,7 +18,7 @@ import {
 vi.mock("../utils/project.js", () => resolveProjectMock());
 vi.mock("@hyperframes/core/compiler", () => bundleToSingleHtmlFailureMock());
 
-import { createInspectCommand } from "./layout.js";
+import { createInspectCommand, parseLayoutTolerance } from "./layout.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -47,5 +47,16 @@ describe("layout command deprecation (U5)", () => {
     const jsonCall = await runAndFindJsonLogCall(createInspectCommand("inspect"));
     const parsed = JSON.parse(String(jsonCall?.[0]));
     expect(parsed._meta.deprecated).toBe(true);
+  });
+});
+
+describe("parseLayoutTolerance", () => {
+  it("preserves an explicit zero tolerance", () => {
+    expect(parseLayoutTolerance("0")).toBe(0);
+  });
+
+  it("clamps negative tolerance and defaults invalid input", () => {
+    expect(parseLayoutTolerance("-1")).toBe(0);
+    expect(parseLayoutTolerance("invalid")).toBe(2);
   });
 });

--- a/packages/cli/src/commands/layout.ts
+++ b/packages/cli/src/commands/layout.ts
@@ -44,6 +44,11 @@ const INSPECT_SCHEMA_VERSION = 1;
 const MOTION_FPS = 20;
 const MOTION_MAX_SAMPLES = 300;
 
+export function parseLayoutTolerance(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Math.max(0, Number.isFinite(parsed) ? parsed : 2);
+}
+
 export const examples: Example[] = [
   ["Inspect visual layout across the current composition", "hyperframes layout"],
   ["Inspect a specific project", "hyperframes layout ./my-video"],
@@ -486,7 +491,7 @@ export function createInspectCommand(commandName: "inspect" | "layout") {
       printDeprecationNotice(commandName);
       const project = resolveProject(args.dir);
       const samples = Math.max(1, parseInt(args.samples as string, 10) || 9);
-      const tolerance = Math.max(0, parseFloat(args.tolerance as string) || 2);
+      const tolerance = parseLayoutTolerance(args.tolerance as string);
       const timeout = Math.max(500, parseInt(args.timeout as string, 10) || 5000);
       const maxIssues = Math.max(1, parseInt(args["max-issues"] as string, 10) || 80);
       const at = parseAt(args.at);


### PR DESCRIPTION
## Summary
- preserve an explicit `--tolerance 0` for layout inspection
- continue clamping negative values to zero
- retain the default tolerance of 2 for invalid input

## Why
The previous `parseFloat(value) || 2` expression treated a valid zero as missing, so callers could not request exact, zero-tolerance overflow checks.

## Validation
- `bunx oxfmt packages/cli/src/commands/layout.ts packages/cli/src/commands/layout.test.ts`
- `bunx oxlint packages/cli/src/commands/layout.ts packages/cli/src/commands/layout.test.ts`
- `bun run --filter @hyperframes/cli test -- layout.test.ts`
- `bun run --filter @hyperframes/cli typecheck`