### PR TITLE
fix(media): preserve zero end times

### DIFF
--- a/packages/core/src/generators/hyperframes.test.ts
+++ b/packages/core/src/generators/hyperframes.test.ts
@@ -220,6 +220,8 @@ describe("generateGsapTimelineScript", () => {
 
     expect(script).toContain("Sync media playback");
     expect(script).toContain("media.currentTime");
+    expect(script).toContain("Number.isFinite(parsedEnd) ? parsedEnd : Infinity");
+    expect(script).not.toContain("parseFloat(media.dataset.end) || Infinity");
   });
 
   it("generates initial position sets for elements with x/y offsets", () => {

--- a/packages/core/src/generators/hyperframes.ts
+++ b/packages/core/src/generators/hyperframes.ts
@@ -739,7 +739,8 @@ function generateDefaultGsapAnimations(
       const time = tl.time();
       document.querySelectorAll("video[data-start], audio[data-start]").forEach(function(media) {
         const start = parseFloat(media.dataset.start);
-        const end = parseFloat(media.dataset.end) || Infinity;
+        const parsedEnd = parseFloat(media.dataset.end);
+        const end = Number.isFinite(parsedEnd) ? parsedEnd : Infinity;
         const mediaTime = time - start;
         if (time >= start && time < end) {
           if (Math.abs(media.currentTime - mediaTime) > 0.1) {

--- a/packages/parsers/src/gsapParser.test.ts
+++ b/packages/parsers/src/gsapParser.test.ts
@@ -948,6 +948,13 @@ describe("serializeGsapAnimations", () => {
     expect(result).toContain("const myTimeline = gsap.timeline({ paused: true });");
     expect(result).toContain('myTimeline.set("#el1"');
   });
+
+  it("preserves a zero media end time", () => {
+    const result = serializeGsapAnimations([], "tl", { includeMediaSync: true });
+
+    expect(result).toContain("Number.isFinite(parsedEnd) ? parsedEnd : Infinity");
+    expect(result).not.toContain("parseFloat(media.dataset.end) || Infinity");
+  });
 });
 
 describe("validateCompositionGsap", () => {

--- a/packages/parsers/src/gsapSerialize.ts
+++ b/packages/parsers/src/gsapSerialize.ts
@@ -231,7 +231,8 @@ export function serializeGsapAnimations(
       const time = ${timelineVar}.time();
       document.querySelectorAll("video[data-start], audio[data-start]").forEach(function(media) {
         const start = parseFloat(media.dataset.start);
-        const end = parseFloat(media.dataset.end) || Infinity;
+        const parsedEnd = parseFloat(media.dataset.end);
+        const end = Number.isFinite(parsedEnd) ? parsedEnd : Infinity;
         const mediaTime = time - start;
         if (time >= start && time < end) {
           if (Math.abs(media.currentTime - mediaTime) > 0.1) {


### PR DESCRIPTION
## Summary
- preserve `data-end="0"` in generated media synchronization code
- apply the same finite-number handling to core generation and parser serialization
- add regression assertions for both output paths

## Why
The previous `parseFloat(media.dataset.end) || Infinity` fallback treated a valid zero as missing. Media with an explicit zero end time was therefore considered active indefinitely.

## Validation
- `bunx oxfmt` and `bunx oxlint` on all changed files
- `bun run --filter @hyperframes/core test -- hyperframes.test.ts` (29 passed)
- `bun run --filter @hyperframes/parsers test -- gsapParser.test.ts` (202 passed)
- core and parser typechecks