### PR TITLE
feat(studio): add keyframe ease controls

### DIFF
--- a/packages/studio/src/components/editor/EaseParamFields.test.tsx
+++ b/packages/studio/src/components/editor/EaseParamFields.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseWiggleEase } from "@hyperframes/core/wiggle-ease";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EaseBezierField, SpringBounceField, WiggleField } from "./EaseParamFields";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+afterEach(() => {
+  act(() => roots.splice(0).forEach((root) => root.unmount()));
+  document.body.innerHTML = "";
+});
+
+function renderField(field: React.ReactNode): HTMLElement {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.push(root);
+  act(() => root.render(field));
+  return host;
+}
+
+function parsedWiggle(ease: string) {
+  const config = parseWiggleEase(ease);
+  expect(config).not.toBeNull();
+  if (!config) throw new Error(`Expected a valid wiggle ease: ${ease}`);
+  return config;
+}
+
+function expectWiggleCommit(onCommit: ReturnType<typeof vi.fn>, ease: string): void {
+  expect(onCommit).toHaveBeenLastCalledWith(ease);
+  const emitted = onCommit.mock.lastCall?.[0];
+  expect(typeof emitted === "string" ? parseWiggleEase(emitted) : null).not.toBeNull();
+}
+
+function inputValue(input: HTMLInputElement, value: string): void {
+  act(() => {
+    input.value = value;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+// Render a default wiggle field, type `value` into the input labelled `label`,
+// and return the commit spy — the shared body of the input-edit cases.
+function editWiggle(label: string, value: string): ReturnType<typeof vi.fn> {
+  const onCommit = vi.fn();
+  const host = renderField(
+    <WiggleField config={parsedWiggle("wiggle(6,easeOut,0.26)")} onCommit={onCommit} />,
+  );
+  const input = host.querySelector<HTMLInputElement>(`[aria-label="${label}"]`);
+  expect(input).not.toBeNull();
+  if (input) inputValue(input, value);
+  return onCommit;
+}
+
+describe("WiggleField", () => {
+  it("reflects a parsed wiggle config", () => {
+    const host = renderField(
+      <WiggleField config={parsedWiggle("wiggle(6,easeOut,0.26)")} onCommit={vi.fn()} />,
+    );
+
+    expect(host.querySelector<HTMLInputElement>('[aria-label="Wiggle count"]')?.value).toBe("6");
+    expect(host.querySelector<HTMLSelectElement>('[aria-label="Wiggle type"]')?.value).toBe(
+      "easeOut",
+    );
+    expect(host.querySelector<HTMLInputElement>('[aria-label="Wiggle amplitude"]')?.value).toBe(
+      "0.26",
+    );
+  });
+
+  it("commits an edited count", () => {
+    expectWiggleCommit(editWiggle("Wiggle count", "4"), "wiggle(4,easeOut,0.26)");
+  });
+
+  it("commits an edited type", () => {
+    const onCommit = vi.fn();
+    const host = renderField(
+      <WiggleField config={parsedWiggle("wiggle(6,easeOut,0.26)")} onCommit={onCommit} />,
+    );
+
+    const select = host.querySelector<HTMLSelectElement>('[aria-label="Wiggle type"]');
+    expect(select).not.toBeNull();
+    act(() => {
+      if (!select) return;
+      select.value = "anticipate";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expectWiggleCommit(onCommit, "wiggle(6,anticipate,0.26)");
+  });
+
+  it("commits an edited amplitude", () => {
+    expectWiggleCommit(editWiggle("Wiggle amplitude", "0.1"), "wiggle(6,easeOut,0.1)");
+  });
+
+  it("seeds and explicitly commits the per-type default amplitude", () => {
+    const onCommit = vi.fn();
+    const host = renderField(
+      <WiggleField config={parsedWiggle("wiggle(3,easeInOut)")} onCommit={onCommit} />,
+    );
+
+    expect(host.querySelector<HTMLInputElement>('[aria-label="Wiggle amplitude"]')?.value).toBe(
+      "0.08",
+    );
+    const count = host.querySelector<HTMLInputElement>('[aria-label="Wiggle count"]');
+    expect(count).not.toBeNull();
+    if (count) inputValue(count, "4");
+
+    expectWiggleCommit(onCommit, "wiggle(4,easeInOut,0.08)");
+  });
+
+  it("ignores an empty amplitude", () => {
+    expect(editWiggle("Wiggle amplitude", "")).not.toHaveBeenCalled();
+  });
+
+  it("rejects a count below one", () => {
+    expect(editWiggle("Wiggle count", "0")).not.toHaveBeenCalled();
+  });
+});
+
+describe("moved ease parameter fields", () => {
+  it("keeps the spring bounce commit behavior", () => {
+    const onCommit = vi.fn();
+    const host = renderField(<SpringBounceField springBounce={0.5} onCommit={onCommit} />);
+    const input = host.querySelector<HTMLInputElement>('[aria-label="Spring bounce"]');
+    expect(input).not.toBeNull();
+    if (input) inputValue(input, "0.333");
+
+    expect(onCommit).toHaveBeenLastCalledWith("spring(0.33)");
+  });
+
+  it("keeps the cubic-bezier tuple commit behavior", () => {
+    const onCommit = vi.fn();
+    const host = renderField(<EaseBezierField tuple={[0.33, 0, 0.67, 1]} onCommit={onCommit} />);
+    const input = host.querySelector<HTMLInputElement>(
+      '[aria-label="Cubic bezier control points"]',
+    );
+    expect(input).not.toBeNull();
+    act(() => {
+      if (!input) return;
+      input.value = "0.111, 0.222, 0.777, 0.888";
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onCommit).toHaveBeenLastCalledWith("custom(M0,0 C0.11,0.22 0.78,0.89 1,1)");
+  });
+});

--- a/packages/studio/src/components/editor/EaseParamFields.tsx
+++ b/packages/studio/src/components/editor/EaseParamFields.tsx
@@ -1,0 +1,173 @@
+import { parseSpringBounce } from "@hyperframes/core/spring-ease";
+import {
+  parseWiggleEase,
+  type WiggleEaseConfig,
+  type WiggleType,
+} from "@hyperframes/core/wiggle-ease";
+import { roundToCenti } from "../../utils/rounding";
+import { MiniCurveSvg } from "./easeCurveSvg";
+
+type Pts = [number, number, number, number];
+
+const round2 = roundToCenti;
+const WIGGLE_TYPES = ["easeOut", "easeInOut", "anticipate", "uniform"] as const;
+const WIGGLE_DEFAULT_AMPLITUDE = {
+  easeOut: 0.16,
+  easeInOut: 0.08,
+  anticipate: 0.12,
+  uniform: 0.14,
+} satisfies Record<WiggleType, number>;
+
+function isWiggleType(value: string): value is WiggleType {
+  return WIGGLE_TYPES.some((type) => type === value);
+}
+
+function commitWiggle(
+  onCommit: (ease: string) => void,
+  count: number,
+  type: WiggleType,
+  amplitude: number,
+): void {
+  const ease = `wiggle(${count},${type},${roundToCenti(amplitude)})`;
+  if (parseWiggleEase(ease)) onCommit(ease);
+}
+
+// Editable cubic-bezier control points, Figma-style ("0.33, 0, 0, 1"). Commits
+// on Enter/blur; remounts (via key) when the tuple changes from a drag or preset
+// pick so the text always mirrors the live curve.
+export function EaseBezierField({
+  tuple,
+  onCommit,
+}: {
+  tuple: Pts;
+  onCommit: (ease: string) => void;
+}) {
+  const text = tuple.join(", ");
+  const commit = (raw: string) => {
+    const nums = raw
+      .split(/[\s,]+/)
+      .map(Number)
+      .filter((value) => Number.isFinite(value));
+    if (nums.length !== 4) return;
+    const [x1, y1, x2, y2] = nums as [number, number, number, number];
+    // Control-point X must stay in [0,1] for a monotonic (valid) time curve;
+    // clamp it so an out-of-range entry can't persist as a broken ease. Y is
+    // left free so overshoot/anticipation curves still work.
+    const cx = (v: number) => Math.max(0, Math.min(1, v));
+    onCommit(`custom(M0,0 C${round2(cx(x1))},${round2(y1)} ${round2(cx(x2))},${round2(y2)} 1,1)`);
+  };
+  return (
+    <div className="mt-1.5 flex items-center gap-1.5 px-0.5">
+      <MiniCurveSvg
+        ease={`custom(M0,0 C${tuple[0]},${tuple[1]} ${tuple[2]},${tuple[3]} 1,1)`}
+        active
+        size={14}
+      />
+      <input
+        key={text}
+        type="text"
+        defaultValue={text}
+        aria-label="Cubic bezier control points"
+        onKeyDown={(event) => {
+          if (event.key === "Enter") commit(event.currentTarget.value);
+        }}
+        onBlur={(event) => commit(event.currentTarget.value)}
+        className="w-full rounded border border-white/10 bg-black/20 px-1.5 py-1 font-mono text-[10px] text-neutral-300 outline-none focus:border-panel-accent/50"
+      />
+    </div>
+  );
+}
+
+export function SpringBounceField({
+  springBounce,
+  onCommit,
+}: {
+  springBounce: number;
+  onCommit: (ease: string) => void;
+}) {
+  return (
+    <label className="mt-1.5 flex items-center gap-2 px-0.5 text-[10px] text-neutral-400">
+      Bounce
+      <input
+        type="number"
+        aria-label="Spring bounce"
+        min="0"
+        max="1"
+        step="0.01"
+        value={springBounce}
+        onInput={(event) => {
+          if (event.currentTarget.value === "") return;
+          const value = Number(event.currentTarget.value);
+          if (!Number.isFinite(value)) return;
+          const bounce = parseSpringBounce(`spring(${value})`);
+          if (bounce !== null) onCommit(`spring(${round2(bounce)})`);
+        }}
+        className="w-16 rounded border border-white/10 bg-black/20 px-1.5 py-1 font-mono text-[10px] text-neutral-300 outline-none focus:border-panel-accent/50"
+      />
+    </label>
+  );
+}
+
+export function WiggleField({
+  config,
+  onCommit,
+}: {
+  config: WiggleEaseConfig;
+  onCommit: (ease: string) => void;
+}) {
+  const amplitude = config.amplitude ?? WIGGLE_DEFAULT_AMPLITUDE[config.type];
+  return (
+    <div className="mt-1.5 flex items-center gap-2 px-0.5 text-[10px] text-neutral-400">
+      <label className="flex items-center gap-1">
+        Count
+        <input
+          type="number"
+          aria-label="Wiggle count"
+          min="1"
+          step="1"
+          value={config.wiggles}
+          onInput={(event) => {
+            if (event.currentTarget.value === "") return;
+            commitWiggle(onCommit, Number(event.currentTarget.value), config.type, amplitude);
+          }}
+          className="w-14 rounded border border-white/10 bg-black/20 px-1.5 py-1 font-mono text-[10px] text-neutral-300 outline-none focus:border-panel-accent/50"
+        />
+      </label>
+      <label className="flex items-center gap-1">
+        Type
+        <select
+          aria-label="Wiggle type"
+          value={config.type}
+          onChange={(event) => {
+            if (isWiggleType(event.currentTarget.value)) {
+              commitWiggle(onCommit, config.wiggles, event.currentTarget.value, amplitude);
+            }
+          }}
+          className="rounded border border-white/10 bg-black/20 px-1.5 py-1 text-[10px] text-neutral-300 outline-none focus:border-panel-accent/50"
+        >
+          {WIGGLE_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-1">
+        Amplitude
+        <input
+          type="number"
+          aria-label="Wiggle amplitude"
+          min="0"
+          max="1"
+          step="0.01"
+          value={amplitude}
+          onInput={(event) => {
+            if (event.currentTarget.value === "") return;
+            commitWiggle(onCommit, config.wiggles, config.type, Number(event.currentTarget.value));
+          }}
+          className="w-16 rounded border border-white/10 bg-black/20 px-1.5 py-1 font-mono text-[10px] text-neutral-300 outline-none focus:border-panel-accent/50"
+        />
+      </label>
+    </div>
+  );
+}

--- a/packages/studio/src/components/editor/easeCurveSvg.tsx
+++ b/packages/studio/src/components/editor/easeCurveSvg.tsx
@@ -1,0 +1,65 @@
+import { evaluateWiggleEase, parseWiggleEase } from "@hyperframes/core/wiggle-ease";
+import { evaluateSpringEase, parseSpringBounce } from "@hyperframes/core/spring-ease";
+import { resolveEaseCurveTuple } from "./gsapAnimationConstants";
+
+export function sampledPath(
+  samples: number,
+  x: (progress: number) => number,
+  y: (value: number) => number,
+  evaluate: (progress: number) => number,
+): string {
+  return Array.from({ length: samples + 1 }, (_, index) => {
+    const progress = index / samples;
+    return `${index === 0 ? "M" : "L"}${x(progress)},${y(evaluate(progress))}`;
+  }).join(" ");
+}
+
+export function holdCurvePath(left: number, bottom: number, right: number, top: number): string {
+  return `M${left},${bottom} L${right},${bottom} L${right},${top}`;
+}
+
+export function MiniCurveSvg({
+  ease,
+  active,
+  size = 24,
+}: {
+  ease: string;
+  active: boolean;
+  size?: number;
+}) {
+  const springBounce = parseSpringBounce(ease);
+  const wiggle = parseWiggleEase(ease);
+  const curve = resolveEaseCurveTuple(ease);
+  const [x1, y1, x2, y2] = curve;
+  const s = size;
+  const p = size / 8;
+  const g = s - p * 2;
+  const sx = (px: number) => p + g * px;
+  const sy = (py: number) => s - p - g * py;
+  const d =
+    ease === "hold"
+      ? holdCurvePath(p, s - p, s - p, p)
+      : wiggle
+        ? sampledPath(64, sx, sy, (progress) =>
+            evaluateWiggleEase(progress, wiggle.wiggles, wiggle.type, wiggle.amplitude),
+          )
+        : springBounce !== null
+          ? sampledPath(
+              24,
+              sx,
+              (value) => sy(value / 1.2),
+              (progress) => evaluateSpringEase(progress, springBounce),
+            )
+          : `M${p},${s - p} C${sx(x1)},${sy(y1)} ${sx(x2)},${sy(y2)} ${s - p},${p}`;
+  return (
+    <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`}>
+      <path
+        d={d}
+        fill="none"
+        stroke={active ? "#3CE6AC" : "#737373"}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/packages/studio/src/components/editor/easePresetLibrary.test.ts
+++ b/packages/studio/src/components/editor/easePresetLibrary.test.ts
@@ -1,0 +1,114 @@
+// Imports the parsers SOURCE (not the published subpath) so newly-added eases
+// like circ.inOut resolve before the parsers dist is rebuilt.
+import { SUPPORTED_EASES } from "../../../../parsers/src/gsapConstants";
+import { parseSpringBounce } from "@hyperframes/core/spring-ease";
+import { parseWiggleEase } from "@hyperframes/core/wiggle-ease";
+import { describe, expect, it } from "vitest";
+import { EASE_PRESETS, easePresetLabel } from "./easePresetLibrary";
+import { resolveEaseCurveTuple } from "./gsapAnimationConstants";
+
+const CUSTOM_EASE_PATTERN =
+  /^custom\(M0,0 C-?\d+(?:\.\d+)?,-?\d+(?:\.\d+)? -?\d+(?:\.\d+)?,-?\d+(?:\.\d+)? 1,1\)$/;
+
+describe("EASE_PRESETS", () => {
+  it("contains the complete 32-preset Graphs library with unique fields", () => {
+    expect(EASE_PRESETS).toHaveLength(32);
+    expect(new Set(EASE_PRESETS.map(({ id }) => id))).toHaveLength(32);
+    expect(new Set(EASE_PRESETS.map(({ label }) => label))).toHaveLength(32);
+    expect(new Set(EASE_PRESETS.map(({ ease }) => ease))).toHaveLength(32);
+  });
+
+  it("preserves the required standard, Flow, and Bounce mappings", () => {
+    const easeByLabel = Object.fromEntries(EASE_PRESETS.map(({ label, ease }) => [label, ease]));
+
+    expect(easeByLabel).toMatchObject({
+      Linear: "none",
+      "Ease In": "power1.in",
+      "Quad In": "power2.in",
+      "Cubic In": "power3.in",
+      "Ease Out": "power1.out",
+      "Quad Out": "power2.out",
+      "Cubic Out": "power3.out",
+      "Ease In & Out": "power1.inOut",
+      "Quad Ease": "power2.inOut",
+      "Cubic Ease": "power3.inOut",
+      "Circular Ease": "circ.inOut",
+      "Ease In Back": "back.in",
+      "Ease Out Back": "back.out",
+      "Flow 1": "wiggle(1,easeInOut,0.20)",
+      "Flow 2": "wiggle(2,easeInOut,0.15)",
+      "Flow 3": "wiggle(3,easeInOut,0.12)",
+      "Flow 4": "wiggle(4,easeInOut,0.10)",
+      "Flow 5": "wiggle(5,easeInOut,0.08)",
+      "Flow 6": "wiggle(6,easeInOut,0.07)",
+      "Flow 7": "wiggle(7,easeInOut,0.06)",
+      "Bounce 1": "wiggle(4,easeOut,0.22)",
+      "Bounce 2": "wiggle(6,easeOut,0.26)",
+      "Bounce 3": "wiggle(9,uniform,0.32)",
+      "Bounce 4": "wiggle(5,anticipate,0.28)",
+      Hold: "hold",
+    });
+
+    const flows = EASE_PRESETS.filter(({ id }) => id.startsWith("flow-"));
+    expect(flows.map(({ label }) => label)).toEqual([
+      "Flow 1",
+      "Flow 2",
+      "Flow 3",
+      "Flow 4",
+      "Flow 5",
+      "Flow 6",
+      "Flow 7",
+    ]);
+    expect(flows.every(({ ease }) => parseWiggleEase(ease) !== null)).toBe(true);
+  });
+
+  it("uses supported or valid custom eases that all resolve to finite geometry", () => {
+    for (const preset of EASE_PRESETS) {
+      expect(
+        SUPPORTED_EASES.includes(preset.ease as (typeof SUPPORTED_EASES)[number]) ||
+          CUSTOM_EASE_PATTERN.test(preset.ease) ||
+          parseSpringBounce(preset.ease) !== null ||
+          parseWiggleEase(preset.ease) !== null,
+        `${preset.label} has unsupported ease ${preset.ease}`,
+      ).toBe(true);
+      expect(resolveEaseCurveTuple(preset.ease).every(Number.isFinite)).toBe(true);
+    }
+  });
+
+  it("assigns every preset a valid kind", () => {
+    const kinds = new Set(["curve", "spring", "wiggle"]);
+
+    for (const preset of EASE_PRESETS) {
+      expect(kinds.has(preset.kind)).toBe(true);
+    }
+  });
+
+  it("uses valid bounce values for spring presets", () => {
+    for (const preset of EASE_PRESETS.filter(({ kind }) => kind === "spring")) {
+      const bounce = parseSpringBounce(preset.ease);
+
+      expect(bounce).not.toBeNull();
+      expect(bounce).toBeGreaterThanOrEqual(0);
+      expect(bounce).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("uses parseable eases for wiggle presets", () => {
+    for (const preset of EASE_PRESETS.filter(({ kind }) => kind === "wiggle")) {
+      expect(parseWiggleEase(preset.ease)).not.toBeNull();
+    }
+  });
+
+  it("preserves stable preset ids", () => {
+    for (const id of ["flow-7", "hold", "rebound-in"]) {
+      expect(EASE_PRESETS.some((preset) => preset.id === id)).toBe(true);
+    }
+  });
+
+  it("resolves preset labels by exact ease", () => {
+    expect(easePresetLabel("spring(0.6)")).toBe("Bouncy");
+    expect(easePresetLabel("back.in")).toBe("Ease In Back");
+    expect(easePresetLabel("wiggle(9,uniform,0.32)")).toBe("Bounce 3");
+    expect(easePresetLabel("custom(x)")).toBeNull();
+  });
+});

--- a/packages/studio/src/components/editor/easePresetLibrary.ts
+++ b/packages/studio/src/components/editor/easePresetLibrary.ts
@@ -1,0 +1,49 @@
+export const EASE_PRESETS = [
+  { id: "linear", label: "Linear", ease: "none", kind: "curve" },
+  { id: "ease-in", label: "Ease In", ease: "power1.in", kind: "curve" },
+  { id: "quad-in", label: "Quad In", ease: "power2.in", kind: "curve" },
+  { id: "cubic-in", label: "Cubic In", ease: "power3.in", kind: "curve" },
+  { id: "ease-out", label: "Ease Out", ease: "power1.out", kind: "curve" },
+  { id: "quad-out", label: "Quad Out", ease: "power2.out", kind: "curve" },
+  { id: "cubic-out", label: "Cubic Out", ease: "power3.out", kind: "curve" },
+  { id: "ease", label: "Ease In & Out", ease: "power1.inOut", kind: "curve" },
+  { id: "quad-ease", label: "Quad Ease", ease: "power2.inOut", kind: "curve" },
+  { id: "cubic-ease", label: "Cubic Ease", ease: "power3.inOut", kind: "curve" },
+  { id: "circular-ease", label: "Circular Ease", ease: "circ.inOut", kind: "curve" },
+  { id: "rebound-in", label: "Ease In Back", ease: "back.in", kind: "curve" },
+  { id: "rebound-out", label: "Ease Out Back", ease: "back.out", kind: "curve" },
+  { id: "flow-1", label: "Flow 1", ease: "wiggle(1,easeInOut,0.20)", kind: "wiggle" },
+  { id: "flow-2", label: "Flow 2", ease: "wiggle(2,easeInOut,0.15)", kind: "wiggle" },
+  { id: "flow-3", label: "Flow 3", ease: "wiggle(3,easeInOut,0.12)", kind: "wiggle" },
+  { id: "flow-4", label: "Flow 4", ease: "wiggle(4,easeInOut,0.10)", kind: "wiggle" },
+  { id: "flow-5", label: "Flow 5", ease: "wiggle(5,easeInOut,0.08)", kind: "wiggle" },
+  { id: "flow-6", label: "Flow 6", ease: "wiggle(6,easeInOut,0.07)", kind: "wiggle" },
+  { id: "flow-7", label: "Flow 7", ease: "wiggle(7,easeInOut,0.06)", kind: "wiggle" },
+  { id: "bounce-1", label: "Bounce 1", ease: "wiggle(4,easeOut,0.22)", kind: "wiggle" },
+  { id: "bounce-2", label: "Bounce 2", ease: "wiggle(6,easeOut,0.26)", kind: "wiggle" },
+  { id: "bounce-3", label: "Bounce 3", ease: "wiggle(9,uniform,0.32)", kind: "wiggle" },
+  { id: "bounce-4", label: "Bounce 4", ease: "wiggle(5,anticipate,0.28)", kind: "wiggle" },
+  { id: "hold", label: "Hold", ease: "hold", kind: "curve" },
+  {
+    id: "rebound-ease",
+    label: "Ease In & Out Back",
+    ease: "back.inOut",
+    kind: "curve",
+  },
+  { id: "expo-in", label: "Expo In", ease: "expo.in", kind: "curve" },
+  { id: "expo-out", label: "Expo Out", ease: "expo.out", kind: "curve" },
+  // Runtime spring(bounce) approximates Figma stiffness and damping with bounce alone.
+  { id: "spring-gentle", label: "Gentle", ease: "spring(0.15)", kind: "spring" },
+  { id: "spring-quick", label: "Quick", ease: "spring(0.4)", kind: "spring" },
+  { id: "spring-bouncy", label: "Bouncy", ease: "spring(0.6)", kind: "spring" },
+  { id: "spring-slow", label: "Slow", ease: "spring(0.25)", kind: "spring" },
+] as const satisfies ReadonlyArray<{
+  id: string;
+  label: string;
+  ease: string;
+  kind: "curve" | "spring" | "wiggle";
+}>;
+
+export function easePresetLabel(ease: string): string | null {
+  return EASE_PRESETS.find((preset) => preset.ease === ease)?.label ?? null;
+}

--- a/packages/studio/src/components/editor/gsapAnimationConstants.ts
+++ b/packages/studio/src/components/editor/gsapAnimationConstants.ts
@@ -1,4 +1,4 @@
-import { controlPointsForGsapEase } from "./studioMotion";
+import { controlPointsForGsapEase, parseStudioCustomEaseData } from "./studioMotion";
 
 export const METHOD_LABELS: Record<string, string> = {
   set: "Set",
@@ -116,9 +116,14 @@ export const EASE_CURVES: Record<string, [number, number, number, number]> = {
   "back.out": [0.34, 1.56, 0.64, 1],
   "back.in": [0.36, 0, 0.66, -0.56],
   "back.inOut": [0.68, -0.55, 0.27, 1.55],
+  "circ.inOut": [0.785, 0.135, 0.15, 0.86],
   "expo.out": [0.16, 1, 0.3, 1],
   "expo.in": [0.7, 0, 0.84, 0],
   "expo.inOut": [0.87, 0, 0.13, 1],
+  "bounce.out": [0.34, 1.56, 0.64, 0.74],
+  "bounce.in": [0.36, 0.26, 0.66, -0.56],
+  "elastic.out(1,0.3)": [0.16, 1.45, 0.28, 0.82],
+  "elastic.inOut(1,0.3)": [0.68, -0.55, 0.32, 1.55],
   // After Effects polarity: "in" eases into the keyframe (slow END, CP2 y=1),
   // "out" eases out of it (slow START, CP1 y=0). Matches the "(AE)" labels.
   "ae-ease": [0.333, 0, 0.667, 1],
@@ -126,18 +131,15 @@ export const EASE_CURVES: Record<string, [number, number, number, number]> = {
   "ae-ease-out": [0.333, 0, 0.667, 0.667],
 };
 
-export function parseCustomEaseFromString(ease: string): {
-  x1: number;
-  y1: number;
-  x2: number;
-  y2: number;
-} {
-  const match = ease.match(/^custom\((.+)\)$/);
-  if (!match) return controlPointsForGsapEase("power2.out");
-  const data = match[1];
-  const nums = data.match(/[\d.]+/g)?.map(Number);
-  if (!nums || nums.length < 6) return controlPointsForGsapEase("power2.out");
-  return { x1: nums[2], y1: nums[3], x2: nums[4], y2: nums[5] };
+export function resolveEaseCurveTuple(ease: string): [number, number, number, number] {
+  if (ease.startsWith("custom(")) {
+    const points = parseStudioCustomEaseData(ease.match(/^custom\((.+)\)$/)?.[1]);
+    if (points) return [points.x1, points.y1, points.x2, points.y2];
+  }
+  const curve = EASE_CURVES[ease];
+  if (curve) return curve;
+  const points = controlPointsForGsapEase(ease);
+  return [points.x1, points.y1, points.x2, points.y2];
 }
 
 export const PERCENT_PROPS = new Set(["opacity", "autoAlpha"]);

--- a/packages/studio/src/telemetry/events.test.ts
+++ b/packages/studio/src/telemetry/events.test.ts
@@ -12,6 +12,7 @@ const {
   trackStudioRenderStart,
   trackStudioRazorSplit,
   trackStudioExpandedClipEdit,
+  trackStudioSegmentEaseEdit,
   trackStudioFeedback,
 } = await import("./events");
 
@@ -69,6 +70,14 @@ describe("studio telemetry events", () => {
   it("trackStudioExpandedClipEdit emits 'studio_expanded_clip_edit' with action", () => {
     trackStudioExpandedClipEdit({ action: "resize" });
     expect(trackEvent).toHaveBeenCalledWith("studio_expanded_clip_edit", { action: "resize" });
+  });
+
+  it("trackStudioSegmentEaseEdit emits 'studio_segment_ease_edit' with action and ease", () => {
+    trackStudioSegmentEaseEdit({ action: "commit", ease: "power2.out" });
+    expect(trackEvent).toHaveBeenCalledWith("studio_segment_ease_edit", {
+      action: "commit",
+      ease: "power2.out",
+    });
   });
 
   it.each([0, 10])("trackStudioFeedback preserves NPS boundary %i and its scale", (rating) => {

--- a/packages/studio/src/telemetry/events.ts
+++ b/packages/studio/src/telemetry/events.ts
@@ -63,6 +63,14 @@ export function trackStudioExpandedClipEdit(props: {
   trackEvent("studio_expanded_clip_edit", { action: props.action });
 }
 
+// Adoption signal for opening and committing the per-segment ease editor.
+export function trackStudioSegmentEaseEdit(props: {
+  action: "open" | "commit";
+  ease?: string;
+}): void {
+  trackEvent("studio_segment_ease_edit", { action: props.action, ease: props.ease });
+}
+
 export function trackStudioFeedback(props: { rating: number; comment?: string }): void {
   trackEvent("survey sent", {
     $survey_id: "studio_experience",


### PR DESCRIPTION
## Summary

The inspector now has reusable preset, parameter, SVG-curve, and telemetry primitives for editing keyframe easing without duplicating ease interpretation.

## Stack

Part 4 of 20. Parent: heygen-com/hyperframes#2561. Next: heygen-com/hyperframes#2562. The golden reference, heygen-com/hyperframes#2387, remains open and unchanged.

## Test plan

- [x] Integrated Studio suite: 2,800 tests passed
- [x] Integrated parser suite: 853 tests passed
- [x] Studio and parser typechecks passed
- [x] Studio and parser production builds passed
- [ ] Per-PR CI completes on the submitted stack

## Post-Deploy Monitoring & Validation

Validation window: first 24 hours after the stack merges. Owner: Studio maintainers. Watch browser console and support reports for `[Timeline]`, `gsap-parser`, failed keyframe mutations, or preview/render easing mismatches. Healthy means edits persist and preview/render agree; revert the first failing layer if authored animation data changes unexpectedly.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

