### PR TITLE
fix(player): stop the shader loader sheen animating while the loader is hidden

### DIFF
--- a/packages/player/src/styles.ts
+++ b/packages/player/src/styles.ts
@@ -124,6 +124,18 @@ export const PLAYER_STYLES = /* css */ `
     animation: hfp-shader-loader-sheen 1.9s linear infinite;
   }
 
+  /*
+   * The loader hides with visibility/opacity so it can transition out, and
+   * visibility: hidden does NOT stop an animation on a descendant. Without
+   * this the sheen keeps ticking for the life of the page: measured at 60
+   * style recalculations per second in an otherwise idle Studio, for a
+   * shimmer nobody can see.
+   */
+  .hfp-shader-loader:not(.hfp-visible):not(.hfp-hiding)
+    .hfp-shader-loader-title-text {
+    animation-play-state: paused;
+  }
+
   .hfp-shader-loader-detail {
     width: 100%;
     height: 26px;


### PR DESCRIPTION
Twelve lines, one CSS rule. Kept as its own PR because it is trivial to review and has an outsized measured effect — it should not wait behind a 700-line sibling.

## The bug

The shader loader title carries a sheen animation. The loader is hidden by class, not unmounted, so the animation kept running against a hidden element for the entire lifetime of the page.

**Measured: 60.2 → 2.0 style recalculations per second at idle.** A running CSS animation forces a style recalculation every frame whether or not the result is ever painted.

## The fix

Pause the animation when the loader carries neither the visible nor the hiding class. The loader still animates normally while visible and while transitioning out.

## Tests

None — this is a CSS rule with no behavioural branch, and a unit test asserting the presence of a CSS declaration would test the stylesheet against itself. The effect is asserted by the idle window of the runtime-cost gate (a separate PR in this sequence), which counts style recalculations directly.

## Verification

`packages/player` suite green (330 tests). Loader still animates while visible.