### PR TITLE
feat(studio): VST FX panel section behind STUDIO_VST_ENABLED

### DIFF
--- a/packages/studio/src/components/StudioRightPanel.test.tsx
+++ b/packages/studio/src/components/StudioRightPanel.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment happy-dom
+//
+// Task 13b regression test: before this fix, `StudioRightPanel` never passed
+// a `vstHost` prop to `PropertyPanel` at all (it defaulted to `null` there),
+// so the FX panel always rendered its "not available" install-hint state.
+// This test proves the panel now forwards the ONE shared `useVstHost()`
+// instance (threaded through `NLEContext`) rather than either omitting it or
+// creating a second, independent connection of its own.
+//
+// Every context `StudioRightPanel` reads is mocked to the minimal shape it
+// actually destructures (mirroring PropertyPanel.test.tsx's established
+// pattern for this codebase), and the real `PropertyPanel` + heavier tab
+// panels are replaced with lightweight stand-ins so this test exercises only
+// the prop-forwarding wiring, not their internals.
+
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { VstHostApi } from "./editor/propertyPanelVstSection";
+import type { SdkSessionPublicationResult } from "../utils/sdkEditTransaction";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let capturedVstHost: VstHostApi | null | undefined;
+
+vi.mock("./editor/PropertyPanel", () => ({
+  PropertyPanel: (props: { vstHost?: VstHostApi | null }) => {
+    capturedVstHost = props.vstHost;
+    return null;
+  },
+}));
+
+vi.mock("./DesignPanelPromoteProvider", () => ({
+  DesignPanelPromoteProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../contexts/StudioContext", async () => {
+  const actual = await vi.importActual<typeof import("../contexts/StudioContext")>(
+    "../contexts/StudioContext",
+  );
+  return {
+    ...actual,
+    useStudioShellContext: () => ({
+      previewIframeRef: { current: null },
+      projectId: "proj-1",
+      activeCompPath: "index.html",
+      showToast: vi.fn(),
+      compositionDimensions: null,
+      waitForPendingDomEditSaves: async () => {},
+      renderQueue: {
+        jobs: [],
+        isRendering: false,
+        loadError: null,
+        actionError: null,
+        dismissActionError: () => {},
+        reloadRenders: () => {},
+        deleteRender: () => {},
+        cancelRender: () => {},
+        clearCompleted: () => {},
+        startRender: async () => {},
+      },
+    }),
+    useStudioPlaybackContext: () => ({ captionEditMode: false, refreshKey: 0 }),
+  };
+});
+
+vi.mock("../contexts/PanelLayoutContext", async () => {
+  const actual = await vi.importActual<typeof import("../contexts/PanelLayoutContext")>(
+    "../contexts/PanelLayoutContext",
+  );
+  return {
+    ...actual,
+    usePanelLayoutContext: () => ({
+      rightWidth: 320,
+      setRightWidth: () => {},
+      rightPanelTab: "design",
+      setRightPanelTab: () => {},
+      rightInspectorPanes: { design: true, layers: false },
+      toggleRightInspectorPane: () => {},
+      handlePanelResizeStart: () => {},
+      handlePanelResizeMove: () => {},
+      handlePanelResizeEnd: () => {},
+    }),
+  };
+});
+
+vi.mock("../contexts/FileManagerContext", async () => {
+  const actual = await vi.importActual<typeof import("../contexts/FileManagerContext")>(
+    "../contexts/FileManagerContext",
+  );
+  return {
+    ...actual,
+    useFileManagerContext: () => ({
+      assets: [],
+      fontAssets: [],
+      projectDir: "",
+      handleImportFiles: async () => {},
+      handleImportFonts: async () => {},
+      refreshFileTree: async () => {},
+      readProjectFile: async () => "",
+      writeProjectFile: async () => {},
+      fileTree: [],
+    }),
+  };
+});
+
+vi.mock("../contexts/DomEditContext", async () => {
+  const actual = await vi.importActual<typeof import("../contexts/DomEditContext")>(
+    "../contexts/DomEditContext",
+  );
+  return {
+    ...actual,
+    useDomEditContext: () => ({
+      domEditSelection: null,
+      domEditGroupSelections: [],
+      copiedAgentPrompt: null,
+      clearDomSelection: () => {},
+      handleUngroupSelection: () => {},
+      handleGroupSelection: () => {},
+      handleDomStyleCommit: () => {},
+      handleDomAttributeCommit: async () => {},
+      handleDomAttributeLiveCommit: () => {},
+      handleDomHtmlAttributeCommit: async () => {},
+      handleDomAttributesCommit: async () => {},
+      handleDomPathOffsetCommit: () => {},
+      handleDomBoxSizeCommit: () => {},
+      handleDomRotationCommit: () => {},
+      handleDomTextCommit: () => {},
+      handleDomTextFieldStyleCommit: () => {},
+      handleDomAddTextField: () => {},
+      handleDomRemoveTextField: () => {},
+      handleAskAgent: () => {},
+      selectedGsapAnimations: [],
+      gsapMultipleTimelines: false,
+      gsapUnsupportedTimelinePattern: null,
+      handleGsapUpdateProperty: () => {},
+      handleGsapUpdateMeta: () => {},
+      handleGsapDeleteAnimation: () => {},
+      handleGsapAddAnimation: () => {},
+      handleGsapAddProperty: () => {},
+      handleGsapRemoveProperty: () => {},
+      handleGsapUpdateFromProperty: () => {},
+      handleGsapAddFromProperty: () => {},
+      handleGsapRemoveFromProperty: () => {},
+      commitAnimatedProperty: () => {},
+      commitAnimatedProperties: () => {},
+      handleSetArcPath: () => {},
+      handleUpdateArcSegment: () => {},
+      handleUnroll: () => {},
+      handleUpdateKeyframeEase: () => {},
+      handleSetAllKeyframeEases: () => {},
+      handleGsapAddKeyframe: () => {},
+      handleGsapRemoveKeyframe: () => {},
+      handleGsapConvertToKeyframes: () => {},
+    }),
+  };
+});
+
+const fakeVstHost = {
+  api: {
+    registry: [],
+    scan: async () => {},
+    openEditor: () => {},
+    setParam: () => {},
+    loadChain: async () => ({ trackIndex: 0, sampleRate: 48000, stable: true }),
+    getState: async () => [],
+  } satisfies VstHostApi,
+  status: "ready" as const,
+  installHint: null,
+  ensureStarted: async () => {},
+  onPcmFrame: () => () => {},
+  sendTransport: () => {},
+  onDisconnect: () => () => {},
+  onChainLoaded: () => () => {},
+};
+
+// StudioRightPanel only imports `useNLEContext` from this module — no need to
+// load the real NLEProvider (and its useTimelinePlayer/useVstHost chain) for
+// this test.
+vi.mock("./nle/NLEContext", () => ({
+  useNLEContext: () => ({ vstHost: fakeVstHost }),
+}));
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  capturedVstHost = undefined;
+  vi.resetModules();
+});
+
+describe("StudioRightPanel — vstHost wiring", () => {
+  // The dynamic import below pulls in StudioRightPanel's full (heavy) module
+  // graph the first time this file runs; under a full-suite run alongside
+  // hundreds of other test files that can exceed vitest's default 5s.
+  it("forwards the shared vstHost.api (not null) into PropertyPanel", async () => {
+    const { StudioRightPanel } = await import("./StudioRightPanel");
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        React.createElement(StudioRightPanel, {
+          designPanelActive: true,
+          sdkSession: null,
+          publishSdkSession: (): SdkSessionPublicationResult => "published",
+          reloadPreview: () => {},
+          domEditSaveTimestampRef: { current: 0 },
+          recordEdit: async () => {},
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(capturedVstHost).toBe(fakeVstHost.api);
+    expect(capturedVstHost).not.toBeNull();
+
+    act(() => root.unmount());
+    host.remove();
+  }, 15000);
+});

--- a/packages/studio/src/components/StudioRightPanel.tsx
+++ b/packages/studio/src/components/StudioRightPanel.tsx
@@ -17,11 +17,12 @@ import { useSlideshowPersist, type UseSlideshowPersistParams } from "../hooks/us
 import { useSlideshowTabState } from "../hooks/useSlideshowTabState";
 import { DesignPanelPromoteProvider } from "./DesignPanelPromoteProvider";
 import { useStudioPlaybackContext, useStudioShellContext } from "../contexts/StudioContext";
+import { useNLEContext } from "./nle/NLEContext";
 import { usePanelLayoutContext } from "../contexts/PanelLayoutContext";
 import { useFileManagerContext } from "../contexts/FileManagerContext";
 import { useDomEditContext } from "../contexts/DomEditContext";
 import { usePlayerStore } from "../player";
-import { waitForMediaJob } from "./studioMediaJobs";
+import { removeBackgroundViaApi } from "./studioBackgroundRemoval";
 import {
   applyColorGradingScopeUpdate,
   EMPTY_COLOR_GRADING_SCOPE_RESULT,
@@ -113,6 +114,11 @@ export function StudioRightPanel({
     renderQueue,
   } = useStudioShellContext();
   const { captionEditMode, refreshKey } = useStudioPlaybackContext();
+  // Single sidecar connection for the whole shell (see NLEContext's `vstHost`
+  // doc-comment) — the FX panel consumes the SAME useVstHost() instance the
+  // live-playback path (useVstPreview, mounted in NLEProvider) streams
+  // through, never a second independent WebSocket.
+  const { vstHost } = useNLEContext();
 
   const {
     domEditSelection,
@@ -281,49 +287,19 @@ export function StudioRightPanel({
   );
 
   const handleRemoveBackground = useCallback(
-    // fallow-ignore-next-line complexity
-    async (
+    (
       inputPath: string,
       options: {
         createBackgroundPlate?: boolean;
         quality?: "fast" | "balanced" | "best";
         onProgress?: (progress: BackgroundRemovalProgress) => void;
       },
-    ) => {
-      const response = await fetch(
-        `/api/projects/${encodeURIComponent(projectId)}/media/remove-background`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            inputPath,
-            createBackgroundPlate: options.createBackgroundPlate === true,
-            quality: options.quality ?? "balanced",
-          }),
-        },
-      );
-      const data = (await response.json().catch(() => ({}))) as {
-        jobId?: string;
-        error?: string;
-      };
-      if (!response.ok || !data.jobId) {
-        throw new Error(data.error || `Background removal failed (${response.status})`);
-      }
-      showToast("Removing background...", "info");
-      backgroundRemovalAbortRef.current?.abort();
-      const controller = new AbortController();
-      backgroundRemovalAbortRef.current = controller;
-      try {
-        const result = await waitForMediaJob(data.jobId, options.onProgress, controller.signal);
-        await refreshFileTree();
-        showToast(`Created transparent asset: ${result.outputPath.split("/").pop()}`, "info");
-        return result;
-      } finally {
-        if (backgroundRemovalAbortRef.current === controller) {
-          backgroundRemovalAbortRef.current = null;
-        }
-      }
-    },
+    ) =>
+      removeBackgroundViaApi(projectId, inputPath, options, {
+        refreshFileTree,
+        showToast,
+        abortRef: backgroundRemovalAbortRef,
+      }),
     [projectId, refreshFileTree, showToast],
   );
   const handleHideAllSelected = () => {
@@ -406,6 +382,8 @@ export function StudioRightPanel({
         recordingState={recordingState}
         recordingDuration={recordingDuration}
         onToggleRecording={onToggleRecording}
+        vstHost={vstHost.api}
+        domEditSaveTimestampRef={domEditSaveTimestampRef}
       />
     </DesignPanelPromoteProvider>
   );

--- a/packages/studio/src/components/editor/PropertyPanel.test.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.test.tsx
@@ -674,6 +674,52 @@ function audioElement() {
   };
 }
 
+describe("PropertyPanel — STUDIO_VST_ENABLED gate", () => {
+  it(
+    "does not render the VST FX section for an audio element by default (flag off)",
+    async () => {
+      const { host, root } = await renderPanel(false, audioElement() as never);
+      expect(host.querySelector('[data-vst-install-hint="true"]')).toBeNull();
+      expect(host.querySelector("[data-vst-add-effect]")).toBeNull();
+      act(() => root.unmount());
+    },
+    RENDER_TIMEOUT_MS,
+  );
+
+  it(
+    "renders the VST FX section for an audio element once STUDIO_VST_ENABLED is on",
+    async () => {
+      vi.doMock("./manualEditingAvailability", async () => {
+        const actual = await vi.importActual<typeof import("./manualEditingAvailability")>(
+          "./manualEditingAvailability",
+        );
+        return { ...actual, STUDIO_FLAT_INSPECTOR_ENABLED: false, STUDIO_VST_ENABLED: true };
+      });
+      vi.resetModules();
+      const { PropertyPanel } = await import("./PropertyPanel");
+      const host = document.createElement("div");
+      document.body.append(host);
+      const root = createRoot(host);
+      const props = {
+        element: audioElement(),
+        assets: [],
+        onSetStyle: vi.fn(),
+        onSetText: vi.fn(),
+        onSetAttributeLive: vi.fn(),
+      } as unknown as PropertyPanelProps;
+      act(() => {
+        root.render(<PropertyPanel {...props} />);
+      });
+      expect(
+        host.querySelector('[data-vst-install-hint="true"]') ||
+          host.querySelector("[data-vst-add-effect]"),
+      ).not.toBeNull();
+      act(() => root.unmount());
+    },
+    RENDER_TIMEOUT_MS,
+  );
+});
+
 // All FlatGroup titles currently mounted (open row + every collapsed row).
 function flatGroupTitles(host: HTMLElement): string[] {
   const open = Array.from(

--- a/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -20,13 +20,14 @@ import { createTransformCommitHandlers } from "./propertyPanelTransformCommit";
 import { resolveAnimIdForProperty } from "../../player/components/TimelinePropertyLanes";
 import { resolveEditingSections } from "@hyperframes/core/editing";
 import { MediaSection } from "./propertyPanelMediaSection";
+import { VstSection } from "./propertyPanelVstSection";
 import { ColorGradingSection } from "./propertyPanelColorGradingSection";
 import { domEditSelectionToFacts } from "./domEditingLayers";
 import { TextSection, StyleSections } from "./propertyPanelSections";
 import { GsapAnimationSection } from "./GsapAnimationSection";
 import { PropertyPanel3dTransform } from "./propertyPanel3dTransform";
 import { KeyframeNavigation } from "./KeyframeNavigation";
-import { STUDIO_FLAT_INSPECTOR_ENABLED } from "./manualEditingAvailability";
+import { STUDIO_FLAT_INSPECTOR_ENABLED, STUDIO_VST_ENABLED } from "./manualEditingAvailability";
 import { PropertyPanelFlat } from "./PropertyPanelFlat";
 import { createGsapLivePreview } from "./gsapLivePreview";
 import { usePlayerStore, liveTime } from "../../player";
@@ -35,20 +36,6 @@ import { type PropertyPanelProps } from "./propertyPanelHelpers";
 import { GestureRecordPanelButton } from "./GestureRecordControl";
 import { PropertyPanelEmptyState } from "./PropertyPanelEmptyState";
 import { DesignPanelInputProvider } from "../../contexts/DesignPanelInputContext";
-
-// Re-export helpers that external consumers import from this module
-export {
-  buildInsetClipPathSides,
-  buildStrokeStyleUpdates,
-  buildStrokeWidthStyleUpdates,
-  getCssFilterFunctionPx,
-  getClipPathInsetPx,
-  inferBoxShadowPreset,
-  inferClipPathPreset,
-  normalizePanelPxValue,
-  parseInsetClipPathSides,
-  setCssFilterFunctionPx,
-} from "./propertyPanelHelpers";
 
 // fallow-ignore-next-line complexity
 export const PropertyPanel = memo(function PropertyPanel(props: PropertyPanelProps) {
@@ -109,6 +96,8 @@ export const PropertyPanel = memo(function PropertyPanel(props: PropertyPanelPro
     recordingState,
     recordingDuration,
     onToggleRecording,
+    vstHost = null,
+    domEditSaveTimestampRef,
   } = props;
   const styles = element?.computedStyles ?? EMPTY_STYLES;
   const { showToast } = useStudioShellContext();
@@ -376,6 +365,16 @@ export const PropertyPanel = memo(function PropertyPanel(props: PropertyPanelPro
             onSetAttribute={onSetAttribute}
             onSetHtmlAttribute={onSetHtmlAttribute}
             onRemoveBackground={onRemoveBackground}
+          />
+        )}
+
+        {STUDIO_VST_ENABLED && sections.vstFx && (
+          <VstSection
+            projectId={projectId}
+            element={element}
+            onSetAttribute={onSetAttribute}
+            vstHost={vstHost}
+            domEditSaveTimestampRef={domEditSaveTimestampRef}
           />
         )}
 

--- a/packages/studio/src/components/editor/propertyPanelTypes.ts
+++ b/packages/studio/src/components/editor/propertyPanelTypes.ts
@@ -1,8 +1,9 @@
-import type { RefObject } from "react";
+import type { MutableRefObject, RefObject } from "react";
 import type { ArcPathSegment, GsapAnimation } from "@hyperframes/parsers/gsap-parser";
 import type { DomEditSelection } from "./domEditing";
 import type { ImportedFontAsset } from "./fontAssets";
 import type { GsapAnimationEditCallbacks } from "./gsapAnimationCallbacks";
+import type { VstHostApi } from "./propertyPanelVstSection";
 
 export interface BackgroundRemovalProgress {
   status: "processing" | "complete" | "failed";
@@ -139,4 +140,10 @@ export interface PropertyPanelProps {
   recordingState?: "idle" | "recording" | "preview";
   recordingDuration?: number;
   onToggleRecording?: () => void;
+  /** Task 12's `useVstHost` supplies the real client; `null`/omitted renders the install hint. */
+  vstHost?: VstHostApi | null;
+  /** Shared timestamp ref — written by any studio save (code tab, timeline,
+   *  DOM edits, VST chain persistence). Used to suppress file-change echoes
+   *  so the preview doesn't reload after our own saves. */
+  domEditSaveTimestampRef?: MutableRefObject<number>;
 }

--- a/packages/studio/src/components/editor/propertyPanelVstCarveSection.tsx
+++ b/packages/studio/src/components/editor/propertyPanelVstCarveSection.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState, type MutableRefObject } from "react";
+import type { DomEditSelection } from "./domEditing";
+import { usePlayerStore } from "../../player/store/playerStore";
+import {
+  appendCarveBands,
+  isRecord,
+  projectRelativeAssetPath,
+  type CarveBand,
+  type ChainFileJson,
+} from "../../utils/vstChainFile";
+import { isAudioTimelineElement } from "../../utils/timelineInspector";
+import { chainFilePath, readChainFile, writeChainFile } from "./propertyPanelVstShared";
+
+/** Maps the carve amount slider (0-100) to the sidecar's `maxCutDb` — 0 -> 2 dB
+ *  (subtle), 100 -> 6 dB (aggressive). */
+function amountToMaxCutDb(amount: number): number {
+  return 2 + (amount / 100) * 4;
+}
+
+/** POSTs to `/vst/carve` and validates the response shape. Null on any failure
+ *  (network, non-2xx, or malformed body) — the caller treats that as "no-op". */
+async function fetchCarveBands(
+  projectId: string,
+  musicPath: string,
+  voicePath: string,
+  maxCutDb: number,
+): Promise<CarveBand[] | null> {
+  const res = await fetch("/api/vst/carve", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ projectId, musicPath, voicePath, maxCutDb }),
+  });
+  if (!res.ok) return null;
+  const body: unknown = await res.json().catch(() => null);
+  return isRecord(body) && Array.isArray(body.bands) ? (body.bands as CarveBand[]) : null;
+}
+
+interface CarveRequest {
+  projectId: string;
+  element: DomEditSelection;
+  musicSrc: string | undefined;
+  voiceSrc: string | undefined;
+  carveAmount: number;
+}
+
+interface CarveResult {
+  chain: ChainFileJson;
+  path: string;
+}
+
+/** Runs the full carve pipeline (resolve asset paths → fetch bands → merge
+ *  into the chain file → write it back). Null on any failure — the caller
+ *  treats that as "no-op" and leaves the panel open. */
+async function runCarve(req: CarveRequest): Promise<CarveResult | null> {
+  const musicSub = req.musicSrc ? projectRelativeAssetPath(req.musicSrc) : null;
+  const voSub = req.voiceSrc ? projectRelativeAssetPath(req.voiceSrc) : null;
+  if (!musicSub || !voSub) return null;
+
+  const bands = await fetchCarveBands(
+    req.projectId,
+    musicSub,
+    voSub,
+    amountToMaxCutDb(req.carveAmount),
+  );
+  if (!bands) return null;
+
+  const path = chainFilePath(req.element);
+  const existing = await readChainFile(req.projectId, path);
+  const nextChain = appendCarveBands(existing, bands);
+  const ok = await writeChainFile(req.projectId, path, nextChain);
+  if (!ok) return null;
+
+  return { chain: nextChain, path };
+}
+
+export interface VstCarveSectionProps {
+  projectId: string;
+  element: DomEditSelection;
+  trackId: string;
+  busy: boolean;
+  setBusy: (busy: boolean) => void;
+  onSetAttribute: (attr: string, value: string) => void | Promise<void>;
+  /** Called with the freshly-written chain right after the PUT succeeds, so
+   *  the parent can update its `chain` state and re-seed the visible param
+   *  sliders (the amount slider must be reflected immediately — see the
+   *  "re-applying carve" regression test). */
+  onChainWritten: (chain: ChainFileJson) => void;
+  /** Stamped after the write so the studio's file-watcher treats it as our
+   *  own save and skips reloading the preview — every other save path in
+   *  this panel does this too. */
+  domEditSaveTimestampRef?: MutableRefObject<number>;
+}
+
+/** The "Make room for voiceover" carve control: renders nothing when there's
+ *  no other audio track eligible as the voiceover source. */
+export function VstCarveSection({
+  projectId,
+  element,
+  trackId,
+  busy,
+  setBusy,
+  onSetAttribute,
+  onChainWritten,
+  domEditSaveTimestampRef,
+}: VstCarveSectionProps) {
+  const elements = usePlayerStore((s) => s.elements);
+  const [carveOpen, setCarveOpen] = useState(false);
+  const [carveAmount, setCarveAmount] = useState(50);
+
+  // Other audio tracks eligible as the voiceover source (exclude this track).
+  const voCandidates = elements.filter(
+    (el) => el.id !== trackId && isAudioTimelineElement(el) && Boolean(el.src),
+  );
+  const defaultVoId =
+    voCandidates.find((el) => el.timelineRole === "voiceover")?.id ?? voCandidates[0]?.id ?? "";
+  const [carveVoId, setCarveVoId] = useState(defaultVoId);
+  // Keep the selection valid as tracks change / the panel first opens.
+  useEffect(() => {
+    if (!voCandidates.some((el) => el.id === carveVoId)) setCarveVoId(defaultVoId);
+  }, [carveVoId, defaultVoId, voCandidates]);
+
+  if (voCandidates.length === 0) return null;
+
+  const handleCarve = async () => {
+    if (busy) return;
+    const music = elements.find((el) => el.id === trackId);
+    const vo = voCandidates.find((el) => el.id === carveVoId);
+    setBusy(true);
+    try {
+      const result = await runCarve({
+        projectId,
+        element,
+        musicSrc: music?.src,
+        voiceSrc: vo?.src,
+        carveAmount,
+      });
+      if (!result) return;
+      if (domEditSaveTimestampRef) domEditSaveTimestampRef.current = Date.now();
+      // Seed the visible param sliders from what was just written (handled by
+      // the parent via `onChainWritten`). The sidecar-polling seed effect is
+      // keyed on the chain's STRUCTURE (formats + paths, deliberately — so
+      // ordinary knob drags don't re-seed and clobber), but re-running carve
+      // at a different amount keeps the same PeakFilter structure and only
+      // changes gains — the effect never re-fires, and the rows kept
+      // displaying the PREVIOUS run's values ("the amount slider does
+      // nothing" when judged by the displayed numbers, even though the file
+      // and the audio were right).
+      onChainWritten(result.chain);
+      await onSetAttribute("vst-chain", result.path);
+      usePlayerStore.getState().bumpVstChainRevision();
+      setCarveOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="border-t border-panel-border pt-2">
+      {!carveOpen ? (
+        <button
+          type="button"
+          data-vst-carve-open="true"
+          disabled={busy}
+          onClick={() => setCarveOpen(true)}
+          className="h-8 w-full rounded-md bg-panel-input px-2.5 text-[11px] font-medium text-panel-text-2 hover:bg-panel-hover disabled:opacity-50"
+        >
+          Make room for voiceover
+        </button>
+      ) : (
+        <div className="space-y-2">
+          <select
+            data-vst-carve-voice="true"
+            value={carveVoId}
+            onChange={(e) => setCarveVoId(e.target.value)}
+            className="h-8 w-full rounded-md bg-panel-input px-2.5 text-[11px] text-panel-text-2"
+          >
+            {voCandidates.map((el) => (
+              <option key={el.id} value={el.id}>
+                {el.id}
+                {el.timelineRole === "voiceover" ? " (voiceover)" : ""}
+              </option>
+            ))}
+          </select>
+          <label className="flex items-center gap-2 text-[10px] text-panel-text-3">
+            <span className="w-16 flex-shrink-0">Amount</span>
+            <input
+              type="range"
+              data-vst-carve-amount="true"
+              min={0}
+              max={100}
+              step={1}
+              value={carveAmount}
+              onChange={(e) => setCarveAmount(Number(e.target.value))}
+              className="h-1 flex-1 accent-panel-accent"
+            />
+            <span className="w-8 text-right tabular-nums text-panel-text-2">{carveAmount}</span>
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              data-vst-carve-apply="true"
+              disabled={busy || !carveVoId}
+              onClick={() => void handleCarve()}
+              className="h-8 flex-1 rounded-md bg-panel-accent px-2.5 text-[11px] font-medium text-white hover:opacity-90 disabled:opacity-50"
+            >
+              Apply
+            </button>
+            <button
+              type="button"
+              onClick={() => setCarveOpen(false)}
+              className="h-8 rounded-md px-2.5 text-[11px] text-panel-text-3 hover:bg-panel-hover"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/studio/src/components/editor/propertyPanelVstPluginRows.tsx
+++ b/packages/studio/src/components/editor/propertyPanelVstPluginRows.tsx
@@ -1,0 +1,198 @@
+import { type MutableRefObject } from "react";
+import { usePlayerStore } from "../../player/store/playerStore";
+import { isPluginEnabled, type ChainFileJson } from "../../utils/vstChainFile";
+import {
+  humanizeParam,
+  paramRange,
+  writeChainFile,
+  type VstHostApi,
+} from "./propertyPanelVstShared";
+
+export interface VstPluginRowsProps {
+  /** Non-null and non-empty-checked by the caller — this component only
+   *  renders once a chain file has actually loaded for the element. */
+  chain: ChainFileJson;
+  chainPath: string;
+  projectId: string;
+  trackId: string;
+  vstHost: VstHostApi;
+  /** Editable parameter values per plugin (null for external plugins, whose
+   *  state is opaque — they keep the native editor). */
+  paramsByPlugin: (Record<string, number> | null)[];
+  busy: boolean;
+  setBusy: (busy: boolean) => void;
+  setChain: (chain: ChainFileJson) => void;
+  /** Stamped after every chain-file write so the studio's file-watcher
+   *  treats it as our own save and skips reloading the preview. */
+  domEditSaveTimestampRef?: MutableRefObject<number>;
+  onParamChange: (pluginIndex: number, param: string, value: number) => void;
+  onOpenEditor: (index: number) => void;
+  onRemovePlugin: (index: number) => void;
+}
+
+/** Renders the "Disable all/Enable all" button plus one row per plugin
+ *  (bypass toggle, native editor launcher, remove, and — for built-ins —
+ *  the live parameter sliders). */
+export function VstPluginRows({
+  chain,
+  chainPath,
+  projectId,
+  trackId,
+  vstHost,
+  paramsByPlugin,
+  busy,
+  setBusy,
+  setChain,
+  domEditSaveTimestampRef,
+  onParamChange,
+  onOpenEditor,
+  onRemovePlugin,
+}: VstPluginRowsProps) {
+  // Shared write path for the bypass toggles: persist the rewritten chain and
+  // poke the preview to hot-reload it (bypass is applied by the sidecar's
+  // processing board, so an audible change requires the chain reload).
+  const persistChainRewrite = async (nextChain: ChainFileJson): Promise<void> => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const ok = await writeChainFile(projectId, chainPath, nextChain);
+      if (!ok) return;
+      if (domEditSaveTimestampRef) domEditSaveTimestampRef.current = Date.now();
+      setChain(nextChain);
+      usePlayerStore.getState().bumpVstChainRevision();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleTogglePlugin = async (index: number) => {
+    await persistChainRewrite({
+      version: 1,
+      plugins: chain.plugins.map((plugin, i) =>
+        i === index ? { ...plugin, enabled: !isPluginEnabled(plugin) } : plugin,
+      ),
+    });
+  };
+
+  const anyEnabled = chain.plugins.some(isPluginEnabled);
+
+  const handleToggleAll = async () => {
+    if (chain.plugins.length === 0) return;
+    // Any enabled -> disable all (quick "hear it dry" A/B); all disabled ->
+    // re-enable all.
+    await persistChainRewrite({
+      version: 1,
+      plugins: chain.plugins.map((plugin) => ({ ...plugin, enabled: !anyEnabled })),
+    });
+  };
+
+  if (chain.plugins.length === 0) {
+    return <div className="text-[11px] text-panel-text-4">No effects in this chain.</div>;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        data-vst-toggle-all="true"
+        disabled={busy}
+        onClick={() => {
+          void handleToggleAll();
+        }}
+        className="h-7 w-full rounded-md bg-panel-input px-2.5 text-[10px] font-medium text-panel-text-3 transition-colors hover:bg-panel-hover disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {anyEnabled ? "Disable all" : "Enable all"}
+      </button>
+
+      {chain.plugins.map((plugin, index) => {
+        const params = paramsByPlugin[index] ?? null;
+        const paramNames = params ? Object.keys(params) : [];
+        const pluginEnabled = isPluginEnabled(plugin);
+        return (
+          <div
+            key={`${plugin.path}-${index}`}
+            data-vst-plugin-row="true"
+            className={`rounded-md bg-panel-input/30 p-2${pluginEnabled ? "" : " opacity-50"}`}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="min-w-0 flex-1 truncate text-[11px] font-medium text-panel-text-2">
+                {plugin.name}
+                {pluginEnabled ? "" : " (off)"}
+              </span>
+              <button
+                type="button"
+                data-vst-toggle-plugin="true"
+                disabled={busy}
+                onClick={() => {
+                  void handleTogglePlugin(index);
+                }}
+                className="h-7 flex-shrink-0 rounded-md px-2 text-[10px] font-medium text-panel-text-3 hover:bg-panel-hover disabled:opacity-50"
+              >
+                {pluginEnabled ? "Disable" : "Enable"}
+              </button>
+              {/* Built-in effects have no native editor window (show_editor
+                  is a VST3/AU-only concept) — offering the button would do
+                  nothing. Only external plugins get it. */}
+              {plugin.format !== "builtin" && (
+                <button
+                  type="button"
+                  data-vst-open-editor="true"
+                  onClick={() => {
+                    vstHost.openEditor(trackId, index);
+                    onOpenEditor(index);
+                  }}
+                  className="h-7 flex-shrink-0 rounded-md px-2 text-[10px] font-medium text-panel-text-3 hover:bg-panel-hover"
+                >
+                  Open editor
+                </button>
+              )}
+              <button
+                type="button"
+                data-vst-remove-plugin="true"
+                disabled={busy}
+                onClick={() => {
+                  onRemovePlugin(index);
+                }}
+                className="h-7 flex-shrink-0 rounded-md px-2 text-[10px] font-medium text-panel-text-3 hover:bg-panel-hover disabled:opacity-50"
+              >
+                Remove
+              </button>
+            </div>
+
+            {paramNames.length > 0 && (
+              <div className="mt-2 space-y-1.5" data-vst-params="true">
+                {paramNames.map((name) => {
+                  const [min, max, step] = paramRange(name);
+                  const value = params?.[name] ?? 0;
+                  return (
+                    <label
+                      key={name}
+                      className="flex items-center gap-2 text-[10px] text-panel-text-3"
+                    >
+                      <span className="w-24 flex-shrink-0 truncate" title={name}>
+                        {humanizeParam(name)}
+                      </span>
+                      <input
+                        type="range"
+                        data-vst-param={name}
+                        min={min}
+                        max={max}
+                        step={step}
+                        value={value}
+                        onChange={(e) => onParamChange(index, name, Number(e.target.value))}
+                        className="h-1 flex-1 accent-panel-accent"
+                      />
+                      <span className="w-10 flex-shrink-0 text-right tabular-nums text-panel-text-2">
+                        {Number.isInteger(step) ? value : value.toFixed(2)}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/studio/src/components/editor/propertyPanelVstSection.test.tsx
+++ b/packages/studio/src/components/editor/propertyPanelVstSection.test.tsx
@@ -1,0 +1,849 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VstSection, type VstHostApi } from "./propertyPanelVstSection";
+import type { DomEditSelection } from "./domEditing";
+import {
+  parseChainFile,
+  serializeChainFile,
+  type CarveBand,
+  type ChainFileJson,
+} from "../../utils/vstChainFile";
+import { usePlayerStore } from "../../player/store/playerStore";
+import { renderInto, setupReactActEnvironment } from "./testRenderUtils";
+
+setupReactActEnvironment();
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function makeAudioElement(overrides: Partial<DomEditSelection> = {}): DomEditSelection {
+  const el = document.createElement("audio");
+  return {
+    element: el,
+    id: "vo-1",
+    selector: "#vo-1",
+    label: "VO 1",
+    tagName: "audio",
+    sourceFile: "index.html",
+    compositionPath: "index.html",
+    isCompositionHost: false,
+    isInsideLockedComposition: false,
+    boundingBox: { x: 0, y: 0, width: 0, height: 0 },
+    textContent: "",
+    dataAttributes: {},
+    inlineStyles: {},
+    computedStyles: {},
+    textFields: [],
+    capabilities: {
+      canSelect: true,
+      canEditStyles: true,
+      canCrop: true,
+      canMove: false,
+      canResize: false,
+      canApplyManualOffset: false,
+      canApplyManualSize: false,
+      canApplyManualRotation: false,
+    },
+    ...overrides,
+  } as DomEditSelection;
+}
+
+function makeVstHost(overrides: Partial<VstHostApi> = {}): VstHostApi {
+  return {
+    registry: [],
+    scan: vi.fn(async () => {}),
+    openEditor: vi.fn(),
+    setParam: vi.fn(),
+    loadChain: vi.fn(async () => ({ trackIndex: 0, sampleRate: 48000, stable: true })),
+    getState: vi.fn(async () => []),
+    ...overrides,
+  };
+}
+
+function requestUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function flushAsyncWork(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+/** Picks option index `i` in the "Add effect" <select> and fires React's onChange. */
+async function selectAddOption(host: HTMLElement, i: number): Promise<void> {
+  const select = host.querySelector<HTMLSelectElement>('[data-vst-add-effect="true"]');
+  expect(select).not.toBeNull();
+  if (!select) return;
+  await act(async () => {
+    select.value = String(i);
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushAsyncWork();
+  });
+}
+
+/** Renders `<VstSection>` against the standard `vo-1` element (with an
+ *  existing `fx/vo-1.vstchain.json` chain unless `overrides.element` picks a
+ *  different one), flushes its mount-time async work, and returns the
+ *  rendered host/root — the shared render shape most tests below need. */
+async function renderVstSectionAsync(
+  vstHost: VstHostApi,
+  overrides: {
+    element?: DomEditSelection;
+    onSetAttribute?: (attr: string, value: string) => void | Promise<void>;
+    domEditSaveTimestampRef?: { current: number };
+  } = {},
+): Promise<ReturnType<typeof renderInto>> {
+  return act(async () => {
+    const rendered = renderInto(
+      <VstSection
+        projectId="p1"
+        element={
+          overrides.element ??
+          makeAudioElement({ dataAttributes: { "vst-chain": "fx/vo-1.vstchain.json" } })
+        }
+        onSetAttribute={overrides.onSetAttribute ?? vi.fn()}
+        vstHost={vstHost}
+        domEditSaveTimestampRef={overrides.domEditSaveTimestampRef}
+      />,
+    );
+    await flushAsyncWork();
+    return rendered;
+  });
+}
+
+/** Renders `<VstSection>` against a fresh (no existing chain) `vo-1` element
+ *  — used by the "add effect" tests, which then flush the picker-population
+ *  effect separately (its scan/registry-population timing is itself under
+ *  test in some of these). */
+async function renderVstSectionForAdd(
+  vstHost: VstHostApi,
+  onSetAttribute: (attr: string, value: string) => void | Promise<void>,
+): Promise<ReturnType<typeof renderInto>> {
+  const rendered = renderInto(
+    <VstSection
+      projectId="p1"
+      element={makeAudioElement()}
+      onSetAttribute={onSetAttribute}
+      vstHost={vstHost}
+    />,
+  );
+  await act(async () => {
+    await flushAsyncWork();
+  });
+  return rendered;
+}
+
+/** Stubs `fetch` to resolve `chain` for a GET on the standard `vo-1` chain
+ *  file URL, and throw for anything else — the shared read-only mock several
+ *  describe blocks below need. */
+function stubChainFileGet(chain: ChainFileJson): ReturnType<typeof vi.fn> {
+  return vi.fn(async (input: Parameters<typeof fetch>[0]): Promise<Response> => {
+    const url = requestUrl(input);
+    if (url.includes("fx%2Fvo-1.vstchain.json")) {
+      return jsonResponse({ content: serializeChainFile(chain) });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+/** Stubs `fetch` to serve `chain` on GET and capture the PUT body (via the
+ *  returned `written()` accessor) on PUT — the standard "load then re-save"
+ *  mock several tests below need. */
+function stubChainFilePutCapture(chain: ChainFileJson): {
+  fetchMock: ReturnType<typeof vi.fn>;
+  written: () => ChainFileJson | null;
+} {
+  let putBody: string | null = null;
+  const fetchMock = vi.fn(
+    async (input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+      const url = requestUrl(input);
+      if (url.includes("/files/fx%2Fvo-1.vstchain.json") && init?.method === "PUT") {
+        putBody = String(init.body);
+        return jsonResponse({ ok: true });
+      }
+      if (url.includes("/files/fx%2Fvo-1.vstchain.json")) {
+        return jsonResponse({ content: serializeChainFile(chain) });
+      }
+      throw new Error(`Unexpected fetch: ${url} ${init?.method}`);
+    },
+  );
+  return { fetchMock, written: () => JSON.parse(putBody ?? "null") as ChainFileJson | null };
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("VstSection — install hint", () => {
+  it("renders an install hint and no chain controls when vstHost is null", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { host, root } = renderInto(
+      <VstSection
+        projectId="p1"
+        element={makeAudioElement()}
+        onSetAttribute={vi.fn()}
+        vstHost={null}
+      />,
+    );
+    const hint = host.querySelector('[data-vst-install-hint="true"]');
+    expect(hint).not.toBeNull();
+    expect(host.textContent).toContain("hyperframes-vst-host");
+    expect(host.querySelector('[data-vst-add-effect="true"]')).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+});
+
+describe("VstSection — bypass toggles", () => {
+  function bypassHarness(chain: ChainFileJson) {
+    const { fetchMock, written } = stubChainFilePutCapture(chain);
+    vi.stubGlobal("fetch", fetchMock);
+    const rendered = renderInto(
+      <VstSection
+        projectId="p1"
+        element={makeAudioElement({ dataAttributes: { "vst-chain": "fx/vo-1.vstchain.json" } })}
+        onSetAttribute={vi.fn()}
+        vstHost={makeVstHost()}
+      />,
+    );
+    return { ...rendered, written };
+  }
+
+  const twoPlugins: ChainFileJson = {
+    version: 1,
+    plugins: [
+      { format: "builtin", path: "Reverb", pluginName: null, name: "Reverb", stateB64: null },
+      { format: "builtin", path: "Delay", pluginName: null, name: "Delay", stateB64: null },
+    ],
+  };
+
+  it("Disable on a row writes enabled:false for that plugin only", async () => {
+    const { host, root, written } = bypassHarness(twoPlugins);
+    await act(async () => {
+      await flushAsyncWork();
+    });
+
+    const toggles = host.querySelectorAll<HTMLButtonElement>('[data-vst-toggle-plugin="true"]');
+    expect(toggles).toHaveLength(2);
+    expect(toggles[0]?.textContent).toBe("Disable");
+
+    await act(async () => {
+      toggles[1]?.click();
+      await flushAsyncWork();
+    });
+
+    const chain = written();
+    expect(chain?.plugins.map((p) => p.enabled)).toEqual([undefined, false]);
+    act(() => root.unmount());
+  });
+
+  it("Disable all writes enabled:false for every plugin; Enable all flips back", async () => {
+    const { host, root, written } = bypassHarness(twoPlugins);
+    await act(async () => {
+      await flushAsyncWork();
+    });
+
+    const all = host.querySelector<HTMLButtonElement>('[data-vst-toggle-all="true"]');
+    expect(all?.textContent).toBe("Disable all");
+    await act(async () => {
+      all?.click();
+      await flushAsyncWork();
+    });
+    expect(written()?.plugins.every((p) => p.enabled === false)).toBe(true);
+
+    // The panel state now reflects the all-disabled chain — the same button
+    // reads "Enable all" and flips everything back on.
+    const allAfter = host.querySelector<HTMLButtonElement>('[data-vst-toggle-all="true"]');
+    expect(allAfter?.textContent).toBe("Enable all");
+    await act(async () => {
+      allAfter?.click();
+      await flushAsyncWork();
+    });
+    expect(written()?.plugins.every((p) => p.enabled === true)).toBe(true);
+    act(() => root.unmount());
+  });
+
+  it("a disabled plugin's row is dimmed and labeled (off)", async () => {
+    const disabledChain: ChainFileJson = {
+      version: 1,
+      plugins: [
+        {
+          format: "builtin",
+          path: "Reverb",
+          pluginName: null,
+          name: "Reverb",
+          stateB64: null,
+          enabled: false,
+        },
+      ],
+    };
+    const { host, root } = bypassHarness(disabledChain);
+    await act(async () => {
+      await flushAsyncWork();
+    });
+
+    const row = host.querySelector('[data-vst-plugin-row="true"]');
+    expect(row?.className).toContain("opacity-50");
+    expect(row?.textContent).toContain("(off)");
+    expect(host.querySelector('[data-vst-toggle-plugin="true"]')?.textContent).toBe("Enable");
+    act(() => root.unmount());
+  });
+});
+
+describe("VstSection — existing chain", () => {
+  it("fetches and lists plugin names from an existing chain file", async () => {
+    const chain: ChainFileJson = {
+      version: 1,
+      plugins: [
+        {
+          format: "vst3",
+          path: "/plugins/Reverb.vst3",
+          pluginName: "Reverb",
+          name: "Reverb",
+          stateB64: null,
+        },
+        {
+          format: "builtin",
+          path: "builtin://eq",
+          pluginName: null,
+          name: "EQ",
+          stateB64: null,
+        },
+      ],
+    };
+    const fetchMock = stubChainFileGet(chain);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { host, root } = await renderVstSectionAsync(makeVstHost());
+
+    expect(host.textContent).toContain("Reverb");
+    expect(host.textContent).toContain("EQ");
+    expect(host.querySelectorAll('[data-vst-plugin-row="true"]')).toHaveLength(2);
+    act(() => root.unmount());
+  });
+
+  it("offers Open editor only for external plugins, not built-ins (they have no native UI)", async () => {
+    const chain: ChainFileJson = {
+      version: 1,
+      plugins: [
+        {
+          format: "vst3",
+          path: "/plugins/Reverb.vst3",
+          pluginName: "Reverb",
+          name: "Reverb",
+          stateB64: null,
+        },
+        { format: "builtin", path: "Delay", pluginName: null, name: "Delay", stateB64: null },
+      ],
+    };
+    const fetchMock = stubChainFileGet(chain);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { host, root } = await renderVstSectionAsync(makeVstHost());
+
+    const rows = host.querySelectorAll('[data-vst-plugin-row="true"]');
+    expect(rows).toHaveLength(2);
+    // vst3 row (Reverb) has Open editor; builtin row (Delay) does not.
+    expect(rows[0]?.querySelector('[data-vst-open-editor="true"]')).not.toBeNull();
+    expect(rows[1]?.querySelector('[data-vst-open-editor="true"]')).toBeNull();
+    act(() => root.unmount());
+  });
+});
+
+describe("VstSection — built-in parameters", () => {
+  it("renders sliders seeded from live state and applies edits via setParam", async () => {
+    const chain: ChainFileJson = {
+      version: 1,
+      plugins: [
+        { format: "builtin", path: "Delay", pluginName: null, name: "Delay", stateB64: null },
+      ],
+    };
+    const fetchMock = stubChainFileGet(chain);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setParam = vi.fn();
+    // The sidecar's live state for a built-in is base64(JSON of {param: value}).
+    const liveState = btoa(JSON.stringify({ mix: 0.5, feedback: 0.2 }));
+    const vstHost = makeVstHost({ setParam, getState: vi.fn(async () => [liveState]) });
+
+    const { host, root } = await renderVstSectionAsync(vstHost);
+
+    const sliders = host.querySelectorAll("[data-vst-param]");
+    expect(sliders.length).toBe(2); // mix + feedback
+
+    const mix = host.querySelector<HTMLInputElement>('[data-vst-param="mix"]');
+    expect(mix).not.toBeNull();
+    if (mix) {
+      // Bypass React's value-tracker (a direct `.value =` is swallowed) so the
+      // synthetic onChange fires, mirroring a real slider drag.
+      const setValue = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setValue?.call(mix, "0.8");
+      await act(async () => {
+        mix.dispatchEvent(new Event("input", { bubbles: true }));
+        await flushAsyncWork();
+      });
+    }
+    // Live audio update: set-param on the streaming instance, plugin index 0.
+    expect(setParam).toHaveBeenCalledWith("vo-1", 0, "mix", 0.8);
+
+    act(() => root.unmount());
+  });
+});
+
+describe("VstSection — add effect", () => {
+  it("writes a new chain file via PUT and commits the vst-chain attribute", async () => {
+    const onSetAttribute = vi.fn();
+    const fetchMock = vi.fn(async (input, init): Promise<Response> => {
+      const url = requestUrl(input);
+      if (
+        url.includes("/api/projects/p1/files/fx%2Fvo-1.vstchain.json") &&
+        init?.method === "PUT"
+      ) {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected fetch: ${url} ${init?.method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const vstHost = makeVstHost({
+      registry: [{ path: "/plugins/Reverb.vst3", name: "Reverb", format: "vst3" }],
+    });
+
+    // Registry already populated → the picker's options appear without a scan.
+    const { host, root } = await renderVstSectionForAdd(vstHost, onSetAttribute);
+
+    await selectAddOption(host, 0);
+    await act(async () => {
+      await flushAsyncWork();
+    });
+
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+    expect(putCall).toBeDefined();
+    expect(requestUrl(putCall?.[0] as Parameters<typeof fetch>[0])).toContain(
+      "fx%2Fvo-1.vstchain.json",
+    );
+    expect(onSetAttribute).toHaveBeenCalledWith("vst-chain", "fx/vo-1.vstchain.json");
+    act(() => root.unmount());
+  });
+
+  it("keeps the picker visible with an existing chain and APPENDS the picked effect to it", async () => {
+    // Regression: the picker used to render only while the element had no
+    // chain, so after the first add there was no UI to stack a second effect.
+    const existing: ChainFileJson = {
+      version: 1,
+      plugins: [
+        { format: "builtin", path: "Reverb", pluginName: null, name: "Reverb", stateB64: null },
+      ],
+    };
+    const onSetAttribute = vi.fn();
+    const { fetchMock, written } = stubChainFilePutCapture(existing);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const vstHost = makeVstHost({
+      registry: [{ path: "Delay", name: "Delay", format: "builtin" }],
+    });
+
+    const { host, root } = await renderVstSectionAsync(vstHost, { onSetAttribute });
+
+    // The picker must still be offered even though a chain already exists.
+    expect(host.querySelector('[data-vst-add-effect="true"]')).not.toBeNull();
+
+    await selectAddOption(host, 0);
+    await act(async () => {
+      await flushAsyncWork();
+    });
+
+    expect(written()?.plugins.map((p) => p.name)).toEqual(["Reverb", "Delay"]); // appended, not replaced
+    // The attribute is already committed — re-setting it would trigger a
+    // needless preview reload.
+    expect(onSetAttribute).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it("scans for available effects when the registry is empty, then adds the picked one", async () => {
+    const onSetAttribute = vi.fn();
+    const fetchMock = vi.fn(async (): Promise<Response> => jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const registry = [{ path: "/plugins/Reverb.vst3", name: "Reverb", format: "vst3" }];
+    const scan = vi.fn(async () => {
+      vstHost.registry = registry;
+    });
+    const vstHost = makeVstHost({ registry: [], scan });
+
+    // Empty registry → the panel scans once on mount to populate the picker.
+    const { host, root } = await renderVstSectionForAdd(vstHost, onSetAttribute);
+    expect(scan).toHaveBeenCalledTimes(1);
+
+    await selectAddOption(host, 0);
+    await act(async () => {
+      await flushAsyncWork();
+    });
+
+    expect(onSetAttribute).toHaveBeenCalledWith("vst-chain", "fx/vo-1.vstchain.json");
+    act(() => root.unmount());
+  });
+
+  it("marks a picked builtin's format as builtin with no pluginName", async () => {
+    const onSetAttribute = vi.fn();
+    let putBody: unknown;
+    const fetchMock = vi.fn(async (input, init): Promise<Response> => {
+      if (init?.method === "PUT") {
+        putBody = JSON.parse(String(init.body));
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected fetch: ${requestUrl(input)} ${init?.method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const vstHost = makeVstHost({
+      registry: [{ path: "Reverb", name: "Reverb", format: "builtin" }],
+    });
+
+    const { host, root } = await renderVstSectionForAdd(vstHost, onSetAttribute);
+    await selectAddOption(host, 0);
+    await act(async () => {
+      await flushAsyncWork();
+    });
+
+    expect(putBody).toMatchObject({
+      version: 1,
+      plugins: [{ format: "builtin", path: "Reverb", pluginName: null, name: "Reverb" }],
+    });
+    act(() => root.unmount());
+  });
+});
+
+// ── Finding 1: native-editor state persistence (polling) ──────────────────
+//
+// A native plugin editor window has no "closed" event on the wire (see
+// propertyPanelVstSection.tsx's doc-comment on VST_STATE_POLL_INTERVAL_MS) —
+// edits only ever land in the sidecar's live in-memory plugin instance. This
+// section polls `getState` after "Open editor" is clicked and persists any
+// diff to the chain file so render doesn't silently diverge from preview.
+
+describe("VstSection — native-editor state persistence", () => {
+  const existingChain: ChainFileJson = {
+    version: 1,
+    plugins: [
+      {
+        format: "vst3",
+        path: "/plugins/Reverb.vst3",
+        pluginName: "Reverb",
+        name: "Reverb",
+        stateB64: "AAAA",
+      },
+    ],
+  };
+
+  /** Enables the fake timers the poll interval under test needs, and stubs
+   *  `fetch` to serve `existingChain` on GET / accept a PUT — the shared
+   *  setup every test below needs. Returns the fetchMock so callers can
+   *  inspect its PUT calls. */
+  function setupPollingFixture(): ReturnType<typeof vi.fn> {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const url = requestUrl(input);
+      if (url.includes("/api/projects/p1/files/fx%2Fvo-1.vstchain.json")) {
+        if (init?.method === "PUT") return jsonResponse({ ok: true });
+        return jsonResponse({ content: serializeChainFile(existingChain) });
+      }
+      throw new Error(`Unexpected fetch: ${url} ${init?.method ?? "GET"}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Sets up the polling fixture + a `getState` returning `stateValues`,
+   *  renders the section, and locates the "Open editor" button — the shared
+   *  setup every poll test below needs. */
+  async function setupPolledEditor(
+    stateValues: string[],
+    overrides: { domEditSaveTimestampRef?: { current: number } } = {},
+  ): Promise<{
+    host: HTMLElement;
+    root: ReturnType<typeof renderInto>["root"];
+    fetchMock: ReturnType<typeof vi.fn>;
+    vstHost: VstHostApi;
+    openButton: HTMLButtonElement | null;
+  }> {
+    const fetchMock = setupPollingFixture();
+    const getState = vi.fn(async () => stateValues);
+    const vstHost = makeVstHost({ getState });
+    const { host, root } = await renderVstSectionAsync(vstHost, overrides);
+    const openButton = host.querySelector<HTMLButtonElement>('[data-vst-open-editor="true"]');
+    return { host, root, fetchMock, vstHost, openButton };
+  }
+
+  it("polls getState after 'Open editor' and PUTs the chain file when state changed", async () => {
+    const { root, fetchMock, vstHost, openButton } = await setupPolledEditor(["NEW_STATE_B64"]);
+
+    expect(openButton).not.toBeNull();
+    await act(async () => {
+      openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+    });
+
+    expect(vstHost.openEditor).toHaveBeenCalledWith("vo-1", 0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+      await flushAsyncWork();
+    });
+
+    expect(vstHost.getState).toHaveBeenCalledWith("vo-1");
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+    expect(putCall).toBeDefined();
+    const body = putCall?.[1]?.body;
+    if (typeof body !== "string") throw new Error("expected a string PUT body");
+    const written = parseChainFile(body);
+    expect(written?.plugins[0]?.stateB64).toBe("NEW_STATE_B64");
+
+    act(() => root.unmount());
+  });
+
+  it("stamps domEditSaveTimestampRef after a poll-triggered PUT (suppresses the studio's own file-change reload)", async () => {
+    const domEditSaveTimestampRef = { current: 0 };
+    const { root, fetchMock, openButton } = await setupPolledEditor(["NEW_STATE_B64"], {
+      domEditSaveTimestampRef,
+    });
+
+    await act(async () => {
+      openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+    });
+
+    expect(domEditSaveTimestampRef.current).toBe(0);
+
+    const beforePoll = Date.now();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+      await flushAsyncWork();
+    });
+
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+    expect(putCall).toBeDefined();
+    // The ref must be stamped to "now" (not left at its initial 0) exactly
+    // when a real write happens, so the studio's file-watcher (which reloads
+    // the preview iframe unless Date.now() - domEditSaveTimestampRef.current
+    // < 4000) treats this as our own save and skips reloading.
+    expect(domEditSaveTimestampRef.current).toBeGreaterThanOrEqual(beforePoll);
+
+    act(() => root.unmount());
+  });
+
+  it("does not PUT when getState reports no change", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+    const fetchMock = stubChainFileGet(existingChain);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const getState = vi.fn(async () => ["AAAA"]); // matches existingChain's stateB64 already
+    const vstHost = makeVstHost({ getState });
+
+    const { host, root } = await renderVstSectionAsync(vstHost);
+
+    const openButton = host.querySelector<HTMLButtonElement>('[data-vst-open-editor="true"]');
+    await act(async () => {
+      openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+      await vi.advanceTimersByTimeAsync(2500);
+      await flushAsyncWork();
+    });
+
+    expect(getState).toHaveBeenCalled();
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  it("stops polling on unmount (no further PUT after unmount + timer advance)", async () => {
+    const { root, fetchMock, openButton } = await setupPolledEditor(["NEW_STATE_B64"]);
+
+    await act(async () => {
+      openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+    });
+
+    // Unmount immediately — this fires the "best effort" flush once (one PUT
+    // from the cleanup-triggered flush is expected), but no MORE polling
+    // ticks should follow.
+    await act(async () => {
+      root.unmount();
+      await flushAsyncWork();
+    });
+
+    const putCallsAfterUnmount = fetchMock.mock.calls.filter(
+      ([, init]) => init?.method === "PUT",
+    ).length;
+    fetchMock.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+      await flushAsyncWork();
+    });
+
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
+    // Sanity: the flush-on-unmount path itself is allowed to have PUT at
+    // most once (the one best-effort save), never more.
+    expect(putCallsAfterUnmount).toBeLessThanOrEqual(1);
+  });
+});
+
+// ── "Make room for voiceover" carve action ─────────────────────────────────
+
+describe("VstSection — make room for voiceover", () => {
+  afterEach(() => {
+    usePlayerStore.setState({ elements: [] });
+  });
+
+  /** Two audio tracks: the selected music track + a voiceover track — the
+   *  shared timeline shape every carve test below needs. */
+  function setTwoTrackElements(): void {
+    usePlayerStore.setState({
+      elements: [
+        { id: "music", src: "./media/music.wav", tag: "audio", timelineRole: "music" },
+        { id: "vo", src: "./media/vo.wav", tag: "audio", timelineRole: "voiceover" },
+      ],
+    } as never);
+  }
+
+  /** The music element the carve action targets — created fresh per test. */
+  function makeMusicElement(): DomEditSelection {
+    return makeAudioElement({
+      id: "music",
+      dataAttributes: { "vst-chain": "fx/music.vstchain.json" },
+    });
+  }
+
+  /** Stubs `fetch` for the carve flow: `/api/vst/carve` returns `bands`, PUT
+   *  accepts, and GET serves `existingChain` — the shared mock shape every
+   *  carve test below needs. */
+  function stubCarveFetch(
+    bands: CarveBand[],
+    existingChain: ChainFileJson,
+  ): ReturnType<typeof vi.fn> {
+    return vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const url = requestUrl(input);
+      if (url.includes("/api/vst/carve")) {
+        return jsonResponse({ bands });
+      }
+      if (init?.method === "PUT") return jsonResponse({ ok: true });
+      return jsonResponse({ content: serializeChainFile(existingChain) });
+    });
+  }
+
+  it("carves a voiceover pocket: calls /vst/carve and appends PeakFilter bands", async () => {
+    setTwoTrackElements();
+
+    const fetchMock = stubCarveFetch([{ freq: 1000, gainDb: -4, q: 1.5 }], {
+      version: 1,
+      plugins: [],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { host, root } = await renderVstSectionAsync(makeVstHost(), {
+      element: makeMusicElement(),
+    });
+
+    const openButton = host.querySelector<HTMLButtonElement>('[data-vst-carve-open="true"]');
+    expect(openButton).not.toBeNull();
+    await act(async () => {
+      openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+    });
+
+    // VO dropdown pre-selects the voiceover-tagged track.
+    const voSelect = host.querySelector<HTMLSelectElement>('[data-vst-carve-voice="true"]');
+    expect(voSelect).not.toBeNull();
+    expect(voSelect?.value).toBe("vo");
+
+    const applyButton = host.querySelector<HTMLButtonElement>('[data-vst-carve-apply="true"]');
+    expect(applyButton).not.toBeNull();
+    await act(async () => {
+      applyButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+    });
+
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+    expect(putCall).toBeTruthy();
+    const written = parseChainFile(String(putCall?.[1]?.body));
+    expect(written?.plugins.some((p) => p.path === "PeakFilter")).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  it("re-applying carve updates the DISPLAYED gain sliders, not just the file", async () => {
+    // Regression: the param-seed effect is keyed on chain STRUCTURE (formats
+    // + paths) so knob drags don't re-seed — but a carve re-run keeps the
+    // same PeakFilter structure and only changes gains, so the rows kept
+    // showing the PREVIOUS run's values. Judged by the displayed numbers,
+    // the amount slider "did nothing" even though the file was right.
+    setTwoTrackElements();
+
+    // Existing chain: one carve band at the OLD gain (-2), whose value the
+    // sidecar's getState also reports (stale, pre-re-carve).
+    const oldState = btoa(JSON.stringify({ cutoff_frequency_hz: 1000, gain_db: -2, q: 1.5 }));
+    const existing: ChainFileJson = {
+      version: 1,
+      plugins: [
+        {
+          format: "builtin",
+          path: "PeakFilter",
+          pluginName: null,
+          name: "Carve 1000Hz",
+          stateB64: oldState,
+        },
+      ],
+    };
+    // NEW deeper gain on re-carve.
+    const fetchMock = stubCarveFetch([{ freq: 1000, gainDb: -6, q: 1.5 }], existing);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const vstHost = makeVstHost({ getState: vi.fn(async () => [oldState]) });
+
+    const { host, root } = await renderVstSectionAsync(vstHost, { element: makeMusicElement() });
+
+    // Sliders seeded from the sidecar's (old) state.
+    const gainInput = () => host.querySelector<HTMLInputElement>('input[data-vst-param="gain_db"]');
+    expect(gainInput()?.value).toBe("-2");
+
+    await act(async () => {
+      host
+        .querySelector('[data-vst-carve-open="true"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+    });
+    await act(async () => {
+      host
+        .querySelector('[data-vst-carve-apply="true"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsyncWork();
+    });
+
+    // The displayed gain must reflect the NEW carve immediately.
+    expect(gainInput()?.value).toBe("-6");
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/components/editor/propertyPanelVstSection.tsx
+++ b/packages/studio/src/components/editor/propertyPanelVstSection.tsx
@@ -1,0 +1,449 @@
+import { useEffect, useRef, useState, type MutableRefObject } from "react";
+import { Zap } from "../../icons/SystemIcons";
+import type { DomEditSelection } from "./domEditing";
+import { Section } from "./propertyPanelPrimitives";
+import { usePlayerStore } from "../../player/store/playerStore";
+import type { ChainFileJson } from "../../utils/vstChainFile";
+import {
+  decodeBuiltinParams,
+  encodeBuiltinParams,
+  normalizePluginFormat,
+  vstElementId,
+  chainFilePath,
+  readChainFile,
+  writeChainFile,
+  type LoadChainResult,
+  type VstHostApi,
+  type VstRegistryEntry,
+} from "./propertyPanelVstShared";
+import { VstCarveSection } from "./propertyPanelVstCarveSection";
+import { VstPluginRows } from "./propertyPanelVstPluginRows";
+
+export type { LoadChainResult, VstHostApi, VstRegistryEntry };
+
+/**
+ * Finding 1 (final whole-branch review): a native plugin editor window edits
+ * the sidecar's live in-memory plugin instance directly — there is no
+ * "editor was closed" event on the wire (the native window closes via its
+ * own OS chrome, not our WebSocket protocol; `close-editor` is a
+ * client-initiated no-op, see useVstHost). Without persistence, the chain
+ * file keeps whatever `stateB64` it had before the user opened the editor,
+ * so `hyperframes render` would silently bounce stale/default plugin state
+ * instead of what the user actually heard in preview.
+ *
+ * Fix: while an editor is presumed open for this track (since the last
+ * `openEditor` click, until the track/chain changes or this section
+ * unmounts), poll `vstHost.getState` and persist any diff to the chain file
+ * via the same `writeChainFile` PUT `handleAddEffect`/`handleRemovePlugin`
+ * already use. 2.5s is a compromise: short enough that the state-loss
+ * window if the studio process dies right after a tweak is small, long
+ * enough to not hammer the project file store with PUTs while a knob is
+ * being dragged continuously (dragging doesn't need every intermediate
+ * value persisted — only the settled result before a render).
+ */
+const VST_STATE_POLL_INTERVAL_MS = 2500;
+
+/** Max attempts the param-seed poll below (`seed` in the effect that keys off
+ *  `pluginSig`) makes before giving up on the sidecar's live state settling. */
+const SEED_MAX_TRIES = 8;
+
+/** Schedules one more seed-poll attempt, unless the effect was cancelled
+ *  (unmount / dep change) or the retry budget is exhausted. */
+function scheduleSeedRetry(cancelled: boolean, tries: number, retry: () => void): void {
+  if (!cancelled && tries < SEED_MAX_TRIES) setTimeout(retry, 400);
+}
+
+/** Decodes each built-in plugin's live sidecar state into its editable param
+ *  map (external VST3/AU plugins stay `null` — their state is opaque, see the
+ *  `paramsByPlugin` doc-comment). */
+function decodeSeedStates(
+  current: ChainFileJson,
+  states: string[],
+): (Record<string, number> | null)[] {
+  return current.plugins.map((p, i) =>
+    p.format === "builtin" ? (decodeBuiltinParams(states[i]) ?? {}) : null,
+  );
+}
+
+export function VstSection({
+  projectId,
+  element,
+  onSetAttribute,
+  vstHost,
+  domEditSaveTimestampRef,
+}: {
+  projectId: string;
+  element: DomEditSelection;
+  onSetAttribute: (attr: string, value: string) => void | Promise<void>;
+  vstHost: VstHostApi | null;
+  /** Stamped after every chain-file write so the studio's file-watcher
+   *  treats it as our own save and skips reloading the preview — every
+   *  other save path in the app does this; the poller below must too. */
+  domEditSaveTimestampRef?: MutableRefObject<number>;
+}) {
+  const trackId = vstElementId(element);
+  const chainPath = element.dataAttributes["vst-chain"] || null;
+  const [chain, setChain] = useState<ChainFileJson | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
+  // The effects offered by the "Add effect" picker: pedalboard's built-ins
+  // plus any installed VST3/AU the sidecar found (see useVstHost's `scan`).
+  const [available, setAvailable] = useState<VstRegistryEntry[]>([]);
+  const [scanning, setScanning] = useState(false);
+  // One scan per mount, regardless of how often `vstHost`'s identity churns
+  // (its `registry` is a ref, so this effect can't just read it reactively).
+  const scanRequestedRef = useRef(false);
+  // Editable parameter values per plugin (null for external plugins, whose
+  // state is opaque — they keep the native editor). Seeded from the sidecar's
+  // live state so freshly-added built-ins show their real defaults.
+  const [paramsByPlugin, setParamsByPlugin] = useState<(Record<string, number> | null)[]>([]);
+  const paramPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Diffing/writing target for the poller below — mutated in place every
+  // render so the poll tick (and its unmount/navigate-away flush) always
+  // reads the latest known chain without needing to be in the polling
+  // effect's dependency array (which would restart the interval on every
+  // add/remove/persist).
+  const chainRef = useRef<ChainFileJson | null>(null);
+  chainRef.current = chain;
+  const busyRef = useRef(busy);
+  busyRef.current = busy;
+  const paramsByPluginRef = useRef(paramsByPlugin);
+  paramsByPluginRef.current = paramsByPlugin;
+  // Structural signature of the chain (formats + paths, NOT param values), so
+  // the param-seed effect re-runs on add/remove/swap but not on a param edit.
+  const pluginSig = (chain?.plugins ?? []).map((p) => `${p.format}:${p.path}`).join("|");
+  const persistingRef = useRef(false);
+
+  useEffect(() => {
+    if (!chainPath) {
+      setChain(null);
+      return;
+    }
+    let cancelled = false;
+    void readChainFile(projectId, chainPath).then((loaded) => {
+      if (!cancelled) setChain(loaded);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, chainPath]);
+
+  // Populate the "Add effect" picker. Built-ins come back instantly with the
+  // scan; installed VST3/AU are discovered by the (subprocess-guarded) disk
+  // probe. `registry` is a live ref on the host, so we copy it into local
+  // state to render options. Runs whether or not the element already has a
+  // chain — adding a SECOND effect appends to the existing chain, so the
+  // picker must stay populated past the first add.
+  useEffect(() => {
+    if (!vstHost) return;
+    if (vstHost.registry.length > 0) {
+      setAvailable([...vstHost.registry]);
+      return;
+    }
+    if (scanRequestedRef.current) return;
+    scanRequestedRef.current = true;
+    setScanning(true);
+    void vstHost
+      .scan()
+      .catch(() => {})
+      .finally(() => {
+        setAvailable([...vstHost.registry]);
+        setScanning(false);
+      });
+  }, [vstHost]);
+
+  // A different selected element/track means any editor presumed open
+  // belonged to the PREVIOUS track — stop treating one as open here (the
+  // polling effect below still gets one final best-effort flush for the old
+  // track via its own cleanup, since chainPath changing also tears it down).
+  useEffect(() => {
+    setEditorOpen(false);
+  }, [chainPath]);
+
+  // Seed editable params for built-in plugins from the sidecar's LIVE state
+  // (so a freshly-added effect shows its real defaults). Retries briefly — the
+  // preview may still be loading the chain into the sidecar on first run.
+  // Keyed on `pluginSig` (structure), so param edits don't re-seed and clobber.
+  useEffect(() => {
+    if (!vstHost || !chainPath) return;
+    const initial = chainRef.current;
+    if (!initial) return;
+    if (!initial.plugins.some((p) => p.format === "builtin")) {
+      setParamsByPlugin(initial.plugins.map(() => null));
+      return;
+    }
+    let cancelled = false;
+    let tries = 0;
+    let lastJson = "";
+    const seed = async (): Promise<void> => {
+      tries += 1;
+      let states: string[];
+      try {
+        states = await vstHost.getState(trackId);
+      } catch {
+        scheduleSeedRetry(cancelled, tries, () => void seed());
+        return;
+      }
+      if (cancelled) return;
+      const current = chainRef.current;
+      if (!current || states.length !== current.plugins.length) {
+        scheduleSeedRetry(false, tries, () => void seed());
+        return;
+      }
+      const decoded = decodeSeedStates(current, states);
+      setParamsByPlugin(decoded);
+      // The sidecar's live state lags the panel's chain write while
+      // useVstPreview reloads the track, so the first read right after a swap
+      // still returns the PREVIOUS effect's params. Keep polling until two
+      // reads agree (reload settled), converging the sliders onto the new one.
+      const json = JSON.stringify(decoded);
+      if (json !== lastJson) {
+        lastJson = json;
+        scheduleSeedRetry(false, tries, () => void seed());
+      }
+    };
+    void seed();
+    return () => {
+      cancelled = true;
+    };
+  }, [vstHost, chainPath, pluginSig, trackId]);
+
+  // Finding 1: persist native-editor edits. See VST_STATE_POLL_INTERVAL_MS's
+  // doc-comment for why polling (vs. an on-close event) and why this
+  // interval.
+  useEffect(() => {
+    if (!editorOpen || !chainPath || !vstHost) return;
+
+    // fallow-ignore-next-line complexity
+    const persistIfChanged = async (): Promise<void> => {
+      if (busyRef.current || persistingRef.current) return;
+      const current = chainRef.current;
+      if (!current || current.plugins.length === 0) return;
+      persistingRef.current = true;
+      try {
+        let states: string[];
+        try {
+          states = await vstHost.getState(trackId);
+        } catch {
+          return; // sidecar unreachable this tick — try again next tick
+        }
+        // Only matches when every plugin in the chain is currently loaded in
+        // the sidecar, in the same order — anything else is ambiguous, so
+        // skip rather than guess at an index mapping.
+        if (states.length !== current.plugins.length) return;
+        if (current.plugins.every((plugin, i) => plugin.stateB64 === states[i])) return;
+        const nextChain: ChainFileJson = {
+          version: 1,
+          plugins: current.plugins.map((plugin, i) => ({ ...plugin, stateB64: states[i] })),
+        };
+        const ok = await writeChainFile(projectId, chainPath, nextChain);
+        if (ok) {
+          chainRef.current = nextChain;
+          if (domEditSaveTimestampRef) domEditSaveTimestampRef.current = Date.now();
+        }
+      } finally {
+        persistingRef.current = false;
+      }
+    };
+
+    const interval = setInterval(() => {
+      void persistIfChanged();
+    }, VST_STATE_POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(interval);
+      // Best-effort flush: the section is unmounting, or the user navigated
+      // to a different element/track — save whatever state we can read
+      // right now instead of losing up to VST_STATE_POLL_INTERVAL_MS of
+      // edits. Skipped (persistingRef guard above) if a tick happens to
+      // already be in flight — acceptable for a best-effort save.
+      void persistIfChanged();
+    };
+  }, [editorOpen, chainPath, projectId, trackId, vstHost, domEditSaveTimestampRef]);
+
+  if (!vstHost) {
+    return (
+      <Section title="VST FX" icon={<Zap size={15} />}>
+        <div className="text-[11px] text-panel-text-4" data-vst-install-hint="true">
+          VST host not available — install with{" "}
+          <code className="text-panel-text-3">uv tool install hyperframes-vst-host</code>
+        </div>
+      </Section>
+    );
+  }
+
+  // Persist the current param values into the chain file so they survive a
+  // reload. Debounced from `handleParamChange` (dragging fires many changes);
+  // the live audio is already updated via `setParam` on every change.
+  const persistParams = async (): Promise<void> => {
+    const current = chainRef.current;
+    if (!current || !chainPath) return;
+    const next: ChainFileJson = {
+      version: 1,
+      plugins: current.plugins.map((plugin, i) => {
+        const params = paramsByPluginRef.current[i];
+        return plugin.format === "builtin" && params
+          ? { ...plugin, stateB64: encodeBuiltinParams(params) }
+          : plugin;
+      }),
+    };
+    const ok = await writeChainFile(projectId, chainPath, next);
+    if (ok) {
+      chainRef.current = next;
+      setChain(next);
+      if (domEditSaveTimestampRef) domEditSaveTimestampRef.current = Date.now();
+    }
+  };
+
+  const handleParamChange = (pluginIndex: number, param: string, value: number) => {
+    // Apply to the live streaming plugin immediately (audible now)...
+    vstHost.setParam(trackId, pluginIndex, param, value);
+    // ...update the visible control...
+    setParamsByPlugin((prev) => {
+      const next = prev.slice();
+      const cur = next[pluginIndex];
+      if (cur) next[pluginIndex] = { ...cur, [param]: value };
+      return next;
+    });
+    // ...and debounce a write so the value persists across reloads.
+    if (paramPersistTimerRef.current) clearTimeout(paramPersistTimerRef.current);
+    paramPersistTimerRef.current = setTimeout(() => void persistParams(), 400);
+  };
+
+  const handleAddPlugin = async (candidate: VstRegistryEntry) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const format = normalizePluginFormat(candidate.format);
+      // Append to any existing chain (effects stack in series, applied in
+      // order) — the first add starts a fresh chain, later adds grow it.
+      const newChain: ChainFileJson = {
+        version: 1,
+        plugins: [
+          ...(chain?.plugins ?? []),
+          {
+            format,
+            path: candidate.path,
+            // Built-ins have no sub-plugin name (their `path` IS the class);
+            // only external VST3/AU bundles carry one for `load_plugin`.
+            pluginName: format === "builtin" ? null : candidate.name,
+            name: candidate.name,
+            stateB64: null,
+          },
+        ],
+      };
+      const path = chainPath ?? chainFilePath(element);
+      const ok = await writeChainFile(projectId, path, newChain);
+      if (!ok) return;
+      if (domEditSaveTimestampRef) domEditSaveTimestampRef.current = Date.now();
+      setChain(newChain);
+      if (!chainPath) await onSetAttribute("vst-chain", path);
+      // Tell useVstPreview to reconcile+reload — a chain-file rewrite is
+      // invisible to the timeline `elements` signal it otherwise watches.
+      usePlayerStore.getState().bumpVstChainRevision();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemovePlugin = async (index: number) => {
+    if (!chain || !chainPath || busy) return;
+    setBusy(true);
+    try {
+      const nextPlugins = chain.plugins.filter((_, i) => i !== index);
+      const nextChain: ChainFileJson = { version: 1, plugins: nextPlugins };
+      const ok = await writeChainFile(projectId, chainPath, nextChain);
+      if (!ok) return;
+      if (domEditSaveTimestampRef) domEditSaveTimestampRef.current = Date.now();
+      setChain(nextChain);
+      if (nextPlugins.length === 0) {
+        // The commit path (`handleDomAttributeCommit`) types `value` as `string`,
+        // not `string | null` — "" is the established sentinel this panel uses
+        // to drop a data-* attribute's meaning (see MediaSection's `has-audio`).
+        await onSetAttribute("vst-chain", "");
+      }
+      usePlayerStore.getState().bumpVstChainRevision();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Seed the visible param sliders from a chain written outside the normal
+  // param-edit path (currently: the carve control) — the sidecar-polling
+  // seed effect is keyed on chain STRUCTURE, so it won't re-fire for a
+  // same-structure rewrite and the sliders would otherwise keep showing
+  // stale values.
+  const handleChainWrittenExternally = (nextChain: ChainFileJson) => {
+    setChain(nextChain);
+    setParamsByPlugin(
+      nextChain.plugins.map((p) =>
+        p.format === "builtin" ? (decodeBuiltinParams(p.stateB64) ?? {}) : null,
+      ),
+    );
+  };
+
+  return (
+    <Section title="VST FX" icon={<Zap size={15} />}>
+      <div className="space-y-2">
+        {/* Always rendered — a chain is a stack, so the picker stays
+            available to append further effects after the first add. */}
+        {scanning && available.length === 0 ? (
+          <div className="text-[11px] text-panel-text-4">Finding effects…</div>
+        ) : available.length === 0 ? (
+          <div className="text-[11px] text-panel-text-4">No effects available.</div>
+        ) : (
+          <select
+            data-vst-add-effect="true"
+            disabled={busy}
+            value=""
+            onChange={(e) => {
+              const picked = available[Number(e.target.value)];
+              if (picked) void handleAddPlugin(picked);
+            }}
+            className="h-8 w-full rounded-md bg-panel-input px-2.5 text-[11px] font-medium text-panel-text-2 transition-colors hover:bg-panel-hover disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <option value="" disabled>
+              Add effect…
+            </option>
+            {available.map((entry, i) => (
+              <option key={`${entry.format}-${entry.path}-${entry.name}`} value={i}>
+                {entry.name}
+                {entry.format === "builtin" ? "" : ` (${entry.format.toUpperCase()})`}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {chainPath && chain && (
+          <VstPluginRows
+            chain={chain}
+            chainPath={chainPath}
+            projectId={projectId}
+            trackId={trackId}
+            vstHost={vstHost}
+            paramsByPlugin={paramsByPlugin}
+            busy={busy}
+            setBusy={setBusy}
+            setChain={setChain}
+            domEditSaveTimestampRef={domEditSaveTimestampRef}
+            onParamChange={handleParamChange}
+            onOpenEditor={() => setEditorOpen(true)}
+            onRemovePlugin={(index) => void handleRemovePlugin(index)}
+          />
+        )}
+
+        <VstCarveSection
+          projectId={projectId}
+          element={element}
+          trackId={trackId}
+          busy={busy}
+          setBusy={setBusy}
+          onSetAttribute={onSetAttribute}
+          onChainWritten={handleChainWrittenExternally}
+          domEditSaveTimestampRef={domEditSaveTimestampRef}
+        />
+      </div>
+    </Section>
+  );
+}

--- a/packages/studio/src/components/studioBackgroundRemoval.ts
+++ b/packages/studio/src/components/studioBackgroundRemoval.ts
@@ -1,0 +1,60 @@
+import { waitForMediaJob } from "./studioMediaJobs";
+import type {
+  BackgroundRemovalProgress,
+  BackgroundRemovalResult,
+} from "./editor/propertyPanelTypes";
+
+/**
+ * POST a background-removal job for `inputPath`, then poll it to completion
+ * via `waitForMediaJob`. Aborts any in-flight removal tracked by
+ * `abortRef` before starting a new one (only one removal proceeds at a time).
+ */
+// fallow-ignore-next-line complexity
+export async function removeBackgroundViaApi(
+  projectId: string,
+  inputPath: string,
+  options: {
+    createBackgroundPlate?: boolean;
+    quality?: "fast" | "balanced" | "best";
+    onProgress?: (progress: BackgroundRemovalProgress) => void;
+  },
+  deps: {
+    refreshFileTree: () => Promise<void>;
+    showToast: (message: string, kind: "info" | "error") => void;
+    abortRef: { current: AbortController | null };
+  },
+): Promise<BackgroundRemovalResult> {
+  const response = await fetch(
+    `/api/projects/${encodeURIComponent(projectId)}/media/remove-background`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        inputPath,
+        createBackgroundPlate: options.createBackgroundPlate === true,
+        quality: options.quality ?? "balanced",
+      }),
+    },
+  );
+  const data = (await response.json().catch(() => ({}))) as {
+    jobId?: string;
+    error?: string;
+  };
+  if (!response.ok || !data.jobId) {
+    throw new Error(data.error || `Background removal failed (${response.status})`);
+  }
+  deps.showToast("Removing background...", "info");
+  deps.abortRef.current?.abort();
+  const controller = new AbortController();
+  deps.abortRef.current = controller;
+  try {
+    const result = await waitForMediaJob(data.jobId, options.onProgress, controller.signal);
+    await deps.refreshFileTree();
+    deps.showToast(`Created transparent asset: ${result.outputPath.split("/").pop()}`, "info");
+    return result;
+  } finally {
+    if (deps.abortRef.current === controller) {
+      deps.abortRef.current = null;
+    }
+  }
+}


### PR DESCRIPTION
**Stack 5/5** — replaces #2602–#2605. Base: #2922.

The audio element's FX section: plugin chain rows, the native editor handoff, and the "make room for voiceover" carve control that calls `POST /vst/carve` and writes the resulting bands into the chain file.

Off by default behind `STUDIO_VST_ENABLED` (`VITE_STUDIO_ENABLE_VST=true`), which was already introduced in #2922 — so unlike the original stack, no window exists where an ungated FX section is on `main`.

Files arrive pre-split (`propertyPanelVstSection` / `VstCarveSection` / `VstPluginRows` / `VstShared`) rather than being written large in one PR and split in the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
