### PR TITLE
perf(runtime): fetch and sync the playhead neighbourhood, not the whole composition

### DIFF
--- a/packages/core/src/runtime/entry.ts
+++ b/packages/core/src/runtime/entry.ts
@@ -1,5 +1,6 @@
 import { initSandboxRuntimeModular } from "./init";
 import { installAuthoredOpacityCapture } from "./colorGrading";
+import { installRuntimeMediaObserver } from "./media";
 import { fitTextFontSize } from "../text/fitTextFontSize";
 import { getVariables } from "./getVariables";
 
@@ -19,6 +20,12 @@ type HyperframeWindow = Window & {
 // composition's animation scripts (and the grading hide) mutate it — must run
 // at script evaluation time, while the document is still parsing.
 installAuthoredOpacityCapture();
+
+// Watch media from script evaluation time, while the document is still
+// parsing, so a clip nowhere near the playhead can be told not to fetch before
+// the browser starts fetching it. Waiting for DOMContentLoaded is too late —
+// see deferParsedMediaPreload in media.ts.
+installRuntimeMediaObserver();
 
 // Expose runtime helpers immediately so composition scripts can use them
 // before DOMContentLoaded (font sizing runs during script evaluation, and

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -2851,5 +2851,84 @@ describe("initSandboxRuntimeModular", () => {
       }).not.toThrow();
       expect(mediaLog).toEqual([]);
     });
+
+    it("buffers the clip at the playhead and not the one 500s away", () => {
+      const root = mountComposition(600);
+      const near = addMedia(root, { id: "near", src: "near.wav", start: 0, duration: 4 });
+      const far = addMedia(root, { id: "far", src: "far.wav", start: 500, duration: 4 });
+
+      initSandboxRuntimeModular();
+
+      expect(mediaLog).toEqual(["load:near"]);
+      expect(near.preload).toBe("auto");
+      expect(far.preload).not.toBe("auto");
+    });
+
+    it("promotes a distant clip as the playhead approaches, before it is in window", () => {
+      const root = mountComposition(600);
+      const upcoming = addMedia(root, { id: "upcoming", src: "up.wav", start: 20, duration: 4 });
+
+      initSandboxRuntimeModular();
+      expect(mediaLog).toEqual([]);
+
+      window.__player?.seek(5);
+      expect(mediaLog).toEqual([]);
+
+      // t=12 is still eight seconds before the clip opens at t=20.
+      window.__player?.seek(12);
+      expect(mediaLog).toEqual(["load:upcoming"]);
+      expect(upcoming.preload).toBe("auto");
+    });
+
+    it("buffers the destination of a far seek rather than waiting for playback", () => {
+      const root = mountComposition(600);
+      const destination = addMedia(root, { id: "dest", src: "dest.wav", start: 500, duration: 4 });
+
+      initSandboxRuntimeModular();
+      window.__player?.seek(495);
+
+      expect(mediaLog).toEqual(["load:dest"]);
+      expect(destination.preload).toBe("auto");
+    });
+
+    // The measured shape of the amplification: seven clips referencing one
+    // file each got their own element and each was told to fetch it.
+    it("fetches one source once however many clips reference it", () => {
+      const root = mountComposition(60);
+      const clips = Array.from({ length: 7 }, (_, index) =>
+        addMedia(root, {
+          id: `share-${index}`,
+          src: "track.wav",
+          start: index,
+          duration: 1,
+        }),
+      );
+
+      initSandboxRuntimeModular();
+
+      expect(mediaLog).toEqual(["load:share-0"]);
+      // Every one of them still buffers — the browser serves the siblings from
+      // its own cache — but only one fetch is issued for the file.
+      for (const clip of clips) expect(clip.preload).toBe("auto");
+    });
+
+    // A clip with no authored `data-duration` takes its window from the source,
+    // so it has to keep probing metadata however far away it is.
+    it("keeps probing metadata for a distant clip whose window is unauthored", () => {
+      const root = mountComposition(600);
+      const unauthored = addMedia(root, { id: "unauthored", src: "a.wav", start: 500 });
+      const authored = addMedia(root, {
+        id: "authored",
+        src: "b.wav",
+        start: 500,
+        duration: 4,
+      });
+
+      initSandboxRuntimeModular();
+
+      expect(mediaLog).toEqual([]);
+      expect(unauthored.preload).toBe("metadata");
+      expect(authored.preload).not.toBe("metadata");
+    });
   });
 });

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -2710,4 +2710,146 @@ describe("initSandboxRuntimeModular", () => {
       }).not.toThrow();
     });
   });
