### PR TITLE
fix: align local WebGPU capture behavior

### DIFF
--- a/packages/cli/src/browser/gpuPolicy.test.ts
+++ b/packages/cli/src/browser/gpuPolicy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertWebGpuRequirement,
+  compositionRequiresWebGpu,
+  resolveLocalBrowserGpuMode,
+} from "./gpuPolicy.js";
+
+describe("local browser GPU policy", () => {
+  it("defaults to auto and preserves explicit CLI/env overrides", () => {
+    expect(resolveLocalBrowserGpuMode(undefined, undefined)).toBe("auto");
+    expect(resolveLocalBrowserGpuMode(undefined, "hardware")).toBe("hardware");
+    expect(resolveLocalBrowserGpuMode(undefined, "software")).toBe("software");
+    expect(resolveLocalBrowserGpuMode(true, "software")).toBe("hardware");
+    expect(resolveLocalBrowserGpuMode(false, "hardware")).toBe("software");
+  });
+
+  it("detects the explicit WebGPU capability marker on the composition root", () => {
+    expect(
+      compositionRequiresWebGpu(
+        '<div data-requires-webgpu data-composition-id="gpu" data-duration="2"></div>',
+      ),
+    ).toBe(true);
+    expect(compositionRequiresWebGpu('<div data-composition-id="dom"></div>')).toBe(false);
+  });
+
+  it("rejects an auto software fallback for required WebGPU compositions", () => {
+    const html = '<div data-composition-id="gpu" data-requires-webgpu></div>';
+    expect(() => assertWebGpuRequirement(html, "auto", "software")).toThrow("data-requires-webgpu");
+    expect(() => assertWebGpuRequirement(html, "hardware", "hardware")).not.toThrow();
+    expect(() => assertWebGpuRequirement(html, "software", "software")).not.toThrow();
+  });
+});

