### PR TITLE
chore: release v0.7.70

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,21 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.70"
+  description="Released - 2026-07-24"
+  tags={["Release", "Producer", "Engine"]}
+>
+Multi-worker renders using experimental fast capture (`--experimental-fast-capture`) now self-verify their frames on the disk path and automatically fall back to screenshot capture when GPU or memory pressure corrupts output — previously that corruption (e.g. a worker's frames displaced into vertical strips) could ship silently.
+
+## Fixes
+
+- **Engine/Producer:** Parallel and sequential disk-path drawElement capture now verify sampled frames against pre-injection ground truth and screenshot-retry on a breach — closing the gap where `--experimental-fast-capture --workers N` shipped compositor-damaged frames with no error (PRINFRA-352) ([060b6f8ae](https://github.com/heygen-com/hyperframes/commit/060b6f8ae53e8ae243d8e2c2c3afd690dbe7f99c), [ec791e91d](https://github.com/heygen-com/hyperframes/commit/ec791e91d97c0070502c4ad208923d4f98005846), [9fc1c2f15](https://github.com/heygen-com/hyperframes/commit/9fc1c2f15990fc44f50533362bec2f075aa1d53d), [c85cfae8f](https://github.com/heygen-com/hyperframes/commit/c85cfae8fa97229e9c4f4d7217cf08b4bc859f3d))
+- **Producer:** Close the orphaned probe session before a verify-triggered retry so the probe Chrome process isn't leaked under the GPU/memory pressure the retry is recovering from ([b8e101547](https://github.com/heygen-com/hyperframes/commit/b8e10154762f5a0fe71fb4a6a9f3d472e9bf99ec))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.69...v0.7.70).
+</Update>
+
+<Update
   label="HyperFrames v0.7.69"
   description="Released - 2026-07-23"
   tags={["Release", "Sdk", "Lint", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.70.md
+++ b/releases/v0.7.70.md
@@ -1,0 +1,14 @@
+# HyperFrames v0.7.70
+
+Released on 2026-07-24.
+
+Multi-worker renders using experimental fast capture (`--experimental-fast-capture`) now self-verify their frames on the disk path and automatically fall back to screenshot capture when GPU or memory pressure corrupts output — previously that corruption (e.g. a worker's frames displaced into vertical strips) could ship silently.
+
+## Fixes
+
+- **Engine/Producer:** Parallel and sequential disk-path drawElement capture now verify sampled frames against pre-injection ground truth and screenshot-retry on a breach — closing the gap where `--experimental-fast-capture --workers N` shipped compositor-damaged frames with no error (PRINFRA-352) ([060b6f8ae](https://github.com/heygen-com/hyperframes/commit/060b6f8ae53e8ae243d8e2c2c3afd690dbe7f99c), [ec791e91d](https://github.com/heygen-com/hyperframes/commit/ec791e91d97c0070502c4ad208923d4f98005846), [9fc1c2f15](https://github.com/heygen-com/hyperframes/commit/9fc1c2f15990fc44f50533362bec2f075aa1d53d), [c85cfae8f](https://github.com/heygen-com/hyperframes/commit/c85cfae8fa97229e9c4f4d7217cf08b4bc859f3d))
+- **Producer:** Close the orphaned probe session before a verify-triggered retry so the probe Chrome process isn't leaked under the GPU/memory pressure the retry is recovering from ([b8e101547](https://github.com/heygen-com/hyperframes/commit/b8e10154762f5a0fe71fb4a6a9f3d472e9bf99ec))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.69...v0.7.70


### PR DESCRIPTION
Release v0.7.70. Merging this `release/v0.7.70` PR triggers the npm publish workflow.

## Summary

Multi-worker renders using experimental fast capture (`--experimental-fast-capture`) now self-verify their frames on the disk path and automatically fall back to screenshot capture when GPU or memory pressure corrupts output — previously that corruption could ship silently (PRINFRA-352).

## Contents (since v0.7.69)

All of PR #2749:
- Parallel + sequential disk-path drawElement self-verification against pre-injection ground truth, with screenshot-retry recovery on a breach.
- Orphaned probe-session cleanup before verify-triggered retries.

Full range: https://github.com/heygen-com/hyperframes/compare/v0.7.69...v0.7.70

## Release checklist
- [x] `release:prepare 0.7.70` run — versions bumped across all packages + plugins, changelog reviewed (both `releases/v0.7.70.md` and `docs/changelog.mdx`), tag `v0.7.70` created locally
- [ ] Push tag `v0.7.70` / merge this PR to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)