### PR TITLE
fix(cli): serialize concurrent model downloads

### DIFF
--- a/packages/cli/src/utils/download.test.ts
+++ b/packages/cli/src/utils/download.test.ts
@@ -1,10 +1,10 @@
 import { EventEmitter } from "node:events";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import type { ClientRequest, IncomingMessage } from "node:http";
+import { get as httpsGet } from "node:https";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { PassThrough } from "node:stream";
-import { get as httpsGet } from "node:https";
-import type { ClientRequest, IncomingMessage } from "node:http";
+import { PassThrough, Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { downloadFile } from "./download.js";
 
@@ -60,7 +60,37 @@ describe("downloadFile", () => {
     await expect(
       downloadFile("https://example.test/model.onnx", dest, { timeoutMs: 10 }),
     ).rejects.toThrow("Download timed out after 10ms");
-    expect(existsSync(`${dest}.tmp`)).toBe(false);
     expect(existsSync(dest)).toBe(false);
+    expect(existsSync(`${dest}.download.lock`)).toBe(false);
+  });
+
+  it("serializes concurrent downloads to the same cache destination", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hyperframes-download-lock-"));
+    tempDirs.push(dir);
+    const dest = join(dir, "model.bin");
+    let requests = 0;
+
+    mockGet.mockImplementation(((_url: string, callback: (response: IncomingMessage) => void) => {
+      requests += 1;
+      const response = Readable.from([Buffer.from("complete-model")]) as Readable & {
+        statusCode: number;
+        headers: Record<string, string>;
+      };
+      response.statusCode = 200;
+      response.headers = {};
+      const request = new EventEmitter() as ClientRequest;
+      request.setTimeout = vi.fn(() => request);
+      queueMicrotask(() => callback(response as unknown as IncomingMessage));
+      return request;
+    }) as typeof httpsGet);
+
+    await Promise.all([
+      downloadFile("https://example.test/model.bin", dest),
+      downloadFile("https://example.test/model.bin", dest),
+    ]);
+
+    expect(requests).toBe(1);
+    expect(readFileSync(dest, "utf8")).toBe("complete-model");
+    expect(existsSync(`${dest}.download.lock`)).toBe(false);
   });
 });

