### PR TITLE
perf(cli): cut wasted waits from the check browser gate

### DIFF
--- a/packages/cli/src/capture/captureCompositionFrame.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.ts
@@ -6,6 +6,11 @@ import { resolveDiagnosticNavigationTimeoutMs } from "../utils/renderArgs.js";
 
 const SHADER_TRANSITIONS_TIMEOUT_MS = 90_000;
 const CAPTURE_SETTLE_MS = 1500;
+// Floor for the post-ready settle. Kept well above a couple of frames so that
+// work which lands after __renderReady but signals nothing observable (image
+// decode, late layout) still gets a margin — the early exit below only trims
+// the tail of the old flat 1500ms wait, it never removes the margin entirely.
+const CAPTURE_SETTLE_FLOOR_MS = 400;
 const PREFERRED_SEEK_TARGET_WAIT_MS = 500;
 const DEFAULT_POST_SEEK_FONT_WAIT_MS = 500;
 
@@ -22,6 +27,19 @@ export const AUDIT_SEEK_OPTIONS = {
 export const DENSE_GEOMETRY_SEEK_OPTIONS = {
   ...AUDIT_SEEK_OPTIONS,
   animationFrameSettle: "none",
+  waitForFontsMs: 0,
+  settleMs: 0,
+} as const;
+
+// Motion-sampling seek for times that carry no layout/contrast/geometry work.
+// __hyperframesMotionSample reads computed transforms and opacity, which the
+// ordered double-rAF already guarantees are committed — so the paint-flush
+// sleep (only needed before a screenshot) and the glyph-subset font wait (only
+// needed when something measures or photographs text) are both dead weight
+// here. At 20fps this profile is applied to the overwhelming majority of the
+// grid, so the per-seek sleep is the single largest cost in a motion-spec run.
+export const MOTION_SAMPLE_SEEK_OPTIONS = {
+  ...AUDIT_SEEK_OPTIONS,
   waitForFontsMs: 0,
   settleMs: 0,
 } as const;
@@ -140,8 +158,51 @@ async function waitForCompositionSettle(
     });
 
   await page.evaluate(() => document.fonts.ready).catch(() => {});
-  await new Promise((resolveSettle) => setTimeout(resolveSettle, CAPTURE_SETTLE_MS));
+  await waitForVisualSettle(page, CAPTURE_SETTLE_FLOOR_MS, CAPTURE_SETTLE_MS);
   return runtimeReady;
+}
+
+// Replaces what used to be an unconditional `sleep(CAPTURE_SETTLE_MS)` on every
+// page open. By this point the runtime has signaled __renderReady, shader
+// transitions have pre-rendered, and document.fonts.ready has resolved — the
+// flat wait existed only to absorb whatever paints after that. Poll instead:
+// hold for `floorMs`, then exit on the first pair of consecutive frames with no
+// font subset in flight, and never exceed `budgetMs`. Worst case is identical
+// to the old behavior; the common case returns roughly a second sooner.
+async function waitForVisualSettle(page: Page, floorMs: number, budgetMs: number): Promise<void> {
+  await page
+    .evaluate(
+      (floor: number, budget: number) =>
+        new Promise<void>((resolveSettle) => {
+          const deadline = setTimeout(resolveSettle, budget);
+          const finish = (): void => {
+            clearTimeout(deadline);
+            resolveSettle();
+          };
+          const fonts = Reflect.get(document, "fonts");
+          const fontsIdle = (): boolean =>
+            typeof fonts !== "object" ||
+            fonts === null ||
+            Reflect.get(fonts, "status") !== "loading";
+          let floorElapsed = false;
+          setTimeout(() => {
+            floorElapsed = true;
+          }, floor);
+          let stableFrames = 0;
+          const tick = (): void => {
+            stableFrames = fontsIdle() ? stableFrames + 1 : 0;
+            if (floorElapsed && stableFrames >= 2) {
+              finish();
+              return;
+            }
+            requestAnimationFrame(tick);
+          };
+          requestAnimationFrame(tick);
+        }),
+      floorMs,
+      budgetMs,
+    )
+    .catch(() => {});
 }
 
 // tsx/esbuild-style dev transpilers run with keepNames, which rewrites named

--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -148,6 +148,7 @@ function fakeDriver(overrides: Partial<CheckAuditDriver> = {}): CheckAuditDriver
     findAmbiguousSelectors: vi.fn(async (_selectors: string[]) => []),
     seek: vi.fn(async (_time: number) => undefined),
     seekGeometry: vi.fn(async (_time: number) => undefined),
