### PR TITLE
fix(studio): keep composition multi-drag positions in sync

### DIFF
--- a/packages/studio/src/hooks/timelineEditingHelpers.test.ts
+++ b/packages/studio/src/hooks/timelineEditingHelpers.test.ts
@@ -142,6 +142,32 @@ describe("applyTimelineStackingReorder", () => {
 });
 
 describe("patchIframeDomTiming", () => {
+  it("patches a top-level composition host in its parent source file", () => {
+    const iframe = makeIframeWith(`
+      <div data-composition-id="root">
+        <div
+          id="scene-host"
+          data-composition-id="scene"
+          data-composition-src="compositions/scene.html"
+          data-start="2"
+        ></div>
+      </div>
+    `);
+    const host = iframe.contentDocument?.getElementById("scene-host");
+    const target = el({
+      id: "scene-host",
+      tag: "div",
+      kind: "composition",
+      domId: "scene-host",
+      sourceFile: "index.html",
+      compositionSrc: "compositions/scene.html",
+    });
+
+    patchIframeDomTiming(iframe, target, [["data-start", "9"]], "index.html");
+
+    expect(host?.getAttribute("data-start")).toBe("9");
+  });
+
   it("resolves selectorIndex within the element's source file", () => {
     const iframe = makeIframeWith(`
       <div data-composition-id="root">

--- a/packages/studio/src/hooks/timelineEditingHelpers.ts
+++ b/packages/studio/src/hooks/timelineEditingHelpers.ts
@@ -13,7 +13,10 @@ import { saveProjectFilesWithHistory, type RecordEditInput } from "../utils/stud
 import type { TimelineZIndexReorderCommit } from "./useTimelineEditingTypes";
 import { setCompositionDurationToContent } from "../utils/timelineAssetDrop";
 import { readFileContent } from "./timelineTimingSync";
-import { findElementForSelection } from "../components/editor/domEditingElement";
+import {
+  findElementForSelection,
+  findElementForTimelineElement,
+} from "../components/editor/domEditingElement";
 export { deleteSelectedKeyframes } from "./deleteSelectedKeyframes";
 export { readFileContent };
 function isHTMLElement(element: Element | null): element is HTMLElement {
@@ -137,6 +140,12 @@ export function findTimelineElementInIframe(
   try {
     const doc = iframe?.contentDocument;
     if (!doc) return null;
+    if (element.kind === "composition" && element.compositionSrc) {
+      return findElementForTimelineElement(doc, element, {
+        activeCompositionPath,
+        isMasterView: true,
+      });
+    }
     return findElementForSelection(
       doc,
       {


### PR DESCRIPTION
## What

Dragging multiple composition tracks now keeps their new positions immediately instead of snapping back until Studio is refreshed.

## Why

The drag already persisted the correct timing to `index.html`, but the live DOM patch resolved a top-level composition host against its child composition file. Because the host was not updated in the preview, a delayed runtime manifest restored its stale start time in Studio state.

## How

Top-level composition tracks now use the existing composition-aware timeline lookup when patching preview timing. Normal timeline elements keep the existing generic selection lookup, limiting the behavior change to composition hosts. A regression test covers patching a composition host in its parent source file.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable — no documentation behavior changed)

- `bun run --filter @hyperframes/studio test -- src/hooks/timelineEditingHelpers.test.ts src/components/editor/domEditing.test.ts` (61 tests passed)
- `bun run --filter @hyperframes/studio typecheck`
- In Studio on port 5190, marquee-selected three composition tracks, dragged them together, and confirmed their positions remained stable after runtime synchronization