### PR TITLE
fix(core): preserve nested-rule selectors in composition CSS scoping (#2721)

### DIFF
--- a/packages/core/src/compiler/compositionScoping.test.ts
+++ b/packages/core/src/compiler/compositionScoping.test.ts
@@ -800,6 +800,51 @@ window.__afterTimeline = window.__timelines.scene;
     expect(result).toContain('[id="intro"]');
   });
 
+  it("preserves nested-rule selectors so CSS Nesting inheritance works (#2721)", () => {
+    // Chrome 112+ / Firefox 117+ / Safari 16.5+ support native CSS Nesting.
+    // A nested rule like `.title { … }` inside `[data-composition-id="intro"] { … }`
+    // resolves at match time to `<parent> .title` via the implicit `&` prefix.
+    // The scoper must NOT re-apply the composition scope to the nested selector —
+    // that produces `<scope> <scope> .title`, which matches nothing because the
+    // composition root only appears once in the DOM.
+    const scoped = scopeCssToComposition(
+      `
+        [data-composition-id="intro"] h1 { color: red; }
+        [data-composition-id="intro"] {
+          .title { color: brown; }
+          h2 { color: blue; }
+        }
+      `,
+      "intro",
+    );
+    // Top-level rules still get scoped.
+    expect(scoped).toContain('[data-composition-id="intro"] h1');
+    // Nested rules keep their author-original selectors verbatim so CSS Nesting
+    // can prepend the parent's `&` at match time.
+    expect(scoped).toMatch(/\.title\s*\{/);
+    expect(scoped).toMatch(/h2\s*\{/);
+    // The pre-fix bug re-scoped nested rules to `[…] .title`, which never matched.
+    expect(scoped).not.toContain('[data-composition-id="intro"] .title');
+    expect(scoped).not.toContain('[data-composition-id="intro"] h2');
+  });
+
+  it("preserves deeply-nested CSS Nesting rules (#2721)", () => {
+    const scoped = scopeCssToComposition(
+      `
+        [data-composition-id="intro"] {
+          .card {
+            .header { font-weight: bold; }
+          }
+        }
+      `,
+      "intro",
+    );
+    expect(scoped).toMatch(/\.card\s*\{/);
+    expect(scoped).toMatch(/\.header\s*\{/);
+    expect(scoped).not.toContain('[data-composition-id="intro"] .card');
+    expect(scoped).not.toContain('[data-composition-id="intro"] .header');
+  });
+
   it("wraps scripts with authored root id normalization for #id GSAP selectors", () => {
     const { document } = parseHTML(`
       <div data-composition-id="intro">

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -200,6 +200,24 @@ function isInsideGlobalAtRule(rule: Rule): boolean {
   return false;
 }
 
+/**
+ * A Rule nested inside another Rule (CSS Nesting Module Level 1) already
+ * inherits scope from its parent's `&` prefix at match time — re-applying
+ * the composition scope to the nested selector produces
+ * `<scope> <scope> .child`, which matches nothing when the composition
+ * root only appears once in the DOM. Only top-level rules get scoped;
+ * their nested descendants inherit the scope naturally via CSS nesting.
+ * See #2721 for the reproducer that motivated this.
+ */
+function isNestedInsideAnotherRule(rule: Rule): boolean {
+  let current: Node["parent"] = rule.parent;
+  while (current) {
+    if (current.type === "rule") return true;
+    current = current.parent;
+  }
+  return false;
+}
+
 export function scopeCssToComposition(
   css: string,
   compositionId: string,
@@ -216,6 +234,7 @@ export function scopeCssToComposition(
 
   root.walkRules((rule) => {
     if (isInsideGlobalAtRule(rule)) return;
+    if (isNestedInsideAnotherRule(rule)) return;
     rule.selectors = rule.selectors.map((selector) =>
       scopeSelector(
         selector,


### PR DESCRIPTION
## Description

Fixes #2721. External-user report from qd3v: a nested CSS rule inside a composition's `<style>` block gets silently ignored.

Reproducer (from the issue, exact):

```html
<style>
  /* All good */
  [data-composition-id="intro-comp"] h1 { color: orangered; font-size: 5rem; }

  /* Just ignored */
  [data-composition-id="intro-comp"] {
    .title { color: brown; font-size: 6rem; }
  }
</style>
<h1>Hyperframes</h1>
<div class="title">Welcome!</div>
```

The `h1` gets styled; the `.title` doesn't.

## Root cause

Modern browsers support native CSS Nesting (Chrome 112+, Firefox 117+, Safari 16.5+). A nested rule `.title { … }` inside `[data-composition-id="intro-comp"] { … }` resolves at match time to `<parent> .title` via the implicit `&` prefix.

`scopeCssToComposition` in `packages/core/src/compiler/compositionScoping.ts` walks every Rule via `root.walkRules` and re-scopes selectors:

```typescript
root.walkRules((rule) => {
  if (isInsideGlobalAtRule(rule)) return;
  rule.selectors = rule.selectors.map((selector) => scopeSelector(selector, scope, …));
});
```

PostCSS's `walkRules` visits nested rules too. The nested `.title` selector was scoped to `[data-composition-id="intro-comp"] .title` — but the parent's selector was also scoped, so when CSS Nesting resolved the inner rule it prepended `&` (the parent scope) AGAIN, producing effectively:

```
[data-composition-id="intro-comp"]:not(:has(…)) [data-composition-id="intro-comp"] .title { … }
```

The composition root only appears once in the DOM, so `<scope> <scope> .title` matches nothing — the rule appears "just ignored" as the reporter described.

## Fix

Add `isNestedInsideAnotherRule` predicate — mirrors the existing `isInsideGlobalAtRule` — and skip nested Rules in the walkRules callback. Top-level rules still get scoped; their nested descendants inherit scope naturally via CSS Nesting at match time.

```diff
 root.walkRules((rule) => {
   if (isInsideGlobalAtRule(rule)) return;
+  if (isNestedInsideAnotherRule(rule)) return;
   rule.selectors = rule.selectors.map((selector) => scopeSelector(…));
 });
```

## Testing

- `bunx vitest run packages/core/src/compiler/compositionScoping.test.ts` — **37 tests pass** (35 pre-existing + 2 new).
- New test: `preserves nested-rule selectors so CSS Nesting inheritance works (#2721)` — asserts nested `.title` and `h2` selectors stay verbatim while top-level rules keep scoping, and no `[…] .title` false-scoped selector appears.
- New test: `preserves deeply-nested CSS Nesting rules (#2721)` — same guarantee at depth 3.
- Traced the exact code path from the postcss `root.walkRules` bit; reproduced the double-scoping via a local postcss probe before writing the fix.

## Note on other issues raised in the ticket

The reporter also mentioned two secondary points that are out of scope for this PR:

1. *"If I try to use `body` tag instead of `template`, the rendering fails"* — that's the standalone sub-composition contract (must have a `<template>` or `<body>` with `[data-composition-id]`). The error is correct; the docs could be clearer. Filing separately if it needs a doc update.
2. *"linter or checker wants me to add `data-layout-allow-overlap`, but there's no such attribute in the docs"* — that's a docs gap on `hyperframes.heygen.com/concepts/data-attributes`. Filing separately if needed.

— Rames Jusso