### PR TITLE
chore: release v0.7.74

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,28 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.74"
+  description="Released - 2026-07-27"
+  tags={["Release", "Producer", "GCP Cloud Run", "Core"]}
+>
+Distributed Plan v2 now handles extraction-cache sentinels and partial color metadata
+without corrupting chunk dependencies. Distributed cold starts also preserve live GSAP
+volume state, while GCP captures honor the effective `BeginFrame` boundary.
+
+## Fixes
+
+- **Producer:** Handle partial color metadata and extraction sentinels in Plan v2 ([58869f087](https://github.com/heygen-com/hyperframes/commit/58869f0878e304fd39d564b93cc4a8b18e885b4e), [#2814](https://github.com/heygen-com/hyperframes/pull/2814))
+- **GCP Cloud Run:** Enforce effective `BeginFrame` capture ([2a284a8e3](https://github.com/heygen-com/hyperframes/commit/2a284a8e3aca62100ec037c23c98706e7146aa14), [#2817](https://github.com/heygen-com/hyperframes/pull/2817))
+- **Core:** Avoid live volume probes during render ([477defc7e](https://github.com/heygen-com/hyperframes/commit/477defc7e7397684c2def4459b3981f62a06816d), [#2816](https://github.com/heygen-com/hyperframes/pull/2816))
+
+## Performance
+
+- **Producer:** Compute regression PSNR in one ffmpeg pass ([98a4cd70f](https://github.com/heygen-com/hyperframes/commit/98a4cd70fd2df38f300a2e19c86f75cd8dd93895), [#2813](https://github.com/heygen-com/hyperframes/pull/2813))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.73...v0.7.74).
+</Update>
+
+<Update
   label="HyperFrames v0.7.73"
   description="Released - 2026-07-26"
   tags={["Release", "Producer", "Render", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.74.md
+++ b/releases/v0.7.74.md
@@ -1,0 +1,21 @@
+# HyperFrames v0.7.74
+
+Released on 2026-07-27.
+
+Distributed Plan v2 now handles extraction-cache sentinels and partial color metadata
+without corrupting chunk dependencies. Distributed cold starts also preserve live GSAP
+volume state, while GCP captures honor the effective `BeginFrame` boundary.
+
+## Fixes
+
+- **Producer:** Handle partial color metadata and extraction sentinels in Plan v2 ([58869f087](https://github.com/heygen-com/hyperframes/commit/58869f0878e304fd39d564b93cc4a8b18e885b4e), [#2814](https://github.com/heygen-com/hyperframes/pull/2814))
+- **GCP Cloud Run:** Enforce effective `BeginFrame` capture ([2a284a8e3](https://github.com/heygen-com/hyperframes/commit/2a284a8e3aca62100ec037c23c98706e7146aa14), [#2817](https://github.com/heygen-com/hyperframes/pull/2817))
+- **Core:** Avoid live volume probes during render ([477defc7e](https://github.com/heygen-com/hyperframes/commit/477defc7e7397684c2def4459b3981f62a06816d), [#2816](https://github.com/heygen-com/hyperframes/pull/2816))
+
+## Performance
+
+- **Producer:** Compute regression PSNR in one ffmpeg pass ([98a4cd70f](https://github.com/heygen-com/hyperframes/commit/98a4cd70fd2df38f300a2e19c86f75cd8dd93895), [#2813](https://github.com/heygen-com/hyperframes/pull/2813))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.73...v0.7.74


### PR DESCRIPTION
## What

Release Hyperframes v0.7.74 across the monorepo packages and editor plugins.

Highlights:

- Plan v2 extraction-sentinel validation in both exact and full-source dependency modes
- partial color-metadata compatibility in Plan v2 manifests
- stable distributed cold starts that do not mutate live GSAP volume state
- effective `BeginFrame` capture enforcement in GCP Cloud Run
- faster producer regression PSNR validation

## Why

This release removes the Plan v2 integrity failure reproduced on the normal dev
distributed-render fleet and packages the adjacent cold-start and GCP capture fixes.
It is the release candidate for the next dev-only v1/v2 parity and bounded concurrency
validation.

## How

The standard release preparation script bumped all public packages and plugin manifests
to `0.7.74`, generated `releases/v0.7.74.md`, and updated the public changelog.

## Test plan

- [x] Release preparation hooks passed
- [x] Release script suite passed (103/103)
- [x] Repository formatting check passed
- [x] Constituent PR CI and review completed before merge
- [ ] Release PR CI passes
- [ ] Verify GitHub and npm publication after merge
- [ ] Deploy the exact producer/core version to the existing normal dev workers
- [ ] Re-run v1/v2 media parity and bounded multi-pod dev soak

Production deployment and production flag changes are explicitly out of scope.
