### PR TITLE
perf(studio): scan the preview document once per timeline derivation

### DIFF
--- a/packages/core/src/runtime/clipIdentity.test.ts
+++ b/packages/core/src/runtime/clipIdentity.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createClipTree } from "./clipTree";
+import { collectRuntimeTimelinePayload } from "./timeline";
+
+/**
+ * Characterization of the ONE contract two runtime paths publish under the same
+ * name: `clip.id` in `__clipManifest` (timeline.ts) and `node.id` in
+ * `__clipTree` (clipTree.ts). Studio joins the two id spaces — the tree builds
+ * `clipParentMap`, the manifest supplies the clip that looks a parent up in it
+ * (see useTimelineSyncCallbacks.ts) — so any change to either side is a change
+ * to element identity, and studio diffs identity to decide "same element" vs
+ * "replaced element". A replacement drops selection, expanded rows, the
+ * keyframe cache and lint findings.
+ *
+ * These tests pin what each path emits TODAY. They are a guard for anyone
+ * unifying the two fallbacks, not an endorsement of the current split.
+ */
+
+const treeParams = {
+  startResolver: { resolveStartForElement: () => 0 },
+  timelineRegistry: {},
+  rootDuration: 10,
+};
+
+function treeIds(): string[] {
+  const ids: string[] = [];
+  const walk = (nodes: readonly { id: string; children: readonly unknown[] }[]): void => {
+    for (const node of nodes) {
+      ids.push(node.id);
+      walk(node.children as readonly { id: string; children: readonly unknown[] }[]);
+    }
+  };
+  walk(createClipTree(treeParams).roots);
+  return ids;
+}
+
+function manifestIds(): (string | null)[] {
+  return collectRuntimeTimelinePayload({ canonicalFps: 30 }).clips.map((clip) => clip.id);
+}
+
+describe("clip identity — manifest vs tree", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("agrees on every clip that carries an id of its own", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-duration="10" data-start="0">
+        <div id="has-dom-id" data-start="0" data-duration="2"></div>
+        <div data-hf-id="hf-only" data-start="0" data-duration="2"></div>
+      </div>`;
+
+    expect(treeIds()).toEqual(["has-dom-id", "hf-only"]);
+    expect(manifestIds()).toEqual(["has-dom-id", "hf-only"]);
+  });
+
+  // The two disagreeing fallbacks. A clip with only a composition id is named
+  // by that composition id in the manifest but ordinally in the tree; a clip
+  // with no identity at all is `null` in the manifest and ordinal in the tree.
+  it("disagrees on clips with no id of their own", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-duration="10" data-start="0">
+        <div data-composition-id="sub" data-start="0" data-duration="2"></div>
+        <div class="anonymous" data-start="0" data-duration="2"></div>
+      </div>`;
+
+    expect(treeIds()).toEqual(["__clip-0", "__clip-1"]);
+    expect(manifestIds()).toEqual(["sub", null]);
+  });
+
+  /**
+   * Why the manifest cannot simply mirror `__clip-${ordinal++}`.
+   *
+   * The two traversals do not enumerate the same elements, so the Nth id-less
+   * clip of one is not the Nth id-less clip of the other:
+   *   - clipTree queries `[data-start]`; the manifest also takes
+   *     `[data-track-index]`, `[data-composition-id]`, `video`, `audio`, `img`.
+   *   - clipTree keeps any element whose window is non-empty against the root
+   *     duration; the manifest drops elements whose duration it cannot resolve
+   *     from an attribute, a registered timeline, media, or an enclosing
+   *     composition.
+   *
+   * Below, the `<img>` is a manifest clip and not a tree node. A mirrored
+   * counter would therefore name it `__clip-0` in the manifest, and name the
+   * DIV — which is `__clip-0` in the tree — `__clip-1`. Studio's parent lookup
+   * would then resolve a clip against another element's tree node: today's
+   * `null` fails closed, a mismatched ordinal fails open.
+   */
+  it("cannot mirror the tree ordinal: the traversals enumerate different elements", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-duration="10" data-start="0">
+        <img data-duration="2" src="a.png" alt="" />
+        <div class="anonymous" data-start="0" data-duration="2"></div>
+      </div>`;
+
+    // The tree never sees the <img> (no data-start), so the DIV is its first
+    // — and only — synthesized ordinal.
+    expect(treeIds()).toEqual(["__clip-0"]);
+
+    // The manifest sees both, and the <img> comes first in document order.
+    const clips = collectRuntimeTimelinePayload({ canonicalFps: 30 }).clips;
+    expect(clips.map((clip) => clip.tagName)).toEqual(["img", "div"]);
+    expect(clips.map((clip) => clip.id)).toEqual([null, null]);
+  });
+});

--- a/packages/studio/src/components/editor/propertyPanelFont.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFont.tsx
@@ -24,6 +24,9 @@ import { useTrackDesignInput } from "../../contexts/DesignPanelInputContext";
 /*  Font helper functions                                              */
 /* ------------------------------------------------------------------ */
 
+/** Shared so a closed font dropdown's memo keeps a stable identity. */
+const EMPTY_FONT_OPTIONS: FontOption[] = [];
+
 function splitFontFamilies(value: string): string[] {
   const families: string[] = [];
   let current = "";
@@ -272,7 +275,12 @@ export function FontFamilyField({
     [importedFonts],
   );
 
+  // Gated on `open`: the dropdown is the only consumer and it renders only
+  // while open, but the memo is keyed on the selected family — which changes on
+  // every click — so it re-collected, de-duplicated and re-sorted ~1,500
+  // families on every selection to feed a list nobody was looking at.
   const options = useMemo(() => {
+    if (!open) return EMPTY_FONT_OPTIONS;
     const documentFonts = collectDocumentFontFamilies();
     const googleSet = new Set(googleFonts.map((f) => f.toLowerCase()));
     const taggedLocal = localFonts.map(
@@ -291,7 +299,7 @@ export function FontFamilyField({
         ...DEFAULT_FONT_FAMILIES.map((f): FontOption => ({ family: f, source: "System" })),
       ]),
     );
-  }, [currentFamily, googleFonts, localFonts, projectFontAssets]);
+  }, [open, currentFamily, googleFonts, localFonts, projectFontAssets]);
 
   const filteredOptions = useMemo(() => {
     const matches = options.filter((o) => fontMatchesQuery(o.family, query));

--- a/packages/studio/src/components/editor/propertyPanelSections.tsx
+++ b/packages/studio/src/components/editor/propertyPanelSections.tsx
@@ -48,16 +48,32 @@ export const WEIGHT_LABELS: Record<string, string> = {
   "900": "900 · Black",
 };
 
+/**
+ * `fonts.check()` is nine synchronous font-matching calls per selection, and a
+ * family's available weights only change when a font finishes loading — which
+ * `loadingdone` announces. So: cache per family, clear on that event. Every
+ * selection re-renders this panel, so without the cache the same nine checks
+ * ran on every click.
+ */
+const availableWeightsByFamily = new Map<string, string[]>();
+if (typeof document !== "undefined" && document.fonts) {
+  document.fonts.addEventListener("loadingdone", () => availableWeightsByFamily.clear());
+}
+
 export function detectAvailableWeights(fontFamily: string): string[] {
   const fonts = document.fonts;
   if (!fonts) return ALL_WEIGHTS;
   const family = fontFamily.split(",")[0]?.trim().replace(/['"]/g, "");
   if (!family) return ALL_WEIGHTS;
+  const cached = availableWeightsByFamily.get(family);
+  if (cached) return cached;
   const available: string[] = [];
   for (const w of ALL_WEIGHTS) {
     if (fonts.check(`${w} 16px "${family}"`)) available.push(w);
   }
-  return available.length > 0 ? available : ALL_WEIGHTS;
+  const weights = available.length > 0 ? available : ALL_WEIGHTS;
+  availableWeightsByFamily.set(family, weights);
+  return weights;
 }
 
 export function TextAreaField({

--- a/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.test.ts
@@ -3,6 +3,7 @@ import { Window } from "happy-dom";
 import {
   buildStandaloneRootTimelineElement,
   createStaticSeekPlaybackAdapter,
+  createTimelineDomPass,
   createTimelineElementFromManifestClip,
   findTimelineDomNodeForClip,
   getTimelineElementSelector,
@@ -306,26 +307,81 @@ describe("findTimelineDomNodeForClip", () => {
         <div class="clip duplicate-card second" data-start="0" data-duration="4" data-track-index="2"></div>
       </div>
     `);
