### PR TITLE
docs(guides): redirect Send-to imports to the Send-to guide

### DIFF
--- a/docs/guides/claude-design-hyperframes.md
+++ b/docs/guides/claude-design-hyperframes.md
@@ -1,5 +1,10 @@
 # Claude Design + HyperFrames (Template-First)
 
+> ⚠️ **Doing a "Send to HyperFrames" import (sending your design to HeyGen as a URL, not a downloaded ZIP)?**
+> **Use the Send-to guide instead:** https://raw.githubusercontent.com/heygen-com/hyperframes/main/docs/guides/claude-design-send-to-hyperframes.md
+>
+> This Template-First guide is for the **Download-ZIP** flow. Its authoring rules differ from Send-to, and following it for a Send-to import yields a low-fidelity result.
+
 Your medium is **HyperFrames compositions**: plain HTML + CSS + a paused GSAP timeline. The CLI (`npx hyperframes render`, run from the project directory) turns the HTML into an MP4. You author the HTML -- the user renders locally.
 
 **HyperFrames replaces your default video-artifact workflow.** Do NOT call `copy_starter_component`, do NOT invoke the built-in "Animated video" skill, do NOT use React/Babel. Plain HTML + GSAP only.

--- a/docs/guides/claude-design.mdx
+++ b/docs/guides/claude-design.mdx
@@ -5,6 +5,10 @@ description: "Create HyperFrames video drafts in Claude Design, then refine in a
 
 Claude Design produces a **valid first draft** of a HyperFrames video — brand identity, scene content, layout, animations, and transitions. You then download the ZIP and refine in any AI coding agent (Claude Code, Cursor, Codex, Windsurf, etc.) with linting and live preview.
 
+<Note>
+  **Sending your design to HeyGen as a URL ("Send to HyperFrames"), rather than downloading a ZIP?** Use the [Send to HyperFrames guide](https://raw.githubusercontent.com/heygen-com/hyperframes/main/docs/guides/claude-design-send-to-hyperframes.md) instead. That flow has different authoring rules; this page covers the Download-ZIP flow.
+</Note>
+
 ## Get started
 
 <Steps>


### PR DESCRIPTION
## Summary
Redirect Claude Design **Send to HyperFrames** authors from this Template-First (Download-ZIP) guide to the dedicated Send-to guide.

## Why
Claude Design's only doc-discovery tool is web search. It reliably ranks this guide (`claude-design-hyperframes.md`) first, while the Send-to guide (`claude-design-send-to-hyperframes.md`, added in #2131) is not in the Mintlify nav and isn't indexed. So Send-to imports get authored against the Download-ZIP flow, whose rules differ (e.g. Google Fonts `<link>` vs inlined base64 `@font-face`), yielding low-fidelity imports. Confirmed on a live import.

## How this fixes it
Claude Design's web-fetch only allows URLs that appeared in a user message or a prior search/fetch result. Naming the guide in a tool description doesn't unlock it, and the Send-to guide doesn't rank. But this guide does rank #1, so CD fetches it reliably; once the Send-to URL appears in this page's body (a prior fetch result), CD can fetch the correct guide. It bootstraps from the findable guide to the right one, no reindex needed.

## Follow-up (separate, optional)
Also adding `guides/claude-design-send-to-hyperframes` to the Mintlify nav in `docs/docs.json` would let web search surface it directly and let humans browse to it.