### PR TITLE
refactor(studio): one media resolution layer for the Studio document

### DIFF
--- a/packages/studio/src/components/ui/VideoFrameThumbnail.tsx
+++ b/packages/studio/src/components/ui/VideoFrameThumbnail.tsx
@@ -1,8 +1,16 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import {
+  extractVideoFrames,
+  mediaCacheKey,
+  thumbnailResolver,
+} from "../../player/lib/mediaResolver";
+
+/** Seek to ~10% of the *source's* duration to avoid black opening frames. */
+const posterTimestamps = (sourceDuration: number) => [Math.min(2, sourceDuration * 0.1 || 2)];
 
 /**
- * Extracts a representative JPEG frame from a video URL using a hidden
- * video + canvas. Seeks to ~10% of duration to avoid black opening frames.
+ * Extracts a representative JPEG frame from a video URL, sharing the one
+ * document-wide extractor and its cache with the timeline strip thumbnails.
  * Used by AssetThumbnail (assets tab) and RenderQueueItem (renders tab).
  */
 export function VideoFrameThumbnail({
@@ -13,47 +21,28 @@ export function VideoFrameThumbnail({
   /** Shown instead of an endless shimmer when the video can't be decoded. */
   fallbackLabel?: string;
 }) {
-  const [frame, setFrame] = useState<string | null>(null);
+  const cacheKey = useMemo(() => mediaCacheKey(src, "poster"), [src]);
+  const [frame, setFrame] = useState<string | null>(
+    () => thumbnailResolver.peek(cacheKey)?.frames[0] ?? null,
+  );
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     setFailed(false);
-    const video = document.createElement("video");
-    video.crossOrigin = "anonymous";
-    video.muted = true;
-    video.preload = "metadata";
-
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-
-    const cleanup = () => {
-      video.src = "";
-      video.load();
+    let cancelled = false;
+    thumbnailResolver
+      .resolve(cacheKey, () => extractVideoFrames(src, posterTimestamps, { quality: 0.7 }))
+      .then((result) => {
+        if (!cancelled) setFrame(result.frames[0] ?? null);
+      })
+      .catch(() => {
+        // Resolve the loading state — a permanent shimmer reads as "still loading".
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
     };
-
-    video.addEventListener("loadedmetadata", () => {
-      video.currentTime = Math.min(2, video.duration * 0.1 || 2);
-    });
-
-    video.addEventListener("seeked", () => {
-      if (!ctx) return;
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      ctx.drawImage(video, 0, 0);
-      setFrame(canvas.toDataURL("image/jpeg", 0.7));
-      cleanup();
-    });
-
-    video.addEventListener("error", () => {
-      // Resolve the loading state — a permanent shimmer reads as "still loading".
-      setFailed(true);
-      cleanup();
-    });
-    video.src = src;
-    video.load();
-
-    return cleanup;
-  }, [src]);
+  }, [src, cacheKey]);
 
   if (failed && !frame) {
     return (

--- a/packages/studio/src/player/components/AudioWaveform.tsx
+++ b/packages/studio/src/player/components/AudioWaveform.tsx
@@ -1,4 +1,5 @@
-import { memo, useRef, useState, useCallback, useEffect } from "react";
+import { memo, useRef, useState, useCallback, useEffect, useMemo } from "react";
+import { mediaCacheKey, waveformResolver } from "../lib/mediaResolver";
 
 interface AudioWaveformProps {
   audioUrl: string;
@@ -60,9 +61,32 @@ function fakePeaks(url: string, count: number): number[] {
   return peaks;
 }
 
-// Module-level cache so decoded audio persists across re-renders and re-mounts
-const peaksCache = new Map<string, number[]>();
-const decodeInFlight = new Map<string, Promise<number[]>>();
+const PEAK_COUNT = 4000;
+
+/**
+ * Fetch + decode one source into peaks. Never rejects: a failed decode falls
+ * back to the deterministic fake pattern, which is a legitimate result worth
+ * caching rather than a failure worth retrying.
+ */
+async function decodeWaveformPeaks(
+  audioUrl: string,
+  waveformUrl: string | undefined,
+  seed: string,
+): Promise<number[]> {
+  try {
+    if (waveformUrl) {
+      const data: { peaks?: number[] } = await fetch(waveformUrl).then((r) => r.json());
+      if (!Array.isArray(data.peaks)) throw new Error("bad response");
+      return data.peaks;
+    }
+    const buf = await fetch(audioUrl).then((r) => r.arrayBuffer());
+    const ctx = new AudioContext();
+    const decoded = await ctx.decodeAudioData(buf).finally(() => ctx.close());
+    return extractPeaks(decoded.getChannelData(0), PEAK_COUNT);
+  } catch {
+    return fakePeaks(seed, PEAK_COUNT);
+  }
+}
 
 /**
  * Audio waveform rendered from real PCM data via Web Audio API.
@@ -80,45 +104,20 @@ export const AudioWaveform = memo(function AudioWaveform({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const barsRef = useRef<HTMLDivElement | null>(null);
   const roRef = useRef<ResizeObserver | null>(null);
-  const cacheKey = waveformUrl ?? audioUrl;
-  const [peaks, setPeaks] = useState<number[] | null>(peaksCache.get(cacheKey) ?? null);
+  const source = waveformUrl ?? audioUrl;
+  const cacheKey = useMemo(() => (source ? mediaCacheKey(source) : ""), [source]);
+  const [peaks, setPeaks] = useState<number[] | null>(
+    () => (cacheKey ? waveformResolver.peek(cacheKey) : undefined) ?? null,
+  );
 
   useEffect(() => {
     if (peaks || !cacheKey) return;
-
     let cancelled = false;
-
-    let promise = decodeInFlight.get(cacheKey);
-    if (!promise) {
-      promise = (
-        waveformUrl
-          ? fetch(waveformUrl)
-              .then((r) => r.json())
-              .then((d: { peaks?: number[] }) => {
-                if (!Array.isArray(d.peaks)) throw new Error("bad response");
-                return d.peaks;
-              })
-          : fetch(audioUrl)
-              .then((r) => r.arrayBuffer())
-              .then((buf) => {
-                const ctx = new AudioContext();
-                return ctx.decodeAudioData(buf).finally(() => ctx.close());
-              })
-              .then((decoded) => extractPeaks(decoded.getChannelData(0), 4000))
-      )
-        .catch(() => fakePeaks(cacheKey, 4000))
-        .then((p) => {
-          peaksCache.set(cacheKey, p);
-          return p;
-        })
-        .finally(() => decodeInFlight.delete(cacheKey));
-
-      decodeInFlight.set(cacheKey, promise);
-    }
-
-    promise.then((p) => {
-      if (!cancelled) setPeaks(p);
-    });
+    waveformResolver
+      .resolve(cacheKey, () => decodeWaveformPeaks(audioUrl, waveformUrl, cacheKey))
+      .then((p) => {
+        if (!cancelled) setPeaks(p);
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/studio/src/player/components/VideoThumbnail.test.tsx
+++ b/packages/studio/src/player/components/VideoThumbnail.test.tsx
@@ -2,6 +2,8 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { thumbnailResolver } from "../lib/mediaResolver";
+import { stubVideoExtraction } from "../lib/mediaResolver.testHelpers";
 import { VideoThumbnail } from "./VideoThumbnail";
 
 Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
@@ -42,24 +44,13 @@ let root: Root | null = null;
 let createdVideos: HTMLVideoElement[];
 
 beforeEach(() => {
+  // Module-level cache: without this a prior test's frames or failure leaks in.
+  thumbnailResolver.reset();
   globalThis.IntersectionObserver =
     MockIntersectionObserver as unknown as typeof IntersectionObserver;
   globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
-  createdVideos = [];
-  const origCreate = document.createElement.bind(document);
-  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
-    const el = origCreate(tag);
-    if (tag === "video") createdVideos.push(el as HTMLVideoElement);
-    return el;
-  });
-
-  // happy-dom's <video>/<canvas> don't decode media; stub the seam the
-  // extractor depends on so the effect can run deterministically.
-  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
-  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
-    drawImage: () => {},
-  } as unknown as CanvasRenderingContext2D);
+  createdVideos = stubVideoExtraction();
 
   host = document.createElement("div");
   document.body.append(host);
@@ -74,10 +65,26 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function render(videoSrc: string) {
+function element(videoSrc: string, duration?: number) {
+  return React.createElement(VideoThumbnail, {
+    videoSrc,
+    label: "",
+    labelColor: "#fff",
+    duration,
+  });
+}
+
+/** Mount and let the resolver's concurrency slot + effect flush. */
+async function render(videoSrc: string, duration?: number) {
   root = createRoot(host);
-  act(() => {
-    root!.render(React.createElement(VideoThumbnail, { videoSrc, label: "", labelColor: "#fff" }));
+  await act(async () => {
+    root!.render(element(videoSrc, duration));
+  });
+}
+
+async function settle() {
+  await act(async () => {
+    await new Promise<void>((r) => setTimeout(r, 0));
   });
 }
 
@@ -87,23 +94,28 @@ function lastVideo(): HTMLVideoElement {
   return v!;
 }
 
+/** Drive one hidden <video> through metadata + `frames` seeks. */
+async function extract(video: HTMLVideoElement, frames: number) {
+  await act(async () => {
+    video.dispatchEvent(new Event("loadedmetadata"));
+  });
+  for (let i = 0; i < frames; i++) {
+    await act(async () => {
+      video.dispatchEvent(new Event("seeked"));
+    });
+  }
+}
+
 describe("VideoThumbnail — tainted-canvas fallback", () => {
-  it("stops the extractor and drops the shimmer when toDataURL throws a SecurityError", () => {
+  it("stops the extractor and drops the shimmer when toDataURL throws a SecurityError", async () => {
     vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockImplementation(() => {
       throw new DOMException("Tainted canvases may not be exported.", "SecurityError");
     });
 
-    render("https://cdn.example.com/no-cors.mp4");
+    await render("https://cdn.example.com/no-cors.mp4");
 
     // The effect ran once visible → a hidden <video> was created.
-    const video = lastVideo();
-
-    act(() => {
-      video.dispatchEvent(new Event("loadedmetadata"));
-    });
-    act(() => {
-      video.dispatchEvent(new Event("seeked"));
-    });
+    await extract(lastVideo(), 1);
 
     // No frame captured, and crucially the shimmer is gone (not spinning
     // forever) — the clip falls back to its plain background.
@@ -111,8 +123,8 @@ describe("VideoThumbnail — tainted-canvas fallback", () => {
     expect(host.querySelector(".animate-pulse")).toBeNull();
   });
 
-  it("drops the shimmer when a no-CORS load fires the video error event (0 frames) (#2214)", () => {
-    render("https://cdn.example.com/no-cors.mp4");
+  it("drops the shimmer when a no-CORS load fires the video error event (0 frames) (#2214)", async () => {
+    await render("https://cdn.example.com/no-cors.mp4");
     // Before the load resolves, the shimmer placeholder is up.
     expect(host.querySelector(".animate-pulse")).not.toBeNull();
 
@@ -120,7 +132,7 @@ describe("VideoThumbnail — tainted-canvas fallback", () => {
     // crossOrigin="anonymous" against a CORS-less server fails the load outright —
     // the error listener fires instead of loadedmetadata/seeked, so no frame is
     // ever captured. The shimmer must stop rather than spin forever.
-    act(() => {
+    await act(async () => {
       video.dispatchEvent(new Event("error"));
     });
 
@@ -128,25 +140,94 @@ describe("VideoThumbnail — tainted-canvas fallback", () => {
     expect(host.querySelector(".animate-pulse")).toBeNull();
   });
 
-  it("keeps streaming frames while the shimmer is up until a frame arrives", () => {
+  it("keeps streaming frames while the shimmer is up until a frame arrives", async () => {
     vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue(
       "data:image/jpeg;base64,AAAA",
     );
 
-    render("/api/projects/p/preview/assets/clip.mp4");
+    await render("/api/projects/p/preview/assets/clip.mp4");
     // Before any seek resolves, the shimmer placeholder is shown.
     expect(host.querySelector(".animate-pulse")).not.toBeNull();
 
-    const video = lastVideo();
-    act(() => {
-      video.dispatchEvent(new Event("loadedmetadata"));
-    });
-    act(() => {
-      video.dispatchEvent(new Event("seeked"));
-    });
+    await extract(lastVideo(), 1);
 
     // A frame was captured, so tiles render and the shimmer clears.
     expect(host.querySelectorAll("img").length).toBeGreaterThanOrEqual(1);
     expect(host.querySelector(".animate-pulse")).toBeNull();
+  });
+});
+
+describe("VideoThumbnail — shared resolution", () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue(
+      "data:image/jpeg;base64,AAAA",
+    );
+  });
+
+  it("extracts once for seven components on the same source at the same duration", async () => {
+    root = createRoot(host);
+    await act(async () => {
+      root!.render(
+        React.createElement(
+          "div",
+          null,
+          ...Array.from({ length: 7 }, (_, i) =>
+            React.createElement(
+              React.Fragment,
+              { key: i },
+              element("/api/projects/p/preview/assets/shared.mp4", 5),
+            ),
+          ),
+        ),
+      );
+    });
+
+    expect(createdVideos).toHaveLength(1);
+    await extract(lastVideo(), 6);
+    expect(createdVideos).toHaveLength(1);
+    // All seven strips render from the one extraction.
+    expect(host.querySelectorAll(".animate-pulse").length).toBe(0);
+  });
+
+  it("extracts separately for two clips trimmed to different durations", async () => {
+    root = createRoot(host);
+    await act(async () => {
+      root!.render(
+        React.createElement(
+          "div",
+          null,
+          React.createElement(
+            React.Fragment,
+            { key: "a" },
+            element("/api/projects/p/preview/assets/shared.mp4", 5),
+          ),
+          React.createElement(
+            React.Fragment,
+            { key: "b" },
+            element("/api/projects/p/preview/assets/shared.mp4", 12),
+          ),
+        ),
+      );
+    });
+
+    await settle();
+    // Two distinct (source, duration) pairs → two extractions, each seeking to
+    // its own clip's stops rather than sharing one frame set.
+    expect(createdVideos).toHaveLength(2);
+  });
+
+  it("serves a re-mount from cache after every consumer unmounted", async () => {
+    await render("/api/projects/p/preview/assets/shared.mp4", 5);
+    await extract(lastVideo(), 6);
+    expect(createdVideos).toHaveLength(1);
+
+    await act(async () => root!.unmount());
+    root = null;
+    await settle();
+
+    await render("/api/projects/p/preview/assets/shared.mp4", 5);
+    // No second extraction, and the frames are on screen immediately.
+    expect(createdVideos).toHaveLength(1);
+    expect(host.querySelectorAll("img").length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/studio/src/player/components/VideoThumbnail.tsx
+++ b/packages/studio/src/player/components/VideoThumbnail.tsx
@@ -1,5 +1,11 @@
-import { memo, useRef, useState, useCallback, useEffect } from "react";
+import { memo, useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import {
+  extractVideoFrames,
+  mediaCacheKey,
+  thumbnailResolver,
+  type VideoFrames,
+} from "../lib/mediaResolver";
 import { computeThumbnailStrip, THUMBNAIL_CLIP_HEIGHT } from "./thumbnailUtils";
 
 interface VideoThumbnailProps {
@@ -11,6 +17,19 @@ interface VideoThumbnailProps {
 
 const CLIP_HEIGHT = THUMBNAIL_CLIP_HEIGHT;
 const MAX_UNIQUE_FRAMES: number = 6;
+const EMPTY: VideoFrames = { frames: [], aspect: 16 / 9 };
+
+/** Evenly spaced stops across the *clip's* duration, nudged off a black frame 0. */
+function stripTimestamps(duration: number): number[] {
+  const minSeek = Math.min(0.4, duration * 0.05);
+  const stops: number[] = [];
+  for (let i = 0; i < MAX_UNIQUE_FRAMES; i++) {
+    const raw =
+      MAX_UNIQUE_FRAMES === 1 ? duration * 0.15 : (i / (MAX_UNIQUE_FRAMES - 1)) * duration;
+    stops.push(Math.max(raw, minSeek));
+  }
+  return stops;
+}
 
 /**
  * Renders a film-strip of video frames extracted client-side via a hidden
@@ -23,14 +42,17 @@ export const VideoThumbnail = memo(function VideoThumbnail({
   labelColor,
   duration = 5,
 }: VideoThumbnailProps) {
+  // Keyed on (source, clip duration): two clips trimmed differently from one
+  // source derive different timestamps and must not share an entry. Memoised so
+  // scrub re-renders don't re-parse the URL.
+  const cacheKey = useMemo(() => mediaCacheKey(videoSrc, "strip", duration), [videoSrc, duration]);
   const [containerWidth, setContainerWidth] = useState(0);
   const [visible, setVisible] = useState(false);
-  const [frames, setFrames] = useState<string[]>([]);
+  const [strip, setStrip] = useState<VideoFrames>(() => thumbnailResolver.peek(cacheKey) ?? EMPTY);
   const [failed, setFailed] = useState(false);
-  const [aspect, setAspect] = useState(16 / 9);
+  const { frames, aspect } = strip;
   const ioRef = useRef<IntersectionObserver | null>(null);
   const roRef = useRef<ResizeObserver | null>(null);
-  const extractingRef = useRef(false);
 
   const setContainerRef = useCallback((el: HTMLDivElement | null) => {
     ioRef.current?.disconnect();
@@ -64,104 +86,48 @@ export const VideoThumbnail = memo(function VideoThumbnail({
     roRef.current?.disconnect();
   });
 
-  // Extract frames progressively — each frame appears as soon as it's ready.
-  // Note: useEffect with deps is acceptable — syncs with external video element API,
-  // requires cleanup (cancel extraction, revoke URLs) when inputs change.
+  // One extraction per (source, duration) across every mounted consumer; each
+  // frame still appears as soon as it's ready, via the resolver's partials.
+  // Note: useEffect with deps is acceptable — syncs with an external resolver,
+  // requires cleanup (ignore late results) when inputs change.
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
-    if (!visible || extractingRef.current) return;
-    extractingRef.current = true;
-
-    const video = document.createElement("video");
-    video.crossOrigin = "anonymous";
-    video.muted = true;
-    video.preload = "auto";
-
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      extractingRef.current = false;
-      return;
-    }
-
-    const timestamps: number[] = [];
-    const minSeek = Math.min(0.4, duration * 0.05);
-    for (let i = 0; i < MAX_UNIQUE_FRAMES; i++) {
-      const raw =
-        MAX_UNIQUE_FRAMES === 1 ? duration * 0.15 : (i / (MAX_UNIQUE_FRAMES - 1)) * duration;
-      timestamps.push(Math.max(raw, minSeek));
-    }
-
-    let idx = 0;
+    if (!visible) return;
     let cancelled = false;
 
-    const extractNext = () => {
-      if (cancelled || idx >= timestamps.length) {
-        if (!cancelled) {
-          video.src = "";
-          video.load();
-        }
-        return;
-      }
-      video.currentTime = timestamps[idx];
+    // Reset for the new inputs, seeding from cache so a re-mount or a re-keyed
+    // clip doesn't flash the shimmer for frames we already hold.
+    setStrip(thumbnailResolver.peek(cacheKey) ?? EMPTY);
+    setFailed(false);
+
+    const apply = (result: VideoFrames) => {
+      if (!cancelled) setStrip(result);
     };
 
-    video.addEventListener("loadedmetadata", () => {
-      if (video.videoWidth > 0 && video.videoHeight > 0) {
-        setAspect(video.videoWidth / video.videoHeight);
-        const h = CLIP_HEIGHT * 2;
-        const w = Math.round(h * (video.videoWidth / video.videoHeight));
-        canvas.width = w;
-        canvas.height = h;
-      }
-      extractNext();
-    });
-
-    video.addEventListener("seeked", () => {
-      if (cancelled) return;
-      let dataUrl: string;
-      try {
-        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-        dataUrl = canvas.toDataURL("image/jpeg", 0.6);
-      } catch {
-        // An external http(s) video served without CORS headers taints the
-        // canvas, so toDataURL throws a SecurityError. Stop the extractor
-        // cleanly and fall back to the no-thumbnail rendering (plain clip
-        // background), matching ImageThumbnail's error path — otherwise the
-        // shimmer placeholder would spin forever.
-        cancelled = true;
-        setFailed(true);
-        video.src = "";
-        video.load();
-        return;
-      }
-      // Stream each frame immediately
-      setFrames((prev) => [...prev, dataUrl]);
-      idx++;
-      extractNext();
-    });
-
-    video.addEventListener("error", () => {
-      // A no-CORS load fails outright (crossOrigin="anonymous" rejects a video
-      // served without CORS headers), firing this instead of the taint path in
-      // "seeked" — so 0 frames are ever extracted. Keep whatever frames we have,
-      // but mark failed so the shimmer placeholder stops spinning forever and we
-      // fall back to the plain clip background (#2214).
-      setFailed(true);
-    });
-
-    video.src = videoSrc;
-    video.load();
+    thumbnailResolver
+      .resolve(
+        cacheKey,
+        (emit) =>
+          extractVideoFrames(
+            videoSrc,
+            stripTimestamps(duration),
+            { frameHeight: CLIP_HEIGHT * 2, quality: 0.6 },
+            emit,
+          ),
+        apply,
+      )
+      .then(apply)
+      .catch(() => {
+        // A tainted canvas or a no-CORS load failure yields no usable strip.
+        // Mark failed so the shimmer stops spinning and the clip falls back to
+        // its plain background (#2214) instead of loading forever.
+        if (!cancelled) setFailed(true);
+      });
 
     return () => {
       cancelled = true;
-      extractingRef.current = false;
-      setFrames([]);
-      setFailed(false);
-      video.src = "";
-      video.load();
     };
-  }, [visible, videoSrc, duration]);
+  }, [visible, videoSrc, duration, cacheKey]);
 
   const { frameW, frameCount } = computeThumbnailStrip(containerWidth, aspect, CLIP_HEIGHT);
 

--- a/packages/studio/src/player/lib/mediaProbe.ts
+++ b/packages/studio/src/player/lib/mediaProbe.ts
@@ -1,16 +1,9 @@
-interface MediaProbeResult {
-  duration: number;
-  width?: number;
-  height?: number;
-  hasVideo: boolean;
-  hasAudio: boolean;
-}
-
-const cache = new Map<string, MediaProbeResult>();
-const inflight = new Map<string, Promise<MediaProbeResult | null>>();
-// URLs whose probe failed (CORS, 404, non-media). Remembered so the rAF-driven
-// timeline re-derive doesn't re-fetch them every frame and flood the console.
-const failed = new Set<string>();
+import {
+  mediaCacheKey,
+  metadataResolver,
+  normalizeMediaUrl,
+  type MediaProbeResult,
+} from "./mediaResolver";
 
 let mediabunnyModule: typeof import("mediabunny") | null | false = null;
 
@@ -26,17 +19,14 @@ async function loadMediabunny() {
   }
 }
 
-function normalizeUrl(url: string): string {
-  try {
-    return new URL(url, window.location.href).href;
-  } catch {
-    return url;
-  }
-}
-
-async function probeOne(url: string): Promise<MediaProbeResult | null> {
+/**
+ * Throws on anything that is not usable media. The resolver turns that into an
+ * expiring failure record, so a transient error is retried after the TTL
+ * instead of being remembered for the life of the tab.
+ */
+async function probeOne(url: string): Promise<MediaProbeResult> {
   const mb = await loadMediabunny();
-  if (!mb) return null;
+  if (!mb) throw new Error("mediaProbe: mediabunny unavailable");
 
   const input = new mb.Input({
     source: new mb.UrlSource(url),
@@ -44,28 +34,27 @@ async function probeOne(url: string): Promise<MediaProbeResult | null> {
   });
   try {
     const duration = await input.getDurationFromMetadata();
-    if (duration == null || !Number.isFinite(duration) || duration <= 0) return null;
+    if (duration == null || !Number.isFinite(duration) || duration <= 0) {
+      throw new Error(`mediaProbe: no usable duration for ${url}`);
+    }
 
     const videoTrack = await input.getPrimaryVideoTrack();
     const audioTracks = await input.getAudioTracks();
 
-    const result: MediaProbeResult = {
+    return {
       duration,
       width: videoTrack?.displayWidth,
       height: videoTrack?.displayHeight,
       hasVideo: videoTrack != null,
       hasAudio: audioTracks.length > 0,
     };
-    return result;
-  } catch {
-    return null;
   } finally {
     input.dispose();
   }
 }
 
 function getCachedProbe(url: string): MediaProbeResult | undefined {
-  return cache.get(normalizeUrl(url));
+  return metadataResolver.peek(mediaCacheKey(url));
 }
 
 /**
@@ -90,7 +79,8 @@ export function applyCachedSourceDurations<
 /**
  * Probe (header-only, cheap) any media elements still missing sourceDuration
  * after the cache pass, applying each resolved duration via `apply(key, secs)`.
- * Skips already-cached srcs.
+ * Skips already-cached srcs and srcs whose last probe failed within the TTL, so
+ * the rAF-driven timeline re-derive neither re-fetches nor floods the console.
  */
 export async function probeMissingSourceDurations<
   T extends { src?: string; tag: string; sourceDuration?: number; key?: string; id: string },
@@ -101,7 +91,7 @@ export async function probeMissingSourceDurations<
       el.sourceDuration == null &&
       ["video", "audio"].includes(el.tag.toLowerCase()) &&
       !getCachedProbe(el.src) &&
-      !failed.has(normalizeUrl(el.src)),
+      !metadataResolver.hasFreshFailure(mediaCacheKey(el.src)),
   );
   if (needs.length === 0) return;
   await Promise.allSettled(
@@ -113,20 +103,11 @@ export async function probeMissingSourceDurations<
 }
 
 async function probeMediaUrl(url: string): Promise<MediaProbeResult | null> {
-  const key = normalizeUrl(url);
-  const cached = cache.get(key);
-  if (cached) return cached;
-  if (failed.has(key)) return null;
-
-  let pending = inflight.get(key);
-  if (pending) return pending;
-
-  pending = probeOne(key).then((result) => {
-    inflight.delete(key);
-    if (result) cache.set(key, result);
-    else failed.add(key);
-    return result;
-  });
-  inflight.set(key, pending);
-  return pending;
+  try {
+    return await metadataResolver.resolve(mediaCacheKey(url), () =>
+      probeOne(normalizeMediaUrl(url)),
+    );
+  } catch {
+    return null;
+  }
 }

--- a/packages/studio/src/player/lib/mediaResolver.test.ts
+++ b/packages/studio/src/player/lib/mediaResolver.test.ts
@@ -1,0 +1,293 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMediaResolver,
+  extractVideoFrames,
+  mediaCacheKey,
+  type MediaResolver,
+} from "./mediaResolver";
+import { stubVideoExtraction } from "./mediaResolver.testHelpers";
+
+/** Drain the microtask queue so queued `produce` calls have actually started. */
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+/** A produce fn that counts calls and resolves only when told to. */
+function deferredProducer<T>() {
+  let calls = 0;
+  const settlers: Array<{ resolve: (v: T) => void; reject: (e: unknown) => void }> = [];
+  const produce = () => {
+    calls++;
+    return new Promise<T>((resolve, reject) => settlers.push({ resolve, reject }));
+  };
+  return {
+    produce,
+    settlers,
+    get calls() {
+      return calls;
+    },
+  };
+}
+
+function makeResolver<T>(overrides: Partial<Parameters<typeof createMediaResolver>[0]> = {}) {
+  return createMediaResolver<T>({
+    maxEntries: 64,
+    concurrency: 8,
+    failureTtlMs: 30_000,
+    ...overrides,
+  });
+}
+
+describe("mediaCacheKey", () => {
+  it("normalizes relative and absolute forms of one source to one key", () => {
+    expect(mediaCacheKey("/a/clip.mp4")).toBe(mediaCacheKey(`${location.origin}/a/clip.mp4`));
+  });
+
+  it("keys on (src, duration), not src alone", () => {
+    expect(mediaCacheKey("/a/clip.mp4", "strip", 5)).not.toBe(
+      mediaCacheKey("/a/clip.mp4", "strip", 12),
+    );
+  });
+});
+
+describe("createMediaResolver", () => {
+  let resolver: MediaResolver<string>;
+
+  beforeEach(() => {
+    resolver = makeResolver<string>();
+  });
+
+  it("seven consumers of one source at one duration produce ONE fetch", async () => {
+    const src = deferredProducer<string>();
+    const key = mediaCacheKey("/a/clip.mp4", "strip", 5);
+
+    const results = Array.from({ length: 7 }, () => resolver.resolve(key, src.produce));
+    expect(src.calls).toBe(0); // not started until the concurrency slot is taken
+    await flush();
+    expect(src.calls).toBe(1);
+
+    src.settlers[0].resolve("frames");
+    expect(await Promise.all(results)).toEqual(Array(7).fill("frames"));
+    expect(src.calls).toBe(1);
+
+    // An eighth consumer arriving after the fact is served from cache.
+    expect(await resolver.resolve(key, src.produce)).toBe("frames");
+    expect(src.calls).toBe(1);
+  });
+
+  it("two consumers at DIFFERENT durations get different frame sets", async () => {
+    const calls: string[] = [];
+    const produceFor = (label: string) => async () => {
+      calls.push(label);
+      return `frames:${label}`;
+    };
+
+    const short = await resolver.resolve(
+      mediaCacheKey("/a/clip.mp4", "strip", 5),
+      produceFor("5s"),
+    );
+    const long = await resolver.resolve(
+      mediaCacheKey("/a/clip.mp4", "strip", 12),
+      produceFor("12s"),
+    );
+
+    expect(short).toBe("frames:5s");
+    expect(long).toBe("frames:12s");
+    expect(calls).toEqual(["5s", "12s"]);
+  });
+
+  it("a request arriving mid-flight joins it and receives its partials", async () => {
+    const key = mediaCacheKey("/a/clip.mp4", "strip", 5);
+    let emitPartial: ((v: string) => void) | undefined;
+    const src = deferredProducer<string>();
+
+    const first: string[] = [];
+    const firstPromise = resolver.resolve(
+      key,
+      (emit) => {
+        emitPartial = emit;
+        return src.produce();
+      },
+      (p) => first.push(p),
+    );
+    await flush();
+    emitPartial!("frame-1");
+
+    // Joiner: no second produce, and it is handed the latest partial at once.
+    const late: string[] = [];
+    const latePromise = resolver.resolve(key, src.produce, (p) => late.push(p));
+    expect(src.calls).toBe(1);
+    expect(late).toEqual(["frame-1"]);
+
+    emitPartial!("frame-2");
+    src.settlers[0].resolve("frame-final");
+
+    expect(await firstPromise).toBe("frame-final");
+    expect(await latePromise).toBe("frame-final");
+    expect(first).toEqual(["frame-1", "frame-2"]);
+    expect(late).toEqual(["frame-1", "frame-2"]);
+  });
+
+  it("does not break a later request after every consumer has gone away", async () => {
+    const key = mediaCacheKey("/a/clip.mp4", "strip", 5);
+    const src = deferredProducer<string>();
+
+    // Consumers mount, then unmount without ever awaiting the result.
+    void resolver.resolve(key, src.produce, () => {}).catch(() => {});
+    void resolver.resolve(key, src.produce, () => {}).catch(() => {});
+    await flush();
+    src.settlers[0].resolve("frames");
+    await flush();
+
+    // A fresh consumer later gets the value with no extra work.
+    expect(await resolver.resolve(key, src.produce)).toBe("frames");
+    expect(src.calls).toBe(1);
+  });
+
+  describe("failure TTL", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("retries a failed resolution after the TTL rather than caching it forever", async () => {
+      const ttlResolver = makeResolver<string>({ failureTtlMs: 30_000 });
+      const key = mediaCacheKey("/a/broken.mp4");
+      let calls = 0;
+      const produce = async () => {
+        calls++;
+        if (calls === 1) throw new Error("boom");
+        return "recovered";
+      };
+
+      await expect(ttlResolver.resolve(key, produce)).rejects.toThrow("boom");
+      expect(ttlResolver.hasFreshFailure(key)).toBe(true);
+
+      // Inside the TTL: rejected without touching the network again.
+      vi.advanceTimersByTime(29_000);
+      await expect(ttlResolver.resolve(key, produce)).rejects.toThrow("boom");
+      expect(calls).toBe(1);
+
+      // Past the TTL: retried, and it succeeds.
+      vi.advanceTimersByTime(2_000);
+      expect(ttlResolver.hasFreshFailure(key)).toBe(false);
+      await expect(ttlResolver.resolve(key, produce)).resolves.toBe("recovered");
+      expect(calls).toBe(2);
+    });
+  });
+
+  it("evicts the least-recently-used entry past the bound and refetches it later", async () => {
+    const lru = makeResolver<string>({ maxEntries: 2 });
+    const calls: string[] = [];
+    const produceFor = (label: string) => async () => {
+      calls.push(label);
+      return label;
+    };
+
+    await lru.resolve("a", produceFor("a"));
+    await lru.resolve("b", produceFor("b"));
+    // Touch "a" so "b" becomes the least-recently-used of the two.
+    expect(lru.peek("a")).toBe("a");
+    await lru.resolve("c", produceFor("c"));
+
+    expect(lru.peek("b")).toBeUndefined();
+    expect(lru.peek("a")).toBe("a");
+    expect(lru.peek("c")).toBe("c");
+
+    // The evicted entry is refetched on the next request; the kept one is not.
+    await lru.resolve("b", produceFor("b"));
+    await lru.resolve("c", produceFor("c"));
+    expect(calls).toEqual(["a", "b", "c", "b"]);
+  });
+
+  it("runs at most `concurrency` producers at once", async () => {
+    const capped = makeResolver<string>({ concurrency: 2 });
+    const src = deferredProducer<string>();
+
+    const pending = ["k1", "k2", "k3", "k4", "k5"].map((k) => capped.resolve(k, src.produce));
+    await flush();
+    expect(src.calls).toBe(2);
+
+    // Draining one slot admits exactly one more.
+    src.settlers[0].resolve("one");
+    await flush();
+    expect(src.calls).toBe(3);
+
+    src.settlers[1].resolve("two");
+    src.settlers[2].resolve("three");
+    await flush();
+    expect(src.calls).toBe(5);
+
+    src.settlers[3].resolve("four");
+    src.settlers[4].resolve("five");
+    await Promise.all(pending);
+  });
+});
+
+describe("extractVideoFrames", () => {
+  let createdVideos: HTMLVideoElement[];
+
+  beforeEach(() => {
+    createdVideos = stubVideoExtraction();
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/jpeg;base64,A");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a partial per seek and resolves with every requested frame", async () => {
+    const partials: number[] = [];
+    const done = extractVideoFrames("/a/clip.mp4", [0.4, 1, 2], { quality: 0.6 }, (p) =>
+      partials.push(p.frames.length),
+    );
+    const video = createdVideos.at(-1)!;
+    video.dispatchEvent(new Event("loadedmetadata"));
+    video.dispatchEvent(new Event("seeked"));
+    video.dispatchEvent(new Event("seeked"));
+    video.dispatchEvent(new Event("seeked"));
+
+    const result = await done;
+    expect(result.frames).toHaveLength(3);
+    expect(partials).toEqual([1, 2, 3]);
+  });
+
+  it("derives timestamps from the source duration when given a function", async () => {
+    const seeks: number[] = [];
+    const done = extractVideoFrames("/a/clip.mp4", (d) => [d * 0.1], { quality: 0.7 });
+    const video = createdVideos.at(-1)!;
+    Object.defineProperty(video, "duration", { value: 30, configurable: true });
+    let assigned = 0;
+    Object.defineProperty(video, "currentTime", {
+      configurable: true,
+      get: () => assigned,
+      set: (v: number) => {
+        assigned = v;
+        seeks.push(v);
+      },
+    });
+
+    video.dispatchEvent(new Event("loadedmetadata"));
+    video.dispatchEvent(new Event("seeked"));
+    await done;
+    expect(seeks).toEqual([3]);
+  });
+
+  it("rejects when the load errors so the caller records an expiring failure", async () => {
+    const done = extractVideoFrames("/a/no-cors.mp4", [0.4], { quality: 0.6 });
+    createdVideos.at(-1)!.dispatchEvent(new Event("error"));
+    await expect(done).rejects.toThrow(/video load failed/);
+  });
+
+  it("rejects when the canvas is tainted", async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockImplementation(() => {
+      throw new DOMException("Tainted canvases may not be exported.", "SecurityError");
+    });
+    const done = extractVideoFrames("/a/no-cors.mp4", [0.4], { quality: 0.6 });
+    const video = createdVideos.at(-1)!;
+    video.dispatchEvent(new Event("loadedmetadata"));
+    video.dispatchEvent(new Event("seeked"));
+    await expect(done).rejects.toThrow(/Tainted/);
+  });
+});

--- a/packages/studio/src/player/lib/mediaResolver.testHelpers.ts
+++ b/packages/studio/src/player/lib/mediaResolver.testHelpers.ts
@@ -1,0 +1,23 @@
+import { vi } from "vitest";
+
+/**
+ * happy-dom's `<video>` / `<canvas>` don't decode media, so stub the seams
+ * `extractVideoFrames` depends on and hand back every hidden `<video>` it
+ * creates — the request count under test.
+ *
+ * Call from `beforeEach`; the mocks come off with `vi.restoreAllMocks()`.
+ */
+export function stubVideoExtraction(): HTMLVideoElement[] {
+  const createdVideos: HTMLVideoElement[] = [];
+  const origCreate = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    const el = origCreate(tag);
+    if (tag === "video") createdVideos.push(el as HTMLVideoElement);
+    return el;
+  });
+  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+    drawImage: () => {},
+  } as unknown as CanvasRenderingContext2D);
+  return createdVideos;
+}

--- a/packages/studio/src/player/lib/mediaResolver.ts
+++ b/packages/studio/src/player/lib/mediaResolver.ts
@@ -1,0 +1,312 @@
+import { TIMELINE_VIEWPORT_BUDGETS as BUDGETS } from "./timelineViewportBudgets";
+
+/**
+ * One media resolution layer for the Studio document.
+ *
+ * Generalises the `peaksCache` / `decodeInFlight` pair `AudioWaveform` already
+ * had: in-flight dedup keyed by normalized URL, a bounded LRU, an expiring
+ * failure record, and a concurrency cap. The two thumbnail extractors gain what
+ * neither had, and `mediaProbe` retires its never-expiring `failed` Set.
+ *
+ * Scope: this only dedups traffic issued *by the Studio document*. Requests
+ * issued by `<audio src>` / `<video src>` inside the preview iframe are not
+ * reachable from here and are not affected.
+ */
+
+/** Publish an intermediate value to everyone waiting on the same key. */
+export type Emit<T> = (partial: T) => void;
+
+/** Does the actual work. `emit` is optional progress; the resolved value wins. */
+export type Produce<T> = (emit: Emit<T>) => Promise<T>;
+
+export interface MediaResolverConfig {
+  /** LRU bound on resolved values (and, separately, on failure records). */
+  maxEntries: number;
+  /** Max `produce` calls running at once. */
+  concurrency: number;
+  /** How long a rejected key stays rejected before it is retried. */
+  failureTtlMs: number;
+}
+
+export interface MediaResolver<T> {
+  resolve(key: string, produce: Produce<T>, onPartial?: Emit<T>): Promise<T>;
+  /** Resolved value if cached (marks it most-recently-used), else undefined. */
+  peek(key: string): T | undefined;
+  /** True while a past failure for `key` is still inside the TTL. */
+  hasFreshFailure(key: string): boolean;
+  /** Test seam — drops every cache, failure record and partial. */
+  reset(): void;
+}
+
+/** Absolute URL so `./a.mp4` and `/dir/a.mp4` share one cache entry. */
+export function normalizeMediaUrl(url: string): string {
+  try {
+    return new URL(url, window.location.href).href;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Cache key. Extra parts matter: `VideoThumbnail` derives its timestamps from
+ * the *clip's* duration, so two clips trimmed differently from one source need
+ * different frames and must not share an entry.
+ */
+export function mediaCacheKey(src: string, ...parts: Array<string | number>): string {
+  return [normalizeMediaUrl(src), ...parts].join("|");
+}
+
+function trim<K, V>(map: Map<K, V>, max: number): void {
+  while (map.size > max) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}
+
+export function createMediaResolver<T>(config: MediaResolverConfig): MediaResolver<T> {
+  const { maxEntries, concurrency, failureTtlMs } = config;
+  // Map iteration order is insertion order, so re-inserting on read gives LRU.
+  const cache = new Map<string, T>();
+  const failures = new Map<string, { at: number; error: unknown }>();
+  const inflight = new Map<string, Promise<T>>();
+  const subscribers = new Map<string, Set<Emit<T>>>();
+  const partials = new Map<string, T>();
+
+  let active = 0;
+  const waiters: Array<() => void> = [];
+  const acquire = async (): Promise<void> => {
+    if (active < concurrency) {
+      active++;
+      return;
+    }
+    // The releasing slot is handed straight over, so `active` stays capped.
+    await new Promise<void>((r) => waiters.push(r));
+  };
+  const release = (): void => {
+    const next = waiters.shift();
+    if (next) next();
+    else active--;
+  };
+
+  function peek(key: string): T | undefined {
+    const value = cache.get(key);
+    if (value === undefined) return undefined;
+    cache.delete(key);
+    cache.set(key, value);
+    return value;
+  }
+
+  function hasFreshFailure(key: string): boolean {
+    const failure = failures.get(key);
+    if (!failure) return false;
+    if (Date.now() - failure.at < failureTtlMs) return true;
+    failures.delete(key);
+    return false;
+  }
+
+  function resolve(key: string, produce: Produce<T>, onPartial?: Emit<T>): Promise<T> {
+    const cached = peek(key);
+    if (cached !== undefined) return Promise.resolve(cached);
+
+    if (hasFreshFailure(key)) return Promise.reject(failures.get(key)?.error);
+
+    const pending = inflight.get(key);
+    if (pending) {
+      if (onPartial) {
+        subscribers.get(key)?.add(onPartial);
+        const partial = partials.get(key);
+        if (partial !== undefined) onPartial(partial);
+      }
+      return pending;
+    }
+
+    const listeners = new Set<Emit<T>>();
+    if (onPartial) listeners.add(onPartial);
+    subscribers.set(key, listeners);
+
+    const emit: Emit<T> = (partial) => {
+      partials.set(key, partial);
+      for (const listener of listeners) listener(partial);
+    };
+
+    const promise = (async () => {
+      await acquire();
+      try {
+        const value = await produce(emit);
+        cache.delete(key);
+        cache.set(key, value);
+        trim(cache, maxEntries);
+        return value;
+      } catch (error) {
+        failures.set(key, { at: Date.now(), error });
+        trim(failures, maxEntries);
+        throw error;
+      } finally {
+        release();
+        inflight.delete(key);
+        subscribers.delete(key);
+        partials.delete(key);
+      }
+    })();
+
+    inflight.set(key, promise);
+    return promise;
+  }
+
+  return {
+    resolve,
+    peek,
+    hasFreshFailure,
+    reset() {
+      cache.clear();
+      failures.clear();
+      inflight.clear();
+      subscribers.clear();
+      partials.clear();
+      // Also free the concurrency slots — abandoned in-flight work from a
+      // previous test would otherwise hold them forever.
+      active = 0;
+      waiters.length = 0;
+    },
+  };
+}
+
+export interface VideoFrames {
+  /** JPEG data URLs, one per requested timestamp, in order. */
+  frames: string[];
+  /** Source display aspect ratio (width / height). */
+  aspect: number;
+}
+
+interface ExtractOptions {
+  /** Canvas height in px. Omit to capture at the source's native height. */
+  frameHeight?: number;
+  /** JPEG quality passed to `toDataURL`. */
+  quality: number;
+}
+
+const DEFAULT_ASPECT = 16 / 9;
+
+/**
+ * The single client-side frame extractor: one hidden `<video>` + `<canvas>`,
+ * seeked to each timestamp in turn. `timestamps` may be a function when the
+ * choice depends on the source's own duration (known only after metadata).
+ *
+ * Rejects on a load error or a tainted canvas so the caller's resolver records
+ * an expiring failure instead of retrying forever.
+ */
+export function extractVideoFrames(
+  src: string,
+  timestamps: number[] | ((sourceDuration: number) => number[]),
+  options: ExtractOptions,
+  emit?: Emit<VideoFrames>,
+): Promise<VideoFrames> {
+  return new Promise<VideoFrames>((resolveFrames, reject) => {
+    const video = document.createElement("video");
+    video.crossOrigin = "anonymous";
+    video.muted = true;
+    video.preload = "auto";
+
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      reject(new Error("mediaResolver: no 2d canvas context"));
+      return;
+    }
+
+    const frames: string[] = [];
+    let stops: number[] = Array.isArray(timestamps) ? timestamps : [];
+    let aspect = DEFAULT_ASPECT;
+    let index = 0;
+    let settled = false;
+
+    const teardown = () => {
+      video.src = "";
+      video.load();
+    };
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      teardown();
+      resolveFrames({ frames, aspect });
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      teardown();
+      reject(error);
+    };
+    const seekNext = () => {
+      if (settled) return;
+      const next = stops[index];
+      if (next === undefined) {
+        finish();
+        return;
+      }
+      video.currentTime = next;
+    };
+
+    video.addEventListener("loadedmetadata", () => {
+      if (video.videoWidth > 0 && video.videoHeight > 0) {
+        aspect = video.videoWidth / video.videoHeight;
+        canvas.height = options.frameHeight ?? video.videoHeight;
+        canvas.width = Math.round(canvas.height * aspect);
+      }
+      if (!Array.isArray(timestamps)) stops = timestamps(video.duration);
+      seekNext();
+    });
+
+    video.addEventListener("seeked", () => {
+      if (settled) return;
+      try {
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        frames.push(canvas.toDataURL("image/jpeg", options.quality));
+      } catch (error) {
+        // An external video served without CORS headers taints the canvas and
+        // toDataURL throws SecurityError. Stop rather than spin.
+        fail(error);
+        return;
+      }
+      emit?.({ frames: [...frames], aspect });
+      index++;
+      seekNext();
+    });
+
+    video.addEventListener("error", () => {
+      fail(new Error(`mediaResolver: video load failed for ${src}`));
+    });
+
+    video.src = src;
+    video.load();
+  });
+}
+
+/** Frame strips and posters — one entry per `(source, timestamps)` pair. */
+export const thumbnailResolver = createMediaResolver<VideoFrames>({
+  maxEntries: BUDGETS.thumbnailCacheEntries,
+  concurrency: BUDGETS.concurrentVideoDecodes,
+  failureTtlMs: BUDGETS.metadataFailureTtlMs,
+});
+
+/** Decoded audio peaks. */
+export const waveformResolver = createMediaResolver<number[]>({
+  maxEntries: BUDGETS.waveformCacheEntries,
+  concurrency: BUDGETS.concurrentVideoDecodes,
+  failureTtlMs: BUDGETS.metadataFailureTtlMs,
+});
+
+export interface MediaProbeResult {
+  duration: number;
+  width?: number;
+  height?: number;
+  hasVideo: boolean;
+  hasAudio: boolean;
+}
+
+/** Container/track metadata probes — header reads, so a wider lane. */
+export const metadataResolver = createMediaResolver<MediaProbeResult>({
+  maxEntries: BUDGETS.metadataRegistryEntries,
+  concurrency: BUDGETS.concurrentMetadataJobs,
+  failureTtlMs: BUDGETS.metadataFailureTtlMs,
+});


### PR DESCRIPTION
Thumbnails, waveforms, and media probes each resolved media independently, with three near-duplicate code paths for the same job. They now share one resolver.

**This is a replacement, not an addition.** The diff reads as 900 added / 256 removed, but the added lines subsume the removed ones — read it as one layer replacing three, not as new surface area.

**681 logic lines**, the second-heaviest review in this sequence.

## What changes for callers

Each of the three consumers previously constructed its own shape from raw probe output. They now receive that shape from the resolver. The consumer-side diffs are mostly deletions.

## What to check

The failure path is the part worth reading closely. A failed resolution surfaces to the caller rather than being swallowed into a placeholder — the old paths differed on this, and the consolidated one had to pick a behaviour. It picks surfacing.

The other is cancellation: resolution is cancelled cleanly when its consumer unmounts mid-flight, which matters because thumbnails mount and unmount constantly under timeline virtualization.

## Related

A follow-up PR stacked on this one adds request de-duplication on top of this layer (each media source fetched once rather than once per referencing clip). That is where the request-volume numbers come from; this PR is the structural precondition and claims no measurement of its own.

## Verification

`packages/studio` suite green (3,288 tests). Thumbnails and waveforms render in a real project.
