### PR TITLE
perf(studio): bound thumbnail decoding resources

### DIFF
--- a/packages/studio/src/hooks/useThumbnailLease.test.tsx
+++ b/packages/studio/src/hooks/useThumbnailLease.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThumbnailScheduler, type ThumbnailRequest } from "../player/lib/thumbnailScheduler";
+import { useThumbnailLease } from "./useThumbnailLease";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useThumbnailLease", () => {
+  it("subscribes once, publishes the result, and releases on unmount", async () => {
+    const scheduler = new ThumbnailScheduler();
+    const load = vi.fn(async () => ({
+      value: { kind: "image" as const, url: "blob:poster", aspect: 16 / 9 },
+      weight: 10,
+    }));
+    const request: ThumbnailRequest = {
+      key: "poster",
+      projectId: "demo",
+      sessionEpoch: 1,
+      kind: "image",
+      priority: "visible",
+      load,
+    };
+    let status = "missing";
+
+    function Probe() {
+      status = useThumbnailLease(request, scheduler).status;
+      return null;
+    }
+
+    const root = createRoot(document.createElement("div"));
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await Promise.resolve();
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(status).toBe("ready");
+    expect(scheduler.getDiagnostics().leases).toBe(1);
+
+    act(() => root.unmount());
+    expect(scheduler.getDiagnostics().leases).toBe(0);
+  });
+
+  it("does not acquire work for a null request", () => {
+    const scheduler = new ThumbnailScheduler();
+    let status = "missing";
+    function Probe() {
+      status = useThumbnailLease(null, scheduler).status;
+      return null;
+    }
+    const root = createRoot(document.createElement("div"));
+    act(() => root.render(React.createElement(Probe)));
+    expect(status).toBe("idle");
+    expect(scheduler.getDiagnostics().leases).toBe(0);
+    act(() => root.unmount());
+  });
+
+  it("updates priority without restarting the active request", async () => {
+    const scheduler = new ThumbnailScheduler();
+    let resolve!: (value: {
+      value: { kind: "image"; url: string; aspect: number };
+      weight: number;
+    }) => void;
+    const pending = new Promise<{
+      value: { kind: "image"; url: string; aspect: number };
+      weight: number;
+    }>((accept) => {
+      resolve = accept;
+    });
+    const load = vi.fn(() => pending);
+    let priority: ThumbnailRequest["priority"] = "overscan";
+    function Probe() {
+      useThumbnailLease(
+        {
+          key: "same-content",
+          projectId: "demo",
+          sessionEpoch: 1,
+          kind: "image",
+          priority,
+          load,
+        },
+        scheduler,
+      );
+      return null;
+    }
+    const root = createRoot(document.createElement("div"));
+    act(() => root.render(React.createElement(Probe)));
+    priority = "interaction";
+    act(() => root.render(React.createElement(Probe)));
+    expect(load).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolve({ value: { kind: "image", url: "blob:done", aspect: 1 }, weight: 1 });
+      await pending;
+    });
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/hooks/useThumbnailLease.ts
+++ b/packages/studio/src/hooks/useThumbnailLease.ts
@@ -1,0 +1,45 @@
+import { useCallback, useLayoutEffect, useRef, useSyncExternalStore } from "react";
+import {
+  thumbnailScheduler,
+  type ThumbnailRequest,
+  type ThumbnailScheduler,
+  type ThumbnailSnapshot,
+} from "../player/lib/thumbnailScheduler";
+
+const IDLE: ThumbnailSnapshot = Object.freeze({ status: "idle" });
+
+export function useThumbnailLease(
+  request: ThumbnailRequest | null,
+  scheduler: ThumbnailScheduler = thumbnailScheduler,
+): ThumbnailSnapshot {
+  const requestRef = useRef(request);
+  requestRef.current = request;
+  const leaseRef = useRef<ReturnType<ThumbnailScheduler["acquire"]> | null>(null);
+  const identity = request
+    ? `${request.projectId}\u0000${request.sessionEpoch}\u0000${request.key}`
+    : null;
+  const priority = request?.priority;
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      const current = requestRef.current;
+      if (!current || identity === null) return () => {};
+      const lease = scheduler.acquire(current, listener);
+      leaseRef.current = lease;
+      return () => {
+        if (leaseRef.current === lease) leaseRef.current = null;
+        lease.release();
+      };
+    },
+    [identity, scheduler],
+  );
+  const getSnapshot = useCallback(() => {
+    const current = requestRef.current;
+    return current && identity !== null ? scheduler.getSnapshot(current) : IDLE;
+  }, [identity, scheduler]);
+
+  useLayoutEffect(() => {
+    if (priority) leaseRef.current?.updatePriority(priority);
+  }, [priority]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => IDLE);
+}

