### PR TITLE
fix(parsers): validate Windows FFmpeg discovery candidates

### DIFF
--- a/packages/parsers/src/ffBinaries.test.ts
+++ b/packages/parsers/src/ffBinaries.test.ts
@@ -52,9 +52,45 @@ describe("findFfBinary", () => {
       const mocked = { execFileSync: () => "C:\\tools\\ffmpeg.cmd\r\nC:\\tools\\ffmpeg.exe\r\n" };
       return { ...mocked, default: mocked };
     });
+    vi.doMock("node:fs", () => {
+      const mocked = {
+        existsSync: (candidate: unknown) => candidate === "C:\\tools\\ffmpeg.exe",
+        accessSync: () => {},
+        constants: { X_OK: 1 },
+      };
+      return { ...mocked, default: mocked };
+    });
     const { findFfBinary } = await importFresh();
 
     expect(findFfBinary("ffmpeg")).toBe(resolve("C:\\tools\\ffmpeg.exe"));
+  });
+
+  it("falls back to PATH when Windows where output decodes to a missing path", async () => {
+    delete process.env.HYPERFRAMES_FFMPEG_PATH;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    process.env.PATH = "/valid-tools";
+    const execFileSync = vi.fn(() => "C:\\Users\\��\\ffmpeg.exe\r\n");
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync,
+      default: { execFileSync },
+    }));
+    vi.doMock("node:fs", () => {
+      const mocked = {
+        existsSync: (candidate: unknown) => candidate === "/valid-tools/ffmpeg.exe",
+        accessSync: () => {},
+        constants: { X_OK: 1 },
+      };
+      return { ...mocked, default: mocked };
+    });
+    const { findFfBinary } = await importFresh();
+
+    expect(findFfBinary("ffmpeg")).toBe("/valid-tools/ffmpeg.exe");
+    expect(execFileSync).toHaveBeenCalledWith(
+      "where",
+      ["ffmpeg"],
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
   });
 
   it("falls back to scanning PATH when which/where fails", async () => {

--- a/packages/parsers/src/ffBinaries.test.ts
+++ b/packages/parsers/src/ffBinaries.test.ts
@@ -17,6 +17,7 @@ describe("findFfBinary", () => {
   const originalPlatform = process.platform;
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.resetModules();
     vi.doUnmock("node:child_process");
     vi.doUnmock("node:fs");
@@ -44,17 +45,14 @@ describe("findFfBinary", () => {
     expect(findFfBinary("ffmpeg")).toBe(resolve(join(tmpdir(), "definitely-missing-ffmpeg")));
   });
 
-  it("prefers the real Windows exe when where lists a cmd shim first", async () => {
+  it("prefers the real Windows exe over a cmd shim in PATH", async () => {
     delete process.env.HYPERFRAMES_FFMPEG_PATH;
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    process.env.PATH = "/tools";
     vi.resetModules();
-    vi.doMock("node:child_process", () => {
-      const mocked = { execFileSync: () => "C:\\tools\\ffmpeg.cmd\r\nC:\\tools\\ffmpeg.exe\r\n" };
-      return { ...mocked, default: mocked };
-    });
     vi.doMock("node:fs", () => {
       const mocked = {
-        existsSync: (candidate: unknown) => candidate === "C:\\tools\\ffmpeg.exe",
+        existsSync: (candidate: unknown) => candidate === "/tools/ffmpeg.exe",
         accessSync: () => {},
         constants: { X_OK: 1 },
       };
@@ -62,14 +60,17 @@ describe("findFfBinary", () => {
     });
     const { findFfBinary } = await importFresh();
 
-    expect(findFfBinary("ffmpeg")).toBe(resolve("C:\\tools\\ffmpeg.exe"));
+    expect(findFfBinary("ffmpeg")).toBe("/tools/ffmpeg.exe");
   });
 
-  it("falls back to PATH when Windows where output decodes to a missing path", async () => {
+  it("discovers a Windows binary in a Unicode current directory without decoding console output", async () => {
     delete process.env.HYPERFRAMES_FFMPEG_PATH;
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
-    process.env.PATH = "/valid-tools";
-    const execFileSync = vi.fn(() => "C:\\Users\\��\\ffmpeg.exe\r\n");
+    process.env.PATH = "";
+    const unicodeDirectory = "/用户/工具";
+    const ffmpegPath = join(unicodeDirectory, "ffmpeg.exe");
+    vi.spyOn(process, "cwd").mockReturnValue(unicodeDirectory);
+    const execFileSync = vi.fn();
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync,
@@ -77,7 +78,7 @@ describe("findFfBinary", () => {
     }));
     vi.doMock("node:fs", () => {
       const mocked = {
-        existsSync: (candidate: unknown) => candidate === "/valid-tools/ffmpeg.exe",
+        existsSync: (candidate: unknown) => candidate === ffmpegPath,
         accessSync: () => {},
         constants: { X_OK: 1 },
       };
@@ -85,12 +86,8 @@ describe("findFfBinary", () => {
     });
     const { findFfBinary } = await importFresh();
 
-    expect(findFfBinary("ffmpeg")).toBe("/valid-tools/ffmpeg.exe");
-    expect(execFileSync).toHaveBeenCalledWith(
-      "where",
-      ["ffmpeg"],
-      expect.objectContaining({ encoding: "utf-8" }),
-    );
+    expect(findFfBinary("ffmpeg")).toBe(ffmpegPath);
+    expect(execFileSync).not.toHaveBeenCalled();
   });
 
   it("falls back to scanning PATH when which/where fails", async () => {

--- a/packages/parsers/src/ffBinaries.ts
+++ b/packages/parsers/src/ffBinaries.ts
@@ -49,7 +49,11 @@ function isExecutablePathCandidate(candidate: string): boolean {
 
 function scanPath(name: FfBinaryName): string | undefined {
   const pathValue = process.env.PATH;
-  if (!pathValue) return undefined;
+  const searchDirs = [
+    ...(process.platform === "win32" ? [process.cwd()] : []),
+    ...(pathValue ? pathValue.split(delimiter) : []),
+  ].filter(Boolean);
+  if (searchDirs.length === 0) return undefined;
 
   const extensions =
     process.platform === "win32"
@@ -65,8 +69,7 @@ function scanPath(name: FfBinaryName): string | undefined {
         ]
       : [""];
   const candidates: string[] = [];
-  for (const dir of pathValue.split(delimiter)) {
-    if (!dir) continue;
+  for (const dir of new Set(searchDirs)) {
     for (const ext of extensions) {
       const candidate = join(dir, `${name}${ext}`);
       if (isExecutablePathCandidate(candidate)) candidates.push(candidate);
@@ -101,17 +104,24 @@ function findInProjectLocalBin(name: FfBinaryName): string | undefined {
 function lookupOnSystem(name: FfBinaryName): string | undefined {
   if (pathLookupCache.has(name)) return pathLookupCache.get(name);
   let found: string | undefined;
-  try {
-    const command = process.platform === "win32" ? "where" : "which";
-    const output = execFileSync(command, [name], {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 5000,
-    });
-    const candidate = chooseBestPathCandidate(name, output.split(/\r?\n/));
-    found = candidate && isExecutablePathCandidate(candidate) ? candidate : scanPath(name);
-  } catch {
+  if (process.platform === "win32") {
+    // `where.exe` writes bytes in the active console code page, while Node
+    // decodes its stdout using a caller-selected encoding. Enumerating the
+    // same current-directory + PATH search space from Node keeps Unicode
+    // paths as native JS strings and avoids mojibake entirely.
     found = scanPath(name);
+  } else {
+    try {
+      const output = execFileSync("which", [name], {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 5000,
+      });
+      const candidate = chooseBestPathCandidate(name, output.split(/\r?\n/));
+      found = candidate && isExecutablePathCandidate(candidate) ? candidate : scanPath(name);
+    } catch {
+      found = scanPath(name);
+    }
   }
   found ??= findInProjectLocalBin(name);
   found ??= findInCommonDirs(name);
@@ -132,8 +142,9 @@ export interface FindFfBinaryOptions {
 }
 
 /**
- * Resolve an FFmpeg-family binary: env override first, then `which`/`where`,
- * then a manual PATH scan (covers Windows PATHEXT), a project-local
+ * Resolve an FFmpeg-family binary: env override first, then a native
+ * current-directory/PATH scan on Windows or `which` plus PATH scan on Unix,
+ * then a project-local
  * `.hyperframes/bin`, then well-known Unix install dirs. System lookups are
  * cached per binary for the process lifetime; the env override is re-read on
  * every call.

--- a/packages/parsers/src/ffBinaries.ts
+++ b/packages/parsers/src/ffBinaries.ts
@@ -108,7 +108,8 @@ function lookupOnSystem(name: FfBinaryName): string | undefined {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
     });
-    found = chooseBestPathCandidate(name, output.split(/\r?\n/));
+    const candidate = chooseBestPathCandidate(name, output.split(/\r?\n/));
+    found = candidate && isExecutablePathCandidate(candidate) ? candidate : scanPath(name);
   } catch {
     found = scanPath(name);
   }


### PR DESCRIPTION
## What

Discover Windows FFmpeg and FFprobe binaries from native current-directory and PATH strings instead of decoding `where.exe` console output.

## Why

`where.exe` writes bytes in the active Windows console code page. Decoding that output as UTF-8 can corrupt non-ASCII paths and pass a nonexistent mojibake path into process launch.

## How

- Enumerate the same current-directory and PATH search space directly in Node on Windows.
- Preserve native Unicode JavaScript path strings end to end.
- Keep PATHEXT handling and prefer the real `.exe` over command shims.
- Retain `which` plus executable validation on Unix and explicit path overrides on every platform.

## Test plan

- [x] Unicode Windows current-directory regression without console output
- [x] Windows `.exe` preference regression
- [x] Parser focused suite: 8 passed
- [x] Parser typecheck
- [x] Changed-file lint, format, diff, and commit hooks
