### PR TITLE
docs(studio): document monorepo dev server port

### DIFF
--- a/docs/packages/studio.mdx
+++ b/docs/packages/studio.mdx
@@ -45,6 +45,8 @@ bun run dev
 bun run --filter @hyperframes/studio dev
 ```
 
+The studio dev server listens on `http://localhost:5190` (see `packages/studio/vite.config.ts` `server.port`).
+
 ## Package Exports
 
 The studio has two entry points:


### PR DESCRIPTION
## Problem

After #2901 fixed the contributing setup guide to use `http://localhost:5190`, the `@hyperframes/studio` package docs still showed `bun run dev` without telling contributors which URL to open. The actual port is `5190` in `packages/studio/vite.config.ts` (`server.port`).

Self-sourced docs drift.

## Triage / Root cause

`docs/packages/studio.mdx` "From the monorepo" section omitted the dev-server URL while `docs/contributing.mdx` was corrected in #2901.

## Fix

Add one sentence noting the studio dev server listens on `http://localhost:5190`, with a pointer to `packages/studio/vite.config.ts` `server.port`.

## Verification

- `python3 ../open-source/scripts/preflight_ship.py --repo heygen-com/hyperframes --local . --branch main --file docs/packages/studio.mdx --must-contain 'bun run dev' --must-not-contain 'localhost:5190' --search 'studio port 5190'` → preflight clear before edit
- `bun run format:check -- docs/packages/studio.mdx` → passed
- Commit SSH-signed (verified on GitHub)

## Notes / Risks

Sibling to merged #2901 (contributing guide only). No behavior change.
