### PR TITLE
fix(registry): register device timeline synchronously

### DIFF
--- a/registry/blocks/vfx-iphone-device/vfx-iphone-device.html
+++ b/registry/blocks/vfx-iphone-device/vfx-iphone-device.html
@@ -614,14 +614,8 @@
       });
 
       function onReady() {
-        requestAnimationFrame(function () {
-          requestAnimationFrame(function () {
-            paintReady = true;
-            captureScreens();
-            window.__timelines = window.__timelines || {};
-            window.__timelines["devices-canvas"] = tl;
-          });
-        });
+        paintReady = true;
+        captureScreens();
       }
 
       // ── Cubic Bezier Implementation ────────────────────────────────────
@@ -757,8 +751,9 @@
       }
 
       // ── GSAP Timeline — Product Review Edit ────────────────────────────
-      // __timelines created in onReady() after GLTF models load
       var tl = gsap.timeline({ paused: true });
+      window.__timelines = window.__timelines || {};
+      window.__timelines["devices-canvas"] = tl;
 
       tl.to(S, { p: 1, drift: 15, duration: 15, ease: "none", onUpdate: render }, 0);
 
@@ -812,8 +807,6 @@
       // Scroll on MacBook reveal
       tl.to(S, { scroll: 0.8, duration: 3, ease: breatheEase }, 9.5);
       tl.to(S, { scroll: 0.3, duration: 2, ease: driftEase }, 13);
-
-      // __timelines registered in onReady() after GLTF models load
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- register the `vfx-iphone-device` paused timeline synchronously
- keep model readiness limited to screen capture setup
- remove the double `requestAnimationFrame` gate from composition startup

## Why
The block previously exposed `window.__timelines["devices-canvas"]` only after both GLTF models loaded and two animation frames elapsed. That violates the synchronous timeline contract and can make renderers wait for the sub-composition polling timeout.

Fixes the device-timeline portion of #2107.

## Validation
- `bunx oxfmt registry/blocks/vfx-iphone-device/vfx-iphone-device.html`
- direct `lintHyperframeHtml`: 0 errors (2 existing tween-overlap warnings)
- `npx hyperframes check` against a temporary project copy: Runtime 0 errors, Motion 0 errors; the overall command remains non-zero because the existing hidden screen-texture DOM triggers 18 layout occlusion findings unrelated to this change