### PR TITLE
fix(registry): remove caption placeholder media

### DIFF
--- a/packages/cli/src/registry/registryBlocks.test.ts
+++ b/packages/cli/src/registry/registryBlocks.test.ts
@@ -4,6 +4,10 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const blocksDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../registry/blocks");
+const componentsDir = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../registry/components",
+);
 
 interface RegistryManifest {
   files: Array<{ path: string; type: string }>;
@@ -47,5 +51,27 @@ describe("registry block manifests", () => {
     }
 
     expect(missing).toEqual([]);
+  });
+});
+
+describe("caption component manifests", () => {
+  it("ships caption overlays without placeholder media elements", () => {
+    const mediaElements: string[] = [];
+
+    for (const entry of readdirSync(componentsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith("caption-")) continue;
+
+      const itemDir = join(componentsDir, entry.name);
+      const manifest = JSON.parse(
+        readFileSync(join(itemDir, "registry-item.json"), "utf8"),
+      ) as RegistryManifest;
+      for (const file of manifest.files) {
+        if (!file.path.endsWith(".html")) continue;
+        const html = readFileSync(join(itemDir, file.path), "utf8").replace(/<!--[\s\S]*?-->/g, "");
+        if (/<(?:video|audio)\b/i.test(html)) mediaElements.push(`${entry.name}: ${file.path}`);
+      }
+    }
+
+    expect(mediaElements).toEqual([]);
   });
 });

--- a/packages/cli/src/registry/registryBlocks.test.ts
+++ b/packages/cli/src/registry/registryBlocks.test.ts
@@ -67,7 +67,8 @@ describe("caption component manifests", () => {
       ) as RegistryManifest;
       for (const file of manifest.files) {
         if (!file.path.endsWith(".html")) continue;
-        const html = readFileSync(join(itemDir, file.path), "utf8").replace(/<!--[\s\S]*?-->/g, "");
+        let html = readFileSync(join(itemDir, file.path), "utf8");
+        while (html.includes("<!--")) html = html.replace(/<!--[\s\S]*?-->/g, "");
         if (/<(?:video|audio)\b/i.test(html)) mediaElements.push(`${entry.name}: ${file.path}`);
       }
     }

--- a/registry/components/caption-clip-wipe/caption-clip-wipe.html
+++ b/registry/components/caption-clip-wipe/caption-clip-wipe.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #wp-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .wp-overlay {
         position: absolute;
         inset: 0;
@@ -92,15 +84,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="wp-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="wp-overlay"></div>
       <div id="wp-container"></div>
     </div>

--- a/registry/components/caption-editorial-emphasis/caption-editorial-emphasis.html
+++ b/registry/components/caption-editorial-emphasis/caption-editorial-emphasis.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -132,17 +123,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-emoji-pop/caption-emoji-pop.html
+++ b/registry/components/caption-emoji-pop/caption-emoji-pop.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -128,16 +119,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-glitch-rgb/caption-glitch-rgb.html
+++ b/registry/components/caption-glitch-rgb/caption-glitch-rgb.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #gl-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .gl-overlay {
         position: absolute;
         inset: 0;
@@ -112,15 +104,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="gl-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="gl-overlay"></div>
       <div class="gl-scanlines"></div>
       <div id="gl-container"></div>

--- a/registry/components/caption-gradient-fill/caption-gradient-fill.html
+++ b/registry/components/caption-gradient-fill/caption-gradient-fill.html
@@ -80,15 +80,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="gr-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div id="gr-container"></div>
     </div>
 

--- a/registry/components/caption-kinetic-slam/caption-kinetic-slam.html
+++ b/registry/components/caption-kinetic-slam/caption-kinetic-slam.html
@@ -30,14 +30,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #kt-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .kt-overlay {
         position: absolute;
         inset: 0;
@@ -79,15 +71,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="kt-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="kt-overlay"></div>
       <div id="kt-container"></div>
     </div>

--- a/registry/components/caption-matrix-decode/caption-matrix-decode.html
+++ b/registry/components/caption-matrix-decode/caption-matrix-decode.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #sc-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .sc-overlay {
         position: absolute;
         inset: 0;
