### PR TITLE
chore: release v0.7.62

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,46 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.62"
+  description="Released - 2026-07-18"
+  tags={["Release", "Studio", "Producer", "CLI"]}
+>
+Studio now plays alpha-channel authoring proxies reliably through Chromium-compatible VP8, while the render pipeline gains stricter serializable request validation and immutable capture planning that preserves OOM retries. Cloud uploads are size-aware, timeline and sidecar recovery are more robust, and capture failures avoid duplicate compositing and pathological parsing.
+
+## Features
+
+- **CLI:** Make cloud archives size-aware ([e73304fb0](https://github.com/heygen-com/hyperframes/commit/e73304fb0e94d2272839e55a0bcc4dd00210db34))
+
+## Fixes
+
+- **Studio:** Preserve alpha proxy playback ([e64a22893](https://github.com/heygen-com/hyperframes/commit/e64a22893a161823c2b9f03522cf9d1246e96a9f), [#2625](https://github.com/heygen-com/hyperframes/pull/2625))
+- **Producer:** Retain streaming retry after OOM ([a7d6f7f7d](https://github.com/heygen-com/hyperframes/commit/a7d6f7f7dc4ed03f9d3b71f83551be01fbc3ac1c))
+- **Producer:** Preserve render request config contracts ([1a66c881b](https://github.com/heygen-com/hyperframes/commit/1a66c881b8f83932ebbf2f9c09b42f2f63de163e))
+- **Producer:** Validate render request engine snapshots ([fc4e9a6c0](https://github.com/heygen-com/hyperframes/commit/fc4e9a6c0ed8aa0eee054edce87e521c7ff3cafe))
+- **Producer:** Omit absent render request options ([25dd4cc8c](https://github.com/heygen-com/hyperframes/commit/25dd4cc8c013c43de7e562465b2b7ddacd863d89))
+- **Producer:** Validate render request wire contracts ([c251db02d](https://github.com/heygen-com/hyperframes/commit/c251db02d089c681a0739386d95489317da3b6ed))
+- **Studio:** Ignore stale failed sidecars for existing renders ([2577aaffe](https://github.com/heygen-com/hyperframes/commit/2577aaffeb9703be3d9dd17c0c5fb3c45b6e32e7), [#2621](https://github.com/heygen-com/hyperframes/pull/2621))
+- **Producer:** Credit held video tails in coverage gate ([209784ab2](https://github.com/heygen-com/hyperframes/commit/209784ab27801b70c9d8e636e4eaf2e3dc796d2b), [#2606](https://github.com/heygen-com/hyperframes/pull/2606))
+- **Studio:** Harden composition timeline reliability ([2b65b4efc](https://github.com/heygen-com/hyperframes/commit/2b65b4efcef9f69ab294aa608b54a89a600ab76f), [#2615](https://github.com/heygen-com/hyperframes/pull/2615))
+- **Engine:** Stop compositing phantom duplicates on captureBeyondViewport ([2be8a62c0](https://github.com/heygen-com/hyperframes/commit/2be8a62c0009e61aeae7f713773013afd9b6f173), [#2607](https://github.com/heygen-com/hyperframes/pull/2607))
+- **Engine:** Avoid polynomial capture failure regex ([5da9f7ab3](https://github.com/heygen-com/hyperframes/commit/5da9f7ab3d53d7b5b95f216d63532f20cb6036dd))
+
+## Docs & Examples
+
+- **Guides:** Resolve the Send-to fidelity contradiction (preserve substance, adapt form) ([7acabbcde](https://github.com/heygen-com/hyperframes/commit/7acabbcdeb9b55ce9f75c7d35d7f281273a99f29), [#2620](https://github.com/heygen-com/hyperframes/pull/2620))
+- **Guides:** Redirect Send-to imports to the Send-to guide ([8bfc67688](https://github.com/heygen-com/hyperframes/commit/8bfc676881c07c3c8ee1f0b6b247cc5f207cd3fd), [#2619](https://github.com/heygen-com/hyperframes/pull/2619))
+
+## Internal
+
+- **Producer:** Preserve parallel plan watchdog coverage ([e9604270b](https://github.com/heygen-com/hyperframes/commit/e9604270b27c73abf7d3f94ebe1dbe198736a8a0))
+- **Producer:** Make capture plans immutable ([6a84e95c6](https://github.com/heygen-com/hyperframes/commit/6a84e95c68fd6009fcd13b33aa2703d72b535d8f))
+- **Producer:** Unify render requests ([65f2e2927](https://github.com/heygen-com/hyperframes/commit/65f2e2927cc033a83ab7bdf5e43d4b63c2b7aa02))
+- **Engine:** Type capture failures ([acb3d81b9](https://github.com/heygen-com/hyperframes/commit/acb3d81b99d4135009cf34ec3cb467054cf0fa66))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.61...v0.7.62).
+</Update>
+
+<Update
   label="HyperFrames v0.7.61"
   description="Released - 2026-07-17"
   tags={["Release", "Media Use", "Studio", "Media"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.62.md
+++ b/releases/v0.7.62.md
@@ -1,0 +1,39 @@
+# HyperFrames v0.7.62
+
+Released on 2026-07-18.
+
+Studio now plays alpha-channel authoring proxies reliably through Chromium-compatible VP8, while the render pipeline gains stricter serializable request validation and immutable capture planning that preserves OOM retries. Cloud uploads are size-aware, timeline and sidecar recovery are more robust, and capture failures avoid duplicate compositing and pathological parsing.
+
+## Features
+
+- **CLI:** Make cloud archives size-aware ([e73304fb0](https://github.com/heygen-com/hyperframes/commit/e73304fb0e94d2272839e55a0bcc4dd00210db34))
+
+## Fixes
+
+- **Studio:** Preserve alpha proxy playback ([e64a22893](https://github.com/heygen-com/hyperframes/commit/e64a22893a161823c2b9f03522cf9d1246e96a9f), [#2625](https://github.com/heygen-com/hyperframes/pull/2625))
+- **Producer:** Retain streaming retry after OOM ([a7d6f7f7d](https://github.com/heygen-com/hyperframes/commit/a7d6f7f7dc4ed03f9d3b71f83551be01fbc3ac1c))
+- **Producer:** Preserve render request config contracts ([1a66c881b](https://github.com/heygen-com/hyperframes/commit/1a66c881b8f83932ebbf2f9c09b42f2f63de163e))
+- **Producer:** Validate render request engine snapshots ([fc4e9a6c0](https://github.com/heygen-com/hyperframes/commit/fc4e9a6c0ed8aa0eee054edce87e521c7ff3cafe))
+- **Producer:** Omit absent render request options ([25dd4cc8c](https://github.com/heygen-com/hyperframes/commit/25dd4cc8c013c43de7e562465b2b7ddacd863d89))
+- **Producer:** Validate render request wire contracts ([c251db02d](https://github.com/heygen-com/hyperframes/commit/c251db02d089c681a0739386d95489317da3b6ed))
+- **Studio:** Ignore stale failed sidecars for existing renders ([2577aaffe](https://github.com/heygen-com/hyperframes/commit/2577aaffeb9703be3d9dd17c0c5fb3c45b6e32e7), [#2621](https://github.com/heygen-com/hyperframes/pull/2621))
+- **Producer:** Credit held video tails in coverage gate ([209784ab2](https://github.com/heygen-com/hyperframes/commit/209784ab27801b70c9d8e636e4eaf2e3dc796d2b), [#2606](https://github.com/heygen-com/hyperframes/pull/2606))
+- **Studio:** Harden composition timeline reliability ([2b65b4efc](https://github.com/heygen-com/hyperframes/commit/2b65b4efcef9f69ab294aa608b54a89a600ab76f), [#2615](https://github.com/heygen-com/hyperframes/pull/2615))
+- **Engine:** Stop compositing phantom duplicates on captureBeyondViewport ([2be8a62c0](https://github.com/heygen-com/hyperframes/commit/2be8a62c0009e61aeae7f713773013afd9b6f173), [#2607](https://github.com/heygen-com/hyperframes/pull/2607))
+- **Engine:** Avoid polynomial capture failure regex ([5da9f7ab3](https://github.com/heygen-com/hyperframes/commit/5da9f7ab3d53d7b5b95f216d63532f20cb6036dd))
+
+## Docs & Examples
+
+- **Guides:** Resolve the Send-to fidelity contradiction (preserve substance, adapt form) ([7acabbcde](https://github.com/heygen-com/hyperframes/commit/7acabbcdeb9b55ce9f75c7d35d7f281273a99f29), [#2620](https://github.com/heygen-com/hyperframes/pull/2620))
+- **Guides:** Redirect Send-to imports to the Send-to guide ([8bfc67688](https://github.com/heygen-com/hyperframes/commit/8bfc676881c07c3c8ee1f0b6b247cc5f207cd3fd), [#2619](https://github.com/heygen-com/hyperframes/pull/2619))
+
+## Internal
+
+- **Producer:** Preserve parallel plan watchdog coverage ([e9604270b](https://github.com/heygen-com/hyperframes/commit/e9604270b27c73abf7d3f94ebe1dbe198736a8a0))
+- **Producer:** Make capture plans immutable ([6a84e95c6](https://github.com/heygen-com/hyperframes/commit/6a84e95c68fd6009fcd13b33aa2703d72b535d8f))
+- **Producer:** Unify render requests ([65f2e2927](https://github.com/heygen-com/hyperframes/commit/65f2e2927cc033a83ab7bdf5e43d4b63c2b7aa02))
+- **Engine:** Type capture failures ([acb3d81b9](https://github.com/heygen-com/hyperframes/commit/acb3d81b99d4135009cf34ec3cb467054cf0fa66))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.61...v0.7.62


### PR DESCRIPTION
## Summary

- bump all 13 published packages and 3 plugin manifests to `0.7.62`
- add reviewed v0.7.62 GitHub release notes and docs changelog entry
- publish as the stable `latest` channel after merge

## Verification

- release-channel validation passed for `release/v0.7.62` → `latest`
- 16/16 version-bearing manifests are `0.7.62`
- 18/18 non-merge commits since v0.7.61 are covered in release notes
- release script tests: 92/92
- full workspace build passed
- packed manifest verification passed for all 13 packages and clean consumer install
- release-only diff; no dependency or lockfile drift