### PR TITLE
fix(cli): stop inferring publish ownership from credential presence

### DIFF
--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -140,8 +140,9 @@ export default defineCommand({
     // Team space: explicit --space wins, else the committed space id, else the personal space.
     const spaceId = spaceOverride ?? committedTeam?.spaceId;
 
-    // Continuity cue: if this directory was published before, show where it lives so the
-    // user knows a re-publish updates that same link (when logged in).
+    // Continuity cue: if this directory was published before, show where it lives. Whether
+    // the re-publish actually lands there is only known from the response, so this cue is a
+    // promise the result must reconcile — the anonymous branch below retracts it by name.
     const priorLink = readProjectLink(dir);
     if (priorLink?.url) {
       console.log();
@@ -235,6 +236,16 @@ export default defineCommand({
           );
           console.log(
             `  ${c.dim("Run 'hyperframes auth login' again, then re-publish to update in place.")}`,
+          );
+        } else if (priorLink?.url) {
+          // This directory had a link and the publish still came back anonymous, so the
+          // link above is NOT that one. Without this the run reads as continuous: the
+          // "Previously published at …" cue prints before the publish and nothing ever
+          // retracts it. Name the abandoned URL — it is the only remaining record of it,
+          // since an anonymous publish no longer overwrites the stored link.
+          console.log(`  ${c.error(`This is a NEW url — ${priorLink.url} was not updated.`)}`);
+          console.log(
+            `  ${c.dim("Publishing without an accepted login always mints a fresh project. Run 'hyperframes auth login', then re-publish to update a link in place.")}`,
           );
         } else {
           console.log(

--- a/packages/cli/src/utils/publishProject.test.ts
+++ b/packages/cli/src/utils/publishProject.test.ts
@@ -786,6 +786,43 @@ describe("publishProjectArchive", () => {
     }
   });
 
+  it("does not persist a link when a credential is present but the server publishes anonymously", async () => {
+    // The uncovered state that shipped the bug: `tryResolveCredential` also returns API
+    // keys, which the server does not accept as ownership — it ignores the stable id and
+    // mints a throwaway project instead. Persisting that would clobber the real link this
+    // directory published to before, so ownership must be read off the RESPONSE.
+    authMocks.tryResolveCredential.mockResolvedValue({
+      type: "api_key",
+      key: "test-key",
+      source: "file_json",
+      refreshable: false,
+    });
+    const dir = makeProjectDir();
+    const fetchMock = stagedFetch({
+      project_id: "hfp_throwaway",
+      url: "https://hyperframes.dev/p/hfp_throwaway",
+      claim_token: "claim-token",
+      claimed: false,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      writeFileSync(join(dir, "index.html"), "<html></html>", "utf-8");
+
+      const result = await publishProjectArchive(dir, { projectId: "hfp_stable" });
+
+      // The id is still sent — a credential was present, and the server decides.
+      const completeBody = JSON.parse(fetchMock.mock.calls[2]![1].body);
+      expect(completeBody.project_id).toBe("hfp_stable");
+      // But the server minted a different, unclaimed project, so nothing is remembered.
+      expect(result.claimed).toBe(false);
+      expect(result.projectId).toBe("hfp_throwaway");
+      expect(linkMocks.writeProjectLink).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   async function publishWithTeamSpace(authed: boolean) {
     // Set explicitly (not just for the authed case) so calling this twice in one test —
     // authed then anonymous — doesn't leak the credential mock across calls.

--- a/packages/cli/src/utils/publishProject.ts
+++ b/packages/cli/src/utils/publishProject.ts
@@ -630,7 +630,12 @@ export async function publishProjectArchive(
       projectId,
     ));
   // Remember the server's id + url so the next publish of this directory updates in place.
-  if (credential) {
+  // Both halves are load-bearing. A credential is necessary but NOT sufficient:
+  // `tryResolveCredential` also returns API keys, which the server does not accept as
+  // ownership — it falls back to an anonymous publish and mints a throwaway project.
+  // Recording that throwaway would overwrite the real link this directory published to
+  // before, losing the only local record of it. Ownership is what the RESPONSE says.
+  if (credential && result.claimed) {
     writeProjectLink(projectDir, { projectId: result.projectId, url: result.url });
   }
   return result;


### PR DESCRIPTION
Publishing the same directory twice is supposed to update one link in place. It silently does not when the resolved credential is an API key.

## The bug

`tryResolveCredential()` returns API keys as well as OAuth tokens, but the publish endpoint does not accept an API key as ownership — it ignores the stable project id and mints a fresh, unclaimed project. The CLI treated *any* resolved credential as an owner, so those users got a different URL on every publish while the run read as continuous.

Two consequences, both downstream of that single inference:

- **Data loss.** `writeProjectLink` ran whenever a credential existed, so an anonymous publish overwrote the stored link of a directory that *had* been published as an owner — destroying the only local record of the real URL.
- **A promise nothing retracts.** The `Previously published at <url>` cue prints *before* the publish. The existing mismatch warning only covers explicit `--update` / `--space`, so a plain `hyperframes publish` printed the cue, minted a different URL, and warned about nothing.

Reproduced end to end: two publishes of one unchanged directory under an API-key credential returned two different project ids, with the first URL orphaned and unrecorded.

## The fix

Ownership is read off the response instead of inferred from the credential:

```ts
if (credential && result.claimed) {   // was: if (credential)
```

Both halves are load-bearing — a credential is necessary but not sufficient, and a client with no credential must never persist a link regardless of what the server returns.

The command then retracts the continuity cue by name when a directory with a prior link publishes anonymously, so the abandoned URL is stated rather than quietly dropped.

## Verification

Against the live service with a locally built CLI:

- **Owned path (regression):** two publishes → identical URL, `Updated existing project`, link persisted, no spurious warning.
- **Credential-but-anonymous:** the abandoned URL is named, and the stored link is left intact where it was previously replaced by the throwaway id.

Adds the uncovered unit case that let this ship — credential present, server returns `claimed: false`. Full publish suite passes.

## Scope

This makes the CLI honest; it does **not** make API-key publishing produce a stable URL. Whether the endpoint should accept API keys as ownership is a server-side policy question — no doc or test in this repo states the intent either way, and it is worth settling separately. This change is correct under either answer.