### PR TITLE
feat(cli): let projects opt out of automatic proxying

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -145,29 +145,6 @@
       "file": "packages/studio/src/utils/studioHelpers.ts",
       "exports": ["resolveDroppedAssetDimensions"],
     },
-    // TEMP (transparent-proxy stack): proxyTranscoder is carved in below its
-    // consumers, which land upstack (mediaProxyPreview + the preview route,
-    // then the CLI surfaces). With no importer yet, a per-PR audit against the
-    // merge base sees the module's whole export surface as unused. Same shape
-    // as the drawElementService entry below. Safe to drop once the preview
-    // weld lands; the stack's final slice greps for zero TEMP entries.
-    {
-      "file": "packages/studio-server/src/helpers/proxyTranscoder.ts",
-      "exports": [
-        "PROXY_PARAMS_VERSION",
-        "TRANSCODE_TIMEOUT_MS",
-        "DEFAULT_PROXY_WAIT_TIMEOUT_MS",
-        "ProxyTranscodeError",
-        "FfmpegMissingFilterError",
-        "ProxyCapacityError",
-        "ProxySourceOutsideProjectError",
-        "ProxyWaitTimeoutError",
-        "waitForProxy",
-        "getProxyCachePath",
-        "clearFailedTranscodesForTest",
-        "resolveProxy",
-      ],
-    },
     // drawElementService is the bottom of the fast-capture Graphite stack
     // (#1917): its consumers (frameCapture in #1919) land two PRs upstack, so
     // a per-PR audit diffing against the merge base sees these exports as

--- a/docs/schema/hyperframes.json
+++ b/docs/schema/hyperframes.json
@@ -40,6 +40,17 @@
           "description": "Where asset files (images, fonts, videos) land. Defaults to `assets`."
         }
       }
+    },
+    "media": {
+      "type": "object",
+      "description": "Media handling options.",
+      "additionalProperties": false,
+      "properties": {
+        "autoProxy": {
+          "type": "boolean",
+          "description": "Automatically create H.264 proxies for browser-hostile video codecs on supported preview surfaces. Defaults to true."
+        }
+      }
     }
   }
 }

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -21,6 +21,10 @@ export const examples: Example[] = [
   ],
   ["List all active preview servers", "hyperframes preview --list"],
   ["Kill all active preview servers", "hyperframes preview --kill-all"],
