### PR TITLE
chore: release v0.7.73

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,51 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.73"
+  description="Released - 2026-07-26"
+  tags={["Release", "Producer", "Render", "Engine"]}
+>
+Distributed Plan v2 publishers now stream content-addressed artifacts directly to
+S3 and GCS, while oversized-plan diagnostics identify the dominant files and phases.
+Rendering is more resilient through atomic media downloads, typed extraction retries,
+and frame-coverage accounting aligned with FFmpeg's CFR rounding.
+
+## Features
+
+- **Studio:** Add professional grading controls ([20ef48abc](https://github.com/heygen-com/hyperframes/commit/20ef48abcb190e3e9ef132d1b1dd711201d3c58b))
+- **CLI:** Expose agent-native color grading ([6d5961b80](https://github.com/heygen-com/hyperframes/commit/6d5961b8024fe70f87879f271dd91149717d41a8))
+- **Gcp Cloud Run:** Publish plan v2 directly to GCS ([74d7bfde4](https://github.com/heygen-com/hyperframes/commit/74d7bfde4870bbc1c6c4471cfc004964807df3e7))
+- **AWS Lambda:** Publish plan v2 directly to S3 ([09998789b](https://github.com/heygen-com/hyperframes/commit/09998789b5ff012adcd97e9fb33537e473f1cc52))
+- **Core:** Add professional color grading controls ([f99fc4e56](https://github.com/heygen-com/hyperframes/commit/f99fc4e5686239f5ef56d4eb6083bee796ceeddc))
+
+## Fixes
+
+- **Producer:** Align frame coverage with extraction rounding ([f0c2c7d23](https://github.com/heygen-com/hyperframes/commit/f0c2c7d23384de589f54c11ff093f128c9a39e56))
+- **Render:** Aggregate extraction launch failures ([33ca1de06](https://github.com/heygen-com/hyperframes/commit/33ca1de0631be66bfa5c591a231256c69667226e))
+- **Producer:** Narrow extraction error shapes honestly ([c01e1a5f9](https://github.com/heygen-com/hyperframes/commit/c01e1a5f96839e1a2650516ceb3745ed7b28517f))
+- **Producer:** Type video extraction failures ([9b63646c8](https://github.com/heygen-com/hyperframes/commit/9b63646c8aa036b786513137f2efcdf637ad432c))
+- **Engine:** Block future-use IPv4 downloads ([2e84faeb2](https://github.com/heygen-com/hyperframes/commit/2e84faeb28ff8689da212a5b7db805f3b454d4d9))
+- **Engine:** Close downloader trust-boundary gaps ([4b81f7858](https://github.com/heygen-com/hyperframes/commit/4b81f785868362fbb5c4bd7f1c5be24b2ccb7f94))
+- **Engine:** Narrow network error shapes honestly ([5ce2eb879](https://github.com/heygen-com/hyperframes/commit/5ce2eb879db1bb2b3dd740bcd7e9abf8adaa3230))
+- **Engine:** Make video downloads atomic and retry transient failures ([c01f6b446](https://github.com/heygen-com/hyperframes/commit/c01f6b446829f15c2c18dfd43da7013b412b2bf7))
+- **Producer:** Reset distributed plan scratch state ([ebb02cafe](https://github.com/heygen-com/hyperframes/commit/ebb02cafe7e1d1e067bc37c00fd3613e20230ee5))
+- **Producer:** Attribute and stop oversized plans early ([d699cbf01](https://github.com/heygen-com/hyperframes/commit/d699cbf014ac2232e3d2cec5c06c9d74103fa61f))
+- **Studio:** Align professional grading contracts ([794930a07](https://github.com/heygen-com/hyperframes/commit/794930a07568deddd55ba0d891b68bec739641fa))
+- **Studio:** Clear stale color scopes ([c1fcf7534](https://github.com/heygen-com/hyperframes/commit/c1fcf7534f730f5677b0d5201e6af6d17bd19cb0))
+- **Core:** Register media analyzer subpath ([9b504045f](https://github.com/heygen-com/hyperframes/commit/9b504045f7cfd1a13e7b4d128cfdfe2e0631017f))
+- **CLI:** Address media treatment review findings ([c1dde2898](https://github.com/heygen-com/hyperframes/commit/c1dde2898076b4d9b71b81d86cdf0f419350d93f))
+- **Core:** Align secondary mask contracts ([e446de602](https://github.com/heygen-com/hyperframes/commit/e446de60234b837672100334fd169d2f2b547218))
+- **Core:** Preserve curve compiler subpath exports ([9a515858c](https://github.com/heygen-com/hyperframes/commit/9a515858c9c65b749f1a976b3a72c5f4868a8256))
+- **Core:** Address grading review findings ([1ffef9a26](https://github.com/heygen-com/hyperframes/commit/1ffef9a262ca13ada04d53d93d6f8bfbbfa83f26))
+
+## Internal
+
+- **CLI:** Harden media treatment parity ([20f4bde46](https://github.com/heygen-com/hyperframes/commit/20f4bde46a8862584470f895c8a6a4bf69716b2a))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.72...v0.7.73).
+</Update>
+
+<Update
   label="HyperFrames v0.7.72"
   description="Released - 2026-07-26"
   tags={["Release", "Producer", "Gcp Cloud Run", "AWS Lambda"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.73.md
+++ b/releases/v0.7.73.md
@@ -1,0 +1,44 @@
+# HyperFrames v0.7.73
+
+Released on 2026-07-26.
+
+Distributed Plan v2 publishers now stream content-addressed artifacts directly to
+S3 and GCS, while oversized-plan diagnostics identify the dominant files and phases.
+Rendering is more resilient through atomic media downloads, typed extraction retries,
+and frame-coverage accounting aligned with FFmpeg's CFR rounding.
+
+## Features
+
+- **Studio:** Add professional grading controls ([20ef48abc](https://github.com/heygen-com/hyperframes/commit/20ef48abcb190e3e9ef132d1b1dd711201d3c58b))
+- **CLI:** Expose agent-native color grading ([6d5961b80](https://github.com/heygen-com/hyperframes/commit/6d5961b8024fe70f87879f271dd91149717d41a8))
+- **Gcp Cloud Run:** Publish plan v2 directly to GCS ([74d7bfde4](https://github.com/heygen-com/hyperframes/commit/74d7bfde4870bbc1c6c4471cfc004964807df3e7))
+- **AWS Lambda:** Publish plan v2 directly to S3 ([09998789b](https://github.com/heygen-com/hyperframes/commit/09998789b5ff012adcd97e9fb33537e473f1cc52))
+- **Core:** Add professional color grading controls ([f99fc4e56](https://github.com/heygen-com/hyperframes/commit/f99fc4e5686239f5ef56d4eb6083bee796ceeddc))
+
+## Fixes
+
+- **Producer:** Align frame coverage with extraction rounding ([f0c2c7d23](https://github.com/heygen-com/hyperframes/commit/f0c2c7d23384de589f54c11ff093f128c9a39e56))
+- **Render:** Aggregate extraction launch failures ([33ca1de06](https://github.com/heygen-com/hyperframes/commit/33ca1de0631be66bfa5c591a231256c69667226e))
+- **Producer:** Narrow extraction error shapes honestly ([c01e1a5f9](https://github.com/heygen-com/hyperframes/commit/c01e1a5f96839e1a2650516ceb3745ed7b28517f))
+- **Producer:** Type video extraction failures ([9b63646c8](https://github.com/heygen-com/hyperframes/commit/9b63646c8aa036b786513137f2efcdf637ad432c))
+- **Engine:** Block future-use IPv4 downloads ([2e84faeb2](https://github.com/heygen-com/hyperframes/commit/2e84faeb28ff8689da212a5b7db805f3b454d4d9))
+- **Engine:** Close downloader trust-boundary gaps ([4b81f7858](https://github.com/heygen-com/hyperframes/commit/4b81f785868362fbb5c4bd7f1c5be24b2ccb7f94))
+- **Engine:** Narrow network error shapes honestly ([5ce2eb879](https://github.com/heygen-com/hyperframes/commit/5ce2eb879db1bb2b3dd740bcd7e9abf8adaa3230))
+- **Engine:** Make video downloads atomic and retry transient failures ([c01f6b446](https://github.com/heygen-com/hyperframes/commit/c01f6b446829f15c2c18dfd43da7013b412b2bf7))
+- **Producer:** Reset distributed plan scratch state ([ebb02cafe](https://github.com/heygen-com/hyperframes/commit/ebb02cafe7e1d1e067bc37c00fd3613e20230ee5))
+- **Producer:** Attribute and stop oversized plans early ([d699cbf01](https://github.com/heygen-com/hyperframes/commit/d699cbf014ac2232e3d2cec5c06c9d74103fa61f))
+- **Studio:** Align professional grading contracts ([794930a07](https://github.com/heygen-com/hyperframes/commit/794930a07568deddd55ba0d891b68bec739641fa))
+- **Studio:** Clear stale color scopes ([c1fcf7534](https://github.com/heygen-com/hyperframes/commit/c1fcf7534f730f5677b0d5201e6af6d17bd19cb0))
+- **Core:** Register media analyzer subpath ([9b504045f](https://github.com/heygen-com/hyperframes/commit/9b504045f7cfd1a13e7b4d128cfdfe2e0631017f))
+- **CLI:** Address media treatment review findings ([c1dde2898](https://github.com/heygen-com/hyperframes/commit/c1dde2898076b4d9b71b81d86cdf0f419350d93f))
+- **Core:** Align secondary mask contracts ([e446de602](https://github.com/heygen-com/hyperframes/commit/e446de60234b837672100334fd169d2f2b547218))
+- **Core:** Preserve curve compiler subpath exports ([9a515858c](https://github.com/heygen-com/hyperframes/commit/9a515858c9c65b749f1a976b3a72c5f4868a8256))
+- **Core:** Address grading review findings ([1ffef9a26](https://github.com/heygen-com/hyperframes/commit/1ffef9a262ca13ada04d53d93d6f8bfbbfa83f26))
+
+## Internal
+
+- **CLI:** Harden media treatment parity ([20f4bde46](https://github.com/heygen-com/hyperframes/commit/20f4bde46a8862584470f895c8a6a4bf69716b2a))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.72...v0.7.73


### PR DESCRIPTION
## What

Release Hyperframes v0.7.73 across the monorepo packages and editor plugins.

Highlights:

- direct content-addressed Plan v2 publishing for AWS Lambda and GCP Cloud Run
- actionable oversized-plan attribution and bounded planning
- atomic remote-video downloads with transient retry
- typed/observable extraction failures with opt-in retry controls
- FFmpeg-aligned one-frame coverage accounting

## Why

This release packages the distributed-render reliability work needed for a
dev-cluster v1/v2 parity rollout, including the fixes for known
`PLAN_TOO_LARGE`, partial-download, extraction, and one-frame boundary cases.

## How

The standard release preparation script bumped all public packages and plugin
manifests to `0.7.73`, generated `releases/v0.7.73.md`, and updated the public
changelog.

## Test plan

- [x] Release preparation hooks passed
- [x] All constituent render-fix PRs passed their focused and repository CI
- [ ] Release PR CI passes
- [x] Documentation updated

After publication, the exact package version will be deployed and exercised in
the dev cluster only before any production rollout is considered.
