### PR TITLE
test(pr-to-video): pin the code-vocabulary section of the frame packet

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -58,7 +58,7 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "922c2714750d5a54",
+      "hash": "41171bbed1c5d8f4",
       "files": 30
     },
     "product-launch-video": {

--- a/skills/pr-to-video/scripts/workflow-guardrails.test.mjs
+++ b/skills/pr-to-video/scripts/workflow-guardrails.test.mjs
@@ -141,6 +141,54 @@ test("code frames without an upstream-selected excerpt fail before dispatch", ()
   );
 });
 
+// The other half of this skill's frame-packets delta. The excerpt guard above is
+// pinned; the code-vocabulary injection was not — deleting `codeVocabularySection`
+// outright left all 455 skills tests green, so the section a code worker reads to
+// pick its registry block could have been dropped silently.
+test("a code frame carries the vocabulary excerpt for the block it names", () => {
+  const project = mkdtempSync(join(tmpdir(), "p2v-packets-vocab-"));
+  write(join(project, "frame.md"), "# frame\n");
+  write(
+    join(project, "STORYBOARD.md"),
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Diff\n\n- duration: 4s\n- src: compositions/frames/01-diff.html\n- focal: code-diff\n\n### Source excerpt\n\n\`\`\`diff\n-oldCall()\n+newCall()\n\`\`\`\n`,
+  );
+
+  const [packet] = buildFramePackets({ projectDir: project });
+  const contents = readFileSync(packet.path, "utf8");
+
+  assert.match(contents, /## Code block excerpt \(code-diff\)/);
+  assert.match(contents, /`code-diff`/);
+});
+
+test("a code block the vocabulary does not describe still names itself for install", () => {
+  const project = mkdtempSync(join(tmpdir(), "p2v-packets-vocab-miss-"));
+  write(join(project, "frame.md"), "# frame\n");
+  write(
+    join(project, "STORYBOARD.md"),
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Diff\n\n- duration: 4s\n- src: compositions/frames/01-diff.html\n- focal: code-not-in-the-vocabulary\n\n### Source excerpt\n\n\`\`\`diff\n-oldCall()\n+newCall()\n\`\`\`\n`,
+  );
+
+  const [packet] = buildFramePackets({ projectDir: project });
+
+  assert.match(
+    readFileSync(packet.path, "utf8"),
+    /## Code block\n\nUse registry block `code-not-in-the-vocabulary`\./,
+  );
+});
+
+test("a mechanism frame gets no code-block section at all", () => {
+  const project = mkdtempSync(join(tmpdir(), "p2v-packets-mechanism-"));
+  write(join(project, "frame.md"), "# frame\n");
+  write(
+    join(project, "STORYBOARD.md"),
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Mechanism\n\n- duration: 4s\n- src: compositions/frames/01-mechanism.html\n- focal: the request-lifecycle flow\n`,
+  );
+
+  const [packet] = buildFramePackets({ projectDir: project });
+
+  assert.doesNotMatch(readFileSync(packet.path, "utf8"), /## Code block/);
+});
+
 test("CLI capability detection rejects skills newer than the available command surface", () => {
   const stableHelp = `Project:\n  lint  Validate a composition\n  snapshot  Capture frames\n\nUnknown command check`;
   const currentHelp = `Project:\n  lint  Validate a composition\n  check Run the full project validation gate\n  snapshot  Capture frames`;


### PR DESCRIPTION
## What

Three test cases in `skills/pr-to-video/scripts/workflow-guardrails.test.mjs` covering the code-vocabulary half of this skill's frame-packet delta, plus the `skills-manifest.json` regeneration that goes with a changed skill.

## Why

`skills/pr-to-video/scripts/frame-packets.mjs` is a thin wrapper over the shared packet builder, and its header names the two reasons it exists:

> this file pins this workflow's paths plus its two behavioral differences: a code frame must carry an upstream-selected `### Source excerpt`, and code frames get a code-vocabulary excerpt appended to their packet.

The first difference is pinned — `"code frames without an upstream-selected excerpt fail before dispatch"` covers it. The second had no test anywhere in the repo. I confirmed that rather than assuming it: replacing the body of `codeVocabularySection` with `return ""`, which deletes the feature outright, left **all 455 skills tests green**.

That matters because the appended section is what tells a frame worker which registry block to install and what its inputs are. The worker never opens `code-vocabulary.md` itself, so if the section silently stopped being emitted, the symptom would be workers hand-building code motion instead of installing the purpose-built block — a quality regression with no red check anywhere.

One existing assertion touches this code path (`assert.doesNotMatch(codePacket, /code-scroll/)` on the `#1092` packet test), but it pins the *narrowing* only. It passes trivially when the section is empty, so it cannot detect deletion.

## How

The cases live beside the existing `frame-packets` tests in `workflow-guardrails.test.mjs` rather than in a new `frame-packets.test.mjs`, so this skill keeps one test home per module. (Both sibling skills use the `frame-packets.test.mjs` name, but their wrappers carry no delta — this skill put its packet tests in the guardrails file first, and splitting them across two files now would be worse than the naming asymmetry.)

- **`a code frame carries the vocabulary excerpt for the block it names`** — a `focal: code-diff` frame's packet gets the `## Code block excerpt (code-diff)` section and the block's own vocabulary line.
- **`a code block the vocabulary does not describe still names itself for install`** — an unrecognized `code-*` id falls back to `Use registry block \`<id>\`.` rather than emitting nothing, so the worker still learns what to install.
- **`a mechanism frame gets no code-block section at all`** — a non-code `focal` appends nothing.

Assertions are on the section's structure and the block id, not on the vocabulary's prose, so rewording `code-vocabulary.md` will not break them.

The `code-vocabulary.md`-missing branch inside `codeVocabularySection` is deliberately not covered: `SKILL_DIR` is resolved from `import.meta.url`, so that branch is only reachable by deleting a checked-in file.

## Test plan

- `node --test` on the full CI-discovered skills set: **458 pass, 0 fail** (455 before, +3 here).
- Sensitivity checked, not just presence: with `codeVocabularySection` neutered to `return ""`, the two positive cases **fail** and the seven pre-existing tests in the file stay green. Reverted before committing.
- `bun scripts/lint-skills.ts` clean (31 skill files), `node scripts/check-skill-mirror.mjs` clean (24 files byte-identical).
- `bun packages/cli/scripts/gen-skills-manifest.ts --check` reported `pr-to-video` out of date, regenerated, re-checked in sync (19 skills).
- `oxfmt --check` clean on the edited file.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

— Rames Jusso