### PR TITLE
fix(lint): recognize compiler-derived data-end as legitimate

### DIFF
--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -1345,4 +1345,46 @@ describe("bundleToSingleHtml", () => {
     );
     expect(styleEls[0]?.parentElement?.tagName.toLowerCase()).toBe("head");
   });
+
+  // Regression: cli-feedback field cluster (crons 61-68, n=25+, cross-OS,
+  // versions 0.7.56-0.7.64). Reporter L3 cite (ts=1784519869):
+  // "bundleToSingleHtml compiles data-duration into data-end, then validates
+  // the compiled HTML and reports its own generated data-end as deprecated.
+  // Raw-source lint passes with 0 errors and 0 warnings." The end-to-end
+  // guarantee: source authored with only data-duration must round-trip through
+  // bundle + StaticGuard without producing a StaticGuard warning on the
+  // compiler's own consistent data-end. Facet-(a)/(e) fix.
+  it("does not emit a StaticGuard warning for source-authored data-duration on media", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html>
+<head><title>t</title></head>
+<body>
+  <div data-composition-id="root" data-width="1920" data-height="1080" data-start="0" data-duration="18">
+    <audio id="bgm" src="bgm.mp3" data-start="0" data-duration="18"></audio>
+    <audio id="narration" src="narr.mp3" data-start="5" data-duration="10"></audio>
+  </div>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines.root = { duration: () => 18, seek() {}, pause() {} };</script>
+</body></html>`,
+      "bgm.mp3": "",
+      "narr.mp3": "",
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const bundled = await bundleToSingleHtml(dir);
+      // Sanity: the compiler MUST have emitted data-end for both audio elements,
+      // so the linter is actually seeing the compiled shape (not the raw source).
+      expect(bundled).toContain('id="bgm"');
+      expect(bundled).toMatch(/id="bgm"[^>]*data-end="18"|data-end="18"[^>]*id="bgm"/);
+      expect(bundled).toMatch(/id="narration"[^>]*data-end="15"|data-end="15"[^>]*id="narration"/);
+
+      const staticGuardWarnings = warnSpy.mock.calls
+        .map((call) => String(call[0] ?? ""))
+        .filter((line) => line.includes("[StaticGuard]"));
+      expect(staticGuardWarnings).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -28,6 +28,42 @@ describe("composition rules", () => {
         result.findings.find(({ code }) => code === "overlapping_clips_same_track"),
       ).toBeUndefined();
     });
+
+    // Regression: cli-feedback field cluster (crons 61-68, n=25+ across
+    // darwin/linux/win32 and versions 0.7.56-0.7.64). `bundleToSingleHtml`
+    // compiles `data-duration` into `data-end`, then re-validates the compiled
+    // HTML. Before this fix the linter fired `deprecated_data_end` on the
+    // compiler's own consistent output — a false-positive that reporters
+    // routed as "check --strict passes but StaticGuard still logs
+    // deprecated-attribute noise" (ts=1784548892, ts=1784541122).
+    it("does not flag deprecated_data_end when compiled data-end matches data-duration", async () => {
+      const result = await lintHyperframeHtml(`<!doctype html><html><body>
+        <div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="30">
+          <audio id="bgm" src="bgm.mp3" data-start="0" data-duration="18" data-end="18"></audio>
+          <audio id="narration" src="narr.mp3" data-start="5" data-duration="10" data-end="15"></audio>
+        </div>
+        <script>window.__timelines = { main: {} };</script>
+      </body></html>`);
+
+      const deprecatedEnd = result.findings.filter(({ code }) => code === "deprecated_data_end");
+      expect(deprecatedEnd).toEqual([]);
+    });
+
+    // Companion regression: a manually authored stale `data-end` still fires
+    // `deprecated_data_end`, with a message that names the disagreement so
+    // the author can spot the drift rather than reading the legacy phrasing.
+    it("still flags deprecated_data_end when data-end disagrees with data-duration", async () => {
+      const result = await lintHyperframeHtml(`<!doctype html><html><body>
+        <div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="30">
+          <audio id="bgm" src="bgm.mp3" data-start="0" data-duration="18" data-end="20"></audio>
+        </div>
+        <script>window.__timelines = { main: {} };</script>
+      </body></html>`);
+
+      const deprecatedEnd = result.findings.find(({ code }) => code === "deprecated_data_end");
+      expect(deprecatedEnd).toBeDefined();
+      expect(deprecatedEnd?.message).toMatch(/disagrees with data-duration/);
+    });
   });
 
   describe("subcomposition guidance", () => {

--- a/packages/lint/src/rules/composition.ts
+++ b/packages/lint/src/rules/composition.ts
@@ -465,10 +465,20 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
       }
       if (timing.diagnostics.some(({ code }) => code === "deprecated-end")) {
         const elementId = readAttr(tag.raw, "id") || undefined;
+        const conflicting = timing.diagnostics.some(({ code }) => code === "conflicting-end");
+        // Two shapes reach here after the false-positive fix (see
+        // compositionContract.ts `diagnoseDerivedEnd`): the truly-legacy shape
+        // (no data-duration, data-end alone) and the stale-companion shape
+        // (data-duration present but paired with a data-end that disagrees).
+        // A consistent data-duration + data-end pair — the shape the compiler
+        // emits — is silent and never reaches this branch.
+        const message = conflicting
+          ? `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> has data-end that disagrees with data-duration. Remove the stale data-end; the compiler regenerates it from data-duration.`
+          : `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> uses data-end without data-duration. Use data-duration in source HTML.`;
         findings.push({
           code: "deprecated_data_end",
           severity: "error",
-          message: `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> uses data-end without data-duration. Use data-duration in source HTML.`,
+          message,
           elementId,
           fixHint:
             "Replace data-end with data-duration. The compiler generates data-end from data-duration automatically.",

--- a/packages/parsers/src/compositionContract.test.ts
+++ b/packages/parsers/src/compositionContract.test.ts
@@ -89,6 +89,39 @@ describe("composition timing contract", () => {
       codes: ["deprecated-end", "conflicting-end", "deprecated-layer", "conflicting-layer"],
     },
     {
+      // Regression: compiler-derived `data-end` matching `data-duration` used
+      // to fire `deprecated-end`, which surfaced as a false-positive
+      // `deprecated_data_end` from StaticGuard whenever bundler output was
+      // re-validated. Field cluster: cli-feedback crons 61-68, n=25+ across
+      // darwin/linux/win32 and versions 0.7.56-0.7.64. Reporter L3 cite
+      // (ts=1784519869): "bundleToSingleHtml compiles data-duration into
+      // data-end, then validates the compiled HTML and reports its own
+      // generated data-end as deprecated." Consistent pairs are silent.
+      name: "compiler-derived end consistent with canonical duration is silent",
+      attrs: {
+        "data-start": "0",
+        "data-duration": "18",
+        "data-end": "18",
+      },
+      expected: { start: 0, duration: 18, end: 18, trackIndex: 0 },
+      codes: [],
+    },
+    {
+      name: "compiler-derived end within float epsilon of canonical duration is silent",
+      // data-start="0.1" + data-duration="0.2" evaluates to 0.30000000000000004
+      // under IEEE-754. The compiler serializes that residual verbatim, so the
+      // parsed derived-end and the reader-computed canonical end differ by ~2 ulps.
+      // A byte-exact comparison would refire the false positive; the epsilon
+      // gate keeps it silent.
+      attrs: {
+        "data-start": "0.1",
+        "data-duration": "0.2",
+        "data-end": "0.30000000000000004",
+      },
+      expected: { start: 0.1, duration: 0.2 },
+      codes: [],
+    },
+    {
       name: "invalid values are diagnosed rather than coerced",
       attrs: { "data-start": "wat +", "data-duration": "-1", "data-track-index": "1.5" },
       expected: { start: null, duration: null, end: null, trackIndex: 0 },

--- a/packages/parsers/src/compositionContract.ts
+++ b/packages/parsers/src/compositionContract.ts
@@ -206,18 +206,57 @@ function resolveStart(
 type DurationRead = Pick<ClipTiming, "duration" | "end" | "durationSource">;
 type TrackRead = Pick<ClipTiming, "trackIndex" | "trackSource">;
 
+// Float pairs like `data-start="0.1" + data-duration="0.2"` add to
+// `0.30000000000000004`, so the compiler-emitted `data-end` string can be a few
+// ulps off the sum a reader computes from the canonical inputs. Any drift below
+// this ceiling is treated as equal for the derived-end reconciliation check —
+// well below one 60fps frame (~16.67 ms) and orders of magnitude above the
+// worst realistic IEEE-754 residual (~2e-16 s).
+const DERIVED_END_EQUALITY_EPSILON_SECONDS = 1e-9;
+
+function derivedEndsAreConsistent(parsedEnd: number, canonicalEnd: number): boolean {
+  return Math.abs(parsedEnd - canonicalEnd) <= DERIVED_END_EQUALITY_EPSILON_SECONDS;
+}
+
+// Reconcile a `data-end` attribute paired with canonical `data-duration`.
+//
+// The compiler (`compileTimingAttrs` in @hyperframes/core) writes
+// `data-end = data-start + data-duration` into the bundled HTML so the runtime
+// can key off a single attribute. That derived attribute is legitimate — it is
+// not a legacy authoring shape. Treating it as `deprecated-end` here made the
+// linter fire `deprecated_data_end` on the compiler's own output whenever
+// StaticGuard re-validated a bundled composition, producing a false-positive
+// cluster reported in the field (n=25+ across cli-feedback crons 61-68).
+//
+// We keep `deprecated-end` for the truly legacy shape (see `readLegacyEnd` —
+// `data-end` present without `data-duration`) and for the *conflicting* case
+// where an author left a stale `data-end` behind a canonical duration edit; a
+// stale end must not be silently overridden without a diagnostic.
 function diagnoseDerivedEnd(
   rawEnd: string,
   canonicalEnd: number | null,
   diagnostics: ClipTimingDiagnostic[],
 ): void {
-  pushDiagnostic(diagnostics, "deprecated-end", COMPOSITION_ATTRIBUTES.derivedEnd, rawEnd);
   const parsedEnd = parseNumeric(rawEnd);
   if (parsedEnd == null) {
+    pushDiagnostic(diagnostics, "deprecated-end", COMPOSITION_ATTRIBUTES.derivedEnd, rawEnd);
     pushDiagnostic(diagnostics, "invalid-end", COMPOSITION_ATTRIBUTES.derivedEnd, rawEnd);
-  } else if (canonicalEnd != null && parsedEnd !== canonicalEnd) {
-    pushDiagnostic(diagnostics, "conflicting-end", COMPOSITION_ATTRIBUTES.derivedEnd, rawEnd);
+    return;
   }
+  if (canonicalEnd == null) {
+    // Canonical duration exists but resolved end is unknown (e.g. unresolved
+    // reference start). Preserve prior behavior — flag as deprecated so authors
+    // remove the stale companion attribute.
+    pushDiagnostic(diagnostics, "deprecated-end", COMPOSITION_ATTRIBUTES.derivedEnd, rawEnd);
+    return;
+  }
+  if (derivedEndsAreConsistent(parsedEnd, canonicalEnd)) {
+    // Compiler-derived (or manually consistent) `data-end` alongside
+    // `data-duration` — silent. No diagnostic.
+    return;
+  }
+  pushDiagnostic(diagnostics, "deprecated-end", COMPOSITION_ATTRIBUTES.derivedEnd, rawEnd);
+  pushDiagnostic(diagnostics, "conflicting-end", COMPOSITION_ATTRIBUTES.derivedEnd, rawEnd);
 }
 
 function readCanonicalDuration(


### PR DESCRIPTION
## What

Stop firing `deprecated_data_end` on the compiler's own output.

`bundleToSingleHtml` calls `compileTimingAttrs` to write
`data-end = data-start + data-duration` into the bundled HTML, then validates
that compiled HTML with `validateHyperframeHtmlContract`. The linter's
`deprecated_data_end` rule fired on the derived attribute — `<audio
data-start="0" data-duration="18" data-end="18">` — because
`diagnoseDerivedEnd` (in `packages/parsers/src/compositionContract.ts`)
unconditionally emitted a `deprecated-end` diagnostic whenever both attributes
were present, ignoring whether the values agreed.

After this change, a `data-end` that matches `data-start + data-duration`
(within a 1 ns epsilon to absorb IEEE-754 residuals like
`0.1 + 0.2 = 0.30000000000000004`) is silent. Truly-legacy shapes still fire:
`data-end` alone with no `data-duration` (`readLegacyEnd` path), and a
`data-end` that disagrees with `data-duration` (drift path — refined message
names the disagreement instead of the misleading legacy phrasing).

## Why

Field cluster from `#hyperframes-cli-feedback`, cron runs 61-68 over the past
~48 h:

- n=25+ reports across `darwin/arm64`, `darwin/x64`, `linux/x64`, `win32/x64`
- versions 0.7.56, 0.7.58, 0.7.60, 0.7.62, 0.7.64 — the bug survives every
  released rev in-cluster
- L3 named-artifact cite (`ts=1784519869`, darwin/arm64, 0.7.64):

  > "bundleToSingleHtml compiles data-duration into data-end, then validates
  > the compiled HTML and reports its own generated data-end as deprecated.
  > Raw-source lint passes with 0 errors and 0 warnings."

- Additional reporter mechanism cites:
  - `ts=1784541122`: "audio id=bgm uses data-end without data-duration even
    though source HTML has data-duration=18 and no data-end; compiled output
    appears to introduce data-end."
  - `ts=1784548892`: full `check --strict` REPRO — "StaticGuard reports that
    audio id=narration uses data-end without data-duration, while source
    index.html contains data-duration and no data-end. Strict check still
    passes and high-quality render completes."
  - `ts=1784528935`: severity variant "check exits non-zero."
  - `ts=1784529503`: reporter self-crossref "had already been reported with a
    full packet" — folklore-normalization phase; volume-gradient understates
    prevalence.

The bug is now discoverability-tier: renders complete correctly and audio
plays, but the noisy StaticGuard warning + misleading `deprecated_data_end`
finding erode trust in `hyperframes check` output and generate support load
proportional to composition author count.

## How

Fix in `packages/parsers/src/compositionContract.ts`:

- `diagnoseDerivedEnd` now compares `parseNumeric(rawEnd)` against the
  reader-computed canonical end. Consistent (compiler-derived) pairs emit no
  diagnostic. Inconsistent pairs still emit both `deprecated-end` and
  `conflicting-end`. Invalid `data-end` values still emit
  `deprecated-end` + `invalid-end`.
- A `DERIVED_END_EQUALITY_EPSILON_SECONDS = 1e-9` gate absorbs IEEE-754
  residuals from float addition. Chosen ~7 orders of magnitude above the
  worst realistic ulp drift (~2e-16 s) and ~7 below one 60 fps frame
  (~16.67 ms), so it can only ever swallow float slop — never mask a
  meaningful timing disagreement.

Refinement in `packages/lint/src/rules/composition.ts`:

- `deprecated_data_end` message text now branches on whether the diagnostic
  also carries `conflicting-end`. The drift case reads "has data-end that
  disagrees with data-duration"; the truly-legacy case keeps the original
  "uses data-end without data-duration." This eliminates the misleading
  message that fired at reporters even when `data-duration` was present.

Facets from the ask:

- **(a) Validator treats compiler-derived data-end as legal when source had
  data-duration** — implemented via option (1) refinement of
  `diagnoseDerivedEnd`. No new marker attribute needed since the derived-end
  value uniquely reconciles against the canonical inputs.
- **(e) Validator recognizes compiler-side rewrite via `bundleToSingleHtml`** —
  same fix; `compileHtml` -> `compileTimingAttrs` writes the derived attribute
  and the parser reader now identifies it structurally rather than requiring
  a marker.
- **(b) stderr gated on gate-failure**, **(c) terminal JSON verdict**,
  **(d) audio-not-dropped on StaticGuard rejection** — unblocked
  transitively. Audit at HEAD:
  - `htmlBundler.ts` line 805-808 already gates `console.warn("[StaticGuard] ...")`
    on `!staticGuard.isValid`; no other consumer of `staticGuard` exists
    (`grep -rn 'staticGuard.isValid'` returns only the bundler).
  - `check.ts` already emits `JSON.stringify(withMeta(report))` on both the
    success path (line 133-134) and the caught-error path (line 141-144);
    `process.exitCode` is set in both. `hyperframes check --json` never exits
    without JSON.
  - StaticGuard rejection has no audio-drop path. Once the false-positive
    stops firing, both the noisy stderr line and the misleading "check appears
    to fail" reporter framing disappear at the source, so the observable
    behavior matches facet (d) without additional wiring.

Reporter follow-ups on facets (b)/(c)/(d) can revisit if a distinct failure
mode surfaces after this ships; the current cluster is fully explained by (a).

## Test plan

- [x] Unit tests added — `packages/parsers/src/compositionContract.test.ts`
      (consistent pair is silent + float-epsilon variant),
      `packages/lint/src/rules/composition.test.ts` (compiled-shape does not
      fire `deprecated_data_end` + conflicting-shape still fires with drift
      message).
- [x] End-to-end regression — `packages/core/src/compiler/htmlBundler.test.ts`
      runs `bundleToSingleHtml` on the reporter's exact scenario (audio with
      only `data-duration`), asserts the compiler emitted `data-end`, and
      asserts `console.warn` was not called with a `[StaticGuard]` line.
- [x] Existing `"canonical values win over conflicting legacy values"` test
      in `compositionContract.test.ts` still passes (uses `data-end="9"`
      with `data-duration="2"` — inconsistent — so the diagnostic still
      fires).
- [x] `bun run --filter '@hyperframes/parsers' test src/compositionContract.test.ts` — 21 passed
- [x] `bun run --filter '@hyperframes/lint' test src/rules/composition.test.ts` — 136 passed
- [x] `bun run --filter '@hyperframes/core' test src/compiler/htmlBundler.test.ts` — 44 passed
- [x] `bunx oxlint` on all touched files — 0 warnings, 0 errors
- [x] `bunx oxfmt --check` on all touched files — clean
- [x] `bunx tsc --noEmit` on `parsers/`, `lint/`, `core/` — clean

Pre-existing test failures in `packages/parsers/src/ffBinaries.test.ts` and
`packages/lint/src/{project,snippetFragment}.test.ts` reproduce on `main` at
`d21883fe0` (verified with `git stash`); unrelated to this change.

---

_PR by Via — cli-feedback field cluster automation, cron 68 default action
(silent veto-window closure after cron 67 offer)._