### PR TITLE
fix(engine): merge colour per field, detect alpha correctly, defer PNG parse

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -3,7 +3,11 @@ import { EventEmitter } from "events";
 import { readFileSync } from "fs";
 import { basename, resolve } from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { extractMediaMetadata, extractPngMetadataFromBuffer } from "./ffprobe.js";
+import {
+  extractMediaMetadata,
+  extractPngMetadataFromBuffer,
+  pixelFormatHasAlpha,
+} from "./ffprobe.js";
 
 function crc32(buf: Buffer): number {
   let crc = 0xffffffff;
@@ -749,4 +753,25 @@ describe("crc32 works on every runtime the package declares", () => {
     const fresh = await loadWithoutNativeCrc32();
     expect(fresh.extractPngMetadataFromBuffer(png)).toBeNull();
   });
+});
+
+describe("pix_fmt alpha detection", () => {
+  // The old pattern's (^|[^a-z]) anchor bound to `yuva` alone, and the list
+  // omitted formats real files actually use.
+  const ALPHA = [
+    "yuva420p",
+    "rgba",
+    "argb",
+    "bgra",
+    "abgr",
+    "gbrap",
+    "ya8",
+    "ya16le",
+    "ayuv64le",
+    "yuva444p12le",
+  ];
+  const OPAQUE = ["yuv420p", "rgb24", "gray", "gbrp", "nv12", "yuv444p10le", "bgr0", "rgb0"];
+
+  it.each(ALPHA)("detects alpha in %s", (fmt) => expect(pixelFormatHasAlpha(fmt)).toBe(true));
+  it.each(OPAQUE)("reports %s as opaque", (fmt) => expect(pixelFormatHasAlpha(fmt)).toBe(false));
 });

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -284,6 +284,23 @@ export function extractPngMetadataFromBuffer(buf: Buffer): StillImageMetadata | 
   return width > 0 && height > 0 ? { width, height, colorSpace: colorSpaceFromCicp } : null;
 }
 