--- a/packages/cli/src/browser/gpuPolicy.test.ts
+++ b/packages/cli/src/browser/gpuPolicy.test.ts
@@ -25,7 +25,9 @@ describe("local browser GPU policy", () => {
 
   it("rejects an auto software fallback for required WebGPU compositions", () => {
     const html = '<div data-composition-id="gpu" data-requires-webgpu></div>';
-    expect(() => assertWebGpuRequirement(html, "auto", "software")).toThrow("data-requires-webgpu");
+    expect(() => assertWebGpuRequirement(html, "auto", "software")).toThrow(
+      "PRODUCER_BROWSER_GPU_MODE=hardware",
+    );
     expect(() => assertWebGpuRequirement(html, "hardware", "hardware")).not.toThrow();
     expect(() => assertWebGpuRequirement(html, "software", "software")).not.toThrow();
   });

--- a/packages/cli/src/browser/gpuPolicy.ts
+++ b/packages/cli/src/browser/gpuPolicy.ts
@@ -1,0 +1,42 @@
+export type BrowserGpuMode = "auto" | "hardware" | "software";
+export type ResolvedBrowserGpuMode = Exclude<BrowserGpuMode, "auto">;
+
+export function resolveLocalBrowserGpuMode(
+  browserGpuArg?: boolean,
+  envMode = process.env.PRODUCER_BROWSER_GPU_MODE,
+): BrowserGpuMode {
+  if (browserGpuArg === true) return "hardware";
+  if (browserGpuArg === false) return "software";
+  if (envMode === "hardware" || envMode === "software" || envMode === "auto") return envMode;
+  return "auto";
+}
+
+export async function resolveCaptureBrowserGpuMode(
+  requestedMode: BrowserGpuMode,
+  chromePath?: string,
+): Promise<ResolvedBrowserGpuMode> {
+  const { resolveBrowserGpuMode } = await import("@hyperframes/engine");
+  return resolveBrowserGpuMode(requestedMode, { chromePath });
+}
+
+export function compositionRequiresWebGpu(html: string): boolean {
+  const compositionRoot = html.match(
+    /<[^>]*\bdata-composition-id(?:\s*=\s*("[^"]*"|'[^']*'|[^\s>]+))?[^>]*>/i,
+  );
+  return compositionRoot ? /\bdata-requires-webgpu(?:\s|=|>)/i.test(compositionRoot[0]) : false;
+}
+
+export function assertWebGpuRequirement(
+  html: string,
+  requestedMode: BrowserGpuMode,
+  resolvedMode: ResolvedBrowserGpuMode,
+): void {
+  if (requestedMode !== "auto" || resolvedMode !== "software" || !compositionRequiresWebGpu(html)) {
+    return;
+  }
+  throw new Error(
+    "This composition declares data-requires-webgpu, but browser GPU auto-detection found no hardware GPU. " +
+      "Run on a WebGPU-capable host or pass --browser-gpu to require hardware explicitly; " +
+      "use --no-browser-gpu only when intentionally testing the composition's software fallback.",
+  );
+}

--- a/packages/cli/src/browser/gpuPolicy.ts
+++ b/packages/cli/src/browser/gpuPolicy.ts
@@ -36,7 +36,8 @@ export function assertWebGpuRequirement(
   }
   throw new Error(
     "This composition declares data-requires-webgpu, but browser GPU auto-detection found no hardware GPU. " +
-      "Run on a WebGPU-capable host or pass --browser-gpu to require hardware explicitly; " +
+      "Run on a WebGPU-capable host or set PRODUCER_BROWSER_GPU_MODE=hardware " +
+      "(or pass --browser-gpu on commands that support it) to require hardware explicitly; " +
       "use --no-browser-gpu only when intentionally testing the composition's software fallback.",
   );
 }

--- a/packages/cli/src/capture/captureCompositionFrame.test.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.test.ts
@@ -55,12 +55,13 @@ describe("seekCompositionTimeline", () => {
     await seekCompositionTimeline(page, 1.25);
 
     expect(waitForFunction).not.toHaveBeenCalled();
-    expect(evaluate).toHaveBeenCalledTimes(3);
+    expect(evaluate).toHaveBeenCalledTimes(4);
     expect(evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), 1.25, false);
-    expect(evaluate.mock.calls[1]?.[0]).toContain("window.setTimeout(finish, 100)");
+    expect(evaluate).toHaveBeenNthCalledWith(2, expect.any(Function));
+    expect(evaluate.mock.calls[2]?.[0]).toContain("window.setTimeout(finish, 100)");
     // Post-seek font settle: a seek can reveal glyphs whose unicode-range
     // subsets only start loading after the next layout (CJK snapshot reports).
-    expect(evaluate).toHaveBeenNthCalledWith(3, expect.any(Function), 500);
+    expect(evaluate).toHaveBeenNthCalledWith(4, expect.any(Function), 500);
   });
 
   it("waitForFontsMs: 0 disables the post-seek font wait", async () => {
@@ -68,7 +69,7 @@ describe("seekCompositionTimeline", () => {
 
     await seekCompositionTimeline(page, 1.25, { waitForFontsMs: 0 });
 
-    expect(evaluate).toHaveBeenCalledTimes(2);
+    expect(evaluate).toHaveBeenCalledTimes(3);
   });
 
   it("prefers renderSeek so the runtime synchronizes clip visibility", async () => {
@@ -148,7 +149,7 @@ describe("seekCompositionTimeline", () => {
     await pending;
 
     expect(waitForFunction).toHaveBeenCalledWith(expect.any(Function), { timeout: 500 });
-    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(evaluate).toHaveBeenCalledTimes(2);
     expect(evaluate).toHaveBeenCalledWith(expect.any(Function), 3, true);
   });
 
@@ -165,39 +166,69 @@ describe("seekCompositionTimeline", () => {
     await vi.advanceTimersByTimeAsync(120);
     await pending;
 
-    expect(evaluate).toHaveBeenCalledTimes(3);
+    expect(evaluate).toHaveBeenCalledTimes(4);
     expect(evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), 4, true);
     expect(evaluate).toHaveBeenNthCalledWith(2, expect.any(Function));
-    expect(evaluate).toHaveBeenNthCalledWith(3, expect.any(Function), 500);
+    expect(evaluate).toHaveBeenNthCalledWith(3, expect.any(Function));
+    expect(evaluate).toHaveBeenNthCalledWith(4, expect.any(Function), 500);
+  });
+
+  it("awaits GPU completion registered by the seek event before settling", async () => {
+    let completeGpu: (() => void) | undefined;
+    const gpuWork = new Promise<void>((resolve) => {
+      completeGpu = resolve;
+    });
+    let evaluateCall = 0;
+    vi.stubGlobal("window", {
+      __player: { renderSeek: vi.fn() },
+      __hfWaitForSeekCompletion: () => gpuWork,
+    });
+    const page: CompositionSeekPage = {
+      evaluate: vi.fn(async (pageFunction, value, fallback) => {
+        evaluateCall += 1;
+        if (typeof pageFunction === "function") {
+          return Reflect.apply(pageFunction, undefined, [value, fallback]);
+        }
+      }),
+    };
+
+    let settled = false;
+    const pending = seekCompositionTimeline(page, 1, {
+      animationFrameSettle: "none",
+      waitForFontsMs: 0,
+    }).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(evaluateCall).toBe(2);
+    expect(settled).toBe(false);
+    completeGpu?.();
+    await pending;
+    expect(settled).toBe(true);
   });
 });
 
 describe("resolveCliChromeGpuMode", () => {
-  it("preserves validate's software-only opt-in mapping", () => {
+  it("preserves auto/hardware/software env mapping", () => {
     expect(resolveCliChromeGpuMode("software")).toBe("software");
     expect(resolveCliChromeGpuMode("hardware")).toBe("hardware");
-    expect(resolveCliChromeGpuMode("auto")).toBe("hardware");
-    expect(resolveCliChromeGpuMode("")).toBe("hardware");
+    expect(resolveCliChromeGpuMode("auto")).toBe("auto");
+    expect(resolveCliChromeGpuMode("")).toBe("auto");
   });
 });
 
 describe("screenshot Chrome arguments", () => {
-  it("leaves shared capture and layout on the engine's software default", () => {
-    const defaultScreenshotArgs =
-      /args:\s*buildChromeArgs\(\s*\{[^}]*captureMode:\s*"screenshot"[^}]*\}\s*\),/;
+  it("resolves auto once and launches shared captures with the concrete mode", () => {
     const captureSource = readFileSync(
       new URL("./captureCompositionFrame.ts", import.meta.url),
       "utf8",
     );
     const layoutSource = readFileSync(new URL("../commands/layout.ts", import.meta.url), "utf8");
 
-    // openSettledCompositionPage threads the caller's optional browserGpuMode;
-    // callers that omit it (snapshot, compare) fall through to the engine's
-    // software default for screenshot capture.
-    expect(captureSource).toMatch(
-      /args:\s*buildChromeArgs\(\s*\{[^}]*captureMode:\s*"screenshot"[^}]*\},\s*\{\s*browserGpuMode:\s*options\.browserGpuMode\s*\},?\s*\),/,
-    );
-    expect(layoutSource).toMatch(defaultScreenshotArgs);
+    expect(captureSource).toContain("resolveCaptureBrowserGpuMode(");
+    expect(captureSource).toContain("{ browserGpuMode: resolvedGpuMode }");
+    expect(layoutSource).toContain("resolveCaptureBrowserGpuMode(");
+    expect(layoutSource).toContain("{ browserGpuMode: resolvedGpuMode }");
   });
 });
 

--- a/packages/cli/src/capture/captureCompositionFrame.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.ts
@@ -1,6 +1,12 @@
 import { spawn } from "node:child_process";
 import type { Browser, Page } from "puppeteer-core";
 import { c } from "../ui/colors.js";
+import {
+  assertWebGpuRequirement,
+  resolveCaptureBrowserGpuMode,
+  resolveLocalBrowserGpuMode,
+  type BrowserGpuMode,
+} from "../browser/gpuPolicy.js";
 import { resolveCompositionViewportFromHtml } from "../utils/compositionViewport.js";
 import { resolveDiagnosticNavigationTimeoutMs } from "../utils/renderArgs.js";
 
@@ -66,9 +72,7 @@ export interface OpenSettledCompositionPageOptions {
   navigationTimeoutMs?: number;
   renderReadyTimeoutMs: number;
   renderReadyWarningSuffix: string;
-  // Screenshot paths take the engine's software-GPU default; validate/check
-  // thread the PRODUCER_BROWSER_GPU_MODE opt-in through here.
-  browserGpuMode?: "software" | "hardware";
+  browserGpuMode?: BrowserGpuMode;
   // Runs after the page exists but before page.goto, so console/pageerror/
   // request listeners can attach without missing load-time events.
   beforeNavigate?: (page: Page) => void | Promise<void>;
@@ -82,8 +86,8 @@ export interface FfmpegRunResult {
 
 export function resolveCliChromeGpuMode(
   envMode = process.env.PRODUCER_BROWSER_GPU_MODE,
-): "software" | "hardware" {
-  return envMode === "software" ? "software" : "hardware";
+): BrowserGpuMode {
+  return resolveLocalBrowserGpuMode(undefined, envMode);
 }
 
 function compositionRuntimeReadyInBrowser(): boolean {
@@ -167,6 +171,12 @@ export async function openSettledCompositionPage(
   const browser = await ensureBrowser();
   const puppeteer = await import("puppeteer-core");
   const { buildChromeArgs } = await import("@hyperframes/engine");
+  const requestedGpuMode = options.browserGpuMode ?? resolveCliChromeGpuMode();
+  const resolvedGpuMode = await resolveCaptureBrowserGpuMode(
+    requestedGpuMode,
+    browser.executablePath,
+  );
+  assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
 
   let chromeBrowser: Browser | undefined;
   try {
@@ -175,7 +185,7 @@ export async function openSettledCompositionPage(
       executablePath: browser.executablePath,
       args: buildChromeArgs(
         { ...viewport, captureMode: "screenshot" },
-        { browserGpuMode: options.browserGpuMode },
+        { browserGpuMode: resolvedGpuMode },
       ),
     });
 
@@ -255,6 +265,13 @@ export async function seekCompositionTimeline(
     timeSeconds,
     options.fallbackToBridgeAndTimelines === true,
   );
+
+  await page.evaluate(async () => {
+    const waitForCompletion = Reflect.get(window, "__hfWaitForSeekCompletion");
+    if (typeof waitForCompletion === "function") {
+      await Reflect.apply(waitForCompletion, window, []);
+    }
+  });
 
   const animationFrameSettle = options.animationFrameSettle ?? "race";
   if (animationFrameSettle === "race") {

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -17,6 +17,7 @@ import {
   type CheckSection,
 } from "../utils/checkPipeline.js";
 import type { CaptionZoneOptions, FrameCheckOptions, LayoutOptions } from "../utils/checkTypes.js";
+import { resolveLocalBrowserGpuMode } from "../browser/gpuPolicy.js";
 
 export const examples: Example[] = [
   ["Run the full verification gate", "hyperframes check"],
@@ -106,6 +107,12 @@ export function createCheckCommand(
           "Auto-transcode browser-hostile video codecs (default: hyperframes.json media.autoProxy, which defaults on)",
         default: undefined,
       },
+      "browser-gpu": {
+        type: "boolean",
+        description:
+          "Use hardware browser GPU capture; pass --no-browser-gpu for deterministic SwiftShader (default: auto-detect, PRODUCER_BROWSER_GPU_MODE overrides)",
+        default: undefined,
+      },
       snapshots: {
         type: "boolean",
         description: "Save the five contrast-pass PNGs under snapshots/",
@@ -175,6 +182,7 @@ function parseCheckOptions(args: Record<string, unknown>): CheckOptions {
     frameCheck: parseFrameCheck(args["frame-check"]),
     layout: parseLayout(args.layout),
     autoProxy: args.proxy as boolean | undefined,
+    browserGpuMode: resolveLocalBrowserGpuMode(args["browser-gpu"] as boolean | undefined),
   };
 }
 

--- a/packages/cli/src/commands/layout.ts
+++ b/packages/cli/src/commands/layout.ts
@@ -203,6 +203,8 @@ async function runLayoutAudit(
   const { ensureBrowser } = await import("../browser/manager.js");
   const puppeteer = await import("puppeteer-core");
   const { buildChromeArgs } = await import("@hyperframes/engine");
+  const { assertWebGpuRequirement, resolveCaptureBrowserGpuMode, resolveLocalBrowserGpuMode } =
+    await import("../browser/gpuPolicy.js");
   const html = await bundleProjectHtml(projectDir);
   const server = await serveStaticProjectHtml(
     projectDir,
@@ -213,10 +215,19 @@ async function runLayoutAudit(
 
   try {
     const browser = await ensureBrowser();
+    const requestedGpuMode = resolveLocalBrowserGpuMode();
+    const resolvedGpuMode = await resolveCaptureBrowserGpuMode(
+      requestedGpuMode,
+      browser.executablePath,
+    );
+    assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
     chromeBrowser = await puppeteer.default.launch({
       headless: true,
       executablePath: browser.executablePath,
-      args: buildChromeArgs({ width: 1920, height: 1080, captureMode: "screenshot" }),
+      args: buildChromeArgs(
+        { width: 1920, height: 1080, captureMode: "screenshot" },
+        { browserGpuMode: resolvedGpuMode },
+      ),
     });
 
     const page = await chromeBrowser.newPage();

--- a/packages/cli/src/commands/motionShot.test.ts
+++ b/packages/cli/src/commands/motionShot.test.ts
@@ -85,4 +85,37 @@ describe("motion-shot adapter seeking", () => {
     window.removeEventListener("hf-seek", handler);
     expect(settled).toBe(true);
   });
+
+  it("falls back to a completion-aware hf-seek when the runtime seek hook throws", async () => {
+    let finishGpuWork!: () => void;
+    const gpuWork = new Promise<void>((resolve) => {
+      finishGpuWork = resolve;
+    });
+    const handler = vi.fn((event: Event) => {
+      (
+        event as CustomEvent<{
+          waitUntil(promise: PromiseLike<unknown>): void;
+        }>
+      ).detail.waitUntil(gpuWork);
+    });
+    window.addEventListener("hf-seek", handler);
+    motionWindow.__player = {
+      renderSeek() {
+        throw new Error("runtime seek failed");
+      },
+    };
+
+    let settled = false;
+    const seeking = seekAllAdaptersInBrowser(2.5).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(settled).toBe(false);
+
+    finishGpuWork();
+    await seeking;
+    window.removeEventListener("hf-seek", handler);
+    expect(settled).toBe(true);
+  });
 });

--- a/packages/cli/src/commands/motionShot.test.ts
+++ b/packages/cli/src/commands/motionShot.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { seekAllAdaptersInBrowser } from "./motionShot.js";
+
+const motionWindow = window as Window & {
+  __player?: { renderSeek?: (time: number) => void };
+  __hfWaitForSeekCompletion?: () => Promise<void>;
+};
+
+afterEach(() => {
+  delete motionWindow.__player;
+  delete motionWindow.__hfWaitForSeekCompletion;
+  vi.restoreAllMocks();
+});
+
+describe("motion-shot adapter seeking", () => {
+  it("awaits GPU work registered by a standalone hf-seek listener", async () => {
+    let finishGpuWork!: () => void;
+    const gpuWork = new Promise<void>((resolve) => {
+      finishGpuWork = resolve;
+    });
+    const handler = (event: Event) => {
+      (
+        event as CustomEvent<{
+          waitUntil(promise: PromiseLike<unknown>): void;
+        }>
+      ).detail.waitUntil(gpuWork);
+    };
+    window.addEventListener("hf-seek", handler);
+
+    let settled = false;
+    const seeking = seekAllAdaptersInBrowser(1.5).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    finishGpuWork();
+    await seeking;
+    window.removeEventListener("hf-seek", handler);
+    expect(settled).toBe(true);
+  });
+
+  it("awaits the runtime completion hook without dispatching a second legacy seek event", async () => {
+    let finishGpuWork!: () => void;
+    const gpuWork = new Promise<void>((resolve) => {
+      finishGpuWork = resolve;
+    });
+    const handler = vi.fn();
+    window.addEventListener("hf-seek", handler);
+    motionWindow.__player = {
+      renderSeek(time) {
+        window.dispatchEvent(new CustomEvent("hf-seek", { detail: { time } }));
+      },
+    };
+    motionWindow.__hfWaitForSeekCompletion = () => gpuWork;
+
+    let settled = false;
+    const seeking = seekAllAdaptersInBrowser(2).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(settled).toBe(false);
+
+    finishGpuWork();
+    await seeking;
+    window.removeEventListener("hf-seek", handler);
+    expect(settled).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/motionShot.test.ts
+++ b/packages/cli/src/commands/motionShot.test.ts
@@ -118,4 +118,60 @@ describe("motion-shot adapter seeking", () => {
     window.removeEventListener("hf-seek", handler);
     expect(settled).toBe(true);
   });
+
+  it("drains runtime work when a runtime seek hook dispatches and then throws", async () => {
+    let finishRuntimeGpuWork!: () => void;
+    let finishFallbackGpuWork!: () => void;
+    const runtimeGpuWork = new Promise<void>((resolve) => {
+      finishRuntimeGpuWork = resolve;
+    });
+    const fallbackGpuWork = new Promise<void>((resolve) => {
+      finishFallbackGpuWork = resolve;
+    });
+    let runtimeCompletion: Promise<void> | undefined;
+    let dispatchCount = 0;
+    const handler = (event: Event) => {
+      dispatchCount += 1;
+      (
+        event as CustomEvent<{
+          waitUntil(promise: PromiseLike<unknown>): void;
+        }>
+      ).detail.waitUntil(dispatchCount === 1 ? runtimeGpuWork : fallbackGpuWork);
+    };
+    window.addEventListener("hf-seek", handler);
+    motionWindow.__player = {
+      renderSeek(time) {
+        const pending: PromiseLike<unknown>[] = [];
+        window.dispatchEvent(
+          new CustomEvent("hf-seek", {
+            detail: {
+              time,
+              waitUntil(promise: PromiseLike<unknown>) {
+                pending.push(promise);
+              },
+            },
+          }),
+        );
+        runtimeCompletion = Promise.all(pending).then(() => undefined);
+        throw new Error("runtime seek failed after dispatch");
+      },
+    };
+    motionWindow.__hfWaitForSeekCompletion = () => runtimeCompletion ?? Promise.resolve();
+
+    let settled = false;
+    const seeking = seekAllAdaptersInBrowser(3).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(dispatchCount).toBe(2);
+
+    finishFallbackGpuWork();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    finishRuntimeGpuWork();
+    await seeking;
+    window.removeEventListener("hf-seek", handler);
+    expect(settled).toBe(true);
+  });
 });

--- a/packages/cli/src/commands/motionShot.test.ts
+++ b/packages/cli/src/commands/motionShot.test.ts
@@ -1,8 +1,12 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { seekAllAdaptersInBrowser } from "./motionShot.js";
 
+const motionShotSourcePath = join(dirname(fileURLToPath(import.meta.url)), "motionShot.ts");
 const motionWindow = window as Window & {
   __player?: { renderSeek?: (time: number) => void };
   __hfWaitForSeekCompletion?: () => Promise<void>;
@@ -11,11 +15,14 @@ const motionWindow = window as Window & {
 afterEach(() => {
   delete motionWindow.__player;
   delete motionWindow.__hfWaitForSeekCompletion;
+  document.body.innerHTML = "";
   vi.restoreAllMocks();
 });
 
 describe("motion-shot adapter seeking", () => {
   it("awaits GPU work registered by a standalone hf-seek listener", async () => {
+    document.body.innerHTML =
+      '<div data-composition-id="gpu" data-requires-webgpu data-duration="2"></div>';
     let finishGpuWork!: () => void;
     const gpuWork = new Promise<void>((resolve) => {
       finishGpuWork = resolve;
@@ -40,6 +47,15 @@ describe("motion-shot adapter seeking", () => {
     await seeking;
     window.removeEventListener("hf-seek", handler);
     expect(settled).toBe(true);
+  });
+
+  it("launches through the shared GPU policy and WebGPU requirement guard", () => {
+    const source = readFileSync(motionShotSourcePath, "utf8");
+
+    expect(source).toContain("resolveCaptureBrowserGpuMode");
+    expect(source).toContain("assertWebGpuRequirement(html");
+    expect(source).toContain("{ browserGpuMode: resolvedGpuMode }");
+    expect(source).not.toContain('"--disable-gpu"');
   });
 
   it("awaits the runtime completion hook without dispatching a second legacy seek event", async () => {

--- a/packages/cli/src/commands/motionShot.ts
+++ b/packages/cli/src/commands/motionShot.ts
@@ -171,11 +171,12 @@ function compositeGhostFrames(
 // callback; it can only be reused by installing its source as a real page
 // global once, up front).
 export async function seekAllAdaptersInBrowser(tt: number): Promise<void> {
-  const tryCall = (fn: () => void): void => {
+  const tryCall = (fn: () => void): boolean => {
     try {
       fn();
+      return true;
     } catch {
-      /* best-effort */
+      return false;
     }
   };
   const w = window as unknown as {
@@ -199,18 +200,13 @@ export async function seekAllAdaptersInBrowser(tt: number): Promise<void> {
   let runtimeSeeked = false;
   const pendingGpuWork: PromiseLike<unknown>[] = [];
 
-  tryCall(() => {
-    if (typeof w.__player?.renderSeek === "function") {
-      runtimeSeeked = true;
-      w.__player.renderSeek(tt);
-    } else if (typeof w.__player?.seek === "function") {
-      runtimeSeeked = true;
-      w.__player.seek(tt);
-    } else if (typeof w.__hfReseekGpu === "function") {
-      runtimeSeeked = true;
-      w.__hfReseekGpu(tt);
-    }
-  });
+  if (typeof w.__player?.renderSeek === "function") {
+    runtimeSeeked = tryCall(() => w.__player?.renderSeek?.(tt));
+  } else if (typeof w.__player?.seek === "function") {
+    runtimeSeeked = tryCall(() => w.__player?.seek?.(tt));
+  } else if (typeof w.__hfReseekGpu === "function") {
+    runtimeSeeked = tryCall(() => w.__hfReseekGpu?.(tt));
+  }
 
   Object.values(w.__timelines ?? {}).forEach((tl) => {
     tryCall(() => {

--- a/packages/cli/src/commands/motionShot.ts
+++ b/packages/cli/src/commands/motionShot.ts
@@ -262,11 +262,7 @@ export async function seekAllAdaptersInBrowser(tt: number): Promise<void> {
   tryCall(() => w.__hfThreeRender?.());
   tryCall(() => w.gsap?.ticker?.tick?.());
 
-  if (runtimeSeeked) {
-    await w.__hfWaitForSeekCompletion?.();
-  } else {
-    await Promise.all(pendingGpuWork);
-  }
+  await Promise.all([Promise.all(pendingGpuWork), w.__hfWaitForSeekCompletion?.()]);
 }
 
 // Installs seekAllAdaptersInBrowser as a real `window` global, once per page

--- a/packages/cli/src/commands/motionShot.ts
+++ b/packages/cli/src/commands/motionShot.ts
@@ -13,6 +13,12 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { resolveDiagnosticNavigationTimeoutMs } from "../utils/renderArgs.js";
+import { resolveCompositionViewportFromHtml } from "../utils/compositionViewport.js";
+import {
+  assertWebGpuRequirement,
+  resolveCaptureBrowserGpuMode,
+  resolveLocalBrowserGpuMode,
+} from "../browser/gpuPolicy.js";
 import {
   buildOnionSvg,
   ghostAlphas,
@@ -156,14 +162,15 @@ function compositeGhostFrames(
 // Runs IN THE BROWSER. Self-contained (only `tt` + window/document — never a
 // Node-side closure variable), pauses/seeks every adapter to time `tt`: GSAP
 // `__timelines`, the Web Animations API, `__hfAnime` instances, then dispatches
-// `hf-seek` and nudges the three/GSAP render hooks. This one routine backs BOTH
+// `hf-seek` and nudges the three/GSAP render hooks. GPU work registered through
+// `waitUntil()` is awaited before returning. This one routine backs BOTH
 // the ghost-frame capture and the marker sampler below — see installSeekHelper
 // for why it's installed as a page global instead of being duplicated inline
 // (Puppeteer's page.evaluate only serializes the single function passed to it,
 // so a Node-side function can't be *called* from inside another evaluate
 // callback; it can only be reused by installing its source as a real page
 // global once, up front).
-function seekAllAdaptersInBrowser(tt: number): void {
+export async function seekAllAdaptersInBrowser(tt: number): Promise<void> {
   const tryCall = (fn: () => void): void => {
     try {
       fn();
@@ -173,6 +180,8 @@ function seekAllAdaptersInBrowser(tt: number): void {
   };
   const w = window as unknown as {
     __player?: { renderSeek?: (t: number) => void; seek?: (t: number) => void };
+    __hfReseekGpu?: (t: number) => void;
+    __hfWaitForSeekCompletion?: () => Promise<void>;
     __hfThreeTime?: number;
     __hfThreeRender?: () => void;
     __hfAnime?: Array<{ pause?: () => void; seek?: (timeMs: number) => void }>;
@@ -187,10 +196,20 @@ function seekAllAdaptersInBrowser(tt: number): void {
     >;
   };
   const timeMs = Math.max(0, tt * 1000);
+  let runtimeSeeked = false;
+  const pendingGpuWork: PromiseLike<unknown>[] = [];
 
   tryCall(() => {
-    if (typeof w.__player?.renderSeek === "function") w.__player.renderSeek(tt);
-    else if (typeof w.__player?.seek === "function") w.__player.seek(tt);
+    if (typeof w.__player?.renderSeek === "function") {
+      runtimeSeeked = true;
+      w.__player.renderSeek(tt);
+    } else if (typeof w.__player?.seek === "function") {
+      runtimeSeeked = true;
+      w.__player.seek(tt);
+    } else if (typeof w.__hfReseekGpu === "function") {
+      runtimeSeeked = true;
+      w.__hfReseekGpu(tt);
+    }
   });
 
   Object.values(w.__timelines ?? {}).forEach((tl) => {
@@ -223,12 +242,35 @@ function seekAllAdaptersInBrowser(tt: number): void {
     });
   }
 
-  tryCall(() => {
-    w.__hfThreeTime = tt;
-    window.dispatchEvent(new CustomEvent("hf-seek", { detail: { time: tt } }));
-    w.__hfThreeRender?.();
-    w.gsap?.ticker?.tick?.();
-  });
+  w.__hfThreeTime = tt;
+  if (!runtimeSeeked) {
+    let acceptingGpuWork = true;
+    try {
+      window.dispatchEvent(
+        new CustomEvent("hf-seek", {
+          detail: {
+            time: tt,
+            waitUntil(promise: PromiseLike<unknown>) {
+              if (!acceptingGpuWork) {
+                throw new Error("hf-seek waitUntil() must be called synchronously");
+              }
+              pendingGpuWork.push(promise);
+            },
+          },
+        }),
+      );
+    } finally {
+      acceptingGpuWork = false;
+    }
+  }
+  tryCall(() => w.__hfThreeRender?.());
+  tryCall(() => w.gsap?.ticker?.tick?.());
+
+  if (runtimeSeeked) {
+    await w.__hfWaitForSeekCompletion?.();
+  } else {
+    await Promise.all(pendingGpuWork);
+  }
 }
 
 // Installs seekAllAdaptersInBrowser as a real `window` global, once per page
@@ -243,6 +285,7 @@ async function installSeekHelper(page: import("puppeteer-core").Page): Promise<v
 // Launch headless Chrome, load the composition sized to its canvas, wait for the
 // timelines + fonts to be ready. Returns the browser (caller closes it), page, size.
 async function openCompositionPage(
+  html: string,
   url: string,
   executablePath: string,
 ): Promise<{
@@ -251,30 +294,21 @@ async function openCompositionPage(
   size: FrameSize;
 }> {
   const puppeteer = await import("puppeteer-core");
+  const { buildChromeArgs } = await import("@hyperframes/engine");
+  const size = resolveCompositionViewportFromHtml(html);
+  const requestedGpuMode = resolveLocalBrowserGpuMode();
+  const resolvedGpuMode = await resolveCaptureBrowserGpuMode(requestedGpuMode, executablePath);
+  assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
   const browser = await puppeteer.default.launch({
     headless: true,
     executablePath,
-    args: [
-      "--no-sandbox",
-      "--disable-gpu",
-      "--disable-dev-shm-usage",
-      "--enable-webgl",
-      "--use-gl=angle",
-      "--use-angle=swiftshader",
-    ],
+    args: buildChromeArgs(
+      { ...size, captureMode: "screenshot" },
+      { browserGpuMode: resolvedGpuMode },
+    ),
   });
   const page = await browser.newPage();
   const navigationTimeout = resolveDiagnosticNavigationTimeoutMs();
-  await page.goto(url, { waitUntil: "domcontentloaded", timeout: navigationTimeout });
-  const size = await page.evaluate(() => {
-    const root = document.querySelector("[data-composition-id][data-width][data-height]");
-    const w = root ? parseInt(root.getAttribute("data-width") ?? "", 10) : 0;
-    const h = root ? parseInt(root.getAttribute("data-height") ?? "", 10) : 0;
-    return {
-      width: Number.isFinite(w) && w > 0 ? Math.min(w, 4096) : 1920,
-      height: Number.isFinite(h) && h > 0 ? Math.min(h, 4096) : 1080,
-    };
-  });
   await page.setViewport(size);
   await page.goto(url, { waitUntil: "domcontentloaded", timeout: navigationTimeout });
   await page
@@ -436,10 +470,10 @@ async function resolveScopedRequests(
 // SAME tick — before the browser clears the GL drawing buffer (works without
 // preserveDrawingBuffer; page.screenshot can't see the GL buffer here).
 function captureGhostFrame(page: import("puppeteer-core").Page, t: number): Promise<string> {
-  return page.evaluate((tt: number) => {
-    (window as unknown as { __hfSeekAllAdapters?: (time: number) => void }).__hfSeekAllAdapters?.(
-      tt,
-    );
+  return page.evaluate(async (tt: number) => {
+    await (
+      window as unknown as { __hfSeekAllAdapters?: (time: number) => Promise<void> }
+    ).__hfSeekAllAdapters?.(tt);
     const root = (document.querySelector("[data-composition-id]") ?? document.body) as HTMLElement;
     const rb = root.getBoundingClientRect();
     const off = document.createElement("canvas");
@@ -537,8 +571,8 @@ async function captureMarkerOnionSkin(
   await applyOrbitCameraIfAngled(page, requests, camera);
 
   const elements = (await page.evaluate(
-    (selectors: string[], ts: number[]) => {
-      const seek = (window as unknown as { __hfSeekAllAdapters?: (t: number) => void })
+    async (selectors: string[], ts: number[]) => {
+      const seek = (window as unknown as { __hfSeekAllAdapters?: (t: number) => Promise<void> })
         .__hfSeekAllAdapters;
 
       const rigs = selectors.map((sel) => {
@@ -563,7 +597,7 @@ async function captureMarkerOnionSkin(
       });
       const out = selectors.map((selector) => ({ selector, samples: [] as PageSample[] }));
       for (const t of ts) {
-        seek?.(t);
+        await seek?.(t);
         rigs.forEach((rig, i) => {
           if (!rig) return;
           const pts = rig.markers.map((m) => {
@@ -638,7 +672,7 @@ export async function captureMotionPathShot(
   let browserInstance: import("puppeteer-core").Browser | undefined;
   try {
     const browser = await ensureBrowser();
-    const opened = await openCompositionPage(server.url, browser.executablePath);
+    const opened = await openCompositionPage(html, server.url, browser.executablePath);
     browserInstance = opened.browser;
     const { page, size } = opened;
 

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -69,6 +69,7 @@ import {
   startBackgroundPreview,
   stopBackgroundPreview,
 } from "./previewLifecycle.js";
+import { resolveLocalBrowserGpuMode, type BrowserGpuMode } from "../browser/gpuPolicy.js";
 
 interface BrowserLaunchOptions {
   noOpen?: boolean;
@@ -81,6 +82,7 @@ interface BrowserLaunchOptions {
 interface StudioLaunchOptions extends BrowserLaunchOptions {
   projectName?: string;
   autoProxy?: boolean;
+  browserGpuMode?: BrowserGpuMode;
 }
 
 interface EmbeddedStudioOptions extends StudioLaunchOptions {
@@ -205,6 +207,7 @@ export default defineCommand({
     },
   },
   async run({ args }) {
+    const browserGpuMode = resolveLocalBrowserGpuMode(args["browser-gpu"] as boolean | undefined);
     if (args["browser-gpu"] === true) process.env.PRODUCER_BROWSER_GPU_MODE = "hardware";
     if (args["browser-gpu"] === false) process.env.PRODUCER_BROWSER_GPU_MODE = "software";
     const startPort = parseInt(args.port ?? "3002", 10);
@@ -389,6 +392,7 @@ export default defineCommand({
       try {
         background = await startBackgroundPreview(dir, startPort, {
           forceNew: Boolean(args["force-new"]),
+          browserGpuMode,
         });
       } catch (error) {
         clack.log.error(errorMessage(error));
@@ -426,6 +430,7 @@ export default defineCommand({
       userDataDir,
       remoteDebuggingPort,
       browserNoGpu,
+      browserGpuMode,
     });
   },
 });
@@ -1055,6 +1060,7 @@ async function runEmbeddedMode(
     projectDir: dir,
     projectName: pName,
     autoProxy: options?.autoProxy,
+    browserGpuMode: options?.browserGpuMode,
   });
   const serverBuildSignature = await loadPreviewServerBuildSignature();
 
@@ -1066,6 +1072,8 @@ async function runEmbeddedMode(
       dir,
       !!options?.forceNew,
       serverBuildSignature,
+      undefined,
+      options?.browserGpuMode,
     );
   } catch (err: unknown) {
     s.stop(c.error("Failed to start studio"));

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -1,4 +1,5 @@
 import { setCommandExitCode, requestCliExit } from "../utils/commandResult.js";
+// fallow-ignore-file code-duplication
 import { defineCommand } from "citty";
 import type { Example } from "./_examples.js";
 import { spawn, type ChildProcessByStdio } from "node:child_process";
@@ -190,6 +191,12 @@ export default defineCommand({
       description:
         "Launch the opened browser with --disable-gpu (requires --browser-path). For hosts where hardware acceleration crashes the graphics driver (e.g. NVIDIA Xid resets); with the system default browser use --no-open instead.",
     },
+    "browser-gpu": {
+      type: "boolean",
+      description:
+        "Use hardware GPU for Studio thumbnails and frame capture; pass --no-browser-gpu for deterministic SwiftShader (default: auto-detect)",
+      default: undefined,
+    },
     proxy: {
       type: "boolean",
       description:
@@ -198,6 +205,8 @@ export default defineCommand({
     },
   },
   async run({ args }) {
+    if (args["browser-gpu"] === true) process.env.PRODUCER_BROWSER_GPU_MODE = "hardware";
+    if (args["browser-gpu"] === false) process.env.PRODUCER_BROWSER_GPU_MODE = "software";
     const startPort = parseInt(args.port ?? "3002", 10);
     const preferredContextPort = hasExplicitPreviewPort(process.argv) ? startPort : undefined;
 

--- a/packages/cli/src/commands/previewLifecycle.test.ts
+++ b/packages/cli/src/commands/previewLifecycle.test.ts
@@ -94,6 +94,32 @@ describe("background preview lifecycle", () => {
     expect(spawn).toHaveBeenCalledOnce();
   });
 
+  it("starts a replacement when the existing server uses a different GPU policy", async () => {
+    const hardwareServer = { ...server, browserGpuMode: "hardware" as const };
+    const softwareServer = {
+      ...server,
+      port: 3211,
+      pid: "5432",
+      browserGpuMode: "software" as const,
+    };
+    let scans = 0;
+    const scan = vi.fn(async () =>
+      ++scans < 2 ? [hardwareServer] : [hardwareServer, softwareServer],
+    );
+    const spawn = vi.fn(() => ({ pid: 5432, unref: vi.fn() }));
+
+    const result = await startBackgroundPreview(projectDir, 3002, {
+      browserGpuMode: "software",
+      scan,
+      spawn,
+      sleep: async () => {},
+      stateHome: mkdtempSync(join(tmpdir(), "hf-preview-state-")),
+    });
+
+    expect(result).toMatchObject({ type: "started", port: 3211, pid: 5432 });
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
   it("returns after a detached child becomes reachable and records its session", async () => {
     let scans = 0;
     const scan = vi.fn(async () => (++scans < 2 ? [] : [server]));

--- a/packages/cli/src/commands/previewLifecycle.ts
+++ b/packages/cli/src/commands/previewLifecycle.ts
@@ -12,6 +12,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { scanActiveServers, type ActiveServer } from "../server/portUtils.js";
+import type { BrowserGpuMode } from "../browser/gpuPolicy.js";
 import { killProcessTree } from "../utils/orphanCleanup.js";
 
 export interface PreviewSession {
@@ -41,6 +42,7 @@ interface LifecycleDependencies {
   kill?: (pid: number) => void;
   stateHome?: string;
   forceNew?: boolean;
+  browserGpuMode?: BrowserGpuMode;
 }
 
 function defaultStateHome(): string {
@@ -97,8 +99,18 @@ function removePreviewSession(projectDir: string, stateHome = defaultStateHome()
   rmSync(previewSessionPath(projectDir, stateHome), { force: true });
 }
 
-function matchingServer(servers: ActiveServer[], projectDir: string): ActiveServer | null {
-  return servers.find((server) => normalized(server.projectDir) === normalized(projectDir)) ?? null;
+function matchingServer(
+  servers: ActiveServer[],
+  projectDir: string,
+  browserGpuMode?: BrowserGpuMode,
+): ActiveServer | null {
+  return (
+    servers.find(
+      (server) =>
+        normalized(server.projectDir) === normalized(projectDir) &&
+        (browserGpuMode === undefined || server.browserGpuMode === browserGpuMode),
+    ) ?? null
+  );
 }
 
 function stopProcess(pid: number): void {
@@ -147,10 +159,11 @@ function startedServer(
   projectDir: string,
   existing: ActiveServer | null,
   forceNew: boolean,
+  browserGpuMode?: BrowserGpuMode,
 ): ActiveServer | null {
   const candidates =
     forceNew && existing ? servers.filter((server) => server.port !== existing.port) : servers;
-  return matchingServer(candidates, projectDir);
+  return matchingServer(candidates, projectDir, browserGpuMode);
 }
 
 export function buildBackgroundPreviewArgs(argv: string[]): string[] {
@@ -198,7 +211,7 @@ export async function startBackgroundPreview(
   | { type: "started"; port: number; pid: number; logPath: string }
 > {
   const scan = dependencies.scan ?? scanActiveServers;
-  const existing = matchingServer(await scan(startPort), projectDir);
+  const existing = matchingServer(await scan(startPort), projectDir, dependencies.browserGpuMode);
   if (existing && !dependencies.forceNew) {
     return {
       type: "reused",
@@ -218,6 +231,7 @@ export async function startBackgroundPreview(
       projectDir,
       existing,
       dependencies.forceNew === true,
+      dependencies.browserGpuMode,
     );
     if (server) {
       const session = {

--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -53,6 +53,13 @@ describe("transparent snapshot capture", () => {
     expect(source).toContain("autoProxy: args.proxy as boolean | undefined");
     expect(source).toContain("opts.autoProxy");
   });
+
+  it("resolves and forwards the shared local browser GPU policy", () => {
+    const source = readFileSync(new URL("./snapshot.ts", import.meta.url), "utf8");
+    expect(source).toContain("resolveLocalBrowserGpuMode");
+    expect(source).toContain("browserGpuMode: opts.browserGpuMode");
+    expect(source).toContain('"browser-gpu": {');
+  });
 });
 
 describe("resolveSnapshotVideoFrameTime", () => {

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -21,6 +21,7 @@ import { c } from "../ui/colors.js";
 import { findFFmpeg, getFFmpegInstallHint } from "../browser/ffmpeg.js";
 import { parseAngle, type Camera } from "./motionShotLayout.js";
 import type { Example } from "./_examples.js";
+import { resolveLocalBrowserGpuMode, type BrowserGpuMode } from "../browser/gpuPolicy.js";
 
 // Runs IN THE BROWSER (serialized into page.evaluate). Tilt the whole stage so
 // the REAL painted pixels are viewed from an orthogonal angle (FINDING [10]:
@@ -244,6 +245,7 @@ async function captureSnapshots(
     zoom?: ZoomTarget;
     zoomScale?: number;
     autoProxy?: boolean;
+    browserGpuMode?: BrowserGpuMode;
   },
 ): Promise<string[]> {
   const { bundleWithLocalizedFonts } = await import("../utils/bundleWithLocalizedFonts.js");
@@ -261,6 +263,7 @@ async function captureSnapshots(
     const { browser: chromeBrowser, page } = await openSettledCompositionPage(html, server.url, {
       renderReadyTimeoutMs: opts.timeout ?? 5000,
       renderReadyWarningSuffix: "snapshots may be inaccurate",
+      browserGpuMode: opts.browserGpuMode,
     });
 
     try {
@@ -638,6 +641,12 @@ export default defineCommand({
         "Auto-transcode browser-hostile video codecs for snapshots (default: on; overrides hyperframes.json media.autoProxy)",
       default: undefined,
     },
+    "browser-gpu": {
+      type: "boolean",
+      description:
+        "Use hardware browser GPU capture; pass --no-browser-gpu for deterministic SwiftShader (default: auto-detect, PRODUCER_BROWSER_GPU_MODE overrides)",
+      default: undefined,
+    },
   },
   async run({ args }) {
     const project = resolveProject(args.dir);
@@ -687,6 +696,7 @@ export default defineCommand({
         zoom: zoomTarget,
         zoomScale,
         autoProxy: args.proxy as boolean | undefined,
+        browserGpuMode: resolveLocalBrowserGpuMode(args["browser-gpu"] as boolean | undefined),
       });
 
       if (paths.length === 0) {

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -418,12 +418,20 @@ async function validateInBrowser(
     const browser = await ensureBrowser();
     const puppeteer = await import("puppeteer-core");
     const { buildChromeArgs, analyzeClipMediaFit } = await import("@hyperframes/engine");
+    const requestedGpuMode = resolveCliChromeGpuMode();
+    const { assertWebGpuRequirement, resolveCaptureBrowserGpuMode } =
+      await import("../browser/gpuPolicy.js");
+    const resolvedGpuMode = await resolveCaptureBrowserGpuMode(
+      requestedGpuMode,
+      browser.executablePath,
+    );
+    assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
     const chromeBrowser = await puppeteer.default.launch({
       headless: true,
       executablePath: browser.executablePath,
       args: buildChromeArgs(
         { ...viewport, captureMode: "screenshot" },
-        { browserGpuMode: resolveCliChromeGpuMode() },
+        { browserGpuMode: resolvedGpuMode },
       ),
     });
 

--- a/packages/cli/src/server/portUtils.test.ts
+++ b/packages/cli/src/server/portUtils.test.ts
@@ -193,4 +193,48 @@ describe("detectHyperframesServer", () => {
 
     expect(result).toEqual({ type: "match" });
   });
+
+  it("treats same-project servers with a different browser GPU policy as mismatch", async () => {
+    const projectDir = "/tmp/demo-project";
+    const port = await startConfigProbeServer({
+      isHyperframes: true,
+      projectName: "demo-project",
+      projectDir,
+      serverBuildSignature: "same-build",
+      browserGpuMode: "hardware",
+      version: "0.6.42",
+    });
+
+    const normalizedProjectDir = resolve(projectDir).replace(/\\/g, "/").toLowerCase();
+    const result = await detectHyperframesServer(
+      port,
+      normalizedProjectDir,
+      "same-build",
+      "software",
+    );
+
+    expect(result).toEqual({ type: "mismatch", projectName: "demo-project" });
+  });
+
+  it("matches same-project servers with the requested browser GPU policy", async () => {
+    const projectDir = "/tmp/demo-project";
+    const port = await startConfigProbeServer({
+      isHyperframes: true,
+      projectName: "demo-project",
+      projectDir,
+      serverBuildSignature: "same-build",
+      browserGpuMode: "software",
+      version: "0.6.42",
+    });
+
+    const normalizedProjectDir = resolve(projectDir).replace(/\\/g, "/").toLowerCase();
+    const result = await detectHyperframesServer(
+      port,
+      normalizedProjectDir,
+      "same-build",
+      "software",
+    );
+
+    expect(result).toEqual({ type: "match" });
+  });
 });

--- a/packages/cli/src/server/portUtils.ts
+++ b/packages/cli/src/server/portUtils.ts
@@ -16,6 +16,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { c } from "../ui/colors.js";
+import type { BrowserGpuMode } from "../browser/gpuPolicy.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -101,6 +102,7 @@ interface HyperframesConfigResponse {
   projectName: string;
   projectDir: string;
   serverBuildSignature?: string | null;
+  browserGpuMode?: BrowserGpuMode;
   version: string;
 }
 
@@ -117,6 +119,7 @@ export function detectHyperframesServer(
   port: number,
   normalizedProjectDir: string,
   expectedServerBuildSignature: string | null = null,
+  expectedBrowserGpuMode?: BrowserGpuMode,
 ): Promise<DetectionResult> {
   return new Promise<DetectionResult>((resolveResult) => {
     const req = http.get(
@@ -158,6 +161,12 @@ export function detectHyperframesServer(
               if (
                 expectedServerBuildSignature !== null &&
                 json.serverBuildSignature !== expectedServerBuildSignature
+              ) {
+                return resolveResult({ type: "mismatch", projectName: json.projectName });
+              }
+              if (
+                expectedBrowserGpuMode !== undefined &&
+                json.browserGpuMode !== expectedBrowserGpuMode
               ) {
                 return resolveResult({ type: "mismatch", projectName: json.projectName });
               }
@@ -217,6 +226,7 @@ export interface ActiveServer {
   projectDir: string;
   version: string;
   pid: string | null;
+  browserGpuMode?: BrowserGpuMode;
 }
 
 /**
@@ -289,6 +299,7 @@ export async function scanActiveServers(startPort = 3002): Promise<ActiveServer[
           projectDir: config.projectDir,
           version: config.version,
           pid,
+          browserGpuMode: config.browserGpuMode,
         };
       }),
     );
@@ -348,6 +359,7 @@ export async function findPortAndServe(
   forceNew: boolean,
   expectedServerBuildSignature: string | null = null,
   bindHost?: string,
+  expectedBrowserGpuMode?: BrowserGpuMode,
 ): Promise<FindPortResult> {
   const { createAdaptorServer } = await import("@hono/node-server");
   // SECURITY (F-001): bind to loopback by default. The studio API exposes
@@ -398,6 +410,7 @@ export async function findPortAndServe(
         port,
         normalizedDir,
         expectedServerBuildSignature,
+        expectedBrowserGpuMode,
       );
       if (detection.type === "match") {
         return { type: "already-running", port };

--- a/packages/cli/src/server/studioServer.test.ts
+++ b/packages/cli/src/server/studioServer.test.ts
@@ -66,4 +66,14 @@ describe("createStudioServer autoProxy plumbing", () => {
 
     expect(server.adapter.autoProxy).toBe(true);
   });
+
+  it("advertises the GPU policy used for thumbnail capture", async () => {
+    const projectDir = tmpProject();
+    server = createStudioServer({ projectDir, browserGpuMode: "software" });
+
+    const response = await server.app.request("/__hyperframes_config");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ browserGpuMode: "software" });
+  });
 });

--- a/packages/cli/src/server/studioServer.test.ts
+++ b/packages/cli/src/server/studioServer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadHyperframeRuntimeSource } from "@hyperframes/core";
@@ -9,6 +9,16 @@ import { createStudioServer, type StudioServer } from "./studioServer.js";
 describe("loadRuntimeSource", () => {
   it("loads runtime source from the published core entrypoint", async () => {
     await expect(loadRuntimeSource()).resolves.toBe(loadHyperframeRuntimeSource());
+  });
+});
+
+describe("Studio thumbnail GPU capture plumbing", () => {
+  it("uses the shared auto probe, resolved launch mode, requirement guard, and completion-aware seek", () => {
+    const source = readFileSync(new URL("./studioServer.ts", import.meta.url), "utf8");
+    expect(source).toContain("resolveCaptureBrowserGpuMode");
+    expect(source).toContain("{ browserGpuMode: resolvedGpuMode }");
+    expect(source).toContain("assertWebGpuRequirement");
+    expect(source).toContain("await seekCompositionTimeline(page, opts.seekTime");
   });
 });
 

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -35,6 +35,14 @@ import { resolveAutoProxy } from "../utils/projectConfig.js";
 import { getElementScreenshotClip } from "@hyperframes/studio-server/screenshot-clip";
 import type { ScreenshotClip } from "@hyperframes/studio-server/screenshot-clip";
 import type { RenderJob } from "@hyperframes/producer";
+import { seekCompositionTimeline } from "../capture/captureCompositionFrame.js";
+import {
+  assertWebGpuRequirement,
+  resolveCaptureBrowserGpuMode,
+  resolveLocalBrowserGpuMode,
+  type BrowserGpuMode,
+  type ResolvedBrowserGpuMode,
+} from "../browser/gpuPolicy.js";
 
 const STUDIO_MANUAL_EDITS_PATH = ".hyperframes/studio-manual-edits.json";
 const REMOTE_GIF_IMG_SRC_RE =
@@ -169,23 +177,37 @@ async function downloadRemoteGifImageSources(
 // share a single Chrome process instead of running two independent ones.
 
 let _thumbnailBrowserLease: import("@hyperframes/engine").BrowserLease | null = null;
-let _thumbnailBrowserInitializing: Promise<
-  import("@hyperframes/engine").BrowserLease | null
-> | null = null;
+let _thumbnailBrowserInitializing: Promise<ThumbnailBrowserSession | null> | null = null;
+let _thumbnailBrowserModes: {
+  requested: BrowserGpuMode;
+  resolved: ResolvedBrowserGpuMode;
+} | null = null;
 
-async function getThumbnailBrowser(): Promise<import("puppeteer-core").Browser | null> {
-  if (_thumbnailBrowserLease?.browser.connected) return _thumbnailBrowserLease.browser;
-  if (_thumbnailBrowserInitializing) {
-    return (await _thumbnailBrowserInitializing)?.browser ?? null;
+interface ThumbnailBrowserSession {
+  browser: import("puppeteer-core").Browser;
+  requestedGpuMode: BrowserGpuMode;
+  resolvedGpuMode: ResolvedBrowserGpuMode;
+}
+
+async function getThumbnailBrowser(): Promise<ThumbnailBrowserSession | null> {
+  if (_thumbnailBrowserLease?.browser.connected && _thumbnailBrowserModes) {
+    return {
+      browser: _thumbnailBrowserLease.browser,
+      requestedGpuMode: _thumbnailBrowserModes.requested,
+      resolvedGpuMode: _thumbnailBrowserModes.resolved,
+    };
   }
+  if (_thumbnailBrowserInitializing) return _thumbnailBrowserInitializing;
 
   _thumbnailBrowserInitializing = (async () => {
     try {
       const { ensureBrowser } = await import("../browser/manager.js");
       const { acquireBrowser, buildChromeArgs } = await import("@hyperframes/engine");
+      let executablePath: string | undefined;
 
       try {
         const b = await ensureBrowser({ preferManagedChrome: true });
+        executablePath = b.executablePath;
         if (b.executablePath && !process.env.PRODUCER_HEADLESS_SHELL_PATH) {
           process.env.PRODUCER_HEADLESS_SHELL_PATH = b.executablePath;
         }
@@ -193,16 +215,23 @@ async function getThumbnailBrowser(): Promise<import("puppeteer-core").Browser |
         /* continue — acquireBrowser will try its own resolution */
       }
 
+      const requestedGpuMode = resolveLocalBrowserGpuMode();
+      const resolvedGpuMode = await resolveCaptureBrowserGpuMode(requestedGpuMode, executablePath);
       const acquired = await acquireBrowser(
-        buildChromeArgs({ width: 1920, height: 1080, captureMode: "screenshot" }),
+        buildChromeArgs(
+          { width: 1920, height: 1080, captureMode: "screenshot" },
+          { browserGpuMode: resolvedGpuMode },
+        ),
         { forceScreenshot: true },
       );
       _thumbnailBrowserLease = acquired;
+      _thumbnailBrowserModes = { requested: requestedGpuMode, resolved: resolvedGpuMode };
       acquired.browser.on("disconnected", () => {
         if (_thumbnailBrowserLease === acquired) _thumbnailBrowserLease = null;
+        _thumbnailBrowserModes = null;
         _thumbnailBrowserInitializing = null;
       });
-      return acquired;
+      return { browser: acquired.browser, requestedGpuMode, resolvedGpuMode };
     } catch (err) {
       console.warn(
         "[Studio] Failed to launch thumbnail browser:",
@@ -213,13 +242,14 @@ async function getThumbnailBrowser(): Promise<import("puppeteer-core").Browser |
     }
   })();
 
-  return (await _thumbnailBrowserInitializing)?.browser ?? null;
+  return _thumbnailBrowserInitializing;
 }
 
 export async function closeThumbnailBrowser(): Promise<void> {
   if (!_thumbnailBrowserLease) return;
   const lease = _thumbnailBrowserLease;
   _thumbnailBrowserLease = null;
+  _thumbnailBrowserModes = null;
   _thumbnailBrowserInitializing = null;
   await lease.release().catch(() => {});
 }
@@ -494,14 +524,22 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     },
 
     async generateThumbnail(opts): Promise<Buffer | null> {
-      const browser = await getThumbnailBrowser();
-      if (!browser) {
+      const session = await getThumbnailBrowser();
+      if (!session) {
         console.warn("[Studio] Thumbnail: no browser available — Chrome may not be installed");
         return null;
       }
+      const sourcePath = join(opts.project.dir, opts.compPath);
+      if (existsSync(sourcePath)) {
+        assertWebGpuRequirement(
+          readFileSync(sourcePath, "utf-8"),
+          session.requestedGpuMode,
+          session.resolvedGpuMode,
+        );
+      }
       let page: import("puppeteer-core").Page | null = null;
       try {
-        page = await browser.newPage();
+        page = await session.browser.newPage();
         await page.setViewport({ width: opts.width || 1920, height: opts.height || 1080 });
         await page.goto(opts.previewUrl, { waitUntil: "domcontentloaded", timeout: 10000 });
         await page
@@ -515,22 +553,12 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
             { timeout: 5000 },
           )
           .catch(() => {});
-        // fallow-ignore-next-line code-duplication
-        await page.evaluate((t: number) => {
-          const w = window as Window & {
-            __player?: { seek?: (time: number) => void };
-            __timelines?: Record<string, { pause?: (time?: number) => void }>;
-            gsap?: { ticker?: { tick?: () => void } };
-          };
-          if (typeof w.__player?.seek === "function") {
-            w.__player.seek(t);
-          } else if (w.__timelines) {
-            for (const tl of Object.values(w.__timelines)) {
-              tl?.pause?.(t);
-            }
-            w.gsap?.ticker?.tick?.();
-          }
-        }, opts.seekTime);
+        await seekCompositionTimeline(page, opts.seekTime, {
+          fallbackToBridgeAndTimelines: true,
+          waitForPreferredSeekTargetMs: 500,
+          animationFrameSettle: "double",
+          waitForFontsMs: 500,
+        });
         const manifestContent = readStudioManualEditManifestContent(opts.project.dir);
         await applyStudioManualEditsToThumbnailPage(page, manifestContent, opts.compPath);
         await page.evaluate(() => {

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -235,7 +235,8 @@ async function getThumbnailBrowser(
       _thumbnailBrowserLease = acquired;
       _thumbnailBrowserModes = { requested: requestedGpuMode, resolved: resolvedGpuMode };
       acquired.browser.on("disconnected", () => {
-        if (_thumbnailBrowserLease === acquired) _thumbnailBrowserLease = null;
+        if (_thumbnailBrowserLease !== acquired) return;
+        _thumbnailBrowserLease = null;
         _thumbnailBrowserModes = null;
         _thumbnailBrowserInitializing = null;
       });

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -189,15 +189,24 @@ interface ThumbnailBrowserSession {
   resolvedGpuMode: ResolvedBrowserGpuMode;
 }
 
-async function getThumbnailBrowser(): Promise<ThumbnailBrowserSession | null> {
-  if (_thumbnailBrowserLease?.browser.connected && _thumbnailBrowserModes) {
+async function getThumbnailBrowser(
+  requestedGpuMode: BrowserGpuMode,
+): Promise<ThumbnailBrowserSession | null> {
+  if (
+    _thumbnailBrowserLease?.browser.connected &&
+    _thumbnailBrowserModes?.requested === requestedGpuMode
+  ) {
     return {
       browser: _thumbnailBrowserLease.browser,
       requestedGpuMode: _thumbnailBrowserModes.requested,
       resolvedGpuMode: _thumbnailBrowserModes.resolved,
     };
   }
-  if (_thumbnailBrowserInitializing) return _thumbnailBrowserInitializing;
+  if (_thumbnailBrowserInitializing) {
+    const session = await _thumbnailBrowserInitializing;
+    if (session?.requestedGpuMode === requestedGpuMode) return session;
+  }
+  if (_thumbnailBrowserLease) await closeThumbnailBrowser();
 
   _thumbnailBrowserInitializing = (async () => {
     try {
@@ -215,7 +224,6 @@ async function getThumbnailBrowser(): Promise<ThumbnailBrowserSession | null> {
         /* continue — acquireBrowser will try its own resolution */
       }
 
-      const requestedGpuMode = resolveLocalBrowserGpuMode();
       const resolvedGpuMode = await resolveCaptureBrowserGpuMode(requestedGpuMode, executablePath);
       const acquired = await acquireBrowser(
         buildChromeArgs(
@@ -267,6 +275,8 @@ export interface StudioServerOptions {
    * config (default true) applies.
    */
   autoProxy?: boolean | undefined;
+  /** GPU policy used by Studio thumbnails and frame capture. */
+  browserGpuMode?: BrowserGpuMode;
 }
 
 export interface StudioServer {
@@ -332,6 +342,7 @@ function rewriteWrittenToHostViewport(projectDir: string, written: string[]): vo
 export function createStudioServer(options: StudioServerOptions): StudioServer {
   const { projectDir, projectName } = options;
   const projectId = projectName || basename(projectDir);
+  const browserGpuMode = options.browserGpuMode ?? resolveLocalBrowserGpuMode();
   const studioDir = resolveDistDir();
   const runtimePath = resolveRuntimePath();
   const watcher = createProjectWatcher(projectDir);
@@ -524,7 +535,7 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     },
 
     async generateThumbnail(opts): Promise<Buffer | null> {
-      const session = await getThumbnailBrowser();
+      const session = await getThumbnailBrowser(browserGpuMode);
       if (!session) {
         console.warn("[Studio] Thumbnail: no browser available — Chrome may not be installed");
         return null;
@@ -653,6 +664,7 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
         projectName: projectId,
         projectDir: projectDir,
         serverBuildSignature,
+        browserGpuMode,
         version,
       });
     };

--- a/packages/cli/src/utils/checkBrowser.test.ts
+++ b/packages/cli/src/utils/checkBrowser.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+// fallow-ignore-file code-duplication
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -431,6 +432,49 @@ it("surfaces the runtime's media-proxy-unavailable console.info line as its own 
       code: "media_proxy_unavailable",
       severity: "info",
       message: unavailableMessage.text(),
+    }),
+  );
+});
+
+it("elevates and deduplicates WebGPU validation warnings while preserving ordinary warnings", async () => {
+  vi.spyOn(Date, "now").mockReturnValue(100);
+  mountCanvasFixture();
+  const page = fakePage();
+  const validationFailure = fakeConsoleMessage(
+    "warn",
+    "WebGPU uncaptured error: GPUValidationError: Destroyed texture used in a submit",
+  );
+  const ordinaryWarning = fakeConsoleMessage("warn", "Optional caption font was not loaded");
+  page.on = vi.fn(
+    (event: string, handler: (message: ReturnType<typeof fakeConsoleMessage>) => void) => {
+      if (event === "console") {
+        handler(validationFailure);
+        handler(validationFailure);
+        handler(ordinaryWarning);
+      }
+    },
+  );
+  installSessionMock(page);
+
+  const result = await runBrowserCheck(
+    PROJECT,
+    { ...DEFAULT_CHECK_OPTIONS, samples: 1, contrast: false },
+    { kind: "none" },
+    runAuditGrid,
+  );
+
+  expect(result.runtimeFindings).toContainEqual(
+    expect.objectContaining({
+      code: "webgpu_runtime_error",
+      severity: "error",
+      message: `${validationFailure.text()} (repeated 2 times)`,
+    }),
+  );
+  expect(result.runtimeFindings).toContainEqual(
+    expect.objectContaining({
+      code: "console_warning",
+      severity: "warning",
+      message: ordinaryWarning.text(),
     }),
   );
 });

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -58,6 +58,7 @@ interface RuntimeDraft {
   time: number;
   url?: string;
   line?: number;
+  count?: number;
 }
 
 interface AnchorRequest {
@@ -168,7 +169,7 @@ export async function runBrowserCheck(
       navigationTimeoutMs: options.timeout,
       renderReadyTimeoutMs: options.timeout,
       renderReadyWarningSuffix: "checking the current page state",
-      browserGpuMode: resolveCliChromeGpuMode(),
+      browserGpuMode: options.browserGpuMode ?? resolveCliChromeGpuMode(),
       beforeNavigate: (page) => wireRuntimeListeners(page, drafts, () => currentTime),
     });
     chromeBrowser = session.browser;
@@ -229,7 +230,7 @@ export async function captureFindingCrops(
       navigationTimeoutMs: options.timeout,
       renderReadyTimeoutMs: options.timeout,
       renderReadyWarningSuffix: "capturing finding crops",
-      browserGpuMode: resolveCliChromeGpuMode(),
+      browserGpuMode: options.browserGpuMode ?? resolveCliChromeGpuMode(),
     });
     chromeBrowser = session.browser;
     const page = session.page;
@@ -263,6 +264,31 @@ export async function captureFindingCrops(
 // `console.info` from a composition author's own script must not.
 const MEDIA_PROXY_MARKER_PREFIX = "[hyperframes] runtime_media_proxy_";
 const MEDIA_PROXY_UNAVAILABLE_MARKER = "[hyperframes] runtime_media_proxy_unavailable";
+const WEBGPU_RUNTIME_FAILURE =
+  /\b(?:GPUValidationError|GPUOutOfMemoryError|GPUInternalError)\b|WebGPU uncaptured error|(?:destroyed\b.*\b(?:GPU )?(?:resource|buffer|texture)\b.*\bsubmit)|(?:(?:GPU )?(?:resource|buffer|texture)\b.*\bdestroyed\b.*\bsubmit)/i;
+
+function isWebGpuRuntimeFailure(text: string): boolean {
+  return WEBGPU_RUNTIME_FAILURE.test(text);
+}
+
+function pushRuntimeDraft(drafts: RuntimeDraft[], draft: RuntimeDraft): void {
+  if (draft.code !== "webgpu_runtime_error") {
+    drafts.push(draft);
+    return;
+  }
+  const duplicate = drafts.find(
+    (entry) =>
+      entry.code === draft.code &&
+      entry.message === draft.message &&
+      entry.url === draft.url &&
+      entry.line === draft.line,
+  );
+  if (duplicate) {
+    duplicate.count = (duplicate.count ?? 1) + 1;
+    return;
+  }
+  drafts.push({ ...draft, count: 1 });
+}
 
 function wireRuntimeListeners(page: Page, drafts: RuntimeDraft[], currentTime: () => number): void {
   page.on("console", (message) => {
@@ -270,7 +296,7 @@ function wireRuntimeListeners(page: Page, drafts: RuntimeDraft[], currentTime: (
     const text = message.text();
     if (type === "error" && !text.startsWith("Failed to load resource")) {
       const location = message.location();
-      drafts.push({
+      pushRuntimeDraft(drafts, {
         code: "console_error",
         severity: "error",
         message: text,
@@ -280,9 +306,10 @@ function wireRuntimeListeners(page: Page, drafts: RuntimeDraft[], currentTime: (
       });
     } else if (type === "warn") {
       const location = message.location();
-      drafts.push({
-        code: "console_warning",
-        severity: "warning",
+      const webGpuFailure = isWebGpuRuntimeFailure(text);
+      pushRuntimeDraft(drafts, {
+        code: webGpuFailure ? "webgpu_runtime_error" : "console_warning",
+        severity: webGpuFailure ? "error" : "warning",
         message: text,
         time: currentTime(),
         url: location.url,
@@ -290,7 +317,7 @@ function wireRuntimeListeners(page: Page, drafts: RuntimeDraft[], currentTime: (
       });
     } else if (type === "info" && text.startsWith(MEDIA_PROXY_MARKER_PREFIX)) {
       const location = message.location();
-      drafts.push({
+      pushRuntimeDraft(drafts, {
         code: text.includes(MEDIA_PROXY_UNAVAILABLE_MARKER)
           ? "media_proxy_unavailable"
           : "media_proxy_fallback",
@@ -307,7 +334,12 @@ function wireRuntimeListeners(page: Page, drafts: RuntimeDraft[], currentTime: (
     if (message.includes("Unexpected token '<'") || message.includes("Unexpected token '&lt;'")) {
       return;
     }
-    drafts.push({ code: "page_error", severity: "error", message, time: currentTime() });
+    pushRuntimeDraft(drafts, {
+      code: "page_error",
+      severity: "error",
+      message,
+      time: currentTime(),
+    });
   });
   wireNetworkListeners(page, drafts, currentTime);
 }
@@ -1088,7 +1120,8 @@ function runtimeFinding(draft: RuntimeDraft, root: CheckAnchor): CheckFinding {
   return {
     code: draft.code,
     severity: draft.severity,
-    message: draft.message,
+    message:
+      (draft.count ?? 1) > 1 ? `${draft.message} (repeated ${draft.count} times)` : draft.message,
     selector: root.selector,
     dataAttributes: root.dataAttributes,
     sourceFile: root.sourceFile,

--- a/packages/cli/src/utils/checkPipeline.ts
+++ b/packages/cli/src/utils/checkPipeline.ts
@@ -85,6 +85,7 @@ export const DEFAULT_CHECK_OPTIONS: CheckOptions = {
   contrast: true,
   strict: false,
   snapshots: false,
+  browserGpuMode: "auto",
 };
 
 /** Pick at most five evenly-strided points from the already-merged layout grid. */

--- a/packages/cli/src/utils/checkTypes.ts
+++ b/packages/cli/src/utils/checkTypes.ts
@@ -3,6 +3,7 @@ import type { LayoutIssue, LayoutOverflow, LayoutRect } from "./layoutAudit.js";
 import type { Canvas, MotionFrame } from "./motionAudit.js";
 import type { MotionSpec } from "./motionSpec.js";
 import type { ProjectDir } from "./project.js";
+import type { BrowserGpuMode } from "../browser/gpuPolicy.js";
 
 export interface CheckOptions {
   samples: number;
@@ -22,6 +23,7 @@ export interface CheckOptions {
   layout?: LayoutOptions;
   /** Explicit --proxy/--no-proxy override; undefined preserves project config. */
   autoProxy?: boolean;
+  browserGpuMode?: BrowserGpuMode;
 }
 
 export interface CaptionZoneOptions {

--- a/packages/core/src/runtime/adapters/seek-dispatch.test.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.test.ts
@@ -71,4 +71,48 @@ describe("seek-dispatch", () => {
     await pending;
     expect(settled).toBe(true);
   });
+
+  it("retains overlapping seek generations until a capture observes them", async () => {
+    let finishFirst: (() => void) | undefined;
+    let finishSecond: (() => void) | undefined;
+    const firstGpuWork = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const secondGpuWork = new Promise<void>((resolve) => {
+      finishSecond = resolve;
+    });
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<HfSeekEventDetail>).detail;
+      detail.waitUntil(detail.time === 10 ? firstGpuWork : secondGpuWork);
+    };
+    window.addEventListener("hf-seek", handler);
+    dispatchSeekEvent(10);
+    dispatchSeekEvent(11);
+    window.removeEventListener("hf-seek", handler);
+
+    let settled = false;
+    const pending = waitForSeekCompletion().then(() => {
+      settled = true;
+    });
+    finishSecond?.();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    finishFirst?.();
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it("reports a rejected generation once, then consumes it", async () => {
+    const failure = new Error("GPU queue failed");
+    const handler = (event: Event) => {
+      (event as CustomEvent<HfSeekEventDetail>).detail.waitUntil(Promise.reject(failure));
+    };
+    window.addEventListener("hf-seek", handler);
+    dispatchSeekEvent(12);
+    window.removeEventListener("hf-seek", handler);
+
+    await expect(waitForSeekCompletion()).rejects.toBe(failure);
+    await expect(waitForSeekCompletion()).resolves.toBeUndefined();
+  });
 });

--- a/packages/core/src/runtime/adapters/seek-dispatch.test.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { dispatchSeekEvent, forceDispatchSeekEvent, resetSeekDispatchState } from "./seek-dispatch";
+import {
+  dispatchSeekEvent,
+  forceDispatchSeekEvent,
+  resetSeekDispatchState,
+  waitForSeekCompletion,
+  type HfSeekEventDetail,
+} from "./seek-dispatch";
 
 describe("seek-dispatch", () => {
   beforeEach(() => {
@@ -41,5 +47,28 @@ describe("seek-dispatch", () => {
     dispatchSeekEvent(8); // deduped — force already recorded t=8
     window.removeEventListener("hf-seek", handler);
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for all GPU work registered synchronously by listeners", async () => {
+    let finish: (() => void) | undefined;
+    const gpuWork = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const handler = (event: Event) => {
+      (event as CustomEvent<HfSeekEventDetail>).detail.waitUntil(gpuWork);
+    };
+    window.addEventListener("hf-seek", handler);
+    dispatchSeekEvent(9);
+    window.removeEventListener("hf-seek", handler);
+
+    let settled = false;
+    const pending = waitForSeekCompletion().then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    finish?.();
+    await pending;
+    expect(settled).toBe(true);
   });
 });

--- a/packages/core/src/runtime/adapters/seek-dispatch.test.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.test.ts
@@ -187,4 +187,28 @@ describe("seek-dispatch", () => {
     await expect(waitForSeekCompletion()).rejects.toBe(failure);
     await expect(waitForSeekCompletion()).resolves.toBeUndefined();
   });
+
+  it("reports one rejected generation to concurrent capture barriers", async () => {
+    let failGpuWork: ((reason: unknown) => void) | undefined;
+    const gpuWork = new Promise<void>((_resolve, reject) => {
+      failGpuWork = reject;
+    });
+    const failure = new Error("GPU queue failed");
+    const handler = (event: Event) => {
+      (event as CustomEvent<HfSeekEventDetail>).detail.waitUntil(gpuWork);
+    };
+    window.addEventListener("hf-seek", handler);
+    dispatchSeekEvent(22);
+    window.removeEventListener("hf-seek", handler);
+
+    const firstCapture = waitForSeekCompletion();
+    const secondCapture = waitForSeekCompletion();
+    failGpuWork?.(failure);
+
+    await expect(Promise.allSettled([firstCapture, secondCapture])).resolves.toEqual([
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+    ]);
+    await expect(waitForSeekCompletion()).resolves.toBeUndefined();
+  });
 });

--- a/packages/core/src/runtime/adapters/seek-dispatch.test.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.test.ts
@@ -103,6 +103,78 @@ describe("seek-dispatch", () => {
     expect(settled).toBe(true);
   });
 
+  it("drains success and failure generations registered after the capture wait starts", async () => {
+    let finishFirst: (() => void) | undefined;
+    let finishSecond: (() => void) | undefined;
+    let failThird: ((reason: unknown) => void) | undefined;
+    const firstGpuWork = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const secondGpuWork = new Promise<void>((resolve) => {
+      finishSecond = resolve;
+    });
+    const thirdGpuWork = new Promise<void>((_resolve, reject) => {
+      failThird = reject;
+    });
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<HfSeekEventDetail>).detail;
+      const gpuWork =
+        detail.time === 13 ? firstGpuWork : detail.time === 14 ? secondGpuWork : thirdGpuWork;
+      detail.waitUntil(gpuWork);
+    };
+    window.addEventListener("hf-seek", handler);
+    dispatchSeekEvent(13);
+
+    let settled = false;
+    const failure = new Error("later GPU queue failed");
+    const pending = waitForSeekCompletion()
+      .then(() => {
+        settled = true;
+      })
+      .catch((reason: unknown) => {
+        settled = true;
+        throw reason;
+      });
+    await Promise.resolve();
+
+    forceDispatchSeekEvent(14);
+    forceDispatchSeekEvent(15);
+    finishFirst?.();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    finishSecond?.();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    failThird?.(failure);
+    await expect(pending).rejects.toBe(failure);
+    window.removeEventListener("hf-seek", handler);
+    await expect(waitForSeekCompletion()).resolves.toBeUndefined();
+  });
+
+  it("does not retain empty or fulfilled heartbeat generations between captures", async () => {
+    for (let i = 0; i < 20; i += 1) {
+      forceDispatchSeekEvent(20);
+    }
+
+    const handler = (event: Event) => {
+      (event as CustomEvent<HfSeekEventDetail>).detail.waitUntil(Promise.resolve());
+    };
+    window.addEventListener("hf-seek", handler);
+    for (let i = 0; i < 20; i += 1) {
+      forceDispatchSeekEvent(21);
+    }
+    window.removeEventListener("hf-seek", handler);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    const promiseAll = vi.spyOn(Promise, "all");
+    await waitForSeekCompletion();
+    expect(promiseAll).not.toHaveBeenCalled();
+  });
+
   it("reports a rejected generation once, then consumes it", async () => {
     const failure = new Error("GPU queue failed");
     const handler = (event: Event) => {

--- a/packages/core/src/runtime/adapters/seek-dispatch.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.ts
@@ -20,7 +20,8 @@ import { swallow } from "../diagnostics";
 
 let _lastDispatchedTime = -1;
 type SeekCompletionResult = { status: "fulfilled" } | { status: "rejected"; reason: unknown };
-let _pendingCompletions: Array<Promise<SeekCompletionResult>> = [];
+let _pendingCompletions = new Set<Promise<SeekCompletionResult>>();
+let _pendingFailure: { reason: unknown } | undefined;
 
 export interface HfSeekEventDetail {
   time: number;
@@ -46,10 +47,17 @@ function dispatch(time: number): void {
   } finally {
     accepting = false;
   }
+  if (pending.length === 0) return;
   const completion = Promise.all(pending)
     .then<SeekCompletionResult>(() => ({ status: "fulfilled" }))
     .catch<SeekCompletionResult>((reason: unknown) => ({ status: "rejected", reason }));
-  _pendingCompletions.push(completion);
+  _pendingCompletions.add(completion);
+  void completion.then((result) => {
+    if (!_pendingCompletions.delete(completion)) return;
+    if (result.status === "rejected" && _pendingFailure === undefined) {
+      _pendingFailure = { reason: result.reason };
+    }
+  });
 }
 
 export function dispatchSeekEvent(time: number): void {
@@ -74,18 +82,17 @@ export function forceDispatchSeekEvent(time: number): void {
 }
 
 export async function waitForSeekCompletion(): Promise<void> {
-  const observed = _pendingCompletions;
-  _pendingCompletions = [];
-  const results = await Promise.all(observed);
-  const failed = results.find(
-    (result): result is Extract<SeekCompletionResult, { status: "rejected" }> =>
-      result.status === "rejected",
-  );
+  while (_pendingCompletions.size > 0) {
+    await Promise.all([..._pendingCompletions]);
+  }
+  const failed = _pendingFailure;
+  _pendingFailure = undefined;
   if (failed) throw failed.reason;
 }
 
 /** Reset internal state — used in tests to prevent cross-test contamination. */
 export function resetSeekDispatchState(): void {
   _lastDispatchedTime = -1;
-  _pendingCompletions = [];
+  _pendingCompletions = new Set();
+  _pendingFailure = undefined;
 }

--- a/packages/core/src/runtime/adapters/seek-dispatch.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.ts
@@ -19,15 +19,39 @@ import { swallow } from "../diagnostics";
  */
 
 let _lastDispatchedTime = -1;
+let _pendingCompletion: Promise<void> = Promise.resolve();
+
+export interface HfSeekEventDetail {
+  time: number;
+  waitUntil: (promise: PromiseLike<unknown>) => void;
+}
+
+function dispatch(time: number): void {
+  const pending: PromiseLike<unknown>[] = [];
+  let accepting = true;
+  const detail: HfSeekEventDetail = {
+    time,
+    waitUntil: (promise) => {
+      if (!accepting) {
+        throw new Error("hf-seek waitUntil() must be called synchronously from the event listener");
+      }
+      pending.push(promise);
+    },
+  };
+  try {
+    window.dispatchEvent(new CustomEvent<HfSeekEventDetail>("hf-seek", { detail }));
+  } catch (err) {
+    swallow("runtime.adapters.seek-dispatch.site1", err);
+  } finally {
+    accepting = false;
+  }
+  _pendingCompletion = Promise.all(pending).then(() => undefined);
+}
 
 export function dispatchSeekEvent(time: number): void {
   if (time === _lastDispatchedTime) return;
   _lastDispatchedTime = time;
-  try {
-    window.dispatchEvent(new CustomEvent("hf-seek", { detail: { time } }));
-  } catch (err) {
-    swallow("runtime.adapters.seek-dispatch.site1", err);
-  }
+  dispatch(time);
 }
 
 /**
@@ -42,14 +66,15 @@ export function dispatchSeekEvent(time: number): void {
  */
 export function forceDispatchSeekEvent(time: number): void {
   _lastDispatchedTime = time;
-  try {
-    window.dispatchEvent(new CustomEvent("hf-seek", { detail: { time } }));
-  } catch (err) {
-    swallow("runtime.adapters.seek-dispatch.force", err);
-  }
+  dispatch(time);
+}
+
+export function waitForSeekCompletion(): Promise<void> {
+  return _pendingCompletion;
 }
 
 /** Reset internal state — used in tests to prevent cross-test contamination. */
 export function resetSeekDispatchState(): void {
   _lastDispatchedTime = -1;
+  _pendingCompletion = Promise.resolve();
 }

--- a/packages/core/src/runtime/adapters/seek-dispatch.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.ts
@@ -19,7 +19,8 @@ import { swallow } from "../diagnostics";
  */
 
 let _lastDispatchedTime = -1;
-let _pendingCompletion: Promise<void> = Promise.resolve();
+type SeekCompletionResult = { status: "fulfilled" } | { status: "rejected"; reason: unknown };
+let _pendingCompletions: Array<Promise<SeekCompletionResult>> = [];
 
 export interface HfSeekEventDetail {
   time: number;
@@ -45,7 +46,12 @@ function dispatch(time: number): void {
   } finally {
     accepting = false;
   }
-  _pendingCompletion = Promise.all(pending).then(() => undefined);
+  _pendingCompletions.push(
+    Promise.all(pending).then<SeekCompletionResult>(
+      () => ({ status: "fulfilled" }),
+      (reason: unknown) => ({ status: "rejected", reason }),
+    ),
+  );
 }
 
 export function dispatchSeekEvent(time: number): void {
@@ -69,12 +75,19 @@ export function forceDispatchSeekEvent(time: number): void {
   dispatch(time);
 }
 
-export function waitForSeekCompletion(): Promise<void> {
-  return _pendingCompletion;
+export async function waitForSeekCompletion(): Promise<void> {
+  const observed = _pendingCompletions;
+  _pendingCompletions = [];
+  const results = await Promise.all(observed);
+  const failed = results.find(
+    (result): result is Extract<SeekCompletionResult, { status: "rejected" }> =>
+      result.status === "rejected",
+  );
+  if (failed) throw failed.reason;
 }
 
 /** Reset internal state — used in tests to prevent cross-test contamination. */
 export function resetSeekDispatchState(): void {
   _lastDispatchedTime = -1;
-  _pendingCompletion = Promise.resolve();
+  _pendingCompletions = [];
 }

--- a/packages/core/src/runtime/adapters/seek-dispatch.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.ts
@@ -46,12 +46,10 @@ function dispatch(time: number): void {
   } finally {
     accepting = false;
   }
-  _pendingCompletions.push(
-    Promise.all(pending).then<SeekCompletionResult>(
-      () => ({ status: "fulfilled" }),
-      (reason: unknown) => ({ status: "rejected", reason }),
-    ),
-  );
+  const completion = Promise.all(pending)
+    .then<SeekCompletionResult>(() => ({ status: "fulfilled" }))
+    .catch<SeekCompletionResult>((reason: unknown) => ({ status: "rejected", reason }));
+  _pendingCompletions.push(completion);
 }
 
 export function dispatchSeekEvent(time: number): void {

--- a/packages/core/src/runtime/adapters/seek-dispatch.ts
+++ b/packages/core/src/runtime/adapters/seek-dispatch.ts
@@ -22,6 +22,7 @@ let _lastDispatchedTime = -1;
 type SeekCompletionResult = { status: "fulfilled" } | { status: "rejected"; reason: unknown };
 let _pendingCompletions = new Set<Promise<SeekCompletionResult>>();
 let _pendingFailure: { reason: unknown } | undefined;
+let _activeCompletionBarriers = 0;
 
 export interface HfSeekEventDetail {
   time: number;
@@ -81,13 +82,35 @@ export function forceDispatchSeekEvent(time: number): void {
   dispatch(time);
 }
 
+export function isSeekCompletionBarrierActive(): boolean {
+  return _activeCompletionBarriers > 0;
+}
+
 export async function waitForSeekCompletion(): Promise<void> {
-  while (_pendingCompletions.size > 0) {
-    await Promise.all([..._pendingCompletions]);
+  _activeCompletionBarriers += 1;
+  let failed = _pendingFailure;
+  try {
+    // Let concurrently started barriers snapshot the same retained failure
+    // before either one consumes it.
+    await Promise.resolve();
+    while (_pendingCompletions.size > 0) {
+      const results = await Promise.all([..._pendingCompletions]);
+      const rejected = results.find((result) => result.status === "rejected");
+      if (failed === undefined && rejected?.status === "rejected") {
+        failed = { reason: rejected.reason };
+      }
+    }
+    const retainedFailure = _pendingFailure;
+    if (failed === undefined) {
+      failed = retainedFailure;
+    }
+    if (_pendingFailure === retainedFailure) {
+      _pendingFailure = undefined;
+    }
+    if (failed) throw failed.reason;
+  } finally {
+    _activeCompletionBarriers -= 1;
   }
-  const failed = _pendingFailure;
-  _pendingFailure = undefined;
-  if (failed) throw failed.reason;
 }
 
 /** Reset internal state — used in tests to prevent cross-test contamination. */
@@ -95,4 +118,5 @@ export function resetSeekDispatchState(): void {
   _lastDispatchedTime = -1;
   _pendingCompletions = new Set();
   _pendingFailure = undefined;
+  _activeCompletionBarriers = 0;
 }

--- a/packages/core/src/runtime/adapters/typegpu.test.ts
+++ b/packages/core/src/runtime/adapters/typegpu.test.ts
@@ -110,4 +110,19 @@ describe("typegpu adapter", () => {
     expect(times).toEqual([1.25, 1.25]);
     expect(gpuWindow.__hfTypegpuTime).toBe(1.25);
   });
+
+  it("does not start a present heartbeat without the WebGPU capability marker", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div data-composition-id="dom" data-duration="2"></div>';
+    const adapter = createTypegpuAdapter();
+    const handler = vi.fn();
+    window.addEventListener("hf-seek", handler);
+
+    adapter.seek({ time: 1.25 });
+    adapter.pause();
+    await vi.advanceTimersByTimeAsync(TYPEGPU_PRESENT_HEARTBEAT_MS * 2);
+    window.removeEventListener("hf-seek", handler);
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/core/src/runtime/adapters/typegpu.test.ts
+++ b/packages/core/src/runtime/adapters/typegpu.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createTypegpuAdapter, TYPEGPU_PRESENT_HEARTBEAT_MS } from "./typegpu";
-import { resetSeekDispatchState } from "./seek-dispatch";
+import {
+  resetSeekDispatchState,
+  waitForSeekCompletion,
+  type HfSeekEventDetail,
+} from "./seek-dispatch";
 
 const gpuWindow = window as Window & { __hfTypegpuTime?: number };
 
@@ -124,5 +128,41 @@ describe("typegpu adapter", () => {
     window.removeEventListener("hf-seek", handler);
 
     expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("pauses presentation heartbeats while a capture barrier drains slow GPU work", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML =
+      '<div data-composition-id="gpu" data-requires-webgpu data-duration="2"></div>';
+    const adapter = createTypegpuAdapter();
+    const times: number[] = [];
+    const completionLatency = TYPEGPU_PRESENT_HEARTBEAT_MS * 2 + 1;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<HfSeekEventDetail>).detail;
+      times.push(detail.time);
+      detail.waitUntil(
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, completionLatency);
+        }),
+      );
+    };
+    window.addEventListener("hf-seek", handler);
+
+    adapter.seek({ time: 1.25 });
+    adapter.pause();
+    let settled = false;
+    const capture = waitForSeekCompletion().then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(TYPEGPU_PRESENT_HEARTBEAT_MS * 2);
+    expect(settled).toBe(false);
+    expect(times).toEqual([1.25]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await capture;
+    adapter.play?.();
+    window.removeEventListener("hf-seek", handler);
+    expect(settled).toBe(true);
+    expect(times).toEqual([1.25]);
   });
 });

--- a/packages/core/src/runtime/adapters/typegpu.test.ts
+++ b/packages/core/src/runtime/adapters/typegpu.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createTypegpuAdapter } from "./typegpu";
+import { createTypegpuAdapter, TYPEGPU_PRESENT_HEARTBEAT_MS } from "./typegpu";
 import { resetSeekDispatchState } from "./seek-dispatch";
 
 const gpuWindow = window as Window & { __hfTypegpuTime?: number };
 
 describe("typegpu adapter", () => {
   beforeEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
     delete gpuWindow.__hfTypegpuTime;
     // Reset shared dedup state so each test starts with a clean dispatch history
     resetSeekDispatchState();
@@ -85,5 +87,27 @@ describe("typegpu adapter", () => {
   it("discover is a no-op and does not throw", () => {
     const adapter = createTypegpuAdapter();
     expect(() => adapter.discover()).not.toThrow();
+  });
+
+  it("re-presents the paused WebGPU frame without advancing seek time", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML =
+      '<div data-composition-id="gpu" data-requires-webgpu data-duration="2"></div>';
+    const adapter = createTypegpuAdapter();
+    const times: number[] = [];
+    const handler = (event: Event) => {
+      times.push((event as CustomEvent<{ time: number }>).detail.time);
+    };
+    window.addEventListener("hf-seek", handler);
+
+    adapter.seek({ time: 1.25 });
+    adapter.pause();
+    await vi.advanceTimersByTimeAsync(TYPEGPU_PRESENT_HEARTBEAT_MS);
+    adapter.play?.();
+    await vi.advanceTimersByTimeAsync(TYPEGPU_PRESENT_HEARTBEAT_MS * 2);
+    window.removeEventListener("hf-seek", handler);
+
+    expect(times).toEqual([1.25, 1.25]);
+    expect(gpuWindow.__hfTypegpuTime).toBe(1.25);
   });
 });

--- a/packages/core/src/runtime/adapters/typegpu.ts
+++ b/packages/core/src/runtime/adapters/typegpu.ts
@@ -1,5 +1,7 @@
 import type { RuntimeDeterministicAdapter } from "../types";
-import { dispatchSeekEvent } from "./seek-dispatch";
+import { dispatchSeekEvent, forceDispatchSeekEvent } from "./seek-dispatch";
+
+export const TYPEGPU_PRESENT_HEARTBEAT_MS = 250;
 
 /**
  * TypeGPU / WebGPU adapter for HyperFrames
@@ -31,7 +33,10 @@ import { dispatchSeekEvent } from "./seek-dispatch";
  *   }
  *
  *   // Seek: fired by HyperFrames whenever the player scrubs or plays
- *   window.addEventListener("hf-seek", (e) => render(e.detail.time));
+ *   window.addEventListener("hf-seek", (e) => {
+ *     render(e.detail.time);
+ *     e.detail.waitUntil(device.queue.onSubmittedWorkDone());
+ *   });
  *
  *   // Initial frame at t=0
  *   render(window.__hfTypegpuTime ?? 0);
@@ -44,9 +49,9 @@ import { dispatchSeekEvent } from "./seek-dispatch";
  *
  * ## Render-mode determinism
  *
- * For frame-perfect video renders, call `await device.queue.onSubmittedWorkDone()`
- * after each `render(time)` invocation before the frame is captured. This ensures
- * the GPU has finished writing to the canvas before the engine screenshots it.
+ * For frame-perfect video renders, register GPU completion synchronously with
+ * `e.detail.waitUntil(device.queue.onSubmittedWorkDone())` after `render(time)`.
+ * HyperFrames awaits the registered work before screenshots and frame capture.
  *
  * ## Browser feature detection
  *
@@ -64,6 +69,23 @@ import { dispatchSeekEvent } from "./seek-dispatch";
 export function createTypegpuAdapter(): RuntimeDeterministicAdapter {
   let forcedTime: number | null = null;
   let lastForcedTime = 0;
+  let presentHeartbeat: number | null = null;
+
+  const stopPresentHeartbeat = () => {
+    if (presentHeartbeat === null) return;
+    window.clearInterval(presentHeartbeat);
+    presentHeartbeat = null;
+  };
+
+  const startPresentHeartbeat = () => {
+    if (presentHeartbeat !== null) return;
+    if (!document.querySelector("[data-composition-id][data-requires-webgpu]")) return;
+    presentHeartbeat = window.setInterval(() => {
+      if (forcedTime === null) return;
+      window.__hfTypegpuTime = forcedTime;
+      forceDispatchSeekEvent(forcedTime);
+    }, TYPEGPU_PRESENT_HEARTBEAT_MS);
+  };
 
   return {
     name: "typegpu",
@@ -83,13 +105,16 @@ export function createTypegpuAdapter(): RuntimeDeterministicAdapter {
       if (forcedTime == null) {
         forcedTime = Math.max(0, lastForcedTime);
       }
+      startPresentHeartbeat();
     },
 
     play: () => {
+      stopPresentHeartbeat();
       forcedTime = null;
     },
 
     revert: () => {
+      stopPresentHeartbeat();
       forcedTime = null;
       lastForcedTime = 0;
     },

--- a/packages/core/src/runtime/adapters/typegpu.ts
+++ b/packages/core/src/runtime/adapters/typegpu.ts
@@ -1,5 +1,9 @@
 import type { RuntimeDeterministicAdapter } from "../types";
-import { dispatchSeekEvent, forceDispatchSeekEvent } from "./seek-dispatch";
+import {
+  dispatchSeekEvent,
+  forceDispatchSeekEvent,
+  isSeekCompletionBarrierActive,
+} from "./seek-dispatch";
 
 export const TYPEGPU_PRESENT_HEARTBEAT_MS = 250;
 
@@ -82,6 +86,7 @@ export function createTypegpuAdapter(): RuntimeDeterministicAdapter {
     if (!document.querySelector("[data-composition-id][data-requires-webgpu]")) return;
     presentHeartbeat = window.setInterval(() => {
       if (forcedTime === null) return;
+      if (isSeekCompletionBarrierActive()) return;
       window.__hfTypegpuTime = forcedTime;
       forceDispatchSeekEvent(forcedTime);
     }, TYPEGPU_PRESENT_HEARTBEAT_MS);

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1,6 +1,7 @@
 // fallow-ignore-file code-duplication
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initSandboxRuntimeModular } from "./init";
+import { TYPEGPU_PRESENT_HEARTBEAT_MS } from "./adapters/typegpu";
 import type { RuntimeTimelineLike } from "./types";
 
 function createMockTimeline(duration: number): RuntimeTimelineLike {
@@ -122,6 +123,7 @@ describe("initSandboxRuntimeModular", () => {
     delete (window as { __hfAutoNoopRegistered?: boolean }).__hfAutoNoopRegistered;
     delete window.gsap;
     vi.restoreAllMocks();
+    vi.useRealTimers();
     window.requestAnimationFrame = originalRequestAnimationFrame;
     window.cancelAnimationFrame = originalCancelAnimationFrame;
   });
@@ -368,6 +370,31 @@ describe("initSandboxRuntimeModular", () => {
     player?.renderSeek(9);
 
     expect(child.style.visibility).toBe("visible");
+  });
+
+  it("keeps WebGPU presentation active after renderSeek pauses the frame", async () => {
+    vi.useFakeTimers();
+
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-requires-webgpu", "");
+    root.setAttribute("data-duration", "10");
+    document.body.appendChild(root);
+    window.__timelines = { main: createMockTimeline(10) };
+
+    const times: number[] = [];
+    const onSeek = (event: Event) => {
+      times.push((event as CustomEvent<{ time: number }>).detail.time);
+    };
+    window.addEventListener("hf-seek", onSeek);
+
+    initSandboxRuntimeModular();
+    window.__player?.renderSeek(4);
+    await vi.advanceTimersByTimeAsync(TYPEGPU_PRESENT_HEARTBEAT_MS);
+
+    window.removeEventListener("hf-seek", onSeek);
+    expect(times).toEqual([0, 4, 4]);
   });
 
   it("uses export render fps when quantizing renderSeek", () => {

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2412,6 +2412,7 @@ export function initSandboxRuntimeModular(): void {
         activateChildren: true,
         suppressEvents: options?.suppressEvents,
       });
+      runAdapters("pause");
       syncMediaForCurrentState();
       colorGrading.redraw();
       postState(true);

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -17,7 +17,7 @@ import {
   patchVideoTextureCompat,
   patchWebGLVideoTextureCompat,
 } from "./adapters/video-texture-compat";
-import { forceDispatchSeekEvent } from "./adapters/seek-dispatch";
+import { forceDispatchSeekEvent, waitForSeekCompletion } from "./adapters/seek-dispatch";
 import { createWaapiAdapter } from "./adapters/waapi";
 import {
   readElementPlaybackRate,
@@ -2514,6 +2514,12 @@ export function initSandboxRuntimeModular(): void {
     window.__hfTypegpuTime = t;
     forceDispatchSeekEvent(t);
   };
+  window.__hfWaitForSeekCompletion = waitForSeekCompletion;
+  runtimeCleanupCallbacks.push(() => {
+    if (window.__hfWaitForSeekCompletion === waitForSeekCompletion) {
+      delete window.__hfWaitForSeekCompletion;
+    }
+  });
   installRuntimeErrorDiagnostics();
   bindMediaMetadataListeners();
   runAdapters("discover");

--- a/packages/core/src/runtime/window.d.ts
+++ b/packages/core/src/runtime/window.d.ts
@@ -73,6 +73,11 @@ declare global {
      */
     __hfReseekGpu?: (time: number) => void;
     /**
+     * Await GPU work registered synchronously by `hf-seek` listeners through
+     * `event.detail.waitUntil(...)`.
+     */
+    __hfWaitForSeekCompletion?: () => Promise<void>;
+    /**
      * Canonical root-timeline start for a media element. Snapshot capture uses
      * this runtime-owned resolver so reference expressions, authored timing
      * restoration, and arbitrary composition nesting cannot drift.

--- a/packages/engine/src/services/frameCapture-gpuCompletion.test.ts
+++ b/packages/engine/src/services/frameCapture-gpuCompletion.test.ts
@@ -1,0 +1,43 @@
+// fallow-ignore-file code-duplication
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { waitForPendingSeekCompletion } from "./frameCapture.js";
+
+describe("WebGPU frame completion", () => {
+  it("blocks capture preparation until the runtime completion promise settles", async () => {
+    let finish: (() => void) | undefined;
+    const gpuWork = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const previousWindow = Reflect.get(globalThis, "window");
+    Reflect.set(globalThis, "window", { __hfWaitForSeekCompletion: () => gpuWork });
+    const page = {
+      evaluate: vi.fn(async (pageFunction: () => unknown) => pageFunction()),
+    };
+
+    try {
+      let settled = false;
+      const pending = waitForPendingSeekCompletion(page).then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      finish?.();
+      await pending;
+      expect(settled).toBe(true);
+    } finally {
+      if (previousWindow === undefined) Reflect.deleteProperty(globalThis, "window");
+      else Reflect.set(globalThis, "window", previousWindow);
+    }
+  });
+
+  it("runs the completion wait after video injection and before screenshot capture", () => {
+    const source = readFileSync(new URL("./frameCapture.ts", import.meta.url), "utf8");
+    const injection = source.indexOf("await session.onBeforeCapture(page, quantizedTime)");
+    const completion = source.indexOf("await waitForPendingSeekCompletion(page)");
+    const screenshot = source.indexOf("async function captureFrameCore");
+    expect(injection).toBeGreaterThan(-1);
+    expect(completion).toBeGreaterThan(injection);
+    expect(screenshot).toBeGreaterThan(completion);
+  });
+});

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -2366,6 +2366,15 @@ async function captureFrameErrorDiagnostics(
  * Shared by captureFrame (disk) and captureFrameToBuffer (buffer).
  * Returns timing breakdown for perf tracking.
  */
+export async function waitForPendingSeekCompletion(page: Pick<Page, "evaluate">): Promise<void> {
+  await page.evaluate(async () => {
+    const waitForCompletion = (
+      window as Window & { __hfWaitForSeekCompletion?: () => Promise<void> }
+    ).__hfWaitForSeekCompletion;
+    await waitForCompletion?.();
+  });
+}
+
 async function prepareFrameForCapture(
   session: CaptureSession,
   frameIndex: number,
@@ -2406,6 +2415,7 @@ async function prepareFrameForCapture(
   if (session.onBeforeCapture) {
     await session.onBeforeCapture(page, quantizedTime);
   }
+  await waitForPendingSeekCompletion(page);
   await page.evaluate(async () => {
     const runtime = (
       window as Window & {

--- a/packages/producer/tests/typegpu-adapter/src/index.html
+++ b/packages/producer/tests/typegpu-adapter/src/index.html
@@ -9,7 +9,7 @@
 </style>
 </head>
 <body>
-<div id="root" data-composition-id="typegpu-test" data-width="1920" data-height="1080" data-start="0" data-duration="6">
+<div id="root" data-composition-id="typegpu-test" data-requires-webgpu data-width="1920" data-height="1080" data-start="0" data-duration="6">
 
   <canvas id="gpu-canvas" style="position:absolute;top:0;left:0;width:1920px;height:1080px"></canvas>
   <div id="label">TypeGPU adapter test</div>
@@ -114,7 +114,10 @@ fn hsv(h: f32, s: f32, v: f32) -> vec3f {
       }
 
       render(0);
-      window.addEventListener('hf-seek', function(e) { render(e.detail.time); });
+      window.addEventListener('hf-seek', function(e) {
+        render(e.detail.time);
+        e.detail.waitUntil(device.queue.onSubmittedWorkDone());
+      });
     })();
   </script>
 </div>

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -22,7 +22,7 @@
       "files": 17
     },
     "hyperframes-animation": {
-      "hash": "6c13cdce4f3a23c2",
+      "hash": "5bc2ce098387a547",
       "files": 121
     },
     "hyperframes-cli": {

--- a/skills/hyperframes-animation/adapters/typegpu.md
+++ b/skills/hyperframes-animation/adapters/typegpu.md
@@ -17,9 +17,10 @@ The render engine auto-passes `--enable-unsafe-webgpu` and `--enable-features=Ca
 - Render from HyperFrames time, not `performance.now()`.
 - Listen for the `hf-seek` event and re-render at exactly that time.
 - Guard against environments where WebGPU is unavailable — the adapter does not check for you.
-- For video renders, call `await device.queue.onSubmittedWorkDone()` after submitting GPU work to ensure the canvas is flushed before the frame is captured.
+- If the composition cannot render without WebGPU, add `data-requires-webgpu` to its composition root. Local capture commands then report an actionable error instead of capturing a no-GPU fallback screen when auto-detection selects software rendering.
+- After submitting GPU work, register queue completion synchronously with `e.detail.waitUntil(device.queue.onSubmittedWorkDone())`. HyperFrames awaits registered work before screenshots and frame capture.
 
-The adapter sets `window.__hfTypegpuTime` and dispatches `new CustomEvent("hf-seek", { detail: { time } })` on each seek.
+The adapter sets `window.__hfTypegpuTime` and dispatches an `hf-seek` event with `{ time, waitUntil }` on each seek. While Studio is paused, HyperFrames may dispatch the same time again to keep the WebGPU swapchain presented. Re-render that exact time; do not advance simulation state.
 
 ## Basic Pattern
 
@@ -67,7 +68,10 @@ The adapter sets `window.__hfTypegpuTime` and dispatches `new CustomEvent("hf-se
     }
 
     render(0);
-    window.addEventListener("hf-seek", (e) => render(e.detail.time));
+    window.addEventListener("hf-seek", (e) => {
+      render(e.detail.time);
+      e.detail.waitUntil(device.queue.onSubmittedWorkDone());
+    });
   })();
 </script>
 ```
@@ -173,6 +177,6 @@ Use this to define inside/ring/outside zones for glass effects. Negative values 
 ## Deterministic Rendering
 
 - No `Math.random()` — use a seeded PRNG.
-- No `requestAnimationFrame` for the render loop — render only in response to `hf-seek`.
+- Do not use an autonomous `requestAnimationFrame` simulation loop. Render in response to `hf-seek`; HyperFrames owns the paused-presentation heartbeat and may re-present the same time.
 - No `performance.now()` for animation time — read `window.__hfTypegpuTime` or `e.detail.time`.
-- After GPU submit, call `await device.queue.onSubmittedWorkDone()` for render-mode frame capture.
+- Register GPU completion with `e.detail.waitUntil(device.queue.onSubmittedWorkDone())` before the event listener returns.


### PR DESCRIPTION
## What

Align local visual-audit and capture surfaces around one browser GPU policy and make WebGPU capture frame-complete.

- Resolve `auto` through the engine's existing cached GPU probe for `snapshot`, `check`, local browser validation/layout capture, and Studio thumbnails/current-frame capture.
- Preserve CLI and `PRODUCER_BROWSER_GPU_MODE` overrides while leaving distributed and Docker rendering on deterministic software GPU paths.
- Add `data-requires-webgpu` as the minimal composition capability marker and fail with an actionable diagnostic when auto-detection resolves to software.
- Add an `hf-seek` `event.detail.waitUntil(...)` completion contract and await registered GPU work before screenshots/frame capture.
- Re-present paused WebGPU canvases at the same seek time through a framework-owned heartbeat without advancing simulation state.
- Promote genuine WebGPU validation warnings to deduplicated runtime errors in `hyperframes check` while preserving ordinary warnings.
- Update the TypeGPU documentation and fixture.

## Why

Local capture paths had diverged: `snapshot` and Studio thumbnail capture omitted `browserGpuMode` and silently fell through to SwiftShader, while `check` forced hardware instead of using the engine's auto probe. WebGPU compositions could therefore capture their no-GPU fallback even on capable hosts.

Separately, `hf-seek` listeners could submit asynchronous GPU work but HyperFrames had no way to observe queue completion before capture. Paused WebGPU swapchains also needed re-presentation, and GPU validation failures emitted as `console.warn` did not fail the checker.

## How

A small CLI GPU-policy module delegates auto resolution to `@hyperframes/engine` and threads the concrete mode into every local capture browser. The runtime's backward-compatible `hf-seek` detail now exposes `waitUntil`, with completion surfaced through a runtime hook consumed by CLI and engine capture paths.

The TypeGPU adapter emits same-time presentation heartbeats only for compositions marked `data-requires-webgpu`. Checker console handling recognizes WebGPU validation/out-of-memory/internal/destroyed-resource failures and deduplicates identical findings with a repeat count.

No distributed-render or Docker GPU defaults were changed.

## Test plan

- `bun run --cwd packages/core test -- src/runtime/adapters/seek-dispatch.test.ts src/runtime/adapters/typegpu.test.ts` — 16 tests
- `bun run --cwd packages/engine test -- src/services/browserManager.test.ts src/services/frameCapture-gpuCompletion.test.ts` — 46 tests
- `bun run --cwd packages/cli test -- src/browser/gpuPolicy.test.ts src/capture/captureCompositionFrame.test.ts src/commands/snapshot.test.ts src/server/studioServer.test.ts src/utils/checkBrowser.test.ts` — 80 tests
- `bun run --filter '@hyperframes/{core,engine,cli}' typecheck`
- `bun run lint`
- Built `@hyperframes/core`, `@hyperframes/engine`, `@hyperframes/studio`, and `@hyperframes/cli`
- Pre-commit tracked-artifact, formatting, Fallow, typecheck, and commitlint gates

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Documentation updated (if applicable)