### PR TITLE
docs: unlist the Send-to guide from the docs nav (tool-served, not web-searched)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -164,7 +164,6 @@
               "guides/antigravity",
               "guides/copilot-cli",
               "guides/claude-design",
-              "guides/claude-design-send-to-hyperframes",
               "guides/open-design",
               "guides/hyperframes-vs-remotion",
               "guides/gsap-animation",


### PR DESCRIPTION
## What

Unlist the "Send to HyperFrames" authoring guide (`guides/claude-design-send-to-hyperframes`) from the docs navigation in `docs.json`, making it an unlisted orphan file (like the sibling `claude-design-hyperframes.md` already is). The guide file itself is unchanged.

## Why

That guide is an internal authoring contract for the Claude Design "Send to HyperFrames" import flow, not general HyperFrames product docs. It's now delivered exclusively by the `get-send-to-hyperframes-guide` MCP tool, which fetches the raw file server-side (`raw.githubusercontent.com/heygen-com/hyperframes/main/docs/guides/claude-design-send-to-hyperframes.md`) and returns it as tool-result data — independent of the docs site. The `llms.txt` / `web_search` discovery path it was published for is no longer used (the import tool tells the agent the guide comes from the tool, "no fetch/search needed"). So the nav entry only surfaces implementation detail in the public product docs without serving the flow.

## How

Remove the one `"guides/claude-design-send-to-hyperframes"` line from `docs/docs.json`. This drops it from the sidebar and the auto-generated `llms.txt`, while:
- **keeping the `.md` file at its path** — the MCP tool's raw fetch URL depends on it and is unchanged, so nothing in the live flow moves;
- keeping the redirect note in `claude-design-hyperframes.md` (it points at the raw GitHub URL, not the docs page, so it still resolves).

Orphan guide files build cleanly in this repo — `claude-design-hyperframes.md` is already an orphan (present but absent from `docs.json`), and no internal doc links reference the page.

## Test plan

- [x] `docs.json` validated as well-formed JSON; guide `.md` confirmed still present; grep confirms no internal doc links to the page.
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)
