### PR TITLE
perf(studio,core): stop the overlay loops and the paused transport from running when nothing moves

### DIFF
--- a/packages/core/src/runtime/init.pausedTransport.test.ts
+++ b/packages/core/src/runtime/init.pausedTransport.test.ts
@@ -1,0 +1,316 @@
+// fallow-ignore-file code-duplication
+// (the timeline/rAF harness mirrors init.test.ts on purpose — these tests pin
+// the paused-state transport contract and must not move when that file does.)
+/**
+ * What the transport loop owes a PAUSED runtime.
+ *
+ * Idle Studio burned a flat ~120 style recalcs/second because `transportTick`
+ * rescheduled itself every frame regardless of play state and re-seeked the
+ * timeline on every one of those frames. The frame loop can stop while paused,
+ * but three of its passengers cannot: they are the only reason a composition
+ * that registers its timeline late, or is edited while parked, ever converges.
+ *
+ * These are characterization tests first: every assertion here describes
+ * behaviour that already held when the loop ran at 60fps, and must still hold
+ * once it runs on a slow timer. `advancePausedTime` drives BOTH schedules so a
+ * test cannot accidentally pin one of them.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initSandboxRuntimeModular } from "./init";
+import type { RuntimeTimelineLike } from "./types";
+
+interface RecordingTimeline extends RuntimeTimelineLike {
+  seekTimes: number[];
+}
+
+function createRecordingTimeline(duration: number): RecordingTimeline {
+  const state = { time: 0, paused: true };
+  const seekTimes: number[] = [];
+  return {
+    seekTimes,
+    play: () => {
+      state.paused = false;
+    },
+    pause: () => {
+      state.paused = true;
+    },
+    seek: (time?: number) => {
+      if (time !== undefined) {
+        state.time = time;
+        seekTimes.push(time);
+      }
+      return state.time;
+    },
+    totalTime: (time?: number) => {
+      if (time !== undefined) {
+        state.time = time;
+        seekTimes.push(time);
+      }
+      return state.time;
+    },
+    time: () => state.time,
+    duration: () => duration,
+    add: () => {},
+    paused: (value?: boolean) => {
+      if (typeof value === "boolean") state.paused = value;
+      return state.paused;
+    },
+    timeScale: () => {},
+    set: () => {},
+    getChildren: () => [],
+  };
+}
+
+function createManualRaf() {
+  let now = 0;
+  let nextId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  return {
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      nextId += 1;
+      callbacks.set(nextId, callback);
+      return nextId;
+    },
+    cancelAnimationFrame: (id: number) => {
+      callbacks.delete(id);
+    },
+    step: (milliseconds: number) => {
+      now += milliseconds;
+      const pending = Array.from(callbacks.entries());
+      callbacks.clear();
+      for (const [, callback] of pending) callback(now);
+    },
+    pending: () => callbacks.size,
+    now: () => now,
+  };
+}
+
+type ManualRaf = ReturnType<typeof createManualRaf>;
+
+/** Drive both possible paused schedules — the frame loop AND any slow timer. */
+function advancePausedTime(raf: ManualRaf, milliseconds: number): void {
+  const frames = Math.max(1, Math.round(milliseconds / 16));
+  for (let index = 0; index < frames; index += 1) {
+    raf.step(16);
+    vi.advanceTimersByTime(16);
+  }
+}
+
+function installManualRaf(): ManualRaf {
+  const raf = createManualRaf();
+  vi.spyOn(performance, "now").mockImplementation(() => raf.now());
+  window.requestAnimationFrame = raf.requestAnimationFrame as typeof window.requestAnimationFrame;
+  window.cancelAnimationFrame = raf.cancelAnimationFrame as typeof window.cancelAnimationFrame;
+  return raf;
+}
+
+function writeRoot(attrs: { duration?: string } = {}): HTMLElement {
+  const root = document.createElement("div");
+  root.setAttribute("data-composition-id", "root");
+  root.setAttribute("data-root", "true");
+  root.setAttribute("data-start", "0");
+  if (attrs.duration !== undefined) root.setAttribute("data-duration", attrs.duration);
+  root.setAttribute("data-width", "1920");
+  root.setAttribute("data-height", "1080");
+  document.body.appendChild(root);
+  return root;
+}
+
+describe("paused transport schedule", () => {
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    (globalThis as typeof globalThis & { CSS?: { escape?: (value: string) => string } }).CSS ??= {};
+    globalThis.CSS.escape ??= (value: string) => value;
+  });
+
+  afterEach(() => {
+    window.__hfRuntimeTeardown?.();
+    document.body.innerHTML = "";
+    window.__timelines = {} as Record<string, RuntimeTimelineLike>;
+    delete window.__player;
+    delete window.__playerReady;
+    delete window.__renderReady;
+    delete (window as { __HF_EXPORT_RENDER_SEEK_CONFIG?: unknown }).__HF_EXPORT_RENDER_SEEK_CONFIG;
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // --- Renderer safety: the three passengers that must survive ---------------
+
+  it("discovers a timeline registered after init while paused, sets its duration, and renders it", () => {
+    const raf = installManualRaf();
+    writeRoot();
+    window.__timelines = {} as Record<string, RuntimeTimelineLike>;
+
+    initSandboxRuntimeModular();
+    expect(window.__player?.getDuration()).toBe(0);
+
+    // The composition's own script runs after runtime init — both the Studio
+    // preview and the renderer sit paused while this happens. Nothing but the
+    // periodic rebind will ever notice it.
+    const late = createRecordingTimeline(6);
+    window.__timelines = { root: late } as Record<string, RuntimeTimelineLike>;
+
+    advancePausedTime(raf, 2_000);
+
+    expect(window.__player?.getDuration()).toBe(6);
+    expect(late.seekTimes.length).toBeGreaterThan(0);
+  });
+
+  it("keeps a usable bound timeline when the registry entry is replaced while paused", () => {
+    // The periodic rebind now runs on the slow schedule; it must still refuse
+    // to adopt a replacement once a usable timeline is bound. (init.test.ts
+    // pinned this against the frame loop, which no longer turns while paused.)
+    const raf = installManualRaf();
+    writeRoot({ duration: "5" });
+    window.__timelines = { root: createRecordingTimeline(5) } as Record<
+      string,
+      RuntimeTimelineLike
+    >;
+
+    initSandboxRuntimeModular();
+    window.__timelines.root = createRecordingTimeline(8);
+    advancePausedTime(raf, 3_000);
+
+    expect(window.__player?.getDuration()).toBe(5);
+  });
+
+  it("picks up a live data-duration edit while paused", () => {
+    const raf = installManualRaf();
+    const root = writeRoot({ duration: "5" });
+    window.__timelines = { root: createRecordingTimeline(5) } as Record<
+      string,
+      RuntimeTimelineLike
+    >;
+
+    initSandboxRuntimeModular();
+    const initialFrames = window.__clipManifest?.durationInFrames;
+    expect(initialFrames).toBeGreaterThan(0);
+
+    // Studio edits a clip's duration on the parked composition.
+    root.setAttribute("data-duration", "9");
+    advancePausedTime(raf, 2_000);
+
+    expect(window.__clipManifest?.durationInFrames).toBeGreaterThan(initialFrames ?? 0);
+  });
+
+  it("re-applies animated state under a stationary playhead after the DOM changes", () => {
+    const raf = installManualRaf();
+    writeRoot({ duration: "5" });
+    const timeline = createRecordingTimeline(5);
+    window.__timelines = { root: timeline } as Record<string, RuntimeTimelineLike>;
+
+    initSandboxRuntimeModular();
+    window.__player?.seek(2);
+
+    // Studio mutates the parked composition; the playhead has not moved, so
+    // only a paused re-seek can put the animated values back on the new DOM.
+    const added = document.createElement("div");
+    added.id = "late-clip";
+    added.setAttribute("data-start", "0");
+    added.setAttribute("data-duration", "5");
+    document.body.firstElementChild?.appendChild(added);
+
+    const before = timeline.seekTimes.length;
+    advancePausedTime(raf, 2_000);
+
+    const applied = timeline.seekTimes.slice(before);
+    expect(applied.length).toBeGreaterThan(0);
+    // Re-applied at the stationary playhead (the root GSAP render nudge adds
+    // a millisecond), never at some other time.
+    for (const time of applied) expect(time).toBeCloseTo(2, 2);
+  });
+
+  // --- The cost: the FRAME loop stops ---------------------------------------
+
+  it("stops the frame loop while paused and re-arms it on play", () => {
+    const raf = installManualRaf();
+    writeRoot({ duration: "5" });
+    const timeline = createRecordingTimeline(5);
+    window.__timelines = { root: timeline } as Record<string, RuntimeTimelineLike>;
+
+    initSandboxRuntimeModular();
+    advancePausedTime(raf, 1_000);
+
+    // Paused, no pending seek: stepping frames does no transport work at all.
+    const beforeIdle = timeline.seekTimes.length;
+    for (let frame = 0; frame < 30; frame += 1) raf.step(16);
+    expect(timeline.seekTimes.length).toBe(beforeIdle);
+    expect(raf.pending()).toBe(0);
+
+    // Play re-arms the frame loop immediately — not on the next slow tick.
+    window.__player?.play();
+    expect(raf.pending()).toBe(1);
+    const beforePlaying = timeline.seekTimes.length;
+    raf.step(16);
+    expect(timeline.seekTimes.length).toBeGreaterThan(beforePlaying);
+
+    // Pause stops it again within one frame.
+    window.__player?.pause();
+    raf.step(16);
+    expect(raf.pending()).toBe(0);
+  });
+
+  it("runs a paused seek's work without leaving the frame loop armed", () => {
+    const raf = installManualRaf();
+    writeRoot({ duration: "5" });
+    const timeline = createRecordingTimeline(5);
+    window.__timelines = { root: timeline } as Record<string, RuntimeTimelineLike>;
+
+    initSandboxRuntimeModular();
+    for (let frame = 0; frame < 5; frame += 1) raf.step(16);
+
+    const before = timeline.seekTimes.length;
+    window.__player?.seek(3);
+
+    expect(timeline.seekTimes.length).toBeGreaterThan(before);
+    expect(timeline.seekTimes.at(-1)).toBeCloseTo(3, 5);
+    expect(raf.pending()).toBe(0);
+  });
+
+  it("cancels the paused schedule on teardown with no callback afterwards", () => {
+    const raf = installManualRaf();
+    writeRoot({ duration: "5" });
+    const timeline = createRecordingTimeline(5);
+    window.__timelines = { root: timeline } as Record<string, RuntimeTimelineLike>;
+
+    initSandboxRuntimeModular();
+    advancePausedTime(raf, 1_000);
+
+    window.__hfRuntimeTeardown?.();
+    const afterTeardown = timeline.seekTimes.length;
+
+    advancePausedTime(raf, 5_000);
+    expect(timeline.seekTimes.length).toBe(afterTeardown);
+    expect(raf.pending()).toBe(0);
+  });
+
+  it("leaves the paused schedule off once the producer capture protocol drives frames", () => {
+    const raf = installManualRaf();
+    writeRoot({ duration: "5" });
+    const timeline = createRecordingTimeline(5);
+    window.__timelines = { root: timeline } as Record<string, RuntimeTimelineLike>;
+    window.__HF_EXPORT_RENDER_SEEK_CONFIG = { fps: 30, fpsSource: "render-options" };
+
+    initSandboxRuntimeModular();
+
+    // renderSeek still does its own seek and media sync.
+    const beforeRenderSeek = timeline.seekTimes.length;
+    window.__player?.renderSeek(1);
+    expect(timeline.seekTimes.length).toBeGreaterThan(beforeRenderSeek);
+    expect(timeline.seekTimes.at(-1)).toBeCloseTo(1, 5);
+
+    // ...and once the load-time work has drained, nothing re-seeks behind its
+    // back between a capture seek and the screenshot that follows it.
+    advancePausedTime(raf, 1_000);
+    const settled = timeline.seekTimes.length;
+    advancePausedTime(raf, 5_000);
+    expect(timeline.seekTimes.length).toBe(settled);
+  });
+});

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -51,7 +51,12 @@ import type {
 } from "./types";
 import type { PlayerAPI } from "../core.types";
 import { swallow } from "./diagnostics";
