### PR TITLE
fix(studio): ignore stale failed sidecars for existing renders

### DIFF
--- a/packages/studio-server/src/routes/render.test.ts
+++ b/packages/studio-server/src/routes/render.test.ts
@@ -33,12 +33,29 @@ function createAdapter(
   return { adapter, rendersDir };
 }
 
-function buildApp(spy: ReturnType<typeof vi.fn>): { app: Hono; cleanup: () => void } {
+function buildApp(spy: ReturnType<typeof vi.fn>): { app: Hono; rendersDir: string; cleanup: () => void } {
   const { adapter, rendersDir } = createAdapter(spy);
   const app = new Hono();
   registerRenderRoutes(app, adapter);
-  return { app, cleanup: () => rmSync(rendersDir, { recursive: true, force: true }) };
+  return { app, rendersDir, cleanup: () => rmSync(rendersDir, { recursive: true, force: true }) };
 }
+
+describe("GET /projects/:id/renders — stale sidecar status", () => {
+  it("does not mark an existing output failed from stale metadata", async () => {
+    const spy = vi.fn();
+    const { app, rendersDir, cleanup } = buildApp(spy);
+    try {
+      writeFileSync(join(rendersDir, "retry.mp4"), "valid-output");
+      writeFileSync(join(rendersDir, "retry.meta.json"), JSON.stringify({ status: "failed", error: "first attempt" }));
+      const res = await app.request("http://localhost/projects/demo/renders");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.renders).toEqual([expect.objectContaining({ id: "retry", status: "complete" })]);
+    } finally {
+      cleanup();
+    }
+  });
+});
 
 describe("POST /projects/:id/render — outputResolution forwarding", () => {
   it("forwards a valid resolution preset to the adapter", async () => {

--- a/packages/studio-server/src/routes/render.test.ts
+++ b/packages/studio-server/src/routes/render.test.ts
@@ -33,7 +33,11 @@ function createAdapter(
   return { adapter, rendersDir };
 }
 
-function buildApp(spy: ReturnType<typeof vi.fn>): { app: Hono; rendersDir: string; cleanup: () => void } {
+function buildApp(spy: ReturnType<typeof vi.fn>): {
+  app: Hono;
+  rendersDir: string;
+  cleanup: () => void;
+} {
   const { adapter, rendersDir } = createAdapter(spy);
   const app = new Hono();
   registerRenderRoutes(app, adapter);
@@ -46,7 +50,10 @@ describe("GET /projects/:id/renders — stale sidecar status", () => {
     const { app, rendersDir, cleanup } = buildApp(spy);
     try {
       writeFileSync(join(rendersDir, "retry.mp4"), "valid-output");
-      writeFileSync(join(rendersDir, "retry.meta.json"), JSON.stringify({ status: "failed", error: "first attempt" }));
+      writeFileSync(
+        join(rendersDir, "retry.meta.json"),
+        JSON.stringify({ status: "failed", error: "first attempt" }),
+      );
       const res = await app.request("http://localhost/projects/demo/renders");
       expect(res.status).toBe(200);
       const body = await res.json();

--- a/packages/studio-server/src/routes/render.ts
+++ b/packages/studio-server/src/routes/render.ts
@@ -287,7 +287,11 @@ export function registerRenderRoutes(api: Hono, adapter: StudioApiAdapter): void
         if (existsSync(metaPath)) {
           try {
             const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
-            if (meta.status === "failed") status = "failed";
+            // A stale failed sidecar can remain after a retry succeeds. An
+            // existing output artifact is authoritative for the list view;
+            // don't present a downloadable render as failed solely because
+            // an earlier attempt left behind failed metadata.
+            if (meta.status === "failed" && !existsSync(fp)) status = "failed";
             if (meta.durationMs) durationMs = meta.durationMs;
           } catch {
             /* ignore */


### PR DESCRIPTION
A stale failed render sidecar can outlive a successful retry, causing Studio render listings to show a valid output as failed.

Changes:
- Treat an existing media artifact as authoritative in GET /projects/:id/renders.
- Add regression coverage for a valid output paired with status:failed metadata.

Verification: focused test is currently blocked in this fresh checkout by missing workspace build dependencies (esbuild/@hyperframes/core exports and happy-dom); code path and fixture are in place.