+    seekMotion: vi.fn(async (_time: number) => undefined),
     collectLayout: vi.fn(async (_time: number, _tolerance: number) => []),
     collectOverlap: vi.fn(async (_time: number) => []),
     collectLayoutGeometry: vi.fn(async () => `geometry-${geometryCallCount++}`),
@@ -712,6 +713,36 @@ it("keeps contrast and snapshot sampling on the pre-gate layout grid", async () 
   expect(report.contrast.samples).toEqual([5]);
   expect(collectContrast).toHaveBeenCalledTimes(1);
   expect(collectContrast).toHaveBeenCalledWith(5);
+});
+
+it("seeks motion-only grid times without the full audit settle", async () => {
+  const motion: MotionSpecResolution = {
+    kind: "valid",
+    path: "/project/index.motion.json",
+    spec: { assertions: [{ kind: "appearsBy", selector: "#hero", bySec: 0.2 }] },
+  };
+  const driver = fakeDriver({
+    getDuration: vi.fn(async () => 1),
+    collectMotionFrame: vi.fn(async (time: number) => heroMotionFrame(time, () => true)),
+  });
+  await runScenario(driver, { samples: 1, contrast: false }, { motion });
+
+  const fullSettleTimes = vi.mocked(driver.seek).mock.calls.map(([time]) => time);
+  const motionOnlyTimes = vi.mocked(driver.seekMotion).mock.calls.map(([time]) => time);
+
+  // The single layout sample measures text, so it keeps the full settle; the
+  // rest of the 20fps motion grid only feeds collectMotionFrame.
+  expect(fullSettleTimes).toEqual([0.5]);
+  expect(motionOnlyTimes.length).toBeGreaterThan(10);
+  expect(motionOnlyTimes).not.toContain(0.5);
+});
+
+it("keeps the full audit settle on contrast times so the screenshot is painted", async () => {
+  const driver = fakeDriver({ getDuration: vi.fn(async () => 10) });
+  await runScenario(driver, { samples: 1, contrast: true });
+
+  expect(vi.mocked(driver.seek).mock.calls.map(([time]) => time)).toContain(5);
+  expect(vi.mocked(driver.seekMotion)).not.toHaveBeenCalled();
 });
 
 function layoutFindingOf(

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -4,6 +4,7 @@ import type { Page } from "puppeteer-core";
 import {
   AUDIT_SEEK_OPTIONS,
   DENSE_GEOMETRY_SEEK_OPTIONS,
+  MOTION_SAMPLE_SEEK_OPTIONS,
   DEFAULT_ZOOM_PADDING_PX,
   DEFAULT_ZOOM_SCALE,
   captureRegionCrop,
@@ -356,6 +357,10 @@ function createPageDriver(page: Page, setTime: (time: number) => void): CheckAud
       setTime(time);
       await seekCompositionTimeline(page, time, DENSE_GEOMETRY_SEEK_OPTIONS);
     },
+    seekMotion: async (time) => {
+      setTime(time);
+      await seekCompositionTimeline(page, time, MOTION_SAMPLE_SEEK_OPTIONS);
+    },
     collectLayout: (time, tolerance, layout) => collectLayout(page, time, tolerance, layout),
     collectOverlap: (time) => collectOverlap(page, time),
     collectLayoutGeometry: () => collectLayoutGeometry(page),
@@ -698,10 +703,15 @@ async function compositionBbox(page: Page): Promise<CheckBbox> {
   });
 }
 
