### PR TITLE
chore: release v0.7.87

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,47 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.87"
+  description="Released - 2026-07-31"
+  tags={["Release", "Skills", "CLI", "Studio"]}
+>
+Website capture now exits predictably: runtime stages share a live budget, blocked or degraded pages fail fast, and vision/Lottie failures retain accurate, sanitized diagnostics. This release also enables Studio timeline virtualization by default and includes dense-keyframe and preview-resource fixes.
+
+## Features
+
+- **Studio:** Enable timeline virtualization by default ([c6925e471](https://github.com/heygen-com/hyperframes/commit/c6925e471a1ab4df911f5b4aab08740084c5412c), [#2926](https://github.com/heygen-com/hyperframes/pull/2926))
+
+## Fixes
+
+- **CLI:** Preserve capture failure diagnostics ([9ae000726](https://github.com/heygen-com/hyperframes/commit/9ae00072614f35785e4a1d7bad48787451462a91))
+- **CLI:** Omit skipped Lottie previews ([ac9458888](https://github.com/heygen-com/hyperframes/commit/ac9458888c7a6e05aa6b4d5d74063b5859782d02))
+- **CLI:** Narrow blocked page titles ([b38e90740](https://github.com/heygen-com/hyperframes/commit/b38e90740407ac50fd83e124b8211d3efc7282be))
+- **CLI:** Report bounded vision failures ([dfc60797a](https://github.com/heygen-com/hyperframes/commit/dfc60797a2adeddef120f4c800f06b30cc155117))
+- **CLI:** Reject blocked website captures ([22e3cca96](https://github.com/heygen-com/hyperframes/commit/22e3cca966e4f3c5dfe0f8b716dec80259206300))
+- **CLI:** Validate capture budget milliseconds ([d3607606e](https://github.com/heygen-com/hyperframes/commit/d3607606eeced5c826923f536d0d33d0cd799fb9))
+- **CLI:** Propagate live capture budget ([49091e614](https://github.com/heygen-com/hyperframes/commit/49091e6142c98b9fcab967c88e210df601a118d9))
+- **CLI:** Bound capture runtime stages ([765a5ae83](https://github.com/heygen-com/hyperframes/commit/765a5ae83f31b01b65426f34a3c80a47330456a0))
+- **Studio:** Keep dense keyframes readable ([723d3381c](https://github.com/heygen-com/hyperframes/commit/723d3381c4cabb3c238d883adf4fca487ead9df6), [#2925](https://github.com/heygen-com/hyperframes/pull/2925))
+- **Studio:** Release retained preview resources ([fbfffb1aa](https://github.com/heygen-com/hyperframes/commit/fbfffb1aa785fe48aa94a3570bd04c9128a80d18), [#2924](https://github.com/heygen-com/hyperframes/pull/2924))
+- Align local WebGPU capture behavior ([3a6b7f061](https://github.com/heygen-com/hyperframes/commit/3a6b7f06127102be719aa4d91f1a8b40b299a0c6), [#2907](https://github.com/heygen-com/hyperframes/pull/2907))
+- **CLI:** Move install-state into the config dir so deleting it is a full reset ([dae1b63d4](https://github.com/heygen-com/hyperframes/commit/dae1b63d4a59fc6dff7fe19861d90efce9dc6948))
+
+## Docs & Examples
+
+- **Skills:** Gate blocked website captures ([30f383074](https://github.com/heygen-com/hyperframes/commit/30f38307411908237201ed227f5350aa18ba156e))
+- Add THU-MAIC as HyperFrames adopter ([1738b5a11](https://github.com/heygen-com/hyperframes/commit/1738b5a11f7eee1c130b29b3c489f79473e7aec2), [#2761](https://github.com/heygen-com/hyperframes/pull/2761))
+- Unlist the Send-to guide from the docs nav (tool-served, not web-searched) ([a3c8f897f](https://github.com/heygen-com/hyperframes/commit/a3c8f897f2cdb4231521a752d6b320c8edb77a45), [#2918](https://github.com/heygen-com/hyperframes/pull/2918))
+
+## Internal
+
+- **CLI:** Cover bounded capture stages ([45aead84c](https://github.com/heygen-com/hyperframes/commit/45aead84c9467398cd18bc0878d6f4943daf65fd))
+- **Producer:** Share plan execution builder ([1d636f603](https://github.com/heygen-com/hyperframes/commit/1d636f603c6502e1d1421b0d04e67e47765f835f), [#2906](https://github.com/heygen-com/hyperframes/pull/2906))
+- **Lint:** Consolidate asset-src placeholder skip into a shared predicate ([5a6e4b1a8](https://github.com/heygen-com/hyperframes/commit/5a6e4b1a8f4176250b5c92b63845399fcfe7f256), [#2894](https://github.com/heygen-com/hyperframes/pull/2894))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.86...v0.7.87).
+</Update>
+
+<Update
   label="HyperFrames v0.7.85"
   description="Released - 2026-07-30"
   tags={["Release", "Prompting", "Studio", "Docs"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.85",
+  "version": "0.7.87",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.87.md
+++ b/releases/v0.7.87.md
@@ -1,0 +1,40 @@
+# HyperFrames v0.7.87
+
+Released on 2026-07-31.
+
+Website capture now exits predictably: runtime stages share a live budget, blocked or degraded pages fail fast, and vision/Lottie failures retain accurate, sanitized diagnostics. This release also enables Studio timeline virtualization by default and includes dense-keyframe and preview-resource fixes.
+
+## Features
+
+- **Studio:** Enable timeline virtualization by default ([c6925e471](https://github.com/heygen-com/hyperframes/commit/c6925e471a1ab4df911f5b4aab08740084c5412c), [#2926](https://github.com/heygen-com/hyperframes/pull/2926))
+
+## Fixes
+
+- **CLI:** Preserve capture failure diagnostics ([9ae000726](https://github.com/heygen-com/hyperframes/commit/9ae00072614f35785e4a1d7bad48787451462a91))
+- **CLI:** Omit skipped Lottie previews ([ac9458888](https://github.com/heygen-com/hyperframes/commit/ac9458888c7a6e05aa6b4d5d74063b5859782d02))
+- **CLI:** Narrow blocked page titles ([b38e90740](https://github.com/heygen-com/hyperframes/commit/b38e90740407ac50fd83e124b8211d3efc7282be))
+- **CLI:** Report bounded vision failures ([dfc60797a](https://github.com/heygen-com/hyperframes/commit/dfc60797a2adeddef120f4c800f06b30cc155117))
+- **CLI:** Reject blocked website captures ([22e3cca96](https://github.com/heygen-com/hyperframes/commit/22e3cca966e4f3c5dfe0f8b716dec80259206300))
+- **CLI:** Validate capture budget milliseconds ([d3607606e](https://github.com/heygen-com/hyperframes/commit/d3607606eeced5c826923f536d0d33d0cd799fb9))
+- **CLI:** Propagate live capture budget ([49091e614](https://github.com/heygen-com/hyperframes/commit/49091e6142c98b9fcab967c88e210df601a118d9))
+- **CLI:** Bound capture runtime stages ([765a5ae83](https://github.com/heygen-com/hyperframes/commit/765a5ae83f31b01b65426f34a3c80a47330456a0))
+- **Studio:** Keep dense keyframes readable ([723d3381c](https://github.com/heygen-com/hyperframes/commit/723d3381c4cabb3c238d883adf4fca487ead9df6), [#2925](https://github.com/heygen-com/hyperframes/pull/2925))
+- **Studio:** Release retained preview resources ([fbfffb1aa](https://github.com/heygen-com/hyperframes/commit/fbfffb1aa785fe48aa94a3570bd04c9128a80d18), [#2924](https://github.com/heygen-com/hyperframes/pull/2924))
+- Align local WebGPU capture behavior ([3a6b7f061](https://github.com/heygen-com/hyperframes/commit/3a6b7f06127102be719aa4d91f1a8b40b299a0c6), [#2907](https://github.com/heygen-com/hyperframes/pull/2907))
+- **CLI:** Move install-state into the config dir so deleting it is a full reset ([dae1b63d4](https://github.com/heygen-com/hyperframes/commit/dae1b63d4a59fc6dff7fe19861d90efce9dc6948))
+
+## Docs & Examples
+
+- **Skills:** Gate blocked website captures ([30f383074](https://github.com/heygen-com/hyperframes/commit/30f38307411908237201ed227f5350aa18ba156e))
+- Add THU-MAIC as HyperFrames adopter ([1738b5a11](https://github.com/heygen-com/hyperframes/commit/1738b5a11f7eee1c130b29b3c489f79473e7aec2), [#2761](https://github.com/heygen-com/hyperframes/pull/2761))
+- Unlist the Send-to guide from the docs nav (tool-served, not web-searched) ([a3c8f897f](https://github.com/heygen-com/hyperframes/commit/a3c8f897f2cdb4231521a752d6b320c8edb77a45), [#2918](https://github.com/heygen-com/hyperframes/pull/2918))
+
+## Internal
+
+- **CLI:** Cover bounded capture stages ([45aead84c](https://github.com/heygen-com/hyperframes/commit/45aead84c9467398cd18bc0878d6f4943daf65fd))
+- **Producer:** Share plan execution builder ([1d636f603](https://github.com/heygen-com/hyperframes/commit/1d636f603c6502e1d1421b0d04e67e47765f835f), [#2906](https://github.com/heygen-com/hyperframes/pull/2906))
+- **Lint:** Consolidate asset-src placeholder skip into a shared predicate ([5a6e4b1a8](https://github.com/heygen-com/hyperframes/commit/5a6e4b1a8f4176250b5c92b63845399fcfe7f256), [#2894](https://github.com/heygen-com/hyperframes/pull/2894))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.86...v0.7.87


### PR DESCRIPTION
## Summary

- publish HyperFrames v0.7.87 with bounded website-capture stages and live budget propagation
- fail fast on blocked/degraded capture results with sanitized failure diagnostics
- publish updated website-capture skill guardrails and the other changes since v0.7.86

## Verification

- `bun test scripts/draft-changelog.test.ts scripts/release-prepare.test.ts scripts/set-version.test.ts` (33 passed)
- release-channel validation for `release/v0.7.87` / `latest`
- `bun run build`
- packed manifests passed for all 13 packages; the final local consumer smoke is blocked by this host glibc version and remains covered by CI

## Release

Merging this `release/v0.7.87` PR triggers the repository publish workflow, creates tag `v0.7.87`, publishes packages to npm with the `latest` dist-tag, and creates the GitHub release.