+
+  // What a media element is told to buffer, and when. The eager promotion
+  // these tests pin exists to keep the first play() from firing on un-fetched
+  // media; the neighbourhood policy that replaces it has to keep that
+  // property, so it is pinned here as behaviour rather than as an
+  // implementation detail of where the promotion happens.
+  describe("media buffering", () => {
+    /** Ordered `load:`/`play:` log across every probe element in one test. */
+    let mediaLog: string[] = [];
+
+    beforeEach(() => {
+      mediaLog = [];
+    });
+
+    afterEach(() => {
+      delete (window as { __HF_RENDER_CAPTURE_MODE?: boolean }).__HF_RENDER_CAPTURE_MODE;
+    });
+
+    function mountComposition(durationSeconds: number): HTMLElement {
+      const root = document.createElement("div");
+      root.setAttribute("data-composition-id", "main");
+      root.setAttribute("data-root", "true");
+      root.setAttribute("data-start", "0");
+      root.setAttribute("data-duration", String(durationSeconds));
+      root.setAttribute("data-width", "1920");
+      root.setAttribute("data-height", "1080");
+      document.body.appendChild(root);
+      window.__timelines = { main: createMockTimeline(durationSeconds) };
+      return root;
+    }
+
+    /**
+     * An `<audio>` whose `load()`/`play()` are recorded rather than performed
+     * (jsdom implements neither). `sourceDuration` is the duration a metadata
+     * probe would resolve; `duration` is the authored `data-duration`, omitted
+     * for a clip whose window has to come from the source instead.
+     */
+    function addMedia(
+      parent: HTMLElement,
+      options: { id: string; src: string; start: number; duration?: number },
+    ): HTMLAudioElement {
+      const el = document.createElement("audio");
+      el.id = options.id;
+      el.setAttribute("data-start", String(options.start));
+      if (options.duration !== undefined) {
+        el.setAttribute("data-duration", String(options.duration));
+      }
+      el.setAttribute("src", options.src);
+      el.load = () => {
+        mediaLog.push(`load:${options.id}`);
+      };
+      el.play = () => {
+        mediaLog.push(`play:${options.id}`);
+        Object.defineProperty(el, "paused", { value: false, writable: true, configurable: true });
+        return Promise.resolve();
+      };
+      el.pause = () => {
+        Object.defineProperty(el, "paused", { value: true, writable: true, configurable: true });
+      };
+      Object.defineProperty(el, "paused", { value: true, writable: true, configurable: true });
+      Object.defineProperty(el, "currentTime", { value: 0, writable: true, configurable: true });
+      parent.appendChild(el);
+      return el;
+    }
+
+    /** The source duration a metadata probe would have resolved. */
+    function setSourceDuration(el: HTMLMediaElement, seconds: number): void {
+      Object.defineProperty(el, "duration", {
+        value: seconds,
+        writable: true,
+        configurable: true,
+      });
+    }
+
+    // The regression the eager load exists to prevent: play() reaching an
+    // element the browser was never told to fetch produces silence until it
+    // catches up. Whatever the buffering policy is, the clip under the
+    // playhead must have been told to buffer before play() reaches it.
+    it("buffers the clip under the playhead before play() reaches it", () => {
+      const root = mountComposition(120);
+      const first = addMedia(root, { id: "first", src: "track.wav", start: 0, duration: 4 });
+      setSourceDuration(first, 4);
+
+      initSandboxRuntimeModular();
+      expect(mediaLog).toEqual(["load:first"]);
+
+      window.__player?.play();
+
+      expect(mediaLog).toEqual(["load:first", "play:first"]);
+      expect(first.preload).toBe("auto");
+    });
+
+    // The renderer captures whatever the browser has decoded at the instant
+    // the frame is taken, so render mode cannot trade buffered bytes for a
+    // faster open: an unbuffered element at capture time is a silent or black
+    // frame in the export.
+    it("buffers every element eagerly in render capture mode", () => {
+      (window as { __HF_RENDER_CAPTURE_MODE?: boolean }).__HF_RENDER_CAPTURE_MODE = true;
+      const root = mountComposition(600);
+      const near = addMedia(root, { id: "near", src: "near.wav", start: 0, duration: 4 });
+      const far = addMedia(root, { id: "far", src: "far.wav", start: 500, duration: 4 });
+
+      initSandboxRuntimeModular();
+
+      expect(mediaLog).toEqual(["load:near", "load:far"]);
+      expect(near.preload).toBe("auto");
+      expect(far.preload).toBe("auto");
+    });
+
+    // Duration probing is the second job the eager load does: a clip with no
+    // authored `data-duration` takes its window from the probed source
+    // duration, so a policy that stops probing would leave the clip with no
+    // window at all.
+    it("resolves an unauthored clip window from the probed source duration", () => {
+      const root = mountComposition(120);
+      const late = addMedia(root, { id: "late", src: "late.wav", start: 60 });
+      setSourceDuration(late, 10);
+
+      initSandboxRuntimeModular();
+      const player = window.__player;
+      player?.seek(65);
+      player?.play();
+
+      expect(mediaLog).toContain("play:late");
+      expect(late.currentTime).toBeCloseTo(5, 5);
+    });
+
+    it("leaves a composition with no media alone", () => {
+      mountComposition(30);
+
+      initSandboxRuntimeModular();
+      const player = window.__player;
+
+      expect(() => {
+        player?.play();
+        player?.seek(12);
+        player?.renderSeek(20);
+        player?.pause();
+      }).not.toThrow();
+      expect(mediaLog).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -24,7 +24,9 @@ import {
   readElementPlaybackStart,
   refreshRuntimeMediaCache,
   resolveRuntimeMediaClipDuration,
+  type RuntimeMediaClip,
   syncRuntimeMedia,
+  usesEagerMediaPreload,
 } from "./media";
 import { handleErrorForProxy, handleMetadataForProxy, maybeProxyProactively } from "./mediaProxy";
 import { probeAndCacheElementVolume, type VolumeKeyframe } from "./mediaVolumeEnvelope.js";
@@ -57,6 +59,20 @@ import { parseNumeric } from "./startExpression";
 
 const AUTHORED_DURATION_ATTR = "data-hf-authored-duration";
 const AUTHORED_END_ATTR = "data-hf-authored-end";
+
+/**
+ * How much timeline either side of the playhead is kept fully buffered.
+ *
+ * This is the bytes-against-first-play-latency trade: too narrow and play
+ * reaches an element the browser was never told to fetch, which is silence —
+ * a worse regression than the refetching this bounds. Playback advances one
+ * second of timeline per second, so the lookahead is a straight
+ * buffering-headroom budget: ten seconds of runway to fetch whatever the
+ * playhead is about to reach. The lookbehind covers a short scrub backwards
+ * onto a clip that only just left the window.
+ */
+const MEDIA_PRELOAD_LOOKAHEAD_SECONDS = 10;
+const MEDIA_PRELOAD_LOOKBEHIND_SECONDS = 2;
 
 /**
  * A `window.__timelines` entry is authored content and may be a PARTIAL
@@ -1837,19 +1853,22 @@ export function initSandboxRuntimeModular(): void {
       mediaEl.addEventListener("error", onMediaErrorForProxy);
 
       // Proactive proxy-fallback trigger: consult the codec map and swap
-      // BEFORE the eager load() below, so a known-hostile asset never even
+      // BEFORE anything asks for bytes, so a known-hostile asset never even
       // attempts to load (and error-flash) the original. No-op in render
       // mode, for <audio>, or when the codec map is absent.
       maybeProxyProactively(mediaEl);
 
-      // Eagerly preload media data so audio/video is buffered before the user
-      // clicks play. Without this, the first play() call fires on un-fetched
-      // media, producing silence or choppy audio until the browser caches it.
-      if (mediaEl.preload !== "auto") {
-        mediaEl.preload = "auto";
-      }
-      if (mediaEl.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
-        mediaEl.load();
+      // Render capture screenshots whatever the browser has decoded at the
+      // instant the frame is taken, so it buffers everything up front and
+      // never consults the playhead: an unbuffered element at capture time is
+      // a silent or black frame in the export.
+      if (usesEagerMediaPreload()) {
+        if (mediaEl.preload !== "auto") {
+          mediaEl.preload = "auto";
+        }
+        if (mediaEl.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
+          mediaEl.load();
+        }
       }
 
       // Probe volume automation from the GSAP timeline — same approach as the
@@ -1859,6 +1878,12 @@ export function initSandboxRuntimeModular(): void {
       // fires after the timeline has been captured (every 30 transport ticks).
       probeAndCacheVolumeKeyframes(mediaEl);
     }
+    // The preview's own buffering pass. It runs over every clip, not just the
+    // newly-bound ones above, because an element already bound is exactly the
+    // one the playhead may since have approached. This is also the only pass
+    // that runs at init, before the first seek or tick, so the clip under the
+    // playhead is buffered before the user can press play.
+    applyMediaPreloadPolicy(resolveMediaClipCache().mediaClips);
   };
 
   const probeAndCacheVolumeKeyframes = (mediaEl: HTMLMediaElement) => {
@@ -1978,8 +2003,8 @@ export function initSandboxRuntimeModular(): void {
     }
   };
 
-  const syncMediaForCurrentState = () => {
-    const cache = refreshRuntimeMediaCache({
+  const resolveMediaClipCache = () =>
+    refreshRuntimeMediaCache({
       shouldIncludeElement: (element) =>
         element.hasAttribute("data-start") ||
         Boolean(resolveMediaCompositionContext(element).compositionRoot),
@@ -2018,12 +2043,71 @@ export function initSandboxRuntimeModular(): void {
         });
       },
     });
+
+  // Which elements have already been raised to `preload="auto"`, and which
+  // have already been given their away-from-the-playhead setting. Sources are
+  // tracked as strings, not elements, so a torn-down runtime retains nothing;
+  // both sets are bounded by the composition's distinct media files.
+  const preloadPromotedMedia = new WeakSet<HTMLMediaElement>();
+  const preloadSettledMedia = new WeakSet<HTMLMediaElement>();
+  const preloadLoadedSources = new Set<string>();
+
+  /**
+   * Buffer the media the playhead is on or about to reach, and nothing else.
+   *
+   * Elements whose clip overlaps the lookahead/lookbehind window are raised to
+   * `preload="auto"` and told to load; everything else keeps the
+   * `preload="none"` the parse-time deferral gave it, except for clips with no
+   * authored `data-duration`, which are held at `metadata` because their
+   * window can only come from the source (see resolveMediaElementDurationSeconds).
+   *
+   * Cheap to call per tick: the pass over `clips` reads plain numbers, and an
+   * element is written at most twice in its life — once when it settles away
+   * from the playhead, once when it is promoted.
+   */
+  const applyMediaPreloadPolicy = (clips: RuntimeMediaClip[]) => {
+    if (usesEagerMediaPreload()) return;
+    const from = state.currentTime - MEDIA_PRELOAD_LOOKBEHIND_SECONDS;
+    const to = state.currentTime + MEDIA_PRELOAD_LOOKAHEAD_SECONDS;
+    for (const clip of clips) {
+      const el = clip.el;
+      if (preloadPromotedMedia.has(el)) continue;
+      const source = el.currentSrc || el.src;
+      if (clip.start <= to && clip.end >= from) {
+        preloadPromotedMedia.add(el);
+        if (el.preload !== "auto") el.preload = "auto";
+        // Seven clips on one file are one fetch, not seven: the browser serves
+        // the siblings from its own cache when they reach the playhead.
+        if (source && preloadLoadedSources.has(source)) continue;
+        if (source) preloadLoadedSources.add(source);
+        // NETWORK_EMPTY means resource selection has not run yet. Calling
+        // load() on an element that is already fetching aborts that fetch and
+        // restarts from zero — the delay syncRuntimeMedia's play() path
+        // documents — so raising `preload` is enough for those.
+        if (el.networkState === HTMLMediaElement.NETWORK_EMPTY) el.load();
+        continue;
+      }
+      if (preloadSettledMedia.has(el)) continue;
+      preloadSettledMedia.add(el);
+      const authoredDuration = Number.parseFloat(el.dataset.duration ?? "");
+      if (Number.isFinite(authoredDuration) && authoredDuration > 0) continue;
+      if (el.preload !== "metadata") el.preload = "metadata";
+    }
+  };
+
+  const syncMediaForCurrentState = () => {
+    const cache = resolveMediaClipCache();
     // Attach probed volume keyframes to clips so syncRuntimeMedia can use the
     // same envelope the renderer uses instead of tracking GSAP-change diffs.
     for (const clip of cache.mediaClips) {
       const kf = volumeKeyframeCache.get(clip.el as HTMLMediaElement);
       if (kf) clip.volumeKeyframes = kf;
     }
+    // Before syncRuntimeMedia, never after: this is the pass that tells an
+    // element to buffer, and play() below must not reach one it has not
+    // visited. A seek lands here too, so seeking far ahead buffers the
+    // destination rather than waiting for playback to arrive.
+    applyMediaPreloadPolicy(cache.mediaClips);
 
     const forceSync = state.mediaForceSyncNextTick;
     if (forceSync) state.mediaForceSyncNextTick = false;

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -1216,4 +1216,89 @@ describe("syncRuntimeMedia active window", () => {
     });
     expect(clip.el.volume).toBeCloseTo(0.4, 10);
   });
+
+  it("pauses an already-playing element the first time it is seen out of window", () => {
+    // An authored `autoplay` element starts on its own. Before windowing every
+    // tick visited it; now only its first sighting can catch it.
+    const clip = createWindowClip({ start: 10, end: 15 });
+    void clip.el.play();
+    expect(clip.el.paused).toBe(false);
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 0, playing: false, playbackRate: 1 });
+    expect(clip.el.paused).toBe(true);
+  });
+
+  it("touches only the in-window and just-departed elements of a 100-clip composition", () => {
+    const touches = new Map<number, number>();
+    const clips = Array.from({ length: 100 }, (_, index) => {
+      const clip = createWindowClip({ start: index, end: index + 3 });
+      touches.set(index, 0);
+      const bump = () => touches.set(index, (touches.get(index) ?? 0) + 1);
+      const el = new Proxy(clip.el, {
+        get(target, prop) {
+          bump();
+          const value = Reflect.get(target, prop, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+        set(target, prop, value) {
+          bump();
+          return Reflect.set(target, prop, value, target);
+        },
+      });
+      return { ...clip, el };
+    });
+    const touched = () =>
+      [...touches.entries()].filter(([, count]) => count > 0).map(([index]) => index);
+    const reset = () => {
+      for (const index of touches.keys()) touches.set(index, 0);
+    };
+
+    // The first tick legitimately sights every element once (autoplay guard).
+    syncRuntimeMedia({ clips, timeSeconds: 50.5, playing: false, playbackRate: 1 });
+    reset();
+    syncRuntimeMedia({ clips, timeSeconds: 50.5, playing: false, playbackRate: 1 });
+    expect(touched()).toEqual([48, 49, 50]);
+
+    reset();
+    syncRuntimeMedia({ clips, timeSeconds: 51.5, playing: false, playbackRate: 1 });
+    // 49-51 are in window; 48 is the departure that has to be paused.
+    expect(touched()).toEqual([48, 49, 50, 51]);
+  });
+});
+
+describe("runtime media registry", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("issues no full-document media query when nothing has been added or removed", () => {
+    createVideo({ "data-start": "0", "data-duration": "5" });
+    refreshRuntimeMediaCache();
+    const querySelectorAll = vi.spyOn(document, "querySelectorAll");
+    refreshRuntimeMediaCache();
+    refreshRuntimeMediaCache();
+    expect(querySelectorAll).not.toHaveBeenCalled();
+    querySelectorAll.mockRestore();
+  });
+
+  it("sees an element added by a composition mutation on the next call", () => {
+    createVideo({ "data-start": "0", "data-duration": "5" });
+    expect(refreshRuntimeMediaCache().mediaClips).toHaveLength(1);
+    createAudio({ "data-start": "1", "data-duration": "2" });
+    expect(refreshRuntimeMediaCache().mediaClips).toHaveLength(2);
+  });
+
+  it("sees media inside a subtree injected in the same task", () => {
+    refreshRuntimeMediaCache();
+    const host = document.createElement("div");
+    host.innerHTML = '<audio data-start="0" data-duration="2"></audio>';
+    document.body.appendChild(host);
+    expect(refreshRuntimeMediaCache().timedMediaEls).toHaveLength(1);
+  });
+
+  it("does not leave a removed element in the registry", () => {
+    const el = createVideo({ "data-start": "0", "data-duration": "5" });
+    expect(refreshRuntimeMediaCache().timedMediaEls).toHaveLength(1);
+    el.remove();
+    expect(refreshRuntimeMediaCache().timedMediaEls).toHaveLength(0);
+  });
 });

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   hasMediaSyncStateForTest,
+  installRuntimeMediaObserver,
   readElementPlaybackRate,
   refreshRuntimeMediaCache,
   resolveRuntimeMediaClipDuration,
