### PR TITLE
fix(core): stop composition variables from shadowing authored CSS custom properties

### DIFF
--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -881,6 +881,44 @@ describe("bundleToSingleHtml", () => {
     expect(bundled).toMatch(/card__hf2[\s\S]*Enterprise[\s\S]*light/);
   });
 
+  it("does not redefine an authored CSS variable for a bundled sub-composition", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><head>
+  <style>:root { --accent: #4287f5; } .host-badge { color: var(--accent); }</style>
+</head><body>
+  <div
+    data-composition-id="main"
+    data-width="1920"
+    data-height="1080"
+    data-start="0"
+    data-duration="5">
+    <div
+      data-composition-id="card"
+      data-composition-src="compositions/card.html"
+      data-variable-values='{"accent":"blue"}'></div>
+  </div>
+  <script>window.__timelines={};</script>
+</body></html>`,
+      "compositions/card.html": `<!doctype html>
+<html data-composition-variables='[{"id":"accent","type":"string","label":"Accent","default":"red"}]'>
+  <body>
+    <div
+      data-composition-id="card"
+      data-width="1920"
+      data-height="1080"
+      data-start="0"
+      data-duration="5"></div>
+  </body>
+</html>`,
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    expect(bundled).toContain(":root { --accent: #4287f5; }");
+    expect(bundled).not.toMatch(/\[data-composition-id="card[^"]*"\]\s*\{[^}]*--accent:\s*blue/);
+  });
+
   it("scopes external sub-composition styles and classic scripts", async () => {
     const dir = makeTempProject({
       "index.html": `<!doctype html>

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -1154,9 +1154,10 @@ export function emitRootCompositionVariableStyles(
   variablesByComp: Record<string, Record<string, unknown>> = {},
   overrides: Record<string, unknown> = {},
 ): boolean {
-  const layerFor = makeVariableLayer(document, overrides);
+  const authoredDefines = authoredDefinesPredicate(document);
+  const layerFor = makeVariableLayer(authoredDefines, overrides);
   const rules = [
-    ...hostScopedVariableRules(variablesByComp, overrides),
+    ...hostScopedVariableRules(variablesByComp, overrides, authoredDefines),
     ...rootDeclaredVariableRules(document, layerFor),
     ...declarerVariableRules(document, layerFor),
   ];
@@ -1173,18 +1174,23 @@ type VariableLayer = (
   hostValues: Record<string, unknown>,
 ) => Record<string, unknown>;
 
+function authoredDefinesPredicate(document: Document): (id: string) => boolean {
+  const authoredCss = [...document.querySelectorAll("style:not([data-hf-composition-variables])")]
+    .map((s) => s.textContent || "")
+    .join("\n");
+  return (id) => new RegExp(`${cssVariableName(id)}\\s*:`).test(authoredCss);
+}
+
 /**
  * Layering for one declarer: authored stylesheet definitions win over
  * declared defaults (the runtime's define-if-absent, applied statically) —
  * a var already defined in any authored <style> block is not emitted. Host
  * values and --variables overrides are explicit intent, never filtered.
  */
-function makeVariableLayer(document: Document, overrides: Record<string, unknown>): VariableLayer {
-  const authoredCss = [...document.querySelectorAll("style:not([data-hf-composition-variables])")]
-    .map((s) => s.textContent || "")
-    .join("\n");
-  const authoredDefines = (id: string): boolean =>
-    new RegExp(`${cssVariableName(id)}\\s*:`).test(authoredCss);
+function makeVariableLayer(
+  authoredDefines: (id: string) => boolean,
+  overrides: Record<string, unknown>,
+): VariableLayer {
   return (declared, hostValues) => {
     const out: Record<string, unknown> = {};
     for (const [id, value] of Object.entries(declared)) {
@@ -1200,14 +1206,24 @@ function makeVariableLayer(document: Document, overrides: Record<string, unknown
   };
 }
 
-/** Host-scoped rules: per-instance values inherited by the host's subtree. */
+/**
+ * Host-scoped rules: per-instance values inherited by the host's subtree.
+ * A composition variable, whether a declared default or an explicit
+ * data-variable-values value, never redefines a custom property authored by
+ * another part of the document. Render-time --variables overrides remain
+ * explicit user intent and always win.
+ */
 function hostScopedVariableRules(
   variablesByComp: Record<string, Record<string, unknown>>,
   overrides: Record<string, unknown>,
+  authoredDefines: (id: string) => boolean,
 ): string[] {
   const rules: string[] = [];
   for (const [compId, vars] of Object.entries(variablesByComp)) {
-    const withOverrides = { ...vars };
+    const withOverrides: Record<string, unknown> = {};
+    for (const [id, value] of Object.entries(vars)) {
+      if (!authoredDefines(id)) withOverrides[id] = value;
+    }
     for (const [id, value] of Object.entries(overrides)) {
       if (id in vars) withOverrides[id] = value;
     }

--- a/packages/core/src/runtime/compositionLoader.test.ts
+++ b/packages/core/src/runtime/compositionLoader.test.ts
@@ -951,6 +951,34 @@ describe("loadExternalCompositions", () => {
       });
     });
 
+    it("does not redefine a CSS variable already authored on the host", async () => {
+      const style = document.createElement("style");
+      style.textContent = ":root { --accent: #4287f5; }";
+      document.head.appendChild(style);
+
+      const host = document.createElement("div");
+      host.setAttribute("data-composition-src", "https://example.com/card.html");
+      host.setAttribute("data-composition-id", "card-authored-token");
+      host.setAttribute("data-variable-values", '{"accent":"blue"}');
+      document.body.appendChild(host);
+
+      const compositionHtml = `
+        <html data-composition-variables='[
+          {"id":"accent","type":"string","label":"Accent","default":"red"}
+        ]'>
+          <body><div data-composition-id="card-authored-token"><p>x</p></div></body>
+        </html>
+      `;
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(compositionHtml, { status: 200 }),
+      );
+
+      await loadExternalCompositions({ ...defaultParams });
+
+      expect(host.style.getPropertyValue("--accent")).toBe("");
+      expect(window.getComputedStyle(host).getPropertyValue("--accent")).toBe("#4287f5");
+    });
+
     it("uses declared defaults when host has no data-variable-values", async () => {
       const host = document.createElement("div");
       host.setAttribute("data-composition-src", "https://example.com/card.html");

--- a/packages/core/src/runtime/compositionLoader.ts
+++ b/packages/core/src/runtime/compositionLoader.ts
@@ -3,6 +3,7 @@ import { markFlattenedInnerRoot } from "./flattenedRoot";
 import {
   applyCssVariables,
   clearAppliedCssVariables,
+  filterVariablesIfAbsent,
   parseHostVariableValues,
   readDeclaredDefaults,
   readRenderOverrides,
@@ -764,9 +765,11 @@ export async function loadExternalCompositions(
  * as CSS custom properties on the host so imported var(--slug, literal)
  * fills inside the sub-comp resolve per instance (cascade beats the document
  * root). Inline templates carry declared defaults on the content root;
- * external loads pass them explicitly. Render-time overrides (--variables)
- * always win. Stale custom properties from a previous mount are cleared
- * before (re)applying.
+ * external loads pass them explicitly. A composition variable, whether a
+ * declared default or an explicit data-variable-values value, never
+ * redefines a custom property already defined on the host. Render-time
+ * overrides (--variables) remain explicit user intent and always win. Stale
+ * custom properties from a previous mount are cleared before (re)applying.
  */
 function stashInstanceVariables(
   params: { host: Element; declaredVariableDefaults?: Record<string, unknown> },
@@ -784,7 +787,10 @@ function stashInstanceVariables(
   if (Object.keys(merged).length > 0) {
     if (!window.__hfVariablesByComp) window.__hfVariablesByComp = {};
     window.__hfVariablesByComp[runtimeScopeCompositionId] = merged;
-    applyCssVariables(params.host, { ...merged, ...readRenderOverrides() });
+    applyCssVariables(params.host, {
+      ...filterVariablesIfAbsent(params.host, merged, window),
+      ...readRenderOverrides(),
+    });
   } else if (window.__hfVariablesByComp) {
     delete window.__hfVariablesByComp[runtimeScopeCompositionId];
   }

--- a/packages/core/src/runtime/getVariables.ts
+++ b/packages/core/src/runtime/getVariables.ts
@@ -99,6 +99,23 @@ export function applyCssVariables(target: Element, variables: Record<string, unk
   if (applied.length > 0) target.setAttribute(APPLIED_VARS_ATTR, applied.join(" "));
 }
 
+/** Keep only variables whose CSS custom property is not already defined. */
+export function filterVariablesIfAbsent(
+  target: Element,
+  variables: Record<string, unknown>,
+  view: Window | null,
+): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const [id, value] of Object.entries(variables)) {
+    const name = cssVariableName(id);
+    const existing =
+      (hasInlineStyle(target) ? target.style.getPropertyValue(name) : "") ||
+      (view ? view.getComputedStyle(target).getPropertyValue(name) : "");
+    if (existing.trim() === "") filtered[id] = value;
+  }
+  return filtered;
+}
+
 /** Remove custom properties a previous applyCssVariables call defined. */
 export function clearAppliedCssVariables(target: Element): void {
   if (!hasInlineStyle(target)) return;


### PR DESCRIPTION
## What

A composition variable mirrored as a scoped `--<slug>` CSS custom property for a mounted sub-composition could silently override a same-named CSS custom property the host document already authored for an unrelated purpose (e.g. a `:root { --accent: <brand color> }` design token), because CSS custom properties inherit down the tree and the mirrored scope selector sits closer to the element than the outer definition.

## Why

`emitRootCompositionVariableStyles` in `packages/core/src/compiler/htmlBundler.ts` emits three groups of variable-mirroring rules. Two of them (`rootDeclaredVariableRules`, `declarerVariableRules`) already skip re-emitting a variable when an authored `<style>` block in the document already defines that same custom property name — a guard that exists precisely to avoid this kind of collision. The third, `hostScopedVariableRules` — the path used for every `data-composition-src` sub-composition mount, the dominant mounting mechanism in this codebase — had no such guard, so it always won regardless of what else in the document already owned that property name. The runtime loader (`stashInstanceVariables` in `packages/core/src/runtime/compositionLoader.ts`) had the identical gap for live-loaded/preview mounts.

Renaming the emitted CSS custom property to a namespaced form (e.g. `--hf-var-<name>`) was considered and rejected: `var(--<slug>, <fallback>)` is a documented, actively used public contract (see the doc comment on `injectCompositionCssVariables` in `packages/core/src/runtime/getVariables.ts`, and real usage in `registry/components/caption-texture/caption-texture.html`, which consumes `var(--mask-size, cover)` etc. directly). Namespacing would break every existing composition that already relies on this convention, so the fix instead extends the already-established "authored CSS wins" protection to the previously-unprotected mount path, in both the compile-time and runtime code paths.

## How

- `packages/core/src/compiler/htmlBundler.ts`: extracted the authored-CSS-definition scan into a shared `authoredDefinesPredicate`, and now filter `hostScopedVariableRules`'s per-instance variable maps through it before applying render-time `--variables` overrides (which still always win, unchanged).
- `packages/core/src/runtime/getVariables.ts`: added `filterVariablesIfAbsent`, mirroring the existing "define-if-absent" check already used elsewhere in this file (own inline style or resolved computed style).
- `packages/core/src/runtime/compositionLoader.ts`: `stashInstanceVariables` now filters mounted per-instance variables through `filterVariablesIfAbsent` before applying them to the host element, so an already-authored/inherited custom property is left alone; render-time overrides are layered on top unconditionally, same as before.

## Not covered

`htmlBundler.ts` has a second, narrower sub-composition mounting mechanism for inline `<template id="X-template">` compositions (`pushSubCompVariableStyles`), which pushes its own CSS block directly and bypasses the guarded path above. That mechanism is not covered by this fix and remains vulnerable to the same shadowing issue; it's a much less common authoring pattern than `data-composition-src` mounting, and left as a disclosed follow-up rather than folded into this change.

## Test plan

- [x] Unit tests added: a compiler-level regression test in `packages/core/src/compiler/htmlBundler.test.ts` (bundles a host with an authored `:root { --accent: ... }` token and a sub-composition mounted with an explicit `data-variable-values` override of the same name, asserts the token survives unshadowed) and a runtime-level regression test in `packages/core/src/runtime/compositionLoader.test.ts` covering the equivalent live-mount path. Both were confirmed to fail against the pre-fix code and pass after the fix.
- [x] Full `packages/core` vitest suite passes (90 files / 1276 tests).
- [x] `bunx oxlint` and `bunx oxfmt --check` clean on all changed files.