### PR TITLE
fix(producer): scale page navigation timeout with compiled document size

### DIFF
--- a/packages/engine/src/config.test.ts
+++ b/packages/engine/src/config.test.ts
@@ -6,6 +6,7 @@ import {
   resolveDefaultDrawElement,
   DEFAULT_CONFIG,
   scaleProtocolTimeoutForComposition,
+  scaleNavigationTimeoutForDocument,
   shouldClampToScreenshotForConcreteGpu,
   applyConcreteGpuScreenshotClamp,
   shouldAutoDisableStreamingEncodeOnWin32Compound,
@@ -835,6 +836,38 @@ describe("scaleProtocolTimeoutForComposition", () => {
     expect(scaleProtocolTimeoutForComposition(base, { width: Number.NaN, height: 1080 })).toBe(
       base,
     );
+  });
+});
+
+describe("scaleNavigationTimeoutForDocument", () => {
+  const base = 60_000;
+  const MB = 1024 * 1024;
+
+  it("keeps the base timeout for a reference-or-smaller document", () => {
+    expect(scaleNavigationTimeoutForDocument(base, 4 * MB)).toBe(base);
+    expect(scaleNavigationTimeoutForDocument(base, 512 * 1024)).toBe(base);
+  });
+
+  it("scales up proportionally with compiled document bytes", () => {
+    // A 13-minute composition compiles to a document many times the 4 MB
+    // reference — heygen-com/hyperframes#2968 died on the flat 60s default.
+    expect(scaleNavigationTimeoutForDocument(base, 16 * MB)).toBe(base * 4);
+  });
+
+  it("clamps at the 10-minute ceiling for a pathological document", () => {
+    expect(scaleNavigationTimeoutForDocument(base, 4096 * MB)).toBe(600_000);
+  });
+
+  it("never lowers a base timeout that already exceeds the ceiling", () => {
+    // An explicit `--browser-timeout 900` must survive the scaling pass.
+    const highBase = 900_000;
+    expect(scaleNavigationTimeoutForDocument(highBase, 8 * MB)).toBeGreaterThanOrEqual(highBase);
+  });
+
+  it("returns the base timeout for degenerate sizes", () => {
+    expect(scaleNavigationTimeoutForDocument(base, 0)).toBe(base);
+    expect(scaleNavigationTimeoutForDocument(base, -1)).toBe(base);
+    expect(scaleNavigationTimeoutForDocument(base, Number.NaN)).toBe(base);
   });
 });
 

