### PR TITLE
docs(guides): update stale Cursor link to cursor.com

### DIFF
--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -19,7 +19,7 @@ The skills split into three groups:
     npx hyperframes skills update
     ```
 
-    Installs exactly the core set — the `/hyperframes` router, the `hyperframes-*` domain skills, and `media-use` — and the router installs each creation workflow on demand the first time it routes there. Always installs from the repo's current `main`. Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor.sh), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex CLI](https://github.com/openai/codex), [GitHub Copilot CLI](/guides/copilot-cli), and [Google Antigravity](/guides/antigravity).
+    Installs exactly the core set — the `/hyperframes` router, the `hyperframes-*` domain skills, and `media-use` — and the router installs each creation workflow on demand the first time it routes there. Always installs from the repo's current `main`. Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor.com), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex CLI](https://github.com/openai/codex), [GitHub Copilot CLI](/guides/copilot-cli), and [Google Antigravity](/guides/antigravity).
   </Step>
   <Step title="Or pick what to install (interactive picker)">
     ```bash

--- a/docs/guides/website-to-video.mdx
+++ b/docs/guides/website-to-video.mdx
@@ -20,7 +20,7 @@ Give your AI agent a URL and a creative direction. It captures the site, extract
     npx skills add heygen-com/hyperframes
     ```
 
-    Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor.sh), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and [Codex CLI](https://github.com/openai/codex).
+    Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor.com), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and [Codex CLI](https://github.com/openai/codex).
   </Step>
   <Step title="Prompt your agent">
     Open your agent in any directory and describe the video you want:


### PR DESCRIPTION
## What

Update the Cursor homepage link from the legacy `https://cursor.sh` domain to the current canonical `https://cursor.com` in `docs/guides/skills.mdx` and `docs/guides/website-to-video.mdx`.

## Why

`cursor.sh` now returns an HTTP 308 redirect to `cursor.com`. Keeping the old domain in install/agent-compatibility docs is a stale link that sends users through an unnecessary redirect and could eventually break if the redirect is removed.

## How

Replaced the two occurrences of `[Cursor](https://cursor.sh)` with `[Cursor](https://cursor.com)`.

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

## Problem

Docs still point to the legacy `cursor.sh` domain.

## Triage / Root cause

Cursor moved their canonical homepage to `cursor.com`; `cursor.sh` now only redirects.

## Fix

Sync the two docs references to `https://cursor.com`.

## Verification

- `curl -I -L https://cursor.sh` → `HTTP/2 308` to `https://cursor.com/`
- `curl -I https://cursor.com` → `HTTP/2 200`
- `python3 ../scripts/preflight_ship.py` passed for both `docs/guides/skills.mdx` and `docs/guides/website-to-video.mdx` (bug marker still present, fix marker absent).
- `git show upstream/main:<file>` confirmed the stale links are on current `main`.
- No open PR duplicates (`gh pr list --state all --search 'cursor.sh OR cursor.com'` returned only unrelated closed #645 and marketplace-branding #461).

## Notes / Risks

None. No generated files or specs touched.
