### PR TITLE
feat(lint): add text_truncated check for content clipped by overflow-hidden containers

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -109,6 +109,14 @@
     return hasAllowOverflowFlag(element) || element.hasAttribute("data-layout-bleed");
   }
 
+  // Truncation (content clipped away by an overflow-hidden box) has its own
+  // explicit opt-out on top of the shared allow-overflow/bleed flags, so an
+  // author can green-light an intentional ellipsis/masked reel without also
+  // silencing bbox-overflow reporting.
+  function hasTruncationOptOut(element) {
+    return hasTextClipOptOut(element) || !!element.closest("[data-layout-allow-truncation]");
+  }
+
   function opacityChain(element) {
     let opacity = 1;
     for (let current = element; current; current = current.parentElement) {
@@ -538,6 +546,99 @@
     }
 
     return issues;
+  }
+
+  const TRUNCATION_MAX_FINDINGS = 40;
+
+  // The clipping box that actually swallows `element`'s overflowing content:
+  // the element itself if it clips, otherwise the nearest clipping ancestor
+  // BELOW the composition root. Root-level clipping is canvas_overflow's job
+  // (a box extending past the canvas edge is a bbox breach, not content-box
+  // truncation), so the walk stops before the root. Returns null when nothing
+  // clips — that overflow is harmlessly visible and already covered by the
+  // bbox-based overflow checks.
+  function truncationClipper(element, root) {
+    if (clipsOverflow(getComputedStyle(element))) return element;
+    for (
+      let current = element.parentElement;
+      current && current !== root;
+      current = current.parentElement
+    ) {
+      if (clipsOverflow(getComputedStyle(current))) return current;
+    }
+    return null;
+  }
+
+  function buildTruncationIssue(candidate, time, tolerance) {
+    const { element, clipper, overflowX, overflowY } = candidate;
+    const clientWidth = element.clientWidth;
+    const clientHeight = element.clientHeight;
+    const scrollWidth = element.scrollWidth;
+    const scrollHeight = element.scrollHeight;
+    const text = textContentFor(element, false);
+    const snippet = text.length > 40 ? `${text.slice(0, 40)}…` : text;
+    const overflow = {};
+    if (overflowX > tolerance) overflow.right = round(overflowX);
+    if (overflowY > tolerance) overflow.bottom = round(overflowY);
+    const dims =
+      overflowX > tolerance
+        ? `content width ${Math.round(scrollWidth)}px exceeds visible ${Math.round(clientWidth)}px`
+        : `content height ${Math.round(scrollHeight)}px exceeds visible ${Math.round(clientHeight)}px`;
+    return {
+      code: "text_truncated",
+      severity: "warning",
+      time,
+      selector: selectorFor(element),
+      containerSelector: selectorFor(clipper),
+      text,
+      message: `Text is clipped by its container — "${snippet}" is truncated (${dims}).`,
+      rect: toRect(element.getBoundingClientRect()),
+      overflow,
+      fixHint:
+        "Widen the container, reduce the text, or allow wrapping; if the clip is intentional add data-layout-allow-truncation.",
+    };
+  }
+
+  // scrollWidth/clientWidth truncation detector. getBoundingClientRect returns
+  // the already-clipped box for text cut off by an overflow:hidden ancestor, so
+  // the bbox overflow checks (text_box_overflow/container_overflow) see no
+  // spill and the lost content is invisible to them. scrollWidth > clientWidth
+  // (or scrollHeight > clientHeight) exposes it: the content box is larger than
+  // the visible box, and a clipping element hides the difference.
+  function textTruncationIssues(root, time, tolerance) {
+    const candidates = [];
+    for (const element of Array.from(root.querySelectorAll("*"))) {
+      if (FRAME_MEDIA_TAGS.has(element.tagName.toUpperCase())) continue;
+      if (element.closest("svg")) continue;
+      if (!isVisibleElement(element, 0.05)) continue;
+      if (hasTruncationOptOut(element)) continue;
+      // Must carry visible text (own or from descendants) — skip pure
+      // containers, spacers and media wrappers.
+      if (!textContentFor(element, false)) continue;
+      const overflowX = element.scrollWidth - element.clientWidth;
+      const overflowY = element.scrollHeight - element.clientHeight;
+      if (overflowX <= tolerance && overflowY <= tolerance) continue;
+      const clipper = truncationClipper(element, root);
+      if (!clipper) continue;
+      // An element that clips its OWN overflow and directly owns its text is
+      // already reported as `clipped_text` (error) — don't double-report it.
+      if (clipper === element && hasOwnTextCandidate(element, true)) continue;
+      candidates.push({ element, clipper, overflowX, overflowY });
+    }
+
+    // Report the innermost truncated box per nesting chain: a clipping
+    // container and the text child that overflows it both trip the check, so
+    // drop any candidate that contains another candidate — the child anchors
+    // the defect tightest and avoids duplicate findings on one clip.
+    const elements = candidates.map((candidate) => candidate.element);
+    const innermost = candidates.filter(
+      (candidate) =>
+        !elements.some((other) => other !== candidate.element && candidate.element.contains(other)),
+    );
+
+    return innermost
+      .slice(0, TRUNCATION_MAX_FINDINGS)
+      .map((candidate) => buildTruncationIssue(candidate, time, tolerance));
   }
 
   function hasAllowOverlapFlag(element) {
@@ -1417,6 +1518,7 @@
     }
 
     issues.push(...containerOverflowIssues(root, time, tolerance));
