### PR TITLE
feat(core): Web Audio graphs for the FX registry

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -146,6 +146,17 @@
       "file": "packages/studio/src/utils/studioHelpers.ts",
       "exports": ["resolveDroppedAssetDimensions"],
     },
+    // Audio FX worklets sit near the bottom of the audio stack: the worklet
+    // source and its test reset are consumed by the runtime and engine PRs
+    // upstack, so a per-PR audit against the merge base sees them as unused.
+    {
+      "file": "packages/core/src/audio/audioFxWorklets.ts",
+      "exports": ["AUDIO_FX_WORKLET_SOURCE", "__resetAudioFxWorkletsForTests"],
+    },
+    {
+      "file": "packages/core/src/audio/audioFxGraph.ts",
+      "exports": ["ensureAudioFxWorklets"],
+    },
     // drawElementService is the bottom of the fast-capture Graphite stack
     // (#1917): its consumers (frameCapture in #1919) land two PRs upstack, so
     // a per-PR audit diffing against the merge base sees these exports as

--- a/packages/core/package-subpaths.json
+++ b/packages/core/package-subpaths.json
@@ -86,6 +86,12 @@
       "types": "./dist/compiler/index.d.ts",
       "environments": ["bun", "node"]
     },
+    "./audio-fx": {
+      "source": "./src/audioFx.ts",
+      "runtime": "./dist/audioFx.js",
+      "types": "./dist/audioFx.d.ts",
+      "environments": ["browser", "bun", "node"]
+    },
     "./color-grading": {
       "source": "./src/colorGrading.ts",
       "runtime": "./dist/colorGrading.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,6 +100,12 @@
       "import": "./src/compiler/index.ts",
       "types": "./src/compiler/index.ts"
     },