-    const used = new Set<Element>();
+    const pass = createTimelineDomPass(doc);
 
     const first = findTimelineDomNodeForClip(
       doc,
       createClip({ id: "__node__index_2", track: 1 }),
       1,
-      used,
+      pass,
     ) as HTMLElement;
-    used.add(first);
     const second = findTimelineDomNodeForClip(
       doc,
       createClip({ id: "__node__index_3", track: 2 }),
       2,
-      used,
+      pass,
     ) as HTMLElement;
 
     expect(first.className).toBe("clip duplicate-card first");
     expect(second.className).toBe("clip duplicate-card second");
     expect(getTimelineElementSelector(first)).toBe(".duplicate-card");
     expect(getTimelineElementSelector(second)).toBe(".duplicate-card");
+  });
+
+  it("scans the document once per pass instead of once per clip", () => {
+    const cards = Array.from(
+      { length: 6 },
+      (_, index) =>
+        `<div class="clip card" data-start="${index}" data-duration="1" data-track-index="${index}"></div>`,
+    ).join("");
+    const doc = createDocument(`
+      <div data-composition-id="main" data-start="0" data-duration="6">${cards}</div>
+    `);
+    const scans: string[] = [];
+    const nativeQuerySelectorAll = doc.querySelectorAll.bind(doc);
+    doc.querySelectorAll = ((selectors: string) => {
+      scans.push(selectors);
+      return nativeQuerySelectorAll(selectors);
+    }) as typeof doc.querySelectorAll;
+
+    const pass = createTimelineDomPass(doc);
+    const resolved = Array.from({ length: 6 }, (_, index) =>
+      findTimelineDomNodeForClip(
+        doc,
+        createClip({ start: index, duration: 1, track: index }),
+        index,
+        pass,
+      ),
+    );
+
+    expect(scans.filter((selectors) => selectors.includes("[data-start]"))).toHaveLength(1);
+    expect(new Set(resolved).size).toBe(6);
+  });
+
+  it("resolves to the live node after the preview document changes", () => {
+    const doc = createDocument(`
+      <div data-composition-id="main" data-start="0" data-duration="8">
+        <div class="clip card first" data-start="0" data-duration="4" data-track-index="0"></div>
+        <div class="clip card second" data-start="4" data-duration="4" data-track-index="1"></div>
+      </div>
+    `);
+    const clip = createClip({ start: 4, duration: 4, track: 1 });
+    const passBeforeEdit = createTimelineDomPass(doc);
+
+    // An edit lands: the runtime replaces the second card with a fresh node.
+    const detached = doc.querySelector(".second") as HTMLElement;
+    const replacement = doc.createElement("div");
+    replacement.className = "clip card second";
+    replacement.setAttribute("data-start", "4");
+    replacement.setAttribute("data-duration", "4");
+    replacement.setAttribute("data-track-index", "1");
+    detached.replaceWith(replacement);
+
+    expect(findTimelineDomNodeForClip(doc, clip, 1, createTimelineDomPass(doc))).toBe(replacement);
+    // ...and the pass built before the edit still points at the node that is now
+    // detached, which is exactly why a pass must never outlive its derivation.
+    expect(findTimelineDomNodeForClip(doc, clip, 1, passBeforeEdit)).toBe(detached);
+    expect(detached.isConnected).toBe(false);
   });
 });
 
