### PR TITLE
feat(media-use): add Edge TTS provider

### DIFF
--- a/skills/media-use/audio/references/tts.md
+++ b/skills/media-use/audio/references/tts.md
@@ -4,19 +4,25 @@
 `--provider` or `--words` flag. For HeyGen audio plus word timestamps, use the
 bundled `heygen-tts.mjs` script below.
 
-> **Run the Preflight first — no credential is not a green light to silently use the local voice.** Before generating a voiceover, complete the sign-in **Preflight** (see `../SKILL.md` → Preflight): run `npx hyperframes auth status`, recommend signing in, and **STOP for the user's choice** (sign in for HeyGen voices, or continue offline with local Kokoro). This applies to a one-off "generate a voiceover" request just as much as inside a full workflow.
+> **Run the Preflight first — no credential is not a green light to silently use a fallback voice.** Before generating a voiceover, complete the sign-in **Preflight** (see `../SKILL.md` → Preflight): run `npx hyperframes auth status`, recommend signing in, and **STOP for the user's choice** (sign in for HeyGen voices, use local Kokoro, or use the keyless Edge CLI). This applies to a one-off "generate a voiceover" request just as much as inside a full workflow.
 
 ## Available routes
 
-| Order | Provider          | Env trigger                                 | Voice IDs                                   | Word timestamps                           | Audio format         |
-| ----- | ----------------- | ------------------------------------------- | ------------------------------------------- | ----------------------------------------- | -------------------- |
-| 1     | HeyGen (Starfish) | `$HEYGEN_API_KEY` / `~/.heygen/credentials` | UUIDs from `GET /v3/voices?engine=starfish` | **Yes** (`word_timestamps[]` in response) | mp3 → wav via ffmpeg |
-| 2     | ElevenLabs        | `$ELEVENLABS_API_KEY`                       | UUIDs from elevenlabs.io dashboard          | No                                        | mp3 → wav via ffmpeg |
-| 3     | Kokoro-82M        | always (local fallback)                     | `am_michael`, `af_heart`, … (54 voices)     | No                                        | wav direct           |
+| Order | Provider          | Env trigger                                 | Voice IDs                                   | Word timestamps                                  | Audio format         |
+| ----- | ----------------- | ------------------------------------------- | ------------------------------------------- | ------------------------------------------------ | -------------------- |
+| 1     | HeyGen (Starfish) | `$HEYGEN_API_KEY` / `~/.heygen/credentials` | UUIDs from `GET /v3/voices?engine=starfish` | **Yes** (`word_timestamps[]` in response)        | mp3 → wav via ffmpeg |
+| 2     | ElevenLabs        | `$ELEVENLABS_API_KEY`                       | UUIDs from elevenlabs.io dashboard          | No                                               | mp3 → wav via ffmpeg |
+| 3     | Kokoro-82M        | `kokoro-onnx` + `soundfile` installed       | `am_michael`, `af_heart`, … (54 voices)     | No                                               | wav direct           |
+| 4     | Edge TTS          | `edge-tts` on PATH                          | Microsoft neural voice names                | **Yes** (`WordBoundary` via `--write-subtitles`) | mp3 → wav via ffmpeg |
 
 ```bash
 # Local Kokoro CLI
 npx hyperframes tts "Welcome to HyperFrames" -o narration.wav
+
+# Shared audio engine: pin Edge explicitly
+node skills/media-use/audio/scripts/audio.mjs \
+  --request audio_request.json --hyperframes . --out audio_meta.json \
+  --provider edge --voice en-US-AndrewNeural
 ```
 
 ## Self-contained HeyGen (no CLI) — `scripts/heygen-tts.mjs`
@@ -60,11 +66,22 @@ node skills/media-use/audio/scripts/heygen-tts.mjs --list   # public starfish vo
 | Best voice quality + word timestamps in one call          | **HeyGen**                                          |
 | Drop-in cloud TTS, big voice catalog                      | **ElevenLabs**                                      |
 | Offline, no API key, fast iteration                       | **Kokoro**                                          |
+| No key or ML deps, with native word timings               | **Edge** (`edge-tts`)                               |
 | Non-English multilingual with deterministic phonemization | **Kokoro** (`ef_dora`, `jf_alpha`, `zf_xiaobei`, …) |