+// `layoutAnnotations` being undefined is the pipeline's signal that --snapshots
+// is off (see checkPipeline's contrast branch): nothing will ever read
+// `pngBase64`, so the restored-page screenshot and its overlay are skipped
+// entirely. Passing an array — even an empty one — still produces the shot,
+// which is what a --snapshots run with no findings at this time needs.
 async function collectContrast(
   page: Page,
   time: number,
-  layoutAnnotations: CheckAnnotationBox[] = [],
+  layoutAnnotations?: CheckAnnotationBox[],
 ): Promise<ContrastCapture> {
   let prepared: PreparedContrast[] = [];
   try {
@@ -723,6 +733,7 @@ async function collectContrast(
     );
     const finished = raw.flatMap(parseFinishedContrast);
     const entries = joinContrastEntries(finished, prepared);
+    if (!layoutAnnotations) return { entries, pngBase64: "" };
     // __contrastAuditFinish restores the text paint hidden by prepare. The
     // measurement screenshot intentionally has glyphs removed so contrast
     // can sample the pixels behind them; never persist that image as visual

--- a/packages/cli/src/utils/checkPipeline.ts
+++ b/packages/cli/src/utils/checkPipeline.ts
@@ -363,6 +363,61 @@ async function collectGeometryAt(
   return issues;
 }
 
+/** A grid time can take the sleep-free motion profile only when nothing at that
+ * time measures text (layout), photographs the frame (contrast), or reads
+ * caption/frame geometry — those all need the paint-flush settle and the
+ * glyph-subset font wait that collectMotionFrame does not. */
+function needsFullAuditSettle(input: {
+  time: number;
+  layoutSet: Set<number>;
+  contrastSet: Set<number>;
+  canvas: Canvas | null;
+  grid: SampleGrid;
+  options: CheckOptions;
+}): boolean {
+  const { time, layoutSet, contrastSet, canvas, grid, options } = input;
+  if (layoutSet.has(time) || contrastSet.has(time)) return true;
+  return canvas !== null && geometryRequest(time, grid, options) !== null;
+}
+
+/** Layout-sample collection for one grid time: the issues plus the three
+ * per-sample accumulators (frozen-sweep fingerprint, rotation, off-pivot) that
+ * only layout times contribute to. Returns the issues so the caller can also
+ * feed them to the contrast annotation overlay. */
+async function collectLayoutAt(
+  driver: CheckAuditDriver,
+  options: CheckOptions,
+  time: number,
+  collected: GridSamples,
+): Promise<AnchoredLayoutIssue[]> {
+  const layoutIssues = await driver.collectLayout(time, options.tolerance, options.layout);
+  collected.layoutIssues.push(...layoutIssues);
+  collected.geometrySignatures.push(await driver.collectLayoutGeometry());
+  collected.rotationSamples.push(...(await driver.collectRotationSample(time)));
+  collected.indicatorFrames.push(await driver.collectOffPivotRotationSample(time));
+  return layoutIssues;
+}
+
+/** Contrast capture for one grid time, plus its share of the contrast timer. */
+async function collectContrastAt(
+  driver: CheckAuditDriver,
+  options: CheckOptions,
+  time: number,
+  issuesAtTime: AnchoredLayoutIssue[],
+  collected: GridSamples,
+): Promise<void> {
+  const contrastStart = Date.now();
+  // Annotation is a --snapshots-only nicety — skip building it (and the
+  // driver's extra overlay screenshot) when nothing will use it; the call
+  // shape without --snapshots stays exactly what it was before this existed.
+  const capture = options.snapshots
+    ? await driver.collectContrast(time, annotationBoxesFrom(issuesAtTime))
+    : await driver.collectContrast(time);
+  collected.contrastMs += Date.now() - contrastStart;
+  collected.contrastEntries.push(...capture.entries);
+  collected.screenshots.push({ time, pngBase64: capture.pngBase64 });
+}
+
 async function collectGridSamples(
   driver: CheckAuditDriver,
   options: CheckOptions,
@@ -386,18 +441,15 @@ async function collectGridSamples(
     indicatorFrames: [],
   };
   for (const time of mergeSampleTimes(grid.layoutSamples, motion.times)) {
-    await driver.seek(time);
+    await (needsFullAuditSettle({ time, layoutSet, contrastSet, canvas, grid, options })
+      ? driver.seek(time)
+      : driver.seekMotion(time));
     // Findings collected for THIS sample time, so the overview overlay (below)
     // only ever annotates a frame with defects that are actually valid at
     // that render time — never a stale bbox from an earlier/later sample.
     const issuesAtTime: AnchoredLayoutIssue[] = [];
     if (layoutSet.has(time)) {
-      const layoutIssues = await driver.collectLayout(time, options.tolerance, options.layout);
-      collected.layoutIssues.push(...layoutIssues);
-      issuesAtTime.push(...layoutIssues);
-      collected.geometrySignatures.push(await driver.collectLayoutGeometry());
-      collected.rotationSamples.push(...(await driver.collectRotationSample(time)));
-      collected.indicatorFrames.push(await driver.collectOffPivotRotationSample(time));
+      issuesAtTime.push(...(await collectLayoutAt(driver, options, time, collected)));
     }
     if (canvas) {
       const geometryIssues = await collectGeometryAt(
@@ -417,16 +469,7 @@ async function collectGridSamples(
       );
     }
     if (contrastSet.has(time)) {
-      const contrastStart = Date.now();
-      // Annotation is a --snapshots-only nicety — skip building it (and the
-      // driver's extra overlay screenshot) when nothing will use it; the call
-      // shape without --snapshots stays exactly what it was before this existed.
-      const capture = options.snapshots
-        ? await driver.collectContrast(time, annotationBoxesFrom(issuesAtTime))
-        : await driver.collectContrast(time);
-      collected.contrastMs += Date.now() - contrastStart;
-      collected.contrastEntries.push(...capture.entries);
-      collected.screenshots.push({ time, pngBase64: capture.pngBase64 });
+      await collectContrastAt(driver, options, time, issuesAtTime, collected);
     }
   }
   await collectMotionOverlapSamples(driver, grid, collected);

--- a/packages/cli/src/utils/checkTypes.ts
+++ b/packages/cli/src/utils/checkTypes.ts
@@ -183,6 +183,11 @@ export interface CheckAuditDriver {
   seek(time: number): Promise<void>;
   /** Settle-free seek for the geometry-only dense content_overlap pass; only collectOverlap consumes it, and getBoundingClientRect is valid synchronously after setTime. */
   seekGeometry(time: number): Promise<void>;
+  /** Sleep-free seek for grid times that only feed collectMotionFrame. Keeps the
+   * ordered double-rAF (transforms must be committed) but drops the paint-flush
+   * sleep and glyph-subset font wait, which only matter when a sample measures
+   * or photographs text. */
+  seekMotion(time: number): Promise<void>;
   collectLayout(
     time: number,
     tolerance: number,


### PR DESCRIPTION
## Why

`hyperframes check` p95 is ~37s in prod (p50 ~10s, min ~8s). This removes three waits that cost time without changing what the gate detects. No detection logic, thresholds, or sample counts change.

## What

**1. Motion-only grid times skip the paint-flush settle**

`AUDIT_SEEK_OPTIONS` pays an unconditional `settleMs: 120` sleep plus a glyph-subset font wait on every seek. A grid time that only feeds `collectMotionFrame` needs neither — `__hyperframesMotionSample` reads computed transforms and opacity, which the ordered double-rAF already guarantees are committed. The sleep exists to flush *paint*, which only matters before a screenshot.

New `MOTION_SAMPLE_SEEK_OPTIONS` keeps the double-rAF and drops the rest. Times that measure text (layout), photograph the frame (contrast), or read caption/frame geometry keep the full settle. The dense content_overlap pass already does the same thing via `DENSE_GEOMETRY_SEEK_OPTIONS`.

At `MOTION_FPS = 20` / `MOTION_MAX_SAMPLES = 300`, this is the dominant cost of any run carrying an `index.motion.json` — a 10s composition is ~201 seeks × ~170ms ≈ 34s, of which ~120ms/seek was this sleep.

**2. Adaptive post-ready settle**

`waitForCompositionSettle` slept a flat 1500ms on every page open — *after* `__renderReady`, shader pre-render, and `document.fonts.ready` had all resolved. Replaced with a poll that holds a 400ms floor, then exits on the first pair of consecutive frames with no font subset in flight, capped at the original 1500ms.

Worst case is unchanged. The floor is deliberate: work that lands after `__renderReady` but signals nothing observable (image decode, late layout) still gets a margin.

**3. Skip the discarded contrast overview screenshot**

`collectContrast` always took a *second* full-page screenshot to build the annotated overview, and the pipeline then discarded it unless `--snapshots` was set. The bare `collectContrast(time)` call shape already meant "no snapshots", so that path now skips the shot and its overlay entirely.

## Scope note

Fix 1 is a **no-op for Zephyr**, which generates only `index.html` and no motion sidecar — so its motion grid never runs. It benefits callers that do ship a motion spec. Fixes 2 and 3 apply to every check.

Per @xuanru, the larger Zephyr-specific wins are caller-side in `experiment-framework`, not here:
- `_build_check_args` never passes `--no-contrast`, yet `DROP_ERROR_SECTIONS = ("contrast",)` throws the whole contrast section away. The CLI flag already exists — the contrast pass is currently pure waste for Zephyr.
- `HYPERFRAMES_CHECK_MAX_CONCURRENCY` is unset in prod, so the per-pod Chrome semaphore falls back to the CPU request.

## Testing

- 2,265 CLI tests pass (168 files)
- Two new tests in `check.test.ts`: motion-only times route to `seekMotion`; layout/contrast times keep `seek`
- `oxlint` / `oxfmt` clean; `fallow audit` clean on all 5 changed files

## Risk

Fix 2 touches every `openSettledCompositionPage` caller (check, snapshot, compare, validate), not just check — it's the one worth a careful look. It can only return *earlier* than before, never later, and the 400ms floor plus the two-stable-frame requirement are the guardrails. If a composition turns out to need the full 1500ms, raising `CAPTURE_SETTLE_FLOOR_MS` restores the old behavior.

Savings figures above are derived from the code paths and the measured 8s floor, not from a before/after benchmark — the check has no per-phase instrumentation today. `launch_settle_ms` / `seek_loop_ms` / `contrast_ms` are already emitted on the `check_report` telemetry event but not surfaced in Datadog; wiring those up would let us verify this directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
