### PR TITLE
feat(cli): roll circuit-breaker state over across config wipes

### DIFF
--- a/docs/contributing/canary-rollouts.mdx
+++ b/docs/contributing/canary-rollouts.mdx
@@ -102,9 +102,11 @@ during the window*, not the instantaneous rate. Two practical consequences:
   far tighter than a 60-day one.
 - **The percentage is not the safety mechanism.** It bounds *initial* exposure
   and decays from there. Per-render verification and per-install circuit
-  breakers are what actually bound harm — and note that a breaker's state
-  lives in the same config file as the id, so a wipe loses both and the
-  install can re-enrol into a path that already failed it.
+  breakers are what actually bound harm. A tripped breaker survives a config
+  wipe: it is mirrored to a machine-local state file (separate from the
+  config, shown by `hyperframes telemetry`) that deliberately holds no
+  identity — the new install gets a fresh id but does not re-enrol into a
+  path that already failed on that machine.
 
 For *measurement* — "is this feature better?" — churn is harmless: re-bucketing
 is random, so it adds noise, not bias. It is specifically the blast-radius

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -8,7 +8,7 @@ export const examples: Example[] = [
   ["Disable telemetry", "hyperframes telemetry disable"],
   ["Enable telemetry", "hyperframes telemetry enable"],
 ];
-import { readConfig, writeConfig, CONFIG_PATH } from "../telemetry/config.js";
+import { readConfig, writeConfig, CONFIG_PATH, STATE_PATH } from "../telemetry/config.js";
 
 function runEnable(): void {
   const config = readConfig();
@@ -30,6 +30,9 @@ function runStatus(): void {
   console.log();
   console.log(`  ${c.dim("Status:")}     ${status}`);
   console.log(`  ${c.dim("Config:")}     ${c.accent(CONFIG_PATH)}`);
+  // Machine-local safety state (no identity): survives a config wipe so a
+  // tripped experiment circuit breaker stays tripped. Listed for transparency.
+  console.log(`  ${c.dim("State:")}      ${c.accent(STATE_PATH)}`);
   console.log(`  ${c.dim("Commands:")}   ${c.bold(String(config.commandCount))}`);
   console.log();
   console.log(`  ${c.dim("Disable:")}    ${c.accent("hyperframes telemetry disable")}`);

--- a/packages/cli/src/telemetry/client.ts
+++ b/packages/cli/src/telemetry/client.ts
@@ -91,6 +91,12 @@ export function trackEvent(
       // cohort. Resolved after the shouldTrack guard, so opted-out installs
       // never pay for it. See telemetry/canary.ts.
       ...canaryEventProperties(),
+      // Did this install's mint find a previous install's state marker?
+      // The fleet-wide rate of `true` IS the recoverable-churn fraction —
+      // the share of "new" ids that are really a config wipe on a machine
+      // we already knew. Absent (not false) when the config predates the
+      // marker, mirroring the canary absent-vs-control distinction.
+      install_predecessor_found: readConfig().predecessorFound,
       agent_env_hints: sys.agent_env_hints ?? undefined,
     },
     distinctId,

--- a/packages/cli/src/telemetry/config.test.ts
+++ b/packages/cli/src/telemetry/config.test.ts
@@ -116,3 +116,120 @@ describe("config.ts — readConfig / readConfigFresh / writeConfig (real module,
     expect(writeConfig(config)).toBe(false);
   });
 });