@@ -1300,5 +1301,67 @@ describe("runtime media registry", () => {
     expect(refreshRuntimeMediaCache().timedMediaEls).toHaveLength(1);
     el.remove();
     expect(refreshRuntimeMediaCache().timedMediaEls).toHaveLength(0);
+  });
+});
+
+describe("installRuntimeMediaObserver", () => {
+  const flushObserver = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__HF_RENDER_CAPTURE_MODE;
+  });
+
+  // The window that matters is between the parser inserting the element and
+  // the browser acting on it, which is the observer's microtask — setting
+  // preload any later has already lost the fetch.
+  it("defers a newly parsed media element before the browser fetches it", async () => {
+    installRuntimeMediaObserver();
+    const el = createAudio({ "data-start": "120", "data-duration": "2" });
+
+    await flushObserver();
+
+    expect(el.preload).toBe("none");
+  });
+
+  it("defers media inside an injected sub-composition subtree", async () => {
+    installRuntimeMediaObserver();
+    const host = document.createElement("div");
+    host.innerHTML = '<video data-start="90" data-duration="2"></video>';
+    document.body.appendChild(host);
+
+    await flushObserver();
+
+    expect(host.querySelector("video")?.preload).toBe("none");
+  });
+
+  it("leaves an authored preload alone", async () => {
+    installRuntimeMediaObserver();
+    const el = createAudio({ "data-start": "120", "data-duration": "2", preload: "auto" });
+
+    await flushObserver();
+
+    expect(el.preload).toBe("auto");
+  });
+
+  it("leaves an autoplay element alone", async () => {
+    installRuntimeMediaObserver();
+    const el = createAudio({ "data-start": "120", "data-duration": "2", autoplay: "" });
+
+    await flushObserver();
+
+    expect(el.preload).toBe("");
+  });
+
+  // Render capture screenshots whatever the browser has decoded, so it must
+  // keep fetching everything up front.
+  it("defers nothing in render capture mode", async () => {
+    window.__HF_RENDER_CAPTURE_MODE = true;
+    installRuntimeMediaObserver();
+    const el = createAudio({ "data-start": "120", "data-duration": "2" });
+
+    await flushObserver();
+
+    expect(el.preload).toBe("");
   });
 });

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
+  hasMediaSyncStateForTest,
   readElementPlaybackRate,
   refreshRuntimeMediaCache,
   resolveRuntimeMediaClipDuration,
