### PR TITLE
docs: make Catalog visual and reproducible

### DIFF
--- a/docs/catalog/blocks/app-showcase.mdx
+++ b/docs/catalog/blocks/app-showcase.mdx
@@ -3,23 +3,34 @@ title: "App Showcase"
 description: "Fitness app product showcase with three floating smartphone screens"
 ---
 
-# App Showcase
-
 Fitness app product showcase with three floating smartphone screens
 
 `showcase` `app` `3d`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/app-showcase.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/app-showcase.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the App Showcase block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add app-showcase
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add app-showcase
 | Dimensions | 1920×1080 |
 | Duration | 5.5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `app-showcase.html` | `compositions/app-showcase.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="app-showcase" data-composition-src="compositions/app-showcase.html" data-start="0" data-duration="5.5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/app-showcase.mdx
+++ b/docs/catalog/blocks/app-showcase.mdx
@@ -3,34 +3,24 @@ title: "App Showcase"
 description: "Fitness app product showcase with three floating smartphone screens"
 ---
 
-Fitness app product showcase with three floating smartphone screens
-
 `showcase` `app` `3d`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/app-showcase.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/app-showcase.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the App Showcase block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add app-showcase
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="app-showcase" data-composition-src="compositions/app-showcase.html" data-start="0" data-duration="5.5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/apple-money-count.mdx
+++ b/docs/catalog/blocks/apple-money-count.mdx
@@ -3,8 +3,6 @@ title: "Apple Money Count"
 description: "Apple-style finance counter that counts from $0 to $10,000, flashes green, and bursts money icons with sound."
 ---
 
-Apple-style finance counter that counts from $0 to $10,000, flashes green, and bursts money icons with sound.
-
 `showcase` `finance` `kinetic` `youtube` `sfx`
 
 Created by [Stronkter](https://x.com/Stronkter).
@@ -19,26 +17,18 @@ Created by [Stronkter](https://x.com/Stronkter).
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Apple Money Count block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add apple-money-count
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -64,3 +54,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="apple-money-count" data-composition-src="compositions/apple-money-count.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/apple-money-count.mdx
+++ b/docs/catalog/blocks/apple-money-count.mdx
@@ -3,8 +3,6 @@ title: "Apple Money Count"
 description: "Apple-style finance counter that counts from $0 to $10,000, flashes green, and bursts money icons with sound."
 ---
 
-# Apple Money Count
-
 Apple-style finance counter that counts from $0 to $10,000, flashes green, and bursts money icons with sound.
 
 `showcase` `finance` `kinetic` `youtube` `sfx`
@@ -19,15 +17,28 @@ Created by [Stronkter](https://x.com/Stronkter).
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/apple-money-count.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/apple-money-count.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Apple Money Count block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add apple-money-count
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -37,16 +48,18 @@ npx hyperframes add apple-money-count
 | Dimensions | 1920×1080 |
 | Duration | 5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `apple-money-count.html` | `compositions/apple-money-count.html` | hyperframes:composition |
 | `assets/sfx-production.wav` | `assets/sfx-production.wav` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="apple-money-count" data-composition-src="compositions/apple-money-count.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/beat-freeze-cut.mdx
+++ b/docs/catalog/blocks/beat-freeze-cut.mdx
@@ -3,23 +3,34 @@ title: "Beat Freeze Cut"
 description: "A beat-driven speed ramp, freeze-frame hit, and hard-cut sequence for music-led promos and montages."
 ---
 
-# Beat Freeze Cut
-
 A beat-driven speed ramp, freeze-frame hit, and hard-cut sequence for music-led promos and montages.
 
 `transition` `music` `beat-driven` `freeze-frame`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/beat-freeze-cut.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/beat-freeze-cut.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Beat Freeze Cut block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add beat-freeze-cut
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add beat-freeze-cut
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `beat-freeze-cut.html` | `compositions/beat-freeze-cut.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="beat-freeze-cut" data-composition-src="compositions/beat-freeze-cut.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/beat-freeze-cut.mdx
+++ b/docs/catalog/blocks/beat-freeze-cut.mdx
@@ -3,34 +3,24 @@ title: "Beat Freeze Cut"
 description: "A beat-driven speed ramp, freeze-frame hit, and hard-cut sequence for music-led promos and montages."
 ---
 
-A beat-driven speed ramp, freeze-frame hit, and hard-cut sequence for music-led promos and montages.
-
 `transition` `music` `beat-driven` `freeze-frame`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/beat-freeze-cut.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/beat-freeze-cut.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Beat Freeze Cut block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add beat-freeze-cut
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="beat-freeze-cut" data-composition-src="compositions/beat-freeze-cut.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/blue-sweater-intro-video.mdx
+++ b/docs/catalog/blocks/blue-sweater-intro-video.mdx
@@ -3,8 +3,6 @@ title: "Blue Sweater Intro Video"
 description: "Warm AI creator intro sequence that resolves into an X follow card for @_blue_sweater_."
 ---
 
