### PR TITLE
fix(regression): schedule Plan v2 color fixture

### DIFF
--- a/packages/producer/tests/shard-schedule.json
+++ b/packages/producer/tests/shard-schedule.json
@@ -26,6 +26,7 @@
     "mp4-h265-sdr": 4,
     "overlay-montage-prod": 512,
     "parallel-capture-regression": 86,
+    "plan-v2-partial-color": 120,
     "png-sequence": 3,
     "portrait-edge-bleed": 25,
     "raf-ball-render-compat": 22,


### PR DESCRIPTION
## Summary

- add the merged `plan-v2-partial-color` regression fixture to the computed shard timing schedule
- restore the exhaustive shard-planner invariant introduced by #2815

## Root cause

#2815 added the correct exhaustive schedule guard, but its branch did not include the fixture added by #2814. Once both merged, current main CI failed because the new fixture was neither scheduled nor explicitly excluded.

## Validation

- `node packages/producer/scripts/plan-regression-shards.mjs` succeeds and includes `plan-v2-partial-color`
- reproduced the same failure in current main producer unit CI before this change