### PR TITLE
docs(send-to-guide): enhance turns are free; render is the paid step

### DIFF
--- a/docs/guides/claude-design-send-to-hyperframes.md
+++ b/docs/guides/claude-design-send-to-hyperframes.md
@@ -30,8 +30,8 @@ The single most important consequence: **there is no file tree on the other side
 
 1. **You (Claude Design)** — author a valid HyperFrames composition as a single self-contained HTML.
 2. **Send to HyperFrames** — one click. The importer fetches your HTML, validates it, and creates a hosted HeyGen project. **Import is free.**
-3. **Enhance in HyperFrames** — a motion-design agent adds what your export can't: sound effects, background music, and (later) HeyGen media. **Enhance turns are free too.**
-4. **Render** — the cloud pipeline produces the MP4. **This is the paid step** (a monthly free-render credit, then charged).
+3. **Enhance in HyperFrames** — a motion-design agent adds what your export can't: sound effects, background music, and (later) HeyGen media. **Enhance turns are free.**
+4. **Render** — the cloud pipeline produces the MP4. **Render is the paid step:** free accounts get 3 renders per month; paid plans are charged 20 credits per rendered minute.
 
 Your job is step 1: a composition that imports cleanly and is a strong on-brand starting point.
 

--- a/docs/guides/claude-design-send-to-hyperframes.md
+++ b/docs/guides/claude-design-send-to-hyperframes.md
@@ -30,8 +30,8 @@ The single most important consequence: **there is no file tree on the other side
 
 1. **You (Claude Design)** — author a valid HyperFrames composition as a single self-contained HTML.
 2. **Send to HyperFrames** — one click. The importer fetches your HTML, validates it, and creates a hosted HeyGen project. **Import is free.**
-3. **Enhance in HyperFrames** — a motion-design agent adds what your export can't: sound effects, background music, and (later) HeyGen media. This is the paid step.
-4. **Render** — the cloud pipeline produces the MP4.
+3. **Enhance in HyperFrames** — a motion-design agent adds what your export can't: sound effects, background music, and (later) HeyGen media. **Enhance turns are free too.**
+4. **Render** — the cloud pipeline produces the MP4. **This is the paid step** (a monthly free-render credit, then charged).
 
 Your job is step 1: a composition that imports cleanly and is a strong on-brand starting point.
 

--- a/packages/cli/src/commands/claude-design/sendToGuideContract.test.ts
+++ b/packages/cli/src/commands/claude-design/sendToGuideContract.test.ts
@@ -28,4 +28,20 @@ describe("Send-to guide fidelity contract", () => {
     expect(GUIDE).not.toContain("lossy by nature");
     expect(GUIDE).not.toContain("content match the brief exactly");
   });
+
+  // Pricing is LLM-facing contract too: the guide once labeled Enhance "the paid step", which
+  // teaches Claude the wrong billing boundary. The shipped model (heygen-server
+  // magic_edit/logic/usage_limits.py) is: import + enhance turns free; only Render is billed —
+  // FREE accounts get 3 renders/month, paid plans 20 credits/rendered-minute. Pin the concept,
+  // not an exact sentence, and block the retired Enhance-as-paid wording from returning.
+  it("identifies Enhance as free and Render as the paid/billed step, with the tiered contract", () => {
+    expect(GUIDE).toContain("Enhance turns are free");
+    expect(GUIDE).toContain("Render is the paid step");
+    expect(GUIDE).toContain("3 renders per month");
+    expect(GUIDE).toContain("20 credits per rendered minute");
+  });
+
+  it("does not restore the retired 'Enhance ... paid step' wording", () => {
+    expect(GUIDE).not.toContain("HeyGen media. This is the paid step");
+  });
 });


### PR DESCRIPTION
## What

One-line correction to the Send-to authoring guide's pricing summary. The guide labeled **Enhance** as "the paid step"; the shipped model is that import and enhance turns are free, and only the final **render** is charged (a monthly free-render credit, then per-minute after).

## Before / after

```
3. Enhance in HyperFrames ... HeyGen media. This is the paid step.
4. Render ... produces the MP4.
```
becomes
```
3. Enhance in HyperFrames ... HeyGen media. Enhance turns are free too.
4. Render ... produces the MP4. This is the paid step (a monthly free-render credit, then charged).
```

## Why

Claude Design fetches this guide (via the get-guide tool) to author Send-to compositions, so the pricing framing it reads should match reality. This aligns the guide with the same fix applied across the internal Send-to docs.
