### PR TITLE
fix(lint): ignore local .scratch directories in oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,6 +5,7 @@
   },
   "plugins": ["react", "typescript"],
   "ignorePatterns": [
+    ".scratch/",
     "dist/",
     "coverage/",
     "node_modules/",


### PR DESCRIPTION
## What

Add `.scratch/` to `ignorePatterns` in `.oxlintrc.json`.

## Why

`oxlint .` sweeps untracked local scratch directories. `.scratch/` folders are ignored via developers' global gitignore rather than the repo `.gitignore`, and oxlint does not read the global ignore file, so any vendored or minified bundle dropped there breaks the whole lint run. A local checkout hit 3,821 errors from two minified JS bundles under `.scratch/`, which made every local pre-commit lint run red.

## How

One entry in the existing `ignorePatterns` list, alongside `dist/`, `coverage/`, and `playground/`.

## Test plan

- Repro: `bunx oxlint .` on a checkout containing minified bundles under `.scratch/` fails with 3,821 errors.
- With this config, the same command on the same checkout reports 0 warnings and 0 errors (1,987 files).
- Lefthook pre-commit checks on the change passed (format, tracked-artifacts, commitlint).

Not covered: no change to git ignore rules or other tooling; only oxlint's sweep is affected.
