### PR TITLE
fix(studio): resolve Chrome on Windows

### DIFF
--- a/packages/studio/vite.browser.test.ts
+++ b/packages/studio/vite.browser.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const launch = vi.fn();
+const originalBrowserPath = process.env["HYPERFRAMES_BROWSER_PATH"];
 
 vi.mock("puppeteer-core", () => ({
   default: { launch },
@@ -8,8 +9,17 @@ vi.mock("puppeteer-core", () => ({
 
 describe("generateThumbnail", () => {
   beforeEach(() => {
+    process.env["HYPERFRAMES_BROWSER_PATH"] = process.execPath;
     launch.mockReset();
     launch.mockRejectedValue(new Error("browser launch failed"));
+  });
+
+  afterEach(() => {
+    if (originalBrowserPath === undefined) {
+      delete process.env["HYPERFRAMES_BROWSER_PATH"];
+    } else {
+      process.env["HYPERFRAMES_BROWSER_PATH"] = originalBrowserPath;
+    }
   });
 
   it("contains browser launch failures and retries them on the next request", async () => {
@@ -46,5 +56,13 @@ describe("findSystemChrome", () => {
       ),
     ).toBe("/custom/browser");
     expect(pathExists).toHaveBeenCalledTimes(1);
+  });
+
+  it("finds a standard Windows Chrome installation", async () => {
+    const { findSystemChrome } = await import("./vite.browser");
+    const chromePath = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+    const pathExists = vi.fn((path: string) => path === chromePath);
+
+    expect(findSystemChrome({}, pathExists, "win32")).toBe(chromePath);
   });
 });

--- a/packages/studio/vite.browser.ts
+++ b/packages/studio/vite.browser.ts
@@ -2,6 +2,7 @@
 
 import { existsSync } from "node:fs";
 import { createHash } from "node:crypto";
+import { win32 as pathWin32 } from "node:path";
 import {
   createStudioDevRenderBodyScripts,
   readStudioDevManualEditManifestContent,
@@ -14,20 +15,34 @@ import { seekThumbnailPreview } from "./vite.thumbnail";
 let _browser: import("puppeteer-core").Browser | null = null;
 let _browserLaunchPromise: Promise<import("puppeteer-core").Browser> | null = null;
 
-const CHROME_PATHS = [
-  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-  "/usr/bin/google-chrome",
-  "/usr/bin/chromium-browser",
-];
+function systemChromePaths(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string[] {
+  if (platform === "win32") {
+    const programFiles = env["PROGRAMFILES"] ?? "C:\\Program Files";
+    const programFilesX86 = env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)";
+    const localAppData = env["LOCALAPPDATA"];
+    return [
+      pathWin32.join(programFiles, "Google", "Chrome", "Application", "chrome.exe"),
+      pathWin32.join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"),
+      ...(localAppData
+        ? [pathWin32.join(localAppData, "Google", "Chrome", "Application", "chrome.exe")]
+        : []),
+    ];
+  }
+  if (platform === "darwin") {
+    return ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"];
+  }
+  return ["/usr/bin/google-chrome", "/usr/bin/chromium-browser"];
+}
 
 /** Resolve the same explicit browser overrides used by the CLI before system paths. */
 export function findSystemChrome(
   env: NodeJS.ProcessEnv = process.env,
   pathExists: (path: string) => boolean = existsSync,
+  platform: NodeJS.Platform = process.platform,
 ): string | undefined {
   const override = env["HYPERFRAMES_BROWSER_PATH"] ?? env["PRODUCER_HEADLESS_SHELL_PATH"];
   if (override && pathExists(override)) return override;
-  return CHROME_PATHS.find((path) => pathExists(path));
+  return systemChromePaths(env, platform).find((path) => pathExists(path));
 }
 
 async function getSharedBrowser(): Promise<import("puppeteer-core").Browser | null> {


### PR DESCRIPTION
## What

Make Studio thumbnail browser discovery support standard Windows Chrome installations and make the browser-launch retry test independent of host-specific Chrome paths.

## Why

The Windows test job on `main` failed because `findSystemChrome()` only knew macOS and Linux locations. The retry test therefore returned before Puppeteer launch on Windows and never exercised the launch-failure retry path. The same omission could prevent standalone Studio/Vite flows from finding an installed Windows Chrome unless an explicit browser override was set.

Failed job: https://github.com/heygen-com/hyperframes/actions/runs/30447512847/job/90561714046

## How

- Resolve Chrome from standard Windows Program Files, Program Files (x86), and per-user LocalAppData locations.
- Keep explicit `HYPERFRAMES_BROWSER_PATH` / `PRODUCER_HEADLESS_SHELL_PATH` overrides first.
- Give the retry test an explicit known executable so it tests retry behavior rather than the CI image filesystem.
- Add a platform-injected regression test for the standard Windows Chrome path.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)

Validation:
- `bun run --cwd packages/studio test vite.browser.test.ts` — 3 passed
- `bun run --cwd packages/studio test` — 3,118 passed, 18 todo
- `bun run --cwd packages/studio typecheck`
- `bunx oxfmt --check packages/studio/vite.browser.ts packages/studio/vite.browser.test.ts`
- `bunx oxlint packages/studio/vite.browser.ts packages/studio/vite.browser.test.ts`
- pre-commit hooks: tracked artifacts, lint, format, fallow, typecheck
