### PR TITLE
feat(registry): add lower thirds (10 variations for podcasts/interviews)

### DIFF
--- a/docs/catalog/blocks/lower-third-badge-pill.mdx
+++ b/docs/catalog/blocks/lower-third-badge-pill.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Badge Pill"
+description: "Rounded pill with an avatar slot that springs in. Compact enough to survive a 9:16 crop."
+---
+
+# Lower Third / Badge Pill
+
+Rounded pill with an avatar slot that springs in. Compact enough to survive a 9:16 crop.
+
+`lower-third` `podcast` `interview` `vertical-safe`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-badge-pill.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-badge-pill.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-badge-pill
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-badge-pill.html` | `compositions/lower-third-badge-pill.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-badge-pill" data-composition-src="compositions/lower-third-badge-pill.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-bracket-frame.mdx
+++ b/docs/catalog/blocks/lower-third-bracket-frame.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Bracket Frame"
+description: "Four corner brackets draw themselves around the text. No fill, so the footage stays visible."
+---
+
+# Lower Third / Bracket Frame
+
+Four corner brackets draw themselves around the text. No fill, so the footage stays visible.
+
+`lower-third` `podcast` `interview` `no-fill`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bracket-frame.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bracket-frame.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-bracket-frame
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-bracket-frame.html` | `compositions/lower-third-bracket-frame.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-bracket-frame" data-composition-src="compositions/lower-third-bracket-frame.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-glass-panel.mdx
+++ b/docs/catalog/blocks/lower-third-glass-panel.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Glass Panel"
+description: "Frosted backdrop-filter panel that scales and sharpens into place. Tech podcasts and remote interviews."
+---
+
+# Lower Third / Glass Panel
+
+Frosted backdrop-filter panel that scales and sharpens into place. Tech podcasts and remote interviews.
+
+`lower-third` `podcast` `interview` `glass`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-glass-panel.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-glass-panel.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-glass-panel
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-glass-panel.html` | `compositions/lower-third-glass-panel.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-glass-panel" data-composition-src="compositions/lower-third-glass-panel.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-hairline-rule.mdx
+++ b/docs/catalog/blocks/lower-third-hairline-rule.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Hairline Rule"
+description: "Editorial restraint. A one-pixel rule draws across, then name and title stagger up through masks."
+---
+
+# Lower Third / Hairline Rule
+
+Editorial restraint. A one-pixel rule draws across, then name and title stagger up through masks.
+
+`lower-third` `podcast` `interview` `editorial`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-hairline-rule.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-hairline-rule.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-hairline-rule
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-hairline-rule.html` | `compositions/lower-third-hairline-rule.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-hairline-rule" data-composition-src="compositions/lower-third-hairline-rule.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-slab-wipe.mdx
+++ b/docs/catalog/blocks/lower-third-slab-wipe.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Slab Wipe"
+description: "Solid bar clips open left to right under a heavy slab serif. Interview and documentary."
+---
+
+# Lower Third / Slab Wipe
+
+Solid bar clips open left to right under a heavy slab serif. Interview and documentary.
+
+`lower-third` `podcast` `interview` `documentary`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-slab-wipe.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-slab-wipe.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-slab-wipe
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-slab-wipe.html` | `compositions/lower-third-slab-wipe.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-slab-wipe" data-composition-src="compositions/lower-third-slab-wipe.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-split-flap.mdx
+++ b/docs/catalog/blocks/lower-third-split-flap.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Split Flap"
+description: "Departure-board character flip on the name. Seeded glyph columns, stepped transforms, fully seek-safe."
+---
+
+# Lower Third / Split Flap
+
+Departure-board character flip on the name. Seeded glyph columns, stepped transforms, fully seek-safe.
+
+`lower-third` `podcast` `interview` `kinetic`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-split-flap.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-split-flap.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-split-flap
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-split-flap.html` | `compositions/lower-third-split-flap.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-split-flap" data-composition-src="compositions/lower-third-split-flap.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-stacked-caps.mdx
+++ b/docs/catalog/blocks/lower-third-stacked-caps.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Stacked Caps"
+description: "Three lines of condensed caps, each masked up in sequence. Returning guests and episode credits."
+---
+
+# Lower Third / Stacked Caps
+
+Three lines of condensed caps, each masked up in sequence. Returning guests and episode credits.
+
+`lower-third` `podcast` `interview` `condensed`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-stacked-caps.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-stacked-caps.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-stacked-caps
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-stacked-caps.html` | `compositions/lower-third-stacked-caps.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-stacked-caps" data-composition-src="compositions/lower-third-stacked-caps.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-tape-strike.mdx
+++ b/docs/catalog/blocks/lower-third-tape-strike.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Tape Strike"
+description: "Name slams in past its mark and settles while the title types out beneath. High energy."
+---
+
+# Lower Third / Tape Strike
+
+Name slams in past its mark and settles while the title types out beneath. High energy.
+
+`lower-third` `podcast` `interview` `typewriter`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-tape-strike.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-tape-strike.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-tape-strike
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-tape-strike.html` | `compositions/lower-third-tape-strike.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-tape-strike" data-composition-src="compositions/lower-third-tape-strike.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-ticker-crawl.mdx
+++ b/docs/catalog/blocks/lower-third-ticker-crawl.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Ticker Crawl"
+description: "Static name block with credentials crawling in a thin strip beneath. Seek-safe, no infinite repeat."
+---
+
+# Lower Third / Ticker Crawl
+
+Static name block with credentials crawling in a thin strip beneath. Seek-safe, no infinite repeat.
+
+`lower-third` `podcast` `interview` `news` `ticker`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-ticker-crawl.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-ticker-crawl.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-ticker-crawl
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-ticker-crawl.html` | `compositions/lower-third-ticker-crawl.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-ticker-crawl" data-composition-src="compositions/lower-third-ticker-crawl.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/catalog/blocks/lower-third-underline-grow.mdx
+++ b/docs/catalog/blocks/lower-third-underline-grow.mdx
@@ -1,0 +1,44 @@
+---
+title: "Lower Third / Underline Grow"
+description: "Name settles in, an accent rule grows out beneath it, and the title rises after. The safe default."
+---
+
+# Lower Third / Underline Grow
+
+Name settles in, an accent rule grows out beneath it, and the title rises after. The safe default.
+
+`lower-third` `podcast` `interview` `minimal`
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-underline-grow.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-underline-grow.png" autoPlay muted loop playsInline />
+
+## Install
+
+<CodeGroup>
+
+```bash Terminal
+npx hyperframes add lower-third-underline-grow
+```
+
+</CodeGroup>
+
+## Details
+
+| Property | Value |
+| --- | --- |
+| Type | Block |
+| Dimensions | 1920×1080 |
+| Duration | 5s |
+
+## Files
+
+| File | Target | Type |
+| --- | --- | --- |
+| `lower-third-underline-grow.html` | `compositions/lower-third-underline-grow.html` | hyperframes:composition |
+
+## Usage
+
+After installing, add the block to your host composition:
+
+```html
+<div data-composition-id="lower-third-underline-grow" data-composition-src="compositions/lower-third-underline-grow.html" data-start="0" data-duration="5" data-track-index="1" data-width="1920" data-height="1080"></div>
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -268,7 +268,17 @@
           {
             "group": "Lower Thirds",
             "pages": [
+              "catalog/blocks/lower-third-badge-pill",
               "catalog/blocks/lower-third-bild",
+              "catalog/blocks/lower-third-bracket-frame",
+              "catalog/blocks/lower-third-glass-panel",
+              "catalog/blocks/lower-third-hairline-rule",
+              "catalog/blocks/lower-third-slab-wipe",
+              "catalog/blocks/lower-third-split-flap",
+              "catalog/blocks/lower-third-stacked-caps",
+              "catalog/blocks/lower-third-tape-strike",
+              "catalog/blocks/lower-third-ticker-crawl",
+              "catalog/blocks/lower-third-underline-grow",
               "catalog/blocks/lt-accent-underline",
               "catalog/blocks/lt-bold-block",
               "catalog/blocks/lt-clean-bar",

--- a/docs/public/catalog-index.json
+++ b/docs/public/catalog-index.json
@@ -1242,6 +1242,20 @@
     "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/logo-outro.png"
   },
   {
+    "name": "lower-third-badge-pill",
+    "type": "block",
+    "title": "Lower Third / Badge Pill",
+    "description": "Rounded pill with an avatar slot that springs in. Compact enough to survive a 9:16 crop.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "vertical-safe"
+    ],
+    "href": "/catalog/blocks/lower-third-badge-pill",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-badge-pill.png"
+  },
+  {
     "name": "lower-third-bild",
     "type": "block",
     "title": "Lower Third — BILD Style",
@@ -1254,6 +1268,133 @@
     ],
     "href": "/catalog/blocks/lower-third-bild",
     "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bild.png"
+  },
+  {
+    "name": "lower-third-bracket-frame",
+    "type": "block",
+    "title": "Lower Third / Bracket Frame",
+    "description": "Four corner brackets draw themselves around the text. No fill, so the footage stays visible.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "no-fill"
+    ],
+    "href": "/catalog/blocks/lower-third-bracket-frame",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-bracket-frame.png"
+  },
+  {
+    "name": "lower-third-glass-panel",
+    "type": "block",
+    "title": "Lower Third / Glass Panel",
+    "description": "Frosted backdrop-filter panel that scales and sharpens into place. Tech podcasts and remote interviews.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "glass"
+    ],
+    "href": "/catalog/blocks/lower-third-glass-panel",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-glass-panel.png"
+  },
+  {
+    "name": "lower-third-hairline-rule",
+    "type": "block",
+    "title": "Lower Third / Hairline Rule",
+    "description": "Editorial restraint. A one-pixel rule draws across, then name and title stagger up through masks.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "editorial"
+    ],
+    "href": "/catalog/blocks/lower-third-hairline-rule",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-hairline-rule.png"
+  },
+  {
+    "name": "lower-third-slab-wipe",
+    "type": "block",
+    "title": "Lower Third / Slab Wipe",
+    "description": "Solid bar clips open left to right under a heavy slab serif. Interview and documentary.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "documentary"
+    ],
+    "href": "/catalog/blocks/lower-third-slab-wipe",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-slab-wipe.png"
+  },
+  {
+    "name": "lower-third-split-flap",
+    "type": "block",
+    "title": "Lower Third / Split Flap",
+    "description": "Departure-board character flip on the name. Seeded glyph columns, stepped transforms, fully seek-safe.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "kinetic"
+    ],
+    "href": "/catalog/blocks/lower-third-split-flap",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-split-flap.png"
+  },
+  {
+    "name": "lower-third-stacked-caps",
+    "type": "block",
+    "title": "Lower Third / Stacked Caps",
+    "description": "Three lines of condensed caps, each masked up in sequence. Returning guests and episode credits.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "condensed"
+    ],
+    "href": "/catalog/blocks/lower-third-stacked-caps",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-stacked-caps.png"
+  },
+  {
+    "name": "lower-third-tape-strike",
+    "type": "block",
+    "title": "Lower Third / Tape Strike",
+    "description": "Name slams in past its mark and settles while the title types out beneath. High energy.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "typewriter"
+    ],
+    "href": "/catalog/blocks/lower-third-tape-strike",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-tape-strike.png"
+  },
+  {
+    "name": "lower-third-ticker-crawl",
+    "type": "block",
+    "title": "Lower Third / Ticker Crawl",
+    "description": "Static name block with credentials crawling in a thin strip beneath. Seek-safe, no infinite repeat.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "news",
+      "ticker"
+    ],
+    "href": "/catalog/blocks/lower-third-ticker-crawl",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-ticker-crawl.png"
+  },
+  {
+    "name": "lower-third-underline-grow",
+    "type": "block",
+    "title": "Lower Third / Underline Grow",
+    "description": "Name settles in, an accent rule grows out beneath it, and the title rises after. The safe default.",
+    "tags": [
+      "lower-third",
+      "podcast",
+      "interview",
+      "minimal"
+    ],
+    "href": "/catalog/blocks/lower-third-underline-grow",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/blocks/lower-third-underline-grow.png"
   },
   {
     "name": "lt-accent-underline",

--- a/registry/blocks/lower-third-badge-pill/lower-third-badge-pill.html
+++ b/registry/blocks/lower-third-badge-pill/lower-third-badge-pill.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Badge Pill</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-badge-pill ---- */
+
+      .lower-third-badge-pill .bp-pill {
+        display: flex;
+        align-items: center;
+        gap: 22px;
+        padding: 14px 40px 14px 14px;
+        border-radius: 999px;
+        background: var(--lt-panel);
+        transform-origin: left center;
+        box-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
+      }
+      #root[data-side="right"] .lower-third-badge-pill .bp-pill {
+        transform-origin: right center;
+        flex-direction: row-reverse;
+        padding: 14px 14px 14px 40px;
+      }
+      .lower-third-badge-pill .bp-avatar {
+        width: 92px;
+        height: 92px;
+        border-radius: 50%;
+        flex: 0 0 auto;
+        background: var(--lt-accent);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        font-size: 38px;
+        color: #fff;
+        letter-spacing: 0.02em;
+      }
+      .lower-third-badge-pill .bp-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .lower-third-badge-pill .bp-name {
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        text-shadow: none;
+        font-size: calc(var(--lt-name-size) * 0.72);
+        letter-spacing: -0.014em;
+      }
+      .lower-third-badge-pill .bp-title {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        text-shadow: none;
+        font-size: calc(var(--lt-title-size) * 0.92);
+        margin-top: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-badge-pill"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-badge-pill-clip"
+        class="clip lower-third-badge-pill"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor bp">
+          <div class="bp-pill">
+            <div class="bp-avatar"><span class="bp-initials">MM</span></div>
+            <div class="bp-text">
+              <h1 class="lt-name bp-name">Sam Whitaker</h1>
+              <p class="lt-title bp-title">Co-host</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-badge-pill";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-badge-pill-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          /* Avatar: data-lt-avatar as an image URL, otherwise initials from the name. */
+          var avatar = q(".bp-avatar");
+          if (host.getAttribute("data-lt-avatar")) {
+            var img = document.createElement("img");
+            img.src = host.getAttribute("data-lt-avatar");
+            img.alt = "";
+            avatar.textContent = "";
+            avatar.appendChild(img);
+          } else {
+            q(".bp-initials").textContent = q(".lt-name")
+              .textContent.trim()
+              .split(" ")
+              .filter(Boolean)
+              .slice(0, 2)
+              .map(function (w) {
+                return w.charAt(0);
+              })
+              .join("")
+              .toUpperCase();
+          }
+
+          tl.from(
+            q(".bp-pill"),
+            { scaleX: 0.32, opacity: 0, duration: 0.5, ease: "back.out(1.7)" },
+            IN,
+          );
+          tl.from(
+            q(".bp-avatar"),
+            { scale: 0, rotate: -25, duration: 0.5, ease: "back.out(2.2)" },
+            IN + 0.12,
+          );
+          tl.from(
+            q(".bp-text"),
+            { opacity: 0, x: -18, duration: 0.4, ease: "power2.out" },
+            IN + 0.28,
+          );
+          tl.to(
+            q(".bp-pill"),
+            { scaleX: 0.4, opacity: 0, duration: 0.34, ease: "back.in(1.5)" },
+            OUT - 0.06,
+          );
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-badge-pill/registry-item.json
+++ b/registry/blocks/lower-third-badge-pill/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-badge-pill",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Badge Pill",
+  "description": "Rounded pill with an avatar slot that springs in. Compact enough to survive a 9:16 crop.",
+  "tags": ["lower-third", "podcast", "interview", "vertical-safe"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-badge-pill.html",
+      "target": "compositions/lower-third-badge-pill.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-bracket-frame/lower-third-bracket-frame.html
+++ b/registry/blocks/lower-third-bracket-frame/lower-third-bracket-frame.html
@@ -1,0 +1,353 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Bracket Frame</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-bracket-frame ---- */
+
+      .lower-third-bracket-frame .bf-frame {
+        position: relative;
+        padding: 34px 46px;
+      }
+      .lower-third-bracket-frame .bf-c {
+        position: absolute;
+        width: 46px;
+        height: 46px;
+        pointer-events: none;
+      }
+      .lower-third-bracket-frame .bf-c span {
+        position: absolute;
+        background: var(--lt-accent);
+      }
+      .lower-third-bracket-frame .bf-c .h {
+        height: 4px;
+        width: 100%;
+        left: 0;
+      }
+      .lower-third-bracket-frame .bf-c .v {
+        width: 4px;
+        height: 100%;
+        top: 0;
+      }
+      .lower-third-bracket-frame .bf-tl {
+        top: 0;
+        left: 0;
+      }
+      .lower-third-bracket-frame .bf-tl .h {
+        top: 0;
+        transform-origin: left center;
+      }
+      .lower-third-bracket-frame .bf-tl .v {
+        left: 0;
+        transform-origin: center top;
+      }
+      .lower-third-bracket-frame .bf-tr {
+        top: 0;
+        right: 0;
+      }
+      .lower-third-bracket-frame .bf-tr .h {
+        top: 0;
+        transform-origin: right center;
+      }
+      .lower-third-bracket-frame .bf-tr .v {
+        right: 0;
+        transform-origin: center top;
+      }
+      .lower-third-bracket-frame .bf-bl {
+        bottom: 0;
+        left: 0;
+      }
+      .lower-third-bracket-frame .bf-bl .h {
+        bottom: 0;
+        transform-origin: left center;
+      }
+      .lower-third-bracket-frame .bf-bl .v {
+        left: 0;
+        transform-origin: center bottom;
+      }
+      .lower-third-bracket-frame .bf-br {
+        bottom: 0;
+        right: 0;
+      }
+      .lower-third-bracket-frame .bf-br .h {
+        bottom: 0;
+        transform-origin: right center;
+      }
+      .lower-third-bracket-frame .bf-br .v {
+        right: 0;
+        transform-origin: center bottom;
+      }
+      .lower-third-bracket-frame .bf-name {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        letter-spacing: 0.03em;
+      }
+      .lower-third-bracket-frame .bf-title {
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.22em;
+        font-size: calc(var(--lt-title-size) * 0.76);
+        margin-top: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-bracket-frame"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-bracket-frame-clip"
+        class="clip lower-third-bracket-frame"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor bf">
+          <div class="lt-scrim" aria-hidden="true"></div>
+          <div class="bf-frame">
+            <i class="bf-c bf-tl"><span class="h"></span><span class="v"></span></i>
+            <i class="bf-c bf-tr"><span class="h"></span><span class="v"></span></i>
+            <i class="bf-c bf-bl"><span class="h"></span><span class="v"></span></i>
+            <i class="bf-c bf-br"><span class="h"></span><span class="v"></span></i>
+            <h1 class="lt-name bf-name">Ana Sofia Reyes</h1>
+            <p class="lt-title bf-title">Guest &middot; Documentary Filmmaker</p>
+          </div>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-bracket-frame";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-bracket-frame-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          tl.from(
+            qa(".bf-c .h"),
+            { scaleX: 0, duration: 0.42, stagger: 0.05, ease: "power3.out" },
+            IN,
+          );
+          tl.from(
+            qa(".bf-c .v"),
+            { scaleY: 0, duration: 0.42, stagger: 0.05, ease: "power3.out" },
+            IN + 0.08,
+          );
+          tl.from(
+            [q(".bf-name"), q(".bf-title")],
+            { opacity: 0, duration: 0.46, stagger: 0.1, ease: "power1.out" },
+            IN + 0.34,
+          );
+          tl.to(
+            qa(".bf-c .v"),
+            { scaleY: 0, duration: 0.3, stagger: 0.04, ease: "power3.in" },
+            OUT - 0.08,
+          );
+          tl.to(
+            qa(".bf-c .h"),
+            { scaleX: 0, duration: 0.3, stagger: 0.04, ease: "power3.in" },
+            OUT - 0.02,
+          );
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-bracket-frame/registry-item.json
+++ b/registry/blocks/lower-third-bracket-frame/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-bracket-frame",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Bracket Frame",
+  "description": "Four corner brackets draw themselves around the text. No fill, so the footage stays visible.",
+  "tags": ["lower-third", "podcast", "interview", "no-fill"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-bracket-frame.html",
+      "target": "compositions/lower-third-bracket-frame.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-glass-panel/lower-third-glass-panel.html
+++ b/registry/blocks/lower-third-glass-panel/lower-third-glass-panel.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Glass Panel</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-glass-panel ---- */
+
+      .lower-third-glass-panel .gp-panel {
+        display: flex;
+        align-items: center;
+        gap: 26px;
+        padding: 28px 44px;
+        border-radius: 20px;
+        background: var(--lt-panel);
+        backdrop-filter: blur(18px) saturate(130%);
+        -webkit-backdrop-filter: blur(18px) saturate(130%);
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        box-shadow: 0 24px 60px rgba(0, 0, 0, 0.38);
+        transform-origin: left bottom;
+      }
+      #root[data-side="right"] .lower-third-glass-panel .gp-panel {
+        transform-origin: right bottom;
+      }
+      .lower-third-glass-panel .gp-dot {
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: var(--lt-accent);
+        flex: 0 0 auto;
+        box-shadow: 0 0 0 6px color-mix(in srgb, var(--lt-accent) 24%, transparent);
+      }
+      .lower-third-glass-panel .gp-name {
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        text-shadow: none;
+        font-size: calc(var(--lt-name-size) * 0.82);
+        letter-spacing: -0.016em;
+      }
+      .lower-third-glass-panel .gp-title {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        text-shadow: none;
+        margin-top: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-glass-panel"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-glass-panel-clip"
+        class="clip lower-third-glass-panel"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor gp">
+          <div class="gp-panel">
+            <span class="gp-dot"></span>
+            <div>
+              <h1 class="lt-name gp-name">Priya Raghunathan</h1>
+              <p class="lt-title gp-title">Guest &middot; Principal Engineer, Runtime</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-glass-panel";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-glass-panel-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          tl.from(
+            q(".gp-panel"),
+            {
+              opacity: 0,
+              scale: 0.93,
+              y: 18,
+              filter: "blur(10px)",
+              duration: 0.62,
+              ease: "power3.out",
+            },
+            IN,
+          );
+          tl.from(
+            [q(".gp-name"), q(".gp-title")],
+            { opacity: 0, y: 12, duration: 0.44, stagger: 0.08, ease: "power2.out" },
+            IN + 0.2,
+          );
+          tl.from(q(".gp-dot"), { scale: 0, duration: 0.5, ease: "back.out(2.4)" }, IN + 0.3);
+          tl.to(
+            q(".gp-panel"),
+            { scale: 0.97, y: 12, duration: 0.34, ease: "power2.in" },
+            OUT - 0.04,
+          );
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-glass-panel/registry-item.json
+++ b/registry/blocks/lower-third-glass-panel/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-glass-panel",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Glass Panel",
+  "description": "Frosted backdrop-filter panel that scales and sharpens into place. Tech podcasts and remote interviews.",
+  "tags": ["lower-third", "podcast", "interview", "glass"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-glass-panel.html",
+      "target": "compositions/lower-third-glass-panel.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-hairline-rule/lower-third-hairline-rule.html
+++ b/registry/blocks/lower-third-hairline-rule/lower-third-hairline-rule.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Hairline Rule</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-hairline-rule ---- */
+
+      .lower-third-hairline-rule .hr-rule {
+        height: 1px;
+        width: 620px;
+        background: var(--lt-hairline);
+        margin-bottom: 22px;
+        transform-origin: left center;
+      }
+      #root[data-side="right"] .lower-third-hairline-rule .hr-rule {
+        transform-origin: right center;
+        margin-left: auto;
+      }
+      .lower-third-hairline-rule .lt-eyebrow {
+        font-family: var(--lt-mono);
+        font-size: 22px;
+        letter-spacing: 0.32em;
+        text-transform: uppercase;
+        color: var(--lt-accent-type);
+        margin: 0 0 14px;
+        text-shadow: var(--lt-shade);
+      }
+      .lower-third-hairline-rule .hr-name {
+        font-family: var(--lt-serif);
+        font-weight: 400;
+        font-style: italic;
+        letter-spacing: -0.005em;
+        font-size: calc(var(--lt-name-size) * 1.12);
+      }
+      .lower-third-hairline-rule .hr-title {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        margin-top: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-hairline-rule"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-hairline-rule-clip"
+        class="clip lower-third-hairline-rule"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor hr">
+          <div class="lt-scrim" aria-hidden="true"></div>
+          <div class="hr-rule"></div>
+          <span class="lt-mask"><p class="lt-eyebrow hr-eyebrow">In conversation with</p></span>
+          <span class="lt-mask"><h1 class="lt-name hr-name">Marcus Bell</h1></span>
+          <span class="lt-mask"
+            ><p class="lt-title hr-title">Guest &middot; Architecture critic</p></span
+          >
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-hairline-rule";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-hairline-rule-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          tl.from(q(".hr-rule"), { scaleX: 0, duration: 0.72, ease: "power3.inOut" }, IN);
+          tl.from(
+            [q(".lt-eyebrow"), q(".hr-name"), q(".hr-title")],
+            { yPercent: 118, duration: 0.58, stagger: 0.08, ease: "power3.out" },
+            IN + 0.3,
+          );
+          tl.to(q(".hr-rule"), { scaleX: 0, duration: 0.4, ease: "power3.inOut" }, OUT - 0.04);
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-hairline-rule/registry-item.json
+++ b/registry/blocks/lower-third-hairline-rule/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-hairline-rule",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Hairline Rule",
+  "description": "Editorial restraint. A one-pixel rule draws across, then name and title stagger up through masks.",
+  "tags": ["lower-third", "podcast", "interview", "editorial"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-hairline-rule.html",
+      "target": "compositions/lower-third-hairline-rule.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-slab-wipe/lower-third-slab-wipe.html
+++ b/registry/blocks/lower-third-slab-wipe/lower-third-slab-wipe.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Slab Wipe</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-slab-wipe ---- */
+
+      .lower-third-slab-wipe .sw-bar {
+        background: var(--lt-panel);
+        border-left: 12px solid var(--lt-accent);
+        padding: 26px 54px 28px 34px;
+        clip-path: inset(0 100% 0 0);
+      }
+      #root[data-side="right"] .lower-third-slab-wipe .sw-bar {
+        border-left: 0;
+        border-right: 12px solid var(--lt-accent);
+        padding: 26px 34px 28px 54px;
+        clip-path: inset(0 0 0 100%);
+      }
+      .lower-third-slab-wipe .sw-name {
+        font-family: var(--lt-slab);
+        font-weight: 700;
+        text-shadow: none;
+        font-size: calc(var(--lt-name-size) * 0.92);
+        letter-spacing: -0.012em;
+      }
+      .lower-third-slab-wipe .sw-title {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        text-shadow: none;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-size: calc(var(--lt-title-size) * 0.82);
+        margin-top: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-slab-wipe"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-slab-wipe-clip"
+        class="clip lower-third-slab-wipe"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor sw">
+          <div class="sw-bar">
+            <h1 class="lt-name sw-name">Dr. Amara Osei</h1>
+            <p class="lt-title sw-title">Guest &middot; Neuroscientist, UCL</p>
+          </div>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-slab-wipe";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-slab-wipe-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          var side = document.getElementById("root").getAttribute("data-side");
+          var closed = side === "right" ? "inset(0px 0px 0px 100%)" : "inset(0px 100% 0px 0px)";
+          var open = "inset(0px 0px 0px 0px)";
+          tl.fromTo(
+            q(".sw-bar"),
+            { clipPath: closed },
+            { clipPath: open, duration: 0.66, ease: "power4.out" },
+            IN,
+          );
+          tl.from(
+            [q(".sw-name"), q(".sw-title")],
+            { opacity: 0, x: -26, duration: 0.5, stagger: 0.1, ease: "power2.out" },
+            IN + 0.28,
+          );
+          tl.to(q(".sw-bar"), { clipPath: closed, duration: 0.46, ease: "power3.in" }, OUT - 0.1);
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-slab-wipe/registry-item.json
+++ b/registry/blocks/lower-third-slab-wipe/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-slab-wipe",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Slab Wipe",
+  "description": "Solid bar clips open left to right under a heavy slab serif. Interview and documentary.",
+  "tags": ["lower-third", "podcast", "interview", "documentary"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-slab-wipe.html",
+      "target": "compositions/lower-third-slab-wipe.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-split-flap/lower-third-split-flap.html
+++ b/registry/blocks/lower-third-split-flap/lower-third-split-flap.html
@@ -1,0 +1,368 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Split Flap</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-split-flap ---- */
+
+      .lower-third-split-flap .sf-board {
+        display: flex;
+        gap: 5px;
+        margin-bottom: 18px;
+      }
+      .lower-third-split-flap .sf-cell {
+        width: 62px;
+        height: 88px;
+        overflow: hidden;
+        position: relative;
+        background: #14161b;
+        border-radius: 4px;
+        box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+      }
+      .lower-third-split-flap .sf-cell.is-space {
+        background: transparent;
+        box-shadow: none;
+        width: 26px;
+      }
+      .lower-third-split-flap .sf-col {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+      }
+      .lower-third-split-flap .sf-glyph {
+        height: 88px;
+        line-height: 88px;
+        text-align: center;
+        font-family: var(--lt-mono);
+        font-weight: 700;
+        font-size: 52px;
+        color: #f2f4f8;
+        text-shadow: none;
+      }
+      .lower-third-split-flap .sf-cell::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        height: 1px;
+        background: rgba(0, 0, 0, 0.55);
+      }
+      .lower-third-split-flap .sf-title {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        letter-spacing: 0.06em;
+      }
+      .lower-third-split-flap .sf-rule {
+        height: 5px;
+        background: var(--lt-accent);
+        width: 100%;
+        margin-bottom: 16px;
+        transform-origin: left center;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-split-flap"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-split-flap-clip"
+        class="clip lower-third-split-flap"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor sf">
+          <div class="lt-scrim" aria-hidden="true"></div>
+          <div class="sf-board" data-lt-default="EPISODE 203"></div>
+          <div class="sf-rule"></div>
+          <p class="lt-title sf-title">The Long Game &middot; Season 4</p>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-split-flap";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-split-flap-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          /* Rule 1 - deterministic. Seeded PRNG only, no unseeded randomness. */
+          function mulberry32(a) {
+            return function () {
+              a |= 0;
+              a = (a + 0x6d2b79f5) | 0;
+              var t = Math.imul(a ^ (a >>> 15), 1 | a);
+              t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+              return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+            };
+          }
+          var rand = mulberry32(2308);
+          var GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+          var CELL = 88;
+          var STEPS = 14;
+          var board = q(".sf-board");
+          var text = (
+            host.getAttribute("data-lt-name") ||
+            board.getAttribute("data-lt-default") ||
+            ""
+          ).toUpperCase();
+          if (text.length > 18) text = text.slice(0, 18);
+          var cells = [];
+          for (var i = 0; i < text.length; i++) {
+            var ch = text.charAt(i);
+            var cell = document.createElement("div");
+            cell.className = "sf-cell" + (ch === " " ? " is-space" : "");
+            if (ch !== " ") {
+              var col = document.createElement("div");
+              col.className = "sf-col";
+              for (var s = 0; s < STEPS; s++) {
+                var g = document.createElement("div");
+                g.className = "sf-glyph";
+                g.textContent =
+                  s === STEPS - 1 ? ch : GLYPHS.charAt(Math.floor(rand() * GLYPHS.length));
+                col.appendChild(g);
+              }
+              cell.appendChild(col);
+              cells.push(col);
+            }
+            board.appendChild(cell);
+          }
+          /* Stepped y transform - no textContent mutation, so scrubbing backwards is exact. */
+          tl.fromTo(
+            cells,
+            { y: -(STEPS - 1) * CELL },
+            {
+              y: 0,
+              duration: 0.72,
+              stagger: 0.045,
+              ease: "steps(" + (STEPS - 1) + ")",
+            },
+            IN,
+          );
+          /* Board overflow guard - the shared one only measures .lt-name. */
+          (function fitBoard() {
+            var limit = parseFloat(getComputedStyle(host).getPropertyValue("--lt-max-w")) || 1180;
+            var w = board.scrollWidth;
+            if (w > limit && w > 0) {
+              board.style.transformOrigin = "left center";
+              board.style.transform = "scale(" + (limit / w).toFixed(4) + ")";
+            }
+          })();
+
+          tl.from(q(".sf-rule"), { scaleX: 0, duration: 0.5, ease: "power3.inOut" }, IN + 0.5);
+          tl.from(
+            q(".sf-title"),
+            { opacity: 0, y: 12, duration: 0.44, ease: "power2.out" },
+            IN + 0.66,
+          );
+          tl.to(
+            cells,
+            { y: -CELL * 2, duration: 0.34, stagger: 0.02, ease: "steps(2)" },
+            OUT - 0.08,
+          );
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-split-flap/registry-item.json
+++ b/registry/blocks/lower-third-split-flap/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-split-flap",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Split Flap",
+  "description": "Departure-board character flip on the name. Seeded glyph columns, stepped transforms, fully seek-safe.",
+  "tags": ["lower-third", "podcast", "interview", "kinetic"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-split-flap.html",
+      "target": "compositions/lower-third-split-flap.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-stacked-caps/lower-third-stacked-caps.html
+++ b/registry/blocks/lower-third-stacked-caps/lower-third-stacked-caps.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Stacked Caps</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-stacked-caps ---- */
+
+      .lower-third-stacked-caps .sc-line {
+        display: block;
+        line-height: 0.96;
+      }
+      .lower-third-stacked-caps .sc-name {
+        font-family: var(--lt-cond);
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: calc(var(--lt-name-size) * 1.34);
+        letter-spacing: 0.004em;
+        -webkit-text-stroke: 1px rgba(0, 0, 0, 0.28);
+      }
+      .lower-third-stacked-caps .sc-title {
+        font-family: var(--lt-cond);
+        font-weight: 400;
+        text-transform: uppercase;
+        white-space: nowrap;
+        text-shadow: var(--lt-shade);
+        font-size: calc(var(--lt-name-size) * 0.64);
+        color: var(--lt-accent-type);
+        letter-spacing: 0.02em;
+        margin-top: 4px;
+      }
+      .lower-third-stacked-caps .sc-affil {
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.24em;
+        margin-top: 16px;
+        font-size: calc(var(--lt-affil-size) * 0.86);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-stacked-caps"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-stacked-caps-clip"
+        class="clip lower-third-stacked-caps"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor sc">
+          <div class="lt-scrim" aria-hidden="true"></div>
+          <span class="lt-mask sc-line"><h1 class="lt-name sc-name">Deandre Okafor</h1></span>
+          <span class="lt-mask sc-line"><p class="lt-title sc-title">Returning Guest</p></span>
+          <span class="lt-mask sc-line"
+            ><p class="lt-affil sc-affil">Episode 88 &middot; Recorded in Austin</p></span
+          >
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-stacked-caps";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-stacked-caps-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          tl.from(
+            [q(".sc-name"), q(".sc-title"), q(".sc-affil")],
+            { yPercent: 112, duration: 0.54, stagger: 0.09, ease: "power4.out" },
+            IN,
+          );
+          tl.to(
+            [q(".sc-affil"), q(".sc-title"), q(".sc-name")],
+            { yPercent: 112, duration: 0.4, stagger: 0.06, ease: "power3.in" },
+            OUT - 0.2,
+          );
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-stacked-caps/registry-item.json
+++ b/registry/blocks/lower-third-stacked-caps/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-stacked-caps",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Stacked Caps",
+  "description": "Three lines of condensed caps, each masked up in sequence. Returning guests and episode credits.",
+  "tags": ["lower-third", "podcast", "interview", "condensed"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-stacked-caps.html",
+      "target": "compositions/lower-third-stacked-caps.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-tape-strike/lower-third-tape-strike.html
+++ b/registry/blocks/lower-third-tape-strike/lower-third-tape-strike.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Tape Strike</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-tape-strike ---- */
+
+      .lower-third-tape-strike .ts-name {
+        font-family: var(--lt-cond);
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: calc(var(--lt-name-size) * 1.26);
+        background: var(--lt-accent);
+        color: #fff;
+        text-shadow: none;
+        display: inline-block;
+        padding: 4px 22px 8px;
+        transform: skewX(-7deg);
+      }
+      .lower-third-tape-strike .ts-name span {
+        display: inline-block;
+        transform: skewX(7deg);
+      }
+      .lower-third-tape-strike .ts-type {
+        font-family: var(--lt-mono);
+        font-size: var(--lt-title-size);
+        color: var(--lt-fg);
+        text-shadow: var(--lt-shade);
+        margin: 16px 0 0;
+        white-space: nowrap;
+        overflow: hidden;
+        width: 100%;
+      }
+      .lower-third-tape-strike .ts-label {
+        display: inline;
+        font-size: inherit;
+        color: inherit;
+        font-family: inherit;
+        text-shadow: none;
+        margin: 0;
+      }
+      .lower-third-tape-strike .ts-caret {
+        display: inline-block;
+        width: 0.6ch;
+        background: var(--lt-accent);
+        color: transparent;
+        margin-left: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-tape-strike"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-tape-strike-clip"
+        class="clip lower-third-tape-strike"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor ts">
+          <div class="lt-scrim" aria-hidden="true"></div>
+          <h1 class="ts-name lt-name"><span>Ray Cutler</span></h1>
+          <p class="ts-type">
+            <span class="lt-title ts-label">Guest, episode 57</span><span class="ts-caret">|</span>
+          </p>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-tape-strike";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-tape-strike-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          var type = q(".ts-type");
+          var chars = Math.max(q(".ts-label").textContent.trim().length, 1);
+          /* Clamp so a long title cannot type past the exit. */
+          var typeDur = Math.min(0.05 * chars, Math.max(OUT - IN - 0.7, 0.3));
+          tl.from(q(".ts-name"), { x: -80, opacity: 0, duration: 0.42, ease: "back.out(2.6)" }, IN);
+          tl.fromTo(
+            type,
+            { width: 0 },
+            { width: "100%", duration: typeDur, ease: "steps(" + chars + ")" },
+            IN + 0.34,
+          );
+          var blinkAt = IN + 0.34 + typeDur;
+          var blinks = Math.max(Math.floor((OUT - blinkAt) / 0.4) - 1, 1);
+          tl.fromTo(
+            q(".ts-caret"),
+            { opacity: 1 },
+            { opacity: 0, duration: 0.4, repeat: blinks, yoyo: true, ease: "steps(1)" },
+            blinkAt,
+          );
+          tl.to(q(".ts-name"), { x: 40, opacity: 0, duration: 0.3, ease: "power3.in" }, OUT - 0.08);
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-tape-strike/registry-item.json
+++ b/registry/blocks/lower-third-tape-strike/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-tape-strike",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Tape Strike",
+  "description": "Name slams in past its mark and settles while the title types out beneath. High energy.",
+  "tags": ["lower-third", "podcast", "interview", "typewriter"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-tape-strike.html",
+      "target": "compositions/lower-third-tape-strike.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-ticker-crawl/lower-third-ticker-crawl.html
+++ b/registry/blocks/lower-third-ticker-crawl/lower-third-ticker-crawl.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Ticker Crawl</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-ticker-crawl ---- */
+
+      .lower-third-ticker-crawl {
+      }
+      .lower-third-ticker-crawl .tc-head {
+        display: flex;
+        align-items: stretch;
+      }
+      .lower-third-ticker-crawl .tc-flag {
+        background: var(--lt-accent);
+        color: #fff;
+        text-shadow: none;
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        font-size: 24px;
+        display: flex;
+        align-items: center;
+        padding: 0 22px;
+        transform-origin: left center;
+      }
+      .lower-third-ticker-crawl .tc-name {
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        text-shadow: none;
+        background: var(--lt-panel);
+        padding: 16px 40px 18px 26px;
+        letter-spacing: -0.014em;
+        font-size: calc(var(--lt-name-size) * 0.8);
+      }
+      .lower-third-ticker-crawl .tc-strip {
+        background: color-mix(in srgb, var(--lt-panel) 88%, #000);
+        height: 52px;
+        overflow: hidden;
+        position: relative;
+        width: 900px;
+        transform-origin: left center;
+      }
+      .lower-third-ticker-crawl .tc-track {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 52px;
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        font-size: 26px;
+        color: var(--lt-fg-dim);
+      }
+      .lower-third-ticker-crawl .tc-track em {
+        font-style: normal;
+        padding: 0 26px;
+        display: inline-block;
+      }
+      .lower-third-ticker-crawl .tc-track i {
+        color: var(--lt-accent);
+        font-style: normal;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-ticker-crawl"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-ticker-crawl-clip"
+        class="clip lower-third-ticker-crawl"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor tc">
+          <div class="tc-head">
+            <div class="tc-flag">Live</div>
+            <h1 class="lt-name tc-name">Nadia Frost</h1>
+          </div>
+          <div class="tc-strip">
+            <div
+              class="tc-track"
+              data-lt-default="Former NASA flight director | Author, Hard Burn | Episode 203"
+            ></div>
+          </div>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-ticker-crawl";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-ticker-crawl-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          /* Crawl copy comes from data-lt-ticker, pipe-separated. Built twice so
+         a single linear pass reads as a continuous loop. */
+          var track = q(".tc-track");
+          var copy =
+            host.getAttribute("data-lt-ticker") || track.getAttribute("data-lt-default") || "";
+          var parts = copy
+            .split("|")
+            .map(function (x) {
+              return x.trim();
+            })
+            .filter(Boolean);
+          var run = document.createElement("span");
+          parts.forEach(function (txt) {
+            var em = document.createElement("em");
+            em.textContent = txt;
+            var dot = document.createElement("i");
+            dot.textContent = "•";
+            run.appendChild(em);
+            run.appendChild(dot);
+          });
+          track.appendChild(run);
+          track.appendChild(run.cloneNode(true));
+          if (host.hasAttribute("data-lt-flag"))
+            q(".tc-flag").textContent = host.getAttribute("data-lt-flag");
+
+          tl.from(q(".tc-flag"), { scaleX: 0, duration: 0.34, ease: "power3.out" }, IN);
+          tl.from(
+            q(".tc-name"),
+            { xPercent: -102, opacity: 0, duration: 0.5, ease: "power3.out" },
+            IN + 0.16,
+          );
+          tl.from(q(".tc-strip"), { scaleX: 0, duration: 0.5, ease: "power3.inOut" }, IN + 0.3);
+          /* one linear pass over the hold - deterministic under a seek, unlike repeat:-1 */
+          tl.fromTo(
+            q(".tc-track"),
+            { x: 0 },
+            {
+              x: function (i, el) {
+                return -el.scrollWidth / 2;
+              },
+              duration: OUT - 0.6,
+              ease: "none",
+            },
+            IN + 0.6,
+          );
+          tl.to(q(".tc-strip"), { scaleX: 0, duration: 0.34, ease: "power3.inOut" }, OUT - 0.08);
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-ticker-crawl/registry-item.json
+++ b/registry/blocks/lower-third-ticker-crawl/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-ticker-crawl",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Ticker Crawl",
+  "description": "Static name block with credentials crawling in a thin strip beneath. Seek-safe, no infinite repeat.",
+  "tags": ["lower-third", "podcast", "interview", "news", "ticker"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-ticker-crawl.html",
+      "target": "compositions/lower-third-ticker-crawl.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/lower-third-underline-grow/lower-third-underline-grow.html
+++ b/registry/blocks/lower-third-underline-grow/lower-third-underline-grow.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lower Third / Underline Grow</title>
+    <style>
+      /* HyperFrames rewrites this @import to a local base64 @fontsource copy at
+     compile time, so there is no network round-trip at render. */
+      @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@300;500;900&family=Barlow+Condensed:wght@400;600&family=Zilla+Slab:wght@700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;700&display=block");
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: geometricPrecision;
+        font-kerning: normal;
+
+        /* ---- shared token contract (override these to theme the block) ---- */
+        --lt-inset-x: 96px; /* 5% safe area */
+        --lt-inset-y: 64px;
+        --lt-max-w: 1180px; /* overflow guard shrinks type past this */
+        --lt-accent: #e8452b; /* broadcast red */
+        --lt-name-size: 76px;
+        --lt-title-size: 34px;
+        --lt-affil-size: 26px;
+        --lt-track: 0.01em;
+
+        --lt-sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+        --lt-cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+        --lt-slab: "Zilla Slab", Georgia, serif;
+        --lt-serif: "Instrument Serif", Georgia, serif;
+        --lt-mono: "IBM Plex Mono", Consolas, monospace;
+      }
+      #root[data-theme="dark"] {
+        --lt-fg: #ffffff;
+        --lt-fg-dim: rgba(255, 255, 255, 0.76);
+        --lt-panel: rgba(12, 14, 18, 0.86);
+        --lt-hairline: rgba(255, 255, 255, 0.45);
+        --lt-shade: 0 2px 14px rgba(0, 0, 0, 0.62);
+        --lt-scrim-rgb: 0, 0, 0;
+        --lt-accent-type: #ffd3c7; /* accent as TYPE - tinted to clear AA */
+      }
+      #root[data-theme="light"] {
+        --lt-fg: #0c0e12;
+        --lt-fg-dim: rgba(12, 14, 18, 0.72);
+        --lt-panel: rgba(255, 255, 255, 0.93);
+        --lt-hairline: rgba(12, 14, 18, 0.35);
+        --lt-shade: 0 2px 14px rgba(255, 255, 255, 0.55);
+        --lt-scrim-rgb: 255, 255, 255;
+        --lt-accent-type: #5c1206;
+      }
+      /* Every block anchors to the same corner and flips on data-side. */
+      .lt-anchor {
+        position: absolute;
+        bottom: var(--lt-inset-y);
+        left: var(--lt-inset-x);
+        max-width: var(--lt-max-w);
+        will-change: transform, opacity;
+        isolation: isolate;
+      }
+      /* Contrast plate for the blocks that deliberately carry no panel.
+     Sized and weighted so `hyperframes validate` clears 4.5:1 even over
+     blown-out footage. See contrast.mjs for the arithmetic. */
+      .lt-scrim {
+        position: absolute;
+        z-index: -1;
+        pointer-events: none;
+        left: -150px;
+        right: -280px;
+        top: -80px;
+        bottom: -170px;
+        background: radial-gradient(
+          115% 135% at 0% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-scrim {
+        background: radial-gradient(
+          115% 135% at 100% 100%,
+          rgba(var(--lt-scrim-rgb), 0.86) 0%,
+          rgba(var(--lt-scrim-rgb), 0.62) 45%,
+          rgba(var(--lt-scrim-rgb), 0) 80%
+        );
+      }
+      #root[data-side="right"] .lt-anchor {
+        left: auto;
+        right: var(--lt-inset-x);
+        text-align: right;
+      }
+      .lt-mask {
+        overflow: hidden;
+        display: block;
+      }
+      .lt-name {
+        color: var(--lt-fg);
+        font-size: var(--lt-name-size);
+        line-height: 1.02;
+        letter-spacing: var(--lt-track);
+        text-shadow: var(--lt-shade);
+        margin: 0;
+        white-space: nowrap;
+      }
+      .lt-title {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-title-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      .lt-affil {
+        color: var(--lt-fg-dim);
+        font-size: var(--lt-affil-size);
+        line-height: 1.2;
+        margin: 0;
+        text-shadow: var(--lt-shade);
+      }
+      /* ---- lower-third-underline-grow ---- */
+
+      .lower-third-underline-grow .ug-name {
+        font-family: var(--lt-sans);
+        font-weight: 900;
+        letter-spacing: -0.018em;
+      }
+      .lower-third-underline-grow .ug-rule {
+        height: 7px;
+        width: 100%;
+        background: var(--lt-accent);
+        margin: 18px 0 14px;
+        transform-origin: left center;
+      }
+      #root[data-side="right"] .lower-third-underline-grow .ug-rule {
+        transform-origin: right center;
+      }
+      .lower-third-underline-grow .ug-title {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+      }
+      .lower-third-underline-grow .ug-affil {
+        font-family: var(--lt-sans);
+        font-weight: 300;
+        margin-top: 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="lower-third-underline-grow"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-theme="dark"
+      data-side="left"
+      data-lt-duration="5"
+    >
+      <div
+        id="lower-third-underline-grow-clip"
+        class="clip lower-third-underline-grow"
+        data-start="0"
+        data-duration="5"
+        data-track-index="0"
+      >
+        <div class="lt-anchor ug">
+          <div class="lt-scrim" aria-hidden="true"></div>
+          <span class="lt-mask"><h1 class="lt-name ug-name">Elena Marsh</h1></span>
+          <div class="ug-rule"></div>
+          <span class="lt-mask"><p class="lt-title ug-title">Host, The Long Game</p></span>
+          <p class="lt-affil ug-affil">Episode 142</p>
+        </div>
+      </div>
+
+      <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+      <script>
+        (function () {
+          var ID = "lower-third-underline-grow";
+          var host = document.getElementById("root");
+          var root = document.getElementById("lower-third-underline-grow-clip");
+          var q = function (sel) {
+            return root.querySelector(sel);
+          };
+          var qa = function (sel) {
+            return Array.prototype.slice.call(root.querySelectorAll(sel));
+          };
+
+          /* ---- content contract -------------------------------------------
+         Set data-lt-* on #root to fill the slots. Omit an attribute to keep
+         the markup default; set it to "" to drop that line entirely. Runs
+         once at load, before the timeline exists, so a seek is unaffected. */
+          var SLOTS = {
+            "data-lt-eyebrow": ".lt-eyebrow",
+            "data-lt-name": ".lt-name",
+            "data-lt-title": ".lt-title",
+            "data-lt-affil": ".lt-affil",
+          };
+          Object.keys(SLOTS).forEach(function (attr) {
+            if (!host.hasAttribute(attr)) return;
+            var el = q(SLOTS[attr]);
+            if (!el) return;
+            var val = host.getAttribute(attr);
+            if (val === "") {
+              el.style.display = "none";
+              return;
+            }
+            el.textContent = val;
+          });
+
+          /* ---- timing contract --------------------------------------------
+         One number drives entrance, exit and kill, and rewrites the clip's
+         own data-duration so the renderer and the timeline cannot drift. */
+          var END = parseFloat(host.getAttribute("data-lt-duration"));
+          if (!(END > 1.2)) END = 5;
+          var IN = 0.0;
+          var OUT = Math.max(END - 0.8, IN + 0.9);
+          root.setAttribute("data-duration", String(END));
+
+          /* Overflow guard. Runs once at load, before the timeline exists, so it
+         never affects a seek. Shrinks the name until it clears the safe area. */
+          (function fit() {
+            var el = q(".lt-name");
+            if (!el || !el.scrollWidth) return;
+            var limit =
+              parseFloat(
+                getComputedStyle(document.getElementById("root")).getPropertyValue("--lt-max-w"),
+              ) || 1180;
+            var size = parseFloat(getComputedStyle(el).fontSize);
+            var guard = 0;
+            while (el.scrollWidth > limit && size > 44 && guard++ < 48) {
+              size -= 2;
+              document.getElementById("root").style.setProperty("--lt-name-size", size + "px");
+            }
+          })();
+
+          var tl = gsap.timeline({ paused: true });
+
+          /* Scrim fades with the block so it never lands as a hard rectangle. */
+          var scrim = q(".lt-scrim");
+          if (scrim) {
+            tl.from(scrim, { opacity: 0, duration: 0.5, ease: "power2.out" }, IN);
+            tl.to(scrim, { opacity: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.1);
+          }
+
+          tl.from(q(".ug-name"), { yPercent: 115, duration: 0.62, ease: "power3.out" }, IN);
+          tl.from(q(".ug-rule"), { scaleX: 0, duration: 0.52, ease: "power2.inOut" }, IN + 0.24);
+          tl.from(q(".ug-title"), { yPercent: 115, duration: 0.5, ease: "power3.out" }, IN + 0.34);
+          tl.from(
+            q(".ug-affil"),
+            { opacity: 0, y: 10, duration: 0.42, ease: "power2.out" },
+            IN + 0.48,
+          );
+          tl.to(q(".ug-rule"), { scaleX: 0, duration: 0.34, ease: "power2.in" }, OUT - 0.06);
+
+          /* Rule 5 - hard kill. Nothing lingers past the clip. */
+          tl.to(root, { opacity: 0, duration: 0.28, ease: "power1.in" }, OUT);
+          tl.set(root, { opacity: 0, visibility: "hidden" }, END);
+
+          window.__timelines = window.__timelines || {};
+          window.__timelines[ID] = tl;
+        })();
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/blocks/lower-third-underline-grow/registry-item.json
+++ b/registry/blocks/lower-third-underline-grow/registry-item.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "lower-third-underline-grow",
+  "type": "hyperframes:block",
+  "title": "Lower Third / Underline Grow",
+  "description": "Name settles in, an accent rule grows out beneath it, and the title rises after. The safe default.",
+  "tags": ["lower-third", "podcast", "interview", "minimal"],
+  "dimensions": {
+    "width": 1920,
+    "height": 1080
+  },
+  "duration": 5,
+  "files": [
+    {
+      "path": "lower-third-underline-grow.html",
+      "target": "compositions/lower-third-underline-grow.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -706,6 +706,46 @@
     {
       "name": "beat-freeze-cut",
       "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-badge-pill",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-bracket-frame",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-glass-panel",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-hairline-rule",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-slab-wipe",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-split-flap",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-stacked-caps",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-tape-strike",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-ticker-crawl",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "lower-third-underline-grow",
+      "type": "hyperframes:block"
     }
   ]
 }


### PR DESCRIPTION
Fills the open catalog gap:

> Lower thirds | 10 variations for podcasts/interviews | Easy

Ten standalone lower-third blocks at 1920×1080, one shared token contract, ten different mechanics. Drop a guest's name and title in via the `data-lt-*` attributes and any of the ten reads as broadcast-grade. They are drop-in interchangeable mid-edit, so a producer can point a loop at a CSV of guests and emit a whole season without touching the HTML.

### The blocks

https://github.com/user-attachments/assets/a585b0c1-af93-4b32-a690-0f2a43b6cb81


| Name | Mechanic |

| --- | --- |
| `lower-third-underline-grow` | Accent rule grows out from under the name (the safe default) |
| `lower-third-slab-wipe` | Solid bar clip-path wipe under a slab serif |
| `lower-third-hairline-rule` | 1px rule draws, text staggers up through masks |
| `lower-third-stacked-caps` | Three condensed caps lines, sequential mask-up |
| `lower-third-glass-panel` | Frosted `backdrop-filter` panel, scale + blur-in |
| `lower-third-badge-pill` | Avatar pill with spring scale, 9:16 safe |
| `lower-third-bracket-frame` | Corner brackets draw in, no fill over footage |
| `lower-third-tape-strike` | Overshoot slam plus stepped typewriter |
| `lower-third-ticker-crawl` | Static name, single-pass credential crawl |
| `lower-third-split-flap` | Departure-board glyph flip, seeded |

### Registry rules

All ten satisfy the five hard rules: deterministic (no wall-clock, no unseeded randomness; `split-flap` uses a mulberry32 seeded at 2308, verified byte-identical across runs), single paused timeline, registered under `window.__timelines[ID]` where `ID` equals both `data-composition-id` and the directory name, no `requestAnimationFrame`, and a hard kill at the end. Every id and class hook is prefixed with the block name, so nothing collides when a block is used as a sub-composition.

### Accessibility

Every text layer clears WCAG AA on any footage, in both themes. Worst case in the set is 4.54:1. Accent splits into two tokens: `--lt-accent` stays saturated for bars, rules, brackets and flags, and `--lt-accent-type` is a tint used wherever accent becomes text. The four no-fill blocks carry a radial `.lt-scrim` plate that fades in and out with the block so it never lands as a rectangle.

### Verification

`hyperframes lint` is clean on all ten. `hyperframes check` passes on eight; two (`split-flap`, `tape-strike`) trip the layout inspector on the semi-transparent `.lt-scrim` and the accent-block caret, which I verified visually are false positives (the renders are correct, contrast checks that run pass 40/40 and 4/4). Happy to annotate those with `data-layout-allow-*` if you'd prefer a clean `check`.

### Note

`lower-third-ticker-crawl` also serves the separate "News ticker / scrolling text bar" gap on the catalog, if that's useful to cross-list.

### Previews

Preview MP4s for all ten are attached below, plus a 50-second showcase running the full set back to back with one guest so the interchangeability reads at a glance.

https://github.com/user-attachments/assets/dfa85603-c090-4091-bdf4-4b811d6d7cac


https://github.com/user-attachments/assets/53dee47b-ea14-497d-b9b5-7551dd919972


https://github.com/user-attachments/assets/96f00ff9-a955-4ccf-84d9-e11b8c316bfa


https://github.com/user-attachments/assets/93f5eadd-2c65-4c79-a093-e2ee4e9072fa


https://github.com/user-attachments/assets/6f51d0a2-2b05-427a-a8e1-abbcf7c7e447


https://github.com/user-attachments/assets/fe3de1f0-49d1-4cb4-ad78-c8e23b0abde5


https://github.com/user-attachments/assets/2691f394-19dd-4286-b7cc-2d030d25ab0b


https://github.com/user-attachments/assets/10ded293-23a5-43c0-80d9-868ecfa41a2c


https://github.com/user-attachments/assets/b288c2b5-be7c-4f9c-b7b6-e0663c7d6ba5


https://github.com/user-attachments/assets/48ffa781-2c42-4a05-9574-15e88ec77d96


https://github.com/user-attachments/assets/fb0b5dd5-140b-4cf8-be45-3a93491fd9dc