### PR TITLE
fix(producer): materialize sparse video directories

### DIFF
--- a/packages/producer/src/services/distributed/planV2.test.ts
+++ b/packages/producer/src/services/distributed/planV2.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -58,6 +59,8 @@ function createV1Plan(
     videoId?: string;
     videoSrcPath?: string;
     framePattern?: string;
+    videoStart?: number;
+    videoEnd?: number;
   },
 ): string {
   const {
@@ -70,6 +73,8 @@ function createV1Plan(
     videoId = "hero",
     videoSrcPath = "/fixture/hero.mp4",
     framePattern = "frame_%05d.jpg",
+    videoStart = 0,
+    videoEnd = 1,
   } = options ?? {};
   const planDir = join(root, "v1");
   mkdirSync(join(planDir, "compiled"), { recursive: true });
@@ -98,8 +103,8 @@ function createV1Plan(
           {
             id: videoId,
             src: "hero.mp4",
-            start: 0,
-            end: 1,
+            start: videoStart,
+            end: videoEnd,
             mediaStart: 0,
             loop: false,
             hasAudio: false,
@@ -328,6 +333,41 @@ describe("Plan v2 manifest", () => {
     );
   });
 
+  it("materializes empty video directories for chunks where the video is inactive", () => {
+    const root = tempPath("hf-plan-v2-inactive-video-directory-");
+    const v1 = createV1Plan(root, {
+      video: true,
+      videoStart: 1 / 30,
+      videoEnd: 1,
+    });
+    const result = createPlanV2FromV1(v1, join(root, "v2"));
+    const manifest = readPlanV2Manifest(result.planDir);
+    const chunk0Artifacts = listPlanV2ArtifactsForTarget(manifest, {
+      role: "chunk",
+      chunkIndex: 0,
+    });
+    const chunk1Artifacts = listPlanV2ArtifactsForTarget(manifest, {
+      role: "chunk",
+      chunkIndex: 1,
+    });
+    const chunk0Dir = join(root, "chunk-0");
+    const chunk1Dir = join(root, "chunk-1");
+
+    expect(chunk0Artifacts.some((artifact) => artifact.path.startsWith("video-frames/hero/"))).toBe(
+      false,
+    );
+    expect(
+      chunk1Artifacts.some((artifact) => artifact.path === "video-frames/hero/frame_00001.jpg"),
+    ).toBe(true);
+
+    materializePlanV2Target(result.planDir, { role: "chunk", chunkIndex: 0 }, chunk0Dir);
+    materializePlanV2Target(result.planDir, { role: "chunk", chunkIndex: 1 }, chunk1Dir);
+
+    expect(existsSync(join(chunk0Dir, "video-frames", "hero"))).toBe(true);
+    expect(readdirSync(join(chunk0Dir, "video-frames", "hero"))).toEqual([]);
+    expect(existsSync(join(chunk1Dir, "video-frames", "hero", "frame_00001.jpg"))).toBe(true);
+  });
+
   const partialColorSpaceCases = [
     {
       name: "matrix-only",
@@ -437,6 +477,15 @@ describe("Plan v2 manifest", () => {
       );
     });
   }
+
+  it("rejects an extracted video identifier that escapes the video-frame root", () => {
+    const root = tempPath("hf-plan-v2-unsafe-video-id-");
+    const v1 = createV1Plan(root, { video: true, videoId: "../escape" });
+
+    expect(() => createPlanV2FromV1(v1, join(root, "v2"))).toThrow(
+      'unsafe extracted video id: "../escape"',
+    );
+  });
 
   it("falls back to the full source frame pack when video metadata is absent", () => {
     const root = tempPath("hf-plan-v2-video-fallback-");

--- a/packages/producer/src/services/distributed/planV2.ts
+++ b/packages/producer/src/services/distributed/planV2.ts
@@ -248,6 +248,15 @@ function isExtractionCacheCompleteSentinelPath(path: string): boolean {
   );
 }
 
+function resolveExtractedVideoOutputDir(planDir: string, videoId: string): string {
+  const videoRoot = resolve(planDir, "video-frames");
+  const outputDir = resolve(videoRoot, videoId);
+  if (outputDir === videoRoot || !outputDir.startsWith(`${videoRoot}${sep}`)) {
+    throw new PlanV2IntegrityError(`unsafe extracted video id: ${JSON.stringify(videoId)}`);
+  }
+  return outputDir;
+}
+
 // This is the fail-safe policy table for every v1 artifact class. Keeping the
 // branches together makes new artifact classes visibly fall through to both roles.
 // fallow-ignore-next-line complexity
@@ -279,7 +288,7 @@ function artifactTargets(
 
 function listVideoFramePaths(planV1Dir: string, videos: PlanVideosJson): ExtractedFrames[] {
   return videos.extracted.map((video) => {
-    const outputDir = join(planV1Dir, "video-frames", video.videoId);
+    const outputDir = resolveExtractedVideoOutputDir(planV1Dir, video.videoId);
     const frameNames = readdirSync(outputDir).sort();
     const framePaths = new Map<number, string>();
     for (const frameName of frameNames) {
@@ -401,6 +410,15 @@ function parsePlanVideosJson(value: unknown): PlanVideosJson {
     };
   });
   return { videos, extracted };
+}
+
+function materializeExtractedVideoDirectories(planDir: string): void {
+  const videosPath = join(planDir, PLAN_VIDEOS_META_RELATIVE_PATH);
+  if (!existsSync(videosPath)) return;
+  const videos = parsePlanVideosJson(readJsonFile(videosPath, PLAN_VIDEOS_META_RELATIVE_PATH));
+  for (const video of videos.extracted) {
+    mkdirSync(resolveExtractedVideoOutputDir(planDir, video.videoId), { recursive: true });
+  }
 }
 
 function parseChunkSlices(value: unknown): ChunkSliceJson[] {
@@ -919,6 +937,12 @@ export function materializePlanV2Target(
       mkdirSync(dirname(destinationPath), { recursive: true });
       copyFileSync(sourcePath, destinationPath);
     }
+    // Plan v2 transports only files, so a chunk where a video is inactive has
+    // no selected frame artifact from which to create its per-video directory.
+    // renderChunk consumes a v1-compatible layout and intentionally validates
+    // every extracted-video directory from meta/videos.json. Recreate those
+    // zero-byte structural directories without downloading unused frame data.
+    if (target.role === "chunk") materializeExtractedVideoDirectories(tempDir);
     writeFileSync(
       join(tempDir, PLAN_V2_MATERIALIZATION_MARKER),
       canonicalJsonStringify({ manifest, target }),


### PR DESCRIPTION
## Summary

- preserve the v1-compatible extracted-video directory layout when a Plan v2 chunk has zero selected frames for a video
- keep sparse transport intact: inactive chunks still download zero unused frame bytes
- validate extracted video IDs before using them as materialization paths

## Root cause

DEV workflow `dff7ca8f-27d1-492f-be68-aa90846d555b` published a complete exact-frame manifest. `act4-final-video` is active only from 21.0–26.7s, so chunks 5–6 correctly received its 168 frame artifacts and succeeded. Chunks 0–4 and 7 correctly received no frame artifacts, but the file-only materializer therefore created no `video-frames/act4-final-video/` directory. `renderChunk()` consumes the v1-compatible layout and rejects every missing extracted-video directory before capture, so those six chunks failed identically across distinct pods and the workflow retry pass.

This change synthesizes only the empty structural directories declared by the integrity-checked `meta/videos.json` after selected artifacts are copied. It does not add shared-filesystem state or full-source fallback. The shared OSS materializer covers internal S3, AWS Lambda, GCP Cloud Run, and local Plan v2 execution.

## Validation

- `bun run build`
- `bun run producer:test:unit` — 404/404 Vitest tests plus all Bun unit lanes passed
- targeted Plan v2/rebuild suites — 57/57 passed
- producer TypeScript typecheck
- oxlint and oxfmt checks

## DEV rollout plan

After merge, cut a patch release, bump only the existing normal DEV producer workers, and replay the same known-bad composition. Production remains unchanged.