### PR TITLE
feat: add hyperframes-py, a Python SDK for the CLI

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -1,0 +1,54 @@
+name: Python SDK
+
+# The Python SDK in sdk/python/ is a companion package that shells out to the
+# `hyperframes` CLI. It has no bearing on the TypeScript build, so it runs as
+# its own workflow, scoped by path, rather than as a job inside CI.
+
+permissions:
+  contents: read
+
+env:
+  HYPERFRAMES_NO_TELEMETRY: "1"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+    paths:
+      - "sdk/python/**"
+      - ".github/workflows/python-sdk.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sdk/python/**"
+      - ".github/workflows/python-sdk.yml"
+
+concurrency:
+  group: python-sdk-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: sdk/python
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported (see requires-python) and current stable.
+        python-version: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: pip install -e ".[dev]"
+      - name: Test
+        # The default suite mocks every subprocess call, so it needs neither
+        # Node nor the CLI. The integration test is marked `integration` and
+        # self-skips; it is excluded here to keep this job hermetic.
+        run: pytest -m "not integration" -q

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.egg-info/
+.pytest_cache/
+dist/

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,188 @@
+# hyperframes-py
+
+Python SDK for [HyperFrames](https://hyperframes.heygen.com) — write HTML, render video.
+
+HyperFrames turns an HTML page into a deterministic MP4. Its engine is a Node
+CLI. This package is a thin, dependency-free wrapper so Python code can drive
+it: scaffold a project, generate a composition from your data, render it, get a
+`Path` back.
+
+It does **not** reimplement rendering. It discovers the CLI, builds an argv,
+runs it as a subprocess, and turns a non-zero exit into an exception carrying
+stderr. No network calls, no telemetry — in fact it switches the CLI's own
+telemetry *off* on every invocation.
+
+## Install
+
+```bash
+pip install hyperframes-py          # imports as `hyperframes`
+npm install -g hyperframes          # the renderer itself — Node >= 22
+```
+
+The SDK finds the CLI in this order:
+
+1. an explicit `Project(path, cli=...)` argument,
+2. `$HYPERFRAMES_CLI` (shell-split, so `export HYPERFRAMES_CLI='npx --yes hyperframes'` works),
+3. `hyperframes` on `PATH`,
+4. `node_modules/.bin/hyperframes`, walking up from the project directory.
+
+If none resolve you get a `CLINotFoundError` that says how to fix it — and
+tells you whether Node is missing too.
+
+## Quickstart
+
+```python
+from hyperframes import Project
+
+project = Project.init("promo", example="blank")     # hyperframes init
+project.index.write_text("<!doctype html>...")       # your composition
+project.run("lint")                                  # optional gate
+mp4 = project.render("promo.mp4", fps=30, quality="high")
+print(mp4)                                           # /abs/path/promo/promo.mp4
+```
+
+Already have a project? Skip `init`:
+
+```python
+Project("./my-video").render()      # -> my-video/renders/my-video.mp4
+```
+
+## API
+
+### `Project(path, *, cli=None, env=None)`
+
+A composition directory — a folder containing `index.html`. `env` is layered
+over the SDK's defaults for every call.
+
+| Attribute | |
+|---|---|
+| `.path` | absolute `Path` to the directory |
+| `.name` | directory basename (what the CLI calls the project name) |
+| `.index` | `Path` to `index.html` |
+| `.exists()` | whether `index.html` is there |
+
+### `Project.init(path, *, example="blank", cli=None, env=None, timeout=None, **opts) -> Project`
+
+Scaffolds via `hyperframes init` and returns the handle. `"blank"` ships with
+the CLI; any other example is downloaded from the registry. Extra flags pass
+through: `resolution="portrait"`, `tailwind=True`, `video="clip.mp4"`.
+
+Non-interactive mode is forced — see [Quirks](#cli-quirks-worth-knowing).
+
+### `.render(output=None, *, format="mp4", timeout=None, **opts) -> Path`
+
+Renders and returns the artifact path. Raises if the CLI fails, or if it exits
+0 without producing a file.
+
+- `output` — relative paths resolve against the **project directory**. Default
+  is `renders/<name>.<ext>`.
+- `format` — `mp4` | `webm` | `mov` | `gif` | `png-sequence` (a directory).
+- `**opts` — any other `hyperframes render` flag, in snake_case:
+
+  | Python | CLI |
+  |---|---|
+  | `fps=60` | `--fps 60` |
+  | `quality="high"` | `--quality high` |
+  | `composition="scenes/intro.html"` | `--composition scenes/intro.html` |
+  | `resolution="portrait"` | `--resolution portrait` |
+  | `variables={"title": "Hi"}` | `--variables '{"title":"Hi"}'` |
+  | `strict=True` | `--strict` |
+  | `page_side_compositing=False` | `--no-page-side-compositing` |
+  | `anything=None` | *(omitted)* |
+
+  The mapping is generic, so every current and future render flag is reachable
+  without an SDK release. `quiet=True` is the default; pass `quiet=False` to
+  see progress.
+
+### `.preview(*, port=3002, open_browser=False, background=False, timeout=None) -> str | None`
+
+Starts the studio preview server. Blocking by default (streams to your
+terminal, returns `None` on exit). With `background=True` it returns
+immediately with the server URL.
+
+### `.stop_preview(*, port=3002)`
+
+Stops the background server for this project.
+
+### `.run(*args, timeout=None, check=True) -> subprocess.CompletedProcess`
+
+Escape hatch to any subcommand, run with the project as cwd:
+
+```python
+project.run("lint")
+project.run("check")
+project.run("compositions", "--json")
+project.run("lint", check=False).returncode    # inspect instead of raise
+```
+
+### Errors
+
+```python
+from hyperframes import HyperframesError, CLINotFoundError   # CLINotFoundError subclasses it
+
+try:
+    project.render(quality="maximum")
+except HyperframesError as error:
+    error.command      # ['/usr/bin/hyperframes', 'render', ...]
+    error.returncode   # 1
+    error.stderr       # 'Invalid quality ...'
+```
+
+### `cli_version() -> str`
+
+Version of the resolved CLI. Cheap enough to use as a health probe — the CLI
+short-circuits `--version` before loading anything.
+
+## CLI quirks worth knowing
+
+Four behaviours the SDK papers over. They're the reason some of this code
+exists.
+
+1. **Output paths resolve against the process cwd, not the project dir.** The
+   CLI does `resolve(args.output)` and `resolve("renders")` against
+   `process.cwd()`. The SDK always passes an absolute `--output` and runs with
+   the project as cwd, so a relative `output=` means what you'd expect.
+2. **The default filename is timestamped** (`renders/<name>_<ts>.mp4`), so it
+   can't be predicted. The SDK therefore *always* passes `--output` — which is
+   why `render()` can return a `Path` at all.
+3. **`hyperframes init` prompts only when stdout is a TTY.** From a subprocess
+   it never is, and in non-interactive mode it *requires* one of `--example` /
+   `--video` / `--audio`. `Project.init` passes `--example blank` and
+   `--non-interactive` so it can't hang or fail on that.
+4. **`--json` on `render` is batch-only.** A single render has no
+   machine-readable output, so the SDK relies on the exit code plus the path it
+   supplied, and checks the artifact landed.
+
+## Limitations
+
+- **Not a binding.** Every call is a process spawn. Fine for batch jobs and web
+  backends; don't put it in a hot loop.
+- **No streaming progress.** `render()` returns when the process exits. Pass
+  `quiet=False` and capture the CLI's own output if you need progress.
+- **Renders are synchronous and can be slow.** `timeout=` defaults to none;
+  set one if you're rendering untrusted input.
+- **Blocking `preview()` owns the terminal** until interrupted. Use
+  `background=True` from a script.
+- **No composition authoring helpers.** Compositions are HTML; build them with
+  whatever templating you already use (see `examples/02_render_from_data.py`).
+- **Node >= 22 required** by the CLI, enforced before it loads. On older Node
+  every call fails with that message on `.stderr`.
+
+## Examples
+
+```bash
+python examples/01_render_example.py     # render an example composition
+python examples/02_render_from_data.py   # data dict -> composition -> MP4
+```
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest                # unit tests — fully mocked, no CLI or Node needed
+pytest -m integration # one real render; auto-skips without Node >= 22 + CLI
+```
+
+## License
+
+Apache-2.0, matching the parent project.

--- a/sdk/python/examples/01_render_example.py
+++ b/sdk/python/examples/01_render_example.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Render one of the repo's example compositions to MP4.
+
+    python examples/01_render_example.py       # scaffolds `swiss-grid` from the registry
+    python examples/01_render_example.py ../../registry/examples/swiss-grid   # render in place
+
+Needs Node >= 22 and the `hyperframes` CLI (npm i -g hyperframes).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from hyperframes import HyperframesError, Project, cli_version
+
+
+def main() -> int:
+    print(f"hyperframes CLI {cli_version()}")
+
+    if len(sys.argv) > 1:
+        project = Project(sys.argv[1])
+        if not project.exists():
+            print(f"No index.html in {project.path}", file=sys.stderr)
+            return 1
+    else:
+        # `swiss-grid` is a registry example, so this one call downloads it.
+        workdir = Path(tempfile.mkdtemp(prefix="hyperframes-"))
+        print(f"Scaffolding swiss-grid in {workdir} ...")
+        project = Project.init(workdir / "swiss-grid", example="swiss-grid")
+
+    print(f"Rendering {project.name} ...")
+    output = project.render("out.mp4", quality="draft")
+    print(f"Wrote {output} ({output.stat().st_size / 1e6:.2f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except HyperframesError as error:
+        print(error, file=sys.stderr)
+        sys.exit(1)

--- a/sdk/python/examples/02_render_from_data.py
+++ b/sdk/python/examples/02_render_from_data.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Generate a composition from a Python data dict, then render it.
+
+The point of HyperFrames is that a video is just HTML. So a chart video is a
+template call away — build the markup from your data, write index.html, render.
+
+    python examples/02_render_from_data.py
+
+Needs Node >= 22 and the `hyperframes` CLI (npm i -g hyperframes).
+"""
+
+from __future__ import annotations
+
+import html
+import sys
+import tempfile
+from pathlib import Path
+
+from hyperframes import HyperframesError, Project
+
+REPORT = {
+    "title": "Q3 Revenue",
+    "duration": 4.0,
+    "bars": [
+        {"label": "North", "value": 82},
+        {"label": "South", "value": 45},
+        {"label": "EMEA", "value": 96},
+        {"label": "APAC", "value": 61},
+    ],
+}
+
+PAGE = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      html, body {{ margin: 0; width: 1920px; height: 1080px; overflow: hidden; background: #0b0b0f; }}
+      #root {{ font-family: Inter, system-ui, sans-serif; color: #f5f5f7; }}
+      #title {{ position: absolute; top: 120px; left: 160px; font-size: 84px; font-weight: 700; }}
+      #chart {{ position: absolute; left: 160px; right: 160px; bottom: 160px;
+                display: flex; gap: 48px; align-items: flex-end; height: 560px; }}
+      .bar {{ flex: 1; display: flex; flex-direction: column; justify-content: flex-end;
+              align-items: center; gap: 20px; }}
+      .fill {{ width: 100%; background: linear-gradient(#7c5cff, #4bd4ff); border-radius: 12px 12px 0 0;
+               transform-origin: bottom; animation: grow 0.9s cubic-bezier(.2,.7,.3,1) both; }}
+      .label {{ font-size: 34px; opacity: .7 }}
+      .value {{ font-size: 40px; font-weight: 600 }}
+      @keyframes grow {{ from {{ transform: scaleY(0) }} to {{ transform: scaleY(1) }} }}
+    </style>
+  </head>
+  <body>
+    <!-- data-no-timeline: motion is pure CSS, so there is no window.__timelines
+         entry to register. Without it the producer polls 45s before giving up. -->
+    <div id="root" data-composition-id="main" data-start="0" data-duration="{duration}"
+         data-width="1920" data-height="1080" data-no-timeline>
+      <h1 id="title" class="clip" data-start="0" data-duration="{duration}" data-track-index="0">{title}</h1>
+      <div id="chart" class="clip" data-start="0" data-duration="{duration}" data-track-index="1">
+{bars}
+      </div>
+    </div>
+  </body>
+</html>
+"""
+
+BAR = """        <div class="bar">
+          <div class="value">{value}</div>
+          <div class="fill" style="height: {height:.1f}%; animation-delay: {delay:.2f}s"></div>
+          <div class="label">{label}</div>
+        </div>"""
+
+
+def build_page(report: dict) -> str:
+    """Render the data dict into a HyperFrames composition.
+
+    Animation is pure CSS keyframes — a supported frame adapter, and it keeps
+    the render deterministic and offline (no CDN script tag).
+    """
+    peak = max(bar["value"] for bar in report["bars"]) or 1
+    bars = "\n".join(
+        BAR.format(
+            value=bar["value"],
+            label=html.escape(bar["label"]),
+            height=100 * bar["value"] / peak,
+            delay=0.12 * index,
+        )
+        for index, bar in enumerate(report["bars"])
+    )
+    return PAGE.format(
+        title=html.escape(report["title"]),
+        duration=report["duration"],
+        bars=bars,
+    )
+
+
+def main() -> int:
+    workdir = Path(tempfile.mkdtemp(prefix="hyperframes-"))
+    project = Project.init(workdir / "revenue", example="blank")
+    project.index.write_text(build_page(REPORT), encoding="utf-8")
+    print(f"Wrote {project.index}")
+
+    project.run("lint")  # raises HyperframesError if the markup is malformed
+
+    output = project.render("revenue.mp4", fps=30, quality="draft")
+    print(f"Wrote {output} ({output.stat().st_size / 1e6:.2f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except HyperframesError as error:
+        print(error, file=sys.stderr)
+        sys.exit(1)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hyperframes-py"
+version = "0.1.0"
+description = "Python SDK for HyperFrames — drive the HTML-to-video CLI from Python."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+keywords = ["video", "rendering", "html", "ffmpeg", "hyperframes"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Multimedia :: Video",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://hyperframes.heygen.com"
+Source = "https://github.com/heygen-com/hyperframes"
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hyperframes"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = ["integration: needs a real Node >= 22 + hyperframes CLI install"]

--- a/sdk/python/src/hyperframes/__init__.py
+++ b/sdk/python/src/hyperframes/__init__.py
@@ -1,0 +1,24 @@
+"""Python SDK for HyperFrames — write HTML, render video.
+
+A thin, dependency-free wrapper around the `hyperframes` Node CLI. It does not
+reimplement rendering; it discovers the CLI, builds argv, and turns failures
+into exceptions that carry stderr.
+
+    >>> from hyperframes import Project
+    >>> project = Project.init("promo", example="blank")
+    >>> project.render("promo.mp4")
+    PosixPath('/abs/path/promo/promo.mp4')
+"""
+
+from ._cli import CLINotFoundError, HyperframesError, cli_version, resolve_cli
+from .project import Project
+
+__all__ = [
+    "Project",
+    "HyperframesError",
+    "CLINotFoundError",
+    "cli_version",
+    "resolve_cli",
+]
+
+__version__ = "0.1.0"

--- a/sdk/python/src/hyperframes/_cli.py
+++ b/sdk/python/src/hyperframes/_cli.py
@@ -1,0 +1,247 @@
+"""Subprocess bridge to the `hyperframes` Node CLI.
+
+Everything here is local process orchestration: discover the CLI, build an
+argv, run it, turn a non-zero exit into an exception that carries stderr.
+No rendering logic is reimplemented — the Node CLI owns all of that.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+__all__ = [
+    "HyperframesError",
+    "CLINotFoundError",
+    "resolve_cli",
+    "run",
+    "cli_version",
+    "build_flags",
+]
+
+# packages/cli/src/runtimeVersion.ts — the shim rejects older Node before any
+# CLI code loads, so the failure surfaces as exit 1 with this on stderr.
+MIN_NODE_MAJOR = 22
+
+#: Env applied to every CLI invocation. The SDK promises no network and no
+#: telemetry; these are the CLI's own opt-out switches.
+#: - HYPERFRAMES_NO_TELEMETRY / DO_NOT_TRACK: packages/cli/src/telemetry/client.ts
+#: - HYPERFRAMES_SKIP_SKILLS: stops `init` phoning GitHub for a skills check
+#: - NO_COLOR: keeps ANSI escapes out of captured stderr
+DEFAULT_ENV: dict[str, str] = {
+    "HYPERFRAMES_NO_TELEMETRY": "1",
+    "DO_NOT_TRACK": "1",
+    "HYPERFRAMES_SKIP_SKILLS": "1",
+    "NO_COLOR": "1",
+}
+
+
+class HyperframesError(RuntimeError):
+    """A `hyperframes` CLI invocation failed.
+
+    Carries the full context of the failed process so callers can log or
+    re-raise without re-running anything.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        command: Sequence[str] = (),
+        returncode: int | None = None,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.command: list[str] = list(command)
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class CLINotFoundError(HyperframesError):
+    """The `hyperframes` executable (or Node itself) could not be located."""
+
+
+def _as_argv(cli: str | Path | Sequence[str]) -> list[str]:
+    if isinstance(cli, Path):
+        return [str(cli)]
+    if isinstance(cli, str):
+        # Allows HYPERFRAMES_CLI="npx --yes hyperframes@latest".
+        return shlex.split(cli)
+    return [str(part) for part in cli]
+
+
+def _node_hint() -> str:
+    node = shutil.which("node")
+    if node is None:
+        return (
+            f"Node.js was not found on PATH either. HyperFrames needs Node.js "
+            f">= {MIN_NODE_MAJOR}."
+        )
+    return f"Node.js was found at {node}; only the hyperframes CLI is missing."
+
+
+def _walk_up_node_modules(start: Path) -> Path | None:
+    name = "hyperframes.cmd" if os.name == "nt" else "hyperframes"
+    for directory in (start, *start.parents):
+        candidate = directory / "node_modules" / ".bin" / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def resolve_cli(
+    cli: str | Path | Sequence[str] | None = None,
+    *,
+    search_from: str | Path | None = None,
+) -> list[str]:
+    """Return the argv prefix used to invoke the CLI.
+
+    Resolution order:
+
+    1. an explicit ``cli`` argument (string, path, or argv sequence),
+    2. the ``HYPERFRAMES_CLI`` environment variable,
+    3. ``hyperframes`` on ``PATH``,
+    4. ``node_modules/.bin/hyperframes``, walking up from ``search_from``.
+
+    Raises:
+        CLINotFoundError: if none of the above resolve.
+    """
+    if cli is not None:
+        return _as_argv(cli)
+
+    env_cli = os.environ.get("HYPERFRAMES_CLI")
+    if env_cli:
+        return _as_argv(env_cli)
+
+    found = shutil.which("hyperframes")
+    if found:
+        return [found]
+
+    local = _walk_up_node_modules(Path(search_from or Path.cwd()).resolve())
+    if local is not None:
+        return [str(local)]
+
+    raise CLINotFoundError(
+        "Could not find the `hyperframes` CLI.\n"
+        f"{_node_hint()}\n"
+        "Fix it with any one of:\n"
+        "  npm install -g hyperframes\n"
+        "  npm install hyperframes           (then run from that project)\n"
+        "  export HYPERFRAMES_CLI='npx --yes hyperframes'\n"
+        "  Project(path, cli='/path/to/hyperframes')"
+    )
+
+
+def _flag_name(key: str) -> str:
+    return key.replace("_", "-").strip("-")
+
+
+def build_flags(opts: Mapping[str, Any]) -> list[str]:
+    """Map python kwargs onto CLI flags.
+
+    ``None`` values are dropped, ``True``/``False`` become ``--flag`` /
+    ``--no-flag`` (citty's negation convention), dicts and lists are JSON
+    encoded, and everything else is stringified. Underscores become dashes,
+    so ``page_side_compositing=False`` yields ``--no-page-side-compositing``.
+    """
+    argv: list[str] = []
+    for key, value in opts.items():
+        if value is None:
+            continue
+        name = _flag_name(key)
+        if value is True:
+            argv.append(f"--{name}")
+        elif value is False:
+            argv.append(f"--no-{name}")
+        elif isinstance(value, (dict, list)):
+            argv += [f"--{name}", json.dumps(value, separators=(",", ":"))]
+        elif isinstance(value, Path):
+            argv += [f"--{name}", str(value)]
+        else:
+            argv += [f"--{name}", str(value)]
+    return argv
+
+
+def run(
+    args: Iterable[str],
+    *,
+    cli: str | Path | Sequence[str] | None = None,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    capture: bool = True,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the CLI once.
+
+    Args:
+        args: CLI arguments after the executable, e.g. ``["render", "-o", "a.mp4"]``.
+        cli: Override the executable (see :func:`resolve_cli`).
+        cwd: Working directory. Matters: the CLI resolves ``--output`` and its
+            default ``renders/`` directory against the *process* cwd, not the
+            project directory.
+        env: Extra environment variables, layered over :data:`DEFAULT_ENV`.
+        timeout: Seconds before the process is killed.
+        capture: Capture stdout/stderr. Pass ``False`` to stream to the
+            terminal (used by the blocking preview server).
+        check: Raise :class:`HyperframesError` on a non-zero exit.
+
+    Raises:
+        HyperframesError: on non-zero exit, timeout, or a CLI that cannot run.
+        CLINotFoundError: if the executable cannot be resolved or spawned.
+    """
+    argv = [*resolve_cli(cli, search_from=cwd), *args]
+    process_env = {**os.environ, **DEFAULT_ENV, **(env or {})}
+
+    try:
+        completed = subprocess.run(  # noqa: S603 - argv is built, never shell
+            argv,
+            cwd=str(cwd) if cwd is not None else None,
+            env=process_env,
+            capture_output=capture,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise CLINotFoundError(
+            f"Could not execute {argv[0]!r}. {_node_hint()}", command=argv
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HyperframesError(
+            f"`{' '.join(argv)}` timed out after {timeout}s.",
+            command=argv,
+            stdout=_text(exc.stdout),
+            stderr=_text(exc.stderr),
+        ) from exc
+
+    if check and completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        raise HyperframesError(
+            f"`{' '.join(argv)}` failed with exit code {completed.returncode}."
+            + (f"\n{detail}" if detail else ""),
+            command=argv,
+            returncode=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+        )
+    return completed
+
+
+def _text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    return value if isinstance(value, str) else value.decode("utf-8", "replace")
+
+
+def cli_version(cli: str | Path | Sequence[str] | None = None) -> str:
+    """Return the CLI version. Cheap — `--version` short-circuits before any
+    heavy import in the CLI, so this doubles as a health probe."""
+    return run(["--version"], cli=cli).stdout.strip()

--- a/sdk/python/src/hyperframes/project.py
+++ b/sdk/python/src/hyperframes/project.py
@@ -1,0 +1,241 @@
+"""The `Project` handle — a composition directory you can render or preview."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from ._cli import HyperframesError, build_flags, run
+
+__all__ = ["Project"]
+
+# packages/cli/src/commands/render/plan.ts — FORMAT_EXT
+_FORMAT_EXT: dict[str, str] = {
+    "mp4": ".mp4",
+    "webm": ".webm",
+    "mov": ".mov",
+    "gif": ".gif",
+    "png-sequence": "",
+}
+
+_URL_RE = re.compile(r"https?://(?:localhost|127\.0\.0\.1):\d+")
+
+
+class Project:
+    """A HyperFrames composition directory.
+
+    A project is just a folder containing ``index.html``. Construct one around
+    an existing folder, or scaffold a new one with :meth:`init`.
+
+        >>> project = Project("my-video")
+        >>> project.render("out.mp4")
+        PosixPath('/abs/path/my-video/out.mp4')
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        cli: str | Path | Sequence[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self.path = Path(path).expanduser().resolve()
+        self._cli = cli
+        self._env = dict(env or {})
+
+    # -- construction -------------------------------------------------------
+
+    @classmethod
+    def init(
+        cls,
+        path: str | Path,
+        *,
+        example: str | None = "blank",
+        cli: str | Path | Sequence[str] | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        **opts: Any,
+    ) -> "Project":
+        """Scaffold a new project with ``hyperframes init`` and return it.
+
+        Args:
+            path: Directory to create. Must not exist, or must be empty.
+            example: Registry example to scaffold from. ``"blank"`` is bundled
+                with the CLI; anything else is downloaded from the registry.
+                Pass ``None`` only alongside ``video=`` or ``audio=``.
+            timeout: Seconds to allow. Registry downloads and whisper
+                transcription can be slow; default is no limit.
+            **opts: Extra flags, e.g. ``resolution="portrait"``,
+                ``tailwind=True``, ``video="clip.mp4"``.
+
+        Non-interactive mode is forced, because the CLI only prompts when
+        stdout is a TTY and it demands one of ``--example`` / ``--video`` /
+        ``--audio`` when it is not.
+        """
+        target = Path(path).expanduser().resolve()
+        opts.setdefault("non_interactive", True)
+        argv = [
+            "init",
+            target.name,
+            *build_flags({"example": example, **opts}),
+        ]
+        # `init` resolves the project name against the process cwd, so run
+        # from the parent and pass a bare name.
+        target.parent.mkdir(parents=True, exist_ok=True)
+        run(argv, cli=cli, cwd=target.parent, env=env, timeout=timeout)
+        return cls(target, cli=cli, env=env)
+
+    # -- properties ---------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Project name — the directory's basename, as the CLI derives it."""
+        return self.path.name
+
+    @property
+    def index(self) -> Path:
+        """Path to the root composition."""
+        return self.path / "index.html"
+
+    def exists(self) -> bool:
+        """True if the directory holds a root composition."""
+        return self.index.is_file()
+
+    def __repr__(self) -> str:
+        return f"Project({str(self.path)!r})"
+
+    # -- actions ------------------------------------------------------------
+
+    def render(
+        self,
+        output: str | Path | None = None,
+        *,
+        format: str = "mp4",
+        timeout: float | None = None,
+        **opts: Any,
+    ) -> Path:
+        """Render the composition and return the path to the artifact.
+
+        Args:
+            output: Where to write. Relative paths resolve against the project
+                directory. Defaults to ``renders/<name>.<ext>`` — note this
+                differs from the CLI, which appends a timestamp; the SDK pins
+                the name so it has a path to hand back.
+            format: ``mp4`` (default), ``webm``, ``mov``, ``gif``, or
+                ``png-sequence``. ``png-sequence`` writes a directory.
+            timeout: Seconds to allow. Renders are slow — default is no limit.
+            **opts: Any other ``hyperframes render`` flag, in snake_case.
+                ``composition="scenes/intro.html"``, ``fps=60``,
+                ``quality="high"``, ``resolution="portrait"``,
+                ``variables={"title": "Hi"}``, ``workers=4``,
+                ``page_side_compositing=False`` → ``--no-page-side-compositing``.
+
+        Raises:
+            HyperframesError: if the CLI fails, or exits 0 without producing
+                the artifact.
+        """
+        if not self.exists():
+            raise HyperframesError(
+                f"No composition at {self.index}. "
+                "Scaffold one with Project.init(...) or point at a project directory."
+            )
+
+        ext = _FORMAT_EXT.get(format, "")
+        target = (
+            self.path / "renders" / f"{self.name}{ext}"
+            if output is None
+            else Path(output).expanduser()
+        )
+        if not target.is_absolute():
+            target = self.path / target
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        opts.setdefault("quiet", True)
+        argv = [
+            "render",
+            str(self.path),
+            *build_flags({"output": target, "format": format, **opts}),
+        ]
+        # cwd is the project dir regardless: `--output` is already absolute,
+        # but any relative path the CLI derives itself lands inside the project.
+        self._run(argv, timeout=timeout)
+
+        if not target.exists():
+            raise HyperframesError(
+                f"Render reported success but produced nothing at {target}.",
+                command=argv,
+            )
+        return target
+
+    def preview(
+        self,
+        *,
+        port: int = 3002,
+        open_browser: bool = False,
+        background: bool = False,
+        timeout: float | None = None,
+        **opts: Any,
+    ) -> str | None:
+        """Start the studio preview server.
+
+        Args:
+            port: Preferred port. The CLI picks another if it is taken, which
+                is why the background URL is read back from its output.
+            open_browser: Let the CLI open a browser window.
+            background: Return immediately with the server URL instead of
+                blocking. Stop it later with :meth:`stop_preview`.
+            timeout: Only meaningful with ``background=True``.
+
+        Returns:
+            The server URL when ``background=True``; ``None`` when blocking
+            (the call returns once the server is interrupted or exits).
+        """
+        argv = [
+            "preview",
+            str(self.path),
+            *build_flags({"port": port, "open": open_browser, **opts}),
+        ]
+        if not background:
+            self._run(argv, capture=False, timeout=timeout)
+            return None
+
+        completed = self._run([*argv, "--background"], timeout=timeout)
+        match = _URL_RE.search(completed.stdout or "")
+        return match.group(0) if match else f"http://localhost:{port}"
+
+    def stop_preview(self, *, port: int = 3002) -> None:
+        """Stop the background preview server for this project."""
+        self._run(["preview", str(self.path), "--port", str(port), "--stop"])
+
+    def run(
+        self, *args: str, timeout: float | None = None, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        """Escape hatch: run any CLI subcommand against this project.
+
+            >>> project.run("lint")
+            >>> project.run("check")
+            >>> project.run("compositions", "--json")
+        """
+        return self._run(list(args), timeout=timeout, check=check)
+
+    # -- internals ----------------------------------------------------------
+
+    def _run(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        capture: bool = True,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return run(
+            argv,
+            cli=self._cli,
+            cwd=self.path if self.path.is_dir() else None,
+            env=self._env,
+            timeout=timeout,
+            capture=capture,
+            check=check,
+        )

--- a/sdk/python/tests/test_cli.py
+++ b/sdk/python/tests/test_cli.py
@@ -1,0 +1,173 @@
+"""Unit tests for CLI discovery, argv construction, and error handling."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hyperframes import CLINotFoundError, HyperframesError, cli_version, resolve_cli
+from hyperframes._cli import DEFAULT_ENV, build_flags, run
+
+
+# -- resolve_cli -----------------------------------------------------------
+
+
+def test_explicit_cli_wins(monkeypatch):
+    monkeypatch.setenv("HYPERFRAMES_CLI", "from-env")
+    assert resolve_cli("/opt/hyperframes") == ["/opt/hyperframes"]
+    assert resolve_cli(Path("/opt/hf")) == ["/opt/hf"]
+    assert resolve_cli(["node", "cli.js"]) == ["node", "cli.js"]
+
+
+def test_env_var_is_shell_split(monkeypatch):
+    monkeypatch.setenv("HYPERFRAMES_CLI", "npx --yes hyperframes@latest")
+    assert resolve_cli() == ["npx", "--yes", "hyperframes@latest"]
+
+
+def test_falls_back_to_path(monkeypatch):
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    assert resolve_cli() == ["/usr/bin/hyperframes"]
+
+
+def test_finds_local_node_modules(monkeypatch, tmp_path):
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    binary = tmp_path / "node_modules" / ".bin" / "hyperframes"
+    binary.parent.mkdir(parents=True)
+    binary.touch()
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    assert resolve_cli(search_from=nested) == [str(binary)]
+
+
+def test_missing_cli_raises_actionable_error(monkeypatch, tmp_path):
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    with pytest.raises(CLINotFoundError) as excinfo:
+        resolve_cli(search_from=tmp_path)
+    message = str(excinfo.value)
+    assert "npm install -g hyperframes" in message
+    assert "Node.js" in message
+
+
+# -- build_flags -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("opts", "expected"),
+    [
+        ({"fps": 60}, ["--fps", "60"]),
+        ({"quality": "high"}, ["--quality", "high"]),
+        ({"skipped": None}, []),
+        ({"strict": True}, ["--strict"]),
+        ({"page_side_compositing": False}, ["--no-page-side-compositing"]),
+        ({"variables": {"title": "Hi"}}, ["--variables", '{"title":"Hi"}']),
+        ({"output": Path("/tmp/a.mp4")}, ["--output", "/tmp/a.mp4"]),
+    ],
+)
+def test_flag_mapping(opts, expected):
+    assert build_flags(opts) == expected
+
+
+def test_flag_order_follows_kwargs():
+    assert build_flags({"fps": 30, "quality": "draft"}) == [
+        "--fps",
+        "30",
+        "--quality",
+        "draft",
+    ]
+
+
+# -- run -------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Capture the subprocess.run call instead of spawning anything."""
+    calls: list[dict] = []
+
+    def _fake(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return subprocess.CompletedProcess(argv, 0, stdout="0.7.65\n", stderr="")
+
+    monkeypatch.setattr("hyperframes._cli.subprocess.run", _fake)
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    return calls
+
+
+def test_run_builds_argv_and_disables_telemetry(fake_run):
+    run(["render", "--fps", "30"], cwd="/projects/demo")
+    call = fake_run[0]
+    assert call["argv"] == ["/usr/bin/hyperframes", "render", "--fps", "30"]
+    assert call["cwd"] == "/projects/demo"
+    for key, value in DEFAULT_ENV.items():
+        assert call["env"][key] == value
+
+
+def test_caller_env_overrides_defaults(fake_run):
+    run(["render"], env={"NO_COLOR": "0", "MY_KEY": "x"})
+    env = fake_run[0]["env"]
+    assert env["NO_COLOR"] == "0"
+    assert env["MY_KEY"] == "x"
+    assert env["HYPERFRAMES_NO_TELEMETRY"] == "1"
+
+
+def test_cli_version_reads_stdout(fake_run):
+    assert cli_version() == "0.7.65"
+    assert fake_run[0]["argv"][1:] == ["--version"]
+
+
+def test_non_zero_exit_raises_with_stderr(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr(
+        "hyperframes._cli.subprocess.run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 2, "", "boom: bad fps"),
+    )
+    with pytest.raises(HyperframesError) as excinfo:
+        run(["render"])
+    error = excinfo.value
+    assert error.returncode == 2
+    assert error.stderr == "boom: bad fps"
+    assert "boom: bad fps" in str(error)
+    assert error.command[0] == "/usr/bin/hyperframes"
+
+
+def test_check_false_returns_failed_process(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr(
+        "hyperframes._cli.subprocess.run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 1, "", "nope"),
+    )
+    assert run(["lint"], check=False).returncode == 1
+
+
+def test_timeout_becomes_hyperframes_error(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+
+    def _timeout(argv, **kwargs):
+        raise subprocess.TimeoutExpired(argv, 1.0, output=b"partial", stderr=None)
+
+    monkeypatch.setattr("hyperframes._cli.subprocess.run", _timeout)
+    with pytest.raises(HyperframesError) as excinfo:
+        run(["render"], timeout=1.0)
+    assert "timed out after 1.0s" in str(excinfo.value)
+    assert excinfo.value.stdout == "partial"
+
+
+def test_unspawnable_cli_raises_cli_not_found(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/hyperframes")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+
+    def _missing(argv, **kwargs):
+        raise FileNotFoundError(argv[0])
+
+    monkeypatch.setattr("hyperframes._cli.subprocess.run", _missing)
+    with pytest.raises(CLINotFoundError):
+        run(["render"])

--- a/sdk/python/tests/test_integration.py
+++ b/sdk/python/tests/test_integration.py
@@ -1,0 +1,69 @@
+"""One real end-to-end render. Skipped unless Node >= 22 and the CLI are present.
+
+Run explicitly:  pytest -m integration
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from hyperframes import CLINotFoundError, Project, cli_version, resolve_cli
+from hyperframes._cli import MIN_NODE_MAJOR
+
+def _skip_reason() -> str | None:
+    try:
+        resolve_cli()
+    except CLINotFoundError:
+        return "hyperframes CLI not installed"
+
+    node = shutil.which("node")
+    if node is None:
+        return "node not on PATH"
+    raw = subprocess.run([node, "--version"], capture_output=True, text=True).stdout
+    major = int(raw.lstrip("v").split(".")[0] or 0)
+    if major < MIN_NODE_MAJOR:
+        return f"node {raw.strip()} < required v{MIN_NODE_MAJOR}"
+    return None
+
+
+SKIP = _skip_reason()
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(SKIP is not None, reason=SKIP or ""),
+]
+
+
+def test_scaffold_and_render(tmp_path):
+    assert cli_version()
+
+    project = Project.init(tmp_path / "smoke", example="blank")
+    assert project.exists()
+
+    # The blank template is a video shell with placeholder sources; replace it
+    # with a self-contained 1-second composition so the render needs no assets.
+    project.index.write_text(
+        """<!doctype html>
+<html lang="en"><head><meta charset="UTF-8" /><style>
+  html, body { margin: 0; width: 1920px; height: 1080px; overflow: hidden; background: #101014; }
+  #title { position: absolute; inset: 0; display: grid; place-items: center;
+           font: 700 96px sans-serif; color: #fff; }
+</style></head><body>
+  <div id="root" data-composition-id="main" data-start="0" data-duration="1"
+       data-width="1920" data-height="1080" data-no-timeline>
+    <h1 id="title" class="clip" data-start="0" data-duration="1" data-track-index="0">
+      Hello from Python
+    </h1>
+  </div>
+</body></html>
+""",
+        encoding="utf-8",
+    )
+
+    project.run("lint")
+    output = project.render("smoke.mp4", fps=24, quality="draft")
+
+    assert output == project.path / "smoke.mp4"
+    assert output.stat().st_size > 0

--- a/sdk/python/tests/test_project.py
+++ b/sdk/python/tests/test_project.py
@@ -1,0 +1,201 @@
+"""Unit tests for Project — argv construction and artifact handling."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hyperframes import HyperframesError, Project
+
+COMPOSITION = '<main data-composition-id="main" data-width="1920" data-height="1080"></main>'
+
+
+@pytest.fixture
+def project(tmp_path) -> Project:
+    (tmp_path / "demo").mkdir()
+    (tmp_path / "demo" / "index.html").write_text(COMPOSITION)
+    return Project(tmp_path / "demo")
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    """Record CLI calls; optionally create the file the CLI was asked for."""
+    calls: list[dict] = []
+
+    def _fake(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        if "--output" in argv:
+            target = Path(argv[argv.index("--output") + 1])
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"\x00")
+        return subprocess.CompletedProcess(argv, 0, stdout=_fake.stdout, stderr="")
+
+    _fake.stdout = ""
+    monkeypatch.setattr("hyperframes._cli.subprocess.run", _fake)
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    return calls
+
+
+def flag(argv: list[str], name: str) -> str:
+    return argv[argv.index(name) + 1]
+
+
+# -- render ----------------------------------------------------------------
+
+
+def test_render_defaults_to_renders_dir(project, spy):
+    result = project.render()
+    assert result == project.path / "renders" / "demo.mp4"
+    argv = spy[0]["argv"]
+    assert argv[1:3] == ["render", str(project.path)]
+    assert flag(argv, "--output") == str(result)
+    assert flag(argv, "--format") == "mp4"
+    assert "--quiet" in argv
+
+
+def test_relative_output_resolves_against_project_not_cwd(project, spy):
+    # The CLI resolves --output against process.cwd(); the SDK pins it to the
+    # project directory so the returned path is what the caller expects.
+    result = project.render("out/final.mp4")
+    assert result == project.path / "out" / "final.mp4"
+    assert flag(spy[0]["argv"], "--output") == str(result)
+    assert spy[0]["cwd"] == str(project.path)
+
+
+def test_absolute_output_is_respected(project, spy, tmp_path):
+    target = tmp_path / "elsewhere" / "clip.mp4"
+    assert project.render(target) == target
+
+
+def test_format_picks_the_extension(project, spy):
+    assert project.render(format="webm").name == "demo.webm"
+    assert project.render(format="gif").name == "demo.gif"
+    assert project.render(format="png-sequence").name == "demo"
+
+
+def test_opts_become_flags(project, spy):
+    project.render(
+        fps=60,
+        quality="high",
+        resolution="portrait",
+        variables={"title": "Hello"},
+        composition="scenes/intro.html",
+        page_side_compositing=False,
+    )
+    argv = spy[0]["argv"]
+    assert flag(argv, "--fps") == "60"
+    assert flag(argv, "--quality") == "high"
+    assert flag(argv, "--resolution") == "portrait"
+    assert flag(argv, "--variables") == '{"title":"Hello"}'
+    assert flag(argv, "--composition") == "scenes/intro.html"
+    assert "--no-page-side-compositing" in argv
+
+
+def test_quiet_can_be_turned_off(project, spy):
+    project.render(quiet=False)
+    assert "--no-quiet" in spy[0]["argv"]
+
+
+def test_render_without_composition_raises(tmp_path, spy):
+    with pytest.raises(HyperframesError, match="No composition at"):
+        Project(tmp_path / "empty").render()
+    assert spy == []
+
+
+def test_render_that_produces_nothing_raises(project, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr(
+        "hyperframes._cli.subprocess.run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 0, "", ""),
+    )
+    with pytest.raises(HyperframesError, match="produced nothing"):
+        project.render()
+
+
+def test_render_failure_surfaces_stderr(project, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr(
+        "hyperframes._cli.subprocess.run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 1, "", "Invalid quality"),
+    )
+    with pytest.raises(HyperframesError) as excinfo:
+        project.render(quality="maximum")
+    assert excinfo.value.stderr == "Invalid quality"
+
+
+# -- init ------------------------------------------------------------------
+
+
+def test_init_runs_from_parent_with_a_bare_name(spy, tmp_path):
+    # `hyperframes init` resolves the project name against process.cwd().
+    created = Project.init(tmp_path / "nested" / "promo")
+    argv = spy[0]["argv"]
+    assert argv[1:3] == ["init", "promo"]
+    assert flag(argv, "--example") == "blank"
+    assert "--non-interactive" in argv
+    assert spy[0]["cwd"] == str(tmp_path / "nested")
+    assert created.path == tmp_path / "nested" / "promo"
+
+
+def test_init_passes_through_extra_flags(spy, tmp_path):
+    Project.init(tmp_path / "vertical", example="warm-grain", resolution="portrait")
+    argv = spy[0]["argv"]
+    assert flag(argv, "--example") == "warm-grain"
+    assert flag(argv, "--resolution") == "portrait"
+
+
+# -- preview ---------------------------------------------------------------
+
+
+def test_blocking_preview_streams_and_returns_none(project, spy):
+    assert project.preview() is None
+    argv = spy[0]["argv"]
+    assert argv[1:3] == ["preview", str(project.path)]
+    assert flag(argv, "--port") == "3002"
+    assert "--no-open" in argv
+    assert "--background" not in argv
+    assert spy[0]["capture_output"] is False
+
+
+def test_background_preview_returns_the_reported_url(project, spy, monkeypatch):
+    # The CLI may bind a different port than requested when 3002 is busy.
+    monkeypatch.setattr(
+        "hyperframes._cli.subprocess.run",
+        lambda argv, **kw: spy.append({"argv": argv, **kw})
+        or subprocess.CompletedProcess(argv, 0, "Studio  http://localhost:3007\n", ""),
+    )
+    assert project.preview(port=3002, background=True) == "http://localhost:3007"
+    assert "--background" in spy[0]["argv"]
+
+
+def test_background_preview_falls_back_to_requested_port(project, spy):
+    assert project.preview(port=4000, background=True) == "http://localhost:4000"
+
+
+def test_stop_preview(project, spy):
+    project.stop_preview(port=4000)
+    assert spy[0]["argv"][1:] == ["preview", str(project.path), "--port", "4000", "--stop"]
+
+
+# -- escape hatch ----------------------------------------------------------
+
+
+def test_run_passes_arbitrary_subcommands(project, spy):
+    project.run("lint", "--json")
+    assert spy[0]["argv"][1:] == ["lint", "--json"]
+    assert spy[0]["cwd"] == str(project.path)
+
+
+def test_run_can_tolerate_failure(project, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("HYPERFRAMES_CLI", raising=False)
+    monkeypatch.setattr(
+        "hyperframes._cli.subprocess.run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 1, "", "2 errors"),
+    )
+    assert project.run("lint", check=False).returncode == 1


### PR DESCRIPTION
Companion package under sdk/python/ that lets Python code drive the existing Node CLI. Thin subprocess wrapper — no rendering is reimplemented, and no existing package is touched.

  Project(path) / Project.init(...)  -> scaffold or wrap a project
  .render(output=None, **opts)       -> Path to the artifact
  .preview(background=...)           -> studio server, blocking or not
  .run(*args)                        -> escape hatch to any subcommand
  HyperframesError                   -> carries argv, exit code, stderr

Render kwargs map generically onto CLI flags (fps=60 -> --fps 60, page_side_compositing=False -> --no-page-side-compositing), so every current and future render flag is reachable without an SDK release.

Works around four CLI behaviours:
  - --output and the default renders/ dir resolve against process.cwd(), not the project dir, so the SDK always sends an absolute path
  - the default filename is timestamped and unpredictable, so --output is always passed explicitly — that is what lets render() return a Path
  - init only prompts on a TTY and otherwise requires one of --example/--video/--audio, so init forces --example blank
  - --json on render is batch-only, so success is verified by exit code plus an artifact-exists check

Telemetry and the GitHub skills check are disabled on every invocation (HYPERFRAMES_NO_TELEMETRY, DO_NOT_TRACK, HYPERFRAMES_SKIP_SKILLS).

Tests: 37 unit tests run fully mocked with no Node or CLI present; one integration test does a real scaffold-lint-render and self-skips without Node >= 22 plus the CLI.

## What

Brief description of the change.

## Why

Why is this change needed?

## How

How was this implemented? Any notable design decisions?

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
