### PR TITLE
chore: release v0.7.64

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,34 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.64"
+  description="Released - 2026-07-18"
+  tags={["Release", "Studio", "Lint", "Core"]}
+>
+Studio editing is more predictable: multi-selection drags now keep composition positions in sync,
+and Acorn-based atomic cuts stay isolated from Recast behind explicit operation-family gates.
+Preview and render compilation now share a semantic-parity contract, while local `.scratch` files
+no longer pollute lint runs.
+
+## Fixes
+
+- **Studio:** Keep composition multi-drag positions in sync ([f7911d10b](https://github.com/heygen-com/hyperframes/commit/f7911d10b0a7deac6fe4630947b53434d237ad21), [#2629](https://github.com/heygen-com/hyperframes/pull/2629))
+- **Lint:** Ignore local .scratch directories in oxlint ([452e9074f](https://github.com/heygen-com/hyperframes/commit/452e9074f413677b0040c7ea231dacf3f0470c0e), [#2624](https://github.com/heygen-com/hyperframes/pull/2624))
+- **Studio:** Keep atomic Acorn splits Recast-free ([8dd7e3dfc](https://github.com/heygen-com/hyperframes/commit/8dd7e3dfc57dd1f44f50818cd9eea5225edd0ec0))
+- **Studio:** Read writer environment explicitly ([022e260ac](https://github.com/heygen-com/hyperframes/commit/022e260ac3096fd4826e14e1924aba2cfd1a84c6))
+- **Studio:** Select writer for atomic cuts ([710a8f1db](https://github.com/heygen-com/hyperframes/commit/710a8f1db2568b078a894ccfde87a07aefcecab8))
+
+## Internal
+
+- **Core:** Own edit protocol contract ([562544f68](https://github.com/heygen-com/hyperframes/commit/562544f68de4f769cdb1faac633b7c8341dbd0fb))
+- **Compiler:** Enforce preview render parity ([f0956e594](https://github.com/heygen-com/hyperframes/commit/f0956e59447de4bf1f02fcc3f765ac8461edd00b))
+- **Studio:** Gate SDK operation families ([38c2d0693](https://github.com/heygen-com/hyperframes/commit/38c2d069333e0d6deae746de970539e8a4d94a5d))
+- **Studio:** Gate Acorn writer migration ([43788c6dd](https://github.com/heygen-com/hyperframes/commit/43788c6dda35badd9333f53a91c5e88f56d502be))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.63...v0.7.64).
+</Update>
+
+<Update
   label="HyperFrames v0.7.63"
   description="Released - 2026-07-18"
   tags={["Release", "Media Use"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.64.md
+++ b/releases/v0.7.64.md
@@ -1,0 +1,27 @@
+# HyperFrames v0.7.64
+
+Released on 2026-07-18.
+
+Studio editing is more predictable: multi-selection drags now keep composition positions in sync,
+and Acorn-based atomic cuts stay isolated from Recast behind explicit operation-family gates.
+Preview and render compilation now share a semantic-parity contract, while local `.scratch` files
+no longer pollute lint runs.
+
+## Fixes
+
+- **Studio:** Keep composition multi-drag positions in sync ([f7911d10b](https://github.com/heygen-com/hyperframes/commit/f7911d10b0a7deac6fe4630947b53434d237ad21), [#2629](https://github.com/heygen-com/hyperframes/pull/2629))
+- **Lint:** Ignore local .scratch directories in oxlint ([452e9074f](https://github.com/heygen-com/hyperframes/commit/452e9074f413677b0040c7ea231dacf3f0470c0e), [#2624](https://github.com/heygen-com/hyperframes/pull/2624))
+- **Studio:** Keep atomic Acorn splits Recast-free ([8dd7e3dfc](https://github.com/heygen-com/hyperframes/commit/8dd7e3dfc57dd1f44f50818cd9eea5225edd0ec0))
+- **Studio:** Read writer environment explicitly ([022e260ac](https://github.com/heygen-com/hyperframes/commit/022e260ac3096fd4826e14e1924aba2cfd1a84c6))
+- **Studio:** Select writer for atomic cuts ([710a8f1db](https://github.com/heygen-com/hyperframes/commit/710a8f1db2568b078a894ccfde87a07aefcecab8))
+
+## Internal
+
+- **Core:** Own edit protocol contract ([562544f68](https://github.com/heygen-com/hyperframes/commit/562544f68de4f769cdb1faac633b7c8341dbd0fb))
+- **Compiler:** Enforce preview render parity ([f0956e594](https://github.com/heygen-com/hyperframes/commit/f0956e59447de4bf1f02fcc3f765ac8461edd00b))
+- **Studio:** Gate SDK operation families ([38c2d0693](https://github.com/heygen-com/hyperframes/commit/38c2d069333e0d6deae746de970539e8a4d94a5d))
+- **Studio:** Gate Acorn writer migration ([43788c6dd](https://github.com/heygen-com/hyperframes/commit/43788c6dda35badd9333f53a91c5e88f56d502be))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.63...v0.7.64


### PR DESCRIPTION
## What

Release HyperFrames v0.7.64 across all 13 publishable packages and three agent plugin manifests. Adds reviewed release notes for the changes since v0.7.63.

## Why

Ship the latest Studio editing reliability, preview/render parity contract, and lint workflow improvements as the next stable npm release.

## How

- Bumped every fixed-version package and plugin manifest to 0.7.64
- Generated the changelog from v0.7.63 through current main
- Rewrote and reviewed the release summary for accuracy

## Test plan

- [x] Release preparation tests (33/33)
- [x] Release artifacts and manifests pass oxfmt
- [x] Documentation updated

Stable release PR: admin-merge/no-review workflow per Miguel.