### PR TITLE
fix(cli): surface HYPERFRAMES_BROWSER_PATH hint on macOS <13 chrome-headless-shell dyld crash

### DIFF
--- a/packages/cli/src/browser/macosOldChromeCrash.test.ts
+++ b/packages/cli/src/browser/macosOldChromeCrash.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  isMacosOldChromeCrashError,
+  macosOldChromeCrashRemediation,
+} from "./macosOldChromeCrash.js";
+
+describe("isMacosOldChromeCrashError", () => {
+  it("matches Puppeteer launch-failure wrapper + dyld Symbol-not-found + macOS-13 VideoToolbox symbol", () => {
+    expect(
+      isMacosOldChromeCrashError(
+        "Failed to launch the browser process!\n" +
+          "dyld: Symbol not found: _kVTCompressionPropertyKey_ReferenceBufferCount\n" +
+          "  Referenced from: /Users/x/.cache/puppeteer/chrome-headless-shell/mac-152.0.7928.2/chrome-headless-shell\n" +
+          "  Expected in: /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the VideoToolbox framework signal even without the exact ReferenceBufferCount symbol name", () => {
+    // Future pinned builds may hit a sibling VT symbol from the same framework
+    // (they all migrated to macOS 13); the framework signal is enough to fire
+    // the same remediation.
+    expect(
+      isMacosOldChromeCrashError(
+        "Failed to launch the browser process. Symbol not found: _kVTSomeFutureSymbol from VideoToolbox",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a launch failure without dyld Symbol-not-found", () => {
+    expect(
+      isMacosOldChromeCrashError(
+        "Failed to launch the browser process (libnss3.so: cannot open shared object file)",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match a darwin Symbol-not-found from an unrelated framework (needs different remediation)", () => {
+    expect(
+      isMacosOldChromeCrashError(
+        "Failed to launch the browser process. dyld: Symbol not found: _some_libcxx_symbol from libc++.dylib",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match the symbol name alone without the launch-failure wrapper", () => {
+    expect(
+      isMacosOldChromeCrashError(
+        "unrelated tool crashed with Symbol not found: _kVTCompressionPropertyKey_ReferenceBufferCount",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isMacosOldChromeCrashError("Composition HTML is empty")).toBe(false);
+  });
+});
+
+describe("macosOldChromeCrashRemediation", () => {
+  it("returns undefined off darwin even for a matching error", () => {
+    if (process.platform === "darwin") return;
+    expect(
+      macosOldChromeCrashRemediation(
+        "Failed to launch the browser process. dyld: Symbol not found: _kVTCompressionPropertyKey_ReferenceBufferCount from VideoToolbox",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for non-launch errors on any platform", () => {
+    expect(macosOldChromeCrashRemediation("Composition HTML is empty")).toBeUndefined();
+  });
+
+  it("returns undefined for a launch failure without the dyld signal on any platform", () => {
+    expect(
+      macosOldChromeCrashRemediation(
+        "Failed to launch the browser process (libnss3.so cannot open)",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for a darwin dyld failure from an unrelated framework", () => {
+    if (process.platform !== "darwin") return;
+    expect(
+      macosOldChromeCrashRemediation(
+        "Failed to launch the browser process. Symbol not found: _some_libcxx_symbol from libc++.dylib",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("mentions HYPERFRAMES_BROWSER_PATH and the PRODUCER_HEADLESS_SHELL_PATH alias when firing on darwin", () => {
+    if (process.platform !== "darwin") return;
+    const remediation = macosOldChromeCrashRemediation(
+      "Failed to launch the browser process. dyld: Symbol not found: _kVTCompressionPropertyKey_ReferenceBufferCount from VideoToolbox",
+    );
+    expect(remediation).toBeDefined();
+    expect(remediation).toMatch(/HYPERFRAMES_BROWSER_PATH/);
+    expect(remediation).toMatch(/PRODUCER_HEADLESS_SHELL_PATH/);
+    expect(remediation).toMatch(/chrome-headless-shell@150/);
+  });
+});

--- a/packages/cli/src/browser/macosOldChromeCrash.ts
+++ b/packages/cli/src/browser/macosOldChromeCrash.ts
@@ -1,0 +1,73 @@
+// fallow-ignore-file code-duplication
+/**
+ * Detection + remediation for macOS-below-13 chrome-headless-shell dyld
+ * launch crashes.
+ *
+ * Field feedback (#hyperframes-cli-feedback ts=1784227832, darwin/x64,
+ * macOS 12, HyperFrames CLI 0.7.60) hit
+ * `dyld: Symbol not found: _kVTCompressionPropertyKey_ReferenceBufferCount`
+ * from `VideoToolbox` when launching the pinned
+ * `chrome-headless-shell mac-152.0.7928.2`. The symbol was added in
+ * macOS 13; older hosts cannot resolve it, so the binary aborts at load
+ * before any browser process starts.
+ *
+ * The reporter recovered by installing an older shell (v150) via
+ * `@puppeteer/browsers install chrome-headless-shell@150` and pointing
+ * `PRODUCER_HEADLESS_SHELL_PATH` at it. Their check/snapshot commands
+ * accepted that older cached shell (they don't force the pinned build),
+ * but the render command required v152 via `preferManagedChrome: true`
+ * and therefore could not fall back on its own. The generic
+ * "Try --docker for containerized rendering" hint didn't name any of
+ * the browser-path env vars, so the workaround is undiscoverable
+ * unaided.
+ *
+ * Same discoverability class as #2443 (download failure), #2078 (arm64
+ * SIGTRAP at launch), and #2481 (Windows STATUS_STACK_BUFFER_OVERRUN):
+ * detect the launch-time crash signal, surface `HYPERFRAMES_BROWSER_PATH`
+ * (and its `PRODUCER_HEADLESS_SHELL_PATH` alias — see #2471) with a
+ * concrete macOS example.
+ *
+ * The match is gated on the Puppeteer launch-failure wrapper text AND
+ * the dyld symbol-not-found signal AND a macOS-13-only symbol, so
+ * unrelated darwin launch failures do not mis-fire this hint. The
+ * symbol-name signal is macOS-version-specific by construction:
+ * `_kVTCompressionPropertyKey_ReferenceBufferCount` only exists on
+ * macOS 13+, so if a user's dyld cannot find it, their host is <13.
+ * That means we do not need a separate `os.release()` gate — the
+ * signal itself is the version discriminator.
+ */
+
+const DYLD_SYMBOL_NOT_FOUND = /Symbol not found:/i;
+const MACOS_13_ONLY_SYMBOL = /_kVTCompressionPropertyKey_ReferenceBufferCount/;
+const VIDEO_TOOLBOX = /VideoToolbox/;
+
+export function isMacosOldChromeCrashError(errorMessage: string): boolean {
+  if (!/Failed to launch the browser process/i.test(errorMessage)) return false;
+  if (!DYLD_SYMBOL_NOT_FOUND.test(errorMessage)) return false;
+  // Both signals must be present. The specific macOS-13-only symbol is what
+  // makes this hint safe to fire (any other Symbol-not-found on darwin
+  // needs different remediation — a shared-lib install, an Xcode SDK
+  // mismatch, etc. — none of which are fixed by HYPERFRAMES_BROWSER_PATH).
+  // We also require VideoToolbox to catch the case where a future pinned
+  // build hits a different `_kVT…` symbol from the same framework.
+  return MACOS_13_ONLY_SYMBOL.test(errorMessage) || VIDEO_TOOLBOX.test(errorMessage);
+}
+
+export function macosOldChromeCrashRemediation(errorMessage: string): string | undefined {
+  if (process.platform !== "darwin") return undefined;
+  if (!isMacosOldChromeCrashError(errorMessage)) return undefined;
+  return [
+    "chrome-headless-shell crashed at launch (macOS dyld: Symbol not found in VideoToolbox).",
+    "The pinned Chromium build requires macOS 13+; on macOS 12 or older, install an older",
+    "chrome-headless-shell and point hyperframes at it:",
+    "",
+    "  npx @puppeteer/browsers install chrome-headless-shell@150",
+    '  export HYPERFRAMES_BROWSER_PATH="$HOME/.cache/puppeteer/chrome-headless-shell/mac-150.0.7422.0/chrome-headless-shell-mac-x64/chrome-headless-shell"',
+    "",
+    "(PRODUCER_HEADLESS_SHELL_PATH works as an alias for the same override.)",
+    "Any working chrome-headless-shell build resolves this — the exact version above is one",
+    "known-good macOS-12 combination. Alternatively, point HYPERFRAMES_BROWSER_PATH at your",
+    'installed Google Chrome ("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")',
+    "to fall back to the screenshot capture path.",
+  ].join("\n");
+}

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -80,6 +80,7 @@ import { formatRenderOutputTimestamp } from "@hyperframes/core";
 import { runEnvironmentChecks } from "../browser/preflight.js";
 import { detectH264EncoderMode } from "../browser/ffmpeg.js";
 import { chromeLaunchRemediation } from "../browser/linuxDeps.js";
+import { macosOldChromeCrashRemediation } from "../browser/macosOldChromeCrash.js";
 import { killOrphanedProcesses } from "../utils/orphanCleanup.js";
 import {
   markRenderSucceeded,
@@ -2104,6 +2105,14 @@ function handleRenderError(
   const remediation = chromeLaunchRemediation(message);
   if (remediation) {
     errorBox("Render failed — Chrome could not launch", message, remediation);
+    process.exit(1);
+  }
+  // macOS <13 dyld Symbol-not-found on the pinned chrome-headless-shell
+  // build. Different remediation shape (older shell + env-var override)
+  // than the Linux shared-lib install, so it lives in its own detector.
+  const macosRemediation = macosOldChromeCrashRemediation(message);
+  if (macosRemediation) {
+    errorBox("Render failed — Chrome could not launch", message, macosRemediation);
     process.exit(1);
   }
   errorBox("Render failed", message, hint);


### PR DESCRIPTION
## What

Add a darwin-scoped launch-crash remediation to `handleRenderError` in `packages/cli/src/commands/render.ts`. When the pinned `chrome-headless-shell` binary fails to launch with `dyld: Symbol not found: _kVTCompressionPropertyKey_ReferenceBufferCount` from `VideoToolbox`, surface a scoped `errorBox` that names `HYPERFRAMES_BROWSER_PATH` (and its `PRODUCER_HEADLESS_SHELL_PATH` alias — see #2471) with a macOS-specific `chrome-headless-shell@150` install command.

## Why

Field feedback in [#hyperframes-cli-feedback](https://heygen.slack.com/archives/C0BGC335AQY) — message ts `1784227832`, `darwin/x64` macOS 12, HyperFrames CLI `0.7.60` — hit the exact error `dyld: Symbol not found: _kVTCompressionPropertyKey_ReferenceBufferCount` referenced from `VideoToolbox` when launching the bundled `chrome-headless-shell mac-152.0.7928.2`. The symbol was added in macOS 13; older hosts cannot resolve it, so the binary aborts at load before any browser process starts.

The reporter recovered by installing `chrome-headless-shell@150` via `@puppeteer/browsers` and pointing `PRODUCER_HEADLESS_SHELL_PATH` at it. Their `check`/`snapshot` commands accepted the older cached shell (they call `ensureBrowser()` without `preferManagedChrome`, so any cached headless-shell is fine), but `render` requires the pinned v152 via `preferManagedChrome: true` and therefore couldn't fall back on its own. Their `49s 1080x1920` render then completed cleanly.

The CLI's generic post-render hint (`Try --docker` etc.) doesn't name any of the browser-path env vars, so the workaround is undiscoverable unaided.

This is the third platform-scoped sibling of #2443 (download-time hint):
- #2078 — arm64 SIGTRAP at launch (macOS ARM, closed-with-invite)
- #2481 — Windows `STATUS_STACK_BUFFER_OVERRUN` at launch (open)
- **this PR** — macOS <13 dyld Symbol-not-found at launch

Same remediation surface, different trigger and platform.

## How

- New `packages/cli/src/browser/macosOldChromeCrash.ts` — exports `isMacosOldChromeCrashError(errorMessage)` and `macosOldChromeCrashRemediation(errorMessage)`. The detector requires ALL of:
  1. Puppeteer wrapper text `Failed to launch the browser process`
  2. dyld `Symbol not found:` signal
  3. either the specific macOS-13-only symbol name `_kVTCompressionPropertyKey_ReferenceBufferCount` OR the `VideoToolbox` framework name
- `macosOldChromeCrashRemediation` returns `undefined` off darwin.
- `render.ts` `handleRenderError` invokes `macosOldChromeCrashRemediation(message)` immediately after the existing `chromeLaunchRemediation` (Linux) check. Neither matching → fall through to the generic `errorBox("Render failed", ...)`. Linux path is untouched; the download-time wrap in `manager.ts` (#2443) is untouched; the Windows detector proposed in #2481 is untouched (different file).
- **Why no `os.release()` gate.** The symbol-name signal is macOS-version-specific by construction: `_kVTCompressionPropertyKey_ReferenceBufferCount` only exists on macOS 13+, so if a user's dyld cannot find it, their host is <13. A `Darwin 22+` check would be redundant.
- The remediation intentionally names both `HYPERFRAMES_BROWSER_PATH` (canonical, per #2443/#2481) and its `PRODUCER_HEADLESS_SHELL_PATH` alias (per #2471) because the reporter reached for the alias first — matching the discovery path the docs already point at.

Net diff: +182 / -0 across 3 files (2 new, 1 modified).

## Test plan

- [x] Unit tests added — `packages/cli/src/browser/macosOldChromeCrash.test.ts` (11 vitest cases):
  - positive match on the exact reporter error text
  - positive match on VideoToolbox framework signal without the exact `ReferenceBufferCount` symbol name (future pinned builds may hit sibling VT symbols)
  - negative on Linux shared-lib launch failures (those hit `chromeLaunchRemediation`)
  - negative on darwin Symbol-not-found from unrelated frameworks (e.g. `libc++.dylib`) — needs different remediation
  - negative on the symbol name alone without the launch-failure wrapper
  - off-platform (non-darwin) short-circuits and non-launch short-circuits
- [x] `bunx vitest run src/browser/macosOldChromeCrash.test.ts` — **11/11 passing**, 4ms
- [x] `bunx oxlint packages/cli/src/browser/macosOldChromeCrash{,\.test}.ts packages/cli/src/commands/render.ts` — 0 warnings 0 errors
- [x] `bunx oxfmt` — clean on all three files
- [ ] Manual testing performed — n/a; requires a macOS 12 host to reproduce the dyld failure. The unit tests deterministically cover the detector, and the reporter's original recovery path (setting `PRODUCER_HEADLESS_SHELL_PATH`) confirms the escape hatch works.
- [ ] Documentation updated — n/a; the hint IS the documentation.

## Enterprise release / feature flag holdout

<!-- pr-check:enterprise-ff:start -->
- [ ] N/A — this PR doesn't touch enterprise-relevant surfaces
- [x] Ships to all users on merge without feature-flag holdout
<!-- pr-check:enterprise-ff:end -->

## UX/Screenshot recording

<!-- pr-check:ui-impact -->
- [x] <!-- pr-opt:no-ui-impact --> No UI impact — CLI error-message content only

<!-- pr-source:cron-authored -->

- Signed-off-by: Via -