### PR TITLE
feat(cli): update feedback rating scale to ten points

### DIFF
--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -18,7 +18,7 @@ No account, email, or identity is tied to responses. Each installation generates
 After a successful `hyperframes render`, a short prompt may appear:
 
 ```
-  How was this render? [1=poor 5=great, enter to skip]
+  How was this render? [1=poor 10=great, enter to skip]
   Any details? (enter to skip)
 ```
 
@@ -64,7 +64,7 @@ You can submit feedback manually at any time:
 
 ```bash
 # Quick rating
-hyperframes feedback --rating 5
+hyperframes feedback --rating 10
 
 # Rating with details
 hyperframes feedback --rating 3 --comment "render succeeded but GSAP timeline didn't animate text overlay"
@@ -72,7 +72,7 @@ hyperframes feedback --rating 3 --comment "render succeeded but GSAP timeline di
 
 | Flag | Description |
 |------|-------------|
-| `--rating` | Satisfaction score, 1–5 (required) |
+| `--rating` | Satisfaction score, 1–10 (required) |
 | `--comment` | Optional free-text details |
 
 This command collects a doctor summary automatically, flushes telemetry, and exits. It appears under the **Settings** group in `hyperframes --help`.
@@ -82,7 +82,7 @@ This command collects a doctor summary automatically, flushes telemetry, and exi
 When an AI agent is detected, HyperFrames **skips the interactive readline prompt** and prints a structured hint instead:
 
 ```
-  [hyperframes] Agent feedback: hyperframes feedback --rating <1-5> --comment "..."
+  [hyperframes] Agent feedback: hyperframes feedback --rating <1-10> --comment "..."
 ```
 
 Agents can then submit feedback using the `hyperframes feedback` command above.
@@ -111,7 +111,7 @@ Only the existence (or in some cases the value) of these variables is checked �
 | Field | Value |
 |-------|-------|
 | `$survey_id` | `render_satisfaction` |
-| `$survey_response` | Rating (1–5) |
+| `$survey_response` | Rating (1–10) |
 | `$survey_response_2` | Free-text comment (only when provided) |
 | `render_duration_ms` | Time the render took in milliseconds |
 | `doctor_summary` | System context (see below) |
@@ -129,7 +129,7 @@ It may also include `wsl` or sandbox runtime flags when those environments are d
 | Field | Value |
 |-------|-------|
 | `$survey_id` | `studio_experience` |
-| `$survey_response` | Rating (1–5) |
+| `$survey_response` | Rating (1–10) |
 | `$survey_response_2` | Free-text comment (only when provided) |
 | `source` | `studio` |
 | `doctor_summary` | Browser context (platform, screen, CPU cores, device memory, network type) |

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -863,8 +863,8 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
     Submit anonymous satisfaction feedback about your experience:
 
     ```bash
-    # Quick rating (1 = poor, 5 = great)
-    npx hyperframes feedback --rating 5
+    # Quick rating (1 = poor, 10 = great)
+    npx hyperframes feedback --rating 10
 
     # Rating with optional details
     npx hyperframes feedback --rating 3 --comment "render succeeded but GSAP timeline didn't animate"
