### PR TITLE
perf(studio): fetch each media source once, and enforce the timeline budgets

### DIFF
--- a/packages/player/src/parent-media.test.ts
+++ b/packages/player/src/parent-media.test.ts
@@ -162,3 +162,56 @@ describe("ParentMediaManager audio-src proxy lifecycle", () => {
     expect(mgr.entries[0]).toBe(adopted);
   });
 });
+
+describe("ParentMediaManager adopted-proxy preloading", () => {
+  /** A document holding one timed `<audio>` the runtime has promoted to load. */
+  function iframeDocWithPromotedAudio(src: string): Document {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const doc = iframe.contentDocument!;
+    const audio = doc.createElement("audio");
+    audio.setAttribute("data-start", "0");
+    audio.setAttribute("data-duration", "5");
+    audio.preload = "auto";
+    audio.src = src;
+    doc.body.appendChild(audio);
+    return doc;
+  }
+
+  it("adopts iframe media without preloading a second copy of the file", () => {
+    const mgr = makeManager();
+    mgr.setupFromIframe(iframeDocWithPromotedAudio("https://example.test/track.mp3"));
+
+    expect(mgr.entries).toHaveLength(1);
+    // The iframe is already fetching this file and nothing reads the proxy
+    // until parent ownership; a second download here is pure waste.
+    expect(mgr.entries[0].el.preload).toBe("none");
+  });
+
+  it("loads the adopted proxies when it takes audio ownership", () => {
+    const mgr = makeManager();
+    mgr.setupFromIframe(iframeDocWithPromotedAudio("https://example.test/track.mp3"));
+    expect(mgr.entries[0].el.preload).toBe("none");
+
+    mgr.promoteToParentProxy(null);
+
+    expect(mgr.audioOwner).toBe("parent");
+    expect(mgr.entries[0].el.preload).toBe("auto");
+  });
+
+  it("preloads media adopted while the parent already owns audio", () => {
+    const mgr = makeManager();
+    mgr.promoteToParentProxy(null);
+    mgr.setupFromIframe(iframeDocWithPromotedAudio("https://example.test/late.mp3"));
+
+    // No iframe output to mirror any more — this proxy is the audible one.
+    expect(mgr.entries[0].el.preload).toBe("auto");
+  });
+
+  it("still preloads the audio-src proxy, which has no iframe copy", () => {
+    const mgr = makeManager();
+    mgr.setupFromUrl("https://example.test/soundtrack.mp3");
+
+    expect(mgr.entries[0].el.preload).toBe("auto");
+  });
+});

--- a/packages/player/src/parent-media.ts
+++ b/packages/player/src/parent-media.ts
@@ -128,6 +128,13 @@ export class ParentMediaManager {
     for (const m of this._entries) m.el.playbackRate = rate;
   }
 
