### PR TITLE
fix(fonts): resolve observed family aliases deterministically

### DIFF
--- a/packages/core/src/fonts/aliases.ts
+++ b/packages/core/src/fonts/aliases.ts
@@ -2,6 +2,8 @@
 export {
   FONT_ALIAS_MAP,
   FONT_ALIAS_KEYS,
+  GOOGLE_FONT_FAMILY_ALIASES,
+  GOOGLE_FONT_FAMILY_ALIAS_KEYS,
   CANONICAL_FONT_DISPLAY_NAMES,
   resolveAliasDisplayName,
 } from "@hyperframes/parsers";

--- a/packages/lint/src/rules/fonts.test.ts
+++ b/packages/lint/src/rules/fonts.test.ts
@@ -212,10 +212,13 @@ describe("font rules", () => {
     });
 
     for (const family of [
+      "FredericktheGreat",
       "Pretendard",
+      "Pyidaungsu",
       "Yantra Manav",
       "Noto Serif Arabic",
       "Noto Serif Urdu",
+      "Noto Serif VI",
       "Noto Sans Greek",
       "Noto Sans Odia",
       "Noto Sans Urdu",

--- a/packages/lint/src/rules/fonts.test.ts
+++ b/packages/lint/src/rules/fonts.test.ts
@@ -211,6 +211,24 @@ describe("font rules", () => {
       expect(findings).toHaveLength(0);
     });
 
+    for (const family of [
+      "Pretendard",
+      "Yantra Manav",
+      "Noto Serif Arabic",
+      "Noto Serif Urdu",
+      "Noto Sans Greek",
+      "Noto Sans Odia",
+      "Noto Sans Urdu",
+    ]) {
+      it(`does not flag the producer-resolved Google family alias ${family}`, async () => {
+        const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
+          <style>body { font-family: '${family}', sans-serif; }</style>
+        </div>`;
+        const findings = await findByCode(html, "font_family_without_font_face");
+        expect(findings).toHaveLength(0);
+      });
+    }
+
     it("still flags Google-Fonts-only fonts not pre-bundled", async () => {
       const html = `<div data-composition-id="test" data-width="1920" data-height="1080">
         <style>body { font-family: 'Geist', sans-serif; }</style>

--- a/packages/lint/src/rules/fonts.ts
+++ b/packages/lint/src/rules/fonts.ts
@@ -1,4 +1,8 @@
-import { FONT_ALIAS_KEYS, resolveAliasDisplayName } from "@hyperframes/parsers/composition";
+import {
+  FONT_ALIAS_KEYS,
+  GOOGLE_FONT_FAMILY_ALIAS_KEYS,
+  resolveAliasDisplayName,
+} from "@hyperframes/parsers/composition";
 import type { LintContext, HyperframeLintFinding } from "../context";
 import { isRegistrySourceFile, isRegistryInstalledFile } from "./composition";
 
@@ -223,6 +227,7 @@ export const fontRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
       (name) =>
         !declared.has(name) &&
         !FONT_ALIAS_KEYS.has(name) &&
+        !GOOGLE_FONT_FAMILY_ALIAS_KEYS.has(name) &&
         !googleFonts.has(name.replace(/\+/g, " ")),
     );
     if (undeclared.length === 0) return findings;

--- a/packages/parsers/src/composition.ts
+++ b/packages/parsers/src/composition.ts
@@ -6,6 +6,8 @@ export * from "./types.js";
 export {
   FONT_ALIAS_MAP,
   FONT_ALIAS_KEYS,
+  GOOGLE_FONT_FAMILY_ALIASES,
+  GOOGLE_FONT_FAMILY_ALIAS_KEYS,
   CANONICAL_FONT_DISPLAY_NAMES,
   resolveAliasDisplayName,
 } from "./fontAliases.js";

--- a/packages/parsers/src/fontAliases.ts
+++ b/packages/parsers/src/fontAliases.ts
@@ -102,10 +102,13 @@ export const FONT_ALIAS_KEYS: ReadonlySet<string> = new Set(Object.keys(FONT_ALI
  * name used to build its injected @font-face rules.
  */
 export const GOOGLE_FONT_FAMILY_ALIASES: Readonly<Record<string, string>> = {
+  frederickthegreat: "Fredericka the Great",
   pretendard: "Noto Sans KR",
+  pyidaungsu: "Noto Sans Myanmar",
   "yantra manav": "Yantramanav",
   "noto serif arabic": "Noto Naskh Arabic",
   "noto serif urdu": "Noto Nastaliq Urdu",
+  "noto serif vi": "Noto Serif",
   "noto sans greek": "Noto Sans",
   "noto sans odia": "Noto Sans Oriya",
   "noto sans urdu": "Noto Sans Arabic",

--- a/packages/parsers/src/fontAliases.ts
+++ b/packages/parsers/src/fontAliases.ts
@@ -33,6 +33,7 @@ export const FONT_ALIAS_MAP = {
   arial: "inter",
   "helvetica bold": "inter",
   futura: "montserrat",
+  "futura std": "montserrat",
   "din alternate": "montserrat",
   "arial black": "montserrat",
   "bebas neue": "league-gothic",
@@ -62,6 +63,7 @@ export const FONT_ALIAS_MAP = {
   corbel: "inter",
   "lucida sans": "inter",
   "lucida sans unicode": "inter",
+  "ms sans serif": "inter",
 
   // ── Linux sans-serif system fonts → inter ─────────────────────────────
   "noto sans": "inter",
@@ -92,6 +94,26 @@ export const FONT_ALIAS_MAP = {
 } satisfies Readonly<Record<string, string>>;
 
 export const FONT_ALIAS_KEYS: ReadonlySet<string> = new Set(Object.keys(FONT_ALIAS_MAP));
+
+/**
+ * Authoring names that are not served by Google Fonts verbatim, but have a
+ * deterministic, script-compatible Google family. Unlike FONT_ALIAS_MAP,
+ * these preserve the authored CSS family and only change the upstream fetch
+ * name used to build its injected @font-face rules.
+ */
+export const GOOGLE_FONT_FAMILY_ALIASES: Readonly<Record<string, string>> = {
+  pretendard: "Noto Sans KR",
+  "yantra manav": "Yantramanav",
+  "noto serif arabic": "Noto Naskh Arabic",
+  "noto serif urdu": "Noto Nastaliq Urdu",
+  "noto sans greek": "Noto Sans",
+  "noto sans odia": "Noto Sans Oriya",
+  "noto sans urdu": "Noto Sans Arabic",
+};
+
+export const GOOGLE_FONT_FAMILY_ALIAS_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(GOOGLE_FONT_FAMILY_ALIASES),
+);
 
 /**
  * Human-readable display names for canonical font slugs. Used by the lint

--- a/packages/parsers/src/index.ts
+++ b/packages/parsers/src/index.ts
@@ -17,6 +17,8 @@ export { scanVariableUsage, type VariableUsageScan } from "./variableUsage.js";
 export {
   FONT_ALIAS_MAP,
   FONT_ALIAS_KEYS,
+  GOOGLE_FONT_FAMILY_ALIASES,
+  GOOGLE_FONT_FAMILY_ALIAS_KEYS,
   CANONICAL_FONT_DISPLAY_NAMES,
   resolveAliasDisplayName,
 } from "./fontAliases.js";

--- a/packages/producer/src/services/deterministicFonts-failClosed.test.ts
+++ b/packages/producer/src/services/deterministicFonts-failClosed.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { parseHTML } from "linkedom";
 import {
   FONT_FETCH_FAILED,
   FontFetchError,
@@ -138,6 +139,38 @@ describe("injectDeterministicFontFaces — failClosedFontFetch: true", () => {
       expect(familyParam?.startsWith(`${authoredFamily}:`)).toBe(false);
       expect(result).toContain(`font-family: "${authoredFamily}"`);
       expect(result).toContain("data-hyperframes-deterministic-fonts");
+    });
+  }
+
+  for (const [authoredFamily, googleFamily] of [
+    ["Pretendard", "Noto Sans KR"],
+    ["Yantra Manav", "Yantramanav"],
+    ["Noto Serif Arabic", "Noto Naskh Arabic"],
+    ["Noto Serif Urdu", "Noto Nastaliq Urdu"],
+    ["Noto Sans Greek", "Noto Sans"],
+    ["Noto Sans Odia", "Noto Sans Oriya"],
+    ["Noto Sans Urdu", "Noto Sans Arabic"],
+  ] as const) {
+    it(`resolves observed family alias ${authoredFamily} through ${googleFamily}`, async () => {
+      const cssRequests: string[] = [];
+      const html = `<!doctype html><html><head><style>
+        body { font-family: "${authoredFamily}", sans-serif; }
+      </style></head><body><p>hello</p></body></html>`;
+
+      const result = await injectDeterministicFontFaces(html, {
+        failClosedFontFetch: true,
+        allowSystemFontCapture: false,
+        fetchImpl: makeGoogleFontFetch(cssRequests),
+      });
+
+      expect(cssRequests).toHaveLength(1);
+      const familyParam = new URL(cssRequests[0]!).searchParams.get("family");
+      expect(familyParam?.startsWith(`${googleFamily}:`)).toBe(true);
+      const { document } = parseHTML(result);
+      const injectedCss = document.querySelector(
+        'style[data-hyperframes-deterministic-fonts="true"]',
+      )?.textContent;
+      expect(injectedCss).toContain(`font-family: "${authoredFamily}"`);
     });
   }
 

--- a/packages/producer/src/services/deterministicFonts-failClosed.test.ts
+++ b/packages/producer/src/services/deterministicFonts-failClosed.test.ts
@@ -143,10 +143,13 @@ describe("injectDeterministicFontFaces — failClosedFontFetch: true", () => {
   }
 
   for (const [authoredFamily, googleFamily] of [
+    ["FredericktheGreat", "Fredericka the Great"],
     ["Pretendard", "Noto Sans KR"],
+    ["Pyidaungsu", "Noto Sans Myanmar"],
     ["Yantra Manav", "Yantramanav"],
     ["Noto Serif Arabic", "Noto Naskh Arabic"],
     ["Noto Serif Urdu", "Noto Nastaliq Urdu"],
+    ["Noto Serif VI", "Noto Serif"],
     ["Noto Sans Greek", "Noto Sans"],
     ["Noto Sans Odia", "Noto Sans Oriya"],
     ["Noto Sans Urdu", "Noto Sans Arabic"],

--- a/packages/producer/src/services/deterministicFonts.test.ts
+++ b/packages/producer/src/services/deterministicFonts.test.ts
@@ -61,6 +61,8 @@ describe("FONT_ALIASES cross-platform coverage", () => {
     expect(FONT_ALIASES["courier new"]).toBe("jetbrains-mono");
     expect(FONT_ALIASES["segoe ui"]).toBe("roboto");
     expect(FONT_ALIASES["futura"]).toBe("montserrat");
+    expect(FONT_ALIASES["futura std"]).toBe("montserrat");
+    expect(FONT_ALIASES["ms sans serif"]).toBe("inter");
     expect(FONT_ALIASES["bebas neue"]).toBe("league-gothic");
   });
 

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -4,7 +4,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { defaultLogger } from "../logger.js";
 
-import { FONT_ALIAS_MAP } from "@hyperframes/core/fonts/aliases";
+import { FONT_ALIAS_MAP, GOOGLE_FONT_FAMILY_ALIASES } from "@hyperframes/core/fonts/aliases";
 import {
   locateSystemFontVariants,
   SYSTEM_FONT_SIZE_LIMIT,
@@ -748,7 +748,8 @@ async function fetchGoogleFont(
   // space. Resolve that URL-style spelling through the canonical Google family
   // while preserving `familyName` for the emitted @font-face alias so the
   // authored CSS still matches it.
-  const googleFamilyName = familyName.replace(/\+/g, " ");
+  const googleFamilyName =
+    GOOGLE_FONT_FAMILY_ALIASES[normalizeFamilyName(familyName)] ?? familyName.replace(/\+/g, " ");
   const encodedFamily = encodeURIComponent(googleFamilyName);
   const textParam = fontText ? `&text=${encodeURIComponent(fontText)}` : "";
   const url = `https://fonts.googleapis.com/css2?family=${encodedFamily}:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,700${textParam}`;


### PR DESCRIPTION
## What

Resolve production-observed font-family spellings that are currently renderable
but fail deterministic distributed font preflight:

- preserve ten authored family names while fetching verified,
  script-compatible Google families
- resolve `Futura Std` and `MS Sans Serif` through the existing bundled-font
  substitution path
- share the Google-fetch alias contract with lint so strict checks do not reject
  a family the producer can resolve

Unknown families still fail closed.

## Why

`font_unresolved` is the largest current Hyperframes failure class. In a
fresh six-hour production sample it accounted for 49 completion failures. The
underlying exception logs included retries; deduplicating by workflow showed
28 affected workflows across 11 family spellings. This PR covers 22 of those
28 workflows:

- the original mappings cover 19 (`MS Sans Serif`, `Noto Sans Greek`,
  `Pretendard`, and `Yantra Manav`);
- the current-cohort extension covers 3 more (`FredericktheGreat`,
  `Noto Serif VI`, and `Pyidaungsu`).

The remaining `Fira GO`, `Bungee Stencil`, and `Yantraavishkar` spellings stay
fail-closed because substituting them would risk changing script coverage or
typography. `inherit` is a CSS cascade/parser issue and is intentionally left
for a separate syntax-aware fix.

The Google CSS2 endpoint does not serve several observed names verbatim even
though a deterministic script-compatible family exists. The producer therefore
reported a customer `font_unresolved` error for content it can safely render.

## How

- add a distinct `GOOGLE_FONT_FAMILY_ALIASES` map in the browser-safe parsers
  package
- re-export it through composition/core for producer and lint consumers
- query the mapped Google family while emitting injected `@font-face` rules
  under the original authored family, so existing CSS selectors still match
- keep this separate from `FONT_ALIAS_MAP`, whose values mean bundled font
  substitutions
- recognize the same fetch aliases in `font_family_without_font_face`

The exact production axis matrix was verified against the official Google Fonts
CSS2 endpoint for every mapped family. `Pyidaungsu` maps to script-compatible
`Noto Sans Myanmar`; it is not metrically identical and must be included in
candidate screenshot/parity monitoring.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)

Validation:

- producer deterministic-font focused suites: 35 passed
- lint font rule suite: 46 passed
- exact Google CSS2 production requests return HTTP 200 and WOFF2 faces for
  every new alias
- parser, lint, and producer typechecks passed
- pre-commit tracked-artifact, lint, format, static-analysis, typecheck, and
  commit-message hooks passed
- independent code review approved the original change and the current-cohort
  extension with no blockers
