### PR TITLE
perf(studio): define timeline viewport budgets and fixtures

### DIFF
--- a/packages/studio/src/hooks/useStudioTestHooks.test.tsx
+++ b/packages/studio/src/hooks/useStudioTestHooks.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePlayerStore } from "../player/store/playerStore";
+import {
+  createTimelinePerformanceFixture,
+  type TimelinePerformanceFixtureProfile,
+} from "../player/lib/timelinePerformanceFixture";
+import { useStudioTestHooks } from "./useStudioTestHooks";
+
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+
+const PROFILES: readonly TimelinePerformanceFixtureProfile[] = [
+  "dense-short",
+  "long-overlap",
+  "keyframe-heavy-expanded",
+  "composition-heavy",
+  "remote-unsupported",
+];
+
+function Probe(): null {
+  useStudioTestHooks({
+    previewIframeRef: { current: null },
+    buildDomSelectionFromTarget: vi.fn(),
+    applyDomSelection: vi.fn(),
+  });
+  return null;
+}
+
+describe("timeline performance fixture", () => {
+  afterEach(() => {
+    window.__studioTest = undefined;
+    usePlayerStore.getState().reset();
+  });
+
+  it("generates the expected dense-short 50k distribution", () => {
+    const first = createTimelinePerformanceFixture({
+      elementCount: 50_000,
+      profile: "dense-short",
+    });
+
+    expect(first.summary).toEqual({
+      elementCount: 50_000,
+      profile: "dense-short",
+      duration: 120,
+      trackCount: 1_000,
+      keyframedElementCount: 0,
+      expandedElementCount: 0,
+    });
+    expect(new Set(first.elements.map((element) => element.track)).size).toBe(1_000);
+    const perTrack = new Map<number, number>();
+    for (const element of first.elements) {
+      perTrack.set(element.track, (perTrack.get(element.track) ?? 0) + 1);
+    }
+    expect(Math.max(...perTrack.values())).toBeLessThanOrEqual(128);
+  });
+
+  it.each(PROFILES)("generates an identical 50k %s fixture", (profile) => {
+    const first = createTimelinePerformanceFixture({ elementCount: 50_000, profile });
+    const second = createTimelinePerformanceFixture({ elementCount: 50_000, profile });
+    expect(second).toEqual(first);
+  });
+
+  it.each(PROFILES)("builds the %s 1k scale profile", (profile) => {
+    const fixture = createTimelinePerformanceFixture({ elementCount: 1_000, profile });
+    expect(fixture.elements).toHaveLength(1_000);
+    expect(fixture.summary.elementCount).toBe(1_000);
+    expect(fixture.summary.duration).toBeGreaterThan(0);
+    expect(new Set(fixture.elements.map((element) => element.key)).size).toBe(1_000);
+    if (profile === "keyframe-heavy-expanded") {
+      expect(fixture.keyframeCache.size).toBe(1_000);
+      expect(fixture.gsapAnimations.size).toBe(1_000);
+      expect(fixture.expandedClipIds.size).toBe(1_000);
+    }
+  });
+
+  it("publishes one dev-only loader that replaces fixture state atomically", () => {
+    const host = document.createElement("div");
+    const root = createRoot(host);
+    act(() => root.render(<Probe />));
+    const api = window.__studioTest;
+    expect(api).toBeDefined();
+    if (!api) throw new Error("Expected dev Studio test API");
+    let notifications = 0;
+    usePlayerStore.setState({
+      isPlaying: true,
+      requestedSeekTime: 42,
+      clipRevealRequest: { elementId: "stale", nonce: 7 },
+      clipManifest: [],
+      lintFindingsByElement: new Map([["stale", { count: 1, messages: ["stale"] }]]),
+    });
+    const unsubscribe = usePlayerStore.subscribe(() => {
+      notifications += 1;
+    });
+
+    const summary = api.loadTimelinePerformanceFixture({
+      elementCount: 1_000,
+      profile: "keyframe-heavy-expanded",
+    });
+
+    expect(summary.elementCount).toBe(1_000);
+    expect(notifications).toBe(1);
+    expect(usePlayerStore.getState()).toMatchObject({
+      isPlaying: false,
+      requestedSeekTime: null,
+      clipRevealRequest: null,
+      clipManifest: null,
+      duration: 600,
+      timelineReady: true,
+    });
+    expect(usePlayerStore.getState().lintFindingsByElement.size).toBe(0);
+    expect(usePlayerStore.getState().elements).toHaveLength(1_000);
+    expect(usePlayerStore.getState().expandedClipIds.size).toBe(1_000);
+    unsubscribe();
+    act(() => root.unmount());
+    expect(window.__studioTest).toBeUndefined();
+  });
+
+  it("does not mutate state when the fixture request is invalid", () => {
+    const host = document.createElement("div");
+    const root = createRoot(host);
+    act(() => root.render(<Probe />));
+    const api = window.__studioTest;
+    if (!api) throw new Error("Expected dev Studio test API");
+    const before = usePlayerStore.getState().elements;
+
+    expect(() =>
+      Reflect.apply(api.loadTimelinePerformanceFixture, api, [
+        { elementCount: 999, profile: "dense-short" },
+      ]),
+    ).toThrow("elementCount must be 1000 or 50000");
+    expect(usePlayerStore.getState().elements).toBe(before);
+    expect(() =>
+      Reflect.apply(api.loadTimelinePerformanceFixture, api, [
+        { elementCount: 1_000, profile: "constructor" },
+      ]),
+    ).toThrow("Unknown timeline performance fixture profile");
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/hooks/useStudioTestHooks.ts
+++ b/packages/studio/src/hooks/useStudioTestHooks.ts
@@ -1,5 +1,16 @@
 import { useEffect } from "react";
 import type { DomEditSelection } from "../components/editor/domEditing";
+import { createTimelineResetState, usePlayerStore } from "../player/store/playerStore";
+import {
+  readTimelinePerformanceDiagnostics,
+  type TimelinePerformanceDiagnostics,
+} from "../player/lib/timelinePerformanceDiagnostics";
+import {
+  createTimelinePerformanceFixture,
+  type TimelinePerformanceFixtureSpec,
+  type TimelinePerformanceFixtureSummary,
+} from "../player/lib/timelinePerformanceFixture";
+import { TIMELINE_VIEWPORT_BUDGETS } from "../player/lib/timelineViewportBudgets";
 
 interface StudioTestHookDeps {
   previewIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
@@ -12,6 +23,11 @@ interface StudioTestHookDeps {
 
 interface StudioTestApi {
   selectByDomId: (id: string) => Promise<boolean>;
+  loadTimelinePerformanceFixture: (
+    spec: TimelinePerformanceFixtureSpec,
+  ) => TimelinePerformanceFixtureSummary;
+  readTimelinePerformanceDiagnostics: () => Readonly<TimelinePerformanceDiagnostics>;
+  timelineViewportBudgets: typeof TIMELINE_VIEWPORT_BUDGETS;
 }
 
 declare global {
@@ -52,6 +68,28 @@ export function useStudioTestHooks({
         applyDomSelection(selection, { revealPanel: true });
         return true;
       },
+      loadTimelinePerformanceFixture: (spec) => {
+        const fixture = createTimelinePerformanceFixture(spec);
+        usePlayerStore.setState({
+          ...createTimelineResetState(),
+          currentTime: 0,
+          duration: fixture.summary.duration,
+          timelineReady: true,
+          loopEnabled: false,
+          zoomMode: "manual",
+          manualZoomPercent: 2_000,
+          elements: fixture.elements,
+          selectedElementId: null,
+          selectedElementIds: new Set(),
+          selectedKeyframes: new Set(),
+          keyframeCache: fixture.keyframeCache,
+          gsapAnimations: fixture.gsapAnimations,
+          expandedClipIds: fixture.expandedClipIds,
+        });
+        return fixture.summary;
+      },
+      readTimelinePerformanceDiagnostics: () => readTimelinePerformanceDiagnostics(),
+      timelineViewportBudgets: TIMELINE_VIEWPORT_BUDGETS,
     };
     window.__studioTest = api;
     return () => {

--- a/packages/studio/src/player/components/TimelineLanes.test.tsx
+++ b/packages/studio/src/player/components/TimelineLanes.test.tsx
@@ -144,6 +144,7 @@ describe("TimelineLanes track numbering", () => {
     });
 
     expect(visibilityLabels(view.host)).toEqual(["Hide track 1", "Hide track 2"]);
+    expect(view.host.querySelectorAll("[data-timeline-row]")).toHaveLength(2);
     expect(view.host.innerHTML).not.toContain("0.16666666666666666");
     act(() => view.root.unmount());
   });

--- a/packages/studio/src/player/components/TimelineLanes.tsx
+++ b/packages/studio/src/player/components/TimelineLanes.tsx
@@ -150,6 +150,7 @@ export function TimelineLanes({
           return (
             <div
               key={trackNum}
+              data-timeline-row
               className="relative flex"
               style={{
                 height: rowHeight,

--- a/packages/studio/src/player/lib/timelinePerformanceDiagnostics.test.ts
+++ b/packages/studio/src/player/lib/timelinePerformanceDiagnostics.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getTimelineResourceBudgetStatus,
+  readTimelinePerformanceDiagnostics,
+  resolveTimelineScrollStrategy,
+} from "./timelinePerformanceDiagnostics";
+import { resolveTimelineViewportBudgets } from "./timelineViewportBudgets";
+
+describe("timeline performance diagnostics", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("reads mounted resources without mutating the timeline", () => {
+    document.body.innerHTML = `
+      <div aria-label="Timeline" data-timeline-scheduler-queued="3"
+           data-timeline-scheduler-active="2" data-timeline-cache-bytes="4096">
+        <div data-timeline-row><div data-clip="true"></div><div data-clip="true"></div></div>
+        <div data-timeline-row><div data-clip="true"></div></div>
+        <div data-clip="true"></div>
+        <div data-timeline-grid-cell></div><div data-timeline-grid-cell></div>
+        <div data-timeline-poster-state="ready"></div>
+        <div data-timeline-poster-state="error"></div>
+        <div data-timeline-poster-state="constructor"></div>
+      </div>`;
+    const before = document.body.innerHTML;
+
+    expect(readTimelinePerformanceDiagnostics()).toMatchObject({
+      timelineRoots: 1,
+      mountedRows: 2,
+      mountedClipRoots: 4,
+      maxMountedClipRootsInOneRow: 2,
+      mountedTimeGridCells: 2,
+      schedulerQueued: 3,
+      schedulerActive: 2,
+      cacheBytes: 4096,
+      posterStates: { idle: 0, loading: 0, ready: 1, fallback: 0, error: 1 },
+    });
+    expect(document.body.innerHTML).toBe(before);
+  });
+
+  it("returns the zero baseline after unmount or reset removes the DOM", () => {
+    document.body.innerHTML = '<div aria-label="Timeline"><div data-clip="true"></div></div>';
+    expect(readTimelinePerformanceDiagnostics().mountedClipRoots).toBe(1);
+
+    document.body.replaceChildren();
+
+    expect(readTimelinePerformanceDiagnostics()).toEqual({
+      timelineRoots: 0,
+      mountedRows: 0,
+      mountedClipRoots: 0,
+      maxMountedClipRootsInOneRow: 0,
+      mountedTimeGridCells: 0,
+      mountedTimelineDescendants: 0,
+      schedulerQueued: 0,
+      schedulerActive: 0,
+      cacheBytes: 0,
+      posterStates: { idle: 0, loading: 0, ready: 0, fallback: 0, error: 0 },
+    });
+  });
+
+  it("treats every DOM ceiling as inclusive", () => {
+    const budgets = resolveTimelineViewportBudgets({
+      maxMountedClipRoots: 2,
+      maxMountedClipRootsPerRow: 1,
+      maxMountedRows: 2,
+      maxMountedTimelineDescendants: 4,
+    });
+    expect(
+      getTimelineResourceBudgetStatus(
+        {
+          ...readTimelinePerformanceDiagnostics(),
+          mountedClipRoots: 2,
+          maxMountedClipRootsInOneRow: 2,
+          mountedTimelineDescendants: 4,
+        },
+        budgets,
+      ),
+    ).toEqual({
+      timelineRoot: false,
+      rows: true,
+      clipRoots: true,
+      clipRootsPerRow: false,
+      descendants: true,
+    });
+  });
+
+  it("fails the resource status when the timeline is absent", () => {
+    expect(getTimelineResourceBudgetStatus(readTimelinePerformanceDiagnostics())).toMatchObject({
+      timelineRoot: false,
+    });
+  });
+
+  it("selects direct scrolling only through the configured safety envelope", () => {
+    expect(resolveTimelineScrollStrategy(8_000_000)).toBe("direct");
+    expect(resolveTimelineScrollStrategy(8_000_001)).toBe("segmented");
+    expect(() => resolveTimelineScrollStrategy(Number.NaN)).toThrow("content width");
+  });
+});

--- a/packages/studio/src/player/lib/timelinePerformanceDiagnostics.ts
+++ b/packages/studio/src/player/lib/timelinePerformanceDiagnostics.ts
@@ -1,0 +1,120 @@
+import { TIMELINE_VIEWPORT_BUDGETS, type TimelineViewportBudgets } from "./timelineViewportBudgets";
+
+export type TimelinePosterState = "idle" | "loading" | "ready" | "fallback" | "error";
+
+export interface TimelinePerformanceDiagnostics {
+  timelineRoots: number;
+  mountedRows: number;
+  mountedClipRoots: number;
+  maxMountedClipRootsInOneRow: number;
+  mountedTimeGridCells: number;
+  mountedTimelineDescendants: number;
+  schedulerQueued: number;
+  schedulerActive: number;
+  cacheBytes: number;
+  posterStates: Readonly<Record<TimelinePosterState, number>>;
+}
+
+export interface TimelineResourceBudgetStatus {
+  timelineRoot: boolean;
+  rows: boolean;
+  clipRoots: boolean;
+  clipRootsPerRow: boolean;
+  descendants: boolean;
+}
+
+function readNonNegativeNumber(value: string | undefined): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : 0;
+}
+
+function countPosters(root: ParentNode): Readonly<Record<TimelinePosterState, number>> {
+  const counts: Record<TimelinePosterState, number> = {
+    idle: 0,
+    loading: 0,
+    ready: 0,
+    fallback: 0,
+    error: 0,
+  };
+  for (const node of root.querySelectorAll<HTMLElement>("[data-timeline-poster-state]")) {
+    const state = node.dataset.timelinePosterState;
+    if (state && Object.hasOwn(counts, state)) counts[state as TimelinePosterState] += 1;
+  }
+  return Object.freeze(counts);
+}
+
+function maxClipsInOneRow(root: ParentNode): number {
+  const byRow = new Map<Element, number>();
+  for (const clip of root.querySelectorAll<HTMLElement>('[data-clip="true"]')) {
+    const row = clip.closest("[data-timeline-row]");
+    if (!row) continue;
+    byRow.set(row, (byRow.get(row) ?? 0) + 1);
+  }
+  return Math.max(0, ...byRow.values());
+}
+
+function sumDataAttribute(root: ParentNode, selector: string, dataKey: string): number {
+  let total = 0;
+  for (const node of root.querySelectorAll<HTMLElement>(selector)) {
+    total += readNonNegativeNumber(node.dataset[dataKey]);
+  }
+  return total;
+}
+
+/**
+ * Read current timeline costs directly from the mounted DOM. No counters are
+ * retained, so an unmount or project reset is reflected as a zero baseline on
+ * the next read rather than depending on cleanup ordering.
+ */
+export function readTimelinePerformanceDiagnostics(
+  root: ParentNode = document,
+): Readonly<TimelinePerformanceDiagnostics> {
+  const timelineRoots = root.querySelectorAll<HTMLElement>('[aria-label="Timeline"]');
+  let mountedTimelineDescendants = 0;
+  for (const timelineRoot of timelineRoots) {
+    mountedTimelineDescendants += timelineRoot.querySelectorAll("*").length;
+  }
+  return Object.freeze({
+    timelineRoots: timelineRoots.length,
+    mountedRows: root.querySelectorAll("[data-timeline-row]").length,
+    mountedClipRoots: root.querySelectorAll('[data-clip="true"]').length,
+    maxMountedClipRootsInOneRow: maxClipsInOneRow(root),
+    mountedTimeGridCells: root.querySelectorAll("[data-timeline-grid-cell]").length,
+    mountedTimelineDescendants,
+    schedulerQueued: sumDataAttribute(
+      root,
+      "[data-timeline-scheduler-queued]",
+      "timelineSchedulerQueued",
+    ),
+    schedulerActive: sumDataAttribute(
+      root,
+      "[data-timeline-scheduler-active]",
+      "timelineSchedulerActive",
+    ),
+    cacheBytes: sumDataAttribute(root, "[data-timeline-cache-bytes]", "timelineCacheBytes"),
+    posterStates: countPosters(root),
+  });
+}
+
+export function getTimelineResourceBudgetStatus(
+  diagnostics: TimelinePerformanceDiagnostics,
+  budgets: Readonly<TimelineViewportBudgets> = TIMELINE_VIEWPORT_BUDGETS,
+): Readonly<TimelineResourceBudgetStatus> {
+  return Object.freeze({
+    timelineRoot: diagnostics.timelineRoots === 1,
+    rows: diagnostics.mountedRows <= budgets.maxMountedRows,
+    clipRoots: diagnostics.mountedClipRoots <= budgets.maxMountedClipRoots,
+    clipRootsPerRow: diagnostics.maxMountedClipRootsInOneRow <= budgets.maxMountedClipRootsPerRow,
+    descendants: diagnostics.mountedTimelineDescendants <= budgets.maxMountedTimelineDescendants,
+  });
+}
+
+export function resolveTimelineScrollStrategy(
+  contentWidthPx: number,
+  budgets: Readonly<TimelineViewportBudgets> = TIMELINE_VIEWPORT_BUDGETS,
+): "direct" | "segmented" {
+  if (!Number.isFinite(contentWidthPx) || contentWidthPx < 0) {
+    throw new RangeError("Timeline content width must be a finite non-negative number");
+  }
+  return contentWidthPx <= budgets.directScrollSafetyPx ? "direct" : "segmented";
+}

--- a/packages/studio/src/player/lib/timelinePerformanceFixture.ts
+++ b/packages/studio/src/player/lib/timelinePerformanceFixture.ts
@@ -1,0 +1,157 @@
+import type { GsapAnimation } from "@hyperframes/core/gsap-parser";
+import type { KeyframeCacheEntry, TimelineElement } from "../store/playerStore";
+
+export type TimelinePerformanceFixtureProfile =
+  | "dense-short"
+  | "long-overlap"
+  | "keyframe-heavy-expanded"
+  | "composition-heavy"
+  | "remote-unsupported";
+
+export interface TimelinePerformanceFixtureSpec {
+  elementCount: 1_000 | 50_000;
+  profile: TimelinePerformanceFixtureProfile;
+}
+
+export interface TimelinePerformanceFixtureSummary extends TimelinePerformanceFixtureSpec {
+  duration: number;
+  trackCount: number;
+  keyframedElementCount: number;
+  expandedElementCount: number;
+}
+
+export interface TimelinePerformanceFixture {
+  summary: Readonly<TimelinePerformanceFixtureSummary>;
+  elements: TimelineElement[];
+  keyframeCache: Map<string, KeyframeCacheEntry>;
+  gsapAnimations: Map<string, GsapAnimation[]>;
+  expandedClipIds: Set<string>;
+}
+
+const TRACK_COUNT = 1_000;
+const PROFILE_GEOMETRY: Readonly<
+  Record<TimelinePerformanceFixtureProfile, { duration: number; clipDuration: number }>
+> = Object.freeze({
+  "dense-short": { duration: 120, clipDuration: 1.5 },
+  "long-overlap": { duration: 7_200, clipDuration: 120 },
+  "keyframe-heavy-expanded": { duration: 600, clipDuration: 8 },
+  "composition-heavy": { duration: 900, clipDuration: 12 },
+  "remote-unsupported": { duration: 900, clipDuration: 12 },
+});
+
+function validateFixtureSpec(spec: TimelinePerformanceFixtureSpec) {
+  if (spec.elementCount !== 1_000 && spec.elementCount !== 50_000) {
+    throw new RangeError("Timeline performance fixture elementCount must be 1000 or 50000");
+  }
+  if (!Object.hasOwn(PROFILE_GEOMETRY, spec.profile)) {
+    throw new RangeError(`Unknown timeline performance fixture profile: ${spec.profile}`);
+  }
+  const geometry = PROFILE_GEOMETRY[spec.profile];
+  return geometry;
+}
+
+function fixtureTrack(index: number, spec: TimelinePerformanceFixtureSpec): number {
+  if (index < TRACK_COUNT) return index;
+  if (spec.profile !== "dense-short") return index % TRACK_COUNT;
+  // Keep the dense profile inside the declared 128-roots-per-row envelope while
+  // still representing every one of the 1,000 logical tracks.
+  const denseTrackCount = Math.ceil((spec.elementCount - TRACK_COUNT) / 127);
+  return (index - TRACK_COUNT) % Math.max(1, denseTrackCount);
+}
+
+function fixtureStart(
+  index: number,
+  profile: TimelinePerformanceFixtureProfile,
+  duration: number,
+  clipDuration: number,
+): number {
+  const available = Math.max(0, duration - clipDuration);
+  if (profile === "dense-short") return (index % 128) * 0.5;
+  if (profile === "long-overlap") return (index * 37) % Math.max(1, available);
+  return (index * 17) % Math.max(1, available);
+}
+
+function keyframeData(): KeyframeCacheEntry {
+  return {
+    format: "percentage",
+    keyframes: [0, 33, 66, 100].map((percentage) => ({
+      percentage,
+      propertyGroup: "position",
+      properties: { x: percentage },
+      ease: "power2.inOut",
+    })),
+  };
+}
+
+function fixtureAnimation(id: string, start: number, duration: number): GsapAnimation {
+  return {
+    id: `animation-${id}`,
+    targetSelector: `#${id}`,
+    method: "to",
+    position: start,
+    resolvedStart: start,
+    duration,
+    propertyGroup: "position",
+    fromProperties: { x: 0 },
+    properties: { x: 100 },
+    ease: "power2.inOut",
+  };
+}
+
+/** Pure deterministic generator; the dev test hook performs the one store mutation. */
+export function createTimelinePerformanceFixture(
+  spec: TimelinePerformanceFixtureSpec,
+): TimelinePerformanceFixture {
+  const geometry = validateFixtureSpec(spec);
+  const elements: TimelineElement[] = [];
+  const keyframeCache = new Map<string, KeyframeCacheEntry>();
+  const gsapAnimations = new Map<string, GsapAnimation[]>();
+  const expandedClipIds = new Set<string>();
+
+  for (let index = 0; index < spec.elementCount; index += 1) {
+    const id = `perf-${spec.profile}-${spec.elementCount}-${index}`;
+    const start = fixtureStart(index, spec.profile, geometry.duration, geometry.clipDuration);
+    const track = fixtureTrack(index, spec);
+    const element: TimelineElement = {
+      id,
+      key: id,
+      domId: id,
+      selector: `#${id}`,
+      label: `Fixture ${index + 1}`,
+      tag: spec.profile === "remote-unsupported" && index % 2 === 0 ? "video" : "div",
+      start,
+      duration: geometry.clipDuration,
+      track,
+      authoredTrack: track,
+    };
+
+    if (spec.profile === "composition-heavy") {
+      element.compositionSrc = `compositions/perf-${index % 32}.html`;
+    } else if (spec.profile === "remote-unsupported") {
+      element.src =
+        index % 2 === 0
+          ? `https://media.invalid/perf-${index % 32}.mp4`
+          : `assets/perf-${index % 32}.unsupported`;
+    }
+    if (spec.profile === "keyframe-heavy-expanded") {
+      keyframeCache.set(id, keyframeData());
+      gsapAnimations.set(id, [fixtureAnimation(id, start, geometry.clipDuration)]);
+      expandedClipIds.add(id);
+    }
+    elements.push(element);
+  }
+
+  return {
+    summary: Object.freeze({
+      ...spec,
+      duration: geometry.duration,
+      trackCount: TRACK_COUNT,
+      keyframedElementCount: keyframeCache.size,
+      expandedElementCount: expandedClipIds.size,
+    }),
+    elements,
+    keyframeCache,
+    gsapAnimations,
+    expandedClipIds,
+  };
+}

--- a/packages/studio/src/player/lib/timelineViewportBudgets.test.ts
+++ b/packages/studio/src/player/lib/timelineViewportBudgets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  TIMELINE_VIEWPORT_BUDGETS,
+  resolveTimelineViewportBudgets,
+} from "./timelineViewportBudgets";
+
+describe("timeline viewport budgets", () => {
+  it("owns the agreed direct-scroll, DOM, media, and measurement ceilings", () => {
+    expect(TIMELINE_VIEWPORT_BUDGETS).toMatchObject({
+      directScrollSafetyPx: 8_000_000,
+      rowOverscanPerSide: 2,
+      timeOverscanViewportRatio: 0.25,
+      maxMountedRows: 64,
+      maxMountedClipRoots: 512,
+      maxMountedClipRootsPerRow: 128,
+      maxMountedTimelineDescendants: 5_000,
+      thumbnailCacheBytes: 64 * 1024 * 1024,
+      waveformCacheBytes: 16 * 1024 * 1024,
+      interactionP95Ms: 50,
+      constrainedInteractionP95Ms: 75,
+      constrainedFrameIntervalP95Ms: 75,
+      longTaskLimitMs: 50,
+      constrainedLongTaskLimitMs: 300,
+      posterCoverageRatio: 0.9,
+      supportedFixtureFallbackRatio: 0.02,
+      warmupRuns: 3,
+      measuredRuns: 5,
+      requiredPassingRuns: 4,
+    });
+    expect(Object.isFrozen(TIMELINE_VIEWPORT_BUDGETS)).toBe(true);
+  });
+
+  it("creates an immutable test override without changing production defaults", () => {
+    const resolved = resolveTimelineViewportBudgets({
+      directScrollSafetyPx: 256,
+      measuredRuns: 1,
+      requiredPassingRuns: 1,
+    });
+
+    expect(resolved.directScrollSafetyPx).toBe(256);
+    expect(resolved.maxMountedClipRoots).toBe(512);
+    expect(TIMELINE_VIEWPORT_BUDGETS.directScrollSafetyPx).toBe(8_000_000);
+    expect(Object.isFrozen(resolved)).toBe(true);
+  });
+
+  it.each([
+    [{ maxMountedClipRoots: -1 }, "maxMountedClipRoots"],
+    [{ frameIntervalP95Ms: Number.NaN }, "frameIntervalP95Ms"],
+    [{ warmupRuns: 0.5 }, "warmupRuns"],
+    [{ measuredRuns: 0 }, "measuredRuns"],
+    [{ requiredPassingRuns: 0 }, "requiredPassingRuns"],
+    [{ measuredRuns: 1.5, requiredPassingRuns: 1 }, "measuredRuns"],
+    [{ measuredRuns: 4, requiredPassingRuns: 5 }, "requiredPassingRuns"],
+    [{ posterCoverageRatio: 1.1 }, "posterCoverageRatio"],
+  ] as const)("rejects an invalid override %#", (overrides, message) => {
+    expect(() => resolveTimelineViewportBudgets(overrides)).toThrow(message);
+  });
+});

--- a/packages/studio/src/player/lib/timelineViewportBudgets.ts
+++ b/packages/studio/src/player/lib/timelineViewportBudgets.ts
@@ -1,0 +1,139 @@
+export interface TimelineViewportBudgets {
+  directScrollSafetyPx: number;
+  rowOverscanPerSide: number;
+  timeOverscanViewportRatio: number;
+  maxMountedRows: number;
+  maxMountedClipRoots: number;
+  maxMountedClipRootsPerRow: number;
+  maxMountedTimelineDescendants: number;
+  posterMaxPhysicalWidth: number;
+  posterMaxPhysicalHeight: number;
+  posterDprCap: number;
+  richPreviewFrameCount: number;
+  concurrentVideoDecodes: number;
+  concurrentMetadataJobs: number;
+  concurrentCompositionFetches: number;
+  concurrentServerPages: number;
+  thumbnailCacheBytes: number;
+  thumbnailCacheEntries: number;
+  thumbnailCacheEntriesPerProject: number;
+  metadataRegistryEntries: number;
+  metadataFailureTtlMs: number;
+  waveformCacheBytes: number;
+  waveformCacheEntries: number;
+  compositionDiskCacheBytes: number;
+  compositionDiskCacheMaxAgeMs: number;
+  interactionP95Ms: number;
+  frameIntervalP95Ms: number;
+  constrainedInteractionP95Ms: number;
+  constrainedFrameIntervalP95Ms: number;
+  longTaskLimitMs: number;
+  constrainedLongTaskLimitMs: number;
+  memoryReturnToleranceRatio: number;
+  posterColdP95Ms: number;
+  posterCachedP95Ms: number;
+  constrainedPosterColdP95Ms: number;
+  constrainedPosterCachedP95Ms: number;
+  posterCoverageRatio: number;
+  posterCoverageSettleMs: number;
+  constrainedPosterCoverageSettleMs: number;
+  richPreviewP95Ms: number;
+  constrainedRichPreviewP95Ms: number;
+  supportedFixtureFallbackRatio: number;
+  warmupRuns: number;
+  measuredRuns: number;
+  requiredPassingRuns: number;
+}
+
+const MEBIBYTE = 1024 * 1024;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The sole default budget owner for timeline viewport and media virtualization.
+ * Consumers may resolve an immutable per-test override; production defaults are
+ * never mutated globally.
+ */
+export const TIMELINE_VIEWPORT_BUDGETS: Readonly<TimelineViewportBudgets> = Object.freeze({
+  directScrollSafetyPx: 8_000_000,
+  rowOverscanPerSide: 2,
+  timeOverscanViewportRatio: 0.25,
+  maxMountedRows: 64,
+  maxMountedClipRoots: 512,
+  maxMountedClipRootsPerRow: 128,
+  maxMountedTimelineDescendants: 5_000,
+  posterMaxPhysicalWidth: 240,
+  posterMaxPhysicalHeight: 135,
+  posterDprCap: 1.5,
+  richPreviewFrameCount: 6,
+  concurrentVideoDecodes: 2,
+  concurrentMetadataJobs: 4,
+  concurrentCompositionFetches: 2,
+  concurrentServerPages: 1,
+  thumbnailCacheBytes: 64 * MEBIBYTE,
+  thumbnailCacheEntries: 256,
+  thumbnailCacheEntriesPerProject: 96,
+  metadataRegistryEntries: 512,
+  metadataFailureTtlMs: 30_000,
+  waveformCacheBytes: 16 * MEBIBYTE,
+  waveformCacheEntries: 256,
+  compositionDiskCacheBytes: 512 * MEBIBYTE,
+  compositionDiskCacheMaxAgeMs: 14 * DAY_MS,
+  interactionP95Ms: 50,
+  frameIntervalP95Ms: 33.3,
+  constrainedInteractionP95Ms: 75,
+  constrainedFrameIntervalP95Ms: 75,
+  longTaskLimitMs: 50,
+  constrainedLongTaskLimitMs: 300,
+  memoryReturnToleranceRatio: 0.15,
+  posterColdP95Ms: 750,
+  posterCachedP95Ms: 250,
+  constrainedPosterColdP95Ms: 1_200,
+  constrainedPosterCachedP95Ms: 400,
+  posterCoverageRatio: 0.9,
+  posterCoverageSettleMs: 1_500,
+  constrainedPosterCoverageSettleMs: 2_500,
+  richPreviewP95Ms: 750,
+  constrainedRichPreviewP95Ms: 1_200,
+  supportedFixtureFallbackRatio: 0.02,
+  warmupRuns: 3,
+  measuredRuns: 5,
+  requiredPassingRuns: 4,
+});
+
+function assertValidBudget(name: keyof TimelineViewportBudgets, value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`Timeline viewport budget ${name} must be a finite non-negative number`);
+  }
+}
+
+export function resolveTimelineViewportBudgets(
+  overrides: Partial<TimelineViewportBudgets> = {},
+): Readonly<TimelineViewportBudgets> {
+  for (const [name, value] of Object.entries(overrides)) {
+    assertValidBudget(name as keyof TimelineViewportBudgets, value);
+  }
+  const resolved = { ...TIMELINE_VIEWPORT_BUDGETS, ...overrides };
+  for (const name of ["warmupRuns", "measuredRuns", "requiredPassingRuns"] as const) {
+    if (!Number.isInteger(resolved[name])) {
+      throw new RangeError(`Timeline viewport budget ${name} must be an integer`);
+    }
+  }
+  if (resolved.measuredRuns === 0 || resolved.requiredPassingRuns === 0) {
+    throw new RangeError(
+      "Timeline viewport budget measuredRuns and requiredPassingRuns must be greater than zero",
+    );
+  }
+  if (resolved.requiredPassingRuns > resolved.measuredRuns) {
+    throw new RangeError("Timeline viewport budget requiredPassingRuns cannot exceed measuredRuns");
+  }
+  for (const name of [
+    "memoryReturnToleranceRatio",
+    "posterCoverageRatio",
+    "supportedFixtureFallbackRatio",
+  ] as const) {
+    if (resolved[name] > 1) {
+      throw new RangeError(`Timeline viewport budget ${name} cannot exceed 1`);
+    }
+  }
+  return Object.freeze(resolved);
+}

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -1,10 +1,11 @@
 import { create } from "zustand";
 import type { MusicBeatAnalysis } from "@hyperframes/core/beats";
+import type { GsapAnimation } from "@hyperframes/core/gsap-parser";
 import type { BeatEditState } from "../../utils/beatEditing";
 import type { ClipManifestClip } from "../lib/playbackTypes";
 import { readStudioUiPreferences, writeStudioUiPreferences } from "../../utils/studioUiPreferences";
 import { computePinnedZoomPercent } from "../components/timelineZoom";
-import { createKeyframeSlice, type KeyframeSlice } from "./keyframeSlice";
+import { createKeyframeSlice, type KeyframeCacheEntry, type KeyframeSlice } from "./keyframeSlice";
 
 export type { KeyframeCacheEntry } from "./keyframeSlice";
 
@@ -283,6 +284,42 @@ export const liveTime = {
   },
 };
 
+export function createTimelineResetState() {
+  return {
+    isPlaying: false,
+    currentTime: 0,
+    duration: 0,
+    timelineReady: false,
+    beatDragging: false,
+    elements: [],
+    selectedElementId: null,
+    zEditVersion: 0,
+    inPoint: null,
+    outPoint: null,
+    activeTool: "select" as const,
+    activeKeyframePct: null,
+    motionPathArmed: false,
+    motionPathCreateAvailable: false,
+    selectedKeyframes: new Set<string>(),
+    expandedClipIds: new Set<string>(),
+    focusedEaseSegment: null,
+    selectedElementIds: new Set<string>(),
+    requestedSeekTime: null,
+    clipRevealRequest: null,
+    lintFindingsByElement: new Map<string, { count: number; messages: string[] }>(),
+    keyframeCache: new Map<string, KeyframeCacheEntry>(),
+    gsapAnimations: new Map<string, GsapAnimation[]>(),
+    beatAnalysis: null,
+    beatEdits: null,
+    beatUndo: [],
+    beatRedo: [],
+    beatPersist: null,
+    clipManifest: null,
+    clipParentMap: new Map<string, string>(),
+    domClipChildren: [],
+  };
+}
+
 export const usePlayerStore = create<PlayerState>((set, get) => ({
   isPlaying: false,
   currentTime: 0,
@@ -517,34 +554,7 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   // Resets project-specific state when switching compositions.
   // playbackRate, audioMuted, loopEnabled, zoomMode, and manualZoomPercent are intentionally preserved
   // because they are user preferences that should survive project switches.
-  reset: () =>
-    set({
-      isPlaying: false,
-      currentTime: 0,
-      duration: 0,
-      timelineReady: false,
-      beatDragging: false,
-      elements: [],
-      selectedElementId: null,
-      inPoint: null,
-      outPoint: null,
-      activeTool: "select",
-      selectedKeyframes: new Set(),
-      expandedClipIds: new Set(),
-      focusedEaseSegment: null,
-      selectedElementIds: new Set(),
-      clipRevealRequest: null,
-      keyframeCache: new Map(),
-      gsapAnimations: new Map(),
-      beatAnalysis: null,
-      beatEdits: null,
-      beatUndo: [],
-      beatRedo: [],
-      beatPersist: null,
-      clipManifest: null,
-      clipParentMap: new Map(),
-      domClipChildren: [],
-    }),
+  reset: () => set(createTimelineResetState()),
 }));
 
 // Bug-bash aid: expose the store so a reproduction can dump live state from the


### PR DESCRIPTION
## What

Define the measurable timeline viewport contract before changing rendering behavior.

## How

- Own immutable budgets for mounted rows, clip roots, per-row clips, descendants, latency, frame cadence, long tasks, memory return, and run quorum.
- Instrument the real `TimelineLanes` row shell and require exactly one mounted Timeline, so a pre-mount or crashed run cannot pass on all-zero diagnostics.
- Keep every DOM ceiling inclusive and exclude orphan clips from the per-row maximum.
- Load fixtures through one atomic, isolated project-state replacement so stale playback, manifests, selections, pending requests, caches, or beat state cannot leak between identical runs.
- Reject zero or fractional measured/quorum counts.
- Validate fixture profiles and poster states with own-key checks, not prototype-chain membership.
- Verify full deep equality for every 50,000-element profile, not samples from only one workload.

This is D1 of Family D. The permanent two-state CI workflow lands later in the same stack in #2884.

## Test plan

- [x] Timeline budget and diagnostics tests
- [x] Real row instrumentation test
- [x] Atomic fixture isolation tests
- [x] All-profile 50,000-element determinism tests
- [x] Full Studio suite
- [x] Studio typecheck, oxfmt, and oxlint

Review fixes are included at head `09b469a31`.
