### PR TITLE
perf(studio): virtualize timeline thumbnail media

### DIFF
--- a/packages/studio/src/player/components/CompositionThumbnail.tsx
+++ b/packages/studio/src/player/components/CompositionThumbnail.tsx
@@ -1,5 +1,7 @@
-import { memo, useCallback, useState, useRef } from "react";
-import { useMountEffect } from "../../hooks/useMountEffect";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useThumbnailLease } from "../../hooks/useThumbnailLease";
+import { createThumbnailKey, type ThumbnailPriority } from "../lib/thumbnailScheduler";
+import { TIMELINE_VIEWPORT_BUDGETS } from "../lib/timelineViewportBudgets";
 
 interface CompositionThumbnailProps {
   previewUrl: string;
@@ -11,6 +13,10 @@ interface CompositionThumbnailProps {
   duration?: number;
   width?: number;
   height?: number;
+  projectId?: string;
+  sessionEpoch?: number;
+  priority?: ThumbnailPriority;
+  rich?: boolean;
 }
 
 const CLIP_HEIGHT = 66;
@@ -34,9 +40,8 @@ export function buildCompositionThumbnailUrl({
   const thumbnailBase = previewUrl
     .replace("/preview/comp/", "/thumbnail/")
     .replace(/\/preview$/, "/thumbnail/index.html");
-  const midTime = seekTime + duration / 2;
   const thumbnailUrl = new URL(thumbnailBase, origin);
-  thumbnailUrl.searchParams.set("t", midTime.toFixed(2));
+  thumbnailUrl.searchParams.set("t", (seekTime + duration / 2).toFixed(2));
   thumbnailUrl.searchParams.set("v", THUMBNAIL_URL_VERSION);
   if (selector) {
     thumbnailUrl.searchParams.set("selector", selector);
@@ -47,6 +52,23 @@ export function buildCompositionThumbnailUrl({
   return thumbnailUrl.toString();
 }
 
+async function loadCompositionImage(url: string, signal: AbortSignal) {
+  const response = await fetch(url, { signal });
+  if (!response.ok) throw new Error(`Composition thumbnail failed (${response.status})`);
+  const blob = await response.blob();
+  if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+  const objectUrl = URL.createObjectURL(blob);
+  return {
+    value: { kind: "image" as const, url: objectUrl, aspect: 16 / 9 },
+    weight:
+      TIMELINE_VIEWPORT_BUDGETS.posterMaxPhysicalWidth *
+      TIMELINE_VIEWPORT_BUDGETS.posterMaxPhysicalHeight *
+      4,
+    dispose: () => URL.revokeObjectURL(objectUrl),
+  };
+}
+
+/** Server-rendered composition poster, deduplicated and budgeted by project/session. */
 export const CompositionThumbnail = memo(function CompositionThumbnail({
   previewUrl,
   label,
@@ -55,31 +77,12 @@ export const CompositionThumbnail = memo(function CompositionThumbnail({
   selectorIndex,
   seekTime = 2,
   duration = 5,
+  projectId = previewUrl,
+  sessionEpoch = 0,
+  priority = "visible",
 }: CompositionThumbnailProps) {
   const [containerWidth, setContainerWidth] = useState(0);
-  const [loaded, setLoaded] = useState(false);
-  const [aspect, setAspect] = useState(16 / 9);
-  const roRef = useRef<ResizeObserver | null>(null);
-
-  const setContainerRef = useCallback((el: HTMLDivElement | null) => {
-    roRef.current?.disconnect();
-    if (!el) return;
-
-    const measured = el.parentElement?.clientWidth || el.clientWidth;
-    // fallow-ignore-next-line code-duplication
-    setContainerWidth(measured);
-
-    const target = el.parentElement || el;
-    roRef.current = new ResizeObserver(([entry]) => {
-      setContainerWidth(entry.contentRect.width);
-    });
-    roRef.current.observe(target);
-  }, []);
-
-  useMountEffect(() => () => {
-    roRef.current?.disconnect();
-  });
-
+  const observerRef = useRef<ResizeObserver | null>(null);
   const url = buildCompositionThumbnailUrl({
     previewUrl,
     seekTime,
@@ -88,57 +91,59 @@ export const CompositionThumbnail = memo(function CompositionThumbnail({
     selectorIndex,
     origin: window.location.origin,
   });
-  const frameW = Math.max(48, Math.round(CLIP_HEIGHT * aspect));
-  const frameCount = containerWidth > 0 ? Math.max(1, Math.ceil(containerWidth / frameW)) : 1;
+  const request = useMemo(
+    () => ({
+      key: createThumbnailKey({ kind: "composition", url }),
+      projectId,
+      sessionEpoch,
+      kind: "composition" as const,
+      priority,
+      rich: true,
+      load: (signal: AbortSignal) => loadCompositionImage(url, signal),
+    }),
+    [priority, projectId, sessionEpoch, url],
+  );
+  const snapshot = useThumbnailLease(request);
+  const value =
+    snapshot.status === "ready" && snapshot.value.kind === "image" ? snapshot.value : null;
+  const frameWidth = Math.max(48, Math.round(CLIP_HEIGHT * (value?.aspect ?? 16 / 9)));
+  const frameCount = containerWidth > 0 ? Math.max(1, Math.ceil(containerWidth / frameWidth)) : 1;
+
+  const setContainerRef = useCallback((element: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    if (!element) return;
+    const target = element.parentElement ?? element;
+    setContainerWidth(target.clientWidth);
+    observerRef.current = new ResizeObserver(([entry]) =>
+      setContainerWidth(entry.contentRect.width),
+    );
+    observerRef.current.observe(target);
+  }, []);
 
   return (
     <div ref={setContainerRef} className="absolute inset-0 overflow-hidden">
-      <img
-        src={url}
-        alt=""
-        draggable={false}
-        loading="eager"
-        onLoad={(e) => {
-          const img = e.currentTarget;
-          if (img.naturalWidth > 0 && img.naturalHeight > 0) {
-            setAspect(img.naturalWidth / img.naturalHeight);
-          }
-          setLoaded(true);
-        }}
-        className="hidden"
-      />
-
-      {loaded && (
-        <div
-          className="absolute inset-0 flex"
-          style={{ animation: "hf-thumb-fade 200ms ease-out", mixBlendMode: "lighten" }}
-        >
-          {Array.from({ length: frameCount }).map((_, i) => (
-            <div
-              key={i}
-              className="relative h-full flex-shrink-0 overflow-hidden"
-              style={{ width: frameW }}
-            >
-              <img
-                src={url}
-                alt=""
-                draggable={false}
-                className="absolute inset-0 h-full w-full object-cover"
-                style={{ opacity: 0.7 }}
-              />
-            </div>
+      {value && (
+        <div className="absolute inset-0 flex">
+          {Array.from({ length: frameCount }, (_, index) => (
+            <img
+              key={index}
+              src={value.url}
+              alt=""
+              draggable={false}
+              className="h-full flex-shrink-0 object-cover opacity-70"
+              style={{ width: frameWidth }}
+            />
           ))}
         </div>
       )}
-
+      {snapshot.status === "loading" && (
+        <div className="absolute inset-0 animate-pulse bg-white/[0.035]" />
+      )}
       {label && (
-        <div className="absolute left-3 top-0 bottom-0 flex items-center" style={{ zIndex: 10 }}>
+        <div className="absolute inset-y-0 left-3 z-10 flex items-center">
           <span
             className="block max-w-full truncate text-[10px] font-semibold leading-none"
-            style={{
-              color: labelColor,
-              textShadow: loaded ? "0 1px 4px rgba(0,0,0,0.9), 0 0 8px rgba(0,0,0,0.6)" : "none",
-            }}
+            style={{ color: labelColor }}
           >
             {label}
           </span>

--- a/packages/studio/src/player/components/ImageThumbnail.test.tsx
+++ b/packages/studio/src/player/components/ImageThumbnail.test.tsx
@@ -3,6 +3,7 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { thumbnailScheduler } from "../lib/thumbnailScheduler";
 import { ImageThumbnail } from "./ImageThumbnail";
 
 Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
@@ -68,6 +69,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root?.unmount());
   root = null;
+  thumbnailScheduler.clear();
   globalThis.IntersectionObserver = originalIO;
   globalThis.ResizeObserver = originalRO;
   globalThis.Image = originalImage;
@@ -82,6 +84,10 @@ function render(props: { imageSrc: string; label?: string; labelColor?: string }
         imageSrc={props.imageSrc}
         label={props.label ?? ""}
         labelColor={props.labelColor ?? "#fff"}
+        projectId="p"
+        sessionEpoch={1}
+        priority="visible"
+        rich={false}
       />,
     );
   });
@@ -91,6 +97,13 @@ function lastProbe(): MockImage {
   const probe = MockImage.instances.at(-1);
   expect(probe).toBeDefined();
   return probe!;
+}
+
+async function resolveProbe(update: (probe: MockImage) => void): Promise<void> {
+  await act(async () => {
+    update(lastProbe());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 }
 
 /** Assert at least one tile rendered and the first tile serves `expectedSrc`. */
@@ -107,15 +120,15 @@ describe("ImageThumbnail", () => {
     expect(host.querySelectorAll("img").length).toBe(0);
   });
 
-  it("probes the resolved src and renders repeated object-cover tiles on load", () => {
+  it("probes the resolved src and renders repeated object-cover tiles on load", async () => {
     render({ imageSrc: "/api/projects/p/preview/assets/pic.png" });
     const probe = lastProbe();
     expect(probe.src).toBe("/api/projects/p/preview/assets/pic.png");
 
-    act(() => {
-      probe.naturalWidth = 1920;
-      probe.naturalHeight = 1080;
-      probe.onload?.();
+    await resolveProbe((current) => {
+      current.naturalWidth = 1920;
+      current.naturalHeight = 1080;
+      current.onload?.();
     });
 
     const imgs = [...host.querySelectorAll("img")];
@@ -127,18 +140,18 @@ describe("ImageThumbnail", () => {
     expect(host.querySelector(".animate-pulse")).toBeNull();
   });
 
-  it("drops the shimmer and renders no tiles when a raster image fails to load", () => {
+  it("drops the shimmer and renders no tiles when a raster image fails to load", async () => {
     render({ imageSrc: "/api/projects/p/preview/assets/missing.png" });
-    act(() => lastProbe().onerror?.());
+    await resolveProbe((probe) => probe.onerror?.());
     expect(host.querySelectorAll("img").length).toBe(0);
     expect(host.querySelector(".animate-pulse")).toBeNull();
   });
 
-  it("renders tiles at 16:9 when an SVG has no intrinsic dimensions (naturalWidth=0)", () => {
+  it("renders tiles at 16:9 when an SVG has no intrinsic dimensions (naturalWidth=0)", async () => {
     render({ imageSrc: "/api/projects/p/preview/assets/logo.svg" });
     const probe = lastProbe();
 
-    act(() => {
+    await resolveProbe(() => {
       // naturalWidth stays 0 — SVG with no width/height attribute
       probe.onload?.();
     });
@@ -147,21 +160,20 @@ describe("ImageThumbnail", () => {
     expect(host.querySelector(".animate-pulse")).toBeNull();
   });
 
-  it("renders SVG tiles at 16:9 fallback even when the probe fires onerror", () => {
+  it("renders SVG tiles at 16:9 fallback even when the probe fires onerror", async () => {
     // Some browser/sandbox environments fire onerror for SVGs even though the
     // <img> element itself can render the file — we must not blank the strip.
     render({ imageSrc: "/api/projects/p/preview/assets/icon.svg" });
 
-    act(() => lastProbe().onerror?.());
+    await resolveProbe((probe) => probe.onerror?.());
 
     expectFirstTileSrc("/api/projects/p/preview/assets/icon.svg");
     expect(host.querySelector(".animate-pulse")).toBeNull();
   });
 
-  it("renders the label above the strip when provided", () => {
+  it("renders the label above the strip when provided", async () => {
     render({ imageSrc: "/x.png", label: "hero", labelColor: "#abc" });
-    act(() => {
-      const probe = lastProbe();
+    await resolveProbe((probe) => {
       probe.naturalWidth = 100;
       probe.naturalHeight = 100;
       probe.onload?.();

--- a/packages/studio/src/player/components/ImageThumbnail.tsx
+++ b/packages/studio/src/player/components/ImageThumbnail.tsx
@@ -1,155 +1,124 @@
-import { memo, useRef, useState, useCallback, useEffect } from "react";
-import { useMountEffect } from "../../hooks/useMountEffect";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useThumbnailLease } from "../../hooks/useThumbnailLease";
+import { createThumbnailKey, type ThumbnailPriority } from "../lib/thumbnailScheduler";
+import { TIMELINE_VIEWPORT_BUDGETS } from "../lib/timelineViewportBudgets";
 import { computeThumbnailStrip } from "./thumbnailUtils";
 
 interface ImageThumbnailProps {
   imageSrc: string;
   label: string;
   labelColor: string;
+  projectId?: string;
+  sessionEpoch?: number;
+  priority?: ThumbnailPriority;
+  rich?: boolean;
 }
 
-/**
- * Renders a film-strip of a still image for a timeline clip. The image is a
- * fixed-width tile (sized by its natural aspect ratio) repeated to fill the
- * clip width — matching VideoThumbnail's visual pattern. Loading is lazy
- * (IntersectionObserver) with the same shimmer fallback while decoding.
- */
+function probeImage(imageSrc: string, signal: AbortSignal) {
+  return new Promise<{ aspect: number }>((resolve, reject) => {
+    const image = new Image();
+    const cleanup = () => {
+      image.onload = null;
+      image.onerror = null;
+      signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      image.src = "";
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    image.onload = () => {
+      cleanup();
+      resolve({
+        aspect:
+          image.naturalWidth > 0 && image.naturalHeight > 0
+            ? image.naturalWidth / image.naturalHeight
+            : 16 / 9,
+      });
+    };
+    image.onerror = () => {
+      cleanup();
+      if (/\.svg($|\?)/i.test(imageSrc)) resolve({ aspect: 16 / 9 });
+      else reject(new Error("Image thumbnail failed to load"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    image.src = imageSrc;
+  });
+}
+
+/** A scheduler-backed still-image strip. Mounting is the sole work trigger. */
 export const ImageThumbnail = memo(function ImageThumbnail({
   imageSrc,
   label,
   labelColor,
+  projectId = imageSrc,
+  sessionEpoch = 0,
+  priority = "visible",
+  rich = false,
 }: ImageThumbnailProps) {
   const [containerWidth, setContainerWidth] = useState(0);
-  const [visible, setVisible] = useState(false);
-  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
-  const [aspect, setAspect] = useState(16 / 9);
-  const ioRef = useRef<IntersectionObserver | null>(null);
-  const roRef = useRef<ResizeObserver | null>(null);
-
-  const setContainerRef = useCallback((el: HTMLDivElement | null) => {
-    ioRef.current?.disconnect();
-    roRef.current?.disconnect();
-    if (!el) return;
-
-    const measured = el.parentElement?.clientWidth || el.clientWidth;
-    setContainerWidth(measured);
-
-    ioRef.current = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-          ioRef.current?.disconnect();
-        }
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const request = useMemo(
+    () => ({
+      key: createThumbnailKey({ kind: "image", source: imageSrc, rich: Number(rich) }),
+      projectId,
+      sessionEpoch,
+      kind: "image" as const,
+      priority,
+      rich,
+      load: async (signal: AbortSignal) => {
+        const { aspect } = await probeImage(imageSrc, signal);
+        return {
+          value: { kind: "image" as const, url: imageSrc, aspect },
+          weight:
+            TIMELINE_VIEWPORT_BUDGETS.posterMaxPhysicalWidth *
+            TIMELINE_VIEWPORT_BUDGETS.posterMaxPhysicalHeight *
+            4,
+        };
       },
-      { rootMargin: "200px" },
-    );
-    // fallow-ignore-next-line code-duplication
-    ioRef.current.observe(el);
-
-    const target = el.parentElement || el;
-    roRef.current = new ResizeObserver(([entry]) => {
-      setContainerWidth(entry.contentRect.width);
-    });
-    roRef.current.observe(target);
-  }, []);
-
-  useMountEffect(() => () => {
-    ioRef.current?.disconnect();
-    roRef.current?.disconnect();
-  });
-
-  // Probe the image once visible — measures the natural aspect ratio so the
-  // tile width matches, and flips to the error state (plain clip background)
-  // if the src can't load. The browser cache makes the tile <img>s free.
-  //
-  // SVG handling: SVGs without intrinsic width/height report naturalWidth=0 on
-  // load (treat as success with the 16:9 default aspect) and may fire onerror
-  // in some environments even though the file is valid and can be displayed —
-  // fall back to loaded-at-16:9 rather than hiding the strip entirely.
-  // eslint-disable-next-line no-restricted-syntax
-  useEffect(() => {
-    if (!visible) return;
-    let cancelled = false;
-    setStatus("loading");
-
-    const isSvg = /\.svg($|\?)/i.test(imageSrc);
-
-    const probe = new Image();
-    probe.onload = () => {
-      if (cancelled) return;
-      if (probe.naturalWidth > 0 && probe.naturalHeight > 0) {
-        setAspect(probe.naturalWidth / probe.naturalHeight);
-      }
-      // naturalWidth===0 (e.g. SVG with no intrinsic dimensions) falls through
-      // to "loaded" with the default 16:9 aspect already set in state.
-      setStatus("loaded");
-    };
-    probe.onerror = () => {
-      if (cancelled) return;
-      // SVGs can fail the probe in certain browser/sandbox environments even
-      // though the <img> tiles themselves render fine (different security
-      // context). Show the strip at the 16:9 fallback rather than blanking.
-      if (isSvg) {
-        setStatus("loaded");
-      } else {
-        setStatus("error");
-      }
-    };
-    probe.src = imageSrc;
-
-    return () => {
-      cancelled = true;
-      probe.onload = null;
-      probe.onerror = null;
-      probe.src = "";
-    };
-  }, [visible, imageSrc]);
-
+    }),
+    [imageSrc, priority, projectId, rich, sessionEpoch],
+  );
+  const snapshot = useThumbnailLease(request);
+  const value = snapshot.status === "ready" ? snapshot.value : null;
+  const aspect = value?.kind === "image" ? value.aspect : 16 / 9;
   const { frameW, frameCount } = computeThumbnailStrip(containerWidth, aspect);
+
+  const setContainerRef = useCallback((element: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    if (!element) return;
+    const target = element.parentElement ?? element;
+    setContainerWidth(target.clientWidth);
+    observerRef.current = new ResizeObserver(([entry]) =>
+      setContainerWidth(entry.contentRect.width),
+    );
+    observerRef.current.observe(target);
+  }, []);
 
   return (
     <div ref={setContainerRef} className="absolute inset-0 overflow-hidden">
-      {visible && status === "loaded" && (
+      {value?.kind === "image" && (
         <div className="absolute inset-0 flex">
-          {Array.from({ length: frameCount }).map((_, i) => (
-            <div
-              key={i}
-              className="flex-shrink-0 h-full relative overflow-hidden bg-neutral-900"
+          {Array.from({ length: frameCount }, (_, index) => (
+            <img
+              key={index}
+              src={value.url}
+              alt=""
+              draggable={false}
+              className="h-full flex-shrink-0 object-cover"
               style={{ width: frameW }}
-            >
-              <img
-                src={imageSrc}
-                alt=""
-                draggable={false}
-                loading="lazy"
-                className="absolute inset-0 w-full h-full object-cover"
-              />
-            </div>
+            />
           ))}
         </div>
       )}
-
-      {visible && status === "loading" && (
-        <div
-          className="absolute inset-0 animate-pulse"
-          style={{
-            background:
-              "linear-gradient(90deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.05) 50%, rgba(255,255,255,0.02) 100%)",
-          }}
-        />
+      {snapshot.status === "loading" && (
+        <div className="absolute inset-0 animate-pulse bg-white/[0.035]" />
       )}
-
       {label && (
-        <div
-          className="absolute bottom-0 left-0 right-0 z-10 px-1.5 pb-0.5 pt-3"
-          style={{
-            background:
-              "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)",
-          }}
-        >
+        <div className="absolute inset-x-0 bottom-0 z-10 px-1.5 pb-0.5 pt-3">
           <span
-            className="text-[9px] font-semibold truncate block leading-tight"
-            style={{ color: labelColor, textShadow: "0 1px 2px rgba(0,0,0,0.9)" }}
+            className="block truncate text-[9px] font-semibold leading-tight"
+            style={{ color: labelColor }}
           >
             {label}
           </span>

--- a/packages/studio/src/player/components/VideoThumbnail.test.tsx
+++ b/packages/studio/src/player/components/VideoThumbnail.test.tsx
@@ -2,31 +2,16 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { thumbnailScheduler } from "../lib/thumbnailScheduler";
+import { decodeVideoThumbnail } from "../lib/thumbnailVideoDecoder";
 import { VideoThumbnail } from "./VideoThumbnail";
+
+vi.mock("../lib/thumbnailVideoDecoder", () => ({ decodeVideoThumbnail: vi.fn() }));
 
 Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
   configurable: true,
   value: true,
 });
-
-// Fire "intersecting" immediately on observe so the extraction effect runs.
-class MockIntersectionObserver {
-  private cb: IntersectionObserverCallback;
-  constructor(cb: IntersectionObserverCallback) {
-    this.cb = cb;
-  }
-  observe() {
-    this.cb(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      this as unknown as IntersectionObserver,
-    );
-  }
-  disconnect() {}
-  unobserve() {}
-  takeRecords(): IntersectionObserverEntry[] {
-    return [];
-  }
-}
 
 class MockResizeObserver {
   observe() {}
@@ -34,33 +19,11 @@ class MockResizeObserver {
   unobserve() {}
 }
 
-const originalIO = globalThis.IntersectionObserver;
-const originalRO = globalThis.ResizeObserver;
-
 let host: HTMLDivElement;
 let root: Root | null = null;
-let createdVideos: HTMLVideoElement[];
 
 beforeEach(() => {
-  globalThis.IntersectionObserver =
-    MockIntersectionObserver as unknown as typeof IntersectionObserver;
   globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
-
-  createdVideos = [];
-  const origCreate = document.createElement.bind(document);
-  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
-    const el = origCreate(tag);
-    if (tag === "video") createdVideos.push(el as HTMLVideoElement);
-    return el;
-  });
-
-  // happy-dom's <video>/<canvas> don't decode media; stub the seam the
-  // extractor depends on so the effect can run deterministically.
-  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
-  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
-    drawImage: () => {},
-  } as unknown as CanvasRenderingContext2D);
-
   host = document.createElement("div");
   document.body.append(host);
 });
@@ -68,85 +31,58 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root?.unmount());
   root = null;
-  vi.restoreAllMocks();
-  globalThis.IntersectionObserver = originalIO;
-  globalThis.ResizeObserver = originalRO;
+  thumbnailScheduler.clear();
+  vi.clearAllMocks();
   document.body.innerHTML = "";
 });
 
-function render(videoSrc: string) {
+async function render(rich = false) {
   root = createRoot(host);
-  act(() => {
-    root!.render(React.createElement(VideoThumbnail, { videoSrc, label: "", labelColor: "#fff" }));
-  });
-}
-
-function lastVideo(): HTMLVideoElement {
-  const v = createdVideos.at(-1);
-  expect(v).toBeDefined();
-  return v!;
-}
-
-describe("VideoThumbnail — tainted-canvas fallback", () => {
-  it("stops the extractor and drops the shimmer when toDataURL throws a SecurityError", () => {
-    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockImplementation(() => {
-      throw new DOMException("Tainted canvases may not be exported.", "SecurityError");
-    });
-
-    render("https://cdn.example.com/no-cors.mp4");
-
-    // The effect ran once visible → a hidden <video> was created.
-    const video = lastVideo();
-
-    act(() => {
-      video.dispatchEvent(new Event("loadedmetadata"));
-    });
-    act(() => {
-      video.dispatchEvent(new Event("seeked"));
-    });
-
-    // No frame captured, and crucially the shimmer is gone (not spinning
-    // forever) — the clip falls back to its plain background.
-    expect(host.querySelectorAll("img").length).toBe(0);
-    expect(host.querySelector(".animate-pulse")).toBeNull();
-  });
-
-  it("drops the shimmer when a no-CORS load fires the video error event (0 frames) (#2214)", () => {
-    render("https://cdn.example.com/no-cors.mp4");
-    // Before the load resolves, the shimmer placeholder is up.
-    expect(host.querySelector(".animate-pulse")).not.toBeNull();
-
-    const video = lastVideo();
-    // crossOrigin="anonymous" against a CORS-less server fails the load outright —
-    // the error listener fires instead of loadedmetadata/seeked, so no frame is
-    // ever captured. The shimmer must stop rather than spin forever.
-    act(() => {
-      video.dispatchEvent(new Event("error"));
-    });
-
-    expect(host.querySelectorAll("img").length).toBe(0);
-    expect(host.querySelector(".animate-pulse")).toBeNull();
-  });
-
-  it("keeps streaming frames while the shimmer is up until a frame arrives", () => {
-    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue(
-      "data:image/jpeg;base64,AAAA",
+  await act(async () => {
+    root!.render(
+      <VideoThumbnail
+        videoSrc="/api/projects/p/preview/assets/clip.mp4"
+        label=""
+        labelColor="#fff"
+        projectId="p"
+        sessionEpoch={1}
+        priority="visible"
+        rich={rich}
+      />,
     );
+    await Promise.resolve();
+  });
+}
 
-    render("/api/projects/p/preview/assets/clip.mp4");
-    // Before any seek resolves, the shimmer placeholder is shown.
-    expect(host.querySelector(".animate-pulse")).not.toBeNull();
-
-    const video = lastVideo();
-    act(() => {
-      video.dispatchEvent(new Event("loadedmetadata"));
-    });
-    act(() => {
-      video.dispatchEvent(new Event("seeked"));
+describe("VideoThumbnail", () => {
+  it("renders a scheduler-provided sparse poster", async () => {
+    vi.mocked(decodeVideoThumbnail).mockResolvedValue({
+      value: { kind: "image", url: "blob:poster", aspect: 16 / 9 },
+      weight: 128,
     });
 
-    // A frame was captured, so tiles render and the shimmer clears.
-    expect(host.querySelectorAll("img").length).toBeGreaterThanOrEqual(1);
+    await render();
+
+    expect(decodeVideoThumbnail).toHaveBeenCalledWith(
+      expect.objectContaining({ frameCount: 1 }),
+      expect.any(AbortSignal),
+    );
+    expect(host.querySelector('img[src="blob:poster"]')).not.toBeNull();
     expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("requests a rich filmstrip only for interaction actors", async () => {
+    vi.mocked(decodeVideoThumbnail).mockResolvedValue({
+      value: { kind: "filmstrip", urls: ["blob:a", "blob:b"], aspect: 16 / 9 },
+      weight: 256,
+    });
+
+    await render(true);
+
+    expect(decodeVideoThumbnail).toHaveBeenCalledWith(
+      expect.objectContaining({ frameCount: 6 }),
+      expect.any(AbortSignal),
+    );
+    expect(host.querySelectorAll("img").length).toBeGreaterThan(0);
   });
 });

--- a/packages/studio/src/player/components/VideoThumbnail.tsx
+++ b/packages/studio/src/player/components/VideoThumbnail.tsx
@@ -1,5 +1,7 @@
-import { memo, useRef, useState, useCallback, useEffect } from "react";
-import { useMountEffect } from "../../hooks/useMountEffect";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useThumbnailLease } from "../../hooks/useThumbnailLease";
+import { createThumbnailKey, type ThumbnailPriority } from "../lib/thumbnailScheduler";
+import { decodeVideoThumbnail } from "../lib/thumbnailVideoDecoder";
 import { computeThumbnailStrip, THUMBNAIL_CLIP_HEIGHT } from "./thumbnailUtils";
 
 interface VideoThumbnailProps {
@@ -7,209 +9,103 @@ interface VideoThumbnailProps {
   label: string;
   labelColor: string;
   duration?: number;
+  sourceStart?: number;
+  sourceRangeDuration?: number;
+  projectId?: string;
+  sessionEpoch?: number;
+  priority?: ThumbnailPriority;
+  rich?: boolean;
 }
 
-const CLIP_HEIGHT = THUMBNAIL_CLIP_HEIGHT;
-const MAX_UNIQUE_FRAMES: number = 6;
-
-/**
- * Renders a film-strip of video frames extracted client-side via a hidden
- * <video> + <canvas>. Each frame is a fixed-width tile; frames repeat to
- * fill the clip width — matching ClipThumbnail's visual pattern.
- */
+/** Sparse, bounded video frames supplied by the shared thumbnail scheduler. */
 export const VideoThumbnail = memo(function VideoThumbnail({
   videoSrc,
   label,
   labelColor,
   duration = 5,
+  sourceStart,
+  sourceRangeDuration,
+  projectId = videoSrc,
+  sessionEpoch = 0,
+  priority = "visible",
+  rich = false,
 }: VideoThumbnailProps) {
   const [containerWidth, setContainerWidth] = useState(0);
-  const [visible, setVisible] = useState(false);
-  const [frames, setFrames] = useState<string[]>([]);
-  const [failed, setFailed] = useState(false);
-  const [aspect, setAspect] = useState(16 / 9);
-  const ioRef = useRef<IntersectionObserver | null>(null);
-  const roRef = useRef<ResizeObserver | null>(null);
-  const extractingRef = useRef(false);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const request = useMemo(
+    () => ({
+      key: createThumbnailKey({
+        kind: "video",
+        source: videoSrc,
+        start: sourceStart,
+        duration: sourceRangeDuration ?? duration,
+        frames: rich ? 6 : 1,
+      }),
+      projectId,
+      sessionEpoch,
+      kind: "video" as const,
+      priority,
+      rich,
+      load: (signal: AbortSignal) =>
+        decodeVideoThumbnail(
+          {
+            source: videoSrc,
+            sourceStart,
+            sourceRangeDuration: sourceRangeDuration ?? duration,
+            frameCount: rich ? 6 : 1,
+            fit: "cover",
+          },
+          signal,
+        ),
+    }),
+    [duration, priority, projectId, rich, sessionEpoch, sourceRangeDuration, sourceStart, videoSrc],
+  );
+  const snapshot = useThumbnailLease(request);
+  const value = snapshot.status === "ready" ? snapshot.value : null;
+  const urls =
+    value?.kind === "filmstrip" ? value.urls : value?.kind === "image" ? [value.url] : [];
+  const aspect = value?.kind === "image" || value?.kind === "filmstrip" ? value.aspect : 16 / 9;
+  const { frameW, frameCount } = computeThumbnailStrip(
+    containerWidth,
+    aspect,
+    THUMBNAIL_CLIP_HEIGHT,
+  );
 
-  const setContainerRef = useCallback((el: HTMLDivElement | null) => {
-    ioRef.current?.disconnect();
-    roRef.current?.disconnect();
-    if (!el) return;
-
-    const measured = el.parentElement?.clientWidth || el.clientWidth;
-    setContainerWidth(measured);
-
-    ioRef.current = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-          ioRef.current?.disconnect();
-        }
-      },
-      { rootMargin: "200px" },
+  const setContainerRef = useCallback((element: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    if (!element) return;
+    const target = element.parentElement ?? element;
+    setContainerWidth(target.clientWidth);
+    observerRef.current = new ResizeObserver(([entry]) =>
+      setContainerWidth(entry.contentRect.width),
     );
-    // fallow-ignore-next-line code-duplication
-    ioRef.current.observe(el);
-
-    const target = el.parentElement || el;
-    roRef.current = new ResizeObserver(([entry]) => {
-      setContainerWidth(entry.contentRect.width);
-    });
-    roRef.current.observe(target);
+    observerRef.current.observe(target);
   }, []);
-
-  useMountEffect(() => () => {
-    ioRef.current?.disconnect();
-    roRef.current?.disconnect();
-  });
-
-  // Extract frames progressively — each frame appears as soon as it's ready.
-  // Note: useEffect with deps is acceptable — syncs with external video element API,
-  // requires cleanup (cancel extraction, revoke URLs) when inputs change.
-  // eslint-disable-next-line no-restricted-syntax
-  useEffect(() => {
-    if (!visible || extractingRef.current) return;
-    extractingRef.current = true;
-
-    const video = document.createElement("video");
-    video.crossOrigin = "anonymous";
-    video.muted = true;
-    video.preload = "auto";
-
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      extractingRef.current = false;
-      return;
-    }
-
-    const timestamps: number[] = [];
-    const minSeek = Math.min(0.4, duration * 0.05);
-    for (let i = 0; i < MAX_UNIQUE_FRAMES; i++) {
-      const raw =
-        MAX_UNIQUE_FRAMES === 1 ? duration * 0.15 : (i / (MAX_UNIQUE_FRAMES - 1)) * duration;
-      timestamps.push(Math.max(raw, minSeek));
-    }
-
-    let idx = 0;
-    let cancelled = false;
-
-    const extractNext = () => {
-      if (cancelled || idx >= timestamps.length) {
-        if (!cancelled) {
-          video.src = "";
-          video.load();
-        }
-        return;
-      }
-      video.currentTime = timestamps[idx];
-    };
-
-    video.addEventListener("loadedmetadata", () => {
-      if (video.videoWidth > 0 && video.videoHeight > 0) {
-        setAspect(video.videoWidth / video.videoHeight);
-        const h = CLIP_HEIGHT * 2;
-        const w = Math.round(h * (video.videoWidth / video.videoHeight));
-        canvas.width = w;
-        canvas.height = h;
-      }
-      extractNext();
-    });
-
-    video.addEventListener("seeked", () => {
-      if (cancelled) return;
-      let dataUrl: string;
-      try {
-        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-        dataUrl = canvas.toDataURL("image/jpeg", 0.6);
-      } catch {
-        // An external http(s) video served without CORS headers taints the
-        // canvas, so toDataURL throws a SecurityError. Stop the extractor
-        // cleanly and fall back to the no-thumbnail rendering (plain clip
-        // background), matching ImageThumbnail's error path — otherwise the
-        // shimmer placeholder would spin forever.
-        cancelled = true;
-        setFailed(true);
-        video.src = "";
-        video.load();
-        return;
-      }
-      // Stream each frame immediately
-      setFrames((prev) => [...prev, dataUrl]);
-      idx++;
-      extractNext();
-    });
-
-    video.addEventListener("error", () => {
-      // A no-CORS load fails outright (crossOrigin="anonymous" rejects a video
-      // served without CORS headers), firing this instead of the taint path in
-      // "seeked" — so 0 frames are ever extracted. Keep whatever frames we have,
-      // but mark failed so the shimmer placeholder stops spinning forever and we
-      // fall back to the plain clip background (#2214).
-      setFailed(true);
-    });
-
-    video.src = videoSrc;
-    video.load();
-
-    return () => {
-      cancelled = true;
-      extractingRef.current = false;
-      setFrames([]);
-      setFailed(false);
-      video.src = "";
-      video.load();
-    };
-  }, [visible, videoSrc, duration]);
-
-  const { frameW, frameCount } = computeThumbnailStrip(containerWidth, aspect, CLIP_HEIGHT);
 
   return (
     <div ref={setContainerRef} className="absolute inset-0 overflow-hidden">
-      {visible && frames.length > 0 && (
+      {urls.length > 0 && (
         <div className="absolute inset-0 flex">
-          {Array.from({ length: frameCount }).map((_, i) => {
-            const src = frames[i % frames.length];
-            return (
-              <div
-                key={i}
-                className="flex-shrink-0 h-full relative overflow-hidden bg-neutral-900"
-                style={{ width: frameW }}
-              >
-                <img
-                  src={src}
-                  alt=""
-                  draggable={false}
-                  className="absolute inset-0 w-full h-full object-cover"
-                />
-              </div>
-            );
-          })}
+          {Array.from({ length: frameCount }, (_, index) => (
+            <img
+              key={index}
+              src={urls[index % urls.length]}
+              alt=""
+              draggable={false}
+              className="h-full flex-shrink-0 object-cover"
+              style={{ width: frameW }}
+            />
+          ))}
         </div>
       )}
-
-      {visible && frames.length === 0 && !failed && (
-        <div
-          className="absolute inset-0 animate-pulse"
-          style={{
-            background:
-              "linear-gradient(90deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.05) 50%, rgba(255,255,255,0.02) 100%)",
-          }}
-        />
+      {snapshot.status === "loading" && urls.length === 0 && (
+        <div className="absolute inset-0 animate-pulse bg-white/[0.035]" />
       )}
-
       {label && (
-        <div
-          className="absolute bottom-0 left-0 right-0 z-10 px-1.5 pb-0.5 pt-3"
-          style={{
-            background:
-              "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)",
-          }}
-        >
+        <div className="absolute inset-x-0 bottom-0 z-10 px-1.5 pb-0.5 pt-3">
           <span
-            className="text-[9px] font-semibold truncate block leading-tight"
-            style={{ color: labelColor, textShadow: "0 1px 2px rgba(0,0,0,0.9)" }}
+            className="block truncate text-[9px] font-semibold leading-tight"
+            style={{ color: labelColor }}
           >
             {label}
           </span>


### PR DESCRIPTION
## What

virtualize timeline thumbnail media.

## Why

Retain the high-value visual thumbnail UX while bounding decoding, network, CPU, and memory work to useful viewport content.

## How

Adds one layer of the thumbnail policy, scheduler, runtime, server, preference, component, context, or coordinator pipeline.

Key files in this layer:

- `packages/studio/src/player/components/CompositionThumbnail.tsx`
- `packages/studio/src/player/components/ImageThumbnail.test.tsx`
- `packages/studio/src/player/components/ImageThumbnail.tsx`
- `packages/studio/src/player/components/VideoThumbnail.test.tsx`

## Test plan

Validated on the complete stacked tip with formatting, lint, Studio typecheck, the full production build, and the Studio test suite (2,946 passing; 18 todo). Focused timeline/thumbnail tests and browser QA cover the affected interaction path.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable for this implementation layer)

## Post-Deploy Monitoring & Validation

- **Owner:** Studio team
- **Window:** First 24 hours after rollout
- **Signals:** Watch thumbnail request volume, abort/error rates, cache behavior, decoder concurrency, and Studio memory use.
- **Rollback trigger:** Reproducible data loss, broken timeline editing/navigation, or sustained performance regression; revert this stack layer and its descendants.