@@ -388,10 +444,9 @@ describe("anonymous timeline identity", () => {
       createClip({ id: null, label: "Card", start: 0, duration: 3, track: 0 }),
       createClip({ id: null, label: "Card", start: 3, duration: 3, track: 1 }),
     ];
-    const used = new Set<Element>();
+    const pass = createTimelineDomPass(doc);
     const elements = clips.map((clip, index) => {
-      const hostEl = findTimelineDomNodeForClip(doc, clip, index, used);
-      if (hostEl) used.add(hostEl);
+      const hostEl = findTimelineDomNodeForClip(doc, clip, index, pass);
       return createTimelineElementFromManifestClip({
         clip,
         fallbackIndex: index,

--- a/packages/studio/src/player/hooks/useTimelinePlayer.ts
+++ b/packages/studio/src/player/hooks/useTimelinePlayer.ts
@@ -10,6 +10,7 @@ export { createStaticSeekPlaybackAdapter } from "../lib/playbackAdapter";
 export {
   buildStandaloneRootTimelineElement,
   createTimelineElementFromManifestClip,
+  createTimelineDomPass,
   findTimelineDomNodeForClip,
   getTimelineElementSelector,
   mergeTimelineElementsPreservingDowngrades,

--- a/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
+++ b/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
@@ -16,6 +16,7 @@ import type { PlaybackAdapter, ClipManifestClip, IframeWindow } from "../lib/pla
 import {
   parseTimelineFromDOM,
   createTimelineElementFromManifestClip,
+  createTimelineDomPass,
   findTimelineDomNodeForClip,
   createImplicitTimelineLayersFromDOM,
   buildStandaloneRootTimelineElement,
@@ -215,12 +216,13 @@ export function useTimelineSyncCallbacks({
         // cross-origin or __clipTree not available — maps stay empty
       }
 
-      const usedHostEls = new Set<Element>();
+      // One scan of the preview document for the whole pass, then dropped: the
+      // document mutates between manifests, so this must never be cached across
+      // them (see TimelineDomPass).
+      const domPass = iframeDoc ? createTimelineDomPass(iframeDoc) : null;
       const els: TimelineElement[] = filtered.map((clip, index) => {
-        const hostEl = iframeDoc
-          ? findTimelineDomNodeForClip(iframeDoc, clip, index, usedHostEls)
-          : null;
-        if (hostEl) usedHostEls.add(hostEl);
+        const hostEl =
+          iframeDoc && domPass ? findTimelineDomNodeForClip(iframeDoc, clip, index, domPass) : null;
         return createTimelineElementFromManifestClip({
           clip,
           fallbackIndex: index,

--- a/packages/studio/src/player/lib/timelineDOM.ts
+++ b/packages/studio/src/player/lib/timelineDOM.ts
@@ -46,6 +46,7 @@ export {
   buildTimelineElementIdentity,
   // fallow-ignore-next-line unused-exports
   getTimelineElementIdentity,
+  createTimelineDomPass,
   findTimelineDomNodeForClip,
 } from "./timelineElementHelpers";
 

--- a/packages/studio/src/player/lib/timelineElementHelpers.ts
+++ b/packages/studio/src/player/lib/timelineElementHelpers.ts
@@ -406,20 +406,50 @@ function findTimelineDomNode(doc: Document, id: string): Element | null {
   );
 }
 
+/**
+ * The candidate scan a manifest→DOM derivation pass shares across its clips,
+ * plus the nodes that pass has already claimed.
+ *
+ * Resolving a clip needs the document's whole timeline-node set, and building
+ * that set is expensive: a `[data-start]` query plus a four-selector
+ * `closest()` on every node it returns. Doing it per clip made the pass
+ * quadratic — on a 273-clip project it was the single largest task in the app,
+ * running on every manifest message (~1/s).
+ *
+ * Deliberately PASS-SCOPED, created and dropped inside one synchronous
+ * derivation: the preview document mutates between passes, and a cached scan
+ * that outlived one would hand back detached nodes — resolving a clip to the
+ * wrong element, which is far worse than a slow scan.
+ */
+export interface TimelineDomPass {
+  readonly candidates: Element[];
+  readonly used: Set<Element>;
+}
+
+export function createTimelineDomPass(doc: Document): TimelineDomPass {
+  return { candidates: getTimelineDomNodes(doc), used: new Set() };
+}
+
 export function findTimelineDomNodeForClip(
   doc: Document,
   clip: ClipManifestClip,
   fallbackIndex: number,
-  usedNodes = new Set<Element>(),
+  pass: TimelineDomPass = createTimelineDomPass(doc),
 ): Element | null {
-  const byIdentity = clip.id ? findTimelineDomNode(doc, clip.id) : null;
-  if (byIdentity && !usedNodes.has(byIdentity)) return byIdentity;
+  const resolve = (): Element | null => {
+    const byIdentity = clip.id ? findTimelineDomNode(doc, clip.id) : null;
+    if (byIdentity && !pass.used.has(byIdentity)) return byIdentity;
 
-  const candidates = getTimelineDomNodes(doc).filter((node) => !usedNodes.has(node));
-  const exact = candidates.find((node) => nodeMatchesManifestClip(node, clip));
-  if (exact) return exact;
+    const candidates = pass.candidates.filter((node) => !pass.used.has(node));
+    const exact = candidates.find((node) => nodeMatchesManifestClip(node, clip));
+    return exact ?? candidates[fallbackIndex] ?? null;
+  };
 
-  return candidates[fallbackIndex] ?? null;
+  // Claiming the node here (rather than leaving it to the caller) is what makes
+  // a shared pass safe to reuse: two clips can never resolve to one node.
+  const node = resolve();
+  if (node) pass.used.add(node);
+  return node;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/studio/src/player/lib/timelineIframeHelpers.test.ts
+++ b/packages/studio/src/player/lib/timelineIframeHelpers.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildMissingCompositionElements } from "./timelineIframeHelpers";
 import type { IframeWindow } from "./playbackTypes";
+import type { TimelineElement } from "../store/playerStore";
 
 function makeDoc(html: string): Document {
   const d = document.implementation.createHTMLDocument();
@@ -47,5 +48,98 @@ describe("buildMissingCompositionElements — hfId (R7)", () => {
 
     expect(entry).toBeDefined();
     expect(entry?.hfId).toBeUndefined();
+  });
+});
+
+/**
+ * A project the way the generator writes one: every clip identified by
+ * `data-hf-id`, a minority also carrying an author `id`. `stableClipId` — what
+ * the manifest puts in `TimelineElement.id` — prefers `id` and falls back to
+ * `data-hf-id`, so a lookup that only asks `getElementById` misses most clips.
+ */
+function makeProject(clipCount: number): { doc: Document; els: TimelineElement[] } {
+  const markup: string[] = [];
+  const els: TimelineElement[] = [];
+  for (let index = 0; index < clipCount; index += 1) {
+    const hfId = `hf-${index}`;
+    const authorId = index % 5 === 0 ? `clip-${index}` : "";
+    // Every third clip is a composition host, so parity has something to patch.
+    const isHost = index % 3 === 0;
+    markup.push(
+      `<div ${authorId ? `id="${authorId}"` : ""} data-hf-id="${hfId}"` +
+        (isHost
+          ? ` data-composition-id="comp-${index}" data-composition-src="scenes/${index}.html"`
+          : "") +
+        ` data-start="${index}" data-duration="1"></div>`,
+    );
+    els.push({
+      id: authorId || hfId,
+      hfId,
+      tag: "div",
+      start: index,
+      duration: 1,
+      track: 0,
+      ...(authorId ? { domId: authorId } : {}),
+    });
+  }
+  return { doc: makeDoc(`<div data-composition-id="root">${markup.join("")}</div>`), els };
+}
+
+describe("buildMissingCompositionElements — identity parity", () => {
+  it("patches compositionSrc onto hf-id-identified clips, which getElementById never saw", () => {
+    const { doc, els } = makeProject(9);
+
+    const { updatedEls, patched } = buildMissingCompositionElements(
+      doc,
+      window as IframeWindow,
+      els,
+      100,
+    );
+
+    expect(patched).toBe(true);
+    // Clips 0, 3, 6 are hosts; only clip 0 carries an author id, so 3 and 6 are
+    // exactly the ones the old getElementById-only lookup could not resolve.
+    expect(updatedEls.map((el) => el.compositionSrc ?? null)).toEqual([
+      "scenes/0.html",
+      null,
+      null,
+      "scenes/3.html",
+      null,
+      null,
+      "scenes/6.html",
+      null,
+      null,
+    ]);
+  });
+
+  it("changes nothing about identity — only compositionSrc differs from the input", () => {
+    const { doc, els } = makeProject(30);
+
+    const { updatedEls } = buildMissingCompositionElements(doc, window as IframeWindow, els, 100);
+
+    expect(updatedEls).toHaveLength(els.length);
+    for (const [index, updated] of updatedEls.entries()) {
+      const { compositionSrc: _dropped, ...rest } = updated;
+      expect(rest).toEqual(els[index]);
+    }
+  });
+
+  it("resolves every clip through a fixed number of whole-document queries", () => {
+    const countQueries = (clipCount: number): number => {
+      const { doc, els } = makeProject(clipCount);
+      const spies = [
+        vi.spyOn(doc, "querySelector"),
+        vi.spyOn(doc, "querySelectorAll"),
+        vi.spyOn(doc, "getElementById"),
+      ];
+      buildMissingCompositionElements(doc, window as IframeWindow, els, 100);
+      const calls = spies.reduce((total, spy) => total + spy.mock.calls.length, 0);
+      for (const spy of spies) spy.mockRestore();
+      return calls;
+    };
+
+    // Twentyfold the clips, same query count: the cost is the document walk, not
+    // a query per clip. Before the fix this grew by one querySelector per clip.
+    expect(countQueries(200)).toBe(countQueries(10));
   });
 });

--- a/packages/studio/src/player/lib/timelineIframeHelpers.ts
+++ b/packages/studio/src/player/lib/timelineIframeHelpers.ts
@@ -394,6 +394,38 @@ function buildMissingCompositionEntry(params: {
 }
 
 /**
+ * Every element carrying a composition source, keyed on each identity a
+ * manifest clip can arrive under.
+ *
+ * A `TimelineElement.id` is the manifest's stableClipId — the author `id` when
+ * there is one, otherwise `data-hf-id` — and `getElementById` cannot see the
+ * second, which is how most generated clips are identified. Resolving hosts
+ * with it alone therefore missed nearly every clip and fell through to a
+ * whole-document `[data-composition-id]` query per clip: 9,276 of them on a
+ * single open of a 3,000-clip project, essentially all finding nothing.
+ *
+ * Keying on both halves of stableClipId is the fix; restricting the index to
+ * the only elements that can change a caller's outcome is what keeps it to one
+ * document query regardless of clip count.
+ */
+function indexCompositionSourceHosts(doc: Document): Map<string, HTMLElement> {
+  const hostsByIdentity = new Map<string, HTMLElement>();
+  for (const host of doc.querySelectorAll<HTMLElement>(
+    "[data-composition-src], [data-composition-file]",
+  )) {
+    const identities = [
+      host.id,
+      host.getAttribute("data-hf-id"),
+      host.getAttribute("data-composition-id"),
+    ];
+    for (const identity of identities) {
+      if (identity && !hostsByIdentity.has(identity)) hostsByIdentity.set(identity, host);
+    }
+  }
+  return hostsByIdentity;
+}
+
+/**
  * Scan the iframe DOM for composition hosts missing from the current
  * timeline elements and add them.  The CDN runtime often fails to resolve
  * element-reference starts (`data-start="intro"`) so composition hosts
@@ -433,14 +465,12 @@ export function buildMissingCompositionElements(
     if (entry) missing.push(entry);
   }
 
-  // Patch existing elements that are missing compositionSrc
+  // Patch existing elements that are missing compositionSrc.
+  const hostsByIdentity = indexCompositionSourceHosts(doc);
   let patched = false;
   const updatedEls = (currentEls as TimelineElement[]).map((existing) => {
     if (existing.compositionSrc) return existing;
-    // Find the matching DOM host by element id or composition id
-    const host =
-      doc.getElementById(existing.id) ??
-      doc.querySelector(`[data-composition-id="${CSS.escape(existing.id)}"]`);
+    const host = hostsByIdentity.get(existing.id);
     if (!host) return existing;
     const compSrc =
       host.getAttribute("data-composition-src") || host.getAttribute("data-composition-file");


### PR DESCRIPTION
Deriving timeline elements from a clip manifest called a resolver once per clip, and **every call rebuilt the entire candidate set** — a `[data-start]` query plus a four-selector `closest()` walk on every node it returned. Quadratic in clip count.

On a 273-clip project this was the single largest task in the application.

**Measured: idle main-thread script time 2,047ms → 882ms per 15s window (−57%),** three runs per arm at 4× CPU throttle.

## Why this shows up at idle

The derivation runs on a **timer at roughly 1.3/s whether or not anyone is interacting**. This is not a cost paid on click; it is a cost paid continuously, which is why the number above comes from a window with no input at all.

## What this does NOT buy

**Click latency is unchanged** — 7.4ms median before, 8.3ms after. Inside noise.

That deserves stating plainly because the obvious framing of this change is wrong. An earlier investigation reported selection as janky at "p95 41.8ms, 53% of frames dropped". Both halves were artifacts: the frame metric counted 16.8ms frames as dropped against a 16.7ms threshold (i.e. it counted vsync jitter), and the p95 came from a sample short enough that a single first-click property-panel mount dominated it. Steady-state selection was always ~8ms.

The win here is real and it is the idle path. It is not a responsiveness win.

## The scan is deliberately pass-scoped

Built once per derivation and dropped with it. It must **never** be cached across derivations: the preview document mutates between them, and a cached scan that outlived one would resolve clips to detached nodes — silently binding to the wrong element, which is far worse than a slow scan. There is a test asserting exactly this: a pass built before a mutation still resolves to the detached node; a fresh pass resolves to the live one.

Node-claiming moved into the resolver so a shared pass cannot hand two clips the same element.

## One commit here is a guard, not a change

`pin clip identity across the manifest and clip-tree paths` adds tests and no behaviour. It pins that the two paths compute clip identity **differently and cannot be unified**: the clip-tree path has an ordinal fallback the manifest path does not.

Unifying them looks like an obvious cleanup and is a data-loss bug. It would change `clip.id` for clips that currently resolve to null, which downstream diffing reads as element replacement — silently dropping selection, expanded state, the keyframe cache, and lint findings. The test exists so the next person to notice the asymmetry finds out why before changing it.

## Note on a shared file

Touches `timelineElementHelpers.ts` around line 412; another PR in this sequence touches it around line 189. Disjoint, merges cleanly either way.

## Verification

`packages/core` green (1,437 tests), `packages/studio` green (3,277 tests).
