### PR TITLE
test(studio): relax large fixture timeout

### DIFF
--- a/packages/studio/src/hooks/useStudioTestHooks.test.tsx
+++ b/packages/studio/src/hooks/useStudioTestHooks.test.tsx
@@ -59,11 +59,15 @@ describe("timeline performance fixture", () => {
     expect(Math.max(...perTrack.values())).toBeLessThanOrEqual(128);
   });
 
-  it.each(PROFILES)("generates an identical 50k %s fixture", (profile) => {
-    const first = createTimelinePerformanceFixture({ elementCount: 50_000, profile });
-    const second = createTimelinePerformanceFixture({ elementCount: 50_000, profile });
-    expect(second).toEqual(first);
-  });
+  it.each(PROFILES)(
+    "generates an identical 50k %s fixture",
+    (profile) => {
+      const first = createTimelinePerformanceFixture({ elementCount: 50_000, profile });
+      const second = createTimelinePerformanceFixture({ elementCount: 50_000, profile });
+      expect(second).toEqual(first);
+    },
+    30_000,
+  );
 
   it.each(PROFILES)("builds the %s 1k scale profile", (profile) => {
     const fixture = createTimelinePerformanceFixture({ elementCount: 1_000, profile });


### PR DESCRIPTION
## What

Give the 50k timeline fixture determinism test a 30-second timeout.

## Why

The keyframe-heavy-expanded case timed out at Vitest’s default 5-second limit on the Windows runner while building and deeply comparing two 50k-element fixtures. The assertions and fixture scale remain unchanged.

Fixes the failure in https://github.com/heygen-com/hyperframes/actions/runs/30961234870/job/92165591660.

## How

Apply the same explicit 30-second budget already used by comparable large timeline tests.

## Test plan

- [x] Focused Studio test: 13/13 passed
- [x] Studio TypeScript typecheck
- [x] oxlint and oxfmt checks
- [ ] Documentation updated (not applicable)