### PR TITLE
perf(studio-server): cache the built preview document

### DIFF
--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -414,6 +414,10 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
       return cachedProjectSignature;
     },
 
+    invalidateProjectSignature(dir: string): void {
+      if (resolve(dir) === resolve(projectDir)) cachedProjectSignature = null;
+    },
+
     async lint(html: string, opts?: { filePath?: string }) {
       const { lintHyperframeHtml } = await import("@hyperframes/lint");
       return await lintHyperframeHtml(html, opts);

--- a/packages/studio-server/src/routes/preview.test.ts
+++ b/packages/studio-server/src/routes/preview.test.ts
@@ -1,10 +1,10 @@
 // fallow-ignore-file code-duplication
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { registerPreviewRoutes } from "./preview";
+import { PreviewDocumentCache, registerPreviewRoutes } from "./preview";
 import type { StudioApiAdapter } from "../types";
 
 const tempDirs: string[] = [];
@@ -65,6 +65,144 @@ async function getPreviewSignature(projectDir: string): Promise<string> {
 }
 
 describe("registerPreviewRoutes", () => {
+  it("caches an hf-id-stamped preview under the post-stamp project signature", async () => {
+    const projectDir = createProjectDir();
+    const sourceHtml =
+      "<!doctype html><html><head></head><body><div class='clip'>Preview</div></body></html>";
+    writeFileSync(join(projectDir, "index.html"), sourceHtml);
+    const bundle = vi.fn(async () => sourceHtml);
+    const app = new Hono();
+    registerPreviewRoutes(app, createAdapter(projectDir, { bundle }));
+
+    const first = await app.request("http://localhost/projects/demo/preview");
+    const firstHtml = await first.text();
+    const second = await app.request("http://localhost/projects/demo/preview");
+    const secondHtml = await second.text();
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(firstHtml).toContain('data-hf-id="hf-');
+    expect(secondHtml).toBe(firstHtml);
+    expect(readFileSync(join(projectDir, "index.html"), "utf-8")).toContain('data-hf-id="hf-');
+    expect(bundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not memoize the bundle-failure fallback — a recovered bundler is served", async () => {
+    const projectDir = createProjectDir();
+    writeFileSync(
+      join(projectDir, "index.html"),
+      '<!doctype html><html><head></head><body><div data-hf-id="hf-root">Fallback</div></body></html>',
+    );
+    let bundlerBroken = true;
+    const bundle = vi.fn(async () => {
+      if (bundlerBroken) throw new Error("bundler unavailable");
+      return '<!doctype html><html><head></head><body><div data-hf-id="hf-root">Bundled</div></body></html>';
+    });
+    const app = new Hono();
+    registerPreviewRoutes(app, createAdapter(projectDir, { bundle }));
+
+    const failedHtml = await (await app.request("http://localhost/projects/demo/preview")).text();
+    bundlerBroken = false;
+    const recoveredHtml = await (
+      await app.request("http://localhost/projects/demo/preview")
+    ).text();
+
+    expect(failedHtml).toContain("Fallback");
+    // The project never changed, so a cached fallback would pin the degraded
+    // document forever; the bundler must be retried instead.
+    expect(recoveredHtml).toContain("Bundled");
+    expect(bundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves byte-identical cached HTML for consecutive cold requests", async () => {
+    const projectDir = createProjectDir();
+    const sourceHtml =
+      '<!doctype html><html><head></head><body><div class="clip" data-hf-id="hf-root">Preview</div></body></html>';
+    writeFileSync(join(projectDir, "index.html"), sourceHtml);
+    const bundle = vi.fn(async () => sourceHtml);
+    const app = new Hono();
+    registerPreviewRoutes(app, createAdapter(projectDir, { bundle }));
+
+    const firstHtml = await (await app.request("http://localhost/projects/demo/preview")).text();
+    const secondHtml = await (await app.request("http://localhost/projects/demo/preview")).text();
+
+    expect(secondHtml).toBe(firstHtml);
+    expect(bundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds the cached preview after a source file edit", async () => {
+    const projectDir = createProjectDir();
+    const indexPath = join(projectDir, "index.html");
+    writeFileSync(
+      indexPath,
+      '<!doctype html><html><head></head><body><div data-hf-id="hf-root">First</div></body></html>',
+    );
+    const bundle = vi.fn(async (dir: string) => readFileSync(join(dir, "index.html"), "utf-8"));
+    const app = new Hono();
+    registerPreviewRoutes(app, createAdapter(projectDir, { bundle }));
+
+    const firstHtml = await (await app.request("http://localhost/projects/demo/preview")).text();
+    writeFileSync(
+      indexPath,
+      '<!doctype html><html><head></head><body><div data-hf-id="hf-root">Second, changed size</div></body></html>',
+    );
+    const secondHtml = await (await app.request("http://localhost/projects/demo/preview")).text();
+
+    expect(firstHtml).toContain("First");
+    expect(secondHtml).toContain("Second, changed size");
+    expect(secondHtml).not.toBe(firstHtml);
+    expect(bundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps matching ETag revalidation on the 304 path without rebuilding", async () => {
+    const projectDir = createProjectDir();
+    const bundle = vi.fn(
+      async () =>
+        '<!doctype html><html><head></head><body><div data-hf-id="hf-root">Preview</div></body></html>',
+    );
+    const app = new Hono();
+    registerPreviewRoutes(app, createAdapter(projectDir, { bundle }));
+
+    const first = await app.request("http://localhost/projects/demo/preview");
+    const etag = first.headers.get("ETag");
+    const revalidated = await app.request("http://localhost/projects/demo/preview", {
+      headers: { "If-None-Match": etag! },
+    });
+
+    expect(etag).toBeTruthy();
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.get("ETag")).toBe(etag);
+    expect(await revalidated.text()).toBe("");
+    expect(bundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates the parent cached preview after a sub-composition edit", async () => {
+    const projectDir = createProjectDir();
+    const scenePath = join(projectDir, "scene.html");
+    writeFileSync(
+      join(projectDir, "index.html"),
+      '<!doctype html><html><head></head><body><main data-hf-id="hf-root"></main></body></html>',
+    );
+    writeFileSync(scenePath, '<section data-hf-id="hf-scene">First scene</section>');
+    const bundle = vi.fn(async (dir: string) => {
+      const scene = readFileSync(join(dir, "scene.html"), "utf-8");
+      return `<!doctype html><html><head></head><body>${scene}</body></html>`;
+    });
+    const app = new Hono();
+    registerPreviewRoutes(app, createAdapter(projectDir, { bundle }));
+
+    const firstHtml = await (await app.request("http://localhost/projects/demo/preview")).text();
+    expect(await (await app.request("http://localhost/projects/demo/preview")).text()).toBe(
+      firstHtml,
+    );
+    writeFileSync(scenePath, '<section data-hf-id="hf-scene">Second scene, changed size</section>');
+    const editedHtml = await (await app.request("http://localhost/projects/demo/preview")).text();
+
+    expect(editedHtml).toContain("Second scene, changed size");
+    expect(editedHtml).not.toBe(firstHtml);
+    expect(bundle).toHaveBeenCalledTimes(2);
+  });
+
   it("injects Studio GSAP motion manifest runtime into project preview", async () => {
     const projectDir = createProjectDir();
     writeFileSync(
@@ -378,6 +516,34 @@ describe("registerPreviewRoutes", () => {
     const signature = await getPreviewSignature(projectDir);
 
     expect(signature).toMatch(/^[a-f0-9]{24}$/);
+  });
+});
+
+describe("PreviewDocumentCache", () => {
+  it("evicts the least-recently-used entry when the entry budget is exceeded", () => {
+    const cache = new PreviewDocumentCache({ maxEntries: 2, maxBytes: 100 });
+    cache.set("recently-accessed", "one");
+    cache.set("oldest-untouched", "two");
+    expect(cache.get("recently-accessed")).toBe("one");
+
+    cache.set("new", "three");
+
+    expect(cache.get("oldest-untouched")).toBeUndefined();
+    expect(cache.get("recently-accessed")).toBe("one");
+    expect(cache.get("new")).toBe("three");
+  });
+
+  it("evicts the least-recently-used entry when the byte budget is exceeded", () => {
+    const cache = new PreviewDocumentCache({ maxEntries: 10, maxBytes: 10 });
+    cache.set("recently-accessed", "1234");
+    cache.set("oldest-untouched", "5678");
+    expect(cache.get("recently-accessed")).toBe("1234");
+
+    cache.set("new", "abcde");
+
+    expect(cache.get("oldest-untouched")).toBeUndefined();
+    expect(cache.get("recently-accessed")).toBe("1234");
+    expect(cache.get("new")).toBe("abcde");
   });
 });
 

--- a/packages/studio-server/src/routes/preview.ts
+++ b/packages/studio-server/src/routes/preview.ts
@@ -45,6 +45,71 @@ const GSAP_CDN_VERSION = "3.15.0";
 const GSAP_CDN_SCRIPT = `<script src="https://cdn.jsdelivr.net/npm/gsap@${GSAP_CDN_VERSION}/dist/gsap.min.js"></script>`;
 const GSAP_CUSTOM_EASE_CDN_SCRIPT = `<script src="https://cdn.jsdelivr.net/npm/gsap@${GSAP_CDN_VERSION}/dist/CustomEase.min.js"></script>`;
 const GSAP_MOTION_PATH_CDN_SCRIPT = `<script src="https://cdn.jsdelivr.net/npm/gsap@${GSAP_CDN_VERSION}/dist/MotionPathPlugin.min.js"></script>`;
+const MEBIBYTE = 1024 * 1024;
+
+interface PreviewDocumentCacheBudgets {
+  maxEntries: number;
+  maxBytes: number;
+}
+
+const PREVIEW_DOCUMENT_CACHE_BUDGETS: Readonly<PreviewDocumentCacheBudgets> = Object.freeze({
+  maxEntries: 16,
+  maxBytes: 16 * MEBIBYTE,
+});
+
+interface PreviewDocumentCacheEntry {
+  html: string;
+  bytes: number;
+}
+
+/**
+ * Remembers built preview documents so a browser without a cached copy — every
+ * first open of a session — doesn't re-pay the linkedom parse, ensureHfIds and
+ * sub-composition inlining. Keyed on the same project signature the ETag uses,
+ * so freshness has exactly one owner: a hit is a document the ETag would have
+ * revalidated to a 304.
+ *
+ * Bounded by entry count AND bytes (a studio session opens many projects, and
+ * an inlined document runs to hundreds of KB); eviction is least-recently-used
+ * via Map insertion order.
+ */
+export class PreviewDocumentCache {
+  private readonly entries = new Map<string, PreviewDocumentCacheEntry>();
+  private totalBytes = 0;
+
+  constructor(
+    private readonly budgets: Readonly<PreviewDocumentCacheBudgets> = PREVIEW_DOCUMENT_CACHE_BUDGETS,
+  ) {}
+
+  get(key: string): string | undefined {
+    const entry = this.entries.get(key);
+    if (entry === undefined) return undefined;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.html;
+  }
+
+  set(key: string, html: string): void {
+    const existing = this.entries.get(key);
+    if (existing !== undefined) {
+      this.entries.delete(key);
+      this.totalBytes -= existing.bytes;
+    }
+
+    const entry = { html, bytes: Buffer.byteLength(html) };
+    if (entry.bytes > this.budgets.maxBytes) return;
+    this.entries.set(key, entry);
+    this.totalBytes += entry.bytes;
+
+    while (this.entries.size > this.budgets.maxEntries || this.totalBytes > this.budgets.maxBytes) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey === undefined) return;
+      const oldest = this.entries.get(oldestKey);
+      this.entries.delete(oldestKey);
+      if (oldest !== undefined) this.totalBytes -= oldest.bytes;
+    }
+  }
+}
 
 function injectProjectSignature(html: string, signature: string): string {
   const tag = `<meta name="${PROJECT_SIGNATURE_META}" content="${signature}">`;
@@ -275,16 +340,12 @@ function previewVariablesFromRequest(rawVariables: string | undefined):
 
 function injectStudioPreviewAugmentations(
   html: string,
-  adapter: StudioApiAdapter,
+  signature: string,
   projectDir: string,
   activeCompositionPath: string,
 ): string {
   return injectStudioMotionScript(
-    injectMotionPathPluginIfNeeded(
-      injectGsapCdnFallback(
-        injectProjectSignature(html, resolveProjectSignature(adapter, projectDir)),
-      ),
-    ),
+    injectMotionPathPluginIfNeeded(injectGsapCdnFallback(injectProjectSignature(html, signature))),
     projectDir,
     activeCompositionPath,
   );
@@ -335,6 +396,7 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
     "Cache-Control": "private, no-cache",
     ETag: etag,
   });
+  const previewDocumentCache = new PreviewDocumentCache();
 
   // One probe cache per server instance (this function runs once per
   // registered API), reused across every preview request so the mtime-cache
@@ -346,20 +408,29 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
   api.get("/projects/:id/preview", async (c) => {
     const resolved = await resolveProjectAndSignature(adapter, c.req.param("id"));
     if (!resolved) return c.json({ error: "not found" }, 404);
-    const { project, signature } = resolved;
+    const { project, signature: requestSignature } = resolved;
 
     // fallow-ignore-next-line code-duplication
     const vars = previewVariablesFromRequest(c.req.query("variables"));
     if (vars.error !== undefined) return c.json({ error: vars.error }, 400);
     const previewVariables = vars.values;
 
-    const etag = `"preview:${signature}${variablesEtagSalt(vars.raw)}"`;
+    const etagSalt = variablesEtagSalt(vars.raw);
+    const requestEtag = `"preview:${requestSignature}${etagSalt}"`;
     const ifNoneMatch = c.req.header("If-None-Match");
-    if (ifNoneMatch === etag) {
+    if (ifNoneMatch === requestEtag) {
       return new Response(null, {
         status: 304,
-        headers: previewCacheHeaders(etag),
+        headers: previewCacheHeaders(requestEtag),
       });
+    }
+    // Serve our own remembered bytes when the browser has none. The key carries
+    // the project id because the injected <base href> embeds it, so two projects
+    // with identical content still build different documents.
+    const requestCacheKey = `${project.id}:${requestEtag}`;
+    const cached = previewDocumentCache.get(requestCacheKey);
+    if (cached !== undefined) {
+      return c.html(cached, 200, previewCacheHeaders(requestEtag));
     }
 
     // Normalize + persist data-hf-id to disk before bundle reads it. Idempotent.
@@ -367,6 +438,20 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
     const normalizedDisk = diskMain
       ? persistHfIdsIfNeeded(join(project.dir, diskMain.compositionPath), diskMain.html)
       : null;
+    // Re-resolve AFTER the stamp: minting ids rewrites the source file, which
+    // changes the project signature. Everything downstream — the cache key, the
+    // served ETag and the signature meta tag — must use this post-stamp value or
+    // the entry is filed under a signature no later request can ever ask for
+    // (and the ETag we hand back is one the next request already disagrees with).
+    const signature = resolveProjectSignature(adapter, project.dir);
+    const etag = `"preview:${signature}${etagSalt}"`;
+    const cacheKey = `${project.id}:${etag}`;
+    if (cacheKey !== requestCacheKey) {
+      const postStampCached = previewDocumentCache.get(cacheKey);
+      if (postStampCached !== undefined) {
+        return c.html(postStampCached, 200, previewCacheHeaders(etag));
+      }
+    }
 
     try {
       let bundled = await adapter.bundle(project.dir);
@@ -404,7 +489,7 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
       // the ids already written to disk by persistHfIdsIfNeeded above.
       bundled = injectStudioPreviewAugmentations(
         ensureHfIds(await transformPreviewHtml(bundled, adapter, project, mainCompositionPath)),
-        adapter,
+        signature,
         project.dir,
         mainCompositionPath,
       );
@@ -416,6 +501,7 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
         mainCompositionPath,
         mediaCodecProbeCache,
       );
+      previewDocumentCache.set(cacheKey, bundled);
       return c.html(bundled, 200, previewCacheHeaders(etag));
     } catch {
       // Re-read disk on bundle failure so we serve the latest file content,
@@ -426,9 +512,16 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
           join(project.dir, fallback.compositionPath),
           fallback.html,
         );
+        // Same post-stamp re-resolve as the success path — this branch re-reads
+        // and re-stamps disk. NOT stored in previewDocumentCache: this document
+        // is the degraded, un-inlined one, and memoizing it would pin a
+        // transient bundler failure until the project changes. The fallback is
+        // also the cheap path (no bundle, no inlining), so there is nothing to win.
+        const fallbackSignature = resolveProjectSignature(adapter, project.dir);
+        const fallbackEtag = `"preview:${fallbackSignature}${etagSalt}"`;
         let fallbackAugmented = injectStudioPreviewAugmentations(
           await transformPreviewHtml(fallbackHtml, adapter, project, fallback.compositionPath),
-          adapter,
+          fallbackSignature,
           project.dir,
           fallback.compositionPath,
         );
@@ -442,7 +535,7 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
           fallback.compositionPath,
           mediaCodecProbeCache,
         );
-        return c.html(fallbackAugmented, 200, previewCacheHeaders(etag));
+        return c.html(fallbackAugmented, 200, previewCacheHeaders(fallbackEtag));
       }
       return c.text("not found", 404);
     }
@@ -515,7 +608,12 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
     );
     if (!html) return c.text("not found", 404);
     html = ensureHfIds(await transformPreviewHtml(html, adapter, project, compPath));
-    html = injectStudioPreviewAugmentations(html, adapter, project.dir, compPath);
+    html = injectStudioPreviewAugmentations(
+      html,
+      resolveProjectSignature(adapter, project.dir),
+      project.dir,
+      compPath,
+    );
     if (previewVariables) html = injectPreviewVariables(html, previewVariables);
     html = await injectMediaCodecMap(html, adapter, project.dir, compPath, mediaCodecProbeCache);
     return c.html(html, 200, previewCacheHeaders(etag));

--- a/packages/studio-server/src/routes/preview.ts
+++ b/packages/studio-server/src/routes/preview.ts
@@ -443,6 +443,11 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
     // served ETag and the signature meta tag — must use this post-stamp value or
     // the entry is filed under a signature no later request can ever ask for
     // (and the ETag we hand back is one the next request already disagrees with).
+    // The adapter memoizes signatures and invalidates from a file watcher, which
+    // has not fired yet for the write persistHfIdsIfNeeded just made. Without
+    // this the "re-resolve" returns the pre-stamp value and the fix above is a
+    // no-op: the served ETag is one the next request already disagrees with.
+    if (normalizedDisk !== null) adapter.invalidateProjectSignature?.(project.dir);
     const signature = resolveProjectSignature(adapter, project.dir);
     const etag = `"preview:${signature}${etagSalt}"`;
     const cacheKey = `${project.id}:${etag}`;

--- a/packages/studio-server/src/types.ts
+++ b/packages/studio-server/src/types.ts
@@ -106,6 +106,14 @@ export interface StudioApiAdapter {
 
   /** Optional: cached signature for project files that should invalidate preview frame caches. */
   getProjectSignature?: (projectDir: string) => string;
+  /**
+   * Drop any memoized signature for this project. Adapters cache the signature
+   * and invalidate it from a file watcher, which is asynchronous — so a write
+   * the server itself just made (minting data-hf-id) is not yet visible to the
+   * next getProjectSignature call in the same request. Callers that mutate
+   * project source must invalidate before re-resolving.
+   */
+  invalidateProjectSignature?: (projectDir: string) => void;
 
   /** Lint a single HTML string. */
   lint(html: string, opts?: { filePath?: string }): Promise<LintResult> | LintResult;

--- a/packages/studio/vite.adapter.ts
+++ b/packages/studio/vite.adapter.ts
@@ -205,6 +205,10 @@ export function createViteAdapter(dataDir: string, server: ViteDevServer): Studi
       return signature;
     },
 
+    invalidateProjectSignature(projectDir: string): void {
+      projectSignatureCache.delete(resolve(projectDir));
+    },
+
     async lint(html: string, opts?: { filePath?: string }) {
       const mod = await server.ssrLoadModule("@hyperframes/core/lint");
       return await mod.lintHyperframeHtml(html, opts);


### PR DESCRIPTION
**PR 3 of 5** · base `perf/studio-load-u4` (#2941)

After PR 2, `preview` is 91% of project-open time. This takes the server half of it from ~450 ms to ~3 ms, and fixes an ETag bug it uncovered.

### The cache

`/preview` already computes an ETag from `resolveProjectSignature` and returns 304 in **0.7 ms** when a browser presents a matching one. What it never did was remember its own output — so any browser without a cached copy paid the full linkedom parse, `ensureHfIds`, and sub-composition inlining. That is every first open of a session, and every gate run.

An in-process LRU bounded at 16 entries / 16 MiB, keyed on the ETag prefixed with the project id. Reusing the ETag means freshness has exactly one owner. The project id is load-bearing: the injected `<base href>` embeds it, so two byte-identical projects legitimately build different documents.

Six consecutive cold requests, 3,000-clip project, bodies byte-identical (single md5 across all six):

| | before | after |
|---|---|---|
| req 2–6 | 0.433–0.557 s | **0.002–0.005 s** |

That is at the transport floor for a 510 KB asset.

### The ETag bug it uncovered

Minting `data-hf-id` rewrites the source file, which changes the project signature. The served ETag was computed *before* that, so the first request for a project handed back an ETag the second request already disagreed with — a guaranteed wasted rebuild.

The first fix re-resolved the signature after stamping. **That was a no-op**, and it took a GET-only round-trip test to catch it: both builds behaved identically, GET #1 serving `preview:2daac7ed…` and GET #3 serving `preview:b123d4df…`. Both adapters memoise the signature and invalidate it from a file watcher, which has not fired for a write the server itself made microseconds earlier — so the "re-resolve" returned the cached pre-stamp value.

Hence `invalidateProjectSignature` on the adapter contract, implemented in both the Vite dev and CLI embedded adapters, called before the re-resolve. Verified end to end:

| | GET #1 ETag | GET #2 presenting it |
|---|---|---|
| before | pre-stamp | **200 — rebuilt** |
| after | post-stamp | **304** |

### One thing deliberately not cached

The bundle-failure fallback. Memoising the degraded un-inlined document would pin a transient bundler failure until the project changed, for no gain — the fallback is already the cheap path. There is a test asserting a recovered bundler is served rather than a frozen fallback; re-adding the `set` fails it and breaks an unrelated proxy test.

### Scope

406 studio-server tests pass. Not included: sub-composition route caching (the 636 KB main route is the cost; add if `comp/*` shows in a profile), request coalescing for simultaneous cold misses, and any disk or cross-process cache.

Note for anyone measuring this: the dev server resolves `@hyperframes/studio-server` through `dist/`, so `bun run --cwd packages/studio-server build` is required first or you measure nothing.
