### PR TITLE
perf(studio): virtualize timeline rows

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -324,6 +324,7 @@
         "@hyperframes/sdk": "workspace:*",
         "@hyperframes/studio-server": "workspace:*",
         "@phosphor-icons/react": "^2.1.10",
+        "@tanstack/react-virtual": "^3.14.6",
         "bpm-detective": "^2.0.5",
         "dompurify": "^3.2.4",
         "gsap": "^3.13.0",
@@ -1101,6 +1102,10 @@
     "@sparticuz/chromium": ["@sparticuz/chromium@148.0.0", "", { "dependencies": { "tar-fs": "^3.1.2" } }, "sha512-na5beDSZkrlcEWEMt+eHu4Xe+MLUgCtHBjHaXGsNaQu5tJWwXE+McxAcMtyumEM/JzXrxGpkO5vAPD9TWhil3g=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.6", "", { "dependencies": { "@tanstack/virtual-core": "3.17.4" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.4", "", {}, "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw=="],
 
     "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -61,6 +61,7 @@
     "@hyperframes/sdk": "workspace:*",
     "@hyperframes/studio-server": "workspace:*",
     "@phosphor-icons/react": "^2.1.10",
+    "@tanstack/react-virtual": "^3.14.6",
     "bpm-detective": "^2.0.5",
     "dompurify": "^3.2.4",
     "gsap": "^3.13.0",

--- a/packages/studio/src/player/components/LayerDisclosureRow.tsx
+++ b/packages/studio/src/player/components/LayerDisclosureRow.tsx
@@ -28,6 +28,7 @@ export function LayerDisclosureRow({
     >
       <button
         type="button"
+        aria-expanded={isExpanded}
         aria-label={`${isExpanded ? "Collapse" : "Expand"} ${name} keyframes`}
         title={`${isExpanded ? "Collapse" : "Expand"} keyframe lanes`}
         className="flex h-5 w-4 shrink-0 items-center justify-center rounded border-0 bg-transparent p-0 text-white/55 hover:text-white focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#3CE6AC]"

--- a/packages/studio/src/player/components/Timeline.test.ts
+++ b/packages/studio/src/player/components/Timeline.test.ts
@@ -274,6 +274,32 @@ describe("Timeline provider boundary", () => {
     act(() => root.unmount());
   });
 
+  it("renders the complete track list while row virtualization is gated off", () => {
+    const host = createSizedTimelineHost(640);
+    usePlayerStore.setState({
+      duration: 4,
+      timelineReady: true,
+      elements: Array.from({ length: 12 }, (_, track) => ({
+        id: `clip-${track}`,
+        tag: "div",
+        start: 0,
+        duration: 2,
+        track,
+      })),
+    });
+    const root = createRoot(host);
+    act(() => root.render(React.createElement(Timeline)));
+
+    const list = host.querySelector<HTMLElement>('[role="list"]');
+    const rows = list?.querySelectorAll('[role="listitem"]') ?? [];
+    expect(rows).toHaveLength(12);
+    expect(rows[0]?.getAttribute("aria-posinset")).toBe("1");
+    expect(rows[0]?.getAttribute("aria-setsize")).toBe("12");
+    expect(rows[11]?.getAttribute("aria-posinset")).toBe("12");
+
+    act(() => root.unmount());
+  });
+
   it("renders the gutter without legacy icons or hue dots", () => {
     const { host, root } = renderBasicTimeline();
 

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useCallback, useState, useLayoutEffect, memo } from "react";
+import { useRef, useMemo, useCallback, useState, memo } from "react";
 import { useMusicBeatAnalysis } from "../../hooks/useMusicBeatAnalysis";
 import { remapBeatAnalysisToComposition } from "../../utils/beatEditActions";
 import { usePlayerStore, type TimelineElement } from "../store/playerStore";
@@ -40,7 +40,7 @@ import { useTimelineSelectionLifecycle } from "./useTimelineSelectionLifecycle";
 import { useTimelineShiftModifier } from "./useTimelineShiftModifier";
 import { useTimelineTicks } from "./useTimelineTicks";
 import { getTimelineElementIndexes } from "../lib/timelineElementIndexes";
-import { getTimelineScrollTopForGeometryChange } from "./timelineViewportGeometry";
+import { useTimelineRowVirtualization } from "./useTimelineRowVirtualization";
 
 // Re-export pure utilities so existing imports from "./Timeline" still resolve.
 export {
@@ -118,6 +118,7 @@ export const Timeline = memo(function Timeline({
   const timelineReady = usePlayerStore((s) => s.timelineReady);
   const selectedElementId = usePlayerStore((s) => s.selectedElementId);
   const selectedElementIds = usePlayerStore((s) => s.selectedElementIds);
+  const clipRevealRequest = usePlayerStore((s) => s.clipRevealRequest);
   const gsapAnimations = usePlayerStore((s) => s.gsapAnimations);
   // Label mode = comp has keyframed clips (not just when expanded): keeps the layer
   // disclosure + property column visible and reserves a GUTTER before 0s (Figma).
@@ -273,32 +274,21 @@ export const Timeline = memo(function Timeline({
       expandedElements.length,
       displayLayout.totalH,
     ]);
-  const previousLayoutRef = useRef(displayLayout.rowGeometry);
-  const previousSessionEpochRef = useRef(sessionEpoch);
-  useLayoutEffect(() => {
-    const scroll = scrollRef.current;
-    const previousGeometry = previousLayoutRef.current;
-    if (previousSessionEpochRef.current !== sessionEpoch) {
-      previousSessionEpochRef.current = sessionEpoch;
-      lastScrollLeftRef.current = 0;
-      if (scroll) {
-        scroll.scrollLeft = 0;
-        scroll.scrollTop = 0;
-        syncScrollViewport(scroll);
-      }
-    } else if (scroll && previousGeometry !== displayLayout.rowGeometry) {
-      const nextScrollTop = getTimelineScrollTopForGeometryChange(
-        previousGeometry,
-        displayLayout.rowGeometry,
-        scroll.scrollTop,
-      );
-      if (nextScrollTop !== scroll.scrollTop) {
-        scroll.scrollTop = nextScrollTop;
-        syncScrollViewport(scroll);
-      }
-    }
-    previousLayoutRef.current = displayLayout.rowGeometry;
-  }, [displayLayout.rowGeometry, sessionEpoch, syncScrollViewport]);
+  const { enabled: rowVirtualizationActive, virtualRows } = useTimelineRowVirtualization({
+    scrollRef,
+    viewport,
+    rowGeometry: displayLayout.rowGeometry,
+    sessionEpoch,
+    elements: expandedElements,
+    selectedElementId,
+    revealElementId: clipRevealRequest?.elementId ?? null,
+    draggedRowKey: draggedClip?.started ? draggedClip.previewTrack : undefined,
+    resizingRowKey: resizingClip?.element.track,
+    clipContextMenuRowKey: clipContextMenu?.element.track,
+    keyframeContextMenuRowKey: kfContextMenu?.element.track,
+    lastScrollLeftRef,
+    syncScrollViewport,
+  });
   const selectedKeyframes = usePlayerStore((s) => s.selectedKeyframes);
   const toggleSelectedKeyframe = usePlayerStore((s) => s.toggleSelectedKeyframe);
   const { onClickKeyframe, onSelectSegment, onShiftClickKeyframe, onContextMenuKeyframe } =
@@ -495,6 +485,9 @@ export const Timeline = memo(function Timeline({
           theme={theme}
           displayTrackOrder={displayLayout.displayTrackOrder}
           rowHeights={displayLayout.displayRowHeights}
+          rowGeometry={displayLayout.rowGeometry}
+          virtualRows={virtualRows}
+          rowsVirtualized={rowVirtualizationActive}
           trackOrder={trackOrder}
           tracks={tracks}
           trackStyles={trackStyles}

--- a/packages/studio/src/player/components/Timeline.virtualization.test.tsx
+++ b/packages/studio/src/player/components/Timeline.virtualization.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+class MockResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          target,
+          borderBoxSize: [{ inlineSize: target.clientWidth, blockSize: target.clientHeight }],
+        } as unknown as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
+
+beforeAll(() => {
+  vi.stubEnv("VITE_STUDIO_TIMELINE_ROW_VIRTUALIZATION_ENABLED", "1");
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => 900,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => 240,
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+  globalThis.ResizeObserver = originalResizeObserver;
+  if (originalClientWidth)
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", originalClientWidth);
+  if (originalClientHeight)
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", originalClientHeight);
+  document.body.innerHTML = "";
+});
+
+describe("Timeline row virtualization", () => {
+  it("mounts a bounded list range over the full geometry height", async () => {
+    const [{ Timeline }, { usePlayerStore }, { getTimelineCanvasHeight }] = await Promise.all([
+      import("./Timeline"),
+      import("../store/playerStore"),
+      import("./timelineLayout"),
+    ]);
+    usePlayerStore.setState({
+      duration: 60,
+      timelineReady: true,
+      elements: Array.from({ length: 1_000 }, (_, track) => ({
+        id: `clip-${track}`,
+        tag: "div",
+        start: 0,
+        duration: 1,
+        track,
+      })),
+    });
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    await act(async () => root.render(React.createElement(Timeline, { sessionEpoch: 3 })));
+    await act(async () => {});
+
+    const list = host.querySelector<HTMLElement>('[role="list"]');
+    const rows = list?.querySelectorAll('[role="listitem"]') ?? [];
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThanOrEqual(16);
+    expect(rows[0]?.getAttribute("aria-posinset")).toBe("1");
+    expect(rows[0]?.getAttribute("aria-setsize")).toBe("1000");
+    expect(list?.parentElement?.style.height).toBe(`${getTimelineCanvasHeight(1_000)}px`);
+
+    const firstRow = rows[0] as HTMLElement;
+    const focusedControl = firstRow.querySelector<HTMLButtonElement>("button");
+    expect(focusedControl).not.toBeNull();
+    act(() => focusedControl?.focus());
+    const scroller = host.querySelector<HTMLElement>("[data-timeline-scroll-viewport]");
+    expect(scroller).not.toBeNull();
+    if (scroller) {
+      scroller.scrollTop = 500 * 48;
+      await act(async () => {
+        scroller.dispatchEvent(new Event("scroll"));
+      });
+    }
+    expect(list?.querySelector('[data-timeline-row-key="0"]')).not.toBeNull();
+    expect(document.activeElement).toBe(focusedControl);
+
+    act(() => root.unmount());
+    usePlayerStore.getState().reset();
+  });
+});

--- a/packages/studio/src/player/components/TimelineCanvas.tsx
+++ b/packages/studio/src/player/components/TimelineCanvas.tsx
@@ -125,7 +125,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
 
       {/* Breathing room between the sticky ruler and the first track lane — the
           top half of the CapCut-style padding (see TRACKS_TOP_PAD). */}
-      <div aria-hidden="true" style={{ height: TRACKS_TOP_PAD }} />
+      <div aria-hidden="true" style={{ height: props.rowsVirtualized ? 0 : TRACKS_TOP_PAD }} />
 
       <TimelineLanes
         {...props}
@@ -142,7 +142,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
       {/* Breathing room below the last track lane (~1.5 track heights) — a real
           scrollable surface, so a clip can be dragged into the void to create a
           new bottom track comfortably (see TRACKS_BOTTOM_PAD / getTimelineCanvasHeight). */}
-      <div aria-hidden="true" style={{ height: TRACKS_BOTTOM_PAD }} />
+      <div aria-hidden="true" style={{ height: props.rowsVirtualized ? 0 : TRACKS_BOTTOM_PAD }} />
 
       {/* Gap strips — loud dashed fill for the gap(s) a hovered "Close gap(s)"
           menu row would collapse; a quiet tint for every gap on the selected

--- a/packages/studio/src/player/components/TimelineLaneTypes.ts
+++ b/packages/studio/src/player/components/TimelineLaneTypes.ts
@@ -6,6 +6,8 @@ import type { TimelineTheme } from "./timelineTheme";
 import type { BlockedClipState, DraggedClipState, ResizingClipState } from "./useTimelineClipDrag";
 import type { TrackVisualStyle } from "./timelineIcons";
 import type { KeyframeCacheEntry, TimelineElement } from "../store/playerStore";
+import type { TimelineRowGeometry } from "./timelineLayout";
+import type { TimelineVirtualRow } from "./useTimelineVirtualRows";
 
 /** Props shared by TimelineCanvas and its lane renderer. */
 export interface TimelineLaneBaseProps {
@@ -16,6 +18,9 @@ export interface TimelineLaneBaseProps {
   theme: TimelineTheme;
   displayTrackOrder: number[];
   rowHeights: readonly number[];
+  rowGeometry: TimelineRowGeometry;
+  virtualRows: readonly TimelineVirtualRow[];
+  rowsVirtualized: boolean;
   trackOrder: number[];
   tracks: [number, TimelineElement[]][];
   trackStyles: Map<number, TrackVisualStyle>;

--- a/packages/studio/src/player/components/TimelineLanes.tsx
+++ b/packages/studio/src/player/components/TimelineLanes.tsx
@@ -5,7 +5,7 @@ import { TimelinePropertyLanes } from "./TimelinePropertyLanes";
 import { TimelineTrackHeader } from "./TimelineTrackHeader";
 import { resolveTrackKeyframeClip } from "./useTimelineTrackLayout";
 import { getTimelineEditCapabilities, resolveBlockedTimelineEditIntent } from "./timelineEditing";
-import { CLIP_Y, CLIP_HANDLE_W, TRACK_H, getTimelineRowHeight } from "./timelineLayout";
+import { CLIP_Y, CLIP_HANDLE_W, TRACK_H } from "./timelineLayout";
 import { usePlayerStore, type TimelineElement } from "../store/playerStore";
 import {
   isMultiDragPassenger,
@@ -19,6 +19,7 @@ import { SPLIT_BOUNDARY_EPSILON_S } from "../../utils/timelineElementSplit";
 import { isAudioTimelineElement, isMusicTrack } from "../../utils/timelineInspector";
 import { renderClipChildren } from "./timelineClipChildren";
 import type { TimelineLaneBaseProps } from "./TimelineLaneTypes";
+import { TimelineTrackRow } from "./TimelineTrackRow";
 
 interface TimelineLanesProps extends TimelineLaneBaseProps {
   /** Live-derived by TimelineCanvas from {@link TimelineLaneBaseProps.draggedClip}. */
@@ -39,7 +40,9 @@ export function TimelineLanes({
   trackContentWidth,
   theme,
   displayTrackOrder,
-  rowHeights,
+  rowGeometry,
+  virtualRows,
+  rowsVirtualized,
   trackOrder,
   tracks,
   trackStyles,
@@ -95,16 +98,17 @@ export function TimelineLanes({
     toggleClipExpanded(key);
   };
   return (
-    <>
+    <div
+      role="list"
+      aria-label="Timeline tracks"
+      className={rowsVirtualized ? "absolute inset-0" : undefined}
+    >
       {
-        // NOTE (deliberate no-virtualization): lanes and their clips render via a
-        // plain `.map()` inside the scroll container rather than a windowing/virtualized
-        // list. NLE clip counts are small (dozens to low hundreds), so the DOM cost is
-        // bounded and virtualization's complexity isn't worth it. TODO: revisit and swap
-        // in a virtualizer if editorial workflows ever push very high clip counts.
         // fallow-ignore-next-line complexity
-        displayTrackOrder.map((trackNum, row) => {
-          const rowHeight = getTimelineRowHeight(row, rowHeights);
+        virtualRows.map(({ index: row, rowKey }) => {
+          const trackNum = displayTrackOrder[row];
+          if (trackNum === undefined) return null;
+          const rowHeight = rowGeometry.getRowHeight(row);
           const els = tracks.find(([t]) => t === trackNum)?.[1] ?? [];
           const ts = trackStyles.get(trackNum) ?? getTrackStyle("");
           const isPendingTrack =
@@ -131,14 +135,16 @@ export function TimelineLanes({
           const keyframeClipExpanded =
             keyframeClipKey != null && expandedClipIds.has(keyframeClipKey);
           return (
-            <div
-              key={trackNum}
-              className="relative flex"
-              style={{
-                height: rowHeight,
-                background: rowBackground,
-                borderBottom: `1px solid ${theme.rowBorder}`,
-              }}
+            <TimelineTrackRow
+              key={rowKey}
+              index={row}
+              rowKey={rowKey}
+              rowCount={displayTrackOrder.length}
+              top={rowGeometry.getRowTop(row)}
+              height={rowHeight}
+              virtualized={rowsVirtualized}
+              background={rowBackground}
+              borderColor={theme.rowBorder}
             >
               <TimelineTrackHeader
                 trackNumber={trackNum}
@@ -501,10 +507,10 @@ export function TimelineLanes({
                   })
                 }
               </div>
-            </div>
+            </TimelineTrackRow>
           );
         })
       }
-    </>
+    </div>
   );
 }

--- a/packages/studio/src/player/components/TimelineTrackRow.tsx
+++ b/packages/studio/src/player/components/TimelineTrackRow.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+interface TimelineTrackRowProps {
+  index: number;
+  rowKey: number;
+  rowCount: number;
+  top: number;
+  height: number;
+  virtualized: boolean;
+  background: string;
+  borderColor: string;
+  children: ReactNode;
+}
+
+/** Accessible row shell; edit geometry owns its exact top and height. */
+export function TimelineTrackRow({
+  index,
+  rowKey,
+  rowCount,
+  top,
+  height,
+  virtualized,
+  background,
+  borderColor,
+  children,
+}: TimelineTrackRowProps) {
+  return (
+    <div
+      role="listitem"
+      aria-posinset={index + 1}
+      aria-setsize={rowCount}
+      data-index={index}
+      data-timeline-row={index}
+      data-timeline-row-key={rowKey}
+      className={`${virtualized ? "absolute left-0 right-0" : "relative"} flex`}
+      style={{
+        top: virtualized ? top : undefined,
+        height,
+        background,
+        borderBottom: `1px solid ${borderColor}`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/studio/src/player/components/timelineFocusIdentity.test.ts
+++ b/packages/studio/src/player/components/timelineFocusIdentity.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineElement } from "../store/playerStore";
+import { resolveTimelineFocusIdentity } from "./timelineFocusIdentity";
+
+describe("timeline focus identity", () => {
+  const elements: TimelineElement[] = [
+    { id: "clip/a", key: "stable:key", tag: "div", start: 0, duration: 1, track: 7.5 },
+  ];
+
+  it("resolves a stable element id and fractional display row from model identity", () => {
+    expect(resolveTimelineFocusIdentity(elements, "stable:key")).toEqual({
+      elementId: "stable:key",
+      rowKey: 7.5,
+    });
+  });
+
+  it("does not invent focus for a missing or cleared identity", () => {
+    expect(resolveTimelineFocusIdentity(elements, "missing")).toBeNull();
+    expect(resolveTimelineFocusIdentity(elements, null)).toBeNull();
+  });
+});

--- a/packages/studio/src/player/components/timelineFocusIdentity.ts
+++ b/packages/studio/src/player/components/timelineFocusIdentity.ts
@@ -1,0 +1,21 @@
+import type { TimelineElement } from "../store/playerStore";
+import { getTimelineElementIndexes } from "../lib/timelineElementIndexes";
+
+export interface TimelineFocusIdentity {
+  readonly elementId: string;
+  readonly rowKey: number;
+}
+
+/** Resolve logical focus from model identity; mount state is deliberately irrelevant. */
+export function resolveTimelineFocusIdentity(
+  elements: readonly TimelineElement[],
+  elementId: string | null,
+): TimelineFocusIdentity | null {
+  if (!elementId) return null;
+  const element = getTimelineElementIndexes(elements).byKey.get(elementId);
+  if (!element) return null;
+  return {
+    elementId,
+    rowKey: element.track,
+  };
+}

--- a/packages/studio/src/player/components/useTimelineRowVirtualization.ts
+++ b/packages/studio/src/player/components/useTimelineRowVirtualization.ts
@@ -1,0 +1,135 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react";
+import type { TimelineElement } from "../store/playerStore";
+import { resolveTimelineFocusIdentity } from "./timelineFocusIdentity";
+import { getTimelineScrollTopForGeometryChange } from "./timelineViewportGeometry";
+import type { TimelineRowGeometry } from "./timelineLayout";
+import type { TimelineScrollViewportSnapshot } from "./useTimelineScrollViewport";
+import {
+  STUDIO_TIMELINE_ROW_VIRTUALIZATION_ENABLED,
+  useTimelineVirtualRows,
+} from "./useTimelineVirtualRows";
+
+interface UseTimelineRowVirtualizationInput {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  viewport: TimelineScrollViewportSnapshot;
+  rowGeometry: TimelineRowGeometry;
+  sessionEpoch: number;
+  elements: TimelineElement[];
+  selectedElementId: string | null;
+  revealElementId: string | null;
+  draggedRowKey?: number;
+  resizingRowKey?: number;
+  clipContextMenuRowKey?: number;
+  keyframeContextMenuRowKey?: number;
+  lastScrollLeftRef: RefObject<number>;
+  syncScrollViewport: (element: HTMLDivElement, isScrolling?: boolean) => void;
+}
+
+function getFocusedTimelineRowKey(target: EventTarget | null): number | undefined {
+  if (!(target instanceof Element)) return undefined;
+  const value = target.closest<HTMLElement>("[data-timeline-row-key]")?.dataset.timelineRowKey;
+  if (value === undefined) return undefined;
+  const rowKey = Number(value);
+  return Number.isFinite(rowKey) ? rowKey : undefined;
+}
+
+export function useTimelineRowVirtualization({
+  scrollRef,
+  viewport,
+  rowGeometry,
+  sessionEpoch,
+  elements,
+  selectedElementId,
+  revealElementId,
+  draggedRowKey,
+  resizingRowKey,
+  clipContextMenuRowKey,
+  keyframeContextMenuRowKey,
+  lastScrollLeftRef,
+  syncScrollViewport,
+}: UseTimelineRowVirtualizationInput) {
+  const enabled =
+    STUDIO_TIMELINE_ROW_VIRTUALIZATION_ENABLED &&
+    viewport.clientWidth > 0 &&
+    viewport.clientHeight > 0;
+  const [domFocusedRowKey, setDomFocusedRowKey] = useState<number>();
+  useEffect(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    const handleFocusIn = (event: FocusEvent) => {
+      setDomFocusedRowKey(getFocusedTimelineRowKey(event.target));
+    };
+    const handleFocusOut = (event: FocusEvent) => {
+      setDomFocusedRowKey(getFocusedTimelineRowKey(event.relatedTarget));
+    };
+    scroll.addEventListener("focusin", handleFocusIn);
+    scroll.addEventListener("focusout", handleFocusOut);
+    return () => {
+      scroll.removeEventListener("focusin", handleFocusIn);
+      scroll.removeEventListener("focusout", handleFocusOut);
+    };
+  }, [scrollRef, sessionEpoch]);
+  const focusIdentity = useMemo(
+    () => resolveTimelineFocusIdentity(elements, selectedElementId),
+    [elements, selectedElementId],
+  );
+  const revealIdentity = useMemo(
+    () => resolveTimelineFocusIdentity(elements, revealElementId),
+    [elements, revealElementId],
+  );
+  const pinnedRowKeys = useMemo(
+    () =>
+      [
+        draggedRowKey,
+        resizingRowKey,
+        revealIdentity?.rowKey,
+        clipContextMenuRowKey,
+        keyframeContextMenuRowKey,
+      ].filter((rowKey): rowKey is number => rowKey !== undefined),
+    [
+      clipContextMenuRowKey,
+      draggedRowKey,
+      keyframeContextMenuRowKey,
+      resizingRowKey,
+      revealIdentity,
+    ],
+  );
+  const virtualRows = useTimelineVirtualRows({
+    enabled,
+    scrollRef,
+    viewport,
+    rowGeometry,
+    sessionEpoch,
+    pinnedRowKeys,
+    focusedRowKey: domFocusedRowKey ?? focusIdentity?.rowKey,
+  });
+
+  const previousLayoutRef = useRef(rowGeometry);
+  const previousSessionEpochRef = useRef(sessionEpoch);
+  useLayoutEffect(() => {
+    const scroll = scrollRef.current;
+    const previousGeometry = previousLayoutRef.current;
+    if (previousSessionEpochRef.current !== sessionEpoch) {
+      previousSessionEpochRef.current = sessionEpoch;
+      lastScrollLeftRef.current = 0;
+      if (scroll) {
+        scroll.scrollLeft = 0;
+        scroll.scrollTop = 0;
+        syncScrollViewport(scroll);
+      }
+    } else if (scroll && previousGeometry !== rowGeometry) {
+      const nextScrollTop = getTimelineScrollTopForGeometryChange(
+        previousGeometry,
+        rowGeometry,
+        scroll.scrollTop,
+      );
+      if (nextScrollTop !== scroll.scrollTop) {
+        scroll.scrollTop = nextScrollTop;
+        syncScrollViewport(scroll);
+      }
+    }
+    previousLayoutRef.current = rowGeometry;
+  }, [lastScrollLeftRef, rowGeometry, scrollRef, sessionEpoch, syncScrollViewport]);
+
+  return { enabled, virtualRows };
+}

--- a/packages/studio/src/player/components/useTimelineVirtualRows.test.tsx
+++ b/packages/studio/src/player/components/useTimelineVirtualRows.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createTimelineRowGeometry, RULER_H, TRACKS_TOP_PAD } from "./timelineLayout";
+import { extractTimelineVirtualRowRange, useTimelineVirtualRows } from "./useTimelineVirtualRows";
+import type { TimelineScrollViewportSnapshot } from "./useTimelineScrollViewport";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+class MockResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+  observe(target: Element) {
+    const { width, height } = target.getBoundingClientRect();
+    this.callback(
+      [
+        {
+          target,
+          borderBoxSize: [{ inlineSize: width, blockSize: height }],
+        } as unknown as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterAll(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function createScrollElement(scrollTop: number, width = 800, height = 192): HTMLDivElement {
+  const element = document.createElement("div");
+  document.body.append(element);
+  Object.defineProperties(element, {
+    scrollTop: { configurable: true, writable: true, value: scrollTop },
+    scrollLeft: { configurable: true, writable: true, value: 0 },
+    clientWidth: { configurable: true, value: width },
+    clientHeight: { configurable: true, value: height },
+    scrollWidth: { configurable: true, value: width },
+    scrollHeight: { configurable: true, value: 60_000 },
+  });
+  element.getBoundingClientRect = () =>
+    ({ width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0 }) as DOMRect;
+  return element;
+}
+
+function viewport(element: HTMLDivElement): TimelineScrollViewportSnapshot {
+  return {
+    scrollLeft: element.scrollLeft,
+    scrollTop: element.scrollTop,
+    clientWidth: element.clientWidth,
+    clientHeight: element.clientHeight,
+    scrollWidth: element.scrollWidth,
+    scrollHeight: element.scrollHeight,
+    isScrolling: false,
+  };
+}
+
+function createLargeGeometry(keyOffset = 0) {
+  const keys = Array.from({ length: 1_000 }, (_, index) => index + keyOffset);
+  return createTimelineRowGeometry(
+    keys,
+    keys.map(() => 48),
+  );
+}
+
+describe("extractTimelineVirtualRowRange", () => {
+  it("unions visible overscan with unique actor pins", () => {
+    expect(
+      extractTimelineVirtualRowRange(
+        { startIndex: 10, endIndex: 12, overscan: 2, count: 100 },
+        [0, 11, 99, 99, -1, 100],
+      ),
+    ).toEqual([0, 8, 9, 10, 11, 12, 13, 14, 99]);
+  });
+});
+
+describe("useTimelineVirtualRows", () => {
+  it("mounts a bounded vertical range plus the focused row", () => {
+    const geometry = createLargeGeometry(0.5);
+    const scroll = createScrollElement(RULER_H + TRACKS_TOP_PAD + 500 * 48);
+    const scrollRef = { current: scroll };
+    let rows: ReturnType<typeof useTimelineVirtualRows> = [];
+
+    function Probe() {
+      rows = useTimelineVirtualRows({
+        enabled: true,
+        scrollRef,
+        viewport: viewport(scroll),
+        rowGeometry: geometry,
+        sessionEpoch: 1,
+        pinnedRowKeys: [],
+        focusedRowKey: 900.5,
+      });
+      return null;
+    }
+
+    const root = createRoot(document.createElement("div"));
+    act(() => root.render(React.createElement(Probe)));
+    act(() => {});
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThanOrEqual(16);
+    expect(rows.some((row) => row.index === 500)).toBe(true);
+    expect(rows.some((row) => row.rowKey === 900.5)).toBe(true);
+    act(() => root.unmount());
+  });
+
+  it("keeps compatibility rendering complete while the gate is disabled", () => {
+    const geometry = createTimelineRowGeometry([10, 5.5, 20], [48, 76, 48]);
+    const scroll = createScrollElement(0);
+    let rows: ReturnType<typeof useTimelineVirtualRows> = [];
+
+    function Probe() {
+      rows = useTimelineVirtualRows({
+        enabled: false,
+        scrollRef: { current: scroll },
+        viewport: viewport(scroll),
+        rowGeometry: geometry,
+        sessionEpoch: 1,
+        pinnedRowKeys: [],
+      });
+      return null;
+    }
+
+    const root = createRoot(document.createElement("div"));
+    act(() => root.render(React.createElement(Probe)));
+    expect(rows.map((row) => row.rowKey)).toEqual([10, 5.5, 20]);
+    act(() => root.unmount());
+  });
+
+  it("observes Timeline's authoritative scroll reset when the session epoch changes", () => {
+    const geometry = createLargeGeometry();
+    const scroll = createScrollElement(RULER_H + TRACKS_TOP_PAD + 500 * 48);
+    const scrollRef = { current: scroll };
+    let rows: ReturnType<typeof useTimelineVirtualRows> = [];
+
+    function Probe({ sessionEpoch }: { sessionEpoch: number }) {
+      rows = useTimelineVirtualRows({
+        enabled: true,
+        scrollRef,
+        viewport: viewport(scroll),
+        rowGeometry: geometry,
+        sessionEpoch,
+        pinnedRowKeys: [],
+      });
+      return null;
+    }
+
+    const root = createRoot(document.createElement("div"));
+    act(() => root.render(React.createElement(Probe, { sessionEpoch: 1 })));
+    expect(rows.some((row) => row.index === 500)).toBe(true);
+
+    scroll.scrollTop = 0;
+    act(() => root.render(React.createElement(Probe, { sessionEpoch: 2 })));
+    expect(rows.some((row) => row.index === 0)).toBe(true);
+    expect(rows.some((row) => row.index === 500)).toBe(false);
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/player/components/useTimelineVirtualRows.ts
+++ b/packages/studio/src/player/components/useTimelineVirtualRows.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, type RefObject } from "react";
+import { defaultRangeExtractor, useVirtualizer, type Range } from "@tanstack/react-virtual";
+import { TIMELINE_VIEWPORT_BUDGETS } from "../lib/timelineViewportBudgets";
+import type { TimelineScrollViewportSnapshot } from "./useTimelineScrollViewport";
+import { RULER_H, TRACKS_TOP_PAD, type TimelineRowGeometry } from "./timelineLayout";
+
+/** Disabled until horizontal windowing and stable gesture lifetime land. */
+export const STUDIO_TIMELINE_ROW_VIRTUALIZATION_ENABLED =
+  import.meta.env.DEV === true &&
+  import.meta.env.VITE_STUDIO_TIMELINE_ROW_VIRTUALIZATION_ENABLED === "1";
+
+export interface TimelineVirtualRow {
+  readonly index: number;
+  readonly rowKey: number;
+}
+
+export function extractTimelineVirtualRowRange(
+  range: Range,
+  pinnedRowIndexes: readonly number[],
+): number[] {
+  const indexes = new Set(defaultRangeExtractor(range));
+  for (const index of pinnedRowIndexes) {
+    if (index >= 0 && index < range.count) indexes.add(index);
+  }
+  return [...indexes].sort((left, right) => left - right);
+}
+
+interface UseTimelineVirtualRowsInput {
+  enabled: boolean;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  viewport: TimelineScrollViewportSnapshot;
+  rowGeometry: TimelineRowGeometry;
+  sessionEpoch: number;
+  pinnedRowKeys: readonly number[];
+  focusedRowKey?: number;
+}
+
+export function useTimelineVirtualRows({
+  enabled,
+  scrollRef,
+  viewport,
+  rowGeometry,
+  sessionEpoch,
+  pinnedRowKeys,
+  focusedRowKey,
+}: UseTimelineVirtualRowsInput): readonly TimelineVirtualRow[] {
+  const pinnedRowIndexes = useMemo(
+    () => [
+      ...new Set(
+        [...pinnedRowKeys, ...(focusedRowKey === undefined ? [] : [focusedRowKey])].map((key) =>
+          rowGeometry.getRowIndex(key),
+        ),
+      ),
+    ],
+    [focusedRowKey, pinnedRowKeys, rowGeometry],
+  );
+  const estimateSize = useCallback(
+    (index: number) => rowGeometry.getRowHeight(index),
+    [rowGeometry],
+  );
+  const getItemKey = useCallback(
+    (index: number) => rowGeometry.rowKeys[index] ?? index,
+    [rowGeometry],
+  );
+  const rangeExtractor = useCallback(
+    (range: Range) => extractTimelineVirtualRowRange(range, pinnedRowIndexes),
+    [pinnedRowIndexes],
+  );
+  const initialOffset = useCallback(() => viewport.scrollTop, [viewport.scrollTop]);
+  const virtualizer = useVirtualizer({
+    enabled,
+    useFlushSync: false,
+    count: rowGeometry.rowKeys.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize,
+    getItemKey,
+    overscan: TIMELINE_VIEWPORT_BUDGETS.rowOverscanPerSide,
+    rangeExtractor,
+    scrollMargin: RULER_H + TRACKS_TOP_PAD,
+    initialRect: { width: viewport.clientWidth, height: viewport.clientHeight },
+    initialOffset,
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    virtualizer.measure();
+    // Timeline owns the epoch reset. This event only makes the virtualizer
+    // observe the authoritative DOM offset after that reset; it never writes
+    // scrollTop itself.
+    scrollRef.current?.dispatchEvent(new Event("scroll"));
+  }, [enabled, scrollRef, sessionEpoch, virtualizer]);
+
+  const focusedRowIndex = focusedRowKey === undefined ? -1 : rowGeometry.getRowIndex(focusedRowKey);
+  const focusedRowHeight = focusedRowIndex < 0 ? 0 : rowGeometry.getRowHeight(focusedRowIndex);
+  useEffect(() => {
+    if (enabled && focusedRowIndex >= 0) {
+      virtualizer.resizeItem(focusedRowIndex, focusedRowHeight);
+    }
+  }, [enabled, focusedRowHeight, focusedRowIndex, sessionEpoch, virtualizer]);
+
+  const allRows = useMemo(
+    () => rowGeometry.rowKeys.map((rowKey, index) => ({ index, rowKey })),
+    [rowGeometry],
+  );
+  if (!enabled) return allRows;
+  return virtualizer.getVirtualItems().map(({ index }) => ({
+    index,
+    rowKey: rowGeometry.rowKeys[index] ?? index,
+  }));
+}


### PR DESCRIPTION
## What

virtualize timeline rows.

## Why

Keep large timelines responsive without losing spatial correctness, selection, or thumbnail context.

## How

Introduces reusable viewport geometry and bounded row/clip rendering over the full logical timeline.

Key files in this layer:

- `bun.lock`
- `packages/studio/package.json`
- `packages/studio/src/player/components/LayerDisclosureRow.tsx`
- `packages/studio/src/player/components/Timeline.test.ts`

## Test plan

Validated on the complete stacked tip with formatting, lint, Studio typecheck, the full production build, and the Studio test suite (2,946 passing; 18 todo). Focused timeline/thumbnail tests and browser QA cover the affected interaction path.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable for this implementation layer)

## Post-Deploy Monitoring & Validation

- **Owner:** Studio team
- **Window:** First 24 hours after rollout
- **Signals:** Watch mounted row/clip counts, scroll stability, and interaction latency on large projects.
- **Rollback trigger:** Reproducible data loss, broken timeline editing/navigation, or sustained performance regression; revert this stack layer and its descendants.