--- a/packages/cli/src/utils/download.ts
+++ b/packages/cli/src/utils/download.ts
@@ -1,12 +1,31 @@
-import { createWriteStream, renameSync, unlinkSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { get as httpsGet } from "node:https";
 import { pipeline } from "node:stream/promises";
 
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 30_000;
+const LOCK_STALE_MS = 120_000;
+const LOCK_POLL_MS = 200;
+const LOCK_HEARTBEAT_MS = 15_000;
 
 export interface DownloadOptions {
   /** Abort after this many milliseconds without network activity. */
   timeoutMs?: number;
+}
+
+function isErrno(err: unknown, code: string): boolean {
+  return (err as NodeJS.ErrnoException).code === code;
 }
 
 function removePartialFile(path: string): void {
@@ -17,54 +36,145 @@ function removePartialFile(path: string): void {
   }
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readLockOwner(lockDir: string): string | null {
+  try {
+    return readFileSync(`${lockDir}/owner`, "utf8");
+  } catch (err) {
+    if (!isErrno(err, "ENOENT")) throw err;
+    return null;
+  }
+}
+
+function tryAcquireLock(lockDir: string, owner: string): boolean {
+  try {
+    mkdirSync(lockDir, { recursive: false });
+  } catch (err) {
+    if (!isErrno(err, "EEXIST")) throw err;
+    return false;
+  }
+
+  try {
+    writeFileSync(`${lockDir}/owner`, owner);
+    return true;
+  } catch (err) {
+    rmSync(lockDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+function reclaimStaleLock(lockDir: string): void {
+  const staleDir = `${lockDir}.stale.${randomUUID()}`;
+  try {
+    if (Date.now() - statSync(lockDir).mtimeMs > LOCK_STALE_MS) {
+      renameSync(lockDir, staleDir);
+      rmSync(staleDir, { recursive: true, force: true });
+    }
+  } catch (err) {
+    if (!isErrno(err, "ENOENT")) throw err;
+  }
+}
+
+async function withDownloadLock<T>(dest: string, fn: (waited: boolean) => Promise<T>): Promise<T> {
+  const lockDir = `${dest}.download.lock`;
+  const owner = `${process.pid}:${randomUUID()}`;
+  let waited = false;
+
+  for (;;) {
+    if (tryAcquireLock(lockDir, owner)) break;
+    waited = true;
+    try {
+      if (Date.now() - statSync(lockDir).mtimeMs > LOCK_STALE_MS) {
+        reclaimStaleLock(lockDir);
+        continue;
+      }
+    } catch (err) {
+      if (!isErrno(err, "ENOENT")) throw err;
+    }
+    await sleep(LOCK_POLL_MS);
+  }
+
+  const heartbeat = setInterval(() => {
+    try {
+      if (readLockOwner(lockDir) !== owner) return;
+      const now = new Date();
+      utimesSync(lockDir, now, now);
+    } catch {
+      // Best effort. A stale lock is still recoverable if this process dies.
+    }
+  }, LOCK_HEARTBEAT_MS);
+  heartbeat.unref();
+
+  try {
+    return await fn(waited);
+  } finally {
+    clearInterval(heartbeat);
+    // A stale owner can resume after its directory was reclaimed. Only the
+    // current owner may release this path, otherwise it could delete the
+    // successor's live lock and reintroduce concurrent writes.
+    if (readLockOwner(lockDir) === owner) {
+      rmSync(lockDir, { recursive: true, force: true });
+    }
+  }
+}
+
 /**
  * Download a file from a URL, following redirects.
- * Uses atomic write (download to .tmp, rename on success) to prevent
- * corrupt partial files from persisting in the cache on interruption.
+ * Uses an owned cross-process lock plus atomic temp-file rename so concurrent
+ * model warmups cannot corrupt a shared cache entry.
  */
 export function downloadFile(
   url: string,
   dest: string,
   options: DownloadOptions = {},
 ): Promise<void> {
-  const tmp = `${dest}.tmp`;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS;
-  return new Promise((resolve, reject) => {
-    const follow = (u: string) => {
-      const request = httpsGet(u, (res) => {
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          const location = res.headers.location;
-          if (location) {
+  return withDownloadLock(dest, async (waited) => {
+    // Another process may have completed the same cache download while this
+    // caller waited for the lock.
+    if (waited && existsSync(dest)) return;
+
+    const tmp = `${dest}.${process.pid}.${randomUUID()}.tmp`;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS;
+    await new Promise<void>((resolve, reject) => {
+      const follow = (currentUrl: string) => {
+        const request = httpsGet(currentUrl, (res) => {
+          if (res.statusCode === 301 || res.statusCode === 302) {
+            const location = res.headers.location;
+            if (location) {
+              res.resume();
+              follow(location);
+              return;
+            }
+          }
+          if (res.statusCode !== 200) {
             res.resume();
-            follow(location);
+            removePartialFile(tmp);
+            reject(new Error(`Download failed: HTTP ${res.statusCode}`));
             return;
           }
-        }
-        if (res.statusCode !== 200) {
-          res.resume();
+          const file = createWriteStream(tmp);
+          pipeline(res, file)
+            .then(() => {
+              renameSync(tmp, dest);
+              resolve();
+            })
+            .catch((err) => {
+              removePartialFile(tmp);
+              reject(err);
+            });
+        });
+        request.setTimeout(timeoutMs, () => {
+          request.destroy(new Error(`Download timed out after ${timeoutMs}ms`));
+        });
+        request.on("error", (err) => {
           removePartialFile(tmp);
-          reject(new Error(`Download failed: HTTP ${res.statusCode}`));
-          return;
-        }
-        const file = createWriteStream(tmp);
-        pipeline(res, file)
-          .then(() => {
-            renameSync(tmp, dest);
-            resolve();
-          })
-          .catch((err) => {
-            removePartialFile(tmp);
-            reject(err);
-          });
-      });
-      request.setTimeout(timeoutMs, () => {
-        request.destroy(new Error(`Download timed out after ${timeoutMs}ms`));
-      });
-      request.on("error", (err) => {
-        removePartialFile(tmp);
-        reject(err);
-      });
-    };
-    follow(url);
+          reject(err);
+        });
+      };
+      follow(url);
+    });
   });
 }


### PR DESCRIPTION
## What

Serialize downloads targeting the same cache file across concurrent CLI processes and use process-unique temporary files.

## Why

Concurrent TTS/transcribe children can warm the same model simultaneously. They previously shared dest.tmp, so one process could rename or delete the other process temporary file and leave the model missing or corrupt.

Originating CLI feedback: https://heygen.slack.com/archives/C0BGC335AQY/p1784215164599379

## How

- acquire an owned atomic filesystem lock per destination
- heartbeat live locks and reclaim stale locks safely
- release only when the owner token still matches
- preserve the merged inactivity timeout from #2415
- re-check the destination after lock contention to deduplicate work
- write through a process-and-UUID temporary path before atomic rename

## Test plan

- [x] Unit tests added/updated
- [x] Concurrent same-destination regression test passes
- [x] Existing stalled-download timeout test passes
- [x] CLI formatting and lint pass
- [x] CLI typecheck passes
- [x] Full CLI suite: 1935 passed; 2 expected skips
- [ ] Documentation updated (not applicable)