### PR TITLE
perf(studio): resolve manifest clips through one pass-scoped DOM index

### DIFF
--- a/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
+++ b/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
@@ -16,6 +16,7 @@ import type { PlaybackAdapter, ClipManifestClip, IframeWindow } from "../lib/pla
 import {
   parseTimelineFromDOM,
   createTimelineElementFromManifestClip,
+  createTimelineDomIndex,
   findTimelineDomNodeForClip,
   createImplicitTimelineLayersFromDOM,
   buildStandaloneRootTimelineElement,
@@ -222,9 +223,10 @@ export function useTimelineSyncCallbacks({
 
       const usedHostEls = new Set<Element>();
       markManifestDeriveStart();
+      const timelineDomIndex = iframeDoc ? createTimelineDomIndex(iframeDoc) : undefined;
       const els: TimelineElement[] = filtered.map((clip, index) => {
         const hostEl = iframeDoc
-          ? findTimelineDomNodeForClip(iframeDoc, clip, index, usedHostEls)
+          ? findTimelineDomNodeForClip(iframeDoc, clip, index, usedHostEls, timelineDomIndex)
           : null;
         if (hostEl) usedHostEls.add(hostEl);
         return createTimelineElementFromManifestClip({
@@ -232,6 +234,7 @@ export function useTimelineSyncCallbacks({
           fallbackIndex: index,
           doc: iframeDoc,
           hostEl,
+          index: timelineDomIndex,
         });
       });
       markManifestDeriveEnd();

--- a/packages/studio/src/player/lib/timelineDOM.test.ts
+++ b/packages/studio/src/player/lib/timelineDOM.test.ts
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createTimelineElementFromManifestClip,
   parseTimelineFromDOM,
   createImplicitTimelineLayersFromDOM,
   mergeTimelineElementsPreservingDowngrades,
+  createTimelineDomIndex,
+  findTimelineDomNodeForClip,
+  type TimelineDomIndex,
 } from "./timelineDOM";
 import type { TimelineElement } from "../store/playerStore";
+import type { ClipManifestClip } from "./playbackTypes";
+import { generateStudioLoadFixture } from "../../../tests/e2e/generateStudioLoadFixture.mjs";
 
 function el(id: string, extra: Partial<TimelineElement> = {}): TimelineElement {
   return { id, tag: "img", start: 0, duration: 5, track: 0, ...extra };
@@ -16,6 +21,47 @@ function makeDoc(html: string): Document {
   const d = document.implementation.createHTMLDocument();
   d.body.innerHTML = html;
   return d;
+}
+
+function manifestClip(element: Element, index: number): ClipManifestClip {
+  const compositionId = element.getAttribute("data-composition-id");
+  return {
+    id: element.id || element.getAttribute("data-hf-id"),
+    label: `Clip ${index}`,
+    start: Number(element.getAttribute("data-start")),
+    duration: Number(element.getAttribute("data-duration")),
+    track: Number(element.getAttribute("data-track-index")),
+    kind: compositionId ? "composition" : "element",
+    tagName: element.tagName.toLowerCase(),
+    compositionId,
+    parentCompositionId: null,
+    compositionSrc: null,
+    assetUrl: null,
+  };
+}
+
+/**
+ * The whole per-clip derivation, exactly as processTimelineMessage runs it.
+ * Async only so the un-indexed arm — which is quadratic by construction, ~80s
+ * at 3,000 clips under jsdom — yields often enough to keep vitest's worker RPC
+ * heartbeat alive; a fully synchronous run makes the suite exit non-zero.
+ */
+async function deriveManifestElements(
+  doc: Document,
+  clips: readonly ClipManifestClip[],
+  index?: TimelineDomIndex,
+): Promise<TimelineElement[]> {
+  const used = new Set<Element>();
+  const elements: TimelineElement[] = [];
+  for (const [fallbackIndex, clip] of clips.entries()) {
+    const hostEl = findTimelineDomNodeForClip(doc, clip, fallbackIndex, used, index);
+    if (hostEl) used.add(hostEl);
+    elements.push(
+      createTimelineElementFromManifestClip({ clip, fallbackIndex, doc, hostEl, index }),
+    );
+    if (fallbackIndex % 100 === 99) await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return elements;
 }
 
 describe("parseTimelineFromDOM — hfId from data-hf-id", () => {
@@ -204,6 +250,129 @@ describe("createTimelineElementFromManifestClip — source-scoped selector ident
     expect(element.sourceFile).toBe("scene.html");
     expect(element.selectorIndex).toBe(1);
     expect(element.key).toBe("scene.html:.sub:1");
+  });
+});
+
+describe("createTimelineElementFromManifestClip — indexed identity parity", () => {
+  it("keeps every id and key byte-identical across the generated 3,000-clip fixture", async () => {
+    const files = generateStudioLoadFixture({ clipCount: 3_000, trackCount: 150 });
+    const doc = makeDoc(files["index.html"]);
+    const subComposition = makeDoc(files["compositions/load-details.html"]);
+    const template = subComposition.querySelector("template");
+    const host = doc.querySelector('[data-composition-id="studio-load-details"]');
+    if (!(template instanceof HTMLTemplateElement) || !host) {
+      throw new Error("invalid generated fixture");
+    }
+    host.append(template.content.cloneNode(true));
+
+    const nodes = Array.from(doc.querySelectorAll(".clip"));
+    nodes.forEach((node, index) => {
+      if (!node.id && index % 29 !== 0) node.setAttribute("data-hf-id", `hf-${index}`);
+    });
+    const clips = nodes.map(manifestClip);
+    const nullIdCount = clips.filter((clip) => clip.id == null).length;
+    // Both arms run the FULL derivation, node resolution included — handing the
+    // legacy arm a pre-resolved hostEl would compare only the identity builder
+    // and could not see the indexed path resolving a clip to a different node.
+    const legacy = await deriveManifestElements(doc, clips);
+    const indexed = await deriveManifestElements(doc, clips, createTimelineDomIndex(doc));
+
+    expect(nodes).toHaveLength(3_000);
+    expect(nullIdCount).toBeGreaterThan(0);
+    expect(indexed.map(({ id, key }) => ({ id, key }))).toEqual(
+      legacy.map(({ id, key }) => ({ id, key })),
+    );
+  }, 300_000);
+
+  it("keeps a null-id clip's selector occurrence identity unchanged", async () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root" data-composition-file="index.html">
+        <div class="clip card" data-start="0" data-duration="4" data-track-index="0"></div>
+        <div class="clip card" data-start="4" data-duration="4" data-track-index="1"></div>
+      </main>
+    `);
+    const clip: ClipManifestClip = {
+      id: null,
+      label: "Card",
+      start: 4,
+      duration: 4,
+      track: 1,
+      kind: "element",
+      tagName: "div",
+      compositionId: null,
+      parentCompositionId: null,
+      compositionSrc: null,
+      assetUrl: null,
+    };
+    const legacy = await deriveManifestElements(doc, [clip]);
+    const indexed = await deriveManifestElements(doc, [clip], createTimelineDomIndex(doc));
+
+    expect(indexed[0]).toMatchObject({
+      id: legacy[0]?.id,
+      key: legacy[0]?.key,
+      selector: ".card",
+      selectorIndex: 1,
+    });
+  });
+
+  it("resolves an inlined composition without extra document queries", async () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root" data-composition-file="index.html">
+        <section data-hf-id="host-hf" data-composition-id="nested"
+          data-composition-file="nested.html" data-start="0" data-duration="4"></section>
+      </main>
+    `);
+    const clip: ClipManifestClip = {
+      id: "host-hf",
+      label: "Nested",
+      start: 0,
+      duration: 4,
+      track: 0,
+      kind: "composition",
+      tagName: "section",
+      compositionId: "nested",
+      parentCompositionId: null,
+      compositionSrc: null,
+      assetUrl: null,
+    };
+    const legacy = (await deriveManifestElements(doc, [clip]))[0];
+    const index = createTimelineDomIndex(doc);
+    const querySpy = vi.spyOn(doc, "querySelector");
+    const indexed = (await deriveManifestElements(doc, [clip], index))[0];
+
+    expect(indexed).toMatchObject({
+      compositionSrc: legacy?.compositionSrc,
+      domId: legacy?.domId,
+      hfId: legacy?.hfId,
+      id: legacy?.id,
+      key: legacy?.key,
+    });
+    expect(querySpy).not.toHaveBeenCalled();
+  });
+
+  it("bounds document-wide queries for a 500-clip manifest including an inlined composition", async () => {
+    const clipsMarkup = Array.from(
+      { length: 499 },
+      (_, index) =>
+        `<div class="clip card" data-hf-id="hf-${index}" data-start="${index}" data-duration="1" data-track-index="${index}"></div>`,
+    ).join("");
+    const doc = makeDoc(`
+      <main data-composition-id="root" data-composition-file="index.html">
+        ${clipsMarkup}
+        <section class="clip card" data-hf-id="composition-host" data-composition-id="nested"
+          data-composition-file="nested.html" data-start="499" data-duration="1" data-track-index="499"></section>
+      </main>
+    `);
+    const clips = Array.from(doc.querySelectorAll(".clip"), manifestClip);
+    const queryAllSpy = vi.spyOn(doc, "querySelectorAll");
+    const querySpy = vi.spyOn(doc, "querySelector");
+    const index = createTimelineDomIndex(doc);
+    const elements = await deriveManifestElements(doc, clips, index);
+
+    expect(elements).toHaveLength(500);
+    expect(elements.at(-1)?.compositionSrc).toBe("nested.html");
+    expect(queryAllSpy).toHaveBeenCalledTimes(1);
+    expect(querySpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/studio/src/player/lib/timelineDOM.ts
+++ b/packages/studio/src/player/lib/timelineDOM.ts
@@ -26,6 +26,7 @@ import {
   getTimelineElementIdentity,
   isTimelineIgnoredElement,
   readTimelineElementZIndex,
+  type TimelineDomIndex,
 } from "./timelineElementHelpers";
 
 // Re-export helpers that were previously public from this module so that
@@ -46,7 +47,9 @@ export {
   buildTimelineElementIdentity,
   // fallow-ignore-next-line unused-exports
   getTimelineElementIdentity,
+  createTimelineDomIndex,
   findTimelineDomNodeForClip,
+  type TimelineDomIndex,
 } from "./timelineElementHelpers";
 
 // Re-export iframe helpers so the hook can keep a single import source.
@@ -73,8 +76,9 @@ export function createTimelineElementFromManifestClip(params: {
   fallbackIndex: number;
   doc?: Document | null;
   hostEl?: Element | null;
+  index?: TimelineDomIndex;
 }): TimelineElement {
-  const { clip, fallbackIndex, doc } = params;
+  const { clip, fallbackIndex, doc, index } = params;
   let hostEl = params.hostEl ?? null;
   const label = getTimelineElementDisplayLabel({
     id: clip.id,
@@ -93,8 +97,8 @@ export function createTimelineElementFromManifestClip(params: {
     hfId = hostEl.getAttribute("data-hf-id") || undefined;
     selector = getTimelineElementSelector(hostEl);
     selectorIndex =
-      doc && selector ? getTimelineElementSelectorIndex(doc, hostEl, selector) : undefined;
-    sourceFile = getTimelineElementSourceFile(hostEl);
+      doc && selector ? getTimelineElementSelectorIndex(doc, hostEl, selector, index) : undefined;
+    sourceFile = getTimelineElementSourceFile(hostEl, index);
   }
 
   const identity = buildTimelineElementIdentity({
@@ -147,7 +151,10 @@ export function createTimelineElementFromManifestClip(params: {
     let resolvedSrc = clip.compositionSrc;
     if (!resolvedSrc) {
       hostEl =
-        doc?.querySelector(`[data-composition-id="${CSS.escape(clip.compositionId)}"]`) ?? hostEl;
+        (index
+          ? index.byCompositionId.get(clip.compositionId)
+          : doc?.querySelector(`[data-composition-id="${CSS.escape(clip.compositionId)}"]`)) ??
+        hostEl;
       resolvedSrc =
         hostEl?.getAttribute("data-composition-src") ??
         hostEl?.getAttribute("data-composition-file") ??
@@ -168,9 +175,9 @@ export function createTimelineElementFromManifestClip(params: {
       entry.selector = getTimelineElementSelector(hostEl);
       entry.selectorIndex =
         doc && entry.selector
-          ? getTimelineElementSelectorIndex(doc, hostEl, entry.selector)
+          ? getTimelineElementSelectorIndex(doc, hostEl, entry.selector, index)
           : undefined;
-      entry.sourceFile = getTimelineElementSourceFile(hostEl);
+      entry.sourceFile = getTimelineElementSourceFile(hostEl, index);
       const nextIdentity = buildTimelineElementIdentity({
         preferredId: clip.id,
         label,

--- a/packages/studio/src/player/lib/timelineElementHelpers.test.ts
+++ b/packages/studio/src/player/lib/timelineElementHelpers.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { createTimelineDomIndex, findTimelineDomNodeForClip } from "./timelineElementHelpers";
+import type { ClipManifestClip } from "./playbackTypes";
+
+function makeDoc(html: string): Document {
+  const doc = document.implementation.createHTMLDocument();
+  doc.body.innerHTML = html;
+  return doc;
+}
+
+function clip(overrides: Partial<ClipManifestClip> = {}): ClipManifestClip {
+  return {
+    id: null,
+    label: "Clip",
+    start: 0,
+    duration: 4,
+    track: 0,
+    kind: "element",
+    tagName: "div",
+    compositionId: null,
+    parentCompositionId: null,
+    compositionSrc: null,
+    assetUrl: null,
+    ...overrides,
+  };
+}
+
+describe("timeline DOM identity index", () => {
+  it("resolves a manifest id that exists only as data-hf-id", () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root">
+        <div data-hf-id="hf-only" data-start="0" data-duration="4"></div>
+      </main>
+    `);
+    const expected = doc.querySelector("[data-hf-id='hf-only']");
+
+    expect(
+      findTimelineDomNodeForClip(
+        doc,
+        clip({ id: "hf-only" }),
+        0,
+        new Set(),
+        createTimelineDomIndex(doc),
+      ),
+    ).toBe(expected);
+  });
+
+  it("keeps DOM id resolution unchanged", () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root">
+        <div id="dom-only" data-start="0" data-duration="4"></div>
+      </main>
+    `);
+
+    expect(
+      findTimelineDomNodeForClip(
+        doc,
+        clip({ id: "dom-only" }),
+        0,
+        new Set(),
+        createTimelineDomIndex(doc),
+      ),
+    ).toBe(doc.getElementById("dom-only"));
+  });
+
+  it("never returns an already-claimed node for duplicate manifest ids", () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root">
+        <div data-hf-id="duplicate" data-start="0" data-duration="4" data-track-index="0"></div>
+        <div data-hf-id="duplicate" data-start="4" data-duration="4" data-track-index="1"></div>
+      </main>
+    `);
+    const index = createTimelineDomIndex(doc);
+    const used = new Set<Element>();
+    const first = findTimelineDomNodeForClip(
+      doc,
+      clip({ id: "duplicate", start: 0, track: 0 }),
+      0,
+      used,
+      index,
+    );
+    if (!first) throw new Error("missing first match");
+    used.add(first);
+    const second = findTimelineDomNodeForClip(
+      doc,
+      clip({ id: "duplicate", start: 4, track: 1 }),
+      1,
+      used,
+      index,
+    );
+
+    expect(second).toBe(doc.querySelectorAll("[data-hf-id='duplicate']")[1]);
+    expect(second).not.toBe(first);
+  });
+
+  it("preserves composition, class, and attribute fallback resolution", () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root">
+        <div data-composition-id="nested" data-start="0" data-duration="4"></div>
+        <div class="class-identity" data-start="4" data-duration="4"></div>
+        <article data-start="8" data-duration="4" data-track-index="2"></article>
+      </main>
+    `);
+    const index = createTimelineDomIndex(doc);
+
+    expect(findTimelineDomNodeForClip(doc, clip({ id: "nested" }), 0, new Set(), index)).toBe(
+      doc.querySelector("[data-composition-id='nested']"),
+    );
+    expect(
+      findTimelineDomNodeForClip(
+        doc,
+        clip({ id: "class-identity", start: 4 }),
+        1,
+        new Set(),
+        index,
+      ),
+    ).toBe(doc.querySelector(".class-identity"));
+    expect(
+      findTimelineDomNodeForClip(
+        doc,
+        clip({ id: "missing", tagName: "article", start: 8, track: 2 }),
+        2,
+        new Set(),
+        index,
+      ),
+    ).toBe(doc.querySelector("article"));
+  });
+
+  it("rebuilds against DOM mutations between sync passes", () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root">
+        <div data-hf-id="mutable" data-version="before" data-start="0" data-duration="4"></div>
+      </main>
+    `);
+    const before = findTimelineDomNodeForClip(
+      doc,
+      clip({ id: "mutable" }),
+      0,
+      new Set(),
+      createTimelineDomIndex(doc),
+    );
+    before?.remove();
+    doc
+      .querySelector("main")
+      ?.insertAdjacentHTML(
+        "beforeend",
+        `<div data-hf-id="mutable" data-version="after" data-start="0" data-duration="4"></div>`,
+      );
+    const after = findTimelineDomNodeForClip(
+      doc,
+      clip({ id: "mutable" }),
+      0,
+      new Set(),
+      createTimelineDomIndex(doc),
+    );
+
+    expect(before?.getAttribute("data-version")).toBe("before");
+    expect(after?.getAttribute("data-version")).toBe("after");
+    expect(after).not.toBe(before);
+  });
+});

--- a/packages/studio/src/player/lib/timelineElementHelpers.ts
+++ b/packages/studio/src/player/lib/timelineElementHelpers.ts
@@ -10,7 +10,11 @@
 import type { TimelineElement } from "../store/playerStore";
 import type { ClipManifestClip } from "./playbackTypes";
 import { isFinitePositive } from "./playbackAdapter";
-import { getSourceScopedSelectorIndex } from "../../utils/sourceScopedSelectorIndex";
+import {
+  createSourceScopedSelectorIndex,
+  getSourceScopedSelectorIndex,
+  type SourceScopedSelectorIndex,
+} from "../../utils/sourceScopedSelectorIndex";
 
 // ---------------------------------------------------------------------------
 // Layer-reveal lift transparency
@@ -261,7 +265,21 @@ export function getTimelineElementSelector(el: Element): string | undefined {
   return undefined;
 }
 
-export function getTimelineElementSourceFile(el: Element): string | undefined {
+export interface TimelineDomIndex {
+  readonly byClass: ReadonlyMap<string, Element>;
+  readonly byCompositionId: ReadonlyMap<string, Element>;
+  readonly byDomId: ReadonlyMap<string, Element>;
+  readonly byHfId: ReadonlyMap<string, Element>;
+  readonly selectorOccurrences: SourceScopedSelectorIndex;
+  readonly sourceFiles: ReadonlyMap<Element, string | undefined>;
+  readonly timelineNodes: readonly Element[];
+}
+
+export function getTimelineElementSourceFile(
+  el: Element,
+  index?: TimelineDomIndex,
+): string | undefined {
+  if (index) return index.sourceFiles.get(el);
   const ownerRoot = el.parentElement?.closest("[data-composition-id]");
   return (
     ownerRoot?.getAttribute("data-composition-file") ??
@@ -274,13 +292,15 @@ export function getTimelineElementSelectorIndex(
   doc: Document,
   el: Element,
   selector: string | undefined,
+  index?: TimelineDomIndex,
 ): number | undefined {
   return getSourceScopedSelectorIndex(
     doc,
     el,
     selector,
-    getTimelineElementSourceFile(el),
+    getTimelineElementSourceFile(el, index),
     getTimelineElementSourceFile,
+    index?.selectorOccurrences,
   );
 }
 
@@ -369,6 +389,76 @@ export function deriveTimelineStoreKey(params: {
 // DOM node querying
 // ---------------------------------------------------------------------------
 
+/**
+ * Source file every element resolves to, in one document-order pass.
+ *
+ * Mirrors {@link getTimelineElementSourceFile} exactly: the scope is read off
+ * the nearest ancestor-or-self `[data-composition-id]` of the element's PARENT,
+ * and only that element's own file/src attribute counts. An untagged nested
+ * composition root therefore scopes to undefined rather than inheriting its
+ * grandparent's file — which is what `closest()` does today, and a scope that
+ * diverged here would change every affected element's key.
+ */
+function buildSourceFileMap(elements: readonly Element[]): Map<Element, string | undefined> {
+  const sourceFiles = new Map<Element, string | undefined>();
+  const childSourceFiles = new Map<Element, string | undefined>();
+  for (const element of elements) {
+    const sourceFile = element.parentElement
+      ? childSourceFiles.get(element.parentElement)
+      : undefined;
+    sourceFiles.set(element, sourceFile);
+    childSourceFiles.set(
+      element,
+      element.hasAttribute("data-composition-id")
+        ? (element.getAttribute("data-composition-file") ??
+            element.getAttribute("data-composition-src") ??
+            undefined)
+        : sourceFile,
+    );
+  }
+  return sourceFiles;
+}
+
+/** First-in-document-order wins, matching getElementById / querySelector. */
+function keepFirst(map: Map<string, Element>, key: string | null, element: Element): void {
+  if (key && !map.has(key)) map.set(key, element);
+}
+
+export function createTimelineDomIndex(doc: Document): TimelineDomIndex {
+  const elements = Array.from(doc.querySelectorAll("*"));
+  const byClass = new Map<string, Element>();
+  const byCompositionId = new Map<string, Element>();
+  const byDomId = new Map<string, Element>();
+  const byHfId = new Map<string, Element>();
+  const sourceFiles = buildSourceFileMap(elements);
+  const timedNodes: Element[] = [];
+  let rootComposition: Element | null = null;
+
+  for (const element of elements) {
+    keepFirst(byDomId, element.id, element);
+    keepFirst(byHfId, element.getAttribute("data-hf-id"), element);
+    const compositionId = element.getAttribute("data-composition-id");
+    keepFirst(byCompositionId, compositionId, element);
+    if (compositionId) rootComposition ??= element;
+    for (const className of element.classList) keepFirst(byClass, className, element);
+    if (element.hasAttribute("data-start")) timedNodes.push(element);
+  }
+
+  return {
+    byClass,
+    byCompositionId,
+    byDomId,
+    byHfId,
+    selectorOccurrences: createSourceScopedSelectorIndex(elements, (element) =>
+      sourceFiles.get(element),
+    ),
+    sourceFiles,
+    timelineNodes: timedNodes.filter(
+      (node) => node !== rootComposition && !isTimelineIgnoredElement(node),
+    ),
+  };
+}
+
 function getTimelineDomNodes(doc: Document): Element[] {
   const rootComp = doc.querySelector("[data-composition-id]");
   return Array.from(doc.querySelectorAll("[data-start]")).filter(
@@ -406,16 +496,33 @@ function findTimelineDomNode(doc: Document, id: string): Element | null {
   );
 }
 
+function findIndexedTimelineDomNode(index: TimelineDomIndex, id: string): Element | null {
+  return (
+    index.byDomId.get(id) ??
+    index.byHfId.get(id) ??
+    index.byCompositionId.get(id) ??
+    index.byClass.get(id) ??
+    null
+  );
+}
+
 export function findTimelineDomNodeForClip(
   doc: Document,
   clip: ClipManifestClip,
   fallbackIndex: number,
   usedNodes = new Set<Element>(),
+  index?: TimelineDomIndex,
 ): Element | null {
-  const byIdentity = clip.id ? findTimelineDomNode(doc, clip.id) : null;
+  const byIdentity = clip.id
+    ? index
+      ? findIndexedTimelineDomNode(index, clip.id)
+      : findTimelineDomNode(doc, clip.id)
+    : null;
   if (byIdentity && !usedNodes.has(byIdentity)) return byIdentity;
 
-  const candidates = getTimelineDomNodes(doc).filter((node) => !usedNodes.has(node));
+  const candidates = (index?.timelineNodes ?? getTimelineDomNodes(doc)).filter(
+    (node) => !usedNodes.has(node),
+  );
   const exact = candidates.find((node) => nodeMatchesManifestClip(node, clip));
   if (exact) return exact;
 

--- a/packages/studio/src/utils/sourceScopedSelectorIndex.test.ts
+++ b/packages/studio/src/utils/sourceScopedSelectorIndex.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSourceScopedSelectorIndex,
+  getSourceScopedSelectorIndex,
+} from "./sourceScopedSelectorIndex";
+
+function makeDoc(html: string): Document {
+  const doc = document.implementation.createHTMLDocument();
+  doc.body.innerHTML = html;
+  return doc;
+}
+
+function sourceFile(element: Element): string | undefined {
+  const owner = element.parentElement?.closest("[data-composition-id]");
+  return (
+    owner?.getAttribute("data-composition-file") ??
+    owner?.getAttribute("data-composition-src") ??
+    undefined
+  );
+}
+
+describe("source-scoped selector index", () => {
+  it("matches fallback occurrence numbers for a class shared across source files", () => {
+    const doc = makeDoc(`
+      <main data-composition-id="root" data-composition-file="index.html">
+        <div class="shared"></div>
+        <section data-composition-id="scene" data-composition-file="scene.html">
+          <div id="also-counted" class="shared"></div>
+          <div class="shared target"></div>
+        </section>
+      </main>
+    `);
+    const target = doc.querySelector(".target");
+    if (!target) throw new Error("missing target");
+    const index = createSourceScopedSelectorIndex(
+      Array.from(doc.querySelectorAll("*")),
+      sourceFile,
+    );
+    const fallback = getSourceScopedSelectorIndex(doc, target, ".shared", "scene.html", sourceFile);
+    const querySpy = vi.spyOn(doc, "querySelectorAll");
+
+    expect(
+      getSourceScopedSelectorIndex(doc, target, ".shared", "scene.html", sourceFile, index),
+    ).toBe(fallback);
+    expect(fallback).toBe(1);
+    expect(querySpy).not.toHaveBeenCalled();
+  });
+
+  it("leaves a clip with no resolvable selector unindexed", () => {
+    const doc = makeDoc(`<main data-composition-id="root"><div data-target></div></main>`);
+    const target = doc.querySelector("[data-target]");
+    if (!target) throw new Error("missing target");
+    const index = createSourceScopedSelectorIndex(
+      Array.from(doc.querySelectorAll("*")),
+      sourceFile,
+    );
+
+    expect(
+      getSourceScopedSelectorIndex(doc, target, undefined, undefined, sourceFile, index),
+    ).toBeUndefined();
+  });
+});

--- a/packages/studio/src/utils/sourceScopedSelectorIndex.ts
+++ b/packages/studio/src/utils/sourceScopedSelectorIndex.ts
@@ -5,19 +5,54 @@
  * `querySelectorAll` index is not a stable source-file identity. Callers supply
  * their existing source resolver; this helper alone owns occurrence scoping.
  */
+export type SourceScopedSelectorIndex = ReadonlyMap<
+  string,
+  ReadonlyMap<string, ReadonlyMap<Element, number>>
+>;
+
+export function createSourceScopedSelectorIndex(
+  elements: readonly Element[],
+  resolveSourceFile: (candidate: Element) => string | undefined,
+): SourceScopedSelectorIndex {
+  const mutableIndex = new Map<string, Map<string, Map<Element, number>>>();
+
+  for (const element of elements) {
+    const scope = resolveSourceFile(element) ?? "index.html";
+    for (const className of element.classList) {
+      const selector = `.${CSS.escape(className)}`;
+      let scopes = mutableIndex.get(selector);
+      if (!scopes) {
+        scopes = new Map();
+        mutableIndex.set(selector, scopes);
+      }
+      let occurrences = scopes.get(scope);
+      if (!occurrences) {
+        occurrences = new Map();
+        scopes.set(scope, occurrences);
+      }
+      occurrences.set(element, occurrences.size);
+    }
+  }
+
+  return mutableIndex;
+}
+
 export function getSourceScopedSelectorIndex(
   doc: Document,
   el: Element,
   selector: string | undefined,
   sourceFile: string | undefined,
   resolveSourceFile: (candidate: Element) => string | undefined,
+  index?: SourceScopedSelectorIndex,
 ): number | undefined {
   if (!selector || selector.startsWith("#") || selector.startsWith("[data-composition-id=")) {
     return undefined;
   }
 
+  const scope = sourceFile ?? "index.html";
+  if (index) return index.get(selector)?.get(scope)?.get(el);
+
   try {
-    const scope = sourceFile ?? "index.html";
     const matches = Array.from(doc.querySelectorAll(selector)).filter(
       (candidate) => (resolveSourceFile(candidate) ?? "index.html") === scope,
     );


### PR DESCRIPTION
**PR 2 of 5** · base `perf/studio-load-and-open` (#2940)

Opening a 3,000-clip project spent 2,880 ms turning the clip manifest into timeline elements. This makes it 10 ms.

### The root cause: two ideas of what a clip's identity is

The runtime mints clip ids as `stableClipId(el) = el.id ?? el.getAttribute("data-hf-id")`. Studio looked them up with `doc.getElementById(id)` — which matches the `id` attribute and **never** `data-hf-id`. In a real sample only 13 of 58 authored clips carry a DOM `id`, so for most clips the indexed lookup missed and fell through to a whole-document scan, per clip, at three separate call sites.

### What the profile actually said

Not what I expected. `isTimelineIgnoredElement` was **5,292 ms of self time — 40% of all CPU during open**. It runs `el.closest()` against a four-selector list, and `getTimelineDomNodes` applies it to every `[data-start]` node, roughly four times per clip. Counted by patching `Element.prototype.closest` in the page:

> **37,175,144 `closest()` calls** to open one project. Plus 18,959 `querySelectorAll`s. Over 3,001 nodes. In the measured fixture the ignore-filter rejects **zero** of them.

The same work done once measures **1.3 ms** in the live page.

### The change

One `TimelineDomIndex` built per `processTimelineMessage` pass from a single document walk, threaded to all three emitters: node resolution (now keyed on `data-hf-id` as well as `id`), the source-scoped selector-occurrence index, and the composition branch that re-resolves a host when `compositionSrc` is absent. Pass-scoped, never memoised on the document — the preview DOM mutates during editing and a stale index would resolve clips to detached nodes. `usedNodes` claiming and the full fallback chain are preserved.

### Two constraints a naive index gets wrong

- **The manifest does not always carry an id.** `timeline.ts` computes `id: stableClipId(node) ?? nodeCompositionId ?? null` with no ordinal fallback, unlike `clipTree.ts`. Clips with no `id`, no `data-hf-id` and no composition id arrive with `clip.id === null` and genuinely need the selector-occurrence path. An id-map-only index silently breaks exactly those.
- **Identity must not change.** `mergeTimelineElementsPreservingDowngrades` and `timelineElementsChanged` diff purely on `key ?? id`. A different identity reads as element replacement and silently drops selection, `expandedClipIds`, the keyframe cache and lint findings — a data-loss bug wearing a performance fix's clothes.

The parity test guards that second one, and it is worth knowing what it cost: an earlier revision passed `hostEl` in directly, so it compared only the identity *builder* and could not have caught the indexed path resolving a clip to a different node — the exact failure it exists to detect. Both arms now run the full derivation. That took the test from 5 s to ~85 s, because the un-indexed control arm *is* the quadratic. It gets cheaper only if someone reintroduces the quadratic, which is itself the signal.

### Result

Same machine, control run at `HEAD~1` reproducing the recorded baseline within 1%, which is what makes the delta attributable rather than machine luck:

| metric (median) | control @HEAD~1 | this PR |
|---|---|---|
| `hf.studio.manifest-derive` | 2,900.0 ms | **9.8 ms** |
| `hf.studio.project-open` | 4,323.1 ms | **1,314.5 ms** |

Virtualization-off arm: derive 2,926 → **10.3 ms**, open 4,915 → **2,250 ms**. Independently reproduced: derive 10.2 ms, open 1,403 ms.

The query-count test asserts a 500-clip derivation (including a composition clip with no `compositionSrc`) calls `doc.querySelectorAll` exactly **once** and `doc.querySelector` **zero** times.

`timeline-virtualization.mjs` passes both arms unchanged. `stableClipId` in `packages/core` is untouched.

Preview is now 91% of open time — PR 3 addresses it.
