### PR TITLE
chore: release v0.7.93

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,59 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.93"
+  description="Released - 2026-08-05"
+  tags={["Release", "Engine", "Studio", "Parsers"]}
+>
+Studio now preserves and recovers external file edits instead of silently
+overwriting them, while logical timeline navigation makes keyboard control more
+predictable. The engine and producer also harden remote downloads, ffprobe
+invocation, telemetry path redaction, GPU verification, and cross-frame-rate
+BeginFrame timing.
+
+## Features
+
+- **Studio:** Model logical timeline navigation ([0f1333c80](https://github.com/heygen-com/hyperframes/commit/0f1333c80d3c18eddf8af69110168cc910d14fec), [#2712](https://github.com/heygen-com/hyperframes/pull/2712))
+- **Studio:** Add external conflict recovery UI ([8a0dccfc7](https://github.com/heygen-com/hyperframes/commit/8a0dccfc72224d993efdb0ae8d95fc0e020327d4), [#2992](https://github.com/heygen-com/hyperframes/pull/2992))
+- **Studio:** Coordinate external file changes ([a99caad58](https://github.com/heygen-com/hyperframes/commit/a99caad581496f2ad8e132b750ced73be8cf3e51), [#2991](https://github.com/heygen-com/hyperframes/pull/2991))
+- **Studio:** Preserve external file conflicts ([b30a23402](https://github.com/heygen-com/hyperframes/commit/b30a23402e2db19b43cb0283e1553048746fb8bb), [#2990](https://github.com/heygen-com/hyperframes/pull/2990))
+
+## Fixes
+
+- **Engine:** Keep BeginFrame time monotonic across frame rates ([b390b71bd](https://github.com/heygen-com/hyperframes/commit/b390b71bde982ffbf55c9ec93f1491d99011bfc3), [#3011](https://github.com/heygen-com/hyperframes/pull/3011))
+- **Engine:** Validate remote download integrity ([bbdfee116](https://github.com/heygen-com/hyperframes/commit/bbdfee1166c45e348ef76d2e384a0ad2243ac847), [#2938](https://github.com/heygen-com/hyperframes/pull/2938))
+- **Studio:** Reconcile external edits before reload ([ebdd1893c](https://github.com/heygen-com/hyperframes/commit/ebdd1893c4a0d86b984fb627fed0283a981d2713), [#2993](https://github.com/heygen-com/hyperframes/pull/2993))
+- **Studio:** Drain pending edits before reload ([471313854](https://github.com/heygen-com/hyperframes/commit/47131385445c0f8ee4203f8d6ff4f5600d8c8b2e), [#2989](https://github.com/heygen-com/hyperframes/pull/2989))
+- **Studio:** Make inspector commits transactional ([552419c52](https://github.com/heygen-com/hyperframes/commit/552419c52d16fa5a5e8d15a9263bc5f41e596360), [#2987](https://github.com/heygen-com/hyperframes/pull/2987))
+- **Engine:** Distinguish probe failure from a genuinely absent GPU ([f69c4a0e3](https://github.com/heygen-com/hyperframes/commit/f69c4a0e3aa8feb1110b52d538f8ca127481c95d))
+- **Studio:** Respect GSAP transform ownership ([cf45c9845](https://github.com/heygen-com/hyperframes/commit/cf45c984549bc41ed4debc99d5283d2a60108cbb), [#2986](https://github.com/heygen-com/hyperframes/pull/2986))
+- **Parsers:** Preserve safe GSAP helper defaults ([532f06158](https://github.com/heygen-com/hyperframes/commit/532f06158b3a930b85a289ab0608d720311cd5a1), [#2985](https://github.com/heygen-com/hyperframes/pull/2985))
+- **Engine:** Warn once per process about unverified hardware GPU ([6703ea7e0](https://github.com/heygen-com/hyperframes/commit/6703ea7e04701b490c5fb563db4f532fbc8aec89))
+- **Engine:** Verify explicit browserGpuMode=hardware instead of trusting it ([131780fe9](https://github.com/heygen-com/hyperframes/commit/131780fe9627ee7fb17cb871ef6a144a6ef02735))
+- **Core,producer,skills:** Unicode paths, non-Error rejections, shell callers ([1664fe6ad](https://github.com/heygen-com/hyperframes/commit/1664fe6ad773c76e0dc7314e7f2eb439cd3687d6))
+- **Producer:** Drop the ReDoS-prone literal-argv regex for a linear scan ([6c5403f7c](https://github.com/heygen-com/hyperframes/commit/6c5403f7cd5e5b21f301b88d6d9f84451751ba15))
+- **Skills,producer:** Terminate ffprobe options in shipped skill scripts ([255cf9291](https://github.com/heygen-com/hyperframes/commit/255cf929150977fa57dc1cadde2e9cf626f5c20c))
+- **Core,producer:** Redact bare relative paths and the known input path ([e79ab3ab3](https://github.com/heygen-com/hyperframes/commit/e79ab3ab31a5f789f8c998430f2b58cb95973f07))
+- **Core:** Redact any path in telemetry, not an allowlist of roots ([d04569e37](https://github.com/heygen-com/hyperframes/commit/d04569e37f1c63967ce7373557ded4e4f150e7de))
+- **Producer,studio Server:** Finish the ffprobe argv sweep, pin the contract ([d0dbf11ef](https://github.com/heygen-com/hyperframes/commit/d0dbf11ef53dd7ca535ed40a10e8f2dad4f12c4d))
+- **Cli,core,lint,producer:** Terminate ffprobe options at every call site ([47564ab94](https://github.com/heygen-com/hyperframes/commit/47564ab94cc4bac5de6715169939353c211af689))
+
+## Docs & Examples
+
+- **Studio:** Document timeline keyboard navigation ([7bf425b7a](https://github.com/heygen-com/hyperframes/commit/7bf425b7a90c5a3c8154c66025261ff9e52c8c72), [#3031](https://github.com/heygen-com/hyperframes/pull/3031))
+
+## Internal
+
+- **Studio:** Relax large fixture timeout ([bce2140ff](https://github.com/heygen-com/hyperframes/commit/bce2140ff208e16f83ee0854bca8baf85ad7216e), [#3040](https://github.com/heygen-com/hyperframes/pull/3040))
+- **Studio:** Extract live timeline clock ([19b8a1f3c](https://github.com/heygen-com/hyperframes/commit/19b8a1f3c5a55c30b5aa367c9054ca1b31552536), [#2711](https://github.com/heygen-com/hyperframes/pull/2711))
+- **Studio:** Pin text-field Backspace routing ([cde5bae4c](https://github.com/heygen-com/hyperframes/commit/cde5bae4c5a6afa167faf827ab1073e66964cd35), [#2988](https://github.com/heygen-com/hyperframes/pull/2988))
+- **Producer:** Treat an all-literal probe argv as taking no input ([c81f68b59](https://github.com/heygen-com/hyperframes/commit/c81f68b59225d0acd34acbc419e408125fa51e36))
+- **Producer:** Discover ffprobe callers and pin terminator position ([91a7cb1f5](https://github.com/heygen-com/hyperframes/commit/91a7cb1f5b7f9a4bb539384fb50645a8feab3f29))
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.92...v0.7.93).
+</Update>
+
+<Update
   label="HyperFrames v0.7.92"
   description="Released - 2026-08-04"
   tags={["Release", "Release", "Studio", "Core"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.93.md
+++ b/releases/v0.7.93.md
@@ -1,0 +1,52 @@
+# HyperFrames v0.7.93
+
+Released on 2026-08-05.
+
+Studio now preserves and recovers external file edits instead of silently
+overwriting them, while logical timeline navigation makes keyboard control more
+predictable. The engine and producer also harden remote downloads, ffprobe
+invocation, telemetry path redaction, GPU verification, and cross-frame-rate
+BeginFrame timing.
+
+## Features
+
+- **Studio:** Model logical timeline navigation ([0f1333c80](https://github.com/heygen-com/hyperframes/commit/0f1333c80d3c18eddf8af69110168cc910d14fec), [#2712](https://github.com/heygen-com/hyperframes/pull/2712))
+- **Studio:** Add external conflict recovery UI ([8a0dccfc7](https://github.com/heygen-com/hyperframes/commit/8a0dccfc72224d993efdb0ae8d95fc0e020327d4), [#2992](https://github.com/heygen-com/hyperframes/pull/2992))
+- **Studio:** Coordinate external file changes ([a99caad58](https://github.com/heygen-com/hyperframes/commit/a99caad581496f2ad8e132b750ced73be8cf3e51), [#2991](https://github.com/heygen-com/hyperframes/pull/2991))
+- **Studio:** Preserve external file conflicts ([b30a23402](https://github.com/heygen-com/hyperframes/commit/b30a23402e2db19b43cb0283e1553048746fb8bb), [#2990](https://github.com/heygen-com/hyperframes/pull/2990))
+
+## Fixes
+
+- **Engine:** Keep BeginFrame time monotonic across frame rates ([b390b71bd](https://github.com/heygen-com/hyperframes/commit/b390b71bde982ffbf55c9ec93f1491d99011bfc3), [#3011](https://github.com/heygen-com/hyperframes/pull/3011))
+- **Engine:** Validate remote download integrity ([bbdfee116](https://github.com/heygen-com/hyperframes/commit/bbdfee1166c45e348ef76d2e384a0ad2243ac847), [#2938](https://github.com/heygen-com/hyperframes/pull/2938))
+- **Studio:** Reconcile external edits before reload ([ebdd1893c](https://github.com/heygen-com/hyperframes/commit/ebdd1893c4a0d86b984fb627fed0283a981d2713), [#2993](https://github.com/heygen-com/hyperframes/pull/2993))
+- **Studio:** Drain pending edits before reload ([471313854](https://github.com/heygen-com/hyperframes/commit/47131385445c0f8ee4203f8d6ff4f5600d8c8b2e), [#2989](https://github.com/heygen-com/hyperframes/pull/2989))
+- **Studio:** Make inspector commits transactional ([552419c52](https://github.com/heygen-com/hyperframes/commit/552419c52d16fa5a5e8d15a9263bc5f41e596360), [#2987](https://github.com/heygen-com/hyperframes/pull/2987))
+- **Engine:** Distinguish probe failure from a genuinely absent GPU ([f69c4a0e3](https://github.com/heygen-com/hyperframes/commit/f69c4a0e3aa8feb1110b52d538f8ca127481c95d))
+- **Studio:** Respect GSAP transform ownership ([cf45c9845](https://github.com/heygen-com/hyperframes/commit/cf45c984549bc41ed4debc99d5283d2a60108cbb), [#2986](https://github.com/heygen-com/hyperframes/pull/2986))
+- **Parsers:** Preserve safe GSAP helper defaults ([532f06158](https://github.com/heygen-com/hyperframes/commit/532f06158b3a930b85a289ab0608d720311cd5a1), [#2985](https://github.com/heygen-com/hyperframes/pull/2985))
+- **Engine:** Warn once per process about unverified hardware GPU ([6703ea7e0](https://github.com/heygen-com/hyperframes/commit/6703ea7e04701b490c5fb563db4f532fbc8aec89))
+- **Engine:** Verify explicit browserGpuMode=hardware instead of trusting it ([131780fe9](https://github.com/heygen-com/hyperframes/commit/131780fe9627ee7fb17cb871ef6a144a6ef02735))
+- **Core,producer,skills:** Unicode paths, non-Error rejections, shell callers ([1664fe6ad](https://github.com/heygen-com/hyperframes/commit/1664fe6ad773c76e0dc7314e7f2eb439cd3687d6))
+- **Producer:** Drop the ReDoS-prone literal-argv regex for a linear scan ([6c5403f7c](https://github.com/heygen-com/hyperframes/commit/6c5403f7cd5e5b21f301b88d6d9f84451751ba15))
+- **Skills,producer:** Terminate ffprobe options in shipped skill scripts ([255cf9291](https://github.com/heygen-com/hyperframes/commit/255cf929150977fa57dc1cadde2e9cf626f5c20c))
+- **Core,producer:** Redact bare relative paths and the known input path ([e79ab3ab3](https://github.com/heygen-com/hyperframes/commit/e79ab3ab31a5f789f8c998430f2b58cb95973f07))
+- **Core:** Redact any path in telemetry, not an allowlist of roots ([d04569e37](https://github.com/heygen-com/hyperframes/commit/d04569e37f1c63967ce7373557ded4e4f150e7de))
+- **Producer,studio Server:** Finish the ffprobe argv sweep, pin the contract ([d0dbf11ef](https://github.com/heygen-com/hyperframes/commit/d0dbf11ef53dd7ca535ed40a10e8f2dad4f12c4d))
+- **Cli,core,lint,producer:** Terminate ffprobe options at every call site ([47564ab94](https://github.com/heygen-com/hyperframes/commit/47564ab94cc4bac5de6715169939353c211af689))
+
+## Docs & Examples
+
+- **Studio:** Document timeline keyboard navigation ([7bf425b7a](https://github.com/heygen-com/hyperframes/commit/7bf425b7a90c5a3c8154c66025261ff9e52c8c72), [#3031](https://github.com/heygen-com/hyperframes/pull/3031))
+
+## Internal
+
+- **Studio:** Relax large fixture timeout ([bce2140ff](https://github.com/heygen-com/hyperframes/commit/bce2140ff208e16f83ee0854bca8baf85ad7216e), [#3040](https://github.com/heygen-com/hyperframes/pull/3040))
+- **Studio:** Extract live timeline clock ([19b8a1f3c](https://github.com/heygen-com/hyperframes/commit/19b8a1f3c5a55c30b5aa367c9054ca1b31552536), [#2711](https://github.com/heygen-com/hyperframes/pull/2711))
+- **Studio:** Pin text-field Backspace routing ([cde5bae4c](https://github.com/heygen-com/hyperframes/commit/cde5bae4c5a6afa167faf827ab1073e66964cd35), [#2988](https://github.com/heygen-com/hyperframes/pull/2988))
+- **Producer:** Treat an all-literal probe argv as taking no input ([c81f68b59](https://github.com/heygen-com/hyperframes/commit/c81f68b59225d0acd34acbc419e408125fa51e36))
+- **Producer:** Discover ffprobe callers and pin terminator position ([91a7cb1f5](https://github.com/heygen-com/hyperframes/commit/91a7cb1f5b7f9a4bb539384fb50645a8feab3f29))
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.92...v0.7.93


### PR DESCRIPTION
## What

Stable release **v0.7.93**, covering the 29 commits merged since v0.7.92.

Highlights:
- Studio preserves and recovers external file edits and adds logical timeline keyboard navigation.
- Engine validates remote download integrity and keeps BeginFrame time monotonic across frame rates.
- Producer/core harden ffprobe invocation, path redaction, Unicode paths, and non-Error rejection handling.
- Engine verifies explicit hardware-GPU mode instead of trusting it.

## Release mechanics

Prepared with `bun run release:prepare 0.7.93 --from v0.7.92 --to HEAD`. Package and plugin manifests are bumped together, and the reviewed release notes are in `releases/v0.7.93.md` plus `docs/changelog.mdx`.

No release tag was pushed from local. Merging this reviewed `release/v0.7.93` PR triggers `publish.yml`, which checks out the immutable merge SHA, creates `v0.7.93`, publishes the npm packages under `latest`, and creates the GitHub release.