-Warm AI creator intro sequence that resolves into an X follow card for @_blue_sweater_.
-
 `showcase` `ai` `creator` `sfx`
 
 Created by [Joe Sai](https://x.com/_blue_sweater_).
@@ -13,26 +11,18 @@ Created by [Joe Sai](https://x.com/_blue_sweater_).
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Blue Sweater Intro Video block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add blue-sweater-intro-video
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -59,3 +49,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="blue-sweater-intro-video" data-composition-src="compositions/blue-sweater-intro-video.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/blue-sweater-intro-video.mdx
+++ b/docs/catalog/blocks/blue-sweater-intro-video.mdx
@@ -3,8 +3,6 @@ title: "Blue Sweater Intro Video"
 description: "Warm AI creator intro sequence that resolves into an X follow card for @_blue_sweater_."
 ---
 
-# Blue Sweater Intro Video
-
 Warm AI creator intro sequence that resolves into an X follow card for @_blue_sweater_.
 
 `showcase` `ai` `creator` `sfx`
@@ -13,15 +11,28 @@ Created by [Joe Sai](https://x.com/_blue_sweater_).
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/blue-sweater-intro-video.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/blue-sweater-intro-video.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Blue Sweater Intro Video block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add blue-sweater-intro-video
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -31,7 +42,7 @@ npx hyperframes add blue-sweater-intro-video
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
@@ -39,9 +50,11 @@ npx hyperframes add blue-sweater-intro-video
 | `assets/joe-sai-avatar.png` | `assets/joe-sai-avatar.png` | hyperframes:asset |
 | `assets/sfx/integrated-melodic-tech-mix.wav` | `assets/sfx/integrated-melodic-tech-mix.wav` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="blue-sweater-intro-video" data-composition-src="compositions/blue-sweater-intro-video.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/camcorder-hud.mdx
+++ b/docs/catalog/blocks/camcorder-hud.mdx
@@ -3,34 +3,24 @@ title: "Camcorder HUD"
 description: "Responsive REC, battery, editable date placeholder, and timeline-driven counter overlay for creator-camera and camcorder treatments"
 ---
 
-Responsive REC, battery, editable date placeholder, and timeline-driven counter overlay for creator-camera and camcorder treatments
-
 `camcorder` `camera` `recording` `hud` `overlay` `creator` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/camcorder-hud.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/camcorder-hud.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Camcorder HUD block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add camcorder-hud
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="camcorder-hud" data-composition-src="compositions/camcorder-hud.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/camcorder-hud.mdx
+++ b/docs/catalog/blocks/camcorder-hud.mdx
@@ -3,23 +3,34 @@ title: "Camcorder HUD"
 description: "Responsive REC, battery, editable date placeholder, and timeline-driven counter overlay for creator-camera and camcorder treatments"
 ---
 
-# Camcorder HUD
-
 Responsive REC, battery, editable date placeholder, and timeline-driven counter overlay for creator-camera and camcorder treatments
 
 `camcorder` `camera` `recording` `hud` `overlay` `creator` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/camcorder-hud.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/camcorder-hud.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Camcorder HUD block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add camcorder-hud
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add camcorder-hud
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `camcorder-hud.html` | `compositions/camcorder-hud.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="camcorder-hud" data-composition-src="compositions/camcorder-hud.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/chromatic-radial-split.mdx
+++ b/docs/catalog/blocks/chromatic-radial-split.mdx
@@ -3,23 +3,34 @@ title: "Chromatic Radial Split"
 description: "Shader transition with chromatic aberration radial split"
 ---
 
-# Chromatic Radial Split
-
 Shader transition with chromatic aberration radial split
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/chromatic-radial-split.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/chromatic-radial-split.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Chromatic Radial Split block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add chromatic-radial-split
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add chromatic-radial-split
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `chromatic-radial-split.html` | `compositions/chromatic-radial-split.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="chromatic-radial-split" data-composition-src="compositions/chromatic-radial-split.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/chromatic-radial-split.mdx
+++ b/docs/catalog/blocks/chromatic-radial-split.mdx
@@ -3,34 +3,24 @@ title: "Chromatic Radial Split"
 description: "Shader transition with chromatic aberration radial split"
 ---
 
-Shader transition with chromatic aberration radial split
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/chromatic-radial-split.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/chromatic-radial-split.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Chromatic Radial Split block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add chromatic-radial-split
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="chromatic-radial-split" data-composition-src="compositions/chromatic-radial-split.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/cinematic-zoom.mdx
+++ b/docs/catalog/blocks/cinematic-zoom.mdx
@@ -3,23 +3,34 @@ title: "Cinematic Zoom"
 description: "Shader transition with dramatic zoom blur"
 ---
 
-# Cinematic Zoom
-
 Shader transition with dramatic zoom blur
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cinematic-zoom.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cinematic-zoom.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Cinematic Zoom block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add cinematic-zoom
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add cinematic-zoom
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `cinematic-zoom.html` | `compositions/cinematic-zoom.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="cinematic-zoom" data-composition-src="compositions/cinematic-zoom.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/cinematic-zoom.mdx
+++ b/docs/catalog/blocks/cinematic-zoom.mdx
@@ -3,34 +3,24 @@ title: "Cinematic Zoom"
 description: "Shader transition with dramatic zoom blur"
 ---
 
-Shader transition with dramatic zoom blur
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cinematic-zoom.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cinematic-zoom.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Cinematic Zoom block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add cinematic-zoom
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="cinematic-zoom" data-composition-src="compositions/cinematic-zoom.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-3d-extrude.mdx
+++ b/docs/catalog/blocks/code-3d-extrude.mdx
@@ -3,23 +3,34 @@ title: "Code 3D Extrude"
 description: "Syntax-highlighted code on a lit, beveled 3D slab that rotates through real space and settles to a readable rest — true WebGL depth and lighting, not a 2D transform."
 ---
 
-# Code 3D Extrude
-
 Syntax-highlighted code on a lit, beveled 3D slab that rotates through real space and settles to a readable rest — true WebGL depth and lighting, not a 2D transform.
 
 `code` `code-animation` `3d` `webgl` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-3d-extrude.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-3d-extrude.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code 3D Extrude block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-3d-extrude
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-3d-extrude
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-3d-extrude.html` | `compositions/code-3d-extrude.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-3d-extrude" data-composition-src="compositions/code-3d-extrude.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-3d-extrude.mdx
+++ b/docs/catalog/blocks/code-3d-extrude.mdx
@@ -3,34 +3,24 @@ title: "Code 3D Extrude"
 description: "Syntax-highlighted code on a lit, beveled 3D slab that rotates through real space and settles to a readable rest — true WebGL depth and lighting, not a 2D transform."
 ---
 
-Syntax-highlighted code on a lit, beveled 3D slab that rotates through real space and settles to a readable rest — true WebGL depth and lighting, not a 2D transform.
-
 `code` `code-animation` `3d` `webgl` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-3d-extrude.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-3d-extrude.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code 3D Extrude block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-3d-extrude
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-3d-extrude" data-composition-src="compositions/code-3d-extrude.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-diff.mdx
+++ b/docs/catalog/blocks/code-diff.mdx
@@ -3,34 +3,24 @@ title: "Code Diff"
 description: "An edit shown as a colored diff — removed lines collapse in red, added lines expand in green."
 ---
 
-An edit shown as a colored diff — removed lines collapse in red, added lines expand in green.
-
 `code` `code-animation` `diff` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-diff.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-diff.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Diff block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-diff
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-diff" data-composition-src="compositions/code-diff.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-diff.mdx
+++ b/docs/catalog/blocks/code-diff.mdx
@@ -3,23 +3,34 @@ title: "Code Diff"
 description: "An edit shown as a colored diff — removed lines collapse in red, added lines expand in green."
 ---
 
-# Code Diff
-
 An edit shown as a colored diff — removed lines collapse in red, added lines expand in green.
 
 `code` `code-animation` `diff` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-diff.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-diff.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Diff block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-diff
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-diff
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-diff.html` | `compositions/code-diff.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-diff" data-composition-src="compositions/code-diff.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-highlight.mdx
+++ b/docs/catalog/blocks/code-highlight.mdx
@@ -3,23 +3,34 @@ title: "Code Highlight Sweep"
 description: "A highlight band sweeps across a target line while the surrounding context dims — draws the eye to one line. `line` is 0-based: `line: 1` targets the second displayed line (unlike code-scroll, whose target is 1-based)."
 ---
 
-# Code Highlight Sweep
-
 A highlight band sweeps across a target line while the surrounding context dims — draws the eye to one line. `line` is 0-based: `line: 1` targets the second displayed line (unlike code-scroll, whose target is 1-based).
 
 `code` `code-animation` `highlight` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-highlight.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Highlight Sweep block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-highlight
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-highlight
 | Dimensions | 1920×1080 |
 | Duration | 5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-highlight.html` | `compositions/code-highlight.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-highlight" data-composition-src="compositions/code-highlight.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-highlight.mdx
+++ b/docs/catalog/blocks/code-highlight.mdx
@@ -3,34 +3,24 @@ title: "Code Highlight Sweep"
 description: "A highlight band sweeps across a target line while the surrounding context dims — draws the eye to one line. `line` is 0-based: `line: 1` targets the second displayed line (unlike code-scroll, whose target is 1-based)."
 ---
 
-A highlight band sweeps across a target line while the surrounding context dims — draws the eye to one line. `line` is 0-based: `line: 1` targets the second displayed line (unlike code-scroll, whose target is 1-based).
-
 `code` `code-animation` `highlight` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-highlight.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Highlight Sweep block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-highlight
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-highlight" data-composition-src="compositions/code-highlight.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-morph.mdx
+++ b/docs/catalog/blocks/code-morph.mdx
@@ -3,23 +3,34 @@ title: "Code Morph"
 description: "One snippet transforms into another — tokens glide between positions, leavers fade out, enterers fade in. Shiki Magic Move re-driven as a paused GSAP timeline."
 ---
 
-# Code Morph
-
 One snippet transforms into another — tokens glide between positions, leavers fade out, enterers fade in. Shiki Magic Move re-driven as a paused GSAP timeline.
 
 `code` `code-animation` `morph` `refactor` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-morph.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-morph.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Morph block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-morph
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-morph
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-morph.html` | `compositions/code-morph.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-morph" data-composition-src="compositions/code-morph.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-morph.mdx
+++ b/docs/catalog/blocks/code-morph.mdx
@@ -3,34 +3,24 @@ title: "Code Morph"
 description: "One snippet transforms into another — tokens glide between positions, leavers fade out, enterers fade in. Shiki Magic Move re-driven as a paused GSAP timeline."
 ---
 
-One snippet transforms into another — tokens glide between positions, leavers fade out, enterers fade in. Shiki Magic Move re-driven as a paused GSAP timeline.
-
 `code` `code-animation` `morph` `refactor` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-morph.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-morph.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Morph block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-morph
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-morph" data-composition-src="compositions/code-morph.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-particle-assemble.mdx
+++ b/docs/catalog/blocks/code-particle-assemble.mdx
@@ -3,23 +3,34 @@ title: "Code Particle Assemble"
 description: "Thousands of GPU points scatter through space and fly to the exact glyph pixels of the code, resolving into readable syntax-highlighted text — a particle system, not a token tween."
 ---
 
-# Code Particle Assemble
-
 Thousands of GPU points scatter through space and fly to the exact glyph pixels of the code, resolving into readable syntax-highlighted text — a particle system, not a token tween.
 
 `code` `code-animation` `particles` `gpu` `webgl` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-particle-assemble.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-particle-assemble.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Particle Assemble block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-particle-assemble
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-particle-assemble
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-particle-assemble.html` | `compositions/code-particle-assemble.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-particle-assemble" data-composition-src="compositions/code-particle-assemble.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-particle-assemble.mdx
+++ b/docs/catalog/blocks/code-particle-assemble.mdx
@@ -3,34 +3,24 @@ title: "Code Particle Assemble"
 description: "Thousands of GPU points scatter through space and fly to the exact glyph pixels of the code, resolving into readable syntax-highlighted text — a particle system, not a token tween."
 ---
 
-Thousands of GPU points scatter through space and fly to the exact glyph pixels of the code, resolving into readable syntax-highlighted text — a particle system, not a token tween.
-
 `code` `code-animation` `particles` `gpu` `webgl` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-particle-assemble.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-particle-assemble.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Particle Assemble block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-particle-assemble
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-particle-assemble" data-composition-src="compositions/code-particle-assemble.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-scroll.mdx
+++ b/docs/catalog/blocks/code-scroll.mdx
@@ -3,34 +3,24 @@ title: "Code Scroll To Line"
 description: "The camera scrolls a long file to bring a target line to center and spotlights it — for walking through real modules."
 ---
 
-The camera scrolls a long file to bring a target line to center and spotlights it — for walking through real modules.
-
 `code` `code-animation` `scroll` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-scroll.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-scroll.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Scroll To Line block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-scroll
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-scroll" data-composition-src="compositions/code-scroll.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-scroll.mdx
+++ b/docs/catalog/blocks/code-scroll.mdx
@@ -3,23 +3,34 @@ title: "Code Scroll To Line"
 description: "The camera scrolls a long file to bring a target line to center and spotlights it — for walking through real modules."
 ---
 
-# Code Scroll To Line
-
 The camera scrolls a long file to bring a target line to center and spotlights it — for walking through real modules.
 
 `code` `code-animation` `scroll` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-scroll.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-scroll.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Scroll To Line block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-scroll
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-scroll
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-scroll.html` | `compositions/code-scroll.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-scroll" data-composition-src="compositions/code-scroll.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-shader-dissolve.mdx
+++ b/docs/catalog/blocks/code-shader-dissolve.mdx
@@ -3,34 +3,24 @@ title: "Code Shader Dissolve"
 description: "The code compiles into existence: a GPU fragment shader resolves it out of seeded noise with a chromatic dissolve front and edge glow, then holds crisp."
 ---
 
-The code compiles into existence: a GPU fragment shader resolves it out of seeded noise with a chromatic dissolve front and edge glow, then holds crisp.
-
 `code` `code-animation` `shader` `webgl` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-shader-dissolve.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-shader-dissolve.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Shader Dissolve block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-shader-dissolve
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-shader-dissolve" data-composition-src="compositions/code-shader-dissolve.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-shader-dissolve.mdx
+++ b/docs/catalog/blocks/code-shader-dissolve.mdx
@@ -3,23 +3,34 @@ title: "Code Shader Dissolve"
 description: "The code compiles into existence: a GPU fragment shader resolves it out of seeded noise with a chromatic dissolve front and edge glow, then holds crisp."
 ---
 
-# Code Shader Dissolve
-
 The code compiles into existence: a GPU fragment shader resolves it out of seeded noise with a chromatic dissolve front and edge glow, then holds crisp.
 
 `code` `code-animation` `shader` `webgl` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-shader-dissolve.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-shader-dissolve.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Shader Dissolve block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-shader-dissolve
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-shader-dissolve
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-shader-dissolve.html` | `compositions/code-shader-dissolve.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-shader-dissolve" data-composition-src="compositions/code-shader-dissolve.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-snippet-apple-terminal-basic.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-basic.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Basic"
 description: "Apple Terminal Basic profile: white background, black text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Basic profile: white background, black text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Basic block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-basic
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-basic" data-composition-src="compositions/code-snippet-apple-terminal-basic.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-basic.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-basic.mdx
@@ -7,7 +7,7 @@ Apple Terminal Basic profile: white background, black text, per-character typing
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-basic.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-basic.mdx
@@ -1,31 +1,36 @@
 ---
-title: "Apple Terminal Basic"
-description: "Apple Terminal Basic profile with white background and black text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Basic"
+description: "Apple Terminal Basic profile: white background, black text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Basic
+Apple Terminal Basic profile: white background, black text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Basic profile — clean white background with black monospace text and a solid black cursor. Per-character typing animation with output reveal.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Apple Terminal Basic block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-basic
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-basic.html` | `compositions/code-snippet-apple-terminal-basic.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-basic"
-  data-composition-src="compositions/code-snippet-apple-terminal-basic.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-basic" data-composition-src="compositions/code-snippet-apple-terminal-basic.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Basic profile — white background, black text, solid cursor
-- macOS window chrome with traffic light buttons (close, minimize, fullscreen) and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-clear-dark.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-clear-dark.mdx
@@ -7,7 +7,7 @@ Apple Terminal Clear Dark profile: semi-transparent dark background, per-charact
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-clear-dark.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-clear-dark.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Clear Dark"
-description: "Apple Terminal Clear Dark profile with semi-transparent dark background and white text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Clear Dark"
+description: "Apple Terminal Clear Dark profile: semi-transparent dark background, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Clear Dark
+Apple Terminal Clear Dark profile: semi-transparent dark background, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Clear Dark profile — translucent black background with white text and a grey cursor. Per-character typing animation with output reveal.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Clear Dark block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-clear-dark
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-clear-dark.html` | `compositions/code-snippet-apple-terminal-clear-dark.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-clear-dark"
-  data-composition-src="compositions/code-snippet-apple-terminal-clear-dark.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-clear-dark" data-composition-src="compositions/code-snippet-apple-terminal-clear-dark.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Clear Dark profile — semi-transparent black background with white text
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-clear-dark.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-clear-dark.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Clear Dark"
 description: "Apple Terminal Clear Dark profile: semi-transparent dark background, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Clear Dark profile: semi-transparent dark background, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Clear Dark block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-clear-dark
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-clear-dark" data-composition-src="compositions/code-snippet-apple-terminal-clear-dark.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-clear-light.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-clear-light.mdx
@@ -1,31 +1,36 @@
 ---
-title: "Apple Terminal Clear Light"
-description: "Apple Terminal Clear Light profile with semi-transparent white background and black text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Clear Light"
+description: "Apple Terminal Clear Light profile: semi-transparent light background, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Clear Light
+Apple Terminal Clear Light profile: semi-transparent light background, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Clear Light profile — translucent white background with black text and a grey cursor. Per-character typing animation with output reveal.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Apple Terminal Clear Light block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-clear-light
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-clear-light.html` | `compositions/code-snippet-apple-terminal-clear-light.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-clear-light"
-  data-composition-src="compositions/code-snippet-apple-terminal-clear-light.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-clear-light" data-composition-src="compositions/code-snippet-apple-terminal-clear-light.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Clear Light profile — semi-transparent white background with black text
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-clear-light.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-clear-light.mdx
@@ -7,7 +7,7 @@ Apple Terminal Clear Light profile: semi-transparent light background, per-chara
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-clear-light.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-clear-light.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Clear Light"
 description: "Apple Terminal Clear Light profile: semi-transparent light background, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Clear Light profile: semi-transparent light background, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Clear Light block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-clear-light
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-clear-light" data-composition-src="compositions/code-snippet-apple-terminal-clear-light.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-grass.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-grass.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Grass"
 description: "Apple Terminal Grass profile: black background with green text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Grass profile: black background with green text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Grass block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-grass
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-grass" data-composition-src="compositions/code-snippet-apple-terminal-grass.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-grass.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-grass.mdx
@@ -1,31 +1,36 @@
 ---
-title: "Apple Terminal Grass"
-description: "Apple Terminal Grass profile with black background and bright green text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Grass"
+description: "Apple Terminal Grass profile: black background with green text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Grass
+Apple Terminal Grass profile: black background with green text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Grass profile — pitch-black background with pure green text and a matching cursor. Classic terminal aesthetic with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Apple Terminal Grass block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-grass
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-grass.html` | `compositions/code-snippet-apple-terminal-grass.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-grass"
-  data-composition-src="compositions/code-snippet-apple-terminal-grass.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-grass" data-composition-src="compositions/code-snippet-apple-terminal-grass.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Grass profile — black background with #00C100 green text
-- macOS window chrome with green-accented title bar and traffic light buttons
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-grass.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-grass.mdx
@@ -7,7 +7,7 @@ Apple Terminal Grass profile: black background with green text, per-character ty
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-homebrew.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-homebrew.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Homebrew"
-description: "Apple Terminal Homebrew profile with black background, bright green text and lime cursor, per-character typing animation."
+title: "Code Snippet - Apple Terminal Homebrew"
+description: "Apple Terminal Homebrew profile: black background with bright green text and lime cursor, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Homebrew
+Apple Terminal Homebrew profile: black background with bright green text and lime cursor, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Homebrew profile — black background with vivid green text and a lime `#48F800` cursor. One of the most beloved classic terminal looks.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Homebrew block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-homebrew
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-homebrew.html` | `compositions/code-snippet-apple-terminal-homebrew.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-homebrew"
-  data-composition-src="compositions/code-snippet-apple-terminal-homebrew.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-homebrew" data-composition-src="compositions/code-snippet-apple-terminal-homebrew.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Homebrew profile — black background with #00CF00 text and #48F800 cursor
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-homebrew.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-homebrew.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Homebrew"
 description: "Apple Terminal Homebrew profile: black background with bright green text and lime cursor, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Homebrew profile: black background with bright green text and lime cursor, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Homebrew block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-homebrew
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-homebrew" data-composition-src="compositions/code-snippet-apple-terminal-homebrew.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-homebrew.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-homebrew.mdx
@@ -7,7 +7,7 @@ Apple Terminal Homebrew profile: black background with bright green text and lim
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-man-page.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-man-page.mdx
@@ -7,7 +7,7 @@ Apple Terminal Man Page profile: pale yellow background with black text, per-cha
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-man-page.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-man-page.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Man Page"
 description: "Apple Terminal Man Page profile: pale yellow background with black text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Man Page profile: pale yellow background with black text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Man Page block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-man-page
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-man-page" data-composition-src="compositions/code-snippet-apple-terminal-man-page.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-man-page.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-man-page.mdx
@@ -1,31 +1,36 @@
 ---
-title: "Apple Terminal Man Page"
-description: "Apple Terminal Man Page profile with pale yellow background and black text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Man Page"
+description: "Apple Terminal Man Page profile: pale yellow background with black text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Man Page
+Apple Terminal Man Page profile: pale yellow background with black text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Man Page profile — pale yellow `#FEF49C` background with black text. Evoking classic Unix manual pages, with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Apple Terminal Man Page block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-man-page
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-man-page.html` | `compositions/code-snippet-apple-terminal-man-page.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-man-page"
-  data-composition-src="compositions/code-snippet-apple-terminal-man-page.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-man-page" data-composition-src="compositions/code-snippet-apple-terminal-man-page.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Man Page profile — pale yellow background with black text
-- Shows a realistic man page output structure with sections and indented content
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-novel.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-novel.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Novel"
 description: "Apple Terminal Novel profile: warm parchment background with dark brown text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Novel profile: warm parchment background with dark brown text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Novel block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-novel
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-novel" data-composition-src="compositions/code-snippet-apple-terminal-novel.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-novel.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-novel.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Novel"
-description: "Apple Terminal Novel profile with warm parchment background and dark brown text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Novel"
+description: "Apple Terminal Novel profile: warm parchment background with dark brown text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Novel
+Apple Terminal Novel profile: warm parchment background with dark brown text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Novel profile — warm parchment `#DFC18A` background with deep brown text. A distinctive earthy look, with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Novel block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-novel
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-novel.html` | `compositions/code-snippet-apple-terminal-novel.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-novel"
-  data-composition-src="compositions/code-snippet-apple-terminal-novel.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-novel" data-composition-src="compositions/code-snippet-apple-terminal-novel.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Novel profile — warm parchment background with #3E2900 dark brown text
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-novel.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-novel.mdx
@@ -7,7 +7,7 @@ Apple Terminal Novel profile: warm parchment background with dark brown text, pe
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-ocean.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-ocean.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Ocean"
 description: "Apple Terminal Ocean profile: deep blue background with white text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Ocean profile: deep blue background with white text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Ocean block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-ocean
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-ocean" data-composition-src="compositions/code-snippet-apple-terminal-ocean.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-ocean.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-ocean.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Ocean"
-description: "Apple Terminal Ocean profile with deep blue background and white text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Ocean"
+description: "Apple Terminal Ocean profile: deep blue background with white text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Ocean
+Apple Terminal Ocean profile: deep blue background with white text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Ocean profile — vivid `#224FBE` blue background with crisp white text. Bold and distinctive, with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Ocean block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-ocean
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-ocean.html` | `compositions/code-snippet-apple-terminal-ocean.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-ocean"
-  data-composition-src="compositions/code-snippet-apple-terminal-ocean.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-ocean" data-composition-src="compositions/code-snippet-apple-terminal-ocean.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Ocean profile — #224FBE blue background with white text
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-ocean.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-ocean.mdx
@@ -7,7 +7,7 @@ Apple Terminal Ocean profile: deep blue background with white text, per-characte
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-pro.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-pro.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Pro"
 description: "Apple Terminal Pro profile: black background with grey text and lime green cursor, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Pro profile: black background with grey text and lime green cursor, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Pro block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-pro
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-pro" data-composition-src="compositions/code-snippet-apple-terminal-pro.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-pro.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-pro.mdx
@@ -7,7 +7,7 @@ Apple Terminal Pro profile: black background with grey text and lime green curso
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-pro.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-pro.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Pro"
-description: "Apple Terminal Pro profile with black background, grey text and lime green cursor, per-character typing animation."
+title: "Code Snippet - Apple Terminal Pro"
+description: "Apple Terminal Pro profile: black background with grey text and lime green cursor, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Pro
+Apple Terminal Pro profile: black background with grey text and lime green cursor, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Pro profile — pure black background with grey `#BBBBBB` text and a distinctive `#88FF67` lime cursor. Hacker aesthetic with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Pro block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-pro
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-pro.html` | `compositions/code-snippet-apple-terminal-pro.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-pro"
-  data-composition-src="compositions/code-snippet-apple-terminal-pro.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-pro" data-composition-src="compositions/code-snippet-apple-terminal-pro.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Pro profile — black background, #BBBBBB grey text, #88FF67 lime cursor
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-red-sands.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-red-sands.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Red Sands"
-description: "Apple Terminal Red Sands profile with deep red background and sandy text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Red Sands"
+description: "Apple Terminal Red Sands profile: deep red background with sandy text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Red Sands
+Apple Terminal Red Sands profile: deep red background with sandy text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Red Sands profile — deep crimson `#7B140E` background with warm sandy `#FFE1B9` text. A bold, dramatic look with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Red Sands block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-red-sands
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-red-sands.html` | `compositions/code-snippet-apple-terminal-red-sands.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-red-sands"
-  data-composition-src="compositions/code-snippet-apple-terminal-red-sands.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-red-sands" data-composition-src="compositions/code-snippet-apple-terminal-red-sands.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Red Sands profile — #7B140E red background with #FFE1B9 sandy text
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-red-sands.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-red-sands.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Red Sands"
 description: "Apple Terminal Red Sands profile: deep red background with sandy text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Red Sands profile: deep red background with sandy text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Red Sands block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-red-sands
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-red-sands" data-composition-src="compositions/code-snippet-apple-terminal-red-sands.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-red-sands.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-red-sands.mdx
@@ -7,7 +7,7 @@ Apple Terminal Red Sands profile: deep red background with sandy text, per-chara
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mdx
@@ -7,7 +7,7 @@ Apple Terminal Silver Aerogel profile: dark grey background with white text, per
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Silver Aerogel"
-description: "Apple Terminal Silver Aerogel profile with dark grey background and white text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Silver Aerogel"
+description: "Apple Terminal Silver Aerogel profile: dark grey background with white text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Silver Aerogel
+Apple Terminal Silver Aerogel profile: dark grey background with white text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Silver Aerogel profile — dark grey `#3D3D3D` background with clean white text. A professional neutral look with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Silver Aerogel block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-silver-aerogel
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-silver-aerogel.html` | `compositions/code-snippet-apple-terminal-silver-aerogel.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-silver-aerogel"
-  data-composition-src="compositions/code-snippet-apple-terminal-silver-aerogel.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-silver-aerogel" data-composition-src="compositions/code-snippet-apple-terminal-silver-aerogel.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Silver Aerogel profile — #3D3D3D dark grey background with white text
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Silver Aerogel"
 description: "Apple Terminal Silver Aerogel profile: dark grey background with white text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Silver Aerogel profile: dark grey background with white text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Silver Aerogel block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-silver-aerogel
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-silver-aerogel" data-composition-src="compositions/code-snippet-apple-terminal-silver-aerogel.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-apple-terminal-solid-colors.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-solid-colors.mdx
@@ -1,32 +1,36 @@
 ---
-title: "Apple Terminal Solid Colors"
-description: "Apple Terminal Solid Colors profile with deep purple background and white text, per-character typing animation."
+title: "Code Snippet - Apple Terminal Solid Colors"
+description: "Apple Terminal Solid Colors profile: deep purple background with white text, per-character typing animation of a shell session."
 ---
 
-# Apple Terminal Solid Colors
+Apple Terminal Solid Colors profile: deep purple background with white text, per-character typing animation of a shell session.
 
-macOS Terminal.app window in the built-in Solid Colors profile — vivid deep purple `#4C0099` background with white text. Eye-catching and vibrant, with per-character typing animation.
-
-`code` `developer` `showcase` `terminal` `apple`
+`code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.png" autoPlay muted loop playsInline />
 
+## Add it to a project
 
-## Install
+<Tabs>
 
-<CodeGroup>
+<Tab title="Ask your agent">
 
-```bash Terminal
+```text
+Add the Code Snippet - Apple Terminal Solid Colors block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-apple-terminal-solid-colors
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all Apple Terminal themes at once:
-
-```bash Terminal
-npx hyperframes add apple-terminal
-```
+</Tabs>
 
 ## Details
 
@@ -36,33 +40,18 @@ npx hyperframes add apple-terminal
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-apple-terminal-solid-colors.html` | `compositions/code-snippet-apple-terminal-solid-colors.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-apple-terminal-solid-colors"
-  data-composition-src="compositions/code-snippet-apple-terminal-solid-colors.html"
-  data-start="0"
-  data-duration="12"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-apple-terminal-solid-colors" data-composition-src="compositions/code-snippet-apple-terminal-solid-colors.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Faithful recreation of macOS Terminal.app Solid Colors profile — #4C0099 deep purple background with white text
-- macOS window chrome with traffic light buttons and centered title bar
-- Per-character GSAP typing animation — command types out character by character
-- Output lines reveal sequentially after command executes
-- Cursor blinks three times at the end then holds steady
-- Self-contained HTML — no external assets, only GSAP CDN

--- a/docs/catalog/blocks/code-snippet-apple-terminal-solid-colors.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-solid-colors.mdx
@@ -7,7 +7,7 @@ Apple Terminal Solid Colors profile: deep purple background with white text, per
 
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/blocks/code-snippet-apple-terminal-solid-colors.mdx
+++ b/docs/catalog/blocks/code-snippet-apple-terminal-solid-colors.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Apple Terminal Solid Colors"
 description: "Apple Terminal Solid Colors profile: deep purple background with white text, per-character typing animation of a shell session."
 ---
 
-Apple Terminal Solid Colors profile: deep purple background with white text, per-character typing animation of a shell session.
-
 `code` `developer` `showcase` `terminal` `apple` `apple-terminal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Apple Terminal Solid Colors block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-apple-terminal-solid-colors
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-apple-terminal-solid-colors" data-composition-src="compositions/code-snippet-apple-terminal-solid-colors.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-dark-2026.mdx
+++ b/docs/catalog/blocks/code-snippet-dark-2026.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Dark 2026"
-description: "The newest VS Code dark theme with refined token scopes and updated palette."
+title: "Code Snippet - Dark 2026"
+description: "VS Code workbench with per-character typing animation in the Dark 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Dark 2026
 
 VS Code workbench with per-character typing animation in the Dark 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Dark 2026 theme. Fu
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-2026.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-2026.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Dark 2026 block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-dark-2026
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-dark-2026.html` | `compositions/code-snippet-dark-2026.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-dark-2026"
-  data-composition-src="compositions/code-snippet-dark-2026.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-dark-2026" data-composition-src="compositions/code-snippet-dark-2026.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-dark-2026.mdx
+++ b/docs/catalog/blocks/code-snippet-dark-2026.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Dark 2026"
 description: "VS Code workbench with per-character typing animation in the Dark 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Dark 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-2026.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-2026.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Dark 2026 block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-dark-2026
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-dark-2026" data-composition-src="compositions/code-snippet-dark-2026.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-dark-modern.mdx
+++ b/docs/catalog/blocks/code-snippet-dark-modern.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Dark Modern"
-description: "The default dark theme — clean and contemporary with comfortable contrast."
+title: "Code Snippet - Dark Modern"
+description: "VS Code workbench with per-character typing animation in the Dark Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Dark Modern
 
 VS Code workbench with per-character typing animation in the Dark Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Dark Modern theme. 
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-modern.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-modern.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Dark Modern block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-dark-modern
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-dark-modern.html` | `compositions/code-snippet-dark-modern.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-dark-modern"
-  data-composition-src="compositions/code-snippet-dark-modern.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-dark-modern" data-composition-src="compositions/code-snippet-dark-modern.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-dark-modern.mdx
+++ b/docs/catalog/blocks/code-snippet-dark-modern.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Dark Modern"
 description: "VS Code workbench with per-character typing animation in the Dark Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Dark Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-modern.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-modern.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Dark Modern block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-dark-modern
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-dark-modern" data-composition-src="compositions/code-snippet-dark-modern.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-dark-plus.mdx
+++ b/docs/catalog/blocks/code-snippet-dark-plus.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Dark+"
 description: "VS Code workbench with per-character typing animation in the Dark+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Dark+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-plus.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-plus.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Dark+ block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-dark-plus
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-dark-plus" data-composition-src="compositions/code-snippet-dark-plus.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-dark-plus.mdx
+++ b/docs/catalog/blocks/code-snippet-dark-plus.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Dark+"
-description: "Classic dark theme with enhanced syntax highlighting for popular languages."
+title: "Code Snippet - Dark+"
+description: "VS Code workbench with per-character typing animation in the Dark+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Dark+
 
 VS Code workbench with per-character typing animation in the Dark+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Dark+ theme. Full e
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-plus.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-dark-plus.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Dark+ block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-dark-plus
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-dark-plus.html` | `compositions/code-snippet-dark-plus.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-dark-plus"
-  data-composition-src="compositions/code-snippet-dark-plus.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-dark-plus" data-composition-src="compositions/code-snippet-dark-plus.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-flight.mdx
+++ b/docs/catalog/blocks/code-snippet-flight.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet Flight"
 description: "Discrete code snippets fly in from the side and assemble into a stacked program, staggered. Block-level FLIP."
 ---
 
-Discrete code snippets fly in from the side and assemble into a stacked program, staggered. Block-level FLIP.
-
 `code` `code-animation` `flight` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-flight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-flight.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet Flight block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-flight
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-flight" data-composition-src="compositions/code-snippet-flight.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-flight.mdx
+++ b/docs/catalog/blocks/code-snippet-flight.mdx
@@ -3,23 +3,34 @@ title: "Code Snippet Flight"
 description: "Discrete code snippets fly in from the side and assemble into a stacked program, staggered. Block-level FLIP."
 ---
 
-# Code Snippet Flight
-
 Discrete code snippets fly in from the side and assemble into a stacked program, staggered. Block-level FLIP.
 
 `code` `code-animation` `flight` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-flight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-flight.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet Flight block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-flight
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-snippet-flight
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-flight.html` | `compositions/code-snippet-flight.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-snippet-flight" data-composition-src="compositions/code-snippet-flight.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/code-snippet-high-contrast-light.mdx
+++ b/docs/catalog/blocks/code-snippet-high-contrast-light.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - High Contrast Light"
 description: "VS Code workbench with per-character typing animation in the High Contrast Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the High Contrast Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast-light.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - High Contrast Light block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-high-contrast-light
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-high-contrast-light" data-composition-src="compositions/code-snippet-high-contrast-light.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-high-contrast-light.mdx
+++ b/docs/catalog/blocks/code-snippet-high-contrast-light.mdx
@@ -1,9 +1,7 @@
 ---
-title: "High Contrast Light"
-description: "Maximum contrast light theme for accessibility."
+title: "Code Snippet - High Contrast Light"
+description: "VS Code workbench with per-character typing animation in the High Contrast Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# High Contrast Light
 
 VS Code workbench with per-character typing animation in the High Contrast Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the High Contrast Light
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast-light.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - High Contrast Light block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-high-contrast-light
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-high-contrast-light.html` | `compositions/code-snippet-high-contrast-light.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-high-contrast-light"
-  data-composition-src="compositions/code-snippet-high-contrast-light.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-high-contrast-light" data-composition-src="compositions/code-snippet-high-contrast-light.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-high-contrast.mdx
+++ b/docs/catalog/blocks/code-snippet-high-contrast.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - High Contrast"
 description: "VS Code workbench with per-character typing animation in the High Contrast theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the High Contrast theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - High Contrast block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-high-contrast
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-high-contrast" data-composition-src="compositions/code-snippet-high-contrast.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-high-contrast.mdx
+++ b/docs/catalog/blocks/code-snippet-high-contrast.mdx
@@ -1,9 +1,7 @@
 ---
-title: "High Contrast"
-description: "Maximum contrast dark theme for accessibility."
+title: "Code Snippet - High Contrast"
+description: "VS Code workbench with per-character typing animation in the High Contrast theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# High Contrast
 
 VS Code workbench with per-character typing animation in the High Contrast theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the High Contrast theme
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-high-contrast.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - High Contrast block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-high-contrast
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-high-contrast.html` | `compositions/code-snippet-high-contrast.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-high-contrast"
-  data-composition-src="compositions/code-snippet-high-contrast.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-high-contrast" data-composition-src="compositions/code-snippet-high-contrast.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-light-2026.mdx
+++ b/docs/catalog/blocks/code-snippet-light-2026.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Light 2026"
-description: "The newest VS Code light theme with refined token scopes and updated palette."
+title: "Code Snippet - Light 2026"
+description: "VS Code workbench with per-character typing animation in the Light 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Light 2026
 
 VS Code workbench with per-character typing animation in the Light 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Light 2026 theme. F
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-2026.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-2026.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Light 2026 block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-light-2026
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-light-2026.html` | `compositions/code-snippet-light-2026.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-light-2026"
-  data-composition-src="compositions/code-snippet-light-2026.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-light-2026" data-composition-src="compositions/code-snippet-light-2026.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-light-2026.mdx
+++ b/docs/catalog/blocks/code-snippet-light-2026.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Light 2026"
 description: "VS Code workbench with per-character typing animation in the Light 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Light 2026 theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-2026.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-2026.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Light 2026 block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-light-2026
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-light-2026" data-composition-src="compositions/code-snippet-light-2026.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-light-modern.mdx
+++ b/docs/catalog/blocks/code-snippet-light-modern.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Light Modern"
-description: "The default light theme — a fresh, modern take on the classic VS light experience."
+title: "Code Snippet - Light Modern"
+description: "VS Code workbench with per-character typing animation in the Light Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Light Modern
 
 VS Code workbench with per-character typing animation in the Light Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Light Modern theme.
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-modern.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-modern.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Light Modern block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-light-modern
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-light-modern.html` | `compositions/code-snippet-light-modern.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-light-modern"
-  data-composition-src="compositions/code-snippet-light-modern.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-light-modern" data-composition-src="compositions/code-snippet-light-modern.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-light-modern.mdx
+++ b/docs/catalog/blocks/code-snippet-light-modern.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Light Modern"
 description: "VS Code workbench with per-character typing animation in the Light Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Light Modern theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-modern.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-modern.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Light Modern block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-light-modern
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-light-modern" data-composition-src="compositions/code-snippet-light-modern.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-light-plus.mdx
+++ b/docs/catalog/blocks/code-snippet-light-plus.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Light+"
-description: "Classic light theme with enhanced syntax highlighting for popular languages."
+title: "Code Snippet - Light+"
+description: "VS Code workbench with per-character typing animation in the Light+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Light+
 
 VS Code workbench with per-character typing animation in the Light+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Light+ theme. Full 
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-plus.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-plus.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Light+ block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-light-plus
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-light-plus.html` | `compositions/code-snippet-light-plus.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-light-plus"
-  data-composition-src="compositions/code-snippet-light-plus.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-light-plus" data-composition-src="compositions/code-snippet-light-plus.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-light-plus.mdx
+++ b/docs/catalog/blocks/code-snippet-light-plus.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Light+"
 description: "VS Code workbench with per-character typing animation in the Light+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Light+ theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-plus.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-light-plus.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Light+ block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-light-plus
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-light-plus" data-composition-src="compositions/code-snippet-light-plus.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-monokai.mdx
+++ b/docs/catalog/blocks/code-snippet-monokai.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Monokai"
 description: "VS Code workbench with per-character typing animation in the Monokai theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Monokai theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-monokai.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-monokai.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Monokai block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-monokai
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-monokai" data-composition-src="compositions/code-snippet-monokai.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-monokai.mdx
+++ b/docs/catalog/blocks/code-snippet-monokai.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Monokai"
-description: "The iconic warm-toned dark theme beloved by developers worldwide."
+title: "Code Snippet - Monokai"
+description: "VS Code workbench with per-character typing animation in the Monokai theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Monokai
 
 VS Code workbench with per-character typing animation in the Monokai theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Monokai theme. Full
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-monokai.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-monokai.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Monokai block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-monokai
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-monokai.html` | `compositions/code-snippet-monokai.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-monokai"
-  data-composition-src="compositions/code-snippet-monokai.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-monokai" data-composition-src="compositions/code-snippet-monokai.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-solarized-light.mdx
+++ b/docs/catalog/blocks/code-snippet-solarized-light.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Solarized Light"
 description: "VS Code workbench with per-character typing animation in the Solarized Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Solarized Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-solarized-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-solarized-light.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Solarized Light block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-solarized-light
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-solarized-light" data-composition-src="compositions/code-snippet-solarized-light.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-solarized-light.mdx
+++ b/docs/catalog/blocks/code-snippet-solarized-light.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Solarized Light"
-description: "Ethan Schoonover's precision-engineered light color scheme."
+title: "Code Snippet - Solarized Light"
+description: "VS Code workbench with per-character typing animation in the Solarized Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Solarized Light
 
 VS Code workbench with per-character typing animation in the Solarized Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Solarized Light the
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-solarized-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-solarized-light.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Solarized Light block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-solarized-light
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-solarized-light.html` | `compositions/code-snippet-solarized-light.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-solarized-light"
-  data-composition-src="compositions/code-snippet-solarized-light.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-solarized-light" data-composition-src="compositions/code-snippet-solarized-light.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-visual-studio-dark.mdx
+++ b/docs/catalog/blocks/code-snippet-visual-studio-dark.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Visual Studio Dark"
 description: "VS Code workbench with per-character typing animation in the Visual Studio Dark theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Visual Studio Dark theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-dark.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-dark.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Visual Studio Dark block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-visual-studio-dark
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-visual-studio-dark" data-composition-src="compositions/code-snippet-visual-studio-dark.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-visual-studio-dark.mdx
+++ b/docs/catalog/blocks/code-snippet-visual-studio-dark.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Visual Studio Dark"
-description: "The traditional Visual Studio dark color scheme."
+title: "Code Snippet - Visual Studio Dark"
+description: "VS Code workbench with per-character typing animation in the Visual Studio Dark theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Visual Studio Dark
 
 VS Code workbench with per-character typing animation in the Visual Studio Dark theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Visual Studio Dark 
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-dark.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-dark.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Visual Studio Dark block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-visual-studio-dark
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-visual-studio-dark.html` | `compositions/code-snippet-visual-studio-dark.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-visual-studio-dark"
-  data-composition-src="compositions/code-snippet-visual-studio-dark.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-visual-studio-dark" data-composition-src="compositions/code-snippet-visual-studio-dark.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-snippet-visual-studio-light.mdx
+++ b/docs/catalog/blocks/code-snippet-visual-studio-light.mdx
@@ -3,34 +3,24 @@ title: "Code Snippet - Visual Studio Light"
 description: "VS Code workbench with per-character typing animation in the Visual Studio Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
 
-VS Code workbench with per-character typing animation in the Visual Studio Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
-
 `code` `developer` `showcase` `vscode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-light.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Snippet - Visual Studio Light block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-snippet-visual-studio-light
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-snippet-visual-studio-light" data-composition-src="compositions/code-snippet-visual-studio-light.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-snippet-visual-studio-light.mdx
+++ b/docs/catalog/blocks/code-snippet-visual-studio-light.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Visual Studio Light"
-description: "The traditional Visual Studio light color scheme."
+title: "Code Snippet - Visual Studio Light"
+description: "VS Code workbench with per-character typing animation in the Visual Studio Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar."
 ---
-
-# Visual Studio Light
 
 VS Code workbench with per-character typing animation in the Visual Studio Light theme. Full editor chrome with activity bar, sidebar, tabs, terminal, and status bar.
 
@@ -11,21 +9,28 @@ VS Code workbench with per-character typing animation in the Visual Studio Light
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-visual-studio-light.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Snippet - Visual Studio Light block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-snippet-visual-studio-light
 ```
 
-</CodeGroup>
+</Tab>
 
-Install all code snippet themes at once:
-
-```bash Terminal
-npx hyperframes add code
-```
+</Tabs>
 
 ## Details
 
@@ -35,33 +40,19 @@ npx hyperframes add code
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-snippet-visual-studio-light.html` | `compositions/code-snippet-visual-studio-light.html` | hyperframes:composition |
 | `background.jpeg` | `assets/background.jpeg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
-<div
-  data-composition-id="code-snippet-visual-studio-light"
-  data-composition-src="compositions/code-snippet-visual-studio-light.html"
-  data-start="0"
-  data-duration="11"
-  data-track-index="1"
-  data-width="1920"
-  data-height="1080"
-></div>
+<div data-composition-id="code-snippet-visual-studio-light" data-composition-src="compositions/code-snippet-visual-studio-light.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
-
-## Features
-
-- Full VS Code workbench recreation — activity bar, sidebar, explorer tree, editor tabs, breadcrumbs, terminal panel, status bar
-- Per-character typing animation with cursor tracking and active line highlight
-- Colors sourced from official `microsoft/vscode` built-in theme JSON
-- 3D perspective tilt at the end of the typing sequence
-- Terminal panel with mock test output

--- a/docs/catalog/blocks/code-typing.mdx
+++ b/docs/catalog/blocks/code-typing.mdx
@@ -3,34 +3,24 @@ title: "Code Typing"
 description: "Token-streamed typing reveal with a caret that tracks the frontier — deterministic, no CSS animation."
 ---
 
-Token-streamed typing reveal with a caret that tracks the frontier — deterministic, no CSS animation.
-
 `code` `code-animation` `typing` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-typing.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-typing.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Code Typing block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add code-typing
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="code-typing" data-composition-src="compositions/code-typing.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/code-typing.mdx
+++ b/docs/catalog/blocks/code-typing.mdx
@@ -3,23 +3,34 @@ title: "Code Typing"
 description: "Token-streamed typing reveal with a caret that tracks the frontier — deterministic, no CSS animation."
 ---
 
-# Code Typing
-
 Token-streamed typing reveal with a caret that tracks the frontier — deterministic, no CSS animation.
 
 `code` `code-animation` `typing` `developer`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-typing.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-typing.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Code Typing block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add code-typing
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add code-typing
 | Dimensions | 1920×1080 |
 | Duration | 5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `code-typing.html` | `compositions/code-typing.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="code-typing" data-composition-src="compositions/code-typing.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/cross-warp-morph.mdx
+++ b/docs/catalog/blocks/cross-warp-morph.mdx
@@ -3,23 +3,34 @@ title: "Cross Warp Morph"
 description: "Shader transition with cross-warped morphing"
 ---
 
-# Cross Warp Morph
-
 Shader transition with cross-warped morphing
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cross-warp-morph.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cross-warp-morph.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Cross Warp Morph block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add cross-warp-morph
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add cross-warp-morph
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `cross-warp-morph.html` | `compositions/cross-warp-morph.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="cross-warp-morph" data-composition-src="compositions/cross-warp-morph.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/cross-warp-morph.mdx
+++ b/docs/catalog/blocks/cross-warp-morph.mdx
@@ -3,34 +3,24 @@ title: "Cross Warp Morph"
 description: "Shader transition with cross-warped morphing"
 ---
 
-Shader transition with cross-warped morphing
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cross-warp-morph.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/cross-warp-morph.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Cross Warp Morph block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add cross-warp-morph
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="cross-warp-morph" data-composition-src="compositions/cross-warp-morph.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/data-chart.mdx
+++ b/docs/catalog/blocks/data-chart.mdx
@@ -3,34 +3,24 @@ title: "Data Chart"
 description: "Animated bar + line chart with staggered reveal, NYT-style typography, and value labels"
 ---
 
-Animated bar + line chart with staggered reveal, NYT-style typography, and value labels
-
 `data` `chart` `statistics`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/data-chart.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/data-chart.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Data Chart block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add data-chart
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="data-chart" data-composition-src="compositions/data-chart.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/data-chart.mdx
+++ b/docs/catalog/blocks/data-chart.mdx
@@ -3,23 +3,34 @@ title: "Data Chart"
 description: "Animated bar + line chart with staggered reveal, NYT-style typography, and value labels"
 ---
 
-# Data Chart
-
 Animated bar + line chart with staggered reveal, NYT-style typography, and value labels
 
 `data` `chart` `statistics`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/data-chart.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/data-chart.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Data Chart block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add data-chart
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add data-chart
 | Dimensions | 1920×1080 |
 | Duration | 15s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `data-chart.html` | `compositions/data-chart.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="data-chart" data-composition-src="compositions/data-chart.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/domain-warp-dissolve.mdx
+++ b/docs/catalog/blocks/domain-warp-dissolve.mdx
@@ -3,34 +3,24 @@ title: "Domain Warp Dissolve"
 description: "Shader transition with fractal noise domain warping"
 ---
 
-Shader transition with fractal noise domain warping
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/domain-warp-dissolve.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/domain-warp-dissolve.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Domain Warp Dissolve block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add domain-warp-dissolve
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="domain-warp-dissolve" data-composition-src="compositions/domain-warp-dissolve.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/domain-warp-dissolve.mdx
+++ b/docs/catalog/blocks/domain-warp-dissolve.mdx
@@ -3,23 +3,34 @@ title: "Domain Warp Dissolve"
 description: "Shader transition with fractal noise domain warping"
 ---
 
-# Domain Warp Dissolve
-
 Shader transition with fractal noise domain warping
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/domain-warp-dissolve.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/domain-warp-dissolve.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Domain Warp Dissolve block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add domain-warp-dissolve
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add domain-warp-dissolve
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `domain-warp-dissolve.html` | `compositions/domain-warp-dissolve.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="domain-warp-dissolve" data-composition-src="compositions/domain-warp-dissolve.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/editorial-flash-overlay.mdx
+++ b/docs/catalog/blocks/editorial-flash-overlay.mdx
@@ -3,34 +3,24 @@ title: "Editorial Flash Overlay"
 description: "Finite neutral-warm light layers for a seek-safe camera-flash cut or social reveal"
 ---
 
-Finite neutral-warm light layers for a seek-safe camera-flash cut or social reveal
-
 `flash` `editorial` `social` `light` `transition` `overlay` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/editorial-flash-overlay.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/editorial-flash-overlay.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Editorial Flash Overlay block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add editorial-flash-overlay
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="editorial-flash-overlay" data-composition-src="compositions/editorial-flash-overlay.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/editorial-flash-overlay.mdx
+++ b/docs/catalog/blocks/editorial-flash-overlay.mdx
@@ -3,23 +3,34 @@ title: "Editorial Flash Overlay"
 description: "Finite neutral-warm light layers for a seek-safe camera-flash cut or social reveal"
 ---
 
-# Editorial Flash Overlay
-
 Finite neutral-warm light layers for a seek-safe camera-flash cut or social reveal
 
 `flash` `editorial` `social` `light` `transition` `overlay` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/editorial-flash-overlay.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/editorial-flash-overlay.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Editorial Flash Overlay block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add editorial-flash-overlay
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add editorial-flash-overlay
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `editorial-flash-overlay.html` | `compositions/editorial-flash-overlay.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="editorial-flash-overlay" data-composition-src="compositions/editorial-flash-overlay.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/flash-through-white.mdx
+++ b/docs/catalog/blocks/flash-through-white.mdx
@@ -3,23 +3,34 @@ title: "Flash Through White"
 description: "Shader transition with white flash crossfade"
 ---
 
-# Flash Through White
-
 Shader transition with white flash crossfade
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flash-through-white.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flash-through-white.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Flash Through White block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add flash-through-white
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add flash-through-white
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `flash-through-white.html` | `compositions/flash-through-white.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="flash-through-white" data-composition-src="compositions/flash-through-white.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/flash-through-white.mdx
+++ b/docs/catalog/blocks/flash-through-white.mdx
@@ -3,34 +3,24 @@ title: "Flash Through White"
 description: "Shader transition with white flash crossfade"
 ---
 
-Shader transition with white flash crossfade
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flash-through-white.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flash-through-white.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Flash Through White block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add flash-through-white
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="flash-through-white" data-composition-src="compositions/flash-through-white.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/flowchart-vertical.mdx
+++ b/docs/catalog/blocks/flowchart-vertical.mdx
@@ -3,34 +3,24 @@ title: "Flowchart Vertical"
 description: "Portrait animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction"
 ---
 
-Portrait animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction
-
 `diagram` `flowchart` `interactive` `portrait`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart-vertical.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart-vertical.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Flowchart Vertical block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add flowchart-vertical
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="flowchart-vertical" data-composition-src="compositions/flowchart-vertical.html" data-start="0" data-duration="12" data-track-index="1" data-width="1440" data-height="2560"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/flowchart-vertical.mdx
+++ b/docs/catalog/blocks/flowchart-vertical.mdx
@@ -3,23 +3,34 @@ title: "Flowchart Vertical"
 description: "Portrait animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction"
 ---
 
-# Flowchart Vertical
-
 Portrait animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction
 
 `diagram` `flowchart` `interactive` `portrait`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart-vertical.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart-vertical.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Flowchart Vertical block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add flowchart-vertical
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add flowchart-vertical
 | Dimensions | 1440×2560 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `flowchart-vertical.html` | `compositions/flowchart-vertical.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="flowchart-vertical" data-composition-src="compositions/flowchart-vertical.html" data-start="0" data-duration="12" data-track-index="1" data-width="1440" data-height="2560"></div>

--- a/docs/catalog/blocks/flowchart.mdx
+++ b/docs/catalog/blocks/flowchart.mdx
@@ -3,34 +3,24 @@ title: "Flowchart"
 description: "Animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction"
 ---
 
-Animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction
-
 `diagram` `flowchart` `interactive`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Flowchart block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add flowchart
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="flowchart" data-composition-src="compositions/flowchart.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/flowchart.mdx
+++ b/docs/catalog/blocks/flowchart.mdx
@@ -3,23 +3,34 @@ title: "Flowchart"
 description: "Animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction"
 ---
 
-# Flowchart
-
 Animated decision tree with SVG connectors, sticky-note nodes, cursor interaction, and typing correction
 
 `diagram` `flowchart` `interactive`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/flowchart.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Flowchart block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add flowchart
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add flowchart
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `flowchart.html` | `compositions/flowchart.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="flowchart" data-composition-src="compositions/flowchart.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/freeze-frame-dressing.mdx
+++ b/docs/catalog/blocks/freeze-frame-dressing.mdx
@@ -3,34 +3,24 @@ title: "Freeze-Frame Dressing"
 description: "Timeline-driven paper, tape, and flash dressing for a freeze-frame or background-removed subject"
 ---
 
-Timeline-driven paper, tape, and flash dressing for a freeze-frame or background-removed subject
-
 `freeze-frame` `cutout` `scrapbook` `paper` `social` `overlay` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/freeze-frame-dressing.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/freeze-frame-dressing.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Freeze-Frame Dressing block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add freeze-frame-dressing
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="freeze-frame-dressing" data-composition-src="compositions/freeze-frame-dressing.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/freeze-frame-dressing.mdx
+++ b/docs/catalog/blocks/freeze-frame-dressing.mdx
@@ -3,23 +3,34 @@ title: "Freeze-Frame Dressing"
 description: "Timeline-driven paper, tape, and flash dressing for a freeze-frame or background-removed subject"
 ---
 
-# Freeze-Frame Dressing
-
 Timeline-driven paper, tape, and flash dressing for a freeze-frame or background-removed subject
 
 `freeze-frame` `cutout` `scrapbook` `paper` `social` `overlay` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/freeze-frame-dressing.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/freeze-frame-dressing.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Freeze-Frame Dressing block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add freeze-frame-dressing
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add freeze-frame-dressing
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `freeze-frame-dressing.html` | `compositions/freeze-frame-dressing.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="freeze-frame-dressing" data-composition-src="compositions/freeze-frame-dressing.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/glitch.mdx
+++ b/docs/catalog/blocks/glitch.mdx
@@ -3,34 +3,24 @@ title: "Glitch"
 description: "Shader transition with digital glitch artifacts"
 ---
 
-Shader transition with digital glitch artifacts
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/glitch.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/glitch.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Glitch block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add glitch
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="glitch" data-composition-src="compositions/glitch.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/glitch.mdx
+++ b/docs/catalog/blocks/glitch.mdx
@@ -3,23 +3,34 @@ title: "Glitch"
 description: "Shader transition with digital glitch artifacts"
 ---
 
-# Glitch
-
 Shader transition with digital glitch artifacts
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/glitch.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/glitch.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Glitch block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add glitch
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add glitch
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `glitch.html` | `compositions/glitch.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="glitch" data-composition-src="compositions/glitch.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/gravitational-lens.mdx
+++ b/docs/catalog/blocks/gravitational-lens.mdx
@@ -3,23 +3,34 @@ title: "Gravitational Lens"
 description: "Shader transition with gravitational lensing distortion"
 ---
 
-# Gravitational Lens
-
 Shader transition with gravitational lensing distortion
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/gravitational-lens.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/gravitational-lens.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Gravitational Lens block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add gravitational-lens
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add gravitational-lens
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `gravitational-lens.html` | `compositions/gravitational-lens.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="gravitational-lens" data-composition-src="compositions/gravitational-lens.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/gravitational-lens.mdx
+++ b/docs/catalog/blocks/gravitational-lens.mdx
@@ -3,34 +3,24 @@ title: "Gravitational Lens"
 description: "Shader transition with gravitational lensing distortion"
 ---
 
-Shader transition with gravitational lensing distortion
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/gravitational-lens.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/gravitational-lens.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Gravitational Lens block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add gravitational-lens
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="gravitational-lens" data-composition-src="compositions/gravitational-lens.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/hw-frame.mdx
+++ b/docs/catalog/blocks/hw-frame.mdx
@@ -3,23 +3,34 @@ title: "Sketched Frame"
 description: "Media in a hand-drawn border with corner doodles and a handwritten caption; the unit tilts slightly and boils (images inside the block; keep live footage in the host)"
 ---
 
-# Sketched Frame
-
 Media in a hand-drawn border with corner doodles and a handwritten caption; the unit tilts slightly and boils (images inside the block; keep live footage in the host)
 
 `handwritten` `frame` `media`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-frame.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-frame.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Sketched Frame block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-frame
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add hw-frame
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-frame.html` | `compositions/hw-frame.html` | hyperframes:composition |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="hw-frame" data-composition-src="compositions/hw-frame.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/hw-frame.mdx
+++ b/docs/catalog/blocks/hw-frame.mdx
@@ -3,34 +3,24 @@ title: "Sketched Frame"
 description: "Media in a hand-drawn border with corner doodles and a handwritten caption; the unit tilts slightly and boils (images inside the block; keep live footage in the host)"
 ---
 
-Media in a hand-drawn border with corner doodles and a handwritten caption; the unit tilts slightly and boils (images inside the block; keep live footage in the host)
-
 `handwritten` `frame` `media`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-frame.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-frame.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Sketched Frame block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-frame
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="hw-frame" data-composition-src="compositions/hw-frame.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/hw-path-text.mdx
+++ b/docs/catalog/blocks/hw-path-text.mdx
@@ -3,34 +3,24 @@ title: "Text Along a Path"
 description: "Handwriting flowing along any SVG path with a per-character reveal; the path is the only geometry input"
 ---
 
-Handwriting flowing along any SVG path with a per-character reveal; the path is the only geometry input
-
 `handwritten` `typography` `path` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-path-text.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-path-text.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Text Along a Path block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-path-text
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="hw-path-text" data-composition-src="compositions/hw-path-text.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/hw-path-text.mdx
+++ b/docs/catalog/blocks/hw-path-text.mdx
@@ -3,23 +3,34 @@ title: "Text Along a Path"
 description: "Handwriting flowing along any SVG path with a per-character reveal; the path is the only geometry input"
 ---
 
-# Text Along a Path
-
 Handwriting flowing along any SVG path with a per-character reveal; the path is the only geometry input
 
 `handwritten` `typography` `path` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-path-text.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-path-text.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Text Along a Path block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-path-text
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add hw-path-text
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-path-text.html` | `compositions/hw-path-text.html` | hyperframes:composition |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="hw-path-text" data-composition-src="compositions/hw-path-text.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/hw-pipeline.mdx
+++ b/docs/catalog/blocks/hw-pipeline.mdx
@@ -3,23 +3,34 @@ title: "Hand-Drawn Flowchart"
 description: "Wobbled boxes with handwritten labels joined by curved connectors, drawing on in sequence from a node list"
 ---
 
-# Hand-Drawn Flowchart
-
 Wobbled boxes with handwritten labels joined by curved connectors, drawing on in sequence from a node list
 
 `handwritten` `diagram` `data-viz` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-pipeline.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-pipeline.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Hand-Drawn Flowchart block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-pipeline
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add hw-pipeline
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-pipeline.html` | `compositions/hw-pipeline.html` | hyperframes:composition |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="hw-pipeline" data-composition-src="compositions/hw-pipeline.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/hw-pipeline.mdx
+++ b/docs/catalog/blocks/hw-pipeline.mdx
@@ -3,34 +3,24 @@ title: "Hand-Drawn Flowchart"
 description: "Wobbled boxes with handwritten labels joined by curved connectors, drawing on in sequence from a node list"
 ---
 
-Wobbled boxes with handwritten labels joined by curved connectors, drawing on in sequence from a node list
-
 `handwritten` `diagram` `data-viz` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-pipeline.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-pipeline.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Hand-Drawn Flowchart block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-pipeline
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="hw-pipeline" data-composition-src="compositions/hw-pipeline.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/hw-scribble-transition.mdx
+++ b/docs/catalog/blocks/hw-scribble-transition.mdx
@@ -3,34 +3,24 @@ title: "Scribble Transition"
 description: "Overlay transition: scribble bands accumulate to cover the frame with a solid backstop, the host cuts beneath, and the scribble clears"
 ---
 
-Overlay transition: scribble bands accumulate to cover the frame with a solid backstop, the host cuts beneath, and the scribble clears
-
 `handwritten` `transition` `wipe`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-scribble-transition.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-scribble-transition.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Scribble Transition block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-scribble-transition
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="hw-scribble-transition" data-composition-src="compositions/hw-scribble-transition.html" data-start="0" data-duration="2.2" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/hw-scribble-transition.mdx
+++ b/docs/catalog/blocks/hw-scribble-transition.mdx
@@ -3,23 +3,34 @@ title: "Scribble Transition"
 description: "Overlay transition: scribble bands accumulate to cover the frame with a solid backstop, the host cuts beneath, and the scribble clears"
 ---
 
-# Scribble Transition
-
 Overlay transition: scribble bands accumulate to cover the frame with a solid backstop, the host cuts beneath, and the scribble clears
 
 `handwritten` `transition` `wipe`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-scribble-transition.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-scribble-transition.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Scribble Transition block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-scribble-transition
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add hw-scribble-transition
 | Dimensions | 1920×1080 |
 | Duration | 2.2s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-scribble-transition.html` | `compositions/hw-scribble-transition.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="hw-scribble-transition" data-composition-src="compositions/hw-scribble-transition.html" data-start="0" data-duration="2.2" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/hw-text-cloud.mdx
+++ b/docs/catalog/blocks/hw-text-cloud.mdx
@@ -3,23 +3,34 @@ title: "Speech Bubble"
 description: "Hand-drawn speech bubble with a positionable tail: outline draws on, paper fill fades in, handwritten text types per character; boils"
 ---
 
-# Speech Bubble
-
 Hand-drawn speech bubble with a positionable tail: outline draws on, paper fill fades in, handwritten text types per character; boils
 
 `handwritten` `speech-bubble` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-text-cloud.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-text-cloud.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Speech Bubble block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-text-cloud
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add hw-text-cloud
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-text-cloud.html` | `compositions/hw-text-cloud.html` | hyperframes:composition |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="hw-text-cloud" data-composition-src="compositions/hw-text-cloud.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/hw-text-cloud.mdx
+++ b/docs/catalog/blocks/hw-text-cloud.mdx
@@ -3,34 +3,24 @@ title: "Speech Bubble"
 description: "Hand-drawn speech bubble with a positionable tail: outline draws on, paper fill fades in, handwritten text types per character; boils"
 ---
 
-Hand-drawn speech bubble with a positionable tail: outline draws on, paper fill fades in, handwritten text types per character; boils
-
 `handwritten` `speech-bubble` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-text-cloud.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-text-cloud.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Speech Bubble block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-text-cloud
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="hw-text-cloud" data-composition-src="compositions/hw-text-cloud.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/hw-title.mdx
+++ b/docs/catalog/blocks/hw-title.mdx
@@ -3,34 +3,24 @@ title: "Handwritten Title"
 description: "Handwritten display text with a scalar-driven word-by-word highlight sweep and a seeded squiggle underline sized to the text; boils"
 ---
 
-Handwritten display text with a scalar-driven word-by-word highlight sweep and a seeded squiggle underline sized to the text; boils
-
 `handwritten` `typography` `title-card` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-title.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-title.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Handwritten Title block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-title
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="hw-title" data-composition-src="compositions/hw-title.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/hw-title.mdx
+++ b/docs/catalog/blocks/hw-title.mdx
@@ -3,23 +3,34 @@ title: "Handwritten Title"
 description: "Handwritten display text with a scalar-driven word-by-word highlight sweep and a seeded squiggle underline sized to the text; boils"
 ---
 
-# Handwritten Title
-
 Handwritten display text with a scalar-driven word-by-word highlight sweep and a seeded squiggle underline sized to the text; boils
 
 `handwritten` `typography` `title-card` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-title.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/hw-title.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Handwritten Title block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-title
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add hw-title
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-title.html` | `compositions/hw-title.html` | hyperframes:composition |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="hw-title" data-composition-src="compositions/hw-title.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/instagram-follow.mdx
+++ b/docs/catalog/blocks/instagram-follow.mdx
@@ -3,23 +3,34 @@ title: "Instagram Follow"
 description: "Animated Instagram follow overlay with profile card and follow button"
 ---
 
-# Instagram Follow
-
 Animated Instagram follow overlay with profile card and follow button
 
 `social` `overlay` `instagram`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/instagram-follow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/instagram-follow.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Instagram Follow block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add instagram-follow
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add instagram-follow
 | Dimensions | 1080×1920 |
 | Duration | 4.5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `instagram-follow.html` | `compositions/instagram-follow.html` | hyperframes:composition |
 | `assets/avatar.jpg` | `assets/avatar.jpg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="instagram-follow" data-composition-src="compositions/instagram-follow.html" data-start="0" data-duration="4.5" data-track-index="1" data-width="1080" data-height="1920"></div>

--- a/docs/catalog/blocks/instagram-follow.mdx
+++ b/docs/catalog/blocks/instagram-follow.mdx
@@ -3,34 +3,24 @@ title: "Instagram Follow"
 description: "Animated Instagram follow overlay with profile card and follow button"
 ---
 
-Animated Instagram follow overlay with profile card and follow button
-
 `social` `overlay` `instagram`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/instagram-follow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/instagram-follow.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Instagram Follow block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add instagram-follow
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="instagram-follow" data-composition-src="compositions/instagram-follow.html" data-start="0" data-duration="4.5" data-track-index="1" data-width="1080" data-height="1920"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/ios26-liquid-glass.mdx
+++ b/docs/catalog/blocks/ios26-liquid-glass.mdx
@@ -3,8 +3,6 @@ title: "iOS 26 Liquid Glass Home Screen"
 description: "3D iPhone with a normal iOS 26 home screen, liquid glass app icons, shader wallpaper, dock, and fluid glass notifications that drop from the status area onto a GLTF device model."
 ---
 
-3D iPhone with a normal iOS 26 home screen, liquid glass app icons, shader wallpaper, dock, and fluid glass notifications that drop from the status area onto a GLTF device model.
-
 `liquid-glass-html-in-canvas` `webgpu` `3d` `iphone` `ios26` `notifications` `gltf` `html-in-canvas`
 
 <Warning>
@@ -15,26 +13,18 @@ description: "3D iPhone with a normal iOS 26 home screen, liquid glass app icons
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the iOS 26 Liquid Glass Home Screen block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add ios26-liquid-glass
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -87,3 +77,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="ios26-liquid-glass" data-composition-src="compositions/ios26-liquid-glass.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/ios26-liquid-glass.mdx
+++ b/docs/catalog/blocks/ios26-liquid-glass.mdx
@@ -3,8 +3,6 @@ title: "iOS 26 Liquid Glass Home Screen"
 description: "3D iPhone with a normal iOS 26 home screen, liquid glass app icons, shader wallpaper, dock, and fluid glass notifications that drop from the status area onto a GLTF device model."
 ---
 
-# iOS 26 Liquid Glass Home Screen
-
 3D iPhone with a normal iOS 26 home screen, liquid glass app icons, shader wallpaper, dock, and fluid glass notifications that drop from the status area onto a GLTF device model.
 
 `liquid-glass-html-in-canvas` `webgpu` `3d` `iphone` `ios26` `notifications` `gltf` `html-in-canvas`
@@ -15,15 +13,28 @@ description: "3D iPhone with a normal iOS 26 home screen, liquid glass app icons
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ios26-liquid-glass.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ios26-liquid-glass.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the iOS 26 Liquid Glass Home Screen block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add ios26-liquid-glass
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,17 +44,45 @@ npx hyperframes add ios26-liquid-glass
 | Dimensions | 1920×1080 |
 | Duration | 15s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `ios26-liquid-glass.html` | `compositions/ios26-liquid-glass.html` | hyperframes:composition |
 | `models/iphone.glb` | `models/iphone.glb` | hyperframes:asset |
 | `lib/liquid-glass.iife.js` | `lib/liquid-glass.iife.js` | hyperframes:asset |
+| `assets/icons/weather.jpg` | `assets/icons/weather.jpg` | hyperframes:asset |
+| `assets/icons/stocks.jpg` | `assets/icons/stocks.jpg` | hyperframes:asset |
+| `assets/icons/find-my.jpg` | `assets/icons/find-my.jpg` | hyperframes:asset |
+| `assets/icons/home.jpg` | `assets/icons/home.jpg` | hyperframes:asset |
+| `assets/icons/books.jpg` | `assets/icons/books.jpg` | hyperframes:asset |
+| `assets/icons/itunes-store.jpg` | `assets/icons/itunes-store.jpg` | hyperframes:asset |
+| `assets/icons/fitness.jpg` | `assets/icons/fitness.jpg` | hyperframes:asset |
+| `assets/icons/watch.jpg` | `assets/icons/watch.jpg` | hyperframes:asset |
+| `assets/icons/contacts.jpg` | `assets/icons/contacts.jpg` | hyperframes:asset |
+| `assets/icons/files.jpg` | `assets/icons/files.jpg` | hyperframes:asset |
+| `assets/icons/translate.jpg` | `assets/icons/translate.jpg` | hyperframes:asset |
+| `assets/icons/calendar.jpg` | `assets/icons/calendar.jpg` | hyperframes:asset |
+| `assets/icons/chatgpt.jpg` | `assets/icons/chatgpt.jpg` | hyperframes:asset |
+| `assets/icons/slack.jpg` | `assets/icons/slack.jpg` | hyperframes:asset |
+| `assets/icons/instagram.jpg` | `assets/icons/instagram.jpg` | hyperframes:asset |
+| `assets/icons/x.jpg` | `assets/icons/x.jpg` | hyperframes:asset |
+| `assets/icons/proton-mail.jpg` | `assets/icons/proton-mail.jpg` | hyperframes:asset |
+| `assets/icons/gmail.jpg` | `assets/icons/gmail.jpg` | hyperframes:asset |
+| `assets/icons/revolut.jpg` | `assets/icons/revolut.jpg` | hyperframes:asset |
+| `assets/icons/photos.jpg` | `assets/icons/photos.jpg` | hyperframes:asset |
+| `assets/icons/phone.jpg` | `assets/icons/phone.jpg` | hyperframes:asset |
+| `assets/icons/brave.jpg` | `assets/icons/brave.jpg` | hyperframes:asset |
+| `assets/icons/messages.jpg` | `assets/icons/messages.jpg` | hyperframes:asset |
+| `assets/icons/whatsapp.jpg` | `assets/icons/whatsapp.jpg` | hyperframes:asset |
+| `assets/icons/notify-messages.jpg` | `assets/icons/notify-messages.jpg` | hyperframes:asset |
+| `assets/icons/music.jpg` | `assets/icons/music.jpg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="ios26-liquid-glass" data-composition-src="compositions/ios26-liquid-glass.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/light-leak.mdx
+++ b/docs/catalog/blocks/light-leak.mdx
@@ -3,34 +3,24 @@ title: "Light Leak"
 description: "Shader transition with cinematic light leak overlay"
 ---
 
-Shader transition with cinematic light leak overlay
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/light-leak.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/light-leak.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Light Leak block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add light-leak
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="light-leak" data-composition-src="compositions/light-leak.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/light-leak.mdx
+++ b/docs/catalog/blocks/light-leak.mdx
@@ -3,23 +3,34 @@ title: "Light Leak"
 description: "Shader transition with cinematic light leak overlay"
 ---
 
-# Light Leak
-
 Shader transition with cinematic light leak overlay
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/light-leak.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/light-leak.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Light Leak block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add light-leak
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add light-leak
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `light-leak.html` | `compositions/light-leak.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="light-leak" data-composition-src="compositions/light-leak.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/liquid-glass-context-menu.mdx
+++ b/docs/catalog/blocks/liquid-glass-context-menu.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Context Menu"
 description: "Frosted glass context menu panel drifting over an aurora shader background"
 ---
 
-# Liquid Glass Context Menu
-
 Frosted glass context menu panel drifting over an aurora shader background
 
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
@@ -15,15 +13,28 @@ Frosted glass context menu panel drifting over an aurora shader background
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-context-menu.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-context-menu.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Liquid Glass Context Menu block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add liquid-glass-context-menu
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,18 @@ npx hyperframes add liquid-glass-context-menu
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `liquid-glass-context-menu.html` | `compositions/liquid-glass-context-menu.html` | hyperframes:composition |
+| `lib/liquid-glass.iife.js` | `compositions/lib/liquid-glass.iife.js` | registry:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="liquid-glass-context-menu" data-composition-src="compositions/liquid-glass-context-menu.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/liquid-glass-context-menu.mdx
+++ b/docs/catalog/blocks/liquid-glass-context-menu.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Context Menu"
 description: "Frosted glass context menu panel drifting over an aurora shader background"
 ---
 
-Frosted glass context menu panel drifting over an aurora shader background
-
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
 
 <Warning>
@@ -15,26 +13,18 @@ Frosted glass context menu panel drifting over an aurora shader background
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Liquid Glass Context Menu block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add liquid-glass-context-menu
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -60,3 +50,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="liquid-glass-context-menu" data-composition-src="compositions/liquid-glass-context-menu.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/liquid-glass-media-controls.mdx
+++ b/docs/catalog/blocks/liquid-glass-media-controls.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Media Controls"
 description: "Frosted glass media control panels spreading over an aurora shader background"
 ---
 
-# Liquid Glass Media Controls
-
 Frosted glass media control panels spreading over an aurora shader background
 
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
@@ -15,15 +13,28 @@ Frosted glass media control panels spreading over an aurora shader background
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-media-controls.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-media-controls.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Liquid Glass Media Controls block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add liquid-glass-media-controls
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,18 @@ npx hyperframes add liquid-glass-media-controls
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `liquid-glass-media-controls.html` | `compositions/liquid-glass-media-controls.html` | hyperframes:composition |
+| `lib/liquid-glass.iife.js` | `compositions/lib/liquid-glass.iife.js` | registry:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="liquid-glass-media-controls" data-composition-src="compositions/liquid-glass-media-controls.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/liquid-glass-media-controls.mdx
+++ b/docs/catalog/blocks/liquid-glass-media-controls.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Media Controls"
 description: "Frosted glass media control panels spreading over an aurora shader background"
 ---
 
-Frosted glass media control panels spreading over an aurora shader background
-
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
 
 <Warning>
@@ -15,26 +13,18 @@ Frosted glass media control panels spreading over an aurora shader background
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Liquid Glass Media Controls block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add liquid-glass-media-controls
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -60,3 +50,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="liquid-glass-media-controls" data-composition-src="compositions/liquid-glass-media-controls.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/liquid-glass-notification.mdx
+++ b/docs/catalog/blocks/liquid-glass-notification.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Notification"
 description: "Frosted glass notification cards floating over an aurora shader background"
 ---
 
-# Liquid Glass Notification
-
 Frosted glass notification cards floating over an aurora shader background
 
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
@@ -15,15 +13,28 @@ Frosted glass notification cards floating over an aurora shader background
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-notification.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-notification.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Liquid Glass Notification block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add liquid-glass-notification
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,19 @@ npx hyperframes add liquid-glass-notification
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `liquid-glass-notification.html` | `compositions/liquid-glass-notification.html` | hyperframes:composition |
+| `lib/liquid-glass.iife.js` | `compositions/lib/liquid-glass.iife.js` | registry:asset |
+| `assets/hyperframes-logo-dark.svg` | `compositions/assets/hyperframes-logo-dark.svg` | registry:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="liquid-glass-notification" data-composition-src="compositions/liquid-glass-notification.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/liquid-glass-notification.mdx
+++ b/docs/catalog/blocks/liquid-glass-notification.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Notification"
 description: "Frosted glass notification cards floating over an aurora shader background"
 ---
 
-Frosted glass notification cards floating over an aurora shader background
-
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
 
 <Warning>
@@ -15,26 +13,18 @@ Frosted glass notification cards floating over an aurora shader background
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Liquid Glass Notification block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add liquid-glass-notification
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -61,3 +51,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="liquid-glass-notification" data-composition-src="compositions/liquid-glass-notification.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/liquid-glass-widgets.mdx
+++ b/docs/catalog/blocks/liquid-glass-widgets.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Widgets"
 description: "Frosted glass stat cards, showcase panel and pill chips over an aurora shader background"
 ---
 
-# Liquid Glass Widgets
-
 Frosted glass stat cards, showcase panel and pill chips over an aurora shader background
 
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
@@ -15,15 +13,28 @@ Frosted glass stat cards, showcase panel and pill chips over an aurora shader ba
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-widgets.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/liquid-glass-widgets.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Liquid Glass Widgets block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add liquid-glass-widgets
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,19 @@ npx hyperframes add liquid-glass-widgets
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `liquid-glass-widgets.html` | `compositions/liquid-glass-widgets.html` | hyperframes:composition |
+| `assets/hyperframes-logo-dark.svg` | `compositions/assets/hyperframes-logo-dark.svg` | registry:asset |
+| `lib/liquid-glass.iife.js` | `compositions/lib/liquid-glass.iife.js` | registry:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="liquid-glass-widgets" data-composition-src="compositions/liquid-glass-widgets.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/liquid-glass-widgets.mdx
+++ b/docs/catalog/blocks/liquid-glass-widgets.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass Widgets"
 description: "Frosted glass stat cards, showcase panel and pill chips over an aurora shader background"
 ---
 
-Frosted glass stat cards, showcase panel and pill chips over an aurora shader background
-
 `html-in-canvas` `liquid-glass-html-in-canvas` `webgpu`
 
 <Warning>
@@ -15,26 +13,18 @@ Frosted glass stat cards, showcase panel and pill chips over an aurora shader ba
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Liquid Glass Widgets block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add liquid-glass-widgets
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -61,3 +51,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="liquid-glass-widgets" data-composition-src="compositions/liquid-glass-widgets.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/logo-outro.mdx
+++ b/docs/catalog/blocks/logo-outro.mdx
@@ -3,23 +3,34 @@ title: "Logo Outro"
 description: "Cinematic logo reveal with piece-by-piece assembly, glow bloom, tagline fade-in, and URL pill"
 ---
 
-# Logo Outro
-
 Cinematic logo reveal with piece-by-piece assembly, glow bloom, tagline fade-in, and URL pill
 
 `branding` `outro` `logo`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/logo-outro.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/logo-outro.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Logo Outro block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add logo-outro
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add logo-outro
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `logo-outro.html` | `compositions/logo-outro.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="logo-outro" data-composition-src="compositions/logo-outro.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/logo-outro.mdx
+++ b/docs/catalog/blocks/logo-outro.mdx
@@ -3,34 +3,24 @@ title: "Logo Outro"
 description: "Cinematic logo reveal with piece-by-piece assembly, glow bloom, tagline fade-in, and URL pill"
 ---
 
-Cinematic logo reveal with piece-by-piece assembly, glow bloom, tagline fade-in, and URL pill
-
 `branding` `outro` `logo`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/logo-outro.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/logo-outro.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Logo Outro block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add logo-outro
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="logo-outro" data-composition-src="compositions/logo-outro.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lower-third-bild.mdx
+++ b/docs/catalog/blocks/lower-third-bild.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — BILD Style"
 description: "News-style lower third with tight-fit text boxes: white headline bar with red drop-shadow, red sub-line with white drop-shadow."
 ---
 
-# Lower Third — BILD Style
-
 News-style lower third with tight-fit text boxes: white headline bar with red drop-shadow, red sub-line with white drop-shadow.
 
 `broadcast` `lower-third` `news` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bild.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bild.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — BILD Style block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lower-third-bild
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,7 +40,7 @@ npx hyperframes add lower-third-bild
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
@@ -37,9 +48,11 @@ npx hyperframes add lower-third-bild
 | `assets/fonts/BarlowCondensed-Bold.woff2` | `compositions/assets/fonts/BarlowCondensed-Bold.woff2` | hyperframes:asset |
 | `assets/fonts/BarlowCondensed-ExtraBold.woff2` | `compositions/assets/fonts/BarlowCondensed-ExtraBold.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lower-third-bild" data-composition-src="compositions/lower-third-bild.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lower-third-bild.mdx
+++ b/docs/catalog/blocks/lower-third-bild.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — BILD Style"
 description: "News-style lower third with tight-fit text boxes: white headline bar with red drop-shadow, red sub-line with white drop-shadow."
 ---
 
-News-style lower third with tight-fit text boxes: white headline bar with red drop-shadow, red sub-line with white drop-shadow.
-
 `broadcast` `lower-third` `news` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bild.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bild.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — BILD Style block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lower-third-bild
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -57,3 +47,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lower-third-bild" data-composition-src="compositions/lower-third-bild.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-accent-underline.mdx
+++ b/docs/catalog/blocks/lt-accent-underline.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Accent Underline"
 description: "Cardless lower third for footage overlay: name rises, an accent rule draws left-to-right, role fades in; text-shadowed for legibility"
 ---
 
-# Lower Third — Accent Underline
-
 Cardless lower third for footage overlay: name rises, an accent rule draws left-to-right, role fades in; text-shadowed for legibility
 
 `lower-third` `overlay` `podcast` `interview` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-accent-underline.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-accent-underline.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Accent Underline block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-accent-underline
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-accent-underline
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-accent-underline.html` | `compositions/lt-accent-underline.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-accent-underline" data-composition-src="compositions/lt-accent-underline.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-accent-underline.mdx
+++ b/docs/catalog/blocks/lt-accent-underline.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Accent Underline"
 description: "Cardless lower third for footage overlay: name rises, an accent rule draws left-to-right, role fades in; text-shadowed for legibility"
 ---
 
-Cardless lower third for footage overlay: name rises, an accent rule draws left-to-right, role fades in; text-shadowed for legibility
-
 `lower-third` `overlay` `podcast` `interview` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-accent-underline.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-accent-underline.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Accent Underline block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-accent-underline
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-accent-underline" data-composition-src="compositions/lt-accent-underline.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-bold-block.mdx
+++ b/docs/catalog/blocks/lt-bold-block.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Bold Block"
 description: "High-energy podcast lower third: solid dark block wipes in, uppercase name slams up, accent tag pops"
 ---
 
-# Lower Third — Bold Block
-
 High-energy podcast lower third: solid dark block wipes in, uppercase name slams up, accent tag pops
 
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-bold-block.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-bold-block.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Bold Block block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-bold-block
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-bold-block
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-bold-block.html` | `compositions/lt-bold-block.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-bold-block" data-composition-src="compositions/lt-bold-block.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-bold-block.mdx
+++ b/docs/catalog/blocks/lt-bold-block.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Bold Block"
 description: "High-energy podcast lower third: solid dark block wipes in, uppercase name slams up, accent tag pops"
 ---
 
-High-energy podcast lower third: solid dark block wipes in, uppercase name slams up, accent tag pops
-
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-bold-block.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-bold-block.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Bold Block block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-bold-block
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-bold-block" data-composition-src="compositions/lt-bold-block.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-clean-bar.mdx
+++ b/docs/catalog/blocks/lt-clean-bar.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Clean Bar"
 description: "Minimal white-card lower third for podcasts/interviews: accent tab, name + role, clip-wipe entrance"
 ---
 
-Minimal white-card lower third for podcasts/interviews: accent tab, name + role, clip-wipe entrance
-
 `lower-third` `overlay` `podcast` `interview`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-clean-bar.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-clean-bar.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Clean Bar block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-clean-bar
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-clean-bar" data-composition-src="compositions/lt-clean-bar.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-clean-bar.mdx
+++ b/docs/catalog/blocks/lt-clean-bar.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Clean Bar"
 description: "Minimal white-card lower third for podcasts/interviews: accent tab, name + role, clip-wipe entrance"
 ---
 
-# Lower Third — Clean Bar
-
 Minimal white-card lower third for podcasts/interviews: accent tab, name + role, clip-wipe entrance
 
 `lower-third` `overlay` `podcast` `interview`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-clean-bar.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-clean-bar.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Clean Bar block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-clean-bar
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-clean-bar
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-clean-bar.html` | `compositions/lt-clean-bar.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-clean-bar" data-composition-src="compositions/lt-clean-bar.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-color-block.mdx
+++ b/docs/catalog/blocks/lt-color-block.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Color Block"
 description: "High-energy lower third: bold accent-color block slides in with overshoot, condensed name + mono role"
 ---
 
-High-energy lower third: bold accent-color block slides in with overshoot, condensed name + mono role
-
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-color-block.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-color-block.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Color Block block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-color-block
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-color-block" data-composition-src="compositions/lt-color-block.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-color-block.mdx
+++ b/docs/catalog/blocks/lt-color-block.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Color Block"
 description: "High-energy lower third: bold accent-color block slides in with overshoot, condensed name + mono role"
 ---
 
-# Lower Third — Color Block
-
 High-energy lower third: bold accent-color block slides in with overshoot, condensed name + mono role
 
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-color-block.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-color-block.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Color Block block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-color-block
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-color-block
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-color-block.html` | `compositions/lt-color-block.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-color-block" data-composition-src="compositions/lt-color-block.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-dark-card.mdx
+++ b/docs/catalog/blocks/lt-dark-card.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Dark Card"
 description: "Charcoal card lower third for bright footage: name, drawn accent underline, role; slide-up entrance"
 ---
 
-Charcoal card lower third for bright footage: name, drawn accent underline, role; slide-up entrance
-
 `lower-third` `overlay` `podcast` `interview` `dark`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-dark-card.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-dark-card.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Dark Card block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-dark-card
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-dark-card" data-composition-src="compositions/lt-dark-card.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-dark-card.mdx
+++ b/docs/catalog/blocks/lt-dark-card.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Dark Card"
 description: "Charcoal card lower third for bright footage: name, drawn accent underline, role; slide-up entrance"
 ---
 
-# Lower Third — Dark Card
-
 Charcoal card lower third for bright footage: name, drawn accent underline, role; slide-up entrance
 
 `lower-third` `overlay` `podcast` `interview` `dark`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-dark-card.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-dark-card.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Dark Card block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-dark-card
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-dark-card
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-dark-card.html` | `compositions/lt-dark-card.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-dark-card" data-composition-src="compositions/lt-dark-card.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-kicker-name.mdx
+++ b/docs/catalog/blocks/lt-kicker-name.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Kicker Name"
 description: "Cardless lower third with an accent eyebrow/kicker tag, heavy name, and a drawn baseline; for footage"
 ---
 
-# Lower Third — Kicker Name
-
 Cardless lower third with an accent eyebrow/kicker tag, heavy name, and a drawn baseline; for footage
 
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-kicker-name.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-kicker-name.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Kicker Name block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-kicker-name
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-kicker-name
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-kicker-name.html` | `compositions/lt-kicker-name.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-kicker-name" data-composition-src="compositions/lt-kicker-name.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-kicker-name.mdx
+++ b/docs/catalog/blocks/lt-kicker-name.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Kicker Name"
 description: "Cardless lower third with an accent eyebrow/kicker tag, heavy name, and a drawn baseline; for footage"
 ---
 
-Cardless lower third with an accent eyebrow/kicker tag, heavy name, and a drawn baseline; for footage
-
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-kicker-name.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-kicker-name.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Kicker Name block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-kicker-name
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-kicker-name" data-composition-src="compositions/lt-kicker-name.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-mask-reveal.mdx
+++ b/docs/catalog/blocks/lt-mask-reveal.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Mask Reveal"
 description: "Cardless lower third: an accent sweep crosses and clip-path-reveals a heavy name, role fades up; for footage"
 ---
 
-# Lower Third — Mask Reveal
-
 Cardless lower third: an accent sweep crosses and clip-path-reveals a heavy name, role fades up; for footage
 
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-mask-reveal.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-mask-reveal.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Mask Reveal block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-mask-reveal
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-mask-reveal
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-mask-reveal.html` | `compositions/lt-mask-reveal.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-mask-reveal" data-composition-src="compositions/lt-mask-reveal.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-mask-reveal.mdx
+++ b/docs/catalog/blocks/lt-mask-reveal.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Mask Reveal"
 description: "Cardless lower third: an accent sweep crosses and clip-path-reveals a heavy name, role fades up; for footage"
 ---
 
-Cardless lower third: an accent sweep crosses and clip-path-reveals a heavy name, role fades up; for footage
-
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-mask-reveal.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-mask-reveal.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Mask Reveal block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-mask-reveal
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-mask-reveal" data-composition-src="compositions/lt-mask-reveal.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-side-rule.mdx
+++ b/docs/catalog/blocks/lt-side-rule.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Side Rule"
 description: "Cardless lower third with a vertical accent bar; condensed display name + mono role, text-shadowed for footage"
 ---
 
-# Lower Third — Side Rule
-
 Cardless lower third with a vertical accent bar; condensed display name + mono role, text-shadowed for footage
 
 `lower-third` `overlay` `podcast` `interview` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-side-rule.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-side-rule.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Side Rule block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-side-rule
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-side-rule
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-side-rule.html` | `compositions/lt-side-rule.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-side-rule" data-composition-src="compositions/lt-side-rule.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-side-rule.mdx
+++ b/docs/catalog/blocks/lt-side-rule.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Side Rule"
 description: "Cardless lower third with a vertical accent bar; condensed display name + mono role, text-shadowed for footage"
 ---
 
-Cardless lower third with a vertical accent bar; condensed display name + mono role, text-shadowed for footage
-
 `lower-third` `overlay` `podcast` `interview` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-side-rule.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-side-rule.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Side Rule block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-side-rule
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-side-rule" data-composition-src="compositions/lt-side-rule.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-soft-pill.mdx
+++ b/docs/catalog/blocks/lt-soft-pill.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Soft Pill"
 description: "Rounded white pill lower third for podcasts/interviews: status dot, name + role, scale-pop entrance"
 ---
 
-Rounded white pill lower third for podcasts/interviews: status dot, name + role, scale-pop entrance
-
 `lower-third` `overlay` `podcast` `interview` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-soft-pill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-soft-pill.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Soft Pill block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-soft-pill
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-soft-pill" data-composition-src="compositions/lt-soft-pill.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/lt-soft-pill.mdx
+++ b/docs/catalog/blocks/lt-soft-pill.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Soft Pill"
 description: "Rounded white pill lower third for podcasts/interviews: status dot, name + role, scale-pop entrance"
 ---
 
-# Lower Third — Soft Pill
-
 Rounded white pill lower third for podcasts/interviews: status dot, name + role, scale-pop entrance
 
 `lower-third` `overlay` `podcast` `interview` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-soft-pill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-soft-pill.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Soft Pill block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-soft-pill
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-soft-pill
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-soft-pill.html` | `compositions/lt-soft-pill.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-soft-pill" data-composition-src="compositions/lt-soft-pill.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-stack-bars.mdx
+++ b/docs/catalog/blocks/lt-stack-bars.mdx
@@ -3,23 +3,34 @@ title: "Lower Third — Stack Bars"
 description: "Two stacked bars: a dark name bar wipes from the left, an accent role bar wipes from the right"
 ---
 
-# Lower Third — Stack Bars
-
 Two stacked bars: a dark name bar wipes from the left, an accent role bar wipes from the right
 
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-stack-bars.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-stack-bars.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Lower Third — Stack Bars block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add lt-stack-bars
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add lt-stack-bars
 | Dimensions | 1920×1080 |
 | Duration | 4.8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `lt-stack-bars.html` | `compositions/lt-stack-bars.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="lt-stack-bars" data-composition-src="compositions/lt-stack-bars.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/lt-stack-bars.mdx
+++ b/docs/catalog/blocks/lt-stack-bars.mdx
@@ -3,34 +3,24 @@ title: "Lower Third — Stack Bars"
 description: "Two stacked bars: a dark name bar wipes from the left, an accent role bar wipes from the right"
 ---
 
-Two stacked bars: a dark name bar wipes from the left, an accent role bar wipes from the right
-
 `lower-third` `overlay` `podcast` `interview` `bold`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-stack-bars.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lt-stack-bars.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Lower Third — Stack Bars block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add lt-stack-bars
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="lt-stack-bars" data-composition-src="compositions/lt-stack-bars.html" data-start="0" data-duration="4.8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/macos-notification.mdx
+++ b/docs/catalog/blocks/macos-notification.mdx
@@ -3,23 +3,34 @@ title: "macOS Notification"
 description: "Animated macOS-style notification banner with app icon and message"
 ---
 
-# macOS Notification
-
 Animated macOS-style notification banner with app icon and message
 
 `social` `overlay` `notification`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/macos-notification.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/macos-notification.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the macOS Notification block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add macos-notification
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add macos-notification
 | Dimensions | 1920×1080 |
 | Duration | 5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `macos-notification.html` | `compositions/macos-notification.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="macos-notification" data-composition-src="compositions/macos-notification.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/macos-notification.mdx
+++ b/docs/catalog/blocks/macos-notification.mdx
@@ -3,34 +3,24 @@ title: "macOS Notification"
 description: "Animated macOS-style notification banner with app icon and message"
 ---
 
-Animated macOS-style notification banner with app icon and message
-
 `social` `overlay` `notification`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/macos-notification.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/macos-notification.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the macOS Notification block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add macos-notification
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="macos-notification" data-composition-src="compositions/macos-notification.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/macos-tahoe-liquid-glass.mdx
+++ b/docs/catalog/blocks/macos-tahoe-liquid-glass.mdx
@@ -3,8 +3,6 @@ title: "macOS Tahoe Liquid Glass Desktop"
 description: "3D MacBook with a macOS Tahoe-style desktop, glass menu bar, Finder window, dock, and cinematic device camera move."
 ---
 
-3D MacBook with a macOS Tahoe-style desktop, glass menu bar, Finder window, dock, and cinematic device camera move.
-
 `html-in-canvas` `3d` `macos` `tahoe` `gltf`
 
 <Warning>
@@ -15,26 +13,18 @@ description: "3D MacBook with a macOS Tahoe-style desktop, glass menu bar, Finde
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the macOS Tahoe Liquid Glass Desktop block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add macos-tahoe-liquid-glass
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -77,3 +67,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="macos-tahoe-liquid-glass" data-composition-src="compositions/macos-tahoe-liquid-glass.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/macos-tahoe-liquid-glass.mdx
+++ b/docs/catalog/blocks/macos-tahoe-liquid-glass.mdx
@@ -3,8 +3,6 @@ title: "macOS Tahoe Liquid Glass Desktop"
 description: "3D MacBook with a macOS Tahoe-style desktop, glass menu bar, Finder window, dock, and cinematic device camera move."
 ---
 
-# macOS Tahoe Liquid Glass Desktop
-
 3D MacBook with a macOS Tahoe-style desktop, glass menu bar, Finder window, dock, and cinematic device camera move.
 
 `html-in-canvas` `3d` `macos` `tahoe` `gltf`
@@ -15,15 +13,28 @@ description: "3D MacBook with a macOS Tahoe-style desktop, glass menu bar, Finde
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/macos-tahoe-liquid-glass.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/macos-tahoe-liquid-glass.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the macOS Tahoe Liquid Glass Desktop block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add macos-tahoe-liquid-glass
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,17 +44,35 @@ npx hyperframes add macos-tahoe-liquid-glass
 | Dimensions | 1920×1080 |
 | Duration | 15s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `macos-tahoe-liquid-glass.html` | `compositions/macos-tahoe-liquid-glass.html` | hyperframes:composition |
 | `models/macbook.glb` | `models/macbook.glb` | hyperframes:asset |
-| `models/iphone.glb` | `models/iphone.glb` | hyperframes:asset |
+| `assets/wallpapers/golden-gate-bridge-san-francisco-5k-0g.jpg` | `assets/wallpapers/golden-gate-bridge-san-francisco-5k-0g.jpg` | hyperframes:asset |
+| `assets/icons/finder.png` | `assets/icons/finder.png` | hyperframes:asset |
+| `assets/icons/safari.jpg` | `assets/icons/safari.jpg` | hyperframes:asset |
+| `assets/icons/mail.jpg` | `assets/icons/mail.jpg` | hyperframes:asset |
+| `assets/icons/calendar.jpg` | `assets/icons/calendar.jpg` | hyperframes:asset |
+| `assets/icons/photos.jpg` | `assets/icons/photos.jpg` | hyperframes:asset |
+| `assets/icons/messages.jpg` | `assets/icons/messages.jpg` | hyperframes:asset |
+| `assets/icons/toast-messages.jpg` | `assets/icons/toast-messages.jpg` | hyperframes:asset |
+| `assets/icons/music.jpg` | `assets/icons/music.jpg` | hyperframes:asset |
+| `assets/icons/brave.jpg` | `assets/icons/brave.jpg` | hyperframes:asset |
+| `assets/icons/slack.jpg` | `assets/icons/slack.jpg` | hyperframes:asset |
+| `assets/icons/files.jpg` | `assets/icons/files.jpg` | hyperframes:asset |
+| `assets/icons/dock-finder.png` | `assets/icons/dock-finder.png` | hyperframes:asset |
+| `assets/icons/dock-safari.jpg` | `assets/icons/dock-safari.jpg` | hyperframes:asset |
+| `assets/icons/dock-mail.jpg` | `assets/icons/dock-mail.jpg` | hyperframes:asset |
+| `assets/icons/dock-photos.jpg` | `assets/icons/dock-photos.jpg` | hyperframes:asset |
+| `assets/icons/dock-music.jpg` | `assets/icons/dock-music.jpg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="macos-tahoe-liquid-glass" data-composition-src="compositions/macos-tahoe-liquid-glass.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-background.mdx
+++ b/docs/catalog/blocks/mk-background.mdx
@@ -3,34 +3,24 @@ title: "Minimal Gradient Background"
 description: "Procedural soft-blob gradient backdrop in a minimalist presentation style: two radial blobs drifting over a base color, with an animatable rounded-card bar mask and optional frosted-glass mode"
 ---
 
-Procedural soft-blob gradient backdrop in a minimalist presentation style: two radial blobs drifting over a base color, with an animatable rounded-card bar mask and optional frosted-glass mode
-
 `background` `gradient` `minimal` `professional` `presentation`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-background.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-background.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Minimal Gradient Background block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-background
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="mk-background" data-composition-src="compositions/mk-background.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/mk-background.mdx
+++ b/docs/catalog/blocks/mk-background.mdx
@@ -3,23 +3,34 @@ title: "Minimal Gradient Background"
 description: "Procedural soft-blob gradient backdrop in a minimalist presentation style: two radial blobs drifting over a base color, with an animatable rounded-card bar mask and optional frosted-glass mode"
 ---
 
-# Minimal Gradient Background
-
 Procedural soft-blob gradient backdrop in a minimalist presentation style: two radial blobs drifting over a base color, with an animatable rounded-card bar mask and optional frosted-glass mode
 
 `background` `gradient` `minimal` `professional` `presentation`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-background.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-background.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Minimal Gradient Background block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-background
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add mk-background
 | Dimensions | 1920×1080 |
 | Duration | 10s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-background.html` | `compositions/mk-background.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="mk-background" data-composition-src="compositions/mk-background.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-callout-highlight.mdx
+++ b/docs/catalog/blocks/mk-callout-highlight.mdx
@@ -3,34 +3,24 @@ title: "Word-Sweep Highlight"
 description: "A sentence whose word-by-word emphasis is driven by a single scalar — tween it to sync the highlight with a voiceover"
 ---
 
-A sentence whose word-by-word emphasis is driven by a single scalar — tween it to sync the highlight with a voiceover
-
 `typography` `karaoke` `captions` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-callout-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-callout-highlight.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Word-Sweep Highlight block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-callout-highlight
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="mk-callout-highlight" data-composition-src="compositions/mk-callout-highlight.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/mk-callout-highlight.mdx
+++ b/docs/catalog/blocks/mk-callout-highlight.mdx
@@ -3,23 +3,34 @@ title: "Word-Sweep Highlight"
 description: "A sentence whose word-by-word emphasis is driven by a single scalar — tween it to sync the highlight with a voiceover"
 ---
 
-# Word-Sweep Highlight
-
 A sentence whose word-by-word emphasis is driven by a single scalar — tween it to sync the highlight with a voiceover
 
 `typography` `karaoke` `captions` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-callout-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-callout-highlight.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Word-Sweep Highlight block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-callout-highlight
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add mk-callout-highlight
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-callout-highlight.html` | `compositions/mk-callout-highlight.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="mk-callout-highlight" data-composition-src="compositions/mk-callout-highlight.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-clone-wall-transition.mdx
+++ b/docs/catalog/blocks/mk-clone-wall-transition.mdx
@@ -3,23 +3,34 @@ title: "Text Clone Wall Transition"
 description: "Overlay transition: a tiled word wall covers the frame, inverts via difference blending, and clears — hard-cut the content beneath while covered"
 ---
 
-# Text Clone Wall Transition
-
 Overlay transition: a tiled word wall covers the frame, inverts via difference blending, and clears — hard-cut the content beneath while covered
 
 `transition` `typography` `wipe`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-clone-wall-transition.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-clone-wall-transition.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Text Clone Wall Transition block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-clone-wall-transition
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add mk-clone-wall-transition
 | Dimensions | 1920×1080 |
 | Duration | 2.4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-clone-wall-transition.html` | `compositions/mk-clone-wall-transition.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="mk-clone-wall-transition" data-composition-src="compositions/mk-clone-wall-transition.html" data-start="0" data-duration="2.4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-clone-wall-transition.mdx
+++ b/docs/catalog/blocks/mk-clone-wall-transition.mdx
@@ -3,34 +3,24 @@ title: "Text Clone Wall Transition"
 description: "Overlay transition: a tiled word wall covers the frame, inverts via difference blending, and clears — hard-cut the content beneath while covered"
 ---
 
-Overlay transition: a tiled word wall covers the frame, inverts via difference blending, and clears — hard-cut the content beneath while covered
-
 `transition` `typography` `wipe`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-clone-wall-transition.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-clone-wall-transition.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Text Clone Wall Transition block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-clone-wall-transition
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="mk-clone-wall-transition" data-composition-src="compositions/mk-clone-wall-transition.html" data-start="0" data-duration="2.4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/mk-line-graph.mdx
+++ b/docs/catalog/blocks/mk-line-graph.mdx
@@ -3,23 +3,34 @@ title: "Minimal Line Graph"
 description: "One or two SVG series draw on with dots popping and value labels riding the draw front; dim baseline axis, x-labels, color-dot legend"
 ---
 
-# Minimal Line Graph
-
 One or two SVG series draw on with dots popping and value labels riding the draw front; dim baseline axis, x-labels, color-dot legend
 
 `data-viz` `chart` `graph` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-line-graph.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-line-graph.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Minimal Line Graph block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-line-graph
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add mk-line-graph
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-line-graph.html` | `compositions/mk-line-graph.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="mk-line-graph" data-composition-src="compositions/mk-line-graph.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-line-graph.mdx
+++ b/docs/catalog/blocks/mk-line-graph.mdx
@@ -3,34 +3,24 @@ title: "Minimal Line Graph"
 description: "One or two SVG series draw on with dots popping and value labels riding the draw front; dim baseline axis, x-labels, color-dot legend"
 ---
 
-One or two SVG series draw on with dots popping and value labels riding the draw front; dim baseline axis, x-labels, color-dot legend
-
 `data-viz` `chart` `graph` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-line-graph.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-line-graph.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Minimal Line Graph block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-line-graph
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="mk-line-graph" data-composition-src="compositions/mk-line-graph.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/mk-placeholder-grid.mdx
+++ b/docs/catalog/blocks/mk-placeholder-grid.mdx
@@ -3,34 +3,24 @@ title: "Rounded Media Grid"
 description: "N-up rounded-corner media grid (2-up, 3-up, 4-up, 3x2, hero plus two): per-cell inside-scale framing, staggered box-in entrance, slow settle"
 ---
 
-N-up rounded-corner media grid (2-up, 3-up, 4-up, 3x2, hero plus two): per-cell inside-scale framing, staggered box-in entrance, slow settle
-
 `placeholder` `media` `grid` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-placeholder-grid.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-placeholder-grid.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Rounded Media Grid block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-placeholder-grid
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="mk-placeholder-grid" data-composition-src="compositions/mk-placeholder-grid.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/mk-placeholder-grid.mdx
+++ b/docs/catalog/blocks/mk-placeholder-grid.mdx
@@ -3,23 +3,34 @@ title: "Rounded Media Grid"
 description: "N-up rounded-corner media grid (2-up, 3-up, 4-up, 3x2, hero plus two): per-cell inside-scale framing, staggered box-in entrance, slow settle"
 ---
 
-# Rounded Media Grid
-
 N-up rounded-corner media grid (2-up, 3-up, 4-up, 3x2, hero plus two): per-cell inside-scale framing, staggered box-in entrance, slow settle
 
 `placeholder` `media` `grid` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-placeholder-grid.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-placeholder-grid.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Rounded Media Grid block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-placeholder-grid
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add mk-placeholder-grid
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-placeholder-grid.html` | `compositions/mk-placeholder-grid.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="mk-placeholder-grid" data-composition-src="compositions/mk-placeholder-grid.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-progress-stat.mdx
+++ b/docs/catalog/blocks/mk-progress-stat.mdx
@@ -3,34 +3,24 @@ title: "Count-Up Stat Card"
 description: "Big-numeral statistic with count-up, label, thin progress track filling to value/max, and caption; light and dark schemes"
 ---
 
-Big-numeral statistic with count-up, label, thin progress track filling to value/max, and caption; light and dark schemes
-
 `data-viz` `stat` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-progress-stat.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-progress-stat.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Count-Up Stat Card block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-progress-stat
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="mk-progress-stat" data-composition-src="compositions/mk-progress-stat.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/mk-progress-stat.mdx
+++ b/docs/catalog/blocks/mk-progress-stat.mdx
@@ -3,23 +3,34 @@ title: "Count-Up Stat Card"
 description: "Big-numeral statistic with count-up, label, thin progress track filling to value/max, and caption; light and dark schemes"
 ---
 
-# Count-Up Stat Card
-
 Big-numeral statistic with count-up, label, thin progress track filling to value/max, and caption; light and dark schemes
 
 `data-viz` `stat` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-progress-stat.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-progress-stat.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Count-Up Stat Card block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-progress-stat
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add mk-progress-stat
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-progress-stat.html` | `compositions/mk-progress-stat.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="mk-progress-stat" data-composition-src="compositions/mk-progress-stat.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-specs-list.mdx
+++ b/docs/catalog/blocks/mk-specs-list.mdx
@@ -3,23 +3,34 @@ title: "Specs Checklist"
 description: "Left-aligned specs/traits checklist over footage or a board: rows slide in staggered with an accent underline sweep; light and dark schemes"
 ---
 
-# Specs Checklist
-
 Left-aligned specs/traits checklist over footage or a board: rows slide in staggered with an accent underline sweep; light and dark schemes
 
 `data-viz` `list` `minimal` `professional`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-specs-list.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-specs-list.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Specs Checklist block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-specs-list
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add mk-specs-list
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-specs-list.html` | `compositions/mk-specs-list.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="mk-specs-list" data-composition-src="compositions/mk-specs-list.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/mk-specs-list.mdx
+++ b/docs/catalog/blocks/mk-specs-list.mdx
@@ -3,34 +3,24 @@ title: "Specs Checklist"
 description: "Left-aligned specs/traits checklist over footage or a board: rows slide in staggered with an accent underline sweep; light and dark schemes"
 ---
 
-Left-aligned specs/traits checklist over footage or a board: rows slide in staggered with an accent underline sweep; light and dark schemes
-
 `data-viz` `list` `minimal` `professional`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-specs-list.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/mk-specs-list.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Specs Checklist block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-specs-list
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="mk-specs-list" data-composition-src="compositions/mk-specs-list.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/news-ticker.mdx
+++ b/docs/catalog/blocks/news-ticker.mdx
@@ -3,23 +3,34 @@ title: "News Ticker"
 description: "Premium broadcast-style lower-third ticker with live label, headline ribbon, and scrolling news crawl."
 ---
 
-# News Ticker
-
 Premium broadcast-style lower-third ticker with live label, headline ribbon, and scrolling news crawl.
 
 `lower-third` `overlay` `news` `ticker`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/news-ticker.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/news-ticker.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the News Ticker block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add news-ticker
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add news-ticker
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `news-ticker.html` | `compositions/news-ticker.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="news-ticker" data-composition-src="compositions/news-ticker.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/news-ticker.mdx
+++ b/docs/catalog/blocks/news-ticker.mdx
@@ -3,34 +3,24 @@ title: "News Ticker"
 description: "Premium broadcast-style lower-third ticker with live label, headline ribbon, and scrolling news crawl."
 ---
 
-Premium broadcast-style lower-third ticker with live label, headline ribbon, and scrolling news crawl.
-
 `lower-third` `overlay` `news` `ticker`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/news-ticker.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/news-ticker.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the News Ticker block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add news-ticker
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="news-ticker" data-composition-src="compositions/news-ticker.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/north-korea-locked-down.mdx
+++ b/docs/catalog/blocks/north-korea-locked-down.mdx
@@ -3,8 +3,6 @@ title: "North Korea Locked Down"
 description: "Realistic map zoom into North Korea with a red scribble circle, locked-down pop-up label, and reddish editorial wash."
 ---
 
-# North Korea Locked Down
-
 Realistic map zoom into North Korea with a red scribble circle, locked-down pop-up label, and reddish editorial wash.
 
 `showcase` `map` `annotation` `youtube` `kinetic`
@@ -19,15 +17,28 @@ use 📷HyperFrames by HeyGen and Image Gen  if you need it for assets or like p
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/north-korea-locked-down.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/north-korea-locked-down.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the North Korea Locked Down block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add north-korea-locked-down
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -37,16 +48,18 @@ npx hyperframes add north-korea-locked-down
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `north-korea-locked-down.html` | `compositions/north-korea-locked-down.html` | hyperframes:composition |
 | `assets/korea-map.png` | `assets/korea-map.png` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="north-korea-locked-down" data-composition-src="compositions/north-korea-locked-down.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/north-korea-locked-down.mdx
+++ b/docs/catalog/blocks/north-korea-locked-down.mdx
@@ -3,8 +3,6 @@ title: "North Korea Locked Down"
 description: "Realistic map zoom into North Korea with a red scribble circle, locked-down pop-up label, and reddish editorial wash."
 ---
 
-Realistic map zoom into North Korea with a red scribble circle, locked-down pop-up label, and reddish editorial wash.
-
 `showcase` `map` `annotation` `youtube` `kinetic`
 
 Created by [Stronkter](https://x.com/Stronkter).
@@ -19,26 +17,18 @@ use 📷HyperFrames by HeyGen and Image Gen  if you need it for assets or like p
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the North Korea Locked Down block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add north-korea-locked-down
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -64,3 +54,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="north-korea-locked-down" data-composition-src="compositions/north-korea-locked-down.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/nyc-paris-flight.mdx
+++ b/docs/catalog/blocks/nyc-paris-flight.mdx
@@ -3,8 +3,6 @@ title: "NYC Paris Flight"
 description: "Apple-style realistic map animation with a plane flying from New York to Paris, marker circle, landing pop, and sound effects."
 ---
 
-Apple-style realistic map animation with a plane flying from New York to Paris, marker circle, landing pop, and sound effects.
-
 `showcase` `travel` `map` `youtube` `sfx`
 
 Created by [Stronkter](https://x.com/Stronkter).
@@ -19,26 +17,18 @@ Created by [Stronkter](https://x.com/Stronkter).
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the NYC Paris Flight block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add nyc-paris-flight
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -65,3 +55,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="nyc-paris-flight" data-composition-src="compositions/nyc-paris-flight.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/nyc-paris-flight.mdx
+++ b/docs/catalog/blocks/nyc-paris-flight.mdx
@@ -3,8 +3,6 @@ title: "NYC Paris Flight"
 description: "Apple-style realistic map animation with a plane flying from New York to Paris, marker circle, landing pop, and sound effects."
 ---
 
-# NYC Paris Flight
-
 Apple-style realistic map animation with a plane flying from New York to Paris, marker circle, landing pop, and sound effects.
 
 `showcase` `travel` `map` `youtube` `sfx`
@@ -19,15 +17,28 @@ Created by [Stronkter](https://x.com/Stronkter).
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/nyc-paris-flight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/nyc-paris-flight.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the NYC Paris Flight block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add nyc-paris-flight
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -37,7 +48,7 @@ npx hyperframes add nyc-paris-flight
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
@@ -45,9 +56,11 @@ npx hyperframes add nyc-paris-flight
 | `assets/map-nyc-paris.png` | `assets/map-nyc-paris.png` | hyperframes:asset |
 | `assets/sfx-mix.wav` | `assets/sfx-mix.wav` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="nyc-paris-flight" data-composition-src="compositions/nyc-paris-flight.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/organic-light-leak-overlay.mdx
+++ b/docs/catalog/blocks/organic-light-leak-overlay.mdx
@@ -3,23 +3,34 @@ title: "Organic Light Leak Overlay"
 description: "Finite CSS light-leak overlay for memory beats and motivated transitions"
 ---
 
-# Organic Light Leak Overlay
-
 Finite CSS light-leak overlay for memory beats and motivated transitions
 
 `light-leak` `film` `memory` `transition` `overlay` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/organic-light-leak-overlay.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/organic-light-leak-overlay.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Organic Light Leak Overlay block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add organic-light-leak-overlay
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add organic-light-leak-overlay
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `organic-light-leak-overlay.html` | `compositions/organic-light-leak-overlay.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="organic-light-leak-overlay" data-composition-src="compositions/organic-light-leak-overlay.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/organic-light-leak-overlay.mdx
+++ b/docs/catalog/blocks/organic-light-leak-overlay.mdx
@@ -3,34 +3,24 @@ title: "Organic Light Leak Overlay"
 description: "Finite CSS light-leak overlay for memory beats and motivated transitions"
 ---
 
-Finite CSS light-leak overlay for memory beats and motivated transitions
-
 `light-leak` `film` `memory` `transition` `overlay` `media-treatment-overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/organic-light-leak-overlay.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/organic-light-leak-overlay.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Organic Light Leak Overlay block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add organic-light-leak-overlay
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="organic-light-leak-overlay" data-composition-src="compositions/organic-light-leak-overlay.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/reddit-post.mdx
+++ b/docs/catalog/blocks/reddit-post.mdx
@@ -3,34 +3,24 @@ title: "Reddit Post Card"
 description: "Animated Reddit post card overlay with upvotes and comments"
 ---
 
-Animated Reddit post card overlay with upvotes and comments
-
 `social` `overlay` `reddit`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/reddit-post.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/reddit-post.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Reddit Post Card block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add reddit-post
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="reddit-post" data-composition-src="compositions/reddit-post.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/reddit-post.mdx
+++ b/docs/catalog/blocks/reddit-post.mdx
@@ -3,23 +3,34 @@ title: "Reddit Post Card"
 description: "Animated Reddit post card overlay with upvotes and comments"
 ---
 
-# Reddit Post Card
-
 Animated Reddit post card overlay with upvotes and comments
 
 `social` `overlay` `reddit`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/reddit-post.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/reddit-post.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Reddit Post Card block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add reddit-post
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add reddit-post
 | Dimensions | 1920×1080 |
 | Duration | 5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `reddit-post.html` | `compositions/reddit-post.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="reddit-post" data-composition-src="compositions/reddit-post.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/ridged-burn.mdx
+++ b/docs/catalog/blocks/ridged-burn.mdx
@@ -3,34 +3,24 @@ title: "Ridged Burn"
 description: "Shader transition with ridged turbulence burn effect"
 ---
 
-Shader transition with ridged turbulence burn effect
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ridged-burn.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ridged-burn.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Ridged Burn block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add ridged-burn
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="ridged-burn" data-composition-src="compositions/ridged-burn.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/ridged-burn.mdx
+++ b/docs/catalog/blocks/ridged-burn.mdx
@@ -3,23 +3,34 @@ title: "Ridged Burn"
 description: "Shader transition with ridged turbulence burn effect"
 ---
 
-# Ridged Burn
-
 Shader transition with ridged turbulence burn effect
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ridged-burn.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ridged-burn.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Ridged Burn block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add ridged-burn
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add ridged-burn
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `ridged-burn.html` | `compositions/ridged-burn.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="ridged-burn" data-composition-src="compositions/ridged-burn.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/ripple-waves.mdx
+++ b/docs/catalog/blocks/ripple-waves.mdx
@@ -3,34 +3,24 @@ title: "Ripple Waves"
 description: "Shader transition with concentric ripple wave distortion"
 ---
 
-Shader transition with concentric ripple wave distortion
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ripple-waves.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ripple-waves.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Ripple Waves block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add ripple-waves
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="ripple-waves" data-composition-src="compositions/ripple-waves.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/ripple-waves.mdx
+++ b/docs/catalog/blocks/ripple-waves.mdx
@@ -3,23 +3,34 @@ title: "Ripple Waves"
 description: "Shader transition with concentric ripple wave distortion"
 ---
 
-# Ripple Waves
-
 Shader transition with concentric ripple wave distortion
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ripple-waves.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ripple-waves.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Ripple Waves block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add ripple-waves
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add ripple-waves
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `ripple-waves.html` | `compositions/ripple-waves.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="ripple-waves" data-composition-src="compositions/ripple-waves.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/sdf-iris.mdx
+++ b/docs/catalog/blocks/sdf-iris.mdx
@@ -3,34 +3,24 @@ title: "SDF Iris"
 description: "Shader transition with signed distance field iris reveal"
 ---
 
-Shader transition with signed distance field iris reveal
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/sdf-iris.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/sdf-iris.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the SDF Iris block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add sdf-iris
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="sdf-iris" data-composition-src="compositions/sdf-iris.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/sdf-iris.mdx
+++ b/docs/catalog/blocks/sdf-iris.mdx
@@ -3,23 +3,34 @@ title: "SDF Iris"
 description: "Shader transition with signed distance field iris reveal"
 ---
 
-# SDF Iris
-
 Shader transition with signed distance field iris reveal
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/sdf-iris.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/sdf-iris.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the SDF Iris block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add sdf-iris
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add sdf-iris
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `sdf-iris.html` | `compositions/sdf-iris.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="sdf-iris" data-composition-src="compositions/sdf-iris.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/spain-map.mdx
+++ b/docs/catalog/blocks/spain-map.mdx
@@ -3,23 +3,34 @@ title: "Spain Map"
 description: "Animated Spain choropleth by autonomous community with staggered reveals and gradient legend — D3 conic conformal projection"
 ---
 
-# Spain Map
-
 Animated Spain choropleth by autonomous community with staggered reveals and gradient legend — D3 conic conformal projection
 
 `data` `map` `geography` `spain` `europe` `choropleth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spain-map.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spain-map.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Spain Map block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add spain-map
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add spain-map
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `spain-map.html` | `compositions/spain-map.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="spain-map" data-composition-src="compositions/spain-map.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/spain-map.mdx
+++ b/docs/catalog/blocks/spain-map.mdx
@@ -3,34 +3,24 @@ title: "Spain Map"
 description: "Animated Spain choropleth by autonomous community with staggered reveals and gradient legend — D3 conic conformal projection"
 ---
 
-Animated Spain choropleth by autonomous community with staggered reveals and gradient legend — D3 conic conformal projection
-
 `data` `map` `geography` `spain` `europe` `choropleth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spain-map.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spain-map.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Spain Map block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add spain-map
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="spain-map" data-composition-src="compositions/spain-map.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/spotify-card.mdx
+++ b/docs/catalog/blocks/spotify-card.mdx
@@ -3,34 +3,24 @@ title: "Spotify Now Playing"
 description: "Animated Spotify now-playing card with album art and progress bar"
 ---
 
-Animated Spotify now-playing card with album art and progress bar
-
 `social` `overlay` `spotify`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spotify-card.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spotify-card.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Spotify Now Playing block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add spotify-card
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="spotify-card" data-composition-src="compositions/spotify-card.html" data-start="0" data-duration="5" data-track-index="1" data-width="1080" data-height="1920"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/spotify-card.mdx
+++ b/docs/catalog/blocks/spotify-card.mdx
@@ -3,23 +3,34 @@ title: "Spotify Now Playing"
 description: "Animated Spotify now-playing card with album art and progress bar"
 ---
 
-# Spotify Now Playing
-
 Animated Spotify now-playing card with album art and progress bar
 
 `social` `overlay` `spotify`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spotify-card.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/spotify-card.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Spotify Now Playing block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add spotify-card
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add spotify-card
 | Dimensions | 1080×1920 |
 | Duration | 5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `spotify-card.html` | `compositions/spotify-card.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="spotify-card" data-composition-src="compositions/spotify-card.html" data-start="0" data-duration="5" data-track-index="1" data-width="1080" data-height="1920"></div>

--- a/docs/catalog/blocks/swirl-vortex.mdx
+++ b/docs/catalog/blocks/swirl-vortex.mdx
@@ -3,34 +3,24 @@ title: "Swirl Vortex"
 description: "Shader transition with swirling vortex distortion"
 ---
 
-Shader transition with swirling vortex distortion
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/swirl-vortex.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/swirl-vortex.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Swirl Vortex block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add swirl-vortex
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="swirl-vortex" data-composition-src="compositions/swirl-vortex.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/swirl-vortex.mdx
+++ b/docs/catalog/blocks/swirl-vortex.mdx
@@ -3,23 +3,34 @@ title: "Swirl Vortex"
 description: "Shader transition with swirling vortex distortion"
 ---
 
-# Swirl Vortex
-
 Shader transition with swirling vortex distortion
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/swirl-vortex.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/swirl-vortex.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Swirl Vortex block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add swirl-vortex
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add swirl-vortex
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `swirl-vortex.html` | `compositions/swirl-vortex.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="swirl-vortex" data-composition-src="compositions/swirl-vortex.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/thermal-distortion.mdx
+++ b/docs/catalog/blocks/thermal-distortion.mdx
@@ -3,34 +3,24 @@ title: "Thermal Distortion"
 description: "Shader transition with heat haze thermal distortion"
 ---
 
-Shader transition with heat haze thermal distortion
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/thermal-distortion.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/thermal-distortion.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Thermal Distortion block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add thermal-distortion
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="thermal-distortion" data-composition-src="compositions/thermal-distortion.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/thermal-distortion.mdx
+++ b/docs/catalog/blocks/thermal-distortion.mdx
@@ -3,23 +3,34 @@ title: "Thermal Distortion"
 description: "Shader transition with heat haze thermal distortion"
 ---
 
-# Thermal Distortion
-
 Shader transition with heat haze thermal distortion
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/thermal-distortion.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/thermal-distortion.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Thermal Distortion block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add thermal-distortion
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add thermal-distortion
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `thermal-distortion.html` | `compositions/thermal-distortion.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="thermal-distortion" data-composition-src="compositions/thermal-distortion.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/tiktok-follow.mdx
+++ b/docs/catalog/blocks/tiktok-follow.mdx
@@ -3,23 +3,34 @@ title: "TikTok Follow"
 description: "Animated TikTok follow overlay with profile card and follow button"
 ---
 
-# TikTok Follow
-
 Animated TikTok follow overlay with profile card and follow button
 
 `social` `overlay` `tiktok`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/tiktok-follow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/tiktok-follow.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the TikTok Follow block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add tiktok-follow
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add tiktok-follow
 | Dimensions | 1080×1920 |
 | Duration | 4.5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `tiktok-follow.html` | `compositions/tiktok-follow.html` | hyperframes:composition |
 | `assets/avatar.jpg` | `assets/avatar.jpg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="tiktok-follow" data-composition-src="compositions/tiktok-follow.html" data-start="0" data-duration="4.5" data-track-index="1" data-width="1080" data-height="1920"></div>

--- a/docs/catalog/blocks/tiktok-follow.mdx
+++ b/docs/catalog/blocks/tiktok-follow.mdx
@@ -3,34 +3,24 @@ title: "TikTok Follow"
 description: "Animated TikTok follow overlay with profile card and follow button"
 ---
 
-Animated TikTok follow overlay with profile card and follow button
-
 `social` `overlay` `tiktok`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/tiktok-follow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/tiktok-follow.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the TikTok Follow block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add tiktok-follow
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="tiktok-follow" data-composition-src="compositions/tiktok-follow.html" data-start="0" data-duration="4.5" data-track-index="1" data-width="1080" data-height="1920"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-3d.mdx
+++ b/docs/catalog/blocks/transitions-3d.mdx
@@ -3,34 +3,24 @@ title: "3D Transitions"
 description: "Showcase of 3D perspective flip and rotate transitions"
 ---
 
-Showcase of 3D perspective flip and rotate transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-3d.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-3d.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the 3D Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-3d
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-3d" data-composition-src="compositions/transitions-3d.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-3d.mdx
+++ b/docs/catalog/blocks/transitions-3d.mdx
@@ -3,23 +3,34 @@ title: "3D Transitions"
 description: "Showcase of 3D perspective flip and rotate transitions"
 ---
 
-# 3D Transitions
-
 Showcase of 3D perspective flip and rotate transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-3d.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-3d.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the 3D Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-3d
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-3d
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-3d.html` | `compositions/transitions-3d.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-3d" data-composition-src="compositions/transitions-3d.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-blur.mdx
+++ b/docs/catalog/blocks/transitions-blur.mdx
@@ -3,34 +3,24 @@ title: "Blur Transitions"
 description: "Showcase of blur-based transitions between scenes"
 ---
 
-Showcase of blur-based transitions between scenes
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-blur.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-blur.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Blur Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-blur
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-blur" data-composition-src="compositions/transitions-blur.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-blur.mdx
+++ b/docs/catalog/blocks/transitions-blur.mdx
@@ -3,23 +3,34 @@ title: "Blur Transitions"
 description: "Showcase of blur-based transitions between scenes"
 ---
 
-# Blur Transitions
-
 Showcase of blur-based transitions between scenes
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-blur.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-blur.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Blur Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-blur
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-blur
 | Dimensions | 1920×1080 |
 | Duration | 20s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-blur.html` | `compositions/transitions-blur.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-blur" data-composition-src="compositions/transitions-blur.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-cover.mdx
+++ b/docs/catalog/blocks/transitions-cover.mdx
@@ -3,34 +3,24 @@ title: "Cover Transitions"
 description: "Showcase of cover/uncover slide transitions"
 ---
 
-Showcase of cover/uncover slide transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-cover.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-cover.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Cover Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-cover
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-cover" data-composition-src="compositions/transitions-cover.html" data-start="0" data-duration="21" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-cover.mdx
+++ b/docs/catalog/blocks/transitions-cover.mdx
@@ -3,23 +3,34 @@ title: "Cover Transitions"
 description: "Showcase of cover/uncover slide transitions"
 ---
 
-# Cover Transitions
-
 Showcase of cover/uncover slide transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-cover.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-cover.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Cover Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-cover
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-cover
 | Dimensions | 1920×1080 |
 | Duration | 21s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-cover.html` | `compositions/transitions-cover.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-cover" data-composition-src="compositions/transitions-cover.html" data-start="0" data-duration="21" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-destruction.mdx
+++ b/docs/catalog/blocks/transitions-destruction.mdx
@@ -3,34 +3,24 @@ title: "Destruction Transitions"
 description: "Showcase of destructive break-apart transitions"
 ---
 
-Showcase of destructive break-apart transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-destruction.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-destruction.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Destruction Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-destruction
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-destruction" data-composition-src="compositions/transitions-destruction.html" data-start="0" data-duration="14" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-destruction.mdx
+++ b/docs/catalog/blocks/transitions-destruction.mdx
@@ -3,23 +3,34 @@ title: "Destruction Transitions"
 description: "Showcase of destructive break-apart transitions"
 ---
 
-# Destruction Transitions
-
 Showcase of destructive break-apart transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-destruction.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-destruction.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Destruction Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-destruction
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-destruction
 | Dimensions | 1920×1080 |
 | Duration | 14s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-destruction.html` | `compositions/transitions-destruction.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-destruction" data-composition-src="compositions/transitions-destruction.html" data-start="0" data-duration="14" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-dissolve.mdx
+++ b/docs/catalog/blocks/transitions-dissolve.mdx
@@ -3,23 +3,34 @@ title: "Dissolve Transitions"
 description: "Showcase of dissolve and fade transitions"
 ---
 
-# Dissolve Transitions
-
 Showcase of dissolve and fade transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-dissolve.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-dissolve.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Dissolve Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-dissolve
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-dissolve
 | Dimensions | 1920×1080 |
 | Duration | 24s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-dissolve.html` | `compositions/transitions-dissolve.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-dissolve" data-composition-src="compositions/transitions-dissolve.html" data-start="0" data-duration="24" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-dissolve.mdx
+++ b/docs/catalog/blocks/transitions-dissolve.mdx
@@ -3,34 +3,24 @@ title: "Dissolve Transitions"
 description: "Showcase of dissolve and fade transitions"
 ---
 
-Showcase of dissolve and fade transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-dissolve.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-dissolve.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Dissolve Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-dissolve
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-dissolve" data-composition-src="compositions/transitions-dissolve.html" data-start="0" data-duration="24" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-distortion.mdx
+++ b/docs/catalog/blocks/transitions-distortion.mdx
@@ -3,23 +3,34 @@ title: "Distortion Transitions"
 description: "Showcase of warp and distortion transitions"
 ---
 
-# Distortion Transitions
-
 Showcase of warp and distortion transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-distortion.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-distortion.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Distortion Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-distortion
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-distortion
 | Dimensions | 1920×1080 |
 | Duration | 21s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-distortion.html` | `compositions/transitions-distortion.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-distortion" data-composition-src="compositions/transitions-distortion.html" data-start="0" data-duration="21" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-distortion.mdx
+++ b/docs/catalog/blocks/transitions-distortion.mdx
@@ -3,34 +3,24 @@ title: "Distortion Transitions"
 description: "Showcase of warp and distortion transitions"
 ---
 
-Showcase of warp and distortion transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-distortion.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-distortion.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Distortion Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-distortion
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-distortion" data-composition-src="compositions/transitions-distortion.html" data-start="0" data-duration="21" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-grid.mdx
+++ b/docs/catalog/blocks/transitions-grid.mdx
@@ -3,34 +3,24 @@ title: "Grid Transitions"
 description: "Showcase of grid-based tile transitions"
 ---
 
-Showcase of grid-based tile transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-grid.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-grid.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Grid Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-grid
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-grid" data-composition-src="compositions/transitions-grid.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-grid.mdx
+++ b/docs/catalog/blocks/transitions-grid.mdx
@@ -3,23 +3,34 @@ title: "Grid Transitions"
 description: "Showcase of grid-based tile transitions"
 ---
 
-# Grid Transitions
-
 Showcase of grid-based tile transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-grid.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-grid.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Grid Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-grid
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-grid
 | Dimensions | 1920×1080 |
 | Duration | 11s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-grid.html` | `compositions/transitions-grid.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-grid" data-composition-src="compositions/transitions-grid.html" data-start="0" data-duration="11" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-light.mdx
+++ b/docs/catalog/blocks/transitions-light.mdx
@@ -3,23 +3,34 @@ title: "Light Transitions"
 description: "Showcase of light-based glow and flash transitions"
 ---
 
-# Light Transitions
-
 Showcase of light-based glow and flash transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-light.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Light Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-light
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-light
 | Dimensions | 1920×1080 |
 | Duration | 21s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-light.html` | `compositions/transitions-light.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-light" data-composition-src="compositions/transitions-light.html" data-start="0" data-duration="21" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-light.mdx
+++ b/docs/catalog/blocks/transitions-light.mdx
@@ -3,34 +3,24 @@ title: "Light Transitions"
 description: "Showcase of light-based glow and flash transitions"
 ---
 
-Showcase of light-based glow and flash transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-light.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-light.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Light Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-light
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-light" data-composition-src="compositions/transitions-light.html" data-start="0" data-duration="21" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-mechanical.mdx
+++ b/docs/catalog/blocks/transitions-mechanical.mdx
@@ -3,34 +3,24 @@ title: "Mechanical Transitions"
 description: "Showcase of mechanical shutter and iris transitions"
 ---
 
-Showcase of mechanical shutter and iris transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-mechanical.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-mechanical.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Mechanical Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-mechanical
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-mechanical" data-composition-src="compositions/transitions-mechanical.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-mechanical.mdx
+++ b/docs/catalog/blocks/transitions-mechanical.mdx
@@ -3,23 +3,34 @@ title: "Mechanical Transitions"
 description: "Showcase of mechanical shutter and iris transitions"
 ---
 
-# Mechanical Transitions
-
 Showcase of mechanical shutter and iris transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-mechanical.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-mechanical.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Mechanical Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-mechanical
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-mechanical
 | Dimensions | 1920×1080 |
 | Duration | 15s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-mechanical.html` | `compositions/transitions-mechanical.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-mechanical" data-composition-src="compositions/transitions-mechanical.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-other.mdx
+++ b/docs/catalog/blocks/transitions-other.mdx
@@ -3,23 +3,34 @@ title: "Other Transitions"
 description: "Showcase of miscellaneous creative transitions"
 ---
 
-# Other Transitions
-
 Showcase of miscellaneous creative transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-other.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-other.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Other Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-other
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-other
 | Dimensions | 1920×1080 |
 | Duration | 20s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-other.html` | `compositions/transitions-other.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-other" data-composition-src="compositions/transitions-other.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-other.mdx
+++ b/docs/catalog/blocks/transitions-other.mdx
@@ -3,34 +3,24 @@ title: "Other Transitions"
 description: "Showcase of miscellaneous creative transitions"
 ---
 
-Showcase of miscellaneous creative transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-other.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-other.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Other Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-other
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-other" data-composition-src="compositions/transitions-other.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-push.mdx
+++ b/docs/catalog/blocks/transitions-push.mdx
@@ -3,23 +3,34 @@ title: "Push Transitions"
 description: "Showcase of push and slide transitions"
 ---
 
-# Push Transitions
-
 Showcase of push and slide transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-push.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-push.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Push Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-push
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-push
 | Dimensions | 1920×1080 |
 | Duration | 24s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-push.html` | `compositions/transitions-push.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-push" data-composition-src="compositions/transitions-push.html" data-start="0" data-duration="24" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-push.mdx
+++ b/docs/catalog/blocks/transitions-push.mdx
@@ -3,34 +3,24 @@ title: "Push Transitions"
 description: "Showcase of push and slide transitions"
 ---
 
-Showcase of push and slide transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-push.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-push.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Push Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-push
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-push" data-composition-src="compositions/transitions-push.html" data-start="0" data-duration="24" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-radial.mdx
+++ b/docs/catalog/blocks/transitions-radial.mdx
@@ -3,23 +3,34 @@ title: "Radial Transitions"
 description: "Showcase of radial wipe and reveal transitions"
 ---
 
-# Radial Transitions
-
 Showcase of radial wipe and reveal transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-radial.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-radial.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Radial Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-radial
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-radial
 | Dimensions | 1920×1080 |
 | Duration | 20s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-radial.html` | `compositions/transitions-radial.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-radial" data-composition-src="compositions/transitions-radial.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/transitions-radial.mdx
+++ b/docs/catalog/blocks/transitions-radial.mdx
@@ -3,34 +3,24 @@ title: "Radial Transitions"
 description: "Showcase of radial wipe and reveal transitions"
 ---
 
-Showcase of radial wipe and reveal transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-radial.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-radial.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Radial Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-radial
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-radial" data-composition-src="compositions/transitions-radial.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-scale.mdx
+++ b/docs/catalog/blocks/transitions-scale.mdx
@@ -3,34 +3,24 @@ title: "Scale Transitions"
 description: "Showcase of scale and zoom transitions"
 ---
 
-Showcase of scale and zoom transitions
-
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-scale.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-scale.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Scale Transitions block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add transitions-scale
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="transitions-scale" data-composition-src="compositions/transitions-scale.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/transitions-scale.mdx
+++ b/docs/catalog/blocks/transitions-scale.mdx
@@ -3,23 +3,34 @@ title: "Scale Transitions"
 description: "Showcase of scale and zoom transitions"
 ---
 
-# Scale Transitions
-
 Showcase of scale and zoom transitions
 
 `transition` `showcase`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-scale.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/transitions-scale.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Scale Transitions block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add transitions-scale
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add transitions-scale
 | Dimensions | 1920×1080 |
 | Duration | 15s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `transitions-scale.html` | `compositions/transitions-scale.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="transitions-scale" data-composition-src="compositions/transitions-scale.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/ui-3d-reveal.mdx
+++ b/docs/catalog/blocks/ui-3d-reveal.mdx
@@ -3,34 +3,24 @@ title: "3D UI Reveal"
 description: "Perspective 3D reveal animation for UI elements"
 ---
 
-Perspective 3D reveal animation for UI elements
-
 `showcase` `3d` `reveal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ui-3d-reveal.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ui-3d-reveal.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the 3D UI Reveal block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add ui-3d-reveal
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="ui-3d-reveal" data-composition-src="compositions/ui-3d-reveal.html" data-start="0" data-duration="13" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/ui-3d-reveal.mdx
+++ b/docs/catalog/blocks/ui-3d-reveal.mdx
@@ -3,23 +3,34 @@ title: "3D UI Reveal"
 description: "Perspective 3D reveal animation for UI elements"
 ---
 
-# 3D UI Reveal
-
 Perspective 3D reveal animation for UI elements
 
 `showcase` `3d` `reveal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ui-3d-reveal.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/ui-3d-reveal.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the 3D UI Reveal block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add ui-3d-reveal
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add ui-3d-reveal
 | Dimensions | 1920×1080 |
 | Duration | 13s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `ui-3d-reveal.html` | `compositions/ui-3d-reveal.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="ui-3d-reveal" data-composition-src="compositions/ui-3d-reveal.html" data-start="0" data-duration="13" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/us-map-bubble.mdx
+++ b/docs/catalog/blocks/us-map-bubble.mdx
@@ -3,34 +3,24 @@ title: "US Bubble Map"
 description: "Animated US bubble map with proportional city markers, value callouts, and connection lines — composable with us-map"
 ---
 
-Animated US bubble map with proportional city markers, value callouts, and connection lines — composable with us-map
-
 `data` `map` `geography` `usa` `bubble` `cities`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-bubble.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-bubble.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the US Bubble Map block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add us-map-bubble
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="us-map-bubble" data-composition-src="compositions/us-map-bubble.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/us-map-bubble.mdx
+++ b/docs/catalog/blocks/us-map-bubble.mdx
@@ -3,23 +3,34 @@ title: "US Bubble Map"
 description: "Animated US bubble map with proportional city markers, value callouts, and connection lines — composable with us-map"
 ---
 
-# US Bubble Map
-
 Animated US bubble map with proportional city markers, value callouts, and connection lines — composable with us-map
 
 `data` `map` `geography` `usa` `bubble` `cities`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-bubble.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-bubble.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the US Bubble Map block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add us-map-bubble
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add us-map-bubble
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `us-map-bubble.html` | `compositions/us-map-bubble.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="us-map-bubble" data-composition-src="compositions/us-map-bubble.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/us-map-flow.mdx
+++ b/docs/catalog/blocks/us-map-flow.mdx
@@ -3,34 +3,24 @@ title: "US Flow Map"
 description: "Animated connection arcs between US cities over a base map — composable origin-destination flow visualization"
 ---
 
-Animated connection arcs between US cities over a base map — composable origin-destination flow visualization
-
 `data` `map` `geography` `usa` `flow` `connections` `arcs`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-flow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-flow.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the US Flow Map block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add us-map-flow
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="us-map-flow" data-composition-src="compositions/us-map-flow.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/us-map-flow.mdx
+++ b/docs/catalog/blocks/us-map-flow.mdx
@@ -3,23 +3,34 @@ title: "US Flow Map"
 description: "Animated connection arcs between US cities over a base map — composable origin-destination flow visualization"
 ---
 
-# US Flow Map
-
 Animated connection arcs between US cities over a base map — composable origin-destination flow visualization
 
 `data` `map` `geography` `usa` `flow` `connections` `arcs`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-flow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-flow.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the US Flow Map block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add us-map-flow
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add us-map-flow
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `us-map-flow.html` | `compositions/us-map-flow.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="us-map-flow" data-composition-src="compositions/us-map-flow.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/us-map-hex.mdx
+++ b/docs/catalog/blocks/us-map-hex.mdx
@@ -3,34 +3,24 @@ title: "US Hex Grid Map"
 description: "Animated hexagonal tile grid map — each state as an equal-weight hex with data fill and abbreviation label"
 ---
 
-Animated hexagonal tile grid map — each state as an equal-weight hex with data fill and abbreviation label
-
 `data` `map` `geography` `usa` `hexgrid` `tilegrid`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-hex.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-hex.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the US Hex Grid Map block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add us-map-hex
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="us-map-hex" data-composition-src="compositions/us-map-hex.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/us-map-hex.mdx
+++ b/docs/catalog/blocks/us-map-hex.mdx
@@ -3,23 +3,34 @@ title: "US Hex Grid Map"
 description: "Animated hexagonal tile grid map — each state as an equal-weight hex with data fill and abbreviation label"
 ---
 
-# US Hex Grid Map
-
 Animated hexagonal tile grid map — each state as an equal-weight hex with data fill and abbreviation label
 
 `data` `map` `geography` `usa` `hexgrid` `tilegrid`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-hex.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map-hex.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the US Hex Grid Map block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add us-map-hex
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add us-map-hex
 | Dimensions | 1920×1080 |
 | Duration | 10s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `us-map-hex.html` | `compositions/us-map-hex.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="us-map-hex" data-composition-src="compositions/us-map-hex.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/us-map.mdx
+++ b/docs/catalog/blocks/us-map.mdx
@@ -3,34 +3,24 @@ title: "US Map"
 description: "Animated US choropleth map with staggered state reveals, value labels, and gradient legend — pure inline SVG with GSAP"
 ---
 
-Animated US choropleth map with staggered state reveals, value labels, and gradient legend — pure inline SVG with GSAP
-
 `data` `map` `geography` `usa` `choropleth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the US Map block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add us-map
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="us-map" data-composition-src="compositions/us-map.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/us-map.mdx
+++ b/docs/catalog/blocks/us-map.mdx
@@ -3,23 +3,34 @@ title: "US Map"
 description: "Animated US choropleth map with staggered state reveals, value labels, and gradient legend — pure inline SVG with GSAP"
 ---
 
-# US Map
-
 Animated US choropleth map with staggered state reveals, value labels, and gradient legend — pure inline SVG with GSAP
 
 `data` `map` `geography` `usa` `choropleth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/us-map.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the US Map block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add us-map
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add us-map
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `us-map.html` | `compositions/us-map.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="us-map" data-composition-src="compositions/us-map.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-iphone-device.mdx
+++ b/docs/catalog/blocks/vfx-iphone-device.mdx
@@ -3,8 +3,6 @@ title: "iPhone & MacBook 3D Showcase"
 description: "Real GLTF iPhone 15 Pro Max and MacBook Pro models with live HTML-in-Canvas screen content, morphing glass lens, product review camera choreography, and 360° turntable."
 ---
 
-# iPhone & MacBook 3D Showcase
-
 Real GLTF iPhone 15 Pro Max and MacBook Pro models with live HTML-in-Canvas screen content, morphing glass lens, product review camera choreography, and 360° turntable.
 
 `html-in-canvas` `3d` `device` `iphone` `macbook` `gltf`
@@ -15,15 +13,28 @@ Real GLTF iPhone 15 Pro Max and MacBook Pro models with live HTML-in-Canvas scre
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-iphone-device.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-iphone-device.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the iPhone & MacBook 3D Showcase block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vfx-iphone-device
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,7 +44,7 @@ npx hyperframes add vfx-iphone-device
 | Dimensions | 1920×1080 |
 | Duration | 15s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
@@ -43,9 +54,11 @@ npx hyperframes add vfx-iphone-device
 | `models/hyperframes-mobile.png` | `models/hyperframes-mobile.png` | asset |
 | `models/hyperframes-desktop.png` | `models/hyperframes-desktop.png` | asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vfx-iphone-device" data-composition-src="compositions/vfx-iphone-device.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-iphone-device.mdx
+++ b/docs/catalog/blocks/vfx-iphone-device.mdx
@@ -3,8 +3,6 @@ title: "iPhone & MacBook 3D Showcase"
 description: "Real GLTF iPhone 15 Pro Max and MacBook Pro models with live HTML-in-Canvas screen content, morphing glass lens, product review camera choreography, and 360° turntable."
 ---
 
-Real GLTF iPhone 15 Pro Max and MacBook Pro models with live HTML-in-Canvas screen content, morphing glass lens, product review camera choreography, and 360° turntable.
-
 `html-in-canvas` `3d` `device` `iphone` `macbook` `gltf`
 
 <Warning>
@@ -15,26 +13,18 @@ Real GLTF iPhone 15 Pro Max and MacBook Pro models with live HTML-in-Canvas scre
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the iPhone & MacBook 3D Showcase block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vfx-iphone-device
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -63,3 +53,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vfx-iphone-device" data-composition-src="compositions/vfx-iphone-device.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/vfx-liquid-background.mdx
+++ b/docs/catalog/blocks/vfx-liquid-background.mdx
@@ -3,8 +3,6 @@ title: "Liquid Background"
 description: "Organic liquid simulation with vertex displacement on a subdivided plane. HTML content floats above rippling fluid surface with real-time wave dynamics."
 ---
 
-Organic liquid simulation with vertex displacement on a subdivided plane. HTML content floats above rippling fluid surface with real-time wave dynamics.
-
 `html-in-canvas` `liquid` `webgl` `displacement` `background`
 
 <Warning>
@@ -15,26 +13,18 @@ Organic liquid simulation with vertex displacement on a subdivided plane. HTML c
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Liquid Background block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vfx-liquid-background
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -59,3 +49,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vfx-liquid-background" data-composition-src="compositions/vfx-liquid-background.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/vfx-liquid-background.mdx
+++ b/docs/catalog/blocks/vfx-liquid-background.mdx
@@ -3,8 +3,6 @@ title: "Liquid Background"
 description: "Organic liquid simulation with vertex displacement on a subdivided plane. HTML content floats above rippling fluid surface with real-time wave dynamics."
 ---
 
-# Liquid Background
-
 Organic liquid simulation with vertex displacement on a subdivided plane. HTML content floats above rippling fluid surface with real-time wave dynamics.
 
 `html-in-canvas` `liquid` `webgl` `displacement` `background`
@@ -15,15 +13,28 @@ Organic liquid simulation with vertex displacement on a subdivided plane. HTML c
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-background.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-background.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Liquid Background block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vfx-liquid-background
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,17 @@ npx hyperframes add vfx-liquid-background
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vfx-liquid-background.html` | `compositions/vfx-liquid-background.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vfx-liquid-background" data-composition-src="compositions/vfx-liquid-background.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-liquid-glass.mdx
+++ b/docs/catalog/blocks/vfx-liquid-glass.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass"
 description: "VFX composition block"
 ---
 
-VFX composition block
-
 `html-in-canvas` `webgl`
 
 <Warning>
@@ -15,26 +13,18 @@ VFX composition block
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Liquid Glass block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vfx-liquid-glass
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -59,3 +49,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vfx-liquid-glass" data-composition-src="compositions/vfx-liquid-glass.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/vfx-liquid-glass.mdx
+++ b/docs/catalog/blocks/vfx-liquid-glass.mdx
@@ -3,8 +3,6 @@ title: "Liquid Glass"
 description: "VFX composition block"
 ---
 
-# Liquid Glass
-
 VFX composition block
 
 `html-in-canvas` `webgl`
@@ -15,15 +13,28 @@ VFX composition block
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-glass.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-liquid-glass.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Liquid Glass block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vfx-liquid-glass
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,17 @@ npx hyperframes add vfx-liquid-glass
 | Dimensions | 1920×1080 |
 | Duration | 20s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vfx-liquid-glass.html` | `compositions/vfx-liquid-glass.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vfx-liquid-glass" data-composition-src="compositions/vfx-liquid-glass.html" data-start="0" data-duration="20" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-magnetic.mdx
+++ b/docs/catalog/blocks/vfx-magnetic.mdx
@@ -3,8 +3,6 @@ title: "Magnetic"
 description: "VFX composition block"
 ---
 
-# Magnetic
-
 VFX composition block
 
 `html-in-canvas` `webgl`
@@ -15,15 +13,28 @@ VFX composition block
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-magnetic.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-magnetic.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Magnetic block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vfx-magnetic
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,17 @@ npx hyperframes add vfx-magnetic
 | Dimensions | 1920×1080 |
 | Duration | 15s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vfx-magnetic.html` | `compositions/vfx-magnetic.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vfx-magnetic" data-composition-src="compositions/vfx-magnetic.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-magnetic.mdx
+++ b/docs/catalog/blocks/vfx-magnetic.mdx
@@ -3,8 +3,6 @@ title: "Magnetic"
 description: "VFX composition block"
 ---
 
-VFX composition block
-
 `html-in-canvas` `webgl`
 
 <Warning>
@@ -15,26 +13,18 @@ VFX composition block
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Magnetic block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vfx-magnetic
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -59,3 +49,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vfx-magnetic" data-composition-src="compositions/vfx-magnetic.html" data-start="0" data-duration="15" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/vfx-portal.mdx
+++ b/docs/catalog/blocks/vfx-portal.mdx
@@ -3,8 +3,6 @@ title: "Portal"
 description: "VFX composition block"
 ---
 
-# Portal
-
 VFX composition block
 
 `html-in-canvas` `webgl`
@@ -15,15 +13,28 @@ VFX composition block
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-portal.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-portal.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Portal block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vfx-portal
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,17 @@ npx hyperframes add vfx-portal
 | Dimensions | 1920×1080 |
 | Duration | 10s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vfx-portal.html` | `compositions/vfx-portal.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vfx-portal" data-composition-src="compositions/vfx-portal.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-portal.mdx
+++ b/docs/catalog/blocks/vfx-portal.mdx
@@ -3,8 +3,6 @@ title: "Portal"
 description: "VFX composition block"
 ---
 
-VFX composition block
-
 `html-in-canvas` `webgl`
 
 <Warning>
@@ -15,26 +13,18 @@ VFX composition block
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Portal block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vfx-portal
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -59,3 +49,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vfx-portal" data-composition-src="compositions/vfx-portal.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/vfx-shatter.mdx
+++ b/docs/catalog/blocks/vfx-shatter.mdx
@@ -3,8 +3,6 @@ title: "Shatter"
 description: "VFX composition block"
 ---
 
-# Shatter
-
 VFX composition block
 
 `html-in-canvas` `webgl`
@@ -15,15 +13,28 @@ VFX composition block
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-shatter.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-shatter.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Shatter block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vfx-shatter
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,17 @@ npx hyperframes add vfx-shatter
 | Dimensions | 1920×1080 |
 | Duration | 12s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vfx-shatter.html` | `compositions/vfx-shatter.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vfx-shatter" data-composition-src="compositions/vfx-shatter.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-shatter.mdx
+++ b/docs/catalog/blocks/vfx-shatter.mdx
@@ -3,8 +3,6 @@ title: "Shatter"
 description: "VFX composition block"
 ---
 
-VFX composition block
-
 `html-in-canvas` `webgl`
 
 <Warning>
@@ -15,26 +13,18 @@ VFX composition block
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Shatter block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vfx-shatter
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -59,3 +49,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vfx-shatter" data-composition-src="compositions/vfx-shatter.html" data-start="0" data-duration="12" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/vfx-text-cursor.mdx
+++ b/docs/catalog/blocks/vfx-text-cursor.mdx
@@ -3,8 +3,6 @@ title: "VFX Text Cursor"
 description: "Dramatic text reveal with cursor glow, chromatic shadow rays, and directional lighting on a black stage. Canvas-based shader post-processing with spectral color edges."
 ---
 
-# VFX Text Cursor
-
 Dramatic text reveal with cursor glow, chromatic shadow rays, and directional lighting on a black stage. Canvas-based shader post-processing with spectral color edges.
 
 `html-in-canvas` `text` `shader` `cursor` `chromatic`
@@ -15,15 +13,28 @@ Dramatic text reveal with cursor glow, chromatic shadow rays, and directional li
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-text-cursor.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vfx-text-cursor.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the VFX Text Cursor block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vfx-text-cursor
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -33,15 +44,17 @@ npx hyperframes add vfx-text-cursor
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vfx-text-cursor.html` | `compositions/vfx-text-cursor.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vfx-text-cursor" data-composition-src="compositions/vfx-text-cursor.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vfx-text-cursor.mdx
+++ b/docs/catalog/blocks/vfx-text-cursor.mdx
@@ -3,8 +3,6 @@ title: "VFX Text Cursor"
 description: "Dramatic text reveal with cursor glow, chromatic shadow rays, and directional lighting on a black stage. Canvas-based shader post-processing with spectral color edges."
 ---
 
-Dramatic text reveal with cursor glow, chromatic shadow rays, and directional lighting on a black stage. Canvas-based shader post-processing with spectral color edges.
-
 `html-in-canvas` `text` `shader` `cursor` `chromatic`
 
 <Warning>
@@ -15,26 +13,18 @@ Dramatic text reveal with cursor glow, chromatic shadow rays, and directional li
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the VFX Text Cursor block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vfx-text-cursor
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -59,3 +49,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vfx-text-cursor" data-composition-src="compositions/vfx-text-cursor.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/vpn-youtube-spot.mdx
+++ b/docs/catalog/blocks/vpn-youtube-spot.mdx
@@ -3,8 +3,6 @@ title: "VPN YouTube Spot"
 description: "Snappy Apple-style YouTube insert showing a phone finding and installing a friendly VPN app with sound effects."
 ---
 
-# VPN YouTube Spot
-
 Snappy Apple-style YouTube insert showing a phone finding and installing a friendly VPN app with sound effects.
 
 `app` `showcase` `youtube` `sfx`
@@ -19,15 +17,28 @@ HyperFrames by HeyGen make me a 7s video with Apple-style bold font and styling:
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vpn-youtube-spot.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/vpn-youtube-spot.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the VPN YouTube Spot block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vpn-youtube-spot
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -37,16 +48,18 @@ npx hyperframes add vpn-youtube-spot
 | Dimensions | 1920×1080 |
 | Duration | 7s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vpn-youtube-spot.html` | `compositions/vpn-youtube-spot.html` | hyperframes:composition |
 | `assets/vpn-sfx.wav` | `assets/vpn-sfx.wav` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="vpn-youtube-spot" data-composition-src="compositions/vpn-youtube-spot.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/vpn-youtube-spot.mdx
+++ b/docs/catalog/blocks/vpn-youtube-spot.mdx
@@ -3,8 +3,6 @@ title: "VPN YouTube Spot"
 description: "Snappy Apple-style YouTube insert showing a phone finding and installing a friendly VPN app with sound effects."
 ---
 
-Snappy Apple-style YouTube insert showing a phone finding and installing a friendly VPN app with sound effects.
-
 `app` `showcase` `youtube` `sfx`
 
 Created by [Stronkter](https://x.com/Stronkter).
@@ -19,26 +17,18 @@ HyperFrames by HeyGen make me a 7s video with Apple-style bold font and styling:
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the VPN YouTube Spot block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vpn-youtube-spot
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -64,3 +54,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="vpn-youtube-spot" data-composition-src="compositions/vpn-youtube-spot.html" data-start="0" data-duration="7" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/whip-pan.mdx
+++ b/docs/catalog/blocks/whip-pan.mdx
@@ -3,23 +3,34 @@ title: "Whip Pan"
 description: "Shader transition simulating a fast camera whip pan"
 ---
 
-# Whip Pan
-
 Shader transition simulating a fast camera whip pan
 
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/whip-pan.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/whip-pan.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Whip Pan block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add whip-pan
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add whip-pan
 | Dimensions | 1920×1080 |
 | Duration | 4s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `whip-pan.html` | `compositions/whip-pan.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="whip-pan" data-composition-src="compositions/whip-pan.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/whip-pan.mdx
+++ b/docs/catalog/blocks/whip-pan.mdx
@@ -3,34 +3,24 @@ title: "Whip Pan"
 description: "Shader transition simulating a fast camera whip pan"
 ---
 
-Shader transition simulating a fast camera whip pan
-
 `transition` `shader`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/whip-pan.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/whip-pan.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Whip Pan block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add whip-pan
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="whip-pan" data-composition-src="compositions/whip-pan.html" data-start="0" data-duration="4" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/world-map.mdx
+++ b/docs/catalog/blocks/world-map.mdx
@@ -3,34 +3,24 @@ title: "World Map"
 description: "Animated world choropleth with country-by-country reveal, tooltip labels, and rotating globe inset — D3 Natural Earth projection"
 ---
 
-Animated world choropleth with country-by-country reveal, tooltip labels, and rotating globe inset — D3 Natural Earth projection
-
 `data` `map` `geography` `world` `choropleth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/world-map.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/world-map.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the World Map block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add world-map
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="world-map" data-composition-src="compositions/world-map.html" data-start="0" data-duration="14" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/world-map.mdx
+++ b/docs/catalog/blocks/world-map.mdx
@@ -3,23 +3,34 @@ title: "World Map"
 description: "Animated world choropleth with country-by-country reveal, tooltip labels, and rotating globe inset — D3 Natural Earth projection"
 ---
 
-# World Map
-
 Animated world choropleth with country-by-country reveal, tooltip labels, and rotating globe inset — D3 Natural Earth projection
 
 `data` `map` `geography` `world` `choropleth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/world-map.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/world-map.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the World Map block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add world-map
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add world-map
 | Dimensions | 1920×1080 |
 | Duration | 14s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `world-map.html` | `compositions/world-map.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="world-map" data-composition-src="compositions/world-map.html" data-start="0" data-duration="14" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/x-post.mdx
+++ b/docs/catalog/blocks/x-post.mdx
@@ -3,23 +3,34 @@ title: "X Post Card"
 description: "Animated X/Twitter post card overlay with engagement metrics"
 ---
 
-# X Post Card
-
 Animated X/Twitter post card overlay with engagement metrics
 
 `social` `overlay` `twitter`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/x-post.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/x-post.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the X Post Card block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add x-post
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add x-post
 | Dimensions | 1920×1080 |
 | Duration | 5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `x-post.html` | `compositions/x-post.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="x-post" data-composition-src="compositions/x-post.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/x-post.mdx
+++ b/docs/catalog/blocks/x-post.mdx
@@ -3,34 +3,24 @@ title: "X Post Card"
 description: "Animated X/Twitter post card overlay with engagement metrics"
 ---
 
-Animated X/Twitter post card overlay with engagement metrics
-
 `social` `overlay` `twitter`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/x-post.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/x-post.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the X Post Card block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add x-post
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="x-post" data-composition-src="compositions/x-post.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/yt-comment-card.mdx
+++ b/docs/catalog/blocks/yt-comment-card.mdx
@@ -3,34 +3,24 @@ title: "Comment Cards"
 description: "Social comments typing on over footage: avatar pop, username and time, per-character typewriter, likes row; image avatars or initials chips"
 ---
 
-Social comments typing on over footage: avatar pop, username and time, per-character typewriter, likes row; image avatars or initials chips
-
 `social` `comments` `creator` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-comment-card.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-comment-card.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Comment Cards block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-comment-card
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="yt-comment-card" data-composition-src="compositions/yt-comment-card.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/yt-comment-card.mdx
+++ b/docs/catalog/blocks/yt-comment-card.mdx
@@ -3,23 +3,34 @@ title: "Comment Cards"
 description: "Social comments typing on over footage: avatar pop, username and time, per-character typewriter, likes row; image avatars or initials chips"
 ---
 
-# Comment Cards
-
 Social comments typing on over footage: avatar pop, username and time, per-character typewriter, likes row; image avatars or initials chips
 
 `social` `comments` `creator` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-comment-card.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-comment-card.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Comment Cards block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-comment-card
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add yt-comment-card
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-comment-card.html` | `compositions/yt-comment-card.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="yt-comment-card" data-composition-src="compositions/yt-comment-card.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/yt-lcd-background.mdx
+++ b/docs/catalog/blocks/yt-lcd-background.mdx
@@ -3,23 +3,34 @@ title: "Scanline Board Background"
 description: "Textured paper board: scanlines with slow drift, optional pixel grid, static grain, and display text with a blur-focus entrance and chromatic-fringe title"
 ---
 
-# Scanline Board Background
-
 Textured paper board: scanlines with slow drift, optional pixel grid, static grain, and display text with a blur-focus entrance and chromatic-fringe title
 
 `background` `texture` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lcd-background.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lcd-background.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Scanline Board Background block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-lcd-background
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add yt-lcd-background
 | Dimensions | 1920×1080 |
 | Duration | 10s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-lcd-background.html` | `compositions/yt-lcd-background.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="yt-lcd-background" data-composition-src="compositions/yt-lcd-background.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/yt-lcd-background.mdx
+++ b/docs/catalog/blocks/yt-lcd-background.mdx
@@ -3,34 +3,24 @@ title: "Scanline Board Background"
 description: "Textured paper board: scanlines with slow drift, optional pixel grid, static grain, and display text with a blur-focus entrance and chromatic-fringe title"
 ---
 
-Textured paper board: scanlines with slow drift, optional pixel grid, static grain, and display text with a blur-focus entrance and chromatic-fringe title
-
 `background` `texture` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lcd-background.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lcd-background.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Scanline Board Background block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-lcd-background
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="yt-lcd-background" data-composition-src="compositions/yt-lcd-background.html" data-start="0" data-duration="10" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/yt-logo-intro.mdx
+++ b/docs/catalog/blocks/yt-logo-intro.mdx
@@ -3,34 +3,24 @@ title: "Logo Intro Sequence"
 description: "Logo stamp pops on a lined board, a kicker line gives way to the title with an accent arrow chip; seeded line distortion"
 ---
 
-Logo stamp pops on a lined board, a kicker line gives way to the title with an accent arrow chip; seeded line distortion
-
 `logo` `intro` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-logo-intro.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-logo-intro.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Logo Intro Sequence block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-logo-intro
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="yt-logo-intro" data-composition-src="compositions/yt-logo-intro.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/yt-logo-intro.mdx
+++ b/docs/catalog/blocks/yt-logo-intro.mdx
@@ -3,23 +3,34 @@ title: "Logo Intro Sequence"
 description: "Logo stamp pops on a lined board, a kicker line gives way to the title with an accent arrow chip; seeded line distortion"
 ---
 
-# Logo Intro Sequence
-
 Logo stamp pops on a lined board, a kicker line gives way to the title with an accent arrow chip; seeded line distortion
 
 `logo` `intro` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-logo-intro.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-logo-intro.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Logo Intro Sequence block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-logo-intro
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add yt-logo-intro
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-logo-intro.html` | `compositions/yt-logo-intro.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="yt-logo-intro" data-composition-src="compositions/yt-logo-intro.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/yt-lower-third.mdx
+++ b/docs/catalog/blocks/yt-lower-third.mdx
@@ -3,23 +3,34 @@ title: "YouTube Lower Third"
 description: "Animated YouTube subscribe lower third with avatar and channel info"
 ---
 
-# YouTube Lower Third
-
 Animated YouTube subscribe lower third with avatar and channel info
 
 `social` `overlay` `youtube`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lower-third.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lower-third.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the YouTube Lower Third block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-lower-third
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,16 +40,18 @@ npx hyperframes add yt-lower-third
 | Dimensions | 1920×1080 |
 | Duration | 4.5s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-lower-third.html` | `compositions/yt-lower-third.html` | hyperframes:composition |
 | `assets/avatar.jpg` | `assets/avatar.jpg` | hyperframes:asset |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="yt-lower-third" data-composition-src="compositions/yt-lower-third.html" data-start="0" data-duration="4.5" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/yt-lower-third.mdx
+++ b/docs/catalog/blocks/yt-lower-third.mdx
@@ -3,34 +3,24 @@ title: "YouTube Lower Third"
 description: "Animated YouTube subscribe lower third with avatar and channel info"
 ---
 
-Animated YouTube subscribe lower third with avatar and channel info
-
 `social` `overlay` `youtube`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lower-third.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-lower-third.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the YouTube Lower Third block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-lower-third
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -56,3 +46,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="yt-lower-third" data-composition-src="compositions/yt-lower-third.html" data-start="0" data-duration="4.5" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/yt-prism-title.mdx
+++ b/docs/catalog/blocks/yt-prism-title.mdx
@@ -3,34 +3,24 @@ title: "Chromatic Fringe Title"
 description: "Display title on a transparent root: blur-focus entrance, red/blue fringe that settles then breathes, perspective bow, slow scale drift"
 ---
 
-Display title on a transparent root: blur-focus entrance, red/blue fringe that settles then breathes, perspective bow, slow scale drift
-
 `typography` `title-card` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-prism-title.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-prism-title.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Chromatic Fringe Title block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-prism-title
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="yt-prism-title" data-composition-src="compositions/yt-prism-title.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/yt-prism-title.mdx
+++ b/docs/catalog/blocks/yt-prism-title.mdx
@@ -3,23 +3,34 @@ title: "Chromatic Fringe Title"
 description: "Display title on a transparent root: blur-focus entrance, red/blue fringe that settles then breathes, perspective bow, slow scale drift"
 ---
 
-# Chromatic Fringe Title
-
 Display title on a transparent root: blur-focus entrance, red/blue fringe that settles then breathes, perspective bow, slow scale drift
 
 `typography` `title-card` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-prism-title.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-prism-title.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Chromatic Fringe Title block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-prism-title
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add yt-prism-title
 | Dimensions | 1920×1080 |
 | Duration | 6s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-prism-title.html` | `compositions/yt-prism-title.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="yt-prism-title" data-composition-src="compositions/yt-prism-title.html" data-start="0" data-duration="6" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/blocks/yt-vertical-fill.mdx
+++ b/docs/catalog/blocks/yt-vertical-fill.mdx
@@ -3,34 +3,24 @@ title: "Vertical Media Filler"
 description: "Portrait media filling a widescreen frame via blurred-scale, mirror, or copy side fills; grid texture and foreground contrast lift (images inside the block; keep live footage in the host)"
 ---
 
-Portrait media filling a widescreen frame via blurred-scale, mirror, or copy side fills; grid texture and foreground contrast lift (images inside the block; keep live footage in the host)
-
 `placeholder` `vertical` `media`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-vertical-fill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-vertical-fill.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Vertical Media Filler block from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-vertical-fill
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ Ask your agent to replace the example content, match the project style, and plac
 ```html
 <div data-composition-id="yt-vertical-fill" data-composition-src="compositions/yt-vertical-fill.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>
 ```
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/blocks/yt-vertical-fill.mdx
+++ b/docs/catalog/blocks/yt-vertical-fill.mdx
@@ -3,23 +3,34 @@ title: "Vertical Media Filler"
 description: "Portrait media filling a widescreen frame via blurred-scale, mirror, or copy side fills; grid texture and foreground contrast lift (images inside the block; keep live footage in the host)"
 ---
 
-# Vertical Media Filler
-
 Portrait media filling a widescreen frame via blurred-scale, mirror, or copy side fills; grid texture and foreground contrast lift (images inside the block; keep live footage in the host)
 
 `placeholder` `vertical` `media`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-vertical-fill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/yt-vertical-fill.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Vertical Media Filler block from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-vertical-fill
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -29,15 +40,17 @@ npx hyperframes add yt-vertical-fill
 | Dimensions | 1920×1080 |
 | Duration | 8s |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-vertical-fill.html` | `compositions/yt-vertical-fill.html` | hyperframes:composition |
 
-## Usage
+## Use it
 
-After installing, add the block to your host composition:
+Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.
+
+**Wiring it by hand.** The installed block can be added to a host composition with:
 
 ```html
 <div data-composition-id="yt-vertical-fill" data-composition-src="compositions/yt-vertical-fill.html" data-start="0" data-duration="8" data-track-index="1" data-width="1920" data-height="1080"></div>

--- a/docs/catalog/components/caption-blend-difference.mdx
+++ b/docs/catalog/components/caption-blend-difference.mdx
@@ -3,34 +3,24 @@ title: "Blend Difference"
 description: "Auto-inverting text using mix-blend-mode: difference — flips between white and black per-pixel against the background"
 ---
 
-Auto-inverting text using mix-blend-mode: difference — flips between white and black per-pixel against the background
-
 `text` `text-effect` `effect` `blend-mode` `contrast` `inversion`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-blend-difference.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-blend-difference.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Blend Difference component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-blend-difference
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-blend-difference
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-blend-difference.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-blend-difference.mdx
+++ b/docs/catalog/components/caption-blend-difference.mdx
@@ -3,23 +3,34 @@ title: "Blend Difference"
 description: "Auto-inverting text using mix-blend-mode: difference — flips between white and black per-pixel against the background"
 ---
 
-# Blend Difference
-
 Auto-inverting text using mix-blend-mode: difference — flips between white and black per-pixel against the background
 
-`text` `effect` `blend-mode` `contrast` `inversion`
+`text` `text-effect` `effect` `blend-mode` `contrast` `inversion`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-blend-difference.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-blend-difference.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Blend Difference component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-blend-difference
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-blend-difference
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-blend-difference.html` | `compositions/components/caption-blend-difference.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-blend-difference.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-blend-difference.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-clip-wipe.mdx
+++ b/docs/catalog/components/caption-clip-wipe.mdx
@@ -3,23 +3,34 @@ title: "Clip Wipe"
 description: "Left-to-right clip-path wipe reveal per word"
 ---
 
-# Clip Wipe
-
 Left-to-right clip-path wipe reveal per word
 
 `captions` `caption-style` `wipe` `clip-path` `reveal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-clip-wipe.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-clip-wipe.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Clip Wipe component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-clip-wipe
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-clip-wipe
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-clip-wipe.html` | `compositions/components/caption-clip-wipe.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-clip-wipe.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-clip-wipe.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-clip-wipe.mdx
+++ b/docs/catalog/components/caption-clip-wipe.mdx
@@ -3,34 +3,24 @@ title: "Clip Wipe"
 description: "Left-to-right clip-path wipe reveal per word"
 ---
 
-Left-to-right clip-path wipe reveal per word
-
 `captions` `caption-style` `wipe` `clip-path` `reveal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-clip-wipe/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-clip-wipe.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Clip Wipe component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-clip-wipe
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-clip-wipe
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-clip-wipe.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-clip-wipe.mdx
+++ b/docs/catalog/components/caption-clip-wipe.mdx
@@ -7,7 +7,7 @@ Left-to-right clip-path wipe reveal per word
 
 `captions` `caption-style` `wipe` `clip-path` `reveal`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-clip-wipe.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-clip-wipe.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-clip-wipe/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-clip-wipe.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-editorial-emphasis.mdx
+++ b/docs/catalog/components/caption-editorial-emphasis.mdx
@@ -3,34 +3,24 @@ title: "Editorial Emphasis"
 description: "Dual-font system with dramatic size contrast for emphasis words"
 ---
 
-Dual-font system with dramatic size contrast for emphasis words
-
 `captions` `caption-style` `editorial` `typography` `emphasis`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-editorial-emphasis/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-editorial-emphasis.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Editorial Emphasis component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-editorial-emphasis
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-editorial-emphasis
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-editorial-emphasis.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-editorial-emphasis.mdx
+++ b/docs/catalog/components/caption-editorial-emphasis.mdx
@@ -3,23 +3,34 @@ title: "Editorial Emphasis"
 description: "Dual-font system with dramatic size contrast for emphasis words"
 ---
 
-# Editorial Emphasis
-
 Dual-font system with dramatic size contrast for emphasis words
 
 `captions` `caption-style` `editorial` `typography` `emphasis`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-editorial-emphasis.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-editorial-emphasis.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Editorial Emphasis component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-editorial-emphasis
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-editorial-emphasis
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-editorial-emphasis.html` | `compositions/components/caption-editorial-emphasis.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-editorial-emphasis.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-editorial-emphasis.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-editorial-emphasis.mdx
+++ b/docs/catalog/components/caption-editorial-emphasis.mdx
@@ -7,7 +7,7 @@ Dual-font system with dramatic size contrast for emphasis words
 
 `captions` `caption-style` `editorial` `typography` `emphasis`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-editorial-emphasis.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-editorial-emphasis.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-editorial-emphasis/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-editorial-emphasis.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-emoji-pop.mdx
+++ b/docs/catalog/components/caption-emoji-pop.mdx
@@ -3,23 +3,34 @@ title: "Emoji Pop"
 description: "Emoji integration with stroked text and horizontal squeeze entrance"
 ---
 
-# Emoji Pop
-
 Emoji integration with stroked text and horizontal squeeze entrance
 
 `captions` `caption-style` `emoji` `social`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-emoji-pop.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-emoji-pop.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Emoji Pop component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-emoji-pop
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-emoji-pop
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-emoji-pop.html` | `compositions/components/caption-emoji-pop.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-emoji-pop.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-emoji-pop.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-emoji-pop.mdx
+++ b/docs/catalog/components/caption-emoji-pop.mdx
@@ -7,7 +7,7 @@ Emoji integration with stroked text and horizontal squeeze entrance
 
 `captions` `caption-style` `emoji` `social`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-emoji-pop.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-emoji-pop.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-emoji-pop/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-emoji-pop.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-emoji-pop.mdx
+++ b/docs/catalog/components/caption-emoji-pop.mdx
@@ -3,34 +3,24 @@ title: "Emoji Pop"
 description: "Emoji integration with stroked text and horizontal squeeze entrance"
 ---
 
-Emoji integration with stroked text and horizontal squeeze entrance
-
 `captions` `caption-style` `emoji` `social`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-emoji-pop/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-emoji-pop.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Emoji Pop component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-emoji-pop
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-emoji-pop
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-emoji-pop.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-glitch-rgb.mdx
+++ b/docs/catalog/components/caption-glitch-rgb.mdx
@@ -3,23 +3,34 @@ title: "Glitch RGB"
 description: "RGB chromatic aberration with CRT scanline overlay"
 ---
 
-# Glitch RGB
-
 RGB chromatic aberration with CRT scanline overlay
 
 `captions` `caption-style` `glitch` `cyber` `tech`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-glitch-rgb.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-glitch-rgb.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Glitch RGB component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-glitch-rgb
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-glitch-rgb
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-glitch-rgb.html` | `compositions/components/caption-glitch-rgb.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-glitch-rgb.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-glitch-rgb.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-glitch-rgb.mdx
+++ b/docs/catalog/components/caption-glitch-rgb.mdx
@@ -3,34 +3,24 @@ title: "Glitch RGB"
 description: "RGB chromatic aberration with CRT scanline overlay"
 ---
 
-RGB chromatic aberration with CRT scanline overlay
-
 `captions` `caption-style` `glitch` `cyber` `tech`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-glitch-rgb/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-glitch-rgb.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Glitch RGB component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-glitch-rgb
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-glitch-rgb
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-glitch-rgb.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-glitch-rgb.mdx
+++ b/docs/catalog/components/caption-glitch-rgb.mdx
@@ -7,7 +7,7 @@ RGB chromatic aberration with CRT scanline overlay
 
 `captions` `caption-style` `glitch` `cyber` `tech`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-glitch-rgb.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-glitch-rgb.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-glitch-rgb/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-glitch-rgb.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-gradient-fill.mdx
+++ b/docs/catalog/components/caption-gradient-fill.mdx
@@ -3,34 +3,24 @@ title: "Gradient Fill"
 description: "Gradient-clipped text with elastic bounce entrance"
 ---
 
-Gradient-clipped text with elastic bounce entrance
-
 `captions` `caption-style` `gradient` `colorful`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-gradient-fill/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-gradient-fill.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Gradient Fill component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-gradient-fill
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-gradient-fill
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-gradient-fill.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-gradient-fill.mdx
+++ b/docs/catalog/components/caption-gradient-fill.mdx
@@ -3,23 +3,34 @@ title: "Gradient Fill"
 description: "Gradient-clipped text with elastic bounce entrance"
 ---
 
-# Gradient Fill
-
 Gradient-clipped text with elastic bounce entrance
 
 `captions` `caption-style` `gradient` `colorful`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-gradient-fill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-gradient-fill.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Gradient Fill component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-gradient-fill
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-gradient-fill
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-gradient-fill.html` | `compositions/components/caption-gradient-fill.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-gradient-fill.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-gradient-fill.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-gradient-fill.mdx
+++ b/docs/catalog/components/caption-gradient-fill.mdx
@@ -7,7 +7,7 @@ Gradient-clipped text with elastic bounce entrance
 
 `captions` `caption-style` `gradient` `colorful`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-gradient-fill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-gradient-fill.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-gradient-fill/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-gradient-fill.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-highlight.mdx
+++ b/docs/catalog/components/caption-highlight.mdx
@@ -3,23 +3,34 @@ title: "Highlight"
 description: "Red background sweep behind each active word, TikTok-style"
 ---
 
-# Highlight
-
 Red background sweep behind each active word, TikTok-style
 
 `captions` `caption-style` `highlight` `social` `tiktok`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-highlight.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Highlight component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-highlight
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-highlight
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-highlight.html` | `compositions/components/caption-highlight.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-highlight.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-highlight.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-highlight.mdx
+++ b/docs/catalog/components/caption-highlight.mdx
@@ -7,7 +7,7 @@ Red background sweep behind each active word, TikTok-style
 
 `captions` `caption-style` `highlight` `social` `tiktok`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-highlight.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-highlight/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-highlight.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-highlight.mdx
+++ b/docs/catalog/components/caption-highlight.mdx
@@ -3,34 +3,24 @@ title: "Highlight"
 description: "Red background sweep behind each active word, TikTok-style"
 ---
 
-Red background sweep behind each active word, TikTok-style
-
 `captions` `caption-style` `highlight` `social` `tiktok`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-highlight/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-highlight.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Highlight component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-highlight
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-highlight
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-highlight.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-kinetic-slam.mdx
+++ b/docs/catalog/components/caption-kinetic-slam.mdx
@@ -3,34 +3,24 @@ title: "Kinetic Slam"
 description: "Full-screen single-word display with alternating entrance directions"
 ---
 
-Full-screen single-word display with alternating entrance directions
-
 `captions` `caption-style` `kinetic` `typography` `slam`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-kinetic-slam/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-kinetic-slam.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Kinetic Slam component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-kinetic-slam
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-kinetic-slam
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-kinetic-slam.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-kinetic-slam.mdx
+++ b/docs/catalog/components/caption-kinetic-slam.mdx
@@ -3,23 +3,34 @@ title: "Kinetic Slam"
 description: "Full-screen single-word display with alternating entrance directions"
 ---
 
-# Kinetic Slam
-
 Full-screen single-word display with alternating entrance directions
 
 `captions` `caption-style` `kinetic` `typography` `slam`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-kinetic-slam.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-kinetic-slam.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Kinetic Slam component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-kinetic-slam
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-kinetic-slam
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-kinetic-slam.html` | `compositions/components/caption-kinetic-slam.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-kinetic-slam.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-kinetic-slam.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-kinetic-slam.mdx
+++ b/docs/catalog/components/caption-kinetic-slam.mdx
@@ -7,7 +7,7 @@ Full-screen single-word display with alternating entrance directions
 
 `captions` `caption-style` `kinetic` `typography` `slam`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-kinetic-slam.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-kinetic-slam.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-kinetic-slam/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-kinetic-slam.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-matrix-decode.mdx
+++ b/docs/catalog/components/caption-matrix-decode.mdx
@@ -3,23 +3,34 @@ title: "Matrix Decode"
 description: "Character scramble animation before text reveal"
 ---
 
-# Matrix Decode
-
 Character scramble animation before text reveal
 
 `captions` `caption-style` `matrix` `scramble` `decode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-matrix-decode.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-matrix-decode.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Matrix Decode component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-matrix-decode
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-matrix-decode
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-matrix-decode.html` | `compositions/components/caption-matrix-decode.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-matrix-decode.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-matrix-decode.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-matrix-decode.mdx
+++ b/docs/catalog/components/caption-matrix-decode.mdx
@@ -7,7 +7,7 @@ Character scramble animation before text reveal
 
 `captions` `caption-style` `matrix` `scramble` `decode`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-matrix-decode.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-matrix-decode.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-matrix-decode/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-matrix-decode.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-matrix-decode.mdx
+++ b/docs/catalog/components/caption-matrix-decode.mdx
@@ -3,34 +3,24 @@ title: "Matrix Decode"
 description: "Character scramble animation before text reveal"
 ---
 
-Character scramble animation before text reveal
-
 `captions` `caption-style` `matrix` `scramble` `decode`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-matrix-decode/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-matrix-decode.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Matrix Decode component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-matrix-decode
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-matrix-decode
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-matrix-decode.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-neon-accent.mdx
+++ b/docs/catalog/components/caption-neon-accent.mdx
@@ -7,7 +7,7 @@ Multi-color neon glow accents with wiggle drift animation
 
 `captions` `caption-style` `neon` `glow` `accent`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-accent.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-accent.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-neon-accent/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-accent.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-neon-accent.mdx
+++ b/docs/catalog/components/caption-neon-accent.mdx
@@ -3,34 +3,24 @@ title: "Neon Accent"
 description: "Multi-color neon glow accents with wiggle drift animation"
 ---
 
-Multi-color neon glow accents with wiggle drift animation
-
 `captions` `caption-style` `neon` `glow` `accent`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-neon-accent/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-accent.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Neon Accent component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-neon-accent
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-neon-accent
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-neon-accent.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-neon-accent.mdx
+++ b/docs/catalog/components/caption-neon-accent.mdx
@@ -3,23 +3,34 @@ title: "Neon Accent"
 description: "Multi-color neon glow accents with wiggle drift animation"
 ---
 
-# Neon Accent
-
 Multi-color neon glow accents with wiggle drift animation
 
 `captions` `caption-style` `neon` `glow` `accent`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-accent.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-accent.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Neon Accent component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-neon-accent
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-neon-accent
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-neon-accent.html` | `compositions/components/caption-neon-accent.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-neon-accent.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-neon-accent.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-neon-glow.mdx
+++ b/docs/catalog/components/caption-neon-glow.mdx
@@ -7,7 +7,7 @@ Cyan and magenta neon glow with keyword accent colors
 
 `captions` `caption-style` `neon` `glow` `gaming`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-glow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-glow.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-neon-glow/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-glow.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-neon-glow.mdx
+++ b/docs/catalog/components/caption-neon-glow.mdx
@@ -3,34 +3,24 @@ title: "Neon Glow"
 description: "Cyan and magenta neon glow with keyword accent colors"
 ---
 
-Cyan and magenta neon glow with keyword accent colors
-
 `captions` `caption-style` `neon` `glow` `gaming`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-neon-glow/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-glow.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Neon Glow component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-neon-glow
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-neon-glow
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-neon-glow.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-neon-glow.mdx
+++ b/docs/catalog/components/caption-neon-glow.mdx
@@ -3,23 +3,34 @@ title: "Neon Glow"
 description: "Cyan and magenta neon glow with keyword accent colors"
 ---
 
-# Neon Glow
-
 Cyan and magenta neon glow with keyword accent colors
 
 `captions` `caption-style` `neon` `glow` `gaming`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-glow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-neon-glow.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Neon Glow component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-neon-glow
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-neon-glow
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-neon-glow.html` | `compositions/components/caption-neon-glow.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-neon-glow.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-neon-glow.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-parallax-layers.mdx
+++ b/docs/catalog/components/caption-parallax-layers.mdx
@@ -3,23 +3,34 @@ title: "Parallax Layers"
 description: "Behind-subject 3D text layering with vertical stretch effect"
 ---
 
-# Parallax Layers
-
 Behind-subject 3D text layering with vertical stretch effect
 
 `captions` `caption-style` `parallax` `3d` `depth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-parallax-layers.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-parallax-layers.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Parallax Layers component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-parallax-layers
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-parallax-layers
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-parallax-layers.html` | `compositions/components/caption-parallax-layers.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-parallax-layers.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-parallax-layers.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-parallax-layers.mdx
+++ b/docs/catalog/components/caption-parallax-layers.mdx
@@ -7,7 +7,7 @@ Behind-subject 3D text layering with vertical stretch effect
 
 `captions` `caption-style` `parallax` `3d` `depth`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-parallax-layers.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-parallax-layers.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-parallax-layers/preview.mp4?v=1779051692" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-parallax-layers.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-parallax-layers.mdx
+++ b/docs/catalog/components/caption-parallax-layers.mdx
@@ -3,34 +3,24 @@ title: "Parallax Layers"
 description: "Behind-subject 3D text layering with vertical stretch effect"
 ---
 
-Behind-subject 3D text layering with vertical stretch effect
-
 `captions` `caption-style` `parallax` `3d` `depth`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-parallax-layers/preview.mp4?v=1779051692" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-parallax-layers.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Parallax Layers component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-parallax-layers
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-parallax-layers
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-parallax-layers.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-particle-burst.mdx
+++ b/docs/catalog/components/caption-particle-burst.mdx
@@ -3,34 +3,24 @@ title: "Particle Burst"
 description: "Keyword words trigger colored particle explosions"
 ---
 
-Keyword words trigger colored particle explosions
-
 `captions` `caption-style` `particles` `burst` `effects`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-particle-burst/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-particle-burst.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Particle Burst component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-particle-burst
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-particle-burst
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-particle-burst.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-particle-burst.mdx
+++ b/docs/catalog/components/caption-particle-burst.mdx
@@ -7,7 +7,7 @@ Keyword words trigger colored particle explosions
 
 `captions` `caption-style` `particles` `burst` `effects`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-particle-burst.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-particle-burst.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-particle-burst/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-particle-burst.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-particle-burst.mdx
+++ b/docs/catalog/components/caption-particle-burst.mdx
@@ -3,23 +3,34 @@ title: "Particle Burst"
 description: "Keyword words trigger colored particle explosions"
 ---
 
-# Particle Burst
-
 Keyword words trigger colored particle explosions
 
 `captions` `caption-style` `particles` `burst` `effects`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-particle-burst.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-particle-burst.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Particle Burst component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-particle-burst
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-particle-burst
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-particle-burst.html` | `compositions/components/caption-particle-burst.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-particle-burst.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-particle-burst.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-pill-karaoke.mdx
+++ b/docs/catalog/components/caption-pill-karaoke.mdx
@@ -3,34 +3,24 @@ title: "Pill Karaoke"
 description: "Pill-shaped container with per-word karaoke color highlight"
 ---
 
-Pill-shaped container with per-word karaoke color highlight
-
 `captions` `caption-style` `karaoke` `pill`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-pill-karaoke/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-pill-karaoke.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Pill Karaoke component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-pill-karaoke
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-pill-karaoke
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-pill-karaoke.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-pill-karaoke.mdx
+++ b/docs/catalog/components/caption-pill-karaoke.mdx
@@ -3,23 +3,34 @@ title: "Pill Karaoke"
 description: "Pill-shaped container with per-word karaoke color highlight"
 ---
 
-# Pill Karaoke
-
 Pill-shaped container with per-word karaoke color highlight
 
 `captions` `caption-style` `karaoke` `pill`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-pill-karaoke.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-pill-karaoke.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Pill Karaoke component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-pill-karaoke
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-pill-karaoke
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-pill-karaoke.html` | `compositions/components/caption-pill-karaoke.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-pill-karaoke.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-pill-karaoke.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-pill-karaoke.mdx
+++ b/docs/catalog/components/caption-pill-karaoke.mdx
@@ -7,7 +7,7 @@ Pill-shaped container with per-word karaoke color highlight
 
 `captions` `caption-style` `karaoke` `pill`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-pill-karaoke.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-pill-karaoke.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-pill-karaoke/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-pill-karaoke.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-texture.mdx
+++ b/docs/catalog/components/caption-texture.mdx
@@ -7,7 +7,7 @@ Flowing texture mask over large uppercase text — ships with 6 textures (lava, 
 
 `captions` `caption-style` `texture` `mask`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-texture.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-texture.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-texture-lava/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-texture.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-texture.mdx
+++ b/docs/catalog/components/caption-texture.mdx
@@ -3,23 +3,34 @@ title: "Texture"
 description: "Flowing texture mask over large uppercase text — ships with 6 textures (lava, marble, metal, wood, concrete, rock), configurable via the texture variable"
 ---
 
-# Texture
-
 Flowing texture mask over large uppercase text — ships with 6 textures (lava, marble, metal, wood, concrete, rock), configurable via the texture variable
 
 `captions` `caption-style` `texture` `mask`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-texture.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-texture.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Texture component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-texture
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,7 +38,7 @@ npx hyperframes add caption-texture
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
@@ -39,6 +50,8 @@ npx hyperframes add caption-texture
 | `concrete-042-a.png` | `compositions/components/concrete-042-a.png` | hyperframes:asset |
 | `rock-058.png` | `compositions/components/rock-058.png` | hyperframes:asset |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-texture.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-texture.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-texture.mdx
+++ b/docs/catalog/components/caption-texture.mdx
@@ -3,34 +3,24 @@ title: "Texture"
 description: "Flowing texture mask over large uppercase text — ships with 6 textures (lava, marble, metal, wood, concrete, rock), configurable via the texture variable"
 ---
 
-Flowing texture mask over large uppercase text — ships with 6 textures (lava, marble, metal, wood, concrete, rock), configurable via the texture variable
-
 `captions` `caption-style` `texture` `mask`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-texture-lava/preview.mp4?v=1779051416" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-texture.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Texture component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-texture
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -55,3 +45,9 @@ npx hyperframes add caption-texture
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-texture.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/caption-weight-shift.mdx
+++ b/docs/catalog/components/caption-weight-shift.mdx
@@ -3,23 +3,34 @@ title: "Weight Shift"
 description: "Elegant font-weight transition between caption lines"
 ---
 
-# Weight Shift
-
 Elegant font-weight transition between caption lines
 
 `captions` `caption-style` `minimal` `typography`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-weight-shift.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-weight-shift.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Weight Shift component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add caption-weight-shift
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add caption-weight-shift
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `caption-weight-shift.html` | `compositions/components/caption-weight-shift.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/caption-weight-shift.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/caption-weight-shift.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/caption-weight-shift.mdx
+++ b/docs/catalog/components/caption-weight-shift.mdx
@@ -7,7 +7,7 @@ Elegant font-weight transition between caption lines
 
 `captions` `caption-style` `minimal` `typography`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-weight-shift.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-weight-shift.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-weight-shift/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-weight-shift.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/caption-weight-shift.mdx
+++ b/docs/catalog/components/caption-weight-shift.mdx
@@ -3,34 +3,24 @@ title: "Weight Shift"
 description: "Elegant font-weight transition between caption lines"
 ---
 
-Elegant font-weight transition between caption lines
-
 `captions` `caption-style` `minimal` `typography`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/registry/components/caption-weight-shift/preview-v2.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/caption-weight-shift.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Weight Shift component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add caption-weight-shift
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add caption-weight-shift
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/caption-weight-shift.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/grain-overlay.mdx
+++ b/docs/catalog/components/grain-overlay.mdx
@@ -3,23 +3,34 @@ title: "Grain Overlay"
 description: "Animated film grain texture overlay using CSS keyframes — adds warmth and analog character to any composition"
 ---
 
-# Grain Overlay
-
 Animated film grain texture overlay using CSS keyframes — adds warmth and analog character to any composition
 
 `texture` `grain` `overlay` `film`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grain-overlay.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grain-overlay.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Grain Overlay component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add grain-overlay
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add grain-overlay
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `grain-overlay.html` | `compositions/components/grain-overlay.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/grain-overlay.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/grain-overlay.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/grain-overlay.mdx
+++ b/docs/catalog/components/grain-overlay.mdx
@@ -3,34 +3,24 @@ title: "Grain Overlay"
 description: "Animated film grain texture overlay using CSS keyframes — adds warmth and analog character to any composition"
 ---
 
-Animated film grain texture overlay using CSS keyframes — adds warmth and analog character to any composition
-
 `texture` `grain` `overlay` `film`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grain-overlay.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grain-overlay.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Grain Overlay component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add grain-overlay
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add grain-overlay
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/grain-overlay.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/grid-pixelate-wipe.mdx
+++ b/docs/catalog/components/grid-pixelate-wipe.mdx
@@ -3,23 +3,34 @@ title: "Grid Pixelate Wipe"
 description: "Transition effect where the screen dissolves into a grid of squares that fade out with staggered timing — use between scenes"
 ---
 
-# Grid Pixelate Wipe
-
 Transition effect where the screen dissolves into a grid of squares that fade out with staggered timing — use between scenes
 
 `transition` `wipe` `grid` `pixelate`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grid-pixelate-wipe.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grid-pixelate-wipe.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Grid Pixelate Wipe component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add grid-pixelate-wipe
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add grid-pixelate-wipe
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `grid-pixelate-wipe.html` | `compositions/components/grid-pixelate-wipe.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/grid-pixelate-wipe.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/grid-pixelate-wipe.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/grid-pixelate-wipe.mdx
+++ b/docs/catalog/components/grid-pixelate-wipe.mdx
@@ -3,34 +3,24 @@ title: "Grid Pixelate Wipe"
 description: "Transition effect where the screen dissolves into a grid of squares that fade out with staggered timing — use between scenes"
 ---
 
-Transition effect where the screen dissolves into a grid of squares that fade out with staggered timing — use between scenes
-
 `transition` `wipe` `grid` `pixelate`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grid-pixelate-wipe.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/grid-pixelate-wipe.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Grid Pixelate Wipe component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add grid-pixelate-wipe
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add grid-pixelate-wipe
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/grid-pixelate-wipe.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/hw-arrow.mdx
+++ b/docs/catalog/components/hw-arrow.mdx
@@ -3,34 +3,24 @@ title: "Hand-Drawn Arrow"
 description: "Wobbled draw-on arrow with straight, gentle, and swoop curve presets; boils while on screen"
 ---
 
-Wobbled draw-on arrow with straight, gentle, and swoop curve presets; boils while on screen
-
 `handwritten` `annotation` `arrow` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-arrow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-arrow.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Hand-Drawn Arrow component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-arrow
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -50,3 +40,9 @@ npx hyperframes add hw-arrow
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/hw-arrow.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/hw-arrow.mdx
+++ b/docs/catalog/components/hw-arrow.mdx
@@ -3,23 +3,34 @@ title: "Hand-Drawn Arrow"
 description: "Wobbled draw-on arrow with straight, gentle, and swoop curve presets; boils while on screen"
 ---
 
-# Hand-Drawn Arrow
-
 Wobbled draw-on arrow with straight, gentle, and swoop curve presets; boils while on screen
 
 `handwritten` `annotation` `arrow` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-arrow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-arrow.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Hand-Drawn Arrow component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-arrow
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,13 +38,15 @@ npx hyperframes add hw-arrow
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-arrow.html` | `compositions/components/hw-arrow.html` | hyperframes:snippet |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-Open `compositions/components/hw-arrow.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/hw-arrow.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/hw-boil.mdx
+++ b/docs/catalog/components/hw-boil.mdx
@@ -3,23 +3,34 @@ title: "Hand-Drawn Boil"
 description: "Hand-drawn jitter that re-poses every N frames, as seek-safe helpers: pose derives from quantized timeline time through a seeded hash; includes the shared onUpdate dispatcher and a wobbled-ellipse path generator"
 ---
 
-# Hand-Drawn Boil
-
 Hand-drawn jitter that re-poses every N frames, as seek-safe helpers: pose derives from quantized timeline time through a seeded hash; includes the shared onUpdate dispatcher and a wobbled-ellipse path generator
 
 `handwritten` `effect` `annotation`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-boil.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-boil.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Hand-Drawn Boil component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-boil
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,13 +38,15 @@ npx hyperframes add hw-boil
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-boil.html` | `compositions/components/hw-boil.html` | hyperframes:snippet |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-Open `compositions/components/hw-boil.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/hw-boil.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/hw-boil.mdx
+++ b/docs/catalog/components/hw-boil.mdx
@@ -3,34 +3,24 @@ title: "Hand-Drawn Boil"
 description: "Hand-drawn jitter that re-poses every N frames, as seek-safe helpers: pose derives from quantized timeline time through a seeded hash; includes the shared onUpdate dispatcher and a wobbled-ellipse path generator"
 ---
 
-Hand-drawn jitter that re-poses every N frames, as seek-safe helpers: pose derives from quantized timeline time through a seeded hash; includes the shared onUpdate dispatcher and a wobbled-ellipse path generator
-
 `handwritten` `effect` `annotation`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-boil.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-boil.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Hand-Drawn Boil component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-boil
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -50,3 +40,9 @@ npx hyperframes add hw-boil
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/hw-boil.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/hw-box-label.mdx
+++ b/docs/catalog/components/hw-box-label.mdx
@@ -3,34 +3,24 @@ title: "Hand-Drawn Box Label"
 description: "Wobbled rounded rectangle draws around a region with a handwritten label above or centered"
 ---
 
-Wobbled rounded rectangle draws around a region with a handwritten label above or centered
-
 `handwritten` `annotation` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-box-label.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-box-label.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Hand-Drawn Box Label component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-box-label
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -50,3 +40,9 @@ npx hyperframes add hw-box-label
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/hw-box-label.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/hw-box-label.mdx
+++ b/docs/catalog/components/hw-box-label.mdx
@@ -3,23 +3,34 @@ title: "Hand-Drawn Box Label"
 description: "Wobbled rounded rectangle draws around a region with a handwritten label above or centered"
 ---
 
-# Hand-Drawn Box Label
-
 Wobbled rounded rectangle draws around a region with a handwritten label above or centered
 
 `handwritten` `annotation` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-box-label.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-box-label.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Hand-Drawn Box Label component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-box-label
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,13 +38,15 @@ npx hyperframes add hw-box-label
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-box-label.html` | `compositions/components/hw-box-label.html` | hyperframes:snippet |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-Open `compositions/components/hw-box-label.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/hw-box-label.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/hw-callout-circle.mdx
+++ b/docs/catalog/components/hw-callout-circle.mdx
@@ -3,23 +3,34 @@ title: "Scribble Callout Circle"
 description: "Wobbled ellipse draws around a target with optional scribble fill, curved connector, and handwritten label"
 ---
 
-# Scribble Callout Circle
-
 Wobbled ellipse draws around a target with optional scribble fill, curved connector, and handwritten label
 
 `handwritten` `annotation` `callout` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-callout-circle.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-callout-circle.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Scribble Callout Circle component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-callout-circle
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,13 +38,15 @@ npx hyperframes add hw-callout-circle
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-callout-circle.html` | `compositions/components/hw-callout-circle.html` | hyperframes:snippet |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-Open `compositions/components/hw-callout-circle.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/hw-callout-circle.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/hw-callout-circle.mdx
+++ b/docs/catalog/components/hw-callout-circle.mdx
@@ -3,34 +3,24 @@ title: "Scribble Callout Circle"
 description: "Wobbled ellipse draws around a target with optional scribble fill, curved connector, and handwritten label"
 ---
 
-Wobbled ellipse draws around a target with optional scribble fill, curved connector, and handwritten label
-
 `handwritten` `annotation` `callout` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-callout-circle.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-callout-circle.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Scribble Callout Circle component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-callout-circle
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -50,3 +40,9 @@ npx hyperframes add hw-callout-circle
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/hw-callout-circle.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/hw-underline.mdx
+++ b/docs/catalog/components/hw-underline.mdx
@@ -3,34 +3,24 @@ title: "Squiggle Marks"
 description: "Hand-drawn squiggle underline, double-pass strikethrough, and bracket marks that draw on"
 ---
 
-Hand-drawn squiggle underline, double-pass strikethrough, and bracket marks that draw on
-
 `handwritten` `annotation` `text-treatment`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-underline.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-underline.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Squiggle Marks component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add hw-underline
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -50,3 +40,9 @@ npx hyperframes add hw-underline
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/hw-underline.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/hw-underline.mdx
+++ b/docs/catalog/components/hw-underline.mdx
@@ -3,23 +3,34 @@ title: "Squiggle Marks"
 description: "Hand-drawn squiggle underline, double-pass strikethrough, and bracket marks that draw on"
 ---
 
-# Squiggle Marks
-
 Hand-drawn squiggle underline, double-pass strikethrough, and bracket marks that draw on
 
 `handwritten` `annotation` `text-treatment`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-underline.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/hw-underline.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Squiggle Marks component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add hw-underline
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,13 +38,15 @@ npx hyperframes add hw-underline
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `hw-underline.html` | `compositions/components/hw-underline.html` | hyperframes:snippet |
 | `assets/fonts/Caveat-700-latin.woff2` | `assets/fonts/Caveat-700-latin.woff2` | hyperframes:asset |
 
-## Usage
+## Use it
 
-Open `compositions/components/hw-underline.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/hw-underline.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/mk-emphasis-type.mdx
+++ b/docs/catalog/components/mk-emphasis-type.mdx
@@ -3,23 +3,34 @@ title: "Background Emphasis Type"
 description: "Oversized low-contrast background word drifting slowly behind the subject — typography as texture"
 ---
 
-# Background Emphasis Type
-
 Oversized low-contrast background word drifting slowly behind the subject — typography as texture
 
 `typography` `text-treatment` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-emphasis-type.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-emphasis-type.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Background Emphasis Type component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-emphasis-type
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add mk-emphasis-type
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-emphasis-type.html` | `compositions/components/mk-emphasis-type.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/mk-emphasis-type.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/mk-emphasis-type.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/mk-emphasis-type.mdx
+++ b/docs/catalog/components/mk-emphasis-type.mdx
@@ -3,34 +3,24 @@ title: "Background Emphasis Type"
 description: "Oversized low-contrast background word drifting slowly behind the subject — typography as texture"
 ---
 
-Oversized low-contrast background word drifting slowly behind the subject — typography as texture
-
 `typography` `text-treatment` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-emphasis-type.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-emphasis-type.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Background Emphasis Type component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-emphasis-type
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add mk-emphasis-type
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/mk-emphasis-type.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/mk-usage-arc.mdx
+++ b/docs/catalog/components/mk-usage-arc.mdx
@@ -3,34 +3,24 @@ title: "Hairline Arc Gauge"
 description: "Thin circular gauge that draws on while its percentage counts up; one helper call drives both"
 ---
 
-Thin circular gauge that draws on while its percentage counts up; one helper call drives both
-
 `data-viz` `gauge` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-usage-arc.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-usage-arc.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Hairline Arc Gauge component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add mk-usage-arc
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add mk-usage-arc
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/mk-usage-arc.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/mk-usage-arc.mdx
+++ b/docs/catalog/components/mk-usage-arc.mdx
@@ -3,23 +3,34 @@ title: "Hairline Arc Gauge"
 description: "Thin circular gauge that draws on while its percentage counts up; one helper call drives both"
 ---
 
-# Hairline Arc Gauge
-
 Thin circular gauge that draws on while its percentage counts up; one helper call drives both
 
 `data-viz` `gauge` `minimal`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-usage-arc.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/mk-usage-arc.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Hairline Arc Gauge component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add mk-usage-arc
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add mk-usage-arc
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `mk-usage-arc.html` | `compositions/components/mk-usage-arc.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/mk-usage-arc.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/mk-usage-arc.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/morph-text.mdx
+++ b/docs/catalog/components/morph-text.mdx
@@ -3,34 +3,24 @@ title: "Morph Text"
 description: "Gooey text morph — cycles through an editable word list using SVG threshold + GSAP-driven blur for a fluid, satisfying transition effect"
 ---
 
-Gooey text morph — cycles through an editable word list using SVG threshold + GSAP-driven blur for a fluid, satisfying transition effect
-
 `text` `text-effect` `typography` `morph` `gooey` `kinetic` `animation`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Morph Text component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add morph-text
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add morph-text
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/morph-text.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/morph-text.mdx
+++ b/docs/catalog/components/morph-text.mdx
@@ -7,7 +7,7 @@ Gooey text morph — cycles through an editable word list using SVG threshold + 
 
 `text` `text-effect` `typography` `morph` `gooey` `kinetic` `animation`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.png" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.mp4" autoPlay muted loop playsInline />
 
 ## Add it to a project
 

--- a/docs/catalog/components/morph-text.mdx
+++ b/docs/catalog/components/morph-text.mdx
@@ -3,23 +3,34 @@ title: "Morph Text"
 description: "Gooey text morph — cycles through an editable word list using SVG threshold + GSAP-driven blur for a fluid, satisfying transition effect"
 ---
 
-# Morph Text
-
 Gooey text morph — cycles through an editable word list using SVG threshold + GSAP-driven blur for a fluid, satisfying transition effect
 
 `text` `text-effect` `typography` `morph` `gooey` `kinetic` `animation`
 
-<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.mp4" autoPlay muted loop playsInline />
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Morph Text component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add morph-text
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,14 +38,14 @@ npx hyperframes add morph-text
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `morph-text.html` | `compositions/components/morph-text.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/morph-text.html` and paste its contents into your composition.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
-Edit the `<ol id="morph-words">` list to change the statements that cycle through. Each `<li>` accepts `data-font` (CSS font-family) and `data-color` (hex) attributes. Adjust `data-morph-speed` (seconds per transition) and `data-morph-pause` (hold time) on the root element.
+**Wiring it by hand.** Open `compositions/components/morph-text.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/motion-blur.mdx
+++ b/docs/catalog/components/motion-blur.mdx
@@ -1,25 +1,36 @@
 ---
 title: "Motion Blur"
-description: "Velocity-driven directional motion blur — samples element position each frame and applies a one-sided ghost trail proportional to speed"
+description: "Velocity-driven motion blur — samples element position each frame and applies a one-sided SVG feGaussianBlur ghost trail proportional to speed"
 ---
 
-# Motion Blur
-
-Velocity-driven directional motion blur — samples element position each frame and applies a one-sided ghost trail proportional to speed.
+Velocity-driven motion blur — samples element position each frame and applies a one-sided SVG feGaussianBlur ghost trail proportional to speed
 
 `effect` `motion-blur` `velocity` `animation` `physics`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/motion-blur.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/motion-blur.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Motion Blur component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add motion-blur
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,44 +38,14 @@ npx hyperframes add motion-blur
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `motion-blur.html` | `compositions/components/motion-blur.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Paste the snippet into your composition, then call `attachMotionBlur()` after your GSAP tweens and before registering `window.__timelines`.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
-```html
-<!-- Extend the timeline to data-duration before calling attachMotionBlur -->
-tl.set(document.body, {}, DATA_DURATION);
-
-attachMotionBlur("#my-box", tl, {
-  axis: "x",      // "x" | "y" | "both"
-  blurMax: 40,    // max blur radius in px (default 20)
-});
-
-window.__timelines = window.__timelines || {};
-window.__timelines["my-composition"] = tl;
-```
-
-## How it works
-
-Each target element gets its own SVG filter. On every timeline seek, `attachMotionBlur` samples the element's GSAP `x`/`y` position, computes velocity, and drives three SVG filter primitives:
-
-1. **Ghost copies** — three faded, blurred copies of the element placed behind it at increasing offsets proportional to speed. Inherently one-sided: no forward blur.
-2. **Top blur** — a small symmetric Gaussian at the current position so the element looks in-motion rather than crisp on top of the trail.
-
-Blur scales linearly with velocity up to `blurMax`. Both the ghost trail and top blur clear automatically when the element decelerates to rest.
-
-## Options
-
-| Option | Default | Description |
-| --- | --- | --- |
-| `axis` | `"both"` | Motion axis — `"x"`, `"y"`, or `"both"` |
-| `blurScale` | `0.008` | Blur per px/s of velocity |
-| `blurMax` | `20` | Max blur radius on the motion axis (px) |
-| `stretchScale` | `0.0002` | scaleX/Y added per px/s (requires `stretchMax > 0`) |
-| `stretchMax` | `0` | Max stretch above 1.0 — disabled by default |
+**Wiring it by hand.** Open `compositions/components/motion-blur.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/motion-blur.mdx
+++ b/docs/catalog/components/motion-blur.mdx
@@ -3,34 +3,24 @@ title: "Motion Blur"
 description: "Velocity-driven motion blur — samples element position each frame and applies a one-sided SVG feGaussianBlur ghost trail proportional to speed"
 ---
 
-Velocity-driven motion blur — samples element position each frame and applies a one-sided SVG feGaussianBlur ghost trail proportional to speed
-
 `effect` `motion-blur` `velocity` `animation` `physics`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/motion-blur.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/motion-blur.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Motion Blur component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add motion-blur
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add motion-blur
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/motion-blur.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/parallax-unzoom.mdx
+++ b/docs/catalog/components/parallax-unzoom.mdx
@@ -3,34 +3,24 @@ title: "Parallax Unzoom"
 description: "Reveal transition — focus card scales down from full frame as siblings parallax in to form a grid (reverse of parallax-zoom)"
 ---
 
-Reveal transition — focus card scales down from full frame as siblings parallax in to form a grid (reverse of parallax-zoom)
-
 `transition` `reveal` `unzoom` `parallax` `grid` `hero`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-unzoom.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-unzoom.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Parallax Unzoom component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add parallax-unzoom
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add parallax-unzoom
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/parallax-unzoom.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/parallax-unzoom.mdx
+++ b/docs/catalog/components/parallax-unzoom.mdx
@@ -3,23 +3,34 @@ title: "Parallax Unzoom"
 description: "Reveal transition — focus card scales down from full frame as siblings parallax in to form a grid (reverse of parallax-zoom)"
 ---
 
-# Parallax Unzoom
-
 Reveal transition — focus card scales down from full frame as siblings parallax in to form a grid (reverse of parallax-zoom)
 
 `transition` `reveal` `unzoom` `parallax` `grid` `hero`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-unzoom.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-unzoom.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Parallax Unzoom component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add parallax-unzoom
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add parallax-unzoom
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `parallax-unzoom.html` | `compositions/components/parallax-unzoom.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/parallax-unzoom.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/parallax-unzoom.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/parallax-zoom.mdx
+++ b/docs/catalog/components/parallax-zoom.mdx
@@ -3,34 +3,24 @@ title: "Parallax Zoom"
 description: "Center card scales up to fill the frame while siblings parallax outward — inspired by the eBay Playbook hero transition"
 ---
 
-Center card scales up to fill the frame while siblings parallax outward — inspired by the eBay Playbook hero transition
-
 `transition` `zoom` `parallax` `grid` `hero`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-zoom.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-zoom.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Parallax Zoom component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add parallax-zoom
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add parallax-zoom
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/parallax-zoom.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/parallax-zoom.mdx
+++ b/docs/catalog/components/parallax-zoom.mdx
@@ -3,23 +3,34 @@ title: "Parallax Zoom"
 description: "Center card scales up to fill the frame while siblings parallax outward — inspired by the eBay Playbook hero transition"
 ---
 
-# Parallax Zoom
-
 Center card scales up to fill the frame while siblings parallax outward — inspired by the eBay Playbook hero transition
 
 `transition` `zoom` `parallax` `grid` `hero`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-zoom.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/parallax-zoom.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Parallax Zoom component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add parallax-zoom
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add parallax-zoom
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `parallax-zoom.html` | `compositions/components/parallax-zoom.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/parallax-zoom.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/parallax-zoom.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/shimmer-sweep.mdx
+++ b/docs/catalog/components/shimmer-sweep.mdx
@@ -3,23 +3,34 @@ title: "Shimmer Sweep"
 description: "Animated light sweep across text or elements using a CSS gradient mask — ideal for AI accents and premium reveals"
 ---
 
-# Shimmer Sweep
-
 Animated light sweep across text or elements using a CSS gradient mask — ideal for AI accents and premium reveals
 
 `text` `shimmer` `highlight` `effect`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/shimmer-sweep.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/shimmer-sweep.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Shimmer Sweep component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add shimmer-sweep
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add shimmer-sweep
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `shimmer-sweep.html` | `compositions/components/shimmer-sweep.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/shimmer-sweep.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/shimmer-sweep.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/shimmer-sweep.mdx
+++ b/docs/catalog/components/shimmer-sweep.mdx
@@ -3,34 +3,24 @@ title: "Shimmer Sweep"
 description: "Animated light sweep across text or elements using a CSS gradient mask — ideal for AI accents and premium reveals"
 ---
 
-Animated light sweep across text or elements using a CSS gradient mask — ideal for AI accents and premium reveals
-
 `text` `shimmer` `highlight` `effect`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/shimmer-sweep.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/shimmer-sweep.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Shimmer Sweep component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add shimmer-sweep
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add shimmer-sweep
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/shimmer-sweep.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/texture-mask-text.mdx
+++ b/docs/catalog/components/texture-mask-text.mdx
@@ -3,8 +3,6 @@ title: "Texture Mask Text"
 description: "CSS luminance masks that cut holes through letterforms - 66 pre-built texture masks from ambientCG PBR color maps"
 ---
 
-CSS luminance masks that cut holes through letterforms - 66 pre-built texture masks from ambientCG PBR color maps
-
 `text` `text-effect` `effect` `texture` `mask`
 
 <div className="hf-texture-preview-panel">
@@ -36,26 +34,18 @@ CSS luminance masks that cut holes through letterforms - 66 pre-built texture ma
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Texture Mask Text component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add texture-mask-text
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -501,3 +491,9 @@ window.__timelines["my-composition"] = tl;
 ## Use it
 
 After `npx hyperframes add texture-mask-text`, the installed snippet lives at `compositions/components/texture-mask-text/texture-mask-text.html` inside your current HyperFrames project. Open that file and paste the real `<style>` element near the bottom into your composition once; it defines `hf-texture-text` and every `hf-texture-*` class used by the examples above. Keep the installed texture PNGs in `assets/texture-mask-text/masks/`; the CSS references them with project-root URLs.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/texture-mask-text.mdx
+++ b/docs/catalog/components/texture-mask-text.mdx
@@ -1,8 +1,11 @@
 ---
 title: "Texture Mask Text"
+description: "CSS luminance masks that cut holes through letterforms - 66 pre-built texture masks from ambientCG PBR color maps"
 ---
 
-`text` `texture` `mask` `effect`
+CSS luminance masks that cut holes through letterforms - 66 pre-built texture masks from ambientCG PBR color maps
+
+`text` `text-effect` `effect` `texture` `mask`
 
 <div className="hf-texture-preview-panel">
   <div className="hf-texture-preview-card" style={{ "--mask-url": "url('https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/texture-mask-text/masks/brick.png')" }}>
@@ -31,15 +34,28 @@ title: "Texture Mask Text"
   </div>
 </div>
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Texture Mask Text component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add texture-mask-text
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -482,6 +498,6 @@ window.__timelines["my-composition"] = tl;
   </div>
 </div>
 
-## Usage
+## Use it
 
 After `npx hyperframes add texture-mask-text`, the installed snippet lives at `compositions/components/texture-mask-text/texture-mask-text.html` inside your current HyperFrames project. Open that file and paste the real `<style>` element near the bottom into your composition once; it defines `hf-texture-text` and every `hf-texture-*` class used by the examples above. Keep the installed texture PNGs in `assets/texture-mask-text/masks/`; the CSS references them with project-root URLs.

--- a/docs/catalog/components/vignette.mdx
+++ b/docs/catalog/components/vignette.mdx
@@ -3,34 +3,24 @@ title: "Vignette"
 description: "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center"
 ---
 
-Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center
-
 `vignette` `overlay` `cinematic` `effect`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Vignette component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add vignette
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add vignette
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/vignette.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/vignette.mdx
+++ b/docs/catalog/components/vignette.mdx
@@ -3,23 +3,34 @@ title: "Vignette"
 description: "Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center"
 ---
 
-# Vignette
-
 Cinematic radial vignette overlay using a pure-CSS gradient — darkens the edges to pull focus toward the center
 
 `vignette` `overlay` `cinematic` `effect`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/vignette.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Vignette component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add vignette
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add vignette
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `vignette.html` | `compositions/components/vignette.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/vignette.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/vignette.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/yt-camera-move.mdx
+++ b/docs/catalog/components/yt-camera-move.mdx
@@ -3,34 +3,24 @@ title: "Camera Punch-In"
 description: "Dynamic zoom, slide, and 3D tilt-pan helpers for any wrapper (video, include, card) with cubic-easing defaults and an edge-defocus pulse overlay"
 ---
 
-Dynamic zoom, slide, and 3D tilt-pan helpers for any wrapper (video, include, card) with cubic-easing defaults and an edge-defocus pulse overlay
-
 `camera` `zoom` `effect` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-camera-move.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-camera-move.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Camera Punch-In component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-camera-move
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add yt-camera-move
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/yt-camera-move.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/yt-camera-move.mdx
+++ b/docs/catalog/components/yt-camera-move.mdx
@@ -3,23 +3,34 @@ title: "Camera Punch-In"
 description: "Dynamic zoom, slide, and 3D tilt-pan helpers for any wrapper (video, include, card) with cubic-easing defaults and an edge-defocus pulse overlay"
 ---
 
-# Camera Punch-In
-
 Dynamic zoom, slide, and 3D tilt-pan helpers for any wrapper (video, include, card) with cubic-easing defaults and an edge-defocus pulse overlay
 
 `camera` `zoom` `effect` `creator`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-camera-move.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-camera-move.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Camera Punch-In component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-camera-move
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add yt-camera-move
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-camera-move.html` | `compositions/components/yt-camera-move.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/yt-camera-move.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/yt-camera-move.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/yt-circle-pointer.mdx
+++ b/docs/catalog/components/yt-circle-pointer.mdx
@@ -3,34 +3,24 @@ title: "Pointer Circle + Countdown"
 description: "Draw-on annotation ellipse around a target plus a countdown chip that pulses each tick"
 ---
 
-Draw-on annotation ellipse around a target plus a countdown chip that pulses each tick
-
 `annotation` `countdown` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-circle-pointer.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-circle-pointer.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Pointer Circle + Countdown component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-circle-pointer
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add yt-circle-pointer
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/yt-circle-pointer.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/yt-circle-pointer.mdx
+++ b/docs/catalog/components/yt-circle-pointer.mdx
@@ -3,23 +3,34 @@ title: "Pointer Circle + Countdown"
 description: "Draw-on annotation ellipse around a target plus a countdown chip that pulses each tick"
 ---
 
-# Pointer Circle + Countdown
-
 Draw-on annotation ellipse around a target plus a countdown chip that pulses each tick
 
 `annotation` `countdown` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-circle-pointer.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-circle-pointer.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Pointer Circle + Countdown component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-circle-pointer
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add yt-circle-pointer
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-circle-pointer.html` | `compositions/components/yt-circle-pointer.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/yt-circle-pointer.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/yt-circle-pointer.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/yt-feather-highlight.mdx
+++ b/docs/catalog/components/yt-feather-highlight.mdx
@@ -3,34 +3,24 @@ title: "Feathered Spotlight"
 description: "Dims the frame except a feathered ellipse; the hole's position and size are CSS variables, so helpers glide the spotlight between targets"
 ---
 
-Dims the frame except a feathered ellipse; the hole's position and size are CSS variables, so helpers glide the spotlight between targets
-
 `highlight` `spotlight` `effect` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-feather-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-feather-highlight.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the Feathered Spotlight component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-feather-highlight
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add yt-feather-highlight
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/yt-feather-highlight.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/components/yt-feather-highlight.mdx
+++ b/docs/catalog/components/yt-feather-highlight.mdx
@@ -3,23 +3,34 @@ title: "Feathered Spotlight"
 description: "Dims the frame except a feathered ellipse; the hole's position and size are CSS variables, so helpers glide the spotlight between targets"
 ---
 
-# Feathered Spotlight
-
 Dims the frame except a feathered ellipse; the hole's position and size are CSS variables, so helpers glide the spotlight between targets
 
 `highlight` `spotlight` `effect` `overlay`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-feather-highlight.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-feather-highlight.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the Feathered Spotlight component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-feather-highlight
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add yt-feather-highlight
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-feather-highlight.html` | `compositions/components/yt-feather-highlight.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/yt-feather-highlight.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/yt-feather-highlight.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/yt-screen-warp.mdx
+++ b/docs/catalog/components/yt-screen-warp.mdx
@@ -3,23 +3,34 @@ title: "On-Screen Display Effect"
 description: "Grid, scanline, vignette, and sheen overlay plus a 3D-warp wrapper class that makes footage read as if playing on a physical display"
 ---
 
-# On-Screen Display Effect
-
 Grid, scanline, vignette, and sheen overlay plus a 3D-warp wrapper class that makes footage read as if playing on a physical display
 
 `effect` `overlay` `texture`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-screen-warp.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-screen-warp.png" autoPlay muted loop playsInline />
 
-## Install
+## Add it to a project
 
-<CodeGroup>
+<Tabs>
 
-```bash Terminal
+<Tab title="Ask your agent">
+
+```text
+Add the On-Screen Display Effect component from the HyperFrames Catalog to this project.
+Replace the demo content with mine and match the existing design and timing.
+```
+
+</Tab>
+
+<Tab title="Terminal">
+
+```bash
 npx hyperframes add yt-screen-warp
 ```
 
-</CodeGroup>
+</Tab>
+
+</Tabs>
 
 ## Details
 
@@ -27,12 +38,14 @@ npx hyperframes add yt-screen-warp
 | --- | --- |
 | Type | Component |
 
-## Files
+**Installed files**
 
 | File | Target | Type |
 | --- | --- | --- |
 | `yt-screen-warp.html` | `compositions/components/yt-screen-warp.html` | hyperframes:snippet |
 
-## Usage
+## Use it
 
-Open `compositions/components/yt-screen-warp.html` and paste its contents into your composition. See the comment header in the file for detailed instructions.
+Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
+
+**Wiring it by hand.** Open `compositions/components/yt-screen-warp.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.

--- a/docs/catalog/components/yt-screen-warp.mdx
+++ b/docs/catalog/components/yt-screen-warp.mdx
@@ -3,34 +3,24 @@ title: "On-Screen Display Effect"
 description: "Grid, scanline, vignette, and sheen overlay plus a 3D-warp wrapper class that makes footage read as if playing on a physical display"
 ---
 
-Grid, scanline, vignette, and sheen overlay plus a 3D-warp wrapper class that makes footage read as if playing on a physical display
-
 `effect` `overlay` `texture`
 
 <video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-screen-warp.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/yt-screen-warp.png" autoPlay muted loop playsInline />
 
 ## Add it to a project
 
-<Tabs>
-
-<Tab title="Ask your agent">
+### Ask your agent
 
 ```text
 Add the On-Screen Display Effect component from the HyperFrames Catalog to this project.
 Replace the demo content with mine and match the existing design and timing.
 ```
 
-</Tab>
-
-<Tab title="Terminal">
+### Install from the terminal
 
 ```bash
 npx hyperframes add yt-screen-warp
 ```
-
-</Tab>
-
-</Tabs>
 
 ## Details
 
@@ -49,3 +39,9 @@ npx hyperframes add yt-screen-warp
 Ask your agent to apply the component to the intended element and preserve the project’s existing timing.
 
 **Wiring it by hand.** Open `compositions/components/yt-screen-warp.html` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/catalog/index.mdx
+++ b/docs/catalog/index.mdx
@@ -26,10 +26,10 @@ Use a **block** when you want a larger scene or self-contained visual. Use a **c
   <Card title="Social overlays" icon="share-nodes" href="/catalog/blocks/x-post">
     Show posts, follow prompts, notifications, names, roles, and platform-inspired cards.
   </Card>
-  <Card title="Data and maps" icon="chart-column" href="/catalog/blocks/data-chart">
+  <Card title="Data and diagrams" icon="chart-column" href="/catalog/blocks/data-chart">
     Explain a number, comparison, trend, location, or geographic movement.
   </Card>
-  <Card title="Showcase scenes" icon="play" href="/catalog/blocks/app-showcase">
+  <Card title="Complete scenes" icon="play" href="/catalog/blocks/app-showcase">
     Start from a larger scene that already combines design, media, and animation.
   </Card>
 </CardGroup>

--- a/docs/catalog/index.mdx
+++ b/docs/catalog/index.mdx
@@ -1,10 +1,6 @@
 ---
 title: "Catalog"
 description: "Browse reusable HyperFrames scenes, transitions, captions, overlays, effects, and components."
-related:
-  - /go-further
-  - /studio/assets-and-blocks
-  - /contributing/catalog
 ---
 
 The Catalog is a library of visuals you can add to a project instead of building each one from scratch.
@@ -59,4 +55,8 @@ Check:
 - Does it feel like part of this project rather than a pasted demo?
 - Is a quieter alternative more effective?
 
-[Learn how to add Catalog items in Studio →](/studio/assets-and-blocks)
+## Related topics
+
+- [Add Catalog items in Studio](/studio/assets-and-blocks)
+- [Build richer compositions](/go-further)
+- [Contribute a Catalog item](/contributing/catalog)

--- a/docs/catalog/index.mdx
+++ b/docs/catalog/index.mdx
@@ -1,6 +1,10 @@
 ---
 title: "Catalog"
 description: "Browse reusable HyperFrames scenes, transitions, captions, overlays, effects, and components."
+related:
+  - /go-further
+  - /studio/assets-and-blocks
+  - /contributing/catalog
 ---
 
 The Catalog is a library of visuals you can add to a project instead of building each one from scratch.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -215,6 +215,35 @@
             ]
           },
           {
+            "group": "Code Themes",
+            "pages": [
+              "catalog/blocks/code-snippet-apple-terminal-basic",
+              "catalog/blocks/code-snippet-apple-terminal-clear-dark",
+              "catalog/blocks/code-snippet-apple-terminal-clear-light",
+              "catalog/blocks/code-snippet-apple-terminal-grass",
+              "catalog/blocks/code-snippet-apple-terminal-homebrew",
+              "catalog/blocks/code-snippet-apple-terminal-man-page",
+              "catalog/blocks/code-snippet-apple-terminal-novel",
+              "catalog/blocks/code-snippet-apple-terminal-ocean",
+              "catalog/blocks/code-snippet-apple-terminal-pro",
+              "catalog/blocks/code-snippet-apple-terminal-red-sands",
+              "catalog/blocks/code-snippet-apple-terminal-silver-aerogel",
+              "catalog/blocks/code-snippet-apple-terminal-solid-colors",
+              "catalog/blocks/code-snippet-dark-2026",
+              "catalog/blocks/code-snippet-dark-modern",
+              "catalog/blocks/code-snippet-dark-plus",
+              "catalog/blocks/code-snippet-high-contrast",
+              "catalog/blocks/code-snippet-high-contrast-light",
+              "catalog/blocks/code-snippet-light-2026",
+              "catalog/blocks/code-snippet-light-modern",
+              "catalog/blocks/code-snippet-light-plus",
+              "catalog/blocks/code-snippet-monokai",
+              "catalog/blocks/code-snippet-solarized-light",
+              "catalog/blocks/code-snippet-visual-studio-dark",
+              "catalog/blocks/code-snippet-visual-studio-light"
+            ]
+          },
+          {
             "group": "Captions",
             "pages": [
               "catalog/components/caption-clip-wipe",
@@ -236,7 +265,7 @@
             ]
           },
           {
-            "group": "HTML-in-Canvas",
+            "group": "Interface & VFX",
             "pages": [
               "catalog/blocks/ios26-liquid-glass",
               "catalog/blocks/liquid-glass-context-menu",
@@ -286,7 +315,7 @@
             ]
           },
           {
-            "group": "Shader Transitions",
+            "group": "Transitions",
             "pages": [
               "catalog/blocks/chromatic-radial-split",
               "catalog/blocks/cinematic-zoom",
@@ -301,12 +330,7 @@
               "catalog/blocks/sdf-iris",
               "catalog/blocks/swirl-vortex",
               "catalog/blocks/thermal-distortion",
-              "catalog/blocks/whip-pan"
-            ]
-          },
-          {
-            "group": "CSS Transitions",
-            "pages": [
+              "catalog/blocks/whip-pan",
               "catalog/blocks/beat-freeze-cut",
               "catalog/blocks/hw-scribble-transition",
               "catalog/blocks/mk-clone-wall-transition",
@@ -323,39 +347,18 @@
               "catalog/blocks/transitions-other",
               "catalog/blocks/transitions-push",
               "catalog/blocks/transitions-radial",
-              "catalog/blocks/transitions-scale"
+              "catalog/blocks/transitions-scale",
+              "catalog/components/grid-pixelate-wipe",
+              "catalog/components/parallax-unzoom",
+              "catalog/components/parallax-zoom"
             ]
           },
           {
-            "group": "Showcases",
+            "group": "Complete Scenes",
             "pages": [
               "catalog/blocks/app-showcase",
               "catalog/blocks/apple-money-count",
               "catalog/blocks/blue-sweater-intro-video",
-              "catalog/blocks/code-snippet-apple-terminal-basic",
-              "catalog/blocks/code-snippet-apple-terminal-clear-dark",
-              "catalog/blocks/code-snippet-apple-terminal-clear-light",
-              "catalog/blocks/code-snippet-apple-terminal-grass",
-              "catalog/blocks/code-snippet-apple-terminal-homebrew",
-              "catalog/blocks/code-snippet-apple-terminal-man-page",
-              "catalog/blocks/code-snippet-apple-terminal-novel",
-              "catalog/blocks/code-snippet-apple-terminal-ocean",
-              "catalog/blocks/code-snippet-apple-terminal-pro",
-              "catalog/blocks/code-snippet-apple-terminal-red-sands",
-              "catalog/blocks/code-snippet-apple-terminal-silver-aerogel",
-              "catalog/blocks/code-snippet-apple-terminal-solid-colors",
-              "catalog/blocks/code-snippet-dark-2026",
-              "catalog/blocks/code-snippet-dark-modern",
-              "catalog/blocks/code-snippet-dark-plus",
-              "catalog/blocks/code-snippet-high-contrast",
-              "catalog/blocks/code-snippet-high-contrast-light",
-              "catalog/blocks/code-snippet-light-2026",
-              "catalog/blocks/code-snippet-light-modern",
-              "catalog/blocks/code-snippet-light-plus",
-              "catalog/blocks/code-snippet-monokai",
-              "catalog/blocks/code-snippet-solarized-light",
-              "catalog/blocks/code-snippet-visual-studio-dark",
-              "catalog/blocks/code-snippet-visual-studio-light",
               "catalog/blocks/north-korea-locked-down",
               "catalog/blocks/nyc-paris-flight",
               "catalog/blocks/ui-3d-reveal",
@@ -363,7 +366,7 @@
             ]
           },
           {
-            "group": "Data",
+            "group": "Data & Diagrams",
             "pages": [
               "catalog/blocks/data-chart",
               "catalog/blocks/mk-line-graph",
@@ -372,15 +375,19 @@
               "catalog/blocks/us-map-bubble",
               "catalog/blocks/us-map-flow",
               "catalog/blocks/us-map-hex",
-              "catalog/blocks/world-map"
+              "catalog/blocks/world-map",
+              "catalog/blocks/flowchart",
+              "catalog/blocks/flowchart-vertical",
+              "catalog/blocks/hw-pipeline",
+              "catalog/blocks/hw-text-cloud",
+              "catalog/blocks/mk-progress-stat",
+              "catalog/blocks/mk-specs-list"
             ]
           },
           {
-            "group": "Effects",
+            "group": "Text & Annotations",
             "pages": [
               "catalog/components/caption-blend-difference",
-              "catalog/components/grain-overlay",
-              "catalog/components/grid-pixelate-wipe",
               "catalog/components/hw-arrow",
               "catalog/components/hw-boil",
               "catalog/components/hw-box-label",
@@ -389,37 +396,40 @@
               "catalog/components/mk-emphasis-type",
               "catalog/components/mk-usage-arc",
               "catalog/components/morph-text",
-              "catalog/components/motion-blur",
-              "catalog/components/parallax-unzoom",
-              "catalog/components/parallax-zoom",
-              "catalog/components/shimmer-sweep",
               "catalog/components/texture-mask-text",
+              "catalog/components/yt-circle-pointer"
+            ]
+          },
+          {
+            "group": "Visual & Camera Effects",
+            "pages": [
+              "catalog/components/grain-overlay",
+              "catalog/components/motion-blur",
+              "catalog/components/shimmer-sweep",
               "catalog/components/vignette",
               "catalog/components/yt-camera-move",
-              "catalog/components/yt-circle-pointer",
               "catalog/components/yt-feather-highlight",
               "catalog/components/yt-screen-warp"
             ]
           },
           {
-            "group": "Blocks",
+            "group": "Titles & Identity",
             "pages": [
-              "catalog/blocks/camcorder-hud",
-              "catalog/blocks/flowchart",
-              "catalog/blocks/flowchart-vertical",
-              "catalog/blocks/hw-frame",
               "catalog/blocks/hw-path-text",
-              "catalog/blocks/hw-pipeline",
-              "catalog/blocks/hw-text-cloud",
               "catalog/blocks/hw-title",
               "catalog/blocks/logo-outro",
+              "catalog/blocks/yt-logo-intro",
+              "catalog/blocks/yt-prism-title"
+            ]
+          },
+          {
+            "group": "Frames & Layouts",
+            "pages": [
+              "catalog/blocks/camcorder-hud",
+              "catalog/blocks/hw-frame",
               "catalog/blocks/mk-background",
               "catalog/blocks/mk-placeholder-grid",
-              "catalog/blocks/mk-progress-stat",
-              "catalog/blocks/mk-specs-list",
               "catalog/blocks/yt-lcd-background",
-              "catalog/blocks/yt-logo-intro",
-              "catalog/blocks/yt-prism-title",
               "catalog/blocks/yt-vertical-fill"
             ]
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -53,15 +53,27 @@
         "groups": [
           {
             "group": "Start here",
-            "pages": ["introduction", "quickstart", "go-further", "developers/index"]
+            "pages": [
+              "introduction",
+              "quickstart",
+              "go-further",
+              "developers/index"
+            ]
           },
           {
             "group": "Explore",
-            "pages": ["examples", "product-updates"]
+            "pages": [
+              "examples",
+              "product-updates"
+            ]
           },
           {
             "group": "Choose where to create",
-            "pages": ["guides/choose-creation-path", "guides/mcp", "guides/design-tools"]
+            "pages": [
+              "guides/choose-creation-path",
+              "guides/mcp",
+              "guides/design-tools"
+            ]
           },
           {
             "group": "Prompt Guide",
@@ -90,7 +102,10 @@
               },
               {
                 "group": "Level 3 — Life",
-                "pages": ["prompting/motion", "prompting/transitions"]
+                "pages": [
+                  "prompting/motion",
+                  "prompting/transitions"
+                ]
               },
               {
                 "group": "Level 4 — Substance",
@@ -107,7 +122,9 @@
               },
               {
                 "group": "Level 5 — Voice and sound",
-                "pages": ["prompting/media-and-audio"]
+                "pages": [
+                  "prompting/media-and-audio"
+                ]
               },
               {
                 "group": "Level 6 — Scale",
@@ -124,11 +141,15 @@
               },
               {
                 "group": "Level 7 — Capstone",
-                "pages": ["prompting/capstone"]
+                "pages": [
+                  "prompting/capstone"
+                ]
               },
               {
                 "group": "Appendix",
-                "pages": ["prompting/rules-and-anti-patterns"]
+                "pages": [
+                  "prompting/rules-and-anti-patterns"
+                ]
               }
             ]
           },
@@ -162,7 +183,11 @@
           },
           {
             "group": "Help",
-            "pages": ["help", "guides/troubleshooting", "guides/feedback"]
+            "pages": [
+              "help",
+              "guides/troubleshooting",
+              "guides/feedback"
+            ]
           }
         ]
       },
@@ -172,23 +197,41 @@
         "groups": [
           {
             "group": "Start in Studio",
-            "pages": ["studio/index", "studio/storyboard"]
+            "pages": [
+              "studio/index",
+              "studio/storyboard"
+            ]
           },
           {
             "group": "Edit",
-            "pages": ["studio/canvas", "studio/timeline", "studio/animation", "studio/captions"]
+            "pages": [
+              "studio/canvas",
+              "studio/timeline",
+              "studio/animation",
+              "studio/captions"
+            ]
           },
           {
             "group": "Build and reuse",
-            "pages": ["studio/assets-and-blocks", "studio/variables", "studio/slideshows"]
+            "pages": [
+              "studio/assets-and-blocks",
+              "studio/variables",
+              "studio/slideshows"
+            ]
           },
           {
             "group": "Finish and recover",
-            "pages": ["studio/export", "studio/troubleshooting"]
+            "pages": [
+              "studio/export",
+              "studio/troubleshooting"
+            ]
           },
           {
             "group": "Reference",
-            "pages": ["studio/source", "studio/shortcuts"]
+            "pages": [
+              "studio/source",
+              "studio/shortcuts"
+            ]
           }
         ]
       },
@@ -198,7 +241,9 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["catalog/index"]
+            "pages": [
+              "catalog/index"
+            ]
           },
           {
             "group": "Code Animations",
@@ -212,35 +257,6 @@
               "catalog/blocks/code-shader-dissolve",
               "catalog/blocks/code-snippet-flight",
               "catalog/blocks/code-typing"
-            ]
-          },
-          {
-            "group": "Code Themes",
-            "pages": [
-              "catalog/blocks/code-snippet-apple-terminal-basic",
-              "catalog/blocks/code-snippet-apple-terminal-clear-dark",
-              "catalog/blocks/code-snippet-apple-terminal-clear-light",
-              "catalog/blocks/code-snippet-apple-terminal-grass",
-              "catalog/blocks/code-snippet-apple-terminal-homebrew",
-              "catalog/blocks/code-snippet-apple-terminal-man-page",
-              "catalog/blocks/code-snippet-apple-terminal-novel",
-              "catalog/blocks/code-snippet-apple-terminal-ocean",
-              "catalog/blocks/code-snippet-apple-terminal-pro",
-              "catalog/blocks/code-snippet-apple-terminal-red-sands",
-              "catalog/blocks/code-snippet-apple-terminal-silver-aerogel",
-              "catalog/blocks/code-snippet-apple-terminal-solid-colors",
-              "catalog/blocks/code-snippet-dark-2026",
-              "catalog/blocks/code-snippet-dark-modern",
-              "catalog/blocks/code-snippet-dark-plus",
-              "catalog/blocks/code-snippet-high-contrast",
-              "catalog/blocks/code-snippet-high-contrast-light",
-              "catalog/blocks/code-snippet-light-2026",
-              "catalog/blocks/code-snippet-light-modern",
-              "catalog/blocks/code-snippet-light-plus",
-              "catalog/blocks/code-snippet-monokai",
-              "catalog/blocks/code-snippet-solarized-light",
-              "catalog/blocks/code-snippet-visual-studio-dark",
-              "catalog/blocks/code-snippet-visual-studio-light"
             ]
           },
           {
@@ -265,7 +281,7 @@
             ]
           },
           {
-            "group": "Interface & VFX",
+            "group": "HTML-in-Canvas",
             "pages": [
               "catalog/blocks/ios26-liquid-glass",
               "catalog/blocks/liquid-glass-context-menu",
@@ -315,7 +331,7 @@
             ]
           },
           {
-            "group": "Transitions",
+            "group": "Shader Transitions",
             "pages": [
               "catalog/blocks/chromatic-radial-split",
               "catalog/blocks/cinematic-zoom",
@@ -330,7 +346,12 @@
               "catalog/blocks/sdf-iris",
               "catalog/blocks/swirl-vortex",
               "catalog/blocks/thermal-distortion",
-              "catalog/blocks/whip-pan",
+              "catalog/blocks/whip-pan"
+            ]
+          },
+          {
+            "group": "CSS Transitions",
+            "pages": [
               "catalog/blocks/beat-freeze-cut",
               "catalog/blocks/hw-scribble-transition",
               "catalog/blocks/mk-clone-wall-transition",
@@ -347,18 +368,39 @@
               "catalog/blocks/transitions-other",
               "catalog/blocks/transitions-push",
               "catalog/blocks/transitions-radial",
-              "catalog/blocks/transitions-scale",
-              "catalog/components/grid-pixelate-wipe",
-              "catalog/components/parallax-unzoom",
-              "catalog/components/parallax-zoom"
+              "catalog/blocks/transitions-scale"
             ]
           },
           {
-            "group": "Complete Scenes",
+            "group": "Showcases",
             "pages": [
               "catalog/blocks/app-showcase",
               "catalog/blocks/apple-money-count",
               "catalog/blocks/blue-sweater-intro-video",
+              "catalog/blocks/code-snippet-apple-terminal-basic",
+              "catalog/blocks/code-snippet-apple-terminal-clear-dark",
+              "catalog/blocks/code-snippet-apple-terminal-clear-light",
+              "catalog/blocks/code-snippet-apple-terminal-grass",
+              "catalog/blocks/code-snippet-apple-terminal-homebrew",
+              "catalog/blocks/code-snippet-apple-terminal-man-page",
+              "catalog/blocks/code-snippet-apple-terminal-novel",
+              "catalog/blocks/code-snippet-apple-terminal-ocean",
+              "catalog/blocks/code-snippet-apple-terminal-pro",
+              "catalog/blocks/code-snippet-apple-terminal-red-sands",
+              "catalog/blocks/code-snippet-apple-terminal-silver-aerogel",
+              "catalog/blocks/code-snippet-apple-terminal-solid-colors",
+              "catalog/blocks/code-snippet-dark-2026",
+              "catalog/blocks/code-snippet-dark-modern",
+              "catalog/blocks/code-snippet-dark-plus",
+              "catalog/blocks/code-snippet-high-contrast",
+              "catalog/blocks/code-snippet-high-contrast-light",
+              "catalog/blocks/code-snippet-light-2026",
+              "catalog/blocks/code-snippet-light-modern",
+              "catalog/blocks/code-snippet-light-plus",
+              "catalog/blocks/code-snippet-monokai",
+              "catalog/blocks/code-snippet-solarized-light",
+              "catalog/blocks/code-snippet-visual-studio-dark",
+              "catalog/blocks/code-snippet-visual-studio-light",
               "catalog/blocks/north-korea-locked-down",
               "catalog/blocks/nyc-paris-flight",
               "catalog/blocks/ui-3d-reveal",
@@ -366,7 +408,7 @@
             ]
           },
           {
-            "group": "Data & Diagrams",
+            "group": "Data",
             "pages": [
               "catalog/blocks/data-chart",
               "catalog/blocks/mk-line-graph",
@@ -375,19 +417,15 @@
               "catalog/blocks/us-map-bubble",
               "catalog/blocks/us-map-flow",
               "catalog/blocks/us-map-hex",
-              "catalog/blocks/world-map",
-              "catalog/blocks/flowchart",
-              "catalog/blocks/flowchart-vertical",
-              "catalog/blocks/hw-pipeline",
-              "catalog/blocks/hw-text-cloud",
-              "catalog/blocks/mk-progress-stat",
-              "catalog/blocks/mk-specs-list"
+              "catalog/blocks/world-map"
             ]
           },
           {
-            "group": "Text & Annotations",
+            "group": "Effects",
             "pages": [
               "catalog/components/caption-blend-difference",
+              "catalog/components/grain-overlay",
+              "catalog/components/grid-pixelate-wipe",
               "catalog/components/hw-arrow",
               "catalog/components/hw-boil",
               "catalog/components/hw-box-label",
@@ -396,40 +434,37 @@
               "catalog/components/mk-emphasis-type",
               "catalog/components/mk-usage-arc",
               "catalog/components/morph-text",
-              "catalog/components/texture-mask-text",
-              "catalog/components/yt-circle-pointer"
-            ]
-          },
-          {
-            "group": "Visual & Camera Effects",
-            "pages": [
-              "catalog/components/grain-overlay",
               "catalog/components/motion-blur",
+              "catalog/components/parallax-unzoom",
+              "catalog/components/parallax-zoom",
               "catalog/components/shimmer-sweep",
+              "catalog/components/texture-mask-text",
               "catalog/components/vignette",
               "catalog/components/yt-camera-move",
+              "catalog/components/yt-circle-pointer",
               "catalog/components/yt-feather-highlight",
               "catalog/components/yt-screen-warp"
             ]
           },
           {
-            "group": "Titles & Identity",
-            "pages": [
-              "catalog/blocks/hw-path-text",
-              "catalog/blocks/hw-title",
-              "catalog/blocks/logo-outro",
-              "catalog/blocks/yt-logo-intro",
-              "catalog/blocks/yt-prism-title"
-            ]
-          },
-          {
-            "group": "Frames & Layouts",
+            "group": "Blocks",
             "pages": [
               "catalog/blocks/camcorder-hud",
+              "catalog/blocks/flowchart",
+              "catalog/blocks/flowchart-vertical",
               "catalog/blocks/hw-frame",
+              "catalog/blocks/hw-path-text",
+              "catalog/blocks/hw-pipeline",
+              "catalog/blocks/hw-text-cloud",
+              "catalog/blocks/hw-title",
+              "catalog/blocks/logo-outro",
               "catalog/blocks/mk-background",
               "catalog/blocks/mk-placeholder-grid",
+              "catalog/blocks/mk-progress-stat",
+              "catalog/blocks/mk-specs-list",
               "catalog/blocks/yt-lcd-background",
+              "catalog/blocks/yt-logo-intro",
+              "catalog/blocks/yt-prism-title",
               "catalog/blocks/yt-vertical-fill"
             ]
           }
@@ -441,11 +476,17 @@
         "groups": [
           {
             "group": "Start here",
-            "pages": ["developers/overview"]
+            "pages": [
+              "developers/overview"
+            ]
           },
           {
             "group": "Command line",
-            "pages": ["developers/cli", "packages/cli", "packages/lint"]
+            "pages": [
+              "developers/cli",
+              "packages/cli",
+              "packages/lint"
+            ]
           },
           {
             "group": "SDK guides",
@@ -487,11 +528,19 @@
           },
           {
             "group": "Composition reference",
-            "pages": ["reference/html-schema", "reference/color-grading"]
+            "pages": [
+              "reference/html-schema",
+              "reference/color-grading"
+            ]
           },
           {
             "group": "Rendering paths",
-            "pages": ["guides/rendering", "deploy/overview", "deploy/cloud", "guides/deploy"]
+            "pages": [
+              "guides/rendering",
+              "deploy/overview",
+              "deploy/cloud",
+              "guides/deploy"
+            ]
           },
           {
             "group": "Cloud infrastructure",
@@ -506,7 +555,11 @@
           },
           {
             "group": "Advanced rendering",
-            "pages": ["guides/4k-rendering", "guides/hdr", "guides/performance"]
+            "pages": [
+              "guides/4k-rendering",
+              "guides/hdr",
+              "guides/performance"
+            ]
           },
           {
             "group": "Packages",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -281,7 +281,7 @@
             ]
           },
           {
-            "group": "HTML-in-Canvas",
+            "group": "Interface & VFX",
             "pages": [
               "catalog/blocks/ios26-liquid-glass",
               "catalog/blocks/liquid-glass-context-menu",
@@ -331,7 +331,7 @@
             ]
           },
           {
-            "group": "Shader Transitions",
+            "group": "Transitions",
             "pages": [
               "catalog/blocks/chromatic-radial-split",
               "catalog/blocks/cinematic-zoom",
@@ -346,12 +346,7 @@
               "catalog/blocks/sdf-iris",
               "catalog/blocks/swirl-vortex",
               "catalog/blocks/thermal-distortion",
-              "catalog/blocks/whip-pan"
-            ]
-          },
-          {
-            "group": "CSS Transitions",
-            "pages": [
+              "catalog/blocks/whip-pan",
               "catalog/blocks/beat-freeze-cut",
               "catalog/blocks/hw-scribble-transition",
               "catalog/blocks/mk-clone-wall-transition",
@@ -372,11 +367,8 @@
             ]
           },
           {
-            "group": "Showcases",
+            "group": "Code Themes",
             "pages": [
-              "catalog/blocks/app-showcase",
-              "catalog/blocks/apple-money-count",
-              "catalog/blocks/blue-sweater-intro-video",
               "catalog/blocks/code-snippet-apple-terminal-basic",
               "catalog/blocks/code-snippet-apple-terminal-clear-dark",
               "catalog/blocks/code-snippet-apple-terminal-clear-light",
@@ -400,7 +392,15 @@
               "catalog/blocks/code-snippet-monokai",
               "catalog/blocks/code-snippet-solarized-light",
               "catalog/blocks/code-snippet-visual-studio-dark",
-              "catalog/blocks/code-snippet-visual-studio-light",
+              "catalog/blocks/code-snippet-visual-studio-light"
+            ]
+          },
+          {
+            "group": "Complete Scenes",
+            "pages": [
+              "catalog/blocks/app-showcase",
+              "catalog/blocks/apple-money-count",
+              "catalog/blocks/blue-sweater-intro-video",
               "catalog/blocks/north-korea-locked-down",
               "catalog/blocks/nyc-paris-flight",
               "catalog/blocks/ui-3d-reveal",
@@ -408,10 +408,16 @@
             ]
           },
           {
-            "group": "Data",
+            "group": "Data & Diagrams",
             "pages": [
               "catalog/blocks/data-chart",
+              "catalog/blocks/flowchart",
+              "catalog/blocks/flowchart-vertical",
+              "catalog/blocks/hw-pipeline",
+              "catalog/blocks/hw-text-cloud",
               "catalog/blocks/mk-line-graph",
+              "catalog/blocks/mk-progress-stat",
+              "catalog/blocks/mk-specs-list",
               "catalog/blocks/spain-map",
               "catalog/blocks/us-map",
               "catalog/blocks/us-map-bubble",
@@ -421,7 +427,7 @@
             ]
           },
           {
-            "group": "Effects",
+            "group": "Effects & Annotations",
             "pages": [
               "catalog/components/caption-blend-difference",
               "catalog/components/grain-overlay",
@@ -447,21 +453,15 @@
             ]
           },
           {
-            "group": "Blocks",
+            "group": "Titles & Layouts",
             "pages": [
               "catalog/blocks/camcorder-hud",
-              "catalog/blocks/flowchart",
-              "catalog/blocks/flowchart-vertical",
               "catalog/blocks/hw-frame",
               "catalog/blocks/hw-path-text",
-              "catalog/blocks/hw-pipeline",
-              "catalog/blocks/hw-text-cloud",
               "catalog/blocks/hw-title",
               "catalog/blocks/logo-outro",
               "catalog/blocks/mk-background",
               "catalog/blocks/mk-placeholder-grid",
-              "catalog/blocks/mk-progress-stat",
-              "catalog/blocks/mk-specs-list",
               "catalog/blocks/yt-lcd-background",
               "catalog/blocks/yt-logo-intro",
               "catalog/blocks/yt-prism-title",

--- a/docs/public/catalog-index.json
+++ b/docs/public/catalog-index.json
@@ -448,8 +448,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-basic",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-basic"
   },
   {
     "name": "code-snippet-apple-terminal-clear-dark",
@@ -464,8 +463,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-clear-dark",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-clear-dark"
   },
   {
     "name": "code-snippet-apple-terminal-clear-light",
@@ -480,8 +478,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-clear-light",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-clear-light"
   },
   {
     "name": "code-snippet-apple-terminal-grass",
@@ -496,8 +493,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-grass",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-grass"
   },
   {
     "name": "code-snippet-apple-terminal-homebrew",
@@ -512,8 +508,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-homebrew",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-homebrew"
   },
   {
     "name": "code-snippet-apple-terminal-man-page",
@@ -528,8 +523,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-man-page",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-man-page"
   },
   {
     "name": "code-snippet-apple-terminal-novel",
@@ -544,8 +538,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-novel",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-novel"
   },
   {
     "name": "code-snippet-apple-terminal-ocean",
@@ -560,8 +553,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-ocean",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-ocean"
   },
   {
     "name": "code-snippet-apple-terminal-pro",
@@ -576,8 +568,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-pro",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-pro"
   },
   {
     "name": "code-snippet-apple-terminal-red-sands",
@@ -592,8 +583,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-red-sands",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-red-sands"
   },
   {
     "name": "code-snippet-apple-terminal-silver-aerogel",
@@ -608,8 +598,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-silver-aerogel",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-silver-aerogel"
   },
   {
     "name": "code-snippet-apple-terminal-solid-colors",
@@ -624,8 +613,7 @@
       "apple",
       "apple-terminal"
     ],
-    "href": "/catalog/blocks/code-snippet-apple-terminal-solid-colors",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.png"
+    "href": "/catalog/blocks/code-snippet-apple-terminal-solid-colors"
   },
   {
     "name": "code-snippet-dark-2026",
@@ -1569,8 +1557,7 @@
       "kinetic",
       "animation"
     ],
-    "href": "/catalog/components/morph-text",
-    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/morph-text.png"
+    "href": "/catalog/components/morph-text"
   },
   {
     "name": "motion-blur",

--- a/registry/blocks/code-snippet-apple-terminal-basic/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-basic/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-basic.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-clear-dark/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-clear-dark/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-dark.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-clear-light/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-clear-light/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-clear-light.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-grass/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-grass/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-grass.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-homebrew/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-homebrew/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-homebrew.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-man-page/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-man-page/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-man-page.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-novel/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-novel/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-novel.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-ocean/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-ocean/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-ocean.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-pro/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-pro/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-pro.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-red-sands/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-red-sands/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-red-sands.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-silver-aerogel/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-silver-aerogel/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-silver-aerogel.mp4"
   }
 }

--- a/registry/blocks/code-snippet-apple-terminal-solid-colors/registry-item.json
+++ b/registry/blocks/code-snippet-apple-terminal-solid-colors/registry-item.json
@@ -18,7 +18,6 @@
     }
   ],
   "preview": {
-    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.mp4",
-    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.png"
+    "video": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/code-snippet-apple-terminal-solid-colors.mp4"
   }
 }

--- a/scripts/generate-catalog-pages.ts
+++ b/scripts/generate-catalog-pages.ts
@@ -304,7 +304,8 @@ function generateTexturePreview(manifest: RegistryItem, textureGroups: TextureGr
   return lines;
 }
 
-function catalogPreviewFor(kind: ItemKind, manifest: RegistryItem): string {
+function catalogPreviewFor(kind: ItemKind, manifest: RegistryItem): string | undefined {
+  if (manifest.preview) return manifest.preview.poster;
   const dir = typeDir(kind);
   return `${catalogImageBase}/${dir}/${manifest.name}.png`;
 }
@@ -354,10 +355,12 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
   if (textureGroups.length > 0) {
     lines.push(...generateTexturePreview(manifest, textureGroups));
   } else {
-    // Preview video with poster — muted loop, no autoPlay (matches examples page).
     const previewPath = `${catalogImageBase}/${typeDir(kind)}/${manifest.name}`;
+    const previewVideo = manifest.preview?.video ?? `${previewPath}.mp4`;
+    const previewPoster = manifest.preview ? manifest.preview.poster : `${previewPath}.png`;
+    const posterAttribute = previewPoster ? ` poster="${previewPoster}"` : "";
     lines.push(
-      `<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="${previewPath}.mp4" poster="${previewPath}.png" autoPlay muted loop playsInline />`,
+      `<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="${previewVideo}"${posterAttribute} autoPlay muted loop playsInline />`,
       "",
     );
   }

--- a/scripts/generate-catalog-pages.ts
+++ b/scripts/generate-catalog-pages.ts
@@ -320,15 +320,14 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
   const source = manifest as RegistryItem & SourceMetadata;
   const textureGroups = textureGroupsFor(manifest);
 
-  const lines: string[] = ["---", `title: ${yamlString(manifest.title)}`];
-  if (textureGroups.length === 0) {
-    lines.push(`description: ${yamlString(manifest.description)}`);
-  }
+  const lines: string[] = [
+    "---",
+    `title: ${yamlString(manifest.title)}`,
+    `description: ${yamlString(manifest.description)}`,
+  ];
   lines.push("---", "");
 
-  if (textureGroups.length === 0) {
-    lines.push(`# ${manifest.title}`, "", manifest.description, "");
-  }
+  lines.push(manifest.description, "");
 
   if (tagBadges) {
     lines.push(tagBadges, "");
@@ -363,25 +362,40 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
     );
   }
 
-  // Install command
+  // Two genuinely parallel ways to do one thing, so they belong in tabs rather
+  // than stacked with the second framed as an afterthought. The agent request
+  // leads because it is the shorter path for most readers.
   lines.push(
-    "## Install",
+    "## Add it to a project",
     "",
-    "<CodeGroup>",
+    "<Tabs>",
     "",
-    "```bash Terminal",
+    '<Tab title="Ask your agent">',
+    "",
+    "```text",
+    `Add the ${manifest.title} ${kind} from the HyperFrames Catalog to this project.`,
+    "Replace the demo content with mine and match the existing design and timing.",
+    "```",
+    "",
+    "</Tab>",
+    "",
+    '<Tab title="Terminal">',
+    "",
+    "```bash",
     installCmd,
     "```",
     "",
-    "</CodeGroup>",
+    "</Tab>",
+    "",
+    "</Tabs>",
     "",
   );
 
-  // Details
+  // Registry metadata, visible. It is short — three rows and a file list — so
+  // hiding it behind a click bought nothing and cost Cmd+F and printing.
+  lines.push("## Details", "");
   if (kind === "block" && manifest.dimensions && manifest.duration) {
     lines.push(
-      "## Details",
-      "",
       `| Property | Value |`,
       `| --- | --- |`,
       `| Type | ${typeLabel(kind)} |`,
@@ -390,29 +404,21 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
       "",
     );
   } else {
-    lines.push(
-      "## Details",
-      "",
-      `| Property | Value |`,
-      `| --- | --- |`,
-      `| Type | ${typeLabel(kind)} |`,
-      "",
-    );
-  }
-
-  if (textureGroups.length > 0) {
-    lines.push(...generateTextureAgentUsage(manifest, textureGroups));
-    lines.push(...generateTextureAnimationExample(manifest, textureGroups));
-    lines.push(...generateTextureExamples(manifest, textureGroups));
+    lines.push(`| Property | Value |`, `| --- | --- |`, `| Type | ${typeLabel(kind)} |`, "");
   }
 
   // Files
   if (textureGroups.length === 0) {
-    lines.push("## Files", "", "| File | Target | Type |", "| --- | --- | --- |");
+    lines.push("**Installed files**", "", "| File | Target | Type |", "| --- | --- | --- |");
     for (const f of manifest.files) {
       lines.push(`| \`${f.path}\` | \`${f.target}\` | ${f.type} |`);
     }
     lines.push("");
+  }
+  if (textureGroups.length > 0) {
+    lines.push(...generateTextureAgentUsage(manifest, textureGroups));
+    lines.push(...generateTextureAnimationExample(manifest, textureGroups));
+    lines.push(...generateTextureExamples(manifest, textureGroups));
   }
 
   // Usage hint — find the primary file by type, not array position.
@@ -426,9 +432,11 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
     const w = manifest.dimensions.width;
     const h = manifest.dimensions.height;
     lines.push(
-      "## Usage",
+      "## Use it",
       "",
-      "After installing, add the block to your host composition:",
+      "Ask your agent to replace the example content, match the project style, and place the block at the right moment in the video.",
+      "",
+      "**Wiring it by hand.** The installed block can be added to a host composition with:",
       "",
       "```html",
       `<div data-composition-id="${manifest.name}" data-composition-src="${primaryTarget}" data-start="0" data-duration="${manifest.duration}" data-track-index="1" data-width="${w}" data-height="${h}"></div>`,
@@ -438,16 +446,18 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
   } else {
     if (textureGroups.length > 0) {
       lines.push(
-        "## Usage",
+        "## Use it",
         "",
         `After \`${installCmd}\`, the installed snippet lives at \`${primaryTarget}\` inside your current HyperFrames project. Open that file and paste the real \`<style>\` element near the bottom into your composition once; it defines \`hf-texture-text\` and every \`hf-texture-*\` class used by the examples above. Keep the installed texture PNGs in \`assets/${manifest.name}/masks/\`; the CSS references them with project-root URLs.`,
         "",
       );
     } else {
       lines.push(
-        "## Usage",
+        "## Use it",
         "",
-        `Open \`${primaryTarget}\` and paste its contents into your composition. See the comment header in the file for detailed instructions.`,
+        "Ask your agent to apply the component to the intended element and preserve the project’s existing timing.",
+        "",
+        `**Wiring it by hand.** Open \`${primaryTarget}\` and paste its contents into your composition. The comment header in that file contains any item-specific instructions.`,
         "",
       );
     }
@@ -569,16 +579,37 @@ function main(): void {
     .map(([group, pages]) => ({ group, pages }));
 
   if (catalogGroups.length > 0) {
-    // Replace or insert the Catalog tab
+    // Update the existing Catalog tab in place. Rebuilding the object dropped
+    // everything except the groups — the tab lost its `icon` — and removing it
+    // before re-inserting moved it, because the anchor tab it looked for
+    // ("Documentation") no longer exists and the fallback index put Catalog
+    // ahead of Studio. Only `groups` is generated; every other property and the
+    // tab's position belong to whoever curates docs.json.
     const existingIdx = tabs.findIndex((t) => t.tab === "Catalog");
-    const catalogTab = { tab: "Catalog", groups: catalogGroups };
-    // Remove existing Catalog tab if present, then insert at position 1
-    // (after Documentation, before Packages).
     if (existingIdx >= 0) {
-      tabs.splice(existingIdx, 1);
+      const existingGroups = Array.isArray(tabs[existingIdx].groups)
+        ? tabs[existingIdx].groups
+        : [];
+      const manualGroups = existingGroups.filter((group) => {
+        if (!Array.isArray(group.pages)) return true;
+        return group.pages.every(
+          (page) =>
+            typeof page !== "string" ||
+            (!page.startsWith("catalog/blocks/") && !page.startsWith("catalog/components/")),
+        );
+      });
+      tabs[existingIdx] = {
+        ...tabs[existingIdx],
+        groups: [...manualGroups, ...catalogGroups],
+      };
+    } else {
+      const anchorIdx = tabs.findIndex((t) => t.tab === "Guides" || t.tab === "Documentation");
+      tabs.splice(anchorIdx >= 0 ? anchorIdx + 1 : 1, 0, {
+        tab: "Catalog",
+        icon: "grid-2",
+        groups: catalogGroups,
+      });
     }
-    const docsIdx = tabs.findIndex((t) => t.tab === "Documentation");
-    tabs.splice(docsIdx >= 0 ? docsIdx + 1 : 1, 0, catalogTab);
     writeFileSync(docsJsonPath, JSON.stringify(docsJson, null, 2) + "\n", "utf-8");
     const totalPages = catalogGroups.reduce((n, g) => n + g.pages.length, 0);
     console.log(`  ✓ docs.json updated with ${catalogGroups.length} groups, ${totalPages} pages`);

--- a/scripts/generate-catalog-pages.ts
+++ b/scripts/generate-catalog-pages.ts
@@ -586,22 +586,28 @@ function main(): void {
     // ahead of Studio. Only `groups` is generated; every other property and the
     // tab's position belong to whoever curates docs.json.
     const existingIdx = tabs.findIndex((t) => t.tab === "Catalog");
+    let navigationChanged = false;
     if (existingIdx >= 0) {
       const existingGroups = Array.isArray(tabs[existingIdx].groups)
         ? tabs[existingIdx].groups
         : [];
-      const manualGroups = existingGroups.filter((group) => {
+      const isGeneratedCatalogGroup = (group: { pages?: unknown }): boolean => {
         if (!Array.isArray(group.pages)) return true;
-        return group.pages.every(
+        return group.pages.some(
           (page) =>
-            typeof page !== "string" ||
-            (!page.startsWith("catalog/blocks/") && !page.startsWith("catalog/components/")),
+            typeof page === "string" &&
+            (page.startsWith("catalog/blocks/") || page.startsWith("catalog/components/")),
         );
-      });
-      tabs[existingIdx] = {
-        ...tabs[existingIdx],
-        groups: [...manualGroups, ...catalogGroups],
       };
+      const generatedGroups = existingGroups.filter(isGeneratedCatalogGroup);
+      if (JSON.stringify(generatedGroups) !== JSON.stringify(catalogGroups)) {
+        const manualGroups = existingGroups.filter((group) => !isGeneratedCatalogGroup(group));
+        tabs[existingIdx] = {
+          ...tabs[existingIdx],
+          groups: [...manualGroups, ...catalogGroups],
+        };
+        navigationChanged = true;
+      }
     } else {
       const anchorIdx = tabs.findIndex((t) => t.tab === "Guides" || t.tab === "Documentation");
       tabs.splice(anchorIdx >= 0 ? anchorIdx + 1 : 1, 0, {
@@ -609,10 +615,15 @@ function main(): void {
         icon: "grid-2",
         groups: catalogGroups,
       });
+      navigationChanged = true;
     }
-    writeFileSync(docsJsonPath, JSON.stringify(docsJson, null, 2) + "\n", "utf-8");
+    if (navigationChanged) {
+      writeFileSync(docsJsonPath, JSON.stringify(docsJson, null, 2) + "\n", "utf-8");
+    }
     const totalPages = catalogGroups.reduce((n, g) => n + g.pages.length, 0);
-    console.log(`  ✓ docs.json updated with ${catalogGroups.length} groups, ${totalPages} pages`);
+    console.log(
+      `  ✓ docs.json ${navigationChanged ? "updated" : "already current"} with ${catalogGroups.length} groups, ${totalPages} pages`,
+    );
   }
 
   console.log("\nDone.");

--- a/scripts/generate-catalog-pages.ts
+++ b/scripts/generate-catalog-pages.ts
@@ -328,8 +328,6 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
   ];
   lines.push("---", "");
 
-  lines.push(manifest.description, "");
-
   if (tagBadges) {
     lines.push(tagBadges, "");
   }
@@ -365,32 +363,23 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
     );
   }
 
-  // Two genuinely parallel ways to do one thing, so they belong in tabs rather
-  // than stacked with the second framed as an afterthought. The agent request
-  // leads because it is the shorter path for most readers.
+  // Keep both paths visible. The agent path leads for the general audience;
+  // the terminal remains available without hiding it behind a control.
   lines.push(
     "## Add it to a project",
     "",
-    "<Tabs>",
-    "",
-    '<Tab title="Ask your agent">',
+    "### Ask your agent",
     "",
     "```text",
     `Add the ${manifest.title} ${kind} from the HyperFrames Catalog to this project.`,
     "Replace the demo content with mine and match the existing design and timing.",
     "```",
     "",
-    "</Tab>",
-    "",
-    '<Tab title="Terminal">',
+    "### Install from the terminal",
     "",
     "```bash",
     installCmd,
     "```",
-    "",
-    "</Tab>",
-    "",
-    "</Tabs>",
     "",
   );
 
@@ -470,6 +459,15 @@ function generateItemMdx(kind: ItemKind, manifest: RegistryItem): string {
   if (manifest.relatedSkill) {
     lines.push(`<Tip>Related skill: \`/${manifest.relatedSkill}\`</Tip>`, "");
   }
+
+  lines.push(
+    "## Related topics",
+    "",
+    "- [Browse the complete Catalog](/catalog)",
+    "- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)",
+    "- [Build a richer composition](/go-further)",
+    "",
+  );
 
   return lines.join("\n");
 }

--- a/scripts/generate-catalog-previews.ts
+++ b/scripts/generate-catalog-previews.ts
@@ -131,6 +131,24 @@ async function prepareProjectDir(item: CatalogItem): Promise<string> {
   mkdirSync(tmpDir, { recursive: true });
   cpSync(item.sourceDir, tmpDir, { recursive: true });
 
+  // Preview the item in the same layout users get after installation. Some
+  // components reference assets by their registry target path rather than by
+  // the flat source path stored beside the manifest.
+  const registryItemPath = join(tmpDir, "registry-item.json");
+  if (existsSync(registryItemPath)) {
+    const manifest = JSON.parse(readFileSync(registryItemPath, "utf-8")) as {
+      files?: { path?: string; target?: string }[];
+    };
+    for (const file of manifest.files ?? []) {
+      if (!file.path || !file.target) continue;
+      const sourcePath = join(tmpDir, file.path);
+      const targetPath = join(tmpDir, file.target);
+      if (!existsSync(sourcePath) || sourcePath === targetPath) continue;
+      mkdirSync(dirname(targetPath), { recursive: true });
+      cpSync(sourcePath, targetPath);
+    }
+  }
+
   // The HyperFrames producer navigates to index.html at the project root.
   // Blocks and component demos are standalone HTML files, not index.html.
   // If the entry file is a standalone HTML (has its own timeline registration),


### PR DESCRIPTION
## Summary

Makes every Catalog destination useful at a glance and keeps the generated result reproducible.

- adds real preview-first presentation across 168 current registry items
- groups items around recognizable use cases instead of implementation accidents
- keeps installation and wiring instructions generated from registry truth
- makes the generator honor each manifest declared video and poster instead of inventing nonexistent media URLs
- keeps a generator rerun from moving the hand-authored Catalog overview or Guides navigation

## Review focus

Sample several blocks and components across categories, then rerun the page generator and confirm no navigation drift.

## Verification

- regenerated all 168 pages with no residual diff
- checked all changed Catalog media URLs; no missing assets remain
- Mintlify validation passed
- Mintlify broken-link check passed
- lint, format, TypeScript, tracked-artifact, and large-file hooks passed

Stack 3 of 4. Review after #2962. Base is `codex/docs-developers-reference`.