### PR TITLE
docs: add THU-MAIC as HyperFrames adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,11 +16,12 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Production
 
-| Organization                             | Contact                                          | How HyperFrames is used                                                                                       |
-| ---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)     | Powers AI-generated video composition and rendering across HeyGen's video product surface.                    |
-| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok)   | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.   |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)     | Exploring HyperFrames for short-form code demo videos and documentation.                                      |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                     | Exploring HyperFrames for marketing and product video content.                                                |
-| [reap](https://reap.video)               | [@usamaabid](https://github.com/usamaabid)       | Powers agent-first AI video clipping, editing, and rendering across reap.video's creator and agent workflows. |
-| [Typeframe](https://typeframe.app)       | [@kiyeonjeon21](https://github.com/kiyeonjeon21) | Renders speech videos into shareable MP4 exports with word-timed typing captions and styled caption layouts.  |
+| Organization                             | Contact                                          | How HyperFrames is used                                                                                                       |
+| ---------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)     | Powers AI-generated video composition and rendering across HeyGen's video product surface.                                    |
+| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok)   | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.                   |
+| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)     | Exploring HyperFrames for short-form code demo videos and documentation.                                                      |
+| [OptinMonster](https://optinmonster.com) | Angie Meeker                                     | Exploring HyperFrames for marketing and product video content.                                                                |
+| [reap](https://reap.video)               | [@usamaabid](https://github.com/usamaabid)       | Powers agent-first AI video clipping, editing, and rendering across reap.video's creator and agent workflows.                 |
+| [Typeframe](https://typeframe.app)       | [@kiyeonjeon21](https://github.com/kiyeonjeon21) | Renders speech videos into shareable MP4 exports with word-timed typing captions and styled caption layouts.                  |
+| [THU-MAIC](https://github.com/THU-MAIC)  | [@wyuc](https://github.com/wyuc)                 | Powers OpenMAIC's one-click MP4 export for AI-generated interactive classrooms using self-contained HyperFrames compositions. |

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -54,6 +54,13 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 
     [@usamaabid](https://github.com/usamaabid)
   </Card>
+  <Card title="THU-MAIC" href="https://github.com/THU-MAIC">
+    <img src="https://avatars.githubusercontent.com/u/163809488?v=4" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
+
+    Powers OpenMAIC's one-click MP4 export for AI-generated interactive classrooms using self-contained HyperFrames compositions.
+
+    [@wyuc](https://github.com/wyuc)
+  </Card>
 </CardGroup>
 
 The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Launch Videos](/launch-videos) for the writeup.


### PR DESCRIPTION
## What

Adds [THU-MAIC](https://github.com/THU-MAIC) to the `ADOPTERS.md` table and the hosted adopters page.

## Why

[OpenMAIC](https://github.com/THU-MAIC/OpenMAIC) is an open-source AI interactive classroom platform that turns topics and documents into lessons with slides, narration, quizzes, and interactive activities.

OpenMAIC uses HyperFrames for one-click MP4 export. It builds a self-contained HyperFrames composition from an AI-generated classroom, including slide frames, narration, subtitles, and embedded media, then renders it through an isolated Chromium and FFmpeg service.

## Entry added

| Organization | Contact | How HyperFrames is used |
| --- | --- | --- |
| [THU-MAIC](https://github.com/THU-MAIC) | [@wyuc](https://github.com/wyuc) | Powers OpenMAIC's one-click MP4 export for AI-generated interactive classrooms using self-contained HyperFrames compositions. |
