### PR TITLE
docs(skills): make the core set the default install on every surface

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,16 +7,9 @@
   },
   "plugins": [
     {
-      "name": "hyperframes",
-      "source": "./",
-      "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-      "homepage": "https://hyperframes.heygen.com",
-      "license": "Apache-2.0"
-    },
-    {
       "name": "core-skills",
       "source": "./",
-      "description": "The always-needed HyperFrames core set: the /hyperframes router, the hyperframes-* domain skills, and media-use. The full plugin (all skills) is `hyperframes`.",
+      "description": "The HyperFrames core set \u2014 install this one: the /hyperframes router, the hyperframes-* domain skills, and media-use. The router installs each creation workflow on demand. The full bundle (all skills at once) is `hyperframes`.",
       "homepage": "https://hyperframes.heygen.com",
       "license": "Apache-2.0",
       "skills": [
@@ -29,6 +22,13 @@
         "./skills/hyperframes-registry",
         "./skills/media-use"
       ]
+    },
+    {
+      "name": "hyperframes",
+      "source": "./",
+      "description": "All HyperFrames skills in one static bundle. Most setups want `core-skills` instead \u2014 the router installs creation workflows on demand. HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
+      "homepage": "https://hyperframes.heygen.com",
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,11 @@ Open-source video rendering framework: write HTML, render video.
 
 ## Skills
 
-This repo ships AI agent skills via [vercel-labs/skills](https://github.com/vercel-labs/skills). Install them before writing compositions — they encode framework-specific patterns that generic docs don't cover.
+This repo ships AI agent skills via [vercel-labs/skills](https://github.com/vercel-labs/skills). Install them before writing compositions — they encode framework-specific patterns that generic docs don't cover. **Default to the core set** — the `/hyperframes` router installs each creation workflow on demand; install everything only when the user explicitly asks for the full set.
 
 ```bash
-npx skills add heygen-com/hyperframes
+npx hyperframes skills update                        # default: installs/refreshes the core set — workflows install on demand
+npx skills add heygen-com/hyperframes --full-depth   # interactive picker (terminal only — non-interactive without --skill installs everything)
 ```
 
 **Creation workflows** route through one entry skill — read `/hyperframes` first: it orients you to the whole surface, confirms the brief up front (the intent layer), and maps "make me a…" intent — usually a video, but also a navigable deck (`/slideshow`) or a composition port (`/remotion-to-hyperframes`) — to a concrete workflow. Consult it before invoking a specific workflow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,12 @@ Open-source video rendering framework: write HTML, render video.
 
 ## Skills
 
-This repo ships 19 AI agent skills via [vercel-labs/skills](https://github.com/vercel-labs/skills). Install them before writing compositions — they encode framework-specific patterns that generic docs don't cover.
+This repo ships 19 AI agent skills via [vercel-labs/skills](https://github.com/vercel-labs/skills). Install them before writing compositions — they encode framework-specific patterns that generic docs don't cover. **Default to the core set**: the `/hyperframes` router installs each creation workflow on demand; install all 19 only when the user explicitly asks for the full set.
 
 ```bash
-npx skills add heygen-com/hyperframes --full-depth              # interactive picker
-npx skills add heygen-com/hyperframes --all --full-depth        # install all 19 (skips picker)
+npx hyperframes skills update                                   # default: installs/refreshes the core set — workflows install on demand
+npx skills add heygen-com/hyperframes --full-depth              # interactive picker (terminal only — non-interactive without --skill installs all 19)
+npx skills add heygen-com/hyperframes --all --full-depth        # all 19 at once — only on explicit request
 npx skills add heygen-com/hyperframes --skill <name> --full-depth  # just one (bare name, no leading slash)
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ HyperFrames is an open-source framework for turning HTML, CSS, media, and seekab
 Install the HyperFrames skills, then describe the video you want:
 
 ```bash
-npx skills add heygen-com/hyperframes --full-depth --yes
+npx skills add heygen-com/hyperframes --full-depth
 ```
 
+> The picker opens with nothing pre-selected — the **Core Skills** group is all you need: the `/hyperframes` router installs each creation workflow on demand. Agents and non-interactive runs should use `npx hyperframes skills update` instead — it installs exactly the core set, whereas a non-interactive `skills add` without `--skill` installs all 19.
+>
 > `--full-depth` does a full clone of the repo's current `main`. Without it, `skills add` fetches the skills.sh registry blob, which lags `main` by hours — you'd get an older copy of a skill. (`hyperframes skills update` already installs full-depth.)
 
 Try a prompt like:
@@ -53,7 +55,7 @@ The skills teach agents the HyperFrames production loop: plan the video, write v
 
 HyperFrames ships 19 skills agents load on demand. Read `/hyperframes` first — it's the router and capability map; it picks a workflow for any "make me a…" request — video, deck, or composition port — and points to the domain skills below.
 
-Run `npx skills add heygen-com/hyperframes --full-depth` for the interactive picker — it lists the **core set** under the "Core Skills" group and the on-demand creation workflows under "Other". Use `npx skills add heygen-com/hyperframes --all --full-depth` to install all 19 at once (skips the picker), or `npx skills add heygen-com/hyperframes --skill <name> --full-depth` for just one (bare name, no leading `/`). Keep `--full-depth` — it installs the current `main`; without it `skills add` fetches the skills.sh blob, which lags by hours.
+Default to the **core set** — the router installs each creation workflow on demand. `npx hyperframes skills update` installs exactly that from anywhere; the interactive picker (`npx skills add heygen-com/hyperframes --full-depth`) lists it as the "Core Skills" group, nothing pre-selected. The picker is interactive-only — a non-interactive or agent run without `--skill` installs all 19. Use `npx skills add heygen-com/hyperframes --all --full-depth` to install all 19 deliberately (skips the picker), or `npx skills add heygen-com/hyperframes --skill <name> --full-depth` for just one (bare name, no leading `/`). Keep `--full-depth` — it installs the current `main`; without it `skills add` fetches the skills.sh blob, which lags by hours.
 
 Installs stay lean after that: `npx hyperframes init` keeps the **core set** fresh (the router, the `hyperframes-*` domain skills, and `media-use` — plus whatever is already installed; `/figma` stays on demand) and never expands a partial install; the creation workflows install **on demand** — the router runs `npx hyperframes skills update <workflow>` before entering one. Nothing re-pulls the full set behind your back.
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -14,19 +14,26 @@ The skills split into three groups:
 ## Install
 
 <Steps>
-  <Step title="Pick what to install (interactive picker)">
+  <Step title="Install the core set (default)">
+    ```bash
+    npx hyperframes skills update
+    ```
+
+    Installs exactly the core set — the `/hyperframes` router, the `hyperframes-*` domain skills, and `media-use` — and the router installs each creation workflow on demand the first time it routes there. Always installs from the repo's current `main`. Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor.sh), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex CLI](https://github.com/openai/codex), [GitHub Copilot CLI](/guides/copilot-cli), and [Google Antigravity](/guides/antigravity).
+  </Step>
+  <Step title="Or pick what to install (interactive picker)">
     ```bash
     npx skills add heygen-com/hyperframes --full-depth
     ```
 
-    Opens a picker so you can choose which skills to add — the core set (the router, the `hyperframes-*` domain skills, and `media-use`) is listed under the "Core Skills" group, the on-demand creation workflows under "Other". Keep `--full-depth`: it installs the current `main`. Without it, `skills add` fetches the skills.sh registry blob, which lags `main` by hours, so you may get an older copy of a skill. Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor.sh), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex CLI](https://github.com/openai/codex), [GitHub Copilot CLI](/guides/copilot-cli), and [Google Antigravity](/guides/antigravity).
+    In a terminal this opens a picker — the core set under the "Core Skills" group, the on-demand creation workflows under "Other", nothing pre-selected. Keep `--full-depth`: it installs the current `main`; without it `skills add` fetches the skills.sh registry blob, which lags `main` by hours. The picker is interactive-only: a non-interactive or agent run without `--skill` installs all 19, so agents should use `npx hyperframes skills update` above.
   </Step>
   <Step title="Or install everything at once (skip the picker)">
     ```bash
     npx skills add heygen-com/hyperframes --all --full-depth
     ```
 
-    Writes every skill to your project in one shot. Recommended when you want the full set without selecting from the picker.
+    Writes every skill to your project in one shot. Use this only when you explicitly want the full set up front — the router installs workflows on demand otherwise.
   </Step>
   <Step title="Or install one skill at a time">
     ```bash


### PR DESCRIPTION
## Why

A field test — a real agent, real "help me make videos" intent, clean environment — ended with all 19 skills installed as an always-on static bundle. Asked afterwards why, the agent's answer was accurate: no source told it to install everything, but no source told it not to. The core-eager / workflow-on-demand design only exists inside `hyperframes/SKILL.md`, which is unreadable until after the install decision.

Two traps made full-install the documented default:

1. **README Quick Start used `skills add --yes`.** skills.sh force-detects agent environments into non-interactive mode (`Agent detected — installing non-interactively`), and a non-interactive run without `--skill` installs all 19. The picker's "Core Skills" grouping is interactive-only.
2. **marketplace.json listed the full bundle first**, under the name `hyperframes` — the name an agent installing "hyperframes" matches. `core-skills` sat second.

## What

| Surface | Before | After |
|---|---|---|
| README Quick Start | `skills add … --full-depth --yes` (agents + hasty humans: all 19) | `skills add … --full-depth` (humans: picker) + callout: agents run `npx hyperframes skills update` |
| CLAUDE.md | picker / `--all` / single | `npx hyperframes skills update` first, policy line, `--all` = explicit request only |
| docs/guides/skills.mdx | picker-first steps | core-set one-liner first, picker second with the non-interactive caveat |
| .claude-plugin/marketplace.json | full bundle first | `core-skills` first, both descriptions steer the default |

## Verified

- **Picker default state** (pty capture): opens with nothing pre-selected — a human can't install all 19 by accident.
- **Agent detection** (live repro): `skills add` without `--skill` in an agent env installs everything, with or without `--yes` — which is why the agent path gets its own command.
- **`npx hyperframes skills update` from a clean HOME**: installs exactly the 8 core skills. On a machine with existing installs: refreshes only stale skills (hash-based), prunes unpublished ones (removed a leftover `website-to-video`), and is idempotent on a second run.
- **marketplace core-pin test**: 56/56 pass; the full entry keeps auto-discovery (no allowlist).

No skill content changes; no count changes (still 19).

## Review follow-ups

**AGENTS.md** carried the same trap in worse form (bare `skills add`, no `--full-depth`) — fixed in `2e26b497a`, now leading with the same core-set one-liner and policy line as CLAUDE.md.

**Marketplace name-resolution, for the record:** `npx skills add owner/repo` never resolves marketplace plugin entries at all — it clones the repo and enumerates `SKILL.md` files. `marketplace.json` matters in exactly two places: the picker's "Core Skills" grouping is looked up **by name** (`core-skills`, order-independent — the behavior the 56/56 core-pin test pins), and the Claude plugin marketplace listing, where this PR's reorder changes what browsers/agents see first. A by-name install of the full bundle (`hyperframes@hyperframes`) still resolves to the full bundle — inherent, since renaming it would break existing installs; the description steering is the mitigation.

**Codex/Cursor manifests** (`.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`) both declare `"skills": "./skills/"` wholesale — no core/full split at the manifest level, so marketplace-native installs on those hosts still get everything. Whether those schemas accept a skill allowlist is unconfirmed; tracked as a follow-up, out of scope here.
