### PR TITLE
fix(check): keep auditing when a motion spec is partly unusable

### DIFF
--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../utils/checkPipeline.js";
 import { resolveCompositionViewportFromHtml } from "../utils/compositionViewport.js";
 import { consumeCommandResult } from "../utils/commandResult.js";
+import { ambiguousIssue } from "../utils/motionAudit.js";
 import type { ProjectLintResult } from "../utils/lintProject.js";
 import type {
   LayoutIssue,
@@ -1108,6 +1109,171 @@ describe("check pipeline", () => {
     expect(report.runtime.errorCount).toBe(1);
     expect(report.layout.errorCount).toBe(1);
     expect(browser).toHaveBeenCalledTimes(1);
+  });
+
+  it("still audits layout when the motion sidecar is invalid", async () => {
+    const motion: MotionSpecResolution = {
+      kind: "invalid",
+      path: "/project/index.motion.json",
+      message: 'assertions[0] (staysInFrame): "selector" must be a non-empty string',
+    };
+    const driver = fakeDriver({
+      collectLayout: vi.fn(async (time: number) => [layoutIssue("error", { time })]),
+    });
+    const { report, browser } = await runScenario(driver, {}, { motion });
+
+    expect(browser).toHaveBeenCalledTimes(1);
+    expect(report.layout.findings.length).toBeGreaterThan(0);
+    expect(report.motion.findings).toEqual([
+      expect.objectContaining({ code: "motion_spec_invalid", severity: "error" }),
+    ]);
+    expect(report.motion).toMatchObject({
+      enabled: true,
+      specPath: "/project/index.motion.json",
+      samples: 0,
+    });
+    expect(report.ok).toBe(false);
+  });
+
+  it("does not sample motion for an invalid sidecar", async () => {
+    const motion: MotionSpecResolution = {
+      kind: "invalid",
+      path: "/project/index.motion.json",
+      message: "version 2 is not supported",
+    };
+    const driver = fakeDriver();
+    const { report } = await runScenario(driver, {}, { motion });
+
+    expect(report.motion.samples).toBe(0);
+    expect(driver.collectMotionFrame).not.toHaveBeenCalled();
+  });
+
+  it("keeps evaluating the unambiguous assertions when one selector is ambiguous", async () => {
+    const motion: MotionSpecResolution = {
+      kind: "valid",
+      path: "/project/index.motion.json",
+      spec: {
+        assertions: [
+          { kind: "appearsBy", selector: ".item", bySec: 1 },
+          { kind: "appearsBy", selector: "#hero", bySec: 0.2 },
+        ],
+      },
+    };
+    const driver = fakeDriver({
+      getDuration: vi.fn(async () => 1),
+      findAmbiguousSelectors: vi.fn(async () => [
+        { ...layoutIssue("error", { code: "motion_selector_ambiguous" }), selector: ".item" },
+      ]),
+      collectMotionFrame: vi.fn(async (time: number) => heroMotionFrame(time, (t) => t >= 0.5)),
+    });
+    const { report } = await runScenario(driver, {}, { motion });
+
+    expect(report.motion.samples).toBeGreaterThan(0);
+    expect(report.motion.findings.map((finding) => finding.code).sort()).toEqual([
+      "motion_appears_late",
+      "motion_selector_ambiguous",
+    ]);
+    expect(report.ok).toBe(false);
+    expect(
+      report.motion.findings.find((finding) => finding.code === "motion_selector_ambiguous")
+        ?.message,
+    ).toContain("1 assertion(s) naming it were not evaluated");
+    expect(driver.collectMotionFrame).toHaveBeenCalledWith(expect.any(Number), ["#hero"], []);
+  });
+
+  it("separates the ambiguity message from the skipped-assertion count", async () => {
+    const motion: MotionSpecResolution = {
+      kind: "valid",
+      path: "/project/index.motion.json",
+      spec: { assertions: [{ kind: "appearsBy", selector: ".item", bySec: 1 }] },
+    };
+    const driver = fakeDriver({
+      getDuration: vi.fn(async () => 1),
+      findAmbiguousSelectors: vi.fn(async () => [
+        { ...layoutIssue("error"), ...ambiguousIssue(".item") },
+      ]),
+    });
+    const { report } = await runScenario(driver, {}, { motion });
+
+    const message = report.motion.findings.find(
+      (finding) => finding.code === "motion_selector_ambiguous",
+    )?.message;
+    expect(message).toContain("exactly one. 1 assertion(s)");
+  });
+
+  it("counts skipped assertions per ambiguous selector, not across all of them", async () => {
+    const motion: MotionSpecResolution = {
+      kind: "valid",
+      path: "/project/index.motion.json",
+      spec: {
+        assertions: [
+          { kind: "appearsBy", selector: ".item", bySec: 1 },
+          { kind: "appearsBy", selector: ".card", bySec: 1 },
+          { kind: "appearsBy", selector: ".card", bySec: 2 },
+        ],
+      },
+    };
+    const driver = fakeDriver({
+      getDuration: vi.fn(async () => 1),
+      findAmbiguousSelectors: vi.fn(async () => [
+        { ...layoutIssue("error", { code: "motion_selector_ambiguous" }), selector: ".item" },
+        { ...layoutIssue("error", { code: "motion_selector_ambiguous" }), selector: ".card" },
+      ]),
+    });
+    const { report } = await runScenario(driver, {}, { motion });
+
+    const messages = report.motion.findings
+      .filter((finding) => finding.code === "motion_selector_ambiguous")
+      .map((finding) => finding.message);
+    expect(messages.filter((m) => m.includes("1 assertion(s) naming it"))).toHaveLength(1);
+    expect(messages.filter((m) => m.includes("2 assertion(s) naming it"))).toHaveLength(1);
+  });
+
+  it("drops a before assertion when either side is ambiguous, keeping the rest", async () => {
+    const motion: MotionSpecResolution = {
+      kind: "valid",
+      path: "/project/index.motion.json",
+      spec: {
+        assertions: [
+          { kind: "before", a: "#hero", b: ".item" },
+          { kind: "appearsBy", selector: "#hero", bySec: 0.2 },
+        ],
+      },
+    };
+    const driver = fakeDriver({
+      getDuration: vi.fn(async () => 1),
+      findAmbiguousSelectors: vi.fn(async () => [
+        { ...layoutIssue("error", { code: "motion_selector_ambiguous" }), selector: ".item" },
+      ]),
+      collectMotionFrame: vi.fn(async (time: number) => heroMotionFrame(time, (t) => t >= 0.5)),
+    });
+    const { report } = await runScenario(driver, {}, { motion });
+
+    expect(report.motion.findings.map((finding) => finding.code).sort()).toEqual([
+      "motion_appears_late",
+      "motion_selector_ambiguous",
+    ]);
+    expect(driver.collectMotionFrame).toHaveBeenCalledWith(expect.any(Number), ["#hero"], []);
+  });
+
+  it("does not sample when every assertion names an ambiguous selector", async () => {
+    const motion: MotionSpecResolution = {
+      kind: "valid",
+      path: "/project/index.motion.json",
+      spec: { assertions: [{ kind: "appearsBy", selector: ".item", bySec: 1 }] },
+    };
+    const driver = fakeDriver({
+      getDuration: vi.fn(async () => 1),
+      findAmbiguousSelectors: vi.fn(async () => [
+        { ...layoutIssue("error", { code: "motion_selector_ambiguous" }), selector: ".item" },
+      ]),
+    });
+    const { report } = await runScenario(driver, {}, { motion });
+
+    expect(report.motion.samples).toBe(0);
+    expect(report.motion.findings.map((finding) => finding.code)).toEqual([
+      "motion_selector_ambiguous",
+    ]);
   });
 
   it("reports a failing appearsBy sidecar as motion_appears_late", async () => {

--- a/packages/cli/src/utils/checkPipeline.ts
+++ b/packages/cli/src/utils/checkPipeline.ts
@@ -16,12 +16,13 @@ import {
   type LayoutRect,
 } from "./layoutAudit.js";
 import {
+  assertionTargets,
   collectSamplingTargets,
   evaluateMotion,
   type Canvas,
   type MotionFrame,
 } from "./motionAudit.js";
-import { findMotionSpec, readMotionSpec } from "./motionSpec.js";
+import { findMotionSpec, readMotionSpec, type MotionAssertion } from "./motionSpec.js";
 import { normalizeErrorMessage } from "./errorMessage.js";
 import {
   parseColorRGBA,
@@ -169,6 +170,7 @@ interface MotionPlan {
   selectors: string[];
   livenessScopes: string[];
   preflightIssues: AnchoredLayoutIssue[];
+  assertions: MotionAssertion[];
 }
 
 async function planMotionSampling(
@@ -177,13 +179,30 @@ async function planMotionSampling(
   duration: number,
 ): Promise<MotionPlan> {
   if (motion.kind !== "valid") {
-    return { times: [], selectors: [], livenessScopes: [], preflightIssues: [] };
+    return { times: [], selectors: [], livenessScopes: [], preflightIssues: [], assertions: [] };
   }
-  const targets = collectSamplingTargets(motion.spec.assertions);
-  const preflightIssues = await driver.findAmbiguousSelectors(targets.selectors);
+  const preflightIssues = await driver.findAmbiguousSelectors(
+    collectSamplingTargets(motion.spec.assertions).selectors,
+  );
+  const ambiguous = new Set(preflightIssues.map((issue) => issue.selector));
+  const assertions = motion.spec.assertions.filter(
+    (assertion) =>
+      !assertionTargets(assertion).selectors.some((selector) => ambiguous.has(selector)),
+  );
+  noteSkippedAssertions(preflightIssues, motion.spec.assertions);
+  const targets = collectSamplingTargets(assertions);
   const times =
-    preflightIssues.length === 0 ? buildMotionSampleTimes(motion.spec.duration ?? duration) : [];
-  return { times, ...targets, preflightIssues };
+    assertions.length > 0 ? buildMotionSampleTimes(motion.spec.duration ?? duration) : [];
+  return { times, ...targets, preflightIssues, assertions };
+}
+
+function noteSkippedAssertions(issues: AnchoredLayoutIssue[], assertions: MotionAssertion[]): void {
+  for (const issue of issues) {
+    const skipped = assertions.filter((assertion) =>
+      assertionTargets(assertion).selectors.includes(issue.selector),
+    ).length;
+    if (skipped > 0) issue.message += ` ${skipped} assertion(s) naming it were not evaluated.`;
+  }
 }
 
 interface GridSamples {
@@ -1061,13 +1080,13 @@ export async function runAuditGrid(
   const seekLoopMs = Date.now() - seekLoopStart;
 
   let motionIssues = plan.preflightIssues;
-  if (motion.kind === "valid" && motionIssues.length === 0 && collected.motionFrames.length > 0) {
+  if (motion.kind === "valid" && plan.assertions.length > 0 && collected.motionFrames.length > 0) {
     const evaluated = evaluateMotion(
       collected.motionFrames,
-      motion.spec.assertions,
+      plan.assertions,
       await driver.getCanvas(),
     );
-    motionIssues = await driver.anchorMotionIssues(evaluated);
+    motionIssues = [...motionIssues, ...(await driver.anchorMotionIssues(evaluated))];
   }
   const sweepFindings = detectSweepStatic(
     grid.duration,
@@ -1131,15 +1150,17 @@ export async function runCheckPipeline(
   }
 
   const motion = dependencies.resolveMotionSpec(project.dir);
-  if (motion.kind === "invalid") {
-    const finding = findingAtRoot(
-      "motion_spec_invalid",
-      "error",
-      motion.message,
-      relative(project.dir, motion.path) || "index.motion.json",
-    );
-    return buildReport(options, lint, emptyBrowserResult(), motion, [finding], []);
-  }
+  const specFindings =
+    motion.kind === "invalid"
+      ? [
+          findingAtRoot(
+            "motion_spec_invalid",
+            "error",
+            motion.message,
+            relative(project.dir, motion.path) || "index.motion.json",
+          ),
+        ]
+      : [];
 
   let browser: CheckBrowserResult;
   try {
@@ -1152,7 +1173,7 @@ export async function runCheckPipeline(
   const snapshotFiles = options.snapshots
     ? await writeContrastSnapshots(dependencies, project.dir, browser)
     : [];
-  const report = buildReport(options, lint, browser, motion, [], snapshotFiles);
+  const report = buildReport(options, lint, browser, motion, specFindings, snapshotFiles);
   return options.snapshots
     ? await withFindingCrops(dependencies, project, options, report)
     : report;

--- a/packages/cli/src/utils/motionAudit.ts
+++ b/packages/cli/src/utils/motionAudit.ts
@@ -36,7 +36,7 @@ export function ambiguousIssue(selector: string): LayoutIssue {
     severity: "error",
     time: 0,
     selector,
-    message: `${selector} matches multiple elements — use a more specific selector so the assertion targets exactly one`,
+    message: `${selector} matches multiple elements — use a more specific selector so the assertion targets exactly one.`,
     rect: ZERO_RECT,
     fixHint:
       "Use #id or :nth-child() instead of a class selector when multiple elements share the same class.",
@@ -236,6 +236,26 @@ export function evaluateMotion(
   });
 }
 
+export function assertionTargets(assertion: MotionAssertion): {
+  selectors: string[];
+  scopes: string[];
+} {
+  switch (assertion.kind) {
+    case "appearsBy":
+    case "staysInFrame":
+      return { selectors: [assertion.selector], scopes: [] };
+    case "before":
+      return { selectors: [assertion.a, assertion.b], scopes: [] };
+    case "keepsMoving":
+      return { selectors: [], scopes: [assertion.withinSelector ?? "*"] };
+    default: {
+      const exhaustive: never = assertion;
+      void exhaustive;
+      return { selectors: [], scopes: [] };
+    }
+  }
+}
+
 /**
  * Selectors and liveness scopes the in-page sampler must read for a spec.
  * Selectors feed the per-element matrix; scopes feed keepsMoving liveness.
@@ -247,19 +267,9 @@ export function collectSamplingTargets(assertions: MotionAssertion[]): {
   const selectors = new Set<string>();
   const scopes = new Set<string>();
   for (const assertion of assertions) {
-    switch (assertion.kind) {
-      case "appearsBy":
-      case "staysInFrame":
-        selectors.add(assertion.selector);
-        break;
-      case "before":
-        selectors.add(assertion.a);
-        selectors.add(assertion.b);
-        break;
-      case "keepsMoving":
-        scopes.add(assertion.withinSelector ?? "*");
-        break;
-    }
+    const targets = assertionTargets(assertion);
+    for (const selector of targets.selectors) selectors.add(selector);
+    for (const scope of targets.scopes) scopes.add(scope);
   }
   return { selectors: [...selectors], livenessScopes: [...scopes] };
 }


### PR DESCRIPTION
Rebuilt onto today's `main` (the July branch shared no ancestry after the history rewrite) and consolidated with #2806, which touched the same two files.

**1. Ambiguous selector no longer aborts the spec (was this PR)**
An ambiguous selector is reported as a finding, the assertions that depend on it are skipped and named, and every other assertion still evaluates. `assertionTargets` is exhaustive over the assertion kinds, so a new kind cannot silently fall back to an arbitrary first match while its selector is also reported ambiguous. Its `default` branch keeps the compile-time `never` check but returns empty targets at runtime, so a future kind that slips past spec validation degrades instead of throwing.

The "N assertion(s) naming it were not evaluated" suffix is counted per ambiguous selector. An earlier draft appended the global skipped total to every message, so two ambiguous selectors with one assertion each both claimed "2".

**2. Unparseable sidecar no longer ends the run (was #2806)**
A motion sidecar that will not parse becomes a spec finding instead of an early return, so the composition is still audited. The invalid spec yields an empty sampling plan, so no motion evaluation runs and the finding still lands in `errorCount` — the gate keeps failing.

Tests: 190 pass on the four affected files (main: 182).

Not addressed here: `hf layout`'s own `runMotionPass` still aborts the whole spec on an ambiguous selector and still exits on an unparseable sidecar, so the same sidecar now behaves differently under `hf check` and `hf layout`. Worth a follow-up that has `layout.ts` reuse `assertionTargets` the same way. Also unchanged: a `keepsMoving` scope is not preflighted for ambiguity, so it is neither reported nor counted.

Closes #2806.