+
+## Edge TTS
+
+The `edge` provider needs no API key and no local ML dependencies, but it does
+need network access to Microsoft's speech service. Install the `edge-tts`
+system CLI and keep it on PATH. Its default house narrator is the male
+`en-US-AndrewNeural`; use `en-US-AvaNeural` for the corresponding female voice,
+or pass any other Edge voice name verbatim with `--voice`. The default rate is
+`-2%`. Word timings come directly from `--write-subtitles` WordBoundary cues,
+so Edge narration skips the transcription pass used by Kokoro and ElevenLabs.
 
 ## ffmpeg requirement
 
-HeyGen + ElevenLabs return mp3. The bundled HeyGen helper transcodes to wav
+HeyGen + ElevenLabs + Edge return mp3. The bundled HeyGen helper and shared audio engine transcode to wav
 when `--output` ends in `.wav` (the default and what downstream `ffprobe` +
 Whisper expect). If you'd rather skip the transcode, pass `-o file.mp3`.
 Without `ffmpeg` on PATH, wav output from cloud providers fails; the local
@@ -134,4 +151,4 @@ When `--words <path>` is passed to a HeyGen call, the file is written in the sam
 ]
 ```
 
-For ElevenLabs / Kokoro, run `npx hyperframes transcribe narration.wav --model small.en` to get the same shape.
+For ElevenLabs / Kokoro, run `npx hyperframes transcribe narration.wav --model small.en` to get the same shape. Edge timings are native and already use this shape.

--- a/skills/media-use/audio/scripts/lib/tts.edge.test.mjs
+++ b/skills/media-use/audio/scripts/lib/tts.edge.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  edgeAvailable,
+  parseEdgeVtt,
+  pickProvider,
+  resolveVoiceId,
+  synthesizeOne,
+  withWordIds,
+} from "./tts.mjs";
+
+const FIXTURE_VTT = [
+  "WEBVTT",
+  "",
+  "00:00:00.100 --> 00:00:00.520",
+  "Attestation",
+  "",
+  "00:00:00.530 --> 00:00:00.900",
+  "receipts",
+  "",
+].join("\n");
+
+test("edgeAvailable probes edge-tts --version", () => {
+  const calls = [];
+  assert.equal(
+    edgeAvailable((cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      return { status: 0 };
+    }),
+    true,
+  );
+  assert.deepEqual(calls, [{ cmd: "edge-tts", args: ["--version"], opts: { stdio: "ignore" } }]);
+});
+
+test("pickProvider accepts explicit edge and appends it after unavailable Kokoro", () => {
+  const unavailable = {
+    heygenAvailable: () => false,
+    elevenlabsAvailable: () => false,
+    kokoroAvailable: () => false,
+    edgeAvailable: () => true,
+  };
+  assert.equal(pickProvider("edge", unavailable), "edge");
+  assert.equal(pickProvider(null, unavailable), "edge");
+  assert.equal(pickProvider(null, { ...unavailable, kokoroAvailable: () => true }), "kokoro");
+});
+
+test("resolveVoiceId uses the Edge house narrator and preserves explicit voices", async () => {
+  assert.equal(await resolveVoiceId({ provider: "edge" }), "en-US-AndrewNeural");
+  assert.equal(
+    await resolveVoiceId({ provider: "edge", userVoice: "en-US-AvaNeural" }),
+    "en-US-AvaNeural",
+  );
+});
+
+test("parseEdgeVtt converts WordBoundary cues to caption-compatible words", () => {
+  assert.deepEqual(withWordIds(parseEdgeVtt(FIXTURE_VTT)), [
+    { id: "w0", text: "Attestation", start: 0.1, end: 0.52 },
+    { id: "w1", text: "receipts", start: 0.53, end: 0.9 },
+  ]);
+});
+
+test("synthesizeOne(edge) uses a fake edge-tts CLI and returns native timings", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "tts-edge-fake-"));
+  const bin = join(dir, "bin");
+  const wavAbs = join(dir, "assets", "voice", "line.wav");
+  const argsFile = join(dir, "edge.args");
+  const originalPath = process.env.PATH;
+  const originalArgsFile = process.env.EDGE_ARGS_FILE;
+  try {
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, "edge-tts"),
+      [
+        "#!/bin/sh",
+        'printf \'%s\\n\' "$@" > "$EDGE_ARGS_FILE"',
+        'while [ "$#" -gt 0 ]; do',
+        '  case "$1" in',
+        '    --write-media) media="$2"; shift 2 ;;',
+        '    --write-subtitles) subtitles="$2"; shift 2 ;;',
+        "    *) shift ;;",
+        "  esac",
+        "done",
+        "printf 'fake mp3' > \"$media\"",
+        "printf 'WEBVTT\\n\\n00:00:00.100 --> 00:00:00.520\\nAttestation\\n' > \"$subtitles\"",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(bin, "ffmpeg"),
+      [
+        "#!/bin/sh",
+        'for arg in "$@"; do output="$arg"; done',
+        "printf 'fake wav' > \"$output\"",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(bin, "ffprobe"), "#!/bin/sh\nprintf '0.520\\n'\n");
+    chmodSync(join(bin, "edge-tts"), 0o755);
+    chmodSync(join(bin, "ffmpeg"), 0o755);
+    chmodSync(join(bin, "ffprobe"), 0o755);
+    process.env.PATH = bin;
+    process.env.EDGE_ARGS_FILE = argsFile;
+
+    const result = await synthesizeOne({
+      provider: "edge",
+      text: "Attestation",
+      voiceId: "en-US-AndrewNeural",
+      wavAbs,
+      hyperframesDir: dir,
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      words: [{ text: "Attestation", start: 0.1, end: 0.52 }],
+    });
+    assert.ok(existsSync(wavAbs));
+    const args = readFileSync(argsFile, "utf8").trim().split("\n");
+    assert.deepEqual(args.slice(0, 6), [
+      "--voice",
+      "en-US-AndrewNeural",
+      "--rate=-2%",
+      "--text",
+      "Attestation",
+      "--write-media",
+    ]);
+    assert.match(args[6], /voice\.mp3$/);
+    assert.equal(args[7], "--write-subtitles");
+    assert.match(args[8], /words\.vtt$/);
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalArgsFile === undefined) delete process.env.EDGE_ARGS_FILE;
+    else process.env.EDGE_ARGS_FILE = originalArgsFile;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/skills/media-use/audio/scripts/lib/tts.mjs
+++ b/skills/media-use/audio/scripts/lib/tts.mjs
@@ -7,8 +7,10 @@
 //        in the same call, so no separate transcribe pass.
 //   2. ElevenLabs         — $ELEVENLABS_API_KEY + `pip install elevenlabs`. No
 //        word timings → caller chains transcribeWav().
-//   3. Kokoro-82M (local) — always available, via the published `hyperframes tts`
-//        CLI. No word timings → caller chains transcribeWav().
+//   3. Kokoro-82M (local) — via the published `hyperframes tts` CLI. No word
+//        timings → caller chains transcribeWav().
+//   4. Edge TTS (CLI)     — no key or ML deps. Native WordBoundary timings
+//        from --write-subtitles, so no transcribe pass.
 //
 // "HeyGen available" is decided by CREDENTIAL presence (heygenCredential), never
 // by the CLI — see the note above.
@@ -32,21 +34,44 @@ export function elevenlabsAvailable() {
   });
   return r.status === 0;
 }
+export function kokoroAvailable(spawnSyncFn = spawnSync) {
+  const { cmd, args } = pythonInvocation(["-c", "import kokoro_onnx, soundfile"]);
+  const r = spawnSyncFn(cmd, args, { stdio: "ignore" });
+  return r.status === 0;
+}
+export function edgeAvailable(spawnSyncFn = spawnSync) {
+  const r = spawnSyncFn("edge-tts", ["--version"], { stdio: "ignore" });
+  return r.status === 0;
+}
 
 // First available provider wins; an explicit choice is honored (and validated).
-export function pickProvider(userProvider) {
+export function pickProvider(userProvider, deps = {}) {
+  const hasHeygen = deps.heygenAvailable ?? heygenAvailable;
+  const hasElevenlabs = deps.elevenlabsAvailable ?? elevenlabsAvailable;
+  const hasKokoro = deps.kokoroAvailable ?? kokoroAvailable;
+  const hasEdge = deps.edgeAvailable ?? edgeAvailable;
   if (userProvider) {
-    if (!["heygen", "elevenlabs", "kokoro"].includes(userProvider))
-      throw new Error(`invalid provider "${userProvider}" (heygen | elevenlabs | kokoro)`);
-    if (userProvider === "heygen" && !heygenAvailable())
+    if (!["heygen", "elevenlabs", "kokoro", "edge"].includes(userProvider))
+      throw new Error(`invalid provider "${userProvider}" (heygen | elevenlabs | kokoro | edge)`);
+    if (userProvider === "heygen" && !hasHeygen())
       throw new Error(
         "provider=heygen but no HeyGen credentials (set $HEYGEN_API_KEY or run `npx hyperframes auth login`)",
       );
     if (userProvider === "elevenlabs" && !process.env.ELEVENLABS_API_KEY)
       throw new Error("provider=elevenlabs but $ELEVENLABS_API_KEY is not set");
+    if (userProvider === "edge" && !hasEdge())
+      throw new Error(
+        "provider=edge but edge-tts is not installed (install with `pipx install edge-tts` or `pip install edge-tts`)",
+      );
     return userProvider;
   }
-  return heygenAvailable() ? "heygen" : elevenlabsAvailable() ? "elevenlabs" : "kokoro";
+  if (hasHeygen()) return "heygen";
+  if (hasElevenlabs()) return "elevenlabs";
+  if (hasKokoro()) return "kokoro";
+  if (hasEdge()) return "edge";
+  // Preserve the existing terminal behavior when no provider can be proven
+  // available: Kokoro will surface its established install diagnostic.
+  return "kokoro";
 }
 
 // ── voice resolution ──────────────────────────────────────────────────────────
@@ -56,6 +81,7 @@ export function pickProvider(userProvider) {
 export async function resolveVoiceId({ provider, userVoice, lang = "en" }) {
   if (userVoice) return userVoice;
   if (provider === "elevenlabs") return "21m00Tcm4TlvDq8ikWAM"; // Rachel
+  if (provider === "edge") return "en-US-AndrewNeural";
   if (provider === "kokoro") {
     if (lang === "en") return "am_michael";
     throw new Error("Kokoro non-English needs an explicit --voice (see references/tts.md)");
@@ -82,6 +108,54 @@ export function withWordIds(words) {
     start: w.start,
     end: w.end,
   }));
+}
+
+function parseVttTimestampMs(value) {
+  const parts = String(value).replace(",", ".").split(":");
+  if (parts.length < 2 || parts.length > 3) return NaN;
+  const seconds = Number(parts.pop());
+  const minutes = Number(parts.pop());
+  const hours = parts.length ? Number(parts.pop()) : 0;
+  if (![hours, minutes, seconds].every(Number.isFinite)) return NaN;
+  return Math.round((hours * 3600 + minutes * 60 + seconds) * 1000);
+}
+
+// edge-tts emits one WordBoundary cue per VTT block. The engine's public timing
+// contract is seconds, so parse at millisecond precision and normalize here.
+export function parseEdgeVtt(vttText) {
+  const words = [];
+  for (const block of String(vttText ?? "")
+    .replace(/\r/g, "")
+    .split(/\n{2,}/)) {
+    const lines = block.split("\n").map((line) => line.trim());
+    const timingIndex = lines.findIndex((line) => line.includes("-->"));
+    if (timingIndex < 0) continue;
+    const match =
+      /^(\d{2}:\d{2}(?::\d{2})?[.,]\d{3})\s+-->\s+(\d{2}:\d{2}(?::\d{2})?[.,]\d{3})(?:\s+.*)?$/.exec(
+        lines[timingIndex],
+      );
+    if (!match) continue;
+    const startMs = parseVttTimestampMs(match[1]);
+    const endMs = parseVttTimestampMs(match[2]);
+    const text = lines
+      .slice(timingIndex + 1)
+      .filter(Boolean)
+      .join(" ");
+    if (!text || !Number.isFinite(startMs) || !Number.isFinite(endMs)) continue;
+    words.push({ text, start: startMs / 1000, end: endMs / 1000 });
+  }
+  return words;
+}
+
+export function edgeRate(speed) {
+  if (typeof speed === "string" && /^[+-]?\d+(?:\.\d+)?%$/.test(speed.trim())) {
+    const rate = speed.trim();
+    return /^[+-]/.test(rate) ? rate : `+${rate}`;
+  }
+  const numeric = Number(speed);
+  if (!Number.isFinite(numeric) || numeric === 1) return "-2%";
+  const percent = Math.round((numeric - 1) * 100);
+  return `${percent >= 0 ? "+" : ""}${percent}%`;
 }
 
 // `ffmpeg -i <file>` prints a `Duration: HH:MM:SS.ms` line to stderr even
@@ -238,8 +312,8 @@ save(audio, sys.argv[3])
 
 // ── synthesize one line ───────────────────────────────────────────────────────
 // Writes wav at wavAbs. Returns { ok, words, error } — words is the raw
-// [{text,start,end}] array for HeyGen (native), or null for ElevenLabs/Kokoro
-// (caller must transcribeWav). Never throws; failures return { ok:false, error }
+// [{text,start,end}] array for HeyGen/Edge (native), or null for ElevenLabs/
+// Kokoro (caller must transcribeWav). Never throws; failures return { ok:false, error }
 // where `error` states WHY (so the caller can surface it, not a bare "TTS failed").
 export async function synthesizeOne({
   provider,
@@ -251,6 +325,7 @@ export async function synthesizeOne({
   hyperframesDir,
 }) {
   if (provider === "heygen") return synthesizeHeygen({ text, voiceId, lang, speed, wavAbs });
+  if (provider === "edge") return synthesizeEdge({ text, voiceId, speed, wavAbs });
   if (provider === "elevenlabs") {
     // The Python helper writes straight to wavAbs; unlike heygen (transcodeToWav)
     // and kokoro (the `hyperframes tts` CLI), it does NOT create the parent dir,
@@ -289,6 +364,46 @@ export function synthResult(r, wavAbs, label) {
   const why =
     r.status !== 0 ? `${label} exited with status ${r.status}` : `${label} produced no wav file`;
   return { ok: false, words: null, error: why };
+}
+
+export async function synthesizeEdge({ text, voiceId, speed, wavAbs }, deps = {}) {
+  const run = deps.spawnP ?? spawnP;
+  const transcode = deps.transcodeToWav ?? transcodeToWav;
+  const probeDuration = deps.ffprobeDuration ?? ffprobeDuration;
+  const td = mkdtempSync(join(tmpdir(), "hf-edge-tts-"));
+  const mp3 = join(td, "voice.mp3");
+  const vtt = join(td, "words.vtt");
+  try {
+    const r = await run("edge-tts", [
+      "--voice",
+      voiceId,
+      `--rate=${edgeRate(speed)}`,
+      "--text",
+      text,
+      "--write-media",
+      mp3,
+      "--write-subtitles",
+      vtt,
+    ]);
+    if (r.status !== 0) {
+      return { ok: false, words: null, error: `edge-tts exited with status ${r.status}` };
+    }
+    if (!existsSync(mp3) || !existsSync(vtt)) {
+      return { ok: false, words: null, error: "edge-tts produced no media or subtitles" };
+    }
+    if (!transcode(readFileSync(mp3), wavAbs)) {
+      return { ok: false, words: null, error: "edge-tts wav transcode failed (ffmpeg)" };
+    }
+    const duration = probeDuration(wavAbs);
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return { ok: false, words: null, error: "edge-tts produced unreadable audio duration" };
+    }
+    return { ok: true, words: parseEdgeVtt(readFileSync(vtt, "utf8")) };
+  } catch (e) {
+    return { ok: false, words: null, error: e?.message ? String(e.message) : String(e) };
+  } finally {
+    rmSync(td, { recursive: true, force: true });
+  }
 }
 
 // `deps` is injectable for tests; production uses the real network/ffmpeg impls.


### PR DESCRIPTION
## What

Adds `edge` as a first-class TTS provider in the media-use audio engine (`skills/media-use/audio/scripts/lib/tts.mjs`), alongside the existing HeyGen / ElevenLabs / Kokoro providers.

## Why

Edge TTS (`edge-tts` CLI) is a strong offline narration option: **no API key and no local ML dependencies**, and it emits **native word-level timings** via `--write-subtitles` (one WordBoundary cue per VTT block) — so unlike Kokoro it needs no separate transcription pass. It's a useful default for signed-out / offline scripted runs where HeyGen isn't available and Kokoro's ML deps aren't installed.

## What's added

- `edgeAvailable()` — probes the `edge-tts` CLI on PATH.
- `pickProvider()` — accepts explicit `"edge"`, and appends `edge` to the **auto** fallback chain only when available and after the existing providers (precedence for heygen/elevenlabs/kokoro is unchanged).
- `resolveVoiceId()` — `edge` defaults to `en-US-AndrewNeural`; any explicit edge voice string is honored.
- `synthesizeEdge()` — spawns `edge-tts --voice … --rate … --write-media … --write-subtitles …`, parses the VTT for word timings, and returns the same shape as the other providers.
- A doc row in `audio/references/tts.md` and unit tests (`tts.edge.test.mjs`, node:test) using a fake `edge-tts` CLI — no network in tests.

## Backward compatibility

New provider only. Existing HeyGen / ElevenLabs / Kokoro selection and precedence are unchanged; `edge` is reached in auto mode only when the others are unavailable.

## Testing

`oxlint` clean, `oxfmt --check` clean, and `node --test tts.edge.test.mjs` passes (5/5).