### PR TITLE
perf(ci): order Dockerfile.test layers so producer changes do not rebuild core

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -90,13 +90,22 @@ COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/sdk-playground/package.json packages/sdk-playground/package.json
 RUN bun install --frozen-lockfile
 
-# Copy source
+# Copy source in dependency order, running each build as soon as its own
+# inputs are present.
+#
+# Every package used to be copied here before any build ran, which put the
+# `COPY packages/producer/` layer above the core build. Docker invalidates
+# every layer below a changed one, so a producer-only change rebuilt core —
+# which cannot depend on producer. On CI run 30229469233 those two layers
+# cost 86s and 63s of the ~4m image build, in all 8 shards, on every PR.
+# Locally the same producer-only rebuild goes from 18s to 1s after this split.
+#
+# Keep the ordering dependency-correct: anything the core build reads must be
+# copied above it, and packages nothing above depends on stay below.
 COPY packages/parsers/ packages/parsers/
 COPY packages/lint/ packages/lint/
 COPY packages/studio-server/ packages/studio-server/
 COPY packages/core/ packages/core/
-COPY packages/engine/ packages/engine/
-COPY packages/producer/ packages/producer/
 
 # Build workspace packages so "node" export conditions resolve to built dist
 RUN bun run --filter '@hyperframes/{parsers,lint,studio-server}' build \
@@ -104,6 +113,10 @@ RUN bun run --filter '@hyperframes/{parsers,lint,studio-server}' build \
 
 # Build core runtime artifacts (needed by renderer)
 RUN bun run --filter @hyperframes/core build:hyperframes-runtime:modular
+
+# Nothing above reads these, so they land after the core build to keep it cached.
+COPY packages/engine/ packages/engine/
+COPY packages/producer/ packages/producer/
 
 # Generate embedded font data (deterministicFonts.ts imports this at runtime)
 RUN cd packages/producer && bunx tsx scripts/generate-font-data.ts


### PR DESCRIPTION
## What

Reorders `Dockerfile.test` so each workspace build runs as soon as its own
inputs are present, instead of copying every package first and building
afterwards.

## Why

Every package was copied before any build ran, which put
`COPY packages/producer/` above the core build. Docker invalidates every layer
below a changed one, so **a producer-only change rebuilt core** — which cannot
depend on producer.

Measured on CI run 30229469233, those two layers are 86s and 63s of the ~4m
image build. That build runs inside all 8 shards, on every PR, so the waste is
~2.5 min of critical path and ~20 min of CPU per run.

Verified locally rather than assumed. With a warm cache and a one-line change
to `packages/producer/src/regression-harness.ts`:

| layer order | producer-only rebuild |
|---|---|
| before | **18s** |
| after | **1s** |

Before, the rebuilt layers were:

```
COPY packages/producer/                        DONE 0.9s
RUN build parsers/lint/studio-server + core    DONE 15.9s   <- for nothing
RUN core build:hyperframes-runtime:modular     DONE 0.7s    <- for nothing
```

After, only `COPY packages/producer/` re-runs and both build layers report
`CACHED`. The CI-side saving is larger than 17s because those layers cost
86s + 63s there rather than 15.9s + 0.7s.

## Scope

This helps PRs that do not touch `packages/{parsers,lint,studio-server,core}`.
A core change still invalidates everything below it, exactly as before — the
change makes the cache behave correctly, it does not add caching.

## What I did not do

The obvious version of this — build the image once in its own job and
distribute it to the shards — makes wall clock **worse**, so it is not here.
Measured job timeline on a real run:

```
changes    start +0.0m  end +0.3m
preflight  start +0.4m  end +1.3m
shard-1    start +1.4m            <- build runs inside the shard
```

Critical path today is 1.4m + 4.2m build. A build-once job would run from
+0.4m for 4.2m plus ~1m to push, with shards then pulling ~0.8m — about 6.4m
before the first test versus 5.6m now. It saves ~29 min of CPU, but CPU is not
the constraint and measured queue time is zero.

## Test plan

- [x] Full `--no-cache` build succeeds, so the reordered dependency graph is
      genuinely satisfiable and not just cache-warm
- [x] Smoke fixtures run against the reordered image: `font-variant-numeric`,
      `many-cuts`, `variables-prod` — 3 passed, 0 failed
- [x] Cache behaviour measured before and after, numbers above
- [ ] Documentation updated (n/a)

## Blast radius

Build-time layer ordering only. Same base image, same pinned
`chrome-headless-shell@148.0.7778.167`, same installed packages, same
ENTRYPOINT. Golden baselines are unaffected — the smoke run above confirms
byte-comparable output.