### PR TITLE
fix(lint): back readAttr with the HTML parser

### DIFF
--- a/packages/lint/src/utils.test.ts
+++ b/packages/lint/src/utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { readAttr, readDecodedAttr } from "./utils.js";
+
+describe("readAttr", () => {
+  it("reads a double-quoted value", () => {
+    expect(readAttr('<div data-start="2.5">', "data-start")).toBe("2.5");
+  });
+
+  it("reads a single-quoted value", () => {
+    expect(readAttr("<div data-start='2.5'>", "data-start")).toBe("2.5");
+  });
+
+  // Unquoted values are valid HTML5 and the runtime reads them, so a
+  // quoted-only pattern both invents "missing attribute" errors and hides
+  // real violations on the attributes it cannot see.
+  it("reads an unquoted value", () => {
+    expect(readAttr("<div data-start=0>", "data-start")).toBe("0");
+  });
+
+  it("reads unquoted values from a tag that mixes quoting styles", () => {
+    const tag = `<div id="root" data-composition-id=main data-start=0 data-width=1920 data-height='1080'>`;
+    expect(readAttr(tag, "data-composition-id")).toBe("main");
+    expect(readAttr(tag, "data-start")).toBe("0");
+    expect(readAttr(tag, "data-width")).toBe("1920");
+    expect(readAttr(tag, "data-height")).toBe("1080");
+  });
+
+  it("agrees with the parser-backed reader across quoting styles and near-misses", () => {
+    const cases: Array<[string, string]> = [
+      ["<div data-track-index=2 data-duration=6>", "data-track-index"],
+      ["<div data-track-index=2 data-duration=6>", "data-duration"],
+      ['<div data-hf-src="x?id=5" id="root">', "id"],
+      ['<img src="x.png?class=big" class="clip">', "class"],
+      ["<div data-composition-src=scenes/a.html>", "data-composition-src"],
+    ];
+    for (const [tag, attr] of cases) {
+      expect(readAttr(tag, attr)).toBe(readDecodedAttr(tag, attr) || null);
+    }
+  });
+
+  it("reads unquoted values that sit next to other attributes", () => {
+    expect(readAttr("<div data-start=0 class=clip>", "class")).toBe("clip");
+    expect(readAttr("<div data-composition-src=scenes/a.html>", "data-composition-src")).toBe(
+      "scenes/a.html",
+    );
+  });
+
+  // A `name=value` pair inside another attribute's value is not an attribute.
+  // Reading it as one made `duplicate_media_id` fire on ids that do not exist
+  // and hid `media_missing_id` on a video that really had none.
+  it("does not read a name=value pair out of another attribute's value", () => {
+    expect(readAttr('<img src="https://cdn.x/i?id=123" class="clip">', "id")).toBeNull();
+    expect(readAttr('<img src="x.png?class=big" class="clip">', "class")).toBe("clip");
+    expect(readAttr('<div data-hf-src="clip.mp4?id=5" id="root">', "id")).toBe("root");
+    expect(readAttr('<video src="v.mp4?preload=none">', "preload")).toBeNull();
+    expect(readAttr('<div title="use id=hero">', "id")).toBeNull();
+  });
+
+  // The `(?<![\w-])` lookbehind, not `\b`: a hyphen would otherwise read as a
+  // word break and match the tail of a longer attribute name.
+  it("does not match the tail of a longer attribute name", () => {
+    expect(readAttr('<div data-hf-id="x">', "id")).toBeNull();
+    expect(readAttr("<div data-width=1920>", "width")).toBeNull();
+  });
+
+  it("returns null for an absent or valueless attribute", () => {
+    expect(readAttr("<video muted>", "muted")).toBeNull();
+    expect(readAttr("<div>", "data-start")).toBeNull();
+    expect(readAttr("", "data-start")).toBeNull();
+  });
+
+  it("treats an empty quoted value as absent, as before", () => {
+    expect(readAttr('<div data-start="">', "data-start")).toBeNull();
+  });
+});

--- a/packages/lint/src/utils.ts
+++ b/packages/lint/src/utils.ts
@@ -162,15 +162,15 @@ export function findRootTag(source: string, parsedTags?: readonly OpenTag[]): Op
   return null;
 }
 
+/**
+ * Read an HTML attribute the way the runtime does. Parser-backed rather than a
+ * regex over the tag text: a regex cannot see unquoted values (valid HTML5, and
+ * the runtime honours them), so it both invents "missing attribute" errors and
+ * hides real violations — and widening it to accept unquoted values makes it
+ * capture `name=value` pairs out of other attributes' quoted values instead.
+ */
 export function readAttr(tagSource: string, attr: string): string | null {
-  if (!tagSource) return null;
-  const escaped = attr.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // `(?<![\w-])` not `\b`: a plain `\b` boundary treats the hyphen in a longer
-  // attribute as a word break, so reading "id" would wrongly match the trailing
-  // `id="…"` inside `data-hf-id="…"` (and "width" inside `data-width`, etc.).
-  // The lookbehind requires the match to start a fresh attribute name.
-  const match = tagSource.match(new RegExp(`(?<![\\w-])${escaped}\\s*=\\s*["']([^"']+)["']`, "i"));
-  return match?.[1] || null;
+  return readDecodedAttr(tagSource, attr) || null;
 }
 
 /** Read an HTML attribute using browser-equivalent character-reference decoding. */