+
+describe("install-state rollover (breaker survives a config wipe)", () => {
+  let readConfig: typeof import("./config.js").readConfig;
+  let readConfigFresh: typeof import("./config.js").readConfigFresh;
+  let writeConfig: typeof import("./config.js").writeConfig;
+  let CONFIG_PATH: typeof import("./config.js").CONFIG_PATH;
+  let STATE_PATH: typeof import("./config.js").STATE_PATH;
+
+  beforeEach(async () => {
+    fsState.files.clear();
+    vi.resetModules();
+    ({ readConfig, readConfigFresh, writeConfig, CONFIG_PATH, STATE_PATH } =
+      await import("./config.js"));
+  });
+
+  /** Simulate the identity reset this feature exists for. */
+  function wipeConfig(): void {
+    fsState.files.delete(CONFIG_PATH);
+  }
+
+  function stateFile(): Record<string, unknown> {
+    const raw = fsState.files.get(STATE_PATH);
+    expect(raw, "install-state file should exist").toBeDefined();
+    return JSON.parse(raw as string) as Record<string, unknown>;
+  }
+
+  it("a truly fresh install writes the marker and records predecessorFound: false", () => {
+    const config = readConfig();
+    expect(config.predecessorFound).toBe(false);
+    expect(stateFile()["markerAt"]).toEqual(expect.any(String));
+  });
+
+  it("a re-mint after a config wipe finds the marker: predecessorFound is true, id is fresh", () => {
+    const first = readConfig();
+    wipeConfig();
+    const second = readConfigFresh();
+    expect(second.predecessorFound).toBe(true);
+    // The rollover carries safety state, never identity.
+    expect(second.anonymousId).not.toBe(first.anonymousId);
+  });
+
+  it("a tripped breaker survives a config wipe — the whole point", () => {
+    const config = readConfig();
+    config.deParallelRouterTrialFired = true;
+    writeConfig(config);
+    wipeConfig();
+    const reborn = readConfigFresh();
+    expect(reborn.deParallelRouterTrialFired).toBe(true);
+  });
+
+  it("an untripped breaker does NOT get invented by the rollover", () => {
+    readConfig();
+    wipeConfig();
+    expect(readConfigFresh().deParallelRouterTrialFired).toBeUndefined();
+  });
+
+  it("a tripped breaker survives config CORRUPTION via the same path", () => {
+    const config = readConfig();
+    config.deParallelRouterTrialFired = true;
+    writeConfig(config);
+    fsState.files.set(CONFIG_PATH, "{not valid json");
+    expect(readConfigFresh().deParallelRouterTrialFired).toBe(true);
+  });
+
+  it("the state file holds no identity — only the marker timestamp and breaker fact", () => {
+    const config = readConfig();
+    config.deParallelRouterTrialFired = true;
+    writeConfig(config);
+    expect(Object.keys(stateFile()).sort()).toEqual(["deParallelRouterTrialFired", "markerAt"]);
+    expect(JSON.stringify(stateFile())).not.toContain(config.anonymousId);
+  });
+
+  it("marker timestamp is written once, not refreshed by later config writes", () => {
+    const config = readConfig();
+    const minted = stateFile()["markerAt"];
+    config.commandCount = 42;
+    config.deParallelRouterTrialFired = true;
+    writeConfig(config);
+    expect(stateFile()["markerAt"]).toBe(minted);
+  });
+
+  it("a corrupted state file reads as absent rather than breaking the mint", () => {
+    fsState.files.set(STATE_PATH, "{not valid json");
+    const config = readConfig();
+    expect(config.predecessorFound).toBe(false);
+    expect(config.anonymousId).toBeTruthy();
+    // And the corrupt file was replaced with a valid marker by the mint's write.
+    expect(stateFile()["markerAt"]).toEqual(expect.any(String));
+  });
+
+  it("a state-file write failure never breaks the config write", async () => {
+    const fs = await import("node:fs");
+    const config = readConfig(); // marker already written by the mint
+    fsState.files.delete(STATE_PATH); // force a re-sync attempt...
+    const { __resetInstallStateSyncForTests } = await import("./config.js");
+    __resetInstallStateSyncForTests();
+    let calls = 0;
+    vi.mocked(fs.writeFileSync).mockImplementation((path, content) => {
+      calls++;
+      if (String(path).startsWith(STATE_PATH)) throw new Error("EACCES");
+      fsState.files.set(String(path), String(content));
+    });
+    config.commandCount = 1;
+    expect(writeConfig(config)).toBe(true); // ...that fails, swallowed
+    expect(calls).toBeGreaterThan(1);
+    vi.mocked(fs.writeFileSync).mockImplementation((path, content) => {
+      fsState.files.set(String(path), String(content));
+    });
+  });
+
+  it("predecessorFound on an EXISTING config predating the field reads as undefined, not false", () => {
+    const base = readConfig();
+    const { predecessorFound: _dropped, ...legacy } = base;
+    fsState.files.set(CONFIG_PATH, JSON.stringify(legacy));
+    expect(readConfigFresh().predecessorFound).toBeUndefined();
+  });
+});

--- a/packages/cli/src/telemetry/config.ts
+++ b/packages/cli/src/telemetry/config.ts
@@ -10,6 +10,124 @@ import { randomUUID } from "node:crypto";
 const CONFIG_DIR = join(homedir(), ".hyperframes");
 const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 
