### PR TITLE
chore: release v0.7.79

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,58 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.79"
+  description="Released - 2026-07-28"
+  tags={["Release", "Check", "Media Use", "Studio"]}
+>
+Studio editing is now more exact and predictable: timeline, motion-path, and playhead
+keyframe operations stay scoped to the intended element; nested-composition timing
+preserves its host rows; and color, shortcuts, ruler, and accessibility interactions
+are more reliable. This release also adds a narrow caption-zone layout waiver, makes
+CLI telemetry opt-out durable, and recognizes the renamed Codex image-generation
+feature flag.
+
+## Features
+
+- **Check:** Add data-layout-allow-caption-zone waiver ([3a7950fd6](https://github.com/heygen-com/hyperframes/commit/3a7950fd63b501788f39f1fd44c12fc317139d79), [#2853](https://github.com/heygen-com/hyperframes/pull/2853))
+
+## Fixes
+
+- **Media Use:** Accept renamed codex image_generation feature flag ([02c57609a](https://github.com/heygen-com/hyperframes/commit/02c57609ab2919792c5f4442b9eb08d729ddf544))
+- **Studio:** Give the motion path and the fallbacks a one-element target ([1f3fd2800](https://github.com/heygen-com/hyperframes/commit/1f3fd2800cd2e4df9e8a2c2b81ea11ed5b799630))
+- **Studio:** Author every new tween against one element ([3d9243606](https://github.com/heygen-com/hyperframes/commit/3d924360667a15745d85dc060689d913b5dcc5d7))
+- **Studio:** Scope lane ids per timeline and stop inventing a track row ([ba0d6406d](https://github.com/heygen-com/hyperframes/commit/ba0d6406d23d11e12305ba79834a69ae672b8432))
+- **Studio:** Never re-author a target the DOM proved is not unique ([f04cdb79c](https://github.com/heygen-com/hyperframes/commit/f04cdb79c5f1475fa7d6048036a4e0af354a60a2))
+- **Studio:** Label undo history with the track display row ([477916cbe](https://github.com/heygen-com/hyperframes/commit/477916cbe25dd6dd1877c09df3d826cd60b609e5))
+- **Studio:** Target one element when adding a keyframe at the playhead ([fd5555be7](https://github.com/heygen-com/hyperframes/commit/fd5555be758450d73335dd3f89c70329aac8ee35))
+- **Studio:** Announce real track numbers and point aria-controls at the lanes ([1faa0cbda](https://github.com/heygen-com/hyperframes/commit/1faa0cbdadc71abdea220d8705682c0a18e499bb))
+- **Studio:** Resolve a panel edit through the lane groups it can see ([be3451aae](https://github.com/heygen-com/hyperframes/commit/be3451aae43779d47cd593e12bdf8fb2f4da2889))
+- **CLI:** Make telemetry opt-out durable ([880021411](https://github.com/heygen-com/hyperframes/commit/880021411d785e7470d3150868dee916245ffce8), [#2852](https://github.com/heygen-com/hyperframes/pull/2852))
+- **Studio:** Lane every tween and attribute tweens to their real target ([59a818e80](https://github.com/heygen-com/hyperframes/commit/59a818e80a3ef561c5cb4a25ea30128cd18458b2))
+- **Studio:** Keep every host row on the drill path, not just the top ([acad7b268](https://github.com/heygen-com/hyperframes/commit/acad7b268ea1e9e4b35e15265ac6c8a178e43865))
+- **Studio:** Keep the host row when drilling into a sub-composition ([d48440a9b](https://github.com/heygen-com/hyperframes/commit/d48440a9bacb83aef8007b3667e78e02a2481d8f))
+- **Studio:** Expand sub-comp children against their resolved parent host ([12546985f](https://github.com/heygen-com/hyperframes/commit/12546985f588df8cf984d241dd27e3417edb3320))
+- **Studio:** Compute keyframe percentages in the tween's own time frame ([3f0c20f63](https://github.com/heygen-com/hyperframes/commit/3f0c20f633e9ac064e45df838e03d4412ddafda8))
+- **Studio:** Accept 3-digit hex shorthand in the colour field ([86f633f98](https://github.com/heygen-com/hyperframes/commit/86f633f98573a79f88422c8a24a69bd55d718c3d))
+- **Studio:** Drop aria-modal from the non-modal shortcuts popup ([7f0cadcbb](https://github.com/heygen-com/hyperframes/commit/7f0cadcbb1f24df12bee091d5156e3cbf67f51e4))
+- **Studio:** Dismiss the shortcuts panel on escape and outside press ([aa2811642](https://github.com/heygen-com/hyperframes/commit/aa2811642fecabdef58ce45329b115993d1e43fb))
+- **Studio:** Let the colour hex field be edited and commit it on outside press ([55614033e](https://github.com/heygen-com/hyperframes/commit/55614033e501b5e55bfd3a2099396b74443652cd))
+- **Studio:** Grow the ease target only where the segment has room ([b82506363](https://github.com/heygen-com/hyperframes/commit/b82506363f08bf9b2efbd37dce94c0eaec71844e))
+- **Studio:** Meet the 24x24 pointer target minimum on toolbar and lane controls ([4e74eefdd](https://github.com/heygen-com/hyperframes/commit/4e74eefddd4c1e38f7c97662cc52fae6d2a01698))
+- **Studio:** Seek ruler clicks to the pressed position and round retime percentages ([69020699d](https://github.com/heygen-com/hyperframes/commit/69020699dfb595194c8bf85117525045439bcdb2))
+
+## Internal
+
+- Regenerate skills-manifest for media-use change ([b6da5bd6b](https://github.com/heygen-com/hyperframes/commit/b6da5bd6b3e95e391ad340c9e11e162f647b8a4b))
+
+## Other Changes
+
+- **Studio:** Keep StudioRightPanel under the 600 line cap ([bb24d0037](https://github.com/heygen-com/hyperframes/commit/bb24d0037a96d14a63eeb4c6e2a983f4971f331d))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.78...v0.7.79).
+</Update>
+
+<Update
   label="HyperFrames v0.7.78"
   description="Released - 2026-07-28"
   tags={["Release", "CLI", "Registry", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.79.md
+++ b/releases/v0.7.79.md
@@ -1,0 +1,51 @@
+# HyperFrames v0.7.79
+
+Released on 2026-07-28.
+
+Studio editing is now more exact and predictable: timeline, motion-path, and playhead
+keyframe operations stay scoped to the intended element; nested-composition timing
+preserves its host rows; and color, shortcuts, ruler, and accessibility interactions
+are more reliable. This release also adds a narrow caption-zone layout waiver, makes
+CLI telemetry opt-out durable, and recognizes the renamed Codex image-generation
+feature flag.
+
+## Features
+
+- **Check:** Add data-layout-allow-caption-zone waiver ([3a7950fd6](https://github.com/heygen-com/hyperframes/commit/3a7950fd63b501788f39f1fd44c12fc317139d79), [#2853](https://github.com/heygen-com/hyperframes/pull/2853))
+
+## Fixes
+
+- **Media Use:** Accept renamed codex image_generation feature flag ([02c57609a](https://github.com/heygen-com/hyperframes/commit/02c57609ab2919792c5f4442b9eb08d729ddf544))
+- **Studio:** Give the motion path and the fallbacks a one-element target ([1f3fd2800](https://github.com/heygen-com/hyperframes/commit/1f3fd2800cd2e4df9e8a2c2b81ea11ed5b799630))
+- **Studio:** Author every new tween against one element ([3d9243606](https://github.com/heygen-com/hyperframes/commit/3d924360667a15745d85dc060689d913b5dcc5d7))
+- **Studio:** Scope lane ids per timeline and stop inventing a track row ([ba0d6406d](https://github.com/heygen-com/hyperframes/commit/ba0d6406d23d11e12305ba79834a69ae672b8432))
+- **Studio:** Never re-author a target the DOM proved is not unique ([f04cdb79c](https://github.com/heygen-com/hyperframes/commit/f04cdb79c5f1475fa7d6048036a4e0af354a60a2))
+- **Studio:** Label undo history with the track display row ([477916cbe](https://github.com/heygen-com/hyperframes/commit/477916cbe25dd6dd1877c09df3d826cd60b609e5))
+- **Studio:** Target one element when adding a keyframe at the playhead ([fd5555be7](https://github.com/heygen-com/hyperframes/commit/fd5555be758450d73335dd3f89c70329aac8ee35))
+- **Studio:** Announce real track numbers and point aria-controls at the lanes ([1faa0cbda](https://github.com/heygen-com/hyperframes/commit/1faa0cbdadc71abdea220d8705682c0a18e499bb))
+- **Studio:** Resolve a panel edit through the lane groups it can see ([be3451aae](https://github.com/heygen-com/hyperframes/commit/be3451aae43779d47cd593e12bdf8fb2f4da2889))
+- **CLI:** Make telemetry opt-out durable ([880021411](https://github.com/heygen-com/hyperframes/commit/880021411d785e7470d3150868dee916245ffce8), [#2852](https://github.com/heygen-com/hyperframes/pull/2852))
+- **Studio:** Lane every tween and attribute tweens to their real target ([59a818e80](https://github.com/heygen-com/hyperframes/commit/59a818e80a3ef561c5cb4a25ea30128cd18458b2))
+- **Studio:** Keep every host row on the drill path, not just the top ([acad7b268](https://github.com/heygen-com/hyperframes/commit/acad7b268ea1e9e4b35e15265ac6c8a178e43865))
+- **Studio:** Keep the host row when drilling into a sub-composition ([d48440a9b](https://github.com/heygen-com/hyperframes/commit/d48440a9bacb83aef8007b3667e78e02a2481d8f))
+- **Studio:** Expand sub-comp children against their resolved parent host ([12546985f](https://github.com/heygen-com/hyperframes/commit/12546985f588df8cf984d241dd27e3417edb3320))
+- **Studio:** Compute keyframe percentages in the tween's own time frame ([3f0c20f63](https://github.com/heygen-com/hyperframes/commit/3f0c20f633e9ac064e45df838e03d4412ddafda8))
+- **Studio:** Accept 3-digit hex shorthand in the colour field ([86f633f98](https://github.com/heygen-com/hyperframes/commit/86f633f98573a79f88422c8a24a69bd55d718c3d))
+- **Studio:** Drop aria-modal from the non-modal shortcuts popup ([7f0cadcbb](https://github.com/heygen-com/hyperframes/commit/7f0cadcbb1f24df12bee091d5156e3cbf67f51e4))
+- **Studio:** Dismiss the shortcuts panel on escape and outside press ([aa2811642](https://github.com/heygen-com/hyperframes/commit/aa2811642fecabdef58ce45329b115993d1e43fb))
+- **Studio:** Let the colour hex field be edited and commit it on outside press ([55614033e](https://github.com/heygen-com/hyperframes/commit/55614033e501b5e55bfd3a2099396b74443652cd))
+- **Studio:** Grow the ease target only where the segment has room ([b82506363](https://github.com/heygen-com/hyperframes/commit/b82506363f08bf9b2efbd37dce94c0eaec71844e))
+- **Studio:** Meet the 24x24 pointer target minimum on toolbar and lane controls ([4e74eefdd](https://github.com/heygen-com/hyperframes/commit/4e74eefddd4c1e38f7c97662cc52fae6d2a01698))
+- **Studio:** Seek ruler clicks to the pressed position and round retime percentages ([69020699d](https://github.com/heygen-com/hyperframes/commit/69020699dfb595194c8bf85117525045439bcdb2))
+
+## Internal
+
+- Regenerate skills-manifest for media-use change ([b6da5bd6b](https://github.com/heygen-com/hyperframes/commit/b6da5bd6b3e95e391ad340c9e11e162f647b8a4b))
+
+## Other Changes
+
+- **Studio:** Keep StudioRightPanel under the 600 line cap ([bb24d0037](https://github.com/heygen-com/hyperframes/commit/bb24d0037a96d14a63eeb4c6e2a983f4971f331d))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.78...v0.7.79


### PR DESCRIPTION
## Summary

- Bump the fixed-version HyperFrames package graph and editor plugin manifests from `0.7.78` to `0.7.79`.
- Add reviewed release notes for the changes merged since `v0.7.78`.
- Publish `0.7.79` to the stable `latest` channel through the protected release-branch workflow after merge.

## Release highlights

- Keep Studio timeline, motion-path, and playhead keyframe edits scoped to the intended element.
- Preserve nested-composition timing and host rows, while tightening ruler, color, shortcuts, and accessibility interactions.
- Add the narrow caption-zone layout waiver, durable CLI telemetry opt-out, and support for the renamed Codex image-generation flag.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run test:scripts` — 104 passed
- [x] `bun run build`
- [x] `bunx oxfmt --check` on every changed manifest and release document
- [x] `git diff --check`
- [x] `bun run verify:packed-manifests` verified all 13 publish manifests
- [ ] Clean-consumer Vite smoke is delegated to exact-head CI: the local host lacks `GLIBC_2.32`, required by Rollup's current Linux binary, after all packed manifests had already passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)
