### PR TITLE
docs(skills): add pre-build gate to changelog-video SKILL.md

### DIFF
--- a/.agents/skills/changelog-video/SKILL.md
+++ b/.agents/skills/changelog-video/SKILL.md
@@ -25,6 +25,26 @@ non-visual items (reliability fix lists).
 
 ## Pipeline
 
+### 0 · Bootstrap the project from THIS skill's assets — non-negotiable
+
+**Do this before writing any composition HTML. Skipping it always produces a video that looks like a similar project you built before, NOT this skill's brand — that's the single most common way this skill goes off-brand.** The skill's assets, fonts, and scaffold are the skill; the SKILL.md prompt is a router.
+
+```bash
+mkdir -p project/assets/fonts
+cp <SKILL_DIR>/assets/fonts/*.woff2 project/assets/fonts/
+cp <SKILL_DIR>/assets/bgm.mp3 project/bgm.mp3
+ffmpeg -y -stream_loop 15 -i <SKILL_DIR>/assets/bg-pattern.mp4 -t <TOTAL> \
+  -vf "scale=1080:1080,fps=30,eq=saturation=0.72,drawbox=c=black@0.5:t=fill" \
+  -an -c:v libx264 -crf 20 -pix_fmt yuv420p project/assets/bg-pattern-<TOTAL>s.mp4
+cp <SKILL_DIR>/examples/master-skeleton.html project/index.html
+```
+
+Then **read `references/build-spec.md` end-to-end** (not skimmed) — it defines the brand tokens (TT Norms Pro + ABC Solar Display + TT Norms Mono, cream `#f5f6f4`, rationed green `#5ef17c`, glass cards with green-tinted borders, kicker/sec-chip pill shape, caption rail at `top: 1002`) that every scene inherits from the scaffold.
+
+Only THEN begin steps 1-6 below. Steps 1-4 (parse, route, script, VO) plan what goes into the scaffold; step 5 fills placeholders (`<RANGE>`, `<TOTAL>`, `<CUT_N>`, `<DUR_N>`, scene bodies) inside the already-copied `project/index.html` — you do NOT rewrite the scaffold's chrome, fonts, palette, or layout shell.
+
+If you catch yourself reaching for `cp` on a prior video's `index.html`, or writing your own `@font-face` declarations, or designing a WebGL shader background instead of using the encoded bg-pattern MP4 above: STOP. Delete the current `index.html` and restart at the `cp` of the master-skeleton scaffold. Rebuilding scene content on the right scaffold is cheaper than retrofitting brand into the wrong scaffold.
+
 ### 1 · Parse + editorial cut
 
 - Extract: week range, headline stats (releases, commits), themes, items.
@@ -116,12 +136,15 @@ projects/active/weekly-changelog-<range>/
 
 ## Anti-patterns
 