+    issues.push(...textTruncationIssues(root, time, tolerance));
     issues.push(...contentOverlapIssues(root, time));
     const escaped = escapedContainerIssues(root, time);
     issues.push(...escaped.issues);

--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -109,10 +109,7 @@
     return hasAllowOverflowFlag(element) || element.hasAttribute("data-layout-bleed");
   }
 
-  // Truncation (content clipped away by an overflow-hidden box) has its own
-  // explicit opt-out on top of the shared allow-overflow/bleed flags, so an
-  // author can green-light an intentional ellipsis/masked reel without also
-  // silencing bbox-overflow reporting.
+  // Explicit truncation opt-out on top of allow-overflow/bleed, so an author can green-light an intentional ellipsis without silencing bbox-overflow reporting.
   function hasTruncationOptOut(element) {
     return hasTextClipOptOut(element) || !!element.closest("[data-layout-allow-truncation]");
   }
@@ -550,13 +547,7 @@
 
   const TRUNCATION_MAX_FINDINGS = 40;
 
-  // The clipping box that actually swallows `element`'s overflowing content:
-  // the element itself if it clips, otherwise the nearest clipping ancestor
-  // BELOW the composition root. Root-level clipping is canvas_overflow's job
-  // (a box extending past the canvas edge is a bbox breach, not content-box
-  // truncation), so the walk stops before the root. Returns null when nothing
-  // clips — that overflow is harmlessly visible and already covered by the
-  // bbox-based overflow checks.
+  // The clipping box that swallows element's overflow: itself if it clips, else the nearest clipping ancestor below root (root-level clipping is canvas_overflow's job); null when nothing clips.
   function truncationClipper(element, root) {
     if (clipsOverflow(getComputedStyle(element))) return element;
     for (
@@ -599,12 +590,7 @@
     };
   }
 
