### PR TITLE
chore: release v0.7.67

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,31 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.67"
+  description="Released - 2026-07-21"
+  tags={["Release", "Producer", "Core", "Skills"]}
+>
+Distributed renders now carry runtime media variables through planning and honor runtime durations during extraction and volume automation, preventing placeholder metadata from clipping full-length audio. This release also adds RenderStretch for longer scenes, applies position edits to SVG elements, and warns when live map viewports are captured.
+
+## Features
+
+- **Producer:** RenderStretch to re-time short compositions across longer scenes ([e786b78b3](https://github.com/heygen-com/hyperframes/commit/e786b78b3311d697e95269ec8fc21a4159af909d), [#2676](https://github.com/heygen-com/hyperframes/pull/2676))
+- **Engine:** Warn when a live map viewport is detected at capture init ([30ca51c61](https://github.com/heygen-com/hyperframes/commit/30ca51c615fce20f5266278cdf5f4c97fd691c88))
+
+## Fixes
+
+- **Producer:** Preserve runtime audio variables in distributed plans ([465c9e764](https://github.com/heygen-com/hyperframes/commit/465c9e764138b94faa48badbee468eb42bd1a39d), [#2725](https://github.com/heygen-com/hyperframes/pull/2725))
+- **Core:** Apply position edits to SVG elements, not just HTML ([63539a0cd](https://github.com/heygen-com/hyperframes/commit/63539a0cdef75597d2e301736740cf3bdd905596), [#2724](https://github.com/heygen-com/hyperframes/pull/2724))
+- **Skills:** Anonymize CLI feedback repro guidance ([78ab9bc88](https://github.com/heygen-com/hyperframes/commit/78ab9bc889908e412e806d80f4ffbd938efc7a78))
+
+## Internal
+
+- **Skills:** Package Codex plugin upload ([696cbdbbd](https://github.com/heygen-com/hyperframes/commit/696cbdbbd0e5c83faf72c767126d4a153110f130), [#2668](https://github.com/heygen-com/hyperframes/pull/2668))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.66...v0.7.67).
+</Update>
+
+<Update
   label="HyperFrames v0.7.66"
   description="Released - 2026-07-21"
   tags={["Release", "Studio", "Skills", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.67.md
+++ b/releases/v0.7.67.md
@@ -1,0 +1,24 @@
+# HyperFrames v0.7.67
+
+Released on 2026-07-21.
+
+Distributed renders now carry runtime media variables through planning and honor runtime durations during extraction and volume automation, preventing placeholder metadata from clipping full-length audio. This release also adds RenderStretch for longer scenes, applies position edits to SVG elements, and warns when live map viewports are captured.
+
+## Features
+
+- **Producer:** RenderStretch to re-time short compositions across longer scenes ([e786b78b3](https://github.com/heygen-com/hyperframes/commit/e786b78b3311d697e95269ec8fc21a4159af909d), [#2676](https://github.com/heygen-com/hyperframes/pull/2676))
+- **Engine:** Warn when a live map viewport is detected at capture init ([30ca51c61](https://github.com/heygen-com/hyperframes/commit/30ca51c615fce20f5266278cdf5f4c97fd691c88))
+
+## Fixes
+
+- **Producer:** Preserve runtime audio variables in distributed plans ([465c9e764](https://github.com/heygen-com/hyperframes/commit/465c9e764138b94faa48badbee468eb42bd1a39d), [#2725](https://github.com/heygen-com/hyperframes/pull/2725))
+- **Core:** Apply position edits to SVG elements, not just HTML ([63539a0cd](https://github.com/heygen-com/hyperframes/commit/63539a0cdef75597d2e301736740cf3bdd905596), [#2724](https://github.com/heygen-com/hyperframes/pull/2724))
+- **Skills:** Anonymize CLI feedback repro guidance ([78ab9bc88](https://github.com/heygen-com/hyperframes/commit/78ab9bc889908e412e806d80f4ffbd938efc7a78))
+
+## Internal
+
+- **Skills:** Package Codex plugin upload ([696cbdbbd](https://github.com/heygen-com/hyperframes/commit/696cbdbbd0e5c83faf72c767126d4a153110f130), [#2668](https://github.com/heygen-com/hyperframes/pull/2668))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.66...v0.7.67


### PR DESCRIPTION
## Release

Publish HyperFrames `v0.7.67` from the latest `main` tip containing #2725.

## Highlights

- distributed plans preserve runtime media variables
- runtime media duration wins over stale placeholder timing during extraction and volume automation
- RenderStretch supports re-timing short compositions across longer scenes
- SVG position edits and live map viewport capture warnings

## Validation

- #2725 full CI passed, including all eight visual-regression shards and Windows rendering
- stable release notes reviewed and TODO markers removed
- versioned all 13 public packages and three plugin manifests to `0.7.67`

Merging this `release/v0.7.67` PR triggers the publish workflow, creates tag `v0.7.67`, publishes npm packages with the `latest` tag, and creates the GitHub release.
