### PR TITLE
fix(cli): stop download tmp cleanup racing the write stream open

### DIFF
--- a/packages/cli/src/utils/download.ts
+++ b/packages/cli/src/utils/download.ts
@@ -31,6 +31,20 @@ export function downloadFile(
   const timeoutMs = options.timeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS;
   return new Promise((resolve, reject) => {
     const follow = (u: string) => {
+      // Set once the 200 branch hands the response to pipeline(). From that
+      // point the pipeline's catch owns BOTH cleanup and rejection: it settles
+      // only after the write stream has closed, so the `.tmp` file provably
+      // exists (or never will) when it unlinks. The request "error" handler
+      // must NOT clean up or reject in that window — createWriteStream opens
+      // asynchronously, so an early unlink+reject races the open and can leave
+      // a stray `.tmp` created AFTER cleanup ran (flaked in CI as
+      // download.test.ts "removes the partial file"; in the wild it strands
+      // partials in the cache dir).
+      let pipelineOwnsCleanup = false;
+      // The request's error (e.g. the timeout message) is more precise than
+      // what the pipeline surfaces for the same failure (destroying the
+      // request can reject the pipeline with a generic premature-close).
+      let requestError: Error | undefined;
       const request = httpsGet(u, (res) => {
         if (res.statusCode === 301 || res.statusCode === 302) {
           const location = res.headers.location;
@@ -46,6 +60,7 @@ export function downloadFile(
           reject(new Error(`Download failed: HTTP ${res.statusCode}`));
           return;
         }
+        pipelineOwnsCleanup = true;
         const file = createWriteStream(tmp);
         pipeline(res, file)
           .then(() => {
@@ -54,13 +69,17 @@ export function downloadFile(
           })
           .catch((err) => {
             removePartialFile(tmp);
-            reject(err);
+            reject(requestError ?? err);
           });
       });
       request.setTimeout(timeoutMs, () => {
         request.destroy(new Error(`Download timed out after ${timeoutMs}ms`));
       });
       request.on("error", (err) => {
+        if (pipelineOwnsCleanup) {
+          requestError = err;
+          return;
+        }
         removePartialFile(tmp);
         reject(err);
       });


### PR DESCRIPTION
## Summary

`downloadFile` had two independent cleanup+reject paths racing each other on failure:

1. `request.on("error")` → unlink `.tmp` + reject
2. `pipeline(res, file).catch` → unlink `.tmp` + reject

`createWriteStream(tmp)` opens **asynchronously** — on a timeout, path 1 can unlink and reject *before the file even exists*; the stream's open then creates `.tmp` *after* cleanup already ran. In CI this flaked `download.test.ts > "rejects an idle response and removes the partial file"` (`expected true to be false` — surfaced on PR #2681's Test job, unrelated to that PR's diff); in the wild it strands partial `.tmp` files in the model cache dir.

## Fix

Once the 200 branch hands the response to `pipeline()`, the pipeline's catch **owns** cleanup and rejection — it settles only after the write stream has closed, so the `.tmp` file provably exists (or never will) when it unlinks. The request error handler stands down in that window, but stashes its error so the precise failure message (e.g. `Download timed out after 30000ms`) survives — destroying the request can otherwise reject the pipeline with a generic premature-close.

Pre-200 failures (connection refused, redirect errors) keep the original request-error path — no pipeline exists to own cleanup there.

## Test plan

- [x] `download.test.ts` 10/10 consecutive passes (was intermittent)
- [x] `tsc --noEmit` clean
- [x] `oxlint` + `oxfmt --check` clean

Pre-existing since #2415 — not introduced by any open PR; fixing it deflakes every PR's Test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)