### PR TITLE
docs(guides): publish the Send-to guide in nav + llms.txt (discoverable via search)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -85,6 +85,7 @@
               "guides/antigravity",
               "guides/copilot-cli",
               "guides/claude-design",
+              "guides/claude-design-send-to-hyperframes",
               "guides/open-design",
               "guides/prompting",
               "guides/hyperframes-vs-remotion",

--- a/docs/guides/claude-design-send-to-hyperframes.md
+++ b/docs/guides/claude-design-send-to-hyperframes.md
@@ -1,3 +1,8 @@
+---
+title: "Send to HyperFrames"
+description: "Author a Claude Design as a single-file HyperFrames composition for the \"Send to HyperFrames\" URL import."
+---
+
 # Claude Design → "Send to HyperFrames" (Single-File Import)
 
 > This guide is **fully self-contained**: everything needed to author a valid "Send to HyperFrames" composition is inline here. Do not rely on fetching any other document — produce the composition from this guide alone.


### PR DESCRIPTION
## Summary
Add the Claude Design **Send to HyperFrames** guide (`guides/claude-design-send-to-hyperframes`) to the Guides nav, next to `claude-design`, and give it frontmatter (title + description).

## Why
The guide already rendered at its URL but was an **orphan** — not in the nav, so not in `llms.txt`, so it never surfaced as a **fetchable search result source** (it only ever appeared as body text inside another page's excerpt, which Claude Design's `web_fetch` rejects). Verified in a dev test: even with the exact published URL named in the import tool description, CD could not fetch it — `web_fetch` only accepts URLs from a user message or a prior search/fetch **result**.

Indexing it here makes it a first-class result source (like `claude-design.md`), so a search returns it directly and CD can fetch the full guide. This is the reliable discovery path.

## Changes
- `docs/docs.json`: one nav entry under Guides.
- `docs/guides/claude-design-send-to-hyperframes.md`: frontmatter `title` + `description` (feeds the nav label + the `llms.txt` line).

Minor: the body keeps its `#` H1 (redundant with the frontmatter title on the rendered page); happy to drop it if the docs style prefers frontmatter-only titles.