+    "./audio-fx": {
+      "bun": "./src/audioFx.ts",
+      "node": "./dist/audioFx.js",
+      "import": "./src/audioFx.ts",
+      "types": "./src/audioFx.ts"
+    },
     "./color-grading": {
       "bun": "./src/colorGrading.ts",
       "node": "./dist/colorGrading.js",
@@ -357,6 +363,10 @@
       "./compiler": {
         "import": "./dist/compiler/index.js",
         "types": "./dist/compiler/index.d.ts"
+      },
+      "./audio-fx": {
+        "import": "./dist/audioFx.js",
+        "types": "./dist/audioFx.d.ts"
       },
       "./color-grading": {
         "import": "./dist/colorGrading.js",

--- a/packages/core/src/audio/audioFxGraph.test.ts
+++ b/packages/core/src/audio/audioFxGraph.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { defaultAudioFxParams, HF_AUDIO_FX, type HfAudioFxChain } from "../audioFx.js";
+import {
+  buildFxChain,
+  buildFxNode,
+  chainNeedsWorklets,
+  synthesizeReverbImpulse,
+} from "./audioFxGraph.js";
+
+/**
+ * happy-dom has no Web Audio, and a real AudioContext needs a browser. These
+ * cover the graph wiring: which nodes get made, how they connect, and when an
+ * update can happen in place instead of forcing a rebuild. Whether each graph
+ * *sounds* like its FFmpeg counterpart is a separate measurement — that is the
+ * parity harness's job, and it runs in a real browser.
+ */
+class FakeParam {
+  constructor(public value = 0) {}
+}
+class FakeNode {
+  connections: FakeNode[] = [];
+  disconnected = false;
+  frequency = new FakeParam();
+  Q = new FakeParam();
+  gain = new FakeParam();
+  delayTime = new FakeParam();
+  type = "";
+  curve: Float32Array | null = null;
+  oversample = "none";
+  buffer: unknown = null;
+  normalize = true;
+  port = { postMessage: (m: unknown) => this.messages.push(m) };
+  messages: unknown[] = [];
+  constructor(public kind: string) {}
+  connect(next: FakeNode): FakeNode {
+    this.connections.push(next);
+    return next;
+  }
+  disconnect(): void {
+    this.disconnected = true;
+  }
+  start(): void {}
+  stop(): void {}
+}
+
+class FakeCtx {
+  sampleRate = 48000;
+  created: FakeNode[] = [];
+  private make(kind: string): FakeNode {
+    const node = new FakeNode(kind);
+    this.created.push(node);
+    return node;
+  }
+  createGain() {
+    return this.make("gain");
+  }
+  createBiquadFilter() {
+    return this.make("biquad");
+  }
+  createIIRFilter() {
+    return this.make("iir");
+  }
+  createDelay() {
+    return this.make("delay");
+  }
+  createOscillator() {
+    return this.make("osc");
+  }
+  createWaveShaper() {
+    return this.make("waveshaper");
+  }
+  createConvolver() {
+    return this.make("convolver");
+  }
+  createBuffer(_c: number, length: number) {
+    return { length, getChannelData: () => new Float32Array(length) };
+  }
+}
+
+// AudioWorkletNode is constructed directly, not via a context factory, so the
+// instances are recorded here rather than in FakeCtx.created.
+const workletNodes: FakeWorkletNode[] = [];
+class FakeWorkletNode extends FakeNode {
+  constructor(
+    _ctx: unknown,
+    public name: string,
+    public options: { processorOptions: unknown },
+  ) {
+    super("worklet");
+    workletNodes.push(this);
+  }
+}
+(globalThis as unknown as { AudioWorkletNode: unknown }).AudioWorkletNode = FakeWorkletNode;
+
+const ctx = (): FakeCtx => new FakeCtx();
+const asCtx = (c: FakeCtx) => c as unknown as BaseAudioContext;
+const chain = (...types: string[]): HfAudioFxChain => ({
+  version: 1,
+  nodes: types.map((t) => ({ type: t, enabled: true, params: defaultAudioFxParams(t) })),
+});
+
+describe("buildFxNode", () => {
+  it("builds a node for every effect in the registry", () => {
+    for (const def of HF_AUDIO_FX) {
+      const c = ctx();
+      expect(
+        () => buildFxNode(asCtx(c), def.id, defaultAudioFxParams(def.id)),
+        `${def.id} failed to build`,
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects an unknown effect", () => {
+    expect(() => buildFxNode(asCtx(ctx()), "nope", {})).toThrow(/Unknown effect/);
+  });
+
+  it("uses a two-pole biquad by default and a one-pole IIR when asked", () => {
+    const two = ctx();
+    buildFxNode(asCtx(two), "highpass", { ...defaultAudioFxParams("highpass"), poles: "2" });
+    expect(two.created.some((n) => n.kind === "biquad")).toBe(true);
+    expect(two.created.some((n) => n.kind === "iir")).toBe(false);
+
+    const one = ctx();
+    buildFxNode(asCtx(one), "highpass", { ...defaultAudioFxParams("highpass"), poles: "1" });
+    expect(one.created.some((n) => n.kind === "iir")).toBe(true);
+  });
+
+  it("applies parameters to the biquad rather than leaving defaults", () => {
+    const c = ctx();
+    buildFxNode(asCtx(c), "peaking", { frequency: 750, gain: -9, q: 3 });
+    const bq = c.created.find((n) => n.kind === "biquad")!;
+    expect(bq.type).toBe("peaking");
+    expect(bq.frequency.value).toBe(750);
+    expect(bq.gain.value).toBe(-9);
+    expect(bq.Q.value).toBe(3);
+  });
+
+  it("clamps an out-of-range value on the way into the graph", () => {
+    const c = ctx();
+    buildFxNode(asCtx(c), "peaking", { frequency: 10_000_000, gain: 0, q: 1 });
+    expect(c.created.find((n) => n.kind === "biquad")!.frequency.value).toBe(20000);
+  });
+
+  it("sends worklet parameters through the port on update", () => {
+    workletNodes.length = 0;
+    const c = ctx();
+    const h = buildFxNode(asCtx(c), "compressor", defaultAudioFxParams("compressor"));
+    expect(workletNodes).toHaveLength(1);
+    expect(workletNodes[0]!.name).toBe("hf-compressor");
+    h.update({ ...defaultAudioFxParams("compressor"), threshold: -30 });
+    // Turning a dial re-parameterises the running processor instead of
+    // rebuilding it, which is what keeps the knob-to-ear loop immediate.
+    expect(workletNodes[0]!.messages).toHaveLength(1);
+    expect(workletNodes[0]!.messages[0]).toMatchObject({ threshold: -30 });
+  });
+
+  it("rebuilds the saturation curve for the selected shape", () => {
+    const c = ctx();
+    buildFxNode(asCtx(c), "saturate", { ...defaultAudioFxParams("saturate"), type: "hard" });
+    const ws = c.created.find((n) => n.kind === "waveshaper")!;
+    expect(ws.curve).toBeInstanceOf(Float32Array);
+    // A hard clip saturates to the threshold and stays flat at the extremes.
+    expect(ws.curve!.at(-1)).toBeCloseTo(ws.curve![ws.curve!.length - 2]!, 6);
+  });
+});
+
+describe("buildFxChain", () => {
+  it("passes audio straight through for an empty chain", () => {
+    const c = ctx();
+    const h = buildFxChain(asCtx(c), { version: 1, nodes: [] });
+    expect(h.input.connect).toBeDefined();
+    expect((h.input as unknown as FakeNode).connections).toContain(h.output);
+  });
+
+  it("chains effects in order", () => {
+    const c = ctx();
+    const h = buildFxChain(asCtx(c), chain("highpass", "peaking"));
+    // input -> highpass -> peaking -> output, so input reaches exactly one node.
+    expect((h.input as unknown as FakeNode).connections).toHaveLength(1);
+    expect(c.created.filter((n) => n.kind === "biquad")).toHaveLength(2);
+  });
+
+  it("skips bypassed nodes", () => {
+    const c = ctx();
+    buildFxChain(asCtx(c), {
+      version: 1,
+      nodes: [
+        { type: "peaking", enabled: false, params: defaultAudioFxParams("peaking") },
+        { type: "lowpass", enabled: true, params: defaultAudioFxParams("lowpass") },
+      ],
+    });
+    expect(c.created.filter((n) => n.kind === "biquad")).toHaveLength(1);
+  });
+
+  it("updates in place when only values changed", () => {
+    const c = ctx();
+    const h = buildFxChain(asCtx(c), chain("peaking"));
+    const before = c.created.length;
+    const ok = h.update({
+      version: 1,
+      nodes: [{ type: "peaking", enabled: true, params: { frequency: 2000, gain: 5, q: 2 } }],
+    });
+    expect(ok).toBe(true);
+    expect(c.created.length).toBe(before); // nothing rebuilt
+    expect(c.created.find((x) => x.kind === "biquad")!.frequency.value).toBe(2000);
+  });
+
+  it("reports that a rebuild is needed when the chain shape changes", () => {
+    const c = ctx();
+    const h = buildFxChain(asCtx(c), chain("peaking"));
+    expect(h.update(chain("peaking", "lowpass"))).toBe(false);
+    expect(h.update(chain("lowpass"))).toBe(false);
+  });
+
+  it("treats a pole-count change as a rebuild, since it changes the node type", () => {
+    const c = ctx();
+    const h = buildFxChain(asCtx(c), chain("highpass"));
+    expect(
+      h.update({
+        version: 1,
+        nodes: [
+          {
+            type: "highpass",
+            enabled: true,
+            params: { ...defaultAudioFxParams("highpass"), poles: "1" },
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("treats bypassing a node as a shape change", () => {
+    const c = ctx();
+    const h = buildFxChain(asCtx(c), chain("peaking", "lowpass"));
+    expect(
+      h.update({
+        version: 1,
+        nodes: [
+          { type: "peaking", enabled: true, params: defaultAudioFxParams("peaking") },
+          { type: "lowpass", enabled: false, params: defaultAudioFxParams("lowpass") },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("disconnects everything it made on dispose", () => {
+    const c = ctx();
+    const h = buildFxChain(asCtx(c), chain("delay"));
+    h.dispose();
+    expect(c.created.every((n) => n.disconnected)).toBe(true);
+  });
+});
+
+describe("chainNeedsWorklets", () => {
+  it("is true only when the chain contains a worklet-backed effect", () => {
+    expect(chainNeedsWorklets(chain("peaking", "delay"))).toBe(false);
+    expect(chainNeedsWorklets(chain("peaking", "compressor"))).toBe(true);
+  });
+});
+
+describe("synthesizeReverbImpulse", () => {
+  it("is deterministic for the same room, so preview and render convolve the same tail", () => {
+    const a = synthesizeReverbImpulse(48000, 0.7, 0.5);
+    const b = synthesizeReverbImpulse(48000, 0.7, 0.5);
+    expect(Array.from(a.slice(0, 64))).toEqual(Array.from(b.slice(0, 64)));
+  });
+
+  it("varies with the room and decays to near-silence", () => {
+    const small = synthesizeReverbImpulse(48000, 0.1, 0.5);
+    const large = synthesizeReverbImpulse(48000, 1.0, 0.5);
+    expect(large.length).toBeGreaterThan(small.length);
+    const tail = large.subarray(large.length - 128);
+    expect(Math.max(...Array.from(tail, Math.abs))).toBeLessThan(0.01);
+  });
+});

--- a/packages/core/src/audio/audioFxGraph.test.ts
+++ b/packages/core/src/audio/audioFxGraph.test.ts
@@ -274,3 +274,70 @@ describe("synthesizeReverbImpulse", () => {
     expect(Math.max(...Array.from(tail, Math.abs))).toBeLessThan(0.01);
   });
 });
+
+describe("levels and per-channel state", () => {
+  const energy = (ir: Float32Array): number => {
+    let e = 0;
+    for (const v of ir) e += v * v;
+    return Math.sqrt(e);
+  };
+
+  it("normalises the reverb impulse, so adding one does not clip the mix", () => {
+    // A ConvolverNode applies the impulse's gain whole (normalize is off so the
+    // room is deterministic). Raw decaying noise ran to +33 dB at the registry
+    // default, which put the wet path ~24 dB over dry at wet: 0.35.
+    for (const [size, damping] of [
+      [0.7, 0.5],
+      [1, 0],
+      [0, 1],
+      [0.5, 0.5],
+    ]) {
+      expect(energy(synthesizeReverbImpulse(48000, size, damping))).toBeCloseTo(1, 5);
+    }
+  });
+
+  it("keeps a phaser at unity, rather than summing its two gains above it", () => {
+    // in_gain/out_gain trim what enters and leaves the effect; wired as a wet/dry
+    // pair their defaults summed to 1.14, so inserting a phaser raised the level.
+    const ctx = new FakeCtx();
+    buildFxNode(ctx as unknown as BaseAudioContext, "phaser", defaultAudioFxParams("phaser"));
+    const gains = ctx.created.filter((n) => n.kind === "gain").map((n) => n.gain.value);
+    // The wet and dry legs are summed at unity; the trims carry the knob values.
+    expect(gains.filter((g) => g === 1).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("sets the phaser LFO waveform it declares", () => {
+    const ctx = new FakeCtx();
+    buildFxNode(ctx as unknown as BaseAudioContext, "phaser", {
+      ...defaultAudioFxParams("phaser"),
+      type: "0",
+    });
+    const osc = ctx.created.find((n) => n.kind === "osc");
+    expect(osc?.type).toBe("triangle");
+    const ctx2 = new FakeCtx();
+    buildFxNode(ctx2 as unknown as BaseAudioContext, "phaser", {
+      ...defaultAudioFxParams("phaser"),
+      type: "1",
+    });
+    expect(ctx2.created.find((n) => n.kind === "osc")?.type).toBe("sine");
+  });
+
+  it("rebuilds a one-pole filter when its cutoff moves", () => {
+    // Its coefficients are fixed at construction, so a cutoff change cannot be
+    // pushed into the running graph — preview kept filtering at the old
+    // frequency while the render used the new one.
+    const ctx = new FakeCtx() as unknown as BaseAudioContext;
+    const chain = (frequency: number): HfAudioFxChain => ({
+      version: 1,
+      nodes: [{ type: "highpass", enabled: true, params: { frequency, q: 0.707, poles: "1" } }],
+    });
+    const built = buildFxChain(ctx, chain(300));
+    expect(built.update(chain(2000))).toBe(false);
+    // A two-pole filter is a BiquadFilterNode and still updates in place.
+    const twoPole = (frequency: number): HfAudioFxChain => ({
+      version: 1,
+      nodes: [{ type: "highpass", enabled: true, params: { frequency, q: 0.707, poles: "2" } }],
+    });
+    expect(buildFxChain(ctx, twoPole(300)).update(twoPole(2000))).toBe(true);
+  });
+});

--- a/packages/core/src/audio/audioFxGraph.ts
+++ b/packages/core/src/audio/audioFxGraph.ts
@@ -1,0 +1,400 @@
+/**
+ * Builds the Web Audio graph for an FX chain, one builder per `web` id in the
+ * core registry.
+ *
+ * Every node exposes `update`, so turning a dial re-parameterises the running
+ * graph instead of rebuilding it. That is the whole point of previewing in the
+ * browser: an AudioParam change lands on the next 128-sample render quantum,
+ * about 2.7 ms at 48 kHz, so the knob-to-ear loop is immediate.
+ */
+
+import {
+  getAudioFxDef,
+  normalizeAudioFxParams,
+  type HfAudioFxChain,
+  type HfAudioFxParamValues,
+} from "../audioFx.js";
+import { ensureAudioFxWorklets } from "./audioFxWorklets.js";
+
+/**
+ * Deterministic reverb impulse, shared by both engines so the browser and the
+ * render convolve the identical response. Exponentially-decaying noise with a
+ * one-pole lowpass standing in for air absorption; the PRNG is seeded from the
+ * parameters so the same room always produces the same tail.
+ */
+export function synthesizeReverbImpulse(
+  sampleRate: number,
+  size: number,
+  damping: number,
+): Float32Array {
+  const seconds = 0.6 + Math.max(0, Math.min(1, size)) * 2.6;
+  const length = Math.max(1, Math.floor(sampleRate * seconds));
+  const out = new Float32Array(length);
+  // Seed from the parameters: same room, same tail, on every machine.
+  let seed = (Math.round(size * 1000) * 2654435761 + Math.round(damping * 1000) * 40503) >>> 0;
+  const rand = (): number => {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    return (seed / 0xffffffff) * 2 - 1;
+  };
+  const cutoff = Math.max(0.001, 1 - Math.max(0, Math.min(1, damping)));
+  let lp = 0;
+  for (let i = 0; i < length; i++) {
+    lp += cutoff * (rand() - lp);
+    out[i] = lp * Math.pow(1 - i / length, 2.5);
+  }
+  return out;
+}
+
+export interface FxNodeHandle {
+  input: AudioNode;
+  output: AudioNode;
+  update(params: HfAudioFxParamValues): void;
+  dispose(): void;
+}
+
+type Builder = (ctx: BaseAudioContext, p: HfAudioFxParamValues) => FxNodeHandle;
+
+const n = (v: number | string | undefined): number => (typeof v === "number" ? v : Number(v ?? 0));
+
+/** A node that is its own input and output and has nothing to tear down. */
+function simple(node: AudioNode, update: (p: HfAudioFxParamValues) => void): FxNodeHandle {
+  return { input: node, output: node, update, dispose: () => node.disconnect() };
+}
+
+function biquad(type: BiquadFilterType, useGain: boolean): Builder {
+  return (ctx, p) => {
+    const f = ctx.createBiquadFilter();
+    f.type = type;
+    const apply = (v: HfAudioFxParamValues): void => {
+      f.frequency.value = n(v.frequency);
+      if (v.q !== undefined) f.Q.value = n(v.q);
+      if (useGain) f.gain.value = n(v.gain);
+    };
+    apply(p);
+    return simple(f, apply);
+  };
+}
+
+/**
+ * FFmpeg's highpass/lowpass take a pole count; Web Audio's biquad is always
+ * two-pole, so one-pole is built from raw coefficients via IIRFilterNode.
+ * Changing the pole count changes the node type, so the chain rebuilds rather
+ * than updates — handled by the caller comparing structural signatures.
+ */
+function onePoleBuilder(kind: "highpass" | "lowpass"): Builder {
+  return (ctx, p) => {
+    const k = Math.tan((Math.PI * n(p.frequency)) / ctx.sampleRate);
+    const node =
+      kind === "highpass"
+        ? ctx.createIIRFilter([1 / (1 + k), -1 / (1 + k)], [1, (k - 1) / (k + 1)])
+        : ctx.createIIRFilter([k / (1 + k), k / (1 + k)], [1, (k - 1) / (k + 1)]);
+    // IIRFilterNode coefficients are immutable; the caller rebuilds on change.
+    return simple(node, () => {});
+  };
+}
+
+function workletBuilder(processor: string): Builder {
+  return (ctx, p) => {
+    const node = new AudioWorkletNode(ctx, processor, { processorOptions: { ...p } });
+    return {
+      input: node,
+      output: node,
+      update: (v) => node.port.postMessage({ ...v }),
+      dispose: () => node.disconnect(),
+    };
+  };
+}
+
+/** Curves matching asoftclip's shapes, sampled once per parameter change. */
+const CURVES: Record<string, (x: number) => number> = {
+  tanh: Math.tanh,
+  atan: (x) => (2 / Math.PI) * Math.atan((Math.PI / 2) * x),
+  cubic: (x) => (Math.abs(x) >= 1 ? Math.sign(x) : x - x ** 3 / 3),
+  exp: (x) => Math.sign(x) * (1 - Math.exp(-Math.abs(x))),
+  alg: (x) => x / Math.sqrt(1 + x * x),
+  quintic: (x) => (Math.abs(x) >= 1 ? Math.sign(x) : x - x ** 5 / 5),
+  sin: (x) => (Math.abs(x) >= 1 ? Math.sign(x) : Math.sin((Math.PI / 2) * x)),
+  erf: (x) => Math.tanh(1.20211 * x),
+  hard: (x) => Math.max(-1, Math.min(1, x)),
+};
+
+const waveshaper: Builder = (ctx, p) => {
+  const ws = ctx.createWaveShaper();
+  const preGain = ctx.createGain();
+  const postGain = ctx.createGain();
+  preGain.connect(ws).connect(postGain);
+  const apply = (v: HfAudioFxParamValues): void => {
+    const shape = CURVES[String(v.type)] ?? Math.tanh;
+    const threshold = Math.pow(10, n(v.threshold) / 20);
+    const SIZE = 8192;
+    const curve = new Float32Array(SIZE);
+    for (let i = 0; i < SIZE; i++) {
+      const x = (i / (SIZE - 1)) * 2 - 1;
+      curve[i] = shape(x / Math.max(1e-6, threshold)) * threshold;
+    }
+    ws.curve = curve;
+    ws.oversample = n(v.oversample) >= 4 ? "4x" : n(v.oversample) >= 2 ? "2x" : "none";
+    postGain.gain.value = Math.pow(10, n(v.output) / 20);
+  };
+  apply(p);
+  return {
+    input: preGain,
+    output: postGain,
+    update: apply,
+    dispose: () => {
+      preGain.disconnect();
+      ws.disconnect();
+      postGain.disconnect();
+    },
+  };
+};
+
+const delayFeedback: Builder = (ctx, p) => {
+  const input = ctx.createGain();
+  const out = ctx.createGain();
+  const dl = ctx.createDelay(5);
+  const fb = ctx.createGain();
+  const wet = ctx.createGain();
+  const dry = ctx.createGain();
+  input.connect(dl);
+  dl.connect(fb);
+  fb.connect(dl);
+  dl.connect(wet).connect(out);
+  input.connect(dry).connect(out);
+  const apply = (v: HfAudioFxParamValues): void => {
+    dl.delayTime.value = Math.min(5, n(v.time) / 1000);
+    fb.gain.value = n(v.feedback);
+    wet.gain.value = n(v.mix);
+    dry.gain.value = 1 - n(v.mix);
+  };
+  apply(p);
+  return {
+    input,
+    output: out,
+    update: apply,
+    dispose: () => [input, out, dl, fb, wet, dry].forEach((x) => x.disconnect()),
+  };
+};
+
+const chorusLfo: Builder = (ctx, p) => {
+  const input = ctx.createGain();
+  const out = ctx.createGain();
+  const dl = ctx.createDelay(0.5);
+  const lfo = ctx.createOscillator();
+  const depth = ctx.createGain();
+  const wet = ctx.createGain();
+  const dry = ctx.createGain();
+  lfo.connect(depth).connect(dl.delayTime);
+  input.connect(dl).connect(wet).connect(out);
+  input.connect(dry).connect(out);
+  lfo.start();
+  const apply = (v: HfAudioFxParamValues): void => {
+    dl.delayTime.value = n(v.delay) / 1000;
+    depth.gain.value = n(v.depth) / 1000;
+    lfo.frequency.value = n(v.speed);
+    wet.gain.value = n(v.mix);
+    dry.gain.value = 1 - n(v.mix);
+  };
+  apply(p);
+  return {
+    input,
+    output: out,
+    update: apply,
+    dispose: () => {
+      try {
+        lfo.stop();
+      } catch {
+        /* already stopped */
+      }
+      [input, out, dl, depth, wet, dry].forEach((x) => x.disconnect());
+    },
+  };
+};
+
+const PHASER_STAGES = 6;
+
+const allpassPhaser: Builder = (ctx, p) => {
+  const input = ctx.createGain();
+  const out = ctx.createGain();
+  const lfo = ctx.createOscillator();
+  const depth = ctx.createGain();
+  const wet = ctx.createGain();
+  const dry = ctx.createGain();
+  const stages: BiquadFilterNode[] = [];
+  let node: AudioNode = input;
+  for (let i = 0; i < PHASER_STAGES; i++) {
+    const ap = ctx.createBiquadFilter();
+    ap.type = "allpass";
+    ap.Q.value = 0.7071;
+    depth.connect(ap.frequency);
+    node.connect(ap);
+    node = ap;
+    stages.push(ap);
+  }
+  lfo.connect(depth);
+  lfo.start();
+  node.connect(wet).connect(out);
+  input.connect(dry).connect(out);
+  const apply = (v: HfAudioFxParamValues): void => {
+    // aphaser sweeps around a centre derived from its delay; mirror the range
+    // rather than the exact curve, and let the parity harness score it.
+    const centre = 1000 / Math.max(0.1, n(v.delay));
+    for (const ap of stages) ap.frequency.value = centre;
+    depth.gain.value = centre * n(v.decay);
+    lfo.frequency.value = n(v.speed);
+    wet.gain.value = n(v.out_gain);
+    dry.gain.value = n(v.in_gain);
+  };
+  apply(p);
+  return {
+    input,
+    output: out,
+    update: apply,
+    dispose: () => {
+      try {
+        lfo.stop();
+      } catch {
+        /* already stopped */
+      }
+      [input, out, depth, wet, dry, ...stages].forEach((x) => x.disconnect());
+    },
+  };
+};
+
+const convolver: Builder = (ctx, p) => {
+  const input = ctx.createGain();
+  const out = ctx.createGain();
+  const conv = ctx.createConvolver();
+  const wet = ctx.createGain();
+  const dry = ctx.createGain();
+  conv.normalize = false;
+  input.connect(conv).connect(wet).connect(out);
+  input.connect(dry).connect(out);
+  let lastKey = "";
+  const apply = (v: HfAudioFxParamValues): void => {
+    const key = `${n(v.size)}:${n(v.damping)}`;
+    if (key !== lastKey) {
+      // Same generator the render uses, so both convolve the identical tail.
+      const ir = synthesizeReverbImpulse(ctx.sampleRate, n(v.size), n(v.damping));
+      const buf = ctx.createBuffer(1, ir.length, ctx.sampleRate);
+      buf.getChannelData(0).set(ir);
+      conv.buffer = buf;
+      lastKey = key;
+    }
+    wet.gain.value = n(v.wet);
+    dry.gain.value = n(v.dry);
+  };
+  apply(p);
+  return {
+    input,
+    output: out,
+    update: apply,
+    dispose: () => [input, out, conv, wet, dry].forEach((x) => x.disconnect()),
+  };
+};
+
+const BUILDERS: Record<string, Builder> = {
+  "biquad-peaking": biquad("peaking", true),
+  "biquad-lowshelf": biquad("lowshelf", true),
+  "biquad-highshelf": biquad("highshelf", true),
+  "biquad-highpass": biquad("highpass", false),
+  "biquad-lowpass": biquad("lowpass", false),
+  "worklet-compressor": workletBuilder("hf-compressor"),
+  "worklet-limiter": workletBuilder("hf-limiter"),
+  "worklet-gate": workletBuilder("hf-gate"),
+  "worklet-bitcrush": workletBuilder("hf-bitcrush"),
+  waveshaper,
+  "delay-feedback": delayFeedback,
+  "chorus-lfo": chorusLfo,
+  "allpass-phaser": allpassPhaser,
+  convolver,
+};
+
+/** Effect ids whose Web Audio node needs a worklet module registered first. */
+export function chainNeedsWorklets(chain: HfAudioFxChain): boolean {
+  return chain.nodes.some((node) => getAudioFxDef(node.type)?.web.startsWith("worklet-") ?? false);
+}
+
+export function buildFxNode(
+  ctx: BaseAudioContext,
+  type: string,
+  params: HfAudioFxParamValues,
+): FxNodeHandle {
+  const def = getAudioFxDef(type);
+  if (!def) throw new Error(`Unknown effect type: ${type}`);
+  const resolved = normalizeAudioFxParams(type, params);
+  // One-pole is a different node type, not a different parameter value.
+  if ((type === "highpass" || type === "lowpass") && String(resolved.poles) === "1") {
+    return onePoleBuilder(type)(ctx, resolved);
+  }
+  const builder = BUILDERS[def.web];
+  if (!builder) throw new Error(`No Web Audio builder for ${def.web}`);
+  return builder(ctx, resolved);
+}
+
+export interface FxChainHandle {
+  input: AudioNode;
+  output: AudioNode;
+  /** Re-parameterise in place when the shape is unchanged; false if a rebuild is needed. */
+  update(chain: HfAudioFxChain): boolean;
+  dispose(): void;
+}
+
+/**
+ * A signature of everything that changes the graph's *shape* rather than its
+ * parameter values. When this is unchanged an update can just push new values
+ * into the running nodes; when it changes, the caller rebuilds.
+ */
+function shapeOf(chain: HfAudioFxChain): string {
+  return chain.nodes
+    .filter((node) => node.enabled !== false)
+    .map((node) => {
+      const p = normalizeAudioFxParams(node.type, node.params);
+      const poles = p.poles !== undefined ? `:${p.poles}` : "";
+      return `${node.type}${poles}`;
+    })
+    .join("|");
+}
+
+/**
+ * Build the whole chain in series. Returns a handle whose `input`/`output` can
+ * be spliced into any graph; an empty chain yields a pass-through.
+ */
+export function buildFxChain(ctx: BaseAudioContext, chain: HfAudioFxChain): FxChainHandle {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+  const handles: { type: string; handle: FxNodeHandle }[] = [];
+
+  let tail: AudioNode = input;
+  for (const node of chain.nodes) {
+    if (node.enabled === false) continue;
+    const handle = buildFxNode(ctx, node.type, node.params ?? {});
+    tail.connect(handle.input);
+    tail = handle.output;
+    handles.push({ type: node.type, handle });
+  }
+  tail.connect(output);
+
+  let shape = shapeOf(chain);
+
+  return {
+    input,
+    output,
+    update(next) {
+      if (shapeOf(next) !== shape) return false;
+      const active = next.nodes.filter((node) => node.enabled !== false);
+      active.forEach((node, i) => {
+        handles[i]?.handle.update(normalizeAudioFxParams(node.type, node.params));
+      });
+      shape = shapeOf(next);
+      return true;
+    },
+    dispose() {
+      for (const { handle } of handles) handle.dispose();
+      input.disconnect();
+      output.disconnect();
+    },
+  };
+}
+
+export { ensureAudioFxWorklets };

--- a/packages/core/src/audio/audioFxGraph.ts
+++ b/packages/core/src/audio/audioFxGraph.ts
@@ -38,9 +38,22 @@ export function synthesizeReverbImpulse(
   };
   const cutoff = Math.max(0.001, 1 - Math.max(0, Math.min(1, damping)));
   let lp = 0;
+  let energy = 0;
   for (let i = 0; i < length; i++) {
     lp += cutoff * (rand() - lp);
-    out[i] = lp * Math.pow(1 - i / length, 2.5);
+    const sample = lp * Math.pow(1 - i / length, 2.5);
+    out[i] = sample;
+    energy += sample * sample;
+  }
+  // Scale to unit energy. A ConvolverNode applies the impulse's gain whole (the
+  // graph sets `normalize = false` so the room is deterministic rather than
+  // browser-defined), and this impulse is decaying noise whose raw energy runs
+  // to +33 dB at the default size — loud enough that simply adding a Reverb
+  // clipped the mix. Normalising here keeps the wet knob meaning what it says
+  // and keeps preview and render identical, since both convolve this buffer.
+  const norm = Math.sqrt(energy);
+  if (norm > 0) {
+    for (let i = 0; i < length; i++) out[i] = (out[i] ?? 0) / norm;
   }
   return out;
 }
@@ -216,12 +229,19 @@ const PHASER_STAGES = 6;
 const allpassPhaser: Builder = (ctx, p) => {
   const input = ctx.createGain();
   const out = ctx.createGain();
+  // aphaser's in_gain/out_gain trim the signal entering and leaving the effect.
+  // Wiring them to the wet and dry legs instead made "Input" mute the dry path
+  // and let the two defaults sum above unity, so inserting a phaser raised the
+  // track level.
+  const inTrim = ctx.createGain();
+  const outTrim = ctx.createGain();
   const lfo = ctx.createOscillator();
   const depth = ctx.createGain();
   const wet = ctx.createGain();
   const dry = ctx.createGain();
   const stages: BiquadFilterNode[] = [];
-  let node: AudioNode = input;
+  input.connect(inTrim);
+  let node: AudioNode = inTrim;
   for (let i = 0; i < PHASER_STAGES; i++) {
     const ap = ctx.createBiquadFilter();
     ap.type = "allpass";
@@ -232,9 +252,14 @@ const allpassPhaser: Builder = (ctx, p) => {
     stages.push(ap);
   }
   lfo.connect(depth);
+  // aphaser's type 0 is triangular, 1 sinusoidal. The builder never set this, so
+  // the declared default ("Triangular") was silently a sine. An OscillatorNode
+  // has no triangle-with-the-same-phase primitive to switch to, so triangle is
+  // the node's own "triangle" type.
   lfo.start();
-  node.connect(wet).connect(out);
-  input.connect(dry).connect(out);
+  node.connect(wet).connect(outTrim);
+  inTrim.connect(dry).connect(outTrim);
+  outTrim.connect(out);
   const apply = (v: HfAudioFxParamValues): void => {
     // aphaser sweeps around a centre derived from its delay; mirror the range
     // rather than the exact curve, and let the parity harness score it.
@@ -242,8 +267,12 @@ const allpassPhaser: Builder = (ctx, p) => {
     for (const ap of stages) ap.frequency.value = centre;
     depth.gain.value = centre * n(v.decay);
     lfo.frequency.value = n(v.speed);
-    wet.gain.value = n(v.out_gain);
-    dry.gain.value = n(v.in_gain);
+    lfo.type = String(v.type) === "1" ? "sine" : "triangle";
+    inTrim.gain.value = n(v.in_gain);
+    outTrim.gain.value = n(v.out_gain);
+    // Summed at unity: the sweep is the effect, not a blend control.
+    wet.gain.value = 1;
+    dry.gain.value = 1;
   };
   apply(p);
   return {
@@ -256,7 +285,7 @@ const allpassPhaser: Builder = (ctx, p) => {
       } catch {
         /* already stopped */
       }
-      [input, out, depth, wet, dry, ...stages].forEach((x) => x.disconnect());
+      [input, out, inTrim, outTrim, depth, wet, dry, ...stages].forEach((x) => x.disconnect());
     },
   };
 };
@@ -351,7 +380,13 @@ function shapeOf(chain: HfAudioFxChain): string {
     .map((node) => {
       const p = normalizeAudioFxParams(node.type, node.params);
       const poles = p.poles !== undefined ? `:${p.poles}` : "";
-      return `${node.type}${poles}`;
+      // A one-pole filter is an IIRFilterNode whose coefficients are fixed at
+      // construction, so its cutoff cannot be pushed into the running graph.
+      // Carrying the frequency here makes a cutoff change rebuild instead of
+      // being pushed into a no-op updater — which is what let preview keep
+      // filtering at the old frequency while the render used the new one.
+      const fixedFreq = String(p.poles) === "1" ? `@${p.frequency}` : "";
+      return `${node.type}${poles}${fixedFreq}`;
     })
     .join("|");
 }

--- a/packages/core/src/audio/audioFxWorklets.ts
+++ b/packages/core/src/audio/audioFxWorklets.ts
@@ -1,0 +1,200 @@
+/**
+ * AudioWorklet processors for the effects Web Audio has no native node for.
+ *
+ * Each one targets the behaviour of its FFmpeg counterpart rather than of any
+ * particular plugin, because the render is FFmpeg and preview only earns its
+ * keep by predicting the render. How closely each lands is measured, not
+ * assumed — see the preview/render parity harness.
+ *
+ * Kept as a source string so it can be registered from a Blob URL without a
+ * separate bundled asset, which keeps the studio's build unchanged.
+ */
+export const AUDIO_FX_WORKLET_SOURCE = `
+const dbToLin = (db) => Math.pow(10, db / 20);
+
+/** One-pole envelope follower shared by the dynamics processors. */
+class Env {
+  constructor(attackMs, releaseMs) { this.set(attackMs, releaseMs); this.value = 0; }
+  set(attackMs, releaseMs) {
+    this.a = Math.exp(-1 / (sampleRate * Math.max(1e-5, attackMs / 1000)));
+    this.r = Math.exp(-1 / (sampleRate * Math.max(1e-5, releaseMs / 1000)));
+  }
+  push(x) {
+    const m = Math.abs(x);
+    const c = m > this.value ? this.a : this.r;
+    this.value = m + c * (this.value - m);
+    return this.value;
+  }
+}
+
+/** Soft-knee gain computer in dB, matching acompressor's shape. */
+function kneeGain(envDb, thresholdDb, ratio, kneeDb) {
+  const over = envDb - thresholdDb;
+  if (kneeDb > 0 && over > -kneeDb && over < kneeDb) {
+    const t = (over + kneeDb) / (2 * kneeDb);
+    return -((1 - 1 / ratio) * kneeDb * t * t);
+  }
+  return over > 0 ? -(over * (1 - 1 / ratio)) : 0;
+}
+
+class HfCompressor extends AudioWorkletProcessor {
+  constructor(o) {
+    super();
+    this.p = o.processorOptions || {};
+    this.env = new Env(this.p.attack ?? 20, this.p.release ?? 250);
+    this.port.onmessage = (e) => {
+      this.p = { ...this.p, ...e.data };
+      this.env.set(this.p.attack ?? 20, this.p.release ?? 250);
+    };
+  }
+  process(inputs, outputs) {
+    const i = inputs[0], o = outputs[0];
+    if (!i || !i.length) return true;
+    const p = this.p;
+    const makeup = dbToLin(p.makeup ?? 0);
+    const mix = p.mix ?? 1;
+    // Knee is expressed as a ratio in FFmpeg; convert to dB width.
+    const kneeDb = 20 * Math.log10(Math.max(1.0001, p.knee ?? 2.83));
+    for (let ch = 0; ch < i.length; ch++) {
+      const inp = i[ch], out = o[ch];
+      for (let n = 0; n < inp.length; n++) {
+        const x = inp[n];
+        const env = this.env.push(x);
+        const envDb = env > 1e-9 ? 20 * Math.log10(env) : -200;
+        const g = dbToLin(kneeGain(envDb, p.threshold ?? -24, p.ratio ?? 4, kneeDb));
+        out[n] = x * g * makeup * mix + x * (1 - mix);
+      }
+    }
+    return true;
+  }
+}
+registerProcessor("hf-compressor", HfCompressor);
+
+class HfLimiter extends AudioWorkletProcessor {
+  constructor(o) {
+    super();
+    this.p = o.processorOptions || {};
+    this.env = new Env(this.p.attack ?? 5, this.p.release ?? 50);
+    this.port.onmessage = (e) => {
+      this.p = { ...this.p, ...e.data };
+      this.env.set(this.p.attack ?? 5, this.p.release ?? 50);
+    };
+  }
+  process(inputs, outputs) {
+    const i = inputs[0], o = outputs[0];
+    if (!i || !i.length) return true;
+    const ceiling = dbToLin(this.p.limit ?? -1);
+    const outGain = dbToLin(this.p.level_out ?? 0);
+    for (let ch = 0; ch < i.length; ch++) {
+      const inp = i[ch], out = o[ch];
+      for (let n = 0; n < inp.length; n++) {
+        const x = inp[n];
+        const env = this.env.push(x);
+        // Only ever attenuate: a limiter that can raise level is a compressor.
+        const g = env > ceiling ? ceiling / env : 1;
+        out[n] = x * g * outGain;
+      }
+    }
+    return true;
+  }
+}
+registerProcessor("hf-limiter", HfLimiter);
+
+class HfGate extends AudioWorkletProcessor {
+  constructor(o) {
+    super();
+    this.p = o.processorOptions || {};
+    this.env = new Env(this.p.attack ?? 1, this.p.release ?? 100);
+    this.gain = 1;
+    this.port.onmessage = (e) => {
+      this.p = { ...this.p, ...e.data };
+      this.env.set(this.p.attack ?? 1, this.p.release ?? 100);
+    };
+  }
+  process(inputs, outputs) {
+    const i = inputs[0], o = outputs[0];
+    if (!i || !i.length) return true;
+    const p = this.p;
+    const threshold = dbToLin(p.threshold ?? -35);
+    const floor = dbToLin(p.range ?? -24);
+    const ratio = p.ratio ?? 10;
+    for (let ch = 0; ch < i.length; ch++) {
+      const inp = i[ch], out = o[ch];
+      for (let n = 0; n < inp.length; n++) {
+        const x = inp[n];
+        const env = this.env.push(x);
+        let target = 1;
+        if (env < threshold) {
+          const under = env > 1e-9 ? threshold / env : 1e9;
+          target = Math.max(floor, 1 / Math.pow(under, ratio - 1));
+          if (!isFinite(target)) target = floor;
+        }
+        // Smooth toward the target so the gate does not click on every sample.
+        const c = target < this.gain ? this.env.r : this.env.a;
+        this.gain = target + c * (this.gain - target);
+        out[n] = x * this.gain;
+      }
+    }
+    return true;
+  }
+}
+registerProcessor("hf-gate", HfGate);
+
+class HfBitcrush extends AudioWorkletProcessor {
+  constructor(o) {
+    super();
+    this.p = o.processorOptions || {};
+    this.hold = 0;
+    this.held = [];
+    this.port.onmessage = (e) => { this.p = { ...this.p, ...e.data }; };
+  }
+  process(inputs, outputs) {
+    const i = inputs[0], o = outputs[0];
+    if (!i || !i.length) return true;
+    const p = this.p;
+    const levels = Math.pow(2, (p.bits ?? 8) - 1);
+    const step = Math.max(1, Math.round(p.samples ?? 1));
+    const mix = p.mix ?? 1;
+    for (let ch = 0; ch < i.length; ch++) {
+      const inp = i[ch], out = o[ch];
+      if (this.held[ch] === undefined) this.held[ch] = 0;
+      for (let n = 0; n < inp.length; n++) {
+        if (this.hold === 0) this.held[ch] = Math.round(inp[n] * levels) / levels;
+        out[n] = this.held[ch] * mix + inp[n] * (1 - mix);
+        if (ch === i.length - 1) this.hold = (this.hold + 1) % step;
+      }
+    }
+    return true;
+  }
+}
+registerProcessor("hf-bitcrush", HfBitcrush);
+`;
+
+let modulePromise: Promise<void> | undefined;
+
+/**
+ * Register the processors on a context. Idempotent per module instance, since
+ * addModule throws if the same processor name is registered twice.
+ */
+export function ensureAudioFxWorklets(ctx: BaseAudioContext): Promise<void> {
+  modulePromise ??= (async () => {
+    if (!ctx.audioWorklet) {
+      throw new Error(
+        "AudioWorklet is unavailable — the page needs a secure context (https, localhost or file://)",
+      );
+    }
+    // A data: URL rather than a blob:, because a blob inherits the page origin
+    // and is treated as opaque on a file:// page, where the module then fails
+    // to load with an unhelpful AbortError.
+    const url = `data:text/javascript;base64,${btoa(
+      String.fromCharCode(...new TextEncoder().encode(AUDIO_FX_WORKLET_SOURCE)),
+    )}`;
+    await ctx.audioWorklet.addModule(url);
+  })();
+  return modulePromise;
+}
+
+/** Test seam: forget the cached registration so a fresh context can register. */
+export function __resetAudioFxWorkletsForTests(): void {
+  modulePromise = undefined;
+}

--- a/packages/core/src/audio/audioFxWorklets.ts
+++ b/packages/core/src/audio/audioFxWorklets.ts
@@ -12,18 +12,28 @@
 export const AUDIO_FX_WORKLET_SOURCE = `
 const dbToLin = (db) => Math.pow(10, db / 20);
 
-/** One-pole envelope follower shared by the dynamics processors. */
-class Env {
-  constructor(attackMs, releaseMs) { this.set(attackMs, releaseMs); this.value = 0; }
+/**
+ * One-pole envelope followers, one per channel.
+ *
+ * Per channel matters: the followers advance once per sample, so a single shared
+ * follower stepped once per channel per sample. On stereo that ran a 20 ms attack
+ * as 10 ms, and gave the right channel a gain computed from an envelope that had
+ * already traversed the left — so the two channels ducked by different amounts
+ * from the same input and the image pumped.
+ */
+class EnvBank {
+  constructor(attackMs, releaseMs) { this.set(attackMs, releaseMs); this.values = []; }
   set(attackMs, releaseMs) {
     this.a = Math.exp(-1 / (sampleRate * Math.max(1e-5, attackMs / 1000)));
     this.r = Math.exp(-1 / (sampleRate * Math.max(1e-5, releaseMs / 1000)));
   }
-  push(x) {
+  push(ch, x) {
+    const prev = this.values[ch] ?? 0;
     const m = Math.abs(x);
-    const c = m > this.value ? this.a : this.r;
-    this.value = m + c * (this.value - m);
-    return this.value;
+    const c = m > prev ? this.a : this.r;
+    const next = m + c * (prev - m);
+    this.values[ch] = next;
+    return next;
   }
 }
 
@@ -41,7 +51,7 @@ class HfCompressor extends AudioWorkletProcessor {
   constructor(o) {
     super();
     this.p = o.processorOptions || {};
-    this.env = new Env(this.p.attack ?? 20, this.p.release ?? 250);
+    this.env = new EnvBank(this.p.attack ?? 20, this.p.release ?? 250);
     this.port.onmessage = (e) => {
       this.p = { ...this.p, ...e.data };
       this.env.set(this.p.attack ?? 20, this.p.release ?? 250);
@@ -59,7 +69,7 @@ class HfCompressor extends AudioWorkletProcessor {
       const inp = i[ch], out = o[ch];
       for (let n = 0; n < inp.length; n++) {
         const x = inp[n];
-        const env = this.env.push(x);
+        const env = this.env.push(ch, x);
         const envDb = env > 1e-9 ? 20 * Math.log10(env) : -200;
         const g = dbToLin(kneeGain(envDb, p.threshold ?? -24, p.ratio ?? 4, kneeDb));
         out[n] = x * g * makeup * mix + x * (1 - mix);
@@ -74,7 +84,7 @@ class HfLimiter extends AudioWorkletProcessor {
   constructor(o) {
     super();
     this.p = o.processorOptions || {};
-    this.env = new Env(this.p.attack ?? 5, this.p.release ?? 50);
+    this.env = new EnvBank(this.p.attack ?? 5, this.p.release ?? 50);
     this.port.onmessage = (e) => {
       this.p = { ...this.p, ...e.data };
       this.env.set(this.p.attack ?? 5, this.p.release ?? 50);
@@ -89,7 +99,7 @@ class HfLimiter extends AudioWorkletProcessor {
       const inp = i[ch], out = o[ch];
       for (let n = 0; n < inp.length; n++) {
         const x = inp[n];
-        const env = this.env.push(x);
+        const env = this.env.push(ch, x);
         // Only ever attenuate: a limiter that can raise level is a compressor.
         const g = env > ceiling ? ceiling / env : 1;
         out[n] = x * g * outGain;
@@ -104,8 +114,8 @@ class HfGate extends AudioWorkletProcessor {
   constructor(o) {
     super();
     this.p = o.processorOptions || {};
-    this.env = new Env(this.p.attack ?? 1, this.p.release ?? 100);
-    this.gain = 1;
+    this.env = new EnvBank(this.p.attack ?? 1, this.p.release ?? 100);
+    this.gains = [];
     this.port.onmessage = (e) => {
       this.p = { ...this.p, ...e.data };
       this.env.set(this.p.attack ?? 1, this.p.release ?? 100);
@@ -118,11 +128,16 @@ class HfGate extends AudioWorkletProcessor {
     const threshold = dbToLin(p.threshold ?? -35);
     const floor = dbToLin(p.range ?? -24);
     const ratio = p.ratio ?? 10;
+    // Knee is declared in the registry as a ratio, like the compressor's; a
+    // hard threshold ignored it and chattered on material sitting right at the
+    // gate point.
+    const kneeDb = 20 * Math.log10(Math.max(1.0001, p.knee ?? 2.83));
+    const kneeLin = dbToLin((p.threshold ?? -35) + kneeDb);
     for (let ch = 0; ch < i.length; ch++) {
       const inp = i[ch], out = o[ch];
       for (let n = 0; n < inp.length; n++) {
         const x = inp[n];
-        const env = this.env.push(x);
+        const env = this.env.push(ch, x);
         let target = 1;
         if (env < threshold) {
           const under = env > 1e-9 ? threshold / env : 1e9;
@@ -130,9 +145,11 @@ class HfGate extends AudioWorkletProcessor {
           if (!isFinite(target)) target = floor;
         }
         // Smooth toward the target so the gate does not click on every sample.
-        const c = target < this.gain ? this.env.r : this.env.a;
-        this.gain = target + c * (this.gain - target);
-        out[n] = x * this.gain;
+        const held = this.gains[ch] ?? 1;
+        const c = target < held ? this.env.r : this.env.a;
+        const smoothed = target + c * (held - target);
+        this.gains[ch] = smoothed;
+        out[n] = x * smoothed;
       }
     }
     return true;
@@ -144,7 +161,7 @@ class HfBitcrush extends AudioWorkletProcessor {
   constructor(o) {
     super();
     this.p = o.processorOptions || {};
-    this.hold = 0;
+    this.holds = [];
     this.held = [];
     this.port.onmessage = (e) => { this.p = { ...this.p, ...e.data }; };
   }
@@ -158,10 +175,14 @@ class HfBitcrush extends AudioWorkletProcessor {
     for (let ch = 0; ch < i.length; ch++) {
       const inp = i[ch], out = o[ch];
       if (this.held[ch] === undefined) this.held[ch] = 0;
+      if (this.holds[ch] === undefined) this.holds[ch] = 0;
       for (let n = 0; n < inp.length; n++) {
-        if (this.hold === 0) this.held[ch] = Math.round(inp[n] * levels) / levels;
+        // Per channel: advancing one shared counter only on the last channel
+        // left every earlier channel either unheld or frozen for a whole
+        // 128-sample quantum, clicking once a block.
+        if (this.holds[ch] === 0) this.held[ch] = Math.round(inp[n] * levels) / levels;
         out[n] = this.held[ch] * mix + inp[n] * (1 - mix);
-        if (ch === i.length - 1) this.hold = (this.hold + 1) % step;
+        this.holds[ch] = (this.holds[ch] + 1) % step;
       }
     }
     return true;

--- a/packages/core/src/audioFx.test.ts
+++ b/packages/core/src/audioFx.test.ts
@@ -3,6 +3,7 @@ import {
   AudioFxChainError,
   defaultAudioFxParams,
   enabledAudioFxNodes,
+  getAudioFxDef,
   HF_AUDIO_FX,
   HF_AUDIO_FX_CHAIN_VERSION,
   HF_AUDIO_FX_IDS,
@@ -111,5 +112,29 @@ describe("enabledAudioFxNodes", () => {
       nodes: [{ type: "peaking" }, { type: "delay", enabled: false }],
     });
     expect(nodes.map((n) => n.type)).toEqual(["peaking"]);
+  });
+});
+
+describe("declared parameters are real", () => {
+  const paramKeys = (id: string): string[] => (getAudioFxDef(id)?.params ?? []).map((p) => p.key);
+
+  it("offers no shelf Q, which a BiquadFilterNode ignores for shelf types", () => {
+    // It was also flagged automatable, so a lane could be drawn on it and heard
+    // not at all.
+    expect(paramKeys("lowshelf")).not.toContain("q");
+    expect(paramKeys("highshelf")).not.toContain("q");
+    // Peaking and the pass filters do use Q.
+    expect(paramKeys("peaking")).toContain("q");
+    expect(paramKeys("lowpass")).toContain("q");
+  });
+
+  it("offers no knob whose builder reads nothing", () => {
+    // chorus `decay` and bitcrush `aa` were declared with ranges and defaults but
+    // no builder ever read them: dials that moved and did nothing.
+    expect(paramKeys("chorus")).not.toContain("decay");
+    expect(paramKeys("bitcrush")).not.toContain("aa");
+    // The phaser's decay does drive its sweep depth, and the gate's knee is read.
+    expect(paramKeys("phaser")).toContain("decay");
+    expect(paramKeys("gate")).toContain("knee");
   });
 });

--- a/packages/core/src/audioFx.test.ts
+++ b/packages/core/src/audioFx.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  AudioFxChainError,
+  defaultAudioFxParams,
+  enabledAudioFxNodes,
+  HF_AUDIO_FX,
+  HF_AUDIO_FX_CHAIN_VERSION,
+  HF_AUDIO_FX_IDS,
+  normalizeAudioFxParams,
+  parseAudioFxChain,
+} from "./audioFx.js";
+
+const chain = (nodes: unknown[]): string =>
+  JSON.stringify({ version: HF_AUDIO_FX_CHAIN_VERSION, nodes });
+
+describe("effect registry", () => {
+  it("has unique ids and unique parameter keys per effect", () => {
+    expect(new Set(HF_AUDIO_FX_IDS).size).toBe(HF_AUDIO_FX.length);
+    for (const def of HF_AUDIO_FX) {
+      const keys = def.params.map((p) => p.key);
+      expect(new Set(keys).size, `${def.id} has duplicate param keys`).toBe(keys.length);
+    }
+  });
+
+  it("declares every default inside its own declared range", () => {
+    for (const def of HF_AUDIO_FX) {
+      for (const p of def.params) {
+        if (p.kind === "enum") {
+          expect(
+            p.options.some((o) => o.value === p.default),
+            `${def.id}.${p.key} default is not one of its options`,
+          ).toBe(true);
+        } else {
+          expect(p.default, `${def.id}.${p.key} default below min`).toBeGreaterThanOrEqual(p.min);
+          expect(p.default, `${def.id}.${p.key} default above max`).toBeLessThanOrEqual(p.max);
+          expect(p.min).toBeLessThan(p.max);
+        }
+      }
+    }
+  });
+
+  it("gives every effect at least one knob to turn", () => {
+    for (const def of HF_AUDIO_FX) {
+      expect(def.params.length, `${def.id} exposes no parameters`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("normalizeAudioFxParams", () => {
+  it("fills missing keys with defaults", () => {
+    expect(normalizeAudioFxParams("peaking", {})).toEqual(defaultAudioFxParams("peaking"));
+  });
+
+  it("clamps out-of-range numbers into the renderable range", () => {
+    const v = normalizeAudioFxParams("peaking", { frequency: 999999, gain: -500, q: 0 });
+    expect(v.frequency).toBe(20000);
+    expect(v.gain).toBe(-40);
+    expect(v.q).toBe(0.1);
+  });
+
+  it("replaces NaN and non-numeric junk with the default", () => {
+    // NaN reaching a filter string fails the entire render, so it must never survive.
+    const v = normalizeAudioFxParams("peaking", {
+      frequency: Number.NaN,
+      gain: "loud" as unknown as number,
+    });
+    expect(v.frequency).toBe(1000);
+    expect(v.gain).toBe(0);
+  });
+
+  it("falls back to the default for an unrecognised enum value", () => {
+    expect(normalizeAudioFxParams("saturate", { type: "sawtooth" }).type).toBe("tanh");
+    expect(normalizeAudioFxParams("saturate", { type: "atan" }).type).toBe("atan");
+  });
+
+  it("drops keys the effect does not declare", () => {
+    const v = normalizeAudioFxParams("peaking", { frequency: 500, nonsense: 1 });
+    expect(Object.keys(v).sort()).toEqual(["frequency", "gain", "q"]);
+  });
+});
+
+describe("parseAudioFxChain", () => {
+  it("round-trips a chain and defaults `enabled` to true", () => {
+    const parsed = parseAudioFxChain(chain([{ type: "peaking", params: { gain: -6 } }]));
+    expect(parsed.nodes).toHaveLength(1);
+    expect(parsed.nodes[0]!.enabled).toBe(true);
+    expect(parsed.nodes[0]!.params!.gain).toBe(-6);
+  });
+
+  it("rejects an unknown effect rather than silently dropping it", () => {
+    // Skipping the node would render something other than what was authored.
+    expect(() => parseAudioFxChain(chain([{ type: "vibrato" }]))).toThrow(AudioFxChainError);
+  });
+
+  it("rejects an unsupported version", () => {
+    expect(() => parseAudioFxChain(JSON.stringify({ version: 99, nodes: [] }))).toThrow(
+      /Unsupported chain version/,
+    );
+  });
+
+  it("rejects malformed JSON and a missing nodes array", () => {
+    expect(() => parseAudioFxChain("{oops")).toThrow(/not valid JSON/);
+    expect(() => parseAudioFxChain(JSON.stringify({ version: 1 }))).toThrow(/missing a `nodes`/);
+  });
+});
+
+describe("enabledAudioFxNodes", () => {
+  it("treats a missing enabled flag as enabled", () => {
+    const nodes = enabledAudioFxNodes({
+      version: 1,
+      nodes: [{ type: "peaking" }, { type: "delay", enabled: false }],
+    });
+    expect(nodes.map((n) => n.type)).toEqual(["peaking"]);
+  });
+});

--- a/packages/core/src/audioFx.ts
+++ b/packages/core/src/audioFx.ts
@@ -1,0 +1,829 @@
+/**
+ * Audio FX chain: the one description of every effect that can be applied to an
+ * audio track.
+ *
+ * Preview and render both run the same Web Audio graph — the studio in a live
+ * AudioContext, the engine in an OfflineAudioContext inside the headless
+ * browser it already drives. There is only one implementation of each effect,
+ * so preview predicting the render is a property of the architecture rather
+ * than something to measure and defend.
+ *
+ * This file holds what both ends need to agree on: the parameter set for each
+ * effect with its usable range, and the id of the graph builder that realises
+ * it. Parameters are declared in the units a person thinks in (dB, ms, Hz);
+ * the graph builders convert where the Web Audio node wants something else.
+ */
+
+export const HF_AUDIO_FX_ATTR = "data-fx-chain";
+
+/** Chain files are versioned; a reader must refuse a version it doesn't know. */
+export const HF_AUDIO_FX_CHAIN_VERSION = 1;
+
+export type HfAudioFxGroup = "filter" | "dynamics" | "nonlinear" | "time";
+
+export interface HfAudioFxNumberParam {
+  kind: "number";
+  key: string;
+  label: string;
+  /** Shown after the value in the panel; "" for a bare ratio. */
+  unit: string;
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+  /** Frequency-style controls need a log knob to be usable. */
+  scale?: "linear" | "log";
+  /** One line explaining what turning this does, shown on the control. */
+  hint?: string;
+}
+
+export interface HfAudioFxEnumParam {
+  kind: "enum";
+  key: string;
+  label: string;
+  options: readonly { value: string; label: string }[];
+  default: string;
+  hint?: string;
+}
+
+export type HfAudioFxParam = HfAudioFxNumberParam | HfAudioFxEnumParam;
+
+export type HfAudioFxParamValues = Record<string, number | string>;
+
+export interface HfAudioFxDef {
+  id: string;
+  label: string;
+  group: HfAudioFxGroup;
+  /** One sentence on what the effect is for, shown when adding it. */
+  description: string;
+  params: readonly HfAudioFxParam[];
+  /**
+   * Identifier for the Web Audio graph builder that realises this effect. Kept
+   * as a string rather than a function so this module stays free of browser
+   * globals and can be imported by the engine and the linter.
+   */
+  web: string;
+}
+
+const freq = (
+  key = "frequency",
+  label = "Frequency",
+  def = 1000,
+  min = 20,
+  max = 20000,
+): HfAudioFxNumberParam => ({
+  kind: "number",
+  key,
+  label,
+  unit: "Hz",
+  min,
+  max,
+  step: 1,
+  default: def,
+  scale: "log",
+});
+
+const qParam = (def = 0.707, hint = "Bandwidth — higher is narrower."): HfAudioFxNumberParam => ({
+  kind: "number",
+  key: "q",
+  label: "Q",
+  unit: "",
+  min: 0.1,
+  max: 20,
+  step: 0.01,
+  default: def,
+  scale: "log",
+  hint,
+});
+
+const gainDb = (min = -40, max = 40, def = 0): HfAudioFxNumberParam => ({
+  kind: "number",
+  key: "gain",
+  label: "Gain",
+  unit: "dB",
+  min,
+  max,
+  step: 0.1,
+  default: def,
+});
+
+const poles: HfAudioFxEnumParam = {
+  kind: "enum",
+  key: "poles",
+  label: "Slope",
+  options: [
+    { value: "1", label: "6 dB/oct" },
+    { value: "2", label: "12 dB/oct" },
+  ],
+  default: "2",
+  hint: "Two poles is the usual biquad; one pole is gentler.",
+};
+
+/**
+ * Every effect, in panel order. Ranges are the usable span for each control;
+ * a value that survives `normalizeAudioFxParams` is always safe to realise.
+ */
+export const HF_AUDIO_FX: readonly HfAudioFxDef[] = [
+  {
+    id: "peaking",
+    label: "Peaking EQ",
+    group: "filter",
+    description: "Boost or cut a band, leaving everything either side alone.",
+    params: [freq("frequency", "Frequency", 1000), gainDb(-40, 40, 0), qParam(1)],
+    web: "biquad-peaking",
+  },
+  {
+    id: "lowshelf",
+    label: "Low Shelf",
+    group: "filter",
+    description: "Lift or drop everything below the corner frequency.",
+    params: [freq("frequency", "Frequency", 200, 20, 2000), gainDb(-40, 40, 0), qParam(0.707)],
+    web: "biquad-lowshelf",
+  },
+  {
+    id: "highshelf",
+    label: "High Shelf",
+    group: "filter",
+    description: "Lift or drop everything above the corner frequency.",
+    params: [freq("frequency", "Frequency", 4000, 500, 20000), gainDb(-40, 40, 0), qParam(0.707)],
+    web: "biquad-highshelf",
+  },
+  {
+    id: "highpass",
+    label: "High-pass",
+    group: "filter",
+    description: "Remove low frequencies — the usual fix for rumble on a voice.",
+    params: [freq("frequency", "Cutoff", 300, 20, 20000), qParam(0.707), poles],
+    web: "biquad-highpass",
+  },
+  {
+    id: "lowpass",
+    label: "Low-pass",
+    group: "filter",
+    description: "Remove high frequencies — darkens or muffles a track.",
+    params: [freq("frequency", "Cutoff", 8000, 100, 20000), qParam(0.707), poles],
+    web: "biquad-lowpass",
+  },
+
+  {
+    id: "compressor",
+    label: "Compressor",
+    group: "dynamics",
+    description: "Pull loud parts down so the quiet ones can come up.",
+    params: [
+      {
+        kind: "number",
+        key: "threshold",
+        label: "Threshold",
+        unit: "dB",
+        min: -60,
+        max: 0,
+        step: 0.5,
+        default: -24,
+        hint: "Level above which the compressor starts working.",
+      },
+      {
+        kind: "number",
+        key: "ratio",
+        label: "Ratio",
+        unit: ":1",
+        min: 1,
+        max: 20,
+        step: 0.1,
+        default: 4,
+      },
+      {
+        kind: "number",
+        key: "attack",
+        label: "Attack",
+        unit: "ms",
+        min: 0.01,
+        max: 2000,
+        step: 0.1,
+        default: 20,
+        scale: "log",
+      },
+      {
+        kind: "number",
+        key: "release",
+        label: "Release",
+        unit: "ms",
+        min: 0.01,
+        max: 9000,
+        step: 1,
+        default: 250,
+        scale: "log",
+      },
+      {
+        kind: "number",
+        key: "knee",
+        label: "Knee",
+        unit: "",
+        min: 1,
+        max: 8,
+        step: 0.01,
+        default: 2.83,
+        hint: "1 is a hard corner; higher eases into it.",
+      },
+      {
+        kind: "number",
+        key: "makeup",
+        label: "Makeup",
+        unit: "dB",
+        min: 0,
+        max: 36,
+        step: 0.1,
+        default: 0,
+      },
+      {
+        kind: "number",
+        key: "mix",
+        label: "Mix",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 1,
+        hint: "Below 1 blends the dry signal back in.",
+      },
+    ],
+    web: "worklet-compressor",
+  },
+  {
+    id: "limiter",
+    label: "Limiter",
+    group: "dynamics",
+    description: "Hard ceiling — nothing gets past the limit.",
+    params: [
+      {
+        kind: "number",
+        key: "limit",
+        label: "Ceiling",
+        unit: "dB",
+        min: -24,
+        max: 0,
+        step: 0.1,
+        default: -1,
+      },
+      {
+        kind: "number",
+        key: "attack",
+        label: "Attack",
+        unit: "ms",
+        min: 0.1,
+        max: 80,
+        step: 0.1,
+        default: 5,
+      },
+      {
+        kind: "number",
+        key: "release",
+        label: "Release",
+        unit: "ms",
+        min: 1,
+        max: 8000,
+        step: 1,
+        default: 50,
+        scale: "log",
+      },
+      {
+        kind: "number",
+        key: "level_out",
+        label: "Output",
+        unit: "dB",
+        min: -24,
+        max: 24,
+        step: 0.1,
+        default: 0,
+      },
+    ],
+    web: "worklet-limiter",
+  },
+  {
+    id: "gate",
+    label: "Noise Gate",
+    group: "dynamics",
+    description: "Silence the track when it drops below the threshold.",
+    params: [
+      {
+        kind: "number",
+        key: "threshold",
+        label: "Threshold",
+        unit: "dB",
+        min: -80,
+        max: 0,
+        step: 0.5,
+        default: -35,
+      },
+      {
+        kind: "number",
+        key: "range",
+        label: "Range",
+        unit: "dB",
+        min: -80,
+        max: 0,
+        step: 0.5,
+        default: -24,
+        hint: "How far down the gate pulls when closed.",
+      },
+      {
+        kind: "number",
+        key: "ratio",
+        label: "Ratio",
+        unit: ":1",
+        min: 1,
+        max: 20,
+        step: 0.1,
+        default: 10,
+      },
+      {
+        kind: "number",
+        key: "attack",
+        label: "Attack",
+        unit: "ms",
+        min: 0.01,
+        max: 9000,
+        step: 0.1,
+        default: 1,
+        scale: "log",
+      },
+      {
+        kind: "number",
+        key: "release",
+        label: "Release",
+        unit: "ms",
+        min: 0.01,
+        max: 9000,
+        step: 1,
+        default: 100,
+        scale: "log",
+      },
+      {
+        kind: "number",
+        key: "knee",
+        label: "Knee",
+        unit: "",
+        min: 1,
+        max: 8,
+        step: 0.01,
+        default: 2.83,
+      },
+    ],
+    web: "worklet-gate",
+  },
+
+  {
+    id: "saturate",
+    label: "Saturation",
+    group: "nonlinear",
+    description: "Soft-clip the waveform for warmth or outright distortion.",
+    params: [
+      {
+        kind: "enum",
+        key: "type",
+        label: "Curve",
+        options: [
+          { value: "tanh", label: "Tanh" },
+          { value: "atan", label: "Arctan" },
+          { value: "cubic", label: "Cubic" },
+          { value: "exp", label: "Exponential" },
+          { value: "alg", label: "Algebraic" },
+          { value: "quintic", label: "Quintic" },
+          { value: "sin", label: "Sine" },
+          { value: "erf", label: "Error function" },
+          { value: "hard", label: "Hard clip" },
+        ],
+        default: "tanh",
+      },
+      {
+        kind: "number",
+        key: "threshold",
+        label: "Threshold",
+        unit: "dB",
+        min: -40,
+        max: 0,
+        step: 0.1,
+        default: -6,
+      },
+      {
+        kind: "number",
+        key: "output",
+        label: "Output",
+        unit: "dB",
+        min: -24,
+        max: 24,
+        step: 0.1,
+        default: 0,
+      },
+      {
+        kind: "number",
+        key: "oversample",
+        label: "Oversample",
+        unit: "x",
+        min: 1,
+        max: 8,
+        step: 1,
+        default: 4,
+        hint: "Higher costs more but keeps aliasing down.",
+      },
+    ],
+    web: "waveshaper",
+  },
+  {
+    id: "bitcrush",
+    label: "Bitcrush",
+    group: "nonlinear",
+    description: "Drop bit depth and sample rate for a lo-fi, digital sound.",
+    params: [
+      {
+        kind: "number",
+        key: "bits",
+        label: "Bit depth",
+        unit: "bit",
+        min: 1,
+        max: 32,
+        step: 0.1,
+        default: 8,
+      },
+      {
+        kind: "number",
+        key: "samples",
+        label: "Sample hold",
+        unit: "x",
+        min: 1,
+        max: 250,
+        step: 1,
+        default: 1,
+        hint: "Repeats each sample N times — a crude downsample.",
+      },
+      {
+        kind: "number",
+        key: "aa",
+        label: "Anti-alias",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 0.5,
+      },
+      {
+        kind: "number",
+        key: "mix",
+        label: "Mix",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 1,
+      },
+    ],
+    web: "worklet-bitcrush",
+  },
+
+  {
+    id: "delay",
+    label: "Delay",
+    group: "time",
+    description: "Repeating echoes behind the dry signal.",
+    params: [
+      {
+        kind: "number",
+        key: "time",
+        label: "Time",
+        unit: "ms",
+        min: 1,
+        max: 5000,
+        step: 1,
+        default: 250,
+        scale: "log",
+      },
+      // aecho rejects a decay of exactly 0 ("out of allowed range: (0, 1]"),
+      // so the floor is a hair above silence rather than at it.
+      {
+        kind: "number",
+        key: "feedback",
+        label: "Feedback",
+        unit: "",
+        min: 0.01,
+        max: 0.95,
+        step: 0.01,
+        default: 0.35,
+      },
+      {
+        kind: "number",
+        key: "mix",
+        label: "Mix",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 0.4,
+      },
+    ],
+    web: "delay-feedback",
+  },
+  {
+    id: "chorus",
+    label: "Chorus",
+    group: "time",
+    description: "Detuned copies of the signal for width and thickness.",
+    params: [
+      {
+        kind: "number",
+        key: "delay",
+        label: "Delay",
+        unit: "ms",
+        min: 1,
+        max: 100,
+        step: 0.1,
+        default: 7,
+      },
+      {
+        kind: "number",
+        key: "depth",
+        label: "Depth",
+        unit: "ms",
+        min: 0,
+        max: 10,
+        step: 0.01,
+        default: 2,
+      },
+      {
+        kind: "number",
+        key: "speed",
+        label: "Rate",
+        unit: "Hz",
+        min: 0.01,
+        max: 10,
+        step: 0.01,
+        default: 1,
+      },
+      {
+        kind: "number",
+        key: "decay",
+        label: "Decay",
+        unit: "",
+        min: 0,
+        max: 0.9,
+        step: 0.01,
+        default: 0.5,
+      },
+      {
+        kind: "number",
+        key: "mix",
+        label: "Mix",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 0.5,
+      },
+    ],
+    web: "chorus-lfo",
+  },
+  {
+    id: "phaser",
+    label: "Phaser",
+    group: "time",
+    description: "Sweeping notches moving through the spectrum.",
+    params: [
+      {
+        kind: "number",
+        key: "in_gain",
+        label: "Input",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 0.4,
+      },
+      {
+        kind: "number",
+        key: "out_gain",
+        label: "Output",
+        unit: "",
+        min: 0,
+        max: 2,
+        step: 0.01,
+        default: 0.74,
+      },
+      // aphaser advertises a delay range starting at 0 but rejects it at
+      // runtime with "delay is too small"; 0.1 ms is the real floor.
+      {
+        kind: "number",
+        key: "delay",
+        label: "Delay",
+        unit: "ms",
+        min: 0.1,
+        max: 5,
+        step: 0.1,
+        default: 3,
+      },
+      {
+        kind: "number",
+        key: "decay",
+        label: "Decay",
+        unit: "",
+        min: 0,
+        max: 0.99,
+        step: 0.01,
+        default: 0.4,
+      },
+      {
+        kind: "number",
+        key: "speed",
+        label: "Rate",
+        unit: "Hz",
+        min: 0.1,
+        max: 2,
+        step: 0.01,
+        default: 0.5,
+      },
+      {
+        kind: "enum",
+        key: "type",
+        label: "Waveform",
+        options: [
+          { value: "0", label: "Triangular" },
+          { value: "1", label: "Sinusoidal" },
+        ],
+        default: "0",
+      },
+    ],
+    web: "allpass-phaser",
+  },
+  {
+    id: "reverb",
+    label: "Reverb",
+    group: "time",
+    description:
+      "Room tail. Both ends convolve the same generated impulse, so preview matches render.",
+    params: [
+      {
+        kind: "number",
+        key: "size",
+        label: "Room size",
+        unit: "",
+        min: 0.05,
+        max: 1,
+        step: 0.01,
+        default: 0.7,
+      },
+      {
+        kind: "number",
+        key: "damping",
+        label: "Damping",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 0.5,
+        hint: "Higher rolls the top off the tail faster.",
+      },
+      {
+        kind: "number",
+        key: "wet",
+        label: "Wet",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 0.35,
+      },
+      {
+        kind: "number",
+        key: "dry",
+        label: "Dry",
+        unit: "",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        default: 0.7,
+      },
+    ],
+    web: "convolver",
+  },
+] as const;
+
+const BY_ID = new Map(HF_AUDIO_FX.map((d) => [d.id, d]));
+
+export function getAudioFxDef(id: string): HfAudioFxDef | undefined {
+  return BY_ID.get(id);
+}
+
+export const HF_AUDIO_FX_IDS: readonly string[] = HF_AUDIO_FX.map((d) => d.id);
+
+/** Every parameter at its declared default, ready to seed a freshly added effect. */
+export function defaultAudioFxParams(id: string): HfAudioFxParamValues {
+  const def = BY_ID.get(id);
+  if (!def) return {};
+  const out: HfAudioFxParamValues = {};
+  for (const p of def.params) out[p.key] = p.default;
+  return out;
+}
+
+/**
+ * Clamp and fill a parameter set so it is always renderable: unknown keys are
+ * dropped, missing keys take their default, numbers are clamped into their
+ * declared range, and an unrecognised enum value falls back to its default.
+ * A non-finite number is treated as missing rather than passed through, since
+ * NaN reaching an AudioParam silences the node for the rest of the render.
+ */
+export function normalizeAudioFxParams(
+  id: string,
+  values: Readonly<HfAudioFxParamValues> | undefined,
+): HfAudioFxParamValues {
+  const def = BY_ID.get(id);
+  if (!def) return {};
+  const out: HfAudioFxParamValues = {};
+  for (const p of def.params) {
+    const raw = values?.[p.key];
+    if (p.kind === "enum") {
+      const ok = p.options.some((o) => o.value === raw);
+      out[p.key] = ok ? (raw as string) : p.default;
+      continue;
+    }
+    const n = typeof raw === "number" ? raw : Number(raw);
+    out[p.key] = Number.isFinite(n) ? Math.min(p.max, Math.max(p.min, n)) : p.default;
+  }
+  return out;
+}
+
+export interface HfAudioFxNode {
+  /** Effect id from HF_AUDIO_FX. */
+  type: string;
+  /** Absent means enabled — chain files written before the field existed still load. */
+  enabled?: boolean;
+  params?: HfAudioFxParamValues;
+}
+
+export interface HfAudioFxChain {
+  version: number;
+  nodes: HfAudioFxNode[];
+}
+
+export class AudioFxChainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AudioFxChainError";
+  }
+}
+
+/**
+ * Parse a chain file. Unknown effect ids are rejected rather than skipped: a
+ * chain that silently loses a node would render differently from the project
+ * the author saved, which is worse than refusing to render at all.
+ */
+export function parseAudioFxChain(json: string): HfAudioFxChain {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch (err) {
+    throw new AudioFxChainError(`Chain file is not valid JSON: ${(err as Error).message}`);
+  }
+  if (typeof raw !== "object" || raw === null) {
+    throw new AudioFxChainError("Chain file must be a JSON object.");
+  }
+  const obj = raw as { version?: unknown; nodes?: unknown };
+  if (obj.version !== HF_AUDIO_FX_CHAIN_VERSION) {
+    throw new AudioFxChainError(`Unsupported chain version: ${String(obj.version)}`);
+  }
+  if (!Array.isArray(obj.nodes)) {
+    throw new AudioFxChainError("Chain file is missing a `nodes` array.");
+  }
+  const nodes: HfAudioFxNode[] = obj.nodes.map((n, i) => {
+    if (typeof n !== "object" || n === null) {
+      throw new AudioFxChainError(`Node ${i} is not an object.`);
+    }
+    const node = n as { type?: unknown; enabled?: unknown; params?: unknown };
+    if (typeof node.type !== "string" || !BY_ID.has(node.type)) {
+      throw new AudioFxChainError(`Node ${i} has unknown effect type: ${String(node.type)}`);
+    }
+    return {
+      type: node.type,
+      enabled: node.enabled !== false,
+      params: normalizeAudioFxParams(
+        node.type,
+        (node.params ?? undefined) as HfAudioFxParamValues | undefined,
+      ),
+    };
+  });
+  return { version: HF_AUDIO_FX_CHAIN_VERSION, nodes };
+}
+
+/** The nodes that should process audio, in order. */
+export function enabledAudioFxNodes(chain: HfAudioFxChain): HfAudioFxNode[] {
+  return chain.nodes.filter((n) => n.enabled !== false);
+}
+
+/** Serialise a chain for the `data-fx-chain` attribute. */
+export function serializeAudioFxChain(chain: HfAudioFxChain): string {
+  return JSON.stringify({
+    version: HF_AUDIO_FX_CHAIN_VERSION,
+    nodes: chain.nodes.map((node) => ({
+      type: node.type,
+      ...(node.enabled === false ? { enabled: false } : {}),
+      params: normalizeAudioFxParams(node.type, node.params),
+    })),
+  });
+}

--- a/packages/core/src/audioFx.ts
+++ b/packages/core/src/audioFx.ts
@@ -137,7 +137,10 @@ export const HF_AUDIO_FX: readonly HfAudioFxDef[] = [
     label: "Low Shelf",
     group: "filter",
     description: "Lift or drop everything below the corner frequency.",
-    params: [freq("frequency", "Frequency", 200, 20, 2000), gainDb(-40, 40, 0), qParam(0.707)],
+    // No Q: the Web Audio spec leaves it unused for shelving filters, so the
+    // control moved nothing — and being automatable, a lane drawn on it would
+    // have been silently inert.
+    params: [freq("frequency", "Frequency", 200, 20, 2000), gainDb(-40, 40, 0)],
     web: "biquad-lowshelf",
   },
   {
@@ -145,7 +148,7 @@ export const HF_AUDIO_FX: readonly HfAudioFxDef[] = [
     label: "High Shelf",
     group: "filter",
     description: "Lift or drop everything above the corner frequency.",
-    params: [freq("frequency", "Frequency", 4000, 500, 20000), gainDb(-40, 40, 0), qParam(0.707)],
+    params: [freq("frequency", "Frequency", 4000, 500, 20000), gainDb(-40, 40, 0)],
     web: "biquad-highshelf",
   },
   {
@@ -458,16 +461,6 @@ export const HF_AUDIO_FX: readonly HfAudioFxDef[] = [
       },
       {
         kind: "number",
-        key: "aa",
-        label: "Anti-alias",
-        unit: "",
-        min: 0,
-        max: 1,
-        step: 0.01,
-        default: 0.5,
-      },
-      {
-        kind: "number",
         key: "mix",
         label: "Mix",
         unit: "",
@@ -557,16 +550,6 @@ export const HF_AUDIO_FX: readonly HfAudioFxDef[] = [
         max: 10,
         step: 0.01,
         default: 1,
-      },
-      {
-        kind: "number",
-        key: "decay",
-        label: "Decay",
-        unit: "",
-        min: 0,
-        max: 0.9,
-        step: 0.01,
-        default: 0.5,
       },
       {
         kind: "number",


### PR DESCRIPTION
The Web Audio graph for each registry entry — turning a `data-fx-chain` node into real audio nodes, wired in signal order.

This is the piece both runtimes share. The studio builds it in a live `AudioContext` and the engine builds the same graph in an `OfflineAudioContext`, so what an author hears while scrubbing is what gets rendered. One implementation, two hosts; a second one would drift and the drift would only show up in a finished video.

Four effects needed worklets rather than native nodes (compressor, limiter, gate, bitcrush) because Web Audio has no primitive for them.

Fixes folded in: reverb level, phaser wiring, per-channel dynamics, and a one-pole filter case — each found by listening to the graph rather than reading it.
