### PR TITLE
test(ci): verify Windows WebM alpha end to end

### DIFF
--- a/.github/workflows/fixtures/windows-webm-alpha.html
+++ b/.github/workflows/fixtures/windows-webm-alpha.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 320px;
+        height: 180px;
+        margin: 0;
+        overflow: hidden;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+      }
+      #card {
+        position: absolute;
+        inset: 40px 80px;
+        border-radius: 16px;
+        background: rgba(255, 64, 96, 0.65);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="1"
+      data-width="320"
+      data-height="180"
+    >
+      <div id="card"></div>
+    </div>
+  </body>
+</html>

--- a/.github/workflows/windows-render.yml
+++ b/.github/workflows/windows-render.yml
@@ -245,6 +245,77 @@ jobs:
 
           Write-Host "canary.mp4 ok: ${width}x${height} @ $fps, ${duration}s"
 
+      - name: Scaffold transparent WebM canary
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $project = "$env:RUNNER_TEMP\windows-webm-alpha"
+          New-Item -ItemType Directory -Force -Path $project | Out-Null
+          Copy-Item `
+            "$env:GITHUB_WORKSPACE\.github\workflows\fixtures\windows-webm-alpha.html" `
+            "$project\index.html" `
+            -Force
+
+      - name: Render transparent WebM canary
+        shell: pwsh
+        run: |
+          cd "$env:RUNNER_TEMP\windows-webm-alpha"
+          node "$env:GITHUB_WORKSPACE\packages\cli\dist\cli.js" render `
+            --format webm `
+            --fps 30 `
+            --quality draft `
+            --workers 1 `
+            --output alpha.webm
+
+      - name: Verify decoded WebM alpha
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $webm = "$env:RUNNER_TEMP\windows-webm-alpha\alpha.webm"
+          $rgba = "$env:RUNNER_TEMP\windows-webm-alpha\frame.rgba"
+          if (-not (Test-Path $webm)) { throw "alpha.webm not produced" }
+
+          $probeJson = ffprobe -v error -select_streams v:0 `
+            -show_entries stream=codec_name,pix_fmt:stream_tags=alpha_mode `
+            -of json $webm
+          $probe = ($probeJson -join "`n") | ConvertFrom-Json
+          $stream = $probe.streams[0]
+          if ($stream.codec_name -ne 'vp9') {
+            throw "expected VP9, got $($stream.codec_name)"
+          }
+
+          # VP9 alpha is a Matroska BlockAdditional sidecar. ffprobe reports
+          # the primary stream as yuv420p even when the alpha plane is valid.
+          Write-Host "ffprobe primary pix_fmt=$($stream.pix_fmt)"
+          $alphaMode = $stream.tags.PSObject.Properties |
+            Where-Object { $_.Name -ieq 'alpha_mode' } |
+            Select-Object -First 1
+          if (-not $alphaMode -or [string]$alphaMode.Value -ne '1') {
+            throw "expected case-insensitive ALPHA_MODE=1 sidecar tag"
+          }
+
+          # FFmpeg's native VP9 decoder ignores BlockAdditional alpha. Force
+          # libvpx-vp9, then inspect the actual RGBA alpha bytes.
+          ffmpeg -v error -c:v libvpx-vp9 -i $webm `
+            -frames:v 1 -vf scale=8:8 -pix_fmt rgba -f rawvideo -y $rgba
+          $bytes = [System.IO.File]::ReadAllBytes($rgba)
+          if ($bytes.Length -ne 256) {
+            throw "expected one 8x8 RGBA frame (256 bytes), got $($bytes.Length)"
+          }
+          $hasTransparency = $false
+          for ($i = 3; $i -lt $bytes.Length; $i += 4) {
+            if ($bytes[$i] -lt 255) {
+              $hasTransparency = $true
+              break
+            }
+          }
+          if (-not $hasTransparency) {
+            throw "decoded VP9 frame is fully opaque"
+          }
+
+          Write-Host "alpha.webm ok: ffprobe pix_fmt=$($stream.pix_fmt), ALPHA_MODE=1, decoded RGBA contains transparency"
+
       - name: Scaffold issue #574 reused-video regression
         shell: pwsh
         run: |
@@ -359,6 +430,7 @@ jobs:
           name: windows-render-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/windows-canary/canary/renders/canary.mp4
+            ${{ runner.temp }}/windows-webm-alpha/alpha.webm
             ${{ runner.temp }}/issue-574-reused-video/renders/issue-574.mp4
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
## What

Windows CI now proves that a transparent HyperFrames WebM contains real decoded alpha, rather than treating FFprobe's expected `pix_fmt=yuv420p` as evidence that alpha was lost.

## Why

HF#2824 reported `yuv420p` as a Windows-only alpha failure, but VP9 stores alpha in a Matroska `BlockAdditional` sidecar, so the primary stream reports `yuv420p` even for valid transparent output. The downstream check also reads only lowercase `tags.alpha_mode`; FFprobe emits `ALPHA_MODE` on the reproduced file, causing a false rejection.

An exact Windows 11 / Gyan FFmpeg 8.1.1 run reproduced the reported metadata while proving the decoded RGBA frame still contains transparency: [Actions run 30277455942](https://github.com/heygen-com/hyperframes/actions/runs/30277455942).

## How

The Windows render job now:

- renders a minimal transparent composition through the real CLI WebM path;
- checks VP9 plus `ALPHA_MODE=1` case-insensitively;
- forces the alpha-aware `libvpx-vp9` decoder; and
- fails unless the decoded RGBA bytes contain a value below 255.

This guards the actual user contract and avoids both common false signals: primary-stream `yuv420p` and FFprobe tag casing.

Context: #2824 was closed after exact Windows reproduction showed the output retains real alpha and the failure is a downstream detection false positive.

## Test plan

- [x] Exact reporter build: Windows runner + Gyan FFmpeg 8.1.1
- [x] `pix_fmt=yuv420p` reproduced
- [x] `ALPHA_MODE=1` verified case-insensitively
- [x] Forced `libvpx-vp9` RGBA decode contains transparency
- [x] Workflow preflight (lint + format)
- [x] Required PR checks

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5.6](https://img.shields.io/badge/GPT--5.6-000000)
