### PR TITLE
fix(producer): keep large local fonts file-backed

### DIFF
--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -906,6 +906,14 @@ describe("local font embedding", () => {
     font-family: "LargeLocal";
     src: url("assets/large.ttc") format("collection");
   }
+  @font-face {
+    font-family: "LargeLocalAlias";
+    src: url("./assets/large.ttc") format("collection");
+  }
+  @font-face {
+    font-family: "LargeLocalNormalized";
+    src: url("assets/../assets/large.ttc") format("collection");
+  }
 </style></head><body>
   <div data-composition-id="root" data-width="640" data-height="360" data-duration="1">
     Text
@@ -913,11 +921,27 @@ describe("local font embedding", () => {
 </body></html>`,
     );
 
-    const compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+    const originalInfo = defaultLogger.info;
+    const fileBackedMessages: string[] = [];
+    defaultLogger.info = (message) => {
+      if (message.includes("Kept large local font file-backed")) {
+        fileBackedMessages.push(message);
+      }
+    };
+
+    let compiled: Awaited<ReturnType<typeof compileForRender>>;
+    try {
+      compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+    } finally {
+      defaultLogger.info = originalInfo;
+    }
 
     expect(compiled.html).toContain('url("assets/large.ttc")');
+    expect(compiled.html).toContain('url("./assets/large.ttc")');
+    expect(compiled.html).toContain('url("assets/../assets/large.ttc")');
     expect(compiled.html).not.toContain("data:font/collection;base64,");
     expect(Buffer.byteLength(compiled.html)).toBeLessThan(1024 * 1024);
+    expect(fileBackedMessages).toHaveLength(1);
   });
 });
 

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -892,6 +892,33 @@ describe("local font embedding", () => {
 
     expect(embeddedMessages).toHaveLength(1);
   });
+
+  it("keeps large local font collections file-backed instead of expanding them into HTML", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-large-local-font-"));
+    const assetsDir = join(projectDir, "assets");
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(join(assetsDir, "large.ttc"), Buffer.alloc(6 * 1024 * 1024, 0x41));
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!DOCTYPE html>
+<html><head><style>
+  @font-face {
+    font-family: "LargeLocal";
+    src: url("assets/large.ttc") format("collection");
+  }
+</style></head><body>
+  <div data-composition-id="root" data-width="640" data-height="360" data-duration="1">
+    Text
+  </div>
+</body></html>`,
+    );
+
+    const compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+
+    expect(compiled.html).toContain('url("assets/large.ttc")');
+    expect(compiled.html).not.toContain("data:font/collection;base64,");
+    expect(Buffer.byteLength(compiled.html)).toBeLessThan(1024 * 1024);
+  });
 });
 
 describe("template-wrapped sub-composition media offsets", () => {

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -1656,9 +1656,10 @@ export async function localizeRemoteFontFaces(
 
 const LOCAL_FONTFACE_URL_RE = /url\(["']?(?!data:|https?:\/\/)([^"')]+)["']?\)/gi;
 // Base64 expands bytes by ~33%, then immutable HTML replacements retain more
-// string copies while compiling. Keeping large project-local fonts file-backed
-// bounds the compiler heap; both local and distributed file servers already
-// serve/copy project assets at their authored relative paths.
+// string copies while compiling. Files up to and including 5 MiB remain inline;
+// the first byte above that stays file-backed. This conservative ceiling keeps
+// verified 19 MiB+ TTC collections out of the V8 heap while both local and
+// distributed file servers continue serving project assets at authored paths.
 const MAX_LOCAL_FONT_DATA_URI_BYTES = 5 * 1024 * 1024;
 
 type LocalFontRead = { kind: "file-backed" } | { kind: "inline"; buffer: Buffer };
@@ -1685,6 +1686,7 @@ async function embedLocalFontFaces(html: string, projectDir: string): Promise<st
   let result = html;
   const embeddedPaths = new Set<string>();
   const dataUriByAbsolutePath = new Map<string, string>();
+  const fileBackedAbsolutePaths = new Set<string>();
 
   let styleMatch: RegExpExecArray | null;
   while ((styleMatch = styleBlockRe.exec(html)) !== null) {
@@ -1702,10 +1704,15 @@ async function embedLocalFontFaces(html: string, projectDir: string): Promise<st
         if (!isPathInside(absPath, projectDir)) continue;
         const ext = absPath.match(/\.(woff2?|ttf|otf|ttc)$/i)?.[1]?.toLowerCase() ?? "ttf";
         try {
+          if (fileBackedAbsolutePaths.has(absPath)) {
+            embeddedPaths.add(localPath);
+            continue;
+          }
           let dataUri = dataUriByAbsolutePath.get(absPath);
           if (!dataUri) {
             const font = await readLocalFont(absPath);
             if (font.kind === "file-backed") {
+              fileBackedAbsolutePaths.add(absPath);
               defaultLogger.info(
                 `[Compiler] Kept large local font file-backed: ${localPath} (> ${(MAX_LOCAL_FONT_DATA_URI_BYTES / 1024 / 1024).toFixed(1)} MB)`,
               );

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -10,7 +10,7 @@
  * recursively extracting nested media from sub-sub-compositions.
  */
 
-import { readFileSync, existsSync, mkdirSync } from "fs";
+import { readFileSync, existsSync, mkdirSync, statSync } from "fs";
 import { join, dirname, resolve, basename } from "path";
 import { parseHTML } from "linkedom";
 import {
@@ -1655,6 +1655,11 @@ export async function localizeRemoteFontFaces(
 }
 
 const LOCAL_FONTFACE_URL_RE = /url\(["']?(?!data:|https?:\/\/)([^"')]+)["']?\)/gi;
+// Base64 expands bytes by ~33%, then immutable HTML replacements retain more
+// string copies while compiling. Keeping large project-local fonts file-backed
+// bounds the compiler heap; both local and distributed file servers already
+// serve/copy project assets at their authored relative paths.
+const MAX_LOCAL_FONT_DATA_URI_BYTES = 5 * 1024 * 1024;
 
 // fallow-ignore-next-line complexity
 async function embedLocalFontFaces(html: string, projectDir: string): Promise<string> {
@@ -1682,6 +1687,14 @@ async function embedLocalFontFaces(html: string, projectDir: string): Promise<st
         if (!existsSync(absPath)) continue;
         const ext = absPath.match(/\.(woff2?|ttf|otf|ttc)$/i)?.[1]?.toLowerCase() ?? "ttf";
         try {
+          const fileSize = statSync(absPath).size;
+          if (fileSize > MAX_LOCAL_FONT_DATA_URI_BYTES) {
+            defaultLogger.info(
+              `[Compiler] Kept large local font file-backed: ${localPath} (${(fileSize / 1024 / 1024).toFixed(1)} MB)`,
+            );
+            embeddedPaths.add(localPath);
+            continue;
+          }
           let dataUri = dataUriByAbsolutePath.get(absPath);
           if (!dataUri) {
             const buffer = readFileSync(absPath);

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -10,7 +10,7 @@
  * recursively extracting nested media from sub-sub-compositions.
  */
 
-import { readFileSync, existsSync, mkdirSync, statSync } from "fs";
+import { closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync } from "fs";
 import { join, dirname, resolve, basename } from "path";
 import { parseHTML } from "linkedom";
 import {
@@ -1661,6 +1661,21 @@ const LOCAL_FONTFACE_URL_RE = /url\(["']?(?!data:|https?:\/\/)([^"')]+)["']?\)/g
 // serve/copy project assets at their authored relative paths.
 const MAX_LOCAL_FONT_DATA_URI_BYTES = 5 * 1024 * 1024;
 
+type LocalFontRead = { kind: "file-backed"; fileSize: number } | { kind: "inline"; buffer: Buffer };
+
+function readLocalFont(absPath: string): LocalFontRead {
+  const file = openSync(absPath, "r");
+  try {
+    const fileSize = fstatSync(file).size;
+    if (fileSize > MAX_LOCAL_FONT_DATA_URI_BYTES) {
+      return { kind: "file-backed", fileSize };
+    }
+    return { kind: "inline", buffer: readFileSync(file) };
+  } finally {
+    closeSync(file);
+  }
+}
+
 // fallow-ignore-next-line complexity
 async function embedLocalFontFaces(html: string, projectDir: string): Promise<string> {
   const { fontToDataUri: toDataUri } = await import("./fontCompression.js");
@@ -1684,24 +1699,22 @@ async function embedLocalFontFaces(html: string, projectDir: string): Promise<st
         if (!localPath || embeddedPaths.has(localPath)) continue;
         const absPath = localPath.startsWith("/") ? localPath : resolve(projectDir, localPath);
         if (!isPathInside(absPath, projectDir)) continue;
-        if (!existsSync(absPath)) continue;
         const ext = absPath.match(/\.(woff2?|ttf|otf|ttc)$/i)?.[1]?.toLowerCase() ?? "ttf";
         try {
-          const fileSize = statSync(absPath).size;
-          if (fileSize > MAX_LOCAL_FONT_DATA_URI_BYTES) {
-            defaultLogger.info(
-              `[Compiler] Kept large local font file-backed: ${localPath} (${(fileSize / 1024 / 1024).toFixed(1)} MB)`,
-            );
-            embeddedPaths.add(localPath);
-            continue;
-          }
           let dataUri = dataUriByAbsolutePath.get(absPath);
           if (!dataUri) {
-            const buffer = readFileSync(absPath);
-            dataUri = await toDataUri(buffer, ext);
+            const font = readLocalFont(absPath);
+            if (font.kind === "file-backed") {
+              defaultLogger.info(
+                `[Compiler] Kept large local font file-backed: ${localPath} (${(font.fileSize / 1024 / 1024).toFixed(1)} MB)`,
+              );
+              embeddedPaths.add(localPath);
+              continue;
+            }
+            dataUri = await toDataUri(font.buffer, ext);
             dataUriByAbsolutePath.set(absPath, dataUri);
             defaultLogger.info(
-              `[Compiler] Embedded local font file: ${localPath} (${(buffer.length / 1024).toFixed(0)} KB → data URI)`,
+              `[Compiler] Embedded local font file: ${localPath} (${(font.buffer.length / 1024).toFixed(0)} KB → data URI)`,
             );
           }
           result = result.replaceAll(localPath, dataUri);

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -10,7 +10,7 @@
  * recursively extracting nested media from sub-sub-compositions.
  */
 
-import { closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync } from "fs";
+import { createReadStream, existsSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve, basename } from "path";
 import { parseHTML } from "linkedom";
 import {
@@ -1661,19 +1661,20 @@ const LOCAL_FONTFACE_URL_RE = /url\(["']?(?!data:|https?:\/\/)([^"')]+)["']?\)/g
 // serve/copy project assets at their authored relative paths.
 const MAX_LOCAL_FONT_DATA_URI_BYTES = 5 * 1024 * 1024;
 
-type LocalFontRead = { kind: "file-backed"; fileSize: number } | { kind: "inline"; buffer: Buffer };
+type LocalFontRead = { kind: "file-backed" } | { kind: "inline"; buffer: Buffer };
 
-function readLocalFont(absPath: string): LocalFontRead {
-  const file = openSync(absPath, "r");
-  try {
-    const fileSize = fstatSync(file).size;
-    if (fileSize > MAX_LOCAL_FONT_DATA_URI_BYTES) {
-      return { kind: "file-backed", fileSize };
+async function readLocalFont(absPath: string): Promise<LocalFontRead> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of createReadStream(absPath)) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.length;
+    if (totalBytes > MAX_LOCAL_FONT_DATA_URI_BYTES) {
+      return { kind: "file-backed" };
     }
-    return { kind: "inline", buffer: readFileSync(file) };
-  } finally {
-    closeSync(file);
+    chunks.push(buffer);
   }
+  return { kind: "inline", buffer: Buffer.concat(chunks, totalBytes) };
 }
 
 // fallow-ignore-next-line complexity
@@ -1703,10 +1704,10 @@ async function embedLocalFontFaces(html: string, projectDir: string): Promise<st
         try {
           let dataUri = dataUriByAbsolutePath.get(absPath);
           if (!dataUri) {
-            const font = readLocalFont(absPath);
+            const font = await readLocalFont(absPath);
             if (font.kind === "file-backed") {
               defaultLogger.info(
-                `[Compiler] Kept large local font file-backed: ${localPath} (${(font.fileSize / 1024 / 1024).toFixed(1)} MB)`,
+                `[Compiler] Kept large local font file-backed: ${localPath} (> ${(MAX_LOCAL_FONT_DATA_URI_BYTES / 1024 / 1024).toFixed(1)} MB)`,
               );
               embeddedPaths.add(localPath);
               continue;


### PR DESCRIPTION
## What

Keep project-local font files larger than 5 MiB file-backed during render compilation instead of expanding them into compiled HTML data URIs.

## Why

Raw font collections can be tens of megabytes. Base64 adds roughly 33%, and repeated immutable HTML strings add further transient copies, so embedding one large local font can exhaust the compiler's V8 heap before capture begins.

Project assets are already available to local and distributed render modes, so large fonts do not need to be inlined for deterministic rendering.

## How

- Stream local font files and stop after the first byte above the 5 MiB ceiling.
- Preserve authored relative URLs for larger files.
- Cache file-backed decisions by resolved absolute path so equivalent URL spellings do not re-read the same large file.
- Keep the existing data-URI behavior for files up to and including 5 MiB.

## Test plan

- [x] Compiler regression with one 6 MiB collection referenced through three equivalent paths
- [x] Producer compiler suite: 105 passed
- [x] Producer typecheck
- [x] Changed-file lint, format, diff, and commit hooks
