### PR TITLE
fix(studio): harden bulk keyframe editing

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -115,7 +115,7 @@ describe("initSandboxRuntimeModular", () => {
     delete window.__hfTimelinesBuilding;
     delete (window as { THREE?: unknown }).THREE;
     delete (window as { __hfAutoNoopRegistered?: boolean }).__hfAutoNoopRegistered;
-    delete (window as { __hfCustomEaseRegistered?: boolean }).__hfCustomEaseRegistered;
+    delete window.__hfCustomEaseRegistered;
     delete window.gsap;
     vi.restoreAllMocks();
     window.requestAnimationFrame = originalRequestAnimationFrame;
@@ -240,7 +240,7 @@ describe("initSandboxRuntimeModular", () => {
     initSandboxRuntimeModular();
     expect(window.gsap.parseEase).toBe(installedParseEase);
 
-    delete (window as { __hfCustomEaseRegistered?: boolean }).__hfCustomEaseRegistered;
+    delete window.__hfCustomEaseRegistered;
     window.gsap = {
       timeline: () => createMockTimeline(1),
       parseEase: vi.fn(() => defaultEase),

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -176,10 +176,9 @@ export function initSandboxRuntimeModular(): void {
   };
   const ensureStudioCustomEase = (): void => {
     const g = window.gsap;
-    const w = window as Window & { __hfCustomEaseRegistered?: boolean };
-    if (!g || w.__hfCustomEaseRegistered) return;
+    if (!g || window.__hfCustomEaseRegistered) return;
     try {
-      if (installStudioCustomEase(g)) w.__hfCustomEaseRegistered = true;
+      if (installStudioCustomEase(g)) window.__hfCustomEaseRegistered = true;
     } catch {
       // falling back to GSAP's default ease is preferable to a broken runtime
     }

--- a/packages/core/src/runtime/window.d.ts
+++ b/packages/core/src/runtime/window.d.ts
@@ -41,6 +41,7 @@ declare global {
     __playerReady?: boolean;
     __renderReady?: boolean;
     __hfRuntimeTeardown?: (() => void) | null;
+    __hfCustomEaseRegistered?: boolean;
     __HF_EXPORT_RENDER_SEEK_CONFIG?: {
       mode?: string;
       diagnostics?: boolean;

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -20,7 +20,6 @@ import type { Composition } from "@hyperframes/sdk";
 import type { EditHistoryKind } from "../utils/editHistory";
 import { useSlideshowPersist, type UseSlideshowPersistParams } from "../hooks/useSlideshowPersist";
 import { DesignPanelPromoteProvider } from "./DesignPanelPromoteProvider";
-
 import { useStudioPlaybackContext, useStudioShellContext } from "../contexts/StudioContext";
 import { usePanelLayoutContext } from "../contexts/PanelLayoutContext";
 import { useFileManagerContext } from "../contexts/FileManagerContext";

--- a/packages/studio/src/components/editor/GsapAnimationSection.tsx
+++ b/packages/studio/src/components/editor/GsapAnimationSection.tsx
@@ -58,7 +58,6 @@ export const GsapAnimationSection = memo(function GsapAnimationSection({
                 focusedEaseSegment?.animationId === anim.id ? focusedEaseSegment : null
               }
               onFocusSegmentConsumed={() => setFocusedEaseSegment(null)}
-              onUpdateSegmentEase={callbacks.onUpdateSegmentEase}
             />
           ))}
 

--- a/packages/studio/src/components/editor/gsapAnimationCallbacks.test.ts
+++ b/packages/studio/src/components/editor/gsapAnimationCallbacks.test.ts
@@ -24,8 +24,10 @@ describe("withTrackedGsapAnimationCallbacks", () => {
     const callbacks = requiredCallbacks();
     const onLivePreview = vi.fn();
     const onLivePreviewEnd = vi.fn();
+    const onUpdateSegmentEase = vi.fn();
     callbacks.onLivePreview = onLivePreview;
     callbacks.onLivePreviewEnd = onLivePreviewEnd;
+    callbacks.onUpdateSegmentEase = onUpdateSegmentEase;
 
     const tracked = withTrackedGsapAnimationCallbacks(callbacks, vi.fn());
 
@@ -39,6 +41,7 @@ describe("withTrackedGsapAnimationCallbacks", () => {
     expect(tracked.onUnroll).toBeUndefined();
     expect(tracked.onLivePreview).toBe(onLivePreview);
     expect(tracked.onLivePreviewEnd).toBe(onLivePreviewEnd);
+    expect(tracked.onUpdateSegmentEase).toBe(onUpdateSegmentEase);
   });
 
   it("tracks each edit once before invoking its mutation callback", () => {

--- a/packages/studio/src/components/editor/gsapAnimationCallbacks.ts
+++ b/packages/studio/src/components/editor/gsapAnimationCallbacks.ts
@@ -122,6 +122,7 @@ export function withTrackedGsapAnimationCallbacks(
       : undefined,
     onLivePreview: callbacks.onLivePreview,
     onLivePreviewEnd: callbacks.onLivePreviewEnd,
+    onUpdateSegmentEase: callbacks.onUpdateSegmentEase,
     onSetArcPath: callbacks.onSetArcPath
       ? (animationId, config) => {
           track("toggle", config.autoRotate !== undefined ? "Auto rotate" : "Arc motion");

--- a/packages/studio/src/components/editor/holdEaseSeek.test.ts
+++ b/packages/studio/src/components/editor/holdEaseSeek.test.ts
@@ -1,0 +1,34 @@
+import { installStudioCustomEase } from "../../../../core/src/runtime/customEase";
+import { gsap } from "gsap";
+import { describe, expect, it } from "vitest";
+
+describe("Studio hold ease", () => {
+  it("holds the start value under seek until the destination time", () => {
+    const runtimeGsap = { parseEase: gsap.parseEase.bind(gsap) };
+    expect(installStudioCustomEase(runtimeGsap)).toBe(true);
+    const hold = runtimeGsap.parseEase("hold");
+    expect(hold).toBeTypeOf("function");
+    if (typeof hold !== "function") return;
+
+    const target = { value: 0 };
+    const timeline = gsap.timeline({ paused: true }).to(
+      target,
+      {
+        value: 100,
+        duration: 2,
+        ease: hold,
+      },
+      0,
+    );
+
+    timeline.seek(0.5);
+    expect(target.value).toBe(0);
+    timeline.seek(1);
+    expect(target.value).toBe(0);
+    timeline.seek(1.99);
+    expect(target.value).toBe(0);
+    timeline.seek(2);
+    expect(target.value).toBe(100);
+    timeline.kill();
+  });
+});

--- a/packages/studio/src/components/editor/propertyPanelFlatMotionSection.test.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFlatMotionSection.test.tsx
@@ -5,11 +5,13 @@ import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FlatMotionSection, FlatTimingRow } from "./propertyPanelFlatMotionSection";
 import type { DomEditSelection } from "./domEditing";
+import { usePlayerStore } from "../../player";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 afterEach(() => {
   document.body.innerHTML = "";
+  usePlayerStore.getState().reset();
 });
 
 function baseElement(overrides: Partial<DomEditSelection> = {}): DomEditSelection {
@@ -267,6 +269,62 @@ describe("FlatMotionSection", () => {
     expect(onAddAnimation).toHaveBeenCalledWith("to");
     // The menu closes back to the trigger after a selection.
     expect(buttons().some((b) => b.textContent === "+ Add effect")).toBe(true);
+    act(() => root.unmount());
+  });
+
+  it("forwards focused bulk segment easing through the flat animation card", () => {
+    const onUpdateKeyframeEase = vi.fn();
+    const onUpdateSegmentEase = vi.fn();
+    usePlayerStore.setState({
+      focusedEaseSegment: {
+        elementId: "index.html#hero",
+        animationId: "a1",
+        tweenPercentage: 50,
+        collidingAnimationIds: ["a1", "a2"],
+      },
+    });
+    const { host, root } = renderInto(
+      <FlatMotionSection
+        element={baseElement()}
+        animations={[
+          {
+            id: "a1",
+            method: "to",
+            position: 0,
+            duration: 1,
+            properties: { x: 100 },
+            keyframes: {
+              format: "percentage",
+              keyframes: [
+                { percentage: 0, properties: { x: 0 } },
+                { percentage: 50, properties: { x: 100 } },
+              ],
+            },
+          } as never,
+        ]}
+        showTiming={false}
+        showEffects
+        onSetAttribute={vi.fn()}
+        onAddAnimation={vi.fn()}
+        onUpdateProperty={vi.fn()}
+        onUpdateMeta={vi.fn()}
+        onDeleteAnimation={vi.fn()}
+        onAddProperty={vi.fn()}
+        onRemoveProperty={vi.fn()}
+        onUpdateKeyframeEase={onUpdateKeyframeEase}
+        onUpdateSegmentEase={onUpdateSegmentEase}
+      />,
+    );
+
+    const dropdown = host.querySelector<HTMLButtonElement>("[data-ease-type-dropdown]");
+    expect(dropdown).not.toBeNull();
+    act(() => dropdown?.click());
+    const preset = host.querySelector<HTMLButtonElement>('[data-ease-preset-id="quad-out"]');
+    expect(preset).not.toBeNull();
+    act(() => preset?.click());
+
+    expect(onUpdateSegmentEase).toHaveBeenCalledExactlyOnceWith(["a1", "a2"], 50, "power2.out");
+    expect(onUpdateKeyframeEase).not.toHaveBeenCalled();
     act(() => root.unmount());
   });
 });

--- a/packages/studio/src/hooks/gsapKeyframeCacheHelpers.test.ts
+++ b/packages/studio/src/hooks/gsapKeyframeCacheHelpers.test.ts
@@ -4,6 +4,7 @@ import { usePlayerStore, type KeyframeCacheEntry } from "../player/store/playerS
 import {
   clearKeyframeCacheForElement,
   clearKeyframeCacheForFile,
+  replaceKeyframeCacheForFile,
   updateKeyframeCacheFromParsed,
 } from "./gsapKeyframeCacheHelpers";
 
@@ -94,6 +95,61 @@ describe("clearKeyframeCacheForFile", () => {
 
     expect(cache().has("other.html#z")).toBe(true);
     expect(cache().has("z")).toBe(true);
+  });
+});
+
+describe("replaceKeyframeCacheForFile", () => {
+  it("publishes complete keyframe and animation maps in one notification", () => {
+    const staleEntry = entry();
+    const otherEntry = entry();
+    const staleAnimation = animWithKeyframes("stale");
+    const freshAnimation = animWithKeyframes("fresh");
+    usePlayerStore.setState({
+      keyframeCache: new Map([
+        ["scene.html#stale", staleEntry],
+        ["index.html#stale", staleEntry],
+        ["stale", staleEntry],
+        ["other.html#other", otherEntry],
+        ["other", otherEntry],
+      ]),
+      gsapAnimations: new Map([
+        ["scene.html#stale", [staleAnimation]],
+        ["index.html#stale", [staleAnimation]],
+        ["stale", [staleAnimation]],
+        ["other.html#other", [staleAnimation]],
+        ["other", [staleAnimation]],
+      ]),
+    });
+    const snapshots: Array<{ cacheKeys: string[]; animationKeys: string[] }> = [];
+    const unsubscribe = usePlayerStore.subscribe((state) => {
+      snapshots.push({
+        cacheKeys: [...state.keyframeCache.keys()].sort(),
+        animationKeys: [...state.gsapAnimations.keys()].sort(),
+      });
+    });
+
+    replaceKeyframeCacheForFile(
+      "scene.html",
+      new Map([["fresh", entry()]]),
+      new Map([["fresh", [freshAnimation]]]),
+    );
+    unsubscribe();
+
+    expect(snapshots).toEqual([
+      {
+        cacheKeys: ["fresh", "index.html#fresh", "other", "other.html#other", "scene.html#fresh"],
+        animationKeys: [
+          "fresh",
+          "index.html#fresh",
+          "other",
+          "other.html#other",
+          "scene.html#fresh",
+        ],
+      },
+    ]);
+    expect(usePlayerStore.getState().gsapAnimations.get("scene.html#fresh")).toEqual([
+      freshAnimation,
+    ]);
   });
 });
 

--- a/packages/studio/src/hooks/gsapKeyframeCacheHelpers.ts
+++ b/packages/studio/src/hooks/gsapKeyframeCacheHelpers.ts
@@ -116,6 +116,17 @@ export function clearKeyframeCacheForElement(sourceFile: string, elementId: stri
  */
 export function clearKeyframeCacheForFile(sourceFile: string): void {
   const { keyframeCache, gsapAnimations } = usePlayerStore.getState();
+  const ids = cachedElementIdsForFile(sourceFile, keyframeCache, gsapAnimations);
+  for (const id of ids) {
+    clearKeyframeCacheForElement(sourceFile, id);
+  }
+}
+
+function cachedElementIdsForFile(
+  sourceFile: string,
+  keyframeCache: ReadonlyMap<string, KeyframeCacheEntry>,
+  gsapAnimations: ReadonlyMap<string, GsapAnimation[]>,
+): Set<string> {
   const sfPrefix = `${sourceFile}#`;
   const fallbackPrefix = "index.html#";
   const ids = new Set<string>();
@@ -126,15 +137,42 @@ export function clearKeyframeCacheForFile(sourceFile: string): void {
     const hashIdx = key.indexOf("#");
     if (hashIdx !== -1) ids.add(key.slice(hashIdx + 1));
   }
-  for (const id of ids) {
-    clearKeyframeCacheForElement(sourceFile, id);
-  }
+  return ids;
 }
 
 function elementCacheKeys(sourceFile: string, elementId: string): string[] {
   return sourceFile === "index.html"
     ? [`index.html#${elementId}`, elementId]
     : [`${sourceFile}#${elementId}`, `index.html#${elementId}`, elementId];
+}
+
+/** Replace one file's complete cache snapshot with one atomic store publish. */
+export function replaceKeyframeCacheForFile(
+  sourceFile: string,
+  entries: ReadonlyMap<string, KeyframeCacheEntry>,
+  animationsByElement: ReadonlyMap<string, GsapAnimation[]>,
+): void {
+  const { keyframeCache, gsapAnimations } = usePlayerStore.getState();
+  const nextKeyframeCache = new Map(keyframeCache);
+  const nextGsapAnimations = new Map(gsapAnimations);
+  for (const id of cachedElementIdsForFile(sourceFile, keyframeCache, gsapAnimations)) {
+    for (const key of elementCacheKeys(sourceFile, id)) {
+      nextKeyframeCache.delete(key);
+      nextGsapAnimations.delete(key);
+    }
+  }
+  for (const [id, entry] of entries) {
+    const animations = animationsByElement.get(id);
+    for (const key of elementCacheKeys(sourceFile, id)) {
+      nextKeyframeCache.set(key, entry);
+      if (animations) nextGsapAnimations.set(key, animations);
+      else nextGsapAnimations.delete(key);
+    }
+  }
+  usePlayerStore.setState({
+    keyframeCache: nextKeyframeCache,
+    gsapAnimations: nextGsapAnimations,
+  });
 }
 
 export function writeGsapAnimationsForElement(

--- a/packages/studio/src/hooks/useDomEditSession.ts
+++ b/packages/studio/src/hooks/useDomEditSession.ts
@@ -20,8 +20,6 @@ import { useDomEditWiring } from "./useDomEditWiring";
 import { useGsapAwareEditing } from "./useGsapAwareEditing";
 import { useStudioSelectionPublisher } from "./useStudioSelectionPublisher";
 
-// ── Types ──
-
 interface RecordEditInput {
   label: string;
   kind: EditHistoryKind;
@@ -71,8 +69,6 @@ export interface UseDomEditSessionParams {
   forceReloadSdkSession?: () => void;
 }
 
-// ── Hook ──
-
 export function useDomEditSession({
   projectId,
   activeCompPath,
@@ -113,8 +109,6 @@ export function useDomEditSession({
   forceReloadSdkSession,
 }: UseDomEditSessionParams) {
   void _setRefreshKey;
-  // ── Selection ──
-
   const {
     domEditSelection,
     domEditGroupSelections,
@@ -148,8 +142,6 @@ export function useDomEditSession({
     refreshKey,
     rightPanelTab,
   });
-
-  // ── Agent modal ──
 
   const {
     agentModalOpen,

--- a/packages/studio/src/hooks/useGsapTweenCache.ts
+++ b/packages/studio/src/hooks/useGsapTweenCache.ts
@@ -5,7 +5,7 @@ import { usePlayerStore } from "../player/store/playerStore";
 import { readRuntimeKeyframes, scanAllRuntimeKeyframes } from "./gsapRuntimeBridge";
 import {
   clearKeyframeCacheForElement,
-  clearKeyframeCacheForFile,
+  replaceKeyframeCacheForFile,
   writeGsapAnimationsForElement,
 } from "./gsapKeyframeCacheHelpers";
 import { toAbsoluteTime } from "./gsapShared";
@@ -466,8 +466,6 @@ export function usePopulateKeyframeCacheForFile(
     // fallow-ignore-next-line complexity
     fetchParsedAnimations(projectId, sf).then((parsed) => {
       if (!parsed) return;
-      const { setKeyframeCache } = usePlayerStore.getState();
-      clearKeyframeCacheForFile(sf);
       const { elements, domClipChildren } = usePlayerStore.getState();
       const doc = iframeRef?.current?.contentDocument;
       const mergedByElement = new Map<string, GsapKeyframesData>();
@@ -522,12 +520,7 @@ export function usePopulateKeyframeCacheForFile(
           }
         }
       }
-      for (const [id, kfData] of mergedByElement) {
-        setKeyframeCache(`${sf}#${id}`, kfData);
-        setKeyframeCache(id, kfData);
-        if (sf !== "index.html") setKeyframeCache(`index.html#${id}`, kfData);
-        writeGsapAnimationsForElement(sf, id, sourceByElement.get(id));
-      }
+      replaceKeyframeCacheForFile(sf, mergedByElement, sourceByElement);
       astFetchDoneRef.current = fetchKey;
     });
     // elementCount is in the deps because new timeline elements (e.g. after a

--- a/packages/studio/src/hooks/useStudioTestHooks.ts
+++ b/packages/studio/src/hooks/useStudioTestHooks.ts
@@ -10,6 +10,16 @@ interface StudioTestHookDeps {
   ) => void;
 }
 
+interface StudioTestApi {
+  selectByDomId: (id: string) => Promise<boolean>;
+}
+
+declare global {
+  interface Window {
+    __studioTest?: StudioTestApi;
+  }
+}
+
 /**
  * Dev-only headless-QA shortcut. Selecting an element normally requires a
  * pixel-precise click inside the preview iframe, which automated verification
@@ -33,7 +43,7 @@ export function useStudioTestHooks({
       isDev = false;
     }
     if (!isDev || typeof window === "undefined") return;
-    const api = {
+    const api: StudioTestApi = {
       selectByDomId: async (id: string): Promise<boolean> => {
         const element = previewIframeRef.current?.contentDocument?.getElementById(id) ?? null;
         if (!element) return false;
@@ -43,9 +53,9 @@ export function useStudioTestHooks({
         return true;
       },
     };
-    (window as unknown as { __studioTest?: typeof api }).__studioTest = api;
+    window.__studioTest = api;
     return () => {
-      (window as unknown as { __studioTest?: typeof api }).__studioTest = undefined;
+      window.__studioTest = undefined;
     };
   }, [applyDomSelection, buildDomSelectionFromTarget, previewIframeRef]);
 }

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -466,7 +466,7 @@ export const Timeline = memo(function Timeline({
         onPointerDown={(e) => {
           // Let interactive controls (keyframe nav/toggle, caret, inputs) handle
           // their own clicks — scrubbing here would preventDefault and eat them.
-          if ((e.target as HTMLElement).closest("button, input, select, a")) return;
+          if (e.target instanceof Element && e.target.closest("button, input, select, a")) return;
           if (activeTool === "razor" && e.shiftKey && e.button === 0 && scrollRef.current) {
             const rect = scrollRef.current.getBoundingClientRect();
             const x = getTimelineContentXFromClient({

--- a/packages/studio/src/player/components/useAutoExpandKeyframedClips.test.tsx
+++ b/packages/studio/src/player/components/useAutoExpandKeyframedClips.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { GsapAnimation } from "@hyperframes/core/gsap-parser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePlayerStore } from "../store/playerStore";
+import { useAutoExpandKeyframedClips } from "./useAutoExpandKeyframedClips";
+
+const studioShell = vi.hoisted(() => ({ projectId: "project-a" }));
+vi.mock("../../contexts/StudioContext", () => ({
+  useStudioShellContextOptional: () => studioShell,
+}));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  studioShell.projectId = "project-a";
+  usePlayerStore.getState().reset();
+});
+
+const animations = new Map<string, GsapAnimation[]>([
+  [
+    "clip-1",
+    [
+      {
+        id: "position-tween",
+        targetSelector: "#clip-1",
+        method: "to",
+        position: 0,
+        duration: 1,
+        properties: { x: 100 },
+        propertyGroup: "position",
+      },
+    ],
+  ],
+]);
+
+function AutoExpandHarness({ value }: { value: Map<string, GsapAnimation[]> }) {
+  useAutoExpandKeyframedClips(value);
+  return null;
+}
+
+describe("useAutoExpandKeyframedClips", () => {
+  it("preserves manual collapse within a project and expands again in a different project", () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    const render = (projectId: string, value = new Map(animations)) => {
+      studioShell.projectId = projectId;
+      act(() => root.render(<AutoExpandHarness value={value} />));
+    };
+
+    const projectAAnimations = new Map(animations);
+    render("project-a", projectAAnimations);
+    expect(usePlayerStore.getState().expandedClipIds).toEqual(new Set(["clip-1"]));
+
+    act(() => usePlayerStore.getState().toggleClipExpanded("clip-1"));
+    expect(usePlayerStore.getState().expandedClipIds).toEqual(new Set());
+
+    const refreshedProjectAAnimations = new Map(animations);
+    render("project-a", refreshedProjectAAnimations);
+    expect(usePlayerStore.getState().expandedClipIds).toEqual(new Set());
+
+    render("project-b", refreshedProjectAAnimations);
+    expect(usePlayerStore.getState().expandedClipIds).toEqual(new Set());
+
+    render("project-b", new Map());
+    render("project-b");
+    expect(usePlayerStore.getState().expandedClipIds).toEqual(new Set(["clip-1"]));
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/player/components/useAutoExpandKeyframedClips.ts
+++ b/packages/studio/src/player/components/useAutoExpandKeyframedClips.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import type { GsapAnimation } from "@hyperframes/core/gsap-parser";
 import { usePlayerStore } from "../store/playerStore";
 import { STUDIO_KEYFRAMES_ENABLED } from "../../components/editor/manualEditingAvailability";
+import { useStudioShellContextOptional } from "../../contexts/StudioContext";
 import { animationContributesLane } from "./TimelinePropertyLanes";
 
 /**
@@ -12,16 +13,24 @@ import { animationContributesLane } from "./TimelinePropertyLanes";
  */
 export function useAutoExpandKeyframedClips(gsapAnimations: Map<string, GsapAnimation[]>): void {
   const expandClips = usePlayerStore((s) => s.expandClips);
-  const seen = useRef<Set<string>>(new Set());
+  const projectId = useStudioShellContextOptional()?.projectId ?? null;
+  const seen = useRef({ projectId, source: gsapAnimations, clips: new Set<string>() });
   useEffect(() => {
     if (!STUDIO_KEYFRAMES_ENABLED) return;
+    if (seen.current.projectId !== projectId) {
+      const sourceChanged = seen.current.source !== gsapAnimations;
+      seen.current = { projectId, source: gsapAnimations, clips: new Set() };
+      if (!sourceChanged) return;
+    } else {
+      seen.current.source = gsapAnimations;
+    }
     const fresh: string[] = [];
     for (const [key, animations] of gsapAnimations) {
-      if (seen.current.has(key)) continue;
+      if (seen.current.clips.has(key)) continue;
       if (animations.some(animationContributesLane)) fresh.push(key);
     }
     if (fresh.length === 0) return;
-    for (const key of fresh) seen.current.add(key);
+    for (const key of fresh) seen.current.clips.add(key);
     expandClips(fresh);
-  }, [gsapAnimations, expandClips]);
+  }, [gsapAnimations, expandClips, projectId]);
 }


### PR DESCRIPTION
## Summary

Bulk keyframe editing now refreshes cache atomically, resets expansion per project, preserves hold behavior, and uses declared runtime and test hooks.

## Stack

Part 16 of 20. Parent: heygen-com/hyperframes#2568. Next: heygen-com/hyperframes#2570. The golden reference, heygen-com/hyperframes#2387, remains open and unchanged.

## Test plan

- [x] Integrated Studio suite: 2,800 tests passed
- [x] Integrated parser suite: 853 tests passed
- [x] Studio and parser typechecks passed
- [x] Studio and parser production builds passed
- [ ] Per-PR CI completes on the submitted stack

## Post-Deploy Monitoring & Validation

Validation window: first 24 hours after the stack merges. Owner: Studio maintainers. Watch browser console and support reports for `[Timeline]`, `gsap-parser`, failed keyframe mutations, or preview/render easing mismatches. Healthy means edits persist and preview/render agree; revert the first failing layer if authored animation data changes unexpectedly.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

