### PR TITLE
test(core): cover late nested video snapshots

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -964,6 +964,42 @@ describe("initSandboxRuntimeModular", () => {
     expect(secondVideo.style.visibility).toBe("visible");
   });
 
+  it("keeps the APPS-982 late local-time video visible for snapshot capture at global 20s", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "25");
+    root.setAttribute("data-width", "360");
+    root.setAttribute("data-height", "640");
+    document.body.appendChild(root);
+
+    const host = document.createElement("div");
+    host.setAttribute("data-composition-id", "late");
+    host.setAttribute("data-composition-file", "compositions/late.html");
+    host.setAttribute("data-start", "15");
+    host.setAttribute("data-duration", "10");
+    root.appendChild(host);
+
+    const video = document.createElement("video");
+    video.setAttribute("data-start", "5");
+    video.setAttribute("data-duration", "3");
+    video.setAttribute("data-media-start", "3");
+    host.appendChild(video);
+
+    window.__timelines = {
+      main: createMockTimeline(25),
+      late: createMockTimeline(10),
+    };
+
+    initSandboxRuntimeModular();
+    window.__player?.renderSeek(20);
+
+    expect(window.__hfResolveMediaStartSeconds?.(video)).toBe(20);
+    expect(host.style.visibility).toBe("visible");
+    expect(video.style.visibility).toBe("visible");
+  });
+
   it("resolves media starts through arbitrarily nested composition hosts", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");


### PR DESCRIPTION
## What

- Add regression coverage for a template host at global 15s with video authored at local 5s.
- Assert that the canonical runtime start resolves to global 20s.
- Verify that both the host and video remain visible during snapshot capture.

## Why

A snapshot could hide a later nested video by interpreting its authored start as root-global instead of scene-local. Current main already contains the canonical runtime timing fix; this PR locks the distinct late-host timing shape as regression coverage without adding overlapping production logic.

## How

Exercise the runtime visibility resolver with a nested template host and a local-time video, then assert the resolved absolute start and visibility at the affected global timestamp.

## Test plan

- Regression fails with the old local-time visibility rule: expected `visible`, received `hidden` at global 20s.
- `packages/core`: `bunx vitest run src/runtime/init.test.ts` — 69 passed.
- Core typecheck passed.
- Full workspace build passed.
- Changed-file format, lint, diff, and commit hooks passed.
- Fixture snapshot checks at 3.4s and 20.0s passed.
- `check --snapshots --at 3.4,20 --json` passed runtime, layout, and lint checks.