### PR TITLE
fix(check): bill a clipped text box once, not twice

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -458,8 +458,12 @@
       ? tolerance
       : Math.max(tolerance, parsePx(elementStyle.fontSize) * 0.2);
     const containerOverflow = overflowFor(textRect, containerRect, tolerance, verticalTolerance);
+    // A clipping box that is its own nearest constraint is `clipped_text`; billing the same defect
+    // here as well double-counted it. A NON-clipping self-constraint still reports — nothing else covers it.
+    const isClippedSelfConstraint = container === element && containerClips;
     if (
       containerOverflow &&
+      !isClippedSelfConstraint &&
       !hasTextClipOptOut(element) &&
       !clippedByAncestor(element, container)
     ) {

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -219,12 +219,37 @@ describe("layout-audit.browser", () => {
         .map((issue) => issue.code)
         .filter((code) => code === "clipped_text" || code === "text_box_overflow");
 
-    expect(textOverflowCodes()).toEqual(["clipped_text", "text_box_overflow"]);
+    // One code: a clipping box that is its own nearest constraint is `clipped_text`, and billing the
+    // same defect as `text_box_overflow` too counted it twice.
+    expect(textOverflowCodes()).toEqual(["clipped_text"]);
     document.querySelector("#overflow-optout")?.setAttribute("data-layout-allow-overflow", "");
     expect(textOverflowCodes()).toEqual([]);
     document.querySelector("#overflow-optout")?.removeAttribute("data-layout-allow-overflow");
     headline.setAttribute("data-layout-bleed", "true");
     expect(textOverflowCodes()).toEqual([]);
+  });
+
+  it("still flags a painted, NON-clipping box that is its own nearest constraint", () => {
+    // `container === element` does not imply the element clips: a painted, sized box is a
+    // constraint candidate too. `clipped_text` cannot speak for it (nothing is clipped), so the
+    // de-duplication guard must not swallow this — it would leave the defect with no code at all.
+    // `#bubble` is the harness's painted, radiused box — here it carries the text itself, so it is
+    // its own nearest constraint while clipping nothing.
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <div id="bubble">Enterprise plan includes unlimited renders</div>
+      </div>
+    `;
+    installGeometry({
+      root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+      bubble: rect({ left: 40, top: 60, width: 200, height: 40 }),
+      text: rect({ left: 40, top: 65, width: 520, height: 30 }),
+    });
+    installAuditScript();
+
+    const found = runAudit().filter((issue) => issue.code === "text_box_overflow");
+    expect(found).toHaveLength(1);
+    expect(found[0]?.selector).toBe("#bubble");
   });
 
   it("does not flag glyph-ink vertical spill within the font-metric band on a non-clipping box", () => {


### PR DESCRIPTION
## Problem

`nearestConstraint` returns the element itself when the element clips — a clipping box *is* a constraint candidate (`isConstraintCandidate`). `textOverflowIssues` then reported the same physical defect a second time as `text_box_overflow <sel> inside <same sel>`, so **every `clipped_text` arrived as two errors** and inflated `errorCount`.

## The guard needs both conditions

`container === element && containerClips`, not `container === element` alone. A painted, sized box is also a constraint candidate **without clipping anything**, and there `clipped_text` cannot speak for it (it requires `clipsOverflow`). An earlier revision of this PR omitted the second condition, and review caught it: a painted 200px chip whose text ink ran 520px past its edge went from `error text_box_overflow {right: 792px}` to reporting **nothing at all**.

Both cases are now pinned:

| implementation | `clipped_text` double-count test | non-clipping self-constraint test |
|---|---|---|
| HEAD | **fails** (still double-bills) | passes |
| `container === element` only | passes | **fails** (silences a real defect) |
| this PR | passes | passes |

## Verification

31 fixtures (`ovf` corpus + the reviewer's own): **9 changed, all the same shape** — the duplicate `text_box_overflow` removed, the `clipped_text` error and `ok: false` retained. 22 unchanged. Among the 9 are four fixtures that are *genuine* defects wearing deliberate-truncation CSS (`overflow:auto` body copy cut off, `overflow:scroll` headline, an `ellipsis` stat truncated to `$1,2…`, a headline clamped from 3 lines to 1) — **all four still gate**, so no recall was traded for the de-duplication.

13 registry examples byte-identical. `packages/cli`: 2148 tests pass; the single failure (`src/telemetry/agent_runtime.test.ts`, agent-env detection) reproduces on clean `HEAD` and is environment-dependent, unrelated. oxlint / oxfmt / `tsc --noEmit` clean.

## Not in scope — three `error`-severity false positives remain

Confirmed by measurement in the same round, and **deliberately left out of this PR** after two reviews rejected my first attempt at them. All three currently fail the build on correct compositions:

- `-webkit-line-clamp`, `text-overflow: ellipsis`, and `overflow: auto/scroll` each produce `clipped_text` at `error`. My first attempt exempted them wholesale; that silenced real defects — 4 of 7 lines of body copy invisible in an `overflow:auto` card, a stat truncated to `$1,2…`, a headline clamped away — because deliberate-truncation CSS is a *mechanism*, not a statement that the truncation is acceptable. It was also axis-blind: `text-overflow` applies only to inline overflow and `-webkit-line-clamp` only to block overflow, but the gate returned early on either. The reviewers' concrete design: keep `auto`/`scroll` reporting (nobody scrolls an MP4 — content past the fold is unconditionally invisible in the output) and exempt `ellipsis`/`line-clamp` only below a hidden-fraction threshold, per axis, using the already-computed `overflowX / scrollWidth` and `scrollHeight / clientHeight`.
- Text placed wholly outside a *non-clipping* container reports `text_box_overflow` at `error`. My first attempt vetoed it downstream; that threw the element away instead of continuing the constraint walk, so text escaping *two* nested boxes reported nothing, and `escaped_container` does not cover the gap (it requires `position: absolute` and explicitly skips the detached-but-hugging case). The right fix is in `isConstraintCandidate` — a non-clipping candidate should have to intersect the text rect, letting `nearestConstraint` walk on — which is a bigger change with its own corpus sweep.

Also unfixed, larger, and deliberately separate: `staticIssueKey` includes `formatOverflow(issue.overflow)`, so a breach whose depth changes between samples splits per-sample and every group is demoted to `info` — un-gating real errors for any moving element across all 9 tiered codes. That fix makes the audit *louder* and touches the same tuple as #2801; landing it alongside "stop failing on ellipsis" would make the net corpus effect unattributable.

## Doc note

`skills/hyperframes-core/references/data-attributes.md:59` states the current doctrine: *"`overflow: hidden` clips the visual but does not suppress a layout finding. This attribute is the escape hatch; CSS overflow is not."* This PR does not change that contract — it only stops double-billing — so the doc stays accurate. The deferred FP fixes above **will** contradict it and must update it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)