+  /** Start fetching a deferred proxy. Idempotent. */
+  private _loadEntry(m: ProxyEntry): void {
+    if (m.el.preload === "auto") return;
+    m.el.preload = "auto";
+    m.el.load();
+  }
+
   private _playEntry(m: ProxyEntry): void {
     if (!m.el.src) return;
     m.el.play().catch((err: unknown) => this._reportPlaybackError(err));
@@ -256,6 +263,10 @@ export class ParentMediaManager {
     if (this._audioOwner === "parent") return;
     this._audioOwner = "parent";
 
+    // Adopted proxies were created unloaded (see `_createEntry`). This is the
+    // moment they become the audible output, so this is where they load.
+    for (const m of this._entries) this._loadEntry(m);
+
     // Synchronously mute iframe media to close the race window.
     if (iframeDoc) {
       for (const el of iframeDoc.querySelectorAll("video, audio")) {
@@ -341,8 +352,19 @@ export class ParentMediaManager {
   }
 
   /**
-   * Create a parent-frame media element and start preloading it. Returns the
-   * new entry, or `null` if a proxy for this src already exists (dedup).
+   * Create a parent-frame media element. Returns the new entry, or `null` if a
+   * proxy for this src already exists (dedup).
+   *
+   * An ADOPTED proxy mirrors a file the iframe is already fetching, and every
+   * path that reads it — playAll, seekAll, scrubAll, mirrorTime — is gated on
+   * parent audio ownership. Preloading it at adopt time therefore fetched every
+   * media file in the composition a second time for a fallback most sessions
+   * never take. It is created unloaded; `promoteToParentProxy` loads the
+   * proxies at the one moment they start mattering.
+   *
+   * A URL-driven proxy (`setupFromUrl`) has no iframe copy — it IS the audio —
+   * so it still preloads eagerly. So does an adoption that happens while the
+   * parent already owns audio: that proxy is needed now.
    */
   private _createEntry(
     src: string,
@@ -354,9 +376,10 @@ export class ParentMediaManager {
     if (this._entries.some((m) => m.el.src === src)) return null;
 
     const el = tag === "video" ? document.createElement("video") : new Audio();
-    el.preload = "auto";
+    const deferred = source != null && this._audioOwner === "runtime";
+    el.preload = deferred ? "none" : "auto";
     el.src = src;
-    el.load();
+    if (!deferred) el.load();
     el.muted = this._getMuted();
     el.volume = this._getVolume();
     const rate = this._getPlaybackRate();

--- a/packages/studio/src/hooks/useMusicBeatAnalysis.ts
+++ b/packages/studio/src/hooks/useMusicBeatAnalysis.ts
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef } from "react";
 import { usePlayerStore } from "../player/store/playerStore";
 import { resolveBeatSourceTrack } from "../utils/timelineInspector";
-import { analyzeMusicFromUrl } from "@hyperframes/core/beats";
+import { analyzeMusicFromBuffer, type MusicBeatAnalysis } from "@hyperframes/core/beats";
+import { decodeAudioFromUrl } from "../player/lib/mediaResolver";
 import { useFileManagerContextOptional } from "../contexts/FileManagerContext";
 import { mergeUserBeats } from "../utils/beatEditing";
 import {
@@ -13,12 +14,15 @@ import {
 
 // Module-level cache so the same URL isn't re-decoded/analyzed on re-mount.
 // Capped so decoded PCM buffers don't accumulate unbounded across a session.
-const analysisCache = new Map<string, ReturnType<typeof analyzeMusicFromUrl>>();
+// The *download* is not deduped here: `decodeAudioFromUrl` shares one fetch per
+// source with every other Studio consumer of the same file (the waveform
+// decoder, chiefly), which this cache — private to beat analysis — cannot.
+const analysisCache = new Map<string, Promise<MusicBeatAnalysis>>();
 const MAX_ANALYSIS_CACHE = 4;
 
 const PERSIST_DEBOUNCE_MS = 350;
 
-function cacheAnalysis(url: string, promise: ReturnType<typeof analyzeMusicFromUrl>): void {
+function cacheAnalysis(url: string, promise: Promise<MusicBeatAnalysis>): void {
   analysisCache.set(url, promise);
   while (analysisCache.size > MAX_ANALYSIS_CACHE) {
     const oldest = analysisCache.keys().next().value;
@@ -63,8 +67,6 @@ async function readHasSavedBeats(io: ProjectIo, beatPath: string): Promise<boole
   }
 }
 
-type MusicAnalysis = Awaited<ReturnType<typeof analyzeMusicFromUrl>>;
-
 /**
  * Analyze a track (memoized per URL) and fold in any saved beat edits. Null on
  * decode/analysis failure — the caller then clears state and drops the cache
@@ -74,10 +76,10 @@ async function loadBeatAnalysis(
   musicSrc: string,
   beatPath: string,
   io: ProjectIo,
-): Promise<{ analysis: MusicAnalysis; times: number[]; strengths: number[] } | null> {
+): Promise<{ analysis: MusicBeatAnalysis; times: number[]; strengths: number[] } | null> {
   let promise = analysisCache.get(musicSrc);
   if (!promise) {
-    promise = analyzeMusicFromUrl(musicSrc);
+    promise = decodeAudioFromUrl(musicSrc).then(analyzeMusicFromBuffer);
     cacheAnalysis(musicSrc, promise);
   }
   try {

--- a/packages/studio/src/player/components/AudioWaveform.tsx
+++ b/packages/studio/src/player/components/AudioWaveform.tsx
@@ -1,5 +1,5 @@
 import { memo, useRef, useState, useCallback, useEffect, useMemo } from "react";
-import { mediaCacheKey, waveformResolver } from "../lib/mediaResolver";
+import { decodeAudioFromUrl, mediaCacheKey, waveformResolver } from "../lib/mediaResolver";
 
 interface AudioWaveformProps {
   audioUrl: string;
@@ -79,9 +79,7 @@ async function decodeWaveformPeaks(
       if (!Array.isArray(data.peaks)) throw new Error("bad response");
       return data.peaks;
     }
-    const buf = await fetch(audioUrl).then((r) => r.arrayBuffer());
-    const ctx = new AudioContext();
-    const decoded = await ctx.decodeAudioData(buf).finally(() => ctx.close());
+    const decoded = await decodeAudioFromUrl(audioUrl);
     return extractPeaks(decoded.getChannelData(0), PEAK_COUNT);
   } catch {
     return fakePeaks(seed, PEAK_COUNT);

--- a/packages/studio/src/player/lib/mediaProbe.test.ts
+++ b/packages/studio/src/player/lib/mediaProbe.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyCachedSourceDurations, probeMissingSourceDurations } from "./mediaProbe";
+import { metadataResolver } from "./mediaResolver";
+
+/**
+ * These cover ONE property: a media file is read from the network at most once
+ * by the Studio document, no matter how many clips reference it and no matter
+ * that the preview iframe is downloading it too.
+ *
+ * `mediabunny` is stubbed so every probe is observable (the URL it was handed)
+ * and fails fast — the real one retries a dead URL with backoff.
+ */
+const probed = vi.hoisted(() => [] as string[]);
+
+vi.mock("mediabunny", () => {
+  class UrlSource {
+    constructor(public url: string) {
+      probed.push(url);
+    }
+  }
+  class Input {
+    constructor(_options: unknown) {}
+    getDurationFromMetadata(): Promise<number> {
+      return Promise.reject(new Error("probe stubbed"));
+    }
+    dispose(): void {}
+  }
+  return { UrlSource, Input, ALL_FORMATS: [] };
+});
+
+type Element = {
+  id: string;
+  tag: string;
+  src?: string;
+  sourceDuration?: number;
+  sourceDurationPending?: boolean;
+};
+
+const clip = (id: string, src: string, extra: Partial<Element> = {}): Element => ({
+  id,
+  tag: "video",
+  src,
+  ...extra,
+});
+
+/** Distinct files the probe actually asked the network for. */
+const probedFiles = () => [...new Set(probed.map((url) => url.split("/").pop()))].sort();
+
+beforeEach(() => {
+  probed.length = 0;
+  metadataResolver.reset();
+});
+
+afterEach(() => {
+  metadataResolver.reset();
+});
+
+describe("probeMissingSourceDurations", () => {
+  it("probes a source nothing else is fetching", async () => {
+    await probeMissingSourceDurations([clip("a", "/assets/a.mp4")], () => {});
+
+    expect(probedFiles()).toEqual(["a.mp4"]);
+  });
+
+  it("skips a source the preview is already fetching", async () => {
+    await probeMissingSourceDurations(
+      [clip("a", "/assets/a.mp4", { sourceDurationPending: true })],
+      () => {},
+    );
+
+    expect(probedFiles()).toEqual([]);
+  });
+
+  it("skips every clip of a source when ANY clip of it is pending", async () => {
+    // The neighbourhood loader promotes one clip out of seven; its siblings
+    // carry no pending mark, and probing one of them downloads the same file.
+    await probeMissingSourceDurations(
+      [
+        clip("a1", "/assets/a.mp4", { sourceDurationPending: true }),
+        clip("a2", "/assets/a.mp4"),
+        clip("a3", "./assets/a.mp4"),
+        clip("b1", "/assets/b.mp4"),
+      ],
+      () => {},
+    );
+
+    expect(probedFiles()).toEqual(["b.mp4"]);
+  });
+});
+
+describe("applyCachedSourceDurations", () => {
+  it("seeds every clip of a source from the one clip that knows its duration", () => {
+    const seeded = applyCachedSourceDurations([
+      clip("a1", "/assets/a.mp4", { sourceDuration: 12 }),
+      clip("a2", "/assets/a.mp4"),
+      clip("a3", "./assets/a.mp4"),
+      clip("b1", "/assets/b.mp4"),
+    ]);
+
+    expect(seeded.map((el) => el.sourceDuration)).toEqual([12, 12, 12, undefined]);
+  });
+
+  it("leaves the seeded siblings out of the probe", async () => {
+    const seeded = applyCachedSourceDurations([
+      clip("a1", "/assets/a.mp4", { sourceDuration: 12 }),
+      clip("a2", "/assets/a.mp4"),
+    ]);
+    await probeMissingSourceDurations(seeded, () => {});
+
+    expect(probedFiles()).toEqual([]);
+  });
+
+  it("does not overwrite a clip that already carries its own duration", () => {
+    const seeded = applyCachedSourceDurations([
+      clip("a1", "/assets/a.mp4", { sourceDuration: 12 }),
+      clip("a2", "/assets/a.mp4", { sourceDuration: 30 }),
+    ]);
+
+    expect(seeded.map((el) => el.sourceDuration)).toEqual([12, 30]);
+  });
+});

--- a/packages/studio/src/player/lib/mediaProbe.ts
+++ b/packages/studio/src/player/lib/mediaProbe.ts
@@ -58,21 +58,30 @@ function getCachedProbe(url: string): MediaProbeResult | undefined {
 }
 
 /**
- * Re-apply the cached probe `sourceDuration` to media elements that arrive
- * without it. Re-deriving the timeline (e.g. after a clip move) produces fresh
- * objects whose duration the DOM scan may not have, and the async probe skips
- * already-cached srcs — so without this, trimmed waveforms lose their window.
+ * Re-apply a known `sourceDuration` to media elements that arrive without one.
+ *
+ * A duration belongs to the SOURCE, not to the clip, and one file typically
+ * backs many clips. Two things know it: the probe cache, and any sibling clip
+ * whose live preview element has already reported `duration`. Both seed every
+ * clip sharing that src — otherwise re-deriving the timeline (a clip move, or
+ * the neighbourhood loader promoting one clip out of seven) leaves the siblings
+ * unknown, which loses trimmed waveforms their window AND sends the probe to
+ * the network for a header the page already has.
  */
 export function applyCachedSourceDurations<
   T extends { src?: string; tag: string; sourceDuration?: number },
 >(elements: T[]): T[] {
+  const bySource = new Map<string, number>();
+  for (const el of elements) {
+    if (el.src && el.sourceDuration != null && el.sourceDuration > 0) {
+      bySource.set(normalizeMediaUrl(el.src), el.sourceDuration);
+    }
+  }
   return elements.map((el) => {
     const tag = el.tag.toLowerCase();
     if (!el.src || el.sourceDuration != null || (tag !== "audio" && tag !== "video")) return el;
-    const cached = getCachedProbe(el.src);
-    return cached?.duration && cached.duration > 0
-      ? { ...el, sourceDuration: cached.duration }
-      : el;
+    const known = bySource.get(normalizeMediaUrl(el.src)) ?? getCachedProbe(el.src)?.duration;
+    return known && known > 0 ? { ...el, sourceDuration: known } : el;
   });
 }
 
@@ -81,14 +90,39 @@ export function applyCachedSourceDurations<
  * after the cache pass, applying each resolved duration via `apply(key, secs)`.
  * Skips already-cached srcs and srcs whose last probe failed within the TTL, so
  * the rAF-driven timeline re-derive neither re-fetches nor floods the console.
+ *
+ * Also skips `sourceDurationPending` elements — the ones the runtime is already
+ * fetching for the preview. Probing those was the Studio document's single
+ * largest source of request amplification: every media file in the composition
+ * was downloaded once by the preview iframe and again here, to learn a number
+ * the preview's own `<video>.duration` reports for free a scan later. If that
+ * preview load fails, the element keeps no duration rather than gaining one
+ * from a second download that would fail the same way.
  */
 export async function probeMissingSourceDurations<
-  T extends { src?: string; tag: string; sourceDuration?: number; key?: string; id: string },
+  T extends {
+    src?: string;
+    tag: string;
+    sourceDuration?: number;
+    sourceDurationPending?: boolean;
+    key?: string;
+    id: string;
+  },
 >(elements: T[], apply: (key: string, durationSeconds: number) => void): Promise<void> {
+  // Per SOURCE, not per element: one file backs many clips, and the runtime
+  // only promotes the clips near the playhead. The siblings of a promoted clip
+  // carry no pending mark, and probing any one of them downloads the very file
+  // the promoted one is already fetching.
+  const pendingSources = new Set(
+    elements
+      .filter((el) => el.src && el.sourceDurationPending)
+      .map((el) => normalizeMediaUrl(el.src!)),
+  );
   const needs = elements.filter(
     (el) =>
       el.src &&
       el.sourceDuration == null &&
+      !pendingSources.has(normalizeMediaUrl(el.src)) &&
       ["video", "audio"].includes(el.tag.toLowerCase()) &&
       !getCachedProbe(el.src) &&
       !metadataResolver.hasFreshFailure(mediaCacheKey(el.src)),

--- a/packages/studio/src/player/lib/mediaResolver.test.ts
+++ b/packages/studio/src/player/lib/mediaResolver.test.ts
@@ -28,11 +28,21 @@ function deferredProducer<T>() {
   };
 }
 
-function makeResolver<T>(overrides: Partial<Parameters<typeof createMediaResolver>[0]> = {}) {
+interface ResolverOverrides<T> {
+  maxEntries?: number;
+  concurrency?: number;
+  failureTtlMs?: number;
+  maxBytes?: number;
+  sizeOf?: (value: T) => number;
+}
+
+function makeResolver<T>(overrides: ResolverOverrides<T> = {}) {
   return createMediaResolver<T>({
     maxEntries: 64,
     concurrency: 8,
     failureTtlMs: 30_000,
+    maxBytes: Number.POSITIVE_INFINITY,
+    sizeOf: () => 0,
     ...overrides,
   });
 }
@@ -199,6 +209,29 @@ describe("createMediaResolver", () => {
     await lru.resolve("b", produceFor("b"));
     await lru.resolve("c", produceFor("c"));
     expect(calls).toEqual(["a", "b", "c", "b"]);
+  });
+
+  it("evicts past the byte bound even when the entry count is nowhere near it", async () => {
+    // 100 entries allowed, but only ~3 of these fit in the byte bound.
+    const bounded = makeResolver<string>({
+      maxEntries: 100,
+      maxBytes: 30,
+      sizeOf: (value) => value.length,
+    });
+    const produceFor = (label: string) => async () => label.repeat(10); // 10 bytes
+
+    await bounded.resolve("a", produceFor("a"));
+    await bounded.resolve("b", produceFor("b"));
+    await bounded.resolve("c", produceFor("c"));
+    expect(bounded.peek("a")).toBe("a".repeat(10));
+
+    // Fourth entry pushes bytes to 40 > 30: the least-recently-used goes, and
+    // "a" survives despite being inserted first, because it was just touched.
+    await bounded.resolve("d", produceFor("d"));
+    expect(bounded.peek("b")).toBeUndefined();
+    expect(bounded.peek("a")).toBe("a".repeat(10));
+    expect(bounded.peek("c")).toBe("c".repeat(10));
+    expect(bounded.peek("d")).toBe("d".repeat(10));
   });
 
   it("runs at most `concurrency` producers at once", async () => {

--- a/packages/studio/src/player/lib/mediaResolver.test.ts
+++ b/packages/studio/src/player/lib/mediaResolver.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMediaResolver,
   extractVideoFrames,
+  fetchMediaBytes,
+  mediaBytesResolver,
   mediaCacheKey,
   type MediaResolver,
 } from "./mediaResolver";
@@ -322,5 +324,70 @@ describe("extractVideoFrames", () => {
     video.dispatchEvent(new Event("loadedmetadata"));
     video.dispatchEvent(new Event("seeked"));
     await expect(done).rejects.toThrow(/Tainted/);
+  });
+});
+
+describe("fetchMediaBytes", () => {
+  let fetches: string[];
+
+  beforeEach(() => {
+    mediaBytesResolver.reset();
+    fetches = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        fetches.push(String(url));
+        return Promise.resolve({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+        });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mediaBytesResolver.reset();
+  });
+
+  it("downloads a source once however many consumers want its bytes", async () => {
+    // The waveform decoder and the beat analyzer, on the same track.
+    const [waveform, beats] = await Promise.all([
+      fetchMediaBytes("/assets/track.mp3"),
+      fetchMediaBytes("/assets/track.mp3"),
+    ]);
+
+    expect(fetches).toHaveLength(1);
+    expect(waveform).toBe(beats);
+  });
+
+  it("shares the download across consumers that arrive later", async () => {
+    await fetchMediaBytes("/assets/track.mp3");
+    await fetchMediaBytes("/assets/track.mp3");
+
+    expect(fetches).toHaveLength(1);
+  });
+
+  it("treats the same file spelled differently as one source", async () => {
+    await fetchMediaBytes("/assets/track.mp3");
+    await fetchMediaBytes("./assets/track.mp3");
+
+    expect(fetches).toHaveLength(1);
+  });
+
+  it("keeps different sources apart", async () => {
+    await fetchMediaBytes("/assets/a.mp3");
+    await fetchMediaBytes("/assets/b.mp3");
+
+    expect(fetches).toHaveLength(2);
+  });
+
+  it("rejects a non-2xx instead of caching an error page as media", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: false, status: 404 })),
+    );
+
+    await expect(fetchMediaBytes("/assets/missing.mp3")).rejects.toThrow(/404/);
   });
 });

--- a/packages/studio/src/player/lib/mediaResolver.ts
+++ b/packages/studio/src/player/lib/mediaResolver.ts
@@ -333,6 +333,45 @@ export const waveformResolver = createMediaResolver<number[]>({
   failureTtlMs: BUDGETS.metadataFailureTtlMs,
 });
 
+/**
+ * Whole media files, shared by every Studio path that decodes one.
+ *
+ * The waveform decoder and the beat analyzer both want the same audio file's
+ * PCM and each used to fetch it for itself — two downloads of one track, which
+ * is what an amplification count sees. This is the single fetch they share.
+ * Bounded by bytes, because one entry is an entire media file.
+ */
+export const mediaBytesResolver = createMediaResolver<ArrayBuffer>({
+  maxEntries: BUDGETS.mediaBytesCacheEntries,
+  maxBytes: BUDGETS.mediaBytesCacheBytes,
+  sizeOf: (bytes) => bytes.byteLength,
+  concurrency: BUDGETS.concurrentVideoDecodes,
+  failureTtlMs: BUDGETS.metadataFailureTtlMs,
+});
+
+/** One download per source. Rejects on a non-2xx so the failure record expires. */
+export function fetchMediaBytes(src: string): Promise<ArrayBuffer> {
+  return mediaBytesResolver.resolve(mediaCacheKey(src), async () => {
+    const response = await fetch(normalizeMediaUrl(src));
+    if (!response.ok) {
+      throw new Error(`mediaResolver: ${response.status} fetching ${src}`);
+    }
+    return response.arrayBuffer();
+  });
+}
+
+/**
+ * Decode a whole audio file to PCM, sharing one download per source.
+ *
+ * `decodeAudioData` DETACHES the buffer it is handed, so each caller decodes a
+ * copy — the cached entry has to survive for the next one.
+ */
+export async function decodeAudioFromUrl(src: string): Promise<AudioBuffer> {
+  const bytes = await fetchMediaBytes(src);
+  const context = new AudioContext();
+  return context.decodeAudioData(bytes.slice(0)).finally(() => void context.close());
+}
+
 export interface MediaProbeResult {
   duration: number;
   width?: number;

--- a/packages/studio/src/player/lib/mediaResolver.ts
+++ b/packages/studio/src/player/lib/mediaResolver.ts
@@ -19,7 +19,7 @@ export type Emit<T> = (partial: T) => void;
 /** Does the actual work. `emit` is optional progress; the resolved value wins. */
 export type Produce<T> = (emit: Emit<T>) => Promise<T>;
 
-export interface MediaResolverConfig {
+interface MediaResolverBounds {
   /** LRU bound on resolved values (and, separately, on failure records). */
   maxEntries: number;
   /** Max `produce` calls running at once. */
@@ -27,6 +27,14 @@ export interface MediaResolverConfig {
   /** How long a rejected key stays rejected before it is retried. */
   failureTtlMs: number;
 }
+
+/**
+ * `maxBytes` and `sizeOf` come as a pair or not at all — a byte bound without a
+ * sizer would silently never evict. Omit both only when every entry is a
+ * fixed-size struct, where the entry count already bounds memory.
+ */
+export type MediaResolverConfig<T> = MediaResolverBounds &
+  ({ maxBytes: number; sizeOf: (value: T) => number } | { maxBytes?: never; sizeOf?: never });
 
 export interface MediaResolver<T> {
   resolve(key: string, produce: Produce<T>, onPartial?: Emit<T>): Promise<T>;
@@ -64,10 +72,12 @@ function trim<K, V>(map: Map<K, V>, max: number): void {
   }
 }
 
-export function createMediaResolver<T>(config: MediaResolverConfig): MediaResolver<T> {
-  const { maxEntries, concurrency, failureTtlMs } = config;
+export function createMediaResolver<T>(config: MediaResolverConfig<T>): MediaResolver<T> {
+  const { maxEntries, concurrency, failureTtlMs, maxBytes, sizeOf } = config;
   // Map iteration order is insertion order, so re-inserting on read gives LRU.
   const cache = new Map<string, T>();
+  const sizes = new Map<string, number>();
+  let cachedBytes = 0;
   const failures = new Map<string, { at: number; error: unknown }>();
   const inflight = new Map<string, Promise<T>>();
   const subscribers = new Map<string, Set<Emit<T>>>();
@@ -88,6 +98,28 @@ export function createMediaResolver<T>(config: MediaResolverConfig): MediaResolv
     if (next) next();
     else active--;
   };
+
+  function forget(key: string): void {
+    if (!cache.delete(key)) return;
+    cachedBytes -= sizes.get(key) ?? 0;
+    sizes.delete(key);
+  }
+
+  /** Insert as most-recently-used, then evict until both bounds hold. */
+  function remember(key: string, value: T): void {
+    forget(key);
+    cache.set(key, value);
+    const size = sizeOf?.(value) ?? 0;
+    sizes.set(key, size);
+    cachedBytes += size;
+    // ponytail: a single value larger than maxBytes is evicted immediately and
+    // recomputed on next use — honouring the bound beats retaining over it.
+    while (cache.size > maxEntries || cachedBytes > (maxBytes ?? Infinity)) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      forget(oldest);
+    }
+  }
 
   function peek(key: string): T | undefined {
     const value = cache.get(key);
@@ -134,9 +166,7 @@ export function createMediaResolver<T>(config: MediaResolverConfig): MediaResolv
       await acquire();
       try {
         const value = await produce(emit);
-        cache.delete(key);
-        cache.set(key, value);
-        trim(cache, maxEntries);
+        remember(key, value);
         return value;
       } catch (error) {
         failures.set(key, { at: Date.now(), error });
@@ -160,6 +190,8 @@ export function createMediaResolver<T>(config: MediaResolverConfig): MediaResolv
     hasFreshFailure,
     reset() {
       cache.clear();
+      sizes.clear();
+      cachedBytes = 0;
       failures.clear();
       inflight.clear();
       subscribers.clear();
@@ -285,6 +317,9 @@ export function extractVideoFrames(
 /** Frame strips and posters — one entry per `(source, timestamps)` pair. */
 export const thumbnailResolver = createMediaResolver<VideoFrames>({
   maxEntries: BUDGETS.thumbnailCacheEntries,
+  maxBytes: BUDGETS.thumbnailCacheBytes,
+  // base64 data URLs are one ASCII char per byte of payload.
+  sizeOf: (value) => value.frames.reduce((total, frame) => total + frame.length, 0),
   concurrency: BUDGETS.concurrentVideoDecodes,
   failureTtlMs: BUDGETS.metadataFailureTtlMs,
 });
@@ -292,6 +327,8 @@ export const thumbnailResolver = createMediaResolver<VideoFrames>({
 /** Decoded audio peaks. */
 export const waveformResolver = createMediaResolver<number[]>({
   maxEntries: BUDGETS.waveformCacheEntries,
+  maxBytes: BUDGETS.waveformCacheBytes,
+  sizeOf: (peaks) => peaks.length * Float64Array.BYTES_PER_ELEMENT,
   concurrency: BUDGETS.concurrentVideoDecodes,
   failureTtlMs: BUDGETS.metadataFailureTtlMs,
 });

--- a/packages/studio/src/player/lib/timelineDOM.test.ts
+++ b/packages/studio/src/player/lib/timelineDOM.test.ts
@@ -296,3 +296,43 @@ describe("mergeTimelineElementsPreservingDowngrades — genuine removal vs trans
     ).toEqual(["a", "c"]);
   });
 });
+
+describe("sourceDurationPending", () => {
+  /** The one element in a parsed timeline, by id. */
+  function parseOne(html: string, id: string): TimelineElement {
+    const doc = makeDoc(`<div data-composition-id="root">${html}</div>`);
+    const found = parseTimelineFromDOM(doc, 10).find((e) => e.domId === id);
+    if (!found) throw new Error(`no element ${id} in the parsed timeline`);
+    return found;
+  }
+
+  it("marks media the runtime has promoted to preload, whose duration is on its way", () => {
+    const parsed = parseOne(
+      `<video id="v" class="clip" src="a.mp4" preload="auto" data-start="0" data-duration="2"></video>`,
+      "v",
+    );
+
+    expect(parsed.sourceDuration).toBeUndefined();
+    expect(parsed.sourceDurationPending).toBe(true);
+  });
+
+  it("leaves media the runtime deferred unmarked, so the probe still covers it", () => {
+    const parsed = parseOne(
+      `<video id="v" class="clip" src="a.mp4" preload="metadata" data-start="0" data-duration="2"></video>`,
+      "v",
+    );
+
+    expect(parsed.sourceDurationPending).toBeUndefined();
+  });
+
+  it("does not mark media whose duration is already known", () => {
+    const parsed = parseOne(
+      `<video id="v" class="clip" src="a.mp4" preload="auto" data-source-duration="9"
+         data-start="0" data-duration="2"></video>`,
+      "v",
+    );
+
+    expect(parsed.sourceDuration).toBe(9);
+    expect(parsed.sourceDurationPending).toBeUndefined();
+  });
+});

--- a/packages/studio/src/player/lib/timelineElementHelpers.ts
+++ b/packages/studio/src/player/lib/timelineElementHelpers.ts
@@ -189,6 +189,12 @@ export function applyMediaMetadataFromElement(entry: TimelineElement, el: Elemen
   const sourceDuration = sourceDurationAttr ? parseFloat(sourceDurationAttr) : mediaEl.duration;
   if (Number.isFinite(sourceDuration) && sourceDuration > 0) {
     entry.sourceDuration = sourceDuration;
+  } else if (mediaEl.preload === "auto") {
+    // The runtime promotes a media element to `preload="auto"` (and calls
+    // load()) exactly when it decides to fetch that file for the preview, so
+    // its duration is already on its way. Marking it keeps `mediaProbe` from
+    // downloading the same file again just to read the same header.
+    entry.sourceDurationPending = true;
   }
 
   const playbackRate = mediaEl.defaultPlaybackRate;

--- a/packages/studio/src/player/lib/timelineViewportBudgets.test.ts
+++ b/packages/studio/src/player/lib/timelineViewportBudgets.test.ts
@@ -1,8 +1,74 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  DIAGNOSTIC_BUDGET_FIELDS,
+  ENFORCED_BUDGET_FIELDS,
   TIMELINE_VIEWPORT_BUDGETS,
   resolveTimelineViewportBudgets,
 } from "./timelineViewportBudgets";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+
+/** Every module allowed to satisfy "enforced": it caps, evicts or switches. */
+const ENFORCING_MODULES = [
+  "src/player/components/timelineViewportGeometry.ts",
+  "src/player/components/useTimelineVirtualRows.ts",
+  "src/player/lib/timelinePerformanceDiagnostics.ts",
+  "src/player/lib/mediaResolver.ts",
+];
+
+/** Every module allowed to satisfy "diagnostic": it only measures and reports. */
+const REPORTING_MODULES = [
+  "src/player/lib/timelinePerformanceDiagnostics.ts",
+  "tests/e2e/timeline-virtualization.mjs",
+];
+
+/**
+ * Fields removed by U7 because nothing anywhere read them. Listed so the sweep
+ * below fails if one is reintroduced without a consumer.
+ */
+const DELETED_FIELDS = [
+  "posterMaxPhysicalWidth",
+  "posterMaxPhysicalHeight",
+  "posterDprCap",
+  "richPreviewFrameCount",
+  "concurrentCompositionFetches",
+  "concurrentServerPages",
+  "thumbnailCacheEntriesPerProject",
+  "compositionDiskCacheBytes",
+  "compositionDiskCacheMaxAgeMs",
+  "posterColdP95Ms",
+  "posterCachedP95Ms",
+  "constrainedPosterColdP95Ms",
+  "constrainedPosterCachedP95Ms",
+  "posterCoverageRatio",
+  "posterCoverageSettleMs",
+  "constrainedPosterCoverageSettleMs",
+  "richPreviewP95Ms",
+  "constrainedRichPreviewP95Ms",
+  "supportedFixtureFallbackRatio",
+];
+
+const SELF = fileURLToPath(import.meta.url);
+const SOURCE_EXTENSIONS = /\.(ts|tsx|mjs|cjs|js|jsx)$/;
+
+function collectSourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue;
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) collectSourceFiles(path, found);
+    else if (SOURCE_EXTENSIONS.test(entry) && path !== SELF) found.push(path);
+  }
+  return found;
+}
+
+function read(relativePath: string): string {
+  return readFileSync(join(PACKAGE_ROOT, relativePath), "utf8");
+}
+
+const mentions = (source: string, field: string) => new RegExp(`\\b${field}\\b`).test(source);
 
 describe("timeline viewport budgets", () => {
   it("owns the agreed direct-scroll, DOM, media, and measurement ceilings", () => {
@@ -16,13 +82,12 @@ describe("timeline viewport budgets", () => {
       maxMountedTimelineDescendants: 5_000,
       thumbnailCacheBytes: 64 * 1024 * 1024,
       waveformCacheBytes: 16 * 1024 * 1024,
+      metadataFailureTtlMs: 30_000,
       interactionP95Ms: 50,
       constrainedInteractionP95Ms: 75,
       constrainedFrameIntervalP95Ms: 75,
       longTaskLimitMs: 50,
       constrainedLongTaskLimitMs: 300,
-      posterCoverageRatio: 0.9,
-      supportedFixtureFallbackRatio: 0.02,
       scrollSamplesPerRun: 21,
       warmupRuns: 3,
       measuredRuns: 5,
@@ -53,8 +118,41 @@ describe("timeline viewport budgets", () => {
     [{ measuredRuns: 1.5, requiredPassingRuns: 1 }, "measuredRuns"],
     [{ measuredRuns: 4, requiredPassingRuns: 5 }, "requiredPassingRuns"],
     [{ scrollSamplesPerRun: 19 }, "scrollSamplesPerRun"],
-    [{ posterCoverageRatio: 1.1 }, "posterCoverageRatio"],
+    [{ memoryReturnToleranceRatio: 1.1 }, "memoryReturnToleranceRatio"],
   ] as const)("rejects an invalid override %#", (overrides, message) => {
     expect(() => resolveTimelineViewportBudgets(overrides)).toThrow(message);
+  });
+
+  describe("every field is enforced or explicitly diagnostic", () => {
+    it("classifies each declared field exactly once", () => {
+      const declared = Object.keys(TIMELINE_VIEWPORT_BUDGETS).sort();
+      const classified = [...ENFORCED_BUDGET_FIELDS, ...DIAGNOSTIC_BUDGET_FIELDS];
+
+      expect(new Set(classified).size).toBe(classified.length);
+      expect([...classified].sort()).toEqual(declared);
+    });
+
+    it.each(ENFORCED_BUDGET_FIELDS)("%s is read by code that enforces it", (field) => {
+      const enforcers = ENFORCING_MODULES.filter((module) => mentions(read(module), field));
+      expect(enforcers, `${field} claims to be enforced but no module reads it`).not.toEqual([]);
+    });
+
+    it.each(DIAGNOSTIC_BUDGET_FIELDS)("%s is reported against by a diagnostic", (field) => {
+      const reporters = REPORTING_MODULES.filter((module) => mentions(read(module), field));
+      expect(reporters, `${field} is annotated diagnostic but nothing reports it`).not.toEqual([]);
+    });
+  });
+
+  it("leaves no reference to a deleted field anywhere in the package", () => {
+    const sources = [
+      ...collectSourceFiles(join(PACKAGE_ROOT, "src")),
+      ...collectSourceFiles(join(PACKAGE_ROOT, "tests")),
+    ].map((path) => ({ path, text: readFileSync(path, "utf8") }));
+
+    const survivors = DELETED_FIELDS.flatMap((field) =>
+      sources.filter(({ text }) => mentions(text, field)).map(({ path }) => `${field} in ${path}`),
+    );
+
+    expect(survivors).toEqual([]);
   });
 });

--- a/packages/studio/src/player/lib/timelineViewportBudgets.ts
+++ b/packages/studio/src/player/lib/timelineViewportBudgets.ts
@@ -39,6 +39,13 @@ export interface TimelineViewportBudgets {
   waveformCacheEntries: number;
   /** LRU byte bound on the decoded-waveform cache. */
   waveformCacheBytes: number;
+  /** LRU entry bound on the shared raw-media-bytes cache. */
+  mediaBytesCacheEntries: number;
+  /**
+   * LRU byte bound on the shared raw-media-bytes cache. Entry count alone does
+   * not bound memory: one entry is a whole media file.
+   */
+  mediaBytesCacheBytes: number;
   /** LRU entry bound on the media-metadata cache. */
   metadataRegistryEntries: number;
   /** How long a failed probe stays failed before it is retried. */
@@ -81,6 +88,8 @@ export const ENFORCED_BUDGET_FIELDS = [
   "thumbnailCacheBytes",
   "waveformCacheEntries",
   "waveformCacheBytes",
+  "mediaBytesCacheEntries",
+  "mediaBytesCacheBytes",
   "metadataRegistryEntries",
   "metadataFailureTtlMs",
 ] as const satisfies readonly (keyof TimelineViewportBudgets)[];
@@ -121,6 +130,8 @@ export const TIMELINE_VIEWPORT_BUDGETS: Readonly<TimelineViewportBudgets> = Obje
   thumbnailCacheBytes: 64 * MEBIBYTE,
   waveformCacheEntries: 256,
   waveformCacheBytes: 16 * MEBIBYTE,
+  mediaBytesCacheEntries: 8,
+  mediaBytesCacheBytes: 64 * MEBIBYTE,
   metadataRegistryEntries: 512,
   metadataFailureTtlMs: 30_000,
   maxMountedRows: 64,

--- a/packages/studio/src/player/lib/timelineViewportBudgets.ts
+++ b/packages/studio/src/player/lib/timelineViewportBudgets.ts
@@ -1,28 +1,60 @@
+/**
+ * Timeline viewport and media budgets.
+ *
+ * Every field is in exactly one of two terminal states, and the split is
+ * machine-checked by the colocated test:
+ *
+ * - **Enforced** (`ENFORCED_BUDGET_FIELDS`) — production code reads it and
+ *   changes behaviour: it caps, evicts, expires or switches strategy.
+ * - **Diagnostic** (`DIAGNOSTIC_BUDGET_FIELDS`) — nothing prevents exceeding
+ *   it. The perf gate (`tests/e2e/timeline-virtualization.mjs`) and
+ *   `timelinePerformanceDiagnostics.ts` only *report* against it.
+ *
+ * There is no third state. A field with no consumer is deleted rather than
+ * left declared — a limit nothing enforces reads as a guarantee during review
+ * and provides none at runtime.
+ */
 export interface TimelineViewportBudgets {
+  // --- Enforced: virtualization geometry -----------------------------------
+  /** Above this content width the timeline switches to segmented scrolling. */
   directScrollSafetyPx: number;
+  /** Rows rendered beyond each edge of the viewport. */
   rowOverscanPerSide: number;
+  /** Time overscan as a fraction of the visible time span. */
   timeOverscanViewportRatio: number;
+
+  // --- Enforced: media resolver (mediaResolver.ts) --------------------------
+  /** Concurrent hidden-`<video>` decodes for thumbnails and waveforms. */
+  concurrentVideoDecodes: number;
+  /** Concurrent header-only metadata probes. */
+  concurrentMetadataJobs: number;
+  /** LRU entry bound on the thumbnail cache. */
+  thumbnailCacheEntries: number;
+  /**
+   * LRU byte bound on the thumbnail cache. Entry count alone does not bound
+   * memory: one entry is a JPEG data-URL strip of arbitrary size.
+   */
+  thumbnailCacheBytes: number;
+  /** LRU entry bound on the decoded-waveform cache. */
+  waveformCacheEntries: number;
+  /** LRU byte bound on the decoded-waveform cache. */
+  waveformCacheBytes: number;
+  /** LRU entry bound on the media-metadata cache. */
+  metadataRegistryEntries: number;
+  /** How long a failed probe stays failed before it is retried. */
+  metadataFailureTtlMs: number;
+
+  // --- Diagnostic: mounted-DOM ceilings ------------------------------------
+  // Asserted by timelinePerformanceDiagnostics.ts and the perf gate. Nothing
+  // prevents exceeding them; windowing is what keeps them true.
   maxMountedRows: number;
   maxMountedClipRoots: number;
   maxMountedClipRootsPerRow: number;
   maxMountedTimelineDescendants: number;
-  posterMaxPhysicalWidth: number;
-  posterMaxPhysicalHeight: number;
-  posterDprCap: number;
-  richPreviewFrameCount: number;
-  concurrentVideoDecodes: number;
-  concurrentMetadataJobs: number;
-  concurrentCompositionFetches: number;
-  concurrentServerPages: number;
-  thumbnailCacheBytes: number;
-  thumbnailCacheEntries: number;
-  thumbnailCacheEntriesPerProject: number;
-  metadataRegistryEntries: number;
-  metadataFailureTtlMs: number;
-  waveformCacheBytes: number;
-  waveformCacheEntries: number;
-  compositionDiskCacheBytes: number;
-  compositionDiskCacheMaxAgeMs: number;
+
+  // --- Diagnostic: perf-gate thresholds ------------------------------------
+  // Consumed only by tests/e2e/timeline-virtualization.mjs. The `constrained*`
+  // variants apply on the low-resource tier.
   interactionP95Ms: number;
   frameIntervalP95Ms: number;
   constrainedInteractionP95Ms: number;
@@ -30,24 +62,49 @@ export interface TimelineViewportBudgets {
   longTaskLimitMs: number;
   constrainedLongTaskLimitMs: number;
   memoryReturnToleranceRatio: number;
-  posterColdP95Ms: number;
-  posterCachedP95Ms: number;
-  constrainedPosterColdP95Ms: number;
-  constrainedPosterCachedP95Ms: number;
-  posterCoverageRatio: number;
-  posterCoverageSettleMs: number;
-  constrainedPosterCoverageSettleMs: number;
-  richPreviewP95Ms: number;
-  constrainedRichPreviewP95Ms: number;
-  supportedFixtureFallbackRatio: number;
+
+  // --- Diagnostic: perf-gate run shape -------------------------------------
   scrollSamplesPerRun: number;
   warmupRuns: number;
   measuredRuns: number;
   requiredPassingRuns: number;
 }
 
+/** Fields production code reads to cap, evict, expire or switch strategy. */
+export const ENFORCED_BUDGET_FIELDS = [
+  "directScrollSafetyPx",
+  "rowOverscanPerSide",
+  "timeOverscanViewportRatio",
+  "concurrentVideoDecodes",
+  "concurrentMetadataJobs",
+  "thumbnailCacheEntries",
+  "thumbnailCacheBytes",
+  "waveformCacheEntries",
+  "waveformCacheBytes",
+  "metadataRegistryEntries",
+  "metadataFailureTtlMs",
+] as const satisfies readonly (keyof TimelineViewportBudgets)[];
+
+/** Fields only reported against. Exceeding one fails a gate, never a user. */
+export const DIAGNOSTIC_BUDGET_FIELDS = [
+  "maxMountedRows",
+  "maxMountedClipRoots",
+  "maxMountedClipRootsPerRow",
+  "maxMountedTimelineDescendants",
+  "interactionP95Ms",
+  "frameIntervalP95Ms",
+  "constrainedInteractionP95Ms",
+  "constrainedFrameIntervalP95Ms",
+  "longTaskLimitMs",
+  "constrainedLongTaskLimitMs",
+  "memoryReturnToleranceRatio",
+  "scrollSamplesPerRun",
+  "warmupRuns",
+  "measuredRuns",
+  "requiredPassingRuns",
+] as const satisfies readonly (keyof TimelineViewportBudgets)[];
+
 const MEBIBYTE = 1024 * 1024;
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
  * The sole default budget owner for timeline viewport and media virtualization.
@@ -58,27 +115,18 @@ export const TIMELINE_VIEWPORT_BUDGETS: Readonly<TimelineViewportBudgets> = Obje
   directScrollSafetyPx: 8_000_000,
   rowOverscanPerSide: 2,
   timeOverscanViewportRatio: 0.25,
+  concurrentVideoDecodes: 2,
+  concurrentMetadataJobs: 4,
+  thumbnailCacheEntries: 256,
+  thumbnailCacheBytes: 64 * MEBIBYTE,
+  waveformCacheEntries: 256,
+  waveformCacheBytes: 16 * MEBIBYTE,
+  metadataRegistryEntries: 512,
+  metadataFailureTtlMs: 30_000,
   maxMountedRows: 64,
   maxMountedClipRoots: 512,
   maxMountedClipRootsPerRow: 128,
   maxMountedTimelineDescendants: 5_000,
-  posterMaxPhysicalWidth: 240,
-  posterMaxPhysicalHeight: 135,
-  posterDprCap: 1.5,
-  richPreviewFrameCount: 6,
-  concurrentVideoDecodes: 2,
-  concurrentMetadataJobs: 4,
-  concurrentCompositionFetches: 2,
-  concurrentServerPages: 1,
-  thumbnailCacheBytes: 64 * MEBIBYTE,
-  thumbnailCacheEntries: 256,
-  thumbnailCacheEntriesPerProject: 96,
-  metadataRegistryEntries: 512,
-  metadataFailureTtlMs: 30_000,
-  waveformCacheBytes: 16 * MEBIBYTE,
-  waveformCacheEntries: 256,
-  compositionDiskCacheBytes: 512 * MEBIBYTE,
-  compositionDiskCacheMaxAgeMs: 14 * DAY_MS,
   interactionP95Ms: 50,
   frameIntervalP95Ms: 33.3,
   constrainedInteractionP95Ms: 75,
@@ -86,16 +134,6 @@ export const TIMELINE_VIEWPORT_BUDGETS: Readonly<TimelineViewportBudgets> = Obje
   longTaskLimitMs: 50,
   constrainedLongTaskLimitMs: 300,
   memoryReturnToleranceRatio: 0.15,
-  posterColdP95Ms: 750,
-  posterCachedP95Ms: 250,
-  constrainedPosterColdP95Ms: 1_200,
-  constrainedPosterCachedP95Ms: 400,
-  posterCoverageRatio: 0.9,
-  posterCoverageSettleMs: 1_500,
-  constrainedPosterCoverageSettleMs: 2_500,
-  richPreviewP95Ms: 750,
-  constrainedRichPreviewP95Ms: 1_200,
-  supportedFixtureFallbackRatio: 0.02,
   scrollSamplesPerRun: 21,
   warmupRuns: 3,
   measuredRuns: 5,
@@ -138,14 +176,8 @@ export function resolveTimelineViewportBudgets(
   if (resolved.requiredPassingRuns > resolved.measuredRuns) {
     throw new RangeError("Timeline viewport budget requiredPassingRuns cannot exceed measuredRuns");
   }
-  for (const name of [
-    "memoryReturnToleranceRatio",
-    "posterCoverageRatio",
-    "supportedFixtureFallbackRatio",
-  ] as const) {
-    if (resolved[name] > 1) {
-      throw new RangeError(`Timeline viewport budget ${name} cannot exceed 1`);
-    }
+  if (resolved.memoryReturnToleranceRatio > 1) {
+    throw new RangeError("Timeline viewport budget memoryReturnToleranceRatio cannot exceed 1");
   }
   return Object.freeze(resolved);
 }

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -57,6 +57,14 @@ export interface TimelineElement {
   playbackStartAttr?: "media-start" | "playback-start";
   playbackRate?: number;
   sourceDuration?: number;
+  /**
+   * Set by the preview DOM scan when `sourceDuration` is not known yet but the
+   * runtime has already promoted this element to `preload="auto"` — the browser
+   * is fetching the file for the preview, and its duration lands on a later
+   * scan. Marks the element as "do not probe": a probe would fetch the same
+   * bytes a second time to learn the same number.
+   */
+  sourceDurationPending?: boolean;
   volume?: number;
   /** Path from data-composition-src — identifies sub-composition elements */
   compositionSrc?: string;


### PR DESCRIPTION
Two related changes to how the Studio treats media at open.

**Measured: media requests per distinct source 8.5× → 1.13×.**

> Stacked on the media resolution PR (hard dependency — same module). Please do not delete that branch while this is open.

## 1. Fetch each source once

A media source referenced by N clips was fetched N times while opening a project. It is now fetched once and shared.

The de-duplication is deliberately **not** a permanent cache: a source that is fetched, evicted, and re-requested fetches again. Making it permanent would trade a request problem for a memory problem, which is the wrong trade for an editor that keeps projects open for hours.

## 2. Make the declared timeline budgets real — or delete them

This is the half worth reading carefully.

`timelineViewportBudgets` declared `concurrentVideoDecodes: 2`, `concurrentMetadataJobs: 4`, `concurrentCompositionFetches: 2`, and `concurrentServerPages: 1`. Not one of them was enforced anywhere in the application. They were read only by diagnostics assertions — that is, by code that checked the numbers against themselves.

A declared-but-unenforced budget is worse than no budget, because every reader assumes it is a guarantee. Each one is now enforced at its stated limit (exceeding it queues rather than drops), explicitly annotated as advisory, or deleted.

## Note on a shared file

Touches `timelineElementHelpers.ts` around line 189; another PR in this sequence touches it around line 412. Disjoint, merges cleanly either way.

## Verification

`packages/player` green (334 tests), `packages/studio` green (3,333 tests).
