### PR TITLE
chore: release v0.7.80

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,36 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.80"
+  description="Released - 2026-07-29"
+  tags={["Release", "Studio"]}
+>
+HyperFrames now renders scene-local video timing correctly across sequential nested templates
+and removes vulnerable runtime dependency paths. Studio also gains exact bulk easing for
+merged keyframes, atomic keyframe-cache refreshes, and smoother optimistic ease-mode changes.
+
+## Features
+
+- **Studio:** Bulk-edit easing for merged keyframes ([10d45def0](https://github.com/heygen-com/hyperframes/commit/10d45def058248d0d59d1448beef6a6ee91ddeba))
+
+## Fixes
+
+- **Studio:** Keep hidden state on expanded sub-composition rows ([5dad52370](https://github.com/heygen-com/hyperframes/commit/5dad52370f77a9a0618827279b8a4dcd86868456))
+- **Studio:** Open the path node menu on arc waypoints ([adb7de535](https://github.com/heygen-com/hyperframes/commit/adb7de5358d7ed6feeb41c55e6152ed7758bf1b5))
+- **Studio:** Switch keyframe ease modes optimistically ([659e22656](https://github.com/heygen-com/hyperframes/commit/659e22656e51aef54d079b3822fa40086d93726b))
+- **Studio:** Publish keyframe cache refresh atomically ([6b11d3743](https://github.com/heygen-com/hyperframes/commit/6b11d3743339c13424073fca63791d941d3fbbf6))
+- **Studio:** Target colliding keyframes exactly ([7482c22d8](https://github.com/heygen-com/hyperframes/commit/7482c22d821c0a46b48cb17421c4df73014dbbd6), [#2692](https://github.com/heygen-com/hyperframes/pull/2692))
+- **Core:** Preserve scene-local video timing across sequential nested templates ([9bbb6d50a](https://github.com/heygen-com/hyperframes/commit/9bbb6d50a02e128fcdab9ae20d33649b65406788), [#2859](https://github.com/heygen-com/hyperframes/pull/2859))
+- **Security:** Remove vulnerable runtime dependency paths ([13ac9e390](https://github.com/heygen-com/hyperframes/commit/13ac9e390585e75b80f5efd46393531315f0be2c))
+
+## Internal
+
+- **Studio:** Split bulk easing helpers ([23ab104af](https://github.com/heygen-com/hyperframes/commit/23ab104aff7a90de6d41aa7af2fb425314015d1d))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.79...v0.7.80).
+</Update>
+
+<Update
   label="HyperFrames v0.7.79"
   description="Released - 2026-07-28"
   tags={["Release", "Check", "Media Use", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.80.md
+++ b/releases/v0.7.80.md
@@ -1,0 +1,29 @@
+# HyperFrames v0.7.80
+
+Released on 2026-07-29.
+
+HyperFrames now renders scene-local video timing correctly across sequential nested templates
+and removes vulnerable runtime dependency paths. Studio also gains exact bulk easing for
+merged keyframes, atomic keyframe-cache refreshes, and smoother optimistic ease-mode changes.
+
+## Features
+
+- **Studio:** Bulk-edit easing for merged keyframes ([10d45def0](https://github.com/heygen-com/hyperframes/commit/10d45def058248d0d59d1448beef6a6ee91ddeba))
+
+## Fixes
+
+- **Studio:** Keep hidden state on expanded sub-composition rows ([5dad52370](https://github.com/heygen-com/hyperframes/commit/5dad52370f77a9a0618827279b8a4dcd86868456))
+- **Studio:** Open the path node menu on arc waypoints ([adb7de535](https://github.com/heygen-com/hyperframes/commit/adb7de5358d7ed6feeb41c55e6152ed7758bf1b5))
+- **Studio:** Switch keyframe ease modes optimistically ([659e22656](https://github.com/heygen-com/hyperframes/commit/659e22656e51aef54d079b3822fa40086d93726b))
+- **Studio:** Publish keyframe cache refresh atomically ([6b11d3743](https://github.com/heygen-com/hyperframes/commit/6b11d3743339c13424073fca63791d941d3fbbf6))
+- **Studio:** Target colliding keyframes exactly ([7482c22d8](https://github.com/heygen-com/hyperframes/commit/7482c22d821c0a46b48cb17421c4df73014dbbd6), [#2692](https://github.com/heygen-com/hyperframes/pull/2692))
+- **Core:** Preserve scene-local video timing across sequential nested templates ([9bbb6d50a](https://github.com/heygen-com/hyperframes/commit/9bbb6d50a02e128fcdab9ae20d33649b65406788), [#2859](https://github.com/heygen-com/hyperframes/pull/2859))
+- **Security:** Remove vulnerable runtime dependency paths ([13ac9e390](https://github.com/heygen-com/hyperframes/commit/13ac9e390585e75b80f5efd46393531315f0be2c))
+
+## Internal
+
+- **Studio:** Split bulk easing helpers ([23ab104af](https://github.com/heygen-com/hyperframes/commit/23ab104aff7a90de6d41aa7af2fb425314015d1d))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.79...v0.7.80


### PR DESCRIPTION
## Summary

- Bump the fixed HyperFrames package graph and editor plugins from `0.7.79` to `0.7.80`.
- Add reviewed release notes and the public changelog entry for the commits since `v0.7.79`.
- Publish the stable `latest` channel through the protected release-branch workflow after merge.

## Release highlights

- Preserve scene-local video timing across sequential nested templates.
- Add exact bulk easing for merged keyframes, atomic keyframe-cache refreshes, and optimistic ease-mode switching.
- Remove vulnerable runtime dependency paths.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run test:scripts` — 104 passed
- [x] `bun run build`
- [x] `bunx oxfmt --check` on all changed manifests and release docs
- [x] `git diff --check`
- [x] Packed-manifest verification — all 13 manifests publish-safe
- [ ] Exact-head CI

## Verification note

The local packed-consumer Vite smoke reached the consumer build after all 13 manifests passed, then encountered the runner host’s Rollup native-binary requirement for `GLIBC_2.32`. Exact-head CI is the clean-environment gate for that final smoke.