### PR TITLE
fix(telemetry): send feedback as plain events, not PostHog surveys

### DIFF
--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -127,12 +127,13 @@ Only the existence (or in some cases the value) of these variables is checked �
 
 ### CLI feedback
 
+Event: `cli_render_feedback`
+
 | Field | Value |
 |-------|-------|
-| `$survey_id` | `render_satisfaction` |
-| `$survey_response` | Raw rating (0–10) |
+| `rating` | Raw rating (0–10) |
 | `rating_scale` | `10` for the current recommendation scale |
-| `$survey_response_2` | Free-text comment (only when provided) |
+| `comment` | Free-text comment (only when provided) |
 | `render_duration_ms` | Time the render took in milliseconds |
 | `doctor_summary` | System context (see below) |
 
@@ -146,12 +147,13 @@ It may also include `wsl` or sandbox runtime flags when those environments are d
 
 ### Studio feedback
 
+Event: `studio_feedback`
+
 | Field | Value |
 |-------|-------|
-| `$survey_id` | `studio_experience` |
-| `$survey_response` | Raw rating (0–10) |
+| `rating` | Raw rating (0–10) |
 | `rating_scale` | `10` for the current recommendation scale |
-| `$survey_response_2` | Free-text comment (only when provided) |
+| `comment` | Free-text comment (only when provided) |
 | `source` | `studio` |
 | `doctor_summary` | Browser context (platform, screen, CPU cores, device memory, network type) |
 

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -33,7 +33,7 @@ function normalizeComment(raw?: string): string | undefined {
 /**
  * Compact PostHog join keys appended to the environment string that rides
  * along with the forwarded report (and therefore lands verbatim in the wild
- * feedback channel): `fid` = this submission's PostHog `survey sent`
+ * feedback channel): `fid` = this submission's PostHog `cli_render_feedback`
  * `feedback_id`; `tid` = the install's telemetry distinct_id; `renders` =
  * recent `render_job_id`s (newest last, `!` suffix = the render failed).
  * Together they turn a wild report into an exact telemetry lookup instead of

--- a/packages/cli/src/telemetry/events.test.ts
+++ b/packages/cli/src/telemetry/events.test.ts
@@ -231,7 +231,7 @@ describe("render telemetry events", () => {
     });
 
     expect(trackEvent).toHaveBeenCalledWith(
-      "survey sent",
+      "cli_render_feedback",
       expect.objectContaining({
         feedback_id: "feedback-uuid",
         recent_render_ids: "render-a,render-b",
@@ -504,7 +504,7 @@ describe("trackRenderFeedback", () => {
 
     const [, props] = trackEvent.mock.calls[0] as [string, Record<string, unknown>];
     expect(props).not.toHaveProperty("render_duration_ms");
-    expect(props.$survey_response).toBe(4);
+    expect(props.rating).toBe(4);
     expect(props.rating_scale).toBe(10);
   });
 
@@ -512,7 +512,7 @@ describe("trackRenderFeedback", () => {
     trackRenderFeedback({ rating: 5, renderDurationMs: 6000 });
 
     expect(trackEvent).toHaveBeenCalledWith(
-      "survey sent",
+      "cli_render_feedback",
       expect.objectContaining({ render_duration_ms: 6000 }),
     );
   });

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -630,17 +630,18 @@ export function trackRenderFeedback(props: {
   /**
    * Join key shared with the forwarded feedback report (Slack/backend): the
    * same uuid rides in the report's env string as `fid=…`, so a wild report
-   * resolves to exactly one PostHog "survey sent" event and vice versa.
+   * resolves to exactly one PostHog `cli_render_feedback` event and vice versa.
    */
   feedbackId?: string;
   /** render_job_id values of this install's recent renders (newest last). */
   recentRenderIds?: string[];
 }): void {
-  trackEvent("survey sent", {
-    $survey_id: "render_satisfaction",
-    $survey_response: props.rating,
+  // Plain product event, not a PostHog survey response: nothing here is served
+  // by the surveys product (no survey definition, no targeting, no popover).
+  trackEvent("cli_render_feedback", {
+    rating: props.rating,
     rating_scale: FEEDBACK_RATING_SCALE,
-    ...(props.comment ? { $survey_response_2: props.comment } : {}),
+    ...(props.comment ? { comment: props.comment } : {}),
     ...(props.renderDurationMs !== undefined ? { render_duration_ms: props.renderDurationMs } : {}),
     ...(props.doctorSummary ? { doctor_summary: props.doctorSummary } : {}),
     ...(props.feedbackId ? { feedback_id: props.feedbackId } : {}),

--- a/packages/studio/src/telemetry/events.test.ts
+++ b/packages/studio/src/telemetry/events.test.ts
@@ -84,8 +84,8 @@ describe("studio telemetry events", () => {
     trackStudioFeedback({ rating });
 
     expect(trackEvent).toHaveBeenCalledWith(
-      "survey sent",
-      expect.objectContaining({ $survey_response: rating, rating_scale: 10 }),
+      "studio_feedback",
+      expect.objectContaining({ rating, rating_scale: 10 }),
     );
   });
 });

--- a/packages/studio/src/telemetry/events.ts
+++ b/packages/studio/src/telemetry/events.ts
@@ -69,11 +69,12 @@ export function trackStudioSegmentEaseEdit(props: { ease: string }): void {
 }
 
 export function trackStudioFeedback(props: { rating: number; comment?: string }): void {
-  trackEvent("survey sent", {
-    $survey_id: "studio_experience",
-    $survey_response: props.rating,
+  // Plain product event, not a PostHog survey response: nothing here is served
+  // by the surveys product (no survey definition, no targeting, no popover).
+  trackEvent("studio_feedback", {
+    rating: props.rating,
     rating_scale: 10,
-    ...(props.comment ? { $survey_response_2: props.comment } : {}),
+    ...(props.comment ? { comment: props.comment } : {}),
     doctor_summary: getBrowserDoctorSummary(),
     source: "studio",
   });


### PR DESCRIPTION
## What

Stop emitting CLI and Studio feedback as PostHog survey responses. `trackRenderFeedback` and `trackStudioFeedback` now send plain product events:

| Before | After |
|---|---|
| `survey sent` + `$survey_id: render_satisfaction` | `cli_render_feedback` |
| `survey sent` + `$survey_id: studio_experience` | `studio_feedback` |
| `$survey_response` | `rating` |
| `$survey_response_2` | `comment` |

Every other property (`rating_scale`, `render_duration_ms`, `doctor_summary`, `feedback_id`, `recent_render_ids`, `source`) is unchanged.

## Why

Neither feedback path is a PostHog survey. There is no survey definition, no targeting, no popover, and no survey UI behind them: the CLI prompt is a readline question after a render, and the Studio one is an in-app rating bar. They were only borrowing the `survey sent` / `$survey_*` shape, which makes every rating get ingested as a survey response and shows up in the wrong product surface.

Renaming keeps the exact same signal, just filed under the product-analytics events where the rest of the CLI/Studio telemetry already lives.

## How

Two call sites, one event name and two property names each. Nothing about the collection flow changes: same prompt, same opt-out (`HYPERFRAMES_TELEMETRY=0`, `hyperframes telemetry off`), same fields, same anonymous distinct id.

`feedback_id` still joins a forwarded feedback report to its analytics event, so the `fid=…` correlation in `hyperframes feedback` is intact.

Not covered here: historical `survey sent` events already ingested keep their old shape, so any saved insight built on `$survey_response` needs to union the old and new event names (or just be re-pointed at the new ones going forward).

## Test plan

- `packages/cli`: `vitest run src/telemetry/events.test.ts` — 39 passed
- `packages/studio`: `vitest run src/telemetry/events.test.ts` — 9 passed
- `oxlint` + `oxfmt --check` clean on all changed files; pre-commit typecheck and fallow audit green

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Documentation updated (if applicable) — `docs/guides/feedback.mdx` "What Is Collected" tables now list the real event names and property names
