### PR TITLE
chore: release v0.7.63

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,23 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.63"
+  description="Released - 2026-07-18"
+  tags={["Release", "Media Use"]}
+>
+Media Use now releases incomplete asset reservations when downloads, cache imports, or LUT
+generation fail, preventing zero-byte placeholders from being mistaken for valid media. Missing
+HeyGen CLI guidance now points to the official setup docs instead of embedding pipe-to-shell
+installer text.
+
+## Fixes
+
+- **Media Use:** Clean failed asset reservations ([49113eb08](https://github.com/heygen-com/hyperframes/commit/49113eb08487b2c53b7404bc26c5e419244ae97f), [#2627](https://github.com/heygen-com/hyperframes/pull/2627))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.62...v0.7.63).
+</Update>
+
+<Update
   label="HyperFrames v0.7.62"
   description="Released - 2026-07-18"
   tags={["Release", "Studio", "Producer", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.63.md
+++ b/releases/v0.7.63.md
@@ -1,0 +1,16 @@
+# HyperFrames v0.7.63
+
+Released on 2026-07-18.
+
+Media Use now releases incomplete asset reservations when downloads, cache imports, or LUT
+generation fail, preventing zero-byte placeholders from being mistaken for valid media. Missing
+HeyGen CLI guidance now points to the official setup docs instead of embedding pipe-to-shell
+installer text.
+
+## Fixes
+
+- **Media Use:** Clean failed asset reservations ([49113eb08](https://github.com/heygen-com/hyperframes/commit/49113eb08487b2c53b7404bc26c5e419244ae97f), [#2627](https://github.com/heygen-com/hyperframes/pull/2627))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.62...v0.7.63


### PR DESCRIPTION
## Summary

- bump all 13 publishable packages and 3 agent plugin manifests to `0.7.63`
- add reviewed v0.7.63 release notes and changelog entry for #2627
- publish the stable `latest` channel after merge

## Verification

- `bun run release:test` (33/33)
- `bun run build`
- `bun run verify:packed-manifests`
- `VERSION=0.7.63 DIST_TAG=latest EVENT_NAME=pull_request PR_HEAD_REF=release/v0.7.63 node scripts/validate-release-channel.mjs`
- `git diff origin/main...HEAD --check`

## Release contents

- #2627 — clean failed Media Use asset reservations and remove runtime pipe-to-shell installer guidance