+/**
+ * Does this pix_fmt carry an alpha channel?
+ *
+ * Exported so the test asserts the shipped predicate rather than a copy of
+ * the pattern. Anchored at the start, matching studio-server's
+ * mediaMetadata.ts: the previous inline pattern bound its `(^|[^a-z])` anchor
+ * to the first alternative only — `|` is looser than concatenation — so the
+ * guard was decorative for every other name. It also missed abgr, ya8/ya16
+ * and ayuv64, and its `gray[a-z0-9]*a` branch matched only gray8a/gray16a,
+ * names FFmpeg renamed to ya8/ya16 in 2013. A `ya8` grayscale-plus-alpha PNG
+ * reported hasAlpha:false, resolveFrameFormat picked jpg, and the overlay
+ * flattened to an opaque rectangle.
+ */
+export function pixelFormatHasAlpha(pixelFormat: string): boolean {
+  return /^(?:yuva|rgba|argb|bgra|abgr|gbrap|ya|ayuv)/i.test(pixelFormat);
+}
+
 function extractStillImageMetadata(filePath: string): StillImageMetadata | null {
   if (extname(filePath).toLowerCase() !== ".png") return null;
 
@@ -336,7 +353,18 @@ export async function extractMediaMetadata(filePath: string): Promise<VideoMetad
   if (cached) return cached;
 
   const probePromise = (async (): Promise<VideoMetadata> => {
-    const stillImageMeta = extractStillImageMetadata(filePath);
+    // Lazily memoized. This is a pure fallback, but it used to run eagerly
+    // and synchronously BEFORE the first await: readFileSync plus a CRC walk
+    // per file, so a caller fanning out over composition.images with
+    // Promise.all executed every parse back-to-back before a single ffprobe
+    // was spawned (12 4K PNGs: 2649 ms vs 170 ms probe-only) — event-loop
+    // stall that also blocks Puppeteer IPC and progress reporting. On the
+    // happy path the result was then discarded.
+    let stillImageMetaMemo: StillImageMetadata | null | undefined;
+    const stillImage = (): StillImageMetadata | null => {
+      stillImageMetaMemo ??= extractStillImageMetadata(filePath);
+      return stillImageMetaMemo;
+    };
 
     let output: FFProbeOutput | null = null;
     try {
@@ -348,11 +376,12 @@ export async function extractMediaMetadata(filePath: string): Promise<VideoMetad
       ]);
       output = parseProbeJson(stdout);
     } catch (error) {
-      if (!stillImageMeta) throw error;
+      if (!stillImage()) throw error;
     }
 
     const videoStream = output?.streams.find((s) => s.codec_type === "video");
     if (!videoStream) {
+      const stillImageMeta = stillImage();
       if (stillImageMeta) {
         return {
           durationSeconds: 0,
@@ -379,15 +408,31 @@ export async function extractMediaMetadata(filePath: string): Promise<VideoMetad
     const colorTransfer = videoStream.color_transfer || "";
     const colorPrimaries = videoStream.color_primaries || "";
     const colorSpaceVal = videoStream.color_space || "";
-    const ffprobeColorSpace =
-      colorTransfer || colorPrimaries || colorSpaceVal
-        ? { colorTransfer, colorPrimaries, colorSpace: colorSpaceVal }
-        : null;
-    const colorSpace = ffprobeColorSpace ?? stillImageMeta?.colorSpace ?? null;
+    // Merged per field, not whole-object. ffprobe emits color_space "gbr" for
+    // every PNG — even a plain rgb24 with no colour metadata — so a
+    // whole-object `??` meant the cICP fallback was discarded whenever
+    // ffprobe ran at all, which is exactly the build it exists to cover: one
+    // that reports gbr but does not decode cICP. An HDR PQ PNG then resolved
+    // colorTransfer "" and graded SDR.
+    const cicp = colorTransfer && colorPrimaries && colorSpaceVal ? null : stillImage()?.colorSpace;
+    const merged = {
+      colorTransfer: colorTransfer || cicp?.colorTransfer || "",
+      colorPrimaries: colorPrimaries || cicp?.colorPrimaries || "",
+      colorSpace: colorSpaceVal || cicp?.colorSpace || "",
+    };
+    const colorSpace =
+      merged.colorTransfer || merged.colorPrimaries || merged.colorSpace ? merged : null;
     const pixelFormat = videoStream.pix_fmt || "";
     const alphaMode = readTagCI(videoStream.tags, "alpha_mode");
-    const hasAlpha =
-      /(^|[^a-z])yuva|rgba|argb|bgra|gbrap|gray[a-z0-9]*a/i.test(pixelFormat) || alphaMode === "1";
+    const hasAlpha = pixelFormatHasAlpha(pixelFormat) || alphaMode === "1";
+    // Anchored at the start, matching studio-server's mediaMetadata.ts. The
+    // previous pattern bound its `(^|[^a-z])` anchor to the FIRST alternative
+    // only — `|` is looser than concatenation — so the guard was decorative
+    // for every other name. It also missed abgr, ya8/ya16 and ayuv64, and its
+    // `gray[a-z0-9]*a` branch matched only gray8a/gray16a, names FFmpeg
+    // renamed to ya8/ya16 in 2013. A `ya8` grayscale-plus-alpha PNG reported
+    // hasAlpha:false, resolveFrameFormat picked jpg, and the overlay
+    // flattened to an opaque rectangle.
 
     const containerDuration = output?.format.duration ? parseFloat(output.format.duration) : 0;
     const streamDuration = videoStream.duration ? parseFloat(videoStream.duration) : 0;
@@ -395,8 +440,8 @@ export async function extractMediaMetadata(filePath: string): Promise<VideoMetad
     return {
       durationSeconds: containerDuration,
       videoStreamDurationSeconds: streamDuration > 0 ? streamDuration : containerDuration,
-      width: videoStream.width || stillImageMeta?.width || 0,
-      height: videoStream.height || stillImageMeta?.height || 0,
+      width: videoStream.width || stillImage()?.width || 0,
+      height: videoStream.height || stillImage()?.height || 0,
       fps,
       videoCodec: videoStream.codec_name || "unknown",
       hasAudio: output?.streams.some((s) => s.codec_type === "audio") ?? false,


### PR DESCRIPTION
**Stack 2/6**, on top of #2912. These are pre-existing bugs, not regressions from #2740 — but they live in the code #2740 touched and one of them makes that commit's fix unreachable.

## The cICP fallback never runs when ffprobe is present

```ts
const colorSpace = ffprobeColorSpace ?? stillImageMeta?.colorSpace ?? null;
```

`ffprobeColorSpace` is non-null if **any** of `color_transfer` / `color_primaries` / `color_space` is non-empty — and ffprobe 8.1.1 emits `color_space: "gbr"` for every PNG, including a plain 2×2 rgb24 with no colour metadata. So the whole-object `??` discards the PNG result unconditionally.

Which means on exactly the build the parser exists for — one that reports `gbr` but does not decode cICP — an HDR PQ PNG resolves `colorTransfer: ""`, `isHdrColorSpace()` returns false, and the still grades SDR. Now merged per field.

Worth noting: the guard test added in #2740 (*"reads HDR PNG cICP metadata when ffprobe color fields are absent"*) is satisfied entirely by the ffprobe branch on modern builds. The PNG fallback could have been deleted and it would still have passed.

## hasAlpha's anchor bound to one alternative

```ts
/(^|[^a-z])yuva|rgba|argb|bgra|gbrap|gray[a-z0-9]*a/i
```

`|` binds looser than concatenation, so `(^|[^a-z])` guards `yuva` and is decorative for everything after it. Against the ffmpeg pix_fmt list, `abgr`, `ya8`, `ya16be`, `ya16le` and `ayuv64le` all return false, and `gray[a-z0-9]*a` matches only `gray8a`/`gray16a` — names FFmpeg renamed to `ya8`/`ya16` in 2013, so dead against every modern build.

A `ya8` grayscale-plus-alpha PNG reports `hasAlpha: false`; `codecMayHaveAlpha` only rescues vp9/vp8/prores, so `resolveFrameFormat` picks jpg, alpha is flattened, and the overlay renders as an opaque rectangle. Replaced with the start-anchored form `studio-server/src/helpers/mediaMetadata.ts:137` already uses.

Extracted as exported `pixelFormatHasAlpha` so the test asserts the shipped predicate rather than a copy of the pattern.

## The PNG parse ran eagerly and was thrown away

`extractStillImageMetadata` sat before the first `await`, so `readFileSync` plus the CRC walk ran for every file before a single ffprobe was spawned. A caller fanning out over `composition.images` with `Promise.all` serialised completely:

| | |
|---|---|
| 12 4K PNGs, probe only | 170 ms |
| 12 4K PNGs, with eager parse | 2649 ms (15.6×) |

2.5 s of event-loop stall that also blocks Puppeteer IPC and progress reporting — for a value discarded on every happy path. Now lazily memoized behind the paths that consult it.

## Verification

18 pix_fmt cases against the real predicate. Reverting the regex fails 4. Engine suite: 1280 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
