### PR TITLE
ci(studio): gate load, open-project time and eager bundle size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,74 @@ jobs:
 
           kill $SERVER_PID 2>/dev/null || true
 
+  studio-load-gate:
+    name: "Studio: load and open-project gate"
+    needs: [changes]
+    if: needs.changes.outputs.studio == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      # vite.config.ts is loaded by Node and resolves workspace packages through
+      # their "node" export condition, so the dists must exist first.
+      - run: bun run --filter '@hyperframes/{parsers,lint,studio-server}' build
+      - run: bun run --cwd packages/core build
+      - run: bun run --cwd packages/core build:hyperframes-runtime
+
+      # Cheap, no browser: runs on every studio PR. Enforces the ratchet and
+      # reports the remaining gap to the target.
+      - name: Eager bundle byte budget
+        run: |
+          bun run --cwd packages/studio build
+          node packages/studio/tests/e2e/studio-bundle-budget.mjs
+
+      - name: Load and open-project gate (dev arm, 3k clips)
+        run: |
+          set -euo pipefail
+          SERVER_PID=""
+          stop_server() {
+            if [[ -n "$SERVER_PID" ]]; then
+              kill "$SERVER_PID" 2>/dev/null || true
+              wait "$SERVER_PID" 2>/dev/null || true
+              SERVER_PID=""
+            fi
+          }
+          trap stop_server EXIT
+
+          # A real on-disk project, generated at run time. The output is ~9,200
+          # lines of derivable markup, so it is not committed.
+          mkdir -p packages/studio/data/projects/studio-load
+          bun -e 'import { writeStudioLoadFixture } from "./packages/studio/tests/e2e/generateStudioLoadFixture.mjs"; writeStudioLoadFixture("packages/studio/data/projects/studio-load", { clipCount: 3000, trackCount: 50 });'
+
+          # Production React: the gate must measure shipped rendering behaviour,
+          # not the development runtime.
+          NODE_ENV=production bun run --cwd packages/studio dev -- --port 5191 --strictPort &
+          SERVER_PID=$!
+          for i in $(seq 1 60); do
+            curl -sf "http://localhost:5191/" >/dev/null 2>&1 && break
+            sleep 1
+          done
+
+          STUDIO_URL="http://localhost:5191/#project/studio-load" \
+            STUDIO_LOAD_ARM=dev \
+            STUDIO_LOAD_CLIPS=3000 \
+            STUDIO_LOAD_TIER=ci \
+            STUDIO_LOAD_ROW_VIRTUALIZATION=on \
+            bun packages/studio/tests/e2e/studio-load.mjs | tee studio-load-evidence.txt
+
+      - name: Upload gate evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: studio-load-evidence
+          path: studio-load-evidence.txt
+          if-no-files-found: ignore
+
   studio-timeline-viewport:
     name: "Studio: timeline viewport gate"
     needs: [changes]

