### PR TITLE
chore: release v0.7.72

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,63 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.72"
+  description="Released - 2026-07-26"
+  tags={["Release", "Producer", "Gcp Cloud Run", "AWS Lambda"]}
+>
+Distributed rendering now has a versioned Plan v2 contract with integrity-checked,
+content-addressed artifacts and a remote publisher seam for object-storage-backed
+workers, while retaining Plan v1 compatibility. This release also improves audio
+duration accuracy, diagnostics, deterministic media treatments, and animation tooling.
+
+## Features
+
+- **AWS Lambda:** Support plan protocol v2 ([5bf61d6df](https://github.com/heygen-com/hyperframes/commit/5bf61d6df0694c3077ecc7e84cd9d72f2029a5e6), [#2789](https://github.com/heygen-com/hyperframes/pull/2789))
+- **Producer:** Version distributed plan protocol ([f9f00b0ef](https://github.com/heygen-com/hyperframes/commit/f9f00b0efc2d1006967d5b2e0009ea3c3f6ed2e6), [#2777](https://github.com/heygen-com/hyperframes/pull/2777))
+- **Lint:** Dense motion re-sampling for content_overlap ([72e2f08f1](https://github.com/heygen-com/hyperframes/commit/72e2f08f15ceec105eb2bca6e9e35b8020e040be), [#2746](https://github.com/heygen-com/hyperframes/pull/2746))
+- **Studio:** Add keyframe ease editor ([c253dec23](https://github.com/heygen-com/hyperframes/commit/c253dec23b0a6f1ccfe49c17371fdc9823f73b4c))
+- **Core:** Add deterministic keyframe ease runtime ([5acbf240c](https://github.com/heygen-com/hyperframes/commit/5acbf240cbab38594d06b59b9ef7f2a4b37d31b7))
+- **Studio:** Add media treatment inspector ([39c2341c4](https://github.com/heygen-com/hyperframes/commit/39c2341c4d1edf52a00fb8db4a49553c739860cc))
+- **CLI:** Add agent-first media treatment tools ([4582881d0](https://github.com/heygen-com/hyperframes/commit/4582881d002c361afff59cc1c74ae072a50e17f7))
+- **Lint:** Add off_pivot_rotation hub-referenced layout check ([e710a1686](https://github.com/heygen-com/hyperframes/commit/e710a1686f2442b460ea4973dca0be97c81ef184), [#2744](https://github.com/heygen-com/hyperframes/pull/2744))
+- **Runtime:** Render media treatments deterministically ([944640c32](https://github.com/heygen-com/hyperframes/commit/944640c3283d604383fd437fcca8c63941d8e3d7))
+
+## Fixes
+
+- **Gcp Cloud Run:** Normalize v2 integrity codes ([0499a5cbc](https://github.com/heygen-com/hyperframes/commit/0499a5cbcb298c7dc4352a2d672b9e18c9db1d81), [#2790](https://github.com/heygen-com/hyperframes/pull/2790))
+- **Producer:** Document read-only plan hashing ([c6fdd9c01](https://github.com/heygen-com/hyperframes/commit/c6fdd9c0154aacef9e16ab9c89d3249d0ef5d356), [#2788](https://github.com/heygen-com/hyperframes/pull/2788))
+- **Producer:** Use portable audio padding filter ([3b9552ef9](https://github.com/heygen-com/hyperframes/commit/3b9552ef9db36b133485e4ce805892346e0b9006))
+- **Producer:** Normalize padded audio on sample timeline ([4b116b988](https://github.com/heygen-com/hyperframes/commit/4b116b98802c05f0eeb541878806692eea975541))
+- **Engine:** Stop mux at shortest normalized stream ([63bc525ca](https://github.com/heygen-com/hyperframes/commit/63bc525ca90b08356d50ebb41d4e15581c9d3470))
+- **Producer:** Preserve normalized audio mux duration ([532461599](https://github.com/heygen-com/hyperframes/commit/532461599b7518f4609002cdb314ff2ce9f3a70f))
+- **Render:** Cap final mux to video duration ([19258ea5b](https://github.com/heygen-com/hyperframes/commit/19258ea5ba47067e9d5756b122051c467ece0b04))
+- **Render:** Cap trimmed audio container duration ([afc4e96bb](https://github.com/heygen-com/hyperframes/commit/afc4e96bbed21dbcd29544a6be95d35db7dd4eed))
+- **Render:** Scope M4A priming preservation to trims ([9289551e9](https://github.com/heygen-com/hyperframes/commit/9289551e98958f006ec14af8ae9058096a4932fe))
+- **Render:** Preserve normalized M4A edit timing ([59c56d325](https://github.com/heygen-com/hyperframes/commit/59c56d325723bbcb7c54315023aedeb72b376cd8))
+- **Render:** Trim AAC packet padding exactly ([113a4985b](https://github.com/heygen-com/hyperframes/commit/113a4985b51bc1d77babe7113d6c96bbe46d41bf))
+- **Engine:** Preserve bounded ffprobe diagnostics ([8c5077068](https://github.com/heygen-com/hyperframes/commit/8c50770684bc87ca67592c45d4101e3c029193d2), [#2772](https://github.com/heygen-com/hyperframes/pull/2772))
+- **Audio:** Preserve causes and use portable padding ([37b88688e](https://github.com/heygen-com/hyperframes/commit/37b88688e7ae854e377c47fe3d9560ab0c930161), [#2769](https://github.com/heygen-com/hyperframes/pull/2769))
+- **Parsers:** Preserve duration-authored keyframe timing ([4bfbd89d6](https://github.com/heygen-com/hyperframes/commit/4bfbd89d633d5fd227023643db62d2a566984edb))
+- **Parsers:** Preserve authored keyframe intent ([d84e999f7](https://github.com/heygen-com/hyperframes/commit/d84e999f728e25cee15a71995805a52d0a7907c4))
+- **Studio:** Preserve composed media treatments ([d5c7d3ee1](https://github.com/heygen-com/hyperframes/commit/d5c7d3ee16c2db53b91c66353d4f6387fe23e920))
+- **Lint:** Drop false media_in_subcomposition rule ([e7f9918d2](https://github.com/heygen-com/hyperframes/commit/e7f9918d21f9fa57f1799c7b3ba38963cfcb52f1), [#2765](https://github.com/heygen-com/hyperframes/pull/2765))
+
+## Catalog
+
+- **Registry:** Add media treatment overlays ([b0d3164dd](https://github.com/heygen-com/hyperframes/commit/b0d3164ddb6177c6b31634f02a908fdae607850f))
+
+## Internal
+
+- **Producer:** Add remote-ready plan v2 publisher ([07f9a3de9](https://github.com/heygen-com/hyperframes/commit/07f9a3de954d663e61d0e7da233fe8d33a06a5f9), [#2792](https://github.com/heygen-com/hyperframes/pull/2792))
+- **Producer:** Remove stale audio concat remnants ([3ef194234](https://github.com/heygen-com/hyperframes/commit/3ef194234e6104664b8b1902ae916dd7480c3617))
+- **Render:** Cover duration-capped audio mux ([20188d637](https://github.com/heygen-com/hyperframes/commit/20188d637b51bed607593592469863ba189ea4ec))
+- **CLI:** Move render module collection outside hooks ([3b3d4f559](https://github.com/heygen-com/hyperframes/commit/3b3d4f559ca0b97a4d48d5dbaef10c296407c9cb), [#2780](https://github.com/heygen-com/hyperframes/pull/2780))
+- **Studio:** Simplify preview workspace layout ([bf47416e1](https://github.com/heygen-com/hyperframes/commit/bf47416e144bbd45c41375f357b229215aa11ccb))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.71...v0.7.72).
+</Update>
+
+<Update
   label="HyperFrames v0.7.71"
   description="Released - 2026-07-24"
   tags={["Release", "Lint", "Preview", "Core"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.72.md
+++ b/releases/v0.7.72.md
@@ -1,0 +1,56 @@
+# HyperFrames v0.7.72
+
+Released on 2026-07-26.
+
+Distributed rendering now has a versioned Plan v2 contract with integrity-checked,
+content-addressed artifacts and a remote publisher seam for object-storage-backed
+workers, while retaining Plan v1 compatibility. This release also improves audio
+duration accuracy, diagnostics, deterministic media treatments, and animation tooling.
+
+## Features
+
+- **AWS Lambda:** Support plan protocol v2 ([5bf61d6df](https://github.com/heygen-com/hyperframes/commit/5bf61d6df0694c3077ecc7e84cd9d72f2029a5e6), [#2789](https://github.com/heygen-com/hyperframes/pull/2789))
+- **Producer:** Version distributed plan protocol ([f9f00b0ef](https://github.com/heygen-com/hyperframes/commit/f9f00b0efc2d1006967d5b2e0009ea3c3f6ed2e6), [#2777](https://github.com/heygen-com/hyperframes/pull/2777))
+- **Lint:** Dense motion re-sampling for content_overlap ([72e2f08f1](https://github.com/heygen-com/hyperframes/commit/72e2f08f15ceec105eb2bca6e9e35b8020e040be), [#2746](https://github.com/heygen-com/hyperframes/pull/2746))
+- **Studio:** Add keyframe ease editor ([c253dec23](https://github.com/heygen-com/hyperframes/commit/c253dec23b0a6f1ccfe49c17371fdc9823f73b4c))
+- **Core:** Add deterministic keyframe ease runtime ([5acbf240c](https://github.com/heygen-com/hyperframes/commit/5acbf240cbab38594d06b59b9ef7f2a4b37d31b7))
+- **Studio:** Add media treatment inspector ([39c2341c4](https://github.com/heygen-com/hyperframes/commit/39c2341c4d1edf52a00fb8db4a49553c739860cc))
+- **CLI:** Add agent-first media treatment tools ([4582881d0](https://github.com/heygen-com/hyperframes/commit/4582881d002c361afff59cc1c74ae072a50e17f7))
+- **Lint:** Add off_pivot_rotation hub-referenced layout check ([e710a1686](https://github.com/heygen-com/hyperframes/commit/e710a1686f2442b460ea4973dca0be97c81ef184), [#2744](https://github.com/heygen-com/hyperframes/pull/2744))
+- **Runtime:** Render media treatments deterministically ([944640c32](https://github.com/heygen-com/hyperframes/commit/944640c3283d604383fd437fcca8c63941d8e3d7))
+
+## Fixes
+
+- **Gcp Cloud Run:** Normalize v2 integrity codes ([0499a5cbc](https://github.com/heygen-com/hyperframes/commit/0499a5cbcb298c7dc4352a2d672b9e18c9db1d81), [#2790](https://github.com/heygen-com/hyperframes/pull/2790))
+- **Producer:** Document read-only plan hashing ([c6fdd9c01](https://github.com/heygen-com/hyperframes/commit/c6fdd9c0154aacef9e16ab9c89d3249d0ef5d356), [#2788](https://github.com/heygen-com/hyperframes/pull/2788))
+- **Producer:** Use portable audio padding filter ([3b9552ef9](https://github.com/heygen-com/hyperframes/commit/3b9552ef9db36b133485e4ce805892346e0b9006))
+- **Producer:** Normalize padded audio on sample timeline ([4b116b988](https://github.com/heygen-com/hyperframes/commit/4b116b98802c05f0eeb541878806692eea975541))
+- **Engine:** Stop mux at shortest normalized stream ([63bc525ca](https://github.com/heygen-com/hyperframes/commit/63bc525ca90b08356d50ebb41d4e15581c9d3470))
+- **Producer:** Preserve normalized audio mux duration ([532461599](https://github.com/heygen-com/hyperframes/commit/532461599b7518f4609002cdb314ff2ce9f3a70f))
+- **Render:** Cap final mux to video duration ([19258ea5b](https://github.com/heygen-com/hyperframes/commit/19258ea5ba47067e9d5756b122051c467ece0b04))
+- **Render:** Cap trimmed audio container duration ([afc4e96bb](https://github.com/heygen-com/hyperframes/commit/afc4e96bbed21dbcd29544a6be95d35db7dd4eed))
+- **Render:** Scope M4A priming preservation to trims ([9289551e9](https://github.com/heygen-com/hyperframes/commit/9289551e98958f006ec14af8ae9058096a4932fe))
+- **Render:** Preserve normalized M4A edit timing ([59c56d325](https://github.com/heygen-com/hyperframes/commit/59c56d325723bbcb7c54315023aedeb72b376cd8))
+- **Render:** Trim AAC packet padding exactly ([113a4985b](https://github.com/heygen-com/hyperframes/commit/113a4985b51bc1d77babe7113d6c96bbe46d41bf))
+- **Engine:** Preserve bounded ffprobe diagnostics ([8c5077068](https://github.com/heygen-com/hyperframes/commit/8c50770684bc87ca67592c45d4101e3c029193d2), [#2772](https://github.com/heygen-com/hyperframes/pull/2772))
+- **Audio:** Preserve causes and use portable padding ([37b88688e](https://github.com/heygen-com/hyperframes/commit/37b88688e7ae854e377c47fe3d9560ab0c930161), [#2769](https://github.com/heygen-com/hyperframes/pull/2769))
+- **Parsers:** Preserve duration-authored keyframe timing ([4bfbd89d6](https://github.com/heygen-com/hyperframes/commit/4bfbd89d633d5fd227023643db62d2a566984edb))
+- **Parsers:** Preserve authored keyframe intent ([d84e999f7](https://github.com/heygen-com/hyperframes/commit/d84e999f728e25cee15a71995805a52d0a7907c4))
+- **Studio:** Preserve composed media treatments ([d5c7d3ee1](https://github.com/heygen-com/hyperframes/commit/d5c7d3ee16c2db53b91c66353d4f6387fe23e920))
+- **Lint:** Drop false media_in_subcomposition rule ([e7f9918d2](https://github.com/heygen-com/hyperframes/commit/e7f9918d21f9fa57f1799c7b3ba38963cfcb52f1), [#2765](https://github.com/heygen-com/hyperframes/pull/2765))
+
+## Catalog
+
+- **Registry:** Add media treatment overlays ([b0d3164dd](https://github.com/heygen-com/hyperframes/commit/b0d3164ddb6177c6b31634f02a908fdae607850f))
+
+## Internal
+
+- **Producer:** Add remote-ready plan v2 publisher ([07f9a3de9](https://github.com/heygen-com/hyperframes/commit/07f9a3de954d663e61d0e7da233fe8d33a06a5f9), [#2792](https://github.com/heygen-com/hyperframes/pull/2792))
+- **Producer:** Remove stale audio concat remnants ([3ef194234](https://github.com/heygen-com/hyperframes/commit/3ef194234e6104664b8b1902ae916dd7480c3617))
+- **Render:** Cover duration-capped audio mux ([20188d637](https://github.com/heygen-com/hyperframes/commit/20188d637b51bed607593592469863ba189ea4ec))
+- **CLI:** Move render module collection outside hooks ([3b3d4f559](https://github.com/heygen-com/hyperframes/commit/3b3d4f559ca0b97a4d48d5dbaef10c296407c9cb), [#2780](https://github.com/heygen-com/hyperframes/pull/2780))
+- **Studio:** Simplify preview workspace layout ([bf47416e1](https://github.com/heygen-com/hyperframes/commit/bf47416e144bbd45c41375f357b229215aa11ccb))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.71...v0.7.72


### PR DESCRIPTION
## Summary

- release HyperFrames `0.7.72` across all fixed-version packages and plugin manifests
- publish the merged Plan v2 producer API required by object-storage-backed Temporal workers
- include reviewed release notes for the complete `v0.7.71...v0.7.72` range

## Why

`@hyperframes/producer@0.7.71` does not export the Plan v2 manifest, publisher, or integrity APIs. The merged producer work on `main` does, so the internal distributed-rendering integration must consume a real published `0.7.72` rather than a local checkout.

Plan v2 is designed for independently scheduled workers: content-addressed artifacts and the manifest are exchanged through object storage. Local disk remains pod-local scratch and is never a cross-node contract.

## Verification

- repository script tests: 15 suites passed; packed-manifest fixture: 9/9 passed outside the filesystem sandbox
- `bun run format:check`
- release channel validation for `release/v0.7.72` → `latest`
- `git diff --check`

Merging this `release/v0.7.72` PR triggers the standard npm publish workflow.
