### PR TITLE
fix(cli): resolve the producer alias in the CLI vitest config

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -14,6 +14,15 @@ export default defineConfig({
         find: /^@hyperframes\/core$/,
         replacement: resolve(__dirname, "../core/src/index.ts"),
       },
+      // Same reason the tsup build aliases this specifier to source: the CLI
+      // bundles the producer rather than depending on it at runtime, so its
+      // dist is not built for the test job. Without the alias, vite's import
+      // analysis resolves studioServer.ts's `import("@hyperframes/producer")`
+      // against an unbuilt package and the whole suite fails to collect.
+      {
+        find: /^@hyperframes\/producer$/,
+        replacement: resolve(__dirname, "../producer/src/index.ts"),
+      },
     ],
   },
   test: {


### PR DESCRIPTION
## What

Aliases `@hyperframes/producer` to its source in the CLI's vitest config, the same way the tsup build already does. Config only, one file.

`main`'s Test job is currently red. This fixes it.

## Why

`studioServer.test.ts` fails to collect:

```
Error: Failed to resolve entry for package "@hyperframes/producer".
Plugin: vite:import-analysis
File: packages/cli/src/server/studioServer.ts:46:19
```

`studioServer.ts` has carried `await import("@hyperframes/producer")` for a long time, but nothing under test imported that module until #2591 added a suite that does. Vite's import analysis resolves the specifier at transform time, and the CI test job builds only parsers, lint, studio-server and core, so there is no producer dist to resolve and the whole file fails to collect. It passes locally only because a full `bun run build` happens to build the producer first.

The tsup build already aliases this exact specifier to `../producer/src/index.ts`, because the CLI bundles the producer rather than depending on it at runtime. The test tooling now resolves it the same way, so the two agree. The neighbouring `@hyperframes/core` alias exists for the same class of reason.

Worth noting for anyone reading CI history: `main`'s most recent run reports success, but its Test job was **skipped** (that commit only touched registry HTML). The last run where Test actually executed is the failing one.

## How

Config only. `studioServer.ts` is deliberately untouched.

Two alternatives were tried and rejected:

- `/* @vite-ignore */` on the literal specifier: vite still resolves a literal, so it does nothing here.
- Holding the specifier in a variable so vite cannot analyse it: this **breaks the shipped CLI**. esbuild then cannot resolve it either, so the bundle emits a runtime `import("@hyperframes/producer")` instead of inlining the producer, and the producer is only a devDependency, so it is not installed for users. The build still passes, which is how that would have shipped silently.

## Test plan

Reproduced the CI condition locally by removing the producer's dist, then running against `main`'s tree:

- without this change: `studioServer.test.ts` fails to collect, matching CI exactly
- with this change: 4 passed, and the full CLI suite is 150 files passed (the 2 `transcribe.test.ts` failures are a pre-existing baseline unrelated to this, and fail on `main` today)

Also confirmed the shipped bundle is unaffected: `packages/cli/dist/cli.js` still contains no runtime import of `@hyperframes/producer`, so the producer remains inlined and installed users are unaffected.