--- a/packages/engine/src/config.ts
+++ b/packages/engine/src/config.ts
@@ -571,6 +571,45 @@ export function scaleProtocolTimeoutForComposition(
 }
 
 /**
+ * Reference compiled-document size for the baseline `pageNavigationTimeout`:
+ * 4 MB. `page.goto(..., { waitUntil: "domcontentloaded" })` blocks on Chrome
+ * parsing the compiled entry HTML, and HyperFrames compiles the WHOLE
+ * composition into one document (inline runtime, inline styles, inline
+ * data-URI assets). Parse cost is ~linear in document bytes, so a long
+ * composition produces a document that legitimately needs more than the flat
+ * 60s default — with `--workers N` every worker pays that parse concurrently.
+ */
+const NAVIGATION_TIMEOUT_REFERENCE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Absolute ceiling on the scaled navigation timeout (10 minutes). A document
+ * that genuinely cannot reach `domcontentloaded` must still fail rather than
+ * hang unbounded.
+ */
+const MAX_SCALED_NAVIGATION_TIMEOUT_MS = 600_000;
+
+/**
+ * Scale a base `pageNavigationTimeout` up for oversized compiled documents.
+ *
+ * Sibling of {@link scaleProtocolTimeoutForComposition}: same clamp contract
+ * (only ever raises, never lowers below the configured base), different
+ * driver. The protocol timeout bounds one CDP call, so it scales with output
+ * pixel area; navigation bounds the initial HTML parse, so it scales with
+ * compiled document bytes. Pure function; exported for tests.
+ */
+export function scaleNavigationTimeoutForDocument(
+  baseTimeoutMs: number,
+  documentBytes: number,
+): number {
+  if (!Number.isFinite(documentBytes) || documentBytes <= 0) return baseTimeoutMs;
+  const factor = documentBytes / NAVIGATION_TIMEOUT_REFERENCE_BYTES;
+  if (factor <= 1) return baseTimeoutMs;
+  const scaled = Math.ceil(baseTimeoutMs * factor);
+  const ceiling = Math.max(baseTimeoutMs, MAX_SCALED_NAVIGATION_TIMEOUT_MS);
+  return Math.min(ceiling, Math.max(baseTimeoutMs, scaled));
+}
+
+/**
  * Auto-disable `enableStreamingEncode` on Windows software-GPU compound.
  *
  * Field signal (`ts=1784131903`, win32/x64, CLI 0.7.58, 156s UI-heavy

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -51,6 +51,7 @@ export {
   validateEngineConfigSnapshot,
   DEFAULT_CONFIG,
   scaleProtocolTimeoutForComposition,
+  scaleNavigationTimeoutForDocument,
   shouldClampToScreenshotForConcreteGpu,
   applyConcreteGpuScreenshotClamp,
   resolveExtractCacheDir,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -80,6 +80,7 @@ import {
   resolveBrowserGpuMode,
   resolveHeadlessShellPath,
   applyConcreteGpuScreenshotClamp,
+  scaleNavigationTimeoutForDocument,
   scaleProtocolTimeoutForComposition,
   classifyCaptureFailure,
   cloneCaptureWarning,
@@ -2257,6 +2258,32 @@ async function executeRenderPipeline(input: {
       });
       cfg.protocolTimeout = scaledProtocolTimeout;
       updateCaptureObservability({ protocolTimeoutMs: scaledProtocolTimeout });
+    }
+
+    // Same treatment for the `page.goto` navigation timeout, driven by the
+    // compiled document size instead of pixel area. HyperFrames compiles the
+    // whole composition into ONE entry document, so a long composition parses
+    // for a long time before `domcontentloaded` fires — and each of N workers
+    // pays that parse concurrently. The flat 60s default therefore fails
+    // long-but-valid renders with a bare `Navigation timeout of 60000 ms
+    // exceeded` (heygen-com/hyperframes#2968: 13-minute composition,
+    // `--workers 4`). `cfg` is passed by reference into every capture session,
+    // and the timeout is read at goto time, so mutating it here (before the
+    // probe launches) reaches the probe and all capture workers. Only ever
+    // raises; small compositions keep the configured base, and an explicit
+    // `--browser-timeout` above the scaled value is never lowered.
+    const scaledNavigationTimeout = scaleNavigationTimeoutForDocument(
+      cfg.pageNavigationTimeout,
+      compiled.html.length,
+    );
+    if (scaledNavigationTimeout > cfg.pageNavigationTimeout) {
+      log.info("[Render] Scaled page navigation timeout up for large compiled document.", {
+        from: cfg.pageNavigationTimeout,
+        to: scaledNavigationTimeout,
+        documentBytes: compiled.html.length,
+      });
+      cfg.pageNavigationTimeout = scaledNavigationTimeout;
+      updateCaptureObservability({ pageNavigationTimeoutMs: scaledNavigationTimeout });
     }
 
     const probeResult = await observeRenderStage(


### PR DESCRIPTION
## What

Scale the Puppeteer `page.goto` navigation timeout with the size of the compiled entry document, instead of applying a flat 60s to every render.

New pure helper `scaleNavigationTimeoutForDocument(baseMs, documentBytes)` in `packages/engine/src/config.ts`, applied in `renderOrchestrator` right next to the existing protocol-timeout scaling.

## Why

Fixes #2968. A 13-minute composition rendered with `--workers 4` failed with a bare `Navigation timeout of 60000 ms exceeded`.

HyperFrames compiles the whole composition into **one** entry document (inline runtime, inline styles, inline data-URI assets), and `page.goto(..., { waitUntil: "domcontentloaded" })` blocks on Chrome parsing that document. Parse cost is roughly linear in document bytes, so a long composition legitimately needs more than 60s, and with `--workers N` every worker pays that parse concurrently.

The sibling knob already handles this: `protocolTimeout` auto-scales via `scaleProtocolTimeoutForComposition`. Navigation was the one fixed wall with no compensating signal, so long-but-valid renders died on a message that names no lever.

## How

Mirrors `scaleProtocolTimeoutForComposition` exactly, including its clamp contract:

- Reference size 4 MB; scales linearly above that.
- **Only ever raises** — a small composition keeps the configured base, and an explicit `--browser-timeout` above the scaled value is never lowered.
- Ceiling of 10 minutes, so a genuinely wedged document still fails rather than hanging unbounded.

Different driver from its sibling for a reason: the protocol timeout bounds one CDP call, so it scales with output pixel area; navigation bounds the initial HTML parse, so it scales with document bytes.

`cfg` is passed by reference into every capture session and the timeout is read at goto time, so mutating it before the probe launches reaches the probe and all capture workers.

## Test plan

Unit tests in `packages/engine/src/config.test.ts` cover the reference boundary, proportional scaling, the ceiling clamp, the never-lower-an-explicit-base contract, and degenerate sizes.

Verified end-to-end on a Linux host (8-core, headless-shell 151) with a 12000-clip composition compiling to a 5.9 MB document, rendered `--workers 4`:

| | `pageNavigationTimeout` | output |
|---|---|---|
| `main` (control) | `60000` flat, no scaling log | `e2cd6a99…` |
| this branch | `Scaled page navigation timeout up… {"from":60000,"to":84373,"documentBytes":5898063}` | `e2cd6a99…` |

5898063 / 4 MB = 1.406 × 60000 = 84373 ms, as designed. Both renders completed and the MP4s are **byte-identical** (same md5) — the change adds headroom only, it does not alter output.

- [x] Unit tests added
- [x] Manual testing performed (Linux, control vs. patched)
- [ ] Documentation updated (n/a — no user-facing flag change)

## Not covered

- The reporter's original 13-minute project is not in the repo, so the exact failing document size is unverified; the mechanism is verified on a synthetic document of the same shape.
- The reporter was on 0.6.102 and also had 0.1 GB free disk, which may have been an independent contributing factor to that specific run.