### PR TITLE
docs(contributing): fix studio dev server port in setup guide

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -32,7 +32,7 @@ Thanks for your interest in contributing to Hyperframes! This guide covers every
     ```bash
     bun run dev
     ```
-    If the studio opens at `http://localhost:3000` with a preview, your environment is ready.
+    If the studio opens at `http://localhost:5190` with a preview, your environment is ready.
   </Step>
   <Step title="Create a branch">
     Create a feature branch for your work:


### PR DESCRIPTION
## What

Update the contributor setup guide to reference the correct studio dev server port.

## Why

`docs/contributing.mdx` told new contributors to expect the studio at `http://localhost:3000` after `bun run dev`, but the studio Vite dev server is configured for port **5190** in `packages/studio/vite.config.ts`. This causes false setup failures for contributors who follow the guide literally.

Self-sourced docs drift fix.

## How

- Change the verification URL in the "Run the studio" step from `localhost:3000` to `localhost:5190`.
- No behavior change — docs only.

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed — read `packages/studio/vite.config.ts` (`server.port: 5190`) and confirmed upstream `main` still documents `3000`
- [x] Documentation updated (if applicable)

**Verification:** `python3 scripts/preflight_ship.py --repo heygen-com/hyperframes --local . --branch main --file docs/contributing.mdx --must-contain 'http://localhost:3000' --must-not-contain 'http://localhost:5190' --search 'contributing studio port localhost'` → exit 0
