### PR TITLE
chore(engine,producer): remove fully rolled-out env flags

### DIFF
--- a/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
+++ b/packages/engine/src/services/frameCapture-staticDedupVerifyDensity.test.ts
@@ -23,8 +23,8 @@ vi.mock("./screenshotService.js", async (importOriginal) => {
  * static.
  *
  * A first version of this fix bounded the STRIDE by `sampleCount` directly —
- * which fixed the density but inverted the config knob's polarity: raising
- * `HF_STATIC_DEDUP_SAMPLES` widened the allowed gap instead of shrinking it.
+ * which fixed the density but inverted the parameter's polarity: raising
+ * `sampleCount` widened the allowed gap instead of shrinking it.
  * The current formula uses a fixed internal reference stride (independent of
  * sampleCount) for the length-scaling fix, and sampleCount as a pure
  * point-count floor that only ever increases density.

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -830,20 +830,17 @@ async function initDrawElementOrTransparentBackground(
       // every run. Conservative by design: comps whose risky tweens drawElement
       // would have handled also fall back, but correctness is never at risk and the
       // fast path stays open for static + plain-2D-transform comps (x/y/scale are
-      // NOT in the at-risk set). Tune the gate's frame-fraction floor with
-      // HF_FAST_CAPTURE_INTERVAL_FRACTION (default 0 = any at-risk frame gates).
+      // NOT in the at-risk set). Any at-risk frame gates the whole comp.
       // Must run BEFORE canvas injection so a whole-comp fallback doesn't leave the
-      // drawElement canvas wrapping the composition root. Disable with
-      // HF_FAST_CAPTURE_INTERVAL_SS=false.
-      if (!forceDE && process.env.HF_FAST_CAPTURE_INTERVAL_SS !== "false") {
+      // drawElement canvas wrapping the composition root.
+      if (!forceDE) {
         const fps = fpsToNumber(session.options.fps);
         const { frames: atRisk, totalFrames } = await computeTimelineAtRiskFrames(page, fps);
         const atRiskFraction = atRisk.size / totalFrames;
-        const fractionFloor = Number(process.env.HF_FAST_CAPTURE_INTERVAL_FRACTION ?? "0");
         logInitPhase(
           `timeline at-risk predictor: ${atRisk.size}/${totalFrames} frames (${Math.round(atRiskFraction * 100)}%)`,
         );
-        if (atRisk.size > 0 && atRiskFraction > fractionFloor) {
+        if (atRisk.size > 0) {
           session.deGateReason = "at_risk_timeline";
           session.deFallbackTrigger = "at_risk_timeline";
           console.log(
@@ -1172,25 +1169,13 @@ async function constructCaptureSession(
   if (useDrawElement) {
     await page.evaluateOnNewDocument(instrumentAcceleratedCanvases);
   }
-  // The opacity → autoAlpha tween rewrite was RETIRED with the requestPaint
-  // contract adoption (crbug 529829538 closed WAI): a requestPaint-driven
-  // paint refreshes nested opacity layers natively, and the rewrite itself
-  // measured ~28 dB of damage on comps whose fades it touched. Warn instead
-  // of silently ignoring the old escape hatch.
-  if (process.env.HF_FAST_CAPTURE_AUTOALPHA !== undefined) {
-    console.warn(
-      "[engine] HF_FAST_CAPTURE_AUTOALPHA is retired and ignored — the requestPaint " +
-        "paint contract captures animated opacity natively (see drawElementService.ts).",
-    );
-  }
   // Re-apply the captured root's own compositor-applied props to the 2D
   // context where the snapshot does not carry them (see the correction
   // comment in drawElementService.ts drawAndEncode: transform always —
   // never baked, verified under the requestPaint contract 2026-07-07;
   // opacity ratio only on non-requestPaint paints, where the snapshot holds
-  // the load-time value). On by default; disable with
-  // HF_FAST_CAPTURE_ROOT_PROPS=false.
-  if (useDrawElement && process.env.HF_FAST_CAPTURE_ROOT_PROPS !== "false") {
+  // the load-time value).
+  if (useDrawElement) {
     await page.evaluateOnNewDocument(() => {
       (window as unknown as { __HF_ROOT_PROPS__?: boolean }).__HF_ROOT_PROPS__ = true;
     });
@@ -2666,6 +2651,9 @@ const STATIC_VERIFY_REFERENCE_STRIDE = 24;
 // disabled and normal capture proceeds.
 const STATIC_VERIFY_MAX_MS = 15_000;
 
+/** Per-run verification point-count floor (see computeStaticVerificationPoints). */
+const STATIC_VERIFY_SAMPLE_FLOOR = 24;
+
 /**
  * Interior verification points for a run [a..b], plus the always-included end `b`.
  * Density used to be a flat point-count cap (min(sampleCount, 8)), so a run's
@@ -2675,12 +2663,11 @@ const STATIC_VERIFY_MAX_MS = 15_000;
  * tween walk can't see) then hides between samples and the whole run gets
  * wrongly trusted as static.
  *
- * `sampleCount` (HF_STATIC_DEDUP_SAMPLES) is a per-run point-count FLOOR, not a
- * stride cap — raising it always increases density, never decreases it. (An
+ * `sampleCount` (STATIC_VERIFY_SAMPLE_FLOOR) is a per-run point-count FLOOR, not
+ * a stride cap — raising it always increases density, never decreases it. (An
  * earlier revision of this fix bounded the stride BY sampleCount directly, which
  * inverted that: raising sampleCount widened the allowed gap instead of shrinking
- * it, and the "raise HF_STATIC_DEDUP_SAMPLES to verify more" log guidance became
- * backwards for exactly the long runs it's meant to help.) The length-scaling
+ * it.) The length-scaling
  * fix itself comes from STATIC_VERIFY_REFERENCE_STRIDE, which is independent of
  * sampleCount, so density scales with run length regardless of how that knob is
  * set; sampleCount only ever raises density further above that floor.
@@ -2791,9 +2778,8 @@ export async function verifyStaticFramesSafe(
 /**
  * Arm static-frame dedup for this render (default-on; opt out with HF_STATIC_DEDUP=false).
  * Runs at init in normal DOM state so the verification screenshots are valid. Predicts
- * the static set, anchor-verifies it (skip with HF_STATIC_DEDUP_VERIFY=false — unsafe),
- * and on success stores it on the session for captureFrameCore to reuse. Sample budget
- * via HF_STATIC_DEDUP_SAMPLES (default 24).
+ * the static set, anchor-verifies it, and on success stores it on the session for
+ * captureFrameCore to reuse.
  */
 async function armStaticDedup(
   session: CaptureSession,
@@ -2855,12 +2841,13 @@ async function armStaticDedup(
     logInitPhase(`static-frame dedup: disabled (${stats.reason})`);
     return;
   }
-  const rawSamples = Number(process.env.HF_STATIC_DEDUP_SAMPLES ?? "24");
-  const samples = Number.isFinite(rawSamples) && rawSamples >= 1 ? rawSamples : 24;
-  const verdict =
-    process.env.HF_STATIC_DEDUP_VERIFY === "false"
-      ? null
-      : await verifyStaticFramesSafe(session, page, stats.staticFrameSet, fps, samples);
+  const verdict = await verifyStaticFramesSafe(
+    session,
+    page,
+    stats.staticFrameSet,
+    fps,
+    STATIC_VERIFY_SAMPLE_FLOOR,
+  );
   if (verdict !== null) {
     session.staticDedupSkipReason = verdict.budgetExhausted
       ? "verification_budget"

--- a/packages/producer/src/services/render/stages/captureStreamingStage.test.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.test.ts
@@ -350,33 +350,6 @@ describe("runCaptureStreamingStage", () => {
     expect((caught as Error).message).toContain("stalled");
   });
 
-  it("still honors the pre-rename HF_DE_PARALLEL_STALL_MS env var for one release", async () => {
-    hangSequentialUntilStall = true;
-    const prevNew = process.env.HF_DE_STALL_MS;
-    const prevOld = process.env.HF_DE_PARALLEL_STALL_MS;
-    delete process.env.HF_DE_STALL_MS;
-    process.env.HF_DE_PARALLEL_STALL_MS = "50";
-    const { runCaptureStreamingStage } = await import("./captureStreamingStage.js");
-    const cfg = { forceScreenshot: false, ffmpegStreamingTimeout: 3_600_000 };
-    const input = { ...createInput(cfg), totalFrames: 10, workerCount: 1 };
-
-    let caught: unknown;
-    try {
-      await runCaptureStreamingStage(input);
-    } catch (error) {
-      caught = error;
-    } finally {
-      hangSequentialUntilStall = false;
-      if (prevNew === undefined) delete process.env.HF_DE_STALL_MS;
-      else process.env.HF_DE_STALL_MS = prevNew;
-      if (prevOld === undefined) delete process.env.HF_DE_PARALLEL_STALL_MS;
-      else process.env.HF_DE_PARALLEL_STALL_MS = prevOld;
-    }
-
-    expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toContain("stalled");
-  });
-
   it("does not relabel a genuine parent-abort as a stall on the sequential path", async () => {
     hangSequentialUntilStall = true;
     const prev = process.env.HF_DE_STALL_MS;

--- a/packages/producer/src/services/render/stages/captureStreamingStage.ts
+++ b/packages/producer/src/services/render/stages/captureStreamingStage.ts
@@ -95,11 +95,7 @@ const DEFAULT_DE_STALL_MS = 60_000;
 const DE_STALL_POLL_MS = 5_000;
 
 function resolveDeStallTimeoutMs(): number {
-  // HF_DE_PARALLEL_STALL_MS is the pre-rename name (this config used to guard
-  // only the parallel path). Bridged for one release so an already-deployed
-  // ops surface (runbook, ConfigMap, ...) tuning the old name doesn't
-  // silently no-op; drop once nothing sets it anymore.
-  const raw = process.env.HF_DE_STALL_MS ?? process.env.HF_DE_PARALLEL_STALL_MS;
+  const raw = process.env.HF_DE_STALL_MS;
   const parsed = raw ? Number(raw) : Number.NaN;
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DE_STALL_MS;
 }


### PR DESCRIPTION
## What

Removes seven environment toggles from `packages/engine` and `packages/producer` whose rollout finished more than two weeks ago. Each was left at its default, so only one side of the branch was live.

| Flag | Why it goes |
|---|---|
| `HF_FAST_CAPTURE_ROOT_PROPS` | default-on since 2026-07-06 |
| `HF_FAST_CAPTURE_INTERVAL_SS` | default-on since 2026-07-06 |
| `HF_FAST_CAPTURE_INTERVAL_FRACTION` | tuning knob, never moved off its default of `0` |
| `HF_FAST_CAPTURE_AUTOALPHA` | retired 2026-07-06; the read only logged a deprecation warning |
| `HF_STATIC_DEDUP_VERIFY` | default-on since 2026-06-18; the code comment already marked disabling it "unsafe" |
| `HF_STATIC_DEDUP_SAMPLES` | tuning knob, never moved off its default of `24` |
| `HF_DE_PARALLEL_STALL_MS` | pre-rename alias for `HF_DE_STALL_MS`, bridged "for one release" on 2026-07-15; 20 releases have shipped since |

## Why

The env surface has grown to ~57 toggles, and it conflates two different things: long-lived configuration (binary paths, URLs, timeouts) and short-lived rollout flags. The rollout flags are the ones that rot: once the feature is on for everyone, the flag is a dead branch that still has to be read, documented, and reasoned about at every call site.

This PR clears only the fully rolled-out group. The dead code goes with them: `HF_FAST_CAPTURE_AUTOALPHA` had no effect at all, and `HF_DE_PARALLEL_STALL_MS` was an explicitly time-boxed compatibility alias whose box expired.

## How

No behavior change. Every flag was removed by inlining its default:

- Boolean opt-outs (`ROOT_PROPS`, `INTERVAL_SS`, `STATIC_DEDUP_VERIFY`) became unconditional.
- Numeric knobs became named constants. `HF_STATIC_DEDUP_SAMPLES` is now `STATIC_VERIFY_SAMPLE_FLOOR = 24`; `HF_FAST_CAPTURE_INTERVAL_FRACTION` was `0`, so the `atRiskFraction > fractionFloor` comparison collapses into the existing `atRisk.size > 0` check.
- `computeStaticVerificationPoints(a, b, sampleCount)` keeps its `sampleCount` parameter so its unit tests still exercise the scaling behavior; only the env plumbing into it is gone.
- The one test asserting the `HF_DE_PARALLEL_STALL_MS` alias is deleted along with the alias. The sibling test covering `HF_DE_STALL_MS` still passes.

Net -44 lines.

### Deliberately not in scope

These read as flags but are not fully rolled out, so they stay:

- `PRODUCER_EXPERIMENTAL_FAST_CAPTURE`, `HF_DE_PARALLEL_ROUTER`, `HF_CAPTURE_PARALLEL_STREAM` - still default-off experiments, all touched within the last two weeks.
- `HF_FAST_CAPTURE_3D` / `_BLEND` / `_ANCESTOR_BG` / `_CSSFX`, `HF_FORCE_DRAWELEMENT`, `HF_DE_PAR_DEBUG`, `HF_SHADER_POOL_TRACE` - default-off R&D and diagnostic escape hatches, not rollout gates.
- `HYPERFRAMES_GSAP_WRITER` - an in-flight recast/acorn migration.
- `HYPERFRAMES_*` binary paths, URLs, cache dirs, timeouts - the long-lived configuration half of the surface.

Two more are worth a follow-up but are behavior deletions rather than flag reads, so they do not belong here:

- `HF_FAST_CAPTURE_BOUNDARY_SS` - rolled *back* rather than out. The proactive boundary-screenshot path is now opt-in because it was measured net-harmful, so removing the flag means deleting that path and the `deBoundaryFrames` telemetry field with it.
- `HF_STATIC_DEDUP` and `HF_DE_WORKER_ENCODE` - genuine kill switches for perf features that can damage frames. Defensible to keep for now; worth revisiting once the telemetry stops moving.

## Test plan

- [x] Unit tests added/updated - deleted the obsolete `HF_DE_PARALLEL_STALL_MS` alias test; updated two stale comments referencing removed flags.
- [x] Manual testing performed - see below.
- [ ] Documentation updated (if applicable) - not needed; a repo-wide grep confirms none of the seven appear in `docs/`, `skills/`, or `registry/`.

```
bun run build                                          # green
packages/engine:   bunx tsc --noEmit                   # clean
packages/producer: bunx tsc --noEmit                   # clean
packages/engine:   bunx vitest run src/services/frameCapture*   # 17 files, 148 tests pass
packages/producer: bun test src/services/render/stages/captureStreamingStage.test.ts   # 10 pass
bunx oxlint <4 changed files>                          # 0 warnings, 0 errors
bunx oxfmt --check <4 changed files>                   # clean
```

Grep confirms zero remaining references to any of the seven names across the repo.
