### PR TITLE
fix(engine): carry frameStride onto WorkerResult

### DIFF
--- a/packages/engine/src/services/parallelCoordinator.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.test.ts
@@ -3,12 +3,14 @@ import {
   calculateOptimalWorkers,
   distributeFrames,
   expectedFramesForTask,
+  flagSilentWorkerExits,
   formatWorkerFailure,
   selectWorkerDiagnostics,
   shouldDisableBrowserPoolForParallelWorker,
   shouldVerifyWorkerGpu,
   synthesizeSilentWorkerExitError,
   resolveParallelDeVerifySamples,
+  type WorkerResult,
 } from "./parallelCoordinator.js";
 import type { EngineConfig } from "../config.js";
 
@@ -247,6 +249,58 @@ describe("synthesizeSilentWorkerExitError", () => {
     expect(message).toContain("range=[60, 120)");
     expect(message).toContain("Field signal ts=1784042064");
     expect(message).toContain("--workers=1");
+  });
+});
+
+describe("flagSilentWorkerExits", () => {
+  it("does not flag a fully-successful interleaved worker (regression: PRINFRA-300)", () => {
+    // 3-way interleave over 150 frames: worker 0 captures 0, 3, ..., 147 → 50
+    // frames, which is its FULL expected count at stride=3. Without
+    // `frameStride` on the result, expectedFramesForTask would fall back to
+    // stride=1 (150) and false-positive this as a silent death.
+    const results: WorkerResult[] = [
+      {
+        workerId: 0,
+        framesCaptured: 50,
+        startFrame: 0,
+        endFrame: 150,
+        frameStride: 3,
+        durationMs: 1000,
+      },
+    ];
+    flagSilentWorkerExits(results);
+    expect(results[0]?.error).toBeUndefined();
+  });
+
+  it("still flags a genuinely under-captured interleaved worker", () => {
+    const results: WorkerResult[] = [
+      {
+        workerId: 1,
+        framesCaptured: 20, // expected 50 at stride=3
+        startFrame: 1,
+        endFrame: 150,
+        frameStride: 3,
+        durationMs: 1000,
+      },
+    ];
+    flagSilentWorkerExits(results);
+    expect(results[0]?.error).toContain("worker 1 exited without terminal error string");
+    expect(results[0]?.error).toContain("expected=50");
+  });
+
+  it("does not overwrite an existing error", () => {
+    const results: WorkerResult[] = [
+      {
+        workerId: 2,
+        framesCaptured: 0,
+        startFrame: 0,
+        endFrame: 10,
+        durationMs: 1000,
+        error: "Protocol error (Page.captureScreenshot): Target closed",
+      },
+    ];
+    flagSilentWorkerExits(results);
+    expect(results[0]?.error).toBe("Protocol error (Page.captureScreenshot): Target closed");
   });
 });
 

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -63,6 +63,14 @@ export interface WorkerResult {
   framesCaptured: number;
   startFrame: number;
   endFrame: number;
+  /**
+   * Mirrors the originating `WorkerTask.frameStride` (default 1). Required by
+   * `expectedFramesForTask` — without it, every interleaved (stride > 1)
+   * worker's expected count is computed as the full contiguous range instead
+   * of range/stride, so a fully-successful worker looks like it under-captured
+   * and gets misclassified as a silent death (see `synthesizeSilentWorkerExitError`).
+   */
+  frameStride?: number;
   durationMs: number;
   perf?: CapturePerfSummary;
   error?: string;
@@ -189,6 +197,24 @@ export function synthesizeSilentWorkerExitError(
     `Field signal ts=1784042064 — this class of failure has been reported; ` +
     `consider re-run with --workers=1 to isolate.`
   );
+}
+
+/**
+ * A worker may return without an error string yet with `framesCaptured`
+ * below its task's expected count — the silent-exit shape field signal
+ * ts=1784042064 called out. Synthesize a terminal error string in-place so
+ * the caller's failure filter treats it as a failure (and so the caller's
+ * failure message actually names what went wrong). Requires each result to
+ * carry `frameStride` (see `WorkerResult`) — without it, an interleaved
+ * worker's true `framesCaptured` (range/stride) is compared against the full
+ * contiguous range and every successful interleaved worker false-positives.
+ */
+export function flagSilentWorkerExits(results: WorkerResult[]): void {
+  for (const r of results) {
+    if (!r.error && r.framesCaptured < expectedFramesForTask(r)) {
+      r.error = synthesizeSilentWorkerExitError(r, expectedFramesForTask(r));
+    }
+  }
 }
 
 export function formatWorkerFailure(result: WorkerResult): string {
@@ -487,6 +513,7 @@ async function executeWorkerTask(
       framesCaptured,
       startFrame: task.startFrame,
       endFrame: task.endFrame,
+      frameStride: task.frameStride,
       durationMs: Date.now() - startTime,
       perf,
     };
@@ -509,6 +536,7 @@ async function executeWorkerTask(
       framesCaptured,
       startFrame: task.startFrame,
       endFrame: task.endFrame,
+      frameStride: task.frameStride,
       durationMs: Date.now() - startTime,
       perf,
       error: failure.message,
@@ -613,16 +641,7 @@ export async function executeParallelCapture(
     ),
   );
 
-  // A worker may return without an error string yet with framesCaptured
-  // below the task's expected count — that's the silent-exit shape field
-  // signal ts=1784042064 called out. Synthesize a terminal error string
-  // in-place so the filter below treats it as a failure (and so the
-  // caller's failure message actually names what went wrong).
-  for (const r of results) {
-    if (!r.error && r.framesCaptured < expectedFramesForTask(r)) {
-      r.error = synthesizeSilentWorkerExitError(r, expectedFramesForTask(r));
-    }
-  }
+  flagSilentWorkerExits(results);
 
   const errors = results.filter((r) => r.failure || r.error);
   if (errors.length > 0) {


### PR DESCRIPTION
## Summary

`expectedFramesForTask` correctly divides by `frameStride` for interleaved parallel workers, but `WorkerResult` never carried `frameStride` in the first place — both return paths in `executeWorkerTask` (success and catch) omitted it. So the silent-worker-exit guard added in `971bcf39a` (v0.7.60) always computed the expected frame count as the full contiguous range instead of `range/stride`.

Net effect: **every fully-successful interleaved worker gets misclassified as a silent death**, and the whole parallel capture throws after 100% of frames were captured correctly.

## Impact (confirmed via fleet telemetry, not just local repro)

`de_parallel_router` revert rate by CLI version — the cliff lands exactly on the release that shipped the guard:

| version | routed | reverted | revert rate |
|---|---|---|---|
| 0.7.55–0.7.59 | 3582 | 88 | ~2.4% |
| 0.7.60–0.7.64 | 669 | 845 | **~56%** |

Also 100% reproducible locally with `HF_CAPTURE_PARALLEL_STREAM=true` / `HF_DE_PARALLEL_STREAM=true` (any interleaved multi-worker render) — logged `framesCompleted: 150/150` immediately before the synthetic "worker exited without terminal error string" failure.

Related: PRINFRA-300 (this fixes part of that ticket's failure cluster — the "silent worker exit, no terminal error string" reports — but not the ticket's primary blank-hook-frame symptom, which is a separate, still-open issue on the non-interleaved disk path).

## Fix

- `WorkerResult` gains an optional `frameStride` field mirroring the originating `WorkerTask`.
- Both `executeWorkerTask` return paths (success, catch) now populate it.
- Extracted the inline guard loop into an exported `flagSilentWorkerExits(results)` so it's unit-testable without a real browser session.

## Test plan

- [x] New unit tests in `parallelCoordinator.test.ts`: a fully-successful interleaved worker is no longer flagged; a genuinely under-captured interleaved worker is still flagged; an existing error is never overwritten.
- [x] `bun test parallelCoordinator.test.ts` — 37/37 pass
- [x] `tsc --noEmit` clean
- [x] `oxlint` + `oxfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)