### PR TITLE
fix(studio-server): stop manual-edits seek wrapper from retaining stale applyManifest closures

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,33 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.86"
+  description="Released - 2026-07-30"
+  tags={["Release", "Studio", "Engine", "Contributing"]}
+>
+Hardens media probing against malformed frame rates, option-like file paths, and
+out-of-order PNG color metadata, while keeping Studio timeline latency telemetry
+non-negative. Contributor documentation now points to the correct Studio
+development port.
+
+## Fixes
+
+- **Studio:** Prevent negative timeline latency telemetry ([b813b1734](https://github.com/heygen-com/hyperframes/commit/b813b17345531874a00b3c755f60ee6f42849fee), [#2905](https://github.com/heygen-com/hyperframes/pull/2905))
+- **Engine:** Harden ffprobe parsing and command arguments ([f75ca076b](https://github.com/heygen-com/hyperframes/commit/f75ca076b790d38e518af892b67a9ea42cca3dd5), [#2740](https://github.com/heygen-com/hyperframes/pull/2740))
+
+## Docs & Examples
+
+- **Studio:** Document monorepo dev server port ([a52dd9c30](https://github.com/heygen-com/hyperframes/commit/a52dd9c3087c63a5c2c7f38d480961794d8c5eae), [#2902](https://github.com/heygen-com/hyperframes/pull/2902))
+- **Contributing:** Fix studio dev server port in setup guide ([ffe5e12cf](https://github.com/heygen-com/hyperframes/commit/ffe5e12cf8f404b86e019d28ca25dc75de903d57), [#2901](https://github.com/heygen-com/hyperframes/pull/2901))
+
+## Internal
+
+- **Pr To Video:** Pin the code-vocabulary section of the frame packet ([7b3d3db8a](https://github.com/heygen-com/hyperframes/commit/7b3d3db8adbfb7e04663d7373b9fd62c71321e6c), [#2900](https://github.com/heygen-com/hyperframes/pull/2900))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.85...v0.7.86).
+</Update>
+
+<Update
   label="HyperFrames v0.7.85"
   description="Released - 2026-07-30"
   tags={["Release", "Prompting", "Studio", "Docs"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio-server/src/helpers/manualEditsRenderScript.ts
+++ b/packages/studio-server/src/helpers/manualEditsRenderScript.ts
@@ -659,6 +659,25 @@ function studioManualEditsRenderRuntime(
     }
     return applied;
   };
+  // `applyManifest` is redefined on every re-run of this script (each studio
+  // edit / soft reload injects a fresh copy of this whole runtime). Route the
+  // wrapped seek functions through this single mutable, window-scoped slot —
+  // rather than closing over `applyManifest` directly — so that if a wrapper
+  // installed by an EARLIER generation is still active (e.g. `isWrapped`
+  // below finds the current seek already marked and skips re-wrapping), it
+  // keeps calling the CURRENT manifest logic instead of a stale closure.
+  //
+  // This also means a stale wrapper's own closure no longer needs to retain
+  // that generation's `applyManifest` (and everything IT closed over —
+  // manifestEdits, resolveTarget, every apply* helper) for the wrapper's
+  // lifetime: once a newer generation overwrites this slot, the OLD
+  // `applyManifest` becomes collectible even if the old wrapper function
+  // object itself is still reachable (e.g. still wrapped-around by another
+  // studio seek-wrapping subsystem — see studioPositionSeekReapplyRuntime's
+  // installSeekTrap above, which wraps the same two functions independently).
+  // Confirmed via a DevTools retainer trace rooted at
+  // `__hfStudioManualEditsApply` during a long editing session that this
+  // closure chain was what stayed alive across repeated re-runs.
   runtimeWindow.__hfStudioManualEditsApply = applyManifest;
 
   const markWrapped = (fn: (time: number) => unknown): void => {
@@ -688,18 +707,22 @@ function studioManualEditsRenderRuntime(
     if (!fn) return false;
     const seek = fn as (time: number) => unknown;
     if (isWrapped(seek)) {
-      applyManifest();
+      runtimeWindow.__hfStudioManualEditsApply?.();
       return true;
     }
 
+    // Calls through the live slot (see above) rather than closing over
+    // `applyManifest` directly, so this wrapper always runs the CURRENT
+    // generation's apply logic even if it's an older wrapper left in place
+    // by a prior script generation.
     const wrappedSeek = function (this: unknown, time: number): unknown {
       const result = seek.call(this, time);
-      applyManifest();
+      runtimeWindow.__hfStudioManualEditsApply?.();
       return result;
     };
     markWrapped(wrappedSeek);
     set(wrappedSeek);
-    applyManifest();
+    runtimeWindow.__hfStudioManualEditsApply?.();
     return true;
   };
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.86.md
+++ b/releases/v0.7.86.md
@@ -1,0 +1,26 @@
+# HyperFrames v0.7.86
+
+Released on 2026-07-30.
+
+Hardens media probing against malformed frame rates, option-like file paths, and
+out-of-order PNG color metadata, while keeping Studio timeline latency telemetry
+non-negative. Contributor documentation now points to the correct Studio
+development port.
+
+## Fixes
+
+- **Studio:** Prevent negative timeline latency telemetry ([b813b1734](https://github.com/heygen-com/hyperframes/commit/b813b17345531874a00b3c755f60ee6f42849fee), [#2905](https://github.com/heygen-com/hyperframes/pull/2905))
+- **Engine:** Harden ffprobe parsing and command arguments ([f75ca076b](https://github.com/heygen-com/hyperframes/commit/f75ca076b790d38e518af892b67a9ea42cca3dd5), [#2740](https://github.com/heygen-com/hyperframes/pull/2740))
+
+## Docs & Examples
+
+- **Studio:** Document monorepo dev server port ([a52dd9c30](https://github.com/heygen-com/hyperframes/commit/a52dd9c3087c63a5c2c7f38d480961794d8c5eae), [#2902](https://github.com/heygen-com/hyperframes/pull/2902))
+- **Contributing:** Fix studio dev server port in setup guide ([ffe5e12cf](https://github.com/heygen-com/hyperframes/commit/ffe5e12cf8f404b86e019d28ca25dc75de903d57), [#2901](https://github.com/heygen-com/hyperframes/pull/2901))
+
+## Internal
+
+- **Pr To Video:** Pin the code-vocabulary section of the frame packet ([7b3d3db8a](https://github.com/heygen-com/hyperframes/commit/7b3d3db8adbfb7e04663d7373b9fd62c71321e6c), [#2900](https://github.com/heygen-com/hyperframes/pull/2900))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.85...v0.7.86


### PR DESCRIPTION
## Problem

Found via a real, long interactive Studio editing session that grew to a 145,592ms local INP and
eventually crashed the tab ("Render process gone"), well after ruling out environment/RAM causes.
Two DevTools heap snapshots ~82s apart showed +487,208 objects; a retainer trace on the top offender
(`PropTween`, GSAP's internal tween-property object) rooted at `window.__hfStudioManualEditsApply`.

`wrapFunction`/`wrapSeekFunctions` in `manualEditsRenderScript.ts` wrap `__hf.seek` /
`__player.renderSeek` so studio manual edits (translate/rotate/box-size) get reapplied after every
seek. Each installed wrapper closes directly over that generation's `applyManifest` — but this whole
runtime script is re-injected fresh on every studio edit. If a wrapper from an earlier generation is
still the active one (`isWrapped` finds it already marked on the current seek function and skips
re-wrapping — by design, e.g. after a plain re-run with no underlying reassignment), it keeps calling
its own **stale** `applyManifest` closure, which retains everything it closed over
(`manifestEdits`, `resolveTarget`, every `apply*` helper) for the rest of the session instead of the
current one. The same risk applies if another seek-wrapping subsystem in this file
(`studioPositionSeekReapplyRuntime`'s `installSeekTrap`, which independently wraps the same two
functions) leaves an older wrapper reachable.

## Fix

Route the wrapper through the `__hfStudioManualEditsApply` window slot — already kept current on
every re-run — instead of closing over `applyManifest` directly. A wrapper now always calls live
logic, and a stale generation's `applyManifest` closure becomes collectible as soon as a newer
generation overwrites the slot, regardless of how long the wrapper function object itself stays
reachable. No change to *when* wrapping happens or the re-entrancy/reassignment-recovery behavior
already covered by the existing interval-polling test (`wrapSeekFunctions` re-wraps a genuinely
replaced, unmarked seek function exactly as before).

## Verified

- `bun test packages/studio-server/src/helpers/manualEditsRenderScript.test.ts
  packages/core/src/studio-api/helpers/manualEditsRenderScript.test.ts` — 28/28 pass, including the
  reassignment-recovery case (external code replaces `__hf.seek`; interval polling re-wraps it).
- `tsc --noEmit` clean for `@hyperframes/studio-server`.
- `oxlint` clean on the changed file.

## Related, not duplicated by this PR

- #1876 (open) — a different bug in the same `window.__timelines` neighborhood (drag-pause never
  resumes sub-composition timelines). Not the same code path, but same general area.
- #2107 (open) — registry `caption-*` blocks registering timelines asynchronously, violating the
  determinism contract. Unrelated mechanism, same general subsystem.
- #1129 (merged) — introduced the soft-reload path (`__hfForceTimelineRebind`) this fix's wrapper
  ultimately runs under.

Two further leak sources were found via retainer traces during the same investigation but aren't
fixed here — filing a separate issue with the evidence rather than bundling unrelated, less-verified
changes into this PR:
1. A React Fiber on a hidden `<img>` (`class="hidden"`), retained via `blink::ThreadState`'s "Pending
   activities" — looks like asset/thumbnail image handling leaving pending decode state uncleaned.
2. GSAP's own global `TimelineLite` (distinct from `window.__timelines`), reached through nested
   `bound_this` closures rooted in Studio's own UI code — plausibly its playhead/scrubber, not yet
   isolated to a specific file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)