### PR TITLE
ci(regression): trigger on PR edited events for Graphite base changes

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -16,6 +16,8 @@ concurrency:
 
 on:
   pull_request:
+    # Re-run when Graphite changes only the PR base for the same head SHA.
+    types: [opened, synchronize, reopened, edited]
   push:
     branches:
       - main


### PR DESCRIPTION
## What

Add `edited` to the regression workflow's pull-request event types.

This is Wave 0: the operational prerequisite for the Studio timeline landing-wave migration.

## Why

Graphite can change a PR base without changing its head SHA. Regression must create fresh evidence for the exact head/base pair before each family merges.

Prerequisite: merged PR #2558 (`735128a61a152267a00b99defbd290f489482cbc`).

Landing order: Wave 0 before Families A-G.

## How

Mirror the existing CI workflow trigger list. No path filters, jobs, or regression behavior change.

## Test plan

- [x] YAML parsed and the exact pull-request event list asserted
- [x] `bunx oxfmt --check .github/workflows/regression.yml`
- [x] Pre-commit hooks passed
- [ ] Live base-only edit retriggers regression after this workflow lands
- [ ] Unit tests added/updated (not applicable: workflow-only change)
- [ ] Manual testing performed (live event validation follows merge)
- [ ] Documentation updated (not applicable)
