### PR TITLE
fix(lint): don't flag unresolved templating-token asset srcs as missing

### DIFF
--- a/packages/lint/src/hevcPreviewLint.ts
+++ b/packages/lint/src/hevcPreviewLint.ts
@@ -3,6 +3,7 @@ import { rewriteAssetPath } from "@hyperframes/parsers/asset-paths";
 import { findFfBinary } from "@hyperframes/parsers/ff-binaries";
 import {
   cleanAssetUrl,
+  hasUnresolvedTemplatingToken,
   isRemoteOrInlineUrl,
   maskNonScannableRanges,
   resolveExistingLocalAsset,
@@ -85,7 +86,10 @@ export function collectLocalVideoCandidates(
     const re = new RegExp(videoSrcRe.source, videoSrcRe.flags);
     let match: RegExpExecArray | null;
     while ((match = re.exec(scannable)) !== null) {
-      const src = cleanAssetUrl(match[1] ?? "");
+      const rawSrc = match[1] ?? "";
+      // Check the RAW value: cleanAssetUrl() splits on ?/# and would chop inside a ${...} token.
+      if (hasUnresolvedTemplatingToken(rawSrc)) continue;
+      const src = cleanAssetUrl(rawSrc);
       if (!src) continue;
       if (isRemoteOrInlineUrl(src)) continue;
       if (/^__[A-Z_]+__$/.test(src)) continue;

--- a/packages/lint/src/project.test.ts
+++ b/packages/lint/src/project.test.ts
@@ -453,3 +453,58 @@ describe("audio_src_not_found with templating tokens", () => {
     expect(await hasAudioSrcNotFound(audioProject("audio/missing.mp3"))).toBe(true);
   });
 });
+
+describe("templating tokens are checked on the raw src, before cleanAssetUrl", () => {
+  // cleanAssetUrl splits on ?/#, which also chops inside a ${...} expression
+  // (e.g. `${asset?.url}` -> `${asset`). The token skip must run on the RAW value or
+  // these still false-positive at the video/img/source and CSS-url() sites.
+  function projectWith(bodyInner: string): string {
+    return makeProject(`<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div>
+  ${bodyInner}
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines["main"] = gsap.timeline({ paused: true });</script>
+</body></html>`);
+  }
+  async function codes(project: string): Promise<Set<string>> {
+    const { results } = await lintProject(project);
+    return new Set(results.flatMap((entry) => entry.result.findings).map((f) => f.code));
+  }
+
+  // The blocker: ?/# lives inside the templating expression, so cleanAssetUrl truncates it.
+  const TRICKY = ["${asset?.url}", "${a ?? b}", "${u}?v=1", "<<video_x>>", "{{ videoUrl }}"];
+
+  it("does not flag missing_local_asset for <video> token srcs (incl. ?/# inside ${...})", async () => {
+    for (const src of TRICKY) {
+      const c = await codes(
+        projectWith(
+          `<video id="v1" class="clip" src="${src}" muted data-start="0" data-duration="3"></video>`,
+        ),
+      );
+      expect(c.has("missing_local_asset")).toBe(false);
+    }
+  });
+
+  it("does not flag missing_local_asset for <img> token srcs (incl. ?/# inside ${...})", async () => {
+    for (const src of TRICKY) {
+      const c = await codes(projectWith(`<img src="${src}" />`));
+      expect(c.has("missing_local_asset")).toBe(false);
+    }
+  });
+
+  it("does not flag texture_mask_asset_not_found for CSS url() token values (incl. ?/# inside ${...})", async () => {
+    for (const url of ["${asset?.url}", "${a ?? b}"]) {
+      const c = await codes(projectWith(`<div style="mask-image: url(${url})"></div>`));
+      expect(c.has("texture_mask_asset_not_found")).toBe(false);
+    }
+  });
+
+  it("still flags a genuinely missing local video file", async () => {
+    const c = await codes(
+      projectWith(
+        `<video id="v1" class="clip" src="assets/missing.mp4" muted data-start="0" data-duration="3"></video>`,
+      ),
+    );
+    expect(c.has("missing_local_asset")).toBe(true);
+  });
+});

--- a/packages/lint/src/project.test.ts
+++ b/packages/lint/src/project.test.ts
@@ -424,3 +424,32 @@ describe("hevc_preview_codec", () => {
     expect(mockExecFile).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("audio_src_not_found with templating tokens", () => {
+  // A src carrying an unresolved templating placeholder is late-bound before render,
+  // so the static linter cannot resolve it to a file and must not report it missing.
+  function audioProject(src: string): string {
+    return makeProject(`<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div>
+  <audio id="a1" class="clip" data-start="0" data-duration="3" data-track-index="10" src="${src}"></audio>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines["main"] = gsap.timeline({ paused: true });</script>
+</body></html>`);
+  }
+
+  async function hasAudioSrcNotFound(project: string): Promise<boolean> {
+    const { results } = await lintProject(project);
+    const findings: HyperframeLintFinding[] = results.flatMap((entry) => entry.result.findings);
+    return findings.some((finding) => finding.code === "audio_src_not_found");
+  }
+
+  it("does not flag unresolved <<token>>, {{ token }}, or ${token} audio srcs", async () => {
+    for (const token of ["<<tts_abc>>", "{{ audioUrl }}", "${audioUrl}"]) {
+      expect(await hasAudioSrcNotFound(audioProject(token))).toBe(false);
+    }
+  });
+
+  it("still flags a genuinely missing local audio file", async () => {
+    expect(await hasAudioSrcNotFound(audioProject("audio/missing.mp3"))).toBe(true);
+  });
+});

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -6,6 +6,7 @@ import { checkSubCompositionUsability } from "@hyperframes/parsers/sub-compositi
 import { parseHTML } from "linkedom";
 import {
   cleanAssetUrl,
+  hasUnresolvedTemplatingToken,
   isRemoteOrInlineUrl,
   isWithinProjectRoot,
   maskNonScannableRanges,
@@ -283,6 +284,7 @@ function lintAudioSrcNotFound(
       const src = match[1]!;
       if (/^(https?:|data:|blob:)/i.test(src)) continue;
       if (/^__[A-Z_]+__$/.test(src)) continue;
+      if (hasUnresolvedTemplatingToken(src)) continue;
       const rootRelative = compSrcPath ? rewriteAssetPath(compSrcPath, src) : src;
       if (!resolveLocalAssetCandidates(projectDir, rootRelative).some(existsSync)) {
         missingSrcs.push(src);
@@ -328,6 +330,7 @@ function lintMissingLocalAsset(
       if (!src) continue;
       if (isRemoteOrInlineUrl(src)) continue;
       if (/^__[A-Z_]+__$/.test(src)) continue;
+      if (hasUnresolvedTemplatingToken(src)) continue;
       const rootRelative = compSrcPath ? rewriteAssetPath(compSrcPath, src) : src;
       const resolvedAsset = resolveExistingLocalAsset(projectDir, rootRelative);
       if (resolvedAsset) continue;
@@ -378,6 +381,7 @@ function lintTextureMaskAssetNotFound(
         const url = cleanAssetUrl(rawUrl);
         if (!url || isRemoteOrInlineUrl(url)) continue;
         if (/^__[A-Z_]+__$/.test(url)) continue;
+        if (hasUnresolvedTemplatingToken(url)) continue;
 
         const candidates = resolveCssAssetCandidates(
           projectDir,
@@ -526,6 +530,7 @@ function lintMissingOrEmptySubComposition(
       const srcPath = (match[1] ?? "").trim();
       if (!srcPath) continue;
       if (/^__[A-Z_]+__$/.test(srcPath)) continue; // template placeholder
+      if (hasUnresolvedTemplatingToken(srcPath)) continue; // late-bound templating token
 
       // data-composition-src is always written root-relative (even from a
       // nested sub-composition) — matches the resolution the renderer uses

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -326,11 +326,12 @@ function lintMissingLocalAsset(
     while ((match = re.exec(scannable)) !== null) {
       const tagName = (match[1] ?? "").toLowerCase();
       const rawSrc = match[2] ?? "";
+      // Check the RAW value: cleanAssetUrl() splits on ?/# and would chop inside a ${...} token.
+      if (hasUnresolvedTemplatingToken(rawSrc)) continue;
       const src = cleanAssetUrl(rawSrc);
       if (!src) continue;
       if (isRemoteOrInlineUrl(src)) continue;
       if (/^__[A-Z_]+__$/.test(src)) continue;
-      if (hasUnresolvedTemplatingToken(src)) continue;
       const rootRelative = compSrcPath ? rewriteAssetPath(compSrcPath, src) : src;
       const resolvedAsset = resolveExistingLocalAsset(projectDir, rootRelative);
       if (resolvedAsset) continue;
@@ -378,10 +379,11 @@ function lintTextureMaskAssetNotFound(
       const pattern = new RegExp(MASK_IMAGE_URL_RE.source, MASK_IMAGE_URL_RE.flags);
       while ((match = pattern.exec(cssSource.content)) !== null) {
         const rawUrl = match[1] ?? match[2] ?? match[3] ?? "";
+        // Check the RAW value: cleanAssetUrl() splits on ?/# and would chop inside a ${...} token.
+        if (hasUnresolvedTemplatingToken(rawUrl)) continue;
         const url = cleanAssetUrl(rawUrl);
         if (!url || isRemoteOrInlineUrl(url)) continue;
         if (/^__[A-Z_]+__$/.test(url)) continue;
-        if (hasUnresolvedTemplatingToken(url)) continue;
 
         const candidates = resolveCssAssetCandidates(
           projectDir,

--- a/packages/parsers/src/assetResolution.ts
+++ b/packages/parsers/src/assetResolution.ts
@@ -18,8 +18,10 @@ export function isRemoteOrInlineUrl(url: string): boolean {
  * `<<token>>`, `{{ token }}`, or `${token}` — that a build or templating step
  * substitutes before render. The static linter runs before that substitution,
  * so it cannot resolve such a value to a file on disk and must not report it as
- * a missing asset. (The legacy `__UPPER__` placeholder shape is matched
- * separately at each call site.)
+ * a missing asset. Check the RAW url, before any `cleanAssetUrl()` step: that
+ * splits on `?`/`#`, which also chops inside a `${...}` expression. (The older
+ * `__UPPER__` placeholder shape predates this and keeps its own inline check at
+ * each call site.)
  */
 export function hasUnresolvedTemplatingToken(url: string): boolean {
   return /<<[^<>]+>>|\{\{[^{}]+\}\}|\$\{[^{}]+\}/.test(url);

--- a/packages/parsers/src/assetResolution.ts
+++ b/packages/parsers/src/assetResolution.ts
@@ -13,6 +13,18 @@ export function isRemoteOrInlineUrl(url: string): boolean {
   return /^(https?:|data:|blob:|\/\/|#)/i.test(url);
 }
 
+/**
+ * True when a URL still contains an unresolved templating placeholder —
+ * `<<token>>`, `{{ token }}`, or `${token}` — that a build or templating step
+ * substitutes before render. The static linter runs before that substitution,
+ * so it cannot resolve such a value to a file on disk and must not report it as
+ * a missing asset. (The legacy `__UPPER__` placeholder shape is matched
+ * separately at each call site.)
+ */
+export function hasUnresolvedTemplatingToken(url: string): boolean {
+  return /<<[^<>]+>>|\{\{[^{}]+\}\}|\$\{[^{}]+\}/.test(url);
+}
+
 export function cleanAssetUrl(url: string): string {
   return url.trim().split(/[?#]/, 1)[0] ?? "";
 }


### PR DESCRIPTION
## What

Stop `audio_src_not_found` (and the sibling local-asset rules) from flagging `<audio>` / `<video>` / `<img>` / CSS `url()` / `data-composition-src` sources that are unresolved templating placeholders (`<<token>>`, `{{ token }}`, `${token}`) as missing files.

## Why

The project linter runs before any build or templating step, so a `src` can legitimately still be a templating token that a later step substitutes with a real URL. The asset-src rules already skip remote URLs and `__UPPER__` placeholders, but treat any other non-file-looking `src` as a missing local asset and raise an error ("...not found in the project. The rendered video will be silent."). For any pipeline that late-binds asset URLs this is a false positive — the file is not missing, the value simply is not resolved yet — producing spurious "video will be silent" errors and, in agent-driven authoring, wasted fix/re-validate loops chasing a non-issue.

## How

Add a shared `hasUnresolvedTemplatingToken(url)` predicate in `@hyperframes/parsers/asset-resolution` that matches the common templating-delimiter shapes (`<<...>>`, `{{...}}`, `${...}`), and skip such srcs at each asset-src lint site (audio, local video/img/source, CSS `url()`, and `data-composition-src`), alongside the existing `__UPPER__` placeholder skip. Net effect: these rules fire only for srcs that actually look like resolvable local paths. No behavior change for real files or remote URLs.

## Test plan

- [x] Unit tests added/updated — new cases in `packages/lint/src/project.test.ts` assert token srcs (`<<token>>`, `{{ }}`, `${}`) do NOT flag `audio_src_not_found`, while a genuinely missing local file still does. Full `@hyperframes/lint` suite green (507).
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)