@@ -872,7 +872,7 @@ This is suppressed in CI environments, non-TTY shells, and when `HYPERFRAMES_NO_
 
     | Flag | Description |
     |------|-------------|
-    | `--rating` | Satisfaction score, 1–5 (required) |
+    | `--rating` | Satisfaction score, 1–10 (required) |
     | `--comment` | Optional free-text details |
 
     This command is also available to AI agents after a render — see [Feedback Collection](/guides/feedback#agent-runtimes) for how agent detection and the automatic post-render hint work.

--- a/packages/cli/src/commands/feedback.test.ts
+++ b/packages/cli/src/commands/feedback.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { parseFeedbackRating } from "../telemetry/rating.js";
+
+describe("parseRating", () => {
+  it("accepts the full 1–10 satisfaction scale", () => {
+    expect(parseFeedbackRating("1")).toBe(1);
+    expect(parseFeedbackRating("10")).toBe(10);
+  });
+
+  it("rejects values outside the satisfaction scale", () => {
+    expect(parseFeedbackRating("0")).toBeNull();
+    expect(parseFeedbackRating("11")).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -3,24 +3,22 @@ import type { Example } from "./_examples.js";
 import { trackRenderFeedback } from "../telemetry/events.js";
 import { shouldTrack, flush } from "../telemetry/client.js";
 import { getDoctorSummary } from "../telemetry/feedback.js";
+import { parseFeedbackRating } from "../telemetry/rating.js";
 import { c } from "../ui/colors.js";
 
 export const examples: Example[] = [
-  ["Submit render feedback", 'hyperframes feedback --rating 4 --comment "fast but font missing"'],
-  ["Quick rating only", "hyperframes feedback --rating 5"],
+  ["Submit render feedback", 'hyperframes feedback --rating 8 --comment "fast but font missing"'],
+  ["Quick rating only", "hyperframes feedback --rating 10"],
 ];
 
-function parseRating(raw: string): number | null {
-  const n = parseInt(raw, 10);
-  return n >= 1 && n <= 5 && Number.isFinite(n) ? n : null;
-}
+export const parseRating = parseFeedbackRating;
 
 export default defineCommand({
   meta: { name: "feedback", description: "Submit anonymous feedback about your experience" },
   args: {
     rating: {
       type: "string",
-      description: "Satisfaction rating (1=poor, 5=great)",
+      description: "Satisfaction rating (1=poor, 10=great)",
       required: true,
     },
     comment: {
@@ -31,7 +29,7 @@ export default defineCommand({
   async run({ args }) {
     const rating = parseRating(args.rating);
     if (rating === null) {
-      console.error(c.error("Rating must be between 1 and 5"));
+      console.error(c.error("Rating must be between 1 and 10"));
       process.exit(1);
     }
 

--- a/packages/cli/src/telemetry/feedback.ts
+++ b/packages/cli/src/telemetry/feedback.ts
@@ -50,7 +50,7 @@ export async function maybePromptRenderFeedback(opts: {
     console.log(
       c.dim("  [hyperframes] ") +
         c.dim("Agent feedback: ") +
-        c.accent('hyperframes feedback --rating <1-5> --comment "..."'),
+        c.accent('hyperframes feedback --rating <1-10> --comment "..."'),
     );
     return;
   }
@@ -66,11 +66,11 @@ export async function maybePromptRenderFeedback(opts: {
   writeConfig(config);
 
   const answer = await askQuestion(
-    `  ${c.dim("How was this render?")} ${c.accent("[1=poor 5=great, enter to skip]")} `,
+    `  ${c.dim("How was this render?")} ${c.accent("[1=poor 10=great, enter to skip]")} `,
   );
 
   const rating = parseInt(answer.trim(), 10);
-  if (rating >= 1 && rating <= 5) {
+  if (rating >= 1 && rating <= 10) {
     // Ask for optional text feedback
     const details = await askQuestion(`  ${c.dim("Any details?")} ${c.accent("(enter to skip)")} `);
     const trimmedDetails = details.trim();

--- a/packages/cli/src/telemetry/rating.ts
+++ b/packages/cli/src/telemetry/rating.ts
@@ -1,0 +1,5 @@
+/** Parse a user satisfaction score on the 1–10 feedback scale. */
+export function parseFeedbackRating(raw: string): number | null {
+  const n = parseInt(raw, 10);
+  return n >= 1 && n <= 10 && Number.isFinite(n) ? n : null;
+}


### PR DESCRIPTION
## Summary
- update CLI and interactive feedback prompts to use a 1–10 satisfaction scale
- validate ratings from 1 through 10 and add boundary tests
- update CLI and feedback documentation, including agent instructions

## Authorization
Direct owner request from Vance Ingalls in Slack thread: https://heygen.slack.com/archives/C0BGC335AQY/p1784581022402429

## Verification
- `bunx vitest run packages/cli/src/commands/feedback.test.ts` (2 passed)
- formatting and lint pre-commit checks passed
- full typecheck could not run in this checkout because workspace dependencies and Node typings are absent; hook also reported no `origin/main` merge base for fallow

No self-merge or self-approval performed.