@@ -100,15 +92,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="sc-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="sc-overlay"></div>
       <div id="sc-container"></div>
     </div>

--- a/registry/components/caption-neon-accent/caption-neon-accent.html
+++ b/registry/components/caption-neon-accent/caption-neon-accent.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -128,16 +119,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-neon-glow/caption-neon-glow.html
+++ b/registry/components/caption-neon-glow/caption-neon-glow.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #ne-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .ne-overlay {
         position: absolute;
         inset: 0;
@@ -91,15 +83,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="ne-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="ne-overlay"></div>
       <div id="ne-container"></div>
     </div>

--- a/registry/components/caption-parallax-layers/caption-parallax-layers.html
+++ b/registry/components/caption-parallax-layers/caption-parallax-layers.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #bg-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       /* Behind captions: big red 3D text */
       .behind-caption-layer {
         position: absolute;
@@ -156,17 +147,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bg-video"
-        muted
-        playsinline
-        preload="auto"
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="behind-caption-layer" aria-hidden="true">
         <div id="behind-stage" class="behind-safe-zone"></div>
       </div>

--- a/registry/components/caption-particle-burst/caption-particle-burst.html
+++ b/registry/components/caption-particle-burst/caption-particle-burst.html
@@ -33,14 +33,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #bs-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .bs-overlay {
         position: absolute;
         inset: 0;
@@ -102,15 +94,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="bs-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="bs-overlay"></div>
       <div id="bs-container"></div>
     </div>

--- a/registry/components/caption-pill-karaoke/caption-pill-karaoke.html
+++ b/registry/components/caption-pill-karaoke/caption-pill-karaoke.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -134,16 +125,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>

--- a/registry/components/caption-texture/caption-texture.html
+++ b/registry/components/caption-texture/caption-texture.html
@@ -40,14 +40,6 @@
         overflow: hidden;
         background: transparent;
       }
-      #lv-video {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
       .lv-overlay {
         position: absolute;
         inset: 0;
@@ -105,15 +97,6 @@
       data-height="1080"
       data-composition-variables='{"texture":{"type":"string","default":"lava"}}'
     >
-      <video
-        id="lv-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
       <div class="lv-overlay"></div>
       <div id="lv-container"></div>
     </div>

--- a/registry/components/caption-weight-shift/caption-weight-shift.html
+++ b/registry/components/caption-weight-shift/caption-weight-shift.html
@@ -37,15 +37,6 @@
         background: transparent;
       }
 
-      #avatar-video {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
       .caption-layer {
         position: absolute;
         inset: 0;
@@ -120,16 +111,6 @@
       data-width="1920"
       data-height="1080"
     >
-      <video
-        id="avatar-video"
-        muted
-        playsinline
-        data-start="0"
-        data-duration="8"
-        data-track-index="0"
-        data-has-audio="false"
-      ></video>
-
       <div class="caption-layer" aria-hidden="true">
         <div id="caption-stage" class="safe-zone"></div>
       </div>


### PR DESCRIPTION
## Summary
- remove unconfigured placeholder videos from 14 installable caption components
- remove their now-unused video-only CSS rules
- add a registry regression test that rejects media elements in caption component manifests

## Why
Caption components are overlays that consumers combine with host footage. Shipping empty or unavailable placeholder videos makes the installed component fail media lint (`media_missing_src` / `media_in_subcomposition`) before the consumer adds real footage.

Fixes the caption-placeholder portion of #2107. Demo files remain unchanged.

## Validation
- `bunx oxfmt` on all changed HTML files
- `bunx oxlint packages/cli/src/registry/registryBlocks.test.ts`
- `bun run --filter @hyperframes/cli test -- registryBlocks.test.ts` (2 passed)
- `bun run --filter @hyperframes/cli typecheck`
- all 16 caption manifests: 0 placeholder-media lint findings
- `npx hyperframes check` on `caption-gradient-fill`: passed with Runtime, Layout, and Motion at 0 errors