### PR TITLE
refactor(parsers): share local-asset resolution across lint and studio-server

### DIFF
--- a/packages/lint/src/hevcPreviewLint.ts
+++ b/packages/lint/src/hevcPreviewLint.ts
@@ -6,7 +6,7 @@ import {
   isRemoteOrInlineUrl,
   maskNonScannableRanges,
   resolveExistingLocalAsset,
-} from "./assetResolution.js";
+} from "@hyperframes/parsers/asset-resolution";
 import type { HyperframeLintFinding } from "./types.js";
 
 /** Structurally compatible with `project.ts`'s (unexported) `HtmlSource` —

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -11,7 +11,7 @@ import {
   maskNonScannableRanges,
   resolveExistingLocalAsset,
   resolveLocalAssetCandidates,
-} from "./assetResolution.js";
+} from "@hyperframes/parsers/asset-resolution";
 import { collectLocalVideoCandidates, lintHevcPreviewCodec } from "./hevcPreviewLint.js";
 import { lintHyperframeHtml } from "./hyperframeLinter.js";
 import type { HyperframeLintFinding, HyperframeLintResult } from "./types.js";

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -99,6 +99,12 @@
       "node": "./dist/ffBinaries.js",
       "import": "./src/ffBinaries.ts",
       "types": "./src/ffBinaries.ts"
+    },
+    "./asset-resolution": {
+      "bun": "./src/assetResolution.ts",
+      "node": "./dist/assetResolution.js",
+      "import": "./src/assetResolution.ts",
+      "types": "./src/assetResolution.ts"
     }
   },
   "publishConfig": {
@@ -160,6 +166,10 @@
       "./ff-binaries": {
         "import": "./dist/ffBinaries.js",
         "types": "./dist/ffBinaries.d.ts"
+      },
+      "./asset-resolution": {
+        "import": "./dist/assetResolution.js",
+        "types": "./dist/assetResolution.d.ts"
       }
     },
     "main": "./dist/index.js",

--- a/packages/parsers/src/assetResolution.ts
+++ b/packages/parsers/src/assetResolution.ts
@@ -1,13 +1,12 @@
 import { existsSync } from "node:fs";
 import { isAbsolute, posix, relative, resolve } from "node:path";
-import { decodeUrlPathVariants } from "@hyperframes/parsers/composition";
+import { decodeUrlPathVariants } from "./composition.js";
 
 /**
- * Shared local-asset resolution helpers used by both the project-level lint
- * rules (`project.ts`) and the HEVC preview-codec check
- * (`hevcPreviewLint.ts`). Split out so the latter doesn't need to import from
- * `project.ts` (which imports it back to run the rule) — that would be a
- * circular import within the package.
+ * Shared local-asset resolution helpers for every package that maps
+ * composition asset URLs to files on disk (lint project rules, the HEVC
+ * preview check, studio-server's media codec scan). Import via the
+ * `@hyperframes/parsers/asset-resolution` subpath.
  */
 
 export function isRemoteOrInlineUrl(url: string): boolean {

--- a/packages/parsers/tsup.config.ts
+++ b/packages/parsers/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     compositionContract: "src/compositionContract.ts",
     subCompositionValidity: "src/subCompositionValidity.ts",
     ffBinaries: "src/ffBinaries.ts",
+    assetResolution: "src/assetResolution.ts",
   },
   format: ["esm"],
   outDir: "dist",


### PR DESCRIPTION
## What

Moves shared local asset resolution from `@hyperframes/lint` into an `@hyperframes/parsers/asset-resolution` subpath, then rewires lint to use it. It also updates the HEVC preview lint guidance and its assertion to describe automatic proxying.

## Why

Slice 1 of 11 in the transparent-proxy stack (parent: the #2453 base). The shared resolver gives later codec scanning one canonical way to map composition URLs to project files without depending on lint.

The overall stack makes any video codec the project's FFmpeg can decode play on every live surface (preview, Studio, play, and published pages) by transparently serving a cached H.264 proxy when the viewing browser cannot decode the original. Render always uses originals.

## How

The existing resolver is moved with its URL cleaning, candidate resolution, and masked-source helpers intact. Parsers exposes and builds the new subpath, while the lint project and HEVC rule import it from that shared owner. The lint message now explains the cached proxy behavior and the `--no-proxy` and `media.autoProxy` opt-outs.

## Test plan

Applicable coverage: the lint project suite exercises asset discovery and the updated `hevc_preview_codec` message. The parsers build and lint package suite cover the moved subpath and its consumers.

CI does not run on stacked PRs (`.github/workflows/ci.yml` filters `branches: [main]`), so Build/Typecheck/Test/Fallow did not gate this PR. Gates were run locally: build, `typecheck --filter '*'`, full non-producer test suite, lint, `format:check`, and fallow with a cleared cache. A thin check rollup here is expected and is not evidence of passing.

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)
