### PR TITLE
fix(docs): correct mediabunny GitHub link in CREDITS.md

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -25,6 +25,6 @@ broader Node.js ecosystem.
 
 ## Third-party licenses
 
-- **[mediabunny](https://github.com/nicoch/mediabunny)** — media toolkit used
+- **[mediabunny](https://github.com/Vanilagy/mediabunny)** — media toolkit used
   in the studio for fast metadata extraction from file headers. Licensed under
   the [Mozilla Public License 2.0 (MPL-2.0)](https://mozilla.org/MPL/2.0/).


### PR DESCRIPTION
Fixes the broken `mediabunny` credit so readers land on the active upstream repository whose npm metadata and MPL-2.0 license match the Studio dependency.

Supersedes #2896, which was closed only because the original contributor could not provide a signed commit. This replacement preserves @millieyesstore-del as the commit author and adds a maintainer signature.

Verification:

- `github.com/nicoch/mediabunny` returns 404.
- npm metadata points to `github.com/Vanilagy/mediabunny` under MPL-2.0.
- The upstream repository exists, is active, and reports MPL-2.0.
- `bunx oxfmt --check CREDITS.md`
- `git diff --check origin/main...HEAD`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
