### PR TITLE
fix(registry): position flowchart typing beats with label-relative offsets

### DIFF
--- a/registry/blocks/flowchart-vertical/flowchart-vertical.html
+++ b/registry/blocks/flowchart-vertical/flowchart-vertical.html
@@ -414,8 +414,10 @@
           // 13. Hold
           tl.addLabel("hold5", "+=0.2");
 
-          // 14. Type correction: "Pythom" → "Python"
-          const typingStart = tl.labels["hold5"];
+          // 14. Type correction: "Pythom" → "Python" — positioned relative to the "hold5"
+          // label. Reading tl.labels back is unavailable under the render compiler's GSAP
+          // proxy (it throws before the timeline is registered, leaving the block blank),
+          // so use GSAP's own label-relative position syntax instead.
           const words = ["P", "Py", "Pyt", "Pyth", "Pytho", "Python"];
           words.forEach((word, i) => {
             tl.add(
@@ -423,18 +425,18 @@
                 if (pythonText)
                   pythonText.innerHTML = `Start with <span class="text-highlight">${word}</span>`;
               },
-              typingStart + i * 0.05,
+              `hold5+=${i * 0.05}`,
             );
           });
 
-          const typingEnd = typingStart + words.length * 0.05;
+          const typingEnd = words.length * 0.05;
           tl.add(() => {
             if (pythonText) pythonText.innerHTML = "Start with Python";
             gsap.set(S + " .squiggle-container", { opacity: 0 });
-          }, typingEnd);
+          }, `hold5+=${typingEnd}`);
 
           // 15. Hold
-          tl.addLabel("hold6", typingEnd + 0.5);
+          tl.addLabel("hold6", `hold5+=${typingEnd + 0.5}`);
 
           // 16. Cursor clicks away to deselect
           tl.to(S + " #cursor", { x: -1050, y: -1520, duration: 0.3, overwrite: "auto" }, "hold6");

--- a/registry/blocks/flowchart/flowchart.html
+++ b/registry/blocks/flowchart/flowchart.html
@@ -414,8 +414,10 @@
           // 13. Hold
           tl.addLabel("hold5", "+=0.2");
 
-          // 14. Type correction: "Pythom" → "Python"
-          const typingStart = tl.labels["hold5"];
+          // 14. Type correction: "Pythom" → "Python" — positioned relative to the "hold5"
+          // label. Reading tl.labels back is unavailable under the render compiler's GSAP
+          // proxy (it throws before the timeline is registered, leaving the block blank),
+          // so use GSAP's own label-relative position syntax instead.
           const words = ["P", "Py", "Pyt", "Pyth", "Pytho", "Python"];
           words.forEach((word, i) => {
             tl.add(
@@ -423,18 +425,18 @@
                 if (pythonText)
                   pythonText.innerHTML = `Start with <span class="text-highlight">${word}</span>`;
               },
-              typingStart + i * 0.05,
+              `hold5+=${i * 0.05}`,
             );
           });
 
-          const typingEnd = typingStart + words.length * 0.05;
+          const typingEnd = words.length * 0.05;
           tl.add(() => {
             if (pythonText) pythonText.innerHTML = "Start with Python";
             gsap.set(S + " .squiggle-container", { opacity: 0 });
-          }, typingEnd);
+          }, `hold5+=${typingEnd}`);
 
           // 15. Hold
-          tl.addLabel("hold6", typingEnd + 0.5);
+          tl.addLabel("hold6", `hold5+=${typingEnd + 0.5}`);
 
           // 16. Cursor clicks away to deselect
           tl.to(S + " #cursor", { x: -1420, y: -500, duration: 0.3, overwrite: "auto" }, "hold6");


### PR DESCRIPTION
Fixes #2548.

### What

`registry/blocks/flowchart/flowchart.html` and `registry/blocks/flowchart-vertical/flowchart-vertical.html` schedule the "Pythom" → "Python" typing correction by reading a label position back off the timeline (`const typingStart = tl.labels["hold5"]`). The render compiler executes composition scripts under a GSAP proxy whose timeline exposes no readable `.labels` map, so the script throws before `window.__timelines` is assigned — the block is never registered, renders capture only the dotted-grid background, and every render pays the 45 s `sub_timeline_readiness_timeout`.

### How

Position the typing beats with GSAP's label-relative syntax (`` `hold5+=${i * 0.05}` ``) — the same idiom every other step in these files already uses (`"hold1+=0.25"`, `"hold6+=0.3"`, …). `typingEnd` becomes a relative offset and `hold6` is added as `` `hold5+=${typingEnd + 0.5}` ``. Timing is byte-identical to the authored intent; no `.labels` read remains.

### Verification

- `npx hyperframes@0.7.60 render` of a composition mounting `flowchart-vertical` in a 3 s window:
  - **before:** blank dotted grid for the whole window + `sub_timeline_readiness_timeout` (+45 s on every render), browser console shows `[Compiler] Composition script failed … reading 'hold5'`
  - **after:** the flowchart animates through its full sequence; no compiler error; the readiness timeout disappears (render time drops accordingly)
- Verified on macOS arm64 (native) and linux/amd64 (Docker).
- `bun run lint` and `bun run format:check` pass.
