### PR TITLE
docs: polish the introduction (kill duplication + hide the 'Start here' label)

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -599,3 +599,10 @@ a:not([class]):hover {
     animation: none;
   }
 }
+
+/* Hide the section/group label ("Start here", etc.) that the theme renders
+ * above every page title. It repeats the sidebar grouping and adds noise on
+ * every page; each page leads with its own H1 instead. */
+.eyebrow {
+  display: none;
+}

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,8 +4,6 @@ sidebarTitle: "What HyperFrames is"
 description: "Tell an AI agent what you want. It builds a real, editable video project — you refine it in Studio and export the film."
 ---
 
-**Tell an AI agent what you want. It builds a real, editable video project — you refine it in Studio and export the film.**
-
 Start from an idea, a website, a script, a recording, a pull request, or a song. The agent does the first build. You keep control of the result.
 
 <Frame caption="One prompt → ~30 seconds of finished video. Made with HyperFrames. Press play — it has sound.">
@@ -81,9 +79,9 @@ The agent does the source-heavy work. Studio is where you stay in control — no
 
 You never have to touch HTML, packages, or the rendering engine to make and review a video. Those live in [Developers](/developers) — for the people integrating or extending HyperFrames.
 
-## Start here
+## Your next step
 
-The shortest path is to **make one**.
+The shortest way to understand HyperFrames is to **make one thing** with it.
 
 <CardGroup cols={3}>
   <Card title="Make your first video" icon="play" href="/quickstart">


### PR DESCRIPTION
Two fixes to the front door landed in #2867:

1. **Remove duplicated lead** — the one-sentence definition was showing twice: once as the auto-rendered subtitle (from the page `description`) and once as a bold line in the body. Dropped the bold repeat; the subtitle carries it.
2. **Hide the repeated `.eyebrow` label** — the grey "Start here" / "Workflows" label the theme stamps above every page title. One line in `custom.css`; each page already leads with its own H1.
3. Renamed the intro's bottom "Start here" section to "Your next step" so it stops colliding with the sidebar group name.

Base is `codex/docs-human-first-refactor` so it flows into #2867's preview.