--- a/packages/studio/src/player/lib/mediaProbe.test.ts
+++ b/packages/studio/src/player/lib/mediaProbe.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMediaProbeDiagnostics, probeMediaUrl, resetMediaProbeRegistry } from "./mediaProbe";
+
+const dispose = vi.fn();
+const getDurationFromMetadata = vi.fn(async () => 5);
+
+vi.mock("mediabunny", () => ({
+  ALL_FORMATS: {},
+  UrlSource: class {
+    constructor(readonly url: string) {}
+  },
+  Input: class {
+    getDurationFromMetadata = getDurationFromMetadata;
+    getPrimaryVideoTrack = vi.fn(async () => ({ displayWidth: 640, displayHeight: 360 }));
+    getAudioTracks = vi.fn(async () => []);
+    dispose = dispose;
+  },
+}));
+
+beforeEach(() => {
+  resetMediaProbeRegistry();
+  vi.clearAllMocks();
+  getDurationFromMetadata.mockResolvedValue(5);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("media probe registry", () => {
+  it("deduplicates and caches successful probes", async () => {
+    const [first, second] = await Promise.all([
+      probeMediaUrl("/video.mp4"),
+      probeMediaUrl("/video.mp4"),
+    ]);
+    expect(first).toEqual(second);
+    expect(getDurationFromMetadata).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(getMediaProbeDiagnostics()).toEqual({ cached: 1, failed: 0, inflight: 0 });
+  });
+
+  it("bounds retained successes to the configured registry count", async () => {
+    for (let index = 0; index < 513; index++) {
+      await probeMediaUrl(`/video-${index}.mp4`);
+    }
+    expect(getMediaProbeDiagnostics().cached).toBe(512);
+  });
+
+  it("limits concurrent metadata probes and drains the queue", async () => {
+    const resolvers: Array<(duration: number) => void> = [];
+    getDurationFromMetadata.mockImplementation(
+      () => new Promise<number>((resolve) => resolvers.push(resolve)),
+    );
+
+    const probes = Array.from({ length: 5 }, (_, index) => probeMediaUrl(`/queued-${index}.mp4`));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getDurationFromMetadata).toHaveBeenCalledTimes(4);
+
+    resolvers[0]?.(5);
+    await vi.waitFor(() => expect(getDurationFromMetadata).toHaveBeenCalledTimes(5));
+
+    for (const resolve of resolvers.slice(1)) resolve(5);
+    await expect(Promise.all(probes)).resolves.toHaveLength(5);
+    expect(getMediaProbeDiagnostics()).toEqual({ cached: 5, failed: 0, inflight: 0 });
+  });
+
+  it("retries failures only after the failure TTL", async () => {
+    vi.useFakeTimers();
+    getDurationFromMetadata.mockRejectedValue(new Error("bad source"));
+    await expect(probeMediaUrl("/bad.mp4")).resolves.toBeNull();
+    await expect(probeMediaUrl("/bad.mp4")).resolves.toBeNull();
+    expect(getDurationFromMetadata).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_001);
+    await expect(probeMediaUrl("/bad.mp4")).resolves.toBeNull();
+    expect(getDurationFromMetadata).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/studio/src/player/lib/mediaProbe.ts
+++ b/packages/studio/src/player/lib/mediaProbe.ts
@@ -1,4 +1,6 @@
-interface MediaProbeResult {
+import { TIMELINE_VIEWPORT_BUDGETS } from "./timelineViewportBudgets";
+
+export interface MediaProbeResult {
   duration: number;
   width?: number;
   height?: number;
@@ -6,11 +8,24 @@ interface MediaProbeResult {
   hasAudio: boolean;
 }
 
-const cache = new Map<string, MediaProbeResult>();
+interface CachedProbe {
+  result: MediaProbeResult;
+  lastAccess: number;
+}
+
+const cache = new Map<string, CachedProbe>();
 const inflight = new Map<string, Promise<MediaProbeResult | null>>();
 // URLs whose probe failed (CORS, 404, non-media). Remembered so the rAF-driven
 // timeline re-derive doesn't re-fetch them every frame and flood the console.
-const failed = new Set<string>();
+const failed = new Map<string, { failedAt: number; lastAccess: number }>();
+let accessSequence = 0;
+let activeProbes = 0;
+let registryEpoch = 0;
+const probeQueue: Array<{
+  key: string;
+  epoch: number;
+  resolve: (result: MediaProbeResult | null) => void;
+}> = [];
 
 let mediabunnyModule: typeof import("mediabunny") | null | false = null;
 
@@ -65,7 +80,22 @@ async function probeOne(url: string): Promise<MediaProbeResult | null> {
 }
 
 function getCachedProbe(url: string): MediaProbeResult | undefined {
-  return cache.get(normalizeUrl(url));
+  const cached = cache.get(normalizeUrl(url));
+  if (cached) cached.lastAccess = ++accessSequence;
+  return cached?.result;
+}
+
+function evictMetadataOverflow(): void {
+  const overflow = cache.size + failed.size - TIMELINE_VIEWPORT_BUDGETS.metadataRegistryEntries;
+  if (overflow <= 0) return;
+  const entries = [
+    ...Array.from(cache, ([key, value]) => ({ key, at: value.lastAccess, failed: false })),
+    ...Array.from(failed, ([key, value]) => ({ key, at: value.lastAccess, failed: true })),
+  ].sort((left, right) => left.at - right.at);
+  for (const entry of entries.slice(0, overflow)) {
+    if (entry.failed) failed.delete(entry.key);
+    else cache.delete(entry.key);
+  }
 }
 
 /**
@@ -101,32 +131,82 @@ export async function probeMissingSourceDurations<
       el.sourceDuration == null &&
       ["video", "audio"].includes(el.tag.toLowerCase()) &&
       !getCachedProbe(el.src) &&
-      !failed.has(normalizeUrl(el.src)),
+      !hasFreshFailure(normalizeUrl(el.src)),
   );
   if (needs.length === 0) return;
   await Promise.allSettled(
     needs.map(async (el) => {
-      const result = await probeMediaUrl(el.src!);
+      const source = el.src;
+      if (!source) return;
+      const result = await probeMediaUrl(source);
       if (result) apply(el.key ?? el.id, result.duration);
     }),
   );
 }
 
-async function probeMediaUrl(url: string): Promise<MediaProbeResult | null> {
+function hasFreshFailure(key: string): boolean {
+  const failedAt = failed.get(key);
+  if (failedAt === undefined) return false;
+  if (Date.now() - failedAt.failedAt < TIMELINE_VIEWPORT_BUDGETS.metadataFailureTtlMs) {
+    failedAt.lastAccess = ++accessSequence;
+    return true;
+  }
+  failed.delete(key);
+  return false;
+}
+
+export async function probeMediaUrl(url: string): Promise<MediaProbeResult | null> {
   const key = normalizeUrl(url);
-  const cached = cache.get(key);
+  const cached = getCachedProbe(key);
   if (cached) return cached;
-  if (failed.has(key)) return null;
+  if (hasFreshFailure(key)) return null;
 
   let pending = inflight.get(key);
   if (pending) return pending;
 
-  pending = probeOne(key).then((result) => {
-    inflight.delete(key);
-    if (result) cache.set(key, result);
-    else failed.add(key);
-    return result;
+  pending = new Promise<MediaProbeResult | null>((resolve) => {
+    probeQueue.push({ key, epoch: registryEpoch, resolve });
+    pumpProbeQueue();
   });
   inflight.set(key, pending);
   return pending;
+}
+
+function pumpProbeQueue(): void {
+  while (activeProbes < TIMELINE_VIEWPORT_BUDGETS.concurrentMetadataJobs) {
+    const queued = probeQueue.shift();
+    if (!queued) return;
+    if (queued.epoch !== registryEpoch) {
+      queued.resolve(null);
+      continue;
+    }
+    activeProbes++;
+    void probeOne(queued.key)
+      .then((result) => {
+        if (queued.epoch !== registryEpoch) return null;
+        inflight.delete(queued.key);
+        if (result) cache.set(queued.key, { result, lastAccess: ++accessSequence });
+        else failed.set(queued.key, { failedAt: Date.now(), lastAccess: ++accessSequence });
+        evictMetadataOverflow();
+        return result;
+      })
+      .then(queued.resolve)
+      .finally(() => {
+        activeProbes--;
+        pumpProbeQueue();
+      });
+  }
+}
+
+export function getMediaProbeDiagnostics() {
+  return { cached: cache.size, failed: failed.size, inflight: inflight.size };
+}
+
+export function resetMediaProbeRegistry(): void {
+  registryEpoch++;
+  for (const queued of probeQueue.splice(0)) queued.resolve(null);
+  cache.clear();
+  failed.clear();
+  inflight.clear();
+  accessSequence = 0;
 }

--- a/packages/studio/src/player/lib/thumbnailVideoDecoder.test.ts
+++ b/packages/studio/src/player/lib/thumbnailVideoDecoder.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { decodeVideoThumbnail, videoThumbnailTimestamps } from "./thumbnailVideoDecoder";
+
+const dispose = vi.fn();
+const canvasesAtTimestamps = vi.fn();
+const input = {
+  getPrimaryVideoTrack: vi.fn(),
+  dispose,
+};
+
+vi.mock("mediabunny", () => ({
+  ALL_FORMATS: {},
+  UrlSource: class {
+    constructor(readonly url: string) {}
+  },
+  Input: class {
+    getPrimaryVideoTrack = input.getPrimaryVideoTrack;
+    dispose = input.dispose;
+  },
+  CanvasSink: class {
+    canvasesAtTimestamps = canvasesAtTimestamps;
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(URL, "createObjectURL").mockReturnValueOnce("blob:one").mockReturnValueOnce("blob:two");
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  HTMLCanvasElement.prototype.toBlob = function toBlob(callback) {
+    callback(new Blob(["frame"], { type: "image/jpeg" }));
+  };
+  input.getPrimaryVideoTrack.mockResolvedValue({
+    getDisplayWidth: vi.fn(async () => 1080),
+    getDisplayHeight: vi.fn(async () => 1920),
+    getDurationFromMetadata: vi.fn(async () => 10),
+  });
+});
+
+describe("videoThumbnailTimestamps", () => {
+  it("uses the midpoint for a poster and sorted sparse points for a strip", () => {
+    expect(videoThumbnailTimestamps(2, 6, 1)).toEqual([5]);
+    expect(videoThumbnailTimestamps(2, 6, 4)).toEqual([2, 4, 6, 8]);
+  });
+
+  it("clamps invalid source ranges", () => {
+    expect(videoThumbnailTimestamps(-2, Number.NaN, 0)).toEqual([0]);
+    expect(videoThumbnailTimestamps(2, 8, Number.NaN)).toEqual([6]);
+  });
+});
+
+describe("decodeVideoThumbnail", () => {
+  it("extracts sparse frames, returns object URLs, and disposes once", async () => {
+    const canvas = document.createElement("canvas");
+    canvasesAtTimestamps.mockImplementation(async function* (timestamps: number[]) {
+      expect(timestamps).toEqual([2, 8]);
+      yield { canvas, timestamp: 2, duration: 1 };
+      yield { canvas, timestamp: 8, duration: 1 };
+    });
+    const result = await decodeVideoThumbnail(
+      { source: "/clip.mp4", sourceStart: 2, sourceRangeDuration: 6, frameCount: 2 },
+      new AbortController().signal,
+    );
+
+    expect(result.value).toEqual({
+      kind: "filmstrip",
+      urls: ["blob:one", "blob:two"],
+      aspect: 9 / 16,
+    });
+    result.dispose?.();
+    result.dispose?.();
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases input and degrades when the source has no video track", async () => {
+    input.getPrimaryVideoTrack.mockResolvedValue(null);
+    await expect(
+      decodeVideoThumbnail({ source: "/audio.mp3", frameCount: 1 }, new AbortController().signal),
+    ).rejects.toThrow("no decodable video track");
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("revokes partial results when cancellation lands during extraction", async () => {
+    const controller = new AbortController();
+    const canvas = document.createElement("canvas");
+    canvasesAtTimestamps.mockImplementation(async function* () {
+      yield { canvas, timestamp: 1, duration: 1 };
+      controller.abort();
+      yield { canvas, timestamp: 2, duration: 1 };
+    });
+    await expect(
+      decodeVideoThumbnail({ source: "/clip.mp4", frameCount: 2 }, controller.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/studio/src/player/lib/thumbnailVideoDecoder.ts
+++ b/packages/studio/src/player/lib/thumbnailVideoDecoder.ts
@@ -1,0 +1,137 @@
+import { TIMELINE_VIEWPORT_BUDGETS, type TimelineViewportBudgets } from "./timelineViewportBudgets";
+import type { ThumbnailLoadedResult, ThumbnailValue } from "./thumbnailScheduler";
+
+export interface VideoThumbnailDecodeRequest {
+  source: string;
+  sourceStart?: number;
+  sourceRangeDuration?: number;
+  frameCount: number;
+  fit?: "contain" | "cover";
+}
+
+export function videoThumbnailTimestamps(
+  start: number,
+  duration: number,
+  frameCount: number,
+): number[] {
+  const safeStart = Math.max(0, Number.isFinite(start) ? start : 0);
+  const safeDuration = Math.max(0, Number.isFinite(duration) ? duration : 0);
+  const count = Math.max(1, Number.isFinite(frameCount) ? Math.floor(frameCount) : 1);
+  if (count === 1) return [safeStart + safeDuration / 2];
+  return Array.from(
+    { length: count },
+    (_, index) => safeStart + (safeDuration * index) / (count - 1),
+  );
+}
+
+async function canvasToBlob(canvas: HTMLCanvasElement | OffscreenCanvas): Promise<Blob> {
+  if (canvas instanceof HTMLCanvasElement) {
+    return new Promise((resolve, reject) => {
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error("Video thumbnail encode failed"))),
+        "image/jpeg",
+        0.72,
+      );
+    });
+  }
+  return canvas.convertToBlob({ type: "image/jpeg", quality: 0.72 });
+}
+
+/** Sparse Mediabunny extraction with one pooled canvas and one cleanup owner. */
+export async function decodeVideoThumbnail(
+  request: VideoThumbnailDecodeRequest,
+  signal: AbortSignal,
+  budgets: Readonly<TimelineViewportBudgets> = TIMELINE_VIEWPORT_BUDGETS,
+): Promise<ThumbnailLoadedResult> {
+  const mediabunny = await import("mediabunny");
+  if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+  const input = new mediabunny.Input({
+    source: new mediabunny.UrlSource(request.source),
+    formats: mediabunny.ALL_FORMATS,
+  });
+  const urls: string[] = [];
+  const canvases = new Set<HTMLCanvasElement | OffscreenCanvas>();
+  try {
+    const track = await input.getPrimaryVideoTrack();
+    if (!track) throw new Error("Video source has no decodable video track");
+    const [displayWidth, displayHeight] = await Promise.all([
+      track.getDisplayWidth(),
+      track.getDisplayHeight(),
+    ]);
+    if (!(displayWidth > 0 && displayHeight > 0)) {
+      throw new Error("Video source has invalid dimensions");
+    }
+    const metadataDuration = await track.getDurationFromMetadata({ skipLiveWait: true });
+    const sourceDuration = Math.max(0, metadataDuration ?? request.sourceRangeDuration ?? 0);
+    const sourceStart = Math.min(Math.max(0, request.sourceStart ?? 0), sourceDuration);
+    const requestedDuration =
+      request.sourceRangeDuration ?? Math.max(0, sourceDuration - sourceStart);
+    const duration = Math.min(
+      Math.max(0, requestedDuration),
+      Math.max(0, sourceDuration - sourceStart),
+    );
+    const timestamps = videoThumbnailTimestamps(
+      sourceStart,
+      duration,
+      Math.min(request.frameCount, budgets.richPreviewFrameCount),
+    );
+    const aspect = displayWidth / displayHeight;
+    const targetWidth = Math.max(
+      1,
+      Math.min(
+        budgets.posterMaxPhysicalWidth,
+        Math.round(budgets.posterMaxPhysicalHeight * aspect),
+      ),
+    );
+    const targetHeight = Math.max(
+      1,
+      Math.min(budgets.posterMaxPhysicalHeight, Math.round(targetWidth / aspect)),
+    );
+    const sink = new mediabunny.CanvasSink(track, {
+      width: Math.max(1, targetWidth),
+      height: Math.max(1, targetHeight),
+      fit: request.fit ?? "cover",
+      poolSize: 1,
+    });
+
+    for await (const wrapped of sink.canvasesAtTimestamps(timestamps)) {
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+      if (!wrapped) continue;
+      canvases.add(wrapped.canvas);
+      const blob = await canvasToBlob(wrapped.canvas);
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+      urls.push(URL.createObjectURL(blob));
+    }
+    if (urls.length === 0) throw new Error("Video source returned no thumbnail frames");
+
+    const dispose = () => {
+      for (const url of urls.splice(0)) URL.revokeObjectURL(url);
+      for (const canvas of canvases) {
+        canvas.width = 0;
+        canvas.height = 0;
+      }
+      canvases.clear();
+    };
+    const firstUrl = urls[0];
+    if (!firstUrl) throw new Error("Video source returned no thumbnail frames");
+    const value: ThumbnailValue =
+      urls.length === 1
+        ? { kind: "image", url: firstUrl, aspect }
+        : { kind: "filmstrip", urls: [...urls], aspect };
+    return {
+      value,
+      weight: targetWidth * targetHeight * 4 * urls.length,
+      dispose,
+    };
+  } catch (error) {
+    for (const url of urls) URL.revokeObjectURL(url);
+    for (const canvas of canvases) {
+      canvas.width = 0;
+      canvas.height = 0;
+    }
+    throw error;
+  } finally {
+    input.dispose();
+  }
+}


### PR DESCRIPTION
## What

bound thumbnail decoding resources.

## Why

Retain the high-value visual thumbnail UX while bounding decoding, network, CPU, and memory work to useful viewport content.

## How

Adds one layer of the thumbnail policy, scheduler, runtime, server, preference, component, context, or coordinator pipeline.

Key files in this layer:

- `packages/studio/src/hooks/useThumbnailLease.test.tsx`
- `packages/studio/src/hooks/useThumbnailLease.ts`
- `packages/studio/src/player/lib/mediaProbe.test.ts`
- `packages/studio/src/player/lib/mediaProbe.ts`

## Test plan

Validated on the complete stacked tip with formatting, lint, Studio typecheck, the full production build, and the Studio test suite (2,946 passing; 18 todo). Focused timeline/thumbnail tests and browser QA cover the affected interaction path.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable for this implementation layer)

## Post-Deploy Monitoring & Validation

- **Owner:** Studio team
- **Window:** First 24 hours after rollout
- **Signals:** Watch thumbnail request volume, abort/error rates, cache behavior, decoder concurrency, and Studio memory use.
- **Rollback trigger:** Reproducible data loss, broken timeline editing/navigation, or sustained performance regression; revert this stack layer and its descendants.