+// ---------------------------------------------------------------------------
+// Install-state file: ~/.local/state/hyperframes/install-state.json
+//
+// A second, deliberately separate location from CONFIG_DIR, so it survives
+// the most common identity reset — deleting or reinstalling ~/.hyperframes.
+// It exists to carry exactly two facts across that reset, and nothing else:
+//
+//   1. `markerAt` — "a hyperframes install existed on this machine". Written
+//      unconditionally, so the fraction of fresh installs that find it is a
+//      direct measurement of recoverable id churn (config wiped, machine
+//      persisted) vs unrecoverable (fresh machine/container/new user).
+//   2. `deParallelRouterTrialFired` — the DE parallel-router circuit
+//      breaker's tripped state. Without this, a config wipe re-enrols the
+//      install into an experimental path that already FAILED on this exact
+//      machine; the breaker's whole point is that a real failure turns the
+//      trial off for good.
+//
+// It intentionally holds NO identity: no anonymousId, no counters, nothing
+// that could link the old install to the new one. A user who wipes their
+// config gets a fresh id unconditionally — this file only stops the wipe
+// from also discarding a safety fact about the machine.
+// ---------------------------------------------------------------------------
+
+const STATE_DIR = join(homedir(), ".local", "state", "hyperframes");
+const STATE_FILE = join(STATE_DIR, "install-state.json");
+
+interface InstallState {
+  /** ISO timestamp of when the marker was first written. */
+  markerAt: string;
+  /** Rolled-over circuit-breaker state — see HyperframesConfig's field. */
+  deParallelRouterTrialFired?: boolean;
+}
+
+/** Read the install-state file; any parse/shape failure reads as absent. */
+function readInstallState(): InstallState | null {
+  try {
+    if (!existsSync(STATE_FILE)) return null;
+    const parsed = JSON.parse(readFileSync(STATE_FILE, "utf-8")) as Partial<InstallState>;
+    if (typeof parsed.markerAt !== "string") return null;
+    return {
+      markerAt: parsed.markerAt,
+      deParallelRouterTrialFired: parsed.deParallelRouterTrialFired === true ? true : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Sync bookkeeping, so the existsSync+read doesn't run on every writeConfig:
+// `stateMarkerSynced` = the marker is known present; `stateFiredSynced` = the
+// state file is known to already carry fired=true.
+let stateMarkerSynced = false;
+let stateFiredSynced = false;
+
+/** Test-only: reset the sync memo (module state leaks across vitest cases). */
+export function __resetInstallStateSyncForTests(): void {
+  stateMarkerSynced = false;
+  stateFiredSynced = false;
+}
+
+/**
+ * Atomic for the same reason writeConfig is: a torn read must never exist,
+ * since a corrupted state file silently reads as absent.
+ */
+function writeInstallState(next: InstallState): void {
+  mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+  const tmpFile = `${STATE_FILE}.${process.pid}.tmp`;
+  writeFileSync(tmpFile, JSON.stringify(next, null, 2) + "\n", { mode: 0o600 });
+  renameSync(tmpFile, STATE_FILE);
+}
+
+/**
+ * Bring the install-state file up to date with this config write: ensure the
+ * marker exists, and mirror a tripped breaker. Called from `writeConfig` so
+ * no breaker write site can forget it. Never throws — same contract as the
+ * rest of this file, telemetry must not break the CLI.
+ */
+/** What the state file should say after this config write; null = already correct. */
+function nextInstallState(state: InstallState | null, wantFired: boolean): InstallState | null {
+  const hadFired = state?.deParallelRouterTrialFired === true;
+  if (state !== null && (hadFired || !wantFired)) return null;
+  return {
+    markerAt: state?.markerAt ?? new Date().toISOString(),
+    deParallelRouterTrialFired: wantFired || hadFired || undefined,
+  };
+}
+
+function syncInstallState(config: HyperframesConfig): void {
+  const wantFired = config.deParallelRouterTrialFired === true;
+  if (stateMarkerSynced && (stateFiredSynced || !wantFired)) return;
+  try {
+    const state = readInstallState();
+    const next = nextInstallState(state, wantFired);
+    if (next !== null) writeInstallState(next);
+    stateMarkerSynced = true;
+    stateFiredSynced = wantFired || state?.deParallelRouterTrialFired === true;
+  } catch {
+    // Leave the memo unset so a later write retries.
+  }
+}
+
+/**
+ * Build a brand-new config for an install with no (readable) config file,
+ * consulting the install-state file for what a previous install on this
+ * machine left behind.
+ */
+function mintConfig(): HyperframesConfig {
+  const state = readInstallState();
+  return {
+    ...DEFAULT_CONFIG,
+    anonymousId: randomUUID(),
+    predecessorFound: state !== null,
+    // The rollover itself: a breaker tripped by a previous install on this
+    // machine stays tripped for the new one.
+    deParallelRouterTrialFired: state?.deParallelRouterTrialFired === true ? true : undefined,
+  };
+}
+
 export interface HyperframesConfig {
   /** Whether anonymous telemetry is enabled (default: true in production) */
   telemetryEnabled: boolean;
@@ -86,6 +204,14 @@ export interface HyperframesConfig {
    */
   deParallelRouterTrialRenderCount?: number;
   /**
+   * Whether a previous install's state marker existed on this machine when
+   * this config was minted. Attached to telemetry so the fraction of fresh
+   * installs that are RECOVERABLE churn (config wiped, machine persisted) is
+   * measurable directly. `undefined` on configs minted before this field
+   * existed — a different fact from `false` (minted fresh, no predecessor).
+   */
+  predecessorFound?: boolean;
+  /**
    * Ring of the last few local renders (newest last). `hyperframes feedback`
    * attaches these ids — which are the `render_job_id` /
    * `observability_render_job_id` on this install's PostHog events — to the
@@ -139,7 +265,7 @@ export function readConfig(): HyperframesConfig {
   if (cachedConfig) return { ...cachedConfig };
 
   if (!existsSync(CONFIG_FILE)) {
-    const config = { ...DEFAULT_CONFIG, anonymousId: randomUUID() };
+    const config = mintConfig();
     writeConfig(config);
     return config;
   }
@@ -175,6 +301,8 @@ export function readConfig(): HyperframesConfig {
         typeof parsed.deParallelRouterTrialRenderCount === "number"
           ? parsed.deParallelRouterTrialRenderCount
           : undefined,
+      predecessorFound:
+        typeof parsed.predecessorFound === "boolean" ? parsed.predecessorFound : undefined,
       recentRenders: Array.isArray(parsed.recentRenders)
         ? parsed.recentRenders
             .filter(
@@ -192,8 +320,9 @@ export function readConfig(): HyperframesConfig {
     cachedConfig = config;
     return { ...config };
   } catch {
-    // Corrupted config — reset
-    const config = { ...DEFAULT_CONFIG, anonymousId: randomUUID() };
+    // Corrupted config — reset. Goes through the same mint path as a missing
+    // file, so a tripped breaker survives config corruption too.
+    const config = mintConfig();
     writeConfig(config);
     return config;
   }
@@ -235,6 +364,9 @@ export function writeConfig(config: HyperframesConfig): boolean {
     writeFileSync(tmpFile, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
     renameSync(tmpFile, CONFIG_FILE);
     cachedConfig = { ...config };
+    // Mirror into the install-state file (marker + tripped breaker) so no
+    // breaker write site has to remember to do it.
+    syncInstallState(config);
     return true;
   } catch {
     // Non-fatal — telemetry should never break the CLI
@@ -254,3 +386,6 @@ export function incrementCommandCount(): number {
 
 /** Expose the config directory path for the telemetry command output */
 export const CONFIG_PATH = CONFIG_FILE;
+
+/** Expose the install-state path for the telemetry command output. */
+export const STATE_PATH = STATE_FILE;


### PR DESCRIPTION
Stacked on #2854.

## What

The DE parallel-router circuit breaker's tripped state lived in the same config file as the install id, so the most common identity reset — deleting `~/.hyperframes` — also re-enrolled the machine into an experimental path that had **already failed on it**.

This mirrors exactly two facts into a machine-local state file (`~/.local/state/hyperframes/install-state.json`) that a config wipe does not touch:

- **`deParallelRouterTrialFired`** — a breaker tripped by a previous install stays tripped for the new one. Config corruption takes the same mint path, so it survives that too.
- **`markerAt`** — written unconditionally on every install, so the fraction of fresh mints that find it directly measures *recoverable* id churn (config wiped, machine persisted) vs unrecoverable (fresh machine / container / new user). Emitted as `install_predecessor_found` on telemetry events; absent (not `false`) on configs predating the field, mirroring the canary absent-vs-control semantics.

## What it deliberately is NOT

The file holds **no identity** — no anonymousId, no counters, nothing linking old install to new. A wiped config still gets a fresh id unconditionally; only the safety fact about the machine survives. Full attribution rollover (aliasing old id to new) was considered and deferred: it collides with deliberate identity resets, and the breaker-only version captures the safety value without the intent problem. The `install_predecessor_found` rate is the data that would justify going further.

## Mechanics

- Sync happens inside `writeConfig`, so no breaker write site can forget it; memoized per process so it's not an fs hit on every write.
- Atomic tmp+rename, same rationale as the config write: a torn read must never exist since a corrupted state file reads as absent.
- Failures swallowed (telemetry must never break the CLI) but leave the memo unset so a later write retries.
- `hyperframes telemetry` lists the state path for transparency.

## Validation

18 config tests (10 new): wipe survival, corruption survival, untripped-breaker-not-invented, no-identity assertion (file keys are exactly `[deParallelRouterTrialFired, markerAt]`, anonymousId never appears in the bytes), marker timestamp written once, state-write failure never breaks the config write, absent-vs-false on legacy configs. Full CLI suite: 2204 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)