### PR TITLE
refactor(studio): extract live timeline clock

### DIFF
--- a/packages/studio/src/player/store/liveTime.ts
+++ b/packages/studio/src/player/store/liveTime.ts
@@ -1,0 +1,11 @@
+// ponytail: Playback RAF updates the playhead/time display without per-frame React renders.
+type TimeListener = (time: number) => void;
+const timeListeners = new Set<TimeListener>();
+
+export const liveTime = {
+  notify: (time: number) => timeListeners.forEach((listener) => listener(time)),
+  subscribe: (listener: TimeListener) => {
+    timeListeners.add(listener);
+    return () => timeListeners.delete(listener);
+  },
+};

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -12,6 +12,7 @@ import { clampTimelineZoomPercent, computePinnedZoomPercent } from "../component
 import { createKeyframeSlice, type KeyframeCacheEntry, type KeyframeSlice } from "./keyframeSlice";
 
 export type { KeyframeCacheEntry } from "./keyframeSlice";
+export { liveTime } from "./liveTime";
 
 export interface TimelineElement {
   id: string;
@@ -278,19 +279,6 @@ interface BeatHistoryEntry {
   at: number;
   label: string;
 }
-
-// Lightweight pub-sub for current time during playback.
-// Bypasses React state so the RAF loop can update the playhead/time display
-// without triggering re-renders on every frame.
-type TimeListener = (time: number) => void;
-const _timeListeners = new Set<TimeListener>();
-export const liveTime = {
-  notify: (t: number) => _timeListeners.forEach((cb) => cb(t)),
-  subscribe: (cb: TimeListener) => {
-    _timeListeners.add(cb);
-    return () => _timeListeners.delete(cb);
-  },
-};
 
 export function createTimelineResetState() {
   return {


### PR DESCRIPTION
## What

Extract the live playback-time publisher into a small shared store module without changing playback behavior.

## Why

High-frequency timeline consumers need one stable clock contract without coupling to the full player state container or causing React renders on every playback frame.

## How

`liveTime.ts` now owns the listener set plus the `notify` and `subscribe` operations. The player store re-exports that contract, so existing consumers keep the same public API while the implementation has one owner.

This is the first PR in the stack and targets `main`.

## Test plan

Exact-head CI completed without failed conclusions, including typecheck, runtime contract, Studio tests, and the timeline viewport gate.

- [ ] Unit tests added/updated (existing live-time coverage retained)
- [ ] Manual testing performed (behavior-preserving extraction)
- [x] Documentation updated in #3031
