### PR TITLE
fix: exclude hidden audio from render mix

### DIFF
--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -844,3 +844,15 @@ describe("parseAudioElements — relative data-start resolution", () => {
     expect(track!.start).toBe(4);
   });
 });
+
+describe("parseAudioElements — hidden tracks", () => {
+  it("excludes an audio element marked data-hidden from the render mix", () => {
+    const html =
+      `<div data-composition-id="main" data-start="0" data-duration="3">` +
+      `<audio id="master" src="master.wav" data-start="0" data-duration="3"></audio>` +
+      `<audio id="hidden" src="hidden.wav" data-start="0" data-duration="3" data-hidden></audio>` +
+      `</div>`;
+
+    expect(parseAudioElements(html).map((track) => track.id)).toEqual(["master"]);
+  });
+});

--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -846,13 +846,31 @@ describe("parseAudioElements — relative data-start resolution", () => {
 });
 
 describe("parseAudioElements — hidden tracks", () => {
-  it("excludes an audio element marked data-hidden from the render mix", () => {
+  it("excludes directly hidden audio and audible video from the render mix", () => {
     const html =
       `<div data-composition-id="main" data-start="0" data-duration="3">` +
       `<audio id="master" src="master.wav" data-start="0" data-duration="3"></audio>` +
       `<audio id="hidden" src="hidden.wav" data-start="0" data-duration="3" data-hidden></audio>` +
+      `<video id="hidden-video" src="hidden.mp4" data-has-audio="true" data-hidden></video>` +
       `</div>`;
 
     expect(parseAudioElements(html).map((track) => track.id)).toEqual(["master"]);
+  });
+
+  it("excludes audio and audible video beneath a hidden ancestor", () => {
+    const html =
+      `<div data-composition-id="main" data-start="0" data-duration="3">` +
+      `<audio id="master" src="master.wav" data-start="0" data-duration="3"></audio>` +
+      `<section data-hidden>` +
+      `<audio id="nested-audio" src="nested.wav"></audio>` +
+      `<video id="nested-video" src="nested.mp4" data-has-audio="true"></video>` +
+      `</section>` +
+      `<video id="visible-video" src="visible.mp4" data-has-audio="true"></video>` +
+      `</div>`;
+
+    expect(parseAudioElements(html).map((track) => track.id)).toEqual([
+      "master",
+      "visible-video-audio",
+    ]);
   });
 });

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -304,6 +304,10 @@ function ffmpegFailure(
 export function parseAudioElements(html: string): AudioElement[] {
   const elements: AudioElement[] = [];
   const { document } = parseHTML(unwrapTemplate(html));
+  interface AudioMediaElement extends RefResolverEl {
+    hasAttribute(name: string): boolean;
+    parentElement: AudioMediaElement | null;
+  }
 
   // Shared resolver state so a relative `data-start` ("start when clip X ends")
   // resolves against every clip in the composition — exactly as
@@ -320,6 +324,12 @@ export function parseAudioElements(html: string): AudioElement[] {
   const parseEnd = (raw: string | null): number => {
     const end = raw ? parseFloat(raw) : 0;
     return Number.isFinite(end) ? end : 0;
+  };
+  const isHidden = (el: AudioMediaElement): boolean => {
+    for (let current: AudioMediaElement | null = el; current; current = current.parentElement) {
+      if (current.hasAttribute("data-hidden")) return true;
+    }
+    return false;
   };
 
   // <audio> and <video data-has-audio> tracks differ only in the emitted id
@@ -342,13 +352,13 @@ export function parseAudioElements(html: string): AudioElement[] {
 
   for (const el of document.querySelectorAll("audio[id][src]")) {
     const id = el.getAttribute("id");
-    if (!id || !el.getAttribute("src") || el.hasAttribute("data-hidden")) continue;
+    if (!id || !el.getAttribute("src") || isHidden(el)) continue;
     elements.push(build(el, id, "audio"));
   }
 
   for (const el of document.querySelectorAll('video[id][src][data-has-audio="true"]')) {
     const id = el.getAttribute("id");
-    if (!id || !el.getAttribute("src")) continue;
+    if (!id || !el.getAttribute("src") || isHidden(el)) continue;
     elements.push(build(el, `${id}-audio`, "video"));
   }
 

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -342,7 +342,7 @@ export function parseAudioElements(html: string): AudioElement[] {
 
   for (const el of document.querySelectorAll("audio[id][src]")) {
     const id = el.getAttribute("id");
-    if (!id || !el.getAttribute("src")) continue;
+    if (!id || !el.getAttribute("src") || el.hasAttribute("data-hidden")) continue;
     elements.push(build(el, id, "audio"));
   }
 


### PR DESCRIPTION
## What

Exclude hidden audio-bearing media from render audio discovery while leaving visible audio and video tracks unchanged.

## Why

Audio discovery did not fully honor `data-hidden` semantics. Directly hidden audio was mixed into the final output, and the same gap also affected audible video and media nested beneath a hidden container.

## How

- Use one ancestor-aware hidden check for both `<audio>` and `<video data-has-audio="true">`.
- Exclude directly hidden media and media inside any `data-hidden` subtree.
- Keep visible sibling tracks in the mix.

## Test plan

- [x] Directly hidden audio regression
- [x] Directly hidden audible-video regression
- [x] Hidden-ancestor audio and audible-video regression
- [x] Engine audio mixer suite: 22 passed
- [x] Engine typecheck
- [x] Changed-file lint, format, diff, and commit hooks