@@ -1044,5 +1045,175 @@ describe("syncRuntimeMedia", () => {
       userMuted: false,
     });
     expect(clip.el.muted).toBe(true);
+  });
+});
+
+/**
+ * The active-window contract, pinned before the loop was windowed.
+ *
+ * `syncRuntimeMedia` used to visit every clip on every tick, so pausing a clip
+ * the playhead had just left fell out of the same pass that activated the one
+ * it had just entered. Windowing splits those two into a transition set, and
+ * these tests are what say the departure half still happens: a clip that leaves
+ * its window must be paused on the very next tick, or its audio runs on past
+ * its clip edge for the rest of an exported video.
+ */
+describe("syncRuntimeMedia active window", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  /** A clip whose element tracks paused state the way a real one does. */
+  function createWindowClip(overrides: Partial<RuntimeMediaClip> = {}): RuntimeMediaClip {
+    const el = document.createElement("audio");
+    document.body.appendChild(el);
+    let paused = true;
+    Object.defineProperty(el, "paused", { get: () => paused, configurable: true });
+    Object.defineProperty(el, "currentTime", { value: 0, writable: true, configurable: true });
+    Object.defineProperty(el, "playbackRate", { value: 1, writable: true, configurable: true });
+    Object.defineProperty(el, "duration", { value: 30, writable: true, configurable: true });
+    el.play = vi.fn(() => {
+      paused = false;
+      return Promise.resolve();
+    });
+    el.pause = vi.fn(() => {
+      paused = true;
+    });
+    return {
+      el,
+      start: 0,
+      mediaStart: 0,
+      duration: 5,
+      end: 5,
+      volume: null,
+      playbackRate: 1,
+      loop: false,
+      sourceDuration: null,
+      ...overrides,
+    };
+  }
+
+  function elementState(el: HTMLMediaElement) {
+    return {
+      paused: el.paused,
+      currentTime: el.currentTime,
+      volume: el.volume,
+      playbackRate: el.playbackRate,
+      preload: el.preload,
+    };
+  }
+
+  it("pauses a clip the playhead just left and evicts its sync state", () => {
+    const clip = createWindowClip({ start: 0, end: 5 });
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 2, playing: true, playbackRate: 1 });
+    expect(clip.el.paused).toBe(false);
+    expect(hasMediaSyncStateForTest(clip.el)).toBe(true);
+
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 6, playing: true, playbackRate: 1 });
+    expect(clip.el.pause).toHaveBeenCalledTimes(1);
+    expect(clip.el.paused).toBe(true);
+    expect(hasMediaSyncStateForTest(clip.el)).toBe(false);
+  });
+
+  it("pauses the departed clip on the next playing frame across a clip boundary", () => {
+    const outgoing = createWindowClip({ start: 0, end: 5 });
+    const incoming = createWindowClip({ start: 5, end: 10 });
+    const clips = [outgoing, incoming];
+
+    syncRuntimeMedia({ clips, timeSeconds: 4.98, playing: true, playbackRate: 1 });
+    expect(outgoing.el.paused).toBe(false);
+    expect(incoming.el.paused).toBe(true);
+
+    // One frame later the playhead has crossed `outgoing.end`. Nothing else in
+    // the runtime pauses it — hardSyncAllMedia only assigns currentTime — so if
+    // this tick misses it, it keeps playing to the end of the composition.
+    syncRuntimeMedia({ clips, timeSeconds: 5.02, playing: true, playbackRate: 1 });
+    expect(outgoing.el.paused).toBe(true);
+    expect(outgoing.el.pause).toHaveBeenCalledTimes(1);
+    expect(incoming.el.paused).toBe(false);
+  });
+
+  it("leaves the same element state whether a boundary is crossed forwards or backwards", () => {
+    const forwardA = createWindowClip({ start: 0, end: 5 });
+    const forwardB = createWindowClip({ start: 5, end: 10 });
+    syncRuntimeMedia({
+      clips: [forwardA, forwardB],
+      timeSeconds: 1,
+      playing: false,
+      playbackRate: 1,
+    });
+    syncRuntimeMedia({
+      clips: [forwardA, forwardB],
+      timeSeconds: 6,
+      playing: false,
+      playbackRate: 1,
+    });
+
+    const backwardA = createWindowClip({ start: 0, end: 5 });
+    const backwardB = createWindowClip({ start: 5, end: 10 });
+    syncRuntimeMedia({
+      clips: [backwardA, backwardB],
+      timeSeconds: 9,
+      playing: false,
+      playbackRate: 1,
+    });
+    syncRuntimeMedia({
+      clips: [backwardA, backwardB],
+      timeSeconds: 6,
+      playing: false,
+      playbackRate: 1,
+    });
+
+    // The clip the playhead is inside lands in the same state either way; the
+    // one it is outside is paused either way. (`currentTime` on the outside
+    // clip is history — nothing rewinds an element the playhead already left.)
+    expect(elementState(backwardB.el)).toEqual(elementState(forwardB.el));
+    expect(backwardA.el.paused).toBe(true);
+    expect(forwardA.el.paused).toBe(true);
+  });
+
+  it("treats the window as half-open at both edges", () => {
+    const clip = createWindowClip({ start: 4, end: 8 });
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 3.999, playing: true, playbackRate: 1 });
+    expect(clip.el.paused).toBe(true);
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 4, playing: true, playbackRate: 1 });
+    expect(clip.el.paused).toBe(false);
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 7.999, playing: true, playbackRate: 1 });
+    expect(clip.el.paused).toBe(false);
+    syncRuntimeMedia({ clips: [clip], timeSeconds: 8, playing: true, playbackRate: 1 });
+    expect(clip.el.paused).toBe(true);
+  });
+
+  it("keeps volume, rate and relative time identical for an in-window clip", () => {
+    const clip = createWindowClip({
+      start: 2,
+      end: 12,
+      mediaStart: 1.5,
+      volume: 0.5,
+      playbackRate: 2,
+    });
+    syncRuntimeMedia({
+      clips: [clip],
+      timeSeconds: 5,
+      playing: false,
+      playbackRate: 1.5,
+      userVolume: 0.8,
+    });
+    // relTime = (5 - 2) * 2 + 1.5
+    expect(clip.el.currentTime).toBe(7.5);
+    expect(clip.el.playbackRate).toBe(3);
+    // First active tick trusts the element's own volume (GSAP has already been
+    // seeked); data-volume only becomes the baseline from the second tick on.
+    expect(clip.el.volume).toBeCloseTo(0.8, 10);
+    expect(clip.el.preload).toBe("auto");
+
+    syncRuntimeMedia({
+      clips: [clip],
+      timeSeconds: 5.5,
+      playing: false,
+      playbackRate: 1.5,
+      userVolume: 0.8,
+    });
+    expect(clip.el.volume).toBeCloseTo(0.4, 10);
   });
 });

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -85,28 +85,101 @@ function nodesTouchMedia(nodes: NodeList): boolean {
   return false;
 }
 
