### PR TITLE
fix(engine): preserve zero root opacity

### DIFF
--- a/packages/engine/src/services/drawElementService.dom.test.ts
+++ b/packages/engine/src/services/drawElementService.dom.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { Page } from "puppeteer-core";
+import { injectDrawElementCanvas } from "./drawElementService.js";
+
+describe("injectDrawElementCanvas", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    Reflect.deleteProperty(window, "__HF_ROOT_BASE_OPACITY__");
+  });
+
+  it("preserves a zero composition root opacity", async () => {
+    const root = document.createElement("main");
+    root.dataset.compositionId = "test";
+    root.style.opacity = "0";
+    document.body.appendChild(root);
+
+    const page = {
+      evaluate: async <T, A>(callback: (arg: A) => T, arg: A) => callback(arg),
+    } as unknown as Page;
+
+    await injectDrawElementCanvas(page, 1920, 1080);
+
+    expect(
+      (window as unknown as { __HF_ROOT_BASE_OPACITY__?: number }).__HF_ROOT_BASE_OPACITY__,
+    ).toBe(0);
+  });
+});

--- a/packages/engine/src/services/drawElementService.ts
+++ b/packages/engine/src/services/drawElementService.ts
@@ -148,8 +148,9 @@ export async function injectDrawElementCanvas(
       // current opacity into the snapshot — BeginFrame (sync=false) captures
       // and builds without canvas.requestPaint(); see __hfDeInvalidate below.
       try {
+        const parsedBaseOpacity = parseFloat(getComputedStyle(root).opacity);
         (window as unknown as { __HF_ROOT_BASE_OPACITY__?: number }).__HF_ROOT_BASE_OPACITY__ =
-          parseFloat(getComputedStyle(root).opacity) || 1;
+          Number.isFinite(parsedBaseOpacity) ? parsedBaseOpacity : 1;
       } catch {
         /* leave undefined → ratio defaults to 1 */
       }


### PR DESCRIPTION
## Summary
- preserve an initial composition-root opacity of zero in DrawElement capture
- fall back to opacity 1 only for non-finite computed values
- add a DOM regression test for canvas injection

## Why
The legacy root-opacity correction records the composition root opacity before wrapping it. The previous truthy fallback converted a valid `opacity: 0` to `1`, producing an incorrect correction ratio on later frames.

## Validation
- `bunx oxfmt` and `bunx oxlint` on changed files
- `bun run --filter @hyperframes/engine test -- drawElementService.dom.test.ts`
- `bun run --filter @hyperframes/engine typecheck`