### PR TITLE
chore: release v0.7.90

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,35 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.90"
+  description="Released - 2026-08-03"
+  tags={["Release", "Producer", "Engine", "Contributing"]}
+>
+Prevents short compositions from decoding entire long video sources and exhausting producer memory through HDR raw-frame scratch and filesystem page cache. Extraction now follows the playable timeline, reserves bounded scratch capacity across concurrent renders, and cleans resources on every exit path.
+
+## Fixes
+
+- **Producer:** Bound video extraction to the composition's playable interval instead of the source's full duration, including negative timeline starts, non-zero media offsets, loops, held tails, and distributed planning ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+- **Producer:** Limit concurrent HDR raw-frame scratch against the configured ceiling, cgroup memory, and free disk; release reservations and temporary resources after success, cancellation, and partial failure ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+- **Engine:** Resolve the true final playable frame for held-tail media, including streams with non-zero or negative timestamp bases, without sharing cancellation state across renders ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+- **Producer API:** Add `outputDynamicRange: auto | hdr | sdr` while temporarily accepting the legacy `hdrMode` field for rolling migrations ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+
+## Rollout
+
+- Upgrade the HyperFrames producer fleet to v0.7.90 before deploying callers that send `outputDynamicRange`; the legacy `hdrMode` field remains accepted only to bridge the rolling deployment.
+
+## Catalog
+
+- **Contributing:** Refresh the catalog contribution guide ([#2954](https://github.com/heygen-com/hyperframes/pull/2954))
+
+## Internal
+
+- **Release:** Publish stable packages only from a reviewed release PR's exact merge commit, with fail-closed checkout/tag verification and safe same-commit retries ([#2959](https://github.com/heygen-com/hyperframes/pull/2959))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.89...v0.7.90).
+</Update>
+
+<Update
   label="HyperFrames v0.7.89"
   description="Released - 2026-08-02"
   tags={["Release", "Studio", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.90.md
+++ b/releases/v0.7.90.md
@@ -1,0 +1,28 @@
+# HyperFrames v0.7.90
+
+Released on 2026-08-03.
+
+Prevents short compositions from decoding entire long video sources and exhausting producer memory through HDR raw-frame scratch and filesystem page cache. Extraction now follows the playable timeline, reserves bounded scratch capacity across concurrent renders, and cleans resources on every exit path.
+
+## Fixes
+
+- **Producer:** Bound video extraction to the composition's playable interval instead of the source's full duration, including negative timeline starts, non-zero media offsets, loops, held tails, and distributed planning ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+- **Producer:** Limit concurrent HDR raw-frame scratch against the configured ceiling, cgroup memory, and free disk; release reservations and temporary resources after success, cancellation, and partial failure ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+- **Engine:** Resolve the true final playable frame for held-tail media, including streams with non-zero or negative timestamp bases, without sharing cancellation state across renders ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+- **Producer API:** Add `outputDynamicRange: auto | hdr | sdr` while temporarily accepting the legacy `hdrMode` field for rolling migrations ([#2955](https://github.com/heygen-com/hyperframes/pull/2955))
+
+## Rollout
+
+- Upgrade the HyperFrames producer fleet to v0.7.90 before deploying callers that send `outputDynamicRange`; the legacy `hdrMode` field remains accepted only to bridge the rolling deployment.
+
+## Catalog
+
+- **Contributing:** Refresh the catalog contribution guide ([#2954](https://github.com/heygen-com/hyperframes/pull/2954))
+
+## Internal
+
+- **Release:** Publish stable packages only from a reviewed release PR's exact merge commit, with fail-closed checkout/tag verification and safe same-commit retries ([#2959](https://github.com/heygen-com/hyperframes/pull/2959))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.89...v0.7.90


### PR DESCRIPTION
## Summary

- publish HyperFrames v0.7.90 with the bounded video/HDR extraction fixes from #2955
- prevent short compositions from decoding entire long sources, reserve concurrent raw-frame scratch against cgroup/disk limits, and clean resources on every exit path
- expose canonical `outputDynamicRange: auto | hdr | sdr` at the producer HTTP boundary while retaining the temporary legacy alias for a rolling migration
- include the catalog contribution guide refresh from #2954
- include the reviewed release-integrity workflow from #2959 so stable artifacts are cut only from this PR's exact merge commit and same-commit recovery is safe

## Verification

- `bun run test:scripts` — 110 passed
- release-channel validation for `release/v0.7.90` / `latest`
- end-to-end release-tag tests cover first creation, same-SHA retry, and mismatched-SHA rejection
- official two-phase `release:prepare` changelog review checkpoint and release commit hooks
- formatting, lint, and `git diff --check`

## Release range

`v0.7.89...bfd8037e5` contains #2954, #2955, #2959, and this release commit.

## Release and rollout

Merging this reviewed `release/v0.7.90` PR triggers the protected publish workflow. It checks out and verifies the exact merge SHA, creates `v0.7.90` at that commit, publishes all packages to npm with the `latest` dist-tag, and creates the GitHub release.

After publication, update and deploy the HyperFrames producer fleet to v0.7.90 before deploying experiment-framework callers that send `outputDynamicRange`; the legacy `hdrMode` alias exists only to bridge that rolling deployment.