-function invalidateMediaRegistryFor(records: MutationRecord[]): void {
-  for (const record of records) {
-    if (nodesTouchMedia(record.addedNodes) || nodesTouchMedia(record.removedNodes)) {
-      mediaRegistry = null;
-      return;
+function forEachMediaIn(nodes: NodeList, visit: (element: RuntimeMediaElement) => void): boolean {
+  let found = false;
+  for (const node of nodes) {
+    if (!(node instanceof Element)) continue;
+    if (node instanceof HTMLVideoElement || node instanceof HTMLAudioElement) {
+      found = true;
+      visit(node);
+    }
+    // Element-scoped, so it only walks the added subtree.
+    for (const nested of node.querySelectorAll("video, audio")) {
+      if (!(nested instanceof HTMLVideoElement || nested instanceof HTMLAudioElement)) continue;
+      found = true;
+      visit(nested);
     }
   }
+  return found;
+}
+
+/**
+ * Whether media is buffered up front instead of following the playhead. True
+ * for render capture, on both of the runtime's render signals: the producer
+ * file server's `RENDER_CAPTURE_MODE_SHIM` (set before any page script, so it
+ * is readable while the document is still parsing) and the export seek
+ * protocol's config (written by the render-mode body script). The renderer
+ * captures whatever the browser has decoded at the instant a frame is taken,
+ * so trading buffered bytes for a faster open there buys nothing and risks a
+ * silent or black export.
+ *
+ * `window.d.ts` declares both globals, but it is outside the package's main
+ * tsconfig program — hence the local shape rather than a bare property read.
+ */
+export function usesEagerMediaPreload(): boolean {
+  const win = window as Window & {
+    __HF_RENDER_CAPTURE_MODE?: boolean;
+    __HF_EXPORT_RENDER_SEEK_CONFIG?: unknown;
+  };
+  return Boolean(win.__HF_RENDER_CAPTURE_MODE || win.__HF_EXPORT_RENDER_SEEK_CONFIG);
+}
+
+/**
+ * Stop a freshly-parsed media element from fetching its source before the
+ * runtime has decided whether the playhead is anywhere near it. The runtime's
+ * neighbourhood policy (`init.ts`) raises it to `metadata` or `auto` once it
+ * can place the element against the current time.
+ *
+ * This has to happen as each element is parsed, not at init: `preload` set
+ * after `DOMContentLoaded` loses the race against the resource-selection task
+ * the parser already queued. Measured on the Studio runtime-cost fixture,
+ * deferring only at init left 30 of 56 elements already fetching; deferring
+ * here left 1.
+ */
+function deferParsedMediaPreload(element: RuntimeMediaElement): void {
+  if (usesEagerMediaPreload()) return;
+  // An authored `preload` or `autoplay` is an explicit instruction about this
+  // element's own buffering — overriding it would be the runtime deciding
+  // against the author rather than for the playhead.
+  if (element.hasAttribute("preload") || element.autoplay) return;
+  element.preload = "none";
+}
+
+function handleMediaMutations(records: MutationRecord[]): void {
+  let touched = false;
+  for (const record of records) {
+    if (forEachMediaIn(record.addedNodes, deferParsedMediaPreload)) touched = true;
+    if (!touched && nodesTouchMedia(record.removedNodes)) touched = true;
+  }
+  if (touched) mediaRegistry = null;
+}
+
+function ensureMediaRegistryObserver(): void {
+  if (mediaRegistryObserver || typeof MutationObserver !== "function") return;
+  mediaRegistryObserver = new MutationObserver(handleMediaMutations);
+  mediaRegistryObserver.observe(document, { childList: true, subtree: true });
+  mediaRegistry = null;
+}
+
+/**
+ * Start observing media at script-evaluation time, while the document is
+ * still parsing, so `deferParsedMediaPreload` sees each element before the
+ * browser acts on it. Called from the runtime entry, not from `init`, which
+ * runs at `DOMContentLoaded` — by then every element has already been parsed.
+ */
+export function installRuntimeMediaObserver(): void {
+  ensureMediaRegistryObserver();
 }
 
 function readMediaRegistry(): RuntimeMediaElement[] {
-  if (!mediaRegistryObserver && typeof MutationObserver === "function") {
-    mediaRegistryObserver = new MutationObserver(invalidateMediaRegistryFor);
-    mediaRegistryObserver.observe(document, { childList: true, subtree: true });
-    mediaRegistry = null;
-  }
+  ensureMediaRegistryObserver();
   if (mediaRegistryObserver) {
     // Drain synchronously rather than waiting for the observer's microtask:
     // the runtime injects a sub-composition and seeks in the same task, and a
     // registry that lagged by a microtask would render that seek without its
     // media. `takeRecords` is proportional to mutations since the last call —
     // zero during a scrub, where only inline styles change.
-    invalidateMediaRegistryFor(mediaRegistryObserver.takeRecords());
+    handleMediaMutations(mediaRegistryObserver.takeRecords());
   } else {
     // ponytail: no observer (non-DOM host), no cache — always re-query.
     mediaRegistry = null;

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -64,6 +64,57 @@ export type RuntimeMediaClip = {
   volumeKeyframes?: VolumeKeyframe[];
 };
 
+type RuntimeMediaElement = HTMLVideoElement | HTMLAudioElement;
+
+// Every media element in the document, in document order. Rebuilt only when a
+// mutation adds or removes one, not once per seek: the full-document
+// `querySelectorAll("video, audio")` this replaces walked the whole tree on
+// every scrub frame, which on a 273-clip project is the single largest
+// per-frame cost in the preview iframe.
+let mediaRegistry: RuntimeMediaElement[] | null = null;
+let mediaRegistryObserver: MutationObserver | null = null;
+
+function nodesTouchMedia(nodes: NodeList): boolean {
+  for (const node of nodes) {
+    if (!(node instanceof Element)) continue;
+    if (node.tagName === "VIDEO" || node.tagName === "AUDIO") return true;
+    // Element-scoped, so it only walks the added/removed subtree — a
+    // sub-composition being swapped in, not the document.
+    if (node.querySelector("video, audio")) return true;
+  }
+  return false;
+}
+
+function invalidateMediaRegistryFor(records: MutationRecord[]): void {
+  for (const record of records) {
+    if (nodesTouchMedia(record.addedNodes) || nodesTouchMedia(record.removedNodes)) {
+      mediaRegistry = null;
+      return;
+    }
+  }
+}
+
+function readMediaRegistry(): RuntimeMediaElement[] {
+  if (!mediaRegistryObserver && typeof MutationObserver === "function") {
+    mediaRegistryObserver = new MutationObserver(invalidateMediaRegistryFor);
+    mediaRegistryObserver.observe(document, { childList: true, subtree: true });
+    mediaRegistry = null;
+  }
+  if (mediaRegistryObserver) {
+    // Drain synchronously rather than waiting for the observer's microtask:
+    // the runtime injects a sub-composition and seeks in the same task, and a
+    // registry that lagged by a microtask would render that seek without its
+    // media. `takeRecords` is proportional to mutations since the last call —
+    // zero during a scrub, where only inline styles change.
+    invalidateMediaRegistryFor(mediaRegistryObserver.takeRecords());
+  } else {
+    // ponytail: no observer (non-DOM host), no cache — always re-query.
+    mediaRegistry = null;
+  }
+  mediaRegistry ??= Array.from(document.querySelectorAll("video, audio")) as RuntimeMediaElement[];
+  return mediaRegistry;
+}
+
 export function refreshRuntimeMediaCache(params?: {
   resolveStartSeconds?: (element: Element) => number;
   resolveDurationSeconds?: (element: HTMLVideoElement | HTMLAudioElement) => number | null;
@@ -74,9 +125,7 @@ export function refreshRuntimeMediaCache(params?: {
   videoClips: RuntimeMediaClip[];
   maxMediaEnd: number;
 } {
-  const mediaEls = Array.from(document.querySelectorAll("video, audio")) as Array<
-    HTMLVideoElement | HTMLAudioElement
-  >;
+  const mediaEls = readMediaRegistry();
   const timedMediaEls = params?.shouldIncludeElement
     ? mediaEls.filter((el) => params.shouldIncludeElement?.(el))
     : mediaEls.filter((el) => el.hasAttribute("data-start"));
@@ -183,6 +232,54 @@ export function evictMediaSyncState(el: HTMLMediaElement): void {
   lastRuntimeAppliedVolume.delete(el);
 }
 
+// Elements inside the previous tick's time window, and every element this
+// module has ever been handed. Together they turn the per-tick visit list into
+// a transition set: clips in window now, plus the ones that just left it.
+// Departures cannot be recovered from a point query at the current time —
+// during playback the playhead crosses a clip's `end` between frames, and the
+// tick that has to call `pause()` on it is the one where it is already out of
+// window. Nothing else pauses it: `hardSyncAllMedia` only assigns
+// `currentTime`, so a missed departure means audio running past its clip edge
+// for the rest of an exported video.
+let lastWindowElements = new Set<HTMLMediaElement>();
+const knownMediaElements = new WeakSet<HTMLMediaElement>();
+
+/**
+ * Split `clips` into the ones whose window contains `timeSeconds` and pause
+ * whatever left the window since the last call. Only in-window (and
+ * newly-departed, and never-before-seen) elements are touched; the pass over
+ * `clips` itself reads plain numbers, no DOM.
+ */
+function selectMediaTransitionSet(
+  clips: RuntimeMediaClip[],
+  timeSeconds: number,
+): RuntimeMediaClip[] {
+  const inWindow: RuntimeMediaClip[] = [];
+  const windowElements = new Set<HTMLMediaElement>();
+  for (const clip of clips) {
+    if (timeSeconds >= clip.start && timeSeconds < clip.end) {
+      inWindow.push(clip);
+      windowElements.add(clip.el);
+      knownMediaElements.add(clip.el);
+      continue;
+    }
+    if (knownMediaElements.has(clip.el)) continue;
+    // First sight, already out of window: an authored `autoplay` element is
+    // running right now and would never be visited again.
+    knownMediaElements.add(clip.el);
+    if (!clip.el.paused) clip.el.pause();
+  }
+  for (const el of lastWindowElements) {
+    if (windowElements.has(el)) continue;
+    // Clip left its active window — drop the offset baseline so the next
+    // activation (e.g. re-entering a sub-composition) gets a hard resync.
+    evictMediaSyncState(el);
+    if (!el.paused) el.pause();
+  }
+  lastWindowElements = windowElements;
+  return inWindow;
+}
+
 /** Test-only seam: whether any per-source sync state is still tracked for `el`. */
 export function hasMediaSyncStateForTest(el: HTMLMediaElement): boolean {
   return (
@@ -228,7 +325,7 @@ export function syncRuntimeMedia(params: {
   forceSync?: boolean;
 }): void {
   const forceMuteAll = !!(params.outputMuted || params.userMuted);
-  for (const clip of params.clips) {
+  for (const clip of selectMediaTransitionSet(params.clips, params.timeSeconds)) {
     const { el } = clip;
     if (!el.isConnected) continue;
     let relTime = (params.timeSeconds - clip.start) * clip.playbackRate + clip.mediaStart;
@@ -439,8 +536,9 @@ export function syncRuntimeMedia(params: {
       }
       continue;
     }
-    // Clip left its active window — drop the offset baseline so the next
-    // activation (e.g. re-entering a sub-composition) gets a hard resync.
+    // In window by time but not playable — audio that ended naturally, or a
+    // negative `data-media-start` that puts relTime before zero. Same
+    // treatment as a departure: drop the baseline so re-activation hard-syncs.
     evictMediaSyncState(el);
     if (!el.paused) el.pause();
   }

--- a/packages/core/src/runtime/window.d.ts
+++ b/packages/core/src/runtime/window.d.ts
@@ -51,6 +51,13 @@ declare global {
       fpsFallbackReason?: "missing" | "invalid";
       owner?: string;
     };
+    /**
+     * Set by the producer's file server (RENDER_CAPTURE_MODE_SHIM) before any
+     * page script runs. Distinct from `__HF_EXPORT_RENDER_SEEK_CONFIG`, which
+     * the render-mode body script writes only once the body is parsed — this
+     * one is the render signal available while the document is still parsing.
+     */
+    __HF_RENDER_CAPTURE_MODE?: boolean;
     __HF_PARITY_MODE?: boolean;
     /** Legacy debug-only fps hint. Render-mode runtime fps uses __HF_EXPORT_RENDER_SEEK_CONFIG.fps. */
     __HF_FPS?: number;

--- a/packages/studio/src/player/components/Player.test.ts
+++ b/packages/studio/src/player/components/Player.test.ts
@@ -153,6 +153,7 @@ describe("composition loading overlay", () => {
 
   it("keeps the asset overlay up while media is still buffering", () => {
     const { audio, iframe } = createAudioIframe();
+    audio.preload = "auto";
     Object.defineProperty(audio, "readyState", {
       value: 0,
       configurable: true,
@@ -163,6 +164,25 @@ describe("composition loading overlay", () => {
     });
 
     expect(hasUnloadedAssets(iframe, false)).toBe(true);
+
+    iframe.remove();
+  });
+
+  // The runtime fetches the playhead's neighbourhood and nothing else, so a
+  // clip far from the playhead never reaches HAVE_FUTURE_DATA by design.
+  it("does not wait on media the runtime deliberately left unfetched", () => {
+    const { audio, iframe } = createAudioIframe();
+    audio.preload = "none";
+    Object.defineProperty(audio, "readyState", {
+      value: 0,
+      configurable: true,
+    });
+    Object.defineProperty(audio, "networkState", {
+      value: 2,
+      configurable: true,
+    });
+
+    expect(hasUnloadedAssets(iframe, false)).toBe(false);
 
     iframe.remove();
   });

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -67,9 +67,17 @@ function isPreviewMediaElement(el: Element): el is HTMLMediaElement {
   return tagName === "video" || tagName === "audio";
 }
 
-// Assets are considered ready when every `<video>`/`<audio>` has enough data
-// to play through without buffering, and every registered Lottie animation has
-// finished loading.
+// Assets are considered ready when every `<video>`/`<audio>` the runtime is
+// buffering has enough data to play through without buffering, and every
+// registered Lottie animation has finished loading.
+//
+// "the runtime is buffering" is `preload="auto"`. The preview runtime fetches
+// only the playhead's neighbourhood and deliberately leaves the rest of a
+// composition's media unfetched (applyMediaPreloadPolicy in
+// @hyperframes/core runtime/init.ts), so a clip two minutes away is *expected*
+// to sit below HAVE_FUTURE_DATA forever. Waiting on those would hold the
+// overlay for its full 10 s cap on any project whose media does not all sit
+// under the playhead — and poll the whole document 100 times getting there.
 //
 // Returns whichever value was returned last on cross-origin / transient DOM
 // races so a brief access failure (e.g. an iframe that just swapped src)
@@ -84,6 +92,7 @@ export function hasUnloadedAssets(iframe: HTMLIFrameElement, lastResult: boolean
     for (const el of doc.querySelectorAll("video, audio")) {
       if (
         isPreviewMediaElement(el) &&
+        el.preload === "auto" &&
         !el.error &&
         el.networkState !== MEDIA_NETWORK_NO_SOURCE &&
         el.readyState < MEDIA_HAVE_FUTURE_DATA


### PR DESCRIPTION
The runtime set `preload="auto"` and called `load()` on **every** media element in a composition, and re-synced all of them on every tick. Both now scale with a window around the playhead rather than with the size of the document.

**Measured: scrub DOM scans 156 → 9.**

## Commit order is the point

The two characterization commits come first and change no behaviour — they pin what media buffering and active-window transitions guarantee **today**. They are included rather than squashed because they are the evidence that the behaviour change preserved what mattered. Read them first; the two perf commits are much easier to judge once you know what was nailed down.

## The window

Preload covers roughly +10s ahead and −2s behind the playhead. Elements leaving the window are evicted and paused.

The one non-obvious rule: the transition set spans the **union of the last tick and this tick**, not just the current one. An element that crosses the window boundary within a single tick would otherwise be dropped without being paused — it would keep decoding, unreferenced, which is exactly the cost this change exists to remove.

## Note on a shared file

Touches `packages/core/src/runtime/init.ts`, which another PR in this sequence also touches. The hunks are in disjoint regions of the file (this one around lines 1842-2119, the other from 2353 on), so they merge cleanly in either order. Worth a glance after whichever lands second.

## Verification

`packages/core` green (1,459 tests), `packages/studio` green (3,273 tests).
