### PR TITLE
docs(audio): avoid weak music openings in short launch videos

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 10
     },
     "media-use": {
-      "hash": "2e02a0799754e411",
+      "hash": "6c40be3e8bd6eacc",
       "files": 152
     },
     "motion-graphics": {
@@ -62,7 +62,7 @@
       "files": 29
     },
     "product-launch-video": {
-      "hash": "8cce4a32487eaf80",
+      "hash": "ee53442514e680bf",
       "files": 26
     },
     "remotion-to-hyperframes": {

--- a/skills/media-use/audio/references/bgm.md
+++ b/skills/media-use/audio/references/bgm.md
@@ -31,6 +31,8 @@ One music bed per composition, produced by the shared audio engine (`scripts/aud
 
 `volume` comes from the engine's `bgmDefaultVolume()`: `BGM_BED_VOLUME` (currently `0.12` ≈ -18 dB — a bed under the voice) under narration, `BGM_SILENT_VOLUME` (currently `0.9`) for a silent film (no voice). Tune those constants in `scripts/lib/bgm.mjs`, not call sites. An explicit `volume` in `audio_meta.json` always overrides this default. `bgm_pending` is `false` — the file is on disk when the engine returns.
 
+For short launch videos, do not assume the beginning of the retrieved file is the best edit point. Check the opening against later five-second sections. If the track starts with a quiet build but a later section has a stronger, clean musical entrance, trim from that section and apply a short fade-in and longer fade-out. Repeat this check whenever the composition duration changes; the final music file must cover the full cut without a silent tail.
+
 ## Local generation (fallback) — Lyria → MusicGen
 
 Spawned **detached** so voice work isn't blocked; `audio_meta.bgm_pending: true` and `bgm_pid` / `bgm_log` are set until it finishes. **Run `scripts/wait-bgm.mjs` before assembling** — it polls the output file / process / log, detects crashes, and writes `bgm_status.json` (`status: ready | failed | timeout | disabled`). A failed/absent track is simply omitted; it never blocks voice/SFX.

--- a/skills/product-launch-video/SKILL.md
+++ b/skills/product-launch-video/SKILL.md
@@ -148,6 +148,8 @@ Wait for Step 3.1 audio to finish if audio was started. Then sync durations and 
 
 Duration sync is mechanical: real voice duration wins; silent frames keep estimates; never hand-edit synced durations.
 
+Check the music against the final cut before assembly. A library track can match the requested mood but open on a quiet build that drains the first seconds of a short launch video. Compare the opening with later five-second sections; when a later section has a stronger, musically clean start, trim from there and keep a short fade-in plus a longer fade-out. If frame or narration timing changes, redo this check against the new final duration so the music never ends early or leaves silence at the tail.
+
 Before dispatch, read `../hyperframes-core/references/subagent-dispatch.md`. Build the per-frame packets and the worker role payload:
 
 `node <SKILL_DIR>/scripts/frame-packets.mjs --project "$PROJECT_DIR" --storyboard "$PROJECT_DIR/STORYBOARD.md"`


### PR DESCRIPTION
## The problem

Music search can find the right mood but still return a track with a slow or quiet opening. In a short launch video, that can make the most important first seconds feel flat. Timing changes can also leave the music ending too early.

## What this changes

- Compare the opening with later five-second sections before assembly.
- Use a stronger, musically clean starting point when the opening is weak.
- Keep a short fade-in and longer fade-out.
- Recheck music after the final video duration changes.

## Why merge this

The soundtrack starts with the energy the video needs and covers the full cut. This is a small, backwards-compatible workflow improvement that uses the existing audio pipeline.

## Validation

- `bun run lint:skills`
- `git diff --check`