+  [
+    "Disable auto-proxying of browser-hostile video codecs (HEVC, ProRes, AV1)",
+    "hyperframes preview --no-proxy",
+  ],
 ];
 import {
   existsSync,
@@ -56,6 +60,8 @@ import {
 } from "../server/portUtils.js";
 import { killOrphanedProcesses, killProcessTree } from "../utils/orphanCleanup.js";
 import { resolveProject } from "../utils/project.js";
+import { resolveAutoProxy } from "../utils/projectConfig.js";
+import { studioProxyEnv } from "../utils/studioProxyEnv.js";
 import {
   readBackgroundPreviewStatus,
   startBackgroundPreview,
@@ -72,10 +78,12 @@ interface BrowserLaunchOptions {
 
 interface StudioLaunchOptions extends BrowserLaunchOptions {
   projectName?: string;
+  autoProxy?: boolean;
 }
 
 interface EmbeddedStudioOptions extends StudioLaunchOptions {
   forceNew?: boolean;
+  autoProxy?: boolean;
 }
 
 type StudioChildProcess = ChildProcessByStdio<null, Readable, Readable>;
@@ -180,6 +188,12 @@ export default defineCommand({
       default: false,
       description:
         "Launch the opened browser with --disable-gpu (requires --browser-path). For hosts where hardware acceleration crashes the graphics driver (e.g. NVIDIA Xid resets); with the system default browser use --no-open instead.",
+    },
+    proxy: {
+      type: "boolean",
+      description:
+        "Auto-transcode browser-hostile video codecs (HEVC, ProRes, AV1) to a cached H.264 proxy for preview (default: on; overrides hyperframes.json's media.autoProxy)",
+      negativeDescription: "Disable auto-proxying of browser-hostile video codecs",
     },
   },
   async run({ args }) {
@@ -321,6 +335,9 @@ export default defineCommand({
       process.exitCode = 1;
       return;
     }
+    // Resolve once so embedded, monorepo-dev, and locally installed Studio
+    // modes all receive identical --proxy/--no-proxy + config semantics.
+    const autoProxy = resolveAutoProxy(dir, args.proxy as boolean | undefined);
 
     if (isDevMode()) {
       if (args.background) {
@@ -335,6 +352,7 @@ export default defineCommand({
         userDataDir,
         remoteDebuggingPort,
         browserNoGpu,
+        autoProxy,
       });
     }
 
@@ -352,6 +370,7 @@ export default defineCommand({
         userDataDir,
         remoteDebuggingPort,
         browserNoGpu,
+        autoProxy,
       });
     }
 
@@ -391,6 +410,7 @@ export default defineCommand({
     return runEmbeddedMode(dir, startPort, {
       projectName,
       forceNew,
+      autoProxy,
       noOpen,
       browserPath,
       userDataDir,
@@ -924,6 +944,7 @@ async function runDevMode(dir: string, options?: StudioLaunchOptions): Promise<v
   const child = spawn("bun", ["run", "dev"], {
     cwd: studioPkgDir,
     stdio: ["ignore", "pipe", "pipe"],
+    env: studioProxyEnv(options?.autoProxy ?? true),
   });
 
   attachStudioReadyHandler(child, s, pName, dir, options);
@@ -973,6 +994,7 @@ async function runLocalStudioMode(dir: string, options?: StudioLaunchOptions): P
   const child = spawn(viteCommand.command, viteCommand.args, {
     cwd: studioPkgPath,
     stdio: ["ignore", "pipe", "pipe"],
+    env: studioProxyEnv(options?.autoProxy ?? true),
   });
 
   attachStudioReadyHandler(child, s, pName, dir, options);
@@ -1019,7 +1041,11 @@ async function runEmbeddedMode(
     return;
   }
 
-  const { app } = createStudioServer({ projectDir: dir, projectName: pName });
+  const { app } = createStudioServer({
+    projectDir: dir,
+    projectName: pName,
+    autoProxy: options?.autoProxy,
+  });
   const serverBuildSignature = await loadPreviewServerBuildSignature();
 
   let result: FindPortResult;

--- a/packages/cli/src/server/studioServer.test.ts
+++ b/packages/cli/src/server/studioServer.test.ts
@@ -1,9 +1,59 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { loadHyperframeRuntimeSource } from "@hyperframes/core";
 import { loadRuntimeSource } from "./runtimeSource.js";
+import { createStudioServer, type StudioServer } from "./studioServer.js";
 
 describe("loadRuntimeSource", () => {
   it("loads runtime source from the published core entrypoint", async () => {
     await expect(loadRuntimeSource()).resolves.toBe(loadHyperframeRuntimeSource());
+  });
+});
+
+describe("createStudioServer autoProxy plumbing", () => {
+  const dirs: string[] = [];
+  let server: StudioServer | undefined;
+
+  function tmpProject(): string {
+    const dir = mkdtempSync(join(tmpdir(), "hf-studio-server-test-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    server?.watcher.close();
+    server = undefined;
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("hyperframes.json media.autoProxy=false flows through to the adapter", () => {
+    const projectDir = tmpProject();
+    writeFileSync(
+      join(projectDir, "hyperframes.json"),
+      JSON.stringify({ media: { autoProxy: false } }),
+    );
+
+    server = createStudioServer({ projectDir });
+
+    expect(server.adapter.autoProxy).toBe(false);
+  });
+
+  it("defaults the adapter to autoProxy=true when neither option nor config disables it", () => {
+    server = createStudioServer({ projectDir: tmpProject() });
+    expect(server.adapter.autoProxy).toBe(true);
+  });
+
+  it("an explicit option (the preview command's resolved --proxy flag) wins over config", () => {
+    const projectDir = tmpProject();
+    writeFileSync(
+      join(projectDir, "hyperframes.json"),
+      JSON.stringify({ media: { autoProxy: false } }),
+    );
+
+    server = createStudioServer({ projectDir, autoProxy: true });
+
+    expect(server.adapter.autoProxy).toBe(true);
   });
 });

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -26,11 +26,12 @@ import {
   createBackgroundRemovalJob,
   consumeFileWriteReceipt,
   getMimeType,
-  type StudioApiAdapter,
+  type PreviewApiAdapter,
   type ResolvedProject,
   type RenderJobState,
   type BackgroundRemovalRender,
 } from "@hyperframes/studio-server";
+import { resolveAutoProxy } from "../utils/projectConfig.js";
 import { getElementScreenshotClip } from "@hyperframes/studio-server/screenshot-clip";
 import type { ScreenshotClip } from "@hyperframes/studio-server/screenshot-clip";
 import type { RenderJob } from "@hyperframes/producer";
@@ -229,11 +230,21 @@ export interface StudioServerOptions {
   projectDir: string;
   /** Display name for the project. Defaults to basename of projectDir. */
   projectName?: string;
+  /**
+   * Auto-transcode browser-hostile video codecs to a cached H.264 preview
+   * proxy. The preview command passes its resolved `--proxy`/`--no-proxy` +
+   * `hyperframes.json` value; when omitted, the project's `media.autoProxy`
+   * config (default true) applies.
+   */
+  autoProxy?: boolean | undefined;
 }
 
 export interface StudioServer {
   app: Hono;
   watcher: ProjectWatcher;
+  /** Exposed for tests: the adapter handed to the shared studio API (carries
+   * the resolved `autoProxy` flag the preview routes read). */
+  adapter: PreviewApiAdapter;
 }
 
 export async function loadPreviewServerBuildSignature(): Promise<string> {
@@ -303,7 +314,13 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     cachedProjectSignature = null;
   });
 
-  const adapter: StudioApiAdapter = {
+  const adapter: PreviewApiAdapter = {
+    // Explicit option wins (preview's resolved --proxy/--no-proxy + config);
+    // otherwise honor the project's hyperframes.json media.autoProxy so every
+    // createStudioServer caller (e.g. the background preview child) gets the
+    // configured behavior without its own plumbing.
+    autoProxy: options.autoProxy ?? resolveAutoProxy(projectDir, undefined),
+
     listProjects: () => [project],
 
     resolveProject: (id: string) => (id === projectId ? project : null),
@@ -785,5 +802,5 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     return c.html(html);
   });
 
-  return { app, watcher };
+  return { app, watcher, adapter };
 }

--- a/packages/cli/src/utils/projectConfig.test.ts
+++ b/packages/cli/src/utils/projectConfig.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeConfig,
   projectConfigPath,
   readProjectConfig,
+  resolveAutoProxy,
   writeProjectConfig,
   PROJECT_CONFIG_FILENAME,
 } from "./projectConfig.js";
@@ -36,6 +37,7 @@ describe("projectConfig", () => {
           $schema: DEFAULT_PROJECT_CONFIG.$schema,
           registry: "https://example.com/my-registry",
           paths: { blocks: "src/blocks", components: "src/fx", assets: "media" },
+          media: { autoProxy: true },
         };
         writeProjectConfig(dir, custom);
         const read = readProjectConfig(dir);
@@ -59,6 +61,28 @@ describe("projectConfig", () => {
       expect(result.paths.blocks).toBe("x");
       expect(result.paths.components).toBe(DEFAULT_PROJECT_CONFIG.paths.components);
       expect(result.paths.assets).toBe(DEFAULT_PROJECT_CONFIG.paths.assets);
+    });
+
+    it("defaults media.autoProxy to true when media is absent", () => {
+      const result = normalizeConfig({ registry: "https://alt.example.com" });
+      expect(result.media).toEqual({ autoProxy: true });
+    });
+
+    it("preserves an explicit media.autoProxy: false", () => {
+      const result = normalizeConfig({ media: { autoProxy: false } });
+      expect(result.media).toEqual({ autoProxy: false });
+    });
+
+    it("falls back to the default when media.autoProxy is malformed", () => {
+      const result = normalizeConfig({
+        media: { autoProxy: "nope" } as unknown as never,
+      });
+      expect(result.media).toEqual({ autoProxy: true });
+    });
+
+    it("falls back to the default when media itself is malformed", () => {
+      const result = normalizeConfig({ media: "nope" as unknown as never });
+      expect(result.media).toEqual({ autoProxy: true });
     });
   });
 
@@ -118,6 +142,87 @@ describe("projectConfig", () => {
         const path = join(dir, PROJECT_CONFIG_FILENAME);
         const parsed = JSON.parse(readFileSync(path, "utf-8"));
         expect(parsed.registry).toBe(DEFAULT_PROJECT_CONFIG.registry);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("resolveAutoProxy", () => {
+    it("defaults to true when no config file exists and no flag is passed", () => {
+      const dir = tmp();
+      try {
+        expect(resolveAutoProxy(dir, undefined)).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("returns false when the config sets media.autoProxy: false", () => {
+      const dir = tmp();
+      try {
+        writeFileSync(
+          projectConfigPath(dir),
+          JSON.stringify({ media: { autoProxy: false } }),
+          "utf-8",
+        );
+        expect(resolveAutoProxy(dir, undefined)).toBe(false);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("defaults to true when the config file is partial and omits media", () => {
+      const dir = tmp();
+      try {
+        writeFileSync(
+          projectConfigPath(dir),
+          JSON.stringify({ registry: "https://only-this.example.com" }),
+          "utf-8",
+        );
+        expect(resolveAutoProxy(dir, undefined)).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("an explicit false flag wins over a config that enables it", () => {
+      const dir = tmp();
+      try {
+        writeFileSync(
+          projectConfigPath(dir),
+          JSON.stringify({ media: { autoProxy: true } }),
+          "utf-8",
+        );
+        expect(resolveAutoProxy(dir, false)).toBe(false);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("an explicit true flag wins over a config that disables it", () => {
+      const dir = tmp();
+      try {
+        writeFileSync(
+          projectConfigPath(dir),
+          JSON.stringify({ media: { autoProxy: false } }),
+          "utf-8",
+        );
+        expect(resolveAutoProxy(dir, true)).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to the default when the on-disk media value is malformed", () => {
+      const dir = tmp();
+      try {
+        writeFileSync(
+          projectConfigPath(dir),
+          JSON.stringify({ media: { autoProxy: "nope" } }),
+          "utf-8",
+        );
+        expect(resolveAutoProxy(dir, undefined)).toBe(true);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/cli/src/utils/projectConfig.ts
+++ b/packages/cli/src/utils/projectConfig.ts
@@ -26,7 +26,7 @@ export interface ProjectConfigPaths {
 export interface ProjectConfigMedia {
   /**
    * Auto-transcode browser-hostile video codecs (e.g. HEVC) to a cached
-   * H.264 proxy for preview/play/publish surfaces. Render always uses the
+   * H.264 proxy for supported preview surfaces. Render always uses the
    * original file regardless of this setting. Default true.
    */
   autoProxy?: boolean;
@@ -115,14 +115,11 @@ export function loadProjectConfig(projectDir: string): ProjectConfig {
 
 /**
  * Resolve whether auto-proxying of browser-hostile video codecs (HEVC, etc.)
- * is enabled for a project's live-preview surfaces. `preview`, `play`, and
- * `publish` each pass their own `--proxy`/`--no-proxy` flag value as
- * `flagValue` (wired by their own units); an explicit flag always wins over
- * the project config, in either direction (`--no-proxy` disables even when
- * config has it on; `--proxy` enables even when config has it off). Falls
- * back to the committed `hyperframes.json` `media.autoProxy` setting, and
- * finally to `true` when neither is set. Render is never affected by this
- * setting: it always uses the original file.
+ * is enabled for a project's live-preview surfaces. A caller's explicit
+ * `--proxy`/`--no-proxy` flag always wins over the project config, in either
+ * direction. Falls back to the committed `hyperframes.json`
+ * `media.autoProxy` setting, and finally to `true` when neither is set.
+ * Render is never affected by this setting: it always uses the original file.
  */
 export function resolveAutoProxy(projectDir: string, flagValue: boolean | undefined): boolean {
   if (typeof flagValue === "boolean") {

--- a/packages/cli/src/utils/projectConfig.ts
+++ b/packages/cli/src/utils/projectConfig.ts
@@ -23,12 +23,23 @@ export interface ProjectConfigPaths {
   assets: string;
 }
 
+export interface ProjectConfigMedia {
+  /**
+   * Auto-transcode browser-hostile video codecs (e.g. HEVC) to a cached
+   * H.264 proxy for preview/play/publish surfaces. Render always uses the
+   * original file regardless of this setting. Default true.
+   */
+  autoProxy?: boolean;
+}
+
 export interface ProjectConfig {
   $schema?: string;
   /** Base URL of the registry to pull items from. */
   registry: string;
   /** Target paths for each item type. */
   paths: ProjectConfigPaths;
+  /** Media handling options (e.g. auto-proxying of browser-hostile codecs). */
+  media?: ProjectConfigMedia;
 }
 
 export const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
@@ -38,6 +49,9 @@ export const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
     blocks: "compositions",
     components: "compositions/components",
     assets: "assets",
+  },
+  media: {
+    autoProxy: true,
   },
 };
 
@@ -72,6 +86,12 @@ export function normalizeConfig(partial: Partial<ProjectConfig>): ProjectConfig 
       components: partial.paths?.components ?? DEFAULT_PROJECT_CONFIG.paths.components,
       assets: partial.paths?.assets ?? DEFAULT_PROJECT_CONFIG.paths.assets,
     },
+    media: {
+      autoProxy:
+        typeof partial.media?.autoProxy === "boolean"
+          ? partial.media.autoProxy
+          : DEFAULT_PROJECT_CONFIG.media?.autoProxy,
+    },
   };
 }
 
@@ -91,4 +111,22 @@ export function writeProjectConfig(
  */
 export function loadProjectConfig(projectDir: string): ProjectConfig {
   return readProjectConfig(projectDir) ?? DEFAULT_PROJECT_CONFIG;
+}
+
+/**
+ * Resolve whether auto-proxying of browser-hostile video codecs (HEVC, etc.)
+ * is enabled for a project's live-preview surfaces. `preview`, `play`, and
+ * `publish` each pass their own `--proxy`/`--no-proxy` flag value as
+ * `flagValue` (wired by their own units); an explicit flag always wins over
+ * the project config, in either direction (`--no-proxy` disables even when
+ * config has it on; `--proxy` enables even when config has it off). Falls
+ * back to the committed `hyperframes.json` `media.autoProxy` setting, and
+ * finally to `true` when neither is set. Render is never affected by this
+ * setting: it always uses the original file.
+ */
+export function resolveAutoProxy(projectDir: string, flagValue: boolean | undefined): boolean {
+  if (typeof flagValue === "boolean") {
+    return flagValue;
+  }
+  return loadProjectConfig(projectDir).media?.autoProxy ?? true;
 }

--- a/packages/cli/src/utils/studioProxyEnv.test.ts
+++ b/packages/cli/src/utils/studioProxyEnv.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { studioProxyEnv } from "./studioProxyEnv.js";
+
+describe("studioProxyEnv", () => {
+  it("forwards an explicit --proxy decision to a Studio child process", () => {
+    expect(studioProxyEnv(true, { KEEP: "yes" })).toEqual({
+      KEEP: "yes",
+      HYPERFRAMES_AUTO_PROXY: "true",
+    });
+    expect(studioProxyEnv(false, { KEEP: "yes" })).toEqual({
+      KEEP: "yes",
+      HYPERFRAMES_AUTO_PROXY: "false",
+    });
+  });
+});

--- a/packages/cli/src/utils/studioProxyEnv.ts
+++ b/packages/cli/src/utils/studioProxyEnv.ts
@@ -1,0 +1,9 @@
+export function studioProxyEnv(
+  autoProxy: boolean,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    HYPERFRAMES_AUTO_PROXY: autoProxy ? "true" : "false",
+  };
+}

--- a/packages/parsers/src/assetResolution.test.ts
+++ b/packages/parsers/src/assetResolution.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { maskNonScannableRanges } from "./assetResolution.js";
+
+describe("maskNonScannableRanges", () => {
+  it("masks complete comments without changing offsets", () => {
+    const html = '<video src="before.mp4"><!-- <video src="hidden.mp4"> --><video src="after.mp4">';
+    const masked = maskNonScannableRanges(html);
+
+    expect(masked).toHaveLength(html.length);
+    expect(masked).toContain('<video src="before.mp4">');
+    expect(masked).not.toContain("hidden.mp4");
+    expect(masked).toContain('<video src="after.mp4">');
+  });
+
+  it("handles many comment openers in linear scans", () => {
+    const html = `prefix${"<!--".repeat(10_000)}-->suffix`;
+    const masked = maskNonScannableRanges(html);
+
+    expect(masked).toHaveLength(html.length);
+    expect(masked).toBe(`prefix${" ".repeat(html.length - 12)}suffix`);
+  });
+});

--- a/packages/parsers/src/assetResolution.ts
+++ b/packages/parsers/src/assetResolution.ts
@@ -64,10 +64,27 @@ function maskRange(src: string, pattern: RegExp): string {
   return src.replace(pattern, (m) => " ".repeat(m.length));
 }
 
+function maskHtmlComments(src: string): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+
+  while (true) {
+    const start = src.indexOf("<!--", cursor);
+    if (start === -1) break;
+    const end = src.indexOf("-->", start + 4);
+    if (end === -1) break;
+    const afterComment = end + 3;
+    chunks.push(src.slice(cursor, start), " ".repeat(afterComment - start));
+    cursor = afterComment;
+  }
+
+  return chunks.length === 0 ? src : chunks.join("") + src.slice(cursor);
+}
+
 /** Blanks out comments, `<style>`, and `<script>` bodies so tag-scanning
  * regexes don't false-positive on commented-out or scripted markup. */
 export function maskNonScannableRanges(html: string): string {
-  let out = maskRange(html, /<!--[\s\S]*?-->/g);
+  let out = maskHtmlComments(html);
   out = maskRange(out, /<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi);
   out = maskRange(out, /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi);
   return out;

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -107,6 +107,18 @@
       "./source-mutation": {
         "import": "./dist/helpers/sourceMutation.js",
         "types": "./dist/helpers/sourceMutation.d.ts"
+      },
+      "./media-codec-map": {
+        "import": "./dist/helpers/mediaCodecMap.js",
+        "types": "./dist/helpers/mediaCodecMap.d.ts"
+      },
+      "./proxy-transcoder": {
+        "import": "./dist/helpers/proxyTranscoder.js",
+        "types": "./dist/helpers/proxyTranscoder.d.ts"
+      },
+      "./media-proxy-preview": {
+        "import": "./dist/helpers/mediaProxyPreview.js",
+        "types": "./dist/helpers/mediaProxyPreview.d.ts"
       }
     },
     "main": "./dist/index.js",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -56,6 +56,24 @@
       "node": "./dist/helpers/sourceMutation.js",
       "import": "./src/helpers/sourceMutation.ts",
       "types": "./src/helpers/sourceMutation.ts"
+    },
+    "./media-codec-map": {
+      "bun": "./src/helpers/mediaCodecMap.ts",
+      "node": "./dist/helpers/mediaCodecMap.js",
+      "import": "./src/helpers/mediaCodecMap.ts",
+      "types": "./src/helpers/mediaCodecMap.ts"
+    },
+    "./proxy-transcoder": {
+      "bun": "./src/helpers/proxyTranscoder.ts",
+      "node": "./dist/helpers/proxyTranscoder.js",
+      "import": "./src/helpers/proxyTranscoder.ts",
+      "types": "./src/helpers/proxyTranscoder.ts"
+    },
+    "./media-proxy-preview": {
+      "bun": "./src/helpers/mediaProxyPreview.ts",
+      "node": "./dist/helpers/mediaProxyPreview.js",
+      "import": "./src/helpers/mediaProxyPreview.ts",
+      "types": "./src/helpers/mediaProxyPreview.ts"
     }
   },
   "publishConfig": {

--- a/packages/studio-server/src/helpers/mediaProxyPreview.ts
+++ b/packages/studio-server/src/helpers/mediaProxyPreview.ts
@@ -1,0 +1,134 @@
+import { resolve } from "node:path";
+import type { StudioApiAdapter } from "../types.js";
+import {
+  createMediaCodecProbeCache,
+  scanProjectMediaCodecMap,
+  type HtmlSourceLike,
+  type MediaCodecMap,
+  type MediaCodecProbeCache,
+} from "./mediaCodecMap.js";
+import { resolveProxy, PROXY_PARAMS_VERSION } from "./proxyTranscoder.js";
+
+/**
+ * Transparent-media-proxy wiring shared by `routes/preview.ts`
+ * (docs/plans/2026-07-14-002-feat-transparent-media-proxies-plan.md, unit U3).
+ * Split out of the route module to keep it under the repo's 600-line file cap.
+ */
+
+/**
+ * Preview-route-local adapter surface for the auto-proxy feature. Both
+ * fields are optional so any existing `StudioApiAdapter` value remains
+ * structurally assignable without editing the shared interface:
+ * `autoProxy` defaults to true (on) when omitted — a later unit wires the
+ * CLI `--no-proxy` flag / `hyperframes.json` setting through it;
+ * `mediaCodecProbeCache` lets a host share one probe cache across
+ * preview/play/static-server surfaces instead of each constructing its own.
+ */
+export type PreviewApiAdapter = StudioApiAdapter & {
+  autoProxy?: boolean;
+  mediaCodecProbeCache?: MediaCodecProbeCache;
+};
+
+export function isAutoProxyEnabled(adapter: PreviewApiAdapter): boolean {
+  return adapter.autoProxy !== false;
+}
+
+/** One probe cache per server instance — construct once in `registerPreviewRoutes`
+ * and reuse across every request so the mtime-cache benefit in
+ * `scanProjectMediaCodecMap` actually applies. A host that wants to share the
+ * cache across other surfaces (play, static project server) can pass its own
+ * via `adapter.mediaCodecProbeCache`. */
+export function resolvePreviewMediaCodecProbeCache(
+  adapter: PreviewApiAdapter,
+): MediaCodecProbeCache {
+  return adapter.mediaCodecProbeCache ?? createMediaCodecProbeCache();
+}
+
+/**
+ * ETag salt for `?hf-proxy=` asset requests, mirroring `variablesEtagSalt` in
+ * preview.ts: salted by the raw param value plus the transcoder's params
+ * version, so a future proxy-recipe change (which bumps `PROXY_PARAMS_VERSION`)
+ * or a different proxy variant invalidates cached 304s without needing to
+ * touch the proxy file itself.
+ */
+export function proxyEtagSalt(raw: string | undefined): string {
+  if (raw === undefined) return "";
+  return `:proxy:${raw}:${PROXY_PARAMS_VERSION}`;
+}
+
+// Mirrors `injectScriptTagIntoHead` in routes/preview.ts (kept local rather
+// than imported to avoid a helpers → routes dependency edge for one
+// two-line utility).
+function injectScriptTagIntoHead(html: string, scriptTag: string): string {
+  if (html.includes("</head>")) return html.replace("</head>", `${scriptTag}\n</head>`);
+  return `${scriptTag}\n${html}`;
+}
+
+/**
+ * Injects `window.__HF_MEDIA_CODEC_MAP__` (the U1 codec-facts scan) into
+ * served composition HTML, and fire-and-forget pre-warms `resolveProxy` for
+ * every browser-hostile entry so an element's proactive swap usually hits a
+ * warm cache (KTD: protects the per-origin connection budget under held
+ * responses). No second concurrency limiter here — the transcoder's own
+ * global bound throttles both pre-warm and element-triggered calls.
+ * Pre-warm failures are swallowed; an actual `?hf-proxy=` request surfaces
+ * them as a 502. Alpha-bearing entries are never pre-warmed: the runtime
+ * never proxies them (transparency would be destroyed).
+ *
+ * The single shared implementation for every auto-proxy surface — the studio
+ * preview route (via `injectMediaCodecMap` below) and the CLI's composition /
+ * static project servers (via the `./media-proxy-preview` subpath export).
+ * Empty maps leave HTML untouched, preserving the normal no-hostile-media
+ * preview path. On-demand proxy requests enforce the same eligibility gate.
+ */
+export async function injectMediaCodecMapIntoHtml(
+  html: string,
+  projectDir: string,
+  htmlSources: HtmlSourceLike[],
+  probeCache?: MediaCodecProbeCache,
+): Promise<string> {
+  let map: MediaCodecMap;
+  try {
+    map = await scanProjectMediaCodecMap(
+      projectDir,
+      htmlSources,
+      probeCache ? { cache: probeCache } : {},
+    );
+  } catch {
+    // Best-effort: a scan failure must never block serving the page.
+    return html;
+  }
+  if (Object.keys(map).length === 0) return html;
+  for (const [rootRelativePathname, facts] of Object.entries(map)) {
+    if (!facts.browserHostile || facts.hasAlpha) continue;
+    resolveProxy(projectDir, resolve(projectDir, rootRelativePathname.replace(/^\/+/, ""))).catch(
+      () => {
+        // Swallowed: the pre-warm is best-effort. A real `?hf-proxy=` request
+        // for this asset re-attempts the transcode and reports failure (502).
+      },
+    );
+  }
+  // <-escape prevents a src path containing "</script>" from breaking out of
+  // the injected tag, mirroring injectPreviewVariables in routes/preview.ts.
+  const json = JSON.stringify(map)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+  const tag = `<script data-hf-media-codec-map>window.__HF_MEDIA_CODEC_MAP__=${json};</script>`;
+  return injectScriptTagIntoHead(html, tag);
+}
+
+/**
+ * Adapter-aware wrapper used by the studio preview routes: skipped entirely
+ * (no scan, no injection) when auto-proxy is off for this adapter.
+ */
+export async function injectMediaCodecMap(
+  html: string,
+  adapter: PreviewApiAdapter,
+  projectDir: string,
+  compSrcPath: string,
+  probeCache: MediaCodecProbeCache,
+): Promise<string> {
+  if (!isAutoProxyEnabled(adapter)) return html;
+  return injectMediaCodecMapIntoHtml(html, projectDir, [{ html, compSrcPath }], probeCache);
+}

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -11,6 +11,7 @@ export type {
   StudioSelectionTextField,
 } from "./types.js";
 export { isSafePath, walkDir } from "./helpers/safePath.js";
+export type { PreviewApiAdapter } from "./helpers/mediaProxyPreview.js";
 export { getMimeType, MIME_TYPES } from "./helpers/mime.js";
 export {
   consumeFileWriteReceipt,

--- a/packages/studio-server/src/routes/files.ts
+++ b/packages/studio-server/src/routes/files.ts
@@ -440,7 +440,12 @@ function walkFiles(dir: string, filter: (name: string) => boolean): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === "node_modules" || entry.name === ".thumbnails" || entry.name === "renders")
+      if (
+        entry.name === "node_modules" ||
+        entry.name === ".thumbnails" ||
+        entry.name === "renders" ||
+        entry.name === ".transcode-cache"
+      )
         continue;
       results.push(...walkFiles(full, filter));
     } else if (filter(entry.name)) {

--- a/packages/studio-server/src/routes/preview.test.ts
+++ b/packages/studio-server/src/routes/preview.test.ts
@@ -24,8 +24,8 @@ function createProjectDir(): string {
 
 function createAdapter(
   projectDir: string,
-  overrides: Partial<StudioApiAdapter> = {},
-): StudioApiAdapter {
+  overrides: Partial<StudioApiAdapter> & { autoProxy?: boolean } = {},
+): StudioApiAdapter & { autoProxy?: boolean } {
   return {
     listProjects: () => [],
     resolveProject: async (id: string) => ({ id, dir: projectDir }),
@@ -635,5 +635,441 @@ describe("sub-composition preview attribute integrity", () => {
     // attribute here silently breaks getVariables() on the comp route.
     const decoded = attr.replace(/&quot;/g, '"').replace(/&amp;/g, "&");
     expect(JSON.parse(decoded)).toEqual(JSON.parse(decls));
+  });
+});
+
+// ── U3: ?hf-proxy=h264 negotiation + __HF_MEDIA_CODEC_MAP__ injection ───────
+// (docs/plans/2026-07-14-002-feat-transparent-media-proxies-plan.md)
+//
+// Both helpers preview.ts depends on (proxyTranscoder's resolveProxy,
+// mediaCodecMap's scanProjectMediaCodecMap) are mocked here rather than
+// exercised for real: their own behavior (ffmpeg spawning/caching, ffprobe
+// codec detection) is already covered by proxyTranscoder.test.ts and
+// mediaCodecMap.test.ts. This suite only tests preview.ts's own wiring —
+// the route branches, ETag salting, 404/502 mapping, and injection point.
+describe("hf-proxy negotiation and media codec map injection (U3)", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../helpers/proxyTranscoder.js");
+    vi.doUnmock("../helpers/mediaCodecMap.js");
+  });
+
+  class FakeProxyTranscodeError extends Error {
+    readonly exitCode: number | null;
+    readonly stderrTail: string;
+    constructor(message: string, exitCode: number | null, stderrTail: string) {
+      super(message);
+      this.name = "ProxyTranscodeError";
+      this.exitCode = exitCode;
+      this.stderrTail = stderrTail;
+    }
+  }
+
+  class FakeProxyCapacityError extends FakeProxyTranscodeError {}
+
+  type ScanMapImpl = (
+    projectDir: string,
+    htmlSources: Array<{ html: string; compSrcPath?: string }>,
+    options?: unknown,
+  ) => Promise<
+    Record<
+      string,
+      {
+        codecName: string;
+        browserHostile: boolean;
+        representativeMime: string | null;
+      }
+    >
+  >;
+
+  async function loadPreviewModule(opts: {
+    resolveProxyImpl?: (projectDir: string, absoluteSourcePath: string) => Promise<string>;
+    scanMapImpl?: ScanMapImpl;
+    probeAssetCodecImpl?: () => Promise<{
+      codecName: string;
+      browserHostile: boolean;
+      representativeMime: string | null;
+      hasAlpha: boolean;
+    } | null>;
+  }): Promise<typeof import("./preview.js")> {
+    vi.resetModules();
+    const resolveProxy =
+      opts.resolveProxyImpl ??
+      (async () => {
+        throw new FakeProxyTranscodeError(
+          "no resolveProxy impl configured for this test",
+          null,
+          "",
+        );
+      });
+    vi.doMock("../helpers/proxyTranscoder.js", () => ({
+      resolveProxy,
+      ProxyTranscodeError: FakeProxyTranscodeError,
+      ProxyCapacityError: FakeProxyCapacityError,
+      PROXY_PARAMS_VERSION: "v1",
+      getProxyCachePath: () => "",
+    }));
+    vi.doMock("../helpers/mediaCodecMap.js", () => ({
+      scanProjectMediaCodecMap: opts.scanMapImpl ?? (async () => ({})),
+      createMediaCodecProbeCache: () => new Map(),
+      probeAssetCodec:
+        opts.probeAssetCodecImpl ??
+        (async () => ({
+          codecName: "hevc",
+          browserHostile: true,
+          representativeMime: null,
+          hasAlpha: false,
+        })),
+      decideMediaProxyEligibility: (
+        facts: {
+          browserHostile: boolean;
+          hasAlpha: boolean;
+        } | null,
+      ) => {
+        if (!facts) return { eligible: false, reason: "unknown_codec" };
+        if (facts.hasAlpha) return { eligible: false, reason: "alpha_source" };
+        if (!facts.browserHostile) {
+          return { eligible: false, reason: "browser_safe_codec" };
+        }
+        return { eligible: true };
+      },
+    }));
+    return import("./preview.js");
+  }
+
+  describe("?hf-proxy=h264 on the static asset route", () => {
+    it("serves proxy bytes with Accept-Ranges on a full request, and a 206 range slice on a Range request", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "original-hevc-bytes");
+      const resolveProxyMock = vi.fn(async () => {
+        const proxyPath = join(projectDir, "proxy.mp4");
+        writeFileSync(proxyPath, "0123456789proxybytes");
+        return proxyPath;
+      });
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const full = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+      );
+      expect(full.status).toBe(200);
+      expect(full.headers.get("Accept-Ranges")).toBe("bytes");
+      expect(full.headers.get("Content-Type")).toBe("video/mp4");
+      expect(await full.text()).toBe("0123456789proxybytes");
+      expect(resolveProxyMock).toHaveBeenCalledTimes(1);
+      expect(resolveProxyMock).toHaveBeenCalledWith(projectDir, join(projectDir, "clip.mp4"));
+
+      const ranged = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+        {
+          headers: { Range: "bytes=0-9" },
+        },
+      );
+      expect(ranged.status).toBe(206);
+      expect(await ranged.text()).toBe("0123456789");
+      expect(ranged.headers.get("Content-Range")).toBe("bytes 0-9/20");
+    });
+
+    it("honors If-None-Match on a repeat request with a 304, without re-invoking resolveProxy", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "original-hevc-bytes");
+      const resolveProxyMock = vi.fn(async () => {
+        const proxyPath = join(projectDir, "proxy.mp4");
+        writeFileSync(proxyPath, "proxy-bytes");
+        return proxyPath;
+      });
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const first = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+      );
+      expect(first.status).toBe(200);
+      const etag = first.headers.get("ETag");
+      expect(etag).toBeTruthy();
+      expect(resolveProxyMock).toHaveBeenCalledTimes(1);
+
+      const second = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+        { headers: { "If-None-Match": etag! } },
+      );
+      expect(second.status).toBe(304);
+      // The 304 shortcut never needs the proxy — no second transcode call.
+      expect(resolveProxyMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 404 without transcoding when the asset is missing", async () => {
+      const projectDir = createProjectDir();
+      const resolveProxyMock = vi.fn(async () => "should-not-be-called");
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const res = await app.request(
+        "http://localhost/projects/demo/preview/does-not-exist.mp4?hf-proxy=h264",
+      );
+      expect(res.status).toBe(404);
+      expect(resolveProxyMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 without transcoding when the asset is not a video", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "notes.txt"), "just text");
+      const resolveProxyMock = vi.fn(async () => "should-not-be-called");
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const res = await app.request(
+        "http://localhost/projects/demo/preview/notes.txt?hf-proxy=h264",
+      );
+      expect(res.status).toBe(404);
+      expect(resolveProxyMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects alpha-bearing and browser-safe sources before transcoding", async () => {
+      for (const facts of [
+        {
+          codecName: "prores",
+          browserHostile: true,
+          representativeMime: null,
+          hasAlpha: true,
+        },
+        {
+          codecName: "h264",
+          browserHostile: false,
+          representativeMime: null,
+          hasAlpha: false,
+        },
+      ]) {
+        const projectDir = createProjectDir();
+        writeFileSync(join(projectDir, "clip.mp4"), "video-bytes");
+        const resolveProxyMock = vi.fn(async () => "should-not-be-called");
+        const { registerPreviewRoutes: register } = await loadPreviewModule({
+          resolveProxyImpl: resolveProxyMock,
+          probeAssetCodecImpl: async () => facts,
+        });
+        const app = new Hono();
+        register(app, createAdapter(projectDir));
+
+        const res = await app.request(
+          "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+        );
+        expect(res.status).toBe(422);
+        expect(resolveProxyMock).not.toHaveBeenCalled();
+      }
+    });
+
+    it("returns 404 without transcoding when the param value is not exactly h264", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "original-hevc-bytes");
+      const resolveProxyMock = vi.fn(async () => "should-not-be-called");
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      for (const value of ["vp9", "H264", ""]) {
+        const res = await app.request(
+          `http://localhost/projects/demo/preview/clip.mp4?hf-proxy=${value}`,
+        );
+        expect(res.status).toBe(404);
+      }
+      expect(resolveProxyMock).not.toHaveBeenCalled();
+    });
+
+    it("maps a ProxyTranscodeError to a 502 carrying the error message", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "original-hevc-bytes");
+      const resolveProxyMock = vi.fn(async () => {
+        throw new FakeProxyTranscodeError("ffmpeg exited with code 1", 1, "unsupported codec");
+      });
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const res = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+      );
+      expect(res.status).toBe(502);
+      expect(await res.text()).toBe("ffmpeg exited with code 1");
+    });
+
+    it("maps a full proxy queue to a retryable 503", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "original-hevc-bytes");
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: async () => {
+          throw new FakeProxyCapacityError("media proxy queue is full", null, "");
+        },
+      });
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const res = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+      );
+      expect(res.status).toBe(503);
+      expect(res.headers.get("Retry-After")).toBe("5");
+    });
+
+    it("rejects a path-traversal attempt through the proxied path (404, no transcode)", async () => {
+      const projectDir = createProjectDir();
+      const resolveProxyMock = vi.fn(async () => "should-not-be-called");
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const res = await app.request(
+        "http://localhost/projects/demo/preview/..%2f..%2f..%2fetc%2fpasswd?hf-proxy=h264",
+      );
+      expect(res.status).toBe(404);
+      expect(resolveProxyMock).not.toHaveBeenCalled();
+    });
+
+    it("404s the param when auto-proxy is disabled for the adapter, without transcoding", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "original-hevc-bytes");
+      const resolveProxyMock = vi.fn(async () => "should-not-be-called");
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir, { autoProxy: false }));
+
+      const res = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+      );
+      expect(res.status).toBe(404);
+      expect(resolveProxyMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("__HF_MEDIA_CODEC_MAP__ injection into composition HTML", () => {
+    it("keeps HTML byte-identical when the scan finds no proxy-eligible media", async () => {
+      const projectDir = createProjectDir();
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        scanMapImpl: async () => ({}),
+      });
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const res = await app.request("http://localhost/projects/demo/preview");
+      const html = await res.text();
+      expect(html).not.toContain("data-hf-media-codec-map");
+    });
+    it("injects the scanned map naming the hostile fixture, and pre-warms resolveProxy for it", async () => {
+      const projectDir = createProjectDir();
+      const resolveProxyMock = vi.fn(async () => join(projectDir, ".transcode-cache", "x.mp4"));
+      const scanMapMock = vi.fn(async () => ({
+        "/videos/hevc.mp4": {
+          codecName: "hevc",
+          browserHostile: true,
+          representativeMime: 'video/mp4; codecs="hvc1.1.6.L120.B0"',
+        },
+      }));
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+        scanMapImpl: scanMapMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const res = await app.request("http://localhost/projects/demo/preview");
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("window.__HF_MEDIA_CODEC_MAP__");
+      expect(html).toContain("/videos/hevc.mp4");
+      expect(html).not.toContain("h264.mp4");
+      expect(scanMapMock).toHaveBeenCalled();
+
+      // Pre-warm: fire-and-forget resolveProxy for the hostile entry.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolveProxyMock).toHaveBeenCalledWith(
+        projectDir,
+        join(projectDir, "/videos/hevc.mp4"),
+      );
+    });
+
+    it("escapes script terminators and JavaScript line separators in codec-map keys", async () => {
+      const projectDir = createProjectDir();
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: async () => join(projectDir, ".transcode-cache", "x.mp4"),
+        scanMapImpl: async () => ({
+          "/videos/</script>\u2028\u2029.mp4": {
+            codecName: "hevc",
+            browserHostile: true,
+            representativeMime: null,
+          },
+        }),
+      });
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const html = await (await app.request("http://localhost/projects/demo/preview")).text();
+
+      const injected = /<script data-hf-media-codec-map>([\s\S]*?)<\/script>/.exec(html)?.[1];
+      expect(injected).toContain("\\u003c/script>");
+      expect(injected).toContain("\\u2028");
+      expect(injected).toContain("\\u2029");
+      expect(injected).not.toContain("</script>");
+    });
+
+    it("does not inject the codec map (and 404s the proxy param) when auto-proxy is disabled", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "bytes");
+      const resolveProxyMock = vi.fn(async () => "should-not-be-called");
+      const scanMapMock = vi.fn(async () => ({
+        "/clip.mp4": {
+          codecName: "hevc",
+          browserHostile: true,
+          representativeMime: null,
+        },
+      }));
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+        scanMapImpl: scanMapMock,
+      });
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir, { autoProxy: false }));
+
+      const res = await app.request("http://localhost/projects/demo/preview");
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("__HF_MEDIA_CODEC_MAP__");
+      expect(scanMapMock).not.toHaveBeenCalled();
+
+      const proxyRes = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+      );
+      expect(proxyRes.status).toBe(404);
+      expect(resolveProxyMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/studio-server/src/routes/preview.ts
+++ b/packages/studio-server/src/routes/preview.ts
@@ -18,6 +18,19 @@ import {
 import { ensureHfIds } from "@hyperframes/parsers/hf-ids";
 import { persistHfIdsIfNeeded, stampFileHfIds } from "../helpers/hfIdPersist.js";
 import { isVariablesPayload, VARIABLES_PAYLOAD_ERROR } from "../helpers/variablesPayload.js";
+import {
+  resolveProxy,
+  ProxyCapacityError,
+  ProxyTranscodeError,
+} from "../helpers/proxyTranscoder.js";
+import { decideMediaProxyEligibility, probeAssetCodec } from "../helpers/mediaCodecMap.js";
+import {
+  isAutoProxyEnabled,
+  injectMediaCodecMap,
+  proxyEtagSalt,
+  resolvePreviewMediaCodecProbeCache,
+  type PreviewApiAdapter,
+} from "../helpers/mediaProxyPreview.js";
 
 const PROJECT_SIGNATURE_META = "hyperframes-project-signature";
 const GSAP_CDN_VERSION = "3.15.0";
@@ -52,7 +65,9 @@ function parseStudioMotionManifestContent(content: string): {
   hasCustomEase: boolean;
 } {
   try {
-    const parsed = JSON.parse(content) as { motions?: Array<{ customEase?: unknown }> };
+    const parsed = JSON.parse(content) as {
+      motions?: Array<{ customEase?: unknown }>;
+    };
     const motions = Array.isArray(parsed.motions) ? parsed.motions : [];
     return {
       hasMotion: motions.length > 0,
@@ -238,11 +253,13 @@ function variablesEtagSalt(raw: string | undefined): string {
  * route should 400; otherwise `values` is the override object (or null when
  * the param is absent) and `raw` feeds the ETag salt.
  */
-function previewVariablesFromRequest(
-  rawVariables: string | undefined,
-):
+function previewVariablesFromRequest(rawVariables: string | undefined):
   | { error: string }
-  | { error?: undefined; raw: string | undefined; values: Record<string, unknown> | null } {
+  | {
+      error?: undefined;
+      raw: string | undefined;
+      values: Record<string, unknown> | null;
+    } {
   const parse = parsePreviewVariablesParam(rawVariables);
   if (!parse.ok) return { error: parse.error };
   return { raw: rawVariables, values: parse.values };
@@ -290,20 +307,31 @@ function resolveProjectMainHtml(
 ): { html: string; compositionPath: string } | null {
   const indexPath = join(projectDir, "index.html");
   if (existsSync(indexPath)) {
-    return { html: readFileSync(indexPath, "utf-8"), compositionPath: "index.html" };
+    return {
+      html: readFileSync(indexPath, "utf-8"),
+      compositionPath: "index.html",
+    };
   }
   const blockHtmlPath = join(projectDir, `${projectId}.html`);
   if (existsSync(blockHtmlPath)) {
-    return { html: readFileSync(blockHtmlPath, "utf-8"), compositionPath: `${projectId}.html` };
+    return {
+      html: readFileSync(blockHtmlPath, "utf-8"),
+      compositionPath: `${projectId}.html`,
+    };
   }
   return null;
 }
 
-export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): void {
+export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): void {
   const previewCacheHeaders = (etag: string) => ({
     "Cache-Control": "private, no-cache",
     ETag: etag,
   });
+
+  // One probe cache per server instance (this function runs once per
+  // registered API), reused across every preview request so the mtime-cache
+  // benefit in scanProjectMediaCodecMap actually applies.
+  const mediaCodecProbeCache = resolvePreviewMediaCodecProbeCache(adapter);
 
   // Bundled composition preview
   // fallow-ignore-next-line complexity
@@ -320,7 +348,10 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
     const etag = `"preview:${signature}${variablesEtagSalt(vars.raw)}"`;
     const ifNoneMatch = c.req.header("If-None-Match");
     if (ifNoneMatch === etag) {
-      return new Response(null, { status: 304, headers: previewCacheHeaders(etag) });
+      return new Response(null, {
+        status: 304,
+        headers: previewCacheHeaders(etag),
+      });
     }
 
     // Normalize + persist data-hf-id to disk before bundle reads it. Idempotent.
@@ -370,6 +401,13 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
         mainCompositionPath,
       );
       if (previewVariables) bundled = injectPreviewVariables(bundled, previewVariables);
+      bundled = await injectMediaCodecMap(
+        bundled,
+        adapter,
+        project.dir,
+        mainCompositionPath,
+        mediaCodecProbeCache,
+      );
       return c.html(bundled, 200, previewCacheHeaders(etag));
     } catch {
       // Re-read disk on bundle failure so we serve the latest file content,
@@ -389,6 +427,13 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
         if (previewVariables) {
           fallbackAugmented = injectPreviewVariables(fallbackAugmented, previewVariables);
         }
+        fallbackAugmented = await injectMediaCodecMap(
+          fallbackAugmented,
+          adapter,
+          project.dir,
+          fallback.compositionPath,
+          mediaCodecProbeCache,
+        );
         return c.html(fallbackAugmented, 200, previewCacheHeaders(etag));
       }
       return c.text("not found", 404);
@@ -443,7 +488,10 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
     const etag = `"comp:v2:${compPath}:${signature}${variablesEtagSalt(vars.raw)}"`;
     const ifNoneMatch = c.req.header("If-None-Match");
     if (ifNoneMatch === etag) {
-      return new Response(null, { status: 304, headers: previewCacheHeaders(etag) });
+      return new Response(null, {
+        status: 304,
+        headers: previewCacheHeaders(etag),
+      });
     }
 
     const stamped = pinSubCompHfIds(compFile, compPath);
@@ -461,6 +509,7 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
     html = ensureHfIds(await transformPreviewHtml(html, adapter, project, compPath));
     html = injectStudioPreviewAugmentations(html, adapter, project.dir, compPath);
     if (previewVariables) html = injectPreviewVariables(html, previewVariables);
+    html = await injectMediaCodecMap(html, adapter, project.dir, compPath, mediaCodecProbeCache);
     return c.html(html, 200, previewCacheHeaders(etag));
   });
 
@@ -483,10 +532,33 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
     const contentType = getMimeType(subPath);
     const isText = /\.(html|css|js|json|svg|txt|md|cube)$/i.test(subPath);
 
-    const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
+    // `?hf-proxy=h264` (per the KTD's `?variables=`-style negotiation): the
+    // param value must be exactly "h264" (matching play/staticProjectServer),
+    // only a video asset can be proxied, and only when auto-proxy is enabled
+    // for this adapter/project. Checked BEFORE any transcode or 304 shortcut
+    // so a bogus/disabled request never spawns ffmpeg.
+    const proxyParam = c.req.query("hf-proxy");
+    if (proxyParam !== undefined) {
+      if (
+        proxyParam !== "h264" ||
+        !contentType.startsWith("video/") ||
+        !isAutoProxyEnabled(adapter)
+      ) {
+        return c.text("not found", 404);
+      }
+      const eligibility = decideMediaProxyEligibility(await probeAssetCodec(file));
+      if (!eligibility.eligible) {
+        return c.text(`media proxy unavailable: ${eligibility.reason}`, 422);
+      }
+    }
+
+    const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}${proxyEtagSalt(proxyParam)}"`;
     const cacheHeaders: Record<string, string> = isText
       ? { "Cache-Control": "no-store" }
-      : { "Cache-Control": "private, max-age=3600, must-revalidate", ETag: etag };
+      : {
+          "Cache-Control": "private, max-age=3600, must-revalidate",
+          ETag: etag,
+        };
 
     if (!isText) {
       const ifNoneMatch = c.req.header("If-None-Match");
@@ -495,9 +567,27 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
       }
     }
 
+    // Resolve to the cached proxy (transcoding on miss) only after the 404/304
+    // shortcuts above — the source's own mtime+size already salts the etag,
+    // so a 304 never needs to await a transcode at all.
+    let servedPath = file;
+    let servedContentType = contentType;
+    if (proxyParam !== undefined) {
+      try {
+        servedPath = await resolveProxy(project.dir, file);
+      } catch (err) {
+        if (err instanceof ProxyCapacityError) {
+          return c.text(err.message, 503, { "Retry-After": "5" });
+        }
+        const message = err instanceof ProxyTranscodeError ? err.message : "proxy transcode failed";
+        return c.text(message, 502);
+      }
+      servedContentType = "video/mp4";
+    }
+
     const buffer: Buffer = isText
       ? Buffer.from(readFileSync(file, "utf-8"), "utf-8")
-      : readFileSync(file);
+      : readFileSync(servedPath);
     const totalSize = buffer.length;
 
     // Support byte-range requests so browsers can seek audio/video elements.
@@ -513,7 +603,7 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
           status: 206,
           headers: {
             ...cacheHeaders,
-            "Content-Type": contentType,
+            "Content-Type": servedContentType,
             "Content-Range": `bytes ${start}-${safeEnd}/${totalSize}`,
             "Accept-Ranges": "bytes",
             "Content-Length": String(chunkSize),
@@ -525,7 +615,7 @@ export function registerPreviewRoutes(api: Hono, adapter: StudioApiAdapter): voi
     return new Response(new Uint8Array(buffer), {
       headers: {
         ...cacheHeaders,
-        "Content-Type": contentType,
+        "Content-Type": servedContentType,
         "Accept-Ranges": "bytes",
         "Content-Length": String(totalSize),
       },

--- a/packages/studio-server/tsup.config.ts
+++ b/packages/studio-server/tsup.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     "helpers/screenshotClip": "src/helpers/screenshotClip.ts",
+    "helpers/mediaCodecMap": "src/helpers/mediaCodecMap.ts",
+    "helpers/proxyTranscoder": "src/helpers/proxyTranscoder.ts",
+    "helpers/mediaProxyPreview": "src/helpers/mediaProxyPreview.ts",
     "helpers/manualEditsRenderScript": "src/helpers/manualEditsRenderScript.ts",
     "helpers/studioMotionRenderScript": "src/helpers/studioMotionRenderScript.ts",
     "helpers/draftMarkers": "src/helpers/draftMarkers.ts",
@@ -15,7 +18,12 @@ export default defineConfig({
   target: "node22",
   platform: "node",
   bundle: true,
-  splitting: false,
+  // Split shared chunks so every entry (index + helper subpaths) imports ONE
+  // copy of stateful modules — proxyTranscoder's in-flight dedupe, transcode
+  // semaphore, and negative cache must be process-global, not per-entry.
+  // With splitting off, each entry inlined its own copy and a pre-warm from
+  // media-proxy-preview couldn't dedupe against a route's proxy-transcoder.
+  splitting: true,
   sourcemap: true,
   clean: true,
   dts: true,

--- a/packages/studio/vite.adapter.proxy.test.ts
+++ b/packages/studio/vite.adapter.proxy.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { resolveViteAutoProxy } from "./vite.adapter";
+
+describe("resolveViteAutoProxy", () => {
+  it("honors the CLI child environment and defaults direct Vite launches on", () => {
+    expect(resolveViteAutoProxy("true")).toBe(true);
+    expect(resolveViteAutoProxy("false")).toBe(false);
+    expect(resolveViteAutoProxy(undefined)).toBe(true);
+  });
+});

--- a/packages/studio/vite.adapter.ts
+++ b/packages/studio/vite.adapter.ts
@@ -33,6 +33,10 @@ export function isPathWithin(parentDir: string, childPath: string): boolean {
   );
 }
 
+export function resolveViteAutoProxy(value: string | undefined): boolean {
+  return value !== "false";
+}
+
 export function createViteAdapter(dataDir: string, server: ViteDevServer): StudioApiAdapter {
   let _bundler:
     | ((
@@ -99,6 +103,11 @@ export function createViteAdapter(dataDir: string, server: ViteDevServer): Studi
   };
 
   return {
+    // The CLI resolves --proxy/--no-proxy against hyperframes.json before it
+    // launches Vite. Direct `bun run dev` keeps the historical default-on
+    // behavior when the child environment is absent.
+    autoProxy: resolveViteAutoProxy(process.env.HYPERFRAMES_AUTO_PROXY),
+
     // fallow-ignore-next-line complexity
     listProjects() {
       if (!existsSync(dataDir)) return [];


### PR DESCRIPTION
## What

Adds the project and CLI opt-out for automatic proxies, then carries the resolved setting through embedded preview, local and development Studio launches, the studio server adapter, and Vite.

## Why

Slice 7 of 11 in the transparent-proxy stack (parent: S5). It lands before S6 turns runtime swapping on, so the default-on behavior is configurable from its first live slice.

The overall stack makes any video codec the project's FFmpeg can decode play on every live surface (preview, Studio, play, and published pages) by transparently serving a cached H.264 proxy when the viewing browser cannot decode the original. Render always uses originals.

## How

`media.autoProxy` normalizes to `true` when absent or malformed. An explicit `--proxy` or `--no-proxy` wins over project config in either direction. Preview resolves that choice once, passes it directly to embedded Studio, and forwards it through `HYPERFRAMES_AUTO_PROXY` for spawned Vite modes. Direct Studio server and Vite entry points retain the default-on behavior.

## Test plan

Applicable coverage: `projectConfig.test.ts` covers defaults, malformed and partial config, and flag precedence. `studioServer.test.ts`, `studioProxyEnv.test.ts`, and `vite.adapter.proxy.test.ts` cover the resolved value across embedded, child-process, and direct Vite adapters.

CI does not run on stacked PRs (`.github/workflows/ci.yml` filters `branches: [main]`), so Build/Typecheck/Test/Fallow did not gate this PR. Gates were run locally: build, `typecheck --filter '*'`, full non-producer test suite, lint, `format:check`, and fallow with a cleared cache. A thin check rollup here is expected and is not evidence of passing.

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)
