### PR TITLE
feat(studio): add timeline keyboard controls

### DIFF
--- a/packages/studio/src/player/components/LayerDisclosureRow.tsx
+++ b/packages/studio/src/player/components/LayerDisclosureRow.tsx
@@ -28,6 +28,7 @@ export function LayerDisclosureRow({
     >
       <button
         type="button"
+        tabIndex={-1}
         aria-expanded={isExpanded}
         aria-label={`${isExpanded ? "Collapse" : "Expand"} ${name} keyframes`}
         title={`${isExpanded ? "Collapse" : "Expand"} keyframe lanes`}

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -276,7 +276,7 @@ export const Timeline = memo(function Timeline({
       lastScrollLeftRef,
       contentOrigin,
     });
-  const { logicalRows, pinnedElementId, rowVirtualizationActive, virtualRows } =
+  const { logicalRows, focusedTargetId, pinnedElementId, rowVirtualizationActive, virtualRows } =
     useTimelineLogicalFocus({
       scrollRef,
       tracks,
@@ -456,7 +456,6 @@ export const Timeline = memo(function Timeline({
         onDragLeave={assetDrop.handleAssetDragLeave}
         onDrop={assetDrop.handleAssetDrop}
         onPointerDown={(e) => {
-          // Interactive controls own their clicks; scrubbing would preventDefault and eat them.
           if (e.target instanceof Element && e.target.closest("button, input, select, a")) return;
           if (activeTool === "razor" && e.shiftKey && e.button === 0 && scrollRef.current) {
             const rect = scrollRef.current.getBoundingClientRect();
@@ -496,6 +495,7 @@ export const Timeline = memo(function Timeline({
           rowGeometry={displayLayout.rowGeometry}
           virtualRows={virtualRows}
           logicalRows={logicalRows}
+          focusedTargetId={focusedTargetId}
           rowsVirtualized={rowVirtualizationActive}
           clipIndex={clipIndex}
           renderTimeRange={renderTimeRange}

--- a/packages/studio/src/player/components/Timeline.virtualization.test.tsx
+++ b/packages/studio/src/player/components/Timeline.virtualization.test.tsx
@@ -81,6 +81,8 @@ describe("Timeline row virtualization", () => {
     expect(rows.length).toBeLessThanOrEqual(16);
     expect(rows[0]?.getAttribute("aria-rowindex")).toBe("1");
     expect(treegrid?.getAttribute("aria-rowcount")).toBe("1000");
+    expect(treegrid?.hasAttribute("aria-multiselectable")).toBe(false);
+    expect(treegrid?.querySelectorAll('[data-timeline-focus-id][tabindex="0"]')).toHaveLength(1);
     expect(treegrid?.parentElement?.style.height).toBe(`${getTimelineCanvasHeight(1_000)}px`);
 
     const firstRow = rows[0] as HTMLElement;

--- a/packages/studio/src/player/components/TimelineClip.test.tsx
+++ b/packages/studio/src/player/components/TimelineClip.test.tsx
@@ -36,6 +36,7 @@ function renderClip({
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
+  const onClick = vi.fn();
 
   act(() => {
     root.render(
@@ -50,7 +51,7 @@ function renderClip({
         isComposition={false}
         onHoverStart={vi.fn()}
         onHoverEnd={vi.fn()}
-        onClick={vi.fn()}
+        onClick={onClick}
         onDoubleClick={vi.fn()}
       >
         <div data-custom-content="true" />
@@ -58,7 +59,7 @@ function renderClip({
     );
   });
 
-  return { host, root };
+  return { host, onClick, root };
 }
 
 describe("TimelineClip", () => {
@@ -111,6 +112,20 @@ describe("TimelineClip", () => {
 
     expect(host.querySelector(".timeline-clip")?.classList.contains("is-selected")).toBe(true);
 
+    act(() => root.unmount());
+  });
+
+  it("is a roving native button with explicit selection semantics", () => {
+    const { host, onClick, root } = renderClip({
+      element: { id: "hero", label: "Hero", tag: "div", start: 1, duration: 2, track: 0 },
+      isSelected: true,
+    });
+    const clip = host.querySelector<HTMLButtonElement>(".timeline-clip")!;
+    expect(clip.type).toBe("button");
+    expect(clip.tabIndex).toBe(-1);
+    expect(clip.getAttribute("aria-pressed")).toBe("true");
+    act(() => clip.click());
+    expect(onClick).toHaveBeenCalledOnce();
     act(() => root.unmount());
   });
 });

--- a/packages/studio/src/player/components/TimelineClip.tsx
+++ b/packages/studio/src/player/components/TimelineClip.tsx
@@ -19,6 +19,7 @@ interface TimelineClipProps {
   capabilities: TimelineEditCapabilities;
   theme?: TimelineTheme;
   isComposition: boolean;
+  tabIndex?: 0 | -1;
   onHoverStart: () => void;
   onHoverEnd: () => void;
   onPointerDown?: (e: React.PointerEvent) => void;
@@ -44,6 +45,7 @@ export const TimelineClip = memo(function TimelineClip({
   capabilities,
   theme = defaultTimelineTheme,
   isComposition,
+  tabIndex = -1,
   onHoverStart,
   onHoverEnd,
   onPointerDown,
@@ -83,11 +85,17 @@ export const TimelineClip = memo(function TimelineClip({
     zIndex: isDragging ? 20 : isSelected ? 10 : isHovered ? 5 : 1,
     // Regular cursor over clips (CapCut-style, user preference) — no grab hand.
     cursor: "default",
+    appearance: "none",
+    color: "inherit",
+    font: "inherit",
+    padding: 0,
+    textAlign: "left",
     transform: isDragging ? "translateY(-1px)" : undefined,
   };
 
   return (
-    <div
+    <button
+      type="button"
       data-clip={isGestureActor ? undefined : "true"}
       data-el-id={isGestureActor ? undefined : (el.key ?? el.id)}
       data-timeline-focus-id={isGestureActor ? undefined : timelineClipFocusId(el.key ?? el.id)}
@@ -96,7 +104,9 @@ export const TimelineClip = memo(function TimelineClip({
       data-clip-hidden={el.hidden ? "true" : undefined}
       data-active={isActive ? "" : undefined}
       aria-hidden={isGestureActor ? "true" : undefined}
-      tabIndex={isGestureActor ? undefined : -1}
+      tabIndex={isGestureActor ? undefined : tabIndex}
+      aria-label={`${displayLabel}, ${startLabel} to ${endLabel} seconds`}
+      aria-pressed={isGestureActor ? undefined : isSelected}
       className={clipClassName}
       style={style}
       title={
@@ -178,6 +188,6 @@ export const TimelineClip = memo(function TimelineClip({
         </span>
       )}
       {children}
-    </div>
+    </button>
   );
 });

--- a/packages/studio/src/player/components/TimelineClipDiamonds.test.tsx
+++ b/packages/studio/src/player/components/TimelineClipDiamonds.test.tsx
@@ -39,7 +39,7 @@ function createTimelineHost() {
   return host;
 }
 
-function renderDiamonds(onClickKeyframe = vi.fn()) {
+function renderDiamonds(onClickKeyframe = vi.fn(), onShiftClickKeyframe = vi.fn()) {
   const host = createTimelineHost();
   const root = createRoot(host);
   act(() => {
@@ -58,12 +58,15 @@ function renderDiamonds(onClickKeyframe = vi.fn()) {
         isSelected
         currentPercentage={0}
         elementId="clip-1"
+        clipStart={10}
+        clipDuration={10}
         selectedKeyframes={new Set()}
         onClickKeyframe={onClickKeyframe}
+        onShiftClickKeyframe={onShiftClickKeyframe}
       />,
     );
   });
-  return { host, root, onClickKeyframe };
+  return { host, root, onClickKeyframe, onShiftClickKeyframe };
 }
 
 function renderRetimeLane(onMoveKeyframe = vi.fn().mockResolvedValue(true), strict = false) {
@@ -120,6 +123,27 @@ function renderRetimeLane(onMoveKeyframe = vi.fn().mockResolvedValue(true), stri
 }
 
 describe("TimelineClipDiamonds", () => {
+  it("gives keyframes time-based names and native keyboard selection semantics", () => {
+    const { host, root, onClickKeyframe } = renderDiamonds();
+    const diamond = host.querySelector<HTMLButtonElement>('button[title="50%"]')!;
+    expect(diamond.getAttribute("aria-label")).toBe("Motion keyframe at 15s");
+    expect(diamond.getAttribute("aria-pressed")).toBe("false");
+    act(() => diamond.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 0 })));
+    expect(onClickKeyframe).toHaveBeenCalledWith(50);
+    act(() => root.unmount());
+  });
+
+  it("uses Shift+Space's native click for additive keyframe selection", () => {
+    const { host, root, onClickKeyframe, onShiftClickKeyframe } = renderDiamonds();
+    const diamond = host.querySelector<HTMLButtonElement>('button[title="50%"]')!;
+    act(() =>
+      diamond.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 0, shiftKey: true })),
+    );
+    expect(onShiftClickKeyframe).toHaveBeenCalledWith("clip-1", 50);
+    expect(onClickKeyframe).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
   it("publishes retime previews after StrictMode effect replay", () => {
     const { diamond, host, root } = renderRetimeLane(undefined, true);
     const initialLeft = diamond.style.left;
@@ -659,6 +683,7 @@ describe("TimelineClipDiamonds", () => {
   const renderSegmentLane = (lastAmbiguous: boolean) => {
     const host = createTimelineHost();
     const root = createRoot(host);
+    const onSelectSegment = vi.fn();
     const kf = (percentage: number, extra: Record<string, unknown> = {}) => ({
       percentage,
       tweenPercentage: percentage,
@@ -691,13 +716,15 @@ describe("TimelineClipDiamonds", () => {
           isSelected
           currentPercentage={0}
           elementId="clip-1"
+          clipStart={10}
+          clipDuration={10}
           selectedKeyframes={new Set()}
-          onSelectSegment={vi.fn()}
+          onSelectSegment={onSelectSegment}
           groupAware
         />,
       );
     });
-    return { host, root };
+    return { host, onSelectSegment, root };
   };
 
   it("shows the inline ease button on a colliding merged segment (bulk edit)", () => {
@@ -710,8 +737,14 @@ describe("TimelineClipDiamonds", () => {
   });
 
   it("shows the inline ease button on single-animation merged segments", () => {
-    const { host, root } = renderSegmentLane(false);
+    const { host, onSelectSegment, root } = renderSegmentLane(false);
     expect(host.querySelectorAll("[data-keyframe-ease-segment]").length).toBe(2);
+    const ease = host.querySelector<HTMLButtonElement>("[data-keyframe-ease-button]")!;
+    expect(ease.getAttribute("aria-label")).toBe("Edit none easing after 10s");
+    expect(ease.classList.contains("opacity-0")).toBe(true);
+    act(() => ease.click());
+    expect(onSelectSegment).toHaveBeenCalledOnce();
+    expect(usePlayerStore.getState().requestedSeekTime).toBeNull();
     act(() => root.unmount());
   });
 

--- a/packages/studio/src/player/components/TimelineClipDiamonds.tsx
+++ b/packages/studio/src/player/components/TimelineClipDiamonds.tsx
@@ -11,6 +11,7 @@ import {
   beginTimelineKeyframeRetime,
   type TimelineKeyframeRetimeHandle,
 } from "./useTimelineKeyframeHandlers";
+import { timelineEaseFocusId, timelineKeyframeFocusId } from "./timelineNavigationIdentity";
 
 export interface TimelineDiamondKeyframe {
   percentage: number;
@@ -42,7 +43,10 @@ interface TimelineClipDiamondsProps {
   isSelected: boolean;
   currentPercentage: number;
   elementId: string;
+  clipStart?: number;
+  clipDuration?: number;
   selectedKeyframes: ReadonlySet<string>;
+  rovingTargetId?: string | null;
   onClickKeyframe?: (percentage: number) => void;
   onShiftClickKeyframe?: (elementId: string, percentage: number) => void;
   onContextMenuKeyframe?: (e: React.MouseEvent, elementId: string, percentage: number) => void;
@@ -89,6 +93,10 @@ const DIAMOND_RATIO = 0.8;
 const KF_MIN_PCT = -5;
 const KF_MAX_PCT = 105;
 
+function keyframeTimeLabel(clipStart: number, clipDuration: number, percentage: number): string {
+  return `${Number((clipStart + (clipDuration * percentage) / 100).toFixed(2))}s`;
+}
+
 function keyframeTarget(
   keyframe: TimelineDiamondKeyframe,
   groupAware: boolean,
@@ -113,7 +121,10 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
   isSelected,
   currentPercentage,
   elementId,
+  clipStart = 0,
+  clipDuration = 0,
   selectedKeyframes,
+  rovingTargetId = null,
   onClickKeyframe,
   onShiftClickKeyframe,
   onContextMenuKeyframe,
@@ -136,10 +147,6 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
   // (that optimistic hold was the #1763 flake). The atomic move-keyframe commit
   // on drop re-keys the diamond from source.
   const [preview, setPreview] = useState<{ kfKey: string; clipPct: number } | null>(null);
-  // Index of the segment whose mid-point ease button is revealed on hover, like
-  // Figma. Null = no segment hovered → no button shown (resting state is just
-  // the connector line + diamonds).
-  const [hoveredSegment, setHoveredSegment] = useState<number | null>(null);
   // The button element can re-render (reposition/unmount) synchronously from
   // the state updates onClickKeyframe/onMoveKeyframe trigger, before the
   // browser gets to auto-synthesize the "click" event that normally follows
@@ -205,6 +212,7 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
         // so there is no tween to target.
         const target = keyframeTarget(kf, true);
         const ease = kf.ease ?? globalEase;
+        const focusId = timelineEaseFocusId(elementId, target);
         return (
           <Fragment key={`line-${i}-${prev.percentage}-${kf.percentage}`}>
             <div
@@ -223,7 +231,7 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
             />
             {onSelectSegment && kf.animationId !== undefined && (
               <div
-                className="absolute"
+                className="group absolute"
                 data-keyframe-ease-segment=""
                 style={{
                   left: x1,
@@ -233,38 +241,36 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
                   transform: "translateY(-50%)",
                   pointerEvents: "auto",
                 }}
-                onMouseEnter={() => setHoveredSegment(i)}
-                onMouseLeave={() => setHoveredSegment((h) => (h === i ? null : h))}
               >
-                {hoveredSegment === i && (
-                  <button
-                    type="button"
-                    data-keyframe-ease-button=""
-                    aria-label={`Edit ${ease} easing`}
-                    title={`Edit ${ease} easing`}
-                    className="absolute flex items-center justify-center rounded"
-                    style={{
-                      left: "50%",
-                      top: "50%",
-                      width: 16,
-                      height: 16,
-                      transform: "translate(-50%, -50%)",
-                      zIndex: 3,
-                      pointerEvents: "auto",
-                      padding: 0,
-                      border: "1px solid rgba(255, 255, 255, 0.14)",
-                      background: "#171717",
-                      cursor: "pointer",
-                    }}
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onSelectSegment(target);
-                    }}
-                  >
-                    <MiniCurveSvg ease={ease} active size={12} />
-                  </button>
-                )}
+                <button
+                  type="button"
+                  data-keyframe-ease-button=""
+                  data-timeline-focus-id={focusId}
+                  tabIndex={focusId === rovingTargetId ? 0 : -1}
+                  aria-label={`Edit ${ease} easing after ${keyframeTimeLabel(clipStart, clipDuration, prev.percentage)}`}
+                  title={`Edit ${ease} easing`}
+                  className="absolute flex items-center justify-center rounded opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                  style={{
+                    left: "50%",
+                    top: "50%",
+                    width: 16,
+                    height: 16,
+                    transform: "translate(-50%, -50%)",
+                    zIndex: 3,
+                    pointerEvents: "auto",
+                    padding: 0,
+                    border: "1px solid rgba(255, 255, 255, 0.14)",
+                    background: "#171717",
+                    cursor: "pointer",
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelectSegment(target);
+                  }}
+                >
+                  <MiniCurveSvg ease={ease} active size={12} />
+                </button>
               </div>
             )}
           </Fragment>
@@ -273,6 +279,7 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
 
       {sorted.map((kf, i) => {
         const target = keyframeTarget(kf, groupAware);
+        const focusId = timelineKeyframeFocusId(elementId, target);
         const kfKey = timelineKeyframeSelectionKey(elementId, target);
         // While dragging this diamond, render it at the live preview clip-%.
         const renderPct = preview?.kfKey === kfKey ? preview.clipPct : kf.percentage;
@@ -334,10 +341,14 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
             key={`${i}-${kf.percentage}`}
             type="button"
             className="absolute"
+            data-timeline-focus-id={focusId}
             data-keyframe-group={groupAware ? kf.propertyGroup : undefined}
             data-keyframe-percentage={
               groupAware ? (kf.tweenPercentage ?? kf.percentage) : undefined
             }
+            tabIndex={focusId === rovingTargetId ? 0 : -1}
+            aria-label={`${kf.propertyGroup ?? "Motion"} keyframe at ${keyframeTimeLabel(clipStart, clipDuration, kf.percentage)}`}
+            aria-pressed={isKfSelected}
             style={{
               left: leftPx,
               top: centerY,
@@ -355,6 +366,13 @@ export const TimelineDiamondLane = memo(function TimelineDiamondLane({
             onPointerDown={onPointerDown}
             onPointerMove={canDrag ? (e) => retimeHandleRef.current?.update(e) : undefined}
             onPointerUp={onPointerUp}
+            onClick={(e) => {
+              if (e.detail !== 0) return;
+              e.stopPropagation();
+              suppressNextClick();
+              if (e.shiftKey) onShiftClickKeyframe?.(target);
+              else onClickKeyframe?.(target);
+            }}
             onPointerCancel={
               canDrag
                 ? (e) => {

--- a/packages/studio/src/player/components/TimelineLaneTypes.ts
+++ b/packages/studio/src/player/components/TimelineLaneTypes.ts
@@ -23,6 +23,7 @@ export interface TimelineLaneBaseProps {
   rowGeometry: TimelineRowGeometry;
   virtualRows: readonly TimelineVirtualRow[];
   logicalRows: readonly TimelineLogicalRow[];
+  focusedTargetId: string | null;
   rowsVirtualized: boolean;
   clipIndex: TimelineClipIndex;
   renderTimeRange: TimelineTimeRange;

--- a/packages/studio/src/player/components/TimelineLanes.tsx
+++ b/packages/studio/src/player/components/TimelineLanes.tsx
@@ -24,6 +24,8 @@ import { TimelineTrackRow } from "./TimelineTrackRow";
 import { isTimelineClipActive } from "./useTimelineActiveClips";
 import { queryTimelineClipIndex } from "../lib/timelineClipIndex";
 import type { TimelineLogicalRow } from "./timelineKeyboardNavigation";
+import { timelineClipFocusId } from "./timelineNavigationIdentity";
+import { useTimelineKeyboardActor } from "./useTimelineKeyboardActor";
 
 interface TimelineLanesProps extends TimelineLaneBaseProps {
   /** Live-derived by TimelineCanvas from {@link TimelineLaneBaseProps.draggedClip}. */
@@ -47,6 +49,7 @@ export function TimelineLanes({
   rowGeometry,
   virtualRows,
   logicalRows,
+  focusedTargetId,
   rowsVirtualized,
   clipIndex,
   renderTimeRange,
@@ -113,12 +116,22 @@ export function TimelineLanes({
     trackStudioKeyframeLaneExpand({ expanded: willExpand });
     toggleClipExpanded(key);
   };
+  const keyboard = useTimelineKeyboardActor({
+    logicalRows,
+    focusedTargetId,
+    rowGeometry,
+    scrollRef,
+    onToggleRow: (row) => {
+      if (row.elementId) toggleClipExpandedTracked(row.elementId);
+    },
+  });
   return (
     <div
       role="treegrid"
       aria-label="Timeline tracks"
-      aria-multiselectable="true"
       aria-rowcount={logicalRows.length}
+      onFocus={keyboard.onFocus}
+      onKeyDown={keyboard.onKeyDown}
       className={rowsVirtualized ? "absolute inset-0" : undefined}
     >
       {
@@ -190,6 +203,7 @@ export function TimelineLanes({
               virtualized={rowsVirtualized}
               background={rowBackground}
               borderColor={theme.rowBorder}
+              rovingTargetId={keyboard.rovingTargetId}
             >
               <TimelineTrackHeader
                 trackNumber={trackNum}
@@ -215,6 +229,7 @@ export function TimelineLanes({
                 onToggleTrackHidden={onToggleTrackHidden}
                 onTogglePropertyGroupKeyframe={onTogglePropertyGroupKeyframe}
                 onSeek={onSeek}
+                rovingTargetId={keyboard.rovingTargetId}
               />
               <div
                 role="gridcell"
@@ -291,20 +306,12 @@ export function TimelineLanes({
                     const isSelected =
                       selectedElementId === elementKey || selectedElementIds.has(elementKey);
                     const isComposition = !!el.compositionSrc;
-                    // elementKey (el.key ?? el.id) is already unique per clip; do NOT
-                    // fold in the map index, or a splice/reorder remounts every clip
-                    // at/after the change (DOM flash, drag interruption).
                     const clipKey = elementKey;
                     const isDraggingClip =
                       draggedClip?.started === true &&
                       (draggedElement?.key ?? draggedElement?.id) === elementKey;
                     if (isDraggingClip) return null;
                     const previewElement = getPreviewElement(el);
-                    // Passenger of a live multi-drag: slide by the SAME formation
-                    // delta (the grabbed clip's group-clamped delta) via a
-                    // compositor transform on a same-geometry wrapper (absolute
-                    // inset-0 → identical offset parent, so the clip's own
-                    // left/top are preserved), plus the ghost's elevated z/opacity.
                     const isPassenger =
                       multiDragPreview != null && isMultiDragPassenger(clipKey, multiDragPreview);
                     const passengerOffsetPx = isPassenger
@@ -329,6 +336,9 @@ export function TimelineLanes({
                         capabilities={capabilities}
                         theme={theme}
                         isComposition={isComposition}
+                        tabIndex={
+                          keyboard.rovingTargetId === timelineClipFocusId(elementKey) ? 0 : -1
+                        }
                         onHoverStart={() => setHoveredClip(clipKey)}
                         onHoverEnd={() => setHoveredClip(null)}
                         onResizeStart={
@@ -466,41 +476,55 @@ export function TimelineLanes({
                           renderClipContent,
                           renderClipOverlay,
                         )}
-                        {STUDIO_KEYFRAMES_ENABLED &&
-                          !showsLanes &&
-                          keyframeCache?.get(elementKey) && (
-                            <TimelineClipDiamonds
-                              keyframesData={keyframeCache.get(elementKey)!}
-                              clipWidthPx={Math.max(previewElement.duration * pps, 4)}
-                              clipHeightPx={rowHeight - 2 * CLIP_Y}
-                              beatsActive={beatStripOnTrack}
-                              accentColor={clipStyle.accent}
-                              isSelected={isSelected}
-                              currentPercentage={
-                                previewElement.duration > 0
-                                  ? ((currentTime - previewElement.start) /
-                                      previewElement.duration) *
-                                    100
-                                  : 0
-                              }
-                              elementId={elementKey}
-                              selectedKeyframes={selectedKeyframes}
-                              onClickKeyframe={(pct) =>
-                                onClickKeyframe?.(previewElement, { percentage: pct })
-                              }
-                              onShiftClickKeyframe={(elId, pct) =>
-                                onShiftClickKeyframe?.(elId, { percentage: pct })
-                              }
-                              onContextMenuKeyframe={(e, elId, pct) =>
-                                onContextMenuKeyframe?.(e, elId, { percentage: pct })
-                              }
-                              onMoveKeyframe={onMoveKeyframe}
-                              onSelectSegment={onSelectSegment}
-                              suppressClickRef={suppressClickRef}
-                            />
-                          )}
                       </TimelineClip>
                     );
+                    const compactDiamonds = STUDIO_KEYFRAMES_ENABLED &&
+                      !showsLanes &&
+                      keyframeCache?.get(elementKey) && (
+                        <div
+                          key={`${clipKey}-diamonds`}
+                          className="absolute pointer-events-none"
+                          style={{
+                            left: previewElement.start * pps,
+                            top: CLIP_Y,
+                            width: Math.max(previewElement.duration * pps, 4),
+                            height: rowHeight - 2 * CLIP_Y,
+                            zIndex: isSelected ? 11 : 6,
+                          }}
+                        >
+                          <TimelineClipDiamonds
+                            keyframesData={keyframeCache.get(elementKey)!}
+                            clipWidthPx={Math.max(previewElement.duration * pps, 4)}
+                            clipHeightPx={rowHeight - 2 * CLIP_Y}
+                            beatsActive={beatStripOnTrack}
+                            accentColor={clipStyle.accent}
+                            isSelected={isSelected}
+                            currentPercentage={
+                              previewElement.duration > 0
+                                ? ((currentTime - previewElement.start) / previewElement.duration) *
+                                  100
+                                : 0
+                            }
+                            elementId={elementKey}
+                            clipStart={previewElement.start}
+                            clipDuration={previewElement.duration}
+                            selectedKeyframes={selectedKeyframes}
+                            rovingTargetId={keyboard.rovingTargetId}
+                            onClickKeyframe={(pct) =>
+                              onClickKeyframe?.(previewElement, { percentage: pct })
+                            }
+                            onShiftClickKeyframe={(elId, pct) =>
+                              onShiftClickKeyframe?.(elId, { percentage: pct })
+                            }
+                            onContextMenuKeyframe={(e, elId, pct) =>
+                              onContextMenuKeyframe?.(e, elId, { percentage: pct })
+                            }
+                            onMoveKeyframe={onMoveKeyframe}
+                            onSelectSegment={onSelectSegment}
+                            suppressClickRef={suppressClickRef}
+                          />
+                        </div>
+                      );
                     const propertyLanes = showsLanes && (
                       <TimelinePropertyLanes
                         key={`${clipKey}-property-lanes`}
@@ -518,6 +542,7 @@ export function TimelineLanes({
                         }
                         elementId={elementKey}
                         selectedKeyframes={selectedKeyframes}
+                        rovingTargetId={keyboard.rovingTargetId}
                         onSelectSegment={(target) => onSelectSegment?.(elementKey, target)}
                         onClickKeyframe={(target) => onClickKeyframe?.(previewElement, target)}
                         onShiftClickKeyframe={(target) =>
@@ -539,7 +564,7 @@ export function TimelineLanes({
                         suppressClickRef={suppressClickRef}
                       />
                     );
-                    if (!isPassenger) return [clip, propertyLanes];
+                    if (!isPassenger) return [clip, compactDiamonds, propertyLanes];
                     return (
                       <div
                         key={clipKey}
@@ -552,6 +577,7 @@ export function TimelineLanes({
                         }}
                       >
                         {clip}
+                        {compactDiamonds}
                         {propertyLanes}
                       </div>
                     );

--- a/packages/studio/src/player/components/TimelinePropertyLanes.test.tsx
+++ b/packages/studio/src/player/components/TimelinePropertyLanes.test.tsx
@@ -281,7 +281,7 @@ describe("TimelinePropertyLanes", () => {
     act(() => root.unmount());
   });
 
-  it("reveals one midpoint ease button per segment on hover, regardless of selection", () => {
+  it("keeps one focusable midpoint ease button mounted per segment", () => {
     const animations = [
       animation("position-tween", "position", [
         { percentage: 0, properties: { x: 0 } },
@@ -295,12 +295,11 @@ describe("TimelinePropertyLanes", () => {
     expect(segments).toHaveLength(2);
     expect(segments.map((segment) => segment.style.left)).toEqual(["0px", "100px"]);
     expect(laneDiamonds(host, "position")).toHaveLength(3);
-    // Resting state: no button until a segment is hovered.
-    expect(laneEaseButtons(host, "position")).toHaveLength(0);
-
-    // Hovering reveals exactly one button — the hovered segment's.
-    expect(revealEaseButton(segments[0]!)).not.toBeNull();
-    expect(laneEaseButtons(host, "position")).toHaveLength(1);
+    const buttons = laneEaseButtons(host, "position");
+    expect(buttons).toHaveLength(2);
+    expect(buttons.every((button) => button.classList.contains("focus-visible:opacity-100"))).toBe(
+      true,
+    );
 
     // The ease button is available on hover even when the element is NOT selected
     // (a lane shows for the track's active/primary clip, not only the selected one).
@@ -323,7 +322,7 @@ describe("TimelinePropertyLanes", () => {
     });
     const unselectedSegments = laneEaseSegments(host, "position");
     expect(unselectedSegments).toHaveLength(2);
-    expect(revealEaseButton(unselectedSegments[0]!)).not.toBeNull();
+    expect(laneEaseButtons(host, "position")).toHaveLength(2);
     act(() => root.unmount());
   });
 

--- a/packages/studio/src/player/components/TimelinePropertyLanes.tsx
+++ b/packages/studio/src/player/components/TimelinePropertyLanes.tsx
@@ -22,6 +22,7 @@ export interface TimelinePropertyLanesProps {
   currentPercentage: number;
   elementId: string;
   selectedKeyframes: ReadonlySet<string>;
+  rovingTargetId?: string | null;
   onSelectSegment?: (target: TimelineKeyframeTarget) => void;
   onClickKeyframe?: (target: TimelineKeyframeTarget) => void;
   onShiftClickKeyframe?: (target: TimelineKeyframeTarget) => void;
@@ -110,6 +111,7 @@ export function TimelinePropertyLanes({
   currentPercentage,
   elementId,
   selectedKeyframes,
+  rovingTargetId = null,
   onSelectSegment,
   onClickKeyframe,
   onShiftClickKeyframe,
@@ -150,7 +152,10 @@ export function TimelinePropertyLanes({
             isSelected={isSelected}
             currentPercentage={currentPercentage}
             elementId={elementId}
+            clipStart={clipStart}
+            clipDuration={clipDuration}
             selectedKeyframes={selectedKeyframes}
+            rovingTargetId={rovingTargetId}
             onSelectSegment={onSelectSegment}
             onClickKeyframe={onClickKeyframe}
             onShiftClickKeyframe={onShiftClickKeyframe}

--- a/packages/studio/src/player/components/TimelineTrackHeader.tsx
+++ b/packages/studio/src/player/components/TimelineTrackHeader.tsx
@@ -41,6 +41,7 @@ interface TimelineTrackHeaderProps {
   isAudioTrack: boolean;
   isActive: boolean;
   isHovered: boolean;
+  rovingTargetId?: string | null;
   theme: TimelineTheme;
   onToggleClipExpanded: () => void;
   onToggleTrackHidden: TimelineEditCallbacks["onToggleTrackHidden"];
@@ -379,6 +380,7 @@ function PropertyGroupHeaderRow({
   onToggleTrackHidden,
   onTogglePropertyGroupKeyframe,
   onSeek,
+  rovingTargetId = null,
 }: {
   lane: TimelinePropertyLane;
   laneIndex: number;
@@ -396,6 +398,7 @@ function PropertyGroupHeaderRow({
   onToggleTrackHidden: TimelineEditCallbacks["onToggleTrackHidden"];
   onTogglePropertyGroupKeyframe?: TimelineEditCallbacks["onTogglePropertyGroupKeyframe"];
   onSeek?: (time: number) => void;
+  rovingTargetId: string | null;
 }) {
   const elementId = expandedElement.key ?? expandedElement.id;
   const { navigation, values, label, toggleTarget } = resolveLaneHeaderState(
@@ -412,7 +415,7 @@ function PropertyGroupHeaderRow({
       id={timelineLogicalRowCellId(timelinePropertyRowId(elementId, lane.group), "header")}
       data-timeline-focus-id={timelinePropertyRowId(elementId, lane.group)}
       data-timeline-element-id={elementId}
-      tabIndex={-1}
+      tabIndex={rovingTargetId === timelinePropertyRowId(elementId, lane.group) ? 0 : -1}
       data-property-group={lane.group}
       data-timeline-lane-top={getTimelineLaneTop(laneIndex)}
       className="absolute left-0 flex items-center gap-1 px-1.5 text-[10px] text-white/65"
@@ -484,6 +487,7 @@ export function TimelineTrackHeader({
   onToggleTrackHidden,
   onTogglePropertyGroupKeyframe,
   onSeek,
+  rovingTargetId = null,
 }: TimelineTrackHeaderProps) {
   const [hoveredGroup, setHoveredGroup] = useState<PropertyGroupName | null>(null);
   const clipPercentage = keyframeClip
@@ -550,6 +554,7 @@ export function TimelineTrackHeader({
                 onToggleTrackHidden={onToggleTrackHidden}
                 onTogglePropertyGroupKeyframe={onTogglePropertyGroupKeyframe}
                 onSeek={onSeek}
+                rovingTargetId={rovingTargetId}
               />
             ))}
         </>

--- a/packages/studio/src/player/components/TimelineTrackRow.tsx
+++ b/packages/studio/src/player/components/TimelineTrackRow.tsx
@@ -12,6 +12,7 @@ interface TimelineTrackRowProps {
   virtualized: boolean;
   background: string;
   borderColor: string;
+  rovingTargetId?: string | null;
   children: ReactNode;
 }
 
@@ -26,6 +27,7 @@ export function TimelineTrackRow({
   virtualized,
   background,
   borderColor,
+  rovingTargetId = null,
   children,
 }: TimelineTrackRowProps) {
   return (
@@ -49,7 +51,7 @@ export function TimelineTrackRow({
         aria-expanded={logicalRow.expandable ? logicalRow.expanded : undefined}
         data-timeline-logical-row-id={logicalRow.id}
         data-timeline-focus-id={logicalRow.id}
-        tabIndex={-1}
+        tabIndex={rovingTargetId === logicalRow.id ? 0 : -1}
         className="flex"
         style={{ height }}
       >

--- a/packages/studio/src/player/components/timelineKeyboardNavigation.ts
+++ b/packages/studio/src/player/components/timelineKeyboardNavigation.ts
@@ -210,7 +210,7 @@ export function buildTimelineLogicalRows({
       logicalIndex: rows.length,
       level: 1,
       parentId: null,
-      elementId: null,
+      elementId: activeId,
       expandable: lanes.length > 0,
       expanded,
       items: clipItems(trackId, elements),

--- a/packages/studio/src/player/components/useTimelineKeyboardActor.test.tsx
+++ b/packages/studio/src/player/components/useTimelineKeyboardActor.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import React, { act, useRef } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePlayerStore } from "../store/playerStore";
+import { createTimelineRowGeometry } from "./timelineLayout";
+import type { TimelineLogicalRow } from "./timelineKeyboardNavigation";
+import { useTimelineKeyboardActor } from "./useTimelineKeyboardActor";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+});
+
+const rows: readonly TimelineLogicalRow[] = [
+  {
+    id: "track-1",
+    kind: "row",
+    physicalTrackKey: 1,
+    logicalIndex: 0,
+    level: 1,
+    parentId: null,
+    elementId: "clip-1",
+    expandable: true,
+    expanded: false,
+    items: [{ id: "clip-1", kind: "clip", rowId: "track-1", elementId: "clip-1", time: 1 }],
+  },
+  {
+    id: "track-2",
+    kind: "row",
+    physicalTrackKey: 2,
+    logicalIndex: 1,
+    level: 1,
+    parentId: null,
+    elementId: "clip-2",
+    expandable: false,
+    expanded: false,
+    items: [{ id: "clip-2", kind: "clip", rowId: "track-2", elementId: "clip-2", time: 2 }],
+  },
+  {
+    id: "track-3",
+    kind: "row",
+    physicalTrackKey: 3,
+    logicalIndex: 2,
+    level: 1,
+    parentId: null,
+    elementId: null,
+    expandable: false,
+    expanded: false,
+    items: [],
+  },
+];
+
+interface HarnessProps {
+  focusedTargetId?: string | null;
+  onToggleRow?: (target: TimelineLogicalRow) => void;
+}
+
+function Harness({ focusedTargetId = null, onToggleRow = vi.fn() }: HarnessProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const keyboard = useTimelineKeyboardActor({
+    logicalRows: rows,
+    focusedTargetId,
+    rowGeometry: createTimelineRowGeometry([1, 2, 3], [48, 48, 48]),
+    scrollRef,
+    onToggleRow,
+  });
+  return (
+    <div ref={scrollRef} onFocus={keyboard.onFocus} onKeyDown={keyboard.onKeyDown}>
+      {rows
+        .flatMap((row) => [row, ...row.items])
+        .map((target) => (
+          <button
+            key={target.id}
+            data-timeline-focus-id={target.id}
+            tabIndex={target.id === keyboard.rovingTargetId ? 0 : -1}
+          >
+            {target.id}
+          </button>
+        ))}
+    </div>
+  );
+}
+
+function renderHarness(props: React.ComponentProps<typeof Harness> = {}) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  act(() => root.render(<Harness {...props} />));
+  return { host, root };
+}
+
+function key(target: Element, value: string, init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: value,
+    ...init,
+  });
+  act(() => target.dispatchEvent(event));
+  return event;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  usePlayerStore.setState({ timelineFocus: null, timelineFocusNonce: 0 });
+});
+
+describe("useTimelineKeyboardActor", () => {
+  it("exposes exactly one roving target and persists focused logical identity", () => {
+    const { host, root } = renderHarness({ focusedTargetId: "clip-2" });
+    expect(host.querySelectorAll('[tabindex="0"]')).toHaveLength(1);
+    const target = host.querySelector<HTMLElement>('[data-timeline-focus-id="track-3"]')!;
+    act(() => target.focus());
+    expect(usePlayerStore.getState().timelineFocus?.id).toBe("track-3");
+    act(() => root.unmount());
+  });
+
+  it("requests navigation focus without clicking or seeking", () => {
+    const { host, root } = renderHarness({ focusedTargetId: "clip-1" });
+    const target = host.querySelector<HTMLElement>('[data-timeline-focus-id="clip-1"]')!;
+    const click = vi.fn();
+    target.addEventListener("click", click);
+    const event = key(target, "ArrowDown");
+    expect(event.defaultPrevented).toBe(true);
+    expect(usePlayerStore.getState().timelineFocus?.id).toBe("clip-2");
+    expect(usePlayerStore.getState().requestedSeekTime).toBeNull();
+    expect(click).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it("supports modified timeline boundaries and viewport-sized paging", () => {
+    const { host, root } = renderHarness({ focusedTargetId: "clip-2" });
+    const viewport = host.firstElementChild as HTMLDivElement;
+    Object.defineProperty(viewport, "clientHeight", { configurable: true, value: 48 });
+    const target = host.querySelector<HTMLElement>('[data-timeline-focus-id="clip-2"]')!;
+    key(target, "End", { metaKey: true });
+    expect(usePlayerStore.getState().timelineFocus?.id).toBe("track-3");
+    key(target, "PageUp");
+    expect(usePlayerStore.getState().timelineFocus?.id).toBe("clip-1");
+    act(() => root.unmount());
+  });
+
+  it("toggles expandable rows but leaves native control activation to the control", () => {
+    const onToggleRow = vi.fn();
+    const { host, root } = renderHarness({ focusedTargetId: "track-1", onToggleRow });
+    const row = host.querySelector<HTMLElement>('[data-timeline-focus-id="track-1"]')!;
+    const clip = host.querySelector<HTMLElement>('[data-timeline-focus-id="clip-1"]')!;
+    expect(key(row, " ").defaultPrevented).toBe(true);
+    expect(onToggleRow).toHaveBeenCalledWith(rows[0]);
+    expect(key(clip, "Enter").defaultPrevented).toBe(false);
+    expect(onToggleRow).toHaveBeenCalledOnce();
+    act(() => root.unmount());
+  });
+
+  it("dispatches the existing scoped context-menu callback", () => {
+    const { host, root } = renderHarness({ focusedTargetId: "clip-1" });
+    const target = host.querySelector<HTMLElement>('[data-timeline-focus-id="clip-1"]')!;
+    const context = vi.fn((event: Event) => event.preventDefault());
+    target.addEventListener("contextmenu", context);
+    key(target, "F10", { shiftKey: true });
+    expect(context).toHaveBeenCalledOnce();
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/player/components/useTimelineKeyboardActor.ts
+++ b/packages/studio/src/player/components/useTimelineKeyboardActor.ts
@@ -1,0 +1,109 @@
+import { useCallback, type FocusEvent, type KeyboardEvent, type RefObject } from "react";
+import { usePlayerStore } from "../store/playerStore";
+import type { TimelineRowGeometry } from "./timelineLayout";
+import {
+  isTimelineNavigationKey,
+  locateTimelineLogicalTarget,
+  resolveTimelineNavigationTarget,
+  type TimelineLogicalRow,
+} from "./timelineKeyboardNavigation";
+
+interface TimelineKeyboardActorInput {
+  logicalRows: readonly TimelineLogicalRow[];
+  focusedTargetId: string | null;
+  rowGeometry: TimelineRowGeometry;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onToggleRow: (target: TimelineLogicalRow) => void;
+}
+
+function eventTarget(event: FocusEvent | KeyboardEvent): HTMLElement | null {
+  if (!(event.target instanceof Element)) return null;
+  const target = event.target.closest<HTMLElement>("[data-timeline-focus-id]");
+  return target && event.currentTarget.contains(target) ? target : null;
+}
+
+function viewportPageSize(
+  rows: readonly TimelineLogicalRow[],
+  geometry: TimelineRowGeometry,
+  viewport: HTMLDivElement | null,
+): number {
+  if (!viewport || rows.length === 0) return 1;
+  const first = Math.max(0, Math.floor(geometry.getRowFromY(viewport.scrollTop)));
+  const last = Math.min(
+    geometry.rowKeys.length - 1,
+    Math.floor(geometry.getRowFromY(viewport.scrollTop + viewport.clientHeight)),
+  );
+  const visibleTracks = new Set(geometry.rowKeys.slice(first, last + 1));
+  return Math.max(1, rows.filter((row) => visibleTracks.has(row.physicalTrackKey)).length);
+}
+
+function openContextMenu(target: HTMLElement): void {
+  const bounds = target.getBoundingClientRect();
+  target.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: bounds.left + bounds.width / 2,
+      clientY: bounds.top + bounds.height / 2,
+    }),
+  );
+}
+
+/** The timeline's sole keyboard actor; controls only describe their logical identity. */
+export function useTimelineKeyboardActor({
+  logicalRows,
+  focusedTargetId,
+  rowGeometry,
+  scrollRef,
+  onToggleRow,
+}: TimelineKeyboardActorInput) {
+  const rovingTargetId =
+    (focusedTargetId && locateTimelineLogicalTarget(logicalRows, focusedTargetId)?.target.id) ??
+    logicalRows[0]?.id ??
+    null;
+
+  const onFocus = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      const id = eventTarget(event)?.dataset.timelineFocusId;
+      if (id && id !== focusedTargetId) usePlayerStore.getState().requestTimelineFocus(id);
+    },
+    [focusedTargetId],
+  );
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      const targetElement = eventTarget(event);
+      const id = targetElement?.dataset.timelineFocusId;
+      if (!targetElement || !id) return;
+      const located = locateTimelineLogicalTarget(logicalRows, id);
+      if (!located) return;
+
+      if (isTimelineNavigationKey(event.key)) {
+        const next = resolveTimelineNavigationTarget(logicalRows, id, event.key, {
+          pageSize: viewportPageSize(logicalRows, rowGeometry, scrollRef.current),
+          timelineBoundary: event.ctrlKey || event.metaKey,
+        });
+        event.preventDefault();
+        if (next && next.id !== id) usePlayerStore.getState().requestTimelineFocus(next.id);
+        return;
+      }
+      if (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey)) {
+        event.preventDefault();
+        openContextMenu(targetElement);
+        return;
+      }
+      if (
+        (event.key !== "Enter" && event.key !== " ") ||
+        located.target.kind !== "row" ||
+        !located.target.expandable
+      ) {
+        return;
+      }
+      event.preventDefault();
+      onToggleRow(located.target);
+    },
+    [logicalRows, onToggleRow, rowGeometry, scrollRef],
+  );
+
+  return { rovingTargetId, onFocus, onKeyDown };
+}


### PR DESCRIPTION
## What

add timeline keyboard controls.

## Why

Keep the virtualized timeline understandable and fully operable with keyboard and assistive technology.

## How

Adds the focused selection, treegrid, roving-focus, or keyboard behavior in this stack layer.

Key files in this layer:

- `packages/studio/src/player/components/LayerDisclosureRow.tsx`
- `packages/studio/src/player/components/Timeline.tsx`
- `packages/studio/src/player/components/Timeline.virtualization.test.tsx`
- `packages/studio/src/player/components/TimelineClip.test.tsx`

## Test plan

Validated on the complete stacked tip with formatting, lint, Studio typecheck, the full production build, and the Studio test suite (2,946 passing; 18 todo). Focused timeline/thumbnail tests and browser QA cover the affected interaction path.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable for this implementation layer)

## Post-Deploy Monitoring & Validation

- **Owner:** Studio team
- **Window:** First 24 hours after rollout
- **Signals:** Watch keyboard navigation, focus restoration, accessibility checks, and inspector-selection consistency.
- **Rollback trigger:** Reproducible data loss, broken timeline editing/navigation, or sustained performance regression; revert this stack layer and its descendants.