-| Don't                                    | Instead                                        |
-| ---------------------------------------- | ---------------------------------------------- |
-| Bullet-point slides for UI changes       | Mock the surface acting out the change         |
-| Fake UI for un-representable items       | Honest checklist scene                         |
-| Plain "JSON"/"CLI" in the TTS text       | Lexicon spoken forms; display stays standard   |
-| Phonetic spellings in captions           | Captions always render the display layer       |
-| Guessing an unknown term's pronunciation | Ask, then grow the lexicon                     |
-| Speaking every changelog item            | ≤3 per theme; the digest link carries the rest |
-| Green accents everywhere                 | One green moment per scene (#5ef17c)           |
+| Don't                                                 | Instead                                                                                                                                               |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bullet-point slides for UI changes                    | Mock the surface acting out the change                                                                                                                |
+| Fake UI for un-representable items                    | Honest checklist scene                                                                                                                                |
+| Plain "JSON"/"CLI" in the TTS text                    | Lexicon spoken forms; display stays standard                                                                                                          |
+| Phonetic spellings in captions                        | Captions always render the display layer                                                                                                              |
+| Guessing an unknown term's pronunciation              | Ask, then grow the lexicon                                                                                                                            |
+| Speaking every changelog item                         | ≤3 per theme; the digest link carries the rest                                                                                                        |
+| Green accents everywhere                              | One green moment per scene (#5ef17c)                                                                                                                  |
+| Starting from a prior video's index.html              | Step 0 — copy `examples/master-skeleton.html` from this skill into `project/index.html`, always                                                       |
+| Hand-crafted `@font-face` / WebGL shader / custom BGM | Step 0 — copy this skill's `assets/` verbatim; the skill's assets ARE the brand                                                                       |
+| Delivered without CloudFront invalidation             | Run `aws cloudfront create-invalidation` on distribution `E2BSLVSZ7FG3U0` for the exact path after any S3 replace — CDN caches the old file otherwise |

--- a/.claude/skills/changelog-video/SKILL.md
+++ b/.claude/skills/changelog-video/SKILL.md
@@ -25,6 +25,26 @@ non-visual items (reliability fix lists).
 
 ## Pipeline
 
+### 0 · Bootstrap the project from THIS skill's assets — non-negotiable
+
+**Do this before writing any composition HTML. Skipping it always produces a video that looks like a similar project you built before, NOT this skill's brand — that's the single most common way this skill goes off-brand.** The skill's assets, fonts, and scaffold are the skill; the SKILL.md prompt is a router.
+
+```bash
+mkdir -p project/assets/fonts
+cp <SKILL_DIR>/assets/fonts/*.woff2 project/assets/fonts/
+cp <SKILL_DIR>/assets/bgm.mp3 project/bgm.mp3
+ffmpeg -y -stream_loop 15 -i <SKILL_DIR>/assets/bg-pattern.mp4 -t <TOTAL> \
+  -vf "scale=1080:1080,fps=30,eq=saturation=0.72,drawbox=c=black@0.5:t=fill" \
+  -an -c:v libx264 -crf 20 -pix_fmt yuv420p project/assets/bg-pattern-<TOTAL>s.mp4
+cp <SKILL_DIR>/examples/master-skeleton.html project/index.html
+```
+
+Then **read `references/build-spec.md` end-to-end** (not skimmed) — it defines the brand tokens (TT Norms Pro + ABC Solar Display + TT Norms Mono, cream `#f5f6f4`, rationed green `#5ef17c`, glass cards with green-tinted borders, kicker/sec-chip pill shape, caption rail at `top: 1002`) that every scene inherits from the scaffold.
+
+Only THEN begin steps 1-6 below. Steps 1-4 (parse, route, script, VO) plan what goes into the scaffold; step 5 fills placeholders (`<RANGE>`, `<TOTAL>`, `<CUT_N>`, `<DUR_N>`, scene bodies) inside the already-copied `project/index.html` — you do NOT rewrite the scaffold's chrome, fonts, palette, or layout shell.
+
+If you catch yourself reaching for `cp` on a prior video's `index.html`, or writing your own `@font-face` declarations, or designing a WebGL shader background instead of using the encoded bg-pattern MP4 above: STOP. Delete the current `index.html` and restart at the `cp` of the master-skeleton scaffold. Rebuilding scene content on the right scaffold is cheaper than retrofitting brand into the wrong scaffold.
+
 ### 1 · Parse + editorial cut
 
 - Extract: week range, headline stats (releases, commits), themes, items.
@@ -116,12 +136,15 @@ projects/active/weekly-changelog-<range>/
 
 ## Anti-patterns
 
-| Don't                                    | Instead                                        |
-| ---------------------------------------- | ---------------------------------------------- |
-| Bullet-point slides for UI changes       | Mock the surface acting out the change         |
-| Fake UI for un-representable items       | Honest checklist scene                         |
-| Plain "JSON"/"CLI" in the TTS text       | Lexicon spoken forms; display stays standard   |
-| Phonetic spellings in captions           | Captions always render the display layer       |
-| Guessing an unknown term's pronunciation | Ask, then grow the lexicon                     |
-| Speaking every changelog item            | ≤3 per theme; the digest link carries the rest |
-| Green accents everywhere                 | One green moment per scene (#5ef17c)           |
+| Don't                                                 | Instead                                                                                                                                               |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bullet-point slides for UI changes                    | Mock the surface acting out the change                                                                                                                |
+| Fake UI for un-representable items                    | Honest checklist scene                                                                                                                                |
+| Plain "JSON"/"CLI" in the TTS text                    | Lexicon spoken forms; display stays standard                                                                                                          |
+| Phonetic spellings in captions                        | Captions always render the display layer                                                                                                              |
+| Guessing an unknown term's pronunciation              | Ask, then grow the lexicon                                                                                                                            |
+| Speaking every changelog item                         | ≤3 per theme; the digest link carries the rest                                                                                                        |
+| Green accents everywhere                              | One green moment per scene (#5ef17c)                                                                                                                  |
+| Starting from a prior video's index.html              | Step 0 — copy `examples/master-skeleton.html` from this skill into `project/index.html`, always                                                       |
+| Hand-crafted `@font-face` / WebGL shader / custom BGM | Step 0 — copy this skill's `assets/` verbatim; the skill's assets ARE the brand                                                                       |
+| Delivered without CloudFront invalidation             | Run `aws cloudfront create-invalidation` on distribution `E2BSLVSZ7FG3U0` for the exact path after any S3 replace — CDN caches the old file otherwise |


### PR DESCRIPTION
## What

Adds an explicit Step 0 above the existing pipeline in `.claude/skills/changelog-video/SKILL.md` (and the mirrored `.agents/skills/changelog-video/SKILL.md`) that spells out the concrete pre-build file copies before any composition HTML is written:

- `cp <SKILL_DIR>/assets/fonts/*.woff2 project/assets/fonts/`
- `cp <SKILL_DIR>/assets/bgm.mp3 project/bgm.mp3`
- `ffmpeg …` re-encode of `<SKILL_DIR>/assets/bg-pattern.mp4` to the total duration
- `cp <SKILL_DIR>/examples/master-skeleton.html project/index.html`
- Read `references/build-spec.md` end-to-end BEFORE writing content

Also extends the anti-patterns table with the three failure modes hit on this week's Jul 13-20 weekly run:

- Starting from a prior video's `index.html`
- Hand-crafting `@font-face` / WebGL shader / custom BGM
- Delivering without a CloudFront invalidation after the S3 replace (distribution `E2BSLVSZ7FG3U0`)

## Why

The previous SKILL.md said "follow `references/build-spec.md` exactly" in step 5. That lets an agent read the build-spec **after already writing composition HTML** on a wrong scaffold — which is exactly what happened on the Jul 13-20 run: three off-brand video iterations (WebGL shader background, JetBrains Mono fonts, blue accents) before finally starting from `master-skeleton.html`. Jake (skill author) called v3 "trash" — the assets, fonts, and scaffold ARE the brand, not the SKILL.md prompt on its own.

The three added anti-patterns are the concrete traps: agents keep starting from similar-looking prior-project templates unless the skill explicitly bans it and points at the exact `cp` commands.

## Test plan

- [x] `bun scripts/lint-skills.ts` — 31 skill file(s), 0 issues (fixed inline-backtick `>` false positives on the first attempt via rewording)
- [x] `node scripts/check-skill-mirror.mjs` — 24 files byte-identical across `.claude/skills/` and `.agents/skills/`
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format:check` — all matched files use the correct format
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — ✓ No issues in 2 changed files

Content-only change; no scripts or assets touched.

## Follow-up

Home's weekly cron (`cron_dfd99766`) — I've sent the corresponding cron-prompt update (via send_to_teammate) so next Monday's autonomous run picks up the pre-build gate before this PR merges. This PR is the durable skill-level fix; the cron update is the specific-cron-flow fix. They're additive.