### PR TITLE
docs: fix preview port in DOCS_GUIDELINES example

### DIFF
--- a/DOCS_GUIDELINES.md
+++ b/DOCS_GUIDELINES.md
@@ -91,8 +91,7 @@ After CLI commands, show what the user should see:
 
 ```bash
 npx hyperframes preview
-# ✓ Server running at http://localhost:3000
-# ✓ Watching for changes...
+# Studio running at http://localhost:3002
 ```
 
 ### Use CodeGroup for multi-platform commands


### PR DESCRIPTION
## Problem

`DOCS_GUIDELINES.md` tells doc authors to show `npx hyperframes preview` output as:

```
# ✓ Server running at http://localhost:3000
# ✓ Watching for changes...
```

The CLI default preview port is **3002** (`packages/cli/src/commands/preview.ts` `args.port.default`), and the actual startup summary matches `packages/cli/README.md` (`Studio running at http://localhost:3002`). Self-sourced docs drift.

## Triage / Root cause

The guidelines example predates the current preview default and output format. Sibling docs (`packages/cli/README.md`, `docs/guides/video-editor-cheatsheet.mdx`) already use port 3002.

## Fix

Update the DOCS_GUIDELINES "Show expected output" example to use port 3002 and the current summary line.

## Verification

- `python3 ../open-source/scripts/preflight_ship.py --repo heygen-com/hyperframes --local . --branch main --file DOCS_GUIDELINES.md --must-contain 'localhost:3000' --must-not-contain 'localhost:3002' --search 'DOCS_GUIDELINES preview port 3002'` → preflight clear
- `bun run format:check -- DOCS_GUIDELINES.md` → passed
- Commit SSH-signed (`gpgsig` present on `0e84008da`)

## Notes / Risks

Docs-only; no behavior change. Sibling to merged #2901/#2902 (studio monorepo port 5190).