### PR DESCRIPTION
## Problem

`readAttr` (`packages/lint/src/utils.ts`) matched only **quoted** attribute values. Unquoted values are valid HTML5 and the runtime honours them, so the quoted-only pattern was simultaneously inventing errors and hiding real violations. `readAttr` backs ~130 call sites across ~68 error-severity rules, and lint errors gate `render --strict` and the lint section of `check`.

| fixture | before | after |
|---|---|---|
| root written `data-composition-id=main data-start=0 data-width=1920 data-height=1080` | **2 errors** — `root_missing_dimensions`, `root_composition_missing_data_start` — for attributes that are **present** | those are gone; the 3 genuine violations it was hiding (`deprecated_data_layer`, `deprecated_data_end`, `timed_element_missing_clip_class`) now surface |
| two genuinely overlapping unquoted clips, no `class="clip"` | **0 errors** | `overlapping_clips_same_track` + 2x `timed_element_missing_clip_class` |

The defect was isolated by the linter's own output: the baseline error message printed the composition id `"main"`, because `readDecodedAttr` — the htmlparser2-backed reader twenty lines below in the same file — parsed that very tag correctly.

## Why not just widen the regex

The first attempt added an unquoted alternative (`(?:["']([^"']+)["']|([^\s"'\`=<>]+))`). Two independent reviews rejected it with measurements, and they were right: the pattern has no notion of attribute-list position, so it captures `name=value` pairs out of **other attributes' quoted values**.

| markup | attr read | regex result | correct |
|---|---|---|---|
| `<div data-hf-src="clip.mp4?id=5" id="root">` | `id` | `"5"` | `"root"` |
| `<img src="x.png?class=big" class="clip">` | `class` | `"big"` | `"clip"` |
| `<video src="v.mp4?preload=none">` | `preload` | `"none"` | none |

`id` is read at 46 of the call sites, so the damage was concrete and error-severity:

- two `<video>` elements with **distinct real ids** sharing a `?id=9` source both read as id `"9"`: `duplicate_media_id` (error) fired on an id that does not exist, **and swallowed two genuine `video_missing_muted` findings** via same-id dedupe;
- a `<video>` with **no id at all** but `?id=7` in its URL had `media_missing_id` (error) **masked** — hiding the frozen-video render bug that rule exists to catch;
- a Google-Drive-style `?export=view&id=<FILEID>` asset URL — a canonical pattern in generated compositions — is enough to trigger it.

Delegating to the parser fixes the blind spot without introducing that class, and drops two further divergences for free: the regex silently truncated any unquoted value containing `=` (`href=a.html?x=1&y=2` -> `"a.html?x"`), and never decoded character references. `|| null` preserves the existing "empty value means absent" contract exactly.

## Verification

- **Corpus unchanged.** All 13 `registry/examples/*` and every `registry/blocks/*` html produce **byte-identical** lint findings before and after (compared via `git show HEAD:<path>` file swaps, not `git stash` — see note below). One reviewer independently reproduced this over 166 targets.
- `packages/lint`: **515 tests pass** (505 pre-existing + 10 new).
- The new tests catch **both** rejected implementations: 4 fail against the original quoted-only regex, 2 fail against the widened regex (the cross-attribute cases). Delegation passes 10/10.
- oxlint / oxfmt / `tsc --noEmit` clean.
- Not slower: a reviewer measured a full 211-file lint pass at 1197ms delegated vs 1282ms with the regex (`readAttr` built an uncached `new RegExp` per call).

## Behaviour change to surface in release notes

There is no `.changeset/` in this repo — release notes are hand-curated from the commit log — so this needs to be stated rather than filed. **Attributes that were invisible are now linted**, so a project written with unquoted attributes **and a real violation** will newly fail `lint` and `render --strict`. A correct unquoted-attribute project lints clean (verified). The repo's own compositions all quote their attributes, hence the zero-delta corpus.

## Not in scope

`readJsonAttr` is left alone. The parser makes it redundant (it exists specifically because the old regex truncated JSON attribute values, per its own docblock), but removing it is its own change.

Four other `lint` defects confirmed in the same testing round are untouched and each needs its own fix: `non_deterministic_code` and `requestanimationframe_in_composition` flag banned identifiers inside **string literals** (this blocks the repo's own `/pr-to-video` output — a typed code-diff animation with `"Math.random()"` in a data array); `new Date(` fires on the deterministic `new Date("2024-01-15")`; `overlapping_clips_same_track` has no hierarchy model (a parent clip "overlaps" its own children) and keys tracks by raw string, so `"1"` and `"01"` are different tracks; `imperative_media_control` misses `?.play()`.

> Process note for reviewers: `git stash` shares one `refs/stash` across all worktrees of this repo. Use `git show HEAD:<path>` for baseline swaps instead — a concurrent stash collision during this work cost one reviewer a 146-path conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)