### PR TITLE
fix(player): construct media observer in iframe realm

### DIFF
--- a/packages/player/src/hyperframes-player.test.ts
+++ b/packages/player/src/hyperframes-player.test.ts
@@ -744,6 +744,39 @@ describe("HyperframesPlayer media MutationObserver scoping", () => {
     expect(observeSpy).toHaveBeenCalledTimes(1);
     expect(observeSpy.mock.calls[0]?.[0]).toBe(fakeDoc.body);
   });
+
+  it("constructs the observer in the iframe document realm", () => {
+    const globalObserveSpy = vi.spyOn(MutationObserver.prototype, "observe");
+    const realmObserve = vi.fn();
+
+    class RealmMutationObserver {
+      constructor(_callback: MutationCallback) {}
+
+      observe = realmObserve;
+      disconnect = vi.fn();
+      takeRecords = vi.fn(() => []);
+    }
+
+    const player = document.createElement("hyperframes-player") as PlayerInternal;
+    document.body.appendChild(player);
+    globalObserveSpy.mockClear();
+
+    const fakeDoc = document.implementation.createHTMLDocument("iframe");
+    fakeDoc.body.innerHTML = `<div data-composition-id="root"></div>`;
+    Object.defineProperty(fakeDoc, "defaultView", {
+      configurable: true,
+      value: { MutationObserver: RealmMutationObserver },
+    });
+
+    player._observeDynamicMedia?.(fakeDoc);
+
+    expect(realmObserve).toHaveBeenCalledTimes(1);
+    expect(realmObserve).toHaveBeenCalledWith(
+      fakeDoc.querySelector("[data-composition-id]"),
+      expect.objectContaining({ childList: true, subtree: true }),
+    );
+    expect(globalObserveSpy).not.toHaveBeenCalled();
+  });
 });
 
 // ── Parent-proxy time-mirror coalescing ──

--- a/packages/player/src/parent-media.ts
+++ b/packages/player/src/parent-media.ts
@@ -411,10 +411,13 @@ export class ParentMediaManager {
 
   private _observeDynamicMedia(doc: Document): void {
     this.teardownObserver();
-    if (typeof MutationObserver === "undefined" || !doc.body) return;
+    const Observer =
+      doc.defaultView?.MutationObserver ??
+      (typeof MutationObserver !== "undefined" ? MutationObserver : undefined);
+    if (!Observer || !doc.body) return;
 
     // fallow-ignore-next-line complexity
-    const obs = new MutationObserver((mutations) => {
+    const obs = new Observer((mutations) => {
       for (const m of mutations) {
         if (m.type === "attributes" && m.attributeName === "preload") {
           const target = m.target;


### PR DESCRIPTION
## What

Construct the player's dynamic-media `MutationObserver` from the observed iframe document's realm, with the global observer retained only as a fallback.

Adds a regression test proving the iframe-realm constructor is used instead of the parent-window constructor.

## Why

The dynamic parent-media proxy work introduced in #307 created a parent-window `MutationObserver` and then attempted to observe iframe-owned DOM nodes. Browsers reject that cross-realm combination in Studio previews, leaving the composition player unable to initialize correctly.

The existing tests used a same-realm synthetic document and spied on the global observer, so they encoded the incorrect ownership assumption.

## How

Resolve the observer constructor from `doc.defaultView?.MutationObserver` before falling back to the global constructor. The regression test supplies distinct iframe/global observer implementations and asserts only the iframe implementation observes the composition host.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)
- [x] `oxfmt` and `oxlint` pass for both changed files
- [x] `hyperframes-player.test.ts`: 128 tests pass
- [x] Player package typecheck passes
- [x] Verified the affected project loads and scrubs in HyperFrames Studio
- [ ] Full player suite in the isolated worktree is blocked by a stale dependency cache missing the newly introduced `@hyperframes/parsers/slideshow` workspace link; 250 other tests pass