### PR TITLE
feat(player): SSR via declarative shadow DOM (stacked on #2758)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           filters: |
             code:
               - "packages/**"
+              - "examples/**"
               - "scripts/**"
               - "package.json"
               - "bun.lock"

--- a/.gitignore
+++ b/.gitignore
@@ -97,8 +97,15 @@ examples/*
 !examples/k8s-jobs/**
 !examples/gcp-cloud-run
 !examples/gcp-cloud-run/**
+!examples/react-player
+!examples/react-player/**
 # …but never the local smoke run's build/render artifacts.
 examples/gcp-cloud-run/scripts/gcp-smoke-artifacts/
+# …and never the react-player example's vite build output or node_modules
+# (the blanket dist/ and node_modules/ rules match unanchored, but the
+# `!examples/react-player/**` negation above would otherwise re-include them).
+examples/react-player/dist/
+examples/react-player/node_modules/
 packages/studio/data/
 
 .desloppify/

--- a/bun.lock
+++ b/bun.lock
@@ -21,9 +21,27 @@
         "yaml": "^2.9.0",
       },
     },
+    "examples/react-player": {
+      "name": "@hyperframes/react-player-example",
+      "version": "0.7.69",
+      "dependencies": {
+        "@hyperframes/player": "workspace:*",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.0.0",
+        "happy-dom": "^20.9.0",
+        "typescript": "^5.0.0",
+        "vite": "^6.4.2",
+        "vitest": "^3.2.4",
+      },
+    },
     "packages/aws-lambda": {
       "name": "@hyperframes/aws-lambda",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-sfn": "^3.700.0",
@@ -55,7 +73,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "bin": {
         "hyperframes": "./bin/hyperframes.mjs",
       },
@@ -106,7 +124,7 @@
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@chenglou/pretext": "^0.0.5",
         "@hyperframes/lint": "workspace:*",
@@ -131,7 +149,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
         "@hyperframes/core": "workspace:^",
@@ -150,7 +168,7 @@
     },
     "packages/gcp-cloud-run": {
       "name": "@hyperframes/gcp-cloud-run",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@google-cloud/storage": "^7.14.0",
         "@google-cloud/workflows": "^4.2.0",
@@ -170,7 +188,7 @@
     },
     "packages/lint": {
       "name": "@hyperframes/lint",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@hyperframes/parsers": "workspace:*",
         "htmlparser2": "^10.1.0",
@@ -188,7 +206,7 @@
     },
     "packages/parsers": {
       "name": "@hyperframes/parsers",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "acorn": "^8.17.0",
@@ -208,22 +226,32 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "gsap": "^3.12.5",
         "puppeteer-core": "^25.2.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.2.4",
       },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+      },
+      "optionalPeers": [
+        "react",
+      ],
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -268,7 +296,7 @@
     },
     "packages/sdk": {
       "name": "@hyperframes/sdk",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",
@@ -298,7 +326,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -310,7 +338,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
@@ -358,7 +386,7 @@
     },
     "packages/studio-server": {
       "name": "@hyperframes/studio-server",
-      "version": "0.7.60",
+      "version": "0.7.69",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",
@@ -740,6 +768,8 @@
     "@hyperframes/player": ["@hyperframes/player@workspace:packages/player"],
 
     "@hyperframes/producer": ["@hyperframes/producer@workspace:packages/producer"],
+
+    "@hyperframes/react-player-example": ["@hyperframes/react-player-example@workspace:examples/react-player"],
 
     "@hyperframes/sdk": ["@hyperframes/sdk@workspace:packages/sdk"],
 

--- a/examples/react-player/README.md
+++ b/examples/react-player/README.md
@@ -1,0 +1,22 @@
+# @hyperframes/react-player-example
+
+Demo app for the React bindings shipped at [`@hyperframes/player/react`](../player#react). Renders the `<HyperframesPlayer>` component against a bundled copy of the `motion-blur` registry example and exercises the full binding surface:
+
+- Props → attributes (`controls`, `muted`, `loop`, `playbackRate`) via the option toggles
+- Event callbacks (`onReady`, `onPlay`, `onPause`, `onTimeUpdate`, `onEnded`, `onScenes`, `onError`) via the event log
+- The imperative ref handle (`play()`, `pause()`, `seek()`) via the custom transport bar
+
+## Run
+
+```bash
+bun install          # from the repo root
+bun run --filter '@hyperframes/{parsers,lint,studio-server}' build
+bun run --filter @hyperframes/core build
+bun run --filter @hyperframes/player build   # the react subpath resolves to player dist
+cd examples/react-player
+bun run dev
+```
+
+The demo composition lives at `public/composition/index.html` — an unmodified copy of `registry/examples/motion-blur`. Swap in any composition (e.g. one scaffolded with `hyperframes init`) by replacing that file or pointing `COMPOSITION_SRC` in `src/App.tsx` elsewhere.
+
+This package is private and never published.

--- a/examples/react-player/index.html
+++ b/examples/react-player/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HyperFrames Player — React Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-player/package.json
+++ b/examples/react-player/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@hyperframes/react-player-example",
+  "version": "0.7.69",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@hyperframes/player": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "happy-dom": "^20.9.0",
+    "typescript": "^5.0.0",
+    "vite": "^6.4.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/examples/react-player/public/composition/index.html
+++ b/examples/react-player/public/composition/index.html
@@ -1,0 +1,572 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>Motion Blur — Velocity Showcase</title>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #06060a;
+      }
+
+      #comp {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        font-family: "SF Mono", ui-monospace, monospace;
+        background: #06060a;
+      }
+
+      .header {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 80px;
+        display: flex;
+        align-items: flex-end;
+        padding: 0 72px 20px;
+        border-bottom: 1px solid #0f0f18;
+      }
+      .header-title {
+        font-size: 11px;
+        letter-spacing: 0.4em;
+        text-transform: uppercase;
+        color: #1e1e2a;
+      }
+      .header-sub {
+        margin-left: auto;
+        font-size: 11px;
+        letter-spacing: 0.25em;
+        text-transform: uppercase;
+        color: #14141c;
+      }
+
+      /* Each group = one speed level, containing a shape row + text row */
+      .group {
+        position: absolute;
+        left: 0;
+        right: 0;
+        height: 184px; /* 72 + 16 + 72 + 24 bottom */
+      }
+
+      /* Group bottom separator */
+      .group::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 72px;
+        right: 72px;
+        height: 1px;
+        background: #0d0d15;
+      }
+
+      /* Duration label — left, spanning both rows */
+      .dur {
+        position: absolute;
+        left: 72px;
+        top: 0;
+        width: 90px;
+        height: 160px; /* 72+16+72 */
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .dur-num {
+        font-size: 28px;
+        font-weight: 700;
+        letter-spacing: -0.04em;
+        color: #fff;
+        line-height: 1;
+      }
+      .dur-unit {
+        font-size: 9px;
+        letter-spacing: 0.25em;
+        text-transform: uppercase;
+        color: #252532;
+        margin-top: 5px;
+      }
+
+      /* Row-type hint ("shape" / "text") — right of dur label */
+      .row-hint {
+        position: absolute;
+        left: 176px;
+        width: 44px;
+        height: 72px;
+        display: flex;
+        align-items: center;
+        font-size: 8px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: #161620;
+      }
+
+      /* Speed label — right, spanning both rows */
+      .spd {
+        position: absolute;
+        right: 72px;
+        top: 0;
+        width: 100px;
+        height: 160px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-end;
+      }
+      .spd-label {
+        font-size: 10px;
+        letter-spacing: 0.3em;
+        text-transform: uppercase;
+        color: #181822;
+      }
+
+      /* Animated elements — both types live at left:0, GSAP drives x */
+      .pill {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 200px;
+        height: 72px;
+        border-radius: 36px;
+        will-change: transform, filter;
+      }
+
+      .word {
+        position: absolute;
+        left: 0;
+        top: 88px; /* 72 + 16 gap */
+        height: 72px;
+        line-height: 72px;
+        white-space: nowrap;
+        font-size: 56px;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        will-change: transform, filter;
+      }
+
+      /* Inner divider between shape row and text row */
+      .inner-div {
+        position: absolute;
+        left: 220px;
+        right: 200px;
+        top: 80px; /* 72 + 8 */
+        height: 1px;
+        background: #0a0a12;
+      }
+
+      /* Track guide lines */
+      .track-a,
+      .track-b {
+        position: absolute;
+        left: 220px;
+        right: 200px;
+        height: 1px;
+        background: #0c0c14;
+      }
+      .track-a {
+        top: 35px;
+      } /* center of shape row */
+      .track-b {
+        top: 123px;
+      } /* 88 + 35 = center of text row */
+    </style>
+  </head>
+  <body>
+    <div
+      id="comp"
+      data-composition-id="motion-blur-example"
+      data-width="1920"
+      data-height="1080"
+      data-start="0"
+      data-duration="4"
+    >
+      <div class="header" data-layout-ignore>
+        <span class="header-title">Motion Blur — Velocity Showcase</span>
+        <span class="header-sub">feGaussianBlur + scaleX · blur ∝ velocity</span>
+      </div>
+
+      <!-- Group 1: 3.0s slow — top: 80 -->
+      <div class="group" style="top: 80px">
+        <div class="dur" data-layout-ignore>
+          <span class="dur-num">3.0</span><span class="dur-unit">seconds</span>
+        </div>
+        <div class="row-hint" data-layout-ignore style="top: 0">shape</div>
+        <div class="row-hint" data-layout-ignore style="top: 88px">text</div>
+        <div class="track-a"></div>
+        <div class="inner-div"></div>
+        <div class="track-b"></div>
+        <div
+          class="pill"
+          id="s1"
+          style="
+            background: linear-gradient(135deg, #60a5fa, #2563eb);
+            box-shadow: 0 0 32px rgba(96, 165, 250, 0.18);
+          "
+        ></div>
+        <div
+          class="word"
+          id="t1"
+          style="color: #3b82f6; text-shadow: 0 0 40px rgba(96, 165, 250, 0.3)"
+        >
+          DRIFT
+        </div>
+        <div class="spd" data-layout-ignore><span class="spd-label">slow</span></div>
+      </div>
+
+      <!-- Group 2: 1.5s medium — top: 264 -->
+      <div class="group" style="top: 264px">
+        <div class="dur" data-layout-ignore>
+          <span class="dur-num">1.5</span><span class="dur-unit">seconds</span>
+        </div>
+        <div class="row-hint" data-layout-ignore style="top: 0">shape</div>
+        <div class="row-hint" data-layout-ignore style="top: 88px">text</div>
+        <div class="track-a"></div>
+        <div class="inner-div"></div>
+        <div class="track-b"></div>
+        <div
+          class="pill"
+          id="s2"
+          style="
+            background: linear-gradient(135deg, #34d399, #059669);
+            box-shadow: 0 0 32px rgba(52, 211, 153, 0.18);
+          "
+        ></div>
+        <div
+          class="word"
+          id="t2"
+          style="color: #10b981; text-shadow: 0 0 40px rgba(52, 211, 153, 0.3)"
+        >
+          GLIDE
+        </div>
+        <div class="spd" data-layout-ignore><span class="spd-label">medium</span></div>
+      </div>
+
+      <!-- Group 3: 0.7s fast — top: 448 -->
+      <div class="group" style="top: 448px">
+        <div class="dur" data-layout-ignore>
+          <span class="dur-num">0.7</span><span class="dur-unit">seconds</span>
+        </div>
+        <div class="row-hint" data-layout-ignore style="top: 0">shape</div>
+        <div class="row-hint" data-layout-ignore style="top: 88px">text</div>
+        <div class="track-a"></div>
+        <div class="inner-div"></div>
+        <div class="track-b"></div>
+        <div
+          class="pill"
+          id="s3"
+          style="
+            background: linear-gradient(135deg, #c084fc, #7c3aed);
+            box-shadow: 0 0 32px rgba(192, 132, 252, 0.18);
+          "
+        ></div>
+        <div
+          class="word"
+          id="t3"
+          style="color: #a855f7; text-shadow: 0 0 40px rgba(192, 132, 252, 0.3)"
+        >
+          RUSH
+        </div>
+        <div class="spd" data-layout-ignore><span class="spd-label">fast</span></div>
+      </div>
+
+      <!-- Group 4: 0.35s faster — top: 632 -->
+      <div class="group" style="top: 632px">
+        <div class="dur" data-layout-ignore>
+          <span class="dur-num">0.35</span><span class="dur-unit">seconds</span>
+        </div>
+        <div class="row-hint" data-layout-ignore style="top: 0">shape</div>
+        <div class="row-hint" data-layout-ignore style="top: 88px">text</div>
+        <div class="track-a"></div>
+        <div class="inner-div"></div>
+        <div class="track-b"></div>
+        <div
+          class="pill"
+          id="s4"
+          style="
+            background: linear-gradient(135deg, #fb923c, #ea580c);
+            box-shadow: 0 0 32px rgba(251, 146, 60, 0.18);
+          "
+        ></div>
+        <div
+          class="word"
+          id="t4"
+          style="color: #f97316; text-shadow: 0 0 40px rgba(251, 146, 60, 0.3)"
+        >
+          BLAST
+        </div>
+        <div class="spd" data-layout-ignore><span class="spd-label">faster</span></div>
+      </div>
+
+      <!-- Group 5: 0.2s extreme — top: 816 -->
+      <div class="group" style="top: 816px">
+        <div class="dur" data-layout-ignore>
+          <span class="dur-num">0.2</span><span class="dur-unit">seconds</span>
+        </div>
+        <div class="row-hint" data-layout-ignore style="top: 0">shape</div>
+        <div class="row-hint" data-layout-ignore style="top: 88px">text</div>
+        <div class="track-a"></div>
+        <div class="inner-div"></div>
+        <div class="track-b"></div>
+        <div
+          class="pill"
+          id="s5"
+          style="
+            background: linear-gradient(135deg, #f87171, #dc2626);
+            box-shadow: 0 0 32px rgba(248, 113, 113, 0.18);
+          "
+        ></div>
+        <div
+          class="word"
+          id="t5"
+          style="color: #ef4444; text-shadow: 0 0 40px rgba(248, 113, 113, 0.3)"
+        >
+          WARP
+        </div>
+        <div class="spd" data-layout-ignore><span class="spd-label">extreme</span></div>
+      </div>
+
+      <script>
+        (function () {
+          /* ── attachMotionBlur ─────────────────────────────────────── */
+          if (!window._hfMbUid) window._hfMbUid = 0;
+          var ns = "http://www.w3.org/2000/svg";
+
+          function attachMotionBlur(selector, tl, opts) {
+            opts = opts || {};
+            var blurScale = opts.blurScale !== undefined ? opts.blurScale : 0.008;
+            var blurMax = opts.blurMax !== undefined ? opts.blurMax : 20;
+            var stretchScale = opts.stretchScale !== undefined ? opts.stretchScale : 0.0002;
+            var stretchMax = opts.stretchMax !== undefined ? opts.stretchMax : 0;
+            var axis = opts.axis || "both";
+
+            var items = Array.isArray(selector) ? selector : [selector];
+            var targets = items.reduce(function (acc, s) {
+              if (typeof s === "string") {
+                document.querySelectorAll(s).forEach(function (el) {
+                  acc.push(el);
+                });
+              } else if (s instanceof Element) {
+                acc.push(s);
+              }
+              return acc;
+            }, []);
+
+            // Ghost trail: copies placed only behind the element → inherently one-sided.
+            // Top layer: small Gaussian at current position so element looks blurry, not sharp.
+            var GHOST_CFG = [
+              { frac: 0.25, slope: 0.55 },
+              { frac: 0.55, slope: 0.28 },
+              { frac: 1.0, slope: 0.1 },
+            ];
+
+            var state = targets.map(function (el) {
+              var uid = "hf-mb-" + window._hfMbUid++;
+              var svg = document.createElementNS(ns, "svg");
+              svg.setAttribute("style", "position:absolute;width:0;height:0;overflow:hidden;");
+
+              var filter = document.createElementNS(ns, "filter");
+              filter.id = uid;
+              filter.setAttribute("x", "-110%");
+              filter.setAttribute("y", "-25%");
+              filter.setAttribute("width", "260%");
+              filter.setAttribute("height", "150%");
+
+              var ghosts = GHOST_CFG.map(function (cfg, gi) {
+                var feOff = document.createElementNS(ns, "feOffset");
+                feOff.setAttribute("in", "SourceGraphic");
+                feOff.setAttribute("dx", "0");
+                feOff.setAttribute("dy", "0");
+                feOff.setAttribute("result", "go" + gi);
+
+                var feGB = document.createElementNS(ns, "feGaussianBlur");
+                feGB.setAttribute("in", "go" + gi);
+                feGB.setAttribute("stdDeviation", "0 0");
+                feGB.setAttribute("result", "gb" + gi);
+
+                var feCT = document.createElementNS(ns, "feComponentTransfer");
+                feCT.setAttribute("in", "gb" + gi);
+                feCT.setAttribute("result", "gf" + gi);
+                var feFuncA = document.createElementNS(ns, "feFuncA");
+                feFuncA.setAttribute("type", "linear");
+                feFuncA.setAttribute("slope", String(cfg.slope));
+                feCT.appendChild(feFuncA);
+
+                filter.appendChild(feOff);
+                filter.appendChild(feGB);
+                filter.appendChild(feCT);
+                return { feOff: feOff, feGB: feGB, frac: cfg.frac };
+              });
+
+              var feTopBlur = document.createElementNS(ns, "feGaussianBlur");
+              feTopBlur.setAttribute("in", "SourceGraphic");
+              feTopBlur.setAttribute("stdDeviation", "0 0");
+              feTopBlur.setAttribute("result", "top");
+              filter.appendChild(feTopBlur);
+
+              var feMerge = document.createElementNS(ns, "feMerge");
+              for (var mi = GHOST_CFG.length - 1; mi >= 0; mi--) {
+                var mn = document.createElementNS(ns, "feMergeNode");
+                mn.setAttribute("in", "gf" + mi);
+                feMerge.appendChild(mn);
+              }
+              var mnTop = document.createElementNS(ns, "feMergeNode");
+              mnTop.setAttribute("in", "top");
+              feMerge.appendChild(mnTop);
+              filter.appendChild(feMerge);
+
+              svg.appendChild(filter);
+              document.body.appendChild(svg);
+
+              return {
+                el: el,
+                ghosts: ghosts,
+                feTopBlur: feTopBlur,
+                filterId: uid,
+                prevX: parseFloat(gsap.getProperty(el, "x")) || 0,
+                prevY: parseFloat(gsap.getProperty(el, "y")) || 0,
+                prevTime: tl.time(),
+              };
+            });
+
+            // tl.eventCallback("onUpdate") is not available in the HyperFrames renderer —
+            // the runtime proxies the timeline. Tween onUpdate fires on every seek instead.
+            var _proxy = { t: 0 };
+            tl.to(
+              _proxy,
+              {
+                t: 1,
+                duration: Math.max(tl.duration(), 0.1),
+                ease: "none",
+                onUpdate: function () {
+                  var time = tl.time();
+
+                  state.forEach(function (s) {
+                    var x = parseFloat(gsap.getProperty(s.el, "x")) || 0;
+                    var y = parseFloat(gsap.getProperty(s.el, "y")) || 0;
+                    var dt = time - s.prevTime;
+
+                    if (dt > 0.0005) {
+                      var vx = axis !== "y" ? (x - s.prevX) / dt : 0;
+                      var vy = axis !== "x" ? (y - s.prevY) / dt : 0;
+
+                      var bx = Math.min(Math.abs(vx) * blurScale, blurMax);
+                      var by = Math.min(Math.abs(vy) * blurScale, blurMax);
+                      var bxFinal = axis !== "y" ? bx : Math.max(by * 0.08, 0.4);
+                      var byFinal = axis !== "x" ? by : Math.max(bx * 0.08, 0.4);
+                      var active = bx > 0.3 || by > 0.3;
+
+                      if (active) {
+                        s.el.style.filter = "url(#" + s.filterId + ")";
+                        s.ghosts.forEach(function (g) {
+                          var dx =
+                            axis !== "y" ? (vx >= 0 ? -bxFinal * g.frac : bxFinal * g.frac) : 0;
+                          var dy =
+                            axis !== "x" ? (vy >= 0 ? -byFinal * g.frac : byFinal * g.frac) : 0;
+                          g.feOff.setAttribute("dx", dx.toFixed(2));
+                          g.feOff.setAttribute("dy", dy.toFixed(2));
+                          var gbx =
+                            axis !== "y"
+                              ? (bxFinal * g.frac * 0.5).toFixed(2)
+                              : Math.max(byFinal * g.frac * 0.04, 0.4).toFixed(2);
+                          var gby =
+                            axis !== "x"
+                              ? (byFinal * g.frac * 0.5).toFixed(2)
+                              : Math.max(bxFinal * g.frac * 0.04, 0.4).toFixed(2);
+                          g.feGB.setAttribute("stdDeviation", gbx + " " + gby);
+                        });
+                        s.feTopBlur.setAttribute(
+                          "stdDeviation",
+                          (bxFinal * 0.15).toFixed(2) + " " + (byFinal * 0.15).toFixed(2),
+                        );
+                        if (stretchMax > 0) {
+                          var sx = 1 + Math.min(Math.abs(vx) * stretchScale, stretchMax);
+                          var sy = 1 + Math.min(Math.abs(vy) * stretchScale, stretchMax);
+                          var ox = axis !== "y" ? (vx >= 0 ? "100% 50%" : "0% 50%") : "50% 50%";
+                          var oy = axis !== "x" ? (vy >= 0 ? "50% 100%" : "50% 0%") : "50% 50%";
+                          gsap.set(s.el, {
+                            scaleX: axis !== "y" ? sx : 1,
+                            scaleY: axis !== "x" ? sy : 1,
+                            transformOrigin: axis === "x" ? ox : axis === "y" ? oy : "50% 50%",
+                          });
+                        }
+                      } else {
+                        s.el.style.filter = "";
+                        s.ghosts.forEach(function (g) {
+                          g.feOff.setAttribute("dx", "0");
+                          g.feOff.setAttribute("dy", "0");
+                          g.feGB.setAttribute("stdDeviation", "0 0");
+                        });
+                        s.feTopBlur.setAttribute("stdDeviation", "0 0");
+                        if (stretchMax > 0) {
+                          gsap.set(s.el, { scaleX: 1, scaleY: 1, transformOrigin: "50% 50%" });
+                        }
+                      }
+
+                      s.prevX = x;
+                      s.prevY = y;
+                      s.prevTime = time;
+                    } else if (dt < -0.0005) {
+                      s.el.style.filter = "";
+                      s.ghosts.forEach(function (g) {
+                        g.feOff.setAttribute("dx", "0");
+                        g.feOff.setAttribute("dy", "0");
+                        g.feGB.setAttribute("stdDeviation", "0 0");
+                      });
+                      s.feTopBlur.setAttribute("stdDeviation", "0 0");
+                      if (stretchMax > 0) {
+                        gsap.set(s.el, { scaleX: 1, scaleY: 1, transformOrigin: "50% 50%" });
+                      }
+                      s.prevX = x;
+                      s.prevY = y;
+                      s.prevTime = time;
+                    }
+                    // dt ≈ 0: runtime double-fires — skip.
+                  });
+                },
+              },
+              0,
+            );
+          }
+
+          /* ── Timeline ─────────────────────────────────────────────── */
+          var tl = gsap.timeline({ paused: true });
+
+          // All elements start at x=-400 (off-screen left), travel to x=1920 (off-screen right).
+          // Shape + text in each group share the same duration → same velocity → same blur.
+          gsap.set(["#s1", "#s2", "#s3", "#s4", "#s5", "#t1", "#t2", "#t3", "#t4", "#t5"], {
+            x: -400,
+          });
+
+          tl.to(["#s1", "#t1"], { x: 1640, duration: 3.0, ease: "power3.inOut" }, 0);
+          tl.to(["#s2", "#t2"], { x: 1640, duration: 1.5, ease: "power3.inOut" }, 0);
+          tl.to(["#s3", "#t3"], { x: 1640, duration: 0.7, ease: "power3.inOut" }, 0);
+          tl.to(["#s4", "#t4"], { x: 1640, duration: 0.35, ease: "power3.inOut" }, 0);
+          tl.to(["#s5", "#t5"], { x: 1640, duration: 0.2, ease: "power3.inOut" }, 0);
+
+          tl.set(document.body, {}, 4);
+
+          attachMotionBlur(
+            ["#s1", "#s2", "#s3", "#s4", "#s5", "#t1", "#t2", "#t3", "#t4", "#t5"],
+            tl,
+            { axis: "x", blurMax: 80, stretchMax: 0 },
+          );
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines["motion-blur-example"] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/examples/react-player/src/App.test.tsx
+++ b/examples/react-player/src/App.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./App.js";
+
+// The react bindings dynamically import the player package root to register
+// the custom element; stub it so the smoke test doesn't exercise the real
+// player's iframe machinery in happy-dom.
+vi.mock("@hyperframes/player", () => ({}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>)["IS_REACT_ACT_ENVIRONMENT"] = true;
+});
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("App", () => {
+  it("renders the player wired to the demo composition", async () => {
+    await act(async () => root.render(<App />));
+    const player = container.querySelector("hyperframes-player");
+    expect(player).not.toBeNull();
+    expect(player?.getAttribute("src")).toBe("/composition/index.html");
+    expect(container.textContent).toContain("React playground");
+  });
+
+  it("reflects option toggles onto the player element", async () => {
+    await act(async () => root.render(<App />));
+    const checkboxes = [...container.querySelectorAll<HTMLInputElement>("input[type=checkbox]")];
+    const mutedToggle = checkboxes.find((c) => c.parentElement?.textContent?.includes("Muted"));
+    if (!mutedToggle) throw new Error("muted toggle not rendered");
+    await act(async () => {
+      mutedToggle.click();
+    });
+    expect(container.querySelector("hyperframes-player")?.hasAttribute("muted")).toBe(true);
+  });
+});

--- a/examples/react-player/src/App.tsx
+++ b/examples/react-player/src/App.tsx
@@ -1,0 +1,130 @@
+import { HyperframesPlayer, type HyperframesPlayerHandle } from "@hyperframes/player/react";
+import { useRef, useState } from "react";
+
+const COMPOSITION_SRC = "/composition/index.html";
+const RATES = [0.5, 1, 1.5, 2];
+const MAX_LOG_ENTRIES = 12;
+
+type LogEntry = { id: number; label: string };
+
+let nextLogId = 0;
+
+export function App() {
+  const player = useRef<HyperframesPlayerHandle>(null);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [rate, setRate] = useState(1);
+  const [muted, setMuted] = useState(false);
+  const [loop, setLoop] = useState(false);
+  const [nativeControls, setNativeControls] = useState(false);
+  const [log, setLog] = useState<LogEntry[]>([]);
+
+  const logEvent = (label: string) =>
+    setLog((prev) => [{ id: nextLogId++, label }, ...prev].slice(0, MAX_LOG_ENTRIES));
+
+  return (
+    <main className="app">
+      <header>
+        <h1>
+          <code>&lt;HyperframesPlayer&gt;</code> React playground
+        </h1>
+        <p>
+          Drives <code>@hyperframes/player/react</code> — props, event callbacks, and the imperative
+          ref handle.
+        </p>
+      </header>
+
+      <HyperframesPlayer
+        ref={player}
+        src={COMPOSITION_SRC}
+        controls={nativeControls}
+        muted={muted}
+        loop={loop}
+        playbackRate={rate}
+        className="player"
+        style={{ width: "100%", aspectRatio: "16 / 9", display: "block", background: "#06060a" }}
+        onReady={(detail) => {
+          setDuration(detail.duration);
+          logEvent(`ready — duration ${detail.duration.toFixed(2)}s`);
+        }}
+        onPlay={() => {
+          setPlaying(true);
+          logEvent("play");
+        }}
+        onPause={() => {
+          setPlaying(false);
+          logEvent("pause");
+        }}
+        onTimeUpdate={(detail) => setCurrentTime(detail.currentTime)}
+        onEnded={() => logEvent("ended")}
+        onError={(detail) => logEvent(`error — ${detail.message}`)}
+        onScenes={(detail) => logEvent(`scenes — ${detail.scenes.length} scene(s)`)}
+      />
+
+      <section className="transport">
+        <button onClick={() => (playing ? player.current?.pause() : player.current?.play())}>
+          {playing ? "Pause" : "Play"}
+        </button>
+        <input
+          type="range"
+          min={0}
+          max={duration || 1}
+          step={0.01}
+          value={currentTime}
+          disabled={!duration}
+          onChange={(e) => {
+            const t = Number(e.target.value);
+            setCurrentTime(t);
+            player.current?.seek(t);
+          }}
+        />
+        <span className="time">
+          {currentTime.toFixed(1)}s / {duration.toFixed(1)}s
+        </span>
+      </section>
+
+      <section className="options">
+        <label>
+          Speed
+          <select value={rate} onChange={(e) => setRate(Number(e.target.value))}>
+            {RATES.map((r) => (
+              <option key={r} value={r}>
+                {r}×
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <input type="checkbox" checked={muted} onChange={(e) => setMuted(e.target.checked)} />
+          Muted
+        </label>
+        <label>
+          <input type="checkbox" checked={loop} onChange={(e) => setLoop(e.target.checked)} />
+          Loop
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={nativeControls}
+            onChange={(e) => setNativeControls(e.target.checked)}
+          />
+          Built-in controls
+        </label>
+      </section>
+
+      <section className="log">
+        <h2>Events</h2>
+        {log.length === 0 ? (
+          <p className="empty">Waiting for the composition to load…</p>
+        ) : (
+          <ul>
+            {log.map((entry) => (
+              <li key={entry.id}>{entry.label}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/examples/react-player/src/main.tsx
+++ b/examples/react-player/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+import "./styles.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("#root missing from index.html");
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/react-player/src/styles.css
+++ b/examples/react-player/src/styles.css
@@ -1,0 +1,124 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0d0d12;
+  color: #e8e8f0;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+.app {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+header h1 {
+  font-size: 22px;
+  margin: 0 0 6px;
+}
+
+header p {
+  margin: 0;
+  color: #9a9ab0;
+  font-size: 14px;
+}
+
+code {
+  font-family: ui-monospace, monospace;
+  color: #8ec7ff;
+}
+
+.player {
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.transport {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.transport button {
+  min-width: 76px;
+  padding: 8px 0;
+  border: 1px solid #2c2c3a;
+  border-radius: 8px;
+  background: #1a1a24;
+  color: inherit;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.transport button:hover {
+  background: #23232f;
+}
+
+.transport input[type="range"] {
+  flex: 1;
+}
+
+.time {
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: #9a9ab0;
+  white-space: nowrap;
+}
+
+.options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  font-size: 14px;
+  color: #c4c4d4;
+}
+
+.options label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.options select {
+  background: #1a1a24;
+  color: inherit;
+  border: 1px solid #2c2c3a;
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+
+.log h2 {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #9a9ab0;
+  margin: 0 0 8px;
+}
+
+.log ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.log li {
+  padding: 6px 10px;
+  background: #14141c;
+  border-radius: 6px;
+}
+
+.empty {
+  color: #62627a;
+  font-size: 13px;
+}

--- a/examples/react-player/tsconfig.json
+++ b/examples/react-player/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/react-player/vite.config.ts
+++ b/examples/react-player/vite.config.ts
@@ -1,0 +1,10 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "url": "https://github.com/heygen-com/hyperframes"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "type": "module",
   "scripts": {
     "dev": "bun run studio",
-    "build": "bun run --filter '@hyperframes/{parsers,lint,studio-server}' build && bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions,aws-lambda,gcp-cloud-run,sdk}' build && bun run --filter @hyperframes/cli build && bun run --filter @hyperframes/sdk-playground build",
+    "build": "bun run --filter '@hyperframes/{parsers,lint,studio-server}' build && bun run --filter @hyperframes/core build && bun run --filter '@hyperframes/{core,engine,producer,player,studio,shader-transitions,aws-lambda,gcp-cloud-run,sdk}' build && bun run --filter @hyperframes/cli build && bun run --filter '@hyperframes/{sdk-playground,react-player-example}' build",
     "build:producer": "bun run --filter @hyperframes/producer build",
     "studio": "bun run --filter @hyperframes/studio dev",
     "build:hyperframes-runtime": "bun run --filter @hyperframes/core build:hyperframes-runtime",

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -34,9 +34,10 @@ The player loads the composition in a sandboxed iframe, auto-detects its dimensi
 import "@hyperframes/player";
 
 // The custom element is now registered — use it in your markup
-// React: <hyperframes-player src="..." controls />
-// Vue:   <hyperframes-player :src="url" controls />
+// Vue: <hyperframes-player :src="url" controls />
 ```
+
+React users should prefer the dedicated bindings — see [React](#react) below.
 
 ### Poster image
 
@@ -131,6 +132,61 @@ player.shaderLoading; // "composition" | "player" | "none" (read/write)
 // Inner iframe access (for advanced consumers — see "Advanced: iframe access" below)
 player.iframeElement; // HTMLIFrameElement (read-only)
 ```
+
+## React
+
+The `@hyperframes/player/react` subpath ships typed React bindings (React 18/19, optional peer dependency) — no manual custom-element wiring:
+
+```tsx
+import { HyperframesPlayer } from "@hyperframes/player/react";
+
+function Demo() {
+  return (
+    <HyperframesPlayer
+      src="./my-composition/index.html"
+      controls
+      onReady={({ duration }) => console.log(`Duration: ${duration}s`)}
+      onEnded={() => console.log("Done!")}
+      style={{ maxWidth: 800, aspectRatio: "16 / 9" }}
+    />
+  );
+}
+```
+
+Props are camelCase mirrors of the attributes above (`audioSrc`, `audioLocked`, `playbackRate`, `autoPlay`, `shaderCaptureScale`, `shaderLoading`, plus `className`/`style`), and every player event has a callback prop with the `CustomEvent` detail unwrapped (`onReady`, `onPlay`, `onPause`, `onTimeUpdate`, `onEnded`, `onError`, `onScenes`, `onShaderTransitionState`, `onRateChange`, `onVolumeChange`).
+
+Imperative control goes through a ref handle:
+
+```tsx
+import { useRef } from "react";
+import { HyperframesPlayer, type HyperframesPlayerHandle } from "@hyperframes/player/react";
+
+function Controlled({ src }: { src: string }) {
+  const player = useRef<HyperframesPlayerHandle>(null);
+
+  return (
+    <>
+      <HyperframesPlayer ref={player} src={src} />
+      <button onClick={() => player.current?.play()}>Play</button>
+      <button onClick={() => player.current?.seek(2.5)}>Jump to 2.5s</button>
+    </>
+  );
+}
+```
+
+The handle exposes `play()`, `pause()`, `seek()`, `stopMedia()`, the color grading API, and read-only state: `currentTime`, `duration`, `paused`, `ready`, `scenes`, `element` (the raw `<hyperframes-player>`), and `iframeElement` (see "Advanced: iframe access" below).
+
+The component registers the custom element on mount via a dynamic import, so it is safe to render from SSR frameworks (Next.js, Remix) — the player module is only evaluated in the browser. To pre-register the element before the first player mounts, call `ensurePlayerDefined()` (browser only — throws during SSR):
+
+```ts
+import { ensurePlayerDefined } from "@hyperframes/player/react";
+
+ensurePlayerDefined();
+```
+
+Handle methods are safe no-ops until the element has registered and upgraded; gate playback logic on `onReady` as you would with the raw element.
+
+A runnable demo app lives at [`examples/react-player`](../../examples/react-player).
 
 ## Advanced: iframe access
 

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -153,7 +153,9 @@ function Demo() {
 }
 ```
 
-Props are camelCase mirrors of the attributes above (`audioSrc`, `audioLocked`, `playbackRate`, `autoPlay`, `shaderCaptureScale`, `shaderLoading`, plus `className`/`style`), and every player event has a callback prop with the `CustomEvent` detail unwrapped (`onReady`, `onPlay`, `onPause`, `onTimeUpdate`, `onEnded`, `onError`, `onScenes`, `onShaderTransitionState`, `onRateChange`, `onVolumeChange`).
+Props are camelCase mirrors of the attributes above (`audioSrc`, `audioLocked`, `playbackRate`, `autoPlay`, `shaderCaptureScale`, `shaderLoading`, plus `className`/`style`). Other host attributes (`id`, `role`, `tabIndex`, `aria-*`, `data-*`, DOM event handlers) pass through the `elementProps` prop.
+
+Every player event has a callback prop with the `CustomEvent` detail unwrapped: `onReady`, `onPlay`, `onPause`, `onTimeUpdate`, `onEnded`, `onError`, `onScenes`, `onShaderTransitionState`, `onRateChange`, `onVolumeChange`, `onRuntimeProtocolError`, `onAudioOwnershipChange`, and `onPlaybackError`. A contract test scans the player sources for `dispatchEvent` sites, so the binding cannot silently drift from the element's event surface.
 
 Imperative control goes through a ref handle:
 

--- a/packages/player/package-subpaths.json
+++ b/packages/player/package-subpaths.json
@@ -20,6 +20,15 @@
       },
       "types": "./dist/slideshow/hyperframes-slideshow.d.ts",
       "environments": ["browser"]
+    },
+    "./react": {
+      "source": "./dist/react/index.js",
+      "runtime": {
+        "import": "./dist/react/index.js",
+        "require": "./dist/react/index.cjs"
+      },
+      "types": "./dist/react/index.d.ts",
+      "environments": ["browser", "bun", "node"]
     }
   }
 }

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -25,6 +25,11 @@
       "script": "./dist/slideshow/hyperframes-slideshow.global.js",
       "import": "./dist/slideshow/hyperframes-slideshow.js",
       "require": "./dist/slideshow/hyperframes-slideshow.cjs"
+    },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "import": "./dist/react/index.js",
+      "require": "./dist/react/index.cjs"
     }
   },
   "scripts": {
@@ -38,10 +43,22 @@
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "gsap": "^3.12.5",
     "puppeteer-core": "^25.2.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/player/src/declarative-shadow.test.ts
+++ b/packages/player/src/declarative-shadow.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+//
+// Contract between the SSR serializer (ssr.ts) and the client adopter
+// (setupPlayerShadowDom): what the server emits must be exactly what the
+// upgrading element recognizes and reuses. If either side drifts, adoption
+// silently degrades into rebuild-and-reload — these tests make that loud.
+import { describe, expect, it } from "vitest";
+import { setupPlayerShadowDom } from "./iframe-dom.js";
+import { renderPlayerShadowDomHtml, renderPlayerTagHtml } from "./ssr.js";
+
+/** Simulate the browser's declarative shadow DOM parse: attach a shadow root
+ *  pre-upgrade and fill it with the serializer's template content. */
+function hostWithDeclarativeShadow(html: string): HTMLElement {
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "open" });
+  shadow.innerHTML = html;
+  return host;
+}
+
+describe("setupPlayerShadowDom", () => {
+  it("adopts the serializer's shadow DOM without rebuilding", () => {
+    const host = hostWithDeclarativeShadow(
+      renderPlayerShadowDomHtml({ src: "./comp/index.html", poster: "./poster.jpg" }),
+    );
+    const declarativeIframe = host.shadowRoot?.querySelector("iframe");
+    const dom = setupPlayerShadowDom(host, ":host { display: block; }");
+    expect(dom.adopted).toBe(true);
+    expect(dom.iframe).toBe(declarativeIframe);
+    expect(dom.iframe.getAttribute("src")).toBe("./comp/index.html");
+    expect(dom.poster?.getAttribute("src")).toBe("./poster.jpg");
+    expect(dom.container.contains(dom.iframe)).toBe(true);
+    // The serialized <style data-hfp-ssr> stands in for adoptedStyleSheets.
+    expect(dom.shadow.querySelector("style[data-hfp-ssr]")).not.toBeNull();
+  });
+
+  it("rebuilds when the declarative root is foreign or malformed", () => {
+    const host = hostWithDeclarativeShadow("<p>not a player</p>");
+    const dom = setupPlayerShadowDom(host, ":host { display: block; }");
+    expect(dom.adopted).toBe(false);
+    expect(dom.shadow.querySelector("p")).toBeNull();
+    expect(dom.container.className).toBe("hfp-container");
+    expect(dom.iframe.className).toBe("hfp-iframe");
+  });
+
+  it("builds imperatively when no shadow root exists", () => {
+    const host = document.createElement("div");
+    const dom = setupPlayerShadowDom(host, ":host { display: block; }");
+    expect(dom.adopted).toBe(false);
+    expect(dom.poster).toBeNull();
+    expect(host.shadowRoot).toBe(dom.shadow);
+    expect(dom.shadow.querySelector("iframe.hfp-iframe")).toBe(dom.iframe);
+  });
+});
+
+describe("renderPlayerShadowDomHtml", () => {
+  it("emits the iframe with sandbox and prepared src", () => {
+    const html = renderPlayerShadowDomHtml({ src: "./comp/index.html" });
+    expect(html).toContain('sandbox="allow-scripts allow-same-origin"');
+    expect(html).toContain('allow="autoplay; fullscreen"');
+    expect(html).toContain('src="./comp/index.html"');
+  });
+
+  it("carries shader options in the src exactly as the element would prepare them", () => {
+    const html = renderPlayerShadowDomHtml({
+      src: "./comp/index.html",
+      shaderCaptureScale: 0.5,
+      shaderLoading: "player",
+    });
+    // Must match prepareSrcForElement output so the upgrade replay skips the
+    // reload; the guard test below closes the loop on the element side.
+    expect(html).toMatch(/src=".\/comp\/index\.html\?[^"]*__hf_shader_capture_scale=0\.5/);
+    expect(html).toMatch(/__hf_shader_loading=player/);
+  });
+
+  it("escapes attribute values", () => {
+    const html = renderPlayerShadowDomHtml({ poster: `x" onerror="alert(1)` });
+    expect(html).not.toContain('" onerror=');
+    expect(html).toContain("&quot;");
+  });
+
+  it("coerces non-numeric dimensions instead of interpolating them into CSS", () => {
+    const html = renderPlayerShadowDomHtml({
+      width: "</style><script>" as unknown as number,
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("width: 1920px");
+  });
+});
+
+describe("renderPlayerTagHtml", () => {
+  it("wraps the shadow DOM in a declarative template", () => {
+    const html = renderPlayerTagHtml({ src: "./comp/index.html", className: "hero", width: 1280 });
+    expect(html).toMatch(
+      /^<hyperframes-player class="hero" src=".\/comp\/index\.html" width="1280">/,
+    );
+    expect(html).toContain('<template shadowrootmode="open">');
+    expect(html).toMatch(/<\/template><\/hyperframes-player>$/);
+  });
+});

--- a/packages/player/src/hyperframes-player.ts
+++ b/packages/player/src/hyperframes-player.ts
@@ -1,6 +1,6 @@
 import { CompositionProbe, type ProbeResult, readPositiveDimension } from "./composition-probe.js";
 import { isControlsClick, setupControls, setupPoster } from "./controls-setup.js";
-import { adoptShadowStyles, createCompositionIframe, scaleIframeToFit } from "./iframe-dom.js";
+import { scaleIframeToFit, setupPlayerShadowDom } from "./iframe-dom.js";
 import { DirectTimelineClock } from "./direct-timeline-clock.js";
 import { ParentMediaManager } from "./parent-media.js";
 import { isRealmHtmlMediaElement } from "./media-element-guards.js";
@@ -71,7 +71,6 @@ class HyperframesPlayer extends HTMLElement {
   }
 
   private shadow: ShadowRoot;
-  private container: HTMLDivElement;
   private iframe: HTMLIFrameElement;
   private posterEl: HTMLImageElement | null = null;
   private controlsApi: ReturnType<typeof setupControls> | null = null;
@@ -97,14 +96,18 @@ class HyperframesPlayer extends HTMLElement {
   private _media: ParentMediaManager;
   private _scenes: { id: string; start: number; duration: number }[] = [];
   private _runtimeFps = 30;
+  private _adoptedDeclarativeDom = false;
 
   constructor() {
     super();
-    this.shadow = this.attachShadow({ mode: "open" });
-
-    adoptShadowStyles(this.shadow, PLAYER_STYLES);
-    ({ container: this.container, iframe: this.iframe } = createCompositionIframe());
-    this.shadow.appendChild(this.container);
+    // Adopts a server-rendered declarative shadow root when present (see
+    // ssr.ts) instead of rebuilding — the iframe inside it may already be
+    // loading the composition.
+    const dom = setupPlayerShadowDom(this, PLAYER_STYLES);
+    this.shadow = dom.shadow;
+    this.iframe = dom.iframe;
+    this._adoptedDeclarativeDom = dom.adopted;
+    if (dom.poster) this.posterEl = dom.poster;
 
     const loaderElements = createShaderLoader();
     this.shadow.appendChild(loaderElements.root);
@@ -163,10 +166,10 @@ class HyperframesPlayer extends HTMLElement {
     if (this.hasAttribute("poster"))
       this.posterEl = setupPoster(this.shadow, this.getAttribute("poster"), this.posterEl);
     if (this.hasAttribute("audio-src")) this._media.setupFromUrl(this.getAttribute("audio-src")!);
-    if (this.hasAttribute("srcdoc"))
-      this.iframe.srcdoc = prepareSrcdocForElement(this, this.getAttribute("srcdoc")!);
-    if (this.hasAttribute("src"))
-      this.iframe.src = prepareSrcForElement(this, this.getAttribute("src")!);
+    if (this.hasAttribute("srcdoc")) this._applySrcdoc(this.getAttribute("srcdoc")!);
+    if (this.hasAttribute("src")) this._applySrc(this.getAttribute("src")!);
+
+    this._kickAdoptedIframeIfLoaded();
 
     // Host-environment audio lock: when the embedding host (e.g. Claude
     // desktop) drops the `audio-locked` attribute, attributeChangedCallback
@@ -198,15 +201,14 @@ class HyperframesPlayer extends HTMLElement {
   attributeChangedCallback(name: string, _old: string | null, val: string | null) {
     switch (name) {
       case "src":
-        if (val) {
-          this._ready = false;
-          this.iframe.src = prepareSrcForElement(this, val);
-        }
+        if (val) this._applySrc(val);
         break;
       case "srcdoc":
-        this._ready = false;
-        if (val !== null) this.iframe.srcdoc = prepareSrcdocForElement(this, val);
-        else this.iframe.removeAttribute("srcdoc");
+        if (val !== null) this._applySrcdoc(val);
+        else {
+          this._ready = false;
+          this.iframe.removeAttribute("srcdoc");
+        }
         break;
       // Reject NaN/zero/negative dimensions the same way the composition
       // probe does (a typo like width="abc" or width="0" would otherwise
@@ -757,6 +759,41 @@ class HyperframesPlayer extends HTMLElement {
         compositionHeight: this._compositionHeight,
       });
     }
+  }
+
+  /** A declaratively-rendered (SSR) iframe may have finished loading before
+   *  this element upgraded, in which case the connectedCallback "load"
+   *  listener never fires — kick the probe manually. The about:blank URL
+   *  check filters the still-loading case (the initial document also reports
+   *  "complete"); cross-origin documents fall back to the load event. */
+  private _kickAdoptedIframeIfLoaded(): void {
+    if (!this._adoptedDeclarativeDom) return;
+    let loadedDoc: Document | null = null;
+    try {
+      loadedDoc = this.iframe.contentDocument;
+    } catch {
+      /* cross-origin — fall back to the load event */
+    }
+    if (loadedDoc && loadedDoc.readyState === "complete" && loadedDoc.URL !== "about:blank") {
+      this._onIframeLoad();
+    }
+  }
+
+  /** Apply the src attribute, skipping the reload when the iframe already
+   *  carries the identical prepared URL (an adopted SSR iframe mid-load or
+   *  loaded — replaying the attribute would restart it from scratch). */
+  private _applySrc(val: string): void {
+    const prepared = prepareSrcForElement(this, val);
+    if (this.iframe.getAttribute("src") === prepared) return;
+    this._ready = false;
+    this.iframe.src = prepared;
+  }
+
+  private _applySrcdoc(val: string): void {
+    const prepared = prepareSrcdocForElement(this, val);
+    if (this.iframe.getAttribute("srcdoc") === prepared) return;
+    this._ready = false;
+    this.iframe.srcdoc = prepared;
   }
 
   private _onIframeLoad() {

--- a/packages/player/src/iframe-dom.ts
+++ b/packages/player/src/iframe-dom.ts
@@ -12,7 +12,7 @@ let _sharedSheet: CSSStyleSheet | null = null;
  * browser supports it, falling back to a `<style>` element injection. The sheet
  * is cached on first creation and reused across all player instances.
  */
-export function adoptShadowStyles(shadow: ShadowRoot, cssText: string): void {
+function adoptShadowStyles(shadow: ShadowRoot, cssText: string): void {
   if (typeof CSSStyleSheet !== "undefined") {
     try {
       if (!_sharedSheet) {
@@ -36,7 +36,7 @@ export function adoptShadowStyles(shadow: ShadowRoot, cssText: string): void {
  * attach them to the shadow root and track references without inlining the
  * boilerplate.
  */
-export function createCompositionIframe(): {
+function createCompositionIframe(): {
   container: HTMLDivElement;
   iframe: HTMLIFrameElement;
 } {
@@ -52,6 +52,54 @@ export function createCompositionIframe(): {
 
   container.appendChild(iframe);
   return { container, iframe };
+}
+
+export interface PlayerShadowDomSetup {
+  shadow: ShadowRoot;
+  container: HTMLDivElement;
+  iframe: HTMLIFrameElement;
+  poster: HTMLImageElement | null;
+  /** True when a server-rendered declarative shadow root was reused. */
+  adopted: boolean;
+}
+
+/**
+ * Build the player's shadow DOM — or ADOPT a server-rendered one.
+ *
+ * When the page was server-rendered with a `<template shadowrootmode="open">`
+ * (see `ssr.ts`), the browser has already attached a shadow root containing
+ * the container/iframe (likely mid-load) before this element upgrades.
+ * Rebuilding would throw that work away and reload the composition, so when
+ * the expected structure is present it is adopted as-is. A foreign or
+ * malformed declarative root is cleared and rebuilt imperatively.
+ */
+export function setupPlayerShadowDom(host: HTMLElement, cssText: string): PlayerShadowDomSetup {
+  const declarative = host.shadowRoot;
+  if (declarative) {
+    const container = declarative.querySelector<HTMLDivElement>("div.hfp-container");
+    const iframe = container?.querySelector<HTMLIFrameElement>("iframe.hfp-iframe") ?? null;
+    if (container && iframe) {
+      // The serialized <style data-hfp-ssr> already carries PLAYER_STYLES
+      // (adoptedStyleSheets cannot be serialized); only adopt the shared
+      // sheet when the SSR payload somehow lacked it.
+      if (!declarative.querySelector("style[data-hfp-ssr]")) {
+        adoptShadowStyles(declarative, cssText);
+      }
+      return {
+        shadow: declarative,
+        container,
+        iframe,
+        poster: declarative.querySelector<HTMLImageElement>("img.hfp-poster"),
+        adopted: true,
+      };
+    }
+    declarative.replaceChildren();
+  }
+  const shadow = declarative ?? host.attachShadow({ mode: "open" });
+  adoptShadowStyles(shadow, cssText);
+  const { container, iframe } = createCompositionIframe();
+  shadow.appendChild(container);
+  return { shadow, container, iframe, poster: null, adopted: false };
 }
 
 /**

--- a/packages/player/src/react/event-surface.test.ts
+++ b/packages/player/src/react/event-surface.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+//
+// Drift guard: the React binding promises a callback prop for every event the
+// player element dispatches. This test scans the player sources for event
+// constructions and fails when one is missing from PLAYER_EVENT_CALLBACKS —
+// so adding an element event without extending the binding breaks the build
+// instead of silently shrinking the React contract.
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { PLAYER_EVENT_CALLBACKS } from "./player.js";
+
+const playerSrcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Player sources whose events reach the <hyperframes-player> element. The
+ * slideshow element and the react binding itself are out of scope. */
+function listPlayerSources(): string[] {
+  return readdirSync(playerSrcDir)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+    .map((name) => join(playerSrcDir, name));
+}
+
+function listDispatchedEventTypes(): string[] {
+  const eventConstruction = /new (?:Custom)?Event\(\s*"([a-z]+)"/g;
+  const types = new Set<string>();
+  for (const file of listPlayerSources()) {
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(eventConstruction)) {
+      types.add(match[1] as string);
+    }
+  }
+  return [...types].sort();
+}
+
+describe("react binding event surface", () => {
+  it("covers every event the player element dispatches", () => {
+    const dispatched = listDispatchedEventTypes();
+    expect(dispatched.length).toBeGreaterThanOrEqual(10);
+    const covered = Object.keys(PLAYER_EVENT_CALLBACKS);
+    const missing = dispatched.filter((type) => !covered.includes(type));
+    expect(missing, `player dispatches events with no React callback: ${missing}`).toEqual([]);
+  });
+
+  it("does not claim events the player never dispatches", () => {
+    const dispatched = listDispatchedEventTypes();
+    const phantom = Object.keys(PLAYER_EVENT_CALLBACKS).filter(
+      (type) => !dispatched.includes(type),
+    );
+    expect(phantom, `binding lists events never dispatched by the player: ${phantom}`).toEqual([]);
+  });
+});

--- a/packages/player/src/react/index.ts
+++ b/packages/player/src/react/index.ts
@@ -1,0 +1,9 @@
+export { HyperframesPlayer } from "./player.js";
+export type { HyperframesPlayerHandle, HyperframesPlayerProps, PlayerScene } from "./player.js";
+export { ensurePlayerDefined } from "./register.js";
+export type {
+  ColorGradingCompareState,
+  ColorGradingTarget,
+  HyperframesPlayer as HyperframesPlayerElement,
+} from "../hyperframes-player.js";
+export type { ShaderLoadingMode } from "../shader-options.js";

--- a/packages/player/src/react/index.ts
+++ b/packages/player/src/react/index.ts
@@ -1,5 +1,12 @@
 export { HyperframesPlayer } from "./player.js";
-export type { HyperframesPlayerHandle, HyperframesPlayerProps, PlayerScene } from "./player.js";
+export type {
+  HyperframesPlayerHandle,
+  HyperframesPlayerProps,
+  PlayerAudioOwner,
+  PlayerElementProps,
+  PlayerRuntimeProtocolErrorCode,
+  PlayerScene,
+} from "./player.js";
 export { ensurePlayerDefined } from "./register.js";
 export type {
   ColorGradingCompareState,

--- a/packages/player/src/react/player.test.tsx
+++ b/packages/player/src/react/player.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+import { act, createRef, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { HyperframesPlayer, type HyperframesPlayerHandle } from "./player.js";
+
+// The component dynamically imports @hyperframes/player to register the
+// element; stub the module and register a lightweight test double instead so
+// tests don't depend on the real player's iframe/ResizeObserver machinery.
+vi.mock("@hyperframes/player", () => ({}));
+
+class StubPlayerElement extends HTMLElement {
+  play = vi.fn();
+  pause = vi.fn();
+  seek = vi.fn();
+  stopMedia = vi.fn();
+  setColorGrading = vi.fn();
+  clearColorGrading = vi.fn();
+  setColorGradingCompare = vi.fn();
+  clearColorGradingCompare = vi.fn();
+  currentTime = 1.5;
+  duration = 10;
+  paused = false;
+  ready = true;
+  scenes = [{ id: "intro", start: 0, duration: 2 }];
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function playerElement(): StubPlayerElement {
+  const el = container.querySelector("hyperframes-player");
+  if (!(el instanceof StubPlayerElement)) throw new Error("player element not rendered");
+  return el;
+}
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>)["IS_REACT_ACT_ENVIRONMENT"] = true;
+  customElements.define("hyperframes-player", StubPlayerElement);
+});
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+async function render(ui: ReactElement) {
+  await act(async () => root.render(ui));
+}
+
+describe("HyperframesPlayer", () => {
+  it("mirrors props to player attributes", async () => {
+    await render(
+      <HyperframesPlayer
+        src="./comp/index.html"
+        width={1280}
+        height={720}
+        controls
+        muted
+        playbackRate={1.5}
+        shaderLoading="player"
+      />,
+    );
+    const el = playerElement();
+    expect(el.getAttribute("src")).toBe("./comp/index.html");
+    expect(el.getAttribute("width")).toBe("1280");
+    expect(el.getAttribute("height")).toBe("720");
+    expect(el.hasAttribute("controls")).toBe(true);
+    expect(el.hasAttribute("muted")).toBe(true);
+    expect(el.getAttribute("playback-rate")).toBe("1.5");
+    expect(el.getAttribute("shader-loading")).toBe("player");
+    expect(el.hasAttribute("loop")).toBe(false);
+  });
+
+  it("updates and removes attributes when props change", async () => {
+    await render(<HyperframesPlayer src="./a.html" controls poster="./a.jpg" />);
+    await render(<HyperframesPlayer src="./b.html" />);
+    const el = playerElement();
+    expect(el.getAttribute("src")).toBe("./b.html");
+    expect(el.hasAttribute("controls")).toBe(false);
+    expect(el.hasAttribute("poster")).toBe(false);
+  });
+
+  it("maps camelCase props to kebab-case attributes", async () => {
+    await render(
+      <HyperframesPlayer audioSrc="./bgm.mp3" audioLocked autoPlay shaderCaptureScale={0.5} />,
+    );
+    const el = playerElement();
+    expect(el.getAttribute("audio-src")).toBe("./bgm.mp3");
+    expect(el.hasAttribute("audio-locked")).toBe(true);
+    expect(el.hasAttribute("autoplay")).toBe(true);
+    expect(el.getAttribute("shader-capture-scale")).toBe("0.5");
+  });
+
+  it("applies className and style", async () => {
+    await render(<HyperframesPlayer className="hero" style={{ maxWidth: "800px" }} />);
+    const el = playerElement();
+    expect(el.getAttribute("class")).toBe("hero");
+    expect(el.style.maxWidth).toBe("800px");
+  });
+
+  it("forwards player events to callbacks", async () => {
+    const onReady = vi.fn();
+    const onTimeUpdate = vi.fn();
+    const onEnded = vi.fn();
+    await render(
+      <HyperframesPlayer onReady={onReady} onTimeUpdate={onTimeUpdate} onEnded={onEnded} />,
+    );
+    const el = playerElement();
+    await act(async () => {
+      el.dispatchEvent(new CustomEvent("ready", { detail: { duration: 12 } }));
+      el.dispatchEvent(new CustomEvent("timeupdate", { detail: { currentTime: 3 } }));
+      el.dispatchEvent(new Event("ended"));
+    });
+    expect(onReady).toHaveBeenCalledWith({ duration: 12 });
+    expect(onTimeUpdate).toHaveBeenCalledWith({ currentTime: 3 });
+    expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the latest callback without rebinding listeners", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    await render(<HyperframesPlayer onPlay={first} />);
+    await render(<HyperframesPlayer onPlay={second} />);
+    await act(async () => playerElement().dispatchEvent(new Event("play")));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes playback control and state through the ref handle", async () => {
+    const ref = createRef<HyperframesPlayerHandle>();
+    await render(<HyperframesPlayer ref={ref} />);
+    const el = playerElement();
+    ref.current?.play();
+    ref.current?.seek(2.5);
+    ref.current?.setColorGrading("main", { exposure: 1 });
+    expect(el.play).toHaveBeenCalledTimes(1);
+    expect(el.seek).toHaveBeenCalledWith(2.5);
+    expect(el.setColorGrading).toHaveBeenCalledWith("main", { exposure: 1 });
+    expect(ref.current?.element).toBe(el);
+    expect(ref.current?.currentTime).toBe(1.5);
+    expect(ref.current?.duration).toBe(10);
+    expect(ref.current?.ready).toBe(true);
+    expect(ref.current?.scenes).toEqual([{ id: "intro", start: 0, duration: 2 }]);
+  });
+});

--- a/packages/player/src/react/player.test.tsx
+++ b/packages/player/src/react/player.test.tsx
@@ -10,6 +10,16 @@ import { HyperframesPlayer, type HyperframesPlayerHandle } from "./player.js";
 vi.mock("@hyperframes/player", () => ({}));
 
 class StubPlayerElement extends HTMLElement {
+  // Mirrors the real element: attribute application synchronously dispatches
+  // events from attributeChangedCallback, so listeners bound too late would
+  // deterministically miss the initial ratechange/volumechange.
+  static get observedAttributes() {
+    return ["playback-rate", "volume"];
+  }
+  attributeChangedCallback(name: string) {
+    if (name === "playback-rate") this.dispatchEvent(new Event("ratechange"));
+    if (name === "volume") this.dispatchEvent(new Event("volumechange"));
+  }
   play = vi.fn();
   pause = vi.fn();
   seek = vi.fn();
@@ -105,6 +115,43 @@ describe("HyperframesPlayer", () => {
     expect(el.style.maxWidth).toBe("800px");
   });
 
+  it("forwards host attributes through elementProps", async () => {
+    await render(
+      <HyperframesPlayer
+        className="hero"
+        elementProps={{
+          id: "promo-player",
+          role: "region",
+          tabIndex: 0,
+          "aria-label": "Launch video",
+          "data-analytics": "hero",
+        }}
+      />,
+    );
+    const el = playerElement();
+    expect(el.getAttribute("id")).toBe("promo-player");
+    expect(el.getAttribute("role")).toBe("region");
+    expect(el.getAttribute("tabindex")).toBe("0");
+    expect(el.getAttribute("aria-label")).toBe("Launch video");
+    expect(el.getAttribute("data-analytics")).toBe("hero");
+    expect(el.getAttribute("class")).toBe("hero");
+  });
+
+  it("captures events dispatched synchronously by the initial attribute sync", async () => {
+    const onRateChange = vi.fn();
+    const onVolumeChange = vi.fn();
+    await render(
+      <HyperframesPlayer
+        playbackRate={2}
+        volume={0.5}
+        onRateChange={onRateChange}
+        onVolumeChange={onVolumeChange}
+      />,
+    );
+    expect(onRateChange).toHaveBeenCalledTimes(1);
+    expect(onVolumeChange).toHaveBeenCalledTimes(1);
+  });
+
   it("forwards player events to callbacks", async () => {
     const onReady = vi.fn();
     const onTimeUpdate = vi.fn();
@@ -121,6 +168,45 @@ describe("HyperframesPlayer", () => {
     expect(onReady).toHaveBeenCalledWith({ duration: 12 });
     expect(onTimeUpdate).toHaveBeenCalledWith({ currentTime: 3 });
     expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards protocol, audio-ownership, and playback-error events", async () => {
+    const onRuntimeProtocolError = vi.fn();
+    const onAudioOwnershipChange = vi.fn();
+    const onPlaybackError = vi.fn();
+    await render(
+      <HyperframesPlayer
+        onRuntimeProtocolError={onRuntimeProtocolError}
+        onAudioOwnershipChange={onAudioOwnershipChange}
+        onPlaybackError={onPlaybackError}
+      />,
+    );
+    const el = playerElement();
+    const error = new Error("NotAllowedError");
+    await act(async () => {
+      el.dispatchEvent(
+        new CustomEvent("runtimeprotocolerror", {
+          detail: { code: "unsupported_protocol_version", receivedVersion: 99 },
+        }),
+      );
+      el.dispatchEvent(
+        new CustomEvent("audioownershipchange", {
+          detail: { owner: "parent", reason: "autoplay-blocked" },
+        }),
+      );
+      el.dispatchEvent(
+        new CustomEvent("playbackerror", { detail: { source: "parent-proxy", error } }),
+      );
+    });
+    expect(onRuntimeProtocolError).toHaveBeenCalledWith({
+      code: "unsupported_protocol_version",
+      receivedVersion: 99,
+    });
+    expect(onAudioOwnershipChange).toHaveBeenCalledWith({
+      owner: "parent",
+      reason: "autoplay-blocked",
+    });
+    expect(onPlaybackError).toHaveBeenCalledWith({ source: "parent-proxy", error });
   });
 
   it("uses the latest callback without rebinding listeners", async () => {

--- a/packages/player/src/react/player.tsx
+++ b/packages/player/src/react/player.tsx
@@ -1,0 +1,282 @@
+import type {
+  ColorGradingCompareState,
+  ColorGradingTarget,
+  HyperframesPlayer as HyperframesPlayerElement,
+} from "../hyperframes-player.js";
+import type { ShaderLoadingMode } from "../shader-options.js";
+import type * as React from "react";
+import {
+  createElement,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+} from "react";
+import { ensurePlayerDefined } from "./register.js";
+
+export type PlayerScene = { id: string; start: number; duration: number };
+
+export interface HyperframesPlayerProps {
+  /** URL to the composition HTML file. */
+  src?: string;
+  /** Inline composition HTML (alternative to `src`). */
+  srcdoc?: string;
+  /** Audio URL preloaded for parent-frame playback (mobile). */
+  audioSrc?: string;
+  /** Composition width in pixels — aspect ratio only, not display size. */
+  width?: number;
+  /** Composition height in pixels — aspect ratio only, not display size. */
+  height?: number;
+  /** Show play/pause, scrubber, and time display. */
+  controls?: boolean;
+  /** Mute audio playback. */
+  muted?: boolean;
+  /** Force-mute and hide volume controls so the viewer cannot enable sound. */
+  audioLocked?: boolean;
+  /** Volume in the 0-1 range. */
+  volume?: number;
+  /** Image URL shown before playback starts. */
+  poster?: string;
+  /** Speed multiplier (0.5 = half, 2 = double). */
+  playbackRate?: number;
+  /** Start playing when the composition is ready. */
+  autoPlay?: boolean;
+  /** Restart when the composition ends. */
+  loop?: boolean;
+  /** Shader transition snapshot scale (0.25-1). */
+  shaderCaptureScale?: number;
+  /** Shader transition prep loading UI ownership. */
+  shaderLoading?: ShaderLoadingMode;
+  className?: string;
+  style?: React.CSSProperties;
+  /** Composition loaded and duration determined. */
+  onReady?: (detail: { duration: number }) => void;
+  onPlay?: () => void;
+  onPause?: () => void;
+  /** Playback position changed (~10 fps). */
+  onTimeUpdate?: (detail: { currentTime: number }) => void;
+  /** Reached the end (when not looping). */
+  onEnded?: () => void;
+  /** Composition failed to load (or the player element failed to register). */
+  onError?: (detail: { message: string }) => void;
+  /** Scene list received from the composition runtime. */
+  onScenes?: (detail: { scenes: PlayerScene[] }) => void;
+  /** Shader transition cache/capture progress. */
+  onShaderTransitionState?: (detail: {
+    compositionId: string | undefined;
+    state: Record<string, unknown>;
+  }) => void;
+  onRateChange?: () => void;
+  onVolumeChange?: () => void;
+}
+
+export interface HyperframesPlayerHandle {
+  /** The underlying `<hyperframes-player>` element, or null before mount. */
+  readonly element: HyperframesPlayerElement | null;
+  /** The inner composition iframe, or null before the element upgrades. */
+  readonly iframeElement: HTMLIFrameElement | null;
+  readonly currentTime: number;
+  readonly duration: number;
+  readonly paused: boolean;
+  readonly ready: boolean;
+  readonly scenes: PlayerScene[];
+  play(): void;
+  pause(): void;
+  seek(timeInSeconds: number): void;
+  /** Stop all timed media inside the composition. */
+  stopMedia(): void;
+  setColorGrading(target: ColorGradingTarget, grading: unknown): void;
+  clearColorGrading(target: ColorGradingTarget): void;
+  setColorGradingCompare(target: ColorGradingTarget, compare: ColorGradingCompareState): void;
+  clearColorGradingCompare(target: ColorGradingTarget): void;
+}
+
+type PlayerCallbacks = Pick<
+  HyperframesPlayerProps,
+  | "onReady"
+  | "onPlay"
+  | "onPause"
+  | "onTimeUpdate"
+  | "onEnded"
+  | "onError"
+  | "onScenes"
+  | "onShaderTransitionState"
+  | "onRateChange"
+  | "onVolumeChange"
+>;
+
+function syncAttribute(el: Element, name: string, value: string | number | undefined) {
+  if (value === undefined) el.removeAttribute(name);
+  else if (el.getAttribute(name) !== String(value)) el.setAttribute(name, String(value));
+}
+
+function syncBooleanAttribute(el: Element, name: string, value: boolean | undefined) {
+  if (value) {
+    if (!el.hasAttribute(name)) el.setAttribute(name, "");
+  } else {
+    el.removeAttribute(name);
+  }
+}
+
+/** The element until upgrade — properties/methods may not exist yet. */
+type MaybeUpgraded = Partial<HyperframesPlayerElement> & HTMLElement;
+
+function detail<T>(event: Event): T {
+  return (event as CustomEvent<T>).detail;
+}
+
+/**
+ * React wrapper for the `<hyperframes-player>` web component.
+ *
+ * Registers the custom element on mount (SSR-safe — `@hyperframes/player` is
+ * only imported in the browser), mirrors props to player attributes, and
+ * forwards player events to callback props. Imperative playback control is
+ * available through the ref handle.
+ */
+export const HyperframesPlayer = forwardRef<HyperframesPlayerHandle, HyperframesPlayerProps>(
+  function HyperframesPlayer(props, ref) {
+    const elementRef = useRef<MaybeUpgraded | null>(null);
+
+    const callbacksRef = useRef<PlayerCallbacks>({});
+    callbacksRef.current = props;
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        get element() {
+          return (elementRef.current as HyperframesPlayerElement | null) ?? null;
+        },
+        get iframeElement() {
+          return elementRef.current?.iframeElement ?? null;
+        },
+        get currentTime() {
+          return elementRef.current?.currentTime ?? 0;
+        },
+        get duration() {
+          return elementRef.current?.duration ?? 0;
+        },
+        get paused() {
+          return elementRef.current?.paused ?? true;
+        },
+        get ready() {
+          return elementRef.current?.ready ?? false;
+        },
+        get scenes() {
+          return elementRef.current?.scenes ?? [];
+        },
+        play: () => elementRef.current?.play?.(),
+        pause: () => elementRef.current?.pause?.(),
+        seek: (timeInSeconds) => elementRef.current?.seek?.(timeInSeconds),
+        stopMedia: () => elementRef.current?.stopMedia?.(),
+        setColorGrading: (target, grading) =>
+          elementRef.current?.setColorGrading?.(target, grading),
+        clearColorGrading: (target) => elementRef.current?.clearColorGrading?.(target),
+        setColorGradingCompare: (target, compare) =>
+          elementRef.current?.setColorGradingCompare?.(target, compare),
+        clearColorGradingCompare: (target) =>
+          elementRef.current?.clearColorGradingCompare?.(target),
+      }),
+      [],
+    );
+
+    // Register the custom element. Attributes set before the upgrade are
+    // replayed by attributeChangedCallback when the definition lands.
+    useEffect(() => {
+      let cancelled = false;
+      ensurePlayerDefined().catch((error: unknown) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : String(error);
+        callbacksRef.current.onError?.({ message });
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, []);
+
+    // Forward player events to the callback props. Listeners read the latest
+    // callbacks through callbacksRef so this only binds once.
+    useEffect(() => {
+      const el = elementRef.current;
+      if (!el) return;
+      const listeners: [string, EventListener][] = [
+        ["ready", (e) => callbacksRef.current.onReady?.(detail(e))],
+        ["play", () => callbacksRef.current.onPlay?.()],
+        ["pause", () => callbacksRef.current.onPause?.()],
+        ["timeupdate", (e) => callbacksRef.current.onTimeUpdate?.(detail(e))],
+        ["ended", () => callbacksRef.current.onEnded?.()],
+        ["error", (e) => callbacksRef.current.onError?.(detail(e))],
+        ["scenes", (e) => callbacksRef.current.onScenes?.(detail(e))],
+        ["shadertransitionstate", (e) => callbacksRef.current.onShaderTransitionState?.(detail(e))],
+        ["ratechange", () => callbacksRef.current.onRateChange?.()],
+        ["volumechange", () => callbacksRef.current.onVolumeChange?.()],
+      ];
+      for (const [type, listener] of listeners) el.addEventListener(type, listener);
+      return () => {
+        for (const [type, listener] of listeners) el.removeEventListener(type, listener);
+      };
+    }, []);
+
+    // Attributes are synced imperatively rather than through JSX: React 18 and
+    // 19 disagree on how JSX props map to custom-element attributes (booleans
+    // especially), and the player treats boolean attributes as presence-based.
+    const {
+      src,
+      srcdoc,
+      audioSrc,
+      width,
+      height,
+      controls,
+      muted,
+      audioLocked,
+      volume,
+      poster,
+      playbackRate,
+      autoPlay,
+      loop,
+      shaderCaptureScale,
+      shaderLoading,
+    } = props;
+    useLayoutEffect(() => {
+      const el = elementRef.current;
+      if (!el) return;
+      syncAttribute(el, "src", src);
+      syncAttribute(el, "srcdoc", srcdoc);
+      syncAttribute(el, "audio-src", audioSrc);
+      syncAttribute(el, "width", width);
+      syncAttribute(el, "height", height);
+      syncBooleanAttribute(el, "controls", controls);
+      syncBooleanAttribute(el, "muted", muted);
+      syncBooleanAttribute(el, "audio-locked", audioLocked);
+      syncAttribute(el, "volume", volume);
+      syncAttribute(el, "poster", poster);
+      syncAttribute(el, "playback-rate", playbackRate);
+      syncBooleanAttribute(el, "autoplay", autoPlay);
+      syncBooleanAttribute(el, "loop", loop);
+      syncAttribute(el, "shader-capture-scale", shaderCaptureScale);
+      syncAttribute(el, "shader-loading", shaderLoading);
+    }, [
+      src,
+      srcdoc,
+      audioSrc,
+      width,
+      height,
+      controls,
+      muted,
+      audioLocked,
+      volume,
+      poster,
+      playbackRate,
+      autoPlay,
+      loop,
+      shaderCaptureScale,
+      shaderLoading,
+    ]);
+
+    return createElement("hyperframes-player", {
+      ref: elementRef,
+      class: props.className,
+      style: props.style,
+    });
+  },
+);

--- a/packages/player/src/react/player.tsx
+++ b/packages/player/src/react/player.tsx
@@ -15,7 +15,27 @@ import {
 } from "react";
 import { ensurePlayerDefined } from "./register.js";
 
+/**
+ * `useLayoutEffect` warns under React 18 server rendering ("useLayoutEffect
+ * does nothing on the server"). Effects never run during SSR either way, so
+ * substituting `useEffect` on the server is behavior-identical and silences
+ * the warning. Exported for the node-environment SSR test.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
 export type PlayerScene = { id: string; start: number; duration: number };
+
+export type PlayerAudioOwner = "runtime" | "parent";
+
+export type PlayerRuntimeProtocolErrorCode =
+  | "unsupported_protocol_version"
+  | "invalid_protocol_metadata";
+
+/** Host attributes forwarded verbatim to the `<hyperframes-player>` element. */
+export type PlayerElementProps = Omit<React.HTMLAttributes<HTMLElement>, "className" | "style"> & {
+  [dataAttribute: `data-${string}`]: string | number | undefined;
+};
 
 export interface HyperframesPlayerProps {
   /** URL to the composition HTML file. */
@@ -50,6 +70,14 @@ export interface HyperframesPlayerProps {
   shaderLoading?: ShaderLoadingMode;
   className?: string;
   style?: React.CSSProperties;
+  /**
+   * Additional host attributes (`id`, `role`, `tabIndex`, `title`, `aria-*`,
+   * `data-*`, DOM event handlers…) forwarded to the element. Player-owned
+   * attributes must go through their dedicated props above — values here are
+   * passed to React verbatim, so prefer strings for custom attributes to keep
+   * React 18 and 19 attribute serialization identical.
+   */
+  elementProps?: PlayerElementProps;
   /** Composition loaded and duration determined. */
   onReady?: (detail: { duration: number }) => void;
   onPlay?: () => void;
@@ -69,6 +97,15 @@ export interface HyperframesPlayerProps {
   }) => void;
   onRateChange?: () => void;
   onVolumeChange?: () => void;
+  /** The composition runtime speaks an incompatible protocol version. */
+  onRuntimeProtocolError?: (detail: {
+    code: PlayerRuntimeProtocolErrorCode;
+    receivedVersion: unknown;
+  }) => void;
+  /** Audio playback moved between the iframe runtime and parent-frame proxies. */
+  onAudioOwnershipChange?: (detail: { owner: PlayerAudioOwner; reason: string }) => void;
+  /** A parent-frame media proxy failed to play (e.g. autoplay rejection). */
+  onPlaybackError?: (detail: { source: string; error: unknown }) => void;
 }
 
 export interface HyperframesPlayerHandle {
@@ -104,7 +141,32 @@ type PlayerCallbacks = Pick<
   | "onShaderTransitionState"
   | "onRateChange"
   | "onVolumeChange"
+  | "onRuntimeProtocolError"
+  | "onAudioOwnershipChange"
+  | "onPlaybackError"
 >;
+
+/**
+ * Every event the `<hyperframes-player>` element dispatches, mapped to its
+ * callback prop. The event-surface contract test asserts this map covers every
+ * `dispatchEvent` site in the player sources — extend BOTH when the element
+ * gains an event, or that test fails the build.
+ */
+export const PLAYER_EVENT_CALLBACKS = {
+  ready: "onReady",
+  play: "onPlay",
+  pause: "onPause",
+  timeupdate: "onTimeUpdate",
+  ended: "onEnded",
+  error: "onError",
+  scenes: "onScenes",
+  shadertransitionstate: "onShaderTransitionState",
+  ratechange: "onRateChange",
+  volumechange: "onVolumeChange",
+  runtimeprotocolerror: "onRuntimeProtocolError",
+  audioownershipchange: "onAudioOwnershipChange",
+  playbackerror: "onPlaybackError",
+} as const satisfies Record<string, keyof PlayerCallbacks>;
 
 function syncAttribute(el: Element, name: string, value: string | number | undefined) {
   if (value === undefined) el.removeAttribute(name);
@@ -122,10 +184,6 @@ function syncBooleanAttribute(el: Element, name: string, value: boolean | undefi
 /** The element until upgrade — properties/methods may not exist yet. */
 type MaybeUpgraded = Partial<HyperframesPlayerElement> & HTMLElement;
 
-function detail<T>(event: Event): T {
-  return (event as CustomEvent<T>).detail;
-}
-
 /**
  * React wrapper for the `<hyperframes-player>` web component.
  *
@@ -138,8 +196,115 @@ export const HyperframesPlayer = forwardRef<HyperframesPlayerHandle, Hyperframes
   function HyperframesPlayer(props, ref) {
     const elementRef = useRef<MaybeUpgraded | null>(null);
 
+    // EFFECT ORDER MATTERS. Layout effects run in declaration order, and the
+    // element dispatches events synchronously while attributes are applied
+    // (e.g. `ratechange` from attributeChangedCallback). The sequence must be:
+    //   1. refresh the callbacks ref (every commit),
+    //   2. bind event listeners (mount),
+    //   3. sync attributes (which may fire those listeners).
+
+    // Latest-callback ref, updated in a layout effect rather than during
+    // render so an interrupted/discarded render can't publish callbacks that
+    // never committed.
     const callbacksRef = useRef<PlayerCallbacks>({});
-    callbacksRef.current = props;
+    useIsomorphicLayoutEffect(() => {
+      callbacksRef.current = props;
+    });
+
+    // Forward player events to the callback props. Listeners read the latest
+    // callbacks through callbacksRef so this binds once, before the attribute
+    // sync below can make the element dispatch anything.
+    useIsomorphicLayoutEffect(() => {
+      const el = elementRef.current;
+      if (!el) return;
+      const listeners = Object.entries(PLAYER_EVENT_CALLBACKS).map(
+        ([type, prop]): [string, EventListener] => [
+          type,
+          (event) => {
+            const callback = callbacksRef.current[prop] as ((detail?: unknown) => void) | undefined;
+            callback?.((event as CustomEvent<unknown>).detail);
+          },
+        ],
+      );
+      for (const [type, listener] of listeners) el.addEventListener(type, listener);
+      return () => {
+        for (const [type, listener] of listeners) el.removeEventListener(type, listener);
+      };
+    }, []);
+
+    const {
+      src,
+      srcdoc,
+      audioSrc,
+      width,
+      height,
+      controls,
+      muted,
+      audioLocked,
+      volume,
+      poster,
+      playbackRate,
+      autoPlay,
+      loop,
+      shaderCaptureScale,
+      shaderLoading,
+    } = props;
+    // Attributes are synced imperatively rather than through JSX: React 18 and
+    // 19 disagree on how JSX props map to custom-element attributes (booleans
+    // especially), and the player treats boolean attributes as presence-based.
+    useIsomorphicLayoutEffect(() => {
+      const el = elementRef.current;
+      if (!el) return;
+      syncAttribute(el, "src", src);
+      syncAttribute(el, "srcdoc", srcdoc);
+      syncAttribute(el, "audio-src", audioSrc);
+      syncAttribute(el, "width", width);
+      syncAttribute(el, "height", height);
+      syncBooleanAttribute(el, "controls", controls);
+      syncBooleanAttribute(el, "muted", muted);
+      syncBooleanAttribute(el, "audio-locked", audioLocked);
+      syncAttribute(el, "volume", volume);
+      syncAttribute(el, "poster", poster);
+      syncAttribute(el, "playback-rate", playbackRate);
+      // autoplay and loop are deliberately NOT in the element's
+      // observedAttributes — it reads them on demand via hasAttribute()
+      // (autoplay at readiness, loop at "ended"). Plain attribute writes are
+      // the correct integration; do not migrate these to property sets.
+      syncBooleanAttribute(el, "autoplay", autoPlay);
+      syncBooleanAttribute(el, "loop", loop);
+      syncAttribute(el, "shader-capture-scale", shaderCaptureScale);
+      syncAttribute(el, "shader-loading", shaderLoading);
+    }, [
+      src,
+      srcdoc,
+      audioSrc,
+      width,
+      height,
+      controls,
+      muted,
+      audioLocked,
+      volume,
+      poster,
+      playbackRate,
+      autoPlay,
+      loop,
+      shaderCaptureScale,
+      shaderLoading,
+    ]);
+
+    // Register the custom element. Attributes set before the upgrade are
+    // replayed by attributeChangedCallback when the definition lands.
+    useEffect(() => {
+      let cancelled = false;
+      ensurePlayerDefined().catch((error: unknown) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : String(error);
+        callbacksRef.current.onError?.({ message });
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, []);
 
     useImperativeHandle(
       ref,
@@ -180,100 +345,9 @@ export const HyperframesPlayer = forwardRef<HyperframesPlayerHandle, Hyperframes
       [],
     );
 
-    // Register the custom element. Attributes set before the upgrade are
-    // replayed by attributeChangedCallback when the definition lands.
-    useEffect(() => {
-      let cancelled = false;
-      ensurePlayerDefined().catch((error: unknown) => {
-        if (cancelled) return;
-        const message = error instanceof Error ? error.message : String(error);
-        callbacksRef.current.onError?.({ message });
-      });
-      return () => {
-        cancelled = true;
-      };
-    }, []);
-
-    // Forward player events to the callback props. Listeners read the latest
-    // callbacks through callbacksRef so this only binds once.
-    useEffect(() => {
-      const el = elementRef.current;
-      if (!el) return;
-      const listeners: [string, EventListener][] = [
-        ["ready", (e) => callbacksRef.current.onReady?.(detail(e))],
-        ["play", () => callbacksRef.current.onPlay?.()],
-        ["pause", () => callbacksRef.current.onPause?.()],
-        ["timeupdate", (e) => callbacksRef.current.onTimeUpdate?.(detail(e))],
-        ["ended", () => callbacksRef.current.onEnded?.()],
-        ["error", (e) => callbacksRef.current.onError?.(detail(e))],
-        ["scenes", (e) => callbacksRef.current.onScenes?.(detail(e))],
-        ["shadertransitionstate", (e) => callbacksRef.current.onShaderTransitionState?.(detail(e))],
-        ["ratechange", () => callbacksRef.current.onRateChange?.()],
-        ["volumechange", () => callbacksRef.current.onVolumeChange?.()],
-      ];
-      for (const [type, listener] of listeners) el.addEventListener(type, listener);
-      return () => {
-        for (const [type, listener] of listeners) el.removeEventListener(type, listener);
-      };
-    }, []);
-
-    // Attributes are synced imperatively rather than through JSX: React 18 and
-    // 19 disagree on how JSX props map to custom-element attributes (booleans
-    // especially), and the player treats boolean attributes as presence-based.
-    const {
-      src,
-      srcdoc,
-      audioSrc,
-      width,
-      height,
-      controls,
-      muted,
-      audioLocked,
-      volume,
-      poster,
-      playbackRate,
-      autoPlay,
-      loop,
-      shaderCaptureScale,
-      shaderLoading,
-    } = props;
-    useLayoutEffect(() => {
-      const el = elementRef.current;
-      if (!el) return;
-      syncAttribute(el, "src", src);
-      syncAttribute(el, "srcdoc", srcdoc);
-      syncAttribute(el, "audio-src", audioSrc);
-      syncAttribute(el, "width", width);
-      syncAttribute(el, "height", height);
-      syncBooleanAttribute(el, "controls", controls);
-      syncBooleanAttribute(el, "muted", muted);
-      syncBooleanAttribute(el, "audio-locked", audioLocked);
-      syncAttribute(el, "volume", volume);
-      syncAttribute(el, "poster", poster);
-      syncAttribute(el, "playback-rate", playbackRate);
-      syncBooleanAttribute(el, "autoplay", autoPlay);
-      syncBooleanAttribute(el, "loop", loop);
-      syncAttribute(el, "shader-capture-scale", shaderCaptureScale);
-      syncAttribute(el, "shader-loading", shaderLoading);
-    }, [
-      src,
-      srcdoc,
-      audioSrc,
-      width,
-      height,
-      controls,
-      muted,
-      audioLocked,
-      volume,
-      poster,
-      playbackRate,
-      autoPlay,
-      loop,
-      shaderCaptureScale,
-      shaderLoading,
-    ]);
-
+    // elementProps spreads first so the binding-owned keys below always win.
     return createElement("hyperframes-player", {
+      ...props.elementProps,
       ref: elementRef,
       class: props.className,
       style: props.style,

--- a/packages/player/src/react/player.tsx
+++ b/packages/player/src/react/player.tsx
@@ -4,6 +4,7 @@ import type {
   HyperframesPlayer as HyperframesPlayerElement,
 } from "../hyperframes-player.js";
 import type { ShaderLoadingMode } from "../shader-options.js";
+import { renderPlayerShadowDomHtml } from "../ssr.js";
 import type * as React from "react";
 import {
   createElement,
@@ -78,6 +79,15 @@ export interface HyperframesPlayerProps {
    * React 18 and 19 attribute serialization identical.
    */
   elementProps?: PlayerElementProps;
+  /**
+   * Server-render the player's shadow DOM as a Declarative Shadow DOM
+   * template. The browser parses it during HTML streaming, so the composition
+   * iframe starts loading — and paints its first frame — before any client
+   * JavaScript runs; on upgrade the element adopts that DOM instead of
+   * rebuilding it. The template is emitted only during server rendering (the
+   * browser consumes it while parsing, so hydration sees no child either way).
+   */
+  ssr?: boolean;
   /** Composition loaded and duration determined. */
   onReady?: (detail: { duration: number }) => void;
   onPlay?: () => void;
@@ -345,12 +355,40 @@ export const HyperframesPlayer = forwardRef<HyperframesPlayerHandle, Hyperframes
       [],
     );
 
+    // Declarative shadow DOM template, server render only. The browser parses
+    // it into the shadow root during HTML streaming and removes it from the
+    // light DOM, so client hydration — which renders no child — still matches.
+    const serverTemplate =
+      props.ssr && typeof window === "undefined"
+        ? createElement("template", {
+            shadowrootmode: "open",
+            dangerouslySetInnerHTML: {
+              __html: renderPlayerShadowDomHtml({
+                src,
+                poster,
+                width,
+                height,
+                shaderCaptureScale,
+                shaderLoading,
+              }),
+            },
+          } as unknown as React.HTMLAttributes<HTMLTemplateElement>)
+        : null;
+
     // elementProps spreads first so the binding-owned keys below always win.
-    return createElement("hyperframes-player", {
-      ...props.elementProps,
-      ref: elementRef,
-      class: props.className,
-      style: props.style,
-    });
+    return createElement(
+      "hyperframes-player",
+      {
+        ...props.elementProps,
+        ref: elementRef,
+        class: props.className,
+        style: props.style,
+        // With ssr, string attributes go into the markup itself (identical on
+        // client renders, so hydration stays clean) — crawlers see them and
+        // the upgrade replay recognizes the declarative iframe's src.
+        ...(props.ssr ? { src, poster, width, height } : null),
+      },
+      serverTemplate,
+    );
   },
 );

--- a/packages/player/src/react/register.ts
+++ b/packages/player/src/react/register.ts
@@ -1,0 +1,23 @@
+let registration: Promise<CustomElementConstructor> | null = null;
+
+/**
+ * Register the `<hyperframes-player>` custom element by loading the package
+ * root on demand. The import is deferred so the `./react` subpath stays
+ * SSR-safe: the player module touches `HTMLElement` at module scope and can
+ * only be evaluated in a DOM environment.
+ *
+ * Safe to call multiple times — the import runs once and the returned promise
+ * resolves when the element is defined. Call it early (e.g. at app startup)
+ * to have the element ready before the first `<HyperframesPlayer>` mounts.
+ */
+export function ensurePlayerDefined(): Promise<CustomElementConstructor> {
+  if (typeof window === "undefined" || typeof customElements === "undefined") {
+    throw new Error(
+      "@hyperframes/player/react: ensurePlayerDefined() requires a DOM environment (browser); it cannot run during server-side rendering.",
+    );
+  }
+  registration ??= import("@hyperframes/player").then(() =>
+    customElements.whenDefined("hyperframes-player"),
+  );
+  return registration;
+}

--- a/packages/player/src/react/ssr.test.tsx
+++ b/packages/player/src/react/ssr.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment node
+//
+// Server-rendering contract: the /react subpath must render via
+// renderToString without evaluating the DOM-touching player module, without
+// emitting React warnings (React 18's "useLayoutEffect does nothing on the
+// server" class of issue), and without producing markup that would mismatch
+// on hydration.
+import { renderToString } from "react-dom/server";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const playerModuleEvaluations = vi.hoisted(() => ({ count: 0 }));
+vi.mock("@hyperframes/player", () => {
+  playerModuleEvaluations.count += 1;
+  return {};
+});
+
+import { HyperframesPlayer, useIsomorphicLayoutEffect } from "./player.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("HyperframesPlayer SSR", () => {
+  it("substitutes useEffect for useLayoutEffect on the server", () => {
+    // Structural guard for the React 18 SSR warning: on the server the
+    // component must not reach useLayoutEffect at all.
+    expect(useIsomorphicLayoutEffect).toBe(useEffect);
+  });
+
+  it("server-renders without warnings and without loading the player module", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const html = renderToString(
+      <HyperframesPlayer
+        src="./comp/index.html"
+        controls
+        playbackRate={1.5}
+        className="hero"
+        onReady={() => {}}
+      />,
+    );
+
+    expect(html).toContain("<hyperframes-player");
+    expect(html).toContain('class="hero"');
+    // Attributes are applied client-side in effects, so the server markup must
+    // stay bare — anything else would hydrate-mismatch against React's output.
+    expect(html).not.toContain("playback-rate");
+    expect(playerModuleEvaluations.count).toBe(0);
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/player/src/react/ssr.test.tsx
+++ b/packages/player/src/react/ssr.test.tsx
@@ -51,4 +51,31 @@ describe("HyperframesPlayer SSR", () => {
     expect(consoleError).not.toHaveBeenCalled();
     expect(consoleWarn).not.toHaveBeenCalled();
   });
+
+  it("with ssr, emits a declarative shadow DOM template around the composition iframe", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const html = renderToString(
+      <HyperframesPlayer
+        ssr
+        src="./comp/index.html"
+        poster="./poster.jpg"
+        width={1280}
+        height={720}
+        className="hero"
+      />,
+    );
+
+    expect(html).toContain('<template shadowrootmode="open">');
+    expect(html).toContain('<iframe class="hfp-iframe"');
+    expect(html).toContain('src="./comp/index.html"');
+    expect(html).toContain('<img class="hfp-poster" src="./poster.jpg">');
+    expect(html).toContain("<style data-hfp-ssr>");
+    // String attributes ride on the host tag too, for crawlers and the
+    // upgrade-time attribute replay.
+    expect(html).toMatch(/<hyperframes-player[^>]* src=".\/comp\/index\.html"/);
+    expect(html).toMatch(/<hyperframes-player[^>]* width="1280"/);
+    expect(playerModuleEvaluations.count).toBe(0);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
 });

--- a/packages/player/src/shader-options.ts
+++ b/packages/player/src/shader-options.ts
@@ -115,11 +115,29 @@ export function getShaderCaptureScaleFromElement(el: Element): number {
   return Number(normalizeShaderCaptureScale(el.getAttribute(SHADER_CAPTURE_SCALE_ATTR)) ?? "1");
 }
 
-export function prepareSrcForElement(el: Element, src: string): string {
+/**
+ * Attribute-free variant of `prepareSrcForElement` for callers with no
+ * element in scope (the SSR serializer). Both paths MUST produce identical
+ * strings for identical inputs — the element skips reloading a
+ * declaratively-rendered iframe only when the prepared src matches.
+ */
+export function prepareSrc(
+  src: string,
+  captureScaleAttr: string | null,
+  loadingModeAttr: string | null,
+): string {
   return withShaderQueryParams(
     src,
-    normalizeShaderCaptureScale(el.getAttribute(SHADER_CAPTURE_SCALE_ATTR)),
-    getShaderModeFromElement(el),
+    normalizeShaderCaptureScale(captureScaleAttr),
+    normalizeShaderLoadingMode(loadingModeAttr),
+  );
+}
+
+export function prepareSrcForElement(el: Element, src: string): string {
+  return prepareSrc(
+    src,
+    el.getAttribute(SHADER_CAPTURE_SCALE_ATTR),
+    el.getAttribute(SHADER_LOADING_ATTR),
   );
 }
 

--- a/packages/player/src/ssr.ts
+++ b/packages/player/src/ssr.ts
@@ -1,0 +1,120 @@
+/**
+ * Server-side rendering for `<hyperframes-player>` via Declarative Shadow DOM.
+ *
+ * `renderPlayerShadowDomHtml` produces the inner HTML of a
+ * `<template shadowrootmode="open">` that the browser parses into the
+ * element's shadow root during HTML streaming — before any JavaScript runs.
+ * The composition iframe therefore starts loading (and paints its first
+ * frame) with zero client JS; when `@hyperframes/player` registers, the
+ * element upgrade ADOPTS this DOM instead of rebuilding it, preserving the
+ * already-loaded iframe.
+ *
+ * This module is DOM-free and safe to import in any server runtime.
+ *
+ * Contract with the client (guarded by declarative-shadow tests):
+ * - the structure must match what `setupPlayerShadowDom` adopts
+ *   (`div.hfp-container > iframe.hfp-iframe`, optional `img.hfp-poster`);
+ * - the iframe src must equal `prepareSrc(...)` output so the upgrade replay
+ *   of the `src` attribute recognizes it and skips the reload.
+ */
+import { prepareSrc, type ShaderLoadingMode } from "./shader-options.js";
+import { PLAYER_STYLES } from "./styles.js";
+
+export interface PlayerSsrOptions {
+  /** URL to the composition HTML file (relative to the page). */
+  src?: string;
+  /** Poster image painted above the iframe until playback starts. */
+  poster?: string;
+  /** Composition width in pixels — aspect ratio only (default 1920). */
+  width?: number;
+  /** Composition height in pixels — aspect ratio only (default 1080). */
+  height?: number;
+  /** Mirror of the shader-capture-scale attribute, if the page sets it. */
+  shaderCaptureScale?: number;
+  /** Mirror of the shader-loading attribute, if the page sets it. */
+  shaderLoading?: ShaderLoadingMode;
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+/**
+ * Pre-JS sizing: the client computes the fit scale in `scaleIframeToFit`
+ * (inline styles, which override these rules after hydration). Server-side
+ * the host box is unknown, so the fit is expressed in CSS — container-query
+ * units divided by the composition size. Browsers without typed calc()
+ * division drop the transform and the (clipped) frame still paints.
+ */
+function ssrSizingStyles(width: number, height: number): string {
+  return [
+    ".hfp-container { container-type: size; }",
+    `.hfp-iframe[data-hfp-ssr] { width: ${width}px; height: ${height}px; ` +
+      `transform: translate(-50%, -50%) ` +
+      `scale(min(calc(100cqw / ${width}px), calc(100cqh / ${height}px))); }`,
+  ].join("\n");
+}
+
+/**
+ * Inner HTML for a `<template shadowrootmode="open">` child of
+ * `<hyperframes-player>`. Framework-agnostic — string in, string out.
+ */
+/** Coerce interpolated dimensions defensively: they land inside a <style>
+ *  block where a non-numeric value (from untyped JS callers) could otherwise
+ *  break out of the stylesheet. */
+function positiveDimension(value: number | undefined, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function renderPlayerShadowDomHtml(options: PlayerSsrOptions = {}): string {
+  const width = positiveDimension(options.width, 1920);
+  const height = positiveDimension(options.height, 1080);
+  const preparedSrc = options.src
+    ? prepareSrc(
+        options.src,
+        options.shaderCaptureScale !== undefined ? String(options.shaderCaptureScale) : null,
+        options.shaderLoading ?? null,
+      )
+    : null;
+  const srcAttribute = preparedSrc ? ` src="${escapeAttribute(preparedSrc)}"` : "";
+  const poster = options.poster
+    ? `<img class="hfp-poster" src="${escapeAttribute(options.poster)}">`
+    : "";
+  return (
+    `<style data-hfp-ssr>${PLAYER_STYLES}\n${ssrSizingStyles(width, height)}</style>` +
+    `<div class="hfp-container">` +
+    `<iframe class="hfp-iframe" data-hfp-ssr ` +
+    `sandbox="allow-scripts allow-same-origin" allow="autoplay; fullscreen" ` +
+    `referrerpolicy="no-referrer" title="HyperFrames Composition"${srcAttribute}></iframe>` +
+    `</div>` +
+    poster
+  );
+}
+
+/**
+ * A complete server-renderable `<hyperframes-player>` tag with its declarative
+ * shadow root, for non-React SSR (raw templates, Astro, etc.). React users get
+ * the same markup from `<HyperframesPlayer ssr />`.
+ */
+export function renderPlayerTagHtml(
+  options: PlayerSsrOptions & { className?: string; style?: string } = {},
+): string {
+  const attributes = [
+    options.className ? ` class="${escapeAttribute(options.className)}"` : "",
+    options.style ? ` style="${escapeAttribute(options.style)}"` : "",
+    options.src ? ` src="${escapeAttribute(options.src)}"` : "",
+    options.poster ? ` poster="${escapeAttribute(options.poster)}"` : "",
+    options.width !== undefined ? ` width="${positiveDimension(options.width, 1920)}"` : "",
+    options.height !== undefined ? ` height="${positiveDimension(options.height, 1080)}"` : "",
+  ].join("");
+  return (
+    `<hyperframes-player${attributes}>` +
+    `<template shadowrootmode="open">${renderPlayerShadowDomHtml(options)}</template>` +
+    `</hyperframes-player>`
+  );
+}

--- a/packages/player/tsconfig.json
+++ b/packages/player/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
@@ -11,7 +12,12 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    // The react subpath dynamic-imports the package by name (self-reference).
+    // Resolve it to source so tsc/dts never treat dist/ output as an input.
+    "paths": {
+      "@hyperframes/player": ["./src/hyperframes-player.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/player/tsup.config.ts
+++ b/packages/player/tsup.config.ts
@@ -4,18 +4,34 @@ import { readFileSync } from "node:fs";
 const packageVersion = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"))
   .version as string;
 
-export default defineConfig({
-  entry: ["src/hyperframes-player.ts", "src/slideshow/hyperframes-slideshow.ts"],
-  format: ["esm", "cjs", "iife"],
-  globalName: "HyperframesPlayer",
-  noExternal: ["@hyperframes/core"],
-  dts: true,
-  clean: true,
-  minify: true,
-  sourcemap: true,
-  define: {
-    __HYPERFRAMES_RUNTIME_CDN_URL__: JSON.stringify(
-      `https://cdn.jsdelivr.net/npm/@hyperframes/core@${packageVersion}/dist/hyperframe.runtime.iife.js`,
-    ),
+export default defineConfig([
+  {
+    entry: ["src/hyperframes-player.ts", "src/slideshow/hyperframes-slideshow.ts"],
+    format: ["esm", "cjs", "iife"],
+    globalName: "HyperframesPlayer",
+    noExternal: ["@hyperframes/core"],
+    dts: true,
+    clean: true,
+    minify: true,
+    sourcemap: true,
+    define: {
+      __HYPERFRAMES_RUNTIME_CDN_URL__: JSON.stringify(
+        `https://cdn.jsdelivr.net/npm/@hyperframes/core@${packageVersion}/dist/hyperframe.runtime.iife.js`,
+      ),
+    },
   },
-});
+  // React bindings (`@hyperframes/player/react`). Built separately so react
+  // stays external and the element itself is loaded via the package
+  // self-reference at runtime — no IIFE build, and no `clean` (the first
+  // config owns dist/ cleanup).
+  {
+    entry: { "react/index": "src/react/index.ts" },
+    format: ["esm", "cjs"],
+    // The bindings load the element via the package self-reference at
+    // runtime; without this esbuild would inline the whole player bundle.
+    external: ["@hyperframes/player"],
+    dts: true,
+    minify: true,
+    sourcemap: true,
+  },
+]);

--- a/packages/player/vitest.config.ts
+++ b/packages/player/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
     alias: {
       "@hyperframes/core/slideshow": resolve(coreRoot, "slideshow/index.ts"),
       "@hyperframes/core/runtime/protocol": resolve(coreRoot, "runtime/protocol.ts"),
+      // Self-reference used by src/react/register.ts — point it at source so
+      // tests (which mock it) resolve without a built dist.
+      "@hyperframes/player": resolve(
+        fileURLToPath(new URL("./src/hyperframes-player.ts", import.meta.url)),
+      ),
     },
   },
   test: {


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #2758** — review only the last commit (`a48708e74`); the first commits are the React bindings PR. Will rebase onto main once #2758 merges. (A formal stacked base isn't possible cross-fork.)

## What this is

Prototype answering *"can the player load with SSR?"* — yes, via **Declarative Shadow DOM**. The server serializes the player's shadow DOM into a `<template shadowrootmode="open">`; the browser parses it during HTML streaming, so the composition iframe **starts loading and paints its first frame before any client JavaScript runs**. When `@hyperframes/player` registers, the element upgrade **adopts** the server-rendered DOM instead of rebuilding it — the in-flight iframe is never reloaded.

## How

- **`src/ssr.ts` (new)** — DOM-free serializer: `renderPlayerShadowDomHtml()` (template inner HTML) and `renderPlayerTagHtml()` (full tag, for non-React SSR). Pre-JS fit is pure CSS: `container-type: size` + `scale(min(calc(100cqw/w), calc(100cqh/h)))`; the client's `scaleIframeToFit` overrides inline after upgrade. Attribute values are escaped; dimensions are numerically coerced before CSS interpolation.
- **`setupPlayerShadowDom` (iframe-dom.ts)** — constructor adopts an existing declarative root (same iframe node, same poster); foreign/malformed roots are cleared and rebuilt imperatively.
- **Reload guards** — `_applySrc`/`_applySrcdoc` skip assignment when the iframe already carries the identical prepared URL, so the upgrade-time attribute replay can't restart an in-flight SSR load. `prepareSrc()` extracted so serializer and element produce byte-identical srcs.
- **Already-loaded kick** — `connectedCallback` invokes the probe manually for an adopted iframe that finished loading before upgrade (its load event pre-dates the listener); about:blank filtered, cross-origin falls back to the load event.
- **React** — new `ssr` prop emits the template during server rendering only. The browser consumes the template while parsing (removed from light DOM), the client renders no child, so hydration matches with no suppression. String attributes additionally ride on the host tag.

## Evidence (manual, Chrome)

- **Zero-JS page** (renderToString output, no scripts): composition first frame painted at correct scale inside the declarative shadow root.
- **Late-JS page** (player global build after markup): upgrade at 104ms during the iframe's initial load, load completed once at 108ms, a document mark set on that load survived the session (**no reload**), `player.iframeElement` is the same node, and the player reached `ready` with `duration: 4`.
- 353 tests pass (+9 over #2758): serializer↔adopter contract suite (adoption, malformed-root rebuild, shader-src byte-equality, escaping, CSS-injection coercion) and a React `ssr` renderToString test. The element's 127 pre-existing tests are untouched and green.

## Open items before this leaves draft

- [ ] Public `./ssr` export + `package-subpaths.json` contract (serializer currently internal)
- [ ] Cross-origin readiness handshake (postMessage) instead of the load-event fallback
- [ ] Real SSR-framework fixture (Next.js) in CI, replacing the manual browser proof
- [ ] Decide whether `ssr` should be default-on for the React binding once hardened