### PR TITLE
fix(cli): stop dropping queued telemetry when process.exit races the final flush

### DIFF
--- a/packages/cli/src/cli.lifecycle.test.ts
+++ b/packages/cli/src/cli.lifecycle.test.ts
@@ -67,4 +67,94 @@ describe("CLI lifecycle", () => {
 
     expect(order).toEqual(["cli_error", "flush"]);
   });
+
+  it("hands queued events to flushSync even after finalizeCli has run", async () => {
+    const flushSync = vi.fn();
+    const trackCommandResult = vi.fn();
+    mockInitCommand(vi.fn());
+    mockTelemetry({ flushSync, trackCommandResult });
+
+    process.argv = ["node", "cli.ts", "init", "--json"];
+    await import("./cli.js");
+    // Command finished → finalizeCli ran and tracked the result once.
+    expect(trackCommandResult).toHaveBeenCalledTimes(1);
+
+    // The process.exit() that follows fires the 'exit' handler. It must not
+    // double-track, but it MUST still hand the queue to flushSync — this is
+    // the fallback that re-delivers a render_complete whose eager flush()
+    // was killed by an EPIPE process.exit(0) racing finalizeCli. Gating it
+    // behind `finalized` was the 0.7.65 render_complete regression.
+    process.emit("exit", 0);
+    expect(trackCommandResult).toHaveBeenCalledTimes(1);
+    expect(flushSync).toHaveBeenCalled();
+  });
+
+  it("keeps an EPIPE after a validated render scored as success", async () => {
+    const trackCommandResult = vi.fn();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    try {
+      mockInitCommand(() => emitStreamEpipe());
+      mockTelemetry({ trackCommandResult });
+
+      const successState = await import("./utils/render-success-state.js");
+      successState.markRenderSucceeded();
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      // The pipe closing after the artifact was validated is a normal agent
+      // teardown: exit 0, and the run must NOT be scored as a failure.
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(trackCommandResult).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+      successState._resetRenderSuccessForTests();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("still scores an EPIPE before the artifact is validated as a failure", async () => {
+    const trackCommandResult = vi.fn();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    try {
+      mockInitCommand(() => emitStreamEpipe());
+      mockTelemetry({ trackCommandResult });
+
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(trackCommandResult).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
 });
+
+function mockInitCommand(run: () => void): void {
+  vi.doMock("./commands/init.js", () => ({
+    default: {
+      meta: { name: "init" },
+      args: { json: { type: "boolean" } },
+      run,
+    },
+  }));
+}
+
+function mockTelemetry(overrides: {
+  flushSync?: ReturnType<typeof vi.fn>;
+  trackCommandResult?: ReturnType<typeof vi.fn>;
+}): void {
+  vi.doMock("./telemetry/index.js", () => ({
+    flush: vi.fn(async () => {}),
+    flushSync: overrides.flushSync ?? vi.fn(),
+    incrementCommandCount: vi.fn(),
+    showTelemetryNotice: vi.fn(),
+    shouldTrack: () => false,
+    trackCliError: vi.fn(),
+    trackCommand: vi.fn(),
+    trackCommandResult: overrides.trackCommandResult ?? vi.fn(),
+  }));
+}
+
+function emitStreamEpipe(): void {
+  process.stdout.emit("error", Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+}

--- a/packages/cli/src/cli.lifecycle.test.ts
+++ b/packages/cli/src/cli.lifecycle.test.ts
@@ -111,6 +111,29 @@ describe("CLI lifecycle", () => {
     }
   });
 
+  it("does not let pre-artifact noise doom a run whose render later validates", async () => {
+    const trackCommandResult = vi.fn();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    try {
+      const successState = await import("./utils/render-success-state.js");
+      // Noise arrives BEFORE the artifact is validated (mid-render EPIPE /
+      // stray rejection shape), then the render completes and validates.
+      mockInitCommand(() => {
+        emitStreamEpipe();
+        successState.markRenderSucceeded();
+      });
+      mockTelemetry({ trackCommandResult });
+
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      expect(trackCommandResult).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+      successState._resetRenderSuccessForTests();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
   it("still scores an EPIPE before the artifact is validated as a failure", async () => {
     const trackCommandResult = vi.fn();
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);

--- a/packages/cli/src/cli.lifecycle.test.ts
+++ b/packages/cli/src/cli.lifecycle.test.ts
@@ -134,6 +134,37 @@ describe("CLI lifecycle", () => {
     }
   });
 
+  it("does not let a pre-validation unhandledRejection doom a validated render", async () => {
+    // The production-reachable producer of the stale-failure override: the
+    // unhandledRejection handler deliberately does NOT exit, so a stray
+    // rejection mid-render sets commandFailed (and exitCode 1), the render
+    // then completes and validates, and finalizeCli writes exit code 0.
+    const trackCommandResult = vi.fn();
+    // Detach the test runner's own unhandledRejection listeners so the
+    // synthetic emit reaches only the CLI's handler, then restore them.
+    const priorListeners = process.listeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+    try {
+      const successState = await import("./utils/render-success-state.js");
+      mockInitCommand(() => {
+        process.emit("unhandledRejection", new Error("stray teardown noise"), Promise.resolve());
+        successState.markRenderSucceeded();
+      });
+      mockTelemetry({ trackCommandResult });
+
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      expect(trackCommandResult).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, exitCode: 0 }),
+      );
+      successState._resetRenderSuccessForTests();
+    } finally {
+      process.removeAllListeners("unhandledRejection");
+      for (const listener of priorListeners) process.on("unhandledRejection", listener);
+    }
+  });
+
   it("still scores an EPIPE before the artifact is validated as a failure", async () => {
     const trackCommandResult = vi.fn();
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,15 +8,16 @@
 //
 // commandFailed must be declared here (before the handlers) so the EPIPE
 // stream-error path can set it before process.exit(0). The telemetry exit
-// handler reads this flag to determine success/failure — an EPIPE exit
-// should NOT score as success:true in telemetry.
+// handler reads this flag to determine success/failure — an EPIPE that
+// interrupts a command should NOT score as success:true, but one that
+// arrives after the render artifact was validated is the normal agent-pipe
+// teardown and must stay success:true (see handleStreamEpipe).
 let commandFailed = false;
 
 for (const stream of [process.stdout, process.stderr]) {
   stream.on("error", (err) => {
     if ((err as NodeJS.ErrnoException).code === "EPIPE") {
-      commandFailed = true;
-      process.exit(0);
+      handleStreamEpipe();
     }
   });
 }
@@ -320,14 +321,21 @@ process.on(
   "exit",
   // fallow-ignore-next-line complexity
   (code) => {
-    if (finalized) return;
-    _trackCommandResult?.({
-      command,
-      success: code === 0 && !commandFailed,
-      exitCode: code,
-      durationMs: Date.now() - commandStart,
-      runId,
-    });
+    if (!finalized) {
+      _trackCommandResult?.({
+        command,
+        success: code === 0 && !commandFailed,
+        exitCode: code,
+        durationMs: Date.now() - commandStart,
+        runId,
+      });
+    }
+    // Unconditional — `finalized` only means finalizeCli STARTED its awaited
+    // flush(). A process.exit() racing that flush (the EPIPE path under agent
+    // pipes) kills the in-flight request, and gating this fallback behind
+    // `finalized` silently dropped the still-queued events — the 0.7.65
+    // render_complete regression. flushSync() is safe to over-call: an empty
+    // queue is a no-op, and event uuids make re-sends idempotent.
     _flushSync?.();
   },
 );
@@ -377,6 +385,19 @@ function exitAfterPostRenderTermination(
   process.exit(0);
 }
 
+// A closed pipe (EPIPE) is the NORMAL teardown when the CLI runs under a
+// piped agent (Claude Code, Codex, …) — the reader may stop consuming as
+// soon as it has what it needs. Exit cleanly, but only score the run as a
+// failure when the pipe died BEFORE the render artifact was validated:
+// unconditionally setting `commandFailed = true` here marked every piped
+// successful render as success:false (0.7.65–0.7.90). Delivery of anything
+// still queued (render_complete's eager flush() dies with the process) is
+// owned by the unconditional flushSync() in the `exit` handler below.
+function handleStreamEpipe(): never {
+  if (!isRenderSucceeded()) commandFailed = true;
+  process.exit(0);
+}
+
 // Terminate the process after a genuine CLI failure — mark commandFailed,
 // emit telemetry, flush, exit(1). Same rationale as above: keeps the arrow
 // handler linear so fallow CRAP stays under threshold.
@@ -392,8 +413,7 @@ function exitAfterCliFailure(
 
 process.on("uncaughtException", (error) => {
   if ((error as NodeJS.ErrnoException).code === "EPIPE") {
-    commandFailed = true;
-    process.exit(0);
+    handleStreamEpipe();
   }
   // Post-artifact-validated shutdown throws must not turn a valid render
   // into an exit-1 "no final error message" failure. The render command

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -286,7 +286,7 @@ async function finalizeCli(result: CommandResult): Promise<void> {
   await telemetryReady.catch(() => {});
   _trackCommandResult?.({
     command,
-    success: result.exitCode === 0 && !commandFailed,
+    success: result.exitCode === 0 && commandSucceededForTelemetry(),
     exitCode: result.exitCode,
     durationMs: Date.now() - commandStart,
     runId,
@@ -324,7 +324,7 @@ process.on(
     if (!finalized) {
       _trackCommandResult?.({
         command,
-        success: code === 0 && !commandFailed,
+        success: code === 0 && commandSucceededForTelemetry(),
         exitCode: code,
         durationMs: Date.now() - commandStart,
         runId,
@@ -396,6 +396,17 @@ function exitAfterPostRenderTermination(
 function handleStreamEpipe(): never {
   if (!isRenderSucceeded()) commandFailed = true;
   process.exit(0);
+}
+
+// Success gate for the cli_command_result telemetry field. `commandFailed`
+// can be set by pre-artifact noise — a stray unhandledRejection mid-render,
+// or an EPIPE that fires before validation on a run that still completes.
+// Once the render artifact has been validated (`isRenderSucceeded()`), that
+// earlier noise must not score the run as a failure: the run delivered.
+// Genuine failures keep a non-zero exit code and are caught by the
+// `exitCode === 0 &&` half of the expression at both call sites.
+function commandSucceededForTelemetry(): boolean {
+  return !commandFailed || isRenderSucceeded();
 }
 
 // Terminate the process after a genuine CLI failure — mark commandFailed,


### PR DESCRIPTION
## Summary

CLI **0.7.65's process-lifecycle refactor introduced an exit race that silently drops queued telemetry**. Fleet-wide `render_complete` delivery fell from **~90% (0.7.55–0.7.64) to 26–45%** from 0.7.65 on, and every piped successful render started scoring **`cli_command_result.success=false`** (fleet success rate 89% → 5–25%). Every render-based tile on the growth dashboard — including all four skills tiles — is currently reading **2–3× below reality**; the July "peak" on those charts is the only two-week window in which delivery was actually working.

## Root cause

Two defects, same refactor (0.7.65, process-lifecycle centralization):

1. **The `exit` handler early-returns once `finalized` is set — which also skips the `flushSync()` fallback** (`packages/cli/src/cli.ts`). Under agent pipes (Claude Code / Codex — `is_tty=false`, the dominant environment), the reader closing the pipe raises EPIPE → `process.exit(0)` **while `finalizeCli()`'s awaited `flush()` is still in flight**. The in-flight request dies with the process, the events stay queued by design (`transport.ts` keeps the queue intact until delivery is confirmed, precisely so the exit-time `flushSync()` child can re-send) — but the `finalized` guard skips that fallback, so the queue is dropped. The transport's safety net was dead code on the normal path.
2. **The EPIPE handlers set `commandFailed = true` unconditionally.** An agent closing the pipe after a successful render is normal teardown, but it scored the run as `success:false`. The `uncaughtException` path *appeared* to have an `isRenderSucceeded()` exemption, but it sat **after** the EPIPE branch that exited first, so it was unreachable for EPIPE — this fix newly covers both the stream-error and the uncaughtException EPIPE paths. (Corrected per review: the original text overstated pre-existing coverage.)

Verified against PostHog (project 356858): per-version delivery (`render_complete ÷ cli_command(render)`) — 0.7.55–0.7.64: 10 consecutive versions, none below 86% (two above 100%, from uuid-dedupe/timing noise); 0.7.65–0.7.90: 26 consecutive versions, none reaching that floor except one outlier. `cli_command_result` from the same runs arrives at 85–99.9% across both bands — the channel works; only the exit-time events are lost. (Ranges corrected per review re-derivation.)

## Fix

- **`flushSync()` in the `exit` handler is now unconditional.** The `finalized` guard still prevents double-tracking `cli_command_result`, but the delivery fallback always runs. Safe to over-call: an empty queue is a no-op, and client-generated event uuids make re-sends idempotent (PostHog dedupes on uuid).
- **New `handleStreamEpipe()`**, shared by the stream-error and `uncaughtException` EPIPE paths: exit 0 as before, but only mark `commandFailed` when the pipe died **before** the render artifact was validated (`isRenderSucceeded()`).
- **`commandSucceededForTelemetry()`** at both `cli_command_result` tracking sites: pre-artifact noise (a stray `unhandledRejection` mid-render, or an EPIPE firing before validation on a run that still completes) no longer scores a validated render as `success:false`. Genuine failures keep a non-zero exit code and are still caught by the `exitCode === 0` check.

## Test plan / Validation

- [x] 5 regression tests in `cli.lifecycle.test.ts`: flushSync-after-finalize, EPIPE-after-validated-render → `success:true`, EPIPE-before-validation → `success:false`, and the stale-failure override pinned via both producers — the EPIPE shape and the production-reachable `unhandledRejection`-then-validation shape (per review note). **Verified red against the unfixed `cli.ts`**.
- [x] Full `packages/cli` suite: 2,329 passed; `bun run build` clean; `oxlint` / `oxfmt` clean.
- [x] **Local end-to-end**: on an install where 4/4 successful piped renders previously delivered **zero** PostHog events, 2/2 renders with this fix delivered `render_complete` (with `authoring_skill`) and `cli_command_result.success=true` within seconds; a deliberately failed invocation in between still scored `success=false`.

## Expected effect / how to verify after release

**This PR's acceptance gate: per-version delivery rate (`render_complete ÷ cli_command(render)`) returns to ≥85%** for the first release carrying this fix.

**On the exit-1 inflation flagged in review** (10.8% → 60.9% piped, 20.7% → 78.4% on TTY): follow-up analysis shows it is **mostly a survivorship artifact of the same queue-drop this PR fixes**, not an independent defect. Failure paths flush explicitly before exiting, so failure results survive; success results ride the finalize flush and die in the race — the delivered population shifts toward exit-1 without any run being relabeled. The TTY absolute numbers show the shape: exit-1 grew only 4,788 → 6,771 while `success=true` collapsed 18,170 → 1,237 (15×). The `unhandledRejection` suspect is not the driver (355 events fleet-wide), but the channel it names is real — a stray rejection or pre-validation EPIPE could doom a run whose artifact later validated; the third fix above closes it. **Expect the success rate to recover substantially post-release.** The residual — whether true failure rates also moved at 0.7.65 (which changed failure-reporting instrumentation, so pre/post bands aren't directly comparable) — needs a clean post-release re-baseline, tracked separately.

- As the fleet upgrades, render-based dashboard tiles will step **up 2–3×** — that's measurement recovery, not organic growth. The dashboard should carry an annotation at the release date to prevent misreading (same as the July 12 one).

## Scope / limitations

- **Forward-only** — historical events are gone; charts before the fix stay as reported.
- **Separate follow-up:** re-baseline true render failure rates on clean post-release data. 0.7.65 also changed how command failures are reported (`CliRuntimeError` counts went 31 → 108K), so pre/post failure-rate bands are not directly comparable; whether real failures moved at all can only be answered once delivery is healthy.
- Out of scope (PostHog-side, not code): a single automation fleet (one machine fingerprint, fresh anonymousId per run, ~2,700 "installs" in 4 days since 07-30) passes the real-human filter and dilutes per-install denominators; and the deprecated render-weighted penetration tile is still live on the dashboard.
