### PR TITLE
perf(studio): take the Node-only AST and DOM stack off the first-paint path

### DIFF
--- a/packages/parsers/package-subpaths.json
+++ b/packages/parsers/package-subpaths.json
@@ -14,6 +14,12 @@
       "types": null,
       "environments": ["browser", "bun", "node"]
     },
+    "./types": {
+      "source": "./src/types.ts",
+      "runtime": "./dist/types.js",
+      "types": "./dist/types.d.ts",
+      "environments": ["browser", "bun", "node"]
+    },
     "./gsap-parser": {
       "source": "./src/gsapParserExports.ts",
       "runtime": "./dist/gsapParserExports.js",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -22,6 +22,12 @@
       "types": "./src/index.ts"
     },
     "./package.json": "./package.json",
+    "./types": {
+      "bun": "./src/types.ts",
+      "node": "./dist/types.js",
+      "import": "./src/types.ts",
+      "types": "./src/types.ts"
+    },
     "./gsap-parser": {
       "bun": "./src/gsapParserExports.ts",
       "node": "./dist/gsapParserExports.js",
@@ -121,6 +127,10 @@
         "types": "./dist/index.d.ts"
       },
       "./package.json": "./package.json",
+      "./types": {
+        "import": "./dist/types.js",
+        "types": "./dist/types.d.ts"
+      },
       "./gsap-parser": {
         "import": "./dist/gsapParserExports.js",
         "types": "./dist/gsapParserExports.d.ts"

--- a/packages/parsers/src/gsapConstants.ts
+++ b/packages/parsers/src/gsapConstants.ts
@@ -126,3 +126,23 @@ export const SUPPORTED_EASES = [
   "hold",
   "steps(1)",
 ];
+
+/** Marker on Studio-emitted pre-keyframe hold `set`s. `data` is a GSAP-reserved
+ * config key (attached to the tween, never applied to the target), so it carries
+ * the tag without triggering GSAP's "Invalid property" warning. */
+export const STUDIO_HOLD_MARKER = "hf-hold";
+
+/** True for a `tl.set(...)` emitted to hold a keyframe before its tween.
+ * The Studio filters these out so they never appear as user keyframes/diamonds.
+ *
+ * Lives here, not in gsapParser/gsapWriterAcorn, because it is a pure predicate
+ * over an already-parsed animation: the studio imports it on the first-paint
+ * path, and re-exporting it from gsapParser.ts dragged recast / @babel/parser /
+ * esprima / ast-types / source-map (~1.3MB of module graph) into the browser
+ * bundle for two lines of logic. */
+export function isStudioHoldSet(anim: {
+  method: string;
+  properties?: Record<string, unknown>;
+}): boolean {
+  return anim.method === "set" && anim.properties?.data === STUDIO_HOLD_MARKER;
+}

--- a/packages/parsers/src/gsapParser.ts
+++ b/packages/parsers/src/gsapParser.ts
@@ -49,7 +49,14 @@ export {
   classifyPropertyGroup,
   classifyTweenPropertyGroup,
 } from "./gsapConstants";
-import { classifyPropertyGroup, classifyTweenPropertyGroup } from "./gsapConstants";
+import {
+  classifyPropertyGroup,
+  classifyTweenPropertyGroup,
+  isStudioHoldSet,
+  STUDIO_HOLD_MARKER,
+} from "./gsapConstants";
+// Kept on this module's public surface for existing `gsap-parser-recast` consumers.
+export { isStudioHoldSet } from "./gsapConstants";
 import type { PropertyGroupName } from "./gsapConstants";
 import {
   findObjectArrayKeyframeIndex,
@@ -1723,17 +1730,6 @@ function insertInheritedStateSet(
     parsed.ast.program.body.push(newStatement);
   }
   return recast.print(parsed.ast).code;
-}
-
-/** Marker on Studio-emitted pre-keyframe hold `set`s. `data` is a GSAP-reserved
- * config key (attached to the tween, never applied to the target), so it carries
- * the tag without triggering GSAP's "Invalid property" warning. */
-const STUDIO_HOLD_MARKER = "hf-hold";
-
-/** True for a `tl.set(...)` this module emitted to hold a keyframe before its tween.
- * The Studio filters these out so they never appear as user keyframes/diamonds. */
-export function isStudioHoldSet(anim: GsapAnimation): boolean {
-  return anim.method === "set" && anim.properties?.data === STUDIO_HOLD_MARKER;
 }
 
 /**

--- a/packages/parsers/src/gsapParserExports.ts
+++ b/packages/parsers/src/gsapParserExports.ts
@@ -32,15 +32,17 @@ export {
   SUPPORTED_PROPS,
   SUPPORTED_EASES,
 } from "./gsapSerialize.js";
-// Studio position-hold predicate (`tl.set(...,{data:"hf-hold"})`). A pure
-// GsapAnimation helper — re-exported here so studio can filter holds via the
-// public entry even though gsapParser.ts is otherwise an internal module.
-export { isStudioHoldSet } from "./gsapParser.js";
 export type { PropertyGroupName } from "./gsapConstants.js";
 export {
   PROPERTY_GROUPS,
   classifyPropertyGroup,
   classifyTweenPropertyGroup,
+  // Studio position-hold predicate (`tl.set(...,{data:"hf-hold"})`). It MUST come
+  // from gsapConstants, not gsapParser: re-exporting it from gsapParser put recast
+  // / @babel/parser / esprima / ast-types / source-map on the studio's first-paint
+  // path for a two-line predicate.
+  isStudioHoldSet,
+  STUDIO_HOLD_MARKER,
 } from "./gsapConstants.js";
 export { generateSpringEaseData, SPRING_PRESETS } from "./springEase.js";
 export type { SpringPreset } from "./springEase.js";

--- a/packages/parsers/src/gsapWriterAcorn.ts
+++ b/packages/parsers/src/gsapWriterAcorn.ts
@@ -24,7 +24,7 @@ import {
   type ParsedGsapAcornForWrite,
   type TweenCallInfo,
 } from "./gsapParserAcorn.js";
-import { classifyPropertyGroup } from "./gsapConstants.js";
+import { classifyPropertyGroup, isStudioHoldSet, STUDIO_HOLD_MARKER } from "./gsapConstants.js";
 import type { PropertyGroupName } from "./gsapConstants.js";
 import {
   findObjectArrayKeyframeIndex,
@@ -2294,12 +2294,6 @@ function insertInheritedStateSetInScript(
     ms.append("\n" + code);
   }
   return ms.toString();
-}
-
-const STUDIO_HOLD_MARKER = "hf-hold";
-
-function isStudioHoldSet(animation: GsapAnimation): boolean {
-  return animation.method === "set" && animation.properties.data === STUDIO_HOLD_MARKER;
 }
 
 function removeStudioHoldSets(script: string, parsed: ParsedGsapAcornForWrite): string {

--- a/packages/parsers/tsup.config.ts
+++ b/packages/parsers/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    types: "src/types.ts",
     gsapParserExports: "src/gsapParserExports.ts",
     gsapParserAcorn: "src/gsapParserAcorn.ts",
     gsapWriterAcorn: "src/gsapWriterAcorn.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -52,7 +52,8 @@
     "test:timeline-virtualization": "TIMELINE_ROW_VIRTUALIZATION=on TIMELINE_ELEMENT_COUNT=50000 node tests/e2e/timeline-virtualization.mjs",
     "test:watch": "vitest",
     "report:sdk-cutover": "bun src/utils/sdkCutoverPolicy.report.ts",
-    "test:timeline-default": "bun run test:timeline-virtualization"
+    "test:timeline-default": "bun run test:timeline-virtualization",
+    "test:studio-bundle-budget": "vite build && node tests/e2e/studio-bundle-budget.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.1",

--- a/packages/studio/src/components/LazyPanel.test.tsx
+++ b/packages/studio/src/components/LazyPanel.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { act, lazy, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LazyPanel } from "./LazyPanel";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  vi.restoreAllMocks();
+});
+
+async function render(node: ReactNode): Promise<HTMLDivElement> {
+  const host = document.createElement("div");
+  root = createRoot(host);
+  await act(async () => root?.render(node));
+  return host;
+}
+
+describe("LazyPanel", () => {
+  it("keeps the panel slot occupied while a chunk loads", async () => {
+    const Pending = lazy(() => new Promise<never>(() => undefined));
+    const host = await render(
+      <LazyPanel label="source editor">
+        <Pending />
+      </LazyPanel>,
+    );
+
+    const status = host.querySelector('[role="status"]');
+    expect(status?.textContent).toBe("Loading source editor…");
+    expect(status?.classList.contains("h-full")).toBe(true);
+    expect(status?.classList.contains("flex-1")).toBe(true);
+  });
+
+  it("surfaces a rejected chunk load as a visible retry state", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const Rejected = lazy(() => Promise.reject(new Error("chunk unavailable")));
+    const host = await render(
+      <LazyPanel label="source editor">
+        <Rejected />
+      </LazyPanel>,
+    );
+
+    const alert = host.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("Couldn’t load source editor.");
+    expect(alert?.querySelector("button")?.textContent).toBe("Retry");
+  });
+});

--- a/packages/studio/src/components/LazyPanel.tsx
+++ b/packages/studio/src/components/LazyPanel.tsx
@@ -1,0 +1,63 @@
+import { Component, Suspense, type ReactNode } from "react";
+
+/**
+ * Suspense + error boundary for a `React.lazy` panel. The fallback fills the
+ * panel's slot (`h-full w-full flex-1`) so a deferred panel can't collapse the
+ * layout while its chunk is in flight, and a rejected chunk load renders a
+ * visible, recoverable error instead of an empty box.
+ */
+interface LazyPanelProps {
+  children: ReactNode;
+  label: string;
+}
+
+interface LazyPanelErrorBoundaryState {
+  failed: boolean;
+}
+
+class LazyPanelErrorBoundary extends Component<LazyPanelProps, LazyPanelErrorBoundaryState> {
+  state: LazyPanelErrorBoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): LazyPanelErrorBoundaryState {
+    return { failed: true };
+  }
+
+  render() {
+    if (!this.state.failed) return this.props.children;
+
+    return (
+      <div
+        role="alert"
+        className="flex h-full min-h-0 w-full flex-1 flex-col items-center justify-center gap-3 text-center text-xs text-red-300"
+      >
+        <span>Couldn’t load {this.props.label}.</span>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="rounded border border-neutral-700 px-3 py-1.5 text-neutral-300 transition-colors hover:bg-neutral-800 hover:text-white"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+}
+
+export function LazyPanel({ children, label }: LazyPanelProps) {
+  return (
+    <LazyPanelErrorBoundary label={label}>
+      <Suspense
+        fallback={
+          <div
+            role="status"
+            className="flex h-full min-h-0 w-full flex-1 items-center justify-center text-xs text-neutral-500"
+          >
+            Loading {label}…
+          </div>
+        }
+      >
+        {children}
+      </Suspense>
+    </LazyPanelErrorBoundary>
+  );
+}

--- a/packages/studio/src/components/StudioLeftSidebar.tsx
+++ b/packages/studio/src/components/StudioLeftSidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, type RefObject } from "react";
-import { SourceEditor } from "./editor/SourceEditor";
+import { LazySourceEditor } from "./editor/LazySourceEditor";
 import { LeftSidebar, type LeftSidebarHandle } from "./sidebar/LeftSidebar";
 import { MediaPreview } from "./MediaPreview";
 import { isMediaFile } from "../utils/mediaTypes";
@@ -133,7 +133,7 @@ export function StudioLeftSidebar({
                 Loading {editingFile.path}…
               </div>
             ) : (
-              <SourceEditor
+              <LazySourceEditor
                 content={editingFile.content}
                 filePath={editingFile.path}
                 onChange={handleContentChange}

--- a/packages/studio/src/components/editor/LazySourceEditor.tsx
+++ b/packages/studio/src/components/editor/LazySourceEditor.tsx
@@ -1,0 +1,15 @@
+import { lazy } from "react";
+import { LazyPanel } from "../LazyPanel";
+import type { SourceEditorProps } from "./SourceEditor";
+
+const SourceEditor = lazy(() =>
+  import("./SourceEditor").then((module) => ({ default: module.SourceEditor })),
+);
+
+export function LazySourceEditor(props: SourceEditorProps) {
+  return (
+    <LazyPanel label="source editor">
+      <SourceEditor {...props} />
+    </LazyPanel>
+  );
+}

--- a/packages/studio/src/components/editor/SourceEditor.tsx
+++ b/packages/studio/src/components/editor/SourceEditor.tsx
@@ -56,7 +56,7 @@ function detectLanguage(filePath: string): string {
   return map[ext] ?? "html";
 }
 
-interface SourceEditorProps {
+export interface SourceEditorProps {
   content: string;
   filePath?: string;
   language?: string;

--- a/packages/studio/src/components/renders/RenderQueue.tsx
+++ b/packages/studio/src/components/renders/RenderQueue.tsx
@@ -1,6 +1,8 @@
 import { memo, useState, useRef, useEffect, useLayoutEffect, useId } from "react";
 import { createPortal } from "react-dom";
-import { CANVAS_DIMENSIONS } from "@hyperframes/parsers";
+// Narrow subpath, not the package barrel: the barrel re-exports hfIds.ts, which
+// pulls linkedom (+ htmlparser2 / css-select / domutils / cssom) into the eager bundle.
+import { CANVAS_DIMENSIONS } from "@hyperframes/parsers/types";
 import { RenderQueueItem } from "./RenderQueueItem";
 import { Button } from "../ui/Button";
 import { resolveFloatingPanelPosition, type FloatingPosition } from "../editor/floatingPanel";

--- a/packages/studio/src/components/renders/useRenderQueue.ts
+++ b/packages/studio/src/components/renders/useRenderQueue.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import type { CanvasResolution } from "@hyperframes/parsers";
+import type { CanvasResolution } from "@hyperframes/parsers/types";
 import { trackStudioRenderStart } from "../../telemetry/events";
 import { getAnonymousId } from "../../telemetry/config";
 import { generateId } from "../../utils/generateId";

--- a/packages/studio/src/components/storyboard/StoryboardLoaded.tsx
+++ b/packages/studio/src/components/storyboard/StoryboardLoaded.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { lazy, useEffect, useMemo, useState } from "react";
 import type { StoryboardResponse } from "../../hooks/useStoryboard";
 import { Button } from "../ui/Button";
+import { LazyPanel } from "../LazyPanel";
 import { StoryboardDirection } from "./StoryboardDirection";
 import { StoryboardGrid } from "./StoryboardGrid";
 import { StoryboardScriptPanel } from "./StoryboardScriptPanel";
-import { StoryboardSourceEditor, type SourceFile } from "./StoryboardSourceEditor";
+import type { SourceFile } from "./StoryboardSourceEditor";
 import { StoryboardFrameFocus } from "./StoryboardFrameFocus";
 import { StoryboardReviewGuide } from "./StoryboardReviewGuide";
 import {
@@ -14,6 +15,12 @@ import {
 import { useFrameComments, type CommentsSubmitState } from "./useFrameComments";
 
 type SubView = "board" | "source";
+
+const StoryboardSourceEditor = lazy(() =>
+  import("./StoryboardSourceEditor").then((module) => ({
+    default: module.StoryboardSourceEditor,
+  })),
+);
 
 export interface StoryboardLoadedProps {
   projectId: string;
@@ -162,11 +169,13 @@ export function StoryboardLoaded({
           </div>
         </div>
       ) : (
-        <StoryboardSourceEditor
-          files={sourceFiles}
-          onSaved={reload}
-          onDirtyChange={setSourceDirty}
-        />
+        <LazyPanel label="storyboard source editor">
+          <StoryboardSourceEditor
+            files={sourceFiles}
+            onSaved={reload}
+            onDirtyChange={setSourceDirty}
+          />
+        </LazyPanel>
       )}
     </div>
   );

--- a/packages/studio/src/components/storyboard/StoryboardSourceEditor.tsx
+++ b/packages/studio/src/components/storyboard/StoryboardSourceEditor.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
-import { SourceEditor } from "../editor/SourceEditor";
+import { LazySourceEditor } from "../editor/LazySourceEditor";
 import { useFileManagerContext } from "../../contexts/FileManagerContext";
 
 export interface SourceFile {
@@ -214,7 +214,7 @@ export function StoryboardSourceEditor({
           {file.loading ? (
             <div className="p-4 text-sm text-neutral-500">Loading {activePath}…</div>
           ) : (
-            <SourceEditor
+            <LazySourceEditor
               content={file.content}
               language="markdown"
               filePath={activePath}

--- a/packages/studio/src/hooks/useProjectCompositionVariables.ts
+++ b/packages/studio/src/hooks/useProjectCompositionVariables.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type MutableRefObject } from "react";
-import { openComposition, type Composition, type CompositionVariable } from "@hyperframes/sdk";
+import type { Composition, CompositionVariable } from "@hyperframes/sdk";
+import { openComposition } from "../utils/sdkLazy";
 import { persistSdkSerialize } from "../utils/sdkCutover";
 import type { EditHistoryKind } from "../utils/editHistory";
 

--- a/packages/studio/src/hooks/useSdkSession.ts
+++ b/packages/studio/src/hooks/useSdkSession.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { MutableRefObject } from "react";
-import { openComposition } from "@hyperframes/sdk";
 import type { Composition } from "@hyperframes/sdk";
+import { openComposition } from "../utils/sdkLazy";
 import { readStudioFileChangePath } from "../components/editor/manualEdits";
 import { isSelfWriteEcho } from "./sdkSelfWriteRegistry";
 import { trackStudioEvent } from "../utils/studioTelemetry";

--- a/packages/studio/src/utils/sdkEditTransaction.ts
+++ b/packages/studio/src/utils/sdkEditTransaction.ts
@@ -1,5 +1,6 @@
 import type { MutableRefObject } from "react";
-import { openComposition, type Composition } from "@hyperframes/sdk";
+import type { Composition } from "@hyperframes/sdk";
+import { openComposition } from "./sdkLazy";
 import type { EditHistoryKind } from "./editHistory";
 import { hashContent, markSelfWrite } from "../hooks/sdkSelfWriteRegistry";
 import { trackStudioEvent } from "./studioTelemetry";

--- a/packages/studio/src/utils/sdkLazy.ts
+++ b/packages/studio/src/utils/sdkLazy.ts
@@ -1,0 +1,26 @@
+/**
+ * Lazy `openComposition`.
+ *
+ * `@hyperframes/sdk` models a composition as a live linkedom document, so a
+ * static import drags linkedom + htmlparser2 / css-select / domutils / cssom /
+ * entities (~410KB of module graph) into the studio's eagerly-loaded bundle —
+ * bytes the browser downloads before first paint even though nothing parses a
+ * composition until a session opens or an edit runs.
+ *
+ * Every openComposition call site is already inside an `async` function that
+ * awaits the result, so routing them through this module defers the whole stack
+ * to its own chunk at zero behavioural cost. Import `openComposition` from here,
+ * never from `@hyperframes/sdk` directly — one static import anywhere on the
+ * eager graph puts all of it back. (Type-only imports are erased and are fine.)
+ *
+ * Same pattern as `player/lib/mediaProbe.ts` does for mediabunny.
+ */
+import type { Composition, OpenCompositionOptions } from "@hyperframes/sdk";
+
+export async function openComposition(
+  html: string,
+  opts?: OpenCompositionOptions,
+): Promise<Composition> {
+  const sdk = await import("@hyperframes/sdk");
+  return sdk.openComposition(html, opts);
+}

--- a/packages/studio/src/utils/sdkResolverShadow.ts
+++ b/packages/studio/src/utils/sdkResolverShadow.ts
@@ -15,8 +15,8 @@
  * Telemetry-only — never writes to disk, never affects the user-visible edit.
  */
 
-import { openComposition } from "@hyperframes/sdk";
 import type { Composition, JsonPatchOp } from "@hyperframes/sdk";
+import { openComposition } from "./sdkLazy";
 import type { PatchOperation } from "./sourcePatcher";
 import { STUDIO_SDK_RESOLVER_SHADOW_ENABLED } from "../components/editor/manualEditingAvailability";
 import { patchOpsToSdkEditOps } from "./sdkOpMapping";

--- a/packages/studio/tests/e2e/studio-bundle-budget.mjs
+++ b/packages/studio/tests/e2e/studio-bundle-budget.mjs
@@ -1,0 +1,137 @@
+/**
+ * Byte budget for the studio's eagerly-loaded JavaScript.
+ *
+ * Reads the built `dist/index.html`, resolves every script the browser must
+ * fetch before it can render anything, gzips them, and fails above
+ * EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES. No browser and no dev server, so it is
+ * cheap enough to run on every studio PR.
+ *
+ * "Eagerly loaded" deliberately means the entry module PLUS the chunks it
+ * statically imports (which Vite emits as `<link rel="modulepreload">`), not
+ * just the entry file. Measuring the entry file alone would let the
+ * `manualChunks` config in vite.config.ts move bytes out of the number without
+ * moving them off the critical path: on the current build the entry file alone
+ * gzips to 444 KB and would report a pass, while the browser actually downloads
+ * 861 KB before first paint.
+ *
+ * Usage: bun tests/e2e/studio-bundle-budget.mjs [distDir]
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+
+/**
+ * The target. Reaching it needs the Node-only AST/DOM stack (@babel/parser,
+ * esprima, acorn, recast, ast-types, source-map, linkedom) out of the browser
+ * bundle — roughly 1.85MB of module graph pulled in through the SDK's
+ * openComposition. That is its own unit; this number is not revised down to
+ * meet what we happen to ship today.
+ */
+export const EAGER_ENTRY_CHUNK_GZIP_TARGET_BYTES = 600 * 1024;
+/**
+ * What the gate enforces: a ratchet just above the measured 860,966B, so the
+ * 23.6% already won cannot be given back. It may only ever move down.
+ * Enforcing the unreached target instead would mean a permanently red check,
+ * and a permanently red check gets muted — so it would protect nothing.
+ */
+export const EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES = 870_000;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_DIST = resolve(HERE, "../../dist");
+
+function attribute(tag, name) {
+  const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i"));
+  return match?.[1] ?? match?.[2] ?? match?.[3] ?? null;
+}
+
+/**
+ * @param {string} html contents of dist/index.html
+ * @returns {{ entries: string[], preloads: string[] }} asset URLs, as authored
+ */
+export function findEagerAssets(html) {
+  const entries = [...html.matchAll(/<script\b[^>]*>/gi)].flatMap(([tag]) => {
+    const src = attribute(tag, "src");
+    return attribute(tag, "type")?.toLowerCase() === "module" && src ? [src] : [];
+  });
+  const preloads = [...html.matchAll(/<link\b[^>]*>/gi)].flatMap(([tag]) => {
+    const href = attribute(tag, "href");
+    return attribute(tag, "rel")?.toLowerCase() === "modulepreload" && href ? [href] : [];
+  });
+  return { entries, preloads };
+}
+
+function resolveAsset(distDir, url) {
+  const pathname = decodeURIComponent(new URL(url, "https://studio.invalid").pathname);
+  const filePath = resolve(distDir, `.${pathname}`);
+  if (relative(distDir, filePath).startsWith("..")) {
+    throw new Error(`Asset resolves outside dist: ${url}`);
+  }
+  if (!existsSync(filePath)) {
+    throw new Error(`index.html references a missing asset: ${filePath}`);
+  }
+  return filePath;
+}
+
+function line(name, measured, budget, passed, unit = "") {
+  const status = passed ? "PASS" : "FAIL";
+  return `[StudioBundleBudget] ${status} ${name} measured=${measured}${unit} budget=${budget}${unit}`;
+}
+
+/**
+ * @param {string} distDir directory holding the built index.html
+ * @param {number} budgetGzipBytes
+ * @returns {{ passed: boolean, report: string, gzipBytes: number }}
+ */
+export function checkEagerBundleBudget(distDir, budgetGzipBytes) {
+  const indexPath = resolve(distDir, "index.html");
+  if (!existsSync(indexPath)) {
+    throw new Error(`No built artifact at ${indexPath} — run \`vite build\` in packages/studio`);
+  }
+
+  const { entries, preloads } = findEagerAssets(readFileSync(indexPath, "utf8"));
+  const lines = [line("eagerEntryModuleCount", entries.length, 1, entries.length === 1)];
+  if (entries.length !== 1) {
+    return { passed: false, report: lines.join("\n"), gzipBytes: 0 };
+  }
+
+  let gzipBytes = 0;
+  for (const url of [entries[0], ...preloads]) {
+    const bytes = gzipSync(readFileSync(resolveAsset(distDir, url))).byteLength;
+    gzipBytes += bytes;
+    lines.push(`[StudioBundleBudget] eager ${url} gzip=${bytes}B`);
+  }
+
+  const passed = gzipBytes <= budgetGzipBytes;
+  lines.push(line("eagerEntryChunkGzipBytes", gzipBytes, budgetGzipBytes, passed, "B"));
+  return { passed, report: lines.join("\n"), gzipBytes };
+}
+
+// Run the gate only when invoked directly, so the vitest suite can import the helpers.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  try {
+    // The ratchet is enforced; the target is reported every run so the
+    // remaining gap stays visible instead of quietly becoming the new normal.
+    const { passed, report, gzipBytes } = checkEagerBundleBudget(
+      resolve(process.argv[2] ?? DEFAULT_DIST),
+      EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES,
+    );
+    console.log(report);
+    const target = EAGER_ENTRY_CHUNK_GZIP_TARGET_BYTES;
+    if (passed && gzipBytes > target) {
+      console.log(
+        `[StudioBundleBudget] NOTE eager gzip ${gzipBytes}B is within the ${EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES}B ratchet ` +
+          `but still ${gzipBytes - target}B over the ${target}B target.`,
+      );
+    }
+    if (passed && gzipBytes < target) {
+      console.log("[StudioBundleBudget] target met — lower the ratchet to lock it in.");
+    }
+    if (!passed) process.exitCode = 1;
+  } catch (error) {
+    console.error(
+      `[StudioBundleBudget] FAIL ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/packages/studio/tests/e2e/studio-bundle-budget.mjs
+++ b/packages/studio/tests/e2e/studio-bundle-budget.mjs
@@ -22,20 +22,24 @@ import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
 
 /**
- * The target. Reaching it needs the Node-only AST/DOM stack (@babel/parser,
- * esprima, acorn, recast, ast-types, source-map, linkedom) out of the browser
- * bundle — roughly 1.85MB of module graph pulled in through the SDK's
- * openComposition. That is its own unit; this number is not revised down to
- * meet what we happen to ship today.
+ * The target — met as of the AST/DOM-stack removal (measured 604,332B).
+ *
+ * Getting here took the Node-only AST/DOM stack off the first-paint path:
+ * recast / @babel/parser / esprima / ast-types / source-map left the browser
+ * graph entirely when `isStudioHoldSet` moved out of the recast-importing
+ * gsapParser.ts, and linkedom (+ htmlparser2 / css-select / domutils / cssom /
+ * entities) moved behind the dynamic `import("@hyperframes/sdk")` in
+ * src/utils/sdkLazy.ts plus the `sdk-parse` manualChunks rule that keeps the
+ * `/node_modules/` catch-all from folding it back into eager `vendor`.
  */
 export const EAGER_ENTRY_CHUNK_GZIP_TARGET_BYTES = 600 * 1024;
 /**
- * What the gate enforces: a ratchet just above the measured 860,966B, so the
- * 23.6% already won cannot be given back. It may only ever move down.
- * Enforcing the unreached target instead would mean a permanently red check,
- * and a permanently red check gets muted — so it would protect nothing.
+ * What the gate enforces: a ratchet just above the measured 604,332B, so what
+ * has been won cannot be given back. It may only ever move down. It sits above
+ * rather than at the target so ordinary churn does not flip the check red — a
+ * permanently red check gets muted, and would protect nothing.
  */
-export const EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES = 870_000;
+export const EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES = 610_000;
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_DIST = resolve(HERE, "../../dist");

--- a/packages/studio/tests/e2e/studio-bundle-budget.test.ts
+++ b/packages/studio/tests/e2e/studio-bundle-budget.test.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs gate script, no type declarations
+import {
+  checkEagerBundleBudget,
+  EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES,
+  findEagerAssets,
+} from "./studio-bundle-budget.mjs";
+
+const ENTRY_TAG = '<script type="module" crossorigin src="/assets/index.js"></script>';
+const PRELOAD_TAG = '<link rel="modulepreload" crossorigin href="/assets/vendor.js">';
+const STYLE_TAG = '<link rel="stylesheet" href="/assets/index.css">';
+const BUDGET: number = EAGER_ENTRY_CHUNK_GZIP_RATCHET_BYTES;
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+/** Incompressible bytes, so each fixture's gzip size tracks its declared size. */
+function fixtureDist(entryBytes: number, preloadBytes?: number): string {
+  const distDir = mkdtempSync(join(tmpdir(), "studio-bundle-budget-"));
+  temporaryDirectories.push(distDir);
+  mkdirSync(join(distDir, "assets"));
+  const preload = preloadBytes == null ? "" : PRELOAD_TAG;
+  writeFileSync(join(distDir, "index.html"), `${ENTRY_TAG}${preload}${STYLE_TAG}`);
+  writeFileSync(join(distDir, "assets/index.js"), randomBytes(entryBytes));
+  if (preloadBytes != null) {
+    writeFileSync(join(distDir, "assets/vendor.js"), randomBytes(preloadBytes));
+  }
+  return distDir;
+}
+
+describe("studio bundle budget", () => {
+  it("reads exactly one eagerly-loaded entry module plus its modulepreloads", () => {
+    const { entries, preloads } = findEagerAssets(`${ENTRY_TAG}${PRELOAD_TAG}${STYLE_TAG}`);
+    expect(entries).toEqual(["/assets/index.js"]);
+    // The stylesheet link must not be mistaken for a preloaded module.
+    expect(preloads).toEqual(["/assets/vendor.js"]);
+  });
+
+  it("fails when index.html has more than one eager entry module", () => {
+    const distDir = fixtureDist(64);
+    writeFileSync(join(distDir, "index.html"), `${ENTRY_TAG}${ENTRY_TAG}`);
+
+    const { passed, report } = checkEagerBundleBudget(distDir, BUDGET);
+
+    expect(passed).toBe(false);
+    expect(report).toContain("FAIL eagerEntryModuleCount measured=2 budget=1");
+  });
+
+  it("fails, naming the measured and budgeted values, on an over-budget artifact", () => {
+    const { passed, report, gzipBytes } = checkEagerBundleBudget(
+      fixtureDist(BUDGET + 64 * 1024),
+      BUDGET,
+    );
+
+    expect(passed).toBe(false);
+    expect(report).toContain(
+      `FAIL eagerEntryChunkGzipBytes measured=${gzipBytes}B budget=${BUDGET}B`,
+    );
+  });
+
+  it("counts modulepreloaded chunks, so a manualChunks split cannot game the budget", () => {
+    const total = BUDGET + 64 * 1024;
+    const whole = checkEagerBundleBudget(fixtureDist(total), BUDGET);
+    const split = checkEagerBundleBudget(fixtureDist(total / 2, total / 2), BUDGET);
+
+    // Same eager payload, two chunks instead of one — the verdict must not change.
+    expect(split.gzipBytes).toBeGreaterThan(whole.gzipBytes * 0.99);
+    expect(split.passed).toBe(false);
+  });
+
+  it("passes when the whole eager graph fits the budget", () => {
+    const { passed, report } = checkEagerBundleBudget(fixtureDist(1_024, 1_024), 5_000_000);
+
+    expect(passed).toBe(true);
+    expect(report).toContain("PASS eagerEntryChunkGzipBytes");
+  });
+});

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -199,6 +199,34 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("/node_modules/@codemirror/") || id.includes("/node_modules/@lezer/")) {
+            return "source-editor";
+          }
+          if (
+            id.includes("/node_modules/crelt/") ||
+            id.includes("/node_modules/style-mod/") ||
+            id.includes("/node_modules/w3c-keyname/")
+          ) {
+            return "source-editor";
+          }
+          if (id.includes("/node_modules/marked/") || id.includes("/node_modules/dompurify/")) {
+            return "markdown";
+          }
+          if (id.includes("/node_modules/mediabunny/")) return "media-probe";
+          if (
+            id.includes("/node_modules/react/") ||
+            id.includes("/node_modules/react-dom/") ||
+            id.includes("/node_modules/scheduler/")
+          ) {
+            return "react-vendor";
+          }
+          if (id.includes("/node_modules/")) return "vendor";
+        },
+      },
+    },
   },
   optimizeDeps: {
     include: ["bpm-detective"],

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -182,6 +182,16 @@ function devProjectApi(): Plugin {
   };
 }
 
+/**
+ * linkedom and everything only it drags in. Kept as one list so the SDK's
+ * HTML-parsing stack stays out of the eager `vendor` chunk — see the
+ * `manualChunks` rule that uses it. Adding a package here is only safe while
+ * nothing on the eager graph imports it; `tests/e2e/studio-bundle-budget.mjs`
+ * is the check that fails if that stops being true.
+ */
+const SDK_PARSE_DEPS =
+  /\/node_modules\/(linkedom|htmlparser2|domhandler|dom-serializer|domelementtype|domutils|css-select|css-what|nth-check|boolbase|entities|cssom|uhyphen)\//;
+
 export default defineConfig({
   plugins: [react(), devProjectApi()],
   define: {
@@ -216,6 +226,14 @@ export default defineConfig({
             return "markdown";
           }
           if (id.includes("/node_modules/mediabunny/")) return "media-probe";
+          // linkedom + its DOM/CSS parsing deps. Reachable ONLY through the
+          // dynamic `import("@hyperframes/sdk")` in src/utils/sdkLazy.ts, but the
+          // `/node_modules/` catch-all below would still fold them into the
+          // modulepreloaded `vendor` chunk and undo that deferral — moving bytes
+          // between eager chunks is not deferral. Naming them keeps them in a
+          // chunk nothing eager references, so the browser fetches it on the
+          // first edit instead of before first paint.
+          if (SDK_PARSE_DEPS.test(id)) return "sdk-parse";
           if (
             id.includes("/node_modules/react/") ||
             id.includes("/node_modules/react-dom/") ||


### PR DESCRIPTION
The eager browser bundle carried a Node-only AST and DOM stack — `@babel/parser`, `esprima`, `acorn`, `recast`, `ast-types`, `source-map`, `linkedom` — reachable from the SDK entry point on the first-paint path.

**Measured: eager entry chunk 1,116 → 604 KB gzip.**

## Two changes

1. **Defer the source editor and markdown preview** off first paint. Neither is visible on load.
2. **Move the AST stack behind a lazy boundary.** It is only needed when a composition is opened for editing, not when the shell renders.

## A correction worth recording

An early investigation concluded `linkedom` was already tree-shaken out. That was a **grep false negative on minified output** — the identifier does not survive minification in a form a text search finds. Sourcemap analysis showed 123 of its modules still present in the eager chunk.

The bundle-budget harness in this PR encodes the lesson: it asserts against the **module graph and gzip size**, never against a text search of the built bundle. If you take one thing from this PR, take that — a grep of minified output cannot prove absence.

## What to verify

- The eager entry chunk stays under the ratchet, asserted on gzip size.
- The AST stack is reachable only through the lazy path.
- The source editor, storyboard source editor, and render queue all still resolve their lazy imports and function after deferral.

## Note on a shared file

Adds a script entry to `packages/studio/package.json` adjacent to one added by the runtime-gate PR in this sequence. Whichever lands second may need a one-line conflict resolution.

## Verification

`packages/studio` suite green (3,279 tests); bundle budget harness passes.