--- a/packages/studio/src/lib/studioLoadBudgets.test.ts
+++ b/packages/studio/src/lib/studioLoadBudgets.test.ts
@@ -13,6 +13,7 @@ const EXPECTED_STUDIO_LOAD_BUDGETS = {
   devProjectOpen3kClipsP95Ms: 5_500,
   constrainedDevProjectOpen3kClipsP95Ms: 9_000,
   eagerEntryChunkGzipBytes: 600 * 1024,
+  eagerEntryChunkGzipRatchetBytes: 870_000,
 };
 
 describe("studio load budgets", () => {

--- a/packages/studio/src/lib/studioLoadBudgets.ts
+++ b/packages/studio/src/lib/studioLoadBudgets.ts
@@ -10,6 +10,7 @@ export interface StudioLoadBudgets {
   devProjectOpen3kClipsP95Ms: number;
   constrainedDevProjectOpen3kClipsP95Ms: number;
   eagerEntryChunkGzipBytes: number;
+  eagerEntryChunkGzipRatchetBytes: number;
 }
 
 // Shell and dev-open budgets were revised once against the 2026-07-31 baseline
@@ -28,7 +29,15 @@ export const STUDIO_LOAD_BUDGETS: Readonly<StudioLoadBudgets> = Object.freeze({
   constrainedDevShellReadyP95Ms: 1_000,
   devProjectOpen3kClipsP95Ms: 5_500,
   constrainedDevProjectOpen3kClipsP95Ms: 9_000,
+  // The target. Reaching it needs the Node-only AST/DOM stack (@babel/parser,
+  // esprima, acorn, recast, ast-types, source-map, linkedom, cssom) out of the
+  // browser bundle — roughly 1.85MB of module graph pulled in through the SDK's
+  // openComposition. That is its own unit; this number is not revised down to
+  // meet what we happen to ship today.
   eagerEntryChunkGzipBytes: 600 * 1024,
+  // What CI enforces: a ratchet just above the measured 860,966B, so the 23.6%
+  // already won cannot be given back. It may only ever move down.
+  eagerEntryChunkGzipRatchetBytes: 870_000,
 });
 
 function assertValidBudget(name: string, value: unknown): void {

--- a/packages/studio/tests/e2e/studio-bundle-budget.mjs
+++ b/packages/studio/tests/e2e/studio-bundle-budget.mjs
@@ -95,11 +95,25 @@ export function checkEagerBundleBudget(distDir, budgetGzipBytes) {
 // Run the gate only when invoked directly, so the vitest suite can import the helpers.
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
   try {
-    const { passed, report } = checkEagerBundleBudget(
+    // CI enforces the ratchet, not the target. Enforcing an unreached target
+    // means a permanently red check, and a permanently red check gets muted —
+    // so it would protect nothing. The ratchet cannot be regressed past; the
+    // target is reported every run so the remaining gap stays visible.
+    const { passed, report, gzipBytes } = checkEagerBundleBudget(
       resolve(process.argv[2] ?? DEFAULT_DIST),
-      STUDIO_LOAD_BUDGETS.eagerEntryChunkGzipBytes,
+      STUDIO_LOAD_BUDGETS.eagerEntryChunkGzipRatchetBytes,
     );
     console.log(report);
+    const target = STUDIO_LOAD_BUDGETS.eagerEntryChunkGzipBytes;
+    if (passed && gzipBytes > target) {
+      console.log(
+        `[StudioBundleBudget] NOTE eager gzip ${gzipBytes}B is within the ${STUDIO_LOAD_BUDGETS.eagerEntryChunkGzipRatchetBytes}B ratchet ` +
+          `but still ${gzipBytes - target}B over the ${target}B target.`,
+      );
+    }
+    if (passed && gzipBytes < target) {
+      console.log("[StudioBundleBudget] target met — lower the ratchet to lock it in.");
+    }
     if (!passed) process.exitCode = 1;
   } catch (error) {
     console.error(


### PR DESCRIPTION
**PR 5 of 5** · base `perf/studio-load-u5` (#2943)

Makes the whole thing a check instead of a one-off measurement. Lands last, and green — a gate wired in red gets muted.

### The job

`studio-load-gate`, gated on `needs.changes.outputs.studio` the same way `studio-timeline-viewport` is:

- **Eager bundle byte budget** — cheap, no browser, runs on every studio PR.
- **Load and open-project gate** — dev arm, 3,000 clips, CI budgets, against a real on-disk project generated at run time (the output is ~9,200 lines of derivable markup, so it is not committed). Runs with `NODE_ENV=production` so it measures shipped rendering behaviour, not the development runtime. Evidence uploaded on pass and fail.

### The bundle budget: target and ratchet

Two numbers, deliberately:

- `eagerEntryChunkGzipBytes: 600 KiB` — the **target**. Reaching it needs the Node-only AST/DOM stack out of the browser bundle (see #2943). It is **not** revised down to match what we happen to ship.
- `eagerEntryChunkGzipRatchetBytes: 870,000` — what **CI enforces**, just above the measured 855,246 B. It may only ever move down.

Enforcing an unreached target means a permanently red check, and a permanently red check gets muted — so it would protect nothing. The ratchet locks in the 23.6% already won; every run prints the remaining gap so it stays visible:

```
[StudioBundleBudget] PASS eagerEntryChunkGzipBytes measured=855246B budget=870000B
[StudioBundleBudget] NOTE eager gzip 855246B is within the 870000B ratchet
                     but still 240846B over the 614400B target.
```

### Not included

The embedded arm. It needs the CLI studio bundle built, which is materially slower on a hosted runner, and whether that is worth a per-PR check is a runner-cost decision rather than a code one. The dev arm plus the static byte check run on every studio PR; the embedded arm stays a local gate for now. Stated as a limitation rather than presented as full coverage.
