### PR TITLE
test(core): cover video timing StaticGuard regression

### DIFF
--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -1363,21 +1363,24 @@ describe("bundleToSingleHtml", () => {
   <div data-composition-id="root" data-width="1920" data-height="1080" data-start="0" data-duration="18">
     <audio id="bgm" src="bgm.mp3" data-start="0" data-duration="18"></audio>
     <audio id="narration" src="narr.mp3" data-start="5" data-duration="10"></audio>
+    <video id="demo" src="demo.mp4" muted playsinline data-start="6" data-duration="8"></video>
   </div>
   <script>window.__timelines = window.__timelines || {}; window.__timelines.root = { duration: () => 18, seek() {}, pause() {} };</script>
 </body></html>`,
       "bgm.mp3": "",
       "narr.mp3": "",
+      "demo.mp4": "",
     });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       const bundled = await bundleToSingleHtml(dir);
-      // Sanity: the compiler MUST have emitted data-end for both audio elements,
+      // Sanity: the compiler MUST have emitted data-end for every media element,
       // so the linter is actually seeing the compiled shape (not the raw source).
       expect(bundled).toContain('id="bgm"');
       expect(bundled).toMatch(/id="bgm"[^>]*data-end="18"|data-end="18"[^>]*id="bgm"/);
       expect(bundled).toMatch(/id="narration"[^>]*data-end="15"|data-end="15"[^>]*id="narration"/);
+      expect(bundled).toMatch(/id="demo"[^>]*data-end="14"|data-end="14"[^>]*id="demo"/);
 
       const staticGuardWarnings = warnSpy.mock.calls
         .map((call) => String(call[0] ?? ""))


### PR DESCRIPTION
## Summary

- extend the existing compiler-derived media timing regression with a canonical `<video>` element
- verify `data-start="6" data-duration="8"` is compiled to `data-end="14"`
- verify StaticGuard accepts the compiled video contract without the misleading source-authoring warning

## Why

Issue #2662 originally demonstrated the regression with audio. An A/B investigation of a real video composition found the same failure mode for `<video>`: v0.7.64 emitted `data-end` during compilation and StaticGuard then rejected the compiled result for not retaining `data-duration`. Releases v0.7.65 through v0.7.68 no longer reproduce it.

This PR adds video coverage to prevent that path from regressing. It is test-only and does not change runtime behavior.

Investigation details: https://github.com/heygen-com/hyperframes/issues/2662#issuecomment-5057636412

## Verification

- RED: the added video case fails on v0.7.64 with `[StaticGuard] Invalid HyperFrame contract: <video id="demo"> uses data-end without data-duration.`
- GREEN: `packages/core/src/compiler/htmlBundler.test.ts` passes 44/44 on current `main`
- `oxfmt` and `oxlint` pass for the changed file
- TypeScript checks pass for `packages/core` and `packages/studio`
- Fallow audit reports no issues in the changed file
- large-file and tracked-artifact checks pass