### PR TITLE
chore: release v0.7.89

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,21 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.89"
+  description="Released - 2026-08-02"
+  tags={["Release", "Studio", "CLI"]}
+>
+Stops generated waveform, thumbnail, and transcode caches from retriggering Studio project reloads or appearing as project files. Real source edits still invalidate previews normally.
+
+## Fixes
+
+- **CLI:** Ignore generated cache directories in the recursive project watcher, preventing preview refresh loops during cache generation ([#2952](https://github.com/heygen-com/hyperframes/pull/2952))
+- **Studio:** Keep generated caches out of Storyboard signatures and the project file tree while retaining invalidation for real source edits ([#2952](https://github.com/heygen-com/hyperframes/pull/2952))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.88...v0.7.89).
+</Update>
+
+<Update
   label="HyperFrames v0.7.88"
   description="Released - 2026-08-01"
   tags={["Release", "Engine", "Guides", "Prompting"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.89.md
+++ b/releases/v0.7.89.md
@@ -1,0 +1,14 @@
+# HyperFrames v0.7.89
+
+Released on 2026-08-02.
+
+Stops generated waveform, thumbnail, and transcode caches from retriggering Studio project reloads or appearing as project files. Real source edits still invalidate previews normally.
+
+## Fixes
+
+- **CLI:** Ignore generated cache directories in the recursive project watcher, preventing preview refresh loops during cache generation ([#2952](https://github.com/heygen-com/hyperframes/pull/2952))
+- **Studio:** Keep generated caches out of Storyboard signatures and the project file tree while retaining invalidation for real source edits ([#2952](https://github.com/heygen-com/hyperframes/pull/2952))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.88...v0.7.89


### PR DESCRIPTION
## Summary

- publish HyperFrames v0.7.89 with the generated-cache watcher fix from #2952
- stop waveform, thumbnail, and transcode caches from retriggering Studio project reloads
- keep generated caches out of Storyboard signatures and the project tree while preserving invalidation for real source edits

## Verification

- `bun run test:scripts` (104 passed)
- release-channel validation for `release/v0.7.89` / `latest`
- `git diff --check`

## Release

Merging this `release/v0.7.89` PR triggers the protected publish workflow, creates tag `v0.7.89`, publishes all packages to npm with the `latest` dist-tag, and creates the GitHub release.