### PR TITLE
feat(studio): gate the VST FX section behind STUDIO_VST_ENABLED

### DIFF
--- a/packages/studio/src/components/editor/PropertyPanel.test.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.test.tsx
@@ -675,6 +675,52 @@ function audioElement() {
   };
 }
 
+describe("PropertyPanel — STUDIO_VST_ENABLED gate", () => {
+  it(
+    "does not render the VST FX section for an audio element by default (flag off)",
+    async () => {
+      const { host, root } = await renderPanel(false, audioElement() as never);
+      expect(host.querySelector('[data-vst-install-hint="true"]')).toBeNull();
+      expect(host.querySelector("[data-vst-add-effect]")).toBeNull();
+      act(() => root.unmount());
+    },
+    RENDER_TIMEOUT_MS,
+  );
+
+  it(
+    "renders the VST FX section for an audio element once STUDIO_VST_ENABLED is on",
+    async () => {
+      vi.doMock("./manualEditingAvailability", async () => {
+        const actual = await vi.importActual<typeof import("./manualEditingAvailability")>(
+          "./manualEditingAvailability",
+        );
+        return { ...actual, STUDIO_FLAT_INSPECTOR_ENABLED: false, STUDIO_VST_ENABLED: true };
+      });
+      vi.resetModules();
+      const { PropertyPanel } = await import("./PropertyPanel");
+      const host = document.createElement("div");
+      document.body.append(host);
+      const root = createRoot(host);
+      const props = {
+        element: audioElement(),
+        assets: [],
+        onSetStyle: vi.fn(),
+        onSetText: vi.fn(),
+        onSetAttributeLive: vi.fn(),
+      } as unknown as PropertyPanelProps;
+      act(() => {
+        root.render(<PropertyPanel {...props} />);
+      });
+      expect(
+        host.querySelector('[data-vst-install-hint="true"]') ||
+          host.querySelector("[data-vst-add-effect]"),
+      ).not.toBeNull();
+      act(() => root.unmount());
+    },
+    RENDER_TIMEOUT_MS,
+  );
+});
+
 // All FlatGroup titles currently mounted (open row + every collapsed row).
 function flatGroupTitles(host: HTMLElement): string[] {
   const open = Array.from(

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -30,6 +30,7 @@ import {
   STUDIO_FLAT_INSPECTOR_ENABLED,
   STUDIO_GSAP_PANEL_ENABLED,
   STUDIO_KEYFRAMES_ENABLED,
+  STUDIO_VST_ENABLED,
 } from "./manualEditingAvailability";
 import { PropertyPanelFlat } from "./PropertyPanelFlat";
 import { createGsapLivePreview } from "./gsapLivePreview";
@@ -374,7 +375,7 @@ export const PropertyPanel = memo(function PropertyPanel(props: PropertyPanelPro
           />
         )}
 
-        {sections.vstFx && (
+        {STUDIO_VST_ENABLED && sections.vstFx && (
           <VstSection
             projectId={projectId}
             element={element}

--- a/packages/studio/src/components/editor/manualEditingAvailability.ts
+++ b/packages/studio/src/components/editor/manualEditingAvailability.ts
@@ -106,4 +106,14 @@ export const STUDIO_FLAT_INSPECTOR_ENABLED = resolveStudioBooleanEnvFlag(
   false,
 );
 
+// VST FX chain editing (the property panel's "Make room for voiceover" carve
+// control + per-plugin chain UI) and its live-preview PCM streaming through
+// the VST host sidecar — new, unreleased surface, off by default pending
+// broader rollout. Default false; enable via VITE_STUDIO_ENABLE_VST=true.
+export const STUDIO_VST_ENABLED = resolveStudioBooleanEnvFlag(
+  env,
+  ["VITE_STUDIO_ENABLE_VST", "VITE_STUDIO_VST_ENABLED"],
+  false,
+);
+
 export const STUDIO_MANUAL_EDITING_DISABLED_TITLE = "Manual editing is temporarily disabled";

--- a/packages/studio/src/player/hooks/useVstPreview.test.tsx
+++ b/packages/studio/src/player/hooks/useVstPreview.test.tsx
@@ -24,6 +24,10 @@ import { FakeSocket, required } from "../../hooks/vstSocketTestFixture";
 import { liveTime, usePlayerStore } from "../store/playerStore";
 import { decodePcmFrame, useVstPreview } from "./useVstPreview";
 
+vi.mock("../../components/editor/manualEditingAvailability", () => ({
+  STUDIO_VST_ENABLED: true,
+}));
+
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 // ── Fake Web Audio (this environment has none at all) ───────────────────────

--- a/packages/studio/src/player/hooks/useVstPreview.ts
+++ b/packages/studio/src/player/hooks/useVstPreview.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type RefObject } from "react";
 import { liveTime, usePlayerStore } from "../store/playerStore";
 import type { TransportMsg, UseVstHostResult } from "../../hooks/useVstHost";
+import { STUDIO_VST_ENABLED } from "../../components/editor/manualEditingAvailability";
 import {
   collectVstChainAudioEls,
   dbg,
@@ -121,6 +122,7 @@ export function useVstPreview(
 
   // ── Lazily start the sidecar once a vst-chain track appears ─────────────
   useEffect(() => {
+    if (!STUDIO_VST_ENABLED) return;
     if (!projectId || status !== "idle") return;
     const doc = iframeRef.current?.contentDocument;
     if (!doc) return;


### PR DESCRIPTION
## What

Gates the VST FX section and everything that triggers the sidecar behind a new `STUDIO_VST_ENABLED` flag (default off, `VITE_STUDIO_ENABLE_VST=true` to turn on), alongside the existing `STUDIO_*_ENABLED` flags in `manualEditingAvailability.ts`:

- `PropertyPanel.tsx`: the `VstSection` render, so the FX panel section never mounts for an audio element while the flag is off.
- `useVstPreview.ts`: the "lazily start the sidecar once a vst-chain track appears" effect — the sole call site of `useVstHost`'s `ensureStarted()` in the app, so gating it here is sufficient (the FX panel never calls it directly, and `useVstHost()` itself does nothing until asked).

Left unflagged on purpose: engine's render-time VST chain application and the Lambda VST-chain rejection guard — those operate on whatever `data-vst-chain` content already exists in a composition's HTML regardless of which UI authored it, so gating them would silently change render behavior for existing content rather than just hiding an editing surface.

## Why

New, unreleased studio surface — stage it in behind a flag for incremental rollout/review rather than shipping it live to everyone by default.

## Test plan

- [x] New tests proving `VstSection` is absent by default and present when the flag is on
- [x] `useVstPreview.test.tsx`'s existing 27 tests updated to mock the flag on, so they keep exercising the real behavior
- [x] Full studio suite (2752 tests) + build + fallow gate all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)