-import { shouldAttemptPeriodicTimelineBind } from "./timelineRebindPolicy";
+import {
+  PAUSED_TRANSPORT_SLOW_WORK_EVERY_TICKS,
+  PAUSED_TRANSPORT_TICK_INTERVAL_MS,
+  shouldAttemptPeriodicTimelineBind,
+  TIMELINE_REBIND_INTERVAL_FRAMES,
+} from "./timelineRebindPolicy";
 import { installStudioCustomEase } from "./customEase";
 import { parseNumeric } from "./startExpression";
 
@@ -2353,6 +2358,9 @@ export function initSandboxRuntimeModular(): void {
       syncMediaForCurrentState();
       colorGrading.redraw();
       postState(true);
+      // Re-arm the frame loop now, not on the next slow tick — otherwise the
+      // first half-second of playback runs at 2fps.
+      scheduleNextTransportTick();
     },
     pause: () => {
       if (!clock.isPlaying()) return;
@@ -2637,6 +2645,7 @@ export function initSandboxRuntimeModular(): void {
   }
   let transportTickCount = 0;
   let inTransportTick = false;
+  let pausedTickTimerId: number | null = null;
 
   const seekRuntimeTimeline = (
     timeline: RuntimeTimelineLike,
@@ -2855,20 +2864,68 @@ export function initSandboxRuntimeModular(): void {
     }
   };
 
+  // Function declarations, not consts: `transport.play()` is reachable from the
+  // control bridge before this point in the module body is evaluated.
+  function cancelScheduledTransportTick() {
+    if (state.transportRafId != null) {
+      window.cancelAnimationFrame(state.transportRafId);
+      state.transportRafId = null;
+    }
+    if (pausedTickTimerId != null) {
+      window.clearTimeout(pausedTickTimerId);
+      pausedTickTimerId = null;
+    }
+  }
+
+  /**
+   * Schedule the next transport tick on the schedule the current play state
+   * calls for: the frame loop while playing, a slow timer while paused.
+   *
+   * A paused tick still re-seeks the timeline, and GSAP answers that by
+   * rewriting inline styles — at 60fps that alone was ~120 style recalcs per
+   * idle second, plus every Studio overlay watching those mutations. But the
+   * loop cannot simply stop: periodic timeline rebind is the only way a GSAP
+   * timeline that registers on `window.__timelines` after runtime init is ever
+   * discovered, and both the Studio preview and the renderer sit paused at
+   * load. The passengers survive on the slow timer; only the frame cadence goes.
+   *
+   * Exception: once the producer's capture protocol is driving frames, nothing
+   * else may touch the timeline. Its virtual-time shim replaces rAF but leaves
+   * setTimeout on the real clock, so a paused tick landing between `renderSeek`
+   * and the screenshot would re-seek WITHOUT `activateChildren` and could
+   * change exported pixels. renderSeek does its own seek and media sync, so
+   * there is nothing left for the paused schedule to do there.
+   */
+  function scheduleNextTransportTick() {
+    cancelScheduledTransportTick();
+    if (state.tornDown) return;
+    if (clock.isPlaying()) {
+      state.transportRafId = window.requestAnimationFrame(transportTick);
+      return;
+    }
+    if (renderCaptureSeekStarted && window.__HF_EXPORT_RENDER_SEEK_CONFIG) return;
+    pausedTickTimerId = window.setTimeout(transportTick, PAUSED_TRANSPORT_TICK_INTERVAL_MS);
+  }
+
   const transportTick = () => {
     if (state.tornDown || inTransportTick) return;
     inTransportTick = true;
     try {
-      state.transportRafId = window.requestAnimationFrame(transportTick);
+      const onPausedSchedule = !clock.isPlaying();
+      scheduleNextTransportTick();
       transportTickCount += 1;
 
-      // Slower operations: timeline binding (~every 60 frames / ~1s at 60fps)
+      // Slower operations: timeline binding (~every 60 frames / ~1s at 60fps,
+      // and every ~1s of the paused schedule too).
       if (
         shouldAttemptPeriodicTimelineBind({
           tick: transportTickCount,
           isPlaying: clock.isPlaying(),
           hasCapturedTimeline: state.capturedTimeline != null,
           currentTimeSeconds: clock.now(),
+          intervalTicks: onPausedSchedule
+            ? PAUSED_TRANSPORT_SLOW_WORK_EVERY_TICKS
+            : TIMELINE_REBIND_INTERVAL_FRAMES,
         })
       ) {
         const prevTimeline = state.capturedTimeline;
@@ -2884,10 +2941,16 @@ export function initSandboxRuntimeModular(): void {
           postTimeline();
         }
       }
-      if (transportTickCount % 20 === 0) {
+      if (
+        transportTickCount % (onPausedSchedule ? PAUSED_TRANSPORT_SLOW_WORK_EVERY_TICKS : 20) ===
+        0
+      ) {
         postTimeline();
       }
-      if (transportTickCount % 30 === 0) {
+      if (
+        transportTickCount % (onPausedSchedule ? PAUSED_TRANSPORT_SLOW_WORK_EVERY_TICKS : 30) ===
+        0
+      ) {
         bindMediaMetadataListeners();
       }
 
@@ -3223,10 +3286,7 @@ export function initSandboxRuntimeModular(): void {
   const teardown = () => {
     if (state.tornDown) return;
     state.tornDown = true;
-    if (state.transportRafId != null) {
-      window.cancelAnimationFrame(state.transportRafId);
-      state.transportRafId = null;
-    }
+    cancelScheduledTransportTick();
     state.transportClock = null;
     webAudio.destroy();
     if (metadataRebindDebounceTimerId != null) {

--- a/packages/core/src/runtime/timelineRebindPolicy.ts
+++ b/packages/core/src/runtime/timelineRebindPolicy.ts
@@ -1,16 +1,38 @@
 export const TIMELINE_REBIND_INTERVAL_FRAMES = 60;
 export const PLAY_REBIND_HOLD_SECONDS = 2;
 
+/**
+ * Period of the transport's PAUSED schedule. The frame loop only runs while the
+ * clock is playing; paused, the tick's passengers (periodic timeline rebind,
+ * duration re-sync, the re-seek that re-applies animated state after a DOM
+ * edit) move onto this timer instead. 500ms keeps the same wall-clock cadence
+ * the 60fps loop gave `bindMediaMetadataListeners` while costing ~2 style
+ * recalcs/second instead of ~120.
+ */
+export const PAUSED_TRANSPORT_TICK_INTERVAL_MS = 500;
+
+/**
+ * Divisor for the tick's periodic work while on the paused schedule. Two ticks
+ * of {@link PAUSED_TRANSPORT_TICK_INTERVAL_MS} is one second — the cadence the
+ * frame loop's `% 60` rebind gate produced at 60fps.
+ */
+export const PAUSED_TRANSPORT_SLOW_WORK_EVERY_TICKS = 2;
+
 export function shouldAttemptPeriodicTimelineBind(input: {
   tick: number;
   isPlaying: boolean;
   hasCapturedTimeline: boolean;
   currentTimeSeconds: number;
+  /** Ticks between attempts; defaults to the 60fps frame-loop interval. */
+  intervalTicks?: number;
 }): boolean {
+  const interval = input.intervalTicks ?? TIMELINE_REBIND_INTERVAL_FRAMES;
   if (
     !Number.isInteger(input.tick) ||
     input.tick <= 0 ||
-    input.tick % TIMELINE_REBIND_INTERVAL_FRAMES !== 0
+    !Number.isInteger(interval) ||
+    interval <= 0 ||
+    input.tick % interval !== 0
   ) {
     return false;
   }

--- a/packages/studio/src/components/editor/DomEditOverlay.tsx
+++ b/packages/studio/src/components/editor/DomEditOverlay.tsx
@@ -28,6 +28,8 @@ import { readDomEditSelectionShapeStyles, resolveBoxChromeClass } from "./domEdi
 import { useDomEditCompositionRect } from "./useDomEditCompositionRect";
 import { useMountEffect } from "../../hooks/useMountEffect";
 import { startOffCanvasIndicatorRefresh } from "./offCanvasIndicatorRefresh";
+import { createGestureActiveRef } from "./overlayFrameLoop";
+import { useOverlayGeometryRefresh } from "./useOverlayGeometryRefresh";
 import { CanvasContextMenu } from "./CanvasContextMenu";
 import type { ZOrderAction, ZOrderPatch } from "./canvasContextMenuZOrder";
 import { getPreviewTargetFromPointer } from "../../utils/studioPreviewHelpers";
@@ -147,7 +149,20 @@ export const DomEditOverlay = memo(function DomEditOverlay({
   const suppressNextBoxMouseDownRef = useRef(false);
   const suppressNextOverlayMouseDownRef = useRef(false);
   const snapGuidesRef = useRef<SnapGuidesState | null>(null);
-  const rafPausedRef = useRef(false);
+  // Written `true` at gesture start and `false` at gesture end by the gesture
+  // handlers, exactly as the plain ref it replaces; the overlay loops that only
+  // have work across that edge subscribe instead of polling it every frame.
+  const gestureActiveRef = useMemo(() => createGestureActiveRef(), []);
+
+  // Every overlay loop below parks the moment it has no work; this owns the
+  // handles that re-arm them, and the preview-document observer they share.
+  const {
+    rectsLoopRef,
+    compRectLoopRef,
+    offCanvasLoopRef,
+    offCanvasDirtyRef,
+    refreshOverlayGeometry,
+  } = useOverlayGeometryRefresh(iframeRef);
 
   const selectionRef = useRef(selection);
   selectionRef.current = selection;
@@ -199,10 +214,11 @@ export const DomEditOverlay = memo(function DomEditOverlay({
     activeCompositionPathRef,
     groupSelectionsRef,
     hoverSelectionRef,
-    rafPausedRef,
+    gestureActiveRef,
+    loopRef: rectsLoopRef,
   });
 
-  const compRect = useDomEditCompositionRect({ iframeRef, overlayRef });
+  const compRect = useDomEditCompositionRect({ iframeRef, overlayRef, loopRef: compRectLoopRef });
   const compRectRef = useRef(compRect);
   compRectRef.current = compRect;
 
@@ -218,9 +234,7 @@ export const DomEditOverlay = memo(function DomEditOverlay({
   // outside the composition bounds so users can find them.
   const offCanvasElementsRef = useRef<Map<string, HTMLElement>>(new Map());
   const [offCanvasRects, setOffCanvasRects] = useState<OffCanvasRect[]>([]);
-  const offCanvasDirtyRef = useRef(true);
   const offCanvasSigRef = useRef("");
-  const offCanvasObserverRef = useRef<MutationObserver | null>(null);
   const offCanvasObservedDocRef = useRef<Document | null>(null);
 
   // Positions depend on live iframe layout, not selection — the selected-element
@@ -234,19 +248,19 @@ export const DomEditOverlay = memo(function DomEditOverlay({
       activeCompositionPathRef,
       dirtyRef: offCanvasDirtyRef,
       sigRef: offCanvasSigRef,
-      observerRef: offCanvasObserverRef,
       observedDocRef: offCanvasObservedDocRef,
       elementsRef: offCanvasElementsRef,
+      loopRef: offCanvasLoopRef,
       setRects: setOffCanvasRects,
     }),
   );
 
-  // Switching compositions may not swap the iframe document (so the observer's
+  // Zoom, pan and panel resizes move every overlay at once, and switching
+  // compositions may not swap the iframe document (so the shared observer's
   // doc-swap detection wouldn't fire) yet changes which elements are off-canvas.
-  // Force a recompute explicitly on comp change.
   useEffect(() => {
-    offCanvasDirtyRef.current = true;
-  }, [activeCompositionPath]);
+    refreshOverlayGeometry();
+  }, [activeCompositionPath, compRect, refreshOverlayGeometry]);
 
   const gestures = createDomEditOverlayGestureHandlers({
     overlayRef,
@@ -259,7 +273,7 @@ export const DomEditOverlay = memo(function DomEditOverlay({
     gestureRef,
     groupGestureRef,
     blockedMoveRef,
-    rafPausedRef,
+    rafPausedRef: gestureActiveRef,
     suppressNextBoxClickRef,
     setOverlayRect,
     setGroupOverlayItems,
@@ -553,6 +567,7 @@ export const DomEditOverlay = memo(function DomEditOverlay({
       />
       <SnapGuideOverlay
         snapGuidesRef={snapGuidesRef}
+        gestureActiveRef={gestureActiveRef}
         compositionLeft={compRect.left}
         compositionTop={compRect.top}
         compositionWidth={compRect.width}

--- a/packages/studio/src/components/editor/SnapGuideOverlay.test.tsx
+++ b/packages/studio/src/components/editor/SnapGuideOverlay.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { SnapGuideOverlay, type SnapGuidesState } from "./SnapGuideOverlay";
+
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+
+async function flushAnimationFrames(count = 3): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        }),
+    );
+  }
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+function mount(snapGuidesRef: { current: SnapGuidesState | null }): HTMLElement {
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  act(() => {
+    root?.render(
+      <SnapGuideOverlay
+        snapGuidesRef={snapGuidesRef}
+        compositionLeft={0}
+        compositionTop={0}
+        compositionWidth={800}
+        compositionHeight={450}
+      />,
+    );
+  });
+  return host;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+const guideElements = (container: HTMLElement): HTMLElement[] =>
+  Array.from(container.querySelectorAll<HTMLElement>("div[style]")).filter(
+    (el) => el.style.position === "absolute",
+  );
+
+describe("SnapGuideOverlay", () => {
+  it("writes no styles while no guides are active", async () => {
+    const snapGuidesRef = { current: null as SnapGuidesState | null };
+    const container = mount(snapGuidesRef);
+    const [first] = guideElements(container);
+    if (!first) throw new Error("Expected guide slots to render");
+
+    // A sentinel the idle loop would clobber if it were still writing every
+    // frame — the previous implementation reset display on all ten slots.
+    first.style.display = "block";
+    await flushAnimationFrames(5);
+
+    expect(first.style.display).toBe("block");
+  });
+
+  it("shows a guide a drag crossed, then clears it exactly once when the drag ends", async () => {
+    const snapGuidesRef = { current: null as SnapGuidesState | null };
+    const container = mount(snapGuidesRef);
+    const [first] = guideElements(container);
+    if (!first) throw new Error("Expected guide slots to render");
+
+    snapGuidesRef.current = {
+      guides: [{ axis: "x", position: 120, from: 0, to: 450 }],
+      spacingGuides: [],
+    };
+    await flushAnimationFrames();
+
+    expect(first.style.display).toBe("");
+    expect(first.style.left).toBe("120px");
+    expect(first.style.height).toBe("450px");
+
+    snapGuidesRef.current = null;
+    await flushAnimationFrames();
+    expect(first.style.display).toBe("none");
+
+    // ...and the clearing pass is the last write: a sentinel survives after it.
+    first.style.display = "block";
+    await flushAnimationFrames(5);
+    expect(first.style.display).toBe("block");
+  });
+});

--- a/packages/studio/src/components/editor/SnapGuideOverlay.test.tsx
+++ b/packages/studio/src/components/editor/SnapGuideOverlay.test.tsx
@@ -4,24 +4,22 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
 import { SnapGuideOverlay, type SnapGuidesState } from "./SnapGuideOverlay";
+import { createGestureActiveRef, type GestureActiveRef } from "./overlayFrameLoop";
+import {
+  countScheduledFrames,
+  flushAnimationFrames,
+  restoreAnimationFrameCounter,
+} from "./overlayLoopTestKit";
 
 Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
-
-async function flushAnimationFrames(count = 3): Promise<void> {
-  for (let index = 0; index < count; index += 1) {
-    await act(
-      () =>
-        new Promise<void>((resolve) => {
-          requestAnimationFrame(() => resolve());
-        }),
-    );
-  }
-}
 
 let root: Root | null = null;
 let host: HTMLElement | null = null;
 
-function mount(snapGuidesRef: { current: SnapGuidesState | null }): HTMLElement {
+function mount(
+  snapGuidesRef: { current: SnapGuidesState | null },
+  gestureActiveRef: GestureActiveRef,
+): HTMLElement {
   host = document.createElement("div");
   document.body.append(host);
   root = createRoot(host);
@@ -29,6 +27,7 @@ function mount(snapGuidesRef: { current: SnapGuidesState | null }): HTMLElement 
     root?.render(
       <SnapGuideOverlay
         snapGuidesRef={snapGuidesRef}
+        gestureActiveRef={gestureActiveRef}
         compositionLeft={0}
         compositionTop={0}
         compositionWidth={800}
@@ -44,6 +43,7 @@ afterEach(() => {
   host?.remove();
   root = null;
   host = null;
+  restoreAnimationFrameCounter();
 });
 
 const guideElements = (container: HTMLElement): HTMLElement[] =>
@@ -52,43 +52,85 @@ const guideElements = (container: HTMLElement): HTMLElement[] =>
   );
 
 describe("SnapGuideOverlay", () => {
-  it("writes no styles while no guides are active", async () => {
+  it("schedules no frames and writes no styles while no gesture runs", async () => {
     const snapGuidesRef = { current: null as SnapGuidesState | null };
-    const container = mount(snapGuidesRef);
+    const container = mount(snapGuidesRef, createGestureActiveRef());
     const [first] = guideElements(container);
     if (!first) throw new Error("Expected guide slots to render");
+    await flushAnimationFrames(3);
 
     // A sentinel the idle loop would clobber if it were still writing every
-    // frame — the previous implementation reset display on all ten slots.
+    // frame — the original implementation reset display on all ten slots.
     first.style.display = "block";
-    await flushAnimationFrames(5);
+    const scheduled = countScheduledFrames();
+    await flushAnimationFrames(6);
 
+    expect(scheduled()).toBe(0);
     expect(first.style.display).toBe("block");
   });
 
-  it("shows a guide a drag crossed, then clears it exactly once when the drag ends", async () => {
+  it("starts on a gesture, draws a guide crossed mid-drag, then clears once and stops", async () => {
     const snapGuidesRef = { current: null as SnapGuidesState | null };
-    const container = mount(snapGuidesRef);
+    const gestureActiveRef = createGestureActiveRef();
+    const container = mount(snapGuidesRef, gestureActiveRef);
     const [first] = guideElements(container);
     if (!first) throw new Error("Expected guide slots to render");
+    await flushAnimationFrames(3);
 
+    // A drag starts before it snaps to anything: the guide appears mid-drag,
+    // with nothing but the gesture flag to have kept the loop alive for it.
+    act(() => {
+      gestureActiveRef.current = true;
+    });
+    await flushAnimationFrames(3);
     snapGuidesRef.current = {
       guides: [{ axis: "x", position: 120, from: 0, to: 450 }],
       spacingGuides: [],
     };
-    await flushAnimationFrames();
+    await flushAnimationFrames(3);
 
     expect(first.style.display).toBe("");
     expect(first.style.left).toBe("120px");
     expect(first.style.height).toBe("450px");
 
+    // Gesture end clears the guides and lowers the flag, in that order.
     snapGuidesRef.current = null;
-    await flushAnimationFrames();
+    act(() => {
+      gestureActiveRef.current = false;
+    });
+    await flushAnimationFrames(3);
     expect(first.style.display).toBe("none");
 
-    // ...and the clearing pass is the last write: a sentinel survives after it.
+    // ...and the clearing pass is the last write: a sentinel survives after it,
+    // and no further frame is scheduled.
     first.style.display = "block";
-    await flushAnimationFrames(5);
+    const scheduled = countScheduledFrames();
+    await flushAnimationFrames(6);
+    expect(scheduled()).toBe(0);
+    expect(first.style.display).toBe("block");
+  });
+
+  it("runs nothing after unmounting mid-gesture", async () => {
+    const snapGuidesRef = { current: null as SnapGuidesState | null };
+    const gestureActiveRef = createGestureActiveRef();
+    const container = mount(snapGuidesRef, gestureActiveRef);
+    const [first] = guideElements(container);
+    if (!first) throw new Error("Expected guide slots to render");
+
+    act(() => {
+      gestureActiveRef.current = true;
+    });
+    snapGuidesRef.current = {
+      guides: [{ axis: "x", position: 120, from: 0, to: 450 }],
+      spacingGuides: [],
+    };
+    act(() => root?.unmount());
+
+    first.style.display = "block";
+    const scheduled = countScheduledFrames();
+    await flushAnimationFrames(6);
+
+    expect(scheduled()).toBe(0);
     expect(first.style.display).toBe("block");
   });
 });

--- a/packages/studio/src/components/editor/SnapGuideOverlay.tsx
+++ b/packages/studio/src/components/editor/SnapGuideOverlay.tsx
@@ -1,6 +1,7 @@
 import { memo, useRef, type RefObject } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
 import { resolveGuideLineRect, type SnapGuide, type SpacingGuide } from "./snapEngine";
+import { createOverlayFrameLoop, type GestureActiveRef } from "./overlayFrameLoop";
 
 export interface SnapGuidesState {
   guides: SnapGuide[];
@@ -16,6 +17,12 @@ const SPACING_BG = "rgba(255, 68, 204, 0.15)";
 
 interface SnapGuideOverlayProps {
   snapGuidesRef: RefObject<SnapGuidesState | null>;
+  /**
+   * True while a canvas gesture runs. Guides exist only during one, so this is
+   * both what starts the loop and what keeps it running: a guide crossed
+   * mid-drag has no other signal to announce itself with.
+   */
+  gestureActiveRef: GestureActiveRef;
   /** Composition rect in overlay space — guide lines span exactly this rect. */
   compositionLeft: number;
   compositionTop: number;
@@ -25,6 +32,7 @@ interface SnapGuideOverlayProps {
 
 export const SnapGuideOverlay = memo(function SnapGuideOverlay({
   snapGuidesRef,
+  gestureActiveRef,
   compositionLeft,
   compositionTop,
   compositionWidth,
@@ -47,23 +55,24 @@ export const SnapGuideOverlay = memo(function SnapGuideOverlay({
   };
 
   useMountEffect(() => {
-    let frame = 0;
     // Guides only exist while a drag is snapping. Idle — which is almost
     // always — this loop still wrote display/left/top/width/height for all ten
-    // slots every frame, invalidating style 60 times a second to draw nothing.
-    // One pass clears the last drawn set; after that the loop writes nothing
-    // until a gesture produces guides again.
+    // slots every frame, invalidating style 60 times a second to draw nothing,
+    // and rescheduled itself even once it stopped writing.
+    //
+    // It now runs only across a gesture: the gesture flag starting arms it, it
+    // keeps running while that flag is set (so a guide crossed mid-drag is
+    // drawn), and one final pass after the gesture ends clears the last drawn
+    // set before it parks.
     let hasDrawnGuides = false;
 
     // fallow-ignore-next-line complexity
-    const update = () => {
-      frame = requestAnimationFrame(update);
-
+    const update = (): boolean => {
       const state = snapGuidesRef.current;
       const guides = state?.guides ?? [];
       const spacingGuides = state?.spacingGuides ?? [];
       const hasGuides = guides.length > 0 || spacingGuides.length > 0;
-      if (!hasGuides && !hasDrawnGuides) return;
+      if (!hasGuides && !hasDrawnGuides) return gestureActiveRef.current;
       hasDrawnGuides = hasGuides;
       const composition = compositionRectRef.current;
 
@@ -123,10 +132,17 @@ export const SnapGuideOverlay = memo(function SnapGuideOverlay({
           label.textContent = `${Math.round(sg.size)}`;
         }
       }
+
+      return gestureActiveRef.current || hasDrawnGuides;
     };
 
-    frame = requestAnimationFrame(update);
-    return () => cancelAnimationFrame(frame);
+    const loop = createOverlayFrameLoop(update);
+    const unsubscribe = gestureActiveRef.subscribe(loop.arm);
+    loop.arm();
+    return () => {
+      unsubscribe();
+      loop.stop();
+    };
   });
 
   return (

--- a/packages/studio/src/components/editor/SnapGuideOverlay.tsx
+++ b/packages/studio/src/components/editor/SnapGuideOverlay.tsx
@@ -48,6 +48,12 @@ export const SnapGuideOverlay = memo(function SnapGuideOverlay({
 
   useMountEffect(() => {
     let frame = 0;
+    // Guides only exist while a drag is snapping. Idle — which is almost
+    // always — this loop still wrote display/left/top/width/height for all ten
+    // slots every frame, invalidating style 60 times a second to draw nothing.
+    // One pass clears the last drawn set; after that the loop writes nothing
+    // until a gesture produces guides again.
+    let hasDrawnGuides = false;
 
     // fallow-ignore-next-line complexity
     const update = () => {
@@ -56,6 +62,9 @@ export const SnapGuideOverlay = memo(function SnapGuideOverlay({
       const state = snapGuidesRef.current;
       const guides = state?.guides ?? [];
       const spacingGuides = state?.spacingGuides ?? [];
+      const hasGuides = guides.length > 0 || spacingGuides.length > 0;
+      if (!hasGuides && !hasDrawnGuides) return;
+      hasDrawnGuides = hasGuides;
       const composition = compositionRectRef.current;
 
       for (let i = 0; i < MAX_GUIDES; i++) {

--- a/packages/studio/src/components/editor/offCanvasIndicatorRefresh.test.tsx
+++ b/packages/studio/src/components/editor/offCanvasIndicatorRefresh.test.tsx
@@ -4,52 +4,26 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { DomEditOverlay } from "./DomEditOverlay";
+import {
+  countScheduledFrames,
+  pinWeakRefStrong,
+  restoreAnimationFrameCounter,
+  testDomRect as domRect,
+  unpinWeakRef,
+} from "./overlayLoopTestKit";
 
 Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
 
-// happy-dom (20.x) holds each MutationObserver's delivery callback ONLY via a
-// WeakRef (MutationObserverListener: `callback: new WeakRef(...)` — the arrow
-// has no strong referent). If V8 runs a GC between observe() and a mutation,
-// deref() returns undefined and mutation delivery silently stops — the
-// indicator-refresh loop never sees its dirty flag and these tests flake under
-// full-suite memory pressure (passing in isolation). Pin WeakRef to a strong
-// ref for this file so the real observer path stays deterministic.
-const RealWeakRef = globalThis.WeakRef;
-class StrongRef<T extends WeakKey> {
-  #value: T;
-  constructor(value: T) {
-    this.#value = value;
-  }
-  deref(): T {
-    return this.#value;
-  }
-}
-beforeAll(() => {
-  (globalThis as { WeakRef: unknown }).WeakRef = StrongRef;
-});
-afterAll(() => {
-  globalThis.WeakRef = RealWeakRef;
-});
+beforeAll(pinWeakRefStrong);
+afterAll(unpinWeakRef);
 
 const INDICATOR = '[aria-label="Select off-canvas element index.html:headline:0"]';
 
-function domRect(left: number, top: number, width: number, height: number): DOMRect {
-  return {
-    left,
-    top,
-    right: left + width,
-    bottom: top + height,
-    width,
-    height,
-    x: left,
-    y: top,
-    toJSON: () => ({}),
-  };
-}
+const nativeRequestAnimationFrame = globalThis.requestAnimationFrame;
 
 async function flushAnimationFrames(): Promise<void> {
   await new Promise<void>((resolve) => {
-    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    nativeRequestAnimationFrame(() => nativeRequestAnimationFrame(() => resolve()));
   });
 }
 
@@ -119,11 +93,57 @@ function mountOverlayWithHeadline(initialLeft: number): OverlayHarness {
     cleanup: () => {
       act(() => root.unmount());
       Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+      restoreAnimationFrameCounter();
       iframe.remove();
       host.remove();
     },
   };
 }
+
+describe("canvas overlay idle cost", () => {
+  it("schedules no animation frames once the overlay has settled", async () => {
+    const h = mountOverlayWithHeadline(760);
+    try {
+      await act(async () => {
+        await flushAnimationFrames();
+        await flushAnimationFrames();
+      });
+      expect(h.host.querySelector(INDICATOR)).toBeTruthy();
+
+      // All four canvas overlay loops are mounted here (selection rects,
+      // composition rect, off-canvas indicators, snap guides). Idle, none of
+      // them may wake the page: this is the runtime-cost gate's idle
+      // animation-frame budget, asserted where it can be debugged.
+      const scheduled = countScheduledFrames();
+      await act(async () => {
+        await flushAnimationFrames();
+        await flushAnimationFrames();
+        await flushAnimationFrames();
+      });
+
+      expect(scheduled()).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  it("runs nothing after unmount", async () => {
+    const h = mountOverlayWithHeadline(760);
+    await act(async () => {
+      await flushAnimationFrames();
+    });
+    act(() => {
+      h.movedElement.style.left = "120px";
+    });
+    h.cleanup();
+
+    const scheduled = countScheduledFrames();
+    await flushAnimationFrames();
+    await flushAnimationFrames();
+    expect(scheduled()).toBe(0);
+    restoreAnimationFrameCounter();
+  });
+});
 
 describe("off-canvas indicator refresh", () => {
   it("removes the indicator when an off-canvas element moves in-canvas (off->on)", async () => {

--- a/packages/studio/src/components/editor/offCanvasIndicatorRefresh.ts
+++ b/packages/studio/src/components/editor/offCanvasIndicatorRefresh.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 import type { OffCanvasRect } from "./OffCanvasIndicators";
 import { recomputeOffCanvasIndicators } from "./offCanvasIndicatorGeometry";
+import { createOverlayFrameLoop, type OverlayFrameLoop } from "./overlayFrameLoop";
 
 interface OffCanvasIndicatorRefreshOptions {
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
@@ -9,9 +10,10 @@ interface OffCanvasIndicatorRefreshOptions {
   activeCompositionPathRef: React.MutableRefObject<string | null>;
   dirtyRef: React.MutableRefObject<boolean>;
   sigRef: React.MutableRefObject<string>;
-  observerRef: React.MutableRefObject<MutationObserver | null>;
   observedDocRef: React.MutableRefObject<Document | null>;
   elementsRef: React.MutableRefObject<Map<string, HTMLElement>>;
+  /** Filled with this loop so the overlay can re-arm it; see DomEditOverlay. */
+  loopRef: React.MutableRefObject<OverlayFrameLoop | null>;
   setRects: (rects: OffCanvasRect[]) => void;
 }
 
@@ -26,57 +28,38 @@ function clearIndicators(options: OffCanvasIndicatorRefreshOptions): void {
   options.setRects([]);
 }
 
-function observeDoc(doc: Document, markDirty: () => void): MutationObserver | null {
-  const Observer = doc.defaultView?.MutationObserver ?? globalThis.MutationObserver;
-  if (!Observer) return null;
-  const observer = new Observer(markDirty);
-  observer.observe(doc.documentElement, {
-    attributes: true,
-    // data-hidden is included explicitly: hiding an element writes data-hidden, and
-    // although the runtime honoring also writes display:"none" (a style mutation we'd
-    // catch anyway), keying on the attribute directly makes the coupling robust to any
-    // future throttling of that runtime sync.
-    attributeFilter: ["style", "class", "transform", "width", "height", "data-hidden"],
-    childList: true,
-    subtree: true,
-  });
-  return observer;
-}
-
+/**
+ * Recomputes the off-canvas indicators when the preview DOM has moved.
+ *
+ * The loop parks as soon as it has caught up; it is re-armed by
+ * `refreshOverlayGeometry` in DomEditOverlay, which is what the shared
+ * preview-document observer, a composition switch and a composition-rect change
+ * all route through.
+ */
 export function startOffCanvasIndicatorRefresh(
   options: OffCanvasIndicatorRefreshOptions,
 ): () => void {
-  let frame = 0;
   let lastCompSig = "";
-  const markDirty = () => {
-    options.dirtyRef.current = true;
-  };
-  const attachObserver = (doc: Document | null) => {
-    options.observerRef.current?.disconnect();
-    options.observerRef.current = doc?.documentElement ? observeDoc(doc, markDirty) : null;
-    options.observedDocRef.current = doc;
-    options.sigRef.current = "";
-  };
-  const update = () => {
-    frame = requestAnimationFrame(update);
+  const update = (): boolean => {
     const iframe = options.iframeRef.current;
     const overlayEl = options.overlayRef.current;
     const doc = iframe?.contentDocument ?? null;
     if (doc !== options.observedDocRef.current) {
-      attachObserver(doc);
-      markDirty();
+      options.observedDocRef.current = doc;
+      options.sigRef.current = "";
+      options.dirtyRef.current = true;
     }
     const comp = options.compRectRef.current;
     const nextCompSig = compSignature(comp);
     if (nextCompSig !== lastCompSig) {
       lastCompSig = nextCompSig;
-      markDirty();
+      options.dirtyRef.current = true;
     }
     if (!iframe || !overlayEl) {
       if (options.dirtyRef.current) clearIndicators(options);
-      return;
+      return false;
     }
-    if (!options.dirtyRef.current) return;
+    if (!options.dirtyRef.current) return false;
     options.dirtyRef.current = false;
     recomputeOffCanvasIndicators(
       iframe,
@@ -88,12 +71,14 @@ export function startOffCanvasIndicatorRefresh(
       options.elementsRef,
       options.setRects,
     );
+    return false;
   };
-  frame = requestAnimationFrame(update);
+  const loop = createOverlayFrameLoop(update);
+  options.loopRef.current = loop;
+  loop.arm();
   return () => {
-    cancelAnimationFrame(frame);
-    options.observerRef.current?.disconnect();
-    options.observerRef.current = null;
+    loop.stop();
+    options.loopRef.current = null;
     options.observedDocRef.current = null;
   };
 }

--- a/packages/studio/src/components/editor/overlayFrameLoop.test.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGestureActiveRef, createOverlayFrameLoop } from "./overlayFrameLoop";
+
+const nativeRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = nativeRequestAnimationFrame;
+});
+
+/** Counts every requestAnimationFrame scheduled while installed — the number the runtime-cost gate reads. */
+function countScheduledFrames(): () => number {
+  let scheduled = 0;
+  globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    scheduled += 1;
+    return nativeRequestAnimationFrame(callback);
+  };
+  return () => scheduled;
+}
+
+function nextFrames(count: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let remaining = count;
+    const tick = () => {
+      remaining -= 1;
+      if (remaining <= 0) resolve();
+      else nativeRequestAnimationFrame(tick);
+    };
+    nativeRequestAnimationFrame(tick);
+  });
+}
+
+describe("createOverlayFrameLoop", () => {
+  it("runs one frame per arm and then parks", async () => {
+    const step = vi.fn(() => false);
+    const loop = createOverlayFrameLoop(step);
+    const scheduled = countScheduledFrames();
+
+    loop.arm();
+    await nextFrames(6);
+
+    expect(step).toHaveBeenCalledTimes(1);
+    expect(scheduled()).toBe(1);
+    loop.stop();
+  });
+
+  it("keeps running while the step reports work left", async () => {
+    let remaining = 3;
+    const step = vi.fn(() => {
+      remaining -= 1;
+      return remaining > 0;
+    });
+    const loop = createOverlayFrameLoop(step);
+
+    loop.arm();
+    await nextFrames(8);
+
+    expect(step).toHaveBeenCalledTimes(3);
+    loop.stop();
+  });
+
+  it("does not double-schedule when armed again while already armed", async () => {
+    const step = vi.fn(() => false);
+    const loop = createOverlayFrameLoop(step);
+    const scheduled = countScheduledFrames();
+
+    loop.arm();
+    loop.arm();
+    loop.arm();
+    await nextFrames(4);
+
+    expect(scheduled()).toBe(1);
+    expect(step).toHaveBeenCalledTimes(1);
+    loop.stop();
+  });
+
+  it("cancels a scheduled frame on stop and refuses to be re-armed after it", async () => {
+    const step = vi.fn(() => true);
+    const loop = createOverlayFrameLoop(step);
+
+    loop.arm();
+    loop.stop();
+    loop.arm();
+    await nextFrames(6);
+
+    expect(step).not.toHaveBeenCalled();
+  });
+});
+
+describe("createGestureActiveRef", () => {
+  it("notifies on a change and stays quiet on a rewrite of the same value", () => {
+    const ref = createGestureActiveRef();
+    const listener = vi.fn();
+    const unsubscribe = ref.subscribe(listener);
+
+    ref.current = true;
+    ref.current = true;
+    expect(ref.current).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    ref.current = false;
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    ref.current = true;
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/studio/src/components/editor/overlayFrameLoop.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.ts
@@ -1,0 +1,83 @@
+/**
+ * An animation-frame loop that parks when it has nothing to do.
+ *
+ * The canvas overlays each ran a `requestAnimationFrame` loop that rescheduled
+ * itself unconditionally, so an idle Studio woke the page 240 times a second
+ * for four bodies that all early-returned. Cheap is not free: the wake-up is
+ * the cost. A loop built here schedules a frame only while `step` reports work
+ * left, and is restarted by whatever signal creates the next piece of work.
+ *
+ * The hazard this shape introduces is a loop that parks and is never re-armed —
+ * a stale overlay. Every caller must therefore have an explicit answer to "what
+ * re-arms this", and a test for it.
+ */
+export interface OverlayFrameLoop {
+  /**
+   * Run `step` on the next frame. A no-op while a frame is already scheduled,
+   * so a burst of signals in one frame costs one frame, and a no-op after
+   * `stop`, so a late observer callback cannot resurrect an unmounted loop.
+   */
+  arm: () => void;
+  /** Cancel any scheduled frame and refuse further arming. Terminal. */
+  stop: () => void;
+}
+
+/** @param step Runs one frame; returns true while work remains. */
+export function createOverlayFrameLoop(step: () => boolean): OverlayFrameLoop {
+  let handle: number | null = null;
+  let stopped = false;
+
+  const arm = () => {
+    if (stopped || handle !== null) return;
+    handle = requestAnimationFrame(() => {
+      handle = null;
+      if (stopped) return;
+      if (step()) arm();
+    });
+  };
+
+  return {
+    arm,
+    stop: () => {
+      stopped = true;
+      if (handle !== null) cancelAnimationFrame(handle);
+      handle = null;
+    },
+  };
+}
+
+/**
+ * A boolean ref that tells listeners when it changes.
+ *
+ * Canvas gestures already announce themselves by writing a plain boolean ref —
+ * true while a drag/resize/rotate runs, false once it ends. Two overlay loops
+ * have work only across that edge (guides exist only during a gesture; the rect
+ * tracker resumes only once one ends), and used to learn about it by reading
+ * the ref every frame. Writers keep writing `.current` exactly as before; the
+ * accessor turns the write into a notification.
+ */
+export interface GestureActiveRef {
+  current: boolean;
+  subscribe: (listener: () => void) => () => void;
+}
+
+export function createGestureActiveRef(): GestureActiveRef {
+  let active = false;
+  const listeners = new Set<() => void>();
+  return {
+    get current(): boolean {
+      return active;
+    },
+    set current(next: boolean) {
+      if (active === next) return;
+      active = next;
+      for (const listener of listeners) listener();
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/packages/studio/src/components/editor/overlayLoopTestKit.ts
+++ b/packages/studio/src/components/editor/overlayLoopTestKit.ts
@@ -1,0 +1,79 @@
+/**
+ * Test-only helpers for the canvas overlay loops.
+ *
+ * Imported by `*.test.tsx` in this directory only. The frame counter is the
+ * thing the tests actually assert on: the runtime-cost gate measures idle cost
+ * as `requestAnimationFrame` calls per second, so the unit tests measure the
+ * same quantity rather than a proxy for it.
+ */
+import { act } from "react";
+
+const nativeRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+/** Advance `count` real frames, flushing React work scheduled by each. */
+export async function flushAnimationFrames(count = 3): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          nativeRequestAnimationFrame(() => resolve());
+        }),
+    );
+  }
+}
+
+/**
+ * Count every frame scheduled from now on. Call `restoreAnimationFrameCounter`
+ * (or let the suite's afterEach do it) once the assertion is made.
+ */
+export function countScheduledFrames(): () => number {
+  let scheduled = 0;
+  globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    scheduled += 1;
+    return nativeRequestAnimationFrame(callback);
+  };
+  return () => scheduled;
+}
+
+export function restoreAnimationFrameCounter(): void {
+  globalThis.requestAnimationFrame = nativeRequestAnimationFrame;
+}
+
+export function testDomRect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+/**
+ * happy-dom holds each MutationObserver's delivery callback only via a WeakRef,
+ * so a GC between observe() and a mutation silently stops delivery and any test
+ * that drives a real observer flakes under full-suite memory pressure. Pin
+ * WeakRef to a strong ref for those files.
+ */
+const RealWeakRef = globalThis.WeakRef;
+class StrongRef<T extends WeakKey> {
+  #value: T;
+  constructor(value: T) {
+    this.#value = value;
+  }
+  deref(): T {
+    return this.#value;
+  }
+}
+
+export function pinWeakRefStrong(): void {
+  (globalThis as { WeakRef: unknown }).WeakRef = StrongRef;
+}
+
+export function unpinWeakRef(): void {
+  globalThis.WeakRef = RealWeakRef;
+}

--- a/packages/studio/src/components/editor/previewDomWatch.ts
+++ b/packages/studio/src/components/editor/previewDomWatch.ts
@@ -1,0 +1,81 @@
+import type { RefObject } from "react";
+
+/**
+ * The one notification that preview geometry may have moved.
+ *
+ * Every canvas overlay measures elements that live inside the preview iframe,
+ * so nothing they draw can go stale without one of three things happening: the
+ * preview document mutating (a seek writing inline styles, an edit landing, an
+ * element appearing), the iframe navigating to another document, or React
+ * swapping the iframe element itself. This watches all three and calls
+ * `onChange` once per change — which is what lets the overlay loops park when
+ * idle instead of polling for it sixty times a second.
+ *
+ * The iframe element is handed around as a ref, so a swap announces itself to
+ * nobody; `poll` is that missing announcement and is meant to be called from a
+ * render effect. It is a pair of identity comparisons — calling it often costs
+ * nothing, and it notifies only when something actually changed.
+ */
+export interface PreviewDomWatch {
+  poll: () => void;
+  dispose: () => void;
+}
+
+// data-hidden is included explicitly: hiding an element writes data-hidden, and
+// although the runtime honoring also writes display:"none" (a style mutation
+// we'd catch anyway), keying on the attribute directly makes the coupling
+// robust to any future throttling of that runtime sync.
+const WATCHED_ATTRIBUTES = ["style", "class", "transform", "width", "height", "data-hidden"];
+
+export function startPreviewDomWatch(
+  iframeRef: RefObject<HTMLIFrameElement | null>,
+  onChange: () => void,
+): PreviewDomWatch {
+  let observedIframe: HTMLIFrameElement | null = null;
+  let observedDoc: Document | null = null;
+  let observer: MutationObserver | null = null;
+  let started = false;
+
+  const observeDoc = (doc: Document | null) => {
+    observer?.disconnect();
+    observer = null;
+    observedDoc = doc;
+    if (!doc?.documentElement) return;
+    const Observer = doc.defaultView?.MutationObserver ?? globalThis.MutationObserver;
+    if (!Observer) return;
+    observer = new Observer(onChange);
+    observer.observe(doc.documentElement, {
+      attributes: true,
+      attributeFilter: WATCHED_ATTRIBUTES,
+      childList: true,
+      subtree: true,
+    });
+  };
+
+  const poll = () => {
+    const iframe = iframeRef.current;
+    const doc = iframe?.contentDocument ?? null;
+    if (started && iframe === observedIframe && doc === observedDoc) return;
+    started = true;
+    if (iframe !== observedIframe) {
+      observedIframe?.removeEventListener("load", poll);
+      observedIframe = iframe;
+      iframe?.addEventListener("load", poll);
+    }
+    if (doc !== observedDoc) observeDoc(doc);
+    onChange();
+  };
+
+  poll();
+
+  return {
+    poll,
+    dispose: () => {
+      observer?.disconnect();
+      observer = null;
+      observedIframe?.removeEventListener("load", poll);
+      observedIframe = null;
+      observedDoc = null;
+    },
+  };
+}

--- a/packages/studio/src/components/editor/previewDomWatch.ts
+++ b/packages/studio/src/components/editor/previewDomWatch.ts
@@ -79,3 +79,54 @@ export function startPreviewDomWatch(
     },
   };
 }
+
+/**
+ * `startPreviewDomWatch` plus the two parent-document movements an overlay
+ * measuring ACROSS the iframe boundary also depends on: the iframe box being
+ * resized, and a stage zoom/pan — written as inline `style` on an ancestor of
+ * the iframe, which no ResizeObserver sees.
+ *
+ * Overlays mounted inside `DomEditOverlay` get these through
+ * `useDomEditCompositionRect`, whose new composition rect routes into
+ * `refreshOverlayGeometry`. An overlay mounted beside it has no such path, so
+ * it asks for them here instead of polling the geometry every frame.
+ */
+export function startPreviewGeometryWatch(
+  iframeRef: RefObject<HTMLIFrameElement | null>,
+  onChange: () => void,
+): PreviewDomWatch {
+  const domWatch = startPreviewDomWatch(iframeRef, onChange);
+  let observedIframe: HTMLIFrameElement | null = null;
+  const resizeObserver =
+    typeof ResizeObserver === "undefined" ? null : new ResizeObserver(onChange);
+  const stageObserver =
+    typeof MutationObserver === "undefined" ? null : new MutationObserver(onChange);
+
+  const observeStage = () => {
+    const iframe = iframeRef.current;
+    if (iframe === observedIframe) return;
+    observedIframe = iframe;
+    resizeObserver?.disconnect();
+    stageObserver?.disconnect();
+    if (!iframe) return;
+    resizeObserver?.observe(iframe);
+    for (let node = iframe.parentElement; node; node = node.parentElement) {
+      stageObserver?.observe(node, { attributes: true, attributeFilter: ["style", "class"] });
+      if (node === iframe.ownerDocument.body) break;
+    }
+  };
+  observeStage();
+
+  return {
+    poll: () => {
+      observeStage();
+      domWatch.poll();
+    },
+    dispose: () => {
+      domWatch.dispose();
+      resizeObserver?.disconnect();
+      stageObserver?.disconnect();
+      observedIframe = null;
+    },
+  };
+}

--- a/packages/studio/src/components/editor/useDomEditCompositionRect.test.tsx
+++ b/packages/studio/src/components/editor/useDomEditCompositionRect.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { useDomEditCompositionRect } from "./useDomEditCompositionRect";
+
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+
+// happy-dom holds a MutationObserver's callback via a WeakRef; a GC between
+// observe() and the mutation silently drops delivery. Same pin as
+// offCanvasIndicatorRefresh.test.tsx.
+const RealWeakRef = globalThis.WeakRef;
+class StrongRef<T extends WeakKey> {
+  #value: T;
+  constructor(value: T) {
+    this.#value = value;
+  }
+  deref(): T {
+    return this.#value;
+  }
+}
+beforeAll(() => {
+  (globalThis as { WeakRef: unknown }).WeakRef = StrongRef;
+});
+afterAll(() => {
+  globalThis.WeakRef = RealWeakRef;
+});
+
+function domRect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+async function flushAnimationFrames(count = 3): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        }),
+    );
+  }
+}
+
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+});
+
+interface Harness {
+  stage: HTMLDivElement;
+  iframeWidth: () => number;
+  setIframeWidth: (value: number) => void;
+  layoutReads: () => number;
+  readScaleX: () => number;
+}
+
+function mountHook(): Harness {
+  const stage = document.createElement("div");
+  const iframe = document.createElement("iframe");
+  stage.append(iframe);
+  document.body.append(stage);
+  const doc = iframe.contentDocument;
+  if (!doc) throw new Error("Expected iframe content document");
+  doc.body.innerHTML = `<div data-composition-id="root" data-width="800" data-height="450"></div>`;
+
+  const overlay = document.createElement("div");
+  document.body.append(overlay);
+
+  let width = 800;
+  let reads = 0;
+  Element.prototype.getBoundingClientRect = function (): DOMRect {
+    reads += 1;
+    if (this === iframe) return domRect(0, 0, width, 450);
+    return domRect(0, 0, 1000, 600);
+  };
+
+  let scaleX = 0;
+  function Probe(): React.ReactElement {
+    const rect = useDomEditCompositionRect({
+      iframeRef: { current: iframe },
+      overlayRef: { current: overlay },
+    });
+    scaleX = rect.scaleX;
+    return <span>{rect.width}</span>;
+  }
+
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  act(() => root?.render(<Probe />));
+
+  return {
+    stage,
+    iframeWidth: () => width,
+    setIframeWidth: (value: number) => {
+      width = value;
+    },
+    layoutReads: () => reads,
+    readScaleX: () => scaleX,
+  };
+}
+
+describe("useDomEditCompositionRect", () => {
+  it("reads no layout at idle", async () => {
+    const harness = mountHook();
+    await flushAnimationFrames(4);
+
+    const settled = harness.layoutReads();
+    expect(settled).toBeGreaterThan(0);
+
+    await flushAnimationFrames(10);
+    expect(harness.layoutReads()).toBe(settled);
+  });
+
+  it("re-measures when the preview stage's transform changes", async () => {
+    const harness = mountHook();
+    await flushAnimationFrames(4);
+    expect(harness.readScaleX()).toBeCloseTo(1, 5);
+    const settled = harness.layoutReads();
+
+    // Zooming writes `transform` on an ancestor of the iframe — a change no
+    // ResizeObserver reports, because the iframe's layout box is unchanged.
+    harness.setIframeWidth(1600);
+    harness.stage.style.transform = "scale(2)";
+    await flushAnimationFrames(4);
+
+    expect(harness.layoutReads()).toBeGreaterThan(settled);
+    expect(harness.readScaleX()).toBeCloseTo(2, 5);
+  });
+});

--- a/packages/studio/src/components/editor/useDomEditCompositionRect.test.tsx
+++ b/packages/studio/src/components/editor/useDomEditCompositionRect.test.tsx
@@ -4,53 +4,20 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useDomEditCompositionRect } from "./useDomEditCompositionRect";
+import type { OverlayFrameLoop } from "./overlayFrameLoop";
+import {
+  countScheduledFrames,
+  flushAnimationFrames,
+  pinWeakRefStrong,
+  restoreAnimationFrameCounter,
+  testDomRect as domRect,
+  unpinWeakRef,
+} from "./overlayLoopTestKit";
 
 Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
 
-// happy-dom holds a MutationObserver's callback via a WeakRef; a GC between
-// observe() and the mutation silently drops delivery. Same pin as
-// offCanvasIndicatorRefresh.test.tsx.
-const RealWeakRef = globalThis.WeakRef;
-class StrongRef<T extends WeakKey> {
-  #value: T;
-  constructor(value: T) {
-    this.#value = value;
-  }
-  deref(): T {
-    return this.#value;
-  }
-}
-beforeAll(() => {
-  (globalThis as { WeakRef: unknown }).WeakRef = StrongRef;
-});
-afterAll(() => {
-  globalThis.WeakRef = RealWeakRef;
-});
-
-function domRect(left: number, top: number, width: number, height: number): DOMRect {
-  return {
-    left,
-    top,
-    right: left + width,
-    bottom: top + height,
-    width,
-    height,
-    x: left,
-    y: top,
-    toJSON: () => ({}),
-  } as DOMRect;
-}
-
-async function flushAnimationFrames(count = 3): Promise<void> {
-  for (let index = 0; index < count; index += 1) {
-    await act(
-      () =>
-        new Promise<void>((resolve) => {
-          requestAnimationFrame(() => resolve());
-        }),
-    );
-  }
-}
+beforeAll(pinWeakRefStrong);
+afterAll(unpinWeakRef);
 
 const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 let root: Root | null = null;
@@ -62,10 +29,35 @@ afterEach(() => {
   root = null;
   host = null;
   Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  restoreAnimationFrameCounter();
+});
+
+// happy-dom's ResizeObserver never delivers, so the observed elements and the
+// callback are captured here and fired by hand — the wiring is what matters.
+const resizeObservers: { targets: Element[]; fire: () => void }[] = [];
+const RealResizeObserver = globalThis.ResizeObserver;
+class RecordingResizeObserver {
+  targets: Element[] = [];
+  constructor(callback: () => void) {
+    resizeObservers.push({ targets: this.targets, fire: callback });
+  }
+  observe(target: Element): void {
+    this.targets.push(target);
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+}
+beforeAll(() => {
+  (globalThis as { ResizeObserver: unknown }).ResizeObserver = RecordingResizeObserver;
+});
+afterAll(() => {
+  globalThis.ResizeObserver = RealResizeObserver;
 });
 
 interface Harness {
   stage: HTMLDivElement;
+  iframe: HTMLIFrameElement;
+  loopRef: { current: OverlayFrameLoop | null };
   iframeWidth: () => number;
   setIframeWidth: (value: number) => void;
   layoutReads: () => number;
@@ -93,10 +85,12 @@ function mountHook(): Harness {
   };
 
   let scaleX = 0;
+  const loopRef: { current: OverlayFrameLoop | null } = { current: null };
   function Probe(): React.ReactElement {
     const rect = useDomEditCompositionRect({
       iframeRef: { current: iframe },
       overlayRef: { current: overlay },
+      loopRef,
     });
     scaleX = rect.scaleX;
     return <span>{rect.width}</span>;
@@ -109,6 +103,8 @@ function mountHook(): Harness {
 
   return {
     stage,
+    iframe,
+    loopRef,
     iframeWidth: () => width,
     setIframeWidth: (value: number) => {
       width = value;
@@ -119,15 +115,65 @@ function mountHook(): Harness {
 }
 
 describe("useDomEditCompositionRect", () => {
-  it("reads no layout at idle", async () => {
+  it("reads no layout and schedules no frame at idle", async () => {
     const harness = mountHook();
     await flushAnimationFrames(4);
 
     const settled = harness.layoutReads();
     expect(settled).toBeGreaterThan(0);
 
+    const scheduled = countScheduledFrames();
     await flushAnimationFrames(10);
     expect(harness.layoutReads()).toBe(settled);
+    expect(scheduled()).toBe(0);
+  });
+
+  it("re-measures when the iframe loads another composition", async () => {
+    const harness = mountHook();
+    await flushAnimationFrames(4);
+    const settled = harness.layoutReads();
+
+    harness.setIframeWidth(400);
+    act(() => {
+      harness.iframe.dispatchEvent(new Event("load"));
+    });
+    await flushAnimationFrames(3);
+
+    expect(harness.layoutReads()).toBeGreaterThan(settled);
+    expect(harness.readScaleX()).toBeCloseTo(0.5, 5);
+  });
+
+  it("re-measures when refreshOverlayGeometry re-arms it", async () => {
+    const harness = mountHook();
+    await flushAnimationFrames(4);
+    const settled = harness.layoutReads();
+
+    // The stand-in for a preview iframe swap: nothing observable happened in
+    // this hook, DomEditOverlay simply armed the loop it was handed.
+    harness.setIframeWidth(1600);
+    act(() => harness.loopRef.current?.arm());
+    await flushAnimationFrames(3);
+
+    expect(harness.layoutReads()).toBeGreaterThan(settled);
+    expect(harness.readScaleX()).toBeCloseTo(2, 5);
+  });
+
+  it("re-measures when the iframe or overlay resizes", async () => {
+    resizeObservers.length = 0;
+    const harness = mountHook();
+    await flushAnimationFrames(4);
+    const settled = harness.layoutReads();
+    const observer = resizeObservers.at(-1);
+    if (!observer) throw new Error("Expected a ResizeObserver on the iframe and overlay");
+    expect(observer.targets).toContain(harness.iframe);
+    expect(observer.targets.length).toBe(2);
+
+    harness.setIframeWidth(1600);
+    act(() => observer.fire());
+    await flushAnimationFrames(3);
+
+    expect(harness.layoutReads()).toBeGreaterThan(settled);
+    expect(harness.readScaleX()).toBeCloseTo(2, 5);
   });
 
   it("re-measures when the preview stage's transform changes", async () => {

--- a/packages/studio/src/components/editor/useDomEditCompositionRect.ts
+++ b/packages/studio/src/components/editor/useDomEditCompositionRect.ts
@@ -40,10 +40,50 @@ export function useDomEditCompositionRect({
 
   useMountEffect(() => {
     let frame = 0;
+    // Every input below changes on an observable event: the iframe or overlay
+    // resizing, the preview stage's zoom/pan transform (written as `style` on
+    // an ancestor of the iframe, so no ResizeObserver sees it), or the iframe
+    // loading a different composition. Idle, this hook read layout twice and
+    // queried the preview document once on every single frame, forever.
+    //
+    // The rAF loop stays only to notice that `iframeRef.current` has become a
+    // DIFFERENT element — the preview Player remounts on composition switch —
+    // which is the same doc-swap check `offCanvasIndicatorRefresh` makes.
+    let dirty = true;
+    let observed: HTMLIFrameElement | null = null;
+    const markDirty = () => {
+      dirty = true;
+    };
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(markDirty);
+    const stageObserver =
+      typeof MutationObserver === "undefined" ? null : new MutationObserver(markDirty);
+
+    const observe = (iframe: HTMLIFrameElement | null) => {
+      if (iframe === observed) return;
+      observed?.removeEventListener("load", markDirty);
+      resizeObserver?.disconnect();
+      stageObserver?.disconnect();
+      observed = iframe;
+      markDirty();
+      if (!iframe) return;
+      iframe.addEventListener("load", markDirty);
+      resizeObserver?.observe(iframe);
+      const overlayEl = overlayRef.current;
+      if (overlayEl) resizeObserver?.observe(overlayEl);
+      for (let node = iframe.parentElement; node; node = node.parentElement) {
+        stageObserver?.observe(node, { attributes: true, attributeFilter: ["style", "class"] });
+        if (node === document.body) break;
+      }
+    };
+
     // fallow-ignore-next-line complexity
     const update = () => {
       frame = requestAnimationFrame(update);
       const iframe = iframeRef.current;
+      observe(iframe);
+      if (!dirty) return;
+      dirty = false;
       const overlayEl = overlayRef.current;
       if (!iframe || !overlayEl) return;
       const iRect = iframe.getBoundingClientRect();
@@ -61,7 +101,12 @@ export function useDomEditCompositionRect({
       setCompRect((prev) => (sameRect(prev, next) ? prev : next));
     };
     frame = requestAnimationFrame(update);
-    return () => cancelAnimationFrame(frame);
+    return () => {
+      cancelAnimationFrame(frame);
+      resizeObserver?.disconnect();
+      stageObserver?.disconnect();
+      observed?.removeEventListener("load", markDirty);
+    };
   });
 
   return compRect;

--- a/packages/studio/src/components/editor/useDomEditCompositionRect.ts
+++ b/packages/studio/src/components/editor/useDomEditCompositionRect.ts
@@ -1,5 +1,6 @@
-import { useState, type RefObject } from "react";
+import { useState, type MutableRefObject, type RefObject } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import { createOverlayFrameLoop, type OverlayFrameLoop } from "./overlayFrameLoop";
 
 export interface DomEditCompositionRect {
   left: number;
@@ -25,9 +26,12 @@ function sameRect(a: DomEditCompositionRect, b: DomEditCompositionRect): boolean
 export function useDomEditCompositionRect({
   iframeRef,
   overlayRef,
+  loopRef,
 }: {
   iframeRef: RefObject<HTMLIFrameElement | null>;
   overlayRef: RefObject<HTMLDivElement | null>;
+  /** Filled with this loop so the overlay can re-arm it; see DomEditOverlay. */
+  loopRef: MutableRefObject<OverlayFrameLoop | null>;
 }): DomEditCompositionRect {
   const [compRect, setCompRect] = useState({
     left: 0,
@@ -39,35 +43,32 @@ export function useDomEditCompositionRect({
   });
 
   useMountEffect(() => {
-    let frame = 0;
     // Every input below changes on an observable event: the iframe or overlay
     // resizing, the preview stage's zoom/pan transform (written as `style` on
     // an ancestor of the iframe, so no ResizeObserver sees it), or the iframe
     // loading a different composition. Idle, this hook read layout twice and
     // queried the preview document once on every single frame, forever.
     //
-    // The rAF loop stays only to notice that `iframeRef.current` has become a
-    // DIFFERENT element — the preview Player remounts on composition switch —
-    // which is the same doc-swap check `offCanvasIndicatorRefresh` makes.
-    let dirty = true;
+    // Being armed IS the dirty flag now: each observer arms the loop, the loop
+    // measures once and parks. `refreshOverlayGeometry` in DomEditOverlay arms
+    // it for the events no observer here sees — chiefly React swapping the
+    // iframe element, which the preview Player does on composition switch.
     let observed: HTMLIFrameElement | null = null;
-    const markDirty = () => {
-      dirty = true;
-    };
+    let loop: OverlayFrameLoop | null = null;
+    const armLoop = () => loop?.arm();
     const resizeObserver =
-      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(markDirty);
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(armLoop);
     const stageObserver =
-      typeof MutationObserver === "undefined" ? null : new MutationObserver(markDirty);
+      typeof MutationObserver === "undefined" ? null : new MutationObserver(armLoop);
 
     const observe = (iframe: HTMLIFrameElement | null) => {
       if (iframe === observed) return;
-      observed?.removeEventListener("load", markDirty);
+      observed?.removeEventListener("load", armLoop);
       resizeObserver?.disconnect();
       stageObserver?.disconnect();
       observed = iframe;
-      markDirty();
       if (!iframe) return;
-      iframe.addEventListener("load", markDirty);
+      iframe.addEventListener("load", armLoop);
       resizeObserver?.observe(iframe);
       const overlayEl = overlayRef.current;
       if (overlayEl) resizeObserver?.observe(overlayEl);
@@ -78,19 +79,16 @@ export function useDomEditCompositionRect({
     };
 
     // fallow-ignore-next-line complexity
-    const update = () => {
-      frame = requestAnimationFrame(update);
+    const update = (): boolean => {
       const iframe = iframeRef.current;
       observe(iframe);
-      if (!dirty) return;
-      dirty = false;
       const overlayEl = overlayRef.current;
-      if (!iframe || !overlayEl) return;
+      if (!iframe || !overlayEl) return false;
       const iRect = iframe.getBoundingClientRect();
       const oRect = overlayEl.getBoundingClientRect();
       const left = iRect.left - oRect.left;
       const top = iRect.top - oRect.top;
-      if (iRect.width <= 0 || iRect.height <= 0) return;
+      if (iRect.width <= 0 || iRect.height <= 0) return false;
       const doc = iframe.contentDocument;
       const root = doc?.querySelector<HTMLElement>("[data-composition-id]") ?? doc?.documentElement;
       const dw = Number.parseFloat(root?.getAttribute("data-width") ?? "");
@@ -99,13 +97,19 @@ export function useDomEditCompositionRect({
       const scaleY = dh > 0 ? iRect.height / dh : 1;
       const next = { left, top, width: iRect.width, height: iRect.height, scaleX, scaleY };
       setCompRect((prev) => (sameRect(prev, next) ? prev : next));
+      return false;
     };
-    frame = requestAnimationFrame(update);
+
+    loop = createOverlayFrameLoop(update);
+    loopRef.current = loop;
+    loop.arm();
+    const started = loop;
     return () => {
-      cancelAnimationFrame(frame);
+      started.stop();
+      loopRef.current = null;
       resizeObserver?.disconnect();
       stageObserver?.disconnect();
-      observed?.removeEventListener("load", markDirty);
+      observed?.removeEventListener("load", armLoop);
     };
   });
 

--- a/packages/studio/src/components/editor/useDomEditOverlayRects.test.tsx
+++ b/packages/studio/src/components/editor/useDomEditOverlayRects.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { useDomEditOverlayRects } from "./useDomEditOverlayRects";
+import { createGestureActiveRef, type OverlayFrameLoop } from "./overlayFrameLoop";
+import {
+  countScheduledFrames,
+  flushAnimationFrames,
+  restoreAnimationFrameCounter,
+  testDomRect as domRect,
+} from "./overlayLoopTestKit";
+import type { DomEditSelection } from "./domEditing";
+import type { OverlayRect } from "./domEditOverlayGeometry";
+
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  restoreAnimationFrameCounter();
+});
+
+interface Harness {
+  gestureActiveRef: ReturnType<typeof createGestureActiveRef>;
+  loopRef: { current: OverlayFrameLoop | null };
+  setSelection: (selection: DomEditSelection | null) => void;
+  moveElement: (left: number) => void;
+  readOverlayRect: () => OverlayRect | null;
+}
+
+function mountHook(): Harness {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  const doc = iframe.contentDocument;
+  if (!doc) throw new Error("Expected iframe content document");
+  doc.body.innerHTML = `
+    <div data-composition-id="root" data-width="800" data-height="450">
+      <div id="headline" style="position:absolute; left:40px; top:40px; width:100px; height:40px;">Headline</div>
+    </div>
+  `;
+  const element = doc.getElementById("headline");
+  if (!element) throw new Error("Expected test element");
+
+  const overlay = document.createElement("div");
+  document.body.append(overlay);
+
+  Element.prototype.getBoundingClientRect = function (): DOMRect {
+    if (this === element) {
+      return domRect(
+        Number.parseFloat(element.style.left),
+        Number.parseFloat(element.style.top),
+        100,
+        40,
+      );
+    }
+    return domRect(0, 0, 800, 450);
+  };
+
+  const selectionRef: { current: DomEditSelection | null } = { current: null };
+  const gestureActiveRef = createGestureActiveRef();
+  const loopRef: { current: OverlayFrameLoop | null } = { current: null };
+  let overlayRect: OverlayRect | null = null;
+
+  function Probe(): React.ReactElement {
+    const rects = useDomEditOverlayRects({
+      iframeRef: { current: iframe },
+      overlayRef: { current: overlay },
+      selectionRef,
+      activeCompositionPathRef: { current: null },
+      groupSelectionsRef: { current: [] },
+      hoverSelectionRef: { current: null },
+      gestureActiveRef,
+      loopRef,
+    });
+    overlayRect = rects.overlayRect;
+    return <span>{rects.overlayRect?.left ?? -1}</span>;
+  }
+
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  act(() => root?.render(<Probe />));
+
+  return {
+    gestureActiveRef,
+    loopRef,
+    setSelection: (selection) => {
+      selectionRef.current = selection;
+      act(() => root?.render(<Probe />));
+    },
+    moveElement: (left) => {
+      element.style.left = `${left}px`;
+    },
+    readOverlayRect: () => overlayRect,
+  };
+}
+
+function selectionForHeadline(): DomEditSelection {
+  return { id: "headline", sourceFile: "index.html" } as unknown as DomEditSelection;
+}
+
+describe("useDomEditOverlayRects", () => {
+  it("schedules no frames at idle", async () => {
+    const harness = mountHook();
+    harness.setSelection(selectionForHeadline());
+    await flushAnimationFrames(4);
+    expect(harness.readOverlayRect()?.left).toBe(40);
+
+    const scheduled = countScheduledFrames();
+    await flushAnimationFrames(8);
+    expect(scheduled()).toBe(0);
+  });
+
+  it("re-arms when the selection changes", async () => {
+    const harness = mountHook();
+    await flushAnimationFrames(4);
+    expect(harness.readOverlayRect()).toBeNull();
+
+    harness.setSelection(selectionForHeadline());
+    await flushAnimationFrames(3);
+
+    expect(harness.readOverlayRect()?.left).toBe(40);
+  });
+
+  it("re-arms when a gesture ends and picks up where the gesture left the element", async () => {
+    const harness = mountHook();
+    harness.setSelection(selectionForHeadline());
+    await flushAnimationFrames(4);
+    expect(harness.readOverlayRect()?.left).toBe(40);
+
+    // A gesture drives the box imperatively, so the loop stands down for it.
+    act(() => {
+      harness.gestureActiveRef.current = true;
+    });
+    harness.moveElement(300);
+    await flushAnimationFrames(4);
+    expect(harness.readOverlayRect()?.left).toBe(40);
+
+    act(() => {
+      harness.gestureActiveRef.current = false;
+    });
+    await flushAnimationFrames(3);
+
+    expect(harness.readOverlayRect()?.left).toBe(300);
+  });
+
+  it("re-arms when refreshOverlayGeometry arms the loop", async () => {
+    const harness = mountHook();
+    harness.setSelection(selectionForHeadline());
+    await flushAnimationFrames(4);
+
+    // What a preview-DOM mutation, a zoom/pan or an iframe swap reduces to.
+    harness.moveElement(220);
+    act(() => harness.loopRef.current?.arm());
+    await flushAnimationFrames(3);
+
+    expect(harness.readOverlayRect()?.left).toBe(220);
+  });
+
+  it("runs nothing after unmounting while armed", async () => {
+    const harness = mountHook();
+    harness.setSelection(selectionForHeadline());
+    await flushAnimationFrames(4);
+
+    act(() => harness.loopRef.current?.arm());
+    act(() => root?.unmount());
+    const scheduled = countScheduledFrames();
+    harness.moveElement(500);
+    await flushAnimationFrames(6);
+
+    expect(scheduled()).toBe(0);
+    expect(harness.readOverlayRect()?.left).toBe(40);
+  });
+});

--- a/packages/studio/src/components/editor/useDomEditOverlayRects.ts
+++ b/packages/studio/src/components/editor/useDomEditOverlayRects.ts
@@ -2,8 +2,13 @@
  * RAF-driven hook that tracks overlay, hover, and group rects from the iframe DOM.
  * Runs a requestAnimationFrame loop and writes React state only when rects change.
  */
-import { useRef, useState, type RefObject } from "react";
+import { useEffect, useRef, useState, type MutableRefObject, type RefObject } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import {
+  createOverlayFrameLoop,
+  type GestureActiveRef,
+  type OverlayFrameLoop,
+} from "./overlayFrameLoop";
 import { hugRectForElement } from "./domEditOverlayCrop";
 import { type DomEditSelection, findElementForSelection } from "./domEditing";
 import {
@@ -35,7 +40,10 @@ interface UseDomEditOverlayRectsOptions {
   activeCompositionPathRef: RefObject<string | null>;
   groupSelectionsRef: RefObject<DomEditSelection[]>;
   hoverSelectionRef: RefObject<DomEditSelection | null>;
-  rafPausedRef: RefObject<boolean>;
+  /** True while a canvas gesture drives the overlay imperatively. */
+  gestureActiveRef: GestureActiveRef;
+  /** Filled with this loop so the overlay can re-arm it; see DomEditOverlay. */
+  loopRef: MutableRefObject<OverlayFrameLoop | null>;
 }
 
 interface UseDomEditOverlayRectsResult {
@@ -58,7 +66,8 @@ export function useDomEditOverlayRects({
   activeCompositionPathRef,
   groupSelectionsRef,
   hoverSelectionRef,
-  rafPausedRef,
+  gestureActiveRef,
+  loopRef,
 }: UseDomEditOverlayRectsOptions): UseDomEditOverlayRectsResult {
   const [overlayRect, setOverlayRectState] = useState<OverlayRect | null>(null);
   const [hoverRect, setHoverRectState] = useState<OverlayRect | null>(null);
@@ -105,9 +114,22 @@ export function useDomEditOverlayRects({
     return next;
   };
 
-  useMountEffect(() => {
-    let frame = 0;
+  // The selection, hover and group inputs arrive as refs (the gesture code
+  // needs them without a re-render), so a change in them announces itself to
+  // nobody. This signature does: it is read during render, right after
+  // DomEditOverlay assigns those refs, and re-arms the loop only when the
+  // resolved identities actually differ.
+  const inputsKey = [
+    activeCompositionPathRef.current ?? "",
+    selectionRef.current ? selectionCacheKey(selectionRef.current) : "",
+    hoverSelectionRef.current ? selectionCacheKey(hoverSelectionRef.current) : "",
+    groupSelectionsRef.current.map(selectionCacheKey).join("|"),
+  ].join("~");
+  useEffect(() => {
+    loopRef.current?.arm();
+  }, [inputsKey, loopRef]);
 
+  useMountEffect(() => {
     const clearAll = () => {
       setOverlayRect(null);
       setHoverRect(null);
@@ -115,8 +137,7 @@ export function useDomEditOverlayRects({
     };
 
     const update = () => {
-      frame = requestAnimationFrame(update);
-      if (rafPausedRef.current) {
+      if (gestureActiveRef.current) {
         if (childRectsRef.current.length > 0) {
           childRectsRef.current = [];
           setChildRectsState([]);
@@ -252,8 +273,22 @@ export function useDomEditOverlayRects({
       setHoverRect(orientedGroupAwareOverlayRect(overlayEl, iframe, hoverEl));
     };
 
-    frame = requestAnimationFrame(update);
-    return () => cancelAnimationFrame(frame);
+    // One pass per arm, then park. The arming signals are: a gesture starting
+    // or ending (below), the selection/hover/group signature above, and
+    // `refreshOverlayGeometry` in DomEditOverlay — which every preview-DOM
+    // mutation, zoom/pan, resize and iframe swap routes through.
+    const loop = createOverlayFrameLoop(() => {
+      update();
+      return false;
+    });
+    loopRef.current = loop;
+    const unsubscribe = gestureActiveRef.subscribe(loop.arm);
+    loop.arm();
+    return () => {
+      unsubscribe();
+      loop.stop();
+      loopRef.current = null;
+    };
   });
 
   return {

--- a/packages/studio/src/components/editor/useMotionPathData.test.tsx
+++ b/packages/studio/src/components/editor/useMotionPathData.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useMotionPathData } from "./useMotionPathData";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const nativeRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+/**
+ * The measurement loop must be silent when nothing moves AND correct when
+ * something does. The second half is the hazard the parked shape introduces:
+ * a loop that parks and is never re-armed leaves a stale motion path.
+ */
+type Measured = ReturnType<typeof useMotionPathData>;
+
+let root: Root | null = null;
+let host: HTMLDivElement;
+let iframe: HTMLIFrameElement;
+let latest: Measured;
+let scheduled: number;
+
+// Stable across renders, exactly like the app's `useRef` — a fresh object every
+// render would re-run the effect and hide the parking this file is about.
+const iframeRef: { current: HTMLIFrameElement | null } = { current: null };
+
+function Probe({ selector }: { selector: string | null }) {
+  latest = useMotionPathData(iframeRef, selector);
+  return null;
+}
+
+function previewDoc(): Document {
+  const doc = iframe.contentDocument;
+  if (!doc) throw new Error("the test iframe has no document");
+  return doc;
+}
+
+function render(selector: string | null): void {
+  act(() => {
+    root!.render(<Probe selector={selector} />);
+  });
+}
+
+/** Let the loop run: several real frames, flushing React between them. */
+async function settle(frames = 6): Promise<void> {
+  for (let i = 0; i < frames; i += 1) {
+    await act(async () => {
+      await new Promise<void>((resolve) => nativeRequestAnimationFrame(() => resolve()));
+    });
+  }
+}
+
+beforeEach(() => {
+  scheduled = 0;
+  globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    scheduled += 1;
+    return nativeRequestAnimationFrame(callback);
+  };
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  iframeRef.current = iframe;
+  previewDoc().body.innerHTML = `<div id="target"></div>`;
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  host.remove();
+  iframe.remove();
+  iframeRef.current = null;
+  globalThis.requestAnimationFrame = nativeRequestAnimationFrame;
+});
+
+describe("useMotionPathData", () => {
+  it("parks instead of measuring every frame while a selection is active", async () => {
+    render("#target");
+    await settle();
+    const afterFirstBurst = scheduled;
+
+    await settle(10);
+
+    // A 60Hz loop would have added ten frames here; a parked one adds none.
+    expect(scheduled).toBe(afterFirstBurst);
+  });
+
+  it("schedules nothing at all with no selection", async () => {
+    render(null);
+    await settle(10);
+
+    expect(scheduled).toBe(0);
+  });
+
+  it("re-arms when the preview document changes, so the path is never stale", async () => {
+    render("#target");
+    await settle();
+    expect(latest.visibleInPreview).toBe(true);
+    const parked = scheduled;
+
+    // A seek, an edit or a GSAP frame — all of them land as a style write.
+    act(() => {
+      previewDoc().getElementById("target")!.style.display = "none";
+    });
+    await settle();
+
+    expect(scheduled).toBeGreaterThan(parked);
+    expect(latest.visibleInPreview).toBe(false);
+  });
+
+  it("picks up a target that only appears after the loop has parked", async () => {
+    previewDoc().body.innerHTML = "";
+    render("#late");
+    await settle();
+    expect(latest.home).toBeNull();
+
+    act(() => {
+      previewDoc().body.innerHTML = `<div id="late"></div>`;
+    });
+    await settle();
+
+    expect(latest.home).not.toBeNull();
+  });
+
+  it("stops scheduling once the selection is cleared", async () => {
+    render("#target");
+    await settle();
+    render(null);
+    await settle();
+    const afterClear = scheduled;
+
+    act(() => {
+      previewDoc().getElementById("target")!.style.display = "none";
+    });
+    await settle(10);
+
+    expect(scheduled).toBe(afterClear);
+  });
+});

--- a/packages/studio/src/components/editor/useMotionPathData.ts
+++ b/packages/studio/src/components/editor/useMotionPathData.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { readRuntimeKeyframes } from "../../hooks/gsapRuntimeKeyframes";
+import { createOverlayFrameLoop } from "./overlayFrameLoop";
+import { startPreviewGeometryWatch, type PreviewDomWatch } from "./previewDomWatch";
 import { isElementVisibleForOverlay } from "./domEditOverlayGeometry";
 import { buildMotionPathGeometry, type MotionPathGeometry } from "./motionPathGeometry";
 
@@ -114,6 +116,14 @@ export function useMotionPathData(
   // path's offset points so depth (translateZ) elements' paths track on screen.
   const [pScale, setPScale] = useState(1);
 
+  // The watch that re-arms the measurement loop below. Held in a ref so the
+  // render effect can poll it for the one change no observer can see: React
+  // swapping the preview iframe element, which arrives here as a ref.
+  const watchRef = useRef<PreviewDomWatch | null>(null);
+  useEffect(() => {
+    watchRef.current?.poll();
+  });
+
   useEffect(() => {
     if (!selector) {
       setRect(null);
@@ -121,8 +131,15 @@ export function useMotionPathData(
       return;
     }
     setHome(null);
-    let raf = 0;
-    const tick = () => {
+    // One measurement per arm, then park. This ran unconditionally at 60Hz for
+    // as long as anything was selected — a fifth always-on animation loop.
+    //
+    // What re-arms it: everything that can move what it measures. The preview
+    // document mutating (a seek or a GSAP frame writing inline styles, an edit
+    // landing, the element appearing), the iframe navigating, React swapping
+    // the iframe element, the iframe box resizing, and a stage zoom/pan.
+    // `startPreviewGeometryWatch` owns all five.
+    const measure = () => {
       const el = iframeRef.current;
       if (el) {
         const r = el.getBoundingClientRect();
@@ -153,10 +170,20 @@ export function useMotionPathData(
           setPScale((p) => (Math.abs(p - ps) < 0.001 ? p : ps));
         }
       }
-      raf = requestAnimationFrame(tick);
     };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
+
+    const loop = createOverlayFrameLoop(() => {
+      measure();
+      return false;
+    });
+    const watch = startPreviewGeometryWatch(iframeRef, loop.arm);
+    watchRef.current = watch;
+    loop.arm();
+    return () => {
+      watchRef.current = null;
+      watch.dispose();
+      loop.stop();
+    };
   }, [selector, iframeRef]);
 
   useEffect(() => {

--- a/packages/studio/src/components/editor/useOverlayGeometryRefresh.ts
+++ b/packages/studio/src/components/editor/useOverlayGeometryRefresh.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, type MutableRefObject, type RefObject } from "react";
+import { useMountEffect } from "../../hooks/useMountEffect";
+import type { OverlayFrameLoop } from "./overlayFrameLoop";
+import { startPreviewDomWatch, type PreviewDomWatch } from "./previewDomWatch";
+
+export interface OverlayGeometryRefresh {
+  /** Handles the overlay loops register themselves in, so they can be re-armed. */
+  rectsLoopRef: MutableRefObject<OverlayFrameLoop | null>;
+  compRectLoopRef: MutableRefObject<OverlayFrameLoop | null>;
+  offCanvasLoopRef: MutableRefObject<OverlayFrameLoop | null>;
+  offCanvasDirtyRef: MutableRefObject<boolean>;
+  refreshOverlayGeometry: () => void;
+}
+
+/**
+ * The single answer to "what re-arms the canvas overlay loops".
+ *
+ * Each loop parks the moment it has caught up, so anything that can move what
+ * they draw has to say so. Everything that can routes through the one function
+ * returned here: the shared preview-document observer (which this hook owns),
+ * React swapping the preview iframe element, and — from the caller, which is
+ * where those values live — a stage zoom/pan or panel resize landing as a new
+ * composition rect, and a composition switch.
+ */
+export function useOverlayGeometryRefresh(
+  iframeRef: RefObject<HTMLIFrameElement | null>,
+): OverlayGeometryRefresh {
+  const rectsLoopRef = useRef<OverlayFrameLoop | null>(null);
+  const compRectLoopRef = useRef<OverlayFrameLoop | null>(null);
+  const offCanvasLoopRef = useRef<OverlayFrameLoop | null>(null);
+  const offCanvasDirtyRef = useRef(true);
+
+  const refreshOverlayGeometry = useCallback(() => {
+    offCanvasDirtyRef.current = true;
+    rectsLoopRef.current?.arm();
+    compRectLoopRef.current?.arm();
+    offCanvasLoopRef.current?.arm();
+  }, []);
+
+  const previewWatchRef = useRef<PreviewDomWatch | null>(null);
+  useMountEffect(() => {
+    const watch = startPreviewDomWatch(iframeRef, refreshOverlayGeometry);
+    previewWatchRef.current = watch;
+    return () => {
+      watch.dispose();
+      previewWatchRef.current = null;
+    };
+  });
+
+  // The preview iframe element arrives in a ref, so React swapping it announces
+  // itself to nobody: every render re-checks. The check is two identity
+  // comparisons and schedules a frame only when something actually changed.
+  useEffect(() => {
+    previewWatchRef.current?.poll();
+  });
+
+  return {
+    rectsLoopRef,
+    compRectLoopRef,
+    offCanvasLoopRef,
+    offCanvasDirtyRef,
+    refreshOverlayGeometry,
+  };
+}


### PR DESCRIPTION
Three render loops that ran continuously regardless of whether anything was moving.

**Measured: idle animation frames 303/s → 1/s.**

## The heaviest review in this sequence — 713 logic lines

I tried to split it and could not do so honestly. The overlay-loop change and the paused-transport change both modify `SnapGuideOverlay` and `useDomEditCompositionRect`, and unlike the other overlaps in this sequence their hunks genuinely **interleave** rather than sitting in separate regions. The natural cut line falls between "the loop" and "what the loop reads", which splits an implementation from its own consumers — a worse review than one large PR.

**The three loops are independent. Read them in any order:**

1. **Canvas overlay loops** — park after a run of idle frames, resume on the next mutation.
2. **Motion-path loop** — stops re-running when no tracked node has moved.
3. **Paused transport** — the subtle one. See below.

## The one behavioural change

The transport previously ticked on `requestAnimationFrame` unconditionally. It now ticks on rAF **while playing** and on a 500ms timer **while paused**. Playback cadence is untouched; only the paused state changes.

This is the only change of the three that alters runtime behaviour rather than suppressing repaints, so it carries the most test weight: a paused runtime that receives a seek must still update within one timer period, and the rebind policy must not attempt a periodic bind while playing with a captured timeline.

## What this does not claim

The idle-frame number is measured with the runtime-cost gate, which is a separate PR in this sequence. Without it, you can still verify the behaviour from the tests; you cannot reproduce the 303 → 1 figure from this PR alone.

## Verification

`packages/core` green (1,442 tests), `packages/studio` green (3,297 tests).