### PR TITLE
fix(studio): release the previous project's render scopes on switch

### DIFF
--- a/packages/studio/src/components/nle/NLEContext.tsx
+++ b/packages/studio/src/components/nle/NLEContext.tsx
@@ -25,6 +25,19 @@ export function shouldDisableTimelineWhileCompositionLoading(compositionLoading:
   return compositionLoading;
 }
 
+/**
+ * Copy a substring off its parent.
+ *
+ * V8 represents a substring of 13+ characters as a SlicedString that keeps the
+ * WHOLE parent alive. A handful of `compositions/*.html` paths cut out of a
+ * 36 KB `index.html` therefore pin that entire document for as long as the map
+ * holding them lives — one document per project opened. Concatenating and
+ * re-slicing re-materialises the value over a throwaway parent its own size.
+ */
+function detachSubstring(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : (" " + value).slice(1);
+}
+
 export interface NLEContextValue {
   projectId: string;
   // player (from useTimelinePlayer — single instance for the whole shell)
@@ -207,8 +220,8 @@ export function NLEProvider({
           /data-composition-id=["']([^"']+)["'][^>]*data-composition-src=["']([^"']+)["']|data-composition-src=["']([^"']+)["'][^>]*data-composition-id=["']([^"']+)["']/g;
         let match;
         while ((match = re.exec(html)) !== null) {
-          const id = match[1] || match[4];
-          const src = match[2] || match[3];
+          const id = detachSubstring(match[1] || match[4]);
+          const src = detachSubstring(match[2] || match[3]);
           if (id && src) map.set(id, src);
         }
         setCompIdToSrc(map);

--- a/packages/studio/src/hooks/useDomSelection.retention.test.tsx
+++ b/packages/studio/src/hooks/useDomSelection.retention.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TimelineElement } from "../player";
+import type { UseDomSelectionParams } from "./useDomSelection";
+
+const resolveDomEditSelection = vi.fn();
+
+vi.mock("../components/editor/domEditing", () => ({
+  resolveDomEditSelection: (...args: unknown[]) => resolveDomEditSelection(...args),
+  findElementForSelection: () => null,
+  findElementForTimelineElement: () => null,
+}));
+vi.mock("../components/editor/manualEdits", () => ({ reapplyPositionEditsAfterSeek: () => {} }));
+vi.mock("./useStudioTestHooks", () => ({ useStudioTestHooks: () => {} }));
+
+const { useDomSelection } = await import("./useDomSelection");
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  resolveDomEditSelection.mockReset();
+});
+
+function paramsFor(suffix: string, selected: string[]): UseDomSelectionParams {
+  return {
+    projectId: `project-${suffix}`,
+    activeCompPath: `compositions/${suffix}.html`,
+    isMasterView: false,
+    compIdToSrc: new Map([[suffix, `compositions/${suffix}.html`]]),
+    captionEditMode: false,
+    previewIframeRef: { current: null },
+    timelineElements: [] as TimelineElement[],
+    setSelectedTimelineElementId: (id) => selected.push(String(id)),
+    setRightCollapsed: () => {},
+    setRightPanelTab: () => {},
+    previewIframe: null,
+    refreshKey: 0,
+    rightPanelTab: "design",
+  };
+}
+
+const CALLBACKS = [
+  "applyDomSelection",
+  "clearDomSelection",
+  "buildDomSelectionFromTarget",
+  "resolveDomSelectionFromPreviewPoint",
+  "resolveAllDomSelectionsFromPreviewPoint",
+  "updateDomEditHoverSelection",
+  "buildDomSelectionForTimelineElement",
+  "handleTimelineElementSelect",
+  "refreshDomEditSelectionFromPreview",
+  "refreshDomEditGroupSelectionsFromPreview",
+  "applyMarqueeSelection",
+  "setActiveGroupElement",
+] as const;
+
+describe("useDomSelection retention", () => {
+  /**
+   * A `useCallback` rebuilt on a dep change is a new closure in the current
+   * render's scope, while every callback whose deps did not change is an older
+   * closure stored into that same scope — one edge chaining render N to render
+   * N-1. A project switch changes projectId, activeCompPath and
+   * timelineElements at once, so every switch added a link that pinned that
+   * render's element snapshot forever. Stable identities are what stops it.
+   */
+  it("keeps every callback identity across a project switch, and still reads the new project", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    const selected: string[] = [];
+    let current: ReturnType<typeof useDomSelection> | null = null;
+
+    function Harness({ params }: { params: UseDomSelectionParams }) {
+      current = useDomSelection(params);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { params: paramsFor("alpha", selected) }));
+    });
+    const first = { ...current! };
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { params: paramsFor("beta", selected) }));
+    });
+    const second = current!;
+
+    for (const name of CALLBACKS) {
+      expect(second[name], `${name} identity changed across the switch`).toBe(first[name]);
+    }
+
+    // Stability must not cost freshness: the once-built callback has to see the
+    // project it was NOT created with.
+    resolveDomEditSelection.mockResolvedValue(null);
+    await act(async () => {
+      await second.buildDomSelectionFromTarget(document.createElement("div"));
+    });
+    expect(resolveDomEditSelection).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        projectId: "project-beta",
+        activeCompositionPath: "compositions/beta.html",
+      }),
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/packages/studio/src/hooks/useDomSelection.ts
+++ b/packages/studio/src/hooks/useDomSelection.ts
@@ -101,21 +101,10 @@ export interface UseDomSelectionReturn {
 
 // ── Hook ──
 
-export function useDomSelection({
-  projectId,
-  activeCompPath,
-  isMasterView,
-  compIdToSrc,
-  captionEditMode,
-  previewIframeRef,
-  timelineElements,
-  setSelectedTimelineElementId,
-  setRightCollapsed,
-  setRightPanelTab,
-  previewIframe,
-  refreshKey,
-  rightPanelTab,
-}: UseDomSelectionParams): UseDomSelectionReturn {
+export function useDomSelection(params: UseDomSelectionParams): UseDomSelectionReturn {
+  const { projectId, activeCompPath, captionEditMode, previewIframe, refreshKey, rightPanelTab } =
+    params;
+
   // ── State ──
 
   const [domEditSelection, setDomEditSelection] = useState<DomEditSelection | null>(null);
@@ -143,6 +132,22 @@ export function useDomSelection({
   domEditHoverSelectionRef.current = domEditHoverSelection;
   activeGroupElementRef.current = activeGroupElement;
 
+  /**
+   * Every callback below reads its render-scoped inputs from here and is built
+   * once (`[]` deps). That is a retention requirement, not a style choice.
+   *
+   * A `useCallback` whose deps changed is a NEW closure living in the current
+   * render's scope; every callback whose deps did NOT change is the closure
+   * from an earlier render, stored into that same fresh scope. That one edge
+   * chains render scope N to render scope N-1. A project switch changes
+   * `projectId`, `activeCompPath` and `timelineElements` together, so each
+   * switch added a link — and every link pinned that render's element snapshot
+   * plus its cached index for the life of the session. Stable identities leave
+   * nothing to chain.
+   */
+  const latest = useRef(params);
+  latest.current = params;
+
   // ── Callbacks ──
 
   const applyDomSelection = useCallback(
@@ -155,6 +160,12 @@ export function useDomSelection({
         preserveGroup?: boolean;
       },
     ) => {
+      const {
+        timelineElements,
+        setSelectedTimelineElementId,
+        setRightCollapsed,
+        setRightPanelTab,
+      } = latest.current;
       if (!selection) {
         domEditSelectionRef.current = null;
         domEditGroupSelectionsRef.current = [];
@@ -222,7 +233,7 @@ export function useDomSelection({
 
       setSelectedTimelineElementId(null);
     },
-    [setSelectedTimelineElementId, timelineElements, setRightCollapsed, setRightPanelTab],
+    [],
   );
 
   const clearDomSelection = useCallback(() => {
@@ -252,6 +263,7 @@ export function useDomSelection({
         activeGroupElement?: HTMLElement | null;
       },
     ) => {
+      const { activeCompPath, isMasterView, projectId } = latest.current;
       return resolveDomEditSelection(target, {
         activeCompositionPath: activeCompPath,
         isMasterView,
@@ -264,7 +276,7 @@ export function useDomSelection({
         projectId,
       });
     },
-    [activeCompPath, isMasterView, projectId],
+    [],
   );
 
   const resolveDomSelectionFromPreviewPoint = useCallback(
@@ -278,6 +290,7 @@ export function useDomSelection({
         activeGroupElement?: HTMLElement | null;
       },
     ) => {
+      const { previewIframeRef, captionEditMode, activeCompPath } = latest.current;
       const iframe = previewIframeRef.current;
       if (!iframe || captionEditMode) return null;
       try {
@@ -301,12 +314,13 @@ export function useDomSelection({
             },
       );
     },
-    [activeCompPath, buildDomSelectionFromTarget, captionEditMode, previewIframeRef],
+    [buildDomSelectionFromTarget],
   );
 
   const resolveAllDomSelectionsFromPreviewPoint = useCallback(
     // fallow-ignore-next-line complexity
     async (clientX: number, clientY: number): Promise<DomEditSelection[]> => {
+      const { previewIframeRef, captionEditMode, activeCompPath } = latest.current;
       const iframe = previewIframeRef.current;
       if (!iframe || captionEditMode) return [];
       try {
@@ -322,7 +336,7 @@ export function useDomSelection({
       }
       return results;
     },
-    [activeCompPath, buildDomSelectionFromTarget, captionEditMode, previewIframeRef],
+    [buildDomSelectionFromTarget],
   );
 
   const updateDomEditHoverSelection = useCallback((selection: DomEditSelection | null) => {
@@ -334,6 +348,7 @@ export function useDomSelection({
   const buildDomSelectionForTimelineElement = useCallback(
     // fallow-ignore-next-line complexity
     async (element: TimelineElement): Promise<DomEditSelection | null> => {
+      const { previewIframeRef, activeCompPath, compIdToSrc, isMasterView } = latest.current;
       const iframe = previewIframeRef.current;
       let doc: Document | null = null;
       try {
@@ -356,7 +371,7 @@ export function useDomSelection({
           })
         : null;
     },
-    [activeCompPath, buildDomSelectionFromTarget, compIdToSrc, isMasterView, previewIframeRef],
+    [buildDomSelectionFromTarget],
   );
 
   const handleTimelineElementSelect = useCallback(
@@ -378,6 +393,7 @@ export function useDomSelection({
   const refreshDomEditSelectionFromPreview = useCallback(
     // fallow-ignore-next-line complexity
     async (selection: DomEditSelection) => {
+      const { previewIframeRef, activeCompPath } = latest.current;
       const iframe = previewIframeRef.current;
       let doc: Document | null = null;
       try {
@@ -401,12 +417,14 @@ export function useDomSelection({
         });
       }
     },
-    [activeCompPath, applyDomSelection, buildDomSelectionFromTarget, previewIframeRef],
+    [applyDomSelection, buildDomSelectionFromTarget],
   );
 
   const refreshDomEditGroupSelectionsFromPreview = useCallback(
     // fallow-ignore-next-line complexity
     async (selections: DomEditSelection[]) => {
+      const { previewIframeRef, activeCompPath, timelineElements, setSelectedTimelineElementId } =
+        latest.current;
       const iframe = previewIframeRef.current;
       let doc: Document | null = null;
       try {
@@ -444,13 +462,7 @@ export function useDomSelection({
         setSelectedTimelineElementId(null);
       }
     },
-    [
-      activeCompPath,
-      buildDomSelectionFromTarget,
-      setSelectedTimelineElementId,
-      timelineElements,
-      previewIframeRef,
-    ],
+    [buildDomSelectionFromTarget],
   );
 
   // ── Effects ──
@@ -498,7 +510,11 @@ export function useDomSelection({
   }, [applyDomSelection, captionEditMode]);
 
   // Dev-only headless-QA shortcut (window.__studioTest.selectByDomId). No-op in prod.
-  useStudioTestHooks({ previewIframeRef, buildDomSelectionFromTarget, applyDomSelection });
+  useStudioTestHooks({
+    previewIframeRef: params.previewIframeRef,
+    buildDomSelectionFromTarget,
+    applyDomSelection,
+  });
 
   const applyMarqueeSelection = useCallback(
     // fallow-ignore-next-line complexity
@@ -522,6 +538,7 @@ export function useDomSelection({
           if (!domEditSelectionInGroup(nextGroup, s)) nextGroup.push(s);
         }
       }
+      const { timelineElements, setSelectedTimelineElementId } = latest.current;
       const nextSelection = additive && current ? current : selections[0];
       domEditSelectionRef.current = nextSelection;
       domEditGroupSelectionsRef.current = nextGroup;
@@ -536,7 +553,7 @@ export function useDomSelection({
         );
       setSelectedTimelineElementId(nextTimelineId);
     },
-    [applyDomSelection, timelineElements, setSelectedTimelineElementId],
+    [applyDomSelection],
   );
 
   return {

--- a/packages/studio/src/hooks/useLintModal.test.tsx
+++ b/packages/studio/src/hooks/useLintModal.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { groupFindings, useLintModal } from "./useLintModal";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const requested: string[] = [];
+
+function findingsFor(projectId: string) {
+  return [
+    { severity: "error", message: `${projectId} one`, elementId: "el-1", file: "index.html" },
+    { severity: "warning", message: `${projectId} two`, elementId: "el-1", file: "index.html" },
+    { severity: "warning", message: `${projectId} three`, elementId: "el-2", file: "other.html" },
+  ];
+}
+
+beforeEach(() => {
+  requested.length = 0;
+  vi.stubGlobal("fetch", (url: string) => {
+    requested.push(url);
+    const projectId = /projects\/([^/]+)\/lint/.exec(url)?.[1] ?? "";
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ findings: findingsFor(projectId) }),
+    });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+describe("groupFindings", () => {
+  it("groups by key and keeps every message", () => {
+    const grouped = groupFindings(
+      findingsFor("p").map((f) => ({ ...f, severity: "warning" as const })),
+      (f) => f.elementId,
+    );
+    expect([...grouped.keys()]).toEqual(["el-1", "el-2"]);
+    expect(grouped.get("el-1")).toEqual({ count: 2, messages: ["p one", "p two"] });
+  });
+
+  it("skips findings whose key is undefined", () => {
+    const grouped = groupFindings(
+      [{ severity: "warning" as const, message: "no id" }],
+      (f) => f.elementId,
+    );
+    expect(grouped.size).toBe(0);
+  });
+});
+
+describe("useLintModal", () => {
+  /**
+   * Retention regression. A `useCallback` keyed on `projectId` is rebuilt on
+   * every project switch, and the stale one is stored into the new render's
+   * scope — chaining each render scope to the previous one so every switch
+   * pins a whole lint result (~240 findings) forever. Stable identities are
+   * the observable form of "the previous scope was released".
+   */
+  it("keeps callback identities across project switches while still linting the new project", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    let current: ReturnType<typeof useLintModal> | null = null;
+
+    function Harness({ projectId }: { projectId: string }) {
+      current = useLintModal(projectId);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { projectId: "alpha" }));
+    });
+    const first = current!;
+    expect(requested).toEqual(["/api/projects/alpha/lint"]);
+    expect(first.backgroundFindings.map((f) => f.message)).toEqual([
+      "alpha one",
+      "alpha two",
+      "alpha three",
+    ]);
+    expect([...first.findingsByElement.keys()]).toEqual(["el-1", "el-2"]);
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { projectId: "beta" }));
+    });
+    const second = current!;
+
+    expect(second.handleLint).toBe(first.handleLint);
+    expect(second.closeLintModal).toBe(first.closeLintModal);
+    // The ref-read project id has to be the CURRENT one, or a stable callback
+    // would keep linting the project the user left.
+    expect(requested).toEqual(["/api/projects/alpha/lint", "/api/projects/beta/lint"]);
+    expect(second.backgroundFindings.map((f) => f.message)).toEqual([
+      "beta one",
+      "beta two",
+      "beta three",
+    ]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/packages/studio/src/hooks/useLintModal.ts
+++ b/packages/studio/src/hooks/useLintModal.ts
@@ -12,7 +12,9 @@ interface RawFinding {
   code?: string;
 }
 
-function parseFinding(f: RawFinding): LintFinding & { elementId?: string; file?: string } {
+type ParsedFinding = LintFinding & { elementId?: string; file?: string };
+
+function parseFinding(f: RawFinding): ParsedFinding {
   return {
     severity: f.severity === "error" ? ("error" as const) : ("warning" as const),
     message: f.message ?? "",
@@ -22,39 +24,65 @@ function parseFinding(f: RawFinding): LintFinding & { elementId?: string; file?:
   };
 }
 
+/**
+ * Module scope, not a `useCallback` capturing `backgroundFindings`.
+ *
+ * A memoized callback that closes over render-scoped state is stored into the
+ * NEXT render's scope whenever its deps are unchanged, which chains every
+ * render scope to the previous one. Each link pins that render's findings
+ * array, so one project switch leaked a full lint result (~240 findings)
+ * forever. Taking the findings as an argument keeps them out of any closure.
+ */
+export function groupFindings(
+  findings: readonly ParsedFinding[],
+  keyFn: (f: ParsedFinding) => string | undefined,
+): Map<string, { count: number; messages: string[] }> {
+  const map = new Map<string, { count: number; messages: string[] }>();
+  for (const f of findings) {
+    const key = keyFn(f);
+    if (!key) continue;
+    const prev = map.get(key) ?? { count: 0, messages: [] };
+    prev.count += 1;
+    prev.messages.push(f.message);
+    map.set(key, prev);
+  }
+  return map;
+}
+
 export function useLintModal(projectId: string | null, refreshKey?: number) {
   const [lintModal, setLintModal] = useState<LintFinding[] | null>(null);
   const [linting, setLinting] = useState(false);
-  const [backgroundFindings, setBackgroundFindings] = useState<
-    Array<LintFinding & { elementId?: string; file?: string }>
-  >([]);
+  const [backgroundFindings, setBackgroundFindings] = useState<ParsedFinding[]>([]);
   const autoLintRanRef = useRef(false);
+  // `runLint` reads the project through a ref so it can be created once. A
+  // `[projectId]`-keyed callback is recreated on every switch and the stale one
+  // lands in the new render's scope, chaining scopes (and their findings).
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
 
-  const runLint = useCallback(
-    async (opts?: { background?: boolean }) => {
-      if (!projectId) return;
-      if (!opts?.background) setLinting(true);
-      try {
-        const res = await fetch(`/api/projects/${projectId}/lint`);
-        const data = await res.json();
-        const parsed = ((data.findings ?? []) as RawFinding[]).map(parseFinding);
-        if (opts?.background) {
-          setBackgroundFindings(parsed);
-        } else {
-          setLintModal(parsed);
-          setBackgroundFindings(parsed);
-        }
-      } catch (err) {
-        if (!opts?.background) {
-          const msg = err instanceof Error ? err.message : String(err);
-          setLintModal([{ severity: "error", message: `Failed to run lint: ${msg}` }]);
-        }
-      } finally {
-        if (!opts?.background) setLinting(false);
+  const runLint = useCallback(async (opts?: { background?: boolean }) => {
+    const projectId = projectIdRef.current;
+    if (!projectId) return;
+    if (!opts?.background) setLinting(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/lint`);
+      const data = await res.json();
+      const parsed = ((data.findings ?? []) as RawFinding[]).map(parseFinding);
+      if (opts?.background) {
+        setBackgroundFindings(parsed);
+      } else {
+        setLintModal(parsed);
+        setBackgroundFindings(parsed);
       }
-    },
-    [projectId],
-  );
+    } catch (err) {
+      if (!opts?.background) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setLintModal([{ severity: "error", message: `Failed to run lint: ${msg}` }]);
+      }
+    } finally {
+      if (!opts?.background) setLinting(false);
+    }
+  }, []);
 
   const handleLint = useCallback(() => runLint(), [runLint]);
 
@@ -77,24 +105,14 @@ export function useLintModal(projectId: string | null, refreshKey?: number) {
 
   const closeLintModal = useCallback(() => setLintModal(null), []);
 
-  const groupFindings = useCallback(
-    (keyFn: (f: (typeof backgroundFindings)[0]) => string | undefined) => {
-      const map = new Map<string, { count: number; messages: string[] }>();
-      for (const f of backgroundFindings) {
-        const key = keyFn(f);
-        if (!key) continue;
-        const prev = map.get(key) ?? { count: 0, messages: [] };
-        prev.count += 1;
-        prev.messages.push(f.message);
-        map.set(key, prev);
-      }
-      return map;
-    },
+  const findingsByElement = useMemo(
+    () => groupFindings(backgroundFindings, (f) => f.elementId),
     [backgroundFindings],
   );
-
-  const findingsByElement = useMemo(() => groupFindings((f) => f.elementId), [groupFindings]);
-  const findingsByFile = useMemo(() => groupFindings((f) => f.file), [groupFindings]);
+  const findingsByFile = useMemo(
+    () => groupFindings(backgroundFindings, (f) => f.file),
+    [backgroundFindings],
+  );
 
   // Sync lint findings directly to the player store — eliminates the
   // mirroring useEffect that was previously in App.tsx.


### PR DESCRIPTION
Switching projects retained the previous project's render scopes. In an editor where people switch between projects repeatedly in one session, that accumulates.

**Measured: retained heap 0.237 → 0.061 MB per switch cycle.**

## The cause

A `useCallback` closed over a scope that outlived the project it belonged to, chaining the previous project's state into the new one's callback identity. Plus one substring reference that was never explicitly detached.

## A caveat for anyone reproducing this

An earlier measurement of this same leak reported **+554 retained DOM nodes per switch**. That number was wrong, and wrong in an instructive way: it was the *measurement harness's own retained element handle* pinning an ancestor chain, not the application.

If you reproduce this, dispose every element handle before sampling the heap. A harness that holds a handle to a node in the tree it is measuring will report a leak that exists only in the harness.

## What to check

- Switching projects releases the previous project's selection scope.
- The lint modal's listeners detach on unmount.
- A switch-and-return cycle does not accumulate retained scopes across N iterations.
- Selection still works normally after a switch — the release is not over-eager, which is the obvious way to break this while making the number look good.

## Verification

`packages/studio` suite green (3,276 tests). The heap figure comes from the switch window of the runtime-cost gate, a separate PR in this sequence; the behaviour is verifiable from the tests here alone.