-  // scrollWidth/clientWidth truncation detector. getBoundingClientRect returns
-  // the already-clipped box for text cut off by an overflow:hidden ancestor, so
-  // the bbox overflow checks (text_box_overflow/container_overflow) see no
-  // spill and the lost content is invisible to them. scrollWidth > clientWidth
-  // (or scrollHeight > clientHeight) exposes it: the content box is larger than
-  // the visible box, and a clipping element hides the difference.
+  // scrollWidth/clientWidth truncation detector: getBoundingClientRect returns the already-clipped box so bbox checks miss text cut off by an overflow:hidden ancestor; scrollWidth/Height > client exposes it.
   function textTruncationIssues(root, time, tolerance) {
     const candidates = [];
     for (const element of Array.from(root.querySelectorAll("*"))) {
@@ -612,24 +598,19 @@
       if (element.closest("svg")) continue;
       if (!isVisibleElement(element, 0.05)) continue;
       if (hasTruncationOptOut(element)) continue;
-      // Must carry visible text (own or from descendants) — skip pure
-      // containers, spacers and media wrappers.
+      // Must carry visible text (own or descendants) — skip pure containers, spacers and media wrappers.
       if (!textContentFor(element, false)) continue;
       const overflowX = element.scrollWidth - element.clientWidth;
       const overflowY = element.scrollHeight - element.clientHeight;
       if (overflowX <= tolerance && overflowY <= tolerance) continue;
       const clipper = truncationClipper(element, root);
       if (!clipper) continue;
-      // An element that clips its OWN overflow and directly owns its text is
-      // already reported as `clipped_text` (error) — don't double-report it.
+      // An element that clips its own overflow and owns its text is already reported as `clipped_text` — don't double-report.
       if (clipper === element && hasOwnTextCandidate(element, true)) continue;
       candidates.push({ element, clipper, overflowX, overflowY });
     }
 
-    // Report the innermost truncated box per nesting chain: a clipping
-    // container and the text child that overflows it both trip the check, so
-    // drop any candidate that contains another candidate — the child anchors
-    // the defect tightest and avoids duplicate findings on one clip.
+    // Report the innermost truncated box per nesting chain — drop any candidate containing another so one clip yields one finding.
     const elements = candidates.map((candidate) => candidate.element);
     const innermost = candidates.filter(
       (candidate) =>

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -310,6 +310,207 @@ describe("layout-audit.browser", () => {
     );
     expect(parentOverflow).toBeUndefined();
   });
+
+  // text_truncated: content clipped away by an overflow-hidden ANCESTOR. The
+  // bbox overflow checks miss this because getBoundingClientRect returns the
+  // already-clipped box — only scrollWidth > clientWidth exposes the lost text.
+  function defineScrollMetrics(
+    id: string,
+    metrics: {
+      clientWidth: number;
+      scrollWidth: number;
+      clientHeight: number;
+      scrollHeight: number;
+    },
+  ): void {
+    const element = document.querySelector(`#${id}`);
+    if (!(element instanceof HTMLElement)) throw new Error(`missing #${id}`);
+    Object.defineProperties(element, {
+      clientWidth: { configurable: true, value: metrics.clientWidth },
+      scrollWidth: { configurable: true, value: metrics.scrollWidth },
+      clientHeight: { configurable: true, value: metrics.clientHeight },
+      scrollHeight: { configurable: true, value: metrics.scrollHeight },
+    });
+  }
+
+  it("flags text whose scrollWidth exceeds clientWidth inside an overflow:hidden ancestor", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="window">
+          <div id="label">Microgrid Active</div>
+        </div>
+      </div>
+    `;
+    defineScrollMetrics("label", {
+      clientWidth: 100,
+      scrollWidth: 240,
+      clientHeight: 20,
+      scrollHeight: 20,
+    });
+    installGeometry(
+      {
+        root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+        window: rect({ left: 40, top: 60, width: 100, height: 20 }),
+        label: rect({ left: 40, top: 60, width: 100, height: 20 }),
+      },
+      { window: { overflow: "hidden", overflowX: "hidden", overflowY: "hidden" } },
+    );
+    installAuditScript();
+
+    const truncated = runAudit().filter((issue) => issue.code === "text_truncated");
+    expect(truncated).toHaveLength(1);
+    expect(truncated[0]).toMatchObject({
+      code: "text_truncated",
+      selector: "#label",
+      containerSelector: "#window",
+    });
+    expect(truncated[0]?.message).toContain("content width 240px exceeds visible 100px");
+    expect(truncated[0]?.fixHint).toContain("data-layout-allow-truncation");
+  });
+
+  it("flags vertical truncation (scrollHeight exceeds clientHeight) under a clipping ancestor", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="window">
+          <div id="label">Two crammed lines of copy</div>
+        </div>
+      </div>
+    `;
+    defineScrollMetrics("label", {
+      clientWidth: 200,
+      scrollWidth: 200,
+      clientHeight: 24,
+      scrollHeight: 60,
+    });
+    installGeometry(
+      {
+        root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+        window: rect({ left: 40, top: 60, width: 200, height: 24 }),
+        label: rect({ left: 40, top: 60, width: 200, height: 24 }),
+      },
+      { window: { overflow: "hidden", overflowX: "hidden", overflowY: "hidden" } },
+    );
+    installAuditScript();
+
+    const truncated = runAudit().filter((issue) => issue.code === "text_truncated");
+    expect(truncated).toHaveLength(1);
+    expect(truncated[0]?.message).toContain("content height 60px exceeds visible 24px");
+  });
+
+  it("does not flag text that fits its box inside a clipping ancestor", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="window">
+          <div id="label">Fits fine</div>
+        </div>
+      </div>
+    `;
+    defineScrollMetrics("label", {
+      clientWidth: 200,
+      scrollWidth: 200,
+      clientHeight: 20,
+      scrollHeight: 20,
+    });
+    installGeometry(
+      {
+        root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+        window: rect({ left: 40, top: 60, width: 200, height: 20 }),
+        label: rect({ left: 40, top: 60, width: 200, height: 20 }),
+      },
+      { window: { overflow: "hidden", overflowX: "hidden", overflowY: "hidden" } },
+    );
+    installAuditScript();
+
+    expect(runAudit().some((issue) => issue.code === "text_truncated")).toBe(false);
+  });
+
+  it("does not flag content overflowing a NON-clipping container (visible overflow, not lost)", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="window">
+          <div id="label">Overflows but stays visible</div>
+        </div>
+      </div>
+    `;
+    defineScrollMetrics("label", {
+      clientWidth: 100,
+      scrollWidth: 240,
+      clientHeight: 20,
+      scrollHeight: 20,
+    });
+    installGeometry({
+      root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+      window: rect({ left: 40, top: 60, width: 100, height: 20 }),
+      label: rect({ left: 40, top: 60, width: 100, height: 20 }),
+    });
+    installAuditScript();
+
+    // #window has default overflow:visible — nothing clips, so the overflow is
+    // painted visibly and belongs to the bbox overflow checks, not truncation.
+    expect(runAudit().some((issue) => issue.code === "text_truncated")).toBe(false);
+  });
+
+  it("leaves self-clipping text with its own text node to clipped_text (no double-report)", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="label">Self clipped ellipsis label</div>
+      </div>
+    `;
+    defineScrollMetrics("label", {
+      clientWidth: 100,
+      scrollWidth: 240,
+      clientHeight: 20,
+      scrollHeight: 20,
+    });
+    installGeometry(
+      {
+        root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+        label: rect({ left: 40, top: 60, width: 100, height: 20 }),
+      },
+      { label: { overflow: "hidden", overflowX: "hidden", overflowY: "hidden" } },
+    );
+    installAuditScript();
+
+    const issues = runAudit();
+    expect(issues.some((issue) => issue.code === "clipped_text")).toBe(true);
+    expect(issues.some((issue) => issue.code === "text_truncated")).toBe(false);
+  });
+
+  it("suppresses truncation under data-layout-allow-truncation and data-layout-allow-overflow", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="window">
+          <div id="label">Intentionally truncated label</div>
+        </div>
+      </div>
+    `;
+    defineScrollMetrics("label", {
+      clientWidth: 100,
+      scrollWidth: 240,
+      clientHeight: 20,
+      scrollHeight: 20,
+    });
+    installGeometry(
+      {
+        root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+        window: rect({ left: 40, top: 60, width: 100, height: 20 }),
+        label: rect({ left: 40, top: 60, width: 100, height: 20 }),
+      },
+      { window: { overflow: "hidden", overflowX: "hidden", overflowY: "hidden" } },
+    );
+    installAuditScript();
+
+    const truncatedCount = () =>
+      runAudit().filter((issue) => issue.code === "text_truncated").length;
+    expect(truncatedCount()).toBe(1);
+
+    document.querySelector("#label")?.setAttribute("data-layout-allow-truncation", "");
+    expect(truncatedCount()).toBe(0);
+    document.querySelector("#label")?.removeAttribute("data-layout-allow-truncation");
+
+    document.querySelector("#window")?.setAttribute("data-layout-allow-overflow", "");
+    expect(truncatedCount()).toBe(0);
+  });
 });
 
 it("is inert unless text or media candidates are explicitly requested", () => {

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -311,9 +311,7 @@ describe("layout-audit.browser", () => {
     expect(parentOverflow).toBeUndefined();
   });
 
-  // text_truncated: content clipped away by an overflow-hidden ANCESTOR. The
-  // bbox overflow checks miss this because getBoundingClientRect returns the
-  // already-clipped box — only scrollWidth > clientWidth exposes the lost text.
+  // text_truncated: content clipped by an overflow-hidden ancestor — bbox checks miss it (clipped box shows no spill), only scrollWidth > clientWidth exposes it.
   function defineScrollMetrics(
     id: string,
     metrics: {
@@ -445,8 +443,7 @@ describe("layout-audit.browser", () => {
     });
     installAuditScript();
 
-    // #window has default overflow:visible — nothing clips, so the overflow is
-    // painted visibly and belongs to the bbox overflow checks, not truncation.
+    // #window has default overflow:visible — nothing clips, so this belongs to bbox overflow checks, not truncation.
     expect(runAudit().some((issue) => issue.code === "text_truncated")).toBe(false);
   });
 

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -1122,6 +1122,7 @@ function parseOverflow(value: unknown): LayoutIssue["overflow"] | null {
 const LAYOUT_ISSUE_CODES: readonly LayoutIssueCode[] = [
   "text_box_overflow",
   "clipped_text",
+  "text_truncated",
   "canvas_overflow",
   "container_overflow",
   "content_overlap",

--- a/packages/cli/src/utils/layoutAudit.ts
+++ b/packages/cli/src/utils/layoutAudit.ts
@@ -12,9 +12,7 @@ export type LayoutOverflow = Partial<Record<"left" | "right" | "top" | "bottom",
 export type LayoutIssueCode =
   | "text_box_overflow"
   | "clipped_text"
-  // Content clipped away by an overflow-hidden ancestor: scrollWidth/scrollHeight
-  // exceeds the visible client box even though the (already-clipped) bbox shows
-  // no spill — the gap the bbox-based overflow checks structurally miss.
+  // Content clipped by an overflow-hidden ancestor: scrollWidth/Height exceeds the visible client box though the clipped bbox shows no spill — the gap bbox checks miss.
   | "text_truncated"
   | "canvas_overflow"
   | "container_overflow"

--- a/packages/cli/src/utils/layoutAudit.ts
+++ b/packages/cli/src/utils/layoutAudit.ts
@@ -12,6 +12,10 @@ export type LayoutOverflow = Partial<Record<"left" | "right" | "top" | "bottom",
 export type LayoutIssueCode =
   | "text_box_overflow"
   | "clipped_text"
+  // Content clipped away by an overflow-hidden ancestor: scrollWidth/scrollHeight
+  // exceeds the visible client box even though the (already-clipped) bbox shows
+  // no spill — the gap the bbox-based overflow checks structurally miss.
+  | "text_truncated"
   | "canvas_overflow"
   | "container_overflow"
   | "content_overlap"
@@ -209,6 +213,7 @@ const HELD_ACROSS_SAMPLES_MIN_OCCURRENCES = 2;
 const PERSISTENCE_TIERED_CODES: ReadonlySet<LayoutIssueCode> = new Set([
   "text_box_overflow",
   "clipped_text",
+  "text_truncated",
   "canvas_overflow",
   "container_overflow",
   "content_overlap",


### PR DESCRIPTION
## The gap

The layout audit's overflow detectors compare bounding boxes: `overflowFor(subject, container, …)` fires only when a subject's bbox extends beyond its container's. But when text is clipped by an `overflow:hidden` ancestor (with or without `text-overflow:ellipsis`), `getBoundingClientRect` returns the **already-clipped** box, constrained to the container. The bbox comparison sees no spill, so the lost content is invisible to every existing check — no `scrollWidth`/`clientWidth`-based truncation detection existed.

## The fix

A new browser-side detector (`textTruncationIssues` in `layout-audit.browser.js`) flags text-bearing elements where `scrollWidth > clientWidth` (horizontal) or `scrollHeight > clientHeight` (vertical) **and** a clipping element — the element itself or an ancestor below the composition root — actually hides that overflow (`clipsOverflow`). It:

- reports the **innermost** truncated box per nesting chain (a clipping container and the text child that overflows it both trip the check; only the child is reported)
- defers self-clipping elements that own their text to the existing `clipped_text` check (no double-report)
- respects `data-layout-allow-overflow`/`data-layout-bleed` and adds an explicit `data-layout-allow-truncation` opt-out
- emits `text_truncated` at **warning** severity (matches the `text_box_overflow` posture — a clipped label is a real defect but not render-breaking), with a snippet, selector, container selector and fix hint

Wired through the same path as the sibling layout findings: browser detector → `checkBrowser.ts` parser allowlist → `LayoutIssueCode` union + persistence tiering in `layoutAudit.ts` → `checkPipeline`.

## Eval

Ran the built CLI (`check <sample> --json`) against the 4 rendered discovery samples the current check misses, plus clean controls:

| Sample | Defect | `text_truncated` fires? |
|--------|--------|------------------------|
| `w3/fuzz000` | concept-hub node labels ("Microgrid Active", "Vertical Farming", "100% Recycled") | ✅ 3 findings on `div.satellite-val` (content width 144px > visible 126px) |
| `w6/fuzz007` | gantt bar status labels ("ACTIVE IN-PROGRE…", "Full Thrust Burn…") | ✅ 4 findings on `.task-bar` (content width 418px > visible 346px) |
| `w3/fuzz007` | matrix quadrant/axis labels clipped vertically | ✅ 4 findings on `div.quad-title` (content height 35px > visible 31px) — vertical truncation |
| `w2/fuzz008` | kanban DONE column, bottom card clipped | ❌ not fired — see note |

**3 of 4** fire, and vertical truncation is covered (`w3/fuzz007`). The kanban miss is honest: its DONE column has no `overflow:hidden` and no height cap — it grows and its bottom card is cut by the **canvas root edge**. That is a bbox-extends-past-canvas defect (`canvas_overflow`'s mechanism), not `scrollWidth > clientWidth` content-box truncation; no element there has content overflowing its own clipped box. Forcing it would duplicate `canvas_overflow` and risk false positives, so it is intentionally out of scope for this check.

Clean controls — **no false positives**: `w1/fuzz003`, `w5/fuzz000`, `w5/fuzz002` all report `text_truncated: 0`.

## Tests

Added to `layout-audit.browser.test.ts`: positive horizontal + vertical truncation under a clipping ancestor, negatives for text that fits and for overflow into a **non-clipping** container (visible, not lost), a no-double-report guard vs `clipped_text`, and opt-out guards for `data-layout-allow-truncation` and `data-layout-allow-overflow`. Full file: 78 tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
