### PR TITLE
fix(docs): correct mediabunny GitHub link in CREDITS.md

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -25,6 +25,6 @@ broader Node.js ecosystem.
 
 ## Third-party licenses
 
-- **[mediabunny](https://github.com/nicoch/mediabunny)** — media toolkit used
+- **[mediabunny](https://github.com/Vanilagy/mediabunny)** — media toolkit used
   in the studio for fast metadata extraction from file headers. Licensed under
   the [Mozilla Public License 2.0 (MPL-2.0)](https://mozilla.org/MPL/2.0/).


### PR DESCRIPTION
The credited repo (github.com/nicoch/mediabunny) doesn't exist (404). The correct upstream is github.com/Vanilagy/mediabunny, matching the package's npm registry `repository` field and the MPL-2.0 license already cited in CREDITS.md.

## Test plan
- [x] Verified `github.com/nicoch/mediabunny` returns 404 via the GitHub API
- [x] Verified `github.com/Vanilagy/mediabunny` exists, is MPL-2.0 licensed, and matches the `repository` field in the published `mediabunny` npm package (